### PR TITLE
Fixed `sui-indexer` compilation errors

### DIFF
--- a/crates/sui-indexer/README.md
+++ b/crates/sui-indexer/README.md
@@ -24,10 +24,6 @@ Postgres must run as a service in the background for other tools to communicate 
 brew services start postgresql@version
 ```
 
-### Local Development(Recommended)
-
-Use [sui-test-validator](../../crates/sui-test-validator/README.md)
-
 ### Running standalone indexer
 1. DB setup, under `sui/crates/sui-indexer` run:
 ```sh
@@ -47,13 +43,13 @@ git fetch upstream devnet && git reset --hard upstream/devnet
 - run indexer as a writer, which pulls data from fullnode and writes data to DB
 ```sh
 # Change the RPC_CLIENT_URL to http://0.0.0.0:9000 to run indexer against local validator & fullnode
-cargo run --bin sui-indexer -- --db-url "<DATABASE_URL>" --rpc-client-url "https://fullnode.devnet.sui.io:443" --fullnode-sync-worker --use-v2 --reset-db
+cargo run --bin sui-indexer -- --db-url "<DATABASE_URL>" --rpc-client-url "https://fullnode.devnet.sui.io:443" --fullnode-sync-worker --reset-db
 ```
 - run indexer as a reader, which is a JSON RPC server with the [interface](https://docs.sui.io/sui-api-ref#suix_getallbalances)
+```sh
+cargo run --bin sui-indexer -- --db-url "<DATABASE_URL>" --rpc-client-url "https://fullnode.devnet.sui.io:443" --rpc-server-worker
 ```
-cargo run --bin sui-indexer -- --db-url "<DATABASE_URL>" --rpc-client-url "https://fullnode.devnet.sui.io:443" --rpc-server-worker --use-v2
-```
-More flags info can be found in this [file](https://github.com/MystenLabs/sui/blob/main/crates/sui-indexer/src/lib.rs#L83-L123).
+More flags info can be found in this [file](https://github.com/iotaledger/kinesis/blob/develop/crates/sui-indexer/src/lib.rs#L51-L82).
 ### DB reset
 Run this command under `sui/crates/sui-indexer`, which will wipe DB; In case of schema changes in `.sql` files, this will also update corresponding `schema.rs` file.
 ```sh

--- a/crates/sui-indexer/src/schema.patch
+++ b/crates/sui-indexer/src/schema.patch
@@ -1,7 +1,11 @@
 diff --git a/crates/sui-indexer/src/schema.rs b/crates/sui-indexer/src/schema.rs
 --- a/crates/sui-indexer/src/schema.rs
 +++ b/crates/sui-indexer/src/schema.rs
-@@ -1 +1,3 @@
+@@ -1 +1,7 @@
 +// Copyright (c) Mysten Labs, Inc.
 +// SPDX-License-Identifier: Apache-2.0
++
++// Modifications Copyright (c) 2024 IOTA Stiftung
++// SPDX-License-Identifier: Apache-2.0
++
  // @generated automatically by Diesel CLI.

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -3,6 +3,7 @@
 
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
+
 // @generated automatically by Diesel CLI.
 
 diesel::table! {


### PR DESCRIPTION
# Description of change

The crate can be compiled, and the tests passed.

I followed the instructions from the `README.md` file, the indexer can be run, and it successfully reads data from the Sui devnet and writes them into a locally run Postgres DB.

The `ingestion_tests.rs` are disabled by default and require the `pg_integration` feature; This command fails at the moment:
```sh
cargo test -p sui-indexer --features pg_integration
```
It fails because we deleted `Simulacrum`. The integration tests seem to be useful, so I decided to leave them. We can consider an option to restore them in the future if we need to.

## Links to any relevant issues

Fixes #55.

