### PR TITLE
fix(apps-backend): Allow decorators in prettier because of `apps-backend`

### DIFF
--- a/apps/apps-backend/package.json
+++ b/apps/apps-backend/package.json
@@ -7,7 +7,7 @@
     "dev": "nest start --watch",
     "debug": "nest start --debug --watch",
     "preview": "pnpm run build && node dist/main",
-    "lint": "eslint --max-warnings=0 \"./src/**/*.{js,jsx,ts,tsx}\"",
+    "lint": "eslint --max-warnings=0 \"{src,apps,libs,test}/**/*.ts\"",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",

--- a/apps/apps-backend/package.json
+++ b/apps/apps-backend/package.json
@@ -7,7 +7,7 @@
     "dev": "nest start --watch",
     "debug": "nest start --debug --watch",
     "preview": "pnpm run build && node dist/main",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "lint": "eslint --max-warnings=0 \"./src/**/*.{js,jsx,ts,tsx}\"",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"wallet-dashboard": "turbo --filter ./apps/wallet-dashboard",
 		"sdk": "turbo --filter ./sdk/typescript",
 		"bcs": "turbo --filter ./sdk/bcs",
+		"apps-backend": "turbo --filter apps-backend",
 		"changeset-version": "pnpm changeset version && pnpm --filter @mysten/sui.js codegen:version",
 		"prettier:check": "prettier -c --ignore-unknown .",
 		"prettier:fix": "prettier -w --ignore-unknown .",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -18,6 +18,7 @@ module.exports = {
 		'',
 		'^[.]',
 	],
+	importOrderParserPlugins: ["typescript", "decorators-legacy"],
 	overrides: [
 		{
 			files: 'apps/explorer/**/*',


### PR DESCRIPTION
# Description of change

Enables decorator support in prettier so `apps-backend` can be formatted. I also took the opportunity to update the lint command and add `apps-backend` as a script in the root.

## Links to any relevant issues

Closes https://github.com/iotaledger/kinesis/issues/372

## Type of change

- Bug fix 

## How the change has been tested

`pnpm apps-backend lint`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
