### PR TITLE
[Cherry Picked] Lower Move compiler stack size

### DIFF
--- a/external-crates/move/crates/move-compiler/src/lib.rs
+++ b/external-crates/move/crates/move-compiler/src/lib.rs
@@ -10,7 +10,7 @@ extern crate move_ir_types;
 #[macro_use(symbol)]
 extern crate move_symbol_pool;
 
-pub const STACK_LIMIT: usize = 42 * 1_000_000_000;
+pub const STACK_LIMIT: usize = 1_000_000_000;
 
 macro_rules! with_large_stack {
     ($e:expr) => {


### PR DESCRIPTION
(cherry picked from commit a24c8ed1297d70978d14f43efec172efd865365d)

## Description 

This temporary solution was cherry-picked from the Sui repository.
It is necessary to track the final solution and synchronize with it later.

Related but do not fix issue #36 