### PR TITLE
Add support for Legacy ED25519 Address type

### DIFF
--- a/crates/sui-keys/src/key_derive.rs
+++ b/crates/sui-keys/src/key_derive.rs
@@ -19,14 +19,14 @@ use sui_types::{
     error::SuiError,
 };
 
-pub const DERIVATION_PATH_COIN_TYPE: u32 = 784;
+pub const DERIVATION_PATH_COIN_TYPE: u32 = 4218;
 pub const DERVIATION_PATH_PURPOSE_ED25519: u32 = 44;
 pub const DERVIATION_PATH_PURPOSE_SECP256K1: u32 = 54;
 pub const DERVIATION_PATH_PURPOSE_SECP256R1: u32 = 74;
 
-/// Ed25519 follows SLIP-0010 using hardened path: m/44'/784'/0'/0'/{index}'
-/// Secp256k1 follows BIP-32/44 using path where the first 3 levels are hardened: m/54'/784'/0'/0/{index}
-/// Secp256r1 follows BIP-32/44 using path where the first 3 levels are hardened: m/74'/784'/0'/0/{index}
+/// Ed25519 follows SLIP-0010 using hardened path: m/44'/4218'/0'/0'/{index}'
+/// Secp256k1 follows BIP-32/44 using path where the first 3 levels are hardened: m/54'/4218'/0'/0/{index}
+/// Secp256r1 follows BIP-32/44 using path where the first 3 levels are hardened: m/74'/4218'/0'/0/{index}
 /// Note that the purpose node is used to distinguish signature schemes.
 pub fn derive_key_pair_from_path(
     seed: &[u8],
@@ -77,7 +77,7 @@ pub fn validate_path(
         SignatureScheme::ED25519 => {
             match path {
                 Some(p) => {
-                    // The derivation path must be hardened at all levels with purpose = 44, coin_type = 784
+                    // The derivation path must be hardened at all levels with purpose = 44, coin_type = 4218
                     if let &[purpose, coin_type, account, change, address] = p.as_ref() {
                         if Some(purpose)
                             == ChildNumber::new(DERVIATION_PATH_PURPOSE_ED25519, true).ok()
@@ -105,7 +105,7 @@ pub fn validate_path(
         SignatureScheme::Secp256k1 => {
             match path {
                 Some(p) => {
-                    // The derivation path must be hardened at first 3 levels with purpose = 54, coin_type = 784
+                    // The derivation path must be hardened at first 3 levels with purpose = 54, coin_type = 4218
                     if let &[purpose, coin_type, account, change, address] = p.as_ref() {
                         if Some(purpose)
                             == ChildNumber::new(DERVIATION_PATH_PURPOSE_SECP256K1, true).ok()
@@ -133,7 +133,7 @@ pub fn validate_path(
         SignatureScheme::Secp256r1 => {
             match path {
                 Some(p) => {
-                    // The derivation path must be hardened at first 3 levels with purpose = 74, coin_type = 784
+                    // The derivation path must be hardened at first 3 levels with purpose = 74, coin_type = 4218
                     if let &[purpose, coin_type, account, change, address] = p.as_ref() {
                         if Some(purpose)
                             == ChildNumber::new(DERVIATION_PATH_PURPOSE_SECP256R1, true).ok()

--- a/crates/sui-keys/src/key_derive.rs
+++ b/crates/sui-keys/src/key_derive.rs
@@ -20,6 +20,7 @@ use sui_types::{
     error::SuiError,
 };
 
+/// Derivation coin type as in https://github.com/satoshilabs/slips/blob/master/slip-0044.md
 pub const DERIVATION_PATH_COIN_TYPE: u32 = 4218;
 pub const DERVIATION_PATH_PURPOSE_ED25519: u32 = 44;
 pub const DERVIATION_PATH_PURPOSE_SECP256K1: u32 = 54;

--- a/crates/sui-rosetta/src/main.rs
+++ b/crates/sui-rosetta/src/main.rs
@@ -228,6 +228,10 @@ fn read_prefunded_account(path: &Path) -> Result<Vec<PrefundedAccount>, anyhow::
                 SuiKeyPair::Secp256r1(k) => {
                     (Hex::encode(k.private().as_bytes()), CurveType::Secp256r1)
                 }
+                SuiKeyPair::Ed25519Legacy(k) => (
+                    Hex::encode(k.0.private().as_bytes()),
+                    CurveType::Edwards25519,
+                ),
             };
             PrefundedAccount {
                 privkey,

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -341,6 +341,10 @@ impl From<SuiPublicKey> for PublicKey {
                 hex_bytes: Hex::from_bytes(&k.0),
                 curve_type: CurveType::ZkLogin, // inaccurate but added for completeness.
             },
+            SuiPublicKey::Ed25519Legacy(k) => PublicKey {
+                hex_bytes: Hex::from_bytes(&k.0),
+                curve_type: CurveType::Edwards25519,
+            },
         }
     }
 }

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -664,15 +664,12 @@ impl<T: SuiPublicKey> From<&T> for SuiAddress {
     fn from(pk: &T) -> Self {
         let mut hasher = DefaultHash::default();
         hasher.update([T::SIGNATURE_SCHEME.flag()]);
-        match T::SIGNATURE_SCHEME {
-            SignatureScheme::ED25519Legacy => {
-                let hashed_pk = Blake2b256::digest(pk);
-                hasher.update(hashed_pk.as_ref());
-            }
-            _ => {
-                hasher.update(pk);
-            }
-        };
+        if let SignatureScheme::ED25519Legacy = T::SIGNATURE_SCHEME {
+            let hashed_pk = Blake2b256::digest(pk);
+            hasher.update(hashed_pk.as_ref());
+        } else {
+            hasher.update(pk);
+        }
         let g_arr = hasher.finalize();
         SuiAddress(g_arr.digest)
     }
@@ -682,15 +679,12 @@ impl From<&PublicKey> for SuiAddress {
     fn from(pk: &PublicKey) -> Self {
         let mut hasher = DefaultHash::default();
         hasher.update([pk.flag()]);
-        match pk.scheme() {
-            SignatureScheme::ED25519Legacy => {
-                let hashed_pk = Blake2b256::digest(pk);
-                hasher.update(hashed_pk.as_ref());
-            }
-            _ => {
-                hasher.update(pk);
-            }
-        };
+        if let SignatureScheme::ED25519Legacy = pk.scheme() {
+            let hashed_pk = Blake2b256::digest(pk);
+            hasher.update(hashed_pk.as_ref());
+        } else {
+            hasher.update(pk);
+        }
         let g_arr = hasher.finalize();
         SuiAddress(g_arr.digest)
     }
@@ -711,15 +705,12 @@ impl From<&MultiSigPublicKey> for SuiAddress {
         hasher.update(multisig_pk.threshold().to_le_bytes());
         multisig_pk.pubkeys().iter().for_each(|(pk, w)| {
             hasher.update([pk.flag()]);
-            match pk.scheme() {
-                SignatureScheme::ED25519Legacy => {
-                    let hashed_pk = Blake2b256::digest(pk);
-                    hasher.update(hashed_pk.as_ref());
-                }
-                _ => {
-                    hasher.update(pk.as_ref());
-                }
-            };
+            if let SignatureScheme::ED25519Legacy = pk.scheme() {
+                let hashed_pk = Blake2b256::digest(pk);
+                hasher.update(hashed_pk.as_ref());
+            } else {
+                hasher.update(pk);
+            }
             hasher.update(w.to_le_bytes());
         });
         SuiAddress(hasher.finalize().digest)

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -666,9 +666,7 @@ impl<T: SuiPublicKey> From<&T> for SuiAddress {
         hasher.update([T::SIGNATURE_SCHEME.flag()]);
         match T::SIGNATURE_SCHEME {
             SignatureScheme::ED25519Legacy => {
-                let mut hasher_for_legacy = Blake2b256::default();
-                hasher_for_legacy.update(pk);
-                let hashed_pk = hasher_for_legacy.finalize();
+                let hashed_pk = Blake2b256::digest(pk);
                 hasher.update(hashed_pk.as_ref());
             }
             _ => {
@@ -686,9 +684,7 @@ impl From<&PublicKey> for SuiAddress {
         hasher.update([pk.flag()]);
         match pk.scheme() {
             SignatureScheme::ED25519Legacy => {
-                let mut hasher_for_legacy = Blake2b256::default();
-                hasher_for_legacy.update(pk);
-                let hashed_pk = hasher_for_legacy.finalize();
+                let hashed_pk = Blake2b256::digest(pk);
                 hasher.update(hashed_pk.as_ref());
             }
             _ => {
@@ -717,9 +713,7 @@ impl From<&MultiSigPublicKey> for SuiAddress {
             hasher.update([pk.flag()]);
             match pk.scheme() {
                 SignatureScheme::ED25519Legacy => {
-                    let mut hasher_for_legacy = Blake2b256::default();
-                    hasher_for_legacy.update(pk);
-                    let hashed_pk = hasher_for_legacy.finalize();
+                    let hashed_pk = Blake2b256::digest(pk);
                     hasher.update(hashed_pk.as_ref());
                 }
                 _ => {

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -1620,6 +1620,7 @@ pub enum SignatureScheme {
     BLS12381, // This is currently not supported for user Sui Address.
     MultiSig,
     ZkLoginAuthenticator,
+    ED25519Legacy,
 }
 
 impl SignatureScheme {
@@ -1631,6 +1632,7 @@ impl SignatureScheme {
             SignatureScheme::MultiSig => 0x03,
             SignatureScheme::BLS12381 => 0x04, // This is currently not supported for user Sui Address.
             SignatureScheme::ZkLoginAuthenticator => 0x05,
+            SignatureScheme::ED25519Legacy => 0xFF,
         }
     }
 
@@ -1649,6 +1651,7 @@ impl SignatureScheme {
             0x03 => Ok(SignatureScheme::MultiSig),
             0x04 => Ok(SignatureScheme::BLS12381),
             0x05 => Ok(SignatureScheme::ZkLoginAuthenticator),
+            0xFF => Ok(SignatureScheme::ED25519Legacy),
             _ => Err(SuiError::KeyConversionError(
                 "Invalid key scheme".to_string(),
             )),

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -1037,7 +1037,7 @@ impl<S: SuiSignatureInner + Sized> SuiSignature for S {
     }
 
     fn scheme(&self) -> SignatureScheme {
-        S::PubKey::SIGNATURE_SCHEME
+        S::SCHEME
     }
 
     fn verify_secure<T>(

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -225,6 +225,11 @@ impl SuiKeyPair {
                         bytes.get(1..).ok_or_else(|| eyre!("Invalid length"))?,
                     )?))
                 }
+                SignatureScheme::ED25519Legacy => Ok(SuiKeyPair::Ed25519Legacy(
+                    Ed25519LegacyKeyPair(Ed25519KeyPair::from_bytes(
+                        bytes.get(1..).ok_or_else(|| eyre!("Invalid length"))?,
+                    )?),
+                )),
                 _ => Err(eyre!("Invalid flag byte")),
             },
             _ => Err(eyre!("Invalid bytes")),
@@ -360,6 +365,9 @@ impl PublicKey {
             )),
             SignatureScheme::Secp256r1 => Ok(PublicKey::Secp256r1(
                 (&Secp256r1PublicKey::from_bytes(key_bytes)?).into(),
+            )),
+            SignatureScheme::ED25519Legacy => Ok(PublicKey::Ed25519Legacy(
+                (&Ed25519PublicKey::from_bytes(key_bytes)?).into(),
             )),
             _ => Err(eyre!("Unsupported curve")),
         }

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -909,8 +909,7 @@ pub trait SuiSignatureInner: Sized + ToFromBytes + PartialEq + Eq + Hash {
         let sig = Signer::sign(kp, message);
 
         let mut signature_bytes: Vec<u8> = Vec::new();
-        signature_bytes
-            .extend_from_slice(&[<Self::PubKey as SuiPublicKey>::SIGNATURE_SCHEME.flag()]);
+        signature_bytes.extend_from_slice(&[Self::SCHEME.flag()]);
         signature_bytes.extend_from_slice(sig.as_ref());
         signature_bytes.extend_from_slice(kp.public().as_ref());
         Self::from_bytes(&signature_bytes[..])

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -1054,10 +1054,12 @@ impl<S: SuiSignatureInner + Sized> SuiSignature for S {
         let digest = hasher.finalize().digest;
 
         let (sig, pk) = &self.get_verification_inputs()?;
+        let sui_pk = PublicKey::try_from_bytes(self.scheme(), self.public_key_bytes())
+            .map_err(|_| SuiError::KeyConversionError("Invalid public key".to_string()))?;
         match scheme {
             SignatureScheme::ZkLoginAuthenticator => {} // Pass this check because zk login does not derive address from pubkey.
             _ => {
-                let address = SuiAddress::from(pk);
+                let address = SuiAddress::from(&sui_pk);
                 if author != address {
                     return Err(SuiError::IncorrectSigner {
                         error: format!(

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -334,7 +334,7 @@ impl EncodeDecodeBase64 for PublicKey {
                     )?;
                     Ok(PublicKey::Secp256r1((&pk).into()))
                 } else if x == &SignatureScheme::ED25519Legacy.flag() {
-                    let pk: Ed25519PublicKey = Ed25519PublicKey::from_bytes(
+                    let pk = Ed25519PublicKey::from_bytes(
                         bytes.get(1..).ok_or_else(|| eyre!("Invalid length"))?,
                     )?;
                     Ok(PublicKey::Ed25519Legacy((&pk).into()))

--- a/crates/sui-types/src/signature.rs
+++ b/crates/sui-types/src/signature.rs
@@ -145,6 +145,14 @@ impl GenericSignature {
                         })?)
                             .into(),
                     )),
+                    SignatureScheme::ED25519Legacy => Ok(CompressedSignature::Ed25519(
+                        (&Ed25519Signature::from_bytes(bytes).map_err(|_| {
+                            SuiError::InvalidSignature {
+                                error: "Cannot parse ed25519 sig".to_string(),
+                            }
+                        })?)
+                            .into(),
+                    )),
                     _ => Err(SuiError::UnsupportedFeatureError {
                         error: "Unsupported signature scheme".to_string(),
                     }),
@@ -184,6 +192,12 @@ impl GenericSignature {
                         })?)
                             .into(),
                     )),
+                    SignatureScheme::ED25519Legacy => Ok(PublicKey::Ed25519Legacy(
+                        (&Ed25519PublicKey::from_bytes(bytes).map_err(|_| {
+                            SuiError::KeyConversionError("Cannot parse ed25519 pk".to_string())
+                        })?)
+                            .into(),
+                    )),
                     _ => Err(SuiError::UnsupportedFeatureError {
                         error: "Unsupported signature scheme in MultiSig".to_string(),
                     }),
@@ -210,7 +224,8 @@ impl ToFromBytes for GenericSignature {
             Ok(x) => match x {
                 SignatureScheme::ED25519
                 | SignatureScheme::Secp256k1
-                | SignatureScheme::Secp256r1 => Ok(GenericSignature::Signature(
+                | SignatureScheme::Secp256r1
+                | SignatureScheme::ED25519Legacy => Ok(GenericSignature::Signature(
                     Signature::from_bytes(bytes).map_err(|_| FastCryptoError::InvalidSignature)?,
                 )),
                 SignatureScheme::MultiSig => match MultiSig::from_bytes(bytes) {

--- a/crates/sui-types/src/unit_tests/multisig_tests.rs
+++ b/crates/sui-types/src/unit_tests/multisig_tests.rs
@@ -246,7 +246,7 @@ fn test_verify_claims_for_legacy() {
         .collect();
     let aux_verify_data = VerifyParams::new(parsed, vec![], ZkLoginEnv::Test, true, true);
     let res = multisig.verify_claims(&msg, address, &aux_verify_data);
-    assert!(res.is_ok());
+    assert!(res.is_ok(), "res was not ok: {:?}", res);
 }
 
 #[test]

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -294,7 +294,7 @@ pub enum SuiClientCommands {
         serialize_signed_transaction: bool,
     },
 
-    /// Generate new address and keypair with keypair scheme flag {ed25519 | secp256k1 | secp256r1}
+    /// Generate new address and keypair with keypair scheme flag {ed25519 | secp256k1 | secp256r1 | ed25519legacy}
     /// with optional derivation path, default to m/44'/784'/0'/0'/0' for ed25519 or
     /// m/54'/784'/0'/0/0 for secp256k1 or m/74'/784'/0'/0/0 for secp256r1. Word length can be
     /// { word12 | word15 | word18 | word21 | word24} default to word12 if not specified.

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -295,8 +295,8 @@ pub enum SuiClientCommands {
     },
 
     /// Generate new address and keypair with keypair scheme flag {ed25519 | secp256k1 | secp256r1 | ed25519legacy}
-    /// with optional derivation path, default to m/44'/784'/0'/0'/0' for ed25519 or
-    /// m/54'/784'/0'/0/0 for secp256k1 or m/74'/784'/0'/0/0 for secp256r1. Word length can be
+    /// with optional derivation path, default to m/44'/4218'/0'/0'/0' for ed25519 or
+    /// m/54'/4218'/0'/0/0 for secp256k1 or m/74'/4218'/0'/0/0 for secp256r1. Word length can be
     /// { word12 | word15 | word18 | word21 | word24} default to word12 if not specified.
     #[clap(name = "new-address")]
     NewAddress {

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -90,8 +90,8 @@ pub enum KeyToolCommand {
         tx_bytes: Option<String>,
     },
     /// Generate a new keypair with key scheme flag {ed25519 | secp256k1 | secp256r1 | ed25519legacy}
-    /// with optional derivation path, default to m/44'/784'/0'/0'/0' for ed25519 or
-    /// m/54'/784'/0'/0/0 for secp256k1 or m/74'/784'/0'/0/0 for secp256r1. Word
+    /// with optional derivation path, default to m/44'/4218'/0'/0'/0' for ed25519 or
+    /// m/54'/4218'/0'/0/0 for secp256k1 or m/74'/4218'/0'/0/0 for secp256r1. Word
     /// length can be { word12 | word15 | word18 | word21 | word24} default to word12
     /// if not specified.
     ///
@@ -107,8 +107,8 @@ pub enum KeyToolCommand {
 
     /// Add a new key to Sui CLI Keystore using either the input mnemonic phrase or a Bech32 encoded 33-byte
     /// `flag || privkey` starting with "suiprivkey", the key scheme flag {ed25519 | secp256k1 | secp256r1 | ed25519legacy}
-    /// and an optional derivation path, default to m/44'/784'/0'/0'/0' for ed25519 or m/54'/784'/0'/0/0
-    /// for secp256k1 or m/74'/784'/0'/0/0 for secp256r1. Supports mnemonic phrase of word length 12, 15,
+    /// and an optional derivation path, default to m/44'/4218'/0'/0'/0' for ed25519 or m/54'/4218'/0'/0/0
+    /// for secp256k1 or m/74'/4218'/0'/0/0 for secp256r1. Supports mnemonic phrase of word length 12, 15,
     /// 18, 21, 24. Set an alias for the key with the --alias flag. If no alias is provided, the tool will
     /// automatically generate one.
     Import {

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -89,7 +89,7 @@ pub enum KeyToolCommand {
         #[clap(long)]
         tx_bytes: Option<String>,
     },
-    /// Generate a new keypair with key scheme flag {ed25519 | secp256k1 | secp256r1}
+    /// Generate a new keypair with key scheme flag {ed25519 | secp256k1 | secp256r1 | ed25519legacy}
     /// with optional derivation path, default to m/44'/784'/0'/0'/0' for ed25519 or
     /// m/54'/784'/0'/0/0 for secp256k1 or m/74'/784'/0'/0/0 for secp256r1. Word
     /// length can be { word12 | word15 | word18 | word21 | word24} default to word12
@@ -106,7 +106,7 @@ pub enum KeyToolCommand {
     },
 
     /// Add a new key to Sui CLI Keystore using either the input mnemonic phrase or a Bech32 encoded 33-byte
-    /// `flag || privkey` starting with "suiprivkey", the key scheme flag {ed25519 | secp256k1 | secp256r1}
+    /// `flag || privkey` starting with "suiprivkey", the key scheme flag {ed25519 | secp256k1 | secp256r1 | ed25519legacy}
     /// and an optional derivation path, default to m/44'/784'/0'/0'/0' for ed25519 or m/54'/784'/0'/0/0
     /// for secp256k1 or m/74'/784'/0'/0/0 for secp256r1. Supports mnemonic phrase of word length 12, 15,
     /// 18, 21, 24. Set an alias for the key with the --alias flag. If no alias is provided, the tool will

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -654,6 +654,7 @@ impl KeyToolCommand {
                             SuiKeyPair::Ed25519(kp) => kp.encode_base64(),
                             SuiKeyPair::Secp256k1(kp) => kp.encode_base64(),
                             SuiKeyPair::Secp256r1(kp) => kp.encode_base64(),
+                            SuiKeyPair::Ed25519Legacy(kp) => kp.encode_base64(),
                         };
                         KeypairData {
                             account_keypair: keypair.encode_base64(),

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -622,7 +622,7 @@ async fn prompt_if_no_config(
             let key_scheme = if accept_defaults {
                 SignatureScheme::ED25519
             } else {
-                println!("Select key scheme to generate keypair (0 for ed25519, 1 for secp256k1, 2: for secp256r1):");
+                println!("Select key scheme to generate keypair (0 for ed25519, 1 for secp256k1, 2 for secp256r1, 255 for ed25519legacy):");
                 match SignatureScheme::from_flag(read_line()?.trim()) {
                     Ok(s) => s,
                     Err(e) => return Err(anyhow!("{e}")),

--- a/crates/sui/src/unit_tests/keytool_tests.rs
+++ b/crates/sui/src/unit_tests/keytool_tests.rs
@@ -418,7 +418,7 @@ async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
         alias: None,
         input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
-        derivation_path: Some("m/0'/784'/0'/0/0".parse().unwrap()),
+        derivation_path: Some("m/0'/4218'/0'/0/0".parse().unwrap()),
     }
     .execute(&mut keystore)
     .await
@@ -428,7 +428,7 @@ async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
         alias: None,
         input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
-        derivation_path: Some("m/54'/784'/0'/0/0".parse().unwrap()),
+        derivation_path: Some("m/54'/4218'/0'/0/0".parse().unwrap()),
     }
     .execute(&mut keystore)
     .await
@@ -438,7 +438,7 @@ async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
         alias: None,
         input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::Secp256k1,
-        derivation_path: Some("m/54'/784'/0'/0'/0'".parse().unwrap()),
+        derivation_path: Some("m/54'/4218'/0'/0'/0'".parse().unwrap()),
     }
     .execute(&mut keystore)
     .await
@@ -448,7 +448,7 @@ async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
         alias: None,
         input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::Secp256k1,
-        derivation_path: Some("m/44'/784'/0'/0/0".parse().unwrap()),
+        derivation_path: Some("m/44'/4218'/0'/0/0".parse().unwrap()),
     }
     .execute(&mut keystore)
     .await
@@ -464,7 +464,7 @@ async fn test_valid_derivation_path() -> Result<(), anyhow::Error> {
         alias: None,
         input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
-        derivation_path: Some("m/44'/784'/0'/0'/0'".parse().unwrap()),
+        derivation_path: Some("m/44'/4218'/0'/0'/0'".parse().unwrap()),
     }
     .execute(&mut keystore)
     .await
@@ -474,7 +474,7 @@ async fn test_valid_derivation_path() -> Result<(), anyhow::Error> {
         alias: None,
         input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
-        derivation_path: Some("m/44'/784'/0'/0'/1'".parse().unwrap()),
+        derivation_path: Some("m/44'/4218'/0'/0'/1'".parse().unwrap()),
     }
     .execute(&mut keystore)
     .await
@@ -484,7 +484,7 @@ async fn test_valid_derivation_path() -> Result<(), anyhow::Error> {
         alias: None,
         input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
-        derivation_path: Some("m/44'/784'/1'/0'/1'".parse().unwrap()),
+        derivation_path: Some("m/44'/4218'/1'/0'/1'".parse().unwrap()),
     }
     .execute(&mut keystore)
     .await
@@ -494,7 +494,7 @@ async fn test_valid_derivation_path() -> Result<(), anyhow::Error> {
         alias: None,
         input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::Secp256k1,
-        derivation_path: Some("m/54'/784'/0'/0/1".parse().unwrap()),
+        derivation_path: Some("m/54'/4218'/0'/0/1".parse().unwrap()),
     }
     .execute(&mut keystore)
     .await
@@ -504,7 +504,7 @@ async fn test_valid_derivation_path() -> Result<(), anyhow::Error> {
         alias: None,
         input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::Secp256k1,
-        derivation_path: Some("m/54'/784'/1'/0/1".parse().unwrap()),
+        derivation_path: Some("m/54'/4218'/1'/0/1".parse().unwrap()),
     }
     .execute(&mut keystore)
     .await

--- a/crates/sui/src/unit_tests/keytool_tests.rs
+++ b/crates/sui/src/unit_tests/keytool_tests.rs
@@ -313,9 +313,23 @@ async fn test_private_keys_import_export() -> Result<(), anyhow::Error> {
 #[test]
 async fn test_mnemonics_ed25519() -> Result<(), anyhow::Error> {
     // Test case matches with /mysten/sui/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
-    const TEST_CASES: [[&str; 3]; 3] = [["film crazy soon outside stand loop subway crumble thrive popular green nuclear struggle pistol arm wife phrase warfare march wheat nephew ask sunny firm", "suiprivkey1qrwsjvr6gwaxmsvxk4cfun99ra8uwxg3c9pl0nhle7xxpe4s80y05ctazer", "a2d14fad60c56049ecf75246a481934691214ce413e6a8ae2fe6834c173a6133"],
-    ["require decline left thought grid priority false tiny gasp angle royal system attack beef setup reward aunt skill wasp tray vital bounce inflict level", "suiprivkey1qzdvpa77ct272ultqcy20dkw78dysnfyg90fhcxkdm60el0qht9mvzlsh4j", "1ada6e6f3f3e4055096f606c746690f1108fcc2ca479055cc434a3e1d3f758aa"],
-    ["organ crash swim stick traffic remember army arctic mesh slice swear summer police vast chaos cradle squirrel hood useless evidence pet hub soap lake", "suiprivkey1qqqscjyyr64jea849dfv9cukurqj2swx0m3rr4hr7sw955jy07tzgcde5ut", "e69e896ca10f5a77732769803cc2b5707f0ab9d4407afb5e4b4464b89769af14"]];
+    const TEST_CASES: [[&str; 3]; 3] = [
+        [
+            "film crazy soon outside stand loop subway crumble thrive popular green nuclear struggle pistol arm wife phrase warfare march wheat nephew ask sunny firm", 
+            "suiprivkey1qrqqxhsu3ndp96644fjk4z5ams5ulgmvprklngt2jhvg2ujn5w4q23vm2y8", 
+            "7ba26cca0b4c313c8d12193263f7df111f32e1835b12204b94e5859187a0aa26"
+        ],
+        [
+            "require decline left thought grid priority false tiny gasp angle royal system attack beef setup reward aunt skill wasp tray vital bounce inflict level", 
+            "suiprivkey1qqcxaf57fnenvflpacacaumf6vl0rt0edddhytanvzhkqhwnjk0zsawjy3x", 
+            "7abd0ad79244dfa245ed4e03b1e5f3295a2332c30f15fb7fa0d3a0f546ca0d74"
+        ],
+        [
+            "organ crash swim stick traffic remember army arctic mesh slice swear summer police vast chaos cradle squirrel hood useless evidence pet hub soap lake", 
+            "suiprivkey1qzq39vxzm0gq7l8dc5dj5allpuww4mavhwhg8mua4cl3lj2c3fvhcsjgphc", 
+            "0f5747833baf8d7794c6a810d74b5bce2cd1286c6634b004bd56a58c92cff7cb"
+        ]
+    ];
 
     for t in TEST_CASES {
         let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
@@ -338,9 +352,23 @@ async fn test_mnemonics_ed25519() -> Result<(), anyhow::Error> {
 #[test]
 async fn test_mnemonics_secp256k1() -> Result<(), anyhow::Error> {
     // Test case matches with /mysten/sui/sdk/typescript/test/unit/cryptography/secp256k1-keypair.test.ts
-    const TEST_CASES: [[&str; 3]; 3] = [["film crazy soon outside stand loop subway crumble thrive popular green nuclear struggle pistol arm wife phrase warfare march wheat nephew ask sunny firm", "suiprivkey1qyqr6yvxdqkh32ep4pk9caqvphmk9epn6rhkczcrhaeermsyvwsg783y9am", "9e8f732575cc5386f8df3c784cd3ed1b53ce538da79926b2ad54dcc1197d2532"],
-    ["require decline left thought grid priority false tiny gasp angle royal system attack beef setup reward aunt skill wasp tray vital bounce inflict level", "suiprivkey1q8hexn5m2u36tx39ln5e22hfseadknp7d2qlkhe30ejy7fc6am5aqkqpqsj", "9fd5a804ed6b46d36949ff7434247f0fd594673973ece24aede6b86a7b5dae01"],
-    ["organ crash swim stick traffic remember army arctic mesh slice swear summer police vast chaos cradle squirrel hood useless evidence pet hub soap lake", "suiprivkey1qxx6yf53jgxvsmccst8cuwnj0rx4k4uzvn9aalvag7ns0xf0g8j2x246jst", "60287d7c38dee783c2ab1077216124011774be6b0764d62bd05f32c88979d5c5"]];
+    const TEST_CASES: [[&str; 3]; 3] = [
+        [
+            "film crazy soon outside stand loop subway crumble thrive popular green nuclear struggle pistol arm wife phrase warfare march wheat nephew ask sunny firm", 
+            "suiprivkey1q8cy2ll8a0dmzzzwn9zavrug0qf47cyuj6k2r4r6rnjtpjhrdh52vallxwz", 
+            "8520d58dde1ab268349b9a46e5124ae6fe7e4c61df4ca2bc9c97d3c4d07b0b55"
+        ],
+        [
+            "require decline left thought grid priority false tiny gasp angle royal system attack beef setup reward aunt skill wasp tray vital bounce inflict level", 
+            "suiprivkey1q9hm330d05jcxfvmztv046p8kclyaj39hk6elqghgpq4sz4x23hk2jtdnjf", 
+            "3740d570eefba29dfc0fdd5829848902064e31ecd059ca05c401907fa8646f61"
+        ],
+        [
+            "organ crash swim stick traffic remember army arctic mesh slice swear summer police vast chaos cradle squirrel hood useless evidence pet hub soap lake", 
+            "suiprivkey1qx2dnch6363h7gdqqfkzmmlequzj4ul3x4fq6dzyajk7wc2c0jgcxdv2dvl", 
+            "943b852c37fef403047e06ff5a2fa216557a4386212fb29554babdd3e1899da5"
+        ]
+    ];
 
     for t in TEST_CASES {
         let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
@@ -366,18 +394,18 @@ async fn test_mnemonics_secp256r1() -> Result<(), anyhow::Error> {
     const TEST_CASES: [[&str; 3]; 3] = [
         [
             "act wing dilemma glory episode region allow mad tourist humble muffin oblige",
-            "suiprivkey1qgj6vet4rstf2p00j860xctkg4fyqqq5hxgu4mm0eg60fq787ujnqs5wc8q",
-            "0x4a822457f1970468d38dae8e63fb60eefdaa497d74d781f581ea2d137ec36f3a",
+            "suiprivkey1qtt65ua2lhal76zg4cxd6umdqynv2rj2gzrntp5rwlnyj370jg3pwhxg9kc",
+            "0x779a63b28528210a5ec6c4af5a70382fa3f0c2d3f98dcbe4e3a4ae2f8c39cc9c",
         ],
         [
             "flag rebel cabbage captain minimum purpose long already valley horn enrich salt",
-            "suiprivkey1qgmgr6dza8slgxn0rcxcy47xeas9l565cc5q440ngdzr575rc2356gzlq7a",
-            "0xcd43ecb9dd32249ff5748f5e4d51855b01c9b1b8bbe7f8638bb8ab4cb463b920",
+            "suiprivkey1qtcjgmue7q8u4gtutfvfpx3zj3aa2r9pqssuusrltxfv68eqhzsgjyhk7e4",
+            "0x8b45523042933aa55f57e2ccc661304baed292529b6e67a0c9857c1f3f871806",
         ],
         [
             "area renew bar language pudding trial small host remind supreme cabbage era",
-            "suiprivkey1qt2gsye4dyn0lxey0ht6d5f2ada7ew9044a49y2f3mymy2uf0hr55jmfze3",
-            "0x0d9047b7e7b698cc09c955ea97b0c68c2be7fb3aebeb59edcc84b1fb87e0f28e",
+            "suiprivkey1qtxafg26qxeqy7f56gd2rvsup0a5kl4cre7nt2rtcrf0p3v5pwd4c595zjp",
+            "0x8528ef86150ec331928a8b3edb8adbe2fb523db8c84679aa57a931da6a4cdb25",
         ],
     ];
 
@@ -398,6 +426,45 @@ async fn test_mnemonics_secp256r1() -> Result<(), anyhow::Error> {
         assert!(keystore.addresses().contains(&addr));
     }
 
+    Ok(())
+}
+
+#[test]
+async fn test_mnemonics_ed25519legacy() -> Result<(), anyhow::Error> {
+    // Test case matches with /mysten/sui/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
+    const TEST_CASES: [[&str; 3]; 3] = [
+        [
+            "film crazy soon outside stand loop subway crumble thrive popular green nuclear struggle pistol arm wife phrase warfare march wheat nephew ask sunny firm", 
+            "suiprivkey1llqqxhsu3ndp96644fjk4z5ams5ulgmvprklngt2jhvg2ujn5w4q2c9ha8m", 
+            "77a58912dac82dcae215d6910ee8ae5e79d4b76555ac0f505c188e91b49cddb3"
+        ],
+        [
+            "require decline left thought grid priority false tiny gasp angle royal system attack beef setup reward aunt skill wasp tray vital bounce inflict level", 
+            "suiprivkey1lucxaf57fnenvflpacacaumf6vl0rt0edddhytanvzhkqhwnjk0zs587nj6", 
+            "58357bc75b7f88132b50040cf5f04cd53710f349fe0095c3027bc2657c589962"
+        ],
+        [
+            "organ crash swim stick traffic remember army arctic mesh slice swear summer police vast chaos cradle squirrel hood useless evidence pet hub soap lake", 
+            "suiprivkey1l7q39vxzm0gq7l8dc5dj5allpuww4mavhwhg8mua4cl3lj2c3fvhcemyk5y", 
+            "8c1eea724b985d649790301a08481b581b42c20c5c044b7c4a44c611b8bbcd13"
+        ]
+    ];
+
+    for t in TEST_CASES {
+        let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
+        KeyToolCommand::Import {
+            alias: None,
+            input_string: t[0].to_string(),
+            key_scheme: SignatureScheme::ED25519Legacy,
+            derivation_path: None,
+        }
+        .execute(&mut keystore)
+        .await?;
+        let kp = SuiKeyPair::decode(t[1]).unwrap();
+        let addr = SuiAddress::from_str(t[2]).unwrap();
+        assert_eq!(SuiAddress::from(&kp.public()), addr);
+        assert!(keystore.addresses().contains(&addr));
+    }
     Ok(())
 }
 

--- a/crates/sui/src/unit_tests/keytool_tests.rs
+++ b/crates/sui/src/unit_tests/keytool_tests.rs
@@ -28,6 +28,8 @@ use sui_types::base_types::SuiAddress;
 use sui_types::crypto::get_key_pair;
 use sui_types::crypto::get_key_pair_from_rng;
 use sui_types::crypto::AuthorityKeyPair;
+use sui_types::crypto::Ed25519LegacyKeyPair;
+use sui_types::crypto::Ed25519LegacySuiSignature;
 use sui_types::crypto::Ed25519SuiSignature;
 use sui_types::crypto::EncodeDecodeBase64;
 use sui_types::crypto::Secp256k1SuiSignature;
@@ -69,6 +71,10 @@ async fn test_flag_in_signature_and_keypair() -> Result<(), anyhow::Error> {
 
     keystore.add_key(None, SuiKeyPair::Secp256k1(get_key_pair().1))?;
     keystore.add_key(None, SuiKeyPair::Ed25519(get_key_pair().1))?;
+    keystore.add_key(
+        None,
+        SuiKeyPair::Ed25519Legacy(Ed25519LegacyKeyPair(get_key_pair().1)),
+    )?;
 
     for pk in keystore.keys() {
         let pk1 = pk.clone();
@@ -96,6 +102,15 @@ async fn test_flag_in_signature_and_keypair() -> Result<(), anyhow::Error> {
                     Secp256r1SuiSignature::SCHEME.flag()
                 );
                 assert!(pk1.flag() == Secp256r1SuiSignature::SCHEME.flag())
+            }
+            Signature::Ed25519LegacySuiSignature(_) => {
+                // signature contains corresponding flag
+                assert_eq!(
+                    *sig.as_ref().first().unwrap(),
+                    Ed25519LegacySuiSignature::SCHEME.flag()
+                );
+                // keystore stores pubkey with corresponding flag
+                assert!(pk1.flag() == Ed25519LegacySuiSignature::SCHEME.flag())
             }
         }
     }

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -2545,6 +2545,10 @@ async fn test_signature_flag() -> Result<(), anyhow::Error> {
     assert!(res.is_ok());
     assert_eq!(res.unwrap().flag(), SignatureScheme::Secp256r1.flag());
 
+    let res = SignatureScheme::from_flag("255");
+    assert!(res.is_ok());
+    assert_eq!(res.unwrap().flag(), SignatureScheme::ED25519Legacy.flag());
+
     let res = SignatureScheme::from_flag("something");
     assert!(res.is_err());
     Ok(())


### PR DESCRIPTION
# Description of change

This PR adds the support for the IOTA legacy ED25519 Address type (limited to the rust framework, not typescript).
The main changes are 3:
1) Change the coin_type to `4218` for BIP-39 key derivation method.
2) Added a new Signature Scheme to work with a new flag (`255`) with ED25519 pub keys.
3) Change to the algorithm for `SuiAddress`derivation. 
 
Detailed description
1) A simple constant replacement performed in [607e400](https://github.com/iotaledger/kinesis/pull/100/commits/607e40032596d580c4548674081028664ec646c0)
2) The majority of the changes have been done in `crates/sui-types/src/crypto.rs`.
    - `SignatureScheme` has been expanded with `ED25519Legacy` setting its flag to `0xFF`.
    - A new wrapper `Ed25519LegacyKeyPair` has been created around the `fastcrypto`'s `Ed25519KeyPair` type  to enable the ED25519 keypairs to have two flags.
    - The type `Ed25519LegacySuiSignature` has been created to generate a Ed25519 signature with a `0xFF` flag (a signature in Sui is a concatenation of `flag || signature || pub_key`).
    - Types `SuiKeyPair` and `PublicKey` have been expanded to support `Ed25519Legacy`.
    - Changes to the Sui logic happened in these commits:
      - [d825c14](https://github.com/iotaledger/kinesis/pull/100/commits/d825c14321a8ce29e98e4d3e50c23433908c7817) and [46c5b9c](https://github.com/iotaledger/kinesis/pull/100/commits/46c5b9cdcd9a71036775e5d61ca65553e3dbe9bb) use the flag indicated in the `SuiSignatureInner` instead of the one associated outside of `SuiSignatureInner` to the `fastcrypto`'s public key type (otherwise for `Ed25519PublicKey` would have been always `0x00`);
      - [df81035](https://github.com/iotaledger/kinesis/pull/100/commits/df8103589c74f83fae00079af68842c36cb5f934) alter the ED25519 BIP-44 key derivation implementation in order to support also ED25519Legacy;
3) The algorithm for address derivation was changed with [26ce351](https://github.com/iotaledger/kinesis/pull/100/commits/26ce351270f41bd8dfc59f56fbb2b99df40dd03f):
    - if flag != `0xFF` then same as before
    - else `sui_address = DefaultHash(0xFF || Blake2b256(ed25519_pub_key))`

## Links to any relevant issues

Closes [kinesis-migration/#45](https://github.com/iotaledger/kinesis/issues/122)
Closes [kinesis-migration/#47](https://github.com/iotaledger/kinesis/issues/121)

## Type of change

- Breaking change (commits [d825c14](https://github.com/iotaledger/kinesis/pull/100/commits/d825c14321a8ce29e98e4d3e50c23433908c7817), [46c5b9c](https://github.com/iotaledger/kinesis/pull/100/commits/46c5b9cdcd9a71036775e5d61ca65553e3dbe9bb) and [df81035](https://github.com/iotaledger/kinesis/pull/100/commits/df8103589c74f83fae00079af68842c36cb5f934)  modified the original Sui code)

## How the change has been tested

Tested in different ways, please suggest more tests:
- Test for correct generation:
  `sui keytool import "jazz photo inject brisk buzz reason transfer repeat garbage oblige win observe summer same glow visit tower perfect genre balance spin eternal stairs scare" ed25519legacy` creates 
  ```
  suiAddress 0xdf186a88cced42d2a170eb927969c40f764e9f83ef37d5ebf3d944541c5db7bf
  publicBase64Key /6AWocApAO7q5viClrkF1nF4ZsDxzihYkcTOw8loawIL
  ``` 
  `sui keytool import "jazz photo inject brisk buzz reason transfer repeat garbage oblige win observe summer same glow visit tower perfect genre balance spin eternal stairs scare" ed25519` creates 
    ```
    suiAddress 0xdcb933adba86b523f9c8a411fe1840413487ea3f62022cddb4e7a4fe6f9ed2b3
    publicBase64Key AKAWocApAO7q5viClrkF1nF4ZsDxzihYkcTOw8loawIL
    ``` 
  see that the pub key only changes the first byte, i.e., the flag -> ed25519legacy: 255, ed25519: 0.
  
- Test for IOTA compatibility: 
  tested through the IOTA-SDK: (1) use the same mnemonic to generate a `iota_ed25519_address`; (2) hash with `Blake2b(0xFF || iota_ed25519_address)`; (3) obtain the same address as the first one above `0xdf186a8...`
  
- Test for multisig:
  created a new unit test with [e169602](https://github.com/iotaledger/kinesis/pull/100/commits/e169602ced531d3127710787bf3fd144e6e48b0d). 

- Test sui cli
  `cargo test --package sui -- --exact --nocapture`
  
- Test e2e after #118 
  `pnpm --filter @mysten/sui.js test:e2e`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
