### PR TITLE
fix(sui-genesis-builder): Fixes some issues related to coins in Basic Output migration

### DIFF
--- a/crates/sui-genesis-builder/src/stardust/types/output.rs
+++ b/crates/sui-genesis-builder/src/stardust/types/output.rs
@@ -168,4 +168,11 @@ impl BasicOutput {
             || self.storage_deposit_return.is_some()
             || self.timelock.is_some())
     }
+
+    pub fn is_simple_basic_output(output: &iota_sdk::types::block::output::BasicOutput) -> bool {
+        let uc = output.unlock_conditions();
+        !(uc.expiration().is_some()
+            || uc.storage_deposit_return().is_some()
+            || uc.timelock().is_some())
+    }
 }


### PR DESCRIPTION
# Description of change

First 3 commits fix 2 issues:
- The first issue is that a "simple basic output" (i.e., no UCs) should be directly converted into Coin<SUI> (and native token coins)
- The second issue is that native tokens coins splits were not registered into the store, thus never decreased from the original coin

The fourth commit is a proposa for removing the fixed ObjectID generation for native token coin objects. This commit could be deleted before the merge if the strategy of  fixed ObjectID generation should be kept.

