### PR TITLE
fix(sui-genesis-builder): fix pt::coin_balance_split

### DIFF
--- a/crates/sui-genesis-builder/src/stardust/migration.rs
+++ b/crates/sui-genesis-builder/src/stardust/migration.rs
@@ -681,20 +681,20 @@ mod pt {
         amount: u64,
     ) -> Result<Argument> {
         let foundry_coin_ref = builder.obj(ObjectArg::ImmOrOwnedObject(foundry_coin_ref))?;
-        let balance = builder.programmable_move_call(
+        let amount = builder.pure(amount)?;
+        let coin = builder.programmable_move_call(
             SUI_FRAMEWORK_PACKAGE_ID,
             ident_str!("coin").into(),
-            ident_str!("balance_mut").into(),
+            ident_str!("split").into(),
             vec![token_type_tag.clone()],
-            vec![foundry_coin_ref],
+            vec![foundry_coin_ref, amount],
         );
-        let amount = builder.pure(amount)?;
         Ok(builder.programmable_move_call(
             SUI_FRAMEWORK_PACKAGE_ID,
-            ident_str!("balance").into(),
-            ident_str!("split").into(),
+            ident_str!("coin").into(),
+            ident_str!("into_balance").into(),
             vec![token_type_tag],
-            vec![balance, amount],
+            vec![coin],
         ))
     }
 


### PR DESCRIPTION


# Description of change

This patch fixes the `pt::coin_balance_split` in the `stardust::migration` module.

The original implementation used `sui::coin::balance_mut` which would make use of a `&mut` inside the PTB, which is not supported under `Normal` mode of execution.

Tests with `DevInspect<true>` while allowing the use of the `&mut` inside the PTB still yielded inconsistent side effects.


## Links to any relevant issues

Part of #302 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

