### PR TITLE
Make Kinesis compile on Windows

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -28,3 +28,9 @@ move-clippy = [
 
 [build]
 rustflags = ["-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes"]
+
+# 64 bit MSVC, override default 1M stack with 8M stack
+[target.x86_64-pc-windows-msvc]
+rustflags = [
+    "-C", "link-arg=/STACK:8000000"
+]

--- a/crates/sui-source-validation-service/tests/tests.rs
+++ b/crates/sui-source-validation-service/tests/tests.rs
@@ -5,6 +5,9 @@ use expect_test::expect;
 use reqwest::Client;
 use std::fs;
 use std::io::Read;
+#[cfg(target_os = "windows")]
+use std::os::windows::fs::FileExt;
+#[cfg(not(target_os = "windows"))]
 use std::os::unix::fs::FileExt;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
@@ -260,7 +263,13 @@ fn copy_with_published_at_manifest(
         format!("published-at = \"{}\"", package_id.to_hex_uncompressed()),
     );
     let new = lines.join("\n");
+
+    #[cfg(target_os = "windows")]
+    move_toml.seek_write(new.as_bytes(), 0).unwrap();
+
+    #[cfg(not(target_os = "windows"))]
     move_toml.write_at(new.as_bytes(), 0).unwrap();
+
     upgrade_pkg_path
 }
 

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -3,9 +3,12 @@
 
 use std::collections::BTreeSet;
 use std::io::Read;
-use std::os::unix::prelude::FileExt;
 use std::str::FromStr;
 use std::{fmt::Write, fs::read_dir, path::PathBuf, str, thread, time::Duration};
+#[cfg(target_os = "windows")]
+use std::os::windows::fs::FileExt;
+#[cfg(not(target_os = "windows"))]
+use std::os::unix::fs::FileExt;
 
 use expect_test::expect;
 use move_package::BuildConfig as MoveBuildConfig;
@@ -1739,6 +1742,9 @@ async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
         ),
     );
     let new = lines.join("\n");
+    #[cfg(target_os = "windows")]
+    move_toml.seek_write(new.as_bytes(), 0).unwrap();
+    #[cfg(not(target_os = "windows"))]
     move_toml.write_at(new.as_bytes(), 0).unwrap();
 
     // Now run the upgrade

--- a/crates/suiop-cli/src/cli/service/init.rs
+++ b/crates/suiop-cli/src/cli/service/init.rs
@@ -15,6 +15,11 @@ use tracing::debug;
 use tracing::info;
 
 // include the boilerplate code in this binary
+
+// hardcode the 'boilerplate' symlink in the Windows compilation for now
+#[cfg(target_os = "windows")]
+static PROJECT_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/../mysten-service-boilerplate");
+#[cfg(not(target_os = "windows"))]
 static PROJECT_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/boilerplate");
 
 #[derive(ValueEnum, Parser, Debug, Clone)]


### PR DESCRIPTION
# Description of change

Add proper flags for linker on Windows to increase stack size from 1M to 8M.
Add conditional compilation to call proper Windows versions of some functions.
Conditionally hard-code boilerplate symlink because symlinks don't work on Windows.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Cargo build no longer fails.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
