### PR TITLE
refactor(general): Update pnpm CI

### DIFF
--- a/.github/actions/ts-e2e/action.yml
+++ b/.github/actions/ts-e2e/action.yml
@@ -16,7 +16,7 @@ runs:
     # - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
     - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # pin@v4.0.0
       with:
-        version: 8
+        version: 9
 
     - name: Check s3 if binaries have been uploaded already
       continue-on-error: true

--- a/.github/actions/ts-e2e/action.yml
+++ b/.github/actions/ts-e2e/action.yml
@@ -14,7 +14,7 @@ runs:
         ref: ${{ inputs.ref }}
     # Disabled for now as it makes test runs take longer
     # - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
-    - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # pin@v3.0.0
+    - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # pin@v4.0.0
       with:
         version: 8
 

--- a/.github/actions/turbo-diffs/action.yml
+++ b/.github/actions/turbo-diffs/action.yml
@@ -12,7 +12,7 @@ runs:
         fetch-depth: 0
     - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # pin@v4.0.0
       with:
-        version: 8
+        version: 9
     - id: changes
       name: Detect changes
       shell: bash

--- a/.github/actions/turbo-diffs/action.yml
+++ b/.github/actions/turbo-diffs/action.yml
@@ -10,7 +10,7 @@ runs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         fetch-depth: 0
-    - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # pin@v3.0.0
+    - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # pin@v4.0.0
       with:
         version: 8
     - id: changes

--- a/.github/workflows/changesets-ci.yml
+++ b/.github/workflows/changesets-ci.yml
@@ -8,9 +8,9 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # Pin v4.1.1
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # pin@v3.0.0
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # pin@v4.0.0
         with:
-          version: 8
+          version: 9
       - name: Install Nodejs
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # pin@v4.0.2
         with:

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -35,9 +35,9 @@ jobs:
         with:
           token: ${{ steps.generate_token.outputs.token }}
           fetch-depth: 0
-      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # pin@v3.0.0
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # pin@v4.0.0
         with:
-          version: 8
+          version: 9
       - name: Install Nodejs
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # pin@v4.0.2
         with:

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -15,9 +15,9 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # Pin v4.1.1
         with:
           fetch-depth: 2
-      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # pin@v3.0.0
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # pin@v4.0.0
         with:
-          version: 8
+          version: 9
       - name: Install Nodejs
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # pin@v4.0.2
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,9 +46,9 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # Pin v4.1.1
       # Disabled for now as it makes test runs take longer
       # - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
-      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # pin@v3.0.0
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # pin@v4.0.0
         with:
-          version: 8
+          version: 9
       - run: cargo build --bin sui-test-validator --bin sui --profile dev
       - name: Install Nodejs
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # pin@v4.0.2

--- a/.github/workflows/turborepo.yml
+++ b/.github/workflows/turborepo.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # Pin v4.1.1
-      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # pin@v3.0.0
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # pin@v4.0.0
         with:
-          version: 8
+          version: 9
       - name: Install Nodejs
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # pin@v4.0.2
         with:
@@ -31,9 +31,9 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # Pin v4.1.1
         with:
           fetch-depth: 2
-      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # pin@v3.0.0
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # pin@v4.0.0
         with:
-          version: 8
+          version: 9
       - name: Install Nodejs
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # pin@v4.0.2
         with:


### PR DESCRIPTION
# Description of change

- Updates the pnpm version in the CI from v8 to v9
- Updates the pinned version of the action used for pnpm `pnpm/action-setup` from a pinned commit equivalent to their v3.0.0 to a new pinned commit equivalent to the v4.0.0

## Links to any relevant issues

Closes https://github.com/iotaledger/kinesis/issues/222

## Type of change

- Refactor

## How the change has been tested

Github Actions

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
