### PR TITLE
feat: parse stardust snapshots 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,15 +86,16 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.2"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "const-random",
  "getrandom 0.2.9",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -179,7 +180,7 @@ dependencies = [
  "rcgen",
  "ring 0.16.20",
  "rustls 0.21.6",
- "rustls-webpki 0.101.4",
+ "rustls-webpki 0.101.7",
  "serde",
  "serde_json",
  "socket2 0.5.6",
@@ -596,13 +597,13 @@ version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d390feeb7f21b78ec997a4081a025baef1e2e0d6069e181939b61864c9779609"
 dependencies = [
- "ahash 0.8.2",
+ "ahash 0.8.11",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
  "chrono",
  "half 2.3.1",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.3",
  "num",
 ]
 
@@ -693,7 +694,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half 2.3.1",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "lexical-core",
  "num",
  "serde",
@@ -721,13 +722,13 @@ version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007035e17ae09c4e8993e4cb8b5b96edf0afb927cd38e2dff27189b274d83dcf"
 dependencies = [
- "ahash 0.8.2",
+ "ahash 0.8.11",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
  "half 2.3.1",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -742,7 +743,7 @@ version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce20973c1912de6514348e064829e50947e35977bb9d7fb637dc99ea9ffd78c"
 dependencies = [
- "ahash 0.8.2",
+ "ahash 0.8.11",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
@@ -873,7 +874,7 @@ dependencies = [
  "futures-util",
  "handlebars",
  "http",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "lru 0.7.8",
  "mime",
  "multer",
@@ -946,7 +947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d74240f9daa8c1e8f73e9cfcc338d20a88d00bbeb83ded49ce8e5b4dcec0f5"
 dependencies = [
  "bytes",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "serde",
  "serde_json",
 ]
@@ -1000,13 +1001,29 @@ source = "git+https://github.com/mystenmark/async-task?rev=4e45b26e11126b191701b
 
 [[package]]
 name = "async-trait"
-version = "0.1.73"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "async-tungstenite"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e9efbe14612da0a19fb983059a0b621e9cf6225d7018ecab4f9988215540dc"
+dependencies = [
+ "futures-io",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls 0.24.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -1018,6 +1035,7 @@ dependencies = [
  "futures",
  "pharos",
  "rustc_version",
+ "tokio",
 ]
 
 [[package]]
@@ -1740,106 +1758,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
-name = "bee-block"
-version = "0.1.0"
-source = "git+https://github.com/Thoralf-M/bee?rev=2429d29752f5af4df538e3ddb6585db9cd6f5b8a#2429d29752f5af4df538e3ddb6585db9cd6f5b8a"
-dependencies = [
- "bech32",
- "bee-pow",
- "bee-ternary",
- "bitflags 1.3.2",
- "bytemuck",
- "derive_more",
- "hashbrown 0.12.3",
- "hex",
- "iota-crypto",
- "iterator-sorted",
- "packable",
- "prefix-hex",
- "primitive-types 0.11.1",
- "serde",
- "serde-big-array",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "bee-ledger"
-version = "0.7.0"
-source = "git+https://github.com/Thoralf-M/bee?rev=2429d29752f5af4df538e3ddb6585db9cd6f5b8a#2429d29752f5af4df538e3ddb6585db9cd6f5b8a"
-dependencies = [
- "bee-block",
- "packable",
- "thiserror",
- "time-helper",
-]
-
-[[package]]
-name = "bee-pow"
-version = "0.2.0"
-source = "git+https://github.com/Thoralf-M/bee?rev=2429d29752f5af4df538e3ddb6585db9cd6f5b8a#2429d29752f5af4df538e3ddb6585db9cd6f5b8a"
-dependencies = [
- "bee-ternary",
- "iota-crypto",
- "thiserror",
-]
-
-[[package]]
-name = "bee-runtime"
-version = "0.1.1-alpha"
-source = "git+https://github.com/Thoralf-M/bee?rev=2429d29752f5af4df538e3ddb6585db9cd6f5b8a#2429d29752f5af4df538e3ddb6585db9cd6f5b8a"
-dependencies = [
- "async-trait",
- "bee-storage",
- "dashmap",
- "futures",
- "log",
-]
-
-[[package]]
-name = "bee-storage"
-version = "0.12.0"
-source = "git+https://github.com/Thoralf-M/bee?rev=2429d29752f5af4df538e3ddb6585db9cd6f5b8a#2429d29752f5af4df538e3ddb6585db9cd6f5b8a"
-dependencies = [
- "packable",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "bee-tangle"
-version = "0.3.0"
-source = "git+https://github.com/Thoralf-M/bee?rev=2429d29752f5af4df538e3ddb6585db9cd6f5b8a#2429d29752f5af4df538e3ddb6585db9cd6f5b8a"
-dependencies = [
- "async-trait",
- "bee-block",
- "bee-runtime",
- "bee-storage",
- "bitflags 1.3.2",
- "futures",
- "hashbrown 0.12.3",
- "log",
- "packable",
- "rand 0.8.5",
- "ref-cast",
- "serde",
- "thiserror",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "bee-ternary"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b9489a68e42231e9f4f1443c765d3f80433a52101510ab413e6a9cd2240d21"
-dependencies = [
- "autocfg",
- "num-traits",
- "serde",
-]
-
-[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,7 +1956,7 @@ checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq",
+ "constant_time_eq 0.3.0",
 ]
 
 [[package]]
@@ -2049,7 +1967,7 @@ checksum = "94230421e395b9920d23df13ea5d77a20e1725331f90fbbf6df6040b33f756ae"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq",
+ "constant_time_eq 0.3.0",
 ]
 
 [[package]]
@@ -2174,7 +2092,7 @@ checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
 dependencies = [
  "memchr",
  "once_cell",
- "regex-automata",
+ "regex-automata 0.1.10",
  "serde",
 ]
 
@@ -2209,9 +2127,9 @@ checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
 name = "bytemuck"
-version = "1.12.3"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaa3a8d9a1ca92e282c96a32d6511b695d7d994d1d102ba85d279f9b2756947f"
+checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
 
 [[package]]
 name = "byteorder"
@@ -2408,6 +2326,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2457,6 +2388,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -2792,9 +2724,9 @@ checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "const-random"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11df32a13d7892ec42d51d3d175faba5211ffe13ed25d4fb348ac9e9ce835593"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
 dependencies = [
  "const-random-macro",
 ]
@@ -2815,6 +2747,12 @@ name = "const-str"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aca749d3d3f5b87a0d6100509879f9cf486ab510803a4a4e1001da1ff61c2bd6"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
@@ -3342,7 +3280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.9",
@@ -3870,6 +3808,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve 0.13.4",
  "rfc6979 0.4.0",
+ "serdect",
  "signature 2.0.0",
 ]
 
@@ -3892,6 +3831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60f6d271ca33075c88028be6f04d502853d63a5ece419d269c15315d4fc1cf1d"
 dependencies = [
  "pkcs8 0.10.2",
+ "serde",
  "signature 2.0.0",
 ]
 
@@ -3941,15 +3881,17 @@ dependencies = [
 
 [[package]]
 name = "ed25519-zebra"
-version = "3.1.0"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
+checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
 dependencies = [
- "curve25519-dalek 3.2.0",
- "hashbrown 0.12.3",
+ "curve25519-dalek 4.1.0",
+ "ed25519 2.2.2",
+ "hashbrown 0.14.3",
  "hex",
  "rand_core 0.6.4",
- "sha2 0.9.9",
+ "serde",
+ "sha2 0.10.6",
  "zeroize",
 ]
 
@@ -3994,6 +3936,7 @@ dependencies = [
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1 0.7.1",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -4141,7 +4084,7 @@ dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.11.0",
  "rand 0.8.5",
- "scrypt",
+ "scrypt 0.10.0",
  "serde",
  "serde_json",
  "sha2 0.10.6",
@@ -4763,6 +4706,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4770,9 +4724,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -4812,9 +4766,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4827,9 +4781,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -4837,26 +4791,27 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+ "num_cpus",
 ]
 
 [[package]]
 name = "futures-io"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-lite"
@@ -4885,9 +4840,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
@@ -4896,15 +4851,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-timer"
@@ -4912,15 +4867,15 @@ version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 dependencies = [
- "gloo-timers",
+ "gloo-timers 0.2.6",
  "send_wrapper 0.4.0",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -5003,6 +4958,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "ghash"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5064,6 +5031,18 @@ name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -5175,7 +5154,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5256,17 +5235,18 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.2",
+ "ahash 0.8.11",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.2",
+ "ahash 0.8.11",
  "allocator-api2",
+ "serde",
 ]
 
 [[package]]
@@ -5322,15 +5302,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -5561,9 +5532,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -5684,12 +5655,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.3",
  "serde",
 ]
 
@@ -5810,14 +5781,96 @@ dependencies = [
 
 [[package]]
 name = "iota-crypto"
-version = "0.12.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03717e934972fad6f1c9b4cd25f662e1753b58a7f76e3dceadeb646e034b252"
+checksum = "a5db0e2d85e258d6d0db66f4a6bf1e8bdf5b10c3353aa87d98b168778d13fdc1"
 dependencies = [
- "bee-ternary",
+ "aead",
+ "aes",
+ "aes-gcm",
+ "autocfg",
+ "base64 0.21.2",
  "blake2",
+ "chacha20poly1305",
+ "cipher",
+ "curve25519-dalek 3.2.0",
  "digest 0.10.7",
  "ed25519-zebra",
+ "generic-array",
+ "getrandom 0.2.9",
+ "hkdf",
+ "hmac 0.12.1",
+ "iterator-sorted",
+ "k256 0.13.1",
+ "num-traits",
+ "pbkdf2 0.12.1",
+ "rand 0.8.5",
+ "scrypt 0.11.0",
+ "serde",
+ "sha2 0.10.6",
+ "tiny-keccak",
+ "unicode-normalization",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "iota-sdk"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d62d16468c4bc555cac621734b5aa4fa971341f8fe3938d4481f7f394b9167"
+dependencies = [
+ "async-trait",
+ "bech32",
+ "bitflags 2.4.1",
+ "bytemuck",
+ "derive_more",
+ "futures",
+ "getset",
+ "gloo-timers 0.3.0",
+ "hashbrown 0.14.3",
+ "hex",
+ "instant",
+ "iota-crypto",
+ "iota_stronghold",
+ "iterator-sorted",
+ "itertools 0.12.0",
+ "lazy_static",
+ "log",
+ "num_cpus",
+ "once_cell",
+ "packable",
+ "prefix-hex",
+ "primitive-types 0.12.2",
+ "rand 0.8.5",
+ "regex",
+ "reqwest",
+ "rumqttc",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "thiserror",
+ "tokio",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "iota_stronghold"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04436fca4c5e566318aa3da37b97cd833d1f2f794a2fe373b05a85b68454a212"
+dependencies = [
+ "bincode",
+ "hkdf",
+ "iota-crypto",
+ "rust-argon2",
+ "serde",
+ "stronghold-derive",
+ "stronghold-utils",
+ "stronghold_engine",
+ "thiserror",
+ "zeroize",
 ]
 
 [[package]]
@@ -5850,7 +5903,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "io-lifetimes",
  "rustix 0.37.7",
  "windows-sys 0.48.0",
@@ -6120,6 +6173,7 @@ dependencies = [
  "ecdsa 0.16.6",
  "elliptic-curve 0.13.4",
  "once_cell",
+ "serdect",
  "sha2 0.10.6",
  "signature 2.0.0",
 ]
@@ -6277,6 +6331,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsodium-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b779387cd56adfbc02ea4a668e704f729be8d6a6abd2c27ca5ee537849a92fd"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "walkdir",
+]
+
+[[package]]
 name = "libtest-mimic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6420,7 +6486,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -6463,9 +6529,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memmap2"
@@ -7484,9 +7550,9 @@ dependencies = [
 
 [[package]]
 name = "multihash-derive"
-version = "0.8.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
+checksum = "fc076939022111618a5026d3be019fd8b366e76314538ff9a1b59ffbcbf98bcd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
@@ -7592,7 +7658,7 @@ dependencies = [
  "fastcrypto-tbls",
  "hashbrown 0.12.3",
  "impl-trait-for-tuples",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "mysten-util-mem-derive",
  "once_cell",
  "parking_lot 0.12.1",
@@ -7675,7 +7741,7 @@ dependencies = [
  "bytes",
  "fastcrypto",
  "futures",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "mockall",
  "mysten-metrics",
  "narwhal-config",
@@ -7790,7 +7856,7 @@ dependencies = [
  "fastcrypto",
  "futures",
  "governor",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "itertools 0.10.5",
  "mockall",
  "mysten-common",
@@ -7853,7 +7919,7 @@ dependencies = [
  "anemo",
  "fastcrypto",
  "fdlimit",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "itertools 0.10.5",
  "mysten-metrics",
  "mysten-network",
@@ -7893,7 +7959,7 @@ dependencies = [
  "enum_dispatch",
  "fastcrypto",
  "futures",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "mockall",
  "mysten-common",
  "mysten-metrics",
@@ -8061,6 +8127,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -8276,11 +8343,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
@@ -8420,9 +8487,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
@@ -8694,21 +8761,21 @@ dependencies = [
 
 [[package]]
 name = "packable"
-version = "0.4.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332ecf21e38a8f3afce70f005b638c67759686a5e3e12d1859c56d0687f164d3"
+checksum = "11259b086696fc9256f790485d8f14f11f0fa60a60351af9693e3d49fd24fdb6"
 dependencies = [
  "autocfg",
  "packable-derive",
- "primitive-types 0.11.1",
+ "primitive-types 0.12.2",
  "serde",
 ]
 
 [[package]]
 name = "packable-derive"
-version = "0.4.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cfe1637c03253dfa99917b97dcb646a540cad292b18fdc72e9a0d0dd29f165e"
+checksum = "e9567693dd2f9a4339cb0a54adfcc0cb431c0ac88b2e46c6ddfb5f5d11a1cc4f"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
@@ -8849,7 +8916,7 @@ version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "547b92ebf0c1177e3892f44c8f79757ee62e678d564a9834189725f2c5b7a750"
 dependencies = [
- "ahash 0.8.2",
+ "ahash 0.8.11",
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
@@ -8863,7 +8930,7 @@ dependencies = [
  "chrono",
  "flate2",
  "half 2.3.1",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.3",
  "lz4_flex",
  "num",
  "num-bigint 0.4.4",
@@ -8976,9 +9043,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
@@ -9302,12 +9369,12 @@ dependencies = [
 
 [[package]]
 name = "prefix-hex"
-version = "0.4.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a85165b6848fe5328066d5cb934dd5c88ff09674db6fcd018df68d9a542b2317"
+checksum = "1f1799f398371ad6957951ec446d3ff322d35c46d9db2e217b67e828b311c249"
 dependencies = [
  "hex",
- "primitive-types 0.11.1",
+ "primitive-types 0.12.2",
  "uint",
 ]
 
@@ -9380,18 +9447,6 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
-dependencies = [
- "fixed-hash 0.7.0",
- "impl-codec 0.6.0",
- "impl-serde 0.3.2",
- "uint",
-]
-
-[[package]]
-name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
@@ -9406,12 +9461,12 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.3"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
- "thiserror",
- "toml 0.5.10",
+ "once_cell",
+ "toml_edit 0.19.10",
 ]
 
 [[package]]
@@ -10025,13 +10080,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick 1.0.2",
  "memchr",
- "regex-syntax 0.7.2",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -10044,16 +10100,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick 1.0.2",
+ "memchr",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "regex-syntax"
@@ -10063,9 +10124,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.20"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "async-compression 0.4.6",
  "base64 0.21.2",
@@ -10092,6 +10153,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
  "tokio",
  "tokio-rustls 0.24.0",
  "tokio-util 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -10321,6 +10384,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rumqttc"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d8941c6791801b667d52bfe9ff4fc7c968d4f3f9ae8ae7abdaaa1c966feafc8"
+dependencies = [
+ "async-tungstenite",
+ "bytes",
+ "flume",
+ "futures-util",
+ "http",
+ "log",
+ "rustls-native-certs",
+ "rustls-pemfile 1.0.2",
+ "rustls-webpki 0.101.7",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.24.0",
+ "ws_stream_tungstenite",
+]
+
+[[package]]
 name = "rusoto_core"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10485,6 +10569,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-argon2"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50162d19404029c1ceca6f6980fe40d45c8b369f6f44446fa14bb39573b5bb9"
+dependencies = [
+ "base64 0.13.1",
+ "blake2b_simd",
+ "constant_time_eq 0.1.5",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10591,7 +10687,7 @@ checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
  "ring 0.16.20",
- "rustls-webpki 0.101.4",
+ "rustls-webpki 0.101.7",
  "sct",
 ]
 
@@ -10658,12 +10754,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.4"
+version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
+ "ring 0.17.3",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -10846,6 +10942,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2 0.12.1",
+ "salsa20",
+ "sha2 0.10.6",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10884,6 +10991,7 @@ dependencies = [
  "der 0.7.5",
  "generic-array",
  "pkcs8 0.10.2",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -10978,20 +11086,11 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.190"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-big-array"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3323f09a748af288c3dc2474ea6803ee81f118321775bffa3ac8f7e65c5e90e7"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -11026,9 +11125,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.190"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
@@ -11048,11 +11147,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -11069,13 +11168,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.10"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
- "syn 1.0.107",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -11159,6 +11258,16 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct 0.2.0",
+ "serde",
 ]
 
 [[package]]
@@ -11565,6 +11674,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spinners"
@@ -11635,6 +11747,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
 dependencies = [
  "vte",
+]
+
+[[package]]
+name = "stronghold-derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2835db23c4724c05a2f85b81c4681f4aa8ea158edc8a7f4ad791c916fb766c2e"
+dependencies = [
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "stronghold-runtime"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d20d73c3c41bdfcfa4e223cd6636111723081ef097a8d90354a9846b3bd60ede"
+dependencies = [
+ "dirs 4.0.0",
+ "iota-crypto",
+ "libc",
+ "libsodium-sys",
+ "log",
+ "nix 0.24.3",
+ "rand 0.8.5",
+ "serde",
+ "thiserror",
+ "windows",
+ "zeroize",
+]
+
+[[package]]
+name = "stronghold-utils"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8300214898af5e153e7f66e49dbd1c6a21585f2d592d9f24f58b969792475ed6"
+dependencies = [
+ "rand 0.8.5",
+ "stronghold-derive",
+]
+
+[[package]]
+name = "stronghold_engine"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ad9c397e3215857f4f8bd2bd2a5b90c6332d0077d8fb4b6ba61b27b544647ca"
+dependencies = [
+ "anyhow",
+ "dirs-next",
+ "hex",
+ "iota-crypto",
+ "once_cell",
+ "paste",
+ "serde",
+ "stronghold-runtime",
+ "thiserror",
+ "zeroize",
 ]
 
 [[package]]
@@ -12242,7 +12412,7 @@ dependencies = [
  "fs_extra",
  "futures",
  "im",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "itertools 0.10.5",
  "lru 0.10.0",
  "mockall",
@@ -12412,7 +12582,7 @@ dependencies = [
  "fastcrypto-zkp",
  "fs_extra",
  "futures",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "insta",
  "jsonrpsee",
  "move-binary-format",
@@ -12600,12 +12770,10 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bcs",
- "bee-block",
- "bee-ledger",
- "bee-tangle",
  "camino",
  "fastcrypto",
  "insta",
+ "iota-sdk",
  "move-binary-format",
  "move-core-types",
  "packable",
@@ -12623,6 +12791,7 @@ dependencies = [
  "sui-simulator",
  "sui-types",
  "tempfile",
+ "thiserror",
  "tracing",
 ]
 
@@ -12819,7 +12988,7 @@ dependencies = [
  "fastcrypto",
  "futures",
  "hyper",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "itertools 0.10.5",
  "jsonrpsee",
  "mockall",
@@ -13084,7 +13253,7 @@ dependencies = [
  "better_any",
  "fastcrypto",
  "fastcrypto-zkp",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "move-binary-format",
  "move-core-types",
  "move-stdlib",
@@ -13144,7 +13313,7 @@ dependencies = [
  "better_any",
  "fastcrypto",
  "fastcrypto-zkp",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "move-binary-format",
  "move-core-types",
  "move-stdlib-v2",
@@ -13798,7 +13967,7 @@ dependencies = [
  "bcs",
  "clap",
  "futures",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "move-binary-format",
  "move-core-types",
  "move-package",
@@ -13924,7 +14093,7 @@ dependencies = [
  "rcgen",
  "reqwest",
  "rustls 0.21.6",
- "rustls-webpki 0.101.4",
+ "rustls-webpki 0.101.7",
  "tokio",
  "tokio-rustls 0.24.0",
  "tower-layer",
@@ -14080,7 +14249,7 @@ dependencies = [
  "fastcrypto-tbls",
  "fastcrypto-zkp",
  "im",
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "itertools 0.10.5",
  "move-binary-format",
  "move-bytecode-utils",
@@ -14342,9 +14511,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
@@ -14371,6 +14540,27 @@ dependencies = [
  "once_cell",
  "rayon",
  "winapi",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -14714,15 +14904,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
-name = "time-helper"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c30f0091717eeeff0b556d830302d5563de8b72fd49127aa5899a06a369808"
-dependencies = [
- "time",
-]
-
-[[package]]
 name = "time-macros"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14913,7 +15094,7 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "futures-util",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.3",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -14929,7 +15110,7 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "futures-util",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.3",
  "pin-project-lite",
  "real_tokio",
  "slab",
@@ -15405,6 +15586,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
+ "rustls 0.21.6",
  "sha1",
  "thiserror",
  "url",
@@ -15526,9 +15708,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -15631,16 +15813,16 @@ dependencies = [
  "log",
  "once_cell",
  "rustls 0.21.6",
- "rustls-webpki 0.101.4",
+ "rustls-webpki 0.101.7",
  "url",
  "webpki-roots 0.25.2",
 ]
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -15838,9 +16020,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -15879,9 +16061,9 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-streams"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -15907,9 +16089,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -16007,6 +16189,19 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e53b97a83176b369b0eb2fd8158d4ae215357d02df9d40c1e1bf1879c5482c80"
+dependencies = [
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
+]
 
 [[package]]
 name = "windows-sys"
@@ -16115,6 +16310,12 @@ checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
@@ -16130,6 +16331,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -16151,6 +16358,12 @@ checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
@@ -16166,6 +16379,12 @@ name = "windows_i686_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -16205,6 +16424,12 @@ checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
@@ -16238,6 +16463,26 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ws_stream_tungstenite"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e283cc794a890f5bdc01e358ad7c34535025f79ba83c1b5c7e01e5d6c60b336d"
+dependencies = [
+ "async-tungstenite",
+ "async_io_stream",
+ "bitflags 2.4.1",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-util",
+ "pharos",
+ "rustc_version",
+ "tokio",
+ "tracing",
+ "tungstenite",
 ]
 
 [[package]]
@@ -16282,6 +16527,17 @@ dependencies = [
  "clap",
  "nexlint",
  "nexlint-lints",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
+dependencies = [
+ "curve25519-dalek 3.2.0",
+ "rand_core 0.5.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -16379,11 +16635,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "zeroize"
-version = "1.6.0"
+name = "zerocopy"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+dependencies = [
+ "serde",
  "zeroize_derive",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,6 +1740,106 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "bee-block"
+version = "0.1.0"
+source = "git+https://github.com/Thoralf-M/bee?rev=2429d29752f5af4df538e3ddb6585db9cd6f5b8a#2429d29752f5af4df538e3ddb6585db9cd6f5b8a"
+dependencies = [
+ "bech32",
+ "bee-pow",
+ "bee-ternary",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "derive_more",
+ "hashbrown 0.12.3",
+ "hex",
+ "iota-crypto",
+ "iterator-sorted",
+ "packable",
+ "prefix-hex",
+ "primitive-types 0.11.1",
+ "serde",
+ "serde-big-array",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "bee-ledger"
+version = "0.7.0"
+source = "git+https://github.com/Thoralf-M/bee?rev=2429d29752f5af4df538e3ddb6585db9cd6f5b8a#2429d29752f5af4df538e3ddb6585db9cd6f5b8a"
+dependencies = [
+ "bee-block",
+ "packable",
+ "thiserror",
+ "time-helper",
+]
+
+[[package]]
+name = "bee-pow"
+version = "0.2.0"
+source = "git+https://github.com/Thoralf-M/bee?rev=2429d29752f5af4df538e3ddb6585db9cd6f5b8a#2429d29752f5af4df538e3ddb6585db9cd6f5b8a"
+dependencies = [
+ "bee-ternary",
+ "iota-crypto",
+ "thiserror",
+]
+
+[[package]]
+name = "bee-runtime"
+version = "0.1.1-alpha"
+source = "git+https://github.com/Thoralf-M/bee?rev=2429d29752f5af4df538e3ddb6585db9cd6f5b8a#2429d29752f5af4df538e3ddb6585db9cd6f5b8a"
+dependencies = [
+ "async-trait",
+ "bee-storage",
+ "dashmap",
+ "futures",
+ "log",
+]
+
+[[package]]
+name = "bee-storage"
+version = "0.12.0"
+source = "git+https://github.com/Thoralf-M/bee?rev=2429d29752f5af4df538e3ddb6585db9cd6f5b8a#2429d29752f5af4df538e3ddb6585db9cd6f5b8a"
+dependencies = [
+ "packable",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "bee-tangle"
+version = "0.3.0"
+source = "git+https://github.com/Thoralf-M/bee?rev=2429d29752f5af4df538e3ddb6585db9cd6f5b8a#2429d29752f5af4df538e3ddb6585db9cd6f5b8a"
+dependencies = [
+ "async-trait",
+ "bee-block",
+ "bee-runtime",
+ "bee-storage",
+ "bitflags 1.3.2",
+ "futures",
+ "hashbrown 0.12.3",
+ "log",
+ "packable",
+ "rand 0.8.5",
+ "ref-cast",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "bee-ternary"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0b9489a68e42231e9f4f1443c765d3f80433a52101510ab413e6a9cd2240d21"
+dependencies = [
+ "autocfg",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3021,6 +3121,19 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622178105f911d937a42cdb140730ba4a3ed2becd8ae6ce39c7d28b5d75d4588"
@@ -3803,7 +3916,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.0",
  "ed25519 2.2.2",
  "rand_core 0.6.4",
  "serde",
@@ -3822,6 +3935,20 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_bytes",
+ "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-zebra"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
+dependencies = [
+ "curve25519-dalek 3.2.0",
+ "hashbrown 0.12.3",
+ "hex",
+ "rand_core 0.6.4",
  "sha2 0.9.9",
  "zeroize",
 ]
@@ -5682,6 +5809,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iota-crypto"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03717e934972fad6f1c9b4cd25f662e1753b58a7f76e3dceadeb646e034b252"
+dependencies = [
+ "bee-ternary",
+ "blake2",
+ "digest 0.10.7",
+ "ed25519-zebra",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5722,6 +5861,12 @@ name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
+name = "iterator-sorted"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d101775d2bc8f99f4ac18bf29b9ed70c0dd138b9a1e88d7b80179470cbbe8bd2"
 
 [[package]]
 name = "itertools"
@@ -8548,6 +8693,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "packable"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332ecf21e38a8f3afce70f005b638c67759686a5e3e12d1859c56d0687f164d3"
+dependencies = [
+ "autocfg",
+ "packable-derive",
+ "primitive-types 0.11.1",
+ "serde",
+]
+
+[[package]]
+name = "packable-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cfe1637c03253dfa99917b97dcb646a540cad292b18fdc72e9a0d0dd29f165e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "pairing"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9131,6 +9301,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-hex"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a85165b6848fe5328066d5cb934dd5c88ff09674db6fcd018df68d9a542b2317"
+dependencies = [
+ "hex",
+ "primitive-types 0.11.1",
+ "uint",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9193,6 +9374,18 @@ checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
  "fixed-hash 0.7.0",
  "impl-codec 0.5.1",
+ "impl-serde 0.3.2",
+ "uint",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
+dependencies = [
+ "fixed-hash 0.7.0",
+ "impl-codec 0.6.0",
  "impl-serde 0.3.2",
  "uint",
 ]
@@ -10223,7 +10416,7 @@ dependencies = [
  "byteorder",
  "chacha20",
  "ctr",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.0",
  "digest 0.10.7",
  "flate2",
  "futures",
@@ -10790,6 +10983,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3323f09a748af288c3dc2474ea6803ee81f118321775bffa3ac8f7e65c5e90e7"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -12398,11 +12600,15 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bcs",
+ "bee-block",
+ "bee-ledger",
+ "bee-tangle",
  "camino",
  "fastcrypto",
  "insta",
  "move-binary-format",
  "move-core-types",
+ "packable",
  "prometheus",
  "rand 0.8.5",
  "serde",
@@ -14506,6 +14712,15 @@ name = "time-core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-helper"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c30f0091717eeeff0b556d830302d5563de8b72fd49127aa5899a06a369808"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "time-macros"

--- a/crates/sui-genesis-builder/Cargo.toml
+++ b/crates/sui-genesis-builder/Cargo.toml
@@ -18,13 +18,14 @@ serde.workspace = true
 serde_with.workspace = true
 serde_yaml.workspace = true
 tempfile.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
 prometheus.workspace = true
 
-bee-block = { git = "https://github.com/Thoralf-M/bee", rev = "2429d29752f5af4df538e3ddb6585db9cd6f5b8a", features = ["dto"] }
-bee-ledger = { git = "https://github.com/Thoralf-M/bee", rev = "2429d29752f5af4df538e3ddb6585db9cd6f5b8a" }
-bee-tangle = { git = "https://github.com/Thoralf-M/bee", rev = "2429d29752f5af4df538e3ddb6585db9cd6f5b8a" }
-packable = { version = "0.4.0", default-features = false, features = [ "serde", "primitive-types" ] }
+iota-sdk = "1.1.4"
+packable = { version = "0.8.3", default-features = false, features = [
+    "primitive-types",
+] }
 
 shared-crypto.workspace = true
 sui-config.workspace = true

--- a/crates/sui-genesis-builder/Cargo.toml
+++ b/crates/sui-genesis-builder/Cargo.toml
@@ -21,6 +21,11 @@ tempfile.workspace = true
 tracing.workspace = true
 prometheus.workspace = true
 
+bee-block = { git = "https://github.com/Thoralf-M/bee", rev = "2429d29752f5af4df538e3ddb6585db9cd6f5b8a", features = ["dto"] }
+bee-ledger = { git = "https://github.com/Thoralf-M/bee", rev = "2429d29752f5af4df538e3ddb6585db9cd6f5b8a" }
+bee-tangle = { git = "https://github.com/Thoralf-M/bee", rev = "2429d29752f5af4df538e3ddb6585db9cd6f5b8a" }
+packable = { version = "0.4.0", default-features = false, features = [ "serde", "primitive-types" ] }
+
 shared-crypto.workspace = true
 sui-config.workspace = true
 sui-execution.workspace = true

--- a/crates/sui-genesis-builder/examples/parse_full_snapshot.rs
+++ b/crates/sui-genesis-builder/examples/parse_full_snapshot.rs
@@ -1,0 +1,22 @@
+//! Example demonstrating parsing Stardust UTXOs from a snapshot file
+//! and verifying the total supply.
+use std::fs::File;
+
+use sui_genesis_builder::stardust::{parse::FullSnapshotParser, types::TOTAL_SUPPLY_IOTA};
+
+fn main() -> anyhow::Result<()> {
+    let Some(path) = std::env::args().nth(1) else {
+        anyhow::bail!("please provide path to the full-snapshot file");
+    };
+    let file = File::open(path)?;
+
+    let parser = FullSnapshotParser::new(file)?;
+    println!("Output count: {}", parser.header.output_count());
+
+    let total_supply = parser.outputs().try_fold(0, |acc, output| {
+        Ok::<_, anyhow::Error>(acc + output?.amount())
+    })?;
+    assert_eq!(total_supply, TOTAL_SUPPLY_IOTA);
+    println!("Total supply: {total_supply}");
+    Ok(())
+}

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -52,6 +52,7 @@ use tracing::trace;
 use validator_info::{GenesisValidatorInfo, GenesisValidatorMetadata, ValidatorInfo};
 
 pub mod validator_info;
+pub mod stardust;
 
 const GENESIS_BUILDER_COMMITTEE_DIR: &str = "committee";
 const GENESIS_BUILDER_PARAMETERS_FILE: &str = "parameters";

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -51,8 +51,8 @@ use sui_types::{SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_ADDRESS};
 use tracing::trace;
 use validator_info::{GenesisValidatorInfo, GenesisValidatorMetadata, ValidatorInfo};
 
-pub mod validator_info;
 pub mod stardust;
+pub mod validator_info;
 
 const GENESIS_BUILDER_COMMITTEE_DIR: &str = "committee";
 const GENESIS_BUILDER_PARAMETERS_FILE: &str = "parameters";

--- a/crates/sui-genesis-builder/src/stardust.rs
+++ b/crates/sui-genesis-builder/src/stardust.rs
@@ -1,17 +1,64 @@
+use anyhow::Result;
+use iota_sdk::types::block::output::Output;
+use iota_sdk::types::block::output::OutputId;
+use iota_sdk::types::block::payload::milestone::MilestoneId;
+use iota_sdk::types::block::payload::milestone::MilestoneIndex;
+use iota_sdk::types::block::payload::milestone::MilestoneOption;
+use iota_sdk::types::block::protocol::ProtocolParameters;
+use iota_sdk::types::block::BlockId;
+use packable::error::UnknownTagError;
+use packable::error::UnpackError;
+use packable::error::UnpackErrorExt;
+use packable::packer::Packer;
+use packable::unpacker::SliceUnpacker;
+use packable::unpacker::Unpacker;
+use packable::Packable;
+use packable::PackableExt;
+use std::convert::Infallible;
 use std::fs::File;
 use std::io::{BufRead, Read};
 use std::mem::size_of;
-
-use anyhow::Result;
-use bee_block::output::OutputId;
-use bee_block::payload::milestone::MilestoneIndex;
-use bee_block::BlockId;
-use bee_ledger::types::snapshot::FullSnapshotHeader;
-use packable::Packable;
-
-type SdkOutput = ();
+use thiserror::Error;
 
 const SNAPSHOT_HEADER_LENGTH: usize = std::mem::size_of::<FullSnapshotHeader>();
+const SNAPSHOT_VERSION: u8 = 2;
+
+#[derive(Debug, Error)]
+pub enum StardustError {
+    #[error("unsupported snapshot version: expected {0}, got {1}")]
+    UnsupportedSnapshotVersion(u8, u8),
+    #[error("invalid snapshot kind: {0}")]
+    InvalidSnapshotKind(u8),
+    #[error("block error: {0}")]
+    BlockError(#[from] iota_sdk::types::block::Error),
+    #[error("unknown tag: {0}")]
+    UnknownTag(u8),
+}
+
+impl From<Infallible> for StardustError {
+    fn from(_: Infallible) -> Self {
+        unreachable!()
+    }
+}
+
+impl From<UnknownTagError<u8>> for StardustError {
+    fn from(err: UnknownTagError<u8>) -> Self {
+        Self::UnknownTag(err.0)
+    }
+}
+
+/// The kind of a snapshot.
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, packable::Packable)]
+#[packable(unpack_error = StardustError)]
+pub enum SnapshotKind {
+    /// Full is a snapshot which contains the full ledger entry for a given milestone plus the milestone diffs which
+    /// subtracted to the ledger milestone reduce to the snapshot milestone ledger.
+    Full = 0,
+    /// Delta is a snapshot which contains solely diffs of milestones newer than a certain ledger milestone instead of
+    /// the complete ledger state of a given milestone.
+    Delta = 1,
+}
 
 #[derive(Debug, Clone, Packable)]
 pub struct OutputHeader {
@@ -29,6 +76,160 @@ impl OutputHeader {
         + 2 * size_of::<u32>();
 }
 
+/// Describes a snapshot header specific to full snapshots.
+#[derive(Clone, Debug)]
+pub struct FullSnapshotHeader {
+    genesis_milestone_index: MilestoneIndex,
+    target_milestone_index: MilestoneIndex,
+    target_milestone_timestamp: u32,
+    target_milestone_id: MilestoneId,
+    ledger_milestone_index: MilestoneIndex,
+    treasury_output_milestone_id: MilestoneId,
+    treasury_output_amount: u64,
+    parameters_milestone_option: MilestoneOption,
+    output_count: u64,
+    milestone_diff_count: u32,
+    sep_count: u16,
+}
+
+impl FullSnapshotHeader {
+    /// Returns the genesis milestone index of a [`FullSnapshotHeader`].
+    pub fn genesis_milestone_index(&self) -> MilestoneIndex {
+        self.genesis_milestone_index
+    }
+
+    /// Returns the target milestone index of a [`FullSnapshotHeader`].
+    pub fn target_milestone_index(&self) -> MilestoneIndex {
+        self.target_milestone_index
+    }
+
+    /// Returns the target milestone timestamp of a [`FullSnapshotHeader`].
+    pub fn target_milestone_timestamp(&self) -> u32 {
+        self.target_milestone_timestamp
+    }
+
+    /// Returns the target milestone ID of a [`FullSnapshotHeader`].
+    pub fn target_milestone_id(&self) -> &MilestoneId {
+        &self.target_milestone_id
+    }
+
+    /// Returns the ledger milestone index of a [`FullSnapshotHeader`].
+    pub fn ledger_milestone_index(&self) -> MilestoneIndex {
+        self.ledger_milestone_index
+    }
+
+    /// Returns the treasury output milestone ID of a [`FullSnapshotHeader`].
+    pub fn treasury_output_milestone_id(&self) -> &MilestoneId {
+        &self.treasury_output_milestone_id
+    }
+
+    /// Returns the treasury output amount of a [`FullSnapshotHeader`].
+    pub fn treasury_output_amount(&self) -> u64 {
+        self.treasury_output_amount
+    }
+
+    /// Returns the parameters milestone option of a [`FullSnapshotHeader`].
+    pub fn parameters_milestone_option(&self) -> &MilestoneOption {
+        &self.parameters_milestone_option
+    }
+
+    /// Returns the output count of a [`FullSnapshotHeader`].
+    pub fn output_count(&self) -> u64 {
+        self.output_count
+    }
+
+    /// Returns the milestone diff count of a [`FullSnapshotHeader`].
+    pub fn milestone_diff_count(&self) -> u32 {
+        self.milestone_diff_count
+    }
+
+    /// Returns the SEP count of a [`FullSnapshotHeader`].
+    pub fn sep_count(&self) -> u16 {
+        self.sep_count
+    }
+}
+
+impl Packable for FullSnapshotHeader {
+    type UnpackVisitor = ();
+    type UnpackError = StardustError;
+
+    fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), P::Error> {
+        SNAPSHOT_VERSION.pack(packer)?;
+        SnapshotKind::Full.pack(packer)?;
+
+        self.genesis_milestone_index.pack(packer)?;
+        self.target_milestone_index.pack(packer)?;
+        self.target_milestone_timestamp.pack(packer)?;
+        self.target_milestone_id.pack(packer)?;
+        self.ledger_milestone_index.pack(packer)?;
+        self.treasury_output_milestone_id.pack(packer)?;
+        self.treasury_output_amount.pack(packer)?;
+        // This is only required in Hornet.
+        (self.parameters_milestone_option.packed_len() as u16).pack(packer)?;
+        self.parameters_milestone_option.pack(packer)?;
+        self.output_count.pack(packer)?;
+        self.milestone_diff_count.pack(packer)?;
+        self.sep_count.pack(packer)?;
+
+        Ok(())
+    }
+
+    fn unpack<U: Unpacker, const VERIFY: bool>(
+        unpacker: &mut U,
+        _: &(),
+    ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+        let version = u8::unpack::<_, VERIFY>(unpacker, &()).coerce()?;
+
+        if VERIFY && SNAPSHOT_VERSION != version {
+            return Err(UnpackError::Packable(
+                StardustError::UnsupportedSnapshotVersion(SNAPSHOT_VERSION, version),
+            ));
+        }
+
+        let kind = SnapshotKind::unpack::<_, VERIFY>(unpacker, &()).coerce()?;
+
+        if VERIFY && kind != SnapshotKind::Full {
+            return Err(UnpackError::Packable(StardustError::InvalidSnapshotKind(
+                kind as u8,
+            )));
+        }
+
+        let genesis_milestone_index =
+            MilestoneIndex::unpack::<_, VERIFY>(unpacker, &()).coerce()?;
+        let target_milestone_index = MilestoneIndex::unpack::<_, VERIFY>(unpacker, &()).coerce()?;
+        let target_milestone_timestamp = u32::unpack::<_, VERIFY>(unpacker, &()).coerce()?;
+        let target_milestone_id = MilestoneId::unpack::<_, VERIFY>(unpacker, &()).coerce()?;
+        let ledger_milestone_index = MilestoneIndex::unpack::<_, VERIFY>(unpacker, &()).coerce()?;
+        let treasury_output_milestone_id =
+            MilestoneId::unpack::<_, VERIFY>(unpacker, &()).coerce()?;
+        let treasury_output_amount = u64::unpack::<_, VERIFY>(unpacker, &()).coerce()?;
+        // This is only required in Hornet.
+        let _parameters_milestone_option_length =
+            u16::unpack::<_, VERIFY>(unpacker, &()).coerce()?;
+        // TODO: Verify that the provided protocol parameters milestone are valid.
+        let parameters_milestone_option =
+            MilestoneOption::unpack::<_, false>(unpacker, &ProtocolParameters::default())
+                .coerce()?;
+        let output_count = u64::unpack::<_, VERIFY>(unpacker, &()).coerce()?;
+        let milestone_diff_count = u32::unpack::<_, VERIFY>(unpacker, &()).coerce()?;
+        let sep_count = u16::unpack::<_, VERIFY>(unpacker, &()).coerce()?;
+
+        Ok(Self {
+            genesis_milestone_index,
+            target_milestone_index,
+            target_milestone_timestamp,
+            target_milestone_id,
+            ledger_milestone_index,
+            treasury_output_milestone_id,
+            treasury_output_amount,
+            parameters_milestone_option,
+            output_count,
+            milestone_diff_count,
+            sep_count,
+        })
+    }
+}
+
 pub fn parse_full_snapshot() -> Result<()> {
     let Some(path) = std::env::args().nth(1) else {
         anyhow::bail!("please provide path to the full-snapshot file");
@@ -39,7 +240,8 @@ pub fn parse_full_snapshot() -> Result<()> {
     let mut buf = [0_u8; SNAPSHOT_HEADER_LENGTH];
     reader.read_exact(&mut buf)?;
 
-    let full_header = FullSnapshotHeader::unpack::<_, true>(&mut buf.as_slice())?;
+    let full_header =
+        FullSnapshotHeader::unpack::<_, true>(&mut SliceUnpacker::new(buf.as_slice()), &())?;
 
     println!("Output count:\t\t\t{}", full_header.output_count());
 
@@ -50,18 +252,19 @@ pub fn parse_full_snapshot() -> Result<()> {
 pub fn iterate_on_outputs(
     src: &mut impl BufRead,
     output_count: u64,
-) -> Result<impl Iterator<Item = Result<SdkOutput, anyhow::Error>> + '_> {
+) -> Result<impl Iterator<Item = Result<Output, anyhow::Error>> + '_> {
     let mut header_buf = [0_u8; OutputHeader::LENGTH];
     let mut output_buf = [0_u8; u16::MAX as usize];
 
     let iter = (0..output_count).map(move |_| {
         src.read_exact(&mut header_buf)?;
-        let header = OutputHeader::unpack::<_, false>(&mut header_buf.as_slice())?;
+        let header =
+            OutputHeader::unpack::<_, false>(&mut SliceUnpacker::new(header_buf.as_slice()), &())?;
         println!("header {:?}", header);
         src.read_exact(&mut output_buf[0..header.length as usize])?;
         // TODO: Use the [iota_sdk::types::block::Output] to unpack the `output_buf`
         // let output = Output::unpack::<_, true>(&mut output_buf.as_slice())?;
-        let output = ();
+        let output = unimplemented!();
         Ok(output)
     });
     Ok(iter)

--- a/crates/sui-genesis-builder/src/stardust.rs
+++ b/crates/sui-genesis-builder/src/stardust.rs
@@ -1,0 +1,68 @@
+use std::fs::File;
+use std::io::{BufRead, Read};
+use std::mem::size_of;
+
+use anyhow::Result;
+use bee_block::output::OutputId;
+use bee_block::payload::milestone::MilestoneIndex;
+use bee_block::BlockId;
+use bee_ledger::types::snapshot::FullSnapshotHeader;
+use packable::Packable;
+
+type SdkOutput = ();
+
+const SNAPSHOT_HEADER_LENGTH: usize = std::mem::size_of::<FullSnapshotHeader>();
+
+#[derive(Debug, Clone, Packable)]
+pub struct OutputHeader {
+    output_id: OutputId,
+    block_id: BlockId,
+    ms_index: MilestoneIndex,
+    ms_ts: u32,
+    length: u32,
+}
+
+impl OutputHeader {
+    pub const LENGTH: usize = OutputId::LENGTH
+        + size_of::<BlockId>()
+        + size_of::<MilestoneIndex>()
+        + 2 * size_of::<u32>();
+}
+
+pub fn parse_full_snapshot() -> Result<()> {
+    let Some(path) = std::env::args().nth(1) else {
+        anyhow::bail!("please provide path to the full-snapshot file");
+    };
+
+    let snapshot_file = File::open(path)?;
+    let mut reader = std::io::BufReader::new(snapshot_file);
+    let mut buf = [0_u8; SNAPSHOT_HEADER_LENGTH];
+    reader.read_exact(&mut buf)?;
+
+    let full_header = FullSnapshotHeader::unpack::<_, true>(&mut buf.as_slice())?;
+
+    println!("Output count:\t\t\t{}", full_header.output_count());
+
+    for _ in iterate_on_outputs(&mut reader, full_header.output_count())? { /* do something */ }
+    Ok(())
+}
+
+pub fn iterate_on_outputs(
+    src: &mut impl BufRead,
+    output_count: u64,
+) -> Result<impl Iterator<Item = Result<SdkOutput, anyhow::Error>> + '_> {
+    let mut header_buf = [0_u8; OutputHeader::LENGTH];
+    let mut output_buf = [0_u8; u16::MAX as usize];
+
+    let iter = (0..output_count).map(move |_| {
+        src.read_exact(&mut header_buf)?;
+        let header = OutputHeader::unpack::<_, false>(&mut header_buf.as_slice())?;
+        println!("header {:?}", header);
+        src.read_exact(&mut output_buf[0..header.length as usize])?;
+        // TODO: Use the [iota_sdk::types::block::Output] to unpack the `output_buf`
+        // let output = Output::unpack::<_, true>(&mut output_buf.as_slice())?;
+        let output = ();
+        Ok(output)
+    });
+    Ok(iter)
+}

--- a/crates/sui-genesis-builder/src/stardust/error.rs
+++ b/crates/sui-genesis-builder/src/stardust/error.rs
@@ -1,0 +1,23 @@
+//! Error types pertaining to deserializing Stardust snapshots
+use std::convert::Infallible;
+
+use packable::error::UnknownTagError;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum StardustError {
+    #[error("unsupported snapshot version: expected {0}, got {1}")]
+    UnsupportedSnapshotVersion(u8, u8),
+    #[error("invalid snapshot kind: {0}")]
+    InvalidSnapshotKind(u8),
+    #[error("block error: {0}")]
+    BlockError(#[from] iota_sdk::types::block::Error),
+    #[error("{0}")]
+    UnknownTag(#[from] UnknownTagError<u8>),
+}
+
+impl From<Infallible> for StardustError {
+    fn from(_: Infallible) -> Self {
+        unreachable!()
+    }
+}

--- a/crates/sui-genesis-builder/src/stardust/mod.rs
+++ b/crates/sui-genesis-builder/src/stardust/mod.rs
@@ -1,0 +1,6 @@
+//! The [`stardust`] module incorporates all the logic necessary for
+//! parsing Stardust UTXOs from a full-snapshot file, and converting
+//! them to the appropriate genesis objects.
+pub mod error;
+pub mod parse;
+pub mod types;

--- a/crates/sui-genesis-builder/src/stardust/parse.rs
+++ b/crates/sui-genesis-builder/src/stardust/parse.rs
@@ -1,0 +1,52 @@
+//! Types and logic to parse a full Stardust snapshot.
+use std::{
+    fs::File,
+    io::{BufRead, Read},
+    path::Path,
+};
+
+use anyhow::Result;
+use iota_sdk::types::block::{output::Output, protocol::ProtocolParameters};
+use packable::PackableExt;
+
+use super::types::{FullSnapshotHeader, OutputHeader, TOTAL_SUPPLY_IOTA};
+
+/// Parse a full snapshot file located at `path` and iterate over the
+/// recorded [`Output`] values.
+pub fn parse_full_snapshot(path: impl AsRef<Path>) -> Result<()> {
+    let snapshot_file = File::open(path)?;
+    let mut reader = std::io::BufReader::new(snapshot_file);
+    let mut buf = [0_u8; FullSnapshotHeader::LENGTH];
+    reader.read_exact(&mut buf)?;
+
+    let full_header = FullSnapshotHeader::unpack_verified(buf.as_slice(), &())?;
+
+    println!("Output count: {}", full_header.output_count());
+
+    let total_supply = iterate_on_outputs(&mut reader, full_header.output_count())
+        .try_fold(0, |acc, output| {
+            Ok::<_, anyhow::Error>(acc + output?.amount())
+        })?;
+    assert_eq!(total_supply, TOTAL_SUPPLY_IOTA);
+    println!("Total supply: {total_supply}");
+    Ok(())
+}
+
+fn iterate_on_outputs(
+    src: &mut impl BufRead,
+    output_count: u64,
+) -> impl Iterator<Item = Result<Output, anyhow::Error>> + '_ {
+    let mut header_buf = [0_u8; OutputHeader::LENGTH];
+    let mut output_buf = [0_u8; u16::MAX as usize];
+
+    (0..output_count).map(move |_| {
+        src.read_exact(&mut header_buf)?;
+        let header = OutputHeader::unpack_verified(header_buf.as_slice(), &())?;
+        src.read_exact(&mut output_buf[0..header.length() as usize])?;
+        let output = Output::unpack_verified(
+            &output_buf[0..header.length() as usize],
+            &ProtocolParameters::default(),
+        )?;
+        Ok(output)
+    })
+}

--- a/crates/sui-genesis-builder/src/stardust/parse.rs
+++ b/crates/sui-genesis-builder/src/stardust/parse.rs
@@ -1,52 +1,41 @@
 //! Types and logic to parse a full Stardust snapshot.
-use std::{
-    fs::File,
-    io::{BufRead, Read},
-    path::Path,
-};
+use std::io::{BufReader, Read};
 
 use anyhow::Result;
 use iota_sdk::types::block::{output::Output, protocol::ProtocolParameters};
 use packable::PackableExt;
 
-use super::types::{FullSnapshotHeader, OutputHeader, TOTAL_SUPPLY_IOTA};
+use super::types::{FullSnapshotHeader, OutputHeader};
 
-/// Parse a full snapshot file located at `path` and iterate over the
-/// recorded [`Output`] values.
-pub fn parse_full_snapshot(path: impl AsRef<Path>) -> Result<()> {
-    let snapshot_file = File::open(path)?;
-    let mut reader = std::io::BufReader::new(snapshot_file);
-    let mut buf = [0_u8; FullSnapshotHeader::LENGTH];
-    reader.read_exact(&mut buf)?;
-
-    let full_header = FullSnapshotHeader::unpack_verified(buf.as_slice(), &())?;
-
-    println!("Output count: {}", full_header.output_count());
-
-    let total_supply = iterate_on_outputs(&mut reader, full_header.output_count())
-        .try_fold(0, |acc, output| {
-            Ok::<_, anyhow::Error>(acc + output?.amount())
-        })?;
-    assert_eq!(total_supply, TOTAL_SUPPLY_IOTA);
-    println!("Total supply: {total_supply}");
-    Ok(())
+/// Parse a full-snapshot using a [`BufReader`] internally.
+pub struct FullSnapshotParser<R: Read> {
+    reader: BufReader<R>,
+    /// The full-snapshot header
+    pub header: FullSnapshotHeader,
 }
 
-fn iterate_on_outputs(
-    src: &mut impl BufRead,
-    output_count: u64,
-) -> impl Iterator<Item = Result<Output, anyhow::Error>> + '_ {
-    let mut header_buf = [0_u8; OutputHeader::LENGTH];
-    let mut output_buf = [0_u8; u16::MAX as usize];
+impl<R: Read> FullSnapshotParser<R> {
+    pub fn new(reader: R) -> Result<Self> {
+        let mut reader = std::io::BufReader::new(reader);
+        let mut buf = [0_u8; FullSnapshotHeader::LENGTH];
+        reader.read_exact(&mut buf)?;
 
-    (0..output_count).map(move |_| {
-        src.read_exact(&mut header_buf)?;
-        let header = OutputHeader::unpack_verified(header_buf.as_slice(), &())?;
-        src.read_exact(&mut output_buf[0..header.length() as usize])?;
-        let output = Output::unpack_verified(
-            &output_buf[0..header.length() as usize],
-            &ProtocolParameters::default(),
-        )?;
-        Ok(output)
-    })
+        let header = FullSnapshotHeader::unpack_verified(buf.as_slice(), &())?;
+        Ok(Self { reader, header })
+    }
+
+    /// Provide an iterator over the Stardust UTXOs recorded in the snapshot.
+    pub fn outputs(mut self) -> impl Iterator<Item = Result<Output, anyhow::Error>> {
+        let mut header_buf = [0_u8; OutputHeader::LENGTH];
+        let mut output_buf = [0_u8; u16::MAX as usize];
+
+        (0..self.header.output_count()).map(move |_| {
+            self.reader.read_exact(&mut header_buf)?;
+            let header = OutputHeader::unpack_verified(header_buf.as_slice(), &())?;
+            let output_bytes = &mut output_buf[0..header.length() as usize];
+            self.reader.read_exact(output_bytes)?;
+            let output = Output::unpack_verified(output_bytes, &ProtocolParameters::default())?;
+            Ok(output)
+        })
+    }
 }


### PR DESCRIPTION
# Description of change

This patch introduces the `FullSnapshotParser` that parses full-snapshot files using a buffer, and exposes an iterator over Stardust UTXOs.

## Links to any relevant issues

Closes https://github.com/iotaledger/kinesis/issues/124
Closes https://github.com/iotaledger/kinesis/issues/125

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

```
cargo run --release -p sui_genesis_builder --example parse_full_snapshot <path-to-stardust-full-snapshot>
```

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
