### PR TITLE
Fix sui-genesis-builder compilation errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,20 +197,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anemo-benchmark"
-version = "0.0.0"
-dependencies = [
- "anemo",
- "anemo-build",
- "clap",
- "mysten-network",
- "rand 0.8.5",
- "telemetry-subscribers",
- "tokio",
- "workspace-hack",
-]
-
-[[package]]
 name = "anemo-build"
 version = "0.0.0"
 source = "git+https://github.com/mystenlabs/anemo.git?rev=26d415eb9aa6a2417be3c03c57d6e93c30bd1ad7#26d415eb9aa6a2417be3c03c57d6e93c30bd1ad7"
@@ -2674,57 +2660,6 @@ dependencies = [
  "strum 0.24.1",
  "strum_macros 0.24.3",
  "unicode-width",
-]
-
-[[package]]
-name = "consensus-config"
-version = "0.1.0"
-dependencies = [
- "fastcrypto",
- "insta",
- "mysten-network",
- "rand 0.8.5",
- "serde",
- "shared-crypto",
- "workspace-hack",
-]
-
-[[package]]
-name = "consensus-core"
-version = "0.1.0"
-dependencies = [
- "anemo",
- "anemo-build",
- "anemo-tower",
- "arc-swap",
- "async-trait",
- "base64 0.21.7",
- "bcs",
- "bytes",
- "cfg-if",
- "consensus-config",
- "enum_dispatch",
- "fastcrypto",
- "futures",
- "mockall",
- "mysten-metrics",
- "mysten-network",
- "parking_lot 0.12.1",
- "prometheus",
- "rand 0.8.5",
- "rstest",
- "serde",
- "shared-crypto",
- "sui-protocol-config",
- "tap",
- "telemetry-subscribers",
- "tempfile",
- "thiserror",
- "tokio",
- "tower",
- "tracing",
- "typed-store",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7566,16 +7501,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
-name = "mysten-common"
-version = "0.1.0"
-dependencies = [
- "futures",
- "parking_lot 0.12.1",
- "tokio",
- "workspace-hack",
-]
-
-[[package]]
 name = "mysten-metrics"
 version = "0.7.0"
 dependencies = [
@@ -7592,90 +7517,6 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid 1.7.0",
- "workspace-hack",
-]
-
-[[package]]
-name = "mysten-network"
-version = "0.2.0"
-dependencies = [
- "anemo",
- "bcs",
- "bytes",
- "eyre",
- "futures",
- "http",
- "multiaddr",
- "pin-project-lite",
- "serde",
- "snap",
- "tokio",
- "tokio-stream",
- "tonic 0.10.2",
- "tonic-health",
- "tower",
- "tower-http",
- "tracing",
- "workspace-hack",
-]
-
-[[package]]
-name = "mysten-service"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "axum",
- "mysten-metrics",
- "prometheus",
- "serde",
- "serde_json",
- "telemetry-subscribers",
- "tokio",
- "tower",
- "tracing",
- "workspace-hack",
-]
-
-[[package]]
-name = "mysten-service-boilerplate"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "axum",
- "mysten-service",
- "prometheus",
- "serde",
- "tokio",
- "tracing",
- "workspace-hack",
-]
-
-[[package]]
-name = "mysten-util-mem"
-version = "0.11.0"
-dependencies = [
- "cfg-if",
- "ed25519-consensus",
- "fastcrypto",
- "fastcrypto-tbls",
- "hashbrown 0.12.3",
- "impl-trait-for-tuples",
- "indexmap 2.2.3",
- "mysten-util-mem-derive",
- "once_cell",
- "parking_lot 0.12.1",
- "roaring",
- "smallvec",
- "workspace-hack",
-]
-
-[[package]]
-name = "mysten-util-mem-derive"
-version = "0.1.0"
-dependencies = [
- "proc-macro2 1.0.78",
- "syn 1.0.109",
- "synstructure",
  "workspace-hack",
 ]
 
@@ -7731,356 +7572,6 @@ dependencies = [
  "thiserror",
  "widestring",
  "winapi",
-]
-
-[[package]]
-name = "narwhal-config"
-version = "0.1.0"
-dependencies = [
- "fastcrypto",
- "fastcrypto-tbls",
- "insta",
- "match_opt",
- "mysten-network",
- "mysten-util-mem",
- "narwhal-crypto",
- "narwhal-test-utils",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror",
- "tracing",
- "workspace-hack",
-]
-
-[[package]]
-name = "narwhal-crypto"
-version = "0.1.0"
-dependencies = [
- "bcs",
- "bincode",
- "criterion",
- "fastcrypto",
- "fastcrypto-tbls",
- "hex-literal 0.3.4",
- "proptest",
- "proptest-derive",
- "serde",
- "serde-reflection",
- "serde_json",
- "shared-crypto",
- "workspace-hack",
-]
-
-[[package]]
-name = "narwhal-executor"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "bcs",
- "bincode",
- "bytes",
- "fastcrypto",
- "futures",
- "indexmap 2.2.3",
- "mockall",
- "mysten-metrics",
- "narwhal-config",
- "narwhal-crypto",
- "narwhal-network",
- "narwhal-node",
- "narwhal-primary",
- "narwhal-storage",
- "narwhal-test-utils",
- "narwhal-types",
- "prometheus",
- "serde",
- "sui-protocol-config",
- "telemetry-subscribers",
- "tempfile",
- "thiserror",
- "tokio",
- "tonic 0.10.2",
- "tracing",
- "typed-store",
- "workspace-hack",
-]
-
-[[package]]
-name = "narwhal-network"
-version = "0.1.0"
-dependencies = [
- "anemo",
- "anemo-tower",
- "anyhow",
- "async-trait",
- "axum",
- "axum-server",
- "backoff",
- "bincode",
- "bytes",
- "dashmap",
- "futures",
- "mysten-common",
- "mysten-metrics",
- "narwhal-crypto",
- "narwhal-test-utils",
- "narwhal-types",
- "parking_lot 0.12.1",
- "prometheus",
- "quinn-proto",
- "rand 0.8.5",
- "sui-macros",
- "tokio",
- "tower",
- "tracing",
- "workspace-hack",
-]
-
-[[package]]
-name = "narwhal-node"
-version = "0.1.0"
-dependencies = [
- "anemo",
- "arc-swap",
- "async-trait",
- "axum",
- "bytes",
- "cfg-if",
- "clap",
- "eyre",
- "fastcrypto",
- "futures",
- "mysten-metrics",
- "mysten-network",
- "narwhal-config",
- "narwhal-crypto",
- "narwhal-executor",
- "narwhal-network",
- "narwhal-primary",
- "narwhal-storage",
- "narwhal-test-utils",
- "narwhal-types",
- "narwhal-worker",
- "pretty_assertions",
- "prometheus",
- "rand 0.8.5",
- "reqwest",
- "serde-reflection",
- "serde_yaml 0.8.26",
- "sui-keys",
- "sui-protocol-config",
- "sui-types",
- "telemetry-subscribers",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tracing",
- "tracing-subscriber",
- "url",
- "workspace-hack",
-]
-
-[[package]]
-name = "narwhal-primary"
-version = "0.1.0"
-dependencies = [
- "anemo",
- "anemo-tower",
- "anyhow",
- "arc-swap",
- "async-trait",
- "backoff",
- "bcs",
- "bincode",
- "bytes",
- "cfg-if",
- "criterion",
- "dashmap",
- "fastcrypto",
- "fastcrypto-tbls",
- "futures",
- "governor",
- "indexmap 2.2.3",
- "itertools 0.10.5",
- "mockall",
- "mysten-common",
- "mysten-metrics",
- "mysten-network",
- "narwhal-config",
- "narwhal-crypto",
- "narwhal-executor",
- "narwhal-network",
- "narwhal-node",
- "narwhal-storage",
- "narwhal-test-utils",
- "narwhal-types",
- "narwhal-worker",
- "once_cell",
- "parking_lot 0.12.1",
- "prometheus",
- "proptest",
- "rand 0.8.5",
- "reqwest",
- "sui-macros",
- "sui-protocol-config",
- "tap",
- "telemetry-subscribers",
- "tempfile",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tower",
- "tracing",
- "typed-store",
- "workspace-hack",
-]
-
-[[package]]
-name = "narwhal-storage"
-version = "0.1.0"
-dependencies = [
- "fastcrypto",
- "fastcrypto-tbls",
- "futures",
- "lru 0.10.1",
- "mysten-common",
- "narwhal-config",
- "narwhal-test-utils",
- "narwhal-types",
- "parking_lot 0.12.1",
- "prometheus",
- "sui-macros",
- "tap",
- "tempfile",
- "tokio",
- "tracing",
- "typed-store",
- "workspace-hack",
-]
-
-[[package]]
-name = "narwhal-test-utils"
-version = "0.1.0"
-dependencies = [
- "anemo",
- "fastcrypto",
- "fdlimit",
- "indexmap 2.2.3",
- "itertools 0.10.5",
- "mysten-metrics",
- "mysten-network",
- "narwhal-config",
- "narwhal-crypto",
- "narwhal-executor",
- "narwhal-network",
- "narwhal-node",
- "narwhal-primary",
- "narwhal-storage",
- "narwhal-types",
- "narwhal-worker",
- "once_cell",
- "prometheus",
- "rand 0.8.5",
- "sui-protocol-config",
- "telemetry-subscribers",
- "tempfile",
- "tokio",
- "tonic 0.10.2",
- "tracing",
- "typed-store",
- "workspace-hack",
-]
-
-[[package]]
-name = "narwhal-types"
-version = "0.1.0"
-dependencies = [
- "anemo",
- "anemo-build",
- "anyhow",
- "base64 0.21.7",
- "bcs",
- "bytes",
- "criterion",
- "derive_builder",
- "enum_dispatch",
- "fastcrypto",
- "fastcrypto-tbls",
- "futures",
- "indexmap 2.2.3",
- "mockall",
- "mysten-common",
- "mysten-metrics",
- "mysten-network",
- "mysten-util-mem",
- "narwhal-config",
- "narwhal-crypto",
- "narwhal-test-utils",
- "once_cell",
- "prometheus",
- "proptest",
- "proptest-derive",
- "prost 0.12.3",
- "prost-build",
- "protobuf-src",
- "rand 0.8.5",
- "roaring",
- "rustversion",
- "serde",
- "serde_test",
- "serde_with",
- "sui-protocol-config",
- "thiserror",
- "tokio",
- "tonic 0.10.2",
- "tonic-build",
- "tracing",
- "typed-store",
- "workspace-hack",
-]
-
-[[package]]
-name = "narwhal-worker"
-version = "0.1.0"
-dependencies = [
- "anemo",
- "anemo-tower",
- "anyhow",
- "arc-swap",
- "async-trait",
- "byteorder",
- "bytes",
- "eyre",
- "fastcrypto",
- "futures",
- "governor",
- "itertools 0.10.5",
- "mysten-metrics",
- "mysten-network",
- "narwhal-config",
- "narwhal-crypto",
- "narwhal-network",
- "narwhal-node",
- "narwhal-primary",
- "narwhal-storage",
- "narwhal-test-utils",
- "narwhal-types",
- "prometheus",
- "rand 0.8.5",
- "reqwest",
- "sui-protocol-config",
- "tap",
- "telemetry-subscribers",
- "tempfile",
- "thiserror",
- "tokio",
- "tonic 0.10.2",
- "tower",
- "tracing",
- "typed-store",
- "workspace-hack",
 ]
 
 [[package]]
@@ -8540,36 +8031,6 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f930c88a43b1c3f6e776dfe495b4afab89882dbc81530c632db2ed65451ebcb4"
-dependencies = [
- "async-trait",
- "base64 0.21.7",
- "bytes",
- "chrono",
- "futures",
- "humantime",
- "hyper",
- "itertools 0.11.0",
- "parking_lot 0.12.1",
- "percent-encoding",
- "quick-xml 0.30.0",
- "rand 0.8.5",
- "reqwest",
- "ring 0.16.20",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "snafu",
- "tokio",
- "tracing",
- "url",
- "walkdir",
-]
-
-[[package]]
-name = "object_store"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d139f545f64630e2e3688fd9f81c470888ab01edeb72d13b4e86c566f1130000"
@@ -8584,7 +8045,7 @@ dependencies = [
  "itertools 0.12.1",
  "parking_lot 0.12.1",
  "percent-encoding",
- "quick-xml 0.31.0",
+ "quick-xml",
  "rand 0.8.5",
  "reqwest",
  "ring 0.17.8",
@@ -9897,16 +9358,6 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
-name = "quick-xml"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "quick-xml"
@@ -11551,37 +11002,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simulacrum"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "bcs",
- "fastcrypto",
- "futures",
- "move-binary-format",
- "move-bytecode-utils",
- "move-core-types",
- "once_cell",
- "prometheus",
- "rand 0.8.5",
- "serde",
- "shared-crypto",
- "sui-config",
- "sui-execution",
- "sui-framework",
- "sui-genesis-builder",
- "sui-keys",
- "sui-protocol-config",
- "sui-storage",
- "sui-swarm-config",
- "sui-transaction-checks",
- "sui-types",
- "tracing",
- "workspace-hack",
-]
-
-[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11661,7 +11081,7 @@ dependencies = [
  "bytes",
  "futures",
  "log",
- "object_store 0.9.0",
+ "object_store",
  "regex",
  "reqwest",
  "reqwest-middleware",
@@ -11948,7 +11368,6 @@ dependencies = [
  "shared-crypto",
  "shell-words",
  "signature 1.6.4",
- "sui-config",
  "sui-execution",
  "sui-genesis-builder",
  "sui-json",
@@ -11960,17 +11379,13 @@ dependencies = [
  "sui-protocol-config",
  "sui-replay",
  "sui-sdk",
- "sui-simulator",
  "sui-source-validation",
- "sui-swarm",
- "sui-swarm-config",
  "sui-test-transaction-builder",
  "sui-types",
  "tabled",
  "tap",
  "telemetry-subscribers",
  "tempfile",
- "test-cluster",
  "tokio",
  "tracing",
  "unescape",
@@ -12069,429 +11484,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sui-analytics-indexer"
-version = "1.19.0"
-dependencies = [
- "anyhow",
- "arrow",
- "arrow-array",
- "async-trait",
- "axum",
- "bcs",
- "byteorder",
- "bytes",
- "chrono",
- "clap",
- "csv",
- "eyre",
- "fastcrypto",
- "gcp-bigquery-client",
- "move-binary-format",
- "move-bytecode-utils",
- "move-core-types",
- "mysten-metrics",
- "num_enum 0.6.1",
- "object_store 0.7.1",
- "parquet",
- "prometheus",
- "rocksdb",
- "serde",
- "serde_json",
- "simulacrum",
- "snowflake-api",
- "strum 0.24.1",
- "strum_macros 0.24.3",
- "sui-analytics-indexer-derive",
- "sui-config",
- "sui-indexer",
- "sui-json-rpc-types",
- "sui-package-resolver",
- "sui-rest-api",
- "sui-storage",
- "sui-types",
- "tap",
- "telemetry-subscribers",
- "tempfile",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tracing",
- "typed-store",
- "typed-store-derive",
- "url",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-analytics-indexer-derive"
-version = "1.19.0"
-dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
- "syn 1.0.109",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-archival"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "byteorder",
- "bytes",
- "ed25519-consensus",
- "fastcrypto",
- "futures",
- "indicatif",
- "more-asserts",
- "move-binary-format",
- "move-core-types",
- "move-package",
- "num_enum 0.6.1",
- "object_store 0.7.1",
- "prometheus",
- "rand 0.8.5",
- "serde",
- "sui-config",
- "sui-macros",
- "sui-simulator",
- "sui-storage",
- "sui-swarm-config",
- "sui-types",
- "telemetry-subscribers",
- "tempfile",
- "tokio",
- "tracing",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-authority-aggregation"
-version = "0.1.0"
-dependencies = [
- "futures",
- "mysten-metrics",
- "sui-types",
- "tokio",
- "tracing",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-aws-orchestrator"
-version = "0.0.1"
-dependencies = [
- "async-trait",
- "aws-config",
- "aws-sdk-ec2",
- "aws-smithy-http",
- "aws-smithy-runtime-api",
- "clap",
- "color-eyre",
- "crossterm 0.25.0",
- "eyre",
- "futures",
- "mysten-metrics",
- "narwhal-config",
- "prettytable-rs",
- "prometheus-parse",
- "reqwest",
- "russh",
- "russh-keys",
- "serde",
- "serde_json",
- "sui-config",
- "sui-swarm-config",
- "sui-types",
- "tempfile",
- "thiserror",
- "tokio",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-benchmark"
-version = "0.0.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "bcs",
- "clap",
- "comfy-table",
- "duration-str",
- "fastcrypto-zkp",
- "futures",
- "hdrhistogram",
- "indicatif",
- "itertools 0.10.5",
- "move-core-types",
- "mysten-metrics",
- "narwhal-node",
- "prometheus",
- "rand 0.8.5",
- "regex",
- "roaring",
- "serde",
- "serde_json",
- "strum 0.24.1",
- "strum_macros 0.24.3",
- "sui-config",
- "sui-core",
- "sui-framework",
- "sui-framework-snapshot",
- "sui-json-rpc-types",
- "sui-keys",
- "sui-macros",
- "sui-network",
- "sui-protocol-config",
- "sui-sdk",
- "sui-simulator",
- "sui-storage",
- "sui-swarm-config",
- "sui-test-transaction-builder",
- "sui-types",
- "sysinfo",
- "telemetry-subscribers",
- "test-cluster",
- "tokio",
- "tokio-util 0.7.10",
- "tracing",
- "typed-store",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-bridge"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "arc-swap",
- "async-trait",
- "axum",
- "bcs",
- "clap",
- "const-str",
- "ethers",
- "eyre",
- "fastcrypto",
- "futures",
- "git-version",
- "hex-literal 0.3.4",
- "lru 0.10.1",
- "move-core-types",
- "mysten-metrics",
- "num_enum 0.6.1",
- "once_cell",
- "prometheus",
- "rand 0.8.5",
- "reqwest",
- "rocksdb",
- "serde",
- "serde_json",
- "serde_with",
- "shared-crypto",
- "sui-common",
- "sui-config",
- "sui-json-rpc-types",
- "sui-sdk",
- "sui-test-transaction-builder",
- "sui-types",
- "tap",
- "telemetry-subscribers",
- "tempfile",
- "test-cluster",
- "tokio",
- "tokio-retry",
- "tracing",
- "typed-store",
- "typed-store-derive",
- "url",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-cluster-test"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "clap",
- "derivative",
- "fastcrypto",
- "futures",
- "jsonrpsee",
- "move-core-types",
- "prometheus",
- "regex",
- "reqwest",
- "serde_json",
- "shared-crypto",
- "sui",
- "sui-config",
- "sui-core",
- "sui-faucet",
- "sui-graphql-rpc",
- "sui-indexer",
- "sui-json",
- "sui-json-rpc-types",
- "sui-keys",
- "sui-sdk",
- "sui-swarm",
- "sui-swarm-config",
- "sui-test-transaction-builder",
- "sui-types",
- "telemetry-subscribers",
- "tempfile",
- "test-cluster",
- "tokio",
- "tracing",
- "uuid 1.7.0",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-common"
-version = "0.1.0"
-dependencies = [
- "futures",
- "mysten-metrics",
- "sui-types",
- "tokio",
- "tracing",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-config"
-version = "0.0.0"
-dependencies = [
- "anemo",
- "anyhow",
- "bcs",
- "clap",
- "csv",
- "dirs 4.0.0",
- "fastcrypto",
- "insta",
- "narwhal-config",
- "object_store 0.7.1",
- "once_cell",
- "prometheus",
- "rand 0.8.5",
- "reqwest",
- "serde",
- "serde_with",
- "serde_yaml 0.8.26",
- "sui-keys",
- "sui-protocol-config",
- "sui-types",
- "tempfile",
- "tracing",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-core"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "arc-swap",
- "async-trait",
- "bcs",
- "bytes",
- "chrono",
- "clap",
- "consensus-config",
- "consensus-core",
- "criterion",
- "dashmap",
- "diffy",
- "either",
- "enum_dispatch",
- "expect-test",
- "eyre",
- "fastcrypto",
- "fastcrypto-tbls",
- "fastcrypto-zkp",
- "fs_extra",
- "futures",
- "im",
- "indexmap 2.2.3",
- "itertools 0.10.5",
- "lru 0.10.1",
- "mockall",
- "more-asserts",
- "move-binary-format",
- "move-bytecode-utils",
- "move-core-types",
- "move-package",
- "move-symbol-pool",
- "mysten-common",
- "mysten-metrics",
- "mysten-network",
- "mysticeti-core",
- "narwhal-config",
- "narwhal-crypto",
- "narwhal-executor",
- "narwhal-network",
- "narwhal-node",
- "narwhal-test-utils",
- "narwhal-types",
- "narwhal-worker",
- "num_cpus",
- "object_store 0.7.1",
- "once_cell",
- "parking_lot 0.12.1",
- "pprof",
- "pretty_assertions",
- "prometheus",
- "rand 0.8.5",
- "roaring",
- "rocksdb",
- "scopeguard",
- "serde",
- "serde-reflection",
- "serde_json",
- "serde_with",
- "serde_yaml 0.8.26",
- "shared-crypto",
- "signature 1.6.4",
- "static_assertions",
- "sui-archival",
- "sui-authority-aggregation",
- "sui-config",
- "sui-execution",
- "sui-framework",
- "sui-genesis-builder",
- "sui-json-rpc-types",
- "sui-macros",
- "sui-move-build",
- "sui-network",
- "sui-protocol-config",
- "sui-simulator",
- "sui-storage",
- "sui-swarm-config",
- "sui-test-transaction-builder",
- "sui-transaction-checks",
- "sui-types",
- "tap",
- "telemetry-subscribers",
- "tempfile",
- "test-cluster",
- "test-fuzz",
- "thiserror",
- "tokio",
- "tokio-retry",
- "tokio-stream",
- "tracing",
- "twox-hash",
- "typed-store",
- "typed-store-derive",
- "workspace-hack",
- "zeroize",
-]
-
-[[package]]
 name = "sui-cost"
 version = "0.1.0"
 dependencies = [
@@ -12503,128 +11495,11 @@ dependencies = [
  "serde",
  "strum 0.24.1",
  "strum_macros 0.24.3",
- "sui-config",
  "sui-json-rpc-types",
  "sui-move-build",
- "sui-swarm-config",
  "sui-test-transaction-builder",
  "sui-types",
- "test-cluster",
  "tokio",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-data-ingestion"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "aws-config",
- "aws-sdk-dynamodb",
- "aws-sdk-s3",
- "backoff",
- "base64-url",
- "bcs",
- "byteorder",
- "bytes",
- "futures",
- "mysten-metrics",
- "notify",
- "object_store 0.7.1",
- "prometheus",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "serde_yaml 0.8.26",
- "sui-archival",
- "sui-data-ingestion-core",
- "sui-storage",
- "sui-types",
- "telemetry-subscribers",
- "tempfile",
- "tokio",
- "tracing",
- "url",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-data-ingestion-core"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "backoff",
- "futures",
- "mysten-metrics",
- "notify",
- "object_store 0.7.1",
- "prometheus",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "sui-storage",
- "sui-types",
- "telemetry-subscribers",
- "tempfile",
- "tokio",
- "tracing",
- "url",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-e2e-tests"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "assert_cmd",
- "async-trait",
- "bcs",
- "clap",
- "expect-test",
- "fastcrypto",
- "fastcrypto-zkp",
- "fs_extra",
- "futures",
- "indexmap 2.2.3",
- "insta",
- "jsonrpsee",
- "move-binary-format",
- "move-core-types",
- "move-package",
- "mysten-metrics",
- "prometheus",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "shared-crypto",
- "sui",
- "sui-config",
- "sui-core",
- "sui-framework",
- "sui-json-rpc",
- "sui-json-rpc-api",
- "sui-json-rpc-types",
- "sui-keys",
- "sui-macros",
- "sui-move-build",
- "sui-node",
- "sui-protocol-config",
- "sui-sdk",
- "sui-simulator",
- "sui-storage",
- "sui-swarm",
- "sui-swarm-config",
- "sui-test-transaction-builder",
- "sui-tool",
- "sui-types",
- "telemetry-subscribers",
- "tempfile",
- "test-cluster",
- "tokio",
- "tracing",
  "workspace-hack",
 ]
 
@@ -12698,7 +11573,6 @@ dependencies = [
  "serde",
  "shared-crypto",
  "sui",
- "sui-config",
  "sui-json-rpc-types",
  "sui-keys",
  "sui-sdk",
@@ -12706,15 +11580,12 @@ dependencies = [
  "tap",
  "telemetry-subscribers",
  "tempfile",
- "test-cluster",
  "thiserror",
  "tokio",
  "tower",
  "tower-http",
  "tracing",
  "ttl_cache",
- "typed-store",
- "typed-store-derive",
  "uuid 1.7.0",
  "workspace-hack",
 ]
@@ -12788,12 +11659,10 @@ dependencies = [
  "serde_with",
  "serde_yaml 0.8.26",
  "shared-crypto",
- "sui-config",
  "sui-execution",
  "sui-framework",
  "sui-framework-snapshot",
  "sui-protocol-config",
- "sui-simulator",
  "sui-types",
  "tempfile",
  "tracing",
@@ -12842,7 +11711,6 @@ dependencies = [
  "move-disassembler",
  "move-ir-types",
  "mysten-metrics",
- "mysten-network",
  "once_cell",
  "prometheus",
  "rand 0.8.5",
@@ -12855,7 +11723,6 @@ dependencies = [
  "serial_test",
  "shared-crypto",
  "similar",
- "simulacrum",
  "sui-framework",
  "sui-graphql-rpc-client",
  "sui-graphql-rpc-headers",
@@ -12866,11 +11733,9 @@ dependencies = [
  "sui-protocol-config",
  "sui-rest-api",
  "sui-sdk",
- "sui-swarm-config",
  "sui-types",
  "tap",
  "telemetry-subscribers",
- "test-cluster",
  "thiserror",
  "tokio",
  "toml 0.7.8",
@@ -12934,7 +11799,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "simulacrum",
  "sui-json",
  "sui-json-rpc",
  "sui-json-rpc-api",
@@ -12951,7 +11815,6 @@ dependencies = [
  "sui-types",
  "tap",
  "telemetry-subscribers",
- "test-cluster",
  "thiserror",
  "tokio",
  "tracing",
@@ -13009,14 +11872,12 @@ dependencies = [
  "serde_json",
  "shared-crypto",
  "signature 1.6.4",
- "sui-core",
  "sui-json",
  "sui-json-rpc-api",
  "sui-json-rpc-types",
  "sui-open-rpc",
  "sui-open-rpc-macros",
  "sui-protocol-config",
- "sui-storage",
  "sui-transaction-builder",
  "sui-types",
  "tap",
@@ -13026,7 +11887,6 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
- "typed-store-error",
  "workspace-hack",
 ]
 
@@ -13063,8 +11923,6 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "reqwest",
- "sui-config",
- "sui-core",
  "sui-json",
  "sui-json-rpc",
  "sui-json-rpc-api",
@@ -13076,12 +11934,9 @@ dependencies = [
  "sui-open-rpc-macros",
  "sui-protocol-config",
  "sui-sdk",
- "sui-simulator",
- "sui-swarm-config",
  "sui-test-transaction-builder",
  "sui-types",
  "telemetry-subscribers",
- "test-cluster",
  "tokio",
  "tracing",
  "workspace-hack",
@@ -13133,31 +11988,6 @@ dependencies = [
  "sui-types",
  "tempfile",
  "tiny-bip39",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-light-client"
-version = "0.0.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "bcs",
- "bytes",
- "clap",
- "move-binary-format",
- "move-core-types",
- "serde",
- "serde_json",
- "serde_yaml 0.8.26",
- "sui-config",
- "sui-json",
- "sui-json-rpc-types",
- "sui-package-resolver",
- "sui-rest-api",
- "sui-sdk",
- "sui-types",
- "tokio",
  "workspace-hack",
 ]
 
@@ -13222,13 +12052,10 @@ dependencies = [
  "rand 0.8.5",
  "serde_json",
  "serde_yaml 0.8.26",
- "sui-core",
  "sui-macros",
  "sui-move-build",
  "sui-move-natives-latest",
- "sui-node",
  "sui-protocol-config",
- "sui-simulator",
  "sui-types",
  "telemetry-subscribers",
  "tempfile",
@@ -13324,91 +12151,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sui-network"
-version = "0.0.0"
-dependencies = [
- "anemo",
- "anemo-build",
- "anemo-tower",
- "anyhow",
- "dashmap",
- "ed25519-consensus",
- "fastcrypto",
- "futures",
- "governor",
- "mysten-metrics",
- "mysten-network",
- "prometheus",
- "rand 0.8.5",
- "serde",
- "sui-archival",
- "sui-config",
- "sui-storage",
- "sui-swarm-config",
- "sui-types",
- "tap",
- "telemetry-subscribers",
- "tempfile",
- "tokio",
- "tonic 0.10.2",
- "tonic-build",
- "tower",
- "tracing",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-node"
-version = "1.19.0"
-dependencies = [
- "anemo",
- "anemo-tower",
- "anyhow",
- "arc-swap",
- "axum",
- "clap",
- "const-str",
- "fastcrypto",
- "fastcrypto-zkp",
- "futures",
- "git-version",
- "humantime",
- "move-vm-profiler",
- "mysten-common",
- "mysten-metrics",
- "mysten-network",
- "narwhal-network",
- "narwhal-worker",
- "prometheus",
- "reqwest",
- "serde",
- "snap",
- "sui-archival",
- "sui-config",
- "sui-core",
- "sui-json-rpc",
- "sui-json-rpc-api",
- "sui-macros",
- "sui-network",
- "sui-protocol-config",
- "sui-rest-api",
- "sui-simulator",
- "sui-snapshot",
- "sui-storage",
- "sui-telemetry",
- "sui-tls",
- "sui-types",
- "tap",
- "telemetry-subscribers",
- "tokio",
- "tower",
- "tracing",
- "typed-store",
- "url",
- "workspace-hack",
-]
-
-[[package]]
 name = "sui-open-rpc"
 version = "1.19.0"
 dependencies = [
@@ -13443,37 +12185,6 @@ dependencies = [
  "quote 1.0.35",
  "syn 1.0.109",
  "unescape",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-oracle"
-version = "1.19.0"
-dependencies = [
- "anyhow",
- "bcs",
- "chrono",
- "clap",
- "dirs 4.0.0",
- "jsonpath_lib",
- "mysten-metrics",
- "once_cell",
- "prometheus",
- "rand 0.8.5",
- "reqwest",
- "serde",
- "serde_json",
- "shared-crypto",
- "sui-config",
- "sui-json-rpc-types",
- "sui-keys",
- "sui-move-build",
- "sui-sdk",
- "sui-types",
- "tap",
- "telemetry-subscribers",
- "tokio",
- "tracing",
  "workspace-hack",
 ]
 
@@ -13538,50 +12249,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sui-proxy"
-version = "0.0.2"
-dependencies = [
- "anyhow",
- "axum",
- "axum-server",
- "bytes",
- "clap",
- "const-str",
- "fastcrypto",
- "git-version",
- "hex",
- "http-body",
- "hyper",
- "ipnetwork",
- "itertools 0.10.5",
- "mime",
- "multiaddr",
- "mysten-metrics",
- "once_cell",
- "prometheus",
- "prost 0.12.3",
- "prost-build",
- "protobuf",
- "rand 0.8.5",
- "reqwest",
- "rustls 0.21.10",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_with",
- "serde_yaml 0.8.26",
- "snap",
- "sui-tls",
- "sui-types",
- "telemetry-subscribers",
- "tokio",
- "tower",
- "tower-http",
- "tracing",
- "workspace-hack",
-]
-
-[[package]]
 name = "sui-replay"
 version = "0.1.0"
 dependencies = [
@@ -13608,8 +12275,6 @@ dependencies = [
  "shared-crypto",
  "shellexpand",
  "similar",
- "sui-config",
- "sui-core",
  "sui-execution",
  "sui-framework",
  "sui-json-rpc",
@@ -13617,7 +12282,6 @@ dependencies = [
  "sui-json-rpc-types",
  "sui-protocol-config",
  "sui-sdk",
- "sui-storage",
  "sui-types",
  "tabled",
  "tempfile",
@@ -13649,79 +12313,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sui-rosetta"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "axum",
- "axum-extra",
- "bcs",
- "clap",
- "eyre",
- "fastcrypto",
- "futures",
- "hyper",
- "move-core-types",
- "mysten-metrics",
- "once_cell",
- "rand 0.8.5",
- "reqwest",
- "serde",
- "serde_json",
- "shared-crypto",
- "signature 1.6.4",
- "strum 0.24.1",
- "strum_macros 0.24.3",
- "sui-config",
- "sui-json-rpc-types",
- "sui-keys",
- "sui-move-build",
- "sui-node",
- "sui-sdk",
- "sui-swarm-config",
- "sui-types",
- "telemetry-subscribers",
- "tempfile",
- "test-cluster",
- "thiserror",
- "tokio",
- "tracing",
- "typed-store",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-rpc-loadgen"
-version = "1.19.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "clap",
- "dashmap",
- "dirs 4.0.0",
- "futures",
- "itertools 0.10.5",
- "serde",
- "serde_json",
- "shared-crypto",
- "shellexpand",
- "strum 0.24.1",
- "strum_macros 0.24.3",
- "sui-json-rpc",
- "sui-json-rpc-types",
- "sui-keys",
- "sui-sdk",
- "sui-types",
- "telemetry-subscribers",
- "test-cluster",
- "tokio",
- "tonic 0.10.2",
- "tracing",
- "workspace-hack",
-]
-
-[[package]]
 name = "sui-sdk"
 version = "1.19.0"
 dependencies = [
@@ -13744,7 +12335,6 @@ dependencies = [
  "serde_with",
  "serde_yaml 0.8.26",
  "shared-crypto",
- "sui-config",
  "sui-json",
  "sui-json-rpc-api",
  "sui-json-rpc-types",
@@ -13754,94 +12344,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tracing",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-simulator"
-version = "0.7.0"
-dependencies = [
- "anemo",
- "anemo-tower",
- "bcs",
- "fastcrypto",
- "lru 0.10.1",
- "move-package",
- "msim",
- "narwhal-network",
- "rand 0.8.5",
- "serde",
- "sui-framework",
- "sui-move-build",
- "sui-types",
- "telemetry-subscribers",
- "tempfile",
- "tower",
- "tracing",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-single-node-benchmark"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "bcs",
- "clap",
- "fs_extra",
- "futures",
- "move-binary-format",
- "move-bytecode-utils",
- "move-core-types",
- "move-package",
- "once_cell",
- "prometheus",
- "serde",
- "serde_json",
- "strum 0.24.1",
- "strum_macros 0.24.3",
- "sui-config",
- "sui-core",
- "sui-macros",
- "sui-move-build",
- "sui-protocol-config",
- "sui-simulator",
- "sui-storage",
- "sui-test-transaction-builder",
- "sui-transaction-checks",
- "sui-types",
- "telemetry-subscribers",
- "tokio",
- "tracing",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-snapshot"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "bcs",
- "byteorder",
- "bytes",
- "fastcrypto",
- "futures",
- "indicatif",
- "integer-encoding",
- "num_enum 0.6.1",
- "object_store 0.7.1",
- "prometheus",
- "serde",
- "serde_json",
- "sui-config",
- "sui-core",
- "sui-protocol-config",
- "sui-storage",
- "sui-types",
- "tempfile",
- "tokio",
- "tokio-stream",
  "tracing",
  "workspace-hack",
 ]
@@ -13870,7 +12372,6 @@ dependencies = [
  "sui-types",
  "tar",
  "tempfile",
- "test-cluster",
  "thiserror",
  "tokio",
  "tracing",
@@ -13907,165 +12408,12 @@ dependencies = [
  "sui-source-validation",
  "telemetry-subscribers",
  "tempfile",
- "test-cluster",
  "tokio",
  "toml 0.7.8",
  "tower",
  "tower-http",
  "tracing",
  "url",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-storage"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "backoff",
- "base64-url",
- "bcs",
- "byteorder",
- "bytes",
- "chrono",
- "clap",
- "criterion",
- "eyre",
- "fastcrypto",
- "futures",
- "hyper",
- "hyper-rustls 0.24.2",
- "indicatif",
- "integer-encoding",
- "itertools 0.10.5",
- "lru 0.10.1",
- "move-binary-format",
- "move-bytecode-utils",
- "move-core-types",
- "mysten-metrics",
- "num_cpus",
- "num_enum 0.6.1",
- "object_store 0.7.1",
- "once_cell",
- "parking_lot 0.12.1",
- "percent-encoding",
- "pretty_assertions",
- "prometheus",
- "reqwest",
- "rocksdb",
- "serde",
- "serde_json",
- "sui-config",
- "sui-json-rpc-types",
- "sui-macros",
- "sui-protocol-config",
- "sui-simulator",
- "sui-test-transaction-builder",
- "sui-types",
- "tap",
- "telemetry-subscribers",
- "tempfile",
- "tokio",
- "tracing",
- "typed-store",
- "typed-store-derive",
- "url",
- "workspace-hack",
- "zstd 0.12.4",
-]
-
-[[package]]
-name = "sui-surfer"
-version = "1.19.0"
-dependencies = [
- "async-trait",
- "bcs",
- "clap",
- "futures",
- "indexmap 2.2.3",
- "move-binary-format",
- "move-core-types",
- "move-package",
- "prometheus",
- "rand 0.8.5",
- "sui-core",
- "sui-json-rpc-types",
- "sui-macros",
- "sui-move-build",
- "sui-protocol-config",
- "sui-simulator",
- "sui-swarm-config",
- "sui-types",
- "telemetry-subscribers",
- "test-cluster",
- "tokio",
- "tracing",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-swarm"
-version = "0.0.0"
-dependencies = [
- "anyhow",
- "futures",
- "mysten-metrics",
- "mysten-network",
- "prometheus",
- "rand 0.8.5",
- "sui-config",
- "sui-macros",
- "sui-node",
- "sui-protocol-config",
- "sui-simulator",
- "sui-swarm-config",
- "sui-types",
- "tap",
- "telemetry-subscribers",
- "tempfile",
- "tokio",
- "tonic-health",
- "tracing",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-swarm-config"
-version = "0.0.0"
-dependencies = [
- "anemo",
- "anyhow",
- "fastcrypto",
- "insta",
- "move-bytecode-utils",
- "narwhal-config",
- "prometheus",
- "rand 0.8.5",
- "serde",
- "serde_with",
- "serde_yaml 0.8.26",
- "shared-crypto",
- "sui-config",
- "sui-execution",
- "sui-genesis-builder",
- "sui-macros",
- "sui-protocol-config",
- "sui-simulator",
- "sui-types",
- "tempfile",
- "tracing",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-telemetry"
-version = "0.1.0"
-dependencies = [
- "reqwest",
- "serde",
- "sui-core",
- "tracing",
  "workspace-hack",
 ]
 
@@ -14080,97 +12428,6 @@ dependencies = [
  "sui-move-build",
  "sui-sdk",
  "sui-types",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-test-validator"
-version = "0.0.0"
-dependencies = [
- "anyhow",
- "axum",
- "clap",
- "http",
- "sui-cluster-test",
- "sui-faucet",
- "telemetry-subscribers",
- "tokio",
- "tower",
- "tower-http",
- "uuid 1.7.0",
- "workspace-hack",
-]
-
-[[package]]
-name = "sui-tls"
-version = "0.0.0"
-dependencies = [
- "anyhow",
- "axum",
- "axum-server",
- "ed25519 1.5.3",
- "fastcrypto",
- "pkcs8 0.9.0",
- "rand 0.8.5",
- "rcgen",
- "reqwest",
- "rustls 0.21.10",
- "rustls-webpki",
- "tokio",
- "tokio-rustls 0.24.1",
- "tower-layer",
- "workspace-hack",
- "x509-parser",
-]
-
-[[package]]
-name = "sui-tool"
-version = "1.19.0"
-dependencies = [
- "anemo",
- "anemo-cli",
- "anyhow",
- "bcs",
- "clap",
- "colored",
- "comfy-table",
- "const-str",
- "diesel",
- "eyre",
- "fastcrypto",
- "futures",
- "git-version",
- "hex",
- "indicatif",
- "itertools 0.10.5",
- "move-core-types",
- "narwhal-storage",
- "narwhal-types",
- "num_cpus",
- "object_store 0.7.1",
- "prometheus",
- "rocksdb",
- "ron",
- "serde",
- "serde_json",
- "strum 0.24.1",
- "strum_macros 0.24.3",
- "sui-archival",
- "sui-config",
- "sui-core",
- "sui-indexer",
- "sui-network",
- "sui-protocol-config",
- "sui-replay",
- "sui-sdk",
- "sui-snapshot",
- "sui-storage",
- "sui-types",
- "telemetry-subscribers",
- "tempfile",
- "tokio",
- "tracing",
- "typed-store",
  "workspace-hack",
 ]
 
@@ -14197,7 +12454,6 @@ version = "0.1.0"
 dependencies = [
  "fastcrypto-zkp",
  "once_cell",
- "sui-config",
  "sui-execution",
  "sui-macros",
  "sui-protocol-config",
@@ -14232,9 +12488,6 @@ dependencies = [
  "regex",
  "rocksdb",
  "serde_json",
- "simulacrum",
- "sui-config",
- "sui-core",
  "sui-framework",
  "sui-framework-snapshot",
  "sui-graphql-rpc",
@@ -14243,14 +12496,10 @@ dependencies = [
  "sui-json-rpc-types",
  "sui-protocol-config",
  "sui-rest-api",
- "sui-storage",
- "sui-swarm-config",
  "sui-types",
  "telemetry-subscribers",
  "tempfile",
  "tokio",
- "typed-store",
- "typed-store-derive",
  "workspace-hack",
 ]
 
@@ -14263,7 +12512,6 @@ dependencies = [
  "bcs",
  "bincode",
  "byteorder",
- "consensus-config",
  "criterion",
  "derivative",
  "derive_more",
@@ -14285,10 +12533,8 @@ dependencies = [
  "move-vm-profiler",
  "move-vm-test-utils",
  "move-vm-types",
+ "multiaddr",
  "mysten-metrics",
- "mysten-network",
- "narwhal-config",
- "narwhal-crypto",
  "nonempty",
  "once_cell",
  "prometheus",
@@ -14314,7 +12560,6 @@ dependencies = [
  "thiserror",
  "tonic 0.10.2",
  "tracing",
- "typed-store-error",
  "workspace-hack",
 ]
 
@@ -14383,72 +12628,6 @@ dependencies = [
  "move-core-types",
  "move-vm-config",
  "sui-types",
- "workspace-hack",
-]
-
-[[package]]
-name = "suins-indexer"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "aws-config",
- "aws-sdk-dynamodb",
- "aws-sdk-s3",
- "backoff",
- "base64-url",
- "bcs",
- "bytes",
- "diesel",
- "dotenvy",
- "futures",
- "move-core-types",
- "mysten-metrics",
- "notify",
- "object_store 0.7.1",
- "prometheus",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "serde_yaml 0.8.26",
- "sui-data-ingestion-core",
- "sui-json-rpc",
- "sui-storage",
- "sui-types",
- "telemetry-subscribers",
- "tempfile",
- "tokio",
- "tracing",
- "url",
- "workspace-hack",
-]
-
-[[package]]
-name = "suiop-cli"
-version = "0.1.7"
-dependencies = [
- "anyhow",
- "chrono",
- "clap",
- "colored",
- "docker-api",
- "field_names",
- "include_dir",
- "inquire",
- "prettytable-rs",
- "regex",
- "reqwest",
- "semver 1.0.22",
- "serde",
- "serde_json",
- "serde_yaml 0.8.26",
- "spinners",
- "strum 0.24.1",
- "tempfile",
- "tokio",
- "toml_edit 0.19.15",
- "tracing",
- "tracing-subscriber",
  "workspace-hack",
 ]
 
@@ -14745,38 +12924,6 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
-
-[[package]]
-name = "test-cluster"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "fastcrypto-zkp",
- "futures",
- "jsonrpsee",
- "move-binary-format",
- "prometheus",
- "rand 0.8.5",
- "sui-config",
- "sui-core",
- "sui-framework",
- "sui-json-rpc",
- "sui-json-rpc-api",
- "sui-json-rpc-types",
- "sui-keys",
- "sui-macros",
- "sui-node",
- "sui-protocol-config",
- "sui-sdk",
- "sui-simulator",
- "sui-swarm",
- "sui-swarm-config",
- "sui-test-transaction-builder",
- "sui-types",
- "tokio",
- "tracing",
- "workspace-hack",
-]
 
 [[package]]
 name = "test-fuzz"
@@ -15577,7 +13724,6 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.8.5",
- "sui-core",
  "sui-move-build",
  "sui-protocol-config",
  "sui-types",
@@ -15649,65 +13795,6 @@ dependencies = [
  "cfg-if",
  "rand 0.8.5",
  "static_assertions",
-]
-
-[[package]]
-name = "typed-store"
-version = "0.4.0"
-dependencies = [
- "async-trait",
- "bcs",
- "bincode",
- "collectable",
- "eyre",
- "fdlimit",
- "hdrhistogram",
- "itertools 0.10.5",
- "msim",
- "once_cell",
- "ouroboros",
- "proc-macro2 1.0.78",
- "prometheus",
- "quote 1.0.35",
- "rand 0.8.5",
- "rocksdb",
- "rstest",
- "serde",
- "sui-macros",
- "syn 1.0.109",
- "tap",
- "tempfile",
- "thiserror",
- "tokio",
- "tracing",
- "typed-store-derive",
- "typed-store-error",
- "uint",
- "workspace-hack",
-]
-
-[[package]]
-name = "typed-store-derive"
-version = "0.3.0"
-dependencies = [
- "eyre",
- "proc-macro2 1.0.78",
- "quote 1.0.35",
- "rocksdb",
- "syn 1.0.109",
- "tempfile",
- "tokio",
- "typed-store",
- "workspace-hack",
-]
-
-[[package]]
-name = "typed-store-error"
-version = "0.4.0"
-dependencies = [
- "serde",
- "thiserror",
- "workspace-hack",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11649,6 +11649,7 @@ dependencies = [
  "anyhow",
  "bcs",
  "camino",
+ "csv",
  "fastcrypto",
  "insta",
  "move-binary-format",

--- a/crates/sui-genesis-builder/Cargo.toml
+++ b/crates/sui-genesis-builder/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 [dependencies]
 anyhow.workspace = true
 bcs.workspace = true
+csv.workspace = true
 camino.workspace = true
 fastcrypto.workspace = true
 move-binary-format.workspace = true

--- a/crates/sui-genesis-builder/src/config.rs
+++ b/crates/sui-genesis-builder/src/config.rs
@@ -1,0 +1,668 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Modifications Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Configuration parameters for use while creating the genesis.
+
+use anyhow::{Context, Result};
+use fastcrypto::encoding::{Base64, Encoding};
+use fastcrypto::hash::HashFunction;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{fs, path::Path};
+use sui_types::authenticator_state::{get_authenticator_state, AuthenticatorStateInner};
+use sui_types::base_types::{ObjectID, SuiAddress};
+use sui_types::clock::Clock;
+use sui_types::committee::CommitteeWithNetworkMetadata;
+use sui_types::crypto::DefaultHash;
+use sui_types::deny_list::{get_coin_deny_list, PerTypeDenyList};
+use sui_types::effects::{TransactionEffects, TransactionEvents};
+use sui_types::gas_coin::TOTAL_SUPPLY_MIST;
+use sui_types::messages_checkpoint::{
+    CertifiedCheckpointSummary, CheckpointContents, CheckpointSummary, VerifiedCheckpoint,
+};
+use sui_types::storage::ObjectStore;
+use sui_types::sui_system_state::{
+    get_sui_system_state, get_sui_system_state_wrapper, SuiSystemState, SuiSystemStateTrait,
+    SuiSystemStateWrapper, SuiValidatorGenesis,
+};
+use sui_types::transaction::Transaction;
+use sui_types::SUI_RANDOMNESS_STATE_OBJECT_ID;
+use sui_types::{
+    committee::{Committee, EpochId, ProtocolVersion},
+    error::SuiResult,
+    object::Object,
+};
+use tracing::trace;
+
+#[derive(Clone, Debug)]
+pub struct Genesis {
+    checkpoint: CertifiedCheckpointSummary,
+    checkpoint_contents: CheckpointContents,
+    transaction: Transaction,
+    effects: TransactionEffects,
+    events: TransactionEvents,
+    objects: Vec<Object>,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
+pub struct UnsignedGenesis {
+    pub checkpoint: CheckpointSummary,
+    pub checkpoint_contents: CheckpointContents,
+    pub transaction: Transaction,
+    pub effects: TransactionEffects,
+    pub events: TransactionEvents,
+    pub objects: Vec<Object>,
+}
+
+// Hand implement PartialEq in order to get around the fact that AuthSigs don't impl Eq
+impl PartialEq for Genesis {
+    fn eq(&self, other: &Self) -> bool {
+        self.checkpoint.data() == other.checkpoint.data()
+            && {
+                let this = self.checkpoint.auth_sig();
+                let other = other.checkpoint.auth_sig();
+
+                this.epoch == other.epoch
+                    && this.signature.as_ref() == other.signature.as_ref()
+                    && this.signers_map == other.signers_map
+            }
+            && self.checkpoint_contents == other.checkpoint_contents
+            && self.transaction == other.transaction
+            && self.effects == other.effects
+            && self.objects == other.objects
+    }
+}
+
+impl Eq for Genesis {}
+
+impl Genesis {
+    pub fn new(
+        checkpoint: CertifiedCheckpointSummary,
+        checkpoint_contents: CheckpointContents,
+        transaction: Transaction,
+        effects: TransactionEffects,
+        events: TransactionEvents,
+        objects: Vec<Object>,
+    ) -> Self {
+        Self {
+            checkpoint,
+            checkpoint_contents,
+            transaction,
+            effects,
+            events,
+            objects,
+        }
+    }
+
+    pub fn objects(&self) -> &[Object] {
+        &self.objects
+    }
+
+    pub fn object(&self, id: ObjectID) -> Option<Object> {
+        self.objects.iter().find(|o| o.id() == id).cloned()
+    }
+
+    pub fn transaction(&self) -> &Transaction {
+        &self.transaction
+    }
+
+    pub fn effects(&self) -> &TransactionEffects {
+        &self.effects
+    }
+    pub fn events(&self) -> &TransactionEvents {
+        &self.events
+    }
+
+    pub fn checkpoint(&self) -> VerifiedCheckpoint {
+        self.checkpoint
+            .clone()
+            .verify(&self.committee().unwrap())
+            .unwrap()
+    }
+
+    pub fn checkpoint_contents(&self) -> &CheckpointContents {
+        &self.checkpoint_contents
+    }
+
+    pub fn epoch(&self) -> EpochId {
+        0
+    }
+
+    pub fn validator_set_for_tooling(&self) -> Vec<SuiValidatorGenesis> {
+        self.sui_system_object()
+            .into_genesis_version_for_tooling()
+            .validators
+            .active_validators
+    }
+
+    pub fn committee_with_network(&self) -> CommitteeWithNetworkMetadata {
+        self.sui_system_object().get_current_epoch_committee()
+    }
+
+    pub fn reference_gas_price(&self) -> u64 {
+        self.sui_system_object().reference_gas_price()
+    }
+
+    // TODO: No need to return SuiResult.
+    pub fn committee(&self) -> SuiResult<Committee> {
+        Ok(self.committee_with_network().committee)
+    }
+
+    pub fn sui_system_wrapper_object(&self) -> SuiSystemStateWrapper {
+        get_sui_system_state_wrapper(&self.objects())
+            .expect("Sui System State Wrapper object must always exist")
+    }
+
+    pub fn sui_system_object(&self) -> SuiSystemState {
+        get_sui_system_state(&self.objects()).expect("Sui System State object must always exist")
+    }
+
+    pub fn clock(&self) -> Clock {
+        let clock = self
+            .objects()
+            .iter()
+            .find(|o| o.id() == sui_types::SUI_CLOCK_OBJECT_ID)
+            .expect("Clock must always exist")
+            .data
+            .try_as_move()
+            .expect("Clock must be a Move object");
+        bcs::from_bytes::<Clock>(clock.contents())
+            .expect("Clock object deserialization cannot fail")
+    }
+
+    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, anyhow::Error> {
+        let path = path.as_ref();
+        trace!("Reading Genesis from {}", path.display());
+        let bytes = fs::read(path)
+            .with_context(|| format!("Unable to load Genesis from {}", path.display()))?;
+        bcs::from_bytes(&bytes)
+            .with_context(|| format!("Unable to parse Genesis from {}", path.display()))
+    }
+
+    pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), anyhow::Error> {
+        let path = path.as_ref();
+        trace!("Writing Genesis to {}", path.display());
+        let bytes = bcs::to_bytes(&self)?;
+        fs::write(path, bytes)
+            .with_context(|| format!("Unable to save Genesis to {}", path.display()))?;
+        Ok(())
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bcs::to_bytes(self).expect("failed to serialize genesis")
+    }
+
+    pub fn hash(&self) -> [u8; 32] {
+        use std::io::Write;
+
+        let mut digest = DefaultHash::default();
+        digest.write_all(&self.to_bytes()).unwrap();
+        let hash = digest.finalize();
+        hash.into()
+    }
+}
+
+impl Serialize for Genesis {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::Error;
+
+        #[derive(Serialize)]
+        struct RawGenesis<'a> {
+            checkpoint: &'a CertifiedCheckpointSummary,
+            checkpoint_contents: &'a CheckpointContents,
+            transaction: &'a Transaction,
+            effects: &'a TransactionEffects,
+            events: &'a TransactionEvents,
+            objects: &'a [Object],
+        }
+
+        let raw_genesis = RawGenesis {
+            checkpoint: &self.checkpoint,
+            checkpoint_contents: &self.checkpoint_contents,
+            transaction: &self.transaction,
+            effects: &self.effects,
+            events: &self.events,
+            objects: &self.objects,
+        };
+
+        let bytes = bcs::to_bytes(&raw_genesis).map_err(|e| Error::custom(e.to_string()))?;
+
+        if serializer.is_human_readable() {
+            let s = Base64::encode(&bytes);
+            serializer.serialize_str(&s)
+        } else {
+            serializer.serialize_bytes(&bytes)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Genesis {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        #[derive(Deserialize)]
+        struct RawGenesis {
+            checkpoint: CertifiedCheckpointSummary,
+            checkpoint_contents: CheckpointContents,
+            transaction: Transaction,
+            effects: TransactionEffects,
+            events: TransactionEvents,
+            objects: Vec<Object>,
+        }
+
+        let bytes = if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            Base64::decode(&s).map_err(|e| Error::custom(e.to_string()))?
+        } else {
+            let data: Vec<u8> = Vec::deserialize(deserializer)?;
+            data
+        };
+
+        let RawGenesis {
+            checkpoint,
+            checkpoint_contents,
+            transaction,
+            effects,
+            events,
+            objects,
+        } = bcs::from_bytes(&bytes).map_err(|e| Error::custom(e.to_string()))?;
+
+        Ok(Genesis {
+            checkpoint,
+            checkpoint_contents,
+            transaction,
+            effects,
+            events,
+            objects,
+        })
+    }
+}
+
+impl UnsignedGenesis {
+    pub fn objects(&self) -> &[Object] {
+        &self.objects
+    }
+
+    pub fn object(&self, id: ObjectID) -> Option<Object> {
+        self.objects.iter().find(|o| o.id() == id).cloned()
+    }
+
+    pub fn transaction(&self) -> &Transaction {
+        &self.transaction
+    }
+
+    pub fn effects(&self) -> &TransactionEffects {
+        &self.effects
+    }
+    pub fn events(&self) -> &TransactionEvents {
+        &self.events
+    }
+
+    pub fn checkpoint(&self) -> &CheckpointSummary {
+        &self.checkpoint
+    }
+
+    pub fn checkpoint_contents(&self) -> &CheckpointContents {
+        &self.checkpoint_contents
+    }
+
+    pub fn epoch(&self) -> EpochId {
+        0
+    }
+
+    pub fn sui_system_wrapper_object(&self) -> SuiSystemStateWrapper {
+        get_sui_system_state_wrapper(&self.objects())
+            .expect("Sui System State Wrapper object must always exist")
+    }
+
+    pub fn sui_system_object(&self) -> SuiSystemState {
+        get_sui_system_state(&self.objects()).expect("Sui System State object must always exist")
+    }
+
+    pub fn authenticator_state_object(&self) -> Option<AuthenticatorStateInner> {
+        get_authenticator_state(&self.objects()).expect("read from genesis cannot fail")
+    }
+
+    pub fn has_randomness_state_object(&self) -> bool {
+        self.objects()
+            .get_object(&SUI_RANDOMNESS_STATE_OBJECT_ID)
+            .expect("read from genesis cannot fail")
+            .is_some()
+    }
+
+    pub fn coin_deny_list_state(&self) -> Option<PerTypeDenyList> {
+        get_coin_deny_list(&self.objects())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct GenesisChainParameters {
+    pub protocol_version: u64,
+    pub chain_start_timestamp_ms: u64,
+    pub epoch_duration_ms: u64,
+
+    // Stake Subsidy parameters
+    pub stake_subsidy_start_epoch: u64,
+    pub stake_subsidy_initial_distribution_amount: u64,
+    pub stake_subsidy_period_length: u64,
+    pub stake_subsidy_decrease_rate: u16,
+
+    // Validator committee parameters
+    pub max_validator_count: u64,
+    pub min_validator_joining_stake: u64,
+    pub validator_low_stake_threshold: u64,
+    pub validator_very_low_stake_threshold: u64,
+    pub validator_low_stake_grace_period: u64,
+}
+
+/// Initial set of parameters for a chain.
+#[derive(Serialize, Deserialize)]
+pub struct GenesisCeremonyParameters {
+    #[serde(default = "GenesisCeremonyParameters::default_timestamp_ms")]
+    pub chain_start_timestamp_ms: u64,
+
+    /// protocol version that the chain starts at.
+    #[serde(default = "ProtocolVersion::max")]
+    pub protocol_version: ProtocolVersion,
+
+    #[serde(default = "GenesisCeremonyParameters::default_allow_insertion_of_extra_objects")]
+    pub allow_insertion_of_extra_objects: bool,
+
+    /// The duration of an epoch, in milliseconds.
+    #[serde(default = "GenesisCeremonyParameters::default_epoch_duration_ms")]
+    pub epoch_duration_ms: u64,
+
+    /// The starting epoch in which stake subsidies start being paid out.
+    #[serde(default)]
+    pub stake_subsidy_start_epoch: u64,
+
+    /// The amount of stake subsidy to be drawn down per distribution.
+    /// This amount decays and decreases over time.
+    #[serde(
+        default = "GenesisCeremonyParameters::default_initial_stake_subsidy_distribution_amount"
+    )]
+    pub stake_subsidy_initial_distribution_amount: u64,
+
+    /// Number of distributions to occur before the distribution amount decays.
+    #[serde(default = "GenesisCeremonyParameters::default_stake_subsidy_period_length")]
+    pub stake_subsidy_period_length: u64,
+
+    /// The rate at which the distribution amount decays at the end of each
+    /// period. Expressed in basis points.
+    #[serde(default = "GenesisCeremonyParameters::default_stake_subsidy_decrease_rate")]
+    pub stake_subsidy_decrease_rate: u16,
+    // Most other parameters (e.g. initial gas schedule) should be derived from protocol_version.
+}
+
+impl GenesisCeremonyParameters {
+    pub fn new() -> Self {
+        Self {
+            chain_start_timestamp_ms: Self::default_timestamp_ms(),
+            protocol_version: ProtocolVersion::MAX,
+            allow_insertion_of_extra_objects: true,
+            stake_subsidy_start_epoch: 0,
+            epoch_duration_ms: Self::default_epoch_duration_ms(),
+            stake_subsidy_initial_distribution_amount:
+                Self::default_initial_stake_subsidy_distribution_amount(),
+            stake_subsidy_period_length: Self::default_stake_subsidy_period_length(),
+            stake_subsidy_decrease_rate: Self::default_stake_subsidy_decrease_rate(),
+        }
+    }
+
+    fn default_timestamp_ms() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64
+    }
+
+    fn default_allow_insertion_of_extra_objects() -> bool {
+        true
+    }
+
+    fn default_epoch_duration_ms() -> u64 {
+        // 24 hrs
+        24 * 60 * 60 * 1000
+    }
+
+    fn default_initial_stake_subsidy_distribution_amount() -> u64 {
+        // 1M Sui
+        1_000_000 * sui_types::gas_coin::MIST_PER_SUI
+    }
+
+    fn default_stake_subsidy_period_length() -> u64 {
+        // 10 distributions or epochs
+        10
+    }
+
+    fn default_stake_subsidy_decrease_rate() -> u16 {
+        // 10% in basis points
+        1000
+    }
+
+    pub fn to_genesis_chain_parameters(&self) -> GenesisChainParameters {
+        GenesisChainParameters {
+            protocol_version: self.protocol_version.as_u64(),
+            stake_subsidy_start_epoch: self.stake_subsidy_start_epoch,
+            chain_start_timestamp_ms: self.chain_start_timestamp_ms,
+            epoch_duration_ms: self.epoch_duration_ms,
+            stake_subsidy_initial_distribution_amount: self
+                .stake_subsidy_initial_distribution_amount,
+            stake_subsidy_period_length: self.stake_subsidy_period_length,
+            stake_subsidy_decrease_rate: self.stake_subsidy_decrease_rate,
+            max_validator_count: sui_types::governance::MAX_VALIDATOR_COUNT,
+            min_validator_joining_stake: sui_types::governance::MIN_VALIDATOR_JOINING_STAKE_MIST,
+            validator_low_stake_threshold:
+                sui_types::governance::VALIDATOR_LOW_STAKE_THRESHOLD_MIST,
+            validator_very_low_stake_threshold:
+                sui_types::governance::VALIDATOR_VERY_LOW_STAKE_THRESHOLD_MIST,
+            validator_low_stake_grace_period:
+                sui_types::governance::VALIDATOR_LOW_STAKE_GRACE_PERIOD,
+        }
+    }
+}
+
+impl Default for GenesisCeremonyParameters {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct TokenDistributionSchedule {
+    pub stake_subsidy_fund_mist: u64,
+    pub allocations: Vec<TokenAllocation>,
+}
+
+impl TokenDistributionSchedule {
+    pub fn validate(&self) {
+        let mut total_mist = self.stake_subsidy_fund_mist;
+
+        for allocation in &self.allocations {
+            total_mist += allocation.amount_mist;
+        }
+
+        if total_mist != TOTAL_SUPPLY_MIST {
+            panic!("TokenDistributionSchedule adds up to {total_mist} and not expected {TOTAL_SUPPLY_MIST}");
+        }
+    }
+
+    pub fn check_all_stake_operations_are_for_valid_validators<
+        I: IntoIterator<Item = SuiAddress>,
+    >(
+        &self,
+        validators: I,
+    ) {
+        use std::collections::HashMap;
+
+        let mut validators: HashMap<SuiAddress, u64> =
+            validators.into_iter().map(|a| (a, 0)).collect();
+
+        // Check that all allocations are for valid validators, while summing up all allocations
+        // for each validator
+        for allocation in &self.allocations {
+            if let Some(staked_with_validator) = &allocation.staked_with_validator {
+                *validators
+                    .get_mut(staked_with_validator)
+                    .expect("allocation must be staked with valid validator") +=
+                    allocation.amount_mist;
+            }
+        }
+
+        // Check that all validators have sufficient stake allocated to ensure they meet the
+        // minimum stake threshold
+        let minimum_required_stake = sui_types::governance::VALIDATOR_LOW_STAKE_THRESHOLD_MIST;
+        for (validator, stake) in validators {
+            if stake < minimum_required_stake {
+                panic!("validator {validator} has '{stake}' stake and does not meet the minimum required stake threshold of '{minimum_required_stake}'");
+            }
+        }
+    }
+
+    pub fn new_for_validators_with_default_allocation<I: IntoIterator<Item = SuiAddress>>(
+        validators: I,
+    ) -> Self {
+        let mut supply = TOTAL_SUPPLY_MIST;
+        let default_allocation = sui_types::governance::VALIDATOR_LOW_STAKE_THRESHOLD_MIST;
+
+        let allocations = validators
+            .into_iter()
+            .map(|a| {
+                supply -= default_allocation;
+                TokenAllocation {
+                    recipient_address: a,
+                    amount_mist: default_allocation,
+                    staked_with_validator: Some(a),
+                }
+            })
+            .collect();
+
+        let schedule = Self {
+            stake_subsidy_fund_mist: supply,
+            allocations,
+        };
+
+        schedule.validate();
+        schedule
+    }
+
+    /// Helper to read a TokenDistributionSchedule from a csv file.
+    ///
+    /// The file is encoded such that the final entry in the CSV file is used to denote the
+    /// allocation to the stake subsidy fund. It must be in the following format:
+    /// `0x0000000000000000000000000000000000000000000000000000000000000000,<amount to stake subsidy fund>,`
+    ///
+    /// All entries in a token distribution schedule must add up to 10B Sui.
+    pub fn from_csv<R: std::io::Read>(reader: R) -> Result<Self> {
+        let mut reader = csv::Reader::from_reader(reader);
+        let mut allocations: Vec<TokenAllocation> =
+            reader.deserialize().collect::<Result<_, _>>()?;
+        assert_eq!(
+            TOTAL_SUPPLY_MIST,
+            allocations.iter().map(|a| a.amount_mist).sum::<u64>(),
+            "Token Distribution Schedule must add up to 10B Sui",
+        );
+        let stake_subsidy_fund_allocation = allocations.pop().unwrap();
+        assert_eq!(
+            SuiAddress::default(),
+            stake_subsidy_fund_allocation.recipient_address,
+            "Final allocation must be for stake subsidy fund",
+        );
+        assert!(
+            stake_subsidy_fund_allocation
+                .staked_with_validator
+                .is_none(),
+            "Can't stake the stake subsidy fund",
+        );
+
+        let schedule = Self {
+            stake_subsidy_fund_mist: stake_subsidy_fund_allocation.amount_mist,
+            allocations,
+        };
+
+        schedule.validate();
+        Ok(schedule)
+    }
+
+    pub fn to_csv<W: std::io::Write>(&self, writer: W) -> Result<()> {
+        let mut writer = csv::Writer::from_writer(writer);
+
+        for allocation in &self.allocations {
+            writer.serialize(allocation)?;
+        }
+
+        writer.serialize(TokenAllocation {
+            recipient_address: SuiAddress::default(),
+            amount_mist: self.stake_subsidy_fund_mist,
+            staked_with_validator: None,
+        })?;
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct TokenAllocation {
+    pub recipient_address: SuiAddress,
+    pub amount_mist: u64,
+
+    /// Indicates if this allocation should be staked at genesis and with which validator
+    pub staked_with_validator: Option<SuiAddress>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenDistributionScheduleBuilder {
+    pool: u64,
+    allocations: Vec<TokenAllocation>,
+}
+
+impl TokenDistributionScheduleBuilder {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            pool: TOTAL_SUPPLY_MIST,
+            allocations: vec![],
+        }
+    }
+
+    pub fn default_allocation_for_validators<I: IntoIterator<Item = SuiAddress>>(
+        &mut self,
+        validators: I,
+    ) {
+        let default_allocation = sui_types::governance::VALIDATOR_LOW_STAKE_THRESHOLD_MIST;
+
+        for validator in validators {
+            self.add_allocation(TokenAllocation {
+                recipient_address: validator,
+                amount_mist: default_allocation,
+                staked_with_validator: Some(validator),
+            });
+        }
+    }
+
+    pub fn add_allocation(&mut self, allocation: TokenAllocation) {
+        self.pool = self.pool.checked_sub(allocation.amount_mist).unwrap();
+        self.allocations.push(allocation);
+    }
+
+    pub fn build(&self) -> TokenDistributionSchedule {
+        let schedule = TokenDistributionSchedule {
+            stake_subsidy_fund_mist: self.pool,
+            allocations: self.allocations.clone(),
+        };
+
+        schedule.validate();
+        schedule
+    }
+}

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -6,6 +6,10 @@
 
 use anyhow::{bail, Context};
 use camino::Utf8Path;
+use config::{
+    Genesis, GenesisCeremonyParameters, GenesisChainParameters, TokenDistributionSchedule,
+    UnsignedGenesis,
+};
 use fastcrypto::hash::HashFunction;
 use fastcrypto::traits::KeyPair;
 use move_binary_format::CompiledModule;
@@ -15,10 +19,6 @@ use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
-use sui_config::genesis::{
-    Genesis, GenesisCeremonyParameters, GenesisChainParameters, TokenDistributionSchedule,
-    UnsignedGenesis,
-};
 use sui_execution::{self, Executor};
 use sui_framework::{BuiltInFramework, SystemPackage};
 use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
@@ -54,6 +54,7 @@ use sui_types::{SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_ADDRESS};
 use tracing::trace;
 use validator_info::{GenesisValidatorInfo, GenesisValidatorMetadata, ValidatorInfo};
 
+pub mod config;
 pub mod validator_info;
 
 const GENESIS_BUILDER_COMMITTEE_DIR: &str = "committee";
@@ -1136,18 +1137,16 @@ pub fn generate_genesis_system_object(
 
 #[cfg(test)]
 mod test {
+    use crate::config::*;
     use crate::validator_info::ValidatorInfo;
     use crate::Builder;
     use fastcrypto::traits::KeyPair;
-    use sui_config::genesis::*;
-    use sui_config::local_ip_utils;
-    use sui_config::node::DEFAULT_COMMISSION_RATE;
-    use sui_config::node::DEFAULT_VALIDATOR_GAS_PRICE;
     use sui_types::base_types::SuiAddress;
     use sui_types::crypto::{
         generate_proof_of_possession, get_key_pair_from_rng, AccountKeyPair, AuthorityKeyPair,
         NetworkKeyPair,
     };
+    use sui_types::utils::local_ip;
 
     #[test]
     fn allocation_csv() {
@@ -1167,7 +1166,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(msim, ignore)]
     fn ceremony() {
         let dir = tempfile::TempDir::new().unwrap();
 
@@ -1181,12 +1179,12 @@ mod test {
             worker_key: worker_key.public().clone(),
             account_address: SuiAddress::from(account_key.public()),
             network_key: network_key.public().clone(),
-            gas_price: DEFAULT_VALIDATOR_GAS_PRICE,
-            commission_rate: DEFAULT_COMMISSION_RATE,
-            network_address: local_ip_utils::new_local_tcp_address_for_testing(),
-            p2p_address: local_ip_utils::new_local_udp_address_for_testing(),
-            narwhal_primary_address: local_ip_utils::new_local_udp_address_for_testing(),
-            narwhal_worker_address: local_ip_utils::new_local_udp_address_for_testing(),
+            gas_price: Default::default(),
+            commission_rate: Default::default(),
+            network_address: local_ip::new_local_tcp_address_for_testing(),
+            p2p_address: local_ip::new_local_udp_address_for_testing(),
+            narwhal_primary_address: local_ip::new_local_udp_address_for_testing(),
+            narwhal_worker_address: local_ip::new_local_udp_address_for_testing(),
             description: String::new(),
             image_url: String::new(),
             project_url: String::new(),

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -84,7 +84,7 @@ pub mod zk_login_authenticator;
 pub mod zk_login_util;
 
 #[cfg(any(test, feature = "test-utils"))]
-#[path = "./unit_tests/utils.rs"]
+#[path = "./unit_tests/utils/mod.rs"]
 pub mod utils;
 
 /// 0x1-- account address where Move stdlib modules are stored

--- a/crates/sui-types/src/unit_tests/utils/local_ip.rs
+++ b/crates/sui-types/src/unit_tests/utils/local_ip.rs
@@ -1,0 +1,94 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Modifications Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Test utilities that relate to local ip addresses.
+
+use std::net::SocketAddr;
+
+use crate::multiaddr::Multiaddr;
+
+/// Returns localhost, which is always 127.0.0.1.
+pub fn localhost_for_testing() -> String {
+    "127.0.0.1".to_string()
+}
+
+/// Return an ephemeral, available port. On unix systems, the port returned will be in the
+/// TIME_WAIT state ensuring that the OS won't hand out this port for some grace period.
+/// Callers should be able to bind to this port given they use SO_REUSEADDR.
+pub fn get_available_port(host: &str) -> u16 {
+    const MAX_PORT_RETRIES: u32 = 1000;
+
+    for _ in 0..MAX_PORT_RETRIES {
+        if let Ok(port) = get_ephemeral_port(host) {
+            return port;
+        }
+    }
+
+    panic!(
+        "Error: could not find an available port on {}: {:?}",
+        host,
+        get_ephemeral_port(host)
+    );
+}
+
+fn get_ephemeral_port(host: &str) -> std::io::Result<u16> {
+    use std::net::{TcpListener, TcpStream};
+
+    // Request a random available port from the OS
+    let listener = TcpListener::bind((host, 0))?;
+    let addr = listener.local_addr()?;
+
+    // Create and accept a connection (which we'll promptly drop) in order to force the port
+    // into the TIME_WAIT state, ensuring that the port will be reserved from some limited
+    // amount of time (roughly 60s on some Linux systems)
+    let _sender = TcpStream::connect(addr)?;
+    let _incoming = listener.accept()?;
+
+    Ok(addr.port())
+}
+
+/// Returns a new unique TCP address for the given host, by finding a new available port.
+pub fn new_tcp_address_for_testing(host: &str) -> Multiaddr {
+    format!("/ip4/{}/tcp/{}/http", host, get_available_port(host))
+        .parse()
+        .unwrap()
+}
+
+/// Returns a new unique UDP address for the given host, by finding a new available port.
+pub fn new_udp_address_for_testing(host: &str) -> Multiaddr {
+    format!("/ip4/{}/udp/{}", host, get_available_port(host))
+        .parse()
+        .unwrap()
+}
+
+/// Returns a new unique TCP address (SocketAddr) for localhost, by finding a new available port on localhost.
+pub fn new_local_tcp_socket_for_testing() -> SocketAddr {
+    format!(
+        "{}:{}",
+        localhost_for_testing(),
+        get_available_port(&localhost_for_testing())
+    )
+    .parse()
+    .unwrap()
+}
+
+/// Returns a new unique TCP address (Multiaddr) for localhost, by finding a new available port on localhost.
+pub fn new_local_tcp_address_for_testing() -> Multiaddr {
+    new_tcp_address_for_testing(&localhost_for_testing())
+}
+
+/// Returns a new unique UDP address for localhost, by finding a new available port.
+pub fn new_local_udp_address_for_testing() -> Multiaddr {
+    new_udp_address_for_testing(&localhost_for_testing())
+}
+
+pub fn new_deterministic_tcp_address_for_testing(host: &str, port: u16) -> Multiaddr {
+    format!("/ip4/{host}/tcp/{port}/http").parse().unwrap()
+}
+
+pub fn new_deterministic_udp_address_for_testing(host: &str, port: u16) -> Multiaddr {
+    format!("/ip4/{host}/udp/{port}/http").parse().unwrap()
+}

--- a/crates/sui-types/src/unit_tests/utils/mod.rs
+++ b/crates/sui-types/src/unit_tests/utils/mod.rs
@@ -34,6 +34,8 @@ use serde::Deserialize;
 use shared_crypto::intent::{Intent, IntentMessage};
 use std::collections::BTreeMap;
 
+pub mod local_ip;
+
 #[derive(Deserialize)]
 pub struct TestData {
     pub zklogin_inputs: String,


### PR DESCRIPTION
## Description 

This fixes the broken dependencies after the removal of `sui-config`, by nesting `sui_config` components as follows:

* `sui_config::genesis -> sui_genesis_builder::config`
* `sui_config::local_ip_utils -> sui_types::utils::local_ip`

## Links to any relevant issues

Fixes #30 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`$ cargo test -p sui-genesis-builder`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
