### PR TITLE
Use IoUnpacker in FullSnapshotParser

### DIFF
--- a/crates/sui-genesis-builder/Cargo.toml
+++ b/crates/sui-genesis-builder/Cargo.toml
@@ -25,6 +25,7 @@ prometheus.workspace = true
 iota-sdk = "1.1.4"
 packable = { version = "0.8.3", default-features = false, features = [
     "primitive-types",
+    "io",
 ] }
 
 shared-crypto.workspace = true
@@ -41,3 +42,7 @@ sui-simulator.workspace = true
 insta.workspace = true
 tempfile.workspace = true
 sui-types = { workspace = true, features = ["test-utils"] }
+
+[[example]]
+name = "parse_full_snapshot"
+path = "examples/parse_full_snapshot.rs"

--- a/crates/sui-genesis-builder/src/stardust/parse.rs
+++ b/crates/sui-genesis-builder/src/stardust/parse.rs
@@ -3,39 +3,34 @@ use std::io::{BufReader, Read};
 
 use anyhow::Result;
 use iota_sdk::types::block::{output::Output, protocol::ProtocolParameters};
-use packable::PackableExt;
+use packable::{unpacker::IoUnpacker, Packable};
 
 use super::types::{FullSnapshotHeader, OutputHeader};
 
 /// Parse a full-snapshot using a [`BufReader`] internally.
 pub struct FullSnapshotParser<R: Read> {
-    reader: BufReader<R>,
+    reader: IoUnpacker<BufReader<R>>,
     /// The full-snapshot header
     pub header: FullSnapshotHeader,
 }
 
 impl<R: Read> FullSnapshotParser<R> {
     pub fn new(reader: R) -> Result<Self> {
-        let mut reader = std::io::BufReader::new(reader);
-        let mut buf = [0_u8; FullSnapshotHeader::LENGTH];
-        reader.read_exact(&mut buf)?;
+        let mut reader = IoUnpacker::new(std::io::BufReader::new(reader));
+        let header = FullSnapshotHeader::unpack::<_, true>(&mut reader, &())?;
 
-        let header = FullSnapshotHeader::unpack_verified(buf.as_slice(), &())?;
         Ok(Self { reader, header })
     }
 
     /// Provide an iterator over the Stardust UTXOs recorded in the snapshot.
     pub fn outputs(mut self) -> impl Iterator<Item = Result<Output, anyhow::Error>> {
-        let mut header_buf = [0_u8; OutputHeader::LENGTH];
-        let mut output_buf = [0_u8; u16::MAX as usize];
-
         (0..self.header.output_count()).map(move |_| {
-            self.reader.read_exact(&mut header_buf)?;
-            let header = OutputHeader::unpack_verified(header_buf.as_slice(), &())?;
-            let output_bytes = &mut output_buf[0..header.length() as usize];
-            self.reader.read_exact(output_bytes)?;
-            let output = Output::unpack_verified(output_bytes, &ProtocolParameters::default())?;
-            Ok(output)
+            let _header = OutputHeader::unpack::<_, true>(&mut self.reader, &())?;
+
+            Ok(Output::unpack::<_, true>(
+                &mut self.reader,
+                &ProtocolParameters::default(),
+            )?)
         })
     }
 }

--- a/crates/sui-genesis-builder/src/stardust/types.rs
+++ b/crates/sui-genesis-builder/src/stardust/types.rs
@@ -93,7 +93,7 @@ pub struct FullSnapshotHeader {
 }
 
 impl FullSnapshotHeader {
-    /// The lengt of the header in bytes
+    /// The length of the header in bytes
     pub const LENGTH: usize = std::mem::size_of::<Self>();
 
     /// Returns the genesis milestone index of a [`FullSnapshotHeader`].


### PR DESCRIPTION
This should allow streaming directly from the `BufReader` to the unpacked object without the need for intermediate copies.