### PR TITLE
fix(sui-genesis-builder): load foundry packages correctly

### DIFF
--- a/crates/sui-genesis-builder/src/stardust/migration.rs
+++ b/crates/sui-genesis-builder/src/stardust/migration.rs
@@ -197,6 +197,7 @@ impl FoundryLedgerData {
     fn new(minted_coin_id: ObjectID, foundry_package: &MovePackage) -> Self {
         Self {
             minted_coin_id,
+            // There must be only one type created in the foundry package.
             coin_type_origin: foundry_package.type_origin_table()[0].clone(),
             package_id: foundry_package.id(),
         }

--- a/crates/sui-genesis-builder/src/stardust/migration.rs
+++ b/crates/sui-genesis-builder/src/stardust/migration.rs
@@ -9,7 +9,7 @@ use sui_types::{
     balance::Balance,
     base_types::{ObjectRef, SequenceNumber},
     collection_types::Bag,
-    move_package::TypeOrigin,
+    move_package::{MovePackage, TypeOrigin},
     object::Object,
     transaction::{Argument, InputObjects, ObjectArg},
     TypeTag,
@@ -180,6 +180,29 @@ fn generate_package(foundry: &FoundryOutput) -> Result<CompiledPackage> {
     package_builder::build_and_compile(native_token_data)
 }
 
+/// On-chain data about the objects created while
+/// publishing foundry packages
+struct FoundryLedgerData {
+    minted_coin_id: ObjectID,
+    coin_type_origin: TypeOrigin,
+    package_id: ObjectID,
+}
+
+impl FoundryLedgerData {
+    /// Store the minted coin `ObjectID` and derive data from the foundry package.
+    ///
+    /// # Panic
+    ///
+    /// Panics if the package does not contain any [`TypeOrigin`].
+    fn new(minted_coin_id: ObjectID, foundry_package: &MovePackage) -> Self {
+        Self {
+            minted_coin_id,
+            coin_type_origin: foundry_package.type_origin_table()[0].clone(),
+            package_id: foundry_package.id(),
+        }
+    }
+}
+
 /// Creates the objects that map to the stardust UTXO ledger.
 ///
 /// Internally uses an unmetered Move VM.
@@ -194,9 +217,9 @@ struct Executor {
     system_packages_and_objects: BTreeSet<ObjectID>,
     move_vm: Arc<MoveVM>,
     metrics: Arc<LimitsMetrics>,
-    /// Map the stardust token id [`TokenId`] to the [`ObjectID`] and of the
-    /// coin minted by the foundry and its [`TypeOrigin`].
-    native_tokens: HashMap<TokenId, (ObjectID, TypeOrigin)>,
+    /// Map the stardust token id [`TokenId`] to the on-chain info of the
+    /// published foundry objects.
+    native_tokens: HashMap<TokenId, FoundryLedgerData>,
 }
 
 impl Executor {
@@ -336,28 +359,27 @@ impl Executor {
             let InnerTemporaryStore { written, .. } = self.execute_pt_unmetered(deps, pt)?;
             // Get on-chain info
             let mut minted_coin_id = None::<ObjectID>;
-            let mut coin_type_origin = None::<TypeOrigin>;
+            let mut foundry_package = None::<&MovePackage>;
             for object in written.values() {
                 if object.is_coin() {
                     minted_coin_id = Some(object.id());
                 } else if object.is_package() {
-                    coin_type_origin = Some(
+                    foundry_package = Some(
                         object
                             .data
                             .try_as_package()
-                            .expect("already verified this is a package")
-                            // there must be only one type created in the package
-                            .type_origin_table()[0]
-                            .clone(),
+                            .expect("already verified this is a package"),
                     );
                 }
             }
-            let (minted_coin_id, coin_type_origin) = (
+            let (minted_coin_id, foundry_package) = (
                 minted_coin_id.expect("a coin must have been minted"),
-                coin_type_origin.expect("the published package should include a type for the coin"),
+                foundry_package.expect("there should be a published package"),
             );
-            self.native_tokens
-                .insert(foundry.token_id(), (minted_coin_id, coin_type_origin));
+            self.native_tokens.insert(
+                foundry.token_id(),
+                FoundryLedgerData::new(minted_coin_id, foundry_package),
+            );
             self.store.finish(
                 written
                     .into_iter()
@@ -436,7 +458,8 @@ impl Executor {
 
     /// Create a [`Bag`] of balances of native tokens.
     fn create_bag(&mut self, native_tokens: &NativeTokens) -> Result<(Bag, SequenceNumber)> {
-        let mut dependencies = Vec::with_capacity(native_tokens.len());
+        let mut object_deps = Vec::with_capacity(native_tokens.len());
+        let mut foundry_package_deps = Vec::with_capacity(native_tokens.len());
         let pt = {
             let mut builder = ProgrammableTransactionBuilder::new();
             let bag = pt::bag_new(&mut builder);
@@ -445,21 +468,24 @@ impl Executor {
                     anyhow::bail!("unsupported number of tokens");
                 }
 
-                let Some((object_id, type_origin)) = self.native_tokens.get(token.token_id())
-                else {
+                let Some(foundry_ledger_data) = self.native_tokens.get(token.token_id()) else {
                     anyhow::bail!("foundry for native token has not been published");
                 };
 
-                let Some(foundry_coin) = self.store.get_object(object_id) else {
+                let Some(foundry_coin) = self.store.get_object(&foundry_ledger_data.minted_coin_id)
+                else {
                     anyhow::bail!("foundry coin should exist");
                 };
                 let object_ref = foundry_coin.compute_object_reference();
 
-                dependencies.push(object_ref);
+                object_deps.push(object_ref);
+                foundry_package_deps.push(foundry_ledger_data.package_id);
 
                 let token_type = format!(
                     "{}::{}::{}",
-                    type_origin.package, type_origin.module_name, type_origin.struct_name
+                    foundry_ledger_data.coin_type_origin.package,
+                    foundry_ledger_data.coin_type_origin.module_name,
+                    foundry_ledger_data.coin_type_origin.struct_name
                 );
                 let balance = pt::coin_balance_split(
                     &mut builder,
@@ -481,7 +507,8 @@ impl Executor {
         };
         let checked_input_objects = CheckedInputObjects::new_for_genesis(
             self.load_packages(PACKAGE_DEPS)
-                .chain(self.load_input_objects(dependencies))
+                .chain(self.load_packages(foundry_package_deps))
+                .chain(self.load_input_objects(object_deps))
                 .collect(),
         );
         let InnerTemporaryStore {
@@ -519,7 +546,8 @@ impl Executor {
         native_tokens: &NativeTokens,
         owner: SuiAddress,
     ) -> Result<()> {
-        let mut dependencies = Vec::with_capacity(native_tokens.len());
+        let mut object_deps = Vec::with_capacity(native_tokens.len());
+        let mut foundry_package_deps = Vec::with_capacity(native_tokens.len());
         let pt = {
             let mut builder = ProgrammableTransactionBuilder::new();
             for token in native_tokens.iter() {
@@ -527,16 +555,18 @@ impl Executor {
                     anyhow::bail!("unsupported number of tokens");
                 }
 
-                let Some((object_id, _)) = self.native_tokens.get(token.token_id()) else {
+                let Some(foundry_ledger_data) = self.native_tokens.get(token.token_id()) else {
                     anyhow::bail!("foundry for native token has not been published");
                 };
 
-                let Some(foundry_coin) = self.store.get_object(object_id) else {
+                let Some(foundry_coin) = self.store.get_object(&foundry_ledger_data.minted_coin_id)
+                else {
                     anyhow::bail!("foundry coin should exist");
                 };
                 let object_ref = foundry_coin.compute_object_reference();
 
-                dependencies.push(object_ref);
+                object_deps.push(object_ref);
+                foundry_package_deps.push(foundry_ledger_data.package_id);
 
                 // Pay using that object
                 builder.pay(vec![object_ref], vec![owner], vec![token.amount().as_u64()])?;
@@ -546,7 +576,8 @@ impl Executor {
         };
         let checked_input_objects = CheckedInputObjects::new_for_genesis(
             self.load_packages(PACKAGE_DEPS)
-                .chain(self.load_input_objects(dependencies))
+                .chain(self.load_packages(foundry_package_deps))
+                .chain(self.load_input_objects(object_deps))
                 .collect(),
         );
         // Execute


### PR DESCRIPTION
# Description of change

This patch introduces the following changes:

* The foundry package id is now stored along with the data of the minted coin id. A new `struct FoundryLedgerData` is introduced to this end.
* The foundry packages are not loaded along with other dependencies in the transaction input while processing native tokens.

## Links to any relevant issues

Fixes #235

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`cargo test -j2 -p sui-genesis-builder`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
