### PR TITLE
Resolve `transaction-fuzzer` compilation issues

### DIFF
--- a/crates/transaction-fuzzer/Cargo.toml
+++ b/crates/transaction-fuzzer/Cargo.toml
@@ -17,7 +17,7 @@ tracing.workspace = true
 
 once_cell.workspace = true
 sui-protocol-config.workspace = true
-sui-types = { workspace = true, features = ["fuzzing"] }
+sui-types = { workspace = true, features = ["fuzzing", "test-utils"] }
 sui-move-build.workspace = true
 workspace-hack.workspace = true
 

--- a/crates/transaction-fuzzer/src/account_universe.rs
+++ b/crates/transaction-fuzzer/src/account_universe.rs
@@ -11,7 +11,7 @@ use crate::executor::{ExecutionResult, Executor};
 use once_cell::sync::Lazy;
 use proptest::{prelude::*, strategy::Union};
 use std::{fmt, sync::Arc};
-use sui_types::{storage::ObjectStore, transaction::Transaction};
+use sui_types::{transaction::Transaction};
 
 mod account;
 mod helpers;
@@ -126,32 +126,8 @@ pub fn run_and_assert_universe(
 }
 
 pub fn assert_accounts_match(
-    universe: &AccountUniverse,
-    executor: &Executor,
+    _universe: &AccountUniverse,
+    _executor: &Executor,
 ) -> Result<(), TestCaseError> {
-    let state = executor.state.clone();
-    let backing_package_store = state.get_backing_package_store();
-    let object_store = state.get_object_store();
-    let epoch_store = state.load_epoch_store_one_call_per_task();
-    let mut layout_resolver = epoch_store
-        .executor()
-        .type_layout_resolver(Box::new(backing_package_store.as_ref()));
-    for (idx, account) in universe.accounts().iter().enumerate() {
-        for (balance_idx, acc_object) in account.current_coins.iter().enumerate() {
-            let object = object_store.get_object(&acc_object.id()).unwrap().unwrap();
-            let total_sui_value =
-                object.get_total_sui(layout_resolver.as_mut()).unwrap() - object.storage_rebate;
-            let account_balance_i = account.current_balances[balance_idx];
-            prop_assert_eq!(
-                account_balance_i,
-                total_sui_value,
-                "account {} should have correct balance {} for object {} but got {}",
-                idx,
-                total_sui_value,
-                acc_object.id(),
-                account_balance_i
-            );
-        }
-    }
-    Ok(())
+    unimplemented!()
 }

--- a/crates/transaction-fuzzer/src/executor.rs
+++ b/crates/transaction-fuzzer/src/executor.rs
@@ -7,19 +7,17 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{fmt::Debug, path::PathBuf, sync::Arc};
+use std::{fmt::Debug, path::PathBuf};
 
-use sui_core::authority::test_authority_builder::TestAuthorityBuilder;
-use sui_core::{authority::AuthorityState, test_utils::send_and_confirm_transaction};
 use sui_move_build::BuildConfig;
 use sui_types::base_types::ObjectID;
-use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
+use sui_types::effects::{TransactionEffects};
 use sui_types::error::SuiError;
 use sui_types::execution_status::{ExecutionFailureStatus, ExecutionStatus};
 use sui_types::object::Object;
 use sui_types::transaction::{Transaction, TransactionData};
 use sui_types::utils::to_sender_signed_transaction;
-use tokio::runtime::Runtime;
+
 
 use crate::account_universe::{AccountCurrent, PUBLISH_BUDGET};
 
@@ -52,10 +50,7 @@ pub fn assert_is_acceptable_result(result: &ExecutionResult) {
 }
 
 #[derive(Clone)]
-pub struct Executor {
-    pub state: Arc<AuthorityState>,
-    pub rt: Arc<Runtime>,
-}
+pub struct Executor;
 
 impl Debug for Executor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -71,43 +66,27 @@ impl Default for Executor {
 
 impl Executor {
     pub fn new() -> Self {
-        let rt = Runtime::new().unwrap();
-        let state = rt.block_on(TestAuthorityBuilder::new().build());
-        Self {
-            state,
-            rt: Arc::new(rt),
-        }
+        unimplemented!()
     }
 
-    pub fn new_with_rgp(rgp: u64) -> Self {
-        let rt = Runtime::new().unwrap();
-        let state = rt.block_on(
-            TestAuthorityBuilder::new()
-                .with_reference_gas_price(rgp)
-                .build(),
-        );
-        Self {
-            state,
-            rt: Arc::new(rt),
-        }
+    pub fn new_with_rgp(_rgp: u64) -> Self {
+        unimplemented!()
     }
 
     pub fn get_reference_gas_price(&self) -> u64 {
-        self.state.reference_gas_price_for_testing().unwrap()
+        unimplemented!()
     }
 
-    pub fn add_object(&mut self, object: Object) {
-        self.rt.block_on(self.state.insert_genesis_object(object));
+    pub fn add_object(&mut self, _object: Object) {
+        unimplemented!()
     }
 
-    pub fn add_objects(&mut self, objects: &[Object]) {
-        self.rt.block_on(self.state.insert_genesis_objects(objects));
+    pub fn add_objects(&mut self, _objects: &[Object]) {
+        unimplemented!()
     }
 
-    pub fn execute_transaction(&mut self, txn: Transaction) -> ExecutionResult {
-        self.rt
-            .block_on(send_and_confirm_transaction(&self.state, None, txn))
-            .map(|(_, effects)| effects.into_data().status().clone())
+    pub fn execute_transaction(&mut self, _txn: Transaction) -> ExecutionResult {
+        unimplemented!()
     }
 
     pub fn publish(
@@ -127,20 +106,10 @@ impl Executor {
             PUBLISH_BUDGET,
             1000,
         );
-        let txn = to_sender_signed_transaction(data, &account.initial_data.account.key);
-        let effects = self
-            .rt
-            .block_on(send_and_confirm_transaction(&self.state, None, txn))
-            .unwrap()
-            .1
-            .into_data();
+        let _txn = to_sender_signed_transaction(data, &account.initial_data.account.key);
 
-        assert!(
-            matches!(effects.status(), ExecutionStatus::Success { .. }),
-            "{:?}",
-            effects.status()
-        );
-        effects
+        unimplemented!()
+
     }
 
     pub fn execute_transactions(

--- a/crates/transaction-fuzzer/src/type_arg_fuzzer.rs
+++ b/crates/transaction-fuzzer/src/type_arg_fuzzer.rs
@@ -9,7 +9,6 @@ use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 use proptest::arbitrary::*;
 use proptest::prelude::*;
 
-use sui_core::test_utils::send_and_confirm_transaction;
 use sui_types::base_types::ObjectID;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
 use sui_types::error::SuiError;
@@ -171,8 +170,7 @@ pub fn run_pt_effects(
         GAS,
         GAS_PRICE,
     );
-    let signed_txn = to_sender_signed_transaction(tx_data, &account.initial_data.account.key);
-    exec.rt
-        .block_on(send_and_confirm_transaction(&exec.state, None, signed_txn))
-        .map(|(_, effects)| effects.into_data())
+    let _signed_txn = to_sender_signed_transaction(tx_data, &account.initial_data.account.key);
+
+    unimplemented!()
 }

--- a/crates/transaction-fuzzer/tests/gas_data_tests.rs
+++ b/crates/transaction-fuzzer/tests/gas_data_tests.rs
@@ -44,6 +44,7 @@ fn test_with_random_gas_data(
     Ok(())
 }
 
+#[ignore]
 #[test]
 #[cfg_attr(msim, ignore)]
 fn test_gas_data_owned_or_immut() {
@@ -53,6 +54,7 @@ fn test_gas_data_owned_or_immut() {
     });
 }
 
+#[ignore]
 #[test]
 #[cfg_attr(msim, ignore)]
 fn test_gas_data_any_owner() {

--- a/crates/transaction-fuzzer/tests/gas_data_tests.rs
+++ b/crates/transaction-fuzzer/tests/gas_data_tests.rs
@@ -46,7 +46,6 @@ fn test_with_random_gas_data(
 
 #[ignore]
 #[test]
-#[cfg_attr(msim, ignore)]
 fn test_gas_data_owned_or_immut() {
     let strategy = any_with::<GasDataWithObjects>(GasDataGenConfig::owned_by_sender_or_immut());
     run_proptest(1000, strategy, |gas_data_test, mut executor| {
@@ -56,7 +55,6 @@ fn test_gas_data_owned_or_immut() {
 
 #[ignore]
 #[test]
-#[cfg_attr(msim, ignore)]
 fn test_gas_data_any_owner() {
     let strategy = any_with::<GasDataWithObjects>(GasDataGenConfig::any_owner());
     run_proptest(1000, strategy, |gas_data_test, mut executor| {

--- a/crates/transaction-fuzzer/tests/p2p_fuzz.rs
+++ b/crates/transaction-fuzzer/tests/p2p_fuzz.rs
@@ -15,6 +15,7 @@ use transaction_fuzzer::run_proptest;
 
 const NUM_RUNS: u32 = 20;
 
+#[ignore]
 #[test]
 #[cfg_attr(msim, ignore)]
 fn fuzz_p2p_low_balance() {
@@ -30,6 +31,7 @@ fn fuzz_p2p_low_balance() {
     });
 }
 
+#[ignore]
 #[test]
 #[cfg_attr(msim, ignore)]
 fn fuzz_p2p_high_balance() {
@@ -47,6 +49,7 @@ fn fuzz_p2p_high_balance() {
     });
 }
 
+#[ignore]
 #[test]
 #[cfg_attr(msim, ignore)]
 fn fuzz_p2p_random_gas_budget_high_balance() {
@@ -64,6 +67,7 @@ fn fuzz_p2p_random_gas_budget_high_balance() {
     });
 }
 
+#[ignore]
 #[test]
 #[cfg_attr(msim, ignore)]
 fn fuzz_p2p_random_gas_budget_low_balance() {
@@ -79,6 +83,7 @@ fn fuzz_p2p_random_gas_budget_low_balance() {
     });
 }
 
+#[ignore]
 #[test]
 #[cfg_attr(msim, ignore)]
 fn fuzz_p2p_random_gas_budget_and_price_high_balance() {
@@ -96,6 +101,7 @@ fn fuzz_p2p_random_gas_budget_and_price_high_balance() {
     });
 }
 
+#[ignore]
 #[test]
 #[cfg_attr(msim, ignore)]
 fn fuzz_p2p_random_gas_budget_and_price_low_balance() {
@@ -111,6 +117,7 @@ fn fuzz_p2p_random_gas_budget_and_price_low_balance() {
     });
 }
 
+#[ignore]
 #[test]
 #[cfg_attr(msim, ignore)]
 fn fuzz_p2p_rand_gas_budget_price_and_coins() {
@@ -128,6 +135,7 @@ fn fuzz_p2p_rand_gas_budget_price_and_coins() {
     });
 }
 
+#[ignore]
 #[test]
 #[cfg_attr(msim, ignore)]
 fn fuzz_p2p_random_gas_budget_and_price_high_balance_random_sponsorship() {
@@ -149,6 +157,7 @@ fn fuzz_p2p_random_gas_budget_and_price_high_balance_random_sponsorship() {
     );
 }
 
+#[ignore]
 #[test]
 #[cfg_attr(msim, ignore)]
 fn fuzz_p2p_random_gas_budget_and_price_low_balance_random_sponsorship() {
@@ -168,6 +177,7 @@ fn fuzz_p2p_random_gas_budget_and_price_low_balance_random_sponsorship() {
     );
 }
 
+#[ignore]
 #[test]
 #[cfg_attr(msim, ignore)]
 fn fuzz_p2p_mixed() {

--- a/crates/transaction-fuzzer/tests/p2p_fuzz.rs
+++ b/crates/transaction-fuzzer/tests/p2p_fuzz.rs
@@ -17,7 +17,6 @@ const NUM_RUNS: u32 = 20;
 
 #[ignore]
 #[test]
-#[cfg_attr(msim, ignore)]
 fn fuzz_p2p_low_balance() {
     let universe =
         AccountUniverseGen::strategy(3..default_num_accounts(), 1_000_000u64..10_000_000);
@@ -33,7 +32,6 @@ fn fuzz_p2p_low_balance() {
 
 #[ignore]
 #[test]
-#[cfg_attr(msim, ignore)]
 fn fuzz_p2p_high_balance() {
     let universe = AccountUniverseGen::strategy(
         3..default_num_accounts(),
@@ -51,7 +49,6 @@ fn fuzz_p2p_high_balance() {
 
 #[ignore]
 #[test]
-#[cfg_attr(msim, ignore)]
 fn fuzz_p2p_random_gas_budget_high_balance() {
     let universe = AccountUniverseGen::strategy(
         3..default_num_accounts(),
@@ -69,7 +66,6 @@ fn fuzz_p2p_random_gas_budget_high_balance() {
 
 #[ignore]
 #[test]
-#[cfg_attr(msim, ignore)]
 fn fuzz_p2p_random_gas_budget_low_balance() {
     let universe =
         AccountUniverseGen::strategy(3..default_num_accounts(), 1_000_000u64..10_000_000);
@@ -85,7 +81,6 @@ fn fuzz_p2p_random_gas_budget_low_balance() {
 
 #[ignore]
 #[test]
-#[cfg_attr(msim, ignore)]
 fn fuzz_p2p_random_gas_budget_and_price_high_balance() {
     let universe = AccountUniverseGen::strategy(
         3..default_num_accounts(),
@@ -103,7 +98,6 @@ fn fuzz_p2p_random_gas_budget_and_price_high_balance() {
 
 #[ignore]
 #[test]
-#[cfg_attr(msim, ignore)]
 fn fuzz_p2p_random_gas_budget_and_price_low_balance() {
     let universe =
         AccountUniverseGen::strategy(3..default_num_accounts(), 1_000_000u64..10_000_000);
@@ -119,7 +113,6 @@ fn fuzz_p2p_random_gas_budget_and_price_low_balance() {
 
 #[ignore]
 #[test]
-#[cfg_attr(msim, ignore)]
 fn fuzz_p2p_rand_gas_budget_price_and_coins() {
     let universe = AccountUniverseGen::strategy(
         3..default_num_accounts(),
@@ -137,7 +130,6 @@ fn fuzz_p2p_rand_gas_budget_price_and_coins() {
 
 #[ignore]
 #[test]
-#[cfg_attr(msim, ignore)]
 fn fuzz_p2p_random_gas_budget_and_price_high_balance_random_sponsorship() {
     let universe = AccountUniverseGen::strategy(
         3..default_num_accounts(),
@@ -159,7 +151,6 @@ fn fuzz_p2p_random_gas_budget_and_price_high_balance_random_sponsorship() {
 
 #[ignore]
 #[test]
-#[cfg_attr(msim, ignore)]
 fn fuzz_p2p_random_gas_budget_and_price_low_balance_random_sponsorship() {
     let universe =
         AccountUniverseGen::strategy(3..default_num_accounts(), 1_000_000u64..10_000_000);
@@ -179,7 +170,6 @@ fn fuzz_p2p_random_gas_budget_and_price_low_balance_random_sponsorship() {
 
 #[ignore]
 #[test]
-#[cfg_attr(msim, ignore)]
 fn fuzz_p2p_mixed() {
     let universe = AccountUniverseGen::strategy(
         3..default_num_accounts(),

--- a/crates/transaction-fuzzer/tests/pt_fuzz.rs
+++ b/crates/transaction-fuzzer/tests/pt_fuzz.rs
@@ -23,7 +23,6 @@ use sui_types::{MOVE_STDLIB_PACKAGE_ID, SUI_FRAMEWORK_PACKAGE_ID};
 
 #[ignore]
 #[test]
-#[cfg_attr(msim, ignore)]
 fn invalid_pt_fuzz() {
     let mut exec = Executor::new();
     let mut runner = proptest::test_runner::TestRunner::deterministic();
@@ -94,7 +93,6 @@ pub fn run_pt_success(
 
 #[ignore]
 #[test]
-#[cfg_attr(msim, ignore)]
 fn pt_fuzz_input_match() {
     let mut exec = Executor::new();
     let mut runner = proptest::test_runner::TestRunner::deterministic();

--- a/crates/transaction-fuzzer/tests/pt_fuzz.rs
+++ b/crates/transaction-fuzzer/tests/pt_fuzz.rs
@@ -21,6 +21,7 @@ use sui_types::object::Owner;
 use sui_types::transaction::{CallArg, ObjectArg, ProgrammableTransaction};
 use sui_types::{MOVE_STDLIB_PACKAGE_ID, SUI_FRAMEWORK_PACKAGE_ID};
 
+#[ignore]
 #[test]
 #[cfg_attr(msim, ignore)]
 fn invalid_pt_fuzz() {
@@ -43,31 +44,13 @@ fn publish_coin_factory(
         vec![MOVE_STDLIB_PACKAGE_ID, SUI_FRAMEWORK_PACKAGE_ID],
         account,
     );
-    let package = effects
+    let _package = effects
         .created()
         .into_iter()
         .find(|(_, owner)| matches!(owner, Owner::Immutable))
         .unwrap();
-    let cap = effects
-        .created()
-        .into_iter()
-        .find(|(obj_ref, _)| {
-            if let Some(stag) = exec
-                .rt
-                .block_on(exec.state.get_object(&obj_ref.0))
-                .unwrap()
-                .unwrap()
-                .data
-                .struct_tag()
-            {
-                stag.name.as_str().eq("TreasuryCap")
-            } else {
-                false
-            }
-        })
-        .unwrap();
 
-    (package.0, cap.0)
+    unimplemented!()
 }
 
 /// This function runs programmable transaction block and checks if it executed successfully. It
@@ -105,28 +88,11 @@ pub fn run_pt_success(
         "{:?}",
         status
     );
-    let new_cap = effects
-        .mutated()
-        .into_iter()
-        .find(|(obj_ref, _)| {
-            if let Some(stag) = exec
-                .rt
-                .block_on(exec.state.get_object(&obj_ref.0))
-                .unwrap()
-                .unwrap()
-                .data
-                .struct_tag()
-            {
-                stag.name.as_str().eq("TreasuryCap")
-            } else {
-                false
-            }
-        })
-        .unwrap();
 
-    new_cap.0
+    unimplemented!()
 }
 
+#[ignore]
 #[test]
 #[cfg_attr(msim, ignore)]
 fn pt_fuzz_input_match() {

--- a/crates/transaction-fuzzer/tests/rgp_fuzz.rs
+++ b/crates/transaction-fuzzer/tests/rgp_fuzz.rs
@@ -17,7 +17,6 @@ proptest! {
     #![proptest_config(ProptestConfig::with_cases(20))]
     #[ignore]
     #[test]
-    #[cfg_attr(msim, ignore)]
     fn fuzz_low_rgp_low_gas_price(
         universe in AccountUniverseGen::strategy(3..default_num_accounts(), 1_000_000_000u64..10_000_000_000),
         transfers in vec(any_with::<P2PTransferGenGasPriceInRange>((0u64, 10_000)), 0..default_num_transactions()),
@@ -28,7 +27,6 @@ proptest! {
 
     #[ignore]
     #[test]
-    #[cfg_attr(msim, ignore)]
     fn fuzz_high_rgp_high_gas_price(
         universe in AccountUniverseGen::strategy(3..default_num_accounts(), 1_000_000_000u64..10_000_000_000),
         transfers in vec(any_with::<P2PTransferGenGasPriceInRange>((10_000u64, 100_000u64)), 0..default_num_transactions()),

--- a/crates/transaction-fuzzer/tests/rgp_fuzz.rs
+++ b/crates/transaction-fuzzer/tests/rgp_fuzz.rs
@@ -15,6 +15,7 @@ use transaction_fuzzer::config_fuzzer::run_rgp;
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(20))]
+    #[ignore]
     #[test]
     #[cfg_attr(msim, ignore)]
     fn fuzz_low_rgp_low_gas_price(
@@ -25,6 +26,7 @@ proptest! {
         run_rgp(universe, transfers, rgp);
     }
 
+    #[ignore]
     #[test]
     #[cfg_attr(msim, ignore)]
     fn fuzz_high_rgp_high_gas_price(

--- a/crates/transaction-fuzzer/tests/transaction_data_fuzz.rs
+++ b/crates/transaction-fuzzer/tests/transaction_data_fuzz.rs
@@ -18,7 +18,6 @@ use transaction_fuzzer::{
 
 #[ignore]
 #[test]
-#[cfg_attr(msim, ignore)]
 fn all_random_transaction_data() {
     let mut exec = Executor::new();
     let account = AccountCurrent::new(AccountData::new_random());

--- a/crates/transaction-fuzzer/tests/transaction_data_fuzz.rs
+++ b/crates/transaction-fuzzer/tests/transaction_data_fuzz.rs
@@ -16,6 +16,7 @@ use transaction_fuzzer::{
     transaction_data_gen::transaction_data_gen,
 };
 
+#[ignore]
 #[test]
 #[cfg_attr(msim, ignore)]
 fn all_random_transaction_data() {

--- a/crates/transaction-fuzzer/tests/type_arg_fuzzer.rs
+++ b/crates/transaction-fuzzer/tests/type_arg_fuzzer.rs
@@ -47,7 +47,6 @@ fn _all_valid_type_tag_fuzzing(add_sub: isize) {
 
 #[ignore]
 #[test]
-#[cfg_attr(msim, ignore)]
 fn all_random_single_type_tag_fuzzing() {
     let mut exec = Executor::new();
     let strategy = vec(gen_type_tag(), 1..10);
@@ -61,14 +60,12 @@ fn all_random_single_type_tag_fuzzing() {
 
 #[ignore]
 #[test]
-#[cfg_attr(msim, ignore)]
 fn all_valid_type_tag_fuzzing() {
     _all_valid_type_tag_fuzzing(0)
 }
 
 #[ignore]
 #[test]
-#[cfg_attr(msim, ignore)]
 fn all_valid_type_tag_incorrect_number_fuzzing() {
     _all_valid_type_tag_fuzzing(-1);
     _all_valid_type_tag_fuzzing(1);
@@ -76,7 +73,6 @@ fn all_valid_type_tag_incorrect_number_fuzzing() {
 
 #[ignore]
 #[test]
-#[cfg_attr(msim, ignore)]
 fn interesting_invalid_type_tags_fuzzing() {
     let mut exec = Executor::new();
     let mut runner = proptest::test_runner::TestRunner::deterministic();

--- a/crates/transaction-fuzzer/tests/type_arg_fuzzer.rs
+++ b/crates/transaction-fuzzer/tests/type_arg_fuzzer.rs
@@ -45,6 +45,7 @@ fn _all_valid_type_tag_fuzzing(add_sub: isize) {
     }
 }
 
+#[ignore]
 #[test]
 #[cfg_attr(msim, ignore)]
 fn all_random_single_type_tag_fuzzing() {
@@ -58,12 +59,14 @@ fn all_random_single_type_tag_fuzzing() {
     }
 }
 
+#[ignore]
 #[test]
 #[cfg_attr(msim, ignore)]
 fn all_valid_type_tag_fuzzing() {
     _all_valid_type_tag_fuzzing(0)
 }
 
+#[ignore]
 #[test]
 #[cfg_attr(msim, ignore)]
 fn all_valid_type_tag_incorrect_number_fuzzing() {
@@ -71,6 +74,7 @@ fn all_valid_type_tag_incorrect_number_fuzzing() {
     _all_valid_type_tag_fuzzing(1);
 }
 
+#[ignore]
 #[test]
 #[cfg_attr(msim, ignore)]
 fn interesting_invalid_type_tags_fuzzing() {


### PR DESCRIPTION
## Description 

Fixes the compilation issues for `transaction-fuzzer`.

## Issues

Fixes https://github.com/iotaledger/kinesis/issues/29

## Notes

For some more context, the compilation issues for the `transaction-fuzzer` did appear when running `cargo test` in the `transaction-fuzzer` crate, testing  `transaction-fuzzer/tests`. The tests rely on an `Executor` type (defined in `sui-types`) which makes use of the  `AuthorityState` implementation to execute transactions.
I left the general `Executor` type, as we should integrate our execution environment (whenever available) with it.

Even though the `transaction-fuzzer` compilation issues are solved with this PR, mind that the tests don't pass. We should fix the tests once we have our own `Executor` type available.


