### PR TITLE
feat(sui-genesis-builder): Transformation Logic for Foundry Outputs

### DIFF
--- a/crates/sui-genesis-builder/src/stardust/migration.rs
+++ b/crates/sui-genesis-builder/src/stardust/migration.rs
@@ -297,7 +297,12 @@ impl Executor {
             let deps = self.checked_system_packages();
             let pt = {
                 let mut builder = ProgrammableTransactionBuilder::new();
-                builder.command(Command::Publish(modules, PACKAGE_DEPS.into()));
+                let upgrade_cap = builder.command(Command::Publish(modules, PACKAGE_DEPS.into()));
+                // We make a dummy transfer because the `UpgradeCap` does
+                // not have the drop ability.
+                //
+                // We ignore it in the genesis, to render the package immutable.
+                builder.transfer_arg(Default::default(), upgrade_cap);
                 builder.finish()
             };
             let InnerTemporaryStore { written, .. } = self.execute_pt_unmetered(deps, pt)?;

--- a/crates/sui-genesis-builder/src/stardust/migration.rs
+++ b/crates/sui-genesis-builder/src/stardust/migration.rs
@@ -323,10 +323,8 @@ impl Executor {
                 minted_coin_id.expect("a coin must have been minted"),
                 coin_type_origin.expect("the published package should include a type for the coin"),
             );
-            self.native_tokens.insert(
-                *foundry.native_tokens()[0].token_id(),
-                (minted_coin_id, coin_type_origin),
-            );
+            self.native_tokens
+                .insert(foundry.token_id(), (minted_coin_id, coin_type_origin));
             self.store.finish(
                 written
                     .into_iter()

--- a/crates/sui-genesis-builder/src/stardust/migration.rs
+++ b/crates/sui-genesis-builder/src/stardust/migration.rs
@@ -48,6 +48,8 @@ use sui_types::{
 
 use super::types::snapshot::OutputHeader;
 use crate::process_package;
+use crate::stardust::native_token::package_builder;
+use crate::stardust::native_token::package_data::NativeTokenPackageData;
 
 /// The dependencies of the generated packages for native tokens.
 pub const PACKAGE_DEPS: [ObjectID; 4] = [
@@ -152,9 +154,10 @@ impl Migration {
     }
 }
 
-// stub of package generation and build logic
-fn generate_package(_foundry: &FoundryOutput) -> Result<CompiledPackage> {
-    todo!()
+// Build a `CompiledPackage` from a given `FoundryOutput`.
+fn generate_package(foundry: &FoundryOutput) -> Result<CompiledPackage> {
+    let native_token_data = NativeTokenPackageData::try_from(foundry)?;
+    package_builder::build_and_compile(native_token_data)
 }
 
 /// Creates the objects that map to the stardust UTXO ledger.

--- a/crates/sui-genesis-builder/src/stardust/native_token/package_builder.rs
+++ b/crates/sui-genesis-builder/src/stardust/native_token/package_builder.rs
@@ -110,7 +110,11 @@ fn adjust_native_token_module(package_path: &Path, package: &NativeTokenPackageD
         .replace("$COIN_NAME", &package.module().coin_name)
         .replace("$COIN_DESCRIPTION", &package.module().coin_description)
         .replace("$ICON_URL", &icon_url)
-        .replace("$ALIAS", &package.module().alias_address.to_string());
+        .replace(
+            "$ALIAS",
+            // Remove the "0x" prefix
+            &package.module().alias_address.to_string().replace("0x", ""),
+        );
 
     fs::write(&new_move_file_path, new_contents)?;
 

--- a/crates/sui-genesis-builder/src/stardust/native_token/package_data.rs
+++ b/crates/sui-genesis-builder/src/stardust/native_token/package_data.rs
@@ -86,9 +86,9 @@ impl NativeTokenModuleData {
     }
 }
 
-impl TryFrom<FoundryOutput> for NativeTokenPackageData {
+impl TryFrom<&FoundryOutput> for NativeTokenPackageData {
     type Error = StardustError;
-    fn try_from(output: FoundryOutput) -> Result<Self, StardustError> {
+    fn try_from(output: &FoundryOutput) -> Result<Self, StardustError> {
         let metadata =
             output
                 .features()
@@ -223,7 +223,7 @@ mod tests {
         let output = builder.finish().unwrap();
 
         // Step 2: Convert the FoundryOutput to NativeTokenPackageData
-        let native_token_data = NativeTokenPackageData::try_from(output)?;
+        let native_token_data = NativeTokenPackageData::try_from(&output)?;
 
         // Step 3: Verify the conversion
         assert!(package_builder::build_and_compile(native_token_data).is_ok());
@@ -262,7 +262,7 @@ mod tests {
         let output = builder.finish().unwrap();
 
         // Step 2: Convert the FoundryOutput to NativeTokenPackageData
-        let native_token_data = NativeTokenPackageData::try_from(output)?;
+        let native_token_data = NativeTokenPackageData::try_from(&output)?;
 
         // Step 3: Verify the conversion
         assert!(package_builder::build_and_compile(native_token_data).is_ok());


### PR DESCRIPTION
# Description of change

Wires the native token package builder in order to transform Foundry Outputs in the `migration.rs`.

## Links to any relevant issues

Fixes https://github.com/iotaledger/kinesis/issues/200

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo build -p sui-genesis-builder`

Tests will be added as part of the dedicated issue: https://github.com/iotaledger/kinesis/issues/204

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
