### PR TITLE
feat(dapps/isc): add second ISC model

### DIFF
--- a/dapps/isc/Move.toml
+++ b/dapps/isc/Move.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ISC"
+version = "0.0.1"
+edition = "2024.beta"
+
+[dependencies]
+MoveStdlib = {local = "../../crates/sui-framework/packages/move-stdlib"}
+Stardust = { local = "../../crates/sui-framework/packages/stardust" }
+Sui = { local = "../../crates/sui-framework/packages/sui-framework" }
+
+[addresses]
+isc = "0x0"
+std = "0x1"
+sui = "0x2"

--- a/dapps/isc/sources/anchor.move
+++ b/dapps/isc/sources/anchor.move
@@ -16,6 +16,13 @@ module isc::anchor {
         id: UID,
         /// Anchor assets.
         assets: Referent<AssetsBag>,
+        /// Anchor assets.
+        state_root: vector<u8>,
+    }
+
+    public struct Receipt {
+        /// ID of the request object
+        request_id: ID,
     }
 
     // === Anchor packing and unpacking ===
@@ -25,12 +32,13 @@ module isc::anchor {
         Anchor{
             id: object::new(ctx),
             assets: borrow::new(assets_bag::new(ctx), ctx),
+            state_root: vector::empty(),
          }
     }
 
     /// Destroys an Anchor object and returns its assets bag.   
     public fun destroy(self: Anchor): AssetsBag {
-        let Anchor { id, assets } = self;
+        let Anchor { id, assets, state_root: _ } = self;
         id.delete();
         
         assets.destroy()
@@ -55,8 +63,33 @@ module isc::anchor {
     // === Receive a Request ===
 
     /// The Anchor receives a request and destroys it, implementing the HotPotato pattern.
-    public fun receive_request(anchor: &mut Anchor, request: transfer::Receiving<Request>): AssetsBag {
-        let req = request::receive(&mut anchor.id, request);
-        req.destroy()
+    public fun receive_request(self: &mut Anchor, request: transfer::Receiving<Request>): (Receipt, AssetsBag) {
+        let req = request::receive(&mut self.id, request);
+        let (request_id, assets) = req.destroy();
+        (Receipt { request_id }, assets)
     }
+
+    public fun update_state_root(self: &mut Anchor, new_state_root: vector<u8>, mut receipts: vector<Receipt>) {
+        let receipts_len = receipts.length();
+        let mut i = 0;
+        while (i < receipts_len) {
+            let Receipt { 
+                request_id: _ 
+            } = receipts.pop_back();
+            // here performs some cryptographic proof of inclusion with request_id and the new state root?? 
+            i = i + 1;
+        };
+        receipts.destroy_empty();
+        self.state_root = new_state_root
+    } 
+    
+
+    // === Test Functions ===
+
+    // test only function to create a receipt
+    #[test_only]
+    public fun create_receipt_for_testing(request_id: ID): Receipt {
+        Receipt { request_id }
+    }
+
 }

--- a/dapps/isc/sources/anchor.move
+++ b/dapps/isc/sources/anchor.move
@@ -1,0 +1,62 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+module isc::anchor {
+    use sui::borrow::{Self, Referent, Borrow};   
+    use isc::{
+        request::{Self, Request},
+        assets_bag::{Self, AssetsBag},
+    }; 
+
+    // === Main structs ===
+
+    /// An object which allows managing assets within the "ISC" ecosystem.
+    /// By default it is owned by a single address.
+    public struct Anchor has key, store {
+        id: UID,
+        /// Anchor assets.
+        assets: Referent<AssetsBag>,
+    }
+
+    // === Anchor packing and unpacking ===
+
+    /// Starts a new chain by creating a new `Anchor` for it
+    public fun start_new_chain(ctx: &mut TxContext): Anchor {
+        Anchor{
+            id: object::new(ctx),
+            assets: borrow::new(assets_bag::new(ctx), ctx),
+         }
+    }
+
+    /// Destroys an Anchor object and returns its assets bag.   
+    public fun destroy(self: Anchor): AssetsBag {
+        let Anchor { id, assets } = self;
+        id.delete();
+        
+        assets.destroy()
+    }
+    
+    // === Borrow assets from the Anchor ===
+
+    /// Simulates a borrow mutable for the AssetsBag implementing the HotPotato pattern.   
+    public fun borrow_assets(self: &mut Anchor): (AssetsBag, Borrow) {
+        borrow::borrow(&mut self.assets)
+    }
+
+    /// Finishes the simulation of a borrow mutable putting back the HotPotato. 
+    public fun return_assets_from_borrow(
+        self: &mut Anchor,
+        assets: AssetsBag,
+        b: Borrow
+    ) {
+        borrow::put_back(&mut self.assets, assets, b)
+    }
+
+    // === Receive a Request ===
+
+    /// The Anchor receives a request and destroys it, implementing the HotPotato pattern.
+    public fun receive_request(anchor: &mut Anchor, request: transfer::Receiving<Request>): AssetsBag {
+        let req = request::receive(&mut anchor.id, request);
+        req.destroy()
+    }
+}

--- a/dapps/isc/sources/assets_bag.move
+++ b/dapps/isc/sources/assets_bag.move
@@ -1,0 +1,166 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+module isc::assets_bag {
+    use std::ascii::{String};
+    use std::type_name;
+    use sui::{
+        coin::{Self, Coin},
+        balance::{Self, Balance},
+        sui::SUI,
+        dynamic_object_field as dof,
+        dynamic_field as df,
+    };   
+
+    // Attempted to destroy a non-empty assets bag
+    const EBagNotEmpty: u64 = 0;
+    /// place_coin was called with a SUI coin
+    const EInvalidSuiCoin: u64 = 1;
+
+    // === Main structs ===
+
+    /// An object which allows managing assets within the "ISC" ecosystem.
+    /// By default it is owned by a single address.
+    public struct AssetsBag has key, store {
+        id: UID,
+        /// Balance of the AssetsBag - all Sui coins go here.
+        balance: Balance<SUI>,
+        /// the number of key-value pairs in the bag
+        size: u64,
+    }
+
+    // === Dynamic Field keys ===
+
+    /// Dynamic field key for an asset placed into the AssetsBag.
+    public struct Asset has store, copy, drop { id: ID }
+
+    // === AssetsBag packing and unpacking ===
+
+    /// Creates a new empty `AssetsBag`
+    public fun new(ctx: &mut TxContext): AssetsBag {
+        AssetsBag{
+            id: object::new(ctx),
+            balance: balance::zero(),
+            size: 0,
+         }
+    }
+
+    /// Destroys an empty AssetsBag object and returns its balance.    
+    public fun destroy_empty(self: AssetsBag) {
+        let AssetsBag { id, balance, size } = self;
+        balance.destroy_zero();
+        assert!(size == 0, EBagNotEmpty);
+        id.delete();    
+    }
+    
+    // === Place into the AssetsBag ===
+
+    /// Adds a the balance of a Coin as a dinamyc field of the AssetsBag where the key is 
+    /// the type of the Coin (OTW).
+    /// Aborts with `EInvalidSuiCoin` if the coin is of type SUI.
+    public fun place_coin<T>(self: &mut AssetsBag, coin: Coin<T>) {
+        let balance = coin::into_balance(coin);
+        place_coin_balance_internal(self, balance)
+    }
+
+    /// Adds a the balance as a dinamyc field of the AssetsBag where the key is 
+    /// the type of the Coin (OTW).
+    /// Aborts with `EInvalidSuiCoin` if the coin is of type SUI.
+    public fun place_coin_balance<T>(self: &mut AssetsBag, balance: Balance<T>) {
+        place_coin_balance_internal(self, balance)
+    }
+    
+    /// Increases the SUI balance of the AssetsBag.
+    public fun place_sui_coin(self: &mut AssetsBag, coin: Coin<SUI>) {
+        self.balance.join(coin::into_balance(coin)); 
+    }
+
+    /// Increases the SUI balance of the AssetsBag.
+    public fun place_sui_balance(self: &mut AssetsBag, balance: Balance<SUI>) {
+        self.balance.join(balance); 
+    }
+ 
+    /// Adds an asset as a dinamyc field of the AssetsBag where the key is 
+    /// of type Asset (indexed by object id).
+    public fun place_asset<T: key + store>(self: &mut AssetsBag, asset: T) {
+        place_asset_internal(self, asset)
+    }
+
+    // === Take from the AssetsBag ===
+
+    /// Takes an amount from the balance of a Coin set as a dinamyc field of the AssetsBag.
+    /// Aborts with `EInvalidSuiCoin` if the coin is of type SUI.
+    public fun take_coin_balance<T>(self: &mut AssetsBag, amount: u64): Balance<T> {
+        take_coin_balance_internal(self, amount)
+    }
+
+    /// Takes all the balance of a Coin set as a dinamyc field of the AssetsBag.
+    /// Aborts with `EInvalidSuiCoin` if the coin is of type SUI.
+    public fun take_all_coin_balance<T>(self: &mut AssetsBag): Balance<T> {
+        let coin_type = type_name::get<T>().into_string();
+        assert!(coin_type != type_name::get<SUI>().into_string(), EInvalidSuiCoin);
+        self.size = self.size - 1;
+        df::remove<String, Balance<T>>(&mut self.id, coin_type)
+    }
+
+    /// Takes the SUI balance of the AssetsBag.
+    public fun take_sui_balance(self: &mut AssetsBag, amount: u64): Balance<SUI> {
+        self.balance.split(amount)
+    }
+
+    /// Takes the SUI balance of the AssetsBag.
+    public fun take_all_sui_balance(self: &mut AssetsBag): Balance<SUI> {
+        self.balance.withdraw_all()
+    }
+
+    /// Takes an asset set as a dinamyc field of the AssetsBag.
+    public fun take_asset<T: key + store>(self: &mut AssetsBag, id: ID): T {
+        take_asset_internal(self, id)
+    }
+
+    // === Internal Core ===
+
+    /// Internal: "place" a balance to the AssetsBag.
+    /// Aborts with `EInvalidSuiCoin` if the coin is of type SUI.
+    fun place_coin_balance_internal<T>(self: &mut AssetsBag, balance: Balance<T>) {
+        let coin_type = type_name::get<T>().into_string();
+        assert!(coin_type != type_name::get<SUI>().into_string(), EInvalidSuiCoin);
+
+        if(df::exists_(&self.id, coin_type)) {
+            let placed_balance = df::borrow_mut<String, Balance<T>>(&mut self.id, coin_type);
+            placed_balance.join(balance);
+        } else {
+            df::add(&mut self.id, coin_type, balance);
+            self.size = self.size + 1;
+        }
+    }
+
+    /// Internal: "place" an asset to the AssetsBag.
+    fun place_asset_internal<T: key + store>(self: &mut AssetsBag, asset: T) {
+        dof::add(&mut self.id, Asset { id: object::id(&asset) }, asset);
+        self.size = self.size + 1;
+    }
+
+    /// Internal: "take" a balance from the AssetsBag.
+    /// Aborts with `EInvalidSuiCoin` if the coin is of type SUI.
+    fun take_coin_balance_internal<T>(self: &mut AssetsBag, amount: u64): Balance<T> {
+        let coin_type = type_name::get<T>().into_string();
+        assert!(coin_type != type_name::get<SUI>().into_string(), EInvalidSuiCoin);
+
+        let placed_balance = df::borrow_mut<String, Balance<T>>(&mut self.id, coin_type);
+        let taken_balance = placed_balance.split(amount);
+        if (placed_balance.value() == 0) {
+            let zero_balance = df::remove<String, Balance<T>>(&mut self.id, coin_type);
+            zero_balance.destroy_zero();
+            self.size = self.size - 1;
+        };
+        
+        taken_balance
+    }
+        
+    /// Internal: "take" an asset from the AssetsBag.
+    fun take_asset_internal<T: key + store>(self: &mut AssetsBag, id: ID): T {
+        self.size = self.size - 1;
+        dof::remove(&mut self.id, Asset { id })
+    }
+}

--- a/dapps/isc/sources/request.move
+++ b/dapps/isc/sources/request.move
@@ -76,16 +76,17 @@ module isc::request {
     }
 
     /// Destroys a Request object and returns its balance and assets bag.
-    public fun destroy(self: Request): AssetsBag {
+    public fun destroy(self: Request): (ID, AssetsBag) {
         let Request {
             id,
             sender: _,
             assets_bag,
             data: _,
         } = self;
+        let inner_id = id.uid_to_inner();
         id.delete();
         
-        assets_bag.destroy()
+        (inner_id, assets_bag.destroy())
     }
 
     // === Send and receive the Request ===

--- a/dapps/isc/sources/request.move
+++ b/dapps/isc/sources/request.move
@@ -15,64 +15,71 @@ module isc::request {
 
     /// Contains the request data to be used off-chain.
     public struct RequestData has copy, drop, store {
-        /// ID of the request object
-        request_id: ID,
         /// Contract name
         contract: String,
         /// Function name
         function: String,
         /// Function arguments
         args: vector<vector<u8>>,
-        /// Request sender
-        sender: address,
     }
 
     /// Represents a request object
     public struct Request has key {
         id: UID,
+        /// Request sender
+        sender: address,
         /// Bag of assets associated to the request
         assets_bag: Referent<AssetsBag>,
         /// The request data, to be used off-chain 
-        data: RequestData,
+        data: Option<RequestData>,
     }
 
     // === Events ===
     
     /// Emitted when a request is sent to an address.
     public struct RequestEvent has copy, drop {
-        data: RequestData
+        /// ID of the request object
+        request_id: ID,
+        /// Anchor receiving the request
+        anchor: address,
     }
     
     // === Request packing and unpacking ===
 
     /// Creates a request to call a specific SC function.
-    public fun create_request(
-        contract: String, 
-        function: String, 
-        args: vector<vector<u8>>, 
-        sender: address,
+    public fun create_and_send_request(
+        anchor: address,
         assets_bag: AssetsBag,
+        contract: Option<String>, 
+        function: Option<String>, 
+        args: Option<vector<vector<u8>>>, 
         ctx: &mut TxContext
-    ): Request {
+    ) {
         let id = object::new(ctx);
-        let data = RequestData {
-            request_id: id.uid_to_inner(),
-            contract,
-            function,
-            args,
-            sender,
-        };
-        Request{
+        let data = if (option::is_some(&contract) 
+            && option::is_some(&function)
+            && option::is_some(&args)) {
+                option::some(RequestData {
+                    contract: contract.destroy_some(),
+                    function: function.destroy_some(),
+                    args: args.destroy_some(),
+                })
+            } else {
+                option::none()
+            };
+        send(Request{
             id,
+            sender: ctx.sender(),
             assets_bag: borrow::new(assets_bag, ctx),
             data,
-        }
+        }, anchor)
     }
 
     /// Destroys a Request object and returns its balance and assets bag.
     public fun destroy(self: Request): AssetsBag {
         let Request {
             id,
+            sender: _,
             assets_bag,
             data: _,
         } = self;
@@ -83,10 +90,10 @@ module isc::request {
 
     // === Send and receive the Request ===
 
-    /// Send a Request object to a receiver and emits the RequestEvent.
-    public fun send(self: Request, receiver: address) {
-        event::emit(RequestEvent { data: self.data });
-        transfer::transfer(self, receiver)
+    /// Send a Request object to an anchor and emits the RequestEvent.
+    fun send(self: Request, anchor: address) {
+        event::emit(RequestEvent { request_id: self.id.uid_to_inner(), anchor });
+        transfer::transfer(self, anchor)
     }
 
     /// Utility function to receive a `Request` object in other ISC modules.
@@ -95,4 +102,34 @@ module isc::request {
         transfer::receive(parent, self)
     }
 
+    // === Test Functions ===
+
+    // test only function to create a request
+    #[test_only]
+    public fun create_for_testing(
+        assets_bag: AssetsBag,
+        contract: Option<String>, 
+        function: Option<String>, 
+        args: Option<vector<vector<u8>>>, 
+        ctx: &mut TxContext
+    ): Request {
+        let id = object::new(ctx);
+        let data = if (option::is_some(&contract) 
+            && option::is_some(&function)
+            && option::is_some(&args)) {
+                option::some(RequestData {
+                    contract: contract.destroy_some(),
+                    function: function.destroy_some(),
+                    args: args.destroy_some(),
+                })
+            } else {
+                option::none()
+            };
+        Request{
+            id,
+            sender: ctx.sender(),
+            assets_bag: borrow::new(assets_bag, ctx),
+            data,
+        }
+    }
 }

--- a/dapps/isc/sources/request.move
+++ b/dapps/isc/sources/request.move
@@ -1,0 +1,98 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+module isc::request {
+    use std::string::String;
+    use sui::{
+        borrow::{Self, Referent},
+        event::{Self},
+    };
+    use isc::{
+        assets_bag::{AssetsBag},
+    }; 
+
+    // === Main structs ===
+
+    /// Contains the request data to be used off-chain.
+    public struct RequestData has copy, drop, store {
+        /// ID of the request object
+        request_id: ID,
+        /// Contract name
+        contract: String,
+        /// Function name
+        function: String,
+        /// Function arguments
+        args: vector<vector<u8>>,
+        /// Request sender
+        sender: address,
+    }
+
+    /// Represents a request object
+    public struct Request has key {
+        id: UID,
+        /// Bag of assets associated to the request
+        assets_bag: Referent<AssetsBag>,
+        /// The request data, to be used off-chain 
+        data: RequestData,
+    }
+
+    // === Events ===
+    
+    /// Emitted when a request is sent to an address.
+    public struct RequestEvent has copy, drop {
+        data: RequestData
+    }
+    
+    // === Request packing and unpacking ===
+
+    /// Creates a request to call a specific SC function.
+    public fun create_request(
+        contract: String, 
+        function: String, 
+        args: vector<vector<u8>>, 
+        sender: address,
+        assets_bag: AssetsBag,
+        ctx: &mut TxContext
+    ): Request {
+        let id = object::new(ctx);
+        let data = RequestData {
+            request_id: id.uid_to_inner(),
+            contract,
+            function,
+            args,
+            sender,
+        };
+        Request{
+            id,
+            assets_bag: borrow::new(assets_bag, ctx),
+            data,
+        }
+    }
+
+    /// Destroys a Request object and returns its balance and assets bag.
+    public fun destroy(self: Request): AssetsBag {
+        let Request {
+            id,
+            assets_bag,
+            data: _,
+        } = self;
+        id.delete();
+        
+        assets_bag.destroy()
+    }
+
+    // === Send and receive the Request ===
+
+    /// Send a Request object to a receiver and emits the RequestEvent.
+    public fun send(self: Request, receiver: address) {
+        event::emit(RequestEvent { data: self.data });
+        transfer::transfer(self, receiver)
+    }
+
+    /// Utility function to receive a `Request` object in other ISC modules.
+    /// Other modules in the ISC package can call this function to receive an `Request` object.
+    public(package) fun receive(parent: &mut UID, self: transfer::Receiving<Request>) : Request {
+        transfer::receive(parent, self)
+    }
+
+}

--- a/dapps/isc/tests/anchor_tests.move
+++ b/dapps/isc/tests/anchor_tests.move
@@ -91,8 +91,9 @@ module isc::anchor_tests {
         );
 
         // ServerPTB.1 Now the Anchor receives off-chain an event that tracks the request and can receive it.
-        //let req_extracted_assets = anchor.receive_request(req); // Commented because cannot be executed in this test
-        let mut req_extracted_assets = req.destroy(); //this is not part of the PTB
+        //let (receipt, req_extracted_assets) = anchor.receive_request(req); // Commented because cannot be executed in this test
+        let (id, mut req_extracted_assets) = req.destroy(); //this is not part of the PTB
+        let receipt = anchor::create_receipt_for_testing(id); //this is not part of the PTB
 
         // ServerPTB.2: borrow the asset bag of the anchor
         let (mut anchor_assets, borrow) = anchor.borrow_assets();    
@@ -121,6 +122,13 @@ module isc::anchor_tests {
 
         // ServerPTB.6: return the anchor assets bag from the borrow.
         anchor.return_assets_from_borrow(anchor_assets, borrow);
+
+        // ServerPTB.7: update the state root and destroy the hot potato receipt.
+        // ServerPTB.7.1: create the receipts vector.
+        let mut receipts = vector::empty();
+        receipts.push_back(receipt);
+        // ServerPTB.7.2: update the state root
+        anchor.update_state_root(vector::empty(), receipts);
 
         // !!! END !!!
 

--- a/dapps/isc/tests/anchor_tests.move
+++ b/dapps/isc/tests/anchor_tests.move
@@ -70,7 +70,7 @@ module isc::anchor_tests {
         // ClientPTB.2 Add the assets to the bag.
         let mut req_assets = assets_bag::new(&mut ctx);
         req_assets.place_coin(test_a_coin);
-        req_assets.place_sui_coin(iota);
+        req_assets.place_coin(iota);
         req_assets.place_asset(test_b_nft);
 
         // ClientPTB.3. Create the request and can send it to the Anchor.
@@ -107,9 +107,9 @@ module isc::anchor_tests {
         anchor_assets.place_coin_balance(extracted_test_a_coin_balance);
         
         // ServerPTB.3.1: extract the iota balance.
-        let extracted_iota_balance = req_extracted_assets.take_all_sui_balance();
+        let extracted_iota_balance = req_extracted_assets.take_all_coin_balance<SUI>();
         // ServerPTB.3.2: place it to the anchor assets bag.
-        anchor_assets.place_sui_balance(extracted_iota_balance);
+        anchor_assets.place_coin_balance(extracted_iota_balance);
 
         // ServerPTB.4.1: extract the nft.
         let extracted_nft = req_extracted_assets.take_asset<Nft>(nft_id);

--- a/dapps/isc/tests/anchor_tests.move
+++ b/dapps/isc/tests/anchor_tests.move
@@ -73,17 +73,22 @@ module isc::anchor_tests {
         req_assets.place_sui_coin(iota);
         req_assets.place_asset(test_b_nft);
 
-        let req = request::create_request(
-            string::utf8(b"contract"), 
-            string::utf8(b"function"), 
-            vector::empty(), 
-            sender,
+        // ClientPTB.3. Create the request and can send it to the Anchor.
+        /*request::create_and_send_request(
+            object::id(&anchor).id_to_address(),
             req_assets,
+            option::some(string::utf8(b"contract")), 
+            option::some(string::utf8(b"function")), 
+            option::some(vector::empty()), 
+            &mut ctx,
+        );*/ // Commented because cannot be executed received in this test
+        let req = request::create_for_testing(
+            req_assets,
+            option::some(string::utf8(b"contract")), 
+            option::some(string::utf8(b"function")), 
+            option::some(vector::empty()), 
             &mut ctx,
         );
-
-        // ClientPTB.3. Ready with the request, now we can send it to the Anchor.
-        //req.send(anchor.id) // Commented because cannot be executed in this test
 
         // ServerPTB.1 Now the Anchor receives off-chain an event that tracks the request and can receive it.
         //let req_extracted_assets = anchor.receive_request(req); // Commented because cannot be executed in this test

--- a/dapps/isc/tests/anchor_tests.move
+++ b/dapps/isc/tests/anchor_tests.move
@@ -1,0 +1,124 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+module isc::anchor_tests {
+
+    use std::{
+        fixed_point32::{FixedPoint32},
+        string::{Self, String},
+        ascii::{Self},
+    };
+    use sui::{
+        table::{Self},
+        coin::{Self},
+        sui::SUI,
+        url::{Self},
+        vec_set::{Self},
+    };
+
+    use stardust::{
+        nft::{Self, Nft},
+        irc27::{Self},
+    };
+    use isc::{
+        assets_bag::{Self},
+        anchor::{Self},
+        request::{Self},
+    };
+
+    // One Time Witness for coins used in the tests.
+    public struct TEST_A has drop {}
+    public struct TEST_B has drop {}
+
+    // Demonstration on how to receive a Request inside one PTB.
+    #[test]
+    fun demonstrate_request_ptb() {
+        // Setup
+        let initial_iota_in_request = 10000;
+        let initial_testA_in_request = 100;
+        let governor = @0xA;
+        let sender = @0xB;
+        let mut ctx = tx_context::dummy();
+
+        // Create an Anchor.
+        let mut anchor = anchor::start_new_chain(&mut ctx);
+
+        // ClientPTB.1 Mint some tokens for the request.
+        let iota = coin::mint_for_testing<SUI>(initial_iota_in_request, &mut ctx);
+        let test_a_coin = coin::mint_for_testing<TEST_A>(initial_testA_in_request, &mut ctx);
+        let test_b_nft = nft::create_for_testing(
+            option::some(sender),
+            option::some(b"metadata"),
+            option::some(b"tag"),
+            option::some(sender),
+            irc27::create_for_testing(
+                string::utf8(b"0.0.1"),
+                string::utf8(b"image/png"),
+                url::new_unsafe(ascii::string(b"www.best-nft.com/nft.png")),
+                string::utf8(b"nft"),
+                option::some(string::utf8(b"collection")),
+                table::new<address,FixedPoint32>(&mut ctx),
+                option::some(string::utf8(b"issuer")),
+                option::some(string::utf8(b"description")),
+                vec_set::empty<String>(),
+                table::new<String,String>(&mut ctx),
+            ),
+            &mut ctx,
+        );
+        let nft_id = object::id(&test_b_nft);
+
+        // ClientPTB.2 Add the assets to the bag.
+        let mut req_assets = assets_bag::new(&mut ctx);
+        req_assets.place_coin(test_a_coin);
+        req_assets.place_sui_coin(iota);
+        req_assets.place_asset(test_b_nft);
+
+        let req = request::create_request(
+            string::utf8(b"contract"), 
+            string::utf8(b"function"), 
+            vector::empty(), 
+            sender,
+            req_assets,
+            &mut ctx,
+        );
+
+        // ClientPTB.3. Ready with the request, now we can send it to the Anchor.
+        //req.send(anchor.id) // Commented because cannot be executed in this test
+
+        // ServerPTB.1 Now the Anchor receives off-chain an event that tracks the request and can receive it.
+        //let req_extracted_assets = anchor.receive_request(req); // Commented because cannot be executed in this test
+        let mut req_extracted_assets = req.destroy(); //this is not part of the PTB
+
+        // ServerPTB.2: borrow the asset bag of the anchor
+        let (mut anchor_assets, borrow) = anchor.borrow_assets();    
+
+        // ServerPTB.2.1: extract half the balance A.
+        let extracted_test_a_coin_balance_half = req_extracted_assets.take_coin_balance<TEST_A>(initial_testA_in_request / 2);
+        // ServerPTB.2.2: place it to the anchor assets bag.
+        anchor_assets.place_coin_balance(extracted_test_a_coin_balance_half);
+        // ServerPTB.2.3: extract all the balance A.
+        let extracted_test_a_coin_balance = req_extracted_assets.take_all_coin_balance<TEST_A>();
+        // ServerPTB.2.4: place it to the anchor assets bag.
+        anchor_assets.place_coin_balance(extracted_test_a_coin_balance);
+        
+        // ServerPTB.3.1: extract the iota balance.
+        let extracted_iota_balance = req_extracted_assets.take_all_sui_balance();
+        // ServerPTB.3.2: place it to the anchor assets bag.
+        anchor_assets.place_sui_balance(extracted_iota_balance);
+
+        // ServerPTB.4.1: extract the nft.
+        let extracted_nft = req_extracted_assets.take_asset<Nft>(nft_id);
+        // ServerPTB.4.2: place it to the anchor assets bag.
+        anchor_assets.place_asset(extracted_nft);
+
+        // ServerPTB.5: destroy the request assets bag.
+        req_extracted_assets.destroy_empty();
+
+        // ServerPTB.6: return the anchor assets bag from the borrow.
+        anchor.return_assets_from_borrow(anchor_assets, borrow);
+
+        // !!! END !!!
+
+        transfer::public_transfer(anchor, governor); // not needed in the PTB
+    }
+}


### PR DESCRIPTION
# Description of change

This ISC model is an alternative based on the new concept of `AssetsBag`, a bag that indexes Objects of all types.
`anchor_tests.move`shows how to construct client (making a request) and server (receiving a request) PTBs. 

## Links to any relevant issues

FIxes #187 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

- `cargo run --bin sui move test`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
