### PR TITLE
fix(sui-genesis-builder): create fresh empty bag ids

### DIFF
--- a/crates/sui-genesis-builder/src/stardust/migration.rs
+++ b/crates/sui-genesis-builder/src/stardust/migration.rs
@@ -9,6 +9,7 @@ use sui_types::{
     balance::Balance,
     base_types::{ObjectRef, SequenceNumber},
     collection_types::Bag,
+    id::UID,
     move_package::TypeOrigin,
     transaction::{Argument, InputObjects, ObjectArg},
     TypeTag,
@@ -548,6 +549,7 @@ impl Executor {
             if !basic_output.native_tokens().is_empty() {
                 self.create_native_token_coins(basic_output.native_tokens(), owner)?;
             }
+            data.native_tokens.id = UID::new(self.tx_context.fresh_id());
             data.into_genesis_coin_object(owner, &self.protocol_config, &self.tx_context, version)?
         } else {
             if !basic_output.native_tokens().is_empty() {

--- a/crates/sui-genesis-builder/src/stardust/migration.rs
+++ b/crates/sui-genesis-builder/src/stardust/migration.rs
@@ -486,11 +486,6 @@ impl Executor {
     }
 
     /// Create [`Coin`] objects representing native tokens in the ledger.
-    ///
-    /// We set the [`ObjectID`] to the `hash(hash(OutputId) || TokenId)`
-    /// so that we avoid generation based on the [`TxContext`]. The latter
-    /// depends on the order of generation, and implies that the outputs
-    /// should be sorted to attain idempotence.
     fn create_native_token_coins(
         &mut self,
         native_tokens: &NativeTokens,

--- a/crates/sui-genesis-builder/src/stardust/migration.rs
+++ b/crates/sui-genesis-builder/src/stardust/migration.rs
@@ -363,7 +363,7 @@ impl Executor {
         let move_alias_object_ref = move_alias_object.compute_object_reference();
         self.store.insert_object(move_alias_object);
 
-        let (bag, version) = self.create_bag(alias.native_tokens())?;
+        let (bag, version) = self.create_bag_with_pt(alias.native_tokens())?;
         let move_alias_output =
             AliasOutput::try_from_stardust(self.tx_context.fresh_id(), &alias, bag)?;
 
@@ -408,8 +408,11 @@ impl Executor {
         Ok(())
     }
 
-    /// Create a [`Bag`] of balances of native tokens.
-    fn create_bag(&mut self, native_tokens: &NativeTokens) -> Result<(Bag, SequenceNumber)> {
+    /// Create a [`Bag`] of balances of native tokens executing a programmable transaction block.
+    fn create_bag_with_pt(
+        &mut self,
+        native_tokens: &NativeTokens,
+    ) -> Result<(Bag, SequenceNumber)> {
         let mut dependencies = Vec::with_capacity(native_tokens.len());
         let pt = {
             let mut builder = ProgrammableTransactionBuilder::new();
@@ -555,7 +558,8 @@ impl Executor {
             if !basic_output.native_tokens().is_empty() {
                 // The bag will be wrapped into the basic output object, so
                 // by equating their versions we emulate a ptb.
-                (data.native_tokens, version) = self.create_bag(basic_output.native_tokens())?;
+                (data.native_tokens, version) =
+                    self.create_bag_with_pt(basic_output.native_tokens())?;
             }
             data.to_genesis_object(owner, &self.protocol_config, &self.tx_context, version)?
         };

--- a/crates/sui-genesis-builder/src/stardust/migration.rs
+++ b/crates/sui-genesis-builder/src/stardust/migration.rs
@@ -547,6 +547,7 @@ impl Executor {
             if !basic_output.native_tokens().is_empty() {
                 self.create_native_token_coins(basic_output.native_tokens(), owner)?;
             }
+            // Overwrite the default 0 UID of `Bag::default()`, since we won't be creating a new bag in this code path.
             data.native_tokens.id = UID::new(self.tx_context.fresh_id());
             data.into_genesis_coin_object(owner, &self.protocol_config, &self.tx_context, version)?
         } else {


### PR DESCRIPTION
# Description of change

This patch creates fresh-ids for empty basic output bags using `TxContext`. 

It also renames `create_bag` to `create_bag_with_pt` to make the API more explicit.

The alias transformation is not amended, because  `create_bag_with_pt` already handles empty native tokens, and hence `dependencies` are also empty leading to no-op when `load_input_objects`. There is a slight overhead because we could avoid storing `written` objects altogether, but I reckon the bulk of operation in this method has to do with execution. So I would see it as a microoptimazation to implement. We could amend the code to create a default `Bag` in `AliasOutput` and then mutate the id if `native_tokens` is empty, but that would lead to more code, which I would not consider as an improvement. 

## Links to any relevant issues

Fixes #233 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
