### PR TITLE
fix(sui-genesis-buidler): re-enable `io` feature for `packable`

### DIFF
--- a/crates/sui-genesis-builder/Cargo.toml
+++ b/crates/sui-genesis-builder/Cargo.toml
@@ -24,7 +24,7 @@ tracing.workspace = true
 prometheus.workspace = true
 
 iota-sdk = { version = "1.1.4", default-features = false, features = ["std"] }
-packable = { version = "0.8.3", default-features = false }
+packable = { version = "0.8.3", default-features = false, features = ["io"] }
 
 shared-crypto.workspace = true
 sui-config.workspace = true


### PR DESCRIPTION
# Description of change

This fix enables the required `io` feature for `packable` in `sui-genesis-builder` that was spuriously removed with https://github.com/iotaledger/kinesis/commit/76b88277286ef68c8129f1916249211057e750dc

## Links to any relevant issues

No issue

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`cargo check -p sui-genesis-builder`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
