### PR TITLE
fix(iota-genesis-builder): Fix vested output tests

### DIFF
--- a/crates/iota-genesis-builder/src/stardust/types/mod.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/mod.rs
@@ -1,5 +1,4 @@
 // Copyright (c) 2024 IOTA Stiftung
-// Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod address;

--- a/crates/iota-genesis-builder/src/stardust/types/snapshot.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/snapshot.rs
@@ -1,5 +1,4 @@
 // Copyright (c) 2024 IOTA Stiftung
-// Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 //! Types representing blocks of data in a Stardust snapshot.
@@ -83,7 +82,7 @@ impl OutputHeader {
 
     /// Creates a new OutputHeader for testing.
     pub fn new_testing(
-        output_id_bytes: [u8; 32],
+        transaction_id_bytes: [u8; 32],
         block_id_bytes: [u8; 32],
         milestone_index: u32,
         milestone_timestamp: u32,
@@ -91,7 +90,7 @@ impl OutputHeader {
         use iota_sdk::types::block::payload::transaction::TransactionId;
 
         OutputHeader {
-            output_id: OutputId::new(TransactionId::new(output_id_bytes), 0).unwrap(),
+            output_id: OutputId::new(TransactionId::new(transaction_id_bytes), 0).unwrap(),
             block_id: BlockId::new(block_id_bytes),
             ms_index: MilestoneIndex::new(milestone_index),
             ms_ts: milestone_timestamp,

--- a/crates/iota-genesis-builder/src/stardust/types/timelock.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/timelock.rs
@@ -1,5 +1,4 @@
 // Copyright (c) 2024 IOTA Stiftung
-// Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_protocol_config::ProtocolConfig;
@@ -163,7 +162,7 @@ mod tests {
     #[test]
     fn is_timelocked_vested_reward_all_correct() {
         let output_id = OutputId::from_str(
-            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb1812345678",
+            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb18123456780000",
         )
         .unwrap();
         let output = vested_reward_output(10, 1000);
@@ -176,7 +175,7 @@ mod tests {
     #[test]
     fn is_timelocked_vested_reward_min_id() {
         let output_id = OutputId::from_str(
-            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb1800000000",
+            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb18000000000000",
         )
         .unwrap();
         let output = vested_reward_output(10, 1000);
@@ -189,7 +188,7 @@ mod tests {
     #[test]
     fn is_timelocked_vested_reward_max_id() {
         let output_id = OutputId::from_str(
-            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb18ffffffff",
+            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb18ffffffff0000",
         )
         .unwrap();
         let output = vested_reward_output(10, 1000);
@@ -202,7 +201,7 @@ mod tests {
     #[test]
     fn is_timelocked_vested_reward_incorrect_id() {
         let output_id = OutputId::from_str(
-            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb1712345678",
+            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb17123456780000",
         )
         .unwrap();
         let output = vested_reward_output(10, 1000);
@@ -215,7 +214,7 @@ mod tests {
     #[test]
     fn is_timelocked_vested_reward_no_timelock_unlock_condition() {
         let output_id = OutputId::from_str(
-            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb1812345678",
+            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb18123456780000",
         )
         .unwrap();
         let output = BasicOutputBuilder::new_with_amount(10)
@@ -236,7 +235,7 @@ mod tests {
     #[test]
     fn is_timelocked_vested_reward_bigger_milestone_time() {
         let output_id = OutputId::from_str(
-            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb1812345678",
+            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb18123456780000",
         )
         .unwrap();
         let output = vested_reward_output(10, 100);
@@ -249,7 +248,7 @@ mod tests {
     #[test]
     fn is_timelocked_vested_reward_same_milestone_time() {
         let output_id = OutputId::from_str(
-            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb1812345678",
+            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb18123456780000",
         )
         .unwrap();
         let output = vested_reward_output(10, 1000);
@@ -262,7 +261,7 @@ mod tests {
     #[test]
     fn timelock_from_stardust_all_correct() {
         let output_id = OutputId::from_str(
-            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb1812345678",
+            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb18123456780000",
         )
         .unwrap();
         let output = vested_reward_output(10, 1000);
@@ -276,7 +275,7 @@ mod tests {
     #[test]
     fn timelock_from_stardust_with_expired_output() {
         let output_id = OutputId::from_str(
-            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb1812345678",
+            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb18123456780000",
         )
         .unwrap();
         let output = vested_reward_output(10, 1000);
@@ -289,7 +288,7 @@ mod tests {
     #[test]
     fn timelock_from_stardust_with_incorrect_id() {
         let output_id = OutputId::from_str(
-            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb1712345678",
+            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb17123456780000",
         )
         .unwrap();
         let output = vested_reward_output(10, 1000);
@@ -302,7 +301,7 @@ mod tests {
     #[test]
     fn timelock_from_stardust_without_timelock_unlock_condition() {
         let output_id = OutputId::from_str(
-            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb1812345678",
+            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb18123456780000",
         )
         .unwrap();
         let output = BasicOutputBuilder::new_with_amount(10)
@@ -334,7 +333,7 @@ mod tests {
     #[test]
     fn timelock_from_stardust_extra_unlock_condition() {
         let output_id = OutputId::from_str(
-            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb1812345678",
+            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb18123456780000",
         )
         .unwrap();
         let output = BasicOutputBuilder::new_with_amount(10)
@@ -370,7 +369,7 @@ mod tests {
     #[test]
     fn timelock_from_stardust_with_native_tokens() {
         let output_id = OutputId::from_str(
-            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb1812345678",
+            "0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb18123456780000",
         )
         .unwrap();
         let output = BasicOutputBuilder::new_with_amount(10)


### PR DESCRIPTION
# Description of change

Some of the tests were failing after #511 because transaction ID strings were mistakenly used in the place of output IDs. This fixes them by adding the final index bytes.

## Links to any relevant issues

Fixes #558
