### PR TITLE
fix(sui-genesis-builder): Initial shared version on Basic Output

### DIFF
--- a/crates/sui-genesis-builder/src/stardust/types/output.rs
+++ b/crates/sui-genesis-builder/src/stardust/types/output.rs
@@ -210,7 +210,7 @@ impl BasicOutput {
         // Resolve ownership
         let owner = if self.expiration.is_some() {
             Owner::Shared {
-                initial_shared_version: 0.into(),
+                initial_shared_version: version,
             }
         } else {
             Owner::AddressOwner(owner)


### PR DESCRIPTION
# Description of change

Set the `initial_shared_version` on `BasicOutput`'s to the version used on the object, rather than 0.

## Links to any relevant issues

fixes #449

## How the change has been tested

n/a

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
