### PR TITLE
fix(sui-genesis-builder): Allow only u64::MAX - 1 as maximum supply for foundries

### DIFF
--- a/crates/sui-genesis-builder/src/stardust/migration/verification/foundry.rs
+++ b/crates/sui-genesis-builder/src/stardust/migration/verification/foundry.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use sui_types::{
     base_types::SuiAddress,
     coin::{CoinMetadata, TreasuryCap},
+    id::UID,
     in_memory_storage::InMemoryStorage,
     object::Owner,
     Identifier,
@@ -174,6 +175,7 @@ pub(super) fn verify_foundry_output(
 
     #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
     struct MaxSupplyPolicy {
+        id: UID,
         maximum_supply: u64,
         treasury_cap: TreasuryCap,
     }

--- a/crates/sui-genesis-builder/src/stardust/migration/verification/foundry.rs
+++ b/crates/sui-genesis-builder/src/stardust/migration/verification/foundry.rs
@@ -21,7 +21,7 @@ use crate::stardust::{
     migration::{
         executor::FoundryLedgerData,
         verification::{
-            util::{truncate_u256_to_u64, verify_parent},
+            util::{truncate_to_max_allowed_u64_supply, verify_parent},
             CreatedObjects,
         },
     },
@@ -55,7 +55,7 @@ pub(super) fn verify_foundry_output(
     );
 
     let circulating_supply =
-        truncate_u256_to_u64(output.token_scheme().as_simple().circulating_supply());
+        truncate_to_max_allowed_u64_supply(output.token_scheme().as_simple().circulating_supply());
     ensure!(
         minted_coin.value() == circulating_supply,
         "coin amount mismatch: found {}, expected {}",

--- a/crates/sui-genesis-builder/src/stardust/migration/verification/util.rs
+++ b/crates/sui-genesis-builder/src/stardust/migration/verification/util.rs
@@ -22,7 +22,7 @@ use sui_types::{
 
 use crate::stardust::{
     migration::executor::FoundryLedgerData,
-    types::{output as migration_output, Alias, Nft},
+    types::{output as migration_output, token_scheme::MAX_ALLOWED_U64_SUPPLY, Alias, Nft},
 };
 
 pub(super) fn verify_native_tokens(
@@ -287,9 +287,9 @@ impl NativeTokenKind for Field<String, Balance> {
     }
 }
 
-pub fn truncate_u256_to_u64(value: U256) -> u64 {
-    if value.bits() > 64 {
-        u64::MAX
+pub fn truncate_to_max_allowed_u64_supply(value: U256) -> u64 {
+    if value > U256::from(MAX_ALLOWED_U64_SUPPLY) {
+        MAX_ALLOWED_U64_SUPPLY
     } else {
         value.as_u64()
     }

--- a/crates/sui-genesis-builder/src/stardust/types/token_scheme.rs
+++ b/crates/sui-genesis-builder/src/stardust/types/token_scheme.rs
@@ -7,6 +7,9 @@ use iota_sdk::{types::block::output::SimpleTokenScheme, U256};
 
 use crate::stardust::error::StardustError;
 
+/// The maximum allowed u64 supply.
+pub const MAX_ALLOWED_U64_SUPPLY: u64 = u64::MAX - 1;
+
 /// This struct represents a conversion from a `SimpleTokenScheme` to a
 /// `SimpleTokenSchemeU64`.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -69,18 +72,21 @@ impl TryFrom<&SimpleTokenScheme> for SimpleTokenSchemeU64 {
             }
 
             // Check if maximum supply can't be converted to u64.
-            let maximum_supply_u64 = if maximum_supply_u256.bits() > 64 {
-                u64::MAX
+            let maximum_supply_u64 = if maximum_supply_u256 > U256::from(MAX_ALLOWED_U64_SUPPLY) {
+                MAX_ALLOWED_U64_SUPPLY
             } else {
                 maximum_supply_u256.as_u64()
             };
 
-            // Check if circulating supply can't be converted to u64, then create the ratio.
-            if circulating_supply_u256.bits() > 64 {
+            // Check if circulating supply can't be converted to max allowed u64 supply.
+            if circulating_supply_u256 > U256::from(MAX_ALLOWED_U64_SUPPLY) {
                 (
-                    u64::MAX,
-                    u64::MAX,
-                    Some(BigDecimal::from(u64::MAX) / u256_to_bigdecimal(circulating_supply_u256)),
+                    MAX_ALLOWED_U64_SUPPLY,
+                    MAX_ALLOWED_U64_SUPPLY,
+                    Some(
+                        BigDecimal::from(MAX_ALLOWED_U64_SUPPLY)
+                            / u256_to_bigdecimal(circulating_supply_u256),
+                    ),
                 )
             } else {
                 (circulating_supply_u256.as_u64(), maximum_supply_u64, None)
@@ -132,9 +138,9 @@ mod tests {
 
     #[test]
     fn calculate_token_adjustment_ratio_at_max() {
-        let minted_tokens = U256::from(u64::MAX);
+        let minted_tokens = U256::from(MAX_ALLOWED_U64_SUPPLY);
         let melted_tokens = U256::from(0);
-        let maximum_supply = U256::from(u64::MAX);
+        let maximum_supply = U256::from(MAX_ALLOWED_U64_SUPPLY);
 
         let token_scheme =
             SimpleTokenScheme::new(minted_tokens, melted_tokens, maximum_supply).unwrap();
@@ -145,16 +151,16 @@ mod tests {
 
     #[test]
     fn calculate_token_adjustment_ratio_above_max() {
-        let minted_tokens = U256::from(u64::MAX) + U256::from(1_u64);
+        let minted_tokens = U256::from(MAX_ALLOWED_U64_SUPPLY) + U256::from(1_u64);
         let melted_tokens = U256::from(0);
-        let maximum_supply = U256::from(u64::MAX) + U256::from(1_u64);
+        let maximum_supply = U256::from(MAX_ALLOWED_U64_SUPPLY) + U256::from(1_u64);
         let circulating_supply_u256 = minted_tokens - melted_tokens;
 
         let token_scheme =
             SimpleTokenScheme::new(minted_tokens, melted_tokens, maximum_supply).unwrap();
         let token_scheme_u64 = SimpleTokenSchemeU64::try_from(&token_scheme).unwrap();
 
-        let u64_max_bd = BigDecimal::from(u64::MAX);
+        let u64_max_bd = BigDecimal::from(MAX_ALLOWED_U64_SUPPLY);
         let circulating_supply_256_bd = u256_to_bigdecimal(circulating_supply_u256);
         let expected_ratio = u64_max_bd / circulating_supply_256_bd;
 
@@ -205,13 +211,13 @@ mod tests {
         let token_scheme_u64 = SimpleTokenSchemeU64::try_from(&token_scheme).unwrap();
 
         assert_eq!(token_scheme_u64.circulating_supply, 4000);
-        assert_eq!(token_scheme_u64.maximum_supply, u64::MAX);
+        assert_eq!(token_scheme_u64.maximum_supply, MAX_ALLOWED_U64_SUPPLY);
         assert!(token_scheme_u64.token_adjustment_ratio.is_none());
     }
 
     #[test]
     fn circulating_supply_ratio_calculation() {
-        let minted_tokens = U256::from(u64::MAX) * U256::from(10);
+        let minted_tokens = U256::from(MAX_ALLOWED_U64_SUPPLY) * U256::from(10);
         let melted_tokens = U256::from(0);
         let maximum_supply = U256::MAX;
 
@@ -220,13 +226,14 @@ mod tests {
 
         let token_scheme_u64 = SimpleTokenSchemeU64::try_from(&token_scheme).unwrap();
 
-        let expected_ratio = BigDecimal::from(u64::MAX) / u256_to_bigdecimal(minted_tokens);
-        assert_eq!(token_scheme_u64.circulating_supply, u64::MAX);
+        let expected_ratio =
+            BigDecimal::from(MAX_ALLOWED_U64_SUPPLY) / u256_to_bigdecimal(minted_tokens);
+        assert_eq!(token_scheme_u64.circulating_supply, MAX_ALLOWED_U64_SUPPLY);
         assert_eq!(
             token_scheme_u64.token_adjustment_ratio.unwrap(),
             expected_ratio
         );
-        assert_eq!(token_scheme_u64.maximum_supply, u64::MAX);
+        assert_eq!(token_scheme_u64.maximum_supply, MAX_ALLOWED_U64_SUPPLY);
     }
 
     #[test]
@@ -240,8 +247,8 @@ mod tests {
 
         let token_scheme_u64 = SimpleTokenSchemeU64::try_from(&token_scheme).unwrap();
 
-        assert_eq!(token_scheme_u64.maximum_supply, 18446744073709551615);
-        assert_eq!(token_scheme_u64.circulating_supply, 18446744073709551615);
+        assert_eq!(token_scheme_u64.maximum_supply, MAX_ALLOWED_U64_SUPPLY);
+        assert_eq!(token_scheme_u64.circulating_supply, MAX_ALLOWED_U64_SUPPLY);
 
         // Verify that the adjusted balance divided by the token_adjustment_ratio is
         // equal the minted tokens.
@@ -252,7 +259,7 @@ mod tests {
 
     #[test]
     fn circulating_supply_exceeds_u64_with_one_holder() {
-        let minted_tokens = U256::from(u64::MAX) + U256::from(1);
+        let minted_tokens = U256::from(MAX_ALLOWED_U64_SUPPLY) + U256::from(1);
         let melted_tokens = U256::from(0);
         let maximum_supply = U256::MAX;
 
@@ -264,17 +271,17 @@ mod tests {
         let address_balance = u256_to_bigdecimal(minted_tokens);
         let adjusted_address_balance = (address_balance
             * token_scheme_u64.token_adjustment_ratio.unwrap())
-        .to_u64()
-        .unwrap();
+            .to_u64()
+            .unwrap();
 
-        assert_eq!(token_scheme_u64.circulating_supply, u64::MAX);
-        assert_eq!(adjusted_address_balance, u64::MAX);
-        assert_eq!(token_scheme_u64.maximum_supply, u64::MAX);
+        assert_eq!(adjusted_address_balance, MAX_ALLOWED_U64_SUPPLY);
+        assert_eq!(token_scheme_u64.circulating_supply, MAX_ALLOWED_U64_SUPPLY);
+        assert_eq!(token_scheme_u64.maximum_supply, MAX_ALLOWED_U64_SUPPLY);
     }
 
     #[test]
     fn circulating_supply_exceeds_u64_with_two_equal_holders() {
-        let minted_tokens = U256::MAX;
+        let minted_tokens = U256::from(MAX_ALLOWED_U64_SUPPLY) + U256::from(1);
         let melted_tokens = U256::from(0);
         let maximum_supply = U256::MAX;
 
@@ -297,19 +304,18 @@ mod tests {
             .to_u64()
             .unwrap();
 
-        assert_eq!(holder1_balance, holder2_balance);
-        assert_eq!(
-            holder1_balance + holder2_balance,
-            u256_to_bigdecimal(U256::MAX)
-        );
+        assert_eq!(adjusted_holder1_balance, MAX_ALLOWED_U64_SUPPLY / 2);
+
+        assert_eq!(adjusted_holder2_balance, MAX_ALLOWED_U64_SUPPLY / 2);
+
         assert_eq!(
             adjusted_holder1_balance + adjusted_holder2_balance,
-            u64::MAX - 1
+            MAX_ALLOWED_U64_SUPPLY
         );
 
-        assert_eq!(token_scheme_u64.circulating_supply, u64::MAX);
+        assert_eq!(token_scheme_u64.circulating_supply, MAX_ALLOWED_U64_SUPPLY);
 
-        assert_eq!(token_scheme_u64.maximum_supply, u64::MAX);
+        assert_eq!(token_scheme_u64.maximum_supply, MAX_ALLOWED_U64_SUPPLY);
     }
 
     #[test]

--- a/crates/sui-genesis-builder/src/stardust/types/token_scheme.rs
+++ b/crates/sui-genesis-builder/src/stardust/types/token_scheme.rs
@@ -271,8 +271,8 @@ mod tests {
         let address_balance = u256_to_bigdecimal(minted_tokens);
         let adjusted_address_balance = (address_balance
             * token_scheme_u64.token_adjustment_ratio.unwrap())
-            .to_u64()
-            .unwrap();
+        .to_u64()
+        .unwrap();
 
         assert_eq!(adjusted_address_balance, MAX_ALLOWED_U64_SUPPLY);
         assert_eq!(token_scheme_u64.circulating_supply, MAX_ALLOWED_U64_SUPPLY);


### PR DESCRIPTION
# Description of change

Currently, minting u64::MAX on foundry creation leads to following VM Abort error:

```rust
thread 'stardust::migration::tests::foundries::migrate_with_mint_u64_max' panicked at crates/sui-genesis-builder/src/stardust/migration/tests/mod.rs:34:38:
called `Result::unwrap()` on an `Err` value: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000002, name: Identifier("balance") }, function: 3, instruction: 12, function_name: Some("increase_supply") }, 1), source: Some(VMError { major_status: ABORTED, sub_status: Some(1), message: Some("0x0000000000000000000000000000000000000000000000000000000000000002::balance::increase_supply at offset 12"), exec_state: None, location: Module(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000002, name: Identifier("balance") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 12)] }), command: Some(0) } }

Caused by:
    VMError with status ABORTED with sub status 1 at location Module ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000002, name: Identifier("balance") } and message 0x0000000000000000000000000000000000000000000000000000000000000002::balance::increase_supply at offset 12 at code offset 12 in function definition 3


Stack backtrace:
   ...
   6: sui_genesis_builder::stardust::migration::executor::Executor::execute_pt_unmetered
             at ./src/stardust/migration/executor.rs:194:9
   7: sui_genesis_builder::stardust::migration::executor::Executor::create_foundries
             at ./src/stardust/migration/executor.rs:232:55
   8: sui_genesis_builder::stardust::migration::migration::Migration::migrate_foundries
             at ./src/stardust/migration/migration.rs:159:21
   9: sui_genesis_builder::stardust::migration::migration::Migration::run_migration
```

Failing following assert in the `increase_supply()` when minting:

```rust
/// Increase supply by `value` and create a new `Balance<T>` with this value.
public fun increase_supply<T>(self: &mut Supply<T>, value: u64): Balance<T> {
    assert!(value < (18446744073709551615u64 - self.value), EOverflow);
    self.value = self.value + value;
    Balance { value }
}
```

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/480

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Part of https://github.com/iotaledger/iota/pull/209

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
