### PR TITLE
cargo-deny integration was fixed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,20 +25,11 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
-dependencies = [
- "gimli 0.27.3",
-]
-
-[[package]]
-name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
- "gimli 0.28.1",
+ "gimli",
 ]
 
 [[package]]
@@ -103,15 +94,6 @@ dependencies = [
  "once_cell",
  "version_check",
  "zerocopy",
-]
-
-[[package]]
-name = "aho-corasick"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -211,20 +193,6 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon 2.1.0",
- "colorchoice",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
@@ -232,7 +200,7 @@ dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
- "anstyle-wincon 3.0.2",
+ "anstyle-wincon",
  "colorchoice",
  "utf8parse",
 ]
@@ -259,16 +227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
-dependencies = [
- "anstyle",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -860,12 +818,12 @@ version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
- "addr2line 0.21.0",
+ "addr2line",
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.7.2",
- "object 0.32.2",
+ "miniz_oxide",
+ "object",
  "rustc-demangle",
 ]
 
@@ -1120,7 +1078,7 @@ checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.4",
- "constant_time_eq 0.3.0",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -1131,7 +1089,7 @@ checksum = "94230421e395b9920d23df13ea5d77a20e1725331f90fbbf6df6040b33f756ae"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.4",
- "constant_time_eq 0.3.0",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -1144,7 +1102,7 @@ dependencies = [
  "arrayvec 0.7.4",
  "cc",
  "cfg-if",
- "constant_time_eq 0.3.0",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -1405,7 +1363,7 @@ checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.22",
+ "semver",
  "serde",
  "serde_json",
  "thiserror",
@@ -1449,16 +1407,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom",
-]
-
-[[package]]
-name = "cfg-expr"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a327683d7499ecc47369531a679fe38acdd300e09bf8c852d08b1e10558622bd"
-dependencies = [
- "smallvec",
- "target-lexicon",
 ]
 
 [[package]]
@@ -1516,7 +1464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
- "half 2.4.0",
+ "half",
 ]
 
 [[package]]
@@ -1537,7 +1485,7 @@ checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.8.2",
+ "libloading",
 ]
 
 [[package]]
@@ -1556,11 +1504,11 @@ version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
 dependencies = [
- "anstream 0.6.13",
+ "anstream",
  "anstyle",
- "clap_lex 0.7.0",
+ "clap_lex",
  "strsim 0.11.0",
- "terminal_size 0.3.0",
+ "terminal_size",
 ]
 
 [[package]]
@@ -1574,12 +1522,6 @@ dependencies = [
  "quote 1.0.35",
  "syn 2.0.52",
 ]
-
-[[package]]
-name = "clap_lex"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "clap_lex"
@@ -1728,12 +1670,6 @@ checksum = "3618cccc083bb987a415d85c02ca6c9994ea5b44731ec28b9ecf09658655fba9"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
-
-[[package]]
-name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
@@ -1870,58 +1806,17 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crossterm"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486d44227f71a1ef39554c0dc47e44b9f4139927c75043312690c3f476d1d788"
-dependencies = [
- "bitflags 1.3.2",
- "crossterm_winapi 0.8.0",
- "libc",
- "mio 0.7.14",
- "parking_lot 0.11.2",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85525306c4291d1b73ce93c8acf9c339f9b213aef6c1d85c3830cbf1c16325c"
-dependencies = [
- "bitflags 1.3.2",
- "crossterm_winapi 0.9.1",
- "libc",
- "mio 0.7.14",
- "parking_lot 0.11.2",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
 dependencies = [
  "bitflags 1.3.2",
- "crossterm_winapi 0.9.1",
+ "crossterm_winapi",
  "libc",
- "mio 0.8.11",
+ "mio",
  "parking_lot 0.12.1",
  "signal-hook",
  "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
-dependencies = [
  "winapi",
 ]
 
@@ -2004,16 +1899,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote 1.0.35",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2710,33 +2595,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -2927,15 +2791,6 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
@@ -2947,7 +2802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
 dependencies = [
  "cfg-if",
- "rustix 0.38.31",
+ "rustix",
  "windows-sys 0.48.0",
 ]
 
@@ -3033,7 +2888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.7.2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -3133,21 +2988,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
-name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3240,12 +3080,6 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
-
-[[package]]
-name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
@@ -3282,7 +3116,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
 dependencies = [
- "aho-corasick 1.1.2",
+ "aho-corasick",
  "bstr",
  "log",
  "regex-automata 0.4.6",
@@ -3333,7 +3167,7 @@ dependencies = [
  "pathdiff",
  "petgraph 0.6.4",
  "rayon",
- "semver 1.0.22",
+ "semver",
  "serde",
  "serde_json",
  "smallvec",
@@ -3352,7 +3186,7 @@ dependencies = [
  "cfg-if",
  "diffus",
  "guppy-workspace-hack",
- "semver 1.0.22",
+ "semver",
  "serde",
  "toml 0.5.11",
 ]
@@ -3409,12 +3243,6 @@ dependencies = [
  "toml_edit 0.17.1",
  "twox-hash",
 ]
-
-[[package]]
-name = "half"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "half"
@@ -3714,16 +3542,6 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
@@ -3846,7 +3664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33e7c1ddeb15c9abcbfef6029d8e29f69b52b6d6c891031b88ed91b5065803b"
 dependencies = [
  "bitflags 1.3.2",
- "crossterm 0.25.0",
+ "crossterm",
  "dyn-clone",
  "lazy_static",
  "newline-converter",
@@ -3891,17 +3709,6 @@ dependencies = [
  "hashbrown 0.12.3",
  "once_cell",
  "parking_lot 0.12.1",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4189,16 +3996,6 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if",
- "winapi",
-]
-
-[[package]]
-name = "libloading"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2caa5afb8bf9f3a2652760ce7d4f62d21c4d5a423e68466fca30df82f2330164"
@@ -4267,18 +4064,6 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4387,15 +4172,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "merlin"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4452,33 +4228,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
-]
-
-[[package]]
-name = "mio"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
-dependencies = [
- "libc",
- "log",
- "miow",
- "ntapi",
- "winapi",
 ]
 
 [[package]]
@@ -4491,15 +4245,6 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -4593,7 +4338,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "crossterm 0.21.0",
+ "crossterm",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-disassembler",
@@ -5344,7 +5089,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "memoffset 0.6.5",
+ "memoffset",
 ]
 
 [[package]]
@@ -5377,15 +5122,6 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "ntest"
@@ -5553,15 +5289,6 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
@@ -5604,22 +5331,12 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4b8347cc26099d3aeee044065ecc3ae11469796b4d65d065a23a584ed92a6f"
-dependencies = [
- "opentelemetry_api 0.19.0",
- "opentelemetry_sdk 0.19.0",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
 dependencies = [
- "opentelemetry_api 0.20.0",
- "opentelemetry_sdk 0.20.0",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
 ]
 
 [[package]]
@@ -5649,8 +5366,8 @@ dependencies = [
  "http",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
- "opentelemetry_api 0.20.0",
- "opentelemetry_sdk 0.20.0",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
  "prost 0.11.9",
  "thiserror",
  "tokio",
@@ -5663,8 +5380,8 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1e3f814aa9f8c905d0ee4bde026afd3b2577a97c10e1699912e3e44f0c4cbeb"
 dependencies = [
- "opentelemetry_api 0.20.0",
- "opentelemetry_sdk 0.20.0",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
  "prost 0.11.9",
  "tonic 0.9.2",
 ]
@@ -5676,21 +5393,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73c9f9340ad135068800e7f1b24e9e09ed9e7143f5bf8518ded3d3ec69789269"
 dependencies = [
  "opentelemetry 0.20.0",
-]
-
-[[package]]
-name = "opentelemetry_api"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed41783a5bf567688eb38372f2b7a8530f5a607a4b49d38dd7573236c23ca7e2"
-dependencies = [
- "futures-channel",
- "futures-util",
- "indexmap 1.9.3",
- "once_cell",
- "pin-project-lite",
- "thiserror",
- "urlencoding",
 ]
 
 [[package]]
@@ -5711,24 +5413,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3a2a91fdbfdd4d212c0dcc2ab540de2c2bcbbd90be17de7a7daf8822d010c1"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "once_cell",
- "opentelemetry_api 0.19.0",
- "percent-encoding",
- "rand 0.8.5",
- "thiserror",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
@@ -5739,7 +5423,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "once_cell",
- "opentelemetry_api 0.20.0",
+ "opentelemetry_api",
  "ordered-float",
  "percent-encoding",
  "rand 0.8.5",
@@ -5787,15 +5471,6 @@ dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "syn 2.0.52",
-]
-
-[[package]]
-name = "output_vt100"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -5867,12 +5542,6 @@ dependencies = [
  "quote 1.0.35",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "parking"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
@@ -6358,12 +6027,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6529,12 +6192,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quinn"
@@ -6775,7 +6432,7 @@ dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "mio 0.8.11",
+ "mio",
  "num_cpus",
  "parking_lot 0.12.1",
  "pin-project-lite",
@@ -6840,7 +6497,7 @@ version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
- "aho-corasick 1.1.2",
+ "aho-corasick",
  "memchr",
  "regex-automata 0.4.6",
  "regex-syntax 0.8.2",
@@ -6861,7 +6518,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
- "aho-corasick 1.1.2",
+ "aho-corasick",
  "memchr",
  "regex-syntax 0.8.2",
 ]
@@ -6871,12 +6528,6 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -6924,12 +6575,6 @@ dependencies = [
  "webpki-roots 0.25.4",
  "winreg",
 ]
-
-[[package]]
-name = "retain_mut"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "rfc6979"
@@ -7139,7 +6784,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.22",
+ "semver",
 ]
 
 [[package]]
@@ -7153,42 +6798,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305efbd14fde4139eb501df5f136994bb520b033fa9fbdce287507dc23b8c7ed"
-dependencies = [
- "bitflags 1.3.2",
- "errno 0.3.8",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.1.4",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "rustix"
-version = "0.37.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
-dependencies = [
- "bitflags 1.3.2",
- "errno 0.3.8",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
  "bitflags 2.4.2",
- "errno 0.3.8",
+ "errno",
  "libc",
- "linux-raw-sys 0.4.13",
+ "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
 
@@ -7260,7 +6877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
 dependencies = [
  "fnv",
- "quick-error 1.2.3",
+ "quick-error",
  "tempfile",
  "wait-timeout",
 ]
@@ -7446,29 +7063,11 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
 ]
 
 [[package]]
@@ -7804,8 +7403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
  "libc",
- "mio 0.7.14",
- "mio 0.8.11",
+ "mio",
  "signal-hook",
 ]
 
@@ -8227,6 +7825,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -9439,7 +9038,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf4306559bd50cb358e7af5692694d6f6fad95cf2c0bea2571dd419f5298e12"
 dependencies = [
- "cfg-expr 0.15.7",
+ "cfg-expr",
  "guppy-workspace-hack",
  "serde",
  "target-lexicon",
@@ -9455,13 +9054,13 @@ dependencies = [
  "camino",
  "clap",
  "console-subscriber",
- "crossterm 0.25.0",
+ "crossterm",
  "futures",
  "once_cell",
  "opentelemetry 0.20.0",
  "opentelemetry-otlp",
  "opentelemetry-proto",
- "opentelemetry_api 0.20.0",
+ "opentelemetry_api",
  "prometheus",
  "prost 0.11.9",
  "tokio",
@@ -9480,8 +9079,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.1",
- "rustix 0.38.31",
+ "fastrand",
+ "rustix",
  "windows-sys 0.52.0",
 ]
 
@@ -9496,21 +9095,11 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
-dependencies = [
- "rustix 0.37.27",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "terminal_size"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix 0.38.31",
+ "rustix",
  "windows-sys 0.48.0",
 ]
 
@@ -9560,7 +9149,7 @@ dependencies = [
  "subprocess",
  "syn 2.0.52",
  "test-fuzz-internal",
- "toolchain_find 0.3.0",
+ "toolchain_find",
 ]
 
 [[package]]
@@ -9700,7 +9289,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 0.8.11",
+ "mio",
  "num_cpus",
  "parking_lot 0.12.1",
  "pin-project-lite",
@@ -9871,18 +9460,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1541ba70885967e662f69d31ab3aeca7b1aaecfcd58679590b893e9239c3646"
-dependencies = [
- "combine",
- "indexmap 1.9.3",
- "itertools 0.10.5",
- "toml_datetime 0.5.1",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a34cc558345efd7e88b9eda9626df2138b80bb46a7606f695e751c892bc7dac6"
@@ -9903,7 +9480,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.5",
- "winnow 0.5.40",
+ "winnow",
 ]
 
 [[package]]
@@ -9966,19 +9543,6 @@ dependencies = [
 
 [[package]]
 name = "toolchain_find"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e85654a10e7a07a47c6f19d93818f3f343e22927f2fa280c84f7c8042743413"
-dependencies = [
- "home",
- "lazy_static",
- "regex",
- "semver 0.11.0",
- "walkdir",
-]
-
-[[package]]
-name = "toolchain_find"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa8c746c4e8d786ff304a6a73d7b406420d9a7c7d8292e090979dc85213113ed"
@@ -9986,7 +9550,7 @@ dependencies = [
  "home",
  "once_cell",
  "regex",
- "semver 1.0.22",
+ "semver",
  "walkdir",
 ]
 
@@ -10140,7 +9704,7 @@ checksum = "75327c6b667828ddc28f5e3f169036cb793c3f588d83bf0f262a7f062ffed3c8"
 dependencies = [
  "once_cell",
  "opentelemetry 0.20.0",
- "opentelemetry_sdk 0.20.0",
+ "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -10231,13 +9795,13 @@ dependencies = [
 
 [[package]]
 name = "tui"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ed0a32c88b039b73f1b6c5acbd0554bfa5b6be94467375fd947c4de3a02271"
+checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
 dependencies = [
  "bitflags 1.3.2",
  "cassowary",
- "crossterm 0.22.1",
+ "crossterm",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -10396,17 +9960,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "unzip-n"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e7e85a0596447f0f2ac090e16bc4c516c6fe91771fb0c0ccf7fa3dae896b9c"
-dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "ureq"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10429,7 +9982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna 0.5.0",
+ "idna",
  "percent-encoding",
  "serde",
 ]
@@ -10529,12 +10082,6 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "waker-fn"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
 
 [[package]]
 name = "walkdir"
@@ -10675,18 +10222,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.31",
-]
-
-[[package]]
 name = "whoami"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10745,30 +10280,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -10783,21 +10294,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.4",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -10832,12 +10328,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -10847,12 +10337,6 @@ name = "windows_aarch64_gnullvm"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -10868,12 +10352,6 @@ checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
@@ -10883,12 +10361,6 @@ name = "windows_i686_gnu"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -10904,12 +10376,6 @@ checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
@@ -10919,12 +10385,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -10940,12 +10400,6 @@ checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
@@ -10955,15 +10409,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
-
-[[package]]
-name = "winnow"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656953b22bcbfb1ec8179d60734981d1904494ecc91f8a3f0ee5c7389bb8eb4b"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"
@@ -10990,26 +10435,25 @@ version = "0.1.0"
 dependencies = [
  "Inflector",
  "addchain",
- "addr2line 0.19.0",
+ "addr2line",
  "adler",
  "aead",
  "aes",
  "aes-gcm",
  "ahash 0.7.8",
  "ahash 0.8.11",
- "aho-corasick 0.7.20",
- "aho-corasick 1.1.2",
+ "aho-corasick",
  "aliasable",
  "alloc-no-stdlib",
  "alloc-stdlib",
  "anemo",
  "anes",
  "ansi_term",
- "anstream 0.5.0",
+ "anstream",
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
- "anstyle-wincon 2.1.0",
+ "anstyle-wincon",
  "anyhow",
  "arbitrary",
  "arc-swap",
@@ -11115,7 +10559,7 @@ dependencies = [
  "cbc",
  "cc",
  "cexpr",
- "cfg-expr 0.13.0",
+ "cfg-expr",
  "cfg-if",
  "chrono",
  "ciborium",
@@ -11126,7 +10570,7 @@ dependencies = [
  "clap",
  "clap_builder",
  "clap_derive",
- "clap_lex 0.5.1",
+ "clap_lex",
  "clear_on_drop",
  "clipboard-win",
  "codespan",
@@ -11140,8 +10584,7 @@ dependencies = [
  "console-subscriber",
  "const-oid",
  "const-str",
- "constant_time_eq 0.2.6",
- "constant_time_eq 0.3.0",
+ "constant_time_eq",
  "convert_case 0.4.0",
  "convert_case 0.6.0",
  "core-foundation",
@@ -11155,11 +10598,8 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-epoch",
  "crossbeam-utils",
- "crossterm 0.21.0",
- "crossterm 0.22.1",
- "crossterm 0.25.0",
- "crossterm_winapi 0.8.0",
- "crossterm_winapi 0.9.1",
+ "crossterm",
+ "crossterm_winapi",
  "crunchy",
  "crypto-bigint 0.4.9",
  "crypto-bigint 0.5.5",
@@ -11167,7 +10607,6 @@ dependencies = [
  "crypto-mac",
  "csv",
  "csv-core",
- "ctor",
  "ctr",
  "curve25519-dalek-fiat",
  "curve25519-dalek-ng",
@@ -11231,8 +10670,7 @@ dependencies = [
  "enum-compat-util",
  "enum_dispatch",
  "equivalent",
- "errno 0.2.8",
- "errno 0.3.8",
+ "errno",
  "error-code",
  "ethnum",
  "event-listener",
@@ -11243,8 +10681,7 @@ dependencies = [
  "fastcrypto-derive",
  "fastcrypto-tbls",
  "fastcrypto-zkp",
- "fastrand 1.9.0",
- "fastrand 2.0.1",
+ "fastrand",
  "fd-lock",
  "ff 0.12.1",
  "ff 0.13.0",
@@ -11266,7 +10703,6 @@ dependencies = [
  "futures-core",
  "futures-executor",
  "futures-io",
- "futures-lite",
  "futures-macro",
  "futures-sink",
  "futures-task",
@@ -11275,7 +10711,7 @@ dependencies = [
  "generic-array",
  "getrandom 0.2.12",
  "ghash",
- "gimli 0.27.3",
+ "gimli",
  "git-version",
  "git-version-macro",
  "glob",
@@ -11287,7 +10723,7 @@ dependencies = [
  "guppy-workspace-hack",
  "h2",
  "hakari",
- "half 1.8.3",
+ "half",
  "handlebars",
  "hashbrown 0.12.3",
  "hashbrown 0.13.2",
@@ -11315,7 +10751,7 @@ dependencies = [
  "hyper-timeout",
  "iana-time-zone",
  "ident_case",
- "idna 0.3.0",
+ "idna",
  "if_chain",
  "im",
  "impl-codec",
@@ -11331,7 +10767,6 @@ dependencies = [
  "insta",
  "instant",
  "internment",
- "io-lifetimes",
  "ipnet",
  "iri-string",
  "is-terminal",
@@ -11356,14 +10791,12 @@ dependencies = [
  "lazycell",
  "leb128",
  "libc",
- "libloading 0.7.4",
+ "libloading",
  "libm",
  "libtest-mimic",
  "libz-sys",
  "linked-hash-map",
- "linux-raw-sys 0.1.4",
- "linux-raw-sys 0.3.8",
- "linux-raw-sys 0.4.13",
+ "linux-raw-sys",
  "lock_api",
  "log",
  "lru 0.10.1",
@@ -11375,18 +10808,15 @@ dependencies = [
  "matchit 0.7.3",
  "md-5",
  "memchr",
- "memoffset 0.6.5",
- "memoffset 0.7.1",
+ "memoffset",
  "merlin",
  "migrations_internals",
  "migrations_macros",
  "mime",
  "mime_guess",
  "minimal-lexical",
- "miniz_oxide 0.6.2",
- "miniz_oxide 0.7.2",
- "mio 0.7.14",
- "mio 0.8.11",
+ "miniz_oxide",
+ "mio",
  "mockall",
  "mockall_derive",
  "move-abstract-stack",
@@ -11433,6 +10863,7 @@ dependencies = [
  "nibble_vec",
  "nix",
  "nom",
+ "nom8",
  "nonempty",
  "normalize-line-endings",
  "ntest",
@@ -11444,31 +10875,29 @@ dependencies = [
  "num-bigint 0.4.4",
  "num-bigint-dig",
  "num-complex",
+ "num-conv",
  "num-integer",
  "num-iter",
  "num-rational",
  "num-traits",
  "num_cpus",
- "object 0.30.4",
+ "object",
  "oid-registry",
  "once_cell",
  "oorandom",
  "opaque-debug",
  "openssl-probe",
- "opentelemetry 0.19.0",
  "opentelemetry 0.20.0",
+ "opentelemetry 0.21.0",
  "opentelemetry-otlp",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
- "opentelemetry_api 0.19.0",
- "opentelemetry_api 0.20.0",
- "opentelemetry_sdk 0.19.0",
- "opentelemetry_sdk 0.20.0",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
  "option-ext",
  "ordered-float",
  "ouroboros",
  "ouroboros_macro",
- "output_vt100",
  "overload",
  "owo-colors",
  "p256",
@@ -11476,10 +10905,7 @@ dependencies = [
  "papergrid",
  "parity-scale-codec",
  "parity-scale-codec-derive",
- "parking",
- "parking_lot 0.11.2",
  "parking_lot 0.12.1",
- "parking_lot_core 0.8.6",
  "parking_lot_core 0.9.9",
  "pasta_curves",
  "paste",
@@ -11516,6 +10942,7 @@ dependencies = [
  "ppv-lite86",
  "pq-sys",
  "predicates 2.1.5",
+ "predicates 3.1.0",
  "predicates-core",
  "predicates-tree",
  "pretty_assertions",
@@ -11525,7 +10952,6 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
  "proc-macro-error-attr",
- "proc-macro-hack",
  "proc-macro2 0.4.30",
  "proc-macro2 1.0.78",
  "prometheus",
@@ -11539,8 +10965,7 @@ dependencies = [
  "prost-types",
  "protobuf",
  "psm",
- "quick-error 1.2.3",
- "quick-error 2.0.1",
+ "quick-error",
  "quinn",
  "quinn-proto",
  "quinn-udp",
@@ -11563,13 +10988,14 @@ dependencies = [
  "ref-cast-impl",
  "regex",
  "regex-automata 0.1.10",
+ "regex-automata 0.4.6",
  "regex-syntax 0.6.29",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
  "reqwest",
- "retain_mut",
  "rfc6979 0.3.1",
  "rfc6979 0.4.0",
  "ring 0.16.20",
+ "ring 0.17.8",
  "ripemd",
  "roaring",
  "rsa",
@@ -11582,9 +11008,7 @@ dependencies = [
  "rustc-hex",
  "rustc_version",
  "rusticata-macros",
- "rustix 0.36.17",
- "rustix 0.37.27",
- "rustix 0.38.31",
+ "rustix",
  "rustls 0.20.9",
  "rustls 0.21.10",
  "rustls-native-certs",
@@ -11608,9 +11032,7 @@ dependencies = [
  "secp256k1-sys",
  "security-framework",
  "security-framework-sys",
- "semver 0.11.0",
- "semver 1.0.22",
- "semver-parser",
+ "semver",
  "serde",
  "serde-name",
  "serde-reflection",
@@ -11651,7 +11073,6 @@ dependencies = [
  "slab",
  "slip10_ed25519",
  "smallvec",
- "socket2 0.4.10",
  "socket2 0.5.6",
  "soketto",
  "spin 0.5.2",
@@ -11663,6 +11084,7 @@ dependencies = [
  "str-buf",
  "strip-ansi-escapes",
  "strsim 0.10.0",
+ "strsim 0.11.0",
  "strum 0.24.1",
  "strum 0.25.0",
  "strum_macros 0.24.3",
@@ -11675,6 +11097,8 @@ dependencies = [
  "syn 2.0.52",
  "sync_wrapper",
  "synstructure",
+ "system-configuration",
+ "system-configuration-sys",
  "tabled",
  "tabled_derive",
  "tabular",
@@ -11684,7 +11108,7 @@ dependencies = [
  "target-spec",
  "tempfile",
  "termcolor",
- "terminal_size 0.2.6",
+ "terminal_size",
  "termtree",
  "test-fuzz",
  "test-fuzz-internal",
@@ -11714,11 +11138,11 @@ dependencies = [
  "toml_datetime 0.5.1",
  "toml_datetime 0.6.5",
  "toml_edit 0.14.4",
- "toml_edit 0.15.0",
+ "toml_edit 0.17.1",
  "toml_edit 0.19.15",
  "tonic 0.10.2",
  "tonic 0.9.2",
- "toolchain_find 0.2.0",
+ "toolchain_find",
  "tower",
  "tower-http",
  "tower-layer",
@@ -11756,7 +11180,7 @@ dependencies = [
  "unsafe-libyaml",
  "unsigned-varint",
  "untrusted 0.7.1",
- "unzip-n",
+ "untrusted 0.9.0",
  "ureq",
  "url",
  "urlencoding",
@@ -11770,23 +11194,22 @@ dependencies = [
  "vte",
  "vte_generate_state_changes",
  "wait-timeout",
- "waker-fn",
  "walkdir",
  "want",
  "webpki",
  "webpki-roots 0.22.6",
  "webpki-roots 0.25.4",
- "which",
  "whoami",
  "widestring",
  "winapi",
  "winapi-util",
- "windows-sys 0.42.0",
  "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
  "windows-targets 0.48.5",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets 0.52.4",
  "windows_x86_64_msvc 0.48.5",
- "winnow 0.4.11",
+ "windows_x86_64_msvc 0.52.4",
+ "winnow",
  "winreg",
  "wyz 0.2.0",
  "wyz 0.5.1",
@@ -11796,6 +11219,7 @@ dependencies = [
  "yaml-rust",
  "yansi",
  "yasna",
+ "zerocopy",
  "zeroize",
  "zeroize_derive",
  "zstd-sys",
@@ -11851,8 +11275,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
 dependencies = [
  "libc",
- "linux-raw-sys 0.4.13",
- "rustix 0.38.31",
+ "linux-raw-sys",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,7 +224,7 @@ criterion = { version = "0.5.0", features = [
 ] }
 crossterm = "0.25.0"
 csv = "1.2.1"
-dashmap = "5.4.0"
+dashmap = "5.5.3"
 # datatest-stable = "0.1.2"
 datatest-stable = { git = "https://github.com/nextest-rs/datatest-stable.git", rev = "72db7f6d1bbe36a5407e96b9488a581f763e106f" }
 derivative = "2.2.0"
@@ -397,11 +397,11 @@ tempfile = "3.3.0"
 test-fuzz = "3.0.4"
 thiserror = "1.0.40"
 tiny-bip39 = "1.0.0"
-tokio = "1.28.1"
+tokio = "1.36.0"
 tokio-retry = "0.3"
 tokio-rustls = "0.24"
 tokio-stream = { version = "0.1.14", features = ["sync", "net"] }
-tokio-util = "0.7.4"
+tokio-util = "0.7.10"
 toml = { version = "0.7.4", features = ["preserve_order"] }
 toml_edit = { version = "0.19.10" }
 tonic = { version = "0.10", features = ["transport", "tls"] }
@@ -424,7 +424,7 @@ tower-http = { version = "0.3.4", features = [
 # tower-http = { version="0.4", features = ["trace"] }
 tower-layer = "0.3.2"
 twox-hash = "1.6.3"
-tracing = "0.1.37"
+tracing = "0.1.40"
 tracing-appender = "0.2.2"
 tracing-subscriber = { version = "0.3.15", default-features = false, features = [
   "std",
@@ -440,7 +440,7 @@ ttl_cache = "0.5.1"
 uint = "0.9.4"
 unescape = "0.1.0"
 ureq = "2.9.1"
-url = "2.3.1"
+url = "2.4.0"
 uuid = { version = "1.1.2", features = ["v4", "fast-rng"] }
 webpki = { version = "0.101.0", package = "rustls-webpki", features = [
   "alloc",

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -20,6 +20,8 @@ tracing.workspace = true
 sui-json-rpc-types.workspace = true
 sui-types.workspace = true
 
+workspace-hack.workspace = true
+
 [dev-dependencies]
 bcs.workspace = true
 move-core-types.workspace = true

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -15,22 +15,20 @@ publish = false
 
 ### BEGIN HAKARI SECTION
 [dependencies]
-addr2line = { version = "0.19", default-features = false }
 adler = { version = "1", default-features = false }
 aead = { version = "0.5", default-features = false, features = ["alloc", "getrandom"] }
 aes = { version = "0.8", default-features = false }
 aes-gcm = { version = "0.10" }
 ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8", default-features = false }
 ahash-ca01ad9e24f5d932 = { package = "ahash", version = "0.7" }
-aho-corasick-ca01ad9e24f5d932 = { package = "aho-corasick", version = "0.7" }
-aho-corasick-dff4ba8e3ae991db = { package = "aho-corasick", version = "1" }
+aho-corasick = { version = "1" }
 aliasable = { version = "0.1" }
 alloc-no-stdlib = { version = "2", default-features = false }
 alloc-stdlib = { version = "0.2", default-features = false }
 anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "26d415eb9aa6a2417be3c03c57d6e93c30bd1ad7", default-features = false }
 anes = { version = "0.1" }
 ansi_term = { version = "0.12", default-features = false }
-anstream = { version = "0.5" }
+anstream = { version = "0.6" }
 anstyle = { version = "1" }
 anstyle-parse = { version = "0.2" }
 anstyle-query = { version = "1", default-features = false }
@@ -86,7 +84,7 @@ bimap = { version = "0.6" }
 bincode = { version = "1", default-features = false }
 bip32 = { version = "0.4" }
 bit-set = { version = "0.5" }
-bit-vec = { version = "0.6", default-features = false, features = ["std"] }
+bit-vec = { version = "0.6" }
 bitcoin-private = { version = "0.1" }
 bitcoin_hashes = { version = "0.12", default-features = false }
 bitflags-dff4ba8e3ae991db = { package = "bitflags", version = "1" }
@@ -124,7 +122,7 @@ cargo_metadata = { version = "0.15" }
 cassowary = { version = "0.3", default-features = false }
 cast = { version = "0.3", default-features = false }
 cbc = { version = "0.1", features = ["std"] }
-cfg-expr = { version = "0.13", features = ["targets"] }
+cfg-expr = { version = "0.15", features = ["targets"] }
 cfg-if = { version = "1", default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
 ciborium = { version = "0.2" }
@@ -133,7 +131,7 @@ ciborium-ll = { version = "0.2", default-features = false }
 cipher = { version = "0.4", default-features = false, features = ["block-padding", "std"] }
 clap = { version = "4", features = ["derive", "wrap_help"] }
 clap_builder = { version = "4", default-features = false, features = ["color", "std", "suggestions", "usage", "wrap_help"] }
-clap_lex = { version = "0.5", default-features = false }
+clap_lex = { version = "0.7", default-features = false }
 clear_on_drop = { version = "0.2", default-features = false }
 codespan = { version = "0.11", default-features = false, features = ["serialization"] }
 codespan-reporting = { version = "0.11", default-features = false, features = ["serialization"] }
@@ -146,8 +144,7 @@ console-api = { version = "0.6", default-features = false, features = ["transpor
 console-subscriber = { version = "0.2" }
 const-oid = { version = "0.9", default-features = false }
 const-str = { version = "0.5" }
-constant_time_eq-468e82937335b1c9 = { package = "constant_time_eq", version = "0.3", default-features = false }
-constant_time_eq-6f8ce4dd05d13bba = { package = "constant_time_eq", version = "0.2", default-features = false }
+constant_time_eq = { version = "0.3", default-features = false }
 core2 = { version = "0.4", default-features = false, features = ["alloc"] }
 crc32fast = { version = "1" }
 criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
@@ -156,9 +153,7 @@ crossbeam-channel = { version = "0.5" }
 crossbeam-deque = { version = "0.8" }
 crossbeam-epoch = { version = "0.9", default-features = false, features = ["std"] }
 crossbeam-utils = { version = "0.8" }
-crossterm-2ffb4c3fe830441c = { package = "crossterm", version = "0.25" }
-crossterm-3c51e837cfc5589a = { package = "crossterm", version = "0.22" }
-crossterm-647d43efb71741da = { package = "crossterm", version = "0.21" }
+crossterm = { version = "0.25" }
 crunchy = { version = "0.2", default-features = false, features = ["std"] }
 crypto-bigint-9fbad63c4bcf4a8f = { package = "crypto-bigint", version = "0.4", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
 crypto-bigint-d8f496e17d97b5cb = { package = "crypto-bigint", version = "0.5", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
@@ -220,8 +215,7 @@ fast_chemail = { version = "0.9", default-features = false }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "ea66012b860d9dd152abb7f2156275698ee91126", features = ["beacon-dkg", "copy_key"] }
 fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "ea66012b860d9dd152abb7f2156275698ee91126" }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "ea66012b860d9dd152abb7f2156275698ee91126", default-features = false }
-fastrand-dff4ba8e3ae991db = { package = "fastrand", version = "1", default-features = false }
-fastrand-f595c2ba2a3f28df = { package = "fastrand", version = "2" }
+fastrand = { version = "2" }
 fd-lock = { version = "3", default-features = false }
 ff-594e8ee84c453af0 = { package = "ff", version = "0.13", features = ["derive"] }
 ff-5ef9efb8ec2df382 = { package = "ff", version = "0.12", default-features = false }
@@ -232,7 +226,7 @@ fixedbitset-9fbad63c4bcf4a8f = { package = "fixedbitset", version = "0.4", defau
 flate2 = { version = "1" }
 float-cmp = { version = "0.9" }
 fnv = { version = "1" }
-form_urlencoded = { version = "1", default-features = false }
+form_urlencoded = { version = "1" }
 fragile = { version = "2", default-features = false }
 fs_extra = { version = "1", default-features = false }
 funty-dff4ba8e3ae991db = { package = "funty", version = "1", default-features = false }
@@ -242,7 +236,6 @@ futures-channel = { version = "0.3", features = ["sink", "unstable"] }
 futures-core = { version = "0.3", features = ["unstable"] }
 futures-executor = { version = "0.3" }
 futures-io = { version = "0.3", features = ["unstable"] }
-futures-lite = { version = "1" }
 futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", features = ["unstable"] }
 futures-timer = { version = "3", default-features = false }
@@ -250,7 +243,6 @@ futures-util = { version = "0.3", default-features = false, features = ["async-a
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "serde", "zeroize"] }
 getrandom = { version = "0.2", default-features = false, features = ["std"] }
 ghash = { version = "0.5", default-features = false }
-gimli = { version = "0.27", default-features = false, features = ["read"] }
 git-version = { version = "0.3", default-features = false }
 glob = { version = "0.3", default-features = false }
 globset = { version = "0.4" }
@@ -261,7 +253,7 @@ guppy-summaries = { version = "0.7", default-features = false }
 guppy-workspace-hack = { version = "0.1", default-features = false }
 h2 = { version = "0.3", default-features = false }
 hakari = { version = "0.13", default-features = false, features = ["cli-support"] }
-half = { version = "1", default-features = false }
+half = { version = "2", default-features = false }
 handlebars = { version = "4" }
 hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["raw"] }
 hashbrown-594e8ee84c453af0 = { package = "hashbrown", version = "0.13", features = ["raw"] }
@@ -284,7 +276,7 @@ humantime = { version = "2", default-features = false }
 hyper = { version = "0.14", features = ["full"] }
 hyper-rustls-2b5c6dc72f624058 = { package = "hyper-rustls", version = "0.23", features = ["http2", "webpki-tokio"] }
 hyper-timeout = { version = "0.4", default-features = false }
-idna = { version = "0.3", default-features = false }
+idna = { version = "0.5" }
 im = { version = "15", default-features = false }
 impl-codec = { version = "0.5", default-features = false, features = ["std"] }
 impl-serde = { version = "0.3", default-features = false }
@@ -297,7 +289,6 @@ inquire = { version = "0.6" }
 insta = { version = "1", features = ["json", "redactions", "yaml"] }
 instant = { version = "0.1", default-features = false }
 internment = { version = "0.5", default-features = false, features = ["arc"] }
-io-lifetimes = { version = "1" }
 iri-string = { version = "0.4" }
 is-terminal = { version = "0.4", default-features = false }
 itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10" }
@@ -319,7 +310,7 @@ libm = { version = "0.2" }
 libtest-mimic = { version = "0.6", default-features = false }
 libz-sys = { version = "1", default-features = false, features = ["static"] }
 linked-hash-map = { version = "0.5", default-features = false }
-lock_api = { version = "0.4", default-features = false }
+lock_api = { version = "0.4" }
 log = { version = "0.4", default-features = false, features = ["serde", "std"] }
 lru-93f6ce9d446188ac = { package = "lru", version = "0.10" }
 lru-ca01ad9e24f5d932 = { package = "lru", version = "0.7" }
@@ -330,15 +321,13 @@ matchit-ca01ad9e24f5d932 = { package = "matchit", version = "0.7" }
 matchit-d8f496e17d97b5cb = { package = "matchit", version = "0.5" }
 md-5 = { version = "0.9" }
 memchr = { version = "2" }
-memoffset-ca01ad9e24f5d932 = { package = "memoffset", version = "0.7" }
 merlin = { version = "3" }
 migrations_internals = { version = "2", default-features = false }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
-miniz_oxide-3b31131e45eafb45 = { package = "miniz_oxide", version = "0.6", default-features = false }
-miniz_oxide-ca01ad9e24f5d932 = { package = "miniz_oxide", version = "0.7", default-features = false, features = ["with-alloc"] }
-mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
+miniz_oxide = { version = "0.7", default-features = false, features = ["with-alloc"] }
+mio = { version = "0.8", default-features = false, features = ["net", "os-ext"] }
 mockall = { version = "0.11", default-features = false }
 move-abstract-stack = { path = "../../external-crates/move/crates/move-abstract-stack", default-features = false }
 move-binary-format = { path = "../../external-crates/move/crates/move-binary-format" }
@@ -381,6 +370,7 @@ nexlint = { git = "https://github.com/nextest-rs/nexlint.git", rev = "94da5c7876
 nexlint-lints = { git = "https://github.com/nextest-rs/nexlint.git", rev = "94da5c787636dad779c340affa65219134d127f5", default-features = false }
 nibble_vec = { version = "0.1", default-features = false }
 nom = { version = "7" }
+nom8 = { version = "0.2" }
 nonempty = { version = "0.9", default-features = false }
 normalize-line-endings = { version = "0.3", default-features = false }
 ntest = { version = "0.9", default-features = false }
@@ -389,25 +379,23 @@ num = { version = "0.4" }
 num-bigint-9fbad63c4bcf4a8f = { package = "num-bigint", version = "0.4", features = ["rand"] }
 num-bigint-dig = { version = "0.8", default-features = false, features = ["i128", "prime", "u64_digit", "zeroize"] }
 num-complex = { version = "0.4", default-features = false, features = ["std"] }
+num-conv = { version = "0.1", default-features = false }
 num-integer = { version = "0.1", features = ["i128"] }
 num-iter = { version = "0.1", default-features = false, features = ["i128", "std"] }
 num-rational = { version = "0.4", default-features = false, features = ["num-bigint-std", "std"] }
 num-traits = { version = "0.2", features = ["i128", "libm"] }
 num_cpus = { version = "1", default-features = false }
-object = { version = "0.30", default-features = false, features = ["archive", "elf", "macho", "pe", "read_core", "unaligned"] }
 oid-registry = { version = "0.6", features = ["crypto", "x509"] }
 once_cell = { version = "1" }
 oorandom = { version = "11", default-features = false }
 opaque-debug = { version = "0.3", default-features = false }
 opentelemetry-56bd22fc3884b12 = { package = "opentelemetry", version = "0.20", features = ["metrics", "rt-tokio"] }
-opentelemetry-cdcf2f9584511fe6 = { package = "opentelemetry", version = "0.19", default-features = false, features = ["trace"] }
+opentelemetry-647d43efb71741da = { package = "opentelemetry", version = "0.21", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.13" }
 opentelemetry-proto = { version = "0.3", features = ["gen-tonic", "traces"] }
 opentelemetry-semantic-conventions = { version = "0.12", default-features = false }
-opentelemetry_api-56bd22fc3884b12 = { package = "opentelemetry_api", version = "0.20", features = ["logs", "metrics"] }
-opentelemetry_api-cdcf2f9584511fe6 = { package = "opentelemetry_api", version = "0.19" }
-opentelemetry_sdk-56bd22fc3884b12 = { package = "opentelemetry_sdk", version = "0.20", features = ["logs", "metrics", "rt-tokio"] }
-opentelemetry_sdk-cdcf2f9584511fe6 = { package = "opentelemetry_sdk", version = "0.19" }
+opentelemetry_api = { version = "0.20", features = ["logs", "metrics"] }
+opentelemetry_sdk = { version = "0.20", features = ["logs", "metrics", "rt-tokio"] }
 option-ext = { version = "0.2", default-features = false }
 ordered-float = { version = "3" }
 ouroboros = { version = "0.17" }
@@ -417,11 +405,8 @@ p256 = { version = "0.13" }
 pairing = { version = "0.23", default-features = false }
 papergrid = { version = "0.9", default-features = false, features = ["std"] }
 parity-scale-codec = { version = "2", default-features = false, features = ["max-encoded-len", "std"] }
-parking = { version = "2", default-features = false }
-parking_lot-5ef9efb8ec2df382 = { package = "parking_lot", version = "0.12" }
-parking_lot-a6292c17cd707f01 = { package = "parking_lot", version = "0.11" }
-parking_lot_core-274715c4dabd11b0 = { package = "parking_lot_core", version = "0.9", default-features = false }
-parking_lot_core-c38e5c1d305a1b54 = { package = "parking_lot_core", version = "0.8", default-features = false }
+parking_lot = { version = "0.12" }
+parking_lot_core = { version = "0.9", default-features = false }
 pasta_curves = { version = "0.5", features = ["gpu", "serde"] }
 pathdiff = { version = "0.2", default-features = false, features = ["camino"] }
 pbkdf2 = { version = "0.11", default-features = false }
@@ -447,8 +432,9 @@ polyval = { version = "0.6", default-features = false }
 powerfmt = { version = "0.2", default-features = false }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 pq-sys = { version = "0.4", default-features = false }
-predicates = { version = "2" }
+predicates-7b89eefb6aaa9bf3 = { package = "predicates", version = "3", default-features = false, features = ["diff"] }
 predicates-core = { version = "1", default-features = false }
+predicates-f595c2ba2a3f28df = { package = "predicates", version = "2" }
 predicates-tree = { version = "1", default-features = false }
 pretty_assertions = { version = "1" }
 primeorder = { version = "0.13", default-features = false }
@@ -462,8 +448,7 @@ prost-a6292c17cd707f01 = { package = "prost", version = "0.11" }
 prost-types = { version = "0.12" }
 protobuf = { version = "2", default-features = false, features = ["with-bytes"] }
 psm = { version = "0.1", default-features = false }
-quick-error-dff4ba8e3ae991db = { package = "quick-error", version = "1", default-features = false }
-quick-error-f595c2ba2a3f28df = { package = "quick-error", version = "2", default-features = false }
+quick-error = { version = "1", default-features = false }
 quinn = { version = "0.10", default-features = false, features = ["futures-io", "runtime-tokio", "tls-rustls"] }
 quinn-proto = { version = "0.10" }
 quinn-udp = { version = "0.4", default-features = false }
@@ -482,16 +467,17 @@ rayon-core = { version = "1", default-features = false }
 rcgen = { version = "0.9" }
 ref-cast = { version = "1", default-features = false }
 regex = { version = "1" }
-regex-automata = { version = "0.1" }
+regex-automata-9fbad63c4bcf4a8f = { package = "regex-automata", version = "0.4", default-features = false, features = ["dfa-onepass", "dfa-search", "hybrid", "meta", "nfa", "perf", "unicode"] }
+regex-automata-c65f7effa3be6d31 = { package = "regex-automata", version = "0.1" }
 regex-syntax-3b31131e45eafb45 = { package = "regex-syntax", version = "0.6" }
-regex-syntax-ca01ad9e24f5d932 = { package = "regex-syntax", version = "0.7" }
+regex-syntax-c38e5c1d305a1b54 = { package = "regex-syntax", version = "0.8" }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
-retain_mut = { version = "0.1", default-features = false }
 rfc6979-468e82937335b1c9 = { package = "rfc6979", version = "0.3", default-features = false }
 rfc6979-9fbad63c4bcf4a8f = { package = "rfc6979", version = "0.4", default-features = false }
-ring = { version = "0.16" }
+ring-9067fe90e8c1f593 = { package = "ring", version = "0.17" }
+ring-986da7b5efc2b80e = { package = "ring", version = "0.16" }
 ripemd = { version = "0.1", default-features = false }
-roaring = { version = "0.10", default-features = false }
+roaring = { version = "0.10" }
 rsa = { version = "0.8", features = ["sha2"] }
 rusoto_core = { version = "0.48", default-features = false, features = ["rustls"] }
 rusoto_credential = { version = "0.48", default-features = false }
@@ -518,7 +504,7 @@ sec1-468e82937335b1c9 = { package = "sec1", version = "0.3", features = ["subtle
 sec1-ca01ad9e24f5d932 = { package = "sec1", version = "0.7", features = ["pem", "std", "subtle"] }
 secp256k1 = { version = "0.27", features = ["bitcoin_hashes", "global-context", "rand-std", "recovery"] }
 secp256k1-sys = { version = "0.8", default-features = false, features = ["recovery", "std"] }
-semver-dff4ba8e3ae991db = { package = "semver", version = "1", features = ["serde"] }
+semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
 serde-name = { version = "0.2", default-features = false }
 serde-reflection = { version = "0.3", default-features = false }
@@ -551,8 +537,7 @@ sized-chunks = { version = "0.6" }
 slab = { version = "0.4" }
 slip10_ed25519 = { version = "0.1", default-features = false }
 smallvec = { version = "1", default-features = false }
-socket2-9fbad63c4bcf4a8f = { package = "socket2", version = "0.4", default-features = false, features = ["all"] }
-socket2-d8f496e17d97b5cb = { package = "socket2", version = "0.5", default-features = false }
+socket2 = { version = "0.5", default-features = false, features = ["all"] }
 soketto = { version = "0.7", features = ["http"] }
 spin-274715c4dabd11b0 = { package = "spin", version = "0.9", default-features = false, features = ["spin_mutex"] }
 spin-d8f496e17d97b5cb = { package = "spin", version = "0.5", default-features = false }
@@ -561,7 +546,7 @@ spki-ca01ad9e24f5d932 = { package = "spki", version = "0.7", default-features = 
 stacker = { version = "0.1", default-features = false }
 static_assertions = { version = "1", default-features = false }
 strip-ansi-escapes = { version = "0.1", default-features = false }
-strsim = { version = "0.10", default-features = false }
+strsim-a6292c17cd707f01 = { package = "strsim", version = "0.11", default-features = false }
 strum-adf3d7031871b0af = { package = "strum", version = "0.24", features = ["derive"] }
 subtle = { version = "2" }
 subtle-ng = { version = "2", default-features = false, features = ["std"] }
@@ -574,7 +559,7 @@ target-lexicon = { version = "0.12", features = ["std"] }
 target-spec = { version = "1", default-features = false, features = ["summaries"] }
 tempfile = { version = "3", default-features = false }
 termcolor = { version = "1", default-features = false }
-terminal_size = { version = "0.2", default-features = false }
+terminal_size = { version = "0.3", default-features = false }
 termtree = { version = "0.4", default-features = false }
 test-fuzz = { version = "3", default-features = false }
 test-fuzz-internal = { version = "3", default-features = false }
@@ -592,15 +577,15 @@ tokio = { version = "1", features = ["full", "test-util", "tracing"] }
 tokio-io-timeout = { version = "1", default-features = false }
 tokio-rustls-2b5c6dc72f624058 = { package = "tokio-rustls", version = "0.23" }
 tokio-rustls-adf3d7031871b0af = { package = "tokio-rustls", version = "0.24" }
-tokio-stream = { version = "0.1", features = ["net"] }
+tokio-stream = { version = "0.1", features = ["net", "sync"] }
 tokio-tungstenite = { version = "0.20" }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
 toml-ca01ad9e24f5d932 = { package = "toml", version = "0.7", features = ["preserve_order"] }
 toml-d8f496e17d97b5cb = { package = "toml", version = "0.5", features = ["preserve_order"] }
 toml_datetime-3b31131e45eafb45 = { package = "toml_datetime", version = "0.6", default-features = false, features = ["serde"] }
 toml_datetime-d8f496e17d97b5cb = { package = "toml_datetime", version = "0.5", default-features = false }
-toml_edit-3575ec1268b04181 = { package = "toml_edit", version = "0.15" }
 toml_edit-582f2526e08bb6a0 = { package = "toml_edit", version = "0.14", features = ["easy"] }
+toml_edit-9067fe90e8c1f593 = { package = "toml_edit", version = "0.17" }
 toml_edit-cdcf2f9584511fe6 = { package = "toml_edit", version = "0.19", features = ["serde"] }
 tonic-274715c4dabd11b0 = { package = "tonic", version = "0.9" }
 tonic-93f6ce9d446188ac = { package = "tonic", version = "0.10", features = ["tls"] }
@@ -619,7 +604,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["a
 treeline = { version = "0.1", default-features = false }
 try-lock = { version = "0.2", default-features = false }
 ttl_cache = { version = "0.5" }
-tui = { version = "0.17" }
+tui = { version = "0.19" }
 tungstenite = { version = "0.20", default-features = false, features = ["handshake"] }
 twox-hash = { version = "1", default-features = false }
 typenum = { version = "1", default-features = false }
@@ -628,7 +613,7 @@ uint = { version = "0.9" }
 unarray = { version = "0.1", default-features = false }
 unescape = { version = "0.1", default-features = false }
 unicase = { version = "2", default-features = false }
-unicode-bidi = { version = "0.3" }
+unicode-bidi = { version = "0.3", default-features = false, features = ["hardcoded-data", "std"] }
 unicode-ident = { version = "1", default-features = false }
 unicode-normalization = { version = "0.1" }
 unicode-segmentation = { version = "1", default-features = false }
@@ -636,7 +621,8 @@ unicode-width = { version = "0.1" }
 universal-hash = { version = "0.5", default-features = false }
 unsafe-libyaml = { version = "0.2", default-features = false }
 unsigned-varint = { version = "0.7", default-features = false, features = ["std"] }
-untrusted = { version = "0.7", default-features = false }
+untrusted-274715c4dabd11b0 = { package = "untrusted", version = "0.9", default-features = false }
+untrusted-ca01ad9e24f5d932 = { package = "untrusted", version = "0.7", default-features = false }
 ureq = { version = "2" }
 url = { version = "2", features = ["serde"] }
 urlencoding = { version = "2", default-features = false }
@@ -646,14 +632,13 @@ uuid = { version = "1", features = ["fast-rng", "v4"] }
 versions = { version = "4", default-features = false }
 vte = { version = "0.10" }
 wait-timeout = { version = "0.2", default-features = false }
-waker-fn = { version = "1", default-features = false }
 walkdir = { version = "2", default-features = false }
 want = { version = "0.3", default-features = false }
 webpki = { version = "0.22", default-features = false, features = ["std"] }
 webpki-roots-2ffb4c3fe830441c = { package = "webpki-roots", version = "0.25", default-features = false }
 webpki-roots-3c51e837cfc5589a = { package = "webpki-roots", version = "0.22", default-features = false }
 whoami = { version = "1" }
-winnow = { version = "0.4" }
+winnow = { version = "0.5" }
 wyz-6f8ce4dd05d13bba = { package = "wyz", version = "0.2", default-features = false, features = ["alloc"] }
 wyz-d8f496e17d97b5cb = { package = "wyz", version = "0.5", default-features = false }
 x509-parser = { version = "0.14" }
@@ -661,28 +646,27 @@ xml-rs = { version = "0.8", default-features = false }
 yaml-rust = { version = "0.4", default-features = false }
 yansi = { version = "0.5", default-features = false }
 yasna = { version = "0.5", features = ["std", "time"] }
+zerocopy = { version = "0.7", default-features = false, features = ["simd"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 zstd-sys = { version = "2" }
 
 [build-dependencies]
 Inflector = { version = "0.11" }
 addchain = { version = "0.2", default-features = false }
-addr2line = { version = "0.19", default-features = false }
 adler = { version = "1", default-features = false }
 aead = { version = "0.5", default-features = false, features = ["alloc", "getrandom"] }
 aes = { version = "0.8", default-features = false }
 aes-gcm = { version = "0.10" }
 ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8", default-features = false }
 ahash-ca01ad9e24f5d932 = { package = "ahash", version = "0.7" }
-aho-corasick-ca01ad9e24f5d932 = { package = "aho-corasick", version = "0.7" }
-aho-corasick-dff4ba8e3ae991db = { package = "aho-corasick", version = "1" }
+aho-corasick = { version = "1" }
 aliasable = { version = "0.1" }
 alloc-no-stdlib = { version = "2", default-features = false }
 alloc-stdlib = { version = "0.2", default-features = false }
 anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "26d415eb9aa6a2417be3c03c57d6e93c30bd1ad7", default-features = false }
 anes = { version = "0.1" }
 ansi_term = { version = "0.12", default-features = false }
-anstream = { version = "0.5" }
+anstream = { version = "0.6" }
 anstyle = { version = "1" }
 anstyle-parse = { version = "0.2" }
 anstyle-query = { version = "1", default-features = false }
@@ -750,7 +734,7 @@ bincode = { version = "1", default-features = false }
 bindgen = { version = "0.65", default-features = false, features = ["runtime"] }
 bip32 = { version = "0.4" }
 bit-set = { version = "0.5" }
-bit-vec = { version = "0.6", default-features = false, features = ["std"] }
+bit-vec = { version = "0.6" }
 bitcoin-private = { version = "0.1" }
 bitcoin_hashes = { version = "0.12", default-features = false }
 bitflags-dff4ba8e3ae991db = { package = "bitflags", version = "1" }
@@ -791,7 +775,7 @@ cast = { version = "0.3", default-features = false }
 cbc = { version = "0.1", features = ["std"] }
 cc = { version = "1", default-features = false, features = ["parallel"] }
 cexpr = { version = "0.6", default-features = false }
-cfg-expr = { version = "0.13", features = ["targets"] }
+cfg-expr = { version = "0.15", features = ["targets"] }
 cfg-if = { version = "1", default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
 ciborium = { version = "0.2" }
@@ -802,7 +786,7 @@ clang-sys = { version = "1", default-features = false, features = ["clang_6_0", 
 clap = { version = "4", features = ["derive", "wrap_help"] }
 clap_builder = { version = "4", default-features = false, features = ["color", "std", "suggestions", "usage", "wrap_help"] }
 clap_derive = { version = "4" }
-clap_lex = { version = "0.5", default-features = false }
+clap_lex = { version = "0.7", default-features = false }
 clear_on_drop = { version = "0.2", default-features = false }
 codespan = { version = "0.11", default-features = false, features = ["serialization"] }
 codespan-reporting = { version = "0.11", default-features = false, features = ["serialization"] }
@@ -815,8 +799,7 @@ console-api = { version = "0.6", default-features = false, features = ["transpor
 console-subscriber = { version = "0.2" }
 const-oid = { version = "0.9", default-features = false }
 const-str = { version = "0.5" }
-constant_time_eq-468e82937335b1c9 = { package = "constant_time_eq", version = "0.3", default-features = false }
-constant_time_eq-6f8ce4dd05d13bba = { package = "constant_time_eq", version = "0.2", default-features = false }
+constant_time_eq = { version = "0.3", default-features = false }
 convert_case-3b31131e45eafb45 = { package = "convert_case", version = "0.6", default-features = false }
 convert_case-9fbad63c4bcf4a8f = { package = "convert_case", version = "0.4", default-features = false }
 core2 = { version = "0.4", default-features = false, features = ["alloc"] }
@@ -827,9 +810,7 @@ crossbeam-channel = { version = "0.5" }
 crossbeam-deque = { version = "0.8" }
 crossbeam-epoch = { version = "0.9", default-features = false, features = ["std"] }
 crossbeam-utils = { version = "0.8" }
-crossterm-2ffb4c3fe830441c = { package = "crossterm", version = "0.25" }
-crossterm-3c51e837cfc5589a = { package = "crossterm", version = "0.22" }
-crossterm-647d43efb71741da = { package = "crossterm", version = "0.21" }
+crossterm = { version = "0.25" }
 crunchy = { version = "0.2", default-features = false, features = ["std"] }
 crypto-bigint-9fbad63c4bcf4a8f = { package = "crypto-bigint", version = "0.4", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
 crypto-bigint-d8f496e17d97b5cb = { package = "crypto-bigint", version = "0.5", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
@@ -908,8 +889,7 @@ fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "ea66012b
 fastcrypto-derive = { git = "https://github.com/MystenLabs/fastcrypto", rev = "ea66012b860d9dd152abb7f2156275698ee91126", default-features = false }
 fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "ea66012b860d9dd152abb7f2156275698ee91126" }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "ea66012b860d9dd152abb7f2156275698ee91126", default-features = false }
-fastrand-dff4ba8e3ae991db = { package = "fastrand", version = "1", default-features = false }
-fastrand-f595c2ba2a3f28df = { package = "fastrand", version = "2" }
+fastrand = { version = "2" }
 fd-lock = { version = "3", default-features = false }
 ff-594e8ee84c453af0 = { package = "ff", version = "0.13", features = ["derive"] }
 ff-5ef9efb8ec2df382 = { package = "ff", version = "0.12", default-features = false }
@@ -921,7 +901,7 @@ fixedbitset-9fbad63c4bcf4a8f = { package = "fixedbitset", version = "0.4", defau
 flate2 = { version = "1" }
 float-cmp = { version = "0.9" }
 fnv = { version = "1" }
-form_urlencoded = { version = "1", default-features = false }
+form_urlencoded = { version = "1" }
 fragile = { version = "2", default-features = false }
 fs_extra = { version = "1", default-features = false }
 funty-dff4ba8e3ae991db = { package = "funty", version = "1", default-features = false }
@@ -931,7 +911,6 @@ futures-channel = { version = "0.3", features = ["sink", "unstable"] }
 futures-core = { version = "0.3", features = ["unstable"] }
 futures-executor = { version = "0.3" }
 futures-io = { version = "0.3", features = ["unstable"] }
-futures-lite = { version = "1" }
 futures-macro = { version = "0.3", default-features = false }
 futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", features = ["unstable"] }
@@ -940,7 +919,6 @@ futures-util = { version = "0.3", default-features = false, features = ["async-a
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "serde", "zeroize"] }
 getrandom = { version = "0.2", default-features = false, features = ["std"] }
 ghash = { version = "0.5", default-features = false }
-gimli = { version = "0.27", default-features = false, features = ["read"] }
 git-version = { version = "0.3", default-features = false }
 git-version-macro = { version = "0.3", default-features = false }
 glob = { version = "0.3", default-features = false }
@@ -952,7 +930,7 @@ guppy-summaries = { version = "0.7", default-features = false }
 guppy-workspace-hack = { version = "0.1", default-features = false }
 h2 = { version = "0.3", default-features = false }
 hakari = { version = "0.13", default-features = false, features = ["cli-support"] }
-half = { version = "1", default-features = false }
+half = { version = "2", default-features = false }
 handlebars = { version = "4" }
 hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["raw"] }
 hashbrown-594e8ee84c453af0 = { package = "hashbrown", version = "0.13", features = ["raw"] }
@@ -978,7 +956,7 @@ hyper = { version = "0.14", features = ["full"] }
 hyper-rustls-2b5c6dc72f624058 = { package = "hyper-rustls", version = "0.23", features = ["http2", "webpki-tokio"] }
 hyper-timeout = { version = "0.4", default-features = false }
 ident_case = { version = "1", default-features = false }
-idna = { version = "0.3", default-features = false }
+idna = { version = "0.5" }
 if_chain = { version = "1", default-features = false }
 im = { version = "15", default-features = false }
 impl-codec = { version = "0.5", default-features = false, features = ["std"] }
@@ -994,7 +972,6 @@ inquire = { version = "0.6" }
 insta = { version = "1", features = ["json", "redactions", "yaml"] }
 instant = { version = "0.1", default-features = false }
 internment = { version = "0.5", default-features = false, features = ["arc"] }
-io-lifetimes = { version = "1" }
 iri-string = { version = "0.4" }
 is-terminal = { version = "0.4", default-features = false }
 itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10" }
@@ -1016,12 +993,12 @@ lazy_static = { version = "1", default-features = false, features = ["spin_no_st
 lazycell = { version = "1", default-features = false }
 leb128 = { version = "0.2", default-features = false }
 libc = { version = "0.2" }
-libloading = { version = "0.7", default-features = false }
+libloading = { version = "0.8", default-features = false }
 libm = { version = "0.2" }
 libtest-mimic = { version = "0.6", default-features = false }
 libz-sys = { version = "1", default-features = false, features = ["static"] }
 linked-hash-map = { version = "0.5", default-features = false }
-lock_api = { version = "0.4", default-features = false }
+lock_api = { version = "0.4" }
 log = { version = "0.4", default-features = false, features = ["serde", "std"] }
 lru-93f6ce9d446188ac = { package = "lru", version = "0.10" }
 lru-ca01ad9e24f5d932 = { package = "lru", version = "0.7" }
@@ -1032,16 +1009,14 @@ matchit-ca01ad9e24f5d932 = { package = "matchit", version = "0.7" }
 matchit-d8f496e17d97b5cb = { package = "matchit", version = "0.5" }
 md-5 = { version = "0.9" }
 memchr = { version = "2" }
-memoffset-ca01ad9e24f5d932 = { package = "memoffset", version = "0.7" }
 merlin = { version = "3" }
 migrations_internals = { version = "2", default-features = false }
 migrations_macros = { version = "2" }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
-miniz_oxide-3b31131e45eafb45 = { package = "miniz_oxide", version = "0.6", default-features = false }
-miniz_oxide-ca01ad9e24f5d932 = { package = "miniz_oxide", version = "0.7", default-features = false, features = ["with-alloc"] }
-mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
+miniz_oxide = { version = "0.7", default-features = false, features = ["with-alloc"] }
+mio = { version = "0.8", default-features = false, features = ["net", "os-ext"] }
 mockall = { version = "0.11", default-features = false }
 mockall_derive = { version = "0.11", default-features = false }
 move-abstract-stack = { path = "../../external-crates/move/crates/move-abstract-stack", default-features = false }
@@ -1087,6 +1062,7 @@ nexlint = { git = "https://github.com/nextest-rs/nexlint.git", rev = "94da5c7876
 nexlint-lints = { git = "https://github.com/nextest-rs/nexlint.git", rev = "94da5c787636dad779c340affa65219134d127f5", default-features = false }
 nibble_vec = { version = "0.1", default-features = false }
 nom = { version = "7" }
+nom8 = { version = "0.2" }
 nonempty = { version = "0.9", default-features = false }
 normalize-line-endings = { version = "0.3", default-features = false }
 ntest = { version = "0.9", default-features = false }
@@ -1098,25 +1074,23 @@ num-bigint-468e82937335b1c9 = { package = "num-bigint", version = "0.3" }
 num-bigint-9fbad63c4bcf4a8f = { package = "num-bigint", version = "0.4", features = ["rand"] }
 num-bigint-dig = { version = "0.8", default-features = false, features = ["i128", "prime", "u64_digit", "zeroize"] }
 num-complex = { version = "0.4", default-features = false, features = ["std"] }
+num-conv = { version = "0.1", default-features = false }
 num-integer = { version = "0.1", features = ["i128"] }
 num-iter = { version = "0.1", default-features = false, features = ["i128", "std"] }
 num-rational = { version = "0.4", default-features = false, features = ["num-bigint-std", "std"] }
 num-traits = { version = "0.2", features = ["i128", "libm"] }
 num_cpus = { version = "1", default-features = false }
-object = { version = "0.30", default-features = false, features = ["archive", "elf", "macho", "pe", "read_core", "unaligned"] }
 oid-registry = { version = "0.6", features = ["crypto", "x509"] }
 once_cell = { version = "1" }
 oorandom = { version = "11", default-features = false }
 opaque-debug = { version = "0.3", default-features = false }
 opentelemetry-56bd22fc3884b12 = { package = "opentelemetry", version = "0.20", features = ["metrics", "rt-tokio"] }
-opentelemetry-cdcf2f9584511fe6 = { package = "opentelemetry", version = "0.19", default-features = false, features = ["trace"] }
+opentelemetry-647d43efb71741da = { package = "opentelemetry", version = "0.21", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.13" }
 opentelemetry-proto = { version = "0.3", features = ["gen-tonic", "traces"] }
 opentelemetry-semantic-conventions = { version = "0.12", default-features = false }
-opentelemetry_api-56bd22fc3884b12 = { package = "opentelemetry_api", version = "0.20", features = ["logs", "metrics"] }
-opentelemetry_api-cdcf2f9584511fe6 = { package = "opentelemetry_api", version = "0.19" }
-opentelemetry_sdk-56bd22fc3884b12 = { package = "opentelemetry_sdk", version = "0.20", features = ["logs", "metrics", "rt-tokio"] }
-opentelemetry_sdk-cdcf2f9584511fe6 = { package = "opentelemetry_sdk", version = "0.19" }
+opentelemetry_api = { version = "0.20", features = ["logs", "metrics"] }
+opentelemetry_sdk = { version = "0.20", features = ["logs", "metrics", "rt-tokio"] }
 option-ext = { version = "0.2", default-features = false }
 ordered-float = { version = "3" }
 ouroboros = { version = "0.17" }
@@ -1128,11 +1102,8 @@ pairing = { version = "0.23", default-features = false }
 papergrid = { version = "0.9", default-features = false, features = ["std"] }
 parity-scale-codec = { version = "2", default-features = false, features = ["max-encoded-len", "std"] }
 parity-scale-codec-derive = { version = "2", default-features = false, features = ["max-encoded-len"] }
-parking = { version = "2", default-features = false }
-parking_lot-5ef9efb8ec2df382 = { package = "parking_lot", version = "0.12" }
-parking_lot-a6292c17cd707f01 = { package = "parking_lot", version = "0.11" }
-parking_lot_core-274715c4dabd11b0 = { package = "parking_lot_core", version = "0.9", default-features = false }
-parking_lot_core-c38e5c1d305a1b54 = { package = "parking_lot_core", version = "0.8", default-features = false }
+parking_lot = { version = "0.12" }
+parking_lot_core = { version = "0.9", default-features = false }
 pasta_curves = { version = "0.5", features = ["gpu", "serde"] }
 paste = { version = "1", default-features = false }
 pathdiff = { version = "0.2", default-features = false, features = ["camino"] }
@@ -1145,7 +1116,7 @@ percent-encoding = { version = "2" }
 pest = { version = "2" }
 pest_derive = { version = "2" }
 pest_generator = { version = "2", default-features = false, features = ["std"] }
-pest_meta = { version = "2", default-features = false }
+pest_meta = { version = "2" }
 petgraph-3b31131e45eafb45 = { package = "petgraph", version = "0.6", default-features = false, features = ["graphmap"] }
 petgraph-d8f496e17d97b5cb = { package = "petgraph", version = "0.5" }
 phf = { version = "0.11", features = ["macros"] }
@@ -1167,8 +1138,9 @@ polyval = { version = "0.6", default-features = false }
 powerfmt = { version = "0.2", default-features = false }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 pq-sys = { version = "0.4", default-features = false }
-predicates = { version = "2" }
+predicates-7b89eefb6aaa9bf3 = { package = "predicates", version = "3", default-features = false, features = ["diff"] }
 predicates-core = { version = "1", default-features = false }
+predicates-f595c2ba2a3f28df = { package = "predicates", version = "2" }
 predicates-tree = { version = "1", default-features = false }
 pretty_assertions = { version = "1" }
 prettyplease = { version = "0.2", default-features = false }
@@ -1177,7 +1149,6 @@ primitive-types = { version = "0.10", features = ["impl-serde"] }
 proc-macro-crate = { version = "1", default-features = false }
 proc-macro-error = { version = "1" }
 proc-macro-error-attr = { version = "1", default-features = false }
-proc-macro-hack = { version = "0.5", default-features = false }
 proc-macro2-9fbad63c4bcf4a8f = { package = "proc-macro2", version = "0.4" }
 proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1", features = ["span-locations"] }
 prometheus = { version = "0.13" }
@@ -1191,8 +1162,7 @@ prost-derive-a6292c17cd707f01 = { package = "prost-derive", version = "0.11", de
 prost-types = { version = "0.12" }
 protobuf = { version = "2", default-features = false, features = ["with-bytes"] }
 psm = { version = "0.1", default-features = false }
-quick-error-dff4ba8e3ae991db = { package = "quick-error", version = "1", default-features = false }
-quick-error-f595c2ba2a3f28df = { package = "quick-error", version = "2", default-features = false }
+quick-error = { version = "1", default-features = false }
 quinn = { version = "0.10", default-features = false, features = ["futures-io", "runtime-tokio", "tls-rustls"] }
 quinn-proto = { version = "0.10" }
 quinn-udp = { version = "0.4", default-features = false }
@@ -1214,16 +1184,17 @@ readonly = { version = "0.2", default-features = false }
 ref-cast = { version = "1", default-features = false }
 ref-cast-impl = { version = "1", default-features = false }
 regex = { version = "1" }
-regex-automata = { version = "0.1" }
+regex-automata-9fbad63c4bcf4a8f = { package = "regex-automata", version = "0.4", default-features = false, features = ["dfa-onepass", "dfa-search", "hybrid", "meta", "nfa", "perf", "unicode"] }
+regex-automata-c65f7effa3be6d31 = { package = "regex-automata", version = "0.1" }
 regex-syntax-3b31131e45eafb45 = { package = "regex-syntax", version = "0.6" }
-regex-syntax-ca01ad9e24f5d932 = { package = "regex-syntax", version = "0.7" }
+regex-syntax-c38e5c1d305a1b54 = { package = "regex-syntax", version = "0.8" }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
-retain_mut = { version = "0.1", default-features = false }
 rfc6979-468e82937335b1c9 = { package = "rfc6979", version = "0.3", default-features = false }
 rfc6979-9fbad63c4bcf4a8f = { package = "rfc6979", version = "0.4", default-features = false }
-ring = { version = "0.16" }
+ring-9067fe90e8c1f593 = { package = "ring", version = "0.17" }
+ring-986da7b5efc2b80e = { package = "ring", version = "0.16" }
 ripemd = { version = "0.1", default-features = false }
-roaring = { version = "0.10", default-features = false }
+roaring = { version = "0.10" }
 rsa = { version = "0.8", features = ["sha2"] }
 rusoto_core = { version = "0.48", default-features = false, features = ["rustls"] }
 rusoto_credential = { version = "0.48", default-features = false }
@@ -1254,9 +1225,7 @@ sec1-468e82937335b1c9 = { package = "sec1", version = "0.3", features = ["subtle
 sec1-ca01ad9e24f5d932 = { package = "sec1", version = "0.7", features = ["pem", "std", "subtle"] }
 secp256k1 = { version = "0.27", features = ["bitcoin_hashes", "global-context", "rand-std", "recovery"] }
 secp256k1-sys = { version = "0.8", default-features = false, features = ["recovery", "std"] }
-semver-a6292c17cd707f01 = { package = "semver", version = "0.11" }
-semver-dff4ba8e3ae991db = { package = "semver", version = "1", features = ["serde"] }
-semver-parser = { version = "0.10", default-features = false }
+semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
 serde-name = { version = "0.2", default-features = false }
 serde-reflection = { version = "0.3", default-features = false }
@@ -1294,8 +1263,7 @@ sized-chunks = { version = "0.6" }
 slab = { version = "0.4" }
 slip10_ed25519 = { version = "0.1", default-features = false }
 smallvec = { version = "1", default-features = false }
-socket2-9fbad63c4bcf4a8f = { package = "socket2", version = "0.4", default-features = false, features = ["all"] }
-socket2-d8f496e17d97b5cb = { package = "socket2", version = "0.5", default-features = false }
+socket2 = { version = "0.5", default-features = false, features = ["all"] }
 soketto = { version = "0.7", features = ["http"] }
 spin-274715c4dabd11b0 = { package = "spin", version = "0.9", default-features = false, features = ["spin_mutex"] }
 spin-d8f496e17d97b5cb = { package = "spin", version = "0.5", default-features = false }
@@ -1304,7 +1272,8 @@ spki-ca01ad9e24f5d932 = { package = "spki", version = "0.7", default-features = 
 stacker = { version = "0.1", default-features = false }
 static_assertions = { version = "1", default-features = false }
 strip-ansi-escapes = { version = "0.1", default-features = false }
-strsim = { version = "0.10", default-features = false }
+strsim-93f6ce9d446188ac = { package = "strsim", version = "0.10", default-features = false }
+strsim-a6292c17cd707f01 = { package = "strsim", version = "0.11", default-features = false }
 strum-2ffb4c3fe830441c = { package = "strum", version = "0.25", features = ["derive"] }
 strum-adf3d7031871b0af = { package = "strum", version = "0.24", features = ["derive"] }
 strum_macros-2ffb4c3fe830441c = { package = "strum_macros", version = "0.25", default-features = false }
@@ -1313,7 +1282,7 @@ subprocess = { version = "0.2", default-features = false }
 subtle = { version = "2" }
 subtle-ng = { version = "2", default-features = false, features = ["std"] }
 syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["extra-traits", "full", "visit"] }
-syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "fold", "full", "visit"] }
 syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 sync_wrapper = { version = "0.1", default-features = false }
 synstructure = { version = "0.12" }
@@ -1326,7 +1295,7 @@ target-lexicon = { version = "0.12", features = ["std"] }
 target-spec = { version = "1", default-features = false, features = ["summaries"] }
 tempfile = { version = "3", default-features = false }
 termcolor = { version = "1", default-features = false }
-terminal_size = { version = "0.2", default-features = false }
+terminal_size = { version = "0.3", default-features = false }
 termtree = { version = "0.4", default-features = false }
 test-fuzz = { version = "3", default-features = false }
 test-fuzz-internal = { version = "3", default-features = false }
@@ -1348,19 +1317,19 @@ tokio-io-timeout = { version = "1", default-features = false }
 tokio-macros = { version = "2", default-features = false }
 tokio-rustls-2b5c6dc72f624058 = { package = "tokio-rustls", version = "0.23" }
 tokio-rustls-adf3d7031871b0af = { package = "tokio-rustls", version = "0.24" }
-tokio-stream = { version = "0.1", features = ["net"] }
+tokio-stream = { version = "0.1", features = ["net", "sync"] }
 tokio-tungstenite = { version = "0.20" }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
 toml-ca01ad9e24f5d932 = { package = "toml", version = "0.7", features = ["preserve_order"] }
 toml-d8f496e17d97b5cb = { package = "toml", version = "0.5", features = ["preserve_order"] }
 toml_datetime-3b31131e45eafb45 = { package = "toml_datetime", version = "0.6", default-features = false, features = ["serde"] }
 toml_datetime-d8f496e17d97b5cb = { package = "toml_datetime", version = "0.5", default-features = false }
-toml_edit-3575ec1268b04181 = { package = "toml_edit", version = "0.15" }
 toml_edit-582f2526e08bb6a0 = { package = "toml_edit", version = "0.14", features = ["easy"] }
+toml_edit-9067fe90e8c1f593 = { package = "toml_edit", version = "0.17" }
 toml_edit-cdcf2f9584511fe6 = { package = "toml_edit", version = "0.19", features = ["serde"] }
 tonic-274715c4dabd11b0 = { package = "tonic", version = "0.9" }
 tonic-93f6ce9d446188ac = { package = "tonic", version = "0.10", features = ["tls"] }
-toolchain_find = { version = "0.2", default-features = false }
+toolchain_find = { version = "0.3", default-features = false }
 tower = { version = "0.4", features = ["full"] }
 tower-http = { version = "0.3", features = ["full"] }
 tower-layer = { version = "0.3", default-features = false }
@@ -1378,7 +1347,7 @@ trait-set = { version = "0.3", default-features = false }
 treeline = { version = "0.1", default-features = false }
 try-lock = { version = "0.2", default-features = false }
 ttl_cache = { version = "0.5" }
-tui = { version = "0.17" }
+tui = { version = "0.19" }
 tungstenite = { version = "0.20", default-features = false, features = ["handshake"] }
 twox-hash = { version = "1", default-features = false }
 typenum = { version = "1", default-features = false }
@@ -1387,7 +1356,7 @@ uint = { version = "0.9" }
 unarray = { version = "0.1", default-features = false }
 unescape = { version = "0.1", default-features = false }
 unicase = { version = "2", default-features = false }
-unicode-bidi = { version = "0.3" }
+unicode-bidi = { version = "0.3", default-features = false, features = ["hardcoded-data", "std"] }
 unicode-ident = { version = "1", default-features = false }
 unicode-normalization = { version = "0.1" }
 unicode-segmentation = { version = "1", default-features = false }
@@ -1397,8 +1366,8 @@ unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 universal-hash = { version = "0.5", default-features = false }
 unsafe-libyaml = { version = "0.2", default-features = false }
 unsigned-varint = { version = "0.7", default-features = false, features = ["std"] }
-untrusted = { version = "0.7", default-features = false }
-unzip-n = { version = "0.1", default-features = false }
+untrusted-274715c4dabd11b0 = { package = "untrusted", version = "0.9", default-features = false }
+untrusted-ca01ad9e24f5d932 = { package = "untrusted", version = "0.7", default-features = false }
 ureq = { version = "2" }
 url = { version = "2", features = ["serde"] }
 urlencoding = { version = "2", default-features = false }
@@ -1406,19 +1375,19 @@ utf-8 = { version = "0.7", default-features = false }
 utf8parse = { version = "0.2" }
 uuid = { version = "1", features = ["fast-rng", "v4"] }
 variant_count = { version = "1", default-features = false }
+vcpkg = { version = "0.2", default-features = false }
 version_check = { version = "0.9", default-features = false }
 versions = { version = "4", default-features = false }
 vte = { version = "0.10" }
 vte_generate_state_changes = { version = "0.1", default-features = false }
 wait-timeout = { version = "0.2", default-features = false }
-waker-fn = { version = "1", default-features = false }
 walkdir = { version = "2", default-features = false }
 want = { version = "0.3", default-features = false }
 webpki = { version = "0.22", default-features = false, features = ["std"] }
 webpki-roots-2ffb4c3fe830441c = { package = "webpki-roots", version = "0.25", default-features = false }
 webpki-roots-3c51e837cfc5589a = { package = "webpki-roots", version = "0.22", default-features = false }
 whoami = { version = "1" }
-winnow = { version = "0.4" }
+winnow = { version = "0.5" }
 wyz-6f8ce4dd05d13bba = { package = "wyz", version = "0.2", default-features = false, features = ["alloc"] }
 wyz-d8f496e17d97b5cb = { package = "wyz", version = "0.5", default-features = false }
 x509-parser = { version = "0.14" }
@@ -1426,162 +1395,160 @@ xml-rs = { version = "0.8", default-features = false }
 yaml-rust = { version = "0.4", default-features = false }
 yansi = { version = "0.5", default-features = false }
 yasna = { version = "0.5", features = ["std", "time"] }
+zerocopy = { version = "0.7", default-features = false, features = ["simd"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 zeroize_derive = { version = "1", default-features = false }
 zstd-sys = { version = "2" }
 
 [target.aarch64-apple-darwin.dependencies]
+addr2line = { version = "0.21", default-features = false }
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false, features = ["std"] }
-core-foundation = { version = "0.9", default-features = false }
-core-foundation-sys = { version = "0.8", default-features = false }
+core-foundation = { version = "0.9" }
+core-foundation-sys = { version = "0.8" }
 cpufeatures = { version = "0.2", default-features = false }
-errno-468e82937335b1c9 = { package = "errno", version = "0.3", default-features = false, features = ["std"] }
-errno-6f8ce4dd05d13bba = { package = "errno", version = "0.2", default-features = false }
+errno = { version = "0.3", default-features = false, features = ["std"] }
+gimli = { version = "0.28", default-features = false, features = ["read"] }
 hyper-rustls-adf3d7031871b0af = { package = "hyper-rustls", version = "0.24", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 ipnet = { version = "2" }
 jemalloc-ctl = { version = "0.5" }
 jemalloc-sys = { version = "0.5" }
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
-memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
-mio-ca01ad9e24f5d932 = { package = "mio", version = "0.7", features = ["os-util", "uds"] }
+memoffset = { version = "0.6" }
+mio = { version = "0.8" }
 nix = { version = "0.23", default-features = false }
-once_cell = { version = "1", default-features = false, features = ["unstable"] }
-rustix-4e55305914c60c55 = { package = "rustix", version = "0.36", features = ["fs"] }
-rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["fs"] }
-rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["termios"] }
+object = { version = "0.32", default-features = false, features = ["archive", "elf", "macho", "pe", "read_core", "unaligned"] }
+rustix = { version = "0.38", features = ["fs", "termios"] }
 security-framework = { version = "2" }
 security-framework-sys = { version = "2", default-features = false, features = ["OSX_10_9"] }
 signal-hook = { version = "0.3" }
-signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_7", "support-v0_8"] }
+signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_8"] }
 signal-hook-registry = { version = "1", default-features = false }
+spin-274715c4dabd11b0 = { package = "spin", version = "0.9", default-features = false, features = ["once"] }
+system-configuration = { version = "0.5", default-features = false }
+system-configuration-sys = { version = "0.5", default-features = false }
 xattr = { version = "1" }
 
 [target.aarch64-apple-darwin.build-dependencies]
+addr2line = { version = "0.21", default-features = false }
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false, features = ["std"] }
-core-foundation = { version = "0.9", default-features = false }
-core-foundation-sys = { version = "0.8", default-features = false }
+core-foundation = { version = "0.9" }
+core-foundation-sys = { version = "0.8" }
 cpufeatures = { version = "0.2", default-features = false }
-errno-468e82937335b1c9 = { package = "errno", version = "0.3", default-features = false, features = ["std"] }
-errno-6f8ce4dd05d13bba = { package = "errno", version = "0.2", default-features = false }
+errno = { version = "0.3", default-features = false, features = ["std"] }
+gimli = { version = "0.28", default-features = false, features = ["read"] }
 hyper-rustls-adf3d7031871b0af = { package = "hyper-rustls", version = "0.24", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 ipnet = { version = "2" }
 jemalloc-ctl = { version = "0.5" }
 jemalloc-sys = { version = "0.5" }
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
-memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
-mio-ca01ad9e24f5d932 = { package = "mio", version = "0.7", features = ["os-util", "uds"] }
+memoffset = { version = "0.6" }
+mio = { version = "0.8" }
 nix = { version = "0.23", default-features = false }
-once_cell = { version = "1", default-features = false, features = ["unstable"] }
-rustix-4e55305914c60c55 = { package = "rustix", version = "0.36", features = ["fs"] }
-rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["fs"] }
-rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["termios"] }
+object = { version = "0.32", default-features = false, features = ["archive", "elf", "macho", "pe", "read_core", "unaligned"] }
+rustix = { version = "0.38", features = ["fs", "termios"] }
 security-framework = { version = "2" }
 security-framework-sys = { version = "2", default-features = false, features = ["OSX_10_9"] }
 signal-hook = { version = "0.3" }
-signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_7", "support-v0_8"] }
+signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_8"] }
 signal-hook-registry = { version = "1", default-features = false }
+spin-274715c4dabd11b0 = { package = "spin", version = "0.9", default-features = false, features = ["once"] }
+system-configuration = { version = "0.5", default-features = false }
+system-configuration-sys = { version = "0.5", default-features = false }
 xattr = { version = "1" }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
+addr2line = { version = "0.21", default-features = false }
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false, features = ["std"] }
 cpufeatures = { version = "0.2", default-features = false }
+gimli = { version = "0.28", default-features = false, features = ["read"] }
 hyper-rustls-adf3d7031871b0af = { package = "hyper-rustls", version = "0.24", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 ipnet = { version = "2" }
 jemalloc-ctl = { version = "0.5" }
 jemalloc-sys = { version = "0.5" }
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
-linux-raw-sys-468e82937335b1c9 = { package = "linux-raw-sys", version = "0.3", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
-linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = ["elf", "errno", "general", "ioctl", "no_std", "std"] }
-linux-raw-sys-c65f7effa3be6d31 = { package = "linux-raw-sys", version = "0.1", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
-memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
-mio-ca01ad9e24f5d932 = { package = "mio", version = "0.7", features = ["os-util", "uds"] }
+linux-raw-sys = { version = "0.4", default-features = false, features = ["elf", "errno", "general", "ioctl", "no_std", "std"] }
+memoffset = { version = "0.6" }
+mio = { version = "0.8" }
 nix = { version = "0.23", default-features = false }
-once_cell = { version = "1", default-features = false, features = ["unstable"] }
+object = { version = "0.32", default-features = false, features = ["archive", "elf", "macho", "pe", "read_core", "unaligned"] }
 openssl-probe = { version = "0.1", default-features = false }
-rustix-4e55305914c60c55 = { package = "rustix", version = "0.36", features = ["fs"] }
-rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["fs"] }
-rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["termios"] }
+rustix = { version = "0.38", features = ["fs", "termios"] }
 signal-hook = { version = "0.3" }
-signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_7", "support-v0_8"] }
+signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_8"] }
 signal-hook-registry = { version = "1", default-features = false }
+spin-274715c4dabd11b0 = { package = "spin", version = "0.9", default-features = false, features = ["once"] }
 xattr = { version = "1" }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
+addr2line = { version = "0.21", default-features = false }
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false, features = ["std"] }
 cpufeatures = { version = "0.2", default-features = false }
+gimli = { version = "0.28", default-features = false, features = ["read"] }
 hyper-rustls-adf3d7031871b0af = { package = "hyper-rustls", version = "0.24", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 ipnet = { version = "2" }
 jemalloc-ctl = { version = "0.5" }
 jemalloc-sys = { version = "0.5" }
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
-linux-raw-sys-468e82937335b1c9 = { package = "linux-raw-sys", version = "0.3", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
-linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = ["elf", "errno", "general", "ioctl", "no_std", "std"] }
-linux-raw-sys-c65f7effa3be6d31 = { package = "linux-raw-sys", version = "0.1", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
-memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
-mio-ca01ad9e24f5d932 = { package = "mio", version = "0.7", features = ["os-util", "uds"] }
+linux-raw-sys = { version = "0.4", default-features = false, features = ["elf", "errno", "general", "ioctl", "no_std", "std"] }
+memoffset = { version = "0.6" }
+mio = { version = "0.8" }
 nix = { version = "0.23", default-features = false }
-once_cell = { version = "1", default-features = false, features = ["unstable"] }
+object = { version = "0.32", default-features = false, features = ["archive", "elf", "macho", "pe", "read_core", "unaligned"] }
 openssl-probe = { version = "0.1", default-features = false }
-rustix-4e55305914c60c55 = { package = "rustix", version = "0.36", features = ["fs"] }
-rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["fs"] }
-rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["termios"] }
+rustix = { version = "0.38", features = ["fs", "termios"] }
 signal-hook = { version = "0.3" }
-signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_7", "support-v0_8"] }
+signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_8"] }
 signal-hook-registry = { version = "1", default-features = false }
+spin-274715c4dabd11b0 = { package = "spin", version = "0.9", default-features = false, features = ["once"] }
 xattr = { version = "1" }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-anstyle-wincon = { version = "2", default-features = false }
+anstyle-wincon = { version = "3", default-features = false }
 clipboard-win = { version = "4", default-features = false }
 cpufeatures = { version = "0.2", default-features = false }
-crossterm_winapi-274715c4dabd11b0 = { package = "crossterm_winapi", version = "0.9", default-features = false }
-crossterm_winapi-c38e5c1d305a1b54 = { package = "crossterm_winapi", version = "0.8", default-features = false }
+crossterm_winapi = { version = "0.9", default-features = false }
 encode_unicode = { version = "0.3" }
 error-code = { version = "2", default-features = false }
 hyper-rustls-adf3d7031871b0af = { package = "hyper-rustls", version = "0.24", default-features = false }
 ipnet = { version = "2" }
-once_cell = { version = "1", default-features = false, features = ["unstable"] }
-output_vt100 = { version = "0.1", default-features = false }
 schannel = { version = "0.1", default-features = false }
+spin-274715c4dabd11b0 = { package = "spin", version = "0.9", default-features = false, features = ["once"] }
 str-buf = { version = "1", default-features = false }
 widestring = { version = "0.5" }
-winapi = { version = "0.3", default-features = false, features = ["basetsd", "consoleapi", "errhandlingapi", "fibersapi", "fileapi", "handleapi", "impl-default", "knownfolders", "libloaderapi", "memoryapi", "minwindef", "namedpipeapi", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "winbase", "wincon", "winerror", "winnt", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
+winapi = { version = "0.3", default-features = false, features = ["basetsd", "consoleapi", "errhandlingapi", "fibersapi", "fileapi", "handleapi", "impl-default", "knownfolders", "memoryapi", "minwindef", "namedpipeapi", "ntsecapi", "objbase", "processenv", "processthreadsapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "sysinfoapi", "winbase", "wincon", "winerror", "winnt", "winuser", "wtypesbase"] }
 winapi-util = { version = "0.1", default-features = false }
-windows-sys-b32c9ddb6d93a9d2 = { package = "windows-sys", version = "0.42", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
+windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_Memory", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell"] }
 windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = ["Win32_Foundation", "Win32_Globalization", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_Diagnostics_Debug", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_Registry", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_Time", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }
-windows-targets = { version = "0.48", default-features = false }
-windows_x86_64_msvc-b32c9ddb6d93a9d2 = { package = "windows_x86_64_msvc", version = "0.42", default-features = false }
+windows-targets-b21d60becc0929df = { package = "windows-targets", version = "0.52", default-features = false }
+windows-targets-c8eced492e86ede7 = { package = "windows-targets", version = "0.48", default-features = false }
+windows_x86_64_msvc-b21d60becc0929df = { package = "windows_x86_64_msvc", version = "0.52", default-features = false }
 windows_x86_64_msvc-c8eced492e86ede7 = { package = "windows_x86_64_msvc", version = "0.48", default-features = false }
 winreg = { version = "0.50", default-features = false }
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
-anstyle-wincon = { version = "2", default-features = false }
+anstyle-wincon = { version = "3", default-features = false }
 clipboard-win = { version = "4", default-features = false }
 cpufeatures = { version = "0.2", default-features = false }
-crossterm_winapi-274715c4dabd11b0 = { package = "crossterm_winapi", version = "0.9", default-features = false }
-crossterm_winapi-c38e5c1d305a1b54 = { package = "crossterm_winapi", version = "0.8", default-features = false }
-ctor = { version = "0.1", default-features = false }
+crossterm_winapi = { version = "0.9", default-features = false }
 encode_unicode = { version = "0.3" }
 error-code = { version = "2", default-features = false }
 hyper-rustls-adf3d7031871b0af = { package = "hyper-rustls", version = "0.24", default-features = false }
 ipnet = { version = "2" }
-once_cell = { version = "1", default-features = false, features = ["unstable"] }
-output_vt100 = { version = "0.1", default-features = false }
 schannel = { version = "0.1", default-features = false }
+spin-274715c4dabd11b0 = { package = "spin", version = "0.9", default-features = false, features = ["once"] }
 str-buf = { version = "1", default-features = false }
-vcpkg = { version = "0.2", default-features = false }
-which = { version = "4", default-features = false }
 widestring = { version = "0.5" }
-winapi = { version = "0.3", default-features = false, features = ["basetsd", "consoleapi", "errhandlingapi", "fibersapi", "fileapi", "handleapi", "impl-default", "knownfolders", "libloaderapi", "memoryapi", "minwindef", "namedpipeapi", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "winbase", "wincon", "winerror", "winnt", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
+winapi = { version = "0.3", default-features = false, features = ["basetsd", "consoleapi", "errhandlingapi", "fibersapi", "fileapi", "handleapi", "impl-default", "knownfolders", "memoryapi", "minwindef", "namedpipeapi", "ntsecapi", "objbase", "processenv", "processthreadsapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "sysinfoapi", "winbase", "wincon", "winerror", "winnt", "winuser", "wtypesbase"] }
 winapi-util = { version = "0.1", default-features = false }
-windows-sys-b32c9ddb6d93a9d2 = { package = "windows-sys", version = "0.42", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
+windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_Memory", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell"] }
 windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = ["Win32_Foundation", "Win32_Globalization", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_Diagnostics_Debug", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_Registry", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_Time", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }
-windows-targets = { version = "0.48", default-features = false }
-windows_x86_64_msvc-b32c9ddb6d93a9d2 = { package = "windows_x86_64_msvc", version = "0.42", default-features = false }
+windows-targets-b21d60becc0929df = { package = "windows-targets", version = "0.52", default-features = false }
+windows-targets-c8eced492e86ede7 = { package = "windows-targets", version = "0.48", default-features = false }
+windows_x86_64_msvc-b21d60becc0929df = { package = "windows_x86_64_msvc", version = "0.52", default-features = false }
 windows_x86_64_msvc-c8eced492e86ede7 = { package = "windows_x86_64_msvc", version = "0.48", default-features = false }
 winreg = { version = "0.50", default-features = false }
 

--- a/deny.toml
+++ b/deny.toml
@@ -48,9 +48,6 @@ notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    # "RUSTSEC-0000-0000",
-    # potential segfault in the time crate, brought by chrono et al.
-    "RUSTSEC-2020-0071",
     # difference 2.0.0 is unmaintained
     "RUSTSEC-2020-0095",
     # rusoto is unmaintained, use aws crates
@@ -99,6 +96,7 @@ allow = [
     "BSL-1.0",
     "Unicode-DFS-2016",
     #"Apache-2.0 WITH LLVM-exception",
+    "WTFPL",
 ]
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -25,7 +25,7 @@ criterion = "0.3.4"
 criterion-cpu-time = "0.1.0"
 crossbeam = "0.8"
 crossbeam-channel = "0.5.0"
-crossterm = "0.21"
+crossterm = "0.25.0"
 curve25519-dalek = { version = "0.1.0", package = "curve25519-dalek-fiat", default-features = false, features = ["std", "u64_backend"] }
 datatest-stable = "0.1.1"
 derivative = "2.2.0"
@@ -100,7 +100,7 @@ toml_edit =  { version = "0.14.3", features = ["easy"] }
 tracing = "0.1.26"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 treeline = "0.1.0"
-tui = "0.17.0"
+tui = "0.19.0"
 uint = "0.9.4"
 url = "2.2.2"
 variant_count = "1.1.0"


### PR DESCRIPTION
# Description of change

[cargo-deny](https://embarkstudios.github.io/cargo-deny/) is a cargo plugin that lets you lint your project's dependency graph to ensure all your dependencies conform to your expectations and requirements.

It is already integrate in our [actions](https://github.com/iotaledger/kinesis/blob/e575028e7a5ed87c6d07b785a381d7fe8e01c05b/.github/workflows/rust.yml#L183-L190):
```yaml
cargo-deny:
  name: cargo-deny (advisories, licenses, bans, ...)
  needs: diff
  if: needs.diff.outputs.isRust == 'true'
  runs-on: [ubuntu-latest]
  steps:
    - uses: actions/checkout@v3
    - uses: mystenlabs/cargo-deny-action@main
```

What has changed in this PR:
1. Sync `deny.toml` with the latest version from the Sui repository.
2. Updated the project dependencies to make `cargo-deny` happy.
3. Regenerated the `workspace-hack` crate and added it as a reference to `sui-core` to fix the integration.

## Links to any relevant issues

Fixes #19 
