### PR TITLE
Enable ci-docs workflow [#28]

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -3,7 +3,7 @@ name: Docs
 on:
   push:
     branches:
-      - main
+      - develop
     paths:
       - "**.rs"
       - "Cargo.toml"
@@ -13,27 +13,16 @@ on:
 jobs:
   docs:
     name: Generate crate documentation
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout sources
         uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # pin@v2
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          # Upgrade below after the workspace upgrades to Rust 1.72 or later.
-          # https://substrate.stackexchange.com/a/9069
-          toolchain: nightly-2023-06-15
-          override: true
-
       - name: Generate documentation
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
-        env:
-          RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
-        with:
-          command: doc
-          args: --workspace --exclude "sui-benchmark" --no-deps
+        shell: bash
+        run: |
+          [ -f ~/.cargo/env ] && source ~/.cargo/env
+          cargo doc --workspace --no-deps
 
       - name: Deploy documentation
         uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # pin@v3


### PR DESCRIPTION
# Description of change

This enables the CI workflow for generating the Rust API documentation of the workspace and deploying to github pages. The workflow is triggered when something gets merged in the `develop` branch.

About deployment:

* The workflow actually pushes the docs into a separate branch `gh-pages`.
* In order for the pages to be actually published (as in public website), we need to [configure the publishing source](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site).

## Links to any relevant issues

Closes #28 

## Type of change

- Documentation Fix

## How the change has been tested

The CI has been tested with `ubuntu-latest` runner in a fork.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
