### PR TITLE
refactor(sui-genesis-builder): pass ExpectedAssets to test utils

### DIFF
--- a/crates/sui-genesis-builder/src/stardust/migration/tests/alias.rs
+++ b/crates/sui-genesis-builder/src/stardust/migration/tests/alias.rs
@@ -27,6 +27,7 @@ use sui_types::{
     TypeTag,
 };
 
+use super::ExpectedAssets;
 use crate::stardust::{
     migration::tests::{
         create_foundry, extract_native_token_from_bag, object_migration_with_object_owner,
@@ -289,6 +290,7 @@ fn alias_migration_with_native_tokens() {
         ],
         ALIAS_OUTPUT_MODULE_NAME,
         native_token,
+        ExpectedAssets::BalanceBagObject,
     )
     .unwrap();
 }

--- a/crates/sui-genesis-builder/src/stardust/migration/tests/nft.rs
+++ b/crates/sui-genesis-builder/src/stardust/migration/tests/nft.rs
@@ -35,7 +35,7 @@ use sui_types::{
     TypeTag,
 };
 
-use super::{unlock_object_test, UnlockObjectTestResult};
+use super::{unlock_object_test, ExpectedAssets, UnlockObjectTestResult};
 use crate::stardust::{
     migration::tests::{
         create_foundry, extract_native_token_from_bag, object_migration_with_object_owner,
@@ -300,6 +300,7 @@ fn nft_migration_with_native_tokens() {
         ],
         NFT_OUTPUT_MODULE_NAME,
         native_token,
+        ExpectedAssets::BalanceBagObject,
     )
     .unwrap();
 }
@@ -536,6 +537,7 @@ fn nft_migration_with_timelock_unlocked() {
         NFT_OUTPUT_MODULE_NAME,
         epoch_start_timestamp_ms as u64,
         UnlockObjectTestResult::Success,
+        ExpectedAssets::BalanceBagObject,
     )
     .unwrap();
 }
@@ -564,6 +566,7 @@ fn nft_migration_with_timelock_still_locked() {
         NFT_OUTPUT_MODULE_NAME,
         epoch_start_timestamp_ms as u64,
         UnlockObjectTestResult::ERROR_TIMELOCK_NOT_EXPIRED_FAILURE,
+        ExpectedAssets::BalanceBagObject,
     )
     .unwrap();
 }
@@ -600,6 +603,7 @@ fn nft_migration_with_expired_unlock_condition() {
         NFT_OUTPUT_MODULE_NAME,
         epoch_start_timestamp_ms as u64,
         UnlockObjectTestResult::ERROR_WRONG_SENDER_FAILURE,
+        ExpectedAssets::BalanceBagObject,
     )
     .unwrap();
 
@@ -611,6 +615,7 @@ fn nft_migration_with_expired_unlock_condition() {
         NFT_OUTPUT_MODULE_NAME,
         epoch_start_timestamp_ms as u64,
         UnlockObjectTestResult::Success,
+        ExpectedAssets::BalanceBagObject,
     )
     .unwrap();
 }
@@ -647,6 +652,7 @@ fn nft_migration_with_unexpired_unlock_condition() {
         NFT_OUTPUT_MODULE_NAME,
         epoch_start_timestamp_ms as u64,
         UnlockObjectTestResult::ERROR_WRONG_SENDER_FAILURE,
+        ExpectedAssets::BalanceBagObject,
     )
     .unwrap();
 
@@ -658,6 +664,7 @@ fn nft_migration_with_unexpired_unlock_condition() {
         NFT_OUTPUT_MODULE_NAME,
         epoch_start_timestamp_ms as u64,
         UnlockObjectTestResult::Success,
+        ExpectedAssets::BalanceBagObject,
     )
     .unwrap();
 }
@@ -688,6 +695,7 @@ fn nft_migration_with_storage_deposit_return_unlock_condition() {
         // Epoch start time is not important for this test.
         0,
         UnlockObjectTestResult::Success,
+        ExpectedAssets::BalanceBagObject,
     )
     .unwrap();
 }


### PR DESCRIPTION
# Description of change

The following functions are extended with an `ExpectedAssets` so that to be used on basic outputs as well

* `unlock_object_test`
* `extract_native_token_from_bag`

## Links to any relevant issues

Fixes #538 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo test -p sui-genesis-builder -j2`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
