### PR TITLE
fix(sui-genesis-builder): sanitize basic output object versions

### DIFF
--- a/crates/sui-genesis-builder/src/stardust/types/output.rs
+++ b/crates/sui-genesis-builder/src/stardust/types/output.rs
@@ -8,7 +8,7 @@ use serde_with::serde_as;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
     balance::Balance,
-    base_types::{ObjectID, SuiAddress, TxContext},
+    base_types::{ObjectID, SequenceNumber, SuiAddress, TxContext},
     coin::Coin,
     collection_types::Bag,
     gas_coin::GAS,
@@ -179,6 +179,7 @@ impl BasicOutput {
         owner: SuiAddress,
         protocol_config: &ProtocolConfig,
         tx_context: &TxContext,
+        version: SequenceNumber,
     ) -> Result<Object> {
         let move_object = unsafe {
             // Safety: we know from the definition of `BasicOutput` in the stardust package
@@ -186,7 +187,7 @@ impl BasicOutput {
             MoveObject::new_from_execution(
                 Self::type_().into(),
                 false,
-                0.into(),
+                version,
                 bcs::to_bytes(self)?,
                 protocol_config,
             )?
@@ -211,6 +212,7 @@ impl BasicOutput {
         owner: SuiAddress,
         protocol_config: &ProtocolConfig,
         tx_context: &TxContext,
+        version: SequenceNumber,
     ) -> Result<Object> {
         let coin = Coin::new(self.id, self.iota.value());
         let move_object = unsafe {
@@ -219,7 +221,7 @@ impl BasicOutput {
             MoveObject::new_from_execution(
                 GAS::type_().into(),
                 true,
-                0.into(),
+                version,
                 bcs::to_bytes(&coin)?,
                 protocol_config,
             )?


### PR DESCRIPTION
# Description of change

This patch introduces two changes:

* A `version` argument is introduced in `BasicOutput::{to_genesis_object, into_coin_genesis_object` that sets the version number of the created object.
* The return type of `Executor::create_bag` is changed to `Result<(Bag, SequenceNumber)>` to let callers deduce the version of the parent objects of the bag based on its version.

## Links to any relevant issues

Resolves #215 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation Fix

