### PR TITLE
fix(sui-genesis-builder): Fix deserialization of `MaxSupplyPolicy` object

### DIFF
--- a/crates/sui-genesis-builder/src/stardust/migration/verification/foundry.rs
+++ b/crates/sui-genesis-builder/src/stardust/migration/verification/foundry.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use sui_types::{
     base_types::SuiAddress,
     coin::{CoinMetadata, TreasuryCap},
+    id::UID,
     in_memory_storage::InMemoryStorage,
     object::Owner,
     Identifier,
@@ -174,6 +175,7 @@ pub(super) fn verify_foundry_output(
 
     #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
     struct MaxSupplyPolicy {
+        id: UID,
         maximum_supply: u64,
         treasury_cap: TreasuryCap,
     }


### PR DESCRIPTION
# Description of change

Adds the missing `UID` field to the type, to pass bcs  deserialization.

## Links to any relevant issues

Fixes https://github.com/iotaledger/kinesis/issues/477

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Part of progressing PR https://github.com/iotaledger/kinesis/pull/209.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
