### PR TITLE
Alias output model

### DIFF
--- a/crates/sui-framework/docs/stardust/address_unlock_condition.md
+++ b/crates/sui-framework/docs/stardust/address_unlock_condition.md
@@ -14,7 +14,9 @@ title: Module `0x107a::address_unlock_condition`
 
 
 <pre><code><b>use</b> <a href="alias.md#0x107a_alias">0x107a::alias</a>;
+<b>use</b> <a href="alias_output.md#0x107a_alias_output">0x107a::alias_output</a>;
 <b>use</b> <a href="basic.md#0x107a_basic">0x107a::basic</a>;
+<b>use</b> <a href="nft.md#0x107a_nft">0x107a::nft</a>;
 <b>use</b> <a href="nft_output.md#0x107a_nft_output">0x107a::nft_output</a>;
 <b>use</b> <a href="../sui-framework/coin.md#0x2_coin">0x2::coin</a>;
 <b>use</b> <a href="../sui-framework/object.md#0x2_object">0x2::object</a>;
@@ -30,7 +32,7 @@ title: Module `0x107a::address_unlock_condition`
 Unlock Basic outputs locked to this alias address
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_basic">unlock_alias_address_owned_basic</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_StateCap">alias::StateCap</a>, output_to_unlock: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="basic.md#0x107a_basic_BasicOutput">basic::BasicOutput</a>&gt;): <a href="basic.md#0x107a_basic_BasicOutput">basic::BasicOutput</a>
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_basic">unlock_alias_address_owned_basic</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_Alias">alias::Alias</a>, output_to_unlock: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="basic.md#0x107a_basic_BasicOutput">basic::BasicOutput</a>&gt;): <a href="basic.md#0x107a_basic_BasicOutput">basic::BasicOutput</a>
 </code></pre>
 
 
@@ -40,11 +42,9 @@ Unlock Basic outputs locked to this alias address
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_basic">unlock_alias_address_owned_basic</a>(
-  self: &<b>mut</b> AliasOutput,
-  cap: &StateCap,
+  self: &<b>mut</b> Alias,
   output_to_unlock: Receiving&lt;BasicOutput&gt;,
   ): BasicOutput {
-    self.state_index_increment(cap);
     <a href="basic.md#0x107a_basic_receive">basic::receive</a>(self.id(), output_to_unlock)
 }
 </code></pre>
@@ -60,7 +60,7 @@ Unlock Basic outputs locked to this alias address
 Unlock NFT outputs locked to this alias address
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_nft">unlock_alias_address_owned_nft</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_StateCap">alias::StateCap</a>, output_to_unlock: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>&gt;): <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_nft">unlock_alias_address_owned_nft</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_Alias">alias::Alias</a>, output_to_unlock: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>&gt;): <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>
 </code></pre>
 
 
@@ -70,11 +70,9 @@ Unlock NFT outputs locked to this alias address
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_nft">unlock_alias_address_owned_nft</a>(
-  self: &<b>mut</b> AliasOutput,
-  cap: &StateCap,
+  self: &<b>mut</b> Alias,
   output_to_unlock: Receiving&lt;NftOutput&gt;,
   ): NftOutput {
-    self.state_index_increment(cap);
     <a href="nft_output.md#0x107a_nft_output_receive">nft_output::receive</a>(self.id(), output_to_unlock)
 }
 </code></pre>
@@ -90,7 +88,7 @@ Unlock NFT outputs locked to this alias address
 Unlock Alias outputs locked to this alias address
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_alias">unlock_alias_address_owned_alias</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_StateCap">alias::StateCap</a>, output_to_unlock: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>&gt;): <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_alias">unlock_alias_address_owned_alias</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_Alias">alias::Alias</a>, output_to_unlock: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>&gt;): <a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>
 </code></pre>
 
 
@@ -100,12 +98,10 @@ Unlock Alias outputs locked to this alias address
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_alias">unlock_alias_address_owned_alias</a>(
-  self: &<b>mut</b> AliasOutput,
-  cap: &StateCap,
+  self: &<b>mut</b> Alias,
   output_to_unlock: Receiving&lt;AliasOutput&gt;,
   ): AliasOutput {
-    self.state_index_increment(cap);
-    <a href="alias.md#0x107a_alias_receive">alias::receive</a>(self.id(), output_to_unlock)
+    <a href="alias_output.md#0x107a_alias_output_receive">alias_output::receive</a>(self.id(), output_to_unlock)
 }
 </code></pre>
 
@@ -120,7 +116,7 @@ Unlock Alias outputs locked to this alias address
 Unlock Alias outputs locked to this alias address
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_treasury">unlock_alias_address_owned_treasury</a>&lt;T: store, key&gt;(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_StateCap">alias::StateCap</a>, treasury_cap: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="../sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;&gt;): <a href="../sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_treasury">unlock_alias_address_owned_treasury</a>&lt;T: store, key&gt;(self: &<b>mut</b> <a href="alias.md#0x107a_alias_Alias">alias::Alias</a>, treasury_cap: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="../sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;&gt;): <a href="../sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;
 </code></pre>
 
 
@@ -130,11 +126,9 @@ Unlock Alias outputs locked to this alias address
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_treasury">unlock_alias_address_owned_treasury</a>&lt;T: key + store&gt;(
-  self: &<b>mut</b> AliasOutput,
-  cap: &StateCap,
+  self: &<b>mut</b> Alias,
   treasury_cap: Receiving&lt;TreasuryCap&lt;T&gt;&gt;,
   ): TreasuryCap&lt;T&gt; {
-    self.state_index_increment(cap);
     <a href="../sui-framework/transfer.md#0x2_transfer_public_receive">transfer::public_receive</a>(self.id(), treasury_cap)
 }
 </code></pre>
@@ -150,7 +144,7 @@ Unlock Alias outputs locked to this alias address
 Unlock Basic outputs locked to this alias address
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_basic">unlock_nft_address_owned_basic</a>(self: &<b>mut</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>, output_to_unlock: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="basic.md#0x107a_basic_BasicOutput">basic::BasicOutput</a>&gt;): <a href="basic.md#0x107a_basic_BasicOutput">basic::BasicOutput</a>
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_basic">unlock_nft_address_owned_basic</a>(self: &<b>mut</b> <a href="nft.md#0x107a_nft_Nft">nft::Nft</a>, output_to_unlock: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="basic.md#0x107a_basic_BasicOutput">basic::BasicOutput</a>&gt;): <a href="basic.md#0x107a_basic_BasicOutput">basic::BasicOutput</a>
 </code></pre>
 
 
@@ -160,7 +154,7 @@ Unlock Basic outputs locked to this alias address
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_basic">unlock_nft_address_owned_basic</a>(
-  self: &<b>mut</b> NftOutput,
+  self: &<b>mut</b> Nft,
   output_to_unlock: Receiving&lt;BasicOutput&gt;,
   ): BasicOutput {
     <a href="basic.md#0x107a_basic_receive">basic::receive</a>(self.id(), output_to_unlock)
@@ -175,10 +169,10 @@ Unlock Basic outputs locked to this alias address
 
 ## Function `unlock_nft_address_owned_nft`
 
-Unlock NFT outputs locked to this alias address
+Unlock NFT outputs locked to this nft address
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_nft">unlock_nft_address_owned_nft</a>(self: &<b>mut</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>, output_to_unlock: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>&gt;): <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_nft">unlock_nft_address_owned_nft</a>(self: &<b>mut</b> <a href="nft.md#0x107a_nft_Nft">nft::Nft</a>, output_to_unlock: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>&gt;): <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>
 </code></pre>
 
 
@@ -188,7 +182,7 @@ Unlock NFT outputs locked to this alias address
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_nft">unlock_nft_address_owned_nft</a>(
-  self: &<b>mut</b> NftOutput,
+  self: &<b>mut</b> Nft,
   output_to_unlock: Receiving&lt;NftOutput&gt;,
   ): NftOutput {
     <a href="nft_output.md#0x107a_nft_output_receive">nft_output::receive</a>(self.id(), output_to_unlock)
@@ -203,10 +197,10 @@ Unlock NFT outputs locked to this alias address
 
 ## Function `unlock_nft_address_owned_alias`
 
-Unlock Alias outputs locked to this alias address
+Unlock Alias outputs locked to this Nft address
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_alias">unlock_nft_address_owned_alias</a>(self: &<b>mut</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>, output_to_unlock: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>&gt;): <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_alias">unlock_nft_address_owned_alias</a>(self: &<b>mut</b> <a href="nft.md#0x107a_nft_Nft">nft::Nft</a>, output_to_unlock: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>&gt;): <a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>
 </code></pre>
 
 
@@ -216,10 +210,10 @@ Unlock Alias outputs locked to this alias address
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_alias">unlock_nft_address_owned_alias</a>(
-  self: &<b>mut</b> NftOutput,
+  self: &<b>mut</b> Nft,
   output_to_unlock: Receiving&lt;AliasOutput&gt;,
   ): AliasOutput {
-    <a href="alias.md#0x107a_alias_receive">alias::receive</a>(self.id(), output_to_unlock)
+    <a href="alias_output.md#0x107a_alias_output_receive">alias_output::receive</a>(self.id(), output_to_unlock)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/stardust/address_unlock_condition.md
+++ b/crates/sui-framework/docs/stardust/address_unlock_condition.md
@@ -1,0 +1,228 @@
+---
+title: Module `0x107a::address_unlock_condition`
+---
+
+
+
+-  [Function `unlock_alias_address_owned_basic`](#0x107a_address_unlock_condition_unlock_alias_address_owned_basic)
+-  [Function `unlock_alias_address_owned_nft`](#0x107a_address_unlock_condition_unlock_alias_address_owned_nft)
+-  [Function `unlock_alias_address_owned_alias`](#0x107a_address_unlock_condition_unlock_alias_address_owned_alias)
+-  [Function `unlock_alias_address_owned_treasury`](#0x107a_address_unlock_condition_unlock_alias_address_owned_treasury)
+-  [Function `unlock_nft_address_owned_basic`](#0x107a_address_unlock_condition_unlock_nft_address_owned_basic)
+-  [Function `unlock_nft_address_owned_nft`](#0x107a_address_unlock_condition_unlock_nft_address_owned_nft)
+-  [Function `unlock_nft_address_owned_alias`](#0x107a_address_unlock_condition_unlock_nft_address_owned_alias)
+
+
+<pre><code><b>use</b> <a href="alias.md#0x107a_alias">0x107a::alias</a>;
+<b>use</b> <a href="basic.md#0x107a_basic">0x107a::basic</a>;
+<b>use</b> <a href="nft_output.md#0x107a_nft_output">0x107a::nft_output</a>;
+<b>use</b> <a href="../sui-framework/coin.md#0x2_coin">0x2::coin</a>;
+<b>use</b> <a href="../sui-framework/object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="../sui-framework/transfer.md#0x2_transfer">0x2::transfer</a>;
+</code></pre>
+
+
+
+<a name="0x107a_address_unlock_condition_unlock_alias_address_owned_basic"></a>
+
+## Function `unlock_alias_address_owned_basic`
+
+Unlock Basic outputs locked to this alias address
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_basic">unlock_alias_address_owned_basic</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_StateCap">alias::StateCap</a>, output_to_unlock: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="basic.md#0x107a_basic_BasicOutput">basic::BasicOutput</a>&gt;): <a href="basic.md#0x107a_basic_BasicOutput">basic::BasicOutput</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_basic">unlock_alias_address_owned_basic</a>(
+  self: &<b>mut</b> AliasOutput,
+  cap: &StateCap,
+  output_to_unlock: Receiving&lt;BasicOutput&gt;,
+  ): BasicOutput {
+    self.state_index_increment(cap);
+    <a href="basic.md#0x107a_basic_receive">basic::receive</a>(self.id(), output_to_unlock)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_address_unlock_condition_unlock_alias_address_owned_nft"></a>
+
+## Function `unlock_alias_address_owned_nft`
+
+Unlock NFT outputs locked to this alias address
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_nft">unlock_alias_address_owned_nft</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_StateCap">alias::StateCap</a>, output_to_unlock: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>&gt;): <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_nft">unlock_alias_address_owned_nft</a>(
+  self: &<b>mut</b> AliasOutput,
+  cap: &StateCap,
+  output_to_unlock: Receiving&lt;NftOutput&gt;,
+  ): NftOutput {
+    self.state_index_increment(cap);
+    <a href="nft_output.md#0x107a_nft_output_receive">nft_output::receive</a>(self.id(), output_to_unlock)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_address_unlock_condition_unlock_alias_address_owned_alias"></a>
+
+## Function `unlock_alias_address_owned_alias`
+
+Unlock Alias outputs locked to this alias address
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_alias">unlock_alias_address_owned_alias</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_StateCap">alias::StateCap</a>, output_to_unlock: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>&gt;): <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_alias">unlock_alias_address_owned_alias</a>(
+  self: &<b>mut</b> AliasOutput,
+  cap: &StateCap,
+  output_to_unlock: Receiving&lt;AliasOutput&gt;,
+  ): AliasOutput {
+    self.state_index_increment(cap);
+    <a href="alias.md#0x107a_alias_receive">alias::receive</a>(self.id(), output_to_unlock)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_address_unlock_condition_unlock_alias_address_owned_treasury"></a>
+
+## Function `unlock_alias_address_owned_treasury`
+
+Unlock Alias outputs locked to this alias address
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_treasury">unlock_alias_address_owned_treasury</a>&lt;T: store, key&gt;(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_StateCap">alias::StateCap</a>, treasury_cap: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="../sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;&gt;): <a href="../sui-framework/coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_treasury">unlock_alias_address_owned_treasury</a>&lt;T: key + store&gt;(
+  self: &<b>mut</b> AliasOutput,
+  cap: &StateCap,
+  treasury_cap: Receiving&lt;TreasuryCap&lt;T&gt;&gt;,
+  ): TreasuryCap&lt;T&gt; {
+    self.state_index_increment(cap);
+    <a href="../sui-framework/transfer.md#0x2_transfer_public_receive">transfer::public_receive</a>(self.id(), treasury_cap)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_address_unlock_condition_unlock_nft_address_owned_basic"></a>
+
+## Function `unlock_nft_address_owned_basic`
+
+Unlock Basic outputs locked to this alias address
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_basic">unlock_nft_address_owned_basic</a>(self: &<b>mut</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>, output_to_unlock: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="basic.md#0x107a_basic_BasicOutput">basic::BasicOutput</a>&gt;): <a href="basic.md#0x107a_basic_BasicOutput">basic::BasicOutput</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_basic">unlock_nft_address_owned_basic</a>(
+  self: &<b>mut</b> NftOutput,
+  output_to_unlock: Receiving&lt;BasicOutput&gt;,
+  ): BasicOutput {
+    <a href="basic.md#0x107a_basic_receive">basic::receive</a>(self.id(), output_to_unlock)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_address_unlock_condition_unlock_nft_address_owned_nft"></a>
+
+## Function `unlock_nft_address_owned_nft`
+
+Unlock NFT outputs locked to this alias address
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_nft">unlock_nft_address_owned_nft</a>(self: &<b>mut</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>, output_to_unlock: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>&gt;): <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_nft">unlock_nft_address_owned_nft</a>(
+  self: &<b>mut</b> NftOutput,
+  output_to_unlock: Receiving&lt;NftOutput&gt;,
+  ): NftOutput {
+    <a href="nft_output.md#0x107a_nft_output_receive">nft_output::receive</a>(self.id(), output_to_unlock)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_address_unlock_condition_unlock_nft_address_owned_alias"></a>
+
+## Function `unlock_nft_address_owned_alias`
+
+Unlock Alias outputs locked to this alias address
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_alias">unlock_nft_address_owned_alias</a>(self: &<b>mut</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>, output_to_unlock: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>&gt;): <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_alias">unlock_nft_address_owned_alias</a>(
+  self: &<b>mut</b> NftOutput,
+  output_to_unlock: Receiving&lt;AliasOutput&gt;,
+  ): AliasOutput {
+    <a href="alias.md#0x107a_alias_receive">alias::receive</a>(self.id(), output_to_unlock)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework/docs/stardust/alias.md
+++ b/crates/sui-framework/docs/stardust/alias.md
@@ -4,78 +4,34 @@ title: Module `0x107a::alias`
 
 
 
--  [Resource `GovernorCap`](#0x107a_alias_GovernorCap)
--  [Resource `StateCap`](#0x107a_alias_StateCap)
--  [Resource `AliasOutput`](#0x107a_alias_AliasOutput)
--  [Constants](#@Constants_0)
--  [Function `governor_set_state_controller`](#0x107a_alias_governor_set_state_controller)
--  [Function `extract_assets`](#0x107a_alias_extract_assets)
+-  [Resource `Alias`](#0x107a_alias_Alias)
 -  [Function `destroy`](#0x107a_alias_destroy)
--  [Function `destroy_state_cap`](#0x107a_alias_destroy_state_cap)
+-  [Function `legacy_state_controller`](#0x107a_alias_legacy_state_controller)
+-  [Function `state_index`](#0x107a_alias_state_index)
+-  [Function `state_metadata`](#0x107a_alias_state_metadata)
+-  [Function `sender`](#0x107a_alias_sender)
+-  [Function `metadata`](#0x107a_alias_metadata)
+-  [Function `immutable_issuer`](#0x107a_alias_immutable_issuer)
+-  [Function `immutable_metadata`](#0x107a_alias_immutable_metadata)
 -  [Function `id`](#0x107a_alias_id)
--  [Function `state_index_increment`](#0x107a_alias_state_index_increment)
--  [Function `receive`](#0x107a_alias_receive)
--  [Function `assert_state_controller`](#0x107a_alias_assert_state_controller)
--  [Function `assert_governor`](#0x107a_alias_assert_governor)
--  [Function `extract_tokens`](#0x107a_alias_extract_tokens)
 
 
 <pre><code><b>use</b> <a href="../move-stdlib/option.md#0x1_option">0x1::option</a>;
-<b>use</b> <a href="../sui-framework/bag.md#0x2_bag">0x2::bag</a>;
-<b>use</b> <a href="../sui-framework/balance.md#0x2_balance">0x2::balance</a>;
-<b>use</b> <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field">0x2::dynamic_field</a>;
 <b>use</b> <a href="../sui-framework/object.md#0x2_object">0x2::object</a>;
-<b>use</b> <a href="../sui-framework/sui.md#0x2_sui">0x2::sui</a>;
-<b>use</b> <a href="../sui-framework/transfer.md#0x2_transfer">0x2::transfer</a>;
-<b>use</b> <a href="../sui-framework/tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 </code></pre>
 
 
 
-<a name="0x107a_alias_GovernorCap"></a>
+<a name="0x107a_alias_Alias"></a>
 
-## Resource `GovernorCap`
+## Resource `Alias`
 
-The capability owned object that the governor must own. This enables the owner address to execute a
-governance transition.
-
-
-<pre><code><b>struct</b> <a href="alias.md#0x107a_alias_GovernorCap">GovernorCap</a> <b>has</b> store, key
-</code></pre>
+The persisted Alias object from stardust, without tokens and assets
+Outputs owned the the AliasID/Address in stardust will be sent to this object and
+they have to be received via this object once extracted from <code>AliasOutput</code>.
 
 
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>id: <a href="../sui-framework/object.md#0x2_object_UID">object::UID</a></code>
-</dt>
-<dd>
-
-</dd>
-<dt>
-<code>alias_id: <a href="../sui-framework/object.md#0x2_object_ID">object::ID</a></code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
-<a name="0x107a_alias_StateCap"></a>
-
-## Resource `StateCap`
-
-The capability owned object that the state must own. This enables the state address to execute a
-state transition. The state_cap_version allows the governor to deprecate the state address.
-
-
-<pre><code><b>struct</b> <a href="alias.md#0x107a_alias_StateCap">StateCap</a> <b>has</b> key
+<pre><code><b>struct</b> <a href="alias.md#0x107a_alias_Alias">Alias</a> <b>has</b> store, key
 </code></pre>
 
 
@@ -89,92 +45,44 @@ state transition. The state_cap_version allows the governor to deprecate the sta
 <code>id: <a href="../sui-framework/object.md#0x2_object_UID">object::UID</a></code>
 </dt>
 <dd>
-
+ The ID of the Alias = hash of the Output ID that created the Alias Output in Stardust.
+ This is the AliasID from stardust.
 </dd>
 <dt>
-<code>alias_id: <a href="../sui-framework/object.md#0x2_object_ID">object::ID</a></code>
+<code>legacy_state_controller: <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<b>address</b>&gt;</code>
 </dt>
 <dd>
-
-</dd>
-<dt>
-<code>state_cap_version: u64</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
-<a name="0x107a_alias_AliasOutput"></a>
-
-## Resource `AliasOutput`
-
-Shared Object that can be controlled with the GovernorCap and StateControllerCap.
-
-
-<pre><code><b>struct</b> <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a> <b>has</b> key
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>id: <a href="../sui-framework/object.md#0x2_object_UID">object::UID</a></code>
-</dt>
-<dd>
- The ID of the AliasOutput.
- This is the hash of the Output ID that created the Alias Output.
- During the migration, any Alias Output with a zeroed ID must have its corresponding computed Alias ID set.
- Alias ID must be kept between the migration from Stardust to Move (for applications like Identity).
-</dd>
-<dt>
-<code>iota: <a href="../sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../sui-framework/sui.md#0x2_sui_SUI">sui::SUI</a>&gt;</code>
-</dt>
-<dd>
-
-</dd>
-<dt>
-<code>state_cap_version: u64</code>
-</dt>
-<dd>
-
+ The last State Controller address assigned before the migration.
 </dd>
 <dt>
 <code>state_index: u32</code>
 </dt>
 <dd>
-
+ A counter increased by 1 every time the alias was state transitioned.
 </dd>
 <dt>
 <code>state_metadata: <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;</code>
 </dt>
 <dd>
-
+ State metadata that can be used to store additional information.
 </dd>
 <dt>
 <code>sender: <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<b>address</b>&gt;</code>
 </dt>
 <dd>
-
+ The sender feature
 </dd>
 <dt>
 <code>metadata: <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;</code>
 </dt>
 <dd>
-
+ The metadata feature.
 </dd>
 <dt>
-<code>issuer: <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<b>address</b>&gt;</code>
+<code>immutable_issuer: <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<b>address</b>&gt;</code>
 </dt>
 <dd>
-
+ Immutable Features
 </dd>
 <dt>
 <code>immutable_metadata: <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;</code>
@@ -187,133 +95,14 @@ Shared Object that can be controlled with the GovernorCap and StateControllerCap
 
 </details>
 
-<a name="@Constants_0"></a>
-
-## Constants
-
-
-<a name="0x107a_alias_ENotGovernor"></a>
-
-
-
-<pre><code><b>const</b> <a href="alias.md#0x107a_alias_ENotGovernor">ENotGovernor</a>: u64 = 2;
-</code></pre>
-
-
-
-<a name="0x107a_alias_ENotStateControllerAliasId"></a>
-
-
-
-<pre><code><b>const</b> <a href="alias.md#0x107a_alias_ENotStateControllerAliasId">ENotStateControllerAliasId</a>: u64 = 0;
-</code></pre>
-
-
-
-<a name="0x107a_alias_ENotStateControllerVersion"></a>
-
-
-
-<pre><code><b>const</b> <a href="alias.md#0x107a_alias_ENotStateControllerVersion">ENotStateControllerVersion</a>: u64 = 1;
-</code></pre>
-
-
-
-<a name="0x107a_alias_TOKENS_NAME"></a>
-
-The tokens bag dynamic field name.
-
-
-<pre><code><b>const</b> <a href="alias.md#0x107a_alias_TOKENS_NAME">TOKENS_NAME</a>: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt; = [116, 111, 107, 101, 110, 115];
-</code></pre>
-
-
-
-<a name="0x107a_alias_governor_set_state_controller"></a>
-
-## Function `governor_set_state_controller`
-
-Set the state controller address
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_governor_set_state_controller">governor_set_state_controller</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_GovernorCap">alias::GovernorCap</a>, state_controller: <b>address</b>, ctx: &<b>mut</b> <a href="../sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_governor_set_state_controller">governor_set_state_controller</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_GovernorCap">GovernorCap</a>, state_controller: <b>address</b>, ctx: &<b>mut</b> TxContext) {
-  self.<a href="alias.md#0x107a_alias_assert_governor">assert_governor</a>(cap);
-  self.state_cap_version = self.state_cap_version + 1;
-
-  <a href="../sui-framework/transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="alias.md#0x107a_alias_StateCap">StateCap</a> {
-    id: <a href="../sui-framework/object.md#0x2_object_new">object::new</a>(ctx),
-    alias_id: self.id.uid_to_inner(),
-    state_cap_version: self.state_cap_version,
-  }, state_controller);
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x107a_alias_extract_assets"></a>
-
-## Function `extract_assets`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_extract_assets">extract_assets</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_StateCap">alias::StateCap</a>): (<a href="../sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../sui-framework/sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>&gt;)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_extract_assets">extract_assets</a>(
-    self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a>,
-    cap: &<a href="alias.md#0x107a_alias_StateCap">StateCap</a>,
-) : (Balance&lt;SUI&gt;, Option&lt;Bag&gt;) {
-    self.<a href="alias.md#0x107a_alias_state_index_increment">state_index_increment</a>(cap);
-    // unpack the output into its <a href="basic.md#0x107a_basic">basic</a> part
-    <b>let</b> <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a> {
-      id: _,
-      iota,
-      state_cap_version: _,
-      state_index: _,
-      state_metadata: _,
-      sender: _,
-      metadata: _,
-      issuer: _,
-      immutable_metadata: _,
-    } = self;
-    // extract all iota coins
-    <b>let</b> all_iota = <a href="../sui-framework/balance.md#0x2_balance_withdraw_all">balance::withdraw_all</a>(iota);
-    // extract the <b>native</b> tokens <a href="../sui-framework/bag.md#0x2_bag">bag</a>
-    <b>let</b> tokens = self.<a href="alias.md#0x107a_alias_extract_tokens">extract_tokens</a>();
-
-    (all_iota, tokens)
-}
-</code></pre>
-
-
-
-</details>
-
 <a name="0x107a_alias_destroy"></a>
 
 ## Function `destroy`
 
-Destroy the AliasOutput Object and return IOTA balance and Bag of tokens
+Destroy the Alias Object, equivalent to <code>burning</code> an Alias Output in Stardust.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_destroy">destroy</a>(self: <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: <a href="alias.md#0x107a_alias_GovernorCap">alias::GovernorCap</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_destroy">destroy</a>(self: <a href="alias.md#0x107a_alias_Alias">alias::Alias</a>)
 </code></pre>
 
 
@@ -322,29 +111,17 @@ Destroy the AliasOutput Object and return IOTA balance and Bag of tokens
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_destroy">destroy</a>(self: <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a>, cap: <a href="alias.md#0x107a_alias_GovernorCap">GovernorCap</a>) {
-  self.<a href="alias.md#0x107a_alias_assert_governor">assert_governor</a>(&cap);
-  <b>let</b> <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_destroy">destroy</a>(self: <a href="alias.md#0x107a_alias_Alias">Alias</a>) {
+  <b>let</b> <a href="alias.md#0x107a_alias_Alias">Alias</a> {
     id,
-    iota,
-    state_cap_version: _,
+    legacy_state_controller: _,
     state_index: _,
     state_metadata: _,
     sender: _,
     metadata: _,
-    issuer: _,
+    immutable_issuer: _,
     immutable_metadata: _,
   } = self;
-
-  // iota amount must be zero, extracted by the state <b>address</b>
-  iota.destroy_zero();
-
-  // destroy the governor cap
-  <b>let</b> <a href="alias.md#0x107a_alias_GovernorCap">GovernorCap</a> {
-    id: governor_cap_id,
-    alias_id: _,
-  } = cap;
-  <a href="../sui-framework/object.md#0x2_object_delete">object::delete</a>(governor_cap_id);
 
   <a href="../sui-framework/object.md#0x2_object_delete">object::delete</a>(id);
 }
@@ -354,14 +131,14 @@ Destroy the AliasOutput Object and return IOTA balance and Bag of tokens
 
 </details>
 
-<a name="0x107a_alias_destroy_state_cap"></a>
+<a name="0x107a_alias_legacy_state_controller"></a>
 
-## Function `destroy_state_cap`
+## Function `legacy_state_controller`
 
-Set the state controller address
+Get the Alias's <code>legacy_state_controller</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_destroy_state_cap">destroy_state_cap</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: <a href="alias.md#0x107a_alias_StateCap">alias::StateCap</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_legacy_state_controller">legacy_state_controller</a>(self: &<a href="alias.md#0x107a_alias_Alias">alias::Alias</a>): &<a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<b>address</b>&gt;
 </code></pre>
 
 
@@ -370,14 +147,158 @@ Set the state controller address
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_destroy_state_cap">destroy_state_cap</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a>, cap: <a href="alias.md#0x107a_alias_StateCap">StateCap</a>) {
-  <b>assert</b>!(self.id.uid_to_inner() == cap.alias_id, <a href="alias.md#0x107a_alias_ENotStateControllerAliasId">ENotStateControllerAliasId</a>);
-  <b>let</b> <a href="alias.md#0x107a_alias_StateCap">StateCap</a> {
-    id,
-    alias_id: _,
-    state_cap_version: _,
-  } = cap;
-  <a href="../sui-framework/object.md#0x2_object_delete">object::delete</a>(id);
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_legacy_state_controller">legacy_state_controller</a>(self: &<a href="alias.md#0x107a_alias_Alias">Alias</a>): &Option&lt;<b>address</b>&gt; {
+    &self.legacy_state_controller
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_alias_state_index"></a>
+
+## Function `state_index`
+
+Get the Alias's <code>state_index</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_state_index">state_index</a>(self: &<a href="alias.md#0x107a_alias_Alias">alias::Alias</a>): u32
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_state_index">state_index</a>(self: &<a href="alias.md#0x107a_alias_Alias">Alias</a>): u32 {
+    self.state_index
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_alias_state_metadata"></a>
+
+## Function `state_metadata`
+
+Get the Alias's <code>state_metadata</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_state_metadata">state_metadata</a>(self: &<a href="alias.md#0x107a_alias_Alias">alias::Alias</a>): &<a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_state_metadata">state_metadata</a>(self: &<a href="alias.md#0x107a_alias_Alias">Alias</a>): &Option&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt; {
+    &self.state_metadata
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_alias_sender"></a>
+
+## Function `sender`
+
+Get the Alias's <code>sender</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_sender">sender</a>(self: &<a href="alias.md#0x107a_alias_Alias">alias::Alias</a>): &<a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<b>address</b>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_sender">sender</a>(self: &<a href="alias.md#0x107a_alias_Alias">Alias</a>): &Option&lt;<b>address</b>&gt; {
+    &self.sender
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_alias_metadata"></a>
+
+## Function `metadata`
+
+Get the Alias's <code>metadata</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_metadata">metadata</a>(self: &<a href="alias.md#0x107a_alias_Alias">alias::Alias</a>): &<a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_metadata">metadata</a>(self: &<a href="alias.md#0x107a_alias_Alias">Alias</a>): &Option&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt; {
+    &self.metadata
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_alias_immutable_issuer"></a>
+
+## Function `immutable_issuer`
+
+Get the Alias's <code>immutable_sender</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_immutable_issuer">immutable_issuer</a>(self: &<a href="alias.md#0x107a_alias_Alias">alias::Alias</a>): &<a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<b>address</b>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_immutable_issuer">immutable_issuer</a>(self: &<a href="alias.md#0x107a_alias_Alias">Alias</a>): &Option&lt;<b>address</b>&gt; {
+    &self.immutable_issuer
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_alias_immutable_metadata"></a>
+
+## Function `immutable_metadata`
+
+Get the Alias's <code>immutable_metadata</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_immutable_metadata">immutable_metadata</a>(self: &<a href="alias.md#0x107a_alias_Alias">alias::Alias</a>): &<a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_immutable_metadata">immutable_metadata</a>(self: &<a href="alias.md#0x107a_alias_Alias">Alias</a>): &Option&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt; {
+    &self.immutable_metadata
 }
 </code></pre>
 
@@ -392,7 +313,7 @@ Set the state controller address
 Get the alias id.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="alias.md#0x107a_alias_id">id</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>): &<b>mut</b> <a href="../sui-framework/object.md#0x2_object_UID">object::UID</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="alias.md#0x107a_alias_id">id</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_Alias">alias::Alias</a>): &<b>mut</b> <a href="../sui-framework/object.md#0x2_object_UID">object::UID</a>
 </code></pre>
 
 
@@ -401,134 +322,8 @@ Get the alias id.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(package) <b>fun</b> <a href="alias.md#0x107a_alias_id">id</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a>): &<b>mut</b> UID {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="alias.md#0x107a_alias_id">id</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_Alias">Alias</a>): &<b>mut</b> UID {
     &<b>mut</b> self.id
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x107a_alias_state_index_increment"></a>
-
-## Function `state_index_increment`
-
-Increment state_index by 1.
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="alias.md#0x107a_alias_state_index_increment">state_index_increment</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_StateCap">alias::StateCap</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(package) <b>fun</b> <a href="alias.md#0x107a_alias_state_index_increment">state_index_increment</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_StateCap">StateCap</a>) {
-  self.<a href="alias.md#0x107a_alias_assert_state_controller">assert_state_controller</a>(cap);
-  self.state_index = self.state_index + 1;
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x107a_alias_receive"></a>
-
-## Function `receive`
-
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="alias.md#0x107a_alias_receive">receive</a>(parent: &<b>mut</b> <a href="../sui-framework/object.md#0x2_object_UID">object::UID</a>, <a href="alias.md#0x107a_alias">alias</a>: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>&gt;): <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(package) <b>fun</b> <a href="alias.md#0x107a_alias_receive">receive</a>(parent: &<b>mut</b> UID, <a href="alias.md#0x107a_alias">alias</a>: Receiving&lt;<a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a>&gt;) : <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a> {
-    <a href="../sui-framework/transfer.md#0x2_transfer_receive">transfer::receive</a>(parent, <a href="alias.md#0x107a_alias">alias</a>)
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x107a_alias_assert_state_controller"></a>
-
-## Function `assert_state_controller`
-
-Assert that the TX sender is equal to the state controller.
-
-
-<pre><code><b>fun</b> <a href="alias.md#0x107a_alias_assert_state_controller">assert_state_controller</a>(self: &<a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_StateCap">alias::StateCap</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="alias.md#0x107a_alias_assert_state_controller">assert_state_controller</a>(self: &<a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_StateCap">StateCap</a>) {
-  <b>assert</b>!(self.id.uid_to_inner() == cap.alias_id, <a href="alias.md#0x107a_alias_ENotStateControllerAliasId">ENotStateControllerAliasId</a>);
-  <b>assert</b>!(self.state_cap_version == cap.state_cap_version, <a href="alias.md#0x107a_alias_ENotStateControllerVersion">ENotStateControllerVersion</a>);
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x107a_alias_assert_governor"></a>
-
-## Function `assert_governor`
-
-Assert that the GovernorCap governs this alias.
-
-
-<pre><code><b>fun</b> <a href="alias.md#0x107a_alias_assert_governor">assert_governor</a>(self: &<a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_GovernorCap">alias::GovernorCap</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="alias.md#0x107a_alias_assert_governor">assert_governor</a>(self: &<a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_GovernorCap">GovernorCap</a>) {
-  <b>assert</b>!(self.id.uid_to_inner() == cap.alias_id, <a href="alias.md#0x107a_alias_ENotGovernor">ENotGovernor</a>);
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x107a_alias_extract_tokens"></a>
-
-## Function `extract_tokens`
-
-extracts the related tokens bag object.
-
-
-<pre><code><b>fun</b> <a href="alias.md#0x107a_alias_extract_tokens">extract_tokens</a>(output: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>): <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>fun</b> <a href="alias.md#0x107a_alias_extract_tokens">extract_tokens</a>(output: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a>): Option&lt;Bag&gt; {
-    <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_remove_if_exists">dynamic_field::remove_if_exists</a>(&<b>mut</b> output.id, <a href="alias.md#0x107a_alias_TOKENS_NAME">TOKENS_NAME</a>)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/stardust/alias.md
+++ b/crates/sui-framework/docs/stardust/alias.md
@@ -1,0 +1,537 @@
+---
+title: Module `0x107a::alias`
+---
+
+
+
+-  [Resource `GovernorCap`](#0x107a_alias_GovernorCap)
+-  [Resource `StateCap`](#0x107a_alias_StateCap)
+-  [Resource `AliasOutput`](#0x107a_alias_AliasOutput)
+-  [Constants](#@Constants_0)
+-  [Function `governor_set_state_controller`](#0x107a_alias_governor_set_state_controller)
+-  [Function `extract_assets`](#0x107a_alias_extract_assets)
+-  [Function `destroy`](#0x107a_alias_destroy)
+-  [Function `destroy_state_cap`](#0x107a_alias_destroy_state_cap)
+-  [Function `id`](#0x107a_alias_id)
+-  [Function `state_index_increment`](#0x107a_alias_state_index_increment)
+-  [Function `receive`](#0x107a_alias_receive)
+-  [Function `assert_state_controller`](#0x107a_alias_assert_state_controller)
+-  [Function `assert_governor`](#0x107a_alias_assert_governor)
+-  [Function `extract_tokens`](#0x107a_alias_extract_tokens)
+
+
+<pre><code><b>use</b> <a href="../move-stdlib/option.md#0x1_option">0x1::option</a>;
+<b>use</b> <a href="../sui-framework/bag.md#0x2_bag">0x2::bag</a>;
+<b>use</b> <a href="../sui-framework/balance.md#0x2_balance">0x2::balance</a>;
+<b>use</b> <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field">0x2::dynamic_field</a>;
+<b>use</b> <a href="../sui-framework/object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="../sui-framework/sui.md#0x2_sui">0x2::sui</a>;
+<b>use</b> <a href="../sui-framework/transfer.md#0x2_transfer">0x2::transfer</a>;
+<b>use</b> <a href="../sui-framework/tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+</code></pre>
+
+
+
+<a name="0x107a_alias_GovernorCap"></a>
+
+## Resource `GovernorCap`
+
+The capability owned object that the governor must own. This enables the owner address to execute a
+governance transition.
+
+
+<pre><code><b>struct</b> <a href="alias.md#0x107a_alias_GovernorCap">GovernorCap</a> <b>has</b> store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="../sui-framework/object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>alias_id: <a href="../sui-framework/object.md#0x2_object_ID">object::ID</a></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x107a_alias_StateCap"></a>
+
+## Resource `StateCap`
+
+The capability owned object that the state must own. This enables the state address to execute a
+state transition. The state_cap_version allows the governor to deprecate the state address.
+
+
+<pre><code><b>struct</b> <a href="alias.md#0x107a_alias_StateCap">StateCap</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="../sui-framework/object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>alias_id: <a href="../sui-framework/object.md#0x2_object_ID">object::ID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>state_cap_version: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x107a_alias_AliasOutput"></a>
+
+## Resource `AliasOutput`
+
+Shared Object that can be controlled with the GovernorCap and StateControllerCap.
+
+
+<pre><code><b>struct</b> <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="../sui-framework/object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+ The ID of the AliasOutput.
+ This is the hash of the Output ID that created the Alias Output.
+ During the migration, any Alias Output with a zeroed ID must have its corresponding computed Alias ID set.
+ Alias ID must be kept between the migration from Stardust to Move (for applications like Identity).
+</dd>
+<dt>
+<code>iota: <a href="../sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../sui-framework/sui.md#0x2_sui_SUI">sui::SUI</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>state_cap_version: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>state_index: u32</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>state_metadata: <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>sender: <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<b>address</b>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>metadata: <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>issuer: <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<b>address</b>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>immutable_metadata: <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x107a_alias_ENotGovernor"></a>
+
+
+
+<pre><code><b>const</b> <a href="alias.md#0x107a_alias_ENotGovernor">ENotGovernor</a>: u64 = 2;
+</code></pre>
+
+
+
+<a name="0x107a_alias_ENotStateControllerAliasId"></a>
+
+
+
+<pre><code><b>const</b> <a href="alias.md#0x107a_alias_ENotStateControllerAliasId">ENotStateControllerAliasId</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x107a_alias_ENotStateControllerVersion"></a>
+
+
+
+<pre><code><b>const</b> <a href="alias.md#0x107a_alias_ENotStateControllerVersion">ENotStateControllerVersion</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x107a_alias_TOKENS_NAME"></a>
+
+The tokens bag dynamic field name.
+
+
+<pre><code><b>const</b> <a href="alias.md#0x107a_alias_TOKENS_NAME">TOKENS_NAME</a>: <a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt; = [116, 111, 107, 101, 110, 115];
+</code></pre>
+
+
+
+<a name="0x107a_alias_governor_set_state_controller"></a>
+
+## Function `governor_set_state_controller`
+
+Set the state controller address
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_governor_set_state_controller">governor_set_state_controller</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_GovernorCap">alias::GovernorCap</a>, state_controller: <b>address</b>, ctx: &<b>mut</b> <a href="../sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_governor_set_state_controller">governor_set_state_controller</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_GovernorCap">GovernorCap</a>, state_controller: <b>address</b>, ctx: &<b>mut</b> TxContext) {
+  self.<a href="alias.md#0x107a_alias_assert_governor">assert_governor</a>(cap);
+  self.state_cap_version = self.state_cap_version + 1;
+
+  <a href="../sui-framework/transfer.md#0x2_transfer_transfer">transfer::transfer</a>(<a href="alias.md#0x107a_alias_StateCap">StateCap</a> {
+    id: <a href="../sui-framework/object.md#0x2_object_new">object::new</a>(ctx),
+    alias_id: self.id.uid_to_inner(),
+    state_cap_version: self.state_cap_version,
+  }, state_controller);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_alias_extract_assets"></a>
+
+## Function `extract_assets`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_extract_assets">extract_assets</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_StateCap">alias::StateCap</a>): (<a href="../sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../sui-framework/sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_extract_assets">extract_assets</a>(
+    self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a>,
+    cap: &<a href="alias.md#0x107a_alias_StateCap">StateCap</a>,
+) : (Balance&lt;SUI&gt;, Option&lt;Bag&gt;) {
+    self.<a href="alias.md#0x107a_alias_state_index_increment">state_index_increment</a>(cap);
+    // unpack the output into its <a href="basic.md#0x107a_basic">basic</a> part
+    <b>let</b> <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a> {
+      id: _,
+      iota,
+      state_cap_version: _,
+      state_index: _,
+      state_metadata: _,
+      sender: _,
+      metadata: _,
+      issuer: _,
+      immutable_metadata: _,
+    } = self;
+    // extract all iota coins
+    <b>let</b> all_iota = <a href="../sui-framework/balance.md#0x2_balance_withdraw_all">balance::withdraw_all</a>(iota);
+    // extract the <b>native</b> tokens <a href="../sui-framework/bag.md#0x2_bag">bag</a>
+    <b>let</b> tokens = self.<a href="alias.md#0x107a_alias_extract_tokens">extract_tokens</a>();
+
+    (all_iota, tokens)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_alias_destroy"></a>
+
+## Function `destroy`
+
+Destroy the AliasOutput Object and return IOTA balance and Bag of tokens
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_destroy">destroy</a>(self: <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: <a href="alias.md#0x107a_alias_GovernorCap">alias::GovernorCap</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_destroy">destroy</a>(self: <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a>, cap: <a href="alias.md#0x107a_alias_GovernorCap">GovernorCap</a>) {
+  self.<a href="alias.md#0x107a_alias_assert_governor">assert_governor</a>(&cap);
+  <b>let</b> <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a> {
+    id,
+    iota,
+    state_cap_version: _,
+    state_index: _,
+    state_metadata: _,
+    sender: _,
+    metadata: _,
+    issuer: _,
+    immutable_metadata: _,
+  } = self;
+
+  // iota amount must be zero, extracted by the state <b>address</b>
+  iota.destroy_zero();
+
+  // destroy the governor cap
+  <b>let</b> <a href="alias.md#0x107a_alias_GovernorCap">GovernorCap</a> {
+    id: governor_cap_id,
+    alias_id: _,
+  } = cap;
+  <a href="../sui-framework/object.md#0x2_object_delete">object::delete</a>(governor_cap_id);
+
+  <a href="../sui-framework/object.md#0x2_object_delete">object::delete</a>(id);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_alias_destroy_state_cap"></a>
+
+## Function `destroy_state_cap`
+
+Set the state controller address
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_destroy_state_cap">destroy_state_cap</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: <a href="alias.md#0x107a_alias_StateCap">alias::StateCap</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="alias.md#0x107a_alias_destroy_state_cap">destroy_state_cap</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a>, cap: <a href="alias.md#0x107a_alias_StateCap">StateCap</a>) {
+  <b>assert</b>!(self.id.uid_to_inner() == cap.alias_id, <a href="alias.md#0x107a_alias_ENotStateControllerAliasId">ENotStateControllerAliasId</a>);
+  <b>let</b> <a href="alias.md#0x107a_alias_StateCap">StateCap</a> {
+    id,
+    alias_id: _,
+    state_cap_version: _,
+  } = cap;
+  <a href="../sui-framework/object.md#0x2_object_delete">object::delete</a>(id);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_alias_id"></a>
+
+## Function `id`
+
+Get the alias id.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="alias.md#0x107a_alias_id">id</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>): &<b>mut</b> <a href="../sui-framework/object.md#0x2_object_UID">object::UID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(package) <b>fun</b> <a href="alias.md#0x107a_alias_id">id</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a>): &<b>mut</b> UID {
+    &<b>mut</b> self.id
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_alias_state_index_increment"></a>
+
+## Function `state_index_increment`
+
+Increment state_index by 1.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="alias.md#0x107a_alias_state_index_increment">state_index_increment</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_StateCap">alias::StateCap</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(package) <b>fun</b> <a href="alias.md#0x107a_alias_state_index_increment">state_index_increment</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_StateCap">StateCap</a>) {
+  self.<a href="alias.md#0x107a_alias_assert_state_controller">assert_state_controller</a>(cap);
+  self.state_index = self.state_index + 1;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_alias_receive"></a>
+
+## Function `receive`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="alias.md#0x107a_alias_receive">receive</a>(parent: &<b>mut</b> <a href="../sui-framework/object.md#0x2_object_UID">object::UID</a>, <a href="alias.md#0x107a_alias">alias</a>: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>&gt;): <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(package) <b>fun</b> <a href="alias.md#0x107a_alias_receive">receive</a>(parent: &<b>mut</b> UID, <a href="alias.md#0x107a_alias">alias</a>: Receiving&lt;<a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a>&gt;) : <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a> {
+    <a href="../sui-framework/transfer.md#0x2_transfer_receive">transfer::receive</a>(parent, <a href="alias.md#0x107a_alias">alias</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_alias_assert_state_controller"></a>
+
+## Function `assert_state_controller`
+
+Assert that the TX sender is equal to the state controller.
+
+
+<pre><code><b>fun</b> <a href="alias.md#0x107a_alias_assert_state_controller">assert_state_controller</a>(self: &<a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_StateCap">alias::StateCap</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="alias.md#0x107a_alias_assert_state_controller">assert_state_controller</a>(self: &<a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_StateCap">StateCap</a>) {
+  <b>assert</b>!(self.id.uid_to_inner() == cap.alias_id, <a href="alias.md#0x107a_alias_ENotStateControllerAliasId">ENotStateControllerAliasId</a>);
+  <b>assert</b>!(self.state_cap_version == cap.state_cap_version, <a href="alias.md#0x107a_alias_ENotStateControllerVersion">ENotStateControllerVersion</a>);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_alias_assert_governor"></a>
+
+## Function `assert_governor`
+
+Assert that the GovernorCap governs this alias.
+
+
+<pre><code><b>fun</b> <a href="alias.md#0x107a_alias_assert_governor">assert_governor</a>(self: &<a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_GovernorCap">alias::GovernorCap</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="alias.md#0x107a_alias_assert_governor">assert_governor</a>(self: &<a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a>, cap: &<a href="alias.md#0x107a_alias_GovernorCap">GovernorCap</a>) {
+  <b>assert</b>!(self.id.uid_to_inner() == cap.alias_id, <a href="alias.md#0x107a_alias_ENotGovernor">ENotGovernor</a>);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_alias_extract_tokens"></a>
+
+## Function `extract_tokens`
+
+extracts the related tokens bag object.
+
+
+<pre><code><b>fun</b> <a href="alias.md#0x107a_alias_extract_tokens">extract_tokens</a>(output: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">alias::AliasOutput</a>): <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="alias.md#0x107a_alias_extract_tokens">extract_tokens</a>(output: &<b>mut</b> <a href="alias.md#0x107a_alias_AliasOutput">AliasOutput</a>): Option&lt;Bag&gt; {
+    <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_remove_if_exists">dynamic_field::remove_if_exists</a>(&<b>mut</b> output.id, <a href="alias.md#0x107a_alias_TOKENS_NAME">TOKENS_NAME</a>)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework/docs/stardust/basic.md
+++ b/crates/sui-framework/docs/stardust/basic.md
@@ -1,0 +1,203 @@
+---
+title: Module `0x107a::basic`
+---
+
+
+
+-  [Resource `BasicOutput`](#0x107a_basic_BasicOutput)
+-  [Function `extract_assets`](#0x107a_basic_extract_assets)
+-  [Function `receive`](#0x107a_basic_receive)
+
+
+<pre><code><b>use</b> <a href="expiration_unlock_condition.md#0x107a_expiration_unlock_condition">0x107a::expiration_unlock_condition</a>;
+<b>use</b> <a href="storage_deposit_return_unlock_condition.md#0x107a_storage_deposit_return_unlock_condition">0x107a::storage_deposit_return_unlock_condition</a>;
+<b>use</b> <a href="timelock_unlock_condition.md#0x107a_timelock_unlock_condition">0x107a::timelock_unlock_condition</a>;
+<b>use</b> <a href="../move-stdlib/option.md#0x1_option">0x1::option</a>;
+<b>use</b> <a href="../sui-framework/bag.md#0x2_bag">0x2::bag</a>;
+<b>use</b> <a href="../sui-framework/balance.md#0x2_balance">0x2::balance</a>;
+<b>use</b> <a href="../sui-framework/object.md#0x2_object">0x2::object</a>;
+<b>use</b> <a href="../sui-framework/sui.md#0x2_sui">0x2::sui</a>;
+<b>use</b> <a href="../sui-framework/transfer.md#0x2_transfer">0x2::transfer</a>;
+<b>use</b> <a href="../sui-framework/tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+</code></pre>
+
+
+
+<a name="0x107a_basic_BasicOutput"></a>
+
+## Resource `BasicOutput`
+
+
+
+<pre><code><b>struct</b> <a href="basic.md#0x107a_basic_BasicOutput">BasicOutput</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="../sui-framework/object.md#0x2_object_UID">object::UID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>iota: <a href="../sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../sui-framework/sui.md#0x2_sui_SUI">sui::SUI</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>tokens: <a href="../sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>sdr: <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="storage_deposit_return_unlock_condition.md#0x107a_storage_deposit_return_unlock_condition_StorageDepositReturnUnlockCondition">storage_deposit_return_unlock_condition::StorageDepositReturnUnlockCondition</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>timelock: <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="timelock_unlock_condition.md#0x107a_timelock_unlock_condition_TimelockUnlockCondition">timelock_unlock_condition::TimelockUnlockCondition</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>expiration: <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="expiration_unlock_condition.md#0x107a_expiration_unlock_condition_ExpirationUnlockCondition">expiration_unlock_condition::ExpirationUnlockCondition</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>metadata: <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>tag: <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>sender: <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<b>address</b>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x107a_basic_extract_assets"></a>
+
+## Function `extract_assets`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="basic.md#0x107a_basic_extract_assets">extract_assets</a>(output: <a href="basic.md#0x107a_basic_BasicOutput">basic::BasicOutput</a>, ctx: &<b>mut</b> <a href="../sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): (<a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../sui-framework/sui.md#0x2_sui_SUI">sui::SUI</a>&gt;&gt;, <a href="../sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="basic.md#0x107a_basic_extract_assets">extract_assets</a>(
+    // the output <b>to</b> be migrated
+    output: <a href="basic.md#0x107a_basic_BasicOutput">BasicOutput</a>,
+    ctx: &<b>mut</b> TxContext
+) : (Option&lt;Balance&lt;SUI&gt;&gt;, Bag) {
+    <b>let</b> <b>mut</b> extracted_base_token : Option&lt;Balance&lt;SUI&gt;&gt; = none();
+
+    // unpack the output into its <a href="basic.md#0x107a_basic">basic</a> part
+    <b>let</b> <a href="basic.md#0x107a_basic_BasicOutput">BasicOutput</a> {
+        id: id_to_delete,
+        iota: <b>mut</b> iota_balance,
+        tokens: tokens,
+        // `none` options can be dropped
+        sdr: <b>mut</b> sdr,
+        timelock: <b>mut</b> timelock,
+        expiration: <b>mut</b> expiration,
+        // the features have `drop` so we can just ignore them
+        sender: _,
+        metadata: _,
+        tag: _ } = output;
+
+    // <b>if</b> the output <b>has</b> a timelock, then we need <b>to</b> check <b>if</b> the timelock <b>has</b> expired
+    <b>if</b> (timelock.is_some()) {
+        // extract will make the <a href="../move-stdlib/option.md#0x1_option">option</a> `None`
+        timelock.extract().unlock(ctx);
+    };
+
+    // <b>if</b> the output <b>has</b> an expiration, then we need <b>to</b> check who can unlock the output
+    <b>if</b> (expiration.is_some()) {
+        // extract will make the <a href="../move-stdlib/option.md#0x1_option">option</a> `None`
+        expiration.extract().unlock(ctx);
+    };
+
+    // <b>if</b> the output <b>has</b> an SDRUC, then we need <b>to</b> <b>return</b> the deposit
+    <b>if</b> (sdr.is_some()) {
+        // extract will make the <a href="../move-stdlib/option.md#0x1_option">option</a> `None`
+        sdr.extract().unlock(&<b>mut</b> iota_balance, ctx);
+    };
+
+    // Destroy the options
+    <a href="../move-stdlib/option.md#0x1_option_destroy_none">option::destroy_none</a>(timelock);
+    <a href="../move-stdlib/option.md#0x1_option_destroy_none">option::destroy_none</a>(expiration);
+    <a href="../move-stdlib/option.md#0x1_option_destroy_none">option::destroy_none</a>(sdr);
+
+    // fil lthe <b>return</b> value <b>with</b> the remaining IOTA <a href="../sui-framework/balance.md#0x2_balance">balance</a>
+    <b>let</b> iotas = iota_balance.value();
+    <b>if</b> (iotas &gt; 0) {
+        // there is a <a href="../sui-framework/balance.md#0x2_balance">balance</a> remaining after fuflilling SDRUC
+        extracted_base_token.fill(iota_balance);
+    } <b>else</b> {
+        // SDRUC consumed all the <a href="../sui-framework/balance.md#0x2_balance">balance</a> of the output
+        iota_balance.destroy_zero();
+    };
+
+    // delete the output <a href="../sui-framework/object.md#0x2_object">object</a>'s UID
+    delete_object(id_to_delete);
+
+    <b>return</b> (extracted_base_token, tokens)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_basic_receive"></a>
+
+## Function `receive`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="basic.md#0x107a_basic_receive">receive</a>(parent: &<b>mut</b> <a href="../sui-framework/object.md#0x2_object_UID">object::UID</a>, <a href="basic.md#0x107a_basic">basic</a>: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="basic.md#0x107a_basic_BasicOutput">basic::BasicOutput</a>&gt;): <a href="basic.md#0x107a_basic_BasicOutput">basic::BasicOutput</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(package) <b>fun</b> <a href="basic.md#0x107a_basic_receive">receive</a>(parent: &<b>mut</b> UID, <a href="basic.md#0x107a_basic">basic</a>: Receiving&lt;<a href="basic.md#0x107a_basic_BasicOutput">BasicOutput</a>&gt;) : <a href="basic.md#0x107a_basic_BasicOutput">BasicOutput</a> {
+    <a href="../sui-framework/transfer.md#0x2_transfer_receive">transfer::receive</a>(parent, <a href="basic.md#0x107a_basic">basic</a>)
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework/docs/stardust/nft.md
+++ b/crates/sui-framework/docs/stardust/nft.md
@@ -11,6 +11,7 @@ title: Module `0x107a::nft`
 -  [Function `tag`](#0x107a_nft_tag)
 -  [Function `immutable_issuer`](#0x107a_nft_immutable_issuer)
 -  [Function `immutable_metadata`](#0x107a_nft_immutable_metadata)
+-  [Function `id`](#0x107a_nft_id)
 
 
 <pre><code><b>use</b> <a href="irc27.md#0x107a_irc27">0x107a::irc27</a>;
@@ -233,6 +234,31 @@ Get the NFT's <code>immutable_metadata</code>.
 
 <pre><code><b>public</b> <b>fun</b> <a href="nft.md#0x107a_nft_immutable_metadata">immutable_metadata</a>(<a href="nft.md#0x107a_nft">nft</a>: &<a href="nft.md#0x107a_nft_Nft">Nft</a>): &Irc27Metadata {
     &<a href="nft.md#0x107a_nft">nft</a>.immutable_metadata
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_nft_id"></a>
+
+## Function `id`
+
+Get the Nft id.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="nft.md#0x107a_nft_id">id</a>(self: &<b>mut</b> <a href="nft.md#0x107a_nft_Nft">nft::Nft</a>): &<b>mut</b> <a href="../sui-framework/object.md#0x2_object_UID">object::UID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(package) <b>fun</b> <a href="nft.md#0x107a_nft_id">id</a>(self: &<b>mut</b> <a href="nft.md#0x107a_nft_Nft">Nft</a>): &<b>mut</b> UID {
+    &<b>mut</b> self.id
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/stardust/nft_output.md
+++ b/crates/sui-framework/docs/stardust/nft_output.md
@@ -8,6 +8,8 @@ title: Module `0x107a::nft_output`
 -  [Constants](#@Constants_0)
 -  [Function `extract_assets`](#0x107a_nft_output_extract_assets)
 -  [Function `load_nft`](#0x107a_nft_output_load_nft)
+-  [Function `id`](#0x107a_nft_output_id)
+-  [Function `receive`](#0x107a_nft_output_receive)
 
 
 <pre><code><b>use</b> <a href="expiration_unlock_condition.md#0x107a_expiration_unlock_condition">0x107a::expiration_unlock_condition</a>;
@@ -19,6 +21,7 @@ title: Module `0x107a::nft_output`
 <b>use</b> <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field">0x2::dynamic_field</a>;
 <b>use</b> <a href="../sui-framework/object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="../sui-framework/sui.md#0x2_sui">0x2::sui</a>;
+<b>use</b> <a href="../sui-framework/transfer.md#0x2_transfer">0x2::transfer</a>;
 <b>use</b> <a href="../sui-framework/tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 </code></pre>
 
@@ -168,6 +171,55 @@ Loads the related <code>Nft</code> object.
 
 <pre><code><b>fun</b> <a href="nft_output.md#0x107a_nft_output_load_nft">load_nft</a>(output: &<b>mut</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">NftOutput</a>): Nft {
     <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_remove">dynamic_field::remove</a>(&<b>mut</b> output.id, <a href="nft_output.md#0x107a_nft_output_NFT_NAME">NFT_NAME</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_nft_output_id"></a>
+
+## Function `id`
+
+Get the alias id.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="nft_output.md#0x107a_nft_output_id">id</a>(self: &<b>mut</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>): &<b>mut</b> <a href="../sui-framework/object.md#0x2_object_UID">object::UID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(package) <b>fun</b> <a href="nft_output.md#0x107a_nft_output_id">id</a>(self: &<b>mut</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">NftOutput</a>): &<b>mut</b> UID {
+    &<b>mut</b> self.id
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_nft_output_receive"></a>
+
+## Function `receive`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="nft_output.md#0x107a_nft_output_receive">receive</a>(parent: &<b>mut</b> <a href="../sui-framework/object.md#0x2_object_UID">object::UID</a>, <a href="nft.md#0x107a_nft">nft</a>: <a href="../sui-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>&gt;): <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(package) <b>fun</b> <a href="nft_output.md#0x107a_nft_output_receive">receive</a>(parent: &<b>mut</b> UID, <a href="nft.md#0x107a_nft">nft</a>: Receiving&lt;<a href="nft_output.md#0x107a_nft_output_NftOutput">NftOutput</a>&gt;) : <a href="nft_output.md#0x107a_nft_output_NftOutput">NftOutput</a> {
+    <a href="../sui-framework/transfer.md#0x2_transfer_receive">transfer::receive</a>(parent, <a href="nft.md#0x107a_nft">nft</a>)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/stardust/nft_output.md
+++ b/crates/sui-framework/docs/stardust/nft_output.md
@@ -8,7 +8,6 @@ title: Module `0x107a::nft_output`
 -  [Constants](#@Constants_0)
 -  [Function `extract_assets`](#0x107a_nft_output_extract_assets)
 -  [Function `load_nft`](#0x107a_nft_output_load_nft)
--  [Function `id`](#0x107a_nft_output_id)
 -  [Function `receive`](#0x107a_nft_output_receive)
 
 
@@ -171,31 +170,6 @@ Loads the related <code>Nft</code> object.
 
 <pre><code><b>fun</b> <a href="nft_output.md#0x107a_nft_output_load_nft">load_nft</a>(output: &<b>mut</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">NftOutput</a>): Nft {
     <a href="../sui-framework/dynamic_field.md#0x2_dynamic_field_remove">dynamic_field::remove</a>(&<b>mut</b> output.id, <a href="nft_output.md#0x107a_nft_output_NFT_NAME">NFT_NAME</a>)
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x107a_nft_output_id"></a>
-
-## Function `id`
-
-Get the alias id.
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="nft_output.md#0x107a_nft_output_id">id</a>(self: &<b>mut</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>): &<b>mut</b> <a href="../sui-framework/object.md#0x2_object_UID">object::UID</a>
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(package) <b>fun</b> <a href="nft_output.md#0x107a_nft_output_id">id</a>(self: &<b>mut</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">NftOutput</a>): &<b>mut</b> UID {
-    &<b>mut</b> self.id
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/stardust/utilities.md
+++ b/crates/sui-framework/docs/stardust/utilities.md
@@ -1,0 +1,144 @@
+---
+title: Module `0x107a::utilities`
+---
+
+
+
+-  [Constants](#@Constants_0)
+-  [Function `create_coin_from_option_balance`](#0x107a_utilities_create_coin_from_option_balance)
+-  [Function `extract_and_send_to`](#0x107a_utilities_extract_and_send_to)
+-  [Function `extract`](#0x107a_utilities_extract)
+-  [Function `extract_`](#0x107a_utilities_extract_)
+
+
+<pre><code><b>use</b> <a href="../move-stdlib/ascii.md#0x1_ascii">0x1::ascii</a>;
+<b>use</b> <a href="../move-stdlib/option.md#0x1_option">0x1::option</a>;
+<b>use</b> <a href="../move-stdlib/type_name.md#0x1_type_name">0x1::type_name</a>;
+<b>use</b> <a href="../sui-framework/bag.md#0x2_bag">0x2::bag</a>;
+<b>use</b> <a href="../sui-framework/balance.md#0x2_balance">0x2::balance</a>;
+<b>use</b> <a href="../sui-framework/coin.md#0x2_coin">0x2::coin</a>;
+<b>use</b> <a href="../sui-framework/transfer.md#0x2_transfer">0x2::transfer</a>;
+<b>use</b> <a href="../sui-framework/tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+</code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x107a_utilities_EZeroNativeTokenBalance"></a>
+
+
+
+<pre><code><b>const</b> <a href="utilities.md#0x107a_utilities_EZeroNativeTokenBalance">EZeroNativeTokenBalance</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x107a_utilities_create_coin_from_option_balance"></a>
+
+## Function `create_coin_from_option_balance`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="utilities.md#0x107a_utilities_create_coin_from_option_balance">create_coin_from_option_balance</a>&lt;T&gt;(b: <a href="../move-stdlib/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;&gt;, ctx: &<b>mut</b> <a href="../sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../sui-framework/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="utilities.md#0x107a_utilities_create_coin_from_option_balance">create_coin_from_option_balance</a>&lt;T&gt;(<b>mut</b> b: Option&lt;Balance&lt;T&gt;&gt;, ctx: &<b>mut</b> TxContext) : Coin&lt;T&gt; {
+    <b>assert</b>!(b.is_some(), 0);
+    <b>let</b> eb = b.<a href="utilities.md#0x107a_utilities_extract">extract</a>();
+    b.destroy_none();
+    from_balance(eb, ctx)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_utilities_extract_and_send_to"></a>
+
+## Function `extract_and_send_to`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="utilities.md#0x107a_utilities_extract_and_send_to">extract_and_send_to</a>&lt;T&gt;(b: <a href="../sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>, <b>to</b>: <b>address</b>, ctx: &<b>mut</b> <a href="../sui-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="utilities.md#0x107a_utilities_extract_and_send_to">extract_and_send_to</a>&lt;T&gt;(<b>mut</b> b: Bag, <b>to</b>: <b>address</b>, ctx: &<b>mut</b> TxContext) : Bag  {
+    <b>let</b> <a href="../sui-framework/coin.md#0x2_coin">coin</a> = from_balance(<a href="utilities.md#0x107a_utilities_extract_">extract_</a>&lt;T&gt;( &<b>mut</b> b), ctx);
+    public_transfer(<a href="../sui-framework/coin.md#0x2_coin">coin</a>, <b>to</b>);
+    b
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_utilities_extract"></a>
+
+## Function `extract`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="utilities.md#0x107a_utilities_extract">extract</a>&lt;T&gt;(b: <a href="../sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>): (<a href="../sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>, <a href="../sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="utilities.md#0x107a_utilities_extract">extract</a>&lt;T&gt;(<b>mut</b> b: Bag) : (Bag, Balance&lt;T&gt;) {
+    <b>let</b> nt = <a href="utilities.md#0x107a_utilities_extract_">extract_</a>&lt;T&gt;(&<b>mut</b> b);
+    (b, nt)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x107a_utilities_extract_"></a>
+
+## Function `extract_`
+
+
+
+<pre><code><b>fun</b> <a href="utilities.md#0x107a_utilities_extract_">extract_</a>&lt;T&gt;(b: &<b>mut</b> <a href="../sui-framework/bag.md#0x2_bag_Bag">bag::Bag</a>): <a href="../sui-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="utilities.md#0x107a_utilities_extract_">extract_</a>&lt;T&gt;(b: &<b>mut</b> Bag) : Balance&lt;T&gt; {
+   <b>let</b> key = get&lt;T&gt;().into_string();
+   // this will <b>abort</b> <b>if</b> the key doesn't exist
+   <b>let</b> nt : Balance&lt;T&gt; = b.remove(key);
+   <b>assert</b>!(nt.value() != 0, <a href="utilities.md#0x107a_utilities_EZeroNativeTokenBalance">EZeroNativeTokenBalance</a>);
+   nt
+}
+</code></pre>
+
+
+
+</details>

--- a/crates/sui-framework/packages/stardust/design.md
+++ b/crates/sui-framework/packages/stardust/design.md
@@ -23,4 +23,4 @@ If a user does not end up with such coin objects at migration, we will have to s
 - State Controller is represented as a `StateCap` that can be updated by the governor. This happens by increasing the `StateCap` version.
 - The Governor Capability contains the ID of the alias which it controls. This is needed such that not _any_ `GovernorCap` can be used to update _any_ Alias.
 - No way for user to create a new Alias in Move by not providing a constructor. These are only created during the migration.
-- We would most likely want to receive Basic and NFT Output objects or Treasury Caps objects and return them in a receiving function (`unlock_alias_address_owned_output`), so we do not have to store them in the Alias itself. Then they can be transferred somewhere else in the calling PTB.
+- We would most likely want to receive Alias, Basic and NFT Output objects or Treasury Caps objects and return them in a receiving function (`unlock_alias_address_owned_output`), so we do not have to store them in the Alias itself. Then they can be transferred somewhere else in the calling PTB.

--- a/crates/sui-framework/packages/stardust/sources/alias/alias.move
+++ b/crates/sui-framework/packages/stardust/sources/alias/alias.move
@@ -1,0 +1,220 @@
+module stardust::alias{
+    use sui::balance::{Self, Balance};
+    use sui::dynamic_field;
+    use sui::sui::SUI;
+    use sui::transfer::{Receiving};
+    use sui::bag::{Bag};
+
+    const ENotStateControllerAliasId: u64 = 0;
+    const ENotStateControllerVersion: u64 = 1;
+    const ENotGovernor: u64 = 2;
+
+    /// The tokens bag dynamic field name.
+    const TOKENS_NAME: vector<u8> = b"tokens";
+
+    /// The capability owned object that the governor must own. This enables the owner address to execute a 
+    /// governance transition.
+    public struct GovernorCap has key, store {
+      id: UID,
+      alias_id: ID,
+    }
+
+    /// The capability owned object that the state must own. This enables the state address to execute a 
+    /// state transition. The state_cap_version allows the governor to deprecate the state address.
+    public struct StateCap has key {
+      id: UID,
+      alias_id: ID,
+      state_cap_version: u64,
+    }
+
+    /// Shared Object that can be controlled with the GovernorCap and StateControllerCap.
+    public struct AliasOutput has key {
+      /// The ID of the AliasOutput.
+      /// This is the hash of the Output ID that created the Alias Output.
+      /// During the migration, any Alias Output with a zeroed ID must have its corresponding computed Alias ID set.
+      /// Alias ID must be kept between the migration from Stardust to Move (for applications like Identity).
+      id: UID,
+      
+      // The amount of IOTA coins held by the output.
+      iota: Balance<SUI>,
+
+      // State representation
+      // The State Controller Address that can unlock in a transaction that state transitions the alias object. The 
+      // state_cap_version enable to validate a StateCap to be able to represent the State Controller Address.
+      state_cap_version: u64,
+      // A counter that must increase by 1 every time the alias is state transitioned.
+      state_index: u32,
+      // Metadata that can only be changed by the state controller. 
+      state_metadata: Option<vector<u8>>,
+
+      // Features
+      // sender feature
+      sender: Option<address>,
+      // DID<version_byte><encoding_byte>
+      metadata: Option<vector<u8>>,
+
+      // Immutable Features
+      issuer: Option<address>,
+      immutable_metadata: Option<vector<u8>>,
+    }
+
+    // === Public-Mutative Functions ===
+
+    /// Set the state controller address
+    public fun governor_set_state_controller(self: &mut AliasOutput, cap: &GovernorCap, state_controller: address, ctx: &mut TxContext) {
+      self.assert_governor(cap);
+      self.state_cap_version = self.state_cap_version + 1;
+
+      transfer::transfer(StateCap {
+        id: object::new(ctx),
+        alias_id: self.id.uid_to_inner(),
+        state_cap_version: self.state_cap_version,
+      }, state_controller);
+    }
+
+    // extract the assets inside the output
+    //  - the object will NOT be destroyd
+    //  - remaining assets (iota coins and native tokens) will be returned
+    public fun extract_assets(
+        self: &mut AliasOutput,
+        cap: &StateCap,
+    ) : (Balance<SUI>, Option<Bag>) {
+        self.state_index_increment(cap);
+        // unpack the output into its basic part
+        let AliasOutput {
+          id: _,
+          iota,
+          state_cap_version: _,
+          state_index: _,
+          state_metadata: _,
+          sender: _,
+          metadata: _,
+          issuer: _,
+          immutable_metadata: _,
+        } = self;
+        // extract all iota coins
+        let all_iota = balance::withdraw_all(iota);
+        // extract the native tokens bag 
+        let tokens = self.extract_tokens();
+
+        (all_iota, tokens)
+    }
+
+    /// Destroy the AliasOutput Object and return IOTA balance and Bag of tokens
+    public fun destroy(self: AliasOutput, cap: GovernorCap) {
+      self.assert_governor(&cap);
+      let AliasOutput {
+        id,
+        iota,
+        state_cap_version: _,
+        state_index: _,
+        state_metadata: _,
+        sender: _,
+        metadata: _,
+        issuer: _,
+        immutable_metadata: _,
+      } = self;
+
+      // iota amount must be zero, extracted by the state address
+      iota.destroy_zero();
+      
+      // destroy the governor cap
+      let GovernorCap {
+        id: governor_cap_id,
+        alias_id: _,
+      } = cap;
+      object::delete(governor_cap_id);
+      
+      object::delete(id);
+    }
+
+    /// Set the state controller address
+    public fun destroy_state_cap(self: &mut AliasOutput, cap: StateCap) {
+      assert!(self.id.uid_to_inner() == cap.alias_id, ENotStateControllerAliasId);
+      let StateCap {
+        id,
+        alias_id: _,
+        state_cap_version: _,
+      } = cap;
+      object::delete(id);
+    }
+
+    // === Public-Package Functions ===
+
+    /// Get the alias id.
+    public(package) fun id(self: &mut AliasOutput): &mut UID {
+        &mut self.id
+    }
+
+    /// Increment state_index by 1.
+    public(package) fun state_index_increment(self: &mut AliasOutput, cap: &StateCap) {
+      self.assert_state_controller(cap);
+      self.state_index = self.state_index + 1;
+    }
+
+    // utility function to receive a alias output in other stardust models
+    // other modules in the stardust pacakge can call this function to receive a alias output (nft)
+    public(package) fun receive(parent: &mut UID, alias: Receiving<AliasOutput>) : AliasOutput {
+        transfer::receive(parent, alias)
+    }
+
+
+    // === Private Functions ===
+
+    /// Assert that the TX sender is equal to the state controller.
+    fun assert_state_controller(self: &AliasOutput, cap: &StateCap) {
+      assert!(self.id.uid_to_inner() == cap.alias_id, ENotStateControllerAliasId);
+      assert!(self.state_cap_version == cap.state_cap_version, ENotStateControllerVersion);
+    }
+
+    /// Assert that the GovernorCap governs this alias.
+    fun assert_governor(self: &AliasOutput, cap: &GovernorCap) {
+      assert!(self.id.uid_to_inner() == cap.alias_id, ENotGovernor);
+    }
+
+    /// extracts the related tokens bag object.
+    fun extract_tokens(output: &mut AliasOutput): Option<Bag> {
+        dynamic_field::remove_if_exists(&mut output.id, TOKENS_NAME)
+    }
+
+    // === Test Functions ===
+
+    #[test_only]
+    public fun create_for_testing(
+        iota: Balance<SUI>,
+        state_cap_version: u64,
+        state_index: u32,
+        state_metadata: Option<vector<u8>>,
+        sender: Option<address>,
+        metadata: Option<vector<u8>>,
+        issuer: Option<address>,
+        immutable_metadata: Option<vector<u8>>,
+        ctx: &mut TxContext
+    ): (AliasOutput, GovernorCap, StateCap)  {
+        let id = object::new(ctx);
+        let inner = id.uid_to_inner();
+        (AliasOutput {
+            id,
+            iota,
+            state_cap_version,
+            state_index,
+            state_metadata,
+            sender,
+            metadata,
+            issuer,
+            immutable_metadata,
+        },GovernorCap {
+            id: object::new(ctx),
+            alias_id: inner,
+        }, StateCap {
+            id: object::new(ctx),
+            alias_id: inner,
+            state_cap_version,
+        })
+    }
+
+    #[test_only]
+    public fun attach_tokens(output: &mut AliasOutput, tokens: Bag) {
+        dynamic_field::add(&mut output.id, TOKENS_NAME, tokens)
+    }
+}

--- a/crates/sui-framework/packages/stardust/sources/alias/alias.move
+++ b/crates/sui-framework/packages/stardust/sources/alias/alias.move
@@ -1,48 +1,14 @@
 module stardust::alias{
-    use sui::balance::{Self, Balance};
-    use sui::dynamic_field;
-    use sui::sui::SUI;
-    use sui::transfer::{Receiving};
-    use sui::bag::{Bag};
-
-    const ENotStateControllerAliasId: u64 = 0;
-    const ENotStateControllerVersion: u64 = 1;
-    const ENotGovernor: u64 = 2;
-
-    /// The tokens bag dynamic field name.
-    const TOKENS_NAME: vector<u8> = b"tokens";
-
-    /// The capability owned object that the governor must own. This enables the owner address to execute a 
-    /// governance transition.
-    public struct GovernorCap has key, store {
-      id: UID,
-      alias_id: ID,
-    }
-
-    /// The capability owned object that the state must own. This enables the state address to execute a 
-    /// state transition. The state_cap_version allows the governor to deprecate the state address.
-    public struct StateCap has key {
-      id: UID,
-      alias_id: ID,
-      state_cap_version: u64,
-    }
-
+  
     /// Shared Object that can be controlled with the GovernorCap and StateControllerCap.
-    public struct AliasOutput has key {
-      /// The ID of the AliasOutput.
-      /// This is the hash of the Output ID that created the Alias Output.
-      /// During the migration, any Alias Output with a zeroed ID must have its corresponding computed Alias ID set.
-      /// Alias ID must be kept between the migration from Stardust to Move (for applications like Identity).
+    public struct Alias has key, store {
+      /// The ID of the Alias = hash of the Output ID that created the Alias Output in Stardust.
       id: UID,
-      
-      // The amount of IOTA coins held by the output.
-      iota: Balance<SUI>,
 
       // State representation
-      // The State Controller Address that can unlock in a transaction that state transitions the alias object. The 
-      // state_cap_version enable to validate a StateCap to be able to represent the State Controller Address.
-      state_cap_version: u64,
-      // A counter that must increase by 1 every time the alias is state transitioned.
+      /// The last State Controller address assigned before the migration.
+      legacy_state_controller: Option<address>,
+      // A counter increased by 1 every time the alias was state transitioned.
       state_index: u32,
       // Metadata that can only be changed by the state controller. 
       state_metadata: Option<vector<u8>>,
@@ -50,171 +16,98 @@ module stardust::alias{
       // Features
       // sender feature
       sender: Option<address>,
-      // DID<version_byte><encoding_byte>
+      // The metadata feature.
       metadata: Option<vector<u8>>,
 
       // Immutable Features
-      issuer: Option<address>,
+      immutable_issuer: Option<address>,
       immutable_metadata: Option<vector<u8>>,
     }
 
     // === Public-Mutative Functions ===
 
-    /// Set the state controller address
-    public fun governor_set_state_controller(self: &mut AliasOutput, cap: &GovernorCap, state_controller: address, ctx: &mut TxContext) {
-      self.assert_governor(cap);
-      self.state_cap_version = self.state_cap_version + 1;
-
-      transfer::transfer(StateCap {
-        id: object::new(ctx),
-        alias_id: self.id.uid_to_inner(),
-        state_cap_version: self.state_cap_version,
-      }, state_controller);
-    }
-
-    // extract the assets inside the output
-    //  - the object will NOT be destroyd
-    //  - remaining assets (iota coins and native tokens) will be returned
-    public fun extract_assets(
-        self: &mut AliasOutput,
-        cap: &StateCap,
-    ) : (Balance<SUI>, Option<Bag>) {
-        self.state_index_increment(cap);
-        // unpack the output into its basic part
-        let AliasOutput {
-          id: _,
-          iota,
-          state_cap_version: _,
-          state_index: _,
-          state_metadata: _,
-          sender: _,
-          metadata: _,
-          issuer: _,
-          immutable_metadata: _,
-        } = self;
-        // extract all iota coins
-        let all_iota = balance::withdraw_all(iota);
-        // extract the native tokens bag 
-        let tokens = self.extract_tokens();
-
-        (all_iota, tokens)
-    }
-
     /// Destroy the AliasOutput Object and return IOTA balance and Bag of tokens
-    public fun destroy(self: AliasOutput, cap: GovernorCap) {
-      self.assert_governor(&cap);
-      let AliasOutput {
+    public fun destroy(self: Alias) {
+      let Alias {
         id,
-        iota,
-        state_cap_version: _,
+        legacy_state_controller: _,
         state_index: _,
         state_metadata: _,
         sender: _,
         metadata: _,
-        issuer: _,
+        immutable_issuer: _,
         immutable_metadata: _,
       } = self;
-
-      // iota amount must be zero, extracted by the state address
-      iota.destroy_zero();
-      
-      // destroy the governor cap
-      let GovernorCap {
-        id: governor_cap_id,
-        alias_id: _,
-      } = cap;
-      object::delete(governor_cap_id);
       
       object::delete(id);
     }
 
-    /// Set the state controller address
-    public fun destroy_state_cap(self: &mut AliasOutput, cap: StateCap) {
-      assert!(self.id.uid_to_inner() == cap.alias_id, ENotStateControllerAliasId);
-      let StateCap {
-        id,
-        alias_id: _,
-        state_cap_version: _,
-      } = cap;
-      object::delete(id);
+    // === Public-Mutative Functions ===
+
+    /// Get the Alias's `legacy_state_controller`.
+    public fun legacy_state_controller(self: &Alias): &Option<address> {
+        &self.legacy_state_controller
+    }
+
+    /// Get the Alias's `state_index`.
+    public fun state_index(self: &Alias): u32 {
+        self.state_index
+    }
+
+    /// Get the Alias's `state_metadata`.
+    public fun state_metadata(self: &Alias): &Option<vector<u8>> {
+        &self.state_metadata
+    }
+
+    /// Get the Alias's `sender`.
+    public fun sender(self: &Alias): &Option<address> {
+        &self.sender
+    }
+
+    /// Get the Alias's `metadata`.
+    public fun metadata(self: &Alias): &Option<vector<u8>> {
+        &self.metadata
+    }
+
+    /// Get the Alias's `immutable_sender`.
+    public fun immutable_issuer(self: &Alias): &Option<address> {
+        &self.immutable_issuer
+    }
+
+    /// Get the Alias's `immutable_metadata`.
+    public fun immutable_metadata(self: &Alias): &Option<vector<u8>> {
+        &self.immutable_metadata
     }
 
     // === Public-Package Functions ===
 
     /// Get the alias id.
-    public(package) fun id(self: &mut AliasOutput): &mut UID {
+    public(package) fun id(self: &mut Alias): &mut UID {
         &mut self.id
-    }
-
-    /// Increment state_index by 1.
-    public(package) fun state_index_increment(self: &mut AliasOutput, cap: &StateCap) {
-      self.assert_state_controller(cap);
-      self.state_index = self.state_index + 1;
-    }
-
-    // utility function to receive a alias output in other stardust models
-    // other modules in the stardust pacakge can call this function to receive a alias output (nft)
-    public(package) fun receive(parent: &mut UID, alias: Receiving<AliasOutput>) : AliasOutput {
-        transfer::receive(parent, alias)
-    }
-
-
-    // === Private Functions ===
-
-    /// Assert that the TX sender is equal to the state controller.
-    fun assert_state_controller(self: &AliasOutput, cap: &StateCap) {
-      assert!(self.id.uid_to_inner() == cap.alias_id, ENotStateControllerAliasId);
-      assert!(self.state_cap_version == cap.state_cap_version, ENotStateControllerVersion);
-    }
-
-    /// Assert that the GovernorCap governs this alias.
-    fun assert_governor(self: &AliasOutput, cap: &GovernorCap) {
-      assert!(self.id.uid_to_inner() == cap.alias_id, ENotGovernor);
-    }
-
-    /// extracts the related tokens bag object.
-    fun extract_tokens(output: &mut AliasOutput): Option<Bag> {
-        dynamic_field::remove_if_exists(&mut output.id, TOKENS_NAME)
     }
 
     // === Test Functions ===
 
     #[test_only]
     public fun create_for_testing(
-        iota: Balance<SUI>,
-        state_cap_version: u64,
+        legacy_state_controller: Option<address>,
         state_index: u32,
         state_metadata: Option<vector<u8>>,
         sender: Option<address>,
         metadata: Option<vector<u8>>,
-        issuer: Option<address>,
+        immutable_issuer: Option<address>,
         immutable_metadata: Option<vector<u8>>,
         ctx: &mut TxContext
-    ): (AliasOutput, GovernorCap, StateCap)  {
-        let id = object::new(ctx);
-        let inner = id.uid_to_inner();
-        (AliasOutput {
-            id,
-            iota,
-            state_cap_version,
+    ): Alias  {
+      Alias {
+            id: object::new(ctx),
+            legacy_state_controller,
             state_index,
             state_metadata,
             sender,
             metadata,
-            issuer,
+            immutable_issuer,
             immutable_metadata,
-        },GovernorCap {
-            id: object::new(ctx),
-            alias_id: inner,
-        }, StateCap {
-            id: object::new(ctx),
-            alias_id: inner,
-            state_cap_version,
-        })
-    }
-
-    #[test_only]
-    public fun attach_tokens(output: &mut AliasOutput, tokens: Bag) {
-        dynamic_field::add(&mut output.id, TOKENS_NAME, tokens)
+        }
     }
 }

--- a/crates/sui-framework/packages/stardust/sources/alias/alias.move
+++ b/crates/sui-framework/packages/stardust/sources/alias/alias.move
@@ -1,32 +1,34 @@
 module stardust::alias{
   
-    /// Shared Object that can be controlled with the GovernorCap and StateControllerCap.
+    /// The persisted Alias object from stardust, without tokens and assets
+    /// Outputs owned the the AliasID/Address in stardust will be sent to this object and
+    /// they have to be received via this object once extracted from `AliasOutput`.
     public struct Alias has key, store {
       /// The ID of the Alias = hash of the Output ID that created the Alias Output in Stardust.
+      /// This is the AliasID from stardust.
       id: UID,
-
       // State representation
       /// The last State Controller address assigned before the migration.
       legacy_state_controller: Option<address>,
-      // A counter increased by 1 every time the alias was state transitioned.
+      /// A counter increased by 1 every time the alias was state transitioned.
       state_index: u32,
-      // Metadata that can only be changed by the state controller. 
+      /// State metadata that can be used to store additional information.
       state_metadata: Option<vector<u8>>,
 
       // Features
-      // sender feature
+      /// The sender feature
       sender: Option<address>,
-      // The metadata feature.
+      /// The metadata feature.
       metadata: Option<vector<u8>>,
 
-      // Immutable Features
+      /// Immutable Features
       immutable_issuer: Option<address>,
       immutable_metadata: Option<vector<u8>>,
     }
 
     // === Public-Mutative Functions ===
 
-    /// Destroy the AliasOutput Object and return IOTA balance and Bag of tokens
+    /// Destroy the Alias Object, equivalent to `burning` an Alias Output in Stardust.
     public fun destroy(self: Alias) {
       let Alias {
         id,

--- a/crates/sui-framework/packages/stardust/sources/alias/alias_output.move
+++ b/crates/sui-framework/packages/stardust/sources/alias/alias_output.move
@@ -1,31 +1,34 @@
 module stardust::alias_output{
     use sui::balance::{Balance};
-    use sui::dynamic_field;
+    use sui::dynamic_object_field;
     use sui::sui::SUI;
     use sui::bag::{Bag};
     use sui::transfer::{Receiving};
 
     use stardust::alias::{Alias};
 
-    /// The Alias dynamic field name.
+    /// The Alias dynamic object field name.
     const ALIAS_NAME: vector<u8> = b"alias";
 
-    /// Owned Object controlled with by the Governor.
+    /// Owned Object controlled by the Governor Address.
     public struct AliasOutput has key {
+      /// This is a "random" UID, not the AliasID from stardust.
       id: UID,
-      
-      // The amount of IOTA coins held by the output.
+      /// The amount of IOTA coins held by the output.
       iota: Balance<SUI>,
-      // the bag holds native tokens, key-ed by the stringified type of the asset
-      // Example: key: "0xabcded::soon::SOON", value: Balance<0xabcded::soon::SOON>
+      /// the bag holds native tokens, key-ed by the stringified type of the asset
+      /// Example: key: "0xabcded::soon::SOON", value: Balance<0xabcded::soon::SOON>
       tokens: Bag,
     }
 
     // === Public-Mutative Functions ===
     
     /// The function extracts assets from a legacy Alias output.
+    ///    - returns the IOTA Balance,
+    ///    - the Tokens Bag,
+    ///    - and the Alias object that persists the AliasID=ObjectID from stardust
     public fun extract_assets(mut self: AliasOutput): (Balance<SUI>, Bag, Alias) {
-        // Load the related Nft object.
+        // Load the related alias object.
         let alias = load_alias(&mut self);
 
         // unpack the output into its basic part
@@ -42,17 +45,17 @@ module stardust::alias_output{
 
     // === Public-Package Functions ===
 
-    // utility function to receive a alias output in other stardust models
-    // other modules in the stardust pacakge can call this function to receive a alias output (nft)
+    /// utility function to receive a alias output in other stardust models
+    /// other modules in the stardust pacakge can call this function to receive an alias output (nft)
     public(package) fun receive(parent: &mut UID, alias_output: Receiving<AliasOutput>) : AliasOutput {
         transfer::receive(parent, alias_output)
     }
 
     // === Private Functions ===
 
-    /// extracts the related tokens bag object.
+    /// loads the alias object from the dynamic object field.
     fun load_alias(output: &mut AliasOutput): Alias {
-        dynamic_field::remove(&mut output.id, ALIAS_NAME)
+        dynamic_object_field::remove(&mut output.id, ALIAS_NAME)
     }
 
     // === Test Functions ===
@@ -72,6 +75,6 @@ module stardust::alias_output{
 
     #[test_only]
     public fun attach_alias(output: &mut AliasOutput, alias: Alias) {
-        dynamic_field::add(&mut output.id, ALIAS_NAME, alias)
+        dynamic_object_field::add(&mut output.id, ALIAS_NAME, alias)
     }
 }

--- a/crates/sui-framework/packages/stardust/sources/alias/alias_output.move
+++ b/crates/sui-framework/packages/stardust/sources/alias/alias_output.move
@@ -1,0 +1,77 @@
+module stardust::alias_output{
+    use sui::balance::{Balance};
+    use sui::dynamic_field;
+    use sui::sui::SUI;
+    use sui::bag::{Bag};
+    use sui::transfer::{Receiving};
+
+    use stardust::alias::{Alias};
+
+    /// The Alias dynamic field name.
+    const ALIAS_NAME: vector<u8> = b"alias";
+
+    /// Owned Object controlled with by the Governor.
+    public struct AliasOutput has key {
+      id: UID,
+      
+      // The amount of IOTA coins held by the output.
+      iota: Balance<SUI>,
+      // the bag holds native tokens, key-ed by the stringified type of the asset
+      // Example: key: "0xabcded::soon::SOON", value: Balance<0xabcded::soon::SOON>
+      tokens: Bag,
+    }
+
+    // === Public-Mutative Functions ===
+    
+    /// The function extracts assets from a legacy Alias output.
+    public fun extract_assets(mut self: AliasOutput): (Balance<SUI>, Bag, Alias) {
+        // Load the related Nft object.
+        let alias = load_alias(&mut self);
+
+        // unpack the output into its basic part
+        let AliasOutput {
+          id,
+          iota,
+          tokens
+        } = self;
+
+        object::delete(id);
+
+        (iota, tokens, alias)
+    }
+
+    // === Public-Package Functions ===
+
+    // utility function to receive a alias output in other stardust models
+    // other modules in the stardust pacakge can call this function to receive a alias output (nft)
+    public(package) fun receive(parent: &mut UID, alias_output: Receiving<AliasOutput>) : AliasOutput {
+        transfer::receive(parent, alias_output)
+    }
+
+    // === Private Functions ===
+
+    /// extracts the related tokens bag object.
+    fun load_alias(output: &mut AliasOutput): Alias {
+        dynamic_field::remove(&mut output.id, ALIAS_NAME)
+    }
+
+    // === Test Functions ===
+
+    #[test_only]
+    public fun create_for_testing(
+        iota: Balance<SUI>,
+        tokens: Bag,
+        ctx: &mut TxContext
+    ): AliasOutput  {
+        AliasOutput {
+            id: object::new(ctx),
+            iota,
+            tokens,
+        }
+    }
+
+    #[test_only]
+    public fun attach_alias(output: &mut AliasOutput, alias: Alias) {
+        dynamic_field::add(&mut output.id, ALIAS_NAME, alias)
+    }
+}

--- a/crates/sui-framework/packages/stardust/sources/nft/nft.move
+++ b/crates/sui-framework/packages/stardust/sources/nft/nft.move
@@ -65,6 +65,11 @@ module stardust::nft {
         &nft.immutable_metadata
     }
 
+    /// Get the Nft id.
+    public(package) fun id(self: &mut Nft): &mut UID {
+        &mut self.id
+    }
+
     #[test_only]
     public fun create_for_testing(
         legacy_sender: Option<address>,

--- a/crates/sui-framework/packages/stardust/sources/nft/nft_output.move
+++ b/crates/sui-framework/packages/stardust/sources/nft/nft_output.move
@@ -6,6 +6,7 @@ module stardust::nft_output {
     use sui::balance::Balance;
     use sui::dynamic_field;
     use sui::sui::SUI;
+    use sui::transfer::Receiving;
 
     use stardust::nft::Nft;
 
@@ -74,6 +75,23 @@ module stardust::nft_output {
     fun load_nft(output: &mut NftOutput): Nft {
         dynamic_field::remove(&mut output.id, NFT_NAME)
     }
+
+    // === Public-Package Functions ===
+
+
+    /// Get the alias id.
+    public(package) fun id(self: &mut NftOutput): &mut UID {
+        &mut self.id
+    }
+
+    // utility function to receive a nft output in other stardust models
+    // other modules in the stardust pacakge can call this function to receive a nft output (alias)
+    public(package) fun receive(parent: &mut UID, nft: Receiving<NftOutput>) : NftOutput {
+        transfer::receive(parent, nft)
+    }
+
+    // === Test Functions ===
+
 
     #[test_only]
     public fun attach_nft(output: &mut NftOutput, nft: Nft) {

--- a/crates/sui-framework/packages/stardust/sources/nft/nft_output.move
+++ b/crates/sui-framework/packages/stardust/sources/nft/nft_output.move
@@ -78,12 +78,6 @@ module stardust::nft_output {
 
     // === Public-Package Functions ===
 
-
-    /// Get the alias id.
-    public(package) fun id(self: &mut NftOutput): &mut UID {
-        &mut self.id
-    }
-
     // utility function to receive a nft output in other stardust models
     // other modules in the stardust pacakge can call this function to receive a nft output (alias)
     public(package) fun receive(parent: &mut UID, nft: Receiving<NftOutput>) : NftOutput {
@@ -91,7 +85,6 @@ module stardust::nft_output {
     }
 
     // === Test Functions ===
-
 
     #[test_only]
     public fun attach_nft(output: &mut NftOutput, nft: Nft) {

--- a/crates/sui-framework/packages/stardust/sources/unlock_condition/address_unlock_condition.move
+++ b/crates/sui-framework/packages/stardust/sources/unlock_condition/address_unlock_condition.move
@@ -7,6 +7,8 @@ module stardust::address_unlock_condition{
     use stardust::alias::{Alias};
     use stardust::alias_output::{Self,AliasOutput};
 
+    // === Receiving on Alias Address/AliasID as ObjectID ===
+
     /// Unlock Basic outputs locked to this alias address
     public fun unlock_alias_address_owned_basic(
       self: &mut Alias,
@@ -38,6 +40,10 @@ module stardust::address_unlock_condition{
       ): TreasuryCap<T> {
         transfer::public_receive(self.id(), treasury_cap)
     }
+
+    // TODO: be able to receive MaxSupplyPolicy from https://github.com/iotaledger/kinesis/pull/145
+
+    // === Receiving on NFT Address/NFTID as ObjectID ===
     
     /// Unlock Basic outputs locked to this alias address
     public fun unlock_nft_address_owned_basic(
@@ -47,7 +53,7 @@ module stardust::address_unlock_condition{
         basic::receive(self.id(), output_to_unlock)
     }
 
-    /// Unlock NFT outputs locked to this alias address
+    /// Unlock NFT outputs locked to this nft address
     public fun unlock_nft_address_owned_nft(
       self: &mut Nft,
       output_to_unlock: Receiving<NftOutput>,
@@ -55,7 +61,7 @@ module stardust::address_unlock_condition{
         nft_output::receive(self.id(), output_to_unlock)
     }
 
-    /// Unlock Alias outputs locked to this alias address
+    /// Unlock Alias outputs locked to this Nft address
     public fun unlock_nft_address_owned_alias(
       self: &mut Nft,
       output_to_unlock: Receiving<AliasOutput>,

--- a/crates/sui-framework/packages/stardust/sources/unlock_condition/address_unlock_condition.move
+++ b/crates/sui-framework/packages/stardust/sources/unlock_condition/address_unlock_condition.move
@@ -2,53 +2,46 @@ module stardust::address_unlock_condition{
     use sui::coin::{TreasuryCap};
     use sui::transfer::{Receiving};
     use stardust::basic::{Self,BasicOutput};
+    use stardust::nft::{Nft};
     use stardust::nft_output::{Self,NftOutput};
-    use stardust::alias::{Self,AliasOutput,StateCap};
+    use stardust::alias::{Alias};
+    use stardust::alias_output::{Self,AliasOutput};
 
     /// Unlock Basic outputs locked to this alias address
     public fun unlock_alias_address_owned_basic(
-      self: &mut AliasOutput,
-      cap: &StateCap,
+      self: &mut Alias,
       output_to_unlock: Receiving<BasicOutput>,
       ): BasicOutput {
-        self.state_index_increment(cap);
         basic::receive(self.id(), output_to_unlock)
     }
 
     /// Unlock NFT outputs locked to this alias address
     public fun unlock_alias_address_owned_nft(
-      self: &mut AliasOutput,
-      cap: &StateCap,
+      self: &mut Alias,
       output_to_unlock: Receiving<NftOutput>,
       ): NftOutput {
-        self.state_index_increment(cap);
         nft_output::receive(self.id(), output_to_unlock)
     }
 
     /// Unlock Alias outputs locked to this alias address
     public fun unlock_alias_address_owned_alias(
-      self: &mut AliasOutput,
-      cap: &StateCap,
+      self: &mut Alias,
       output_to_unlock: Receiving<AliasOutput>,
       ): AliasOutput {
-        self.state_index_increment(cap);
-        alias::receive(self.id(), output_to_unlock)
+        alias_output::receive(self.id(), output_to_unlock)
     }
 
     /// Unlock Alias outputs locked to this alias address
     public fun unlock_alias_address_owned_treasury<T: key + store>(
-      self: &mut AliasOutput,
-      cap: &StateCap,
+      self: &mut Alias,
       treasury_cap: Receiving<TreasuryCap<T>>,
       ): TreasuryCap<T> {
-        self.state_index_increment(cap);
         transfer::public_receive(self.id(), treasury_cap)
     }
-
     
     /// Unlock Basic outputs locked to this alias address
     public fun unlock_nft_address_owned_basic(
-      self: &mut NftOutput,
+      self: &mut Nft,
       output_to_unlock: Receiving<BasicOutput>,
       ): BasicOutput {
         basic::receive(self.id(), output_to_unlock)
@@ -56,7 +49,7 @@ module stardust::address_unlock_condition{
 
     /// Unlock NFT outputs locked to this alias address
     public fun unlock_nft_address_owned_nft(
-      self: &mut NftOutput,
+      self: &mut Nft,
       output_to_unlock: Receiving<NftOutput>,
       ): NftOutput {
         nft_output::receive(self.id(), output_to_unlock)
@@ -64,9 +57,9 @@ module stardust::address_unlock_condition{
 
     /// Unlock Alias outputs locked to this alias address
     public fun unlock_nft_address_owned_alias(
-      self: &mut NftOutput,
+      self: &mut Nft,
       output_to_unlock: Receiving<AliasOutput>,
       ): AliasOutput {
-        alias::receive(self.id(), output_to_unlock)
+        alias_output::receive(self.id(), output_to_unlock)
     }
 }

--- a/crates/sui-framework/packages/stardust/sources/unlock_condition/address_unlock_condition.move
+++ b/crates/sui-framework/packages/stardust/sources/unlock_condition/address_unlock_condition.move
@@ -1,0 +1,72 @@
+module stardust::address_unlock_condition{
+    use sui::coin::{TreasuryCap};
+    use sui::transfer::{Receiving};
+    use stardust::basic::{Self,BasicOutput};
+    use stardust::nft_output::{Self,NftOutput};
+    use stardust::alias::{Self,AliasOutput,StateCap};
+
+    /// Unlock Basic outputs locked to this alias address
+    public fun unlock_alias_address_owned_basic(
+      self: &mut AliasOutput,
+      cap: &StateCap,
+      output_to_unlock: Receiving<BasicOutput>,
+      ): BasicOutput {
+        self.state_index_increment(cap);
+        basic::receive(self.id(), output_to_unlock)
+    }
+
+    /// Unlock NFT outputs locked to this alias address
+    public fun unlock_alias_address_owned_nft(
+      self: &mut AliasOutput,
+      cap: &StateCap,
+      output_to_unlock: Receiving<NftOutput>,
+      ): NftOutput {
+        self.state_index_increment(cap);
+        nft_output::receive(self.id(), output_to_unlock)
+    }
+
+    /// Unlock Alias outputs locked to this alias address
+    public fun unlock_alias_address_owned_alias(
+      self: &mut AliasOutput,
+      cap: &StateCap,
+      output_to_unlock: Receiving<AliasOutput>,
+      ): AliasOutput {
+        self.state_index_increment(cap);
+        alias::receive(self.id(), output_to_unlock)
+    }
+
+    /// Unlock Alias outputs locked to this alias address
+    public fun unlock_alias_address_owned_treasury<T: key + store>(
+      self: &mut AliasOutput,
+      cap: &StateCap,
+      treasury_cap: Receiving<TreasuryCap<T>>,
+      ): TreasuryCap<T> {
+        self.state_index_increment(cap);
+        transfer::public_receive(self.id(), treasury_cap)
+    }
+
+    
+    /// Unlock Basic outputs locked to this alias address
+    public fun unlock_nft_address_owned_basic(
+      self: &mut NftOutput,
+      output_to_unlock: Receiving<BasicOutput>,
+      ): BasicOutput {
+        basic::receive(self.id(), output_to_unlock)
+    }
+
+    /// Unlock NFT outputs locked to this alias address
+    public fun unlock_nft_address_owned_nft(
+      self: &mut NftOutput,
+      output_to_unlock: Receiving<NftOutput>,
+      ): NftOutput {
+        nft_output::receive(self.id(), output_to_unlock)
+    }
+
+    /// Unlock Alias outputs locked to this alias address
+    public fun unlock_nft_address_owned_alias(
+      self: &mut NftOutput,
+      output_to_unlock: Receiving<AliasOutput>,
+      ): AliasOutput {
+        alias::receive(self.id(), output_to_unlock)
+    }
+}

--- a/crates/sui-framework/packages/stardust/tests/alias_tests.move
+++ b/crates/sui-framework/packages/stardust/tests/alias_tests.move
@@ -1,0 +1,109 @@
+module stardust::alias_tests{
+    use std::{
+        option::{some},
+        type_name::{get}
+    };
+    use sui::{
+        sui::{SUI},
+        balance::{Self},
+        bag::{Self},
+        coin::{Self},
+    };
+    use stardust::{
+        alias::{Self},
+        utilities::{Self as utils},
+    };
+        
+    const ENativeTokenBagEmpty: u64 = 0;
+    const ENativeTokenBagNonEmpty: u64 = 1;
+    
+    // one time witness for a coin used in tests
+    // we can not declare these inside the test function, and there is no constructor for Basic so we can't test it in a test module
+    public struct TEST_A has drop {}
+    public struct TEST_B has drop {}
+
+    // demonstration on how to claim the assets from a basic output with all unlock conditions inside one PTB
+    #[test]
+    fun demonstrate_claiming_ptb() {
+        let initial_iota_in_output = 10000;
+        let initial_testA_in_output = 100;
+        let initial_testB_in_output = 100;
+
+        let owner = @0xA;
+        let migrate_to = @0xD; 
+
+        // create a new tx context
+        let mut ctx = tx_context::new(
+            // sender
+            @0xA,
+            // tx)hash
+            x"3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532",
+            // epoch
+            1,
+            // epoch ts in ms (10 in seconds)
+            10000,
+            // ids created
+            0,
+        );
+
+        // mint some tokens
+        let sui_balance = balance::create_for_testing<SUI>(initial_iota_in_output);
+        let test_a_balance = balance::create_for_testing<TEST_A>(initial_testA_in_output);
+        let test_b_balance = balance::create_for_testing<TEST_B>(initial_testB_in_output);
+
+        let mut token_bag = bag::new(&mut ctx);
+        // add the native token balances to the bag
+        token_bag.add(get<TEST_A>().into_string(), test_a_balance);
+        token_bag.add(get<TEST_B>().into_string(), test_b_balance);
+
+        let (mut output, governor_cap, state_cap) = alias::create_for_testing(
+            sui_balance,
+            // state cap version
+            0,
+            // state index
+            0,
+            // state metadata
+            some(b"state metadata content"),
+            // sender feature
+            some(owner),
+            // metadata feature
+            some(b"metadata content"),
+            // issuer feature
+            some(owner),
+            // immutable metadata
+            some(b"immutable metadata content"),
+            &mut ctx,
+        );
+        output.attach_tokens(token_bag);
+
+        // command 1: extract the base token and native token bag
+        let (extracted_base_token, mut native_token_bag_option) = output.extract_assets(&state_cap);
+        assert!(native_token_bag_option.is_some(), ENativeTokenBagEmpty);
+        let mut native_token_bag = native_token_bag_option.extract();
+        option::destroy_none(native_token_bag_option);
+
+        // command 2: extract asset A and send to user
+        utils::extract_and_send_to<TEST_A>(&mut native_token_bag, migrate_to, &mut ctx);
+
+        // command 3: extract asset B and send to user
+        utils::extract_and_send_to<TEST_B>(&mut native_token_bag, migrate_to, &mut ctx);
+        assert!(native_token_bag.is_empty(), ENativeTokenBagNonEmpty);
+        
+        // command 4: delete the bag
+        native_token_bag.destroy_empty();
+
+        // comand 5: create coin from the extracted iota balance
+        let iota_coin = coin::from_balance(extracted_base_token, &mut ctx);
+
+        // command 6: send back the base token coin to the user
+        transfer::public_transfer(iota_coin, migrate_to);
+
+        // command 7: destroy state cap
+        output.destroy_state_cap(state_cap);
+
+        // command 8: destroy the alias output
+        output.destroy(governor_cap);
+
+        // !!! migration complete !!! 
+    }
+}

--- a/crates/sui-framework/packages/stardust/tests/alias_tests.move
+++ b/crates/sui-framework/packages/stardust/tests/alias_tests.move
@@ -83,10 +83,10 @@ module stardust::alias_tests{
         option::destroy_none(native_token_bag_option);
 
         // command 2: extract asset A and send to user
-        utils::extract_and_send_to<TEST_A>(&mut native_token_bag, migrate_to, &mut ctx);
+        native_token_bag = utils::extract_and_send_to<TEST_A>(native_token_bag, migrate_to, &mut ctx);
 
         // command 3: extract asset B and send to user
-        utils::extract_and_send_to<TEST_B>(&mut native_token_bag, migrate_to, &mut ctx);
+        native_token_bag = utils::extract_and_send_to<TEST_B>(native_token_bag, migrate_to, &mut ctx);
         assert!(native_token_bag.is_empty(), ENativeTokenBagNonEmpty);
         
         // command 4: delete the bag

--- a/crates/sui-framework/packages/stardust/tests/unlock_condition/address_unlock_condition_tests.move
+++ b/crates/sui-framework/packages/stardust/tests/unlock_condition/address_unlock_condition_tests.move
@@ -1,0 +1,132 @@
+module stardust::address_unlock_condition_tests{
+    use std::{
+        option::{some},
+    };
+    use sui::{
+        sui::{SUI},
+        balance::{Self},
+        bag::{Self},
+        coin::{Self},
+    };
+    use stardust::{
+        alias::{Self},
+        basic::{Self},
+        expiration_unlock_condition::{Self as expiration},
+        storage_deposit_return_unlock_condition::{Self as sdruc},
+        timelock_unlock_condition::{Self as timelock},
+        utilities::{Self as utils},
+    };
+        
+    const ENativeTokenBagNonEmpty: u64 = 1;
+    const EIotaBlanceMismatch: u64 = 3;
+    
+    // one time witness for a coin used in tests
+    // we can not declare these inside the test function, and there is no constructor for Basic so we can't test it in a test module
+    public struct TEST_A has drop {}
+    public struct TEST_B has drop {}
+
+    // demonstration on how to claim the assets from a basic alias_output with all unlock conditions inside one PTB
+    #[test]
+    fun demonstrate_alias_address_unlocking() {
+        let initial_iota_in_output = 10000;
+
+        let owner = @0xA;
+        let migrate_to = @0xD; 
+
+        // create a new tx context
+        let mut ctx = tx_context::new(
+            // sender
+            @0xA,
+            // tx)hash
+            x"3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532",
+            // epoch
+            1,
+            // epoch ts in ms (10 in seconds)
+            10000,
+            // ids created
+            0,
+        );
+
+        let sui_balance = balance::create_for_testing<SUI>(initial_iota_in_output);
+        //let token_bag = bag::new(&mut ctx);
+        let (mut alias_output, governor_cap, state_cap) = alias::create_for_testing(
+            sui_balance,
+            // state cap version
+            0,
+            // state index
+            0,
+            // state metadata
+            some(b"state metadata content"),
+            // sender feature
+            some(owner),
+            // metadata feature
+            some(b"metadata content"),
+            // issuer feature
+            some(owner),
+            // immutable metadata
+            some(b"immutable metadata content"),
+            &mut ctx,
+        );
+        //alias_output.attach_tokens(token_bag);
+
+        // Basic Output owned by the alias
+        let basic_sui_balance = balance::create_for_testing<SUI>(initial_iota_in_output);
+        let timelocked_until = 5;
+        let expiration_after = 20;
+        let sdruc_return_address = @0xB;
+        let sdruc_return_amount = 1000;
+        let expiration_return_address = @0xC;
+        let basic_output = basic::create_for_testing(
+            basic_sui_balance,
+            bag::new(&mut ctx),
+            some(sdruc::create_for_testing(sdruc_return_address, sdruc_return_amount)),
+            some(timelock::create_for_testing(timelocked_until)),
+            some(expiration::create_for_testing(owner, expiration_return_address, expiration_after)),
+            // metadata feature
+            some(b"metadata content"),
+            // tag feature
+            some(b"tag content"),
+            // sender feature
+            some(owner),
+            &mut ctx,
+        );
+
+        // command 1: unlock the basic token
+        // TODO: is it possible to create a Receiving object?
+        // transfer::transfer(basic_output,alias_output.id().uid_to_address());
+        // let basic_output = unlock_alias_address_owned_basic(&mut alias_output,&state_cap,basic_output);
+
+        // command 2: extract the base token and native token bag
+        let (extracted_base_token_option, native_token_bag) = basic_output.extract_assets(&mut ctx);
+        
+        // command 3: delete the bag
+        native_token_bag.destroy_empty();
+
+        // comand 4: create coin from the extracted iota balance
+        let iota_coin = utils::create_coin_from_option_balance(extracted_base_token_option, &mut ctx);
+        // we should have `initial_iota_in_output` - `sdruc_return_amount` left in the coin
+        assert!(iota_coin.value() == (initial_iota_in_output - sdruc_return_amount), EIotaBlanceMismatch);
+
+        // command 6: send back the base token coin to the user
+        transfer::public_transfer(iota_coin, migrate_to);
+
+        // command 7: extract the base token and native token bag
+        let (extracted_base_token, native_token_bag) = alias_output.extract_assets(&state_cap);
+        assert!(native_token_bag.is_none(), ENativeTokenBagNonEmpty);
+        option::destroy_none(native_token_bag);
+
+        // comand 8: create coin from the extracted iota balance
+        let iota_coin = coin::from_balance(extracted_base_token, &mut ctx);
+
+        // command 9: send back the base token coin to the user
+        transfer::public_transfer(iota_coin, migrate_to);
+
+        // command 10: destroy state cap
+        alias_output.destroy_state_cap(state_cap);
+
+        // command 11: destroy the alias alias_output
+        alias_output.destroy(governor_cap);
+
+        // !!! migration complete !!! 
+    }
+}


### PR DESCRIPTION
# Description of change

This PR creates a model for managing Alias Outputs. 

This model is in line with the Alias Model requirements discussed with ISC and Identity teams. 

- The Alias Output is a OWNED object that can be modified 
  - by the owner, i.e., the address indicated as Governor before the migration
  - NO State address representation for authentication (only as a read_only field inside the `Alias` object)
  - the owner (Governor) can `extract_assets` (the `AliasOutput` will be destroyed): 
    - iota coins 
    - native tokens (Bag) 
    - the `Alias` object 
- The `Alias` object will persist in the ledger after the assets are extracted from the output:
  - This object's ID is the same as the AliasID in the stardust ledger
  - This object is used to unlock received objects (`BasicOutput`,`NftOutput`,`AliasOutput`,`TreasuryCap`).
- The Foundry Output management capabilities are implemented through the creation of a new package for each NativeToken and by the associated TreasuryCap.
- An `address_unlock_condition` module has been created to deal with address unlock condition where the address is of Alias or NFT type.   

## Links to any relevant issues

Fixes #141 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

- `sui move test` 

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
