### PR TITLE
fix(sui-genesis-builder): Spurious test when generating random identifier

### DIFF
--- a/crates/sui-genesis-builder/src/stardust/native_token/package_data.rs
+++ b/crates/sui-genesis-builder/src/stardust/native_token/package_data.rs
@@ -9,6 +9,7 @@ use iota_sdk::types::block::address::AliasAddress;
 use iota_sdk::types::block::output::feature::Irc30Metadata;
 use iota_sdk::types::block::output::{FoundryId, FoundryOutput};
 use iota_sdk::Url;
+use rand::distributions::{Alphanumeric, DistString};
 use rand::Rng;
 use regex::Regex;
 
@@ -171,15 +172,8 @@ fn derive_lowercase_identifier(input: &str) -> Result<String, StardustError> {
             })
         }
     } else {
-        // Generate a new valid random identifier if still invalid
-        let mut rng = rand::thread_rng();
-        let gen = rand_regex::Regex::compile(VALID_IDENTIFIER_PATTERN, 100).unwrap();
-        let res: String = rng.sample(&gen);
-        if res.len() > 7 {
-            Ok(res[..7].to_string())
-        } else {
-            Ok(res)
-        }
+        // Generate a new valid random identifier if the identifier is empty.
+        Ok(Alphanumeric.sample_string(&mut rand::thread_rng(), 7))
     }
 }
 


### PR DESCRIPTION
# Description of change

Fixes a spurious test when generating a random identifier. Sampling `Alphanumeric` directly will guarantee to yield a string of length 7.

## How the change has been tested

Running the tests locally a bunch of times.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
