### PR TITLE
fix(ci): Update rust.yml to monitor correct branches

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,7 @@ name: Rust
 on:
   push:
     branches:
-      - 'main'
+      - 'develop'
       - 'devnet'
       - 'testnet'
       - 'mainnet'


### PR DESCRIPTION
`develop` instead of `main`
