### PR TITLE
refactor(sui-genesis-builder): register SuiPackageHooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12725,6 +12725,7 @@ dependencies = [
  "iota-sdk",
  "move-binary-format",
  "move-core-types",
+ "move-package",
  "move-vm-runtime-v2",
  "packable",
  "prometheus",

--- a/crates/sui-genesis-builder/Cargo.toml
+++ b/crates/sui-genesis-builder/Cargo.toml
@@ -13,6 +13,7 @@ camino.workspace = true
 fastcrypto.workspace = true
 move-binary-format.workspace = true
 move-core-types.workspace = true
+move-package.workspace = true
 move-vm-runtime-v2 = { path = "../../external-crates/move/move-execution/v2/crates/move-vm-runtime" }
 rand.workspace = true
 rand_regex.workspace = true

--- a/crates/sui-genesis-builder/src/stardust/native_token/package_builder.rs
+++ b/crates/sui-genesis-builder/src/stardust/native_token/package_builder.rs
@@ -10,7 +10,7 @@ use fs_extra::dir::{copy, CopyOptions};
 use tempfile::tempdir;
 
 use crate::stardust::error::StardustError;
-use sui_move_build::{BuildConfig, CompiledPackage};
+use sui_move_build::{BuildConfig, CompiledPackage, SuiPackageHooks};
 
 use crate::stardust::native_token::package_data::NativeTokenPackageData;
 
@@ -39,6 +39,7 @@ pub fn build_and_compile(package: NativeTokenPackageData) -> Result<CompiledPack
     adjust_native_token_module(&package_path, &package)?;
 
     // Step 4: Compile the package
+    move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks));
     let compiled_package = BuildConfig::default().build(package_path)?;
 
     // Clean up the temporary directory


### PR DESCRIPTION
# Description of change

A small patch to properly parse the manifest and suppress the compilation warnings while building foundry packages in the migration process. 

## Links to any relevant issues

Part of #302 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

