### PR TITLE
refactor(iota-genesis-builder): Improve naming of gas coin

### DIFF
--- a/crates/iota-genesis-builder/src/stardust/migration/executor.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/executor.rs
@@ -231,12 +231,12 @@ impl Executor {
             };
             let InnerTemporaryStore { written, .. } = self.execute_pt_unmetered(deps, pt)?;
             // Get on-chain info
-            let mut minted_coin_id = None::<ObjectID>;
+            let mut native_token_coin_id = None::<ObjectID>;
             let mut foundry_package = None::<&MovePackage>;
             for object in written.values() {
                 if object.is_coin() {
-                    minted_coin_id = Some(object.id());
-                    created_objects.set_minted_coin(object.id())?;
+                    native_token_coin_id = Some(object.id());
+                    created_objects.set_native_token_coin(object.id())?;
                 } else if object.type_().map_or(false, |t| t.is_coin_metadata()) {
                     created_objects.set_coin_metadata(object.id())?
                 } else if object.type_().map_or(false, |t| {
@@ -255,14 +255,14 @@ impl Executor {
                     created_objects.set_package(object.id())?;
                 }
             }
-            let (minted_coin_id, foundry_package) = (
-                minted_coin_id.expect("a coin must have been minted"),
+            let (native_token_coin_id, foundry_package) = (
+                native_token_coin_id.expect("a native token coin must have been minted"),
                 foundry_package.expect("there should be a published package"),
             );
             self.native_tokens.insert(
                 foundry.token_id(),
                 FoundryLedgerData::new(
-                    minted_coin_id,
+                    native_token_coin_id,
                     foundry_package,
                     SimpleTokenSchemeU64::try_from(foundry.token_scheme().as_simple())?,
                 ),
@@ -276,7 +276,7 @@ impl Executor {
                 foundry_package.version(),
                 &self.protocol_config,
             )?;
-            created_objects.set_coin(gas_coin.id())?;
+            created_objects.set_gas_coin(gas_coin.id())?;
             self.store.insert_object(gas_coin);
 
             self.store.finish(
@@ -389,7 +389,9 @@ impl Executor {
                     anyhow::bail!("foundry for native token has not been published");
                 };
 
-                let Some(foundry_coin) = self.store.get_object(&foundry_ledger_data.minted_coin_id)
+                let Some(foundry_coin) = self
+                    .store
+                    .get_object(&foundry_ledger_data.native_token_coin_id)
                 else {
                     anyhow::bail!("foundry coin should exist");
                 };
@@ -483,7 +485,9 @@ impl Executor {
                     anyhow::bail!("foundry for native token has not been published");
                 };
 
-                let Some(foundry_coin) = self.store.get_object(&foundry_ledger_data.minted_coin_id)
+                let Some(foundry_coin) = self
+                    .store
+                    .get_object(&foundry_ledger_data.native_token_coin_id)
                 else {
                     anyhow::bail!("foundry coin should exist");
                 };
@@ -538,7 +542,7 @@ impl Executor {
         header: &OutputHeader,
         basic_output: &BasicOutput,
     ) -> Result<CreatedObjects> {
-        let mut data =
+        let mut basic =
             crate::stardust::types::output::BasicOutput::new(header.clone(), basic_output)?;
         let owner: IotaAddress = basic_output.address().to_string().parse()?;
         let mut created_objects = CreatedObjects::default();
@@ -546,34 +550,34 @@ impl Executor {
         // The minimum version of the manually created objects
         let package_deps = InputObjects::new(self.load_packages(PACKAGE_DEPS).collect());
         let mut version = package_deps.lamport_timestamp(&[]);
-        let object = if data.is_simple_coin() {
+        let object = if basic.is_simple_coin() {
             if !basic_output.native_tokens().is_empty() {
                 let coins = self.create_native_token_coins(basic_output.native_tokens(), owner)?;
                 created_objects.set_native_tokens(coins)?;
             }
-            let coin = data.into_genesis_coin_object(
+            let gas_coin = basic.into_genesis_coin_object(
                 owner,
                 &self.protocol_config,
                 &self.tx_context,
                 version,
             )?;
-            created_objects.set_coin(coin.id())?;
-            coin
+            created_objects.set_gas_coin(gas_coin.id())?;
+            gas_coin
         } else {
             if !basic_output.native_tokens().is_empty() {
                 let fields;
                 // The bag will be wrapped into the basic output object, so
                 // by equating their versions we emulate a ptb.
-                (data.native_tokens, version, fields) =
+                (basic.native_tokens, version, fields) =
                     self.create_bag_with_pt(basic_output.native_tokens())?;
                 created_objects.set_native_tokens(fields)?;
             } else {
                 // Overwrite the default 0 UID of `Bag::default()`, since we won't
                 // be creating a new bag in this code path.
-                data.native_tokens.id = UID::new(self.tx_context.fresh_id());
+                basic.native_tokens.id = UID::new(self.tx_context.fresh_id());
             }
             let object =
-                data.to_genesis_object(owner, &self.protocol_config, &self.tx_context, version)?;
+                basic.to_genesis_object(owner, &self.protocol_config, &self.tx_context, version)?;
             created_objects.set_output(object.id())?;
             object
         };
@@ -771,7 +775,7 @@ mod pt {
 /// On-chain data about the objects created while
 /// publishing foundry packages
 pub(crate) struct FoundryLedgerData {
-    pub(crate) minted_coin_id: ObjectID,
+    pub(crate) native_token_coin_id: ObjectID,
     pub(crate) coin_type_origin: TypeOrigin,
     pub(crate) package_id: ObjectID,
     pub(crate) token_scheme_u64: SimpleTokenSchemeU64,
@@ -786,12 +790,12 @@ impl FoundryLedgerData {
     ///
     /// Panics if the package does not contain any [`TypeOrigin`].
     fn new(
-        minted_coin_id: ObjectID,
+        native_token_coin_id: ObjectID,
         foundry_package: &MovePackage,
         token_scheme_u64: SimpleTokenSchemeU64,
     ) -> Self {
         Self {
-            minted_coin_id,
+            native_token_coin_id,
             // There must be only one type created in the foundry package.
             coin_type_origin: foundry_package.type_origin_table()[0].clone(),
             package_id: foundry_package.id(),

--- a/crates/iota-genesis-builder/src/stardust/migration/tests/basic.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/tests/basic.rs
@@ -46,7 +46,7 @@ fn basic_simple_coin_id() {
         .output_objects_map
         .get(&header.output_id())
         .unwrap()
-        .coin()
+        .gas_coin()
         .unwrap();
     let expected_object_id = ObjectID::new(header.output_id().hash());
     assert_eq!(expected_object_id, *migrated_object_id);

--- a/crates/iota-genesis-builder/src/stardust/migration/tests/executor.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/tests/executor.rs
@@ -58,8 +58,8 @@ fn create_bag_with_pt() {
     // * The package
     // * Coin metadata
     // * MaxSupplyPolicy
-    // * The total supply coin
-    // * The foundry gas coin
+    // * The total supply native token coin
+    // * The gas coin
     assert_eq!(executor.store().objects().len() - object_count, 5);
     assert!(executor.native_tokens().get(&foundry_id.into()).is_some());
     let initial_supply_coin_object = executor

--- a/crates/iota-genesis-builder/src/stardust/migration/tests/foundry.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/tests/foundry.rs
@@ -27,8 +27,8 @@ use crate::stardust::{
 };
 
 type PackageObject = Object;
-type CoinObject = Object;
-type MintedCoinObject = Object;
+type GasCoinObject = Object;
+type NativeTokenCoinObject = Object;
 type CoinMetadataObject = Object;
 type MaxSupplyPolicyObject = Object;
 
@@ -37,8 +37,8 @@ fn migrate_foundry(
     foundry: FoundryOutput,
 ) -> Result<(
     PackageObject,
-    CoinObject,
-    MintedCoinObject,
+    GasCoinObject,
+    NativeTokenCoinObject,
     CoinMetadataObject,
     MaxSupplyPolicyObject,
 )> {
@@ -56,8 +56,8 @@ fn migrate_foundry(
     assert_eq!(created_objects.len(), 5);
 
     let package_id = *created_objects_ids.package()?;
-    let coin_id = *created_objects_ids.coin()?;
-    let minted_coin_id = *created_objects_ids.minted_coin()?;
+    let gas_coin_id = *created_objects_ids.gas_coin()?;
+    let native_token_coin_id = *created_objects_ids.native_token_coin()?;
     let coin_metadata_id = *created_objects_ids.coin_metadata()?;
     let max_supply_policy_id = *created_objects_ids.max_supply_policy()?;
 
@@ -65,14 +65,14 @@ fn migrate_foundry(
         .iter()
         .find(|object| object.id() == package_id)
         .ok_or(anyhow!("missing package object"))?;
-    let coin_object = created_objects
+    let gas_coin_object = created_objects
         .iter()
-        .find(|object| object.id() == coin_id)
-        .ok_or(anyhow!("missing coin object"))?;
-    let minted_coin_object = created_objects
+        .find(|object| object.id() == gas_coin_id)
+        .ok_or(anyhow!("missing gas coin object"))?;
+    let native_token_coin_object = created_objects
         .iter()
-        .find(|object| object.id() == minted_coin_id)
-        .ok_or(anyhow!("missing minted coin object"))?;
+        .find(|object| object.id() == native_token_coin_id)
+        .ok_or(anyhow!("missing native token coin object"))?;
     let coin_metadata_object = created_objects
         .iter()
         .find(|object| object.id() == coin_metadata_id)
@@ -84,8 +84,8 @@ fn migrate_foundry(
 
     Ok((
         package_object.clone(),
-        coin_object.clone(),
-        minted_coin_object.clone(),
+        gas_coin_object.clone(),
+        native_token_coin_object.clone(),
         coin_metadata_object.clone(),
         max_supply_policy_object.clone(),
     ))
@@ -105,8 +105,8 @@ fn foundry_with_simple_metadata() -> Result<()> {
 
     let (
         package_object,
-        coin_object,
-        minted_coin_object,
+        gas_coin_object,
+        native_token_coin_object,
         coin_metadata_object,
         max_supply_policy_object,
     ) = migrate_foundry(header, foundry)?;
@@ -122,22 +122,26 @@ fn foundry_with_simple_metadata() -> Result<()> {
     assert_eq!(coin_type_origin.module_name, "doge");
     assert_eq!(coin_type_origin.struct_name, "DOGE");
 
-    // Check the coin object.
-    let coin = coin_object
+    // Check the gas coin object.
+    let gas_coin = gas_coin_object
         .as_coin_maybe()
-        .expect("should be a coin object");
+        .expect("should be a gas coin object");
     assert_eq!(
-        coin_object.owner.get_owner_address().unwrap().to_string(),
+        gas_coin_object
+            .owner
+            .get_owner_address()
+            .unwrap()
+            .to_string(),
         alias_id.to_string()
     );
-    assert_eq!(coin.balance, Balance::new(1_000_000));
+    assert_eq!(gas_coin.balance, Balance::new(1_000_000));
 
-    // Check the minted coin object.
-    let minted_coin = minted_coin_object
+    // Check the native token coin object.
+    let native_token_coin = native_token_coin_object
         .as_coin_maybe()
-        .expect("should be a coin object");
-    assert_eq!(minted_coin_object.owner, IotaAddress::ZERO);
-    assert_eq!(minted_coin.balance, Balance::new(100_000));
+        .expect("should be a native token coin object");
+    assert_eq!(native_token_coin_object.owner, IotaAddress::ZERO);
+    assert_eq!(native_token_coin.balance, Balance::new(100_000));
 
     // Check the coin metadata object.
     let coin_metadata = coin_metadata_object
@@ -208,8 +212,8 @@ fn foundry_with_special_metadata() -> Result<()> {
 
     let (
         package_object,
-        coin_object,
-        minted_coin_object,
+        gas_coin_object,
+        native_token_coin_object,
         coin_metadata_object,
         max_supply_policy_object,
     ) = migrate_foundry(header, foundry)?;
@@ -225,22 +229,26 @@ fn foundry_with_special_metadata() -> Result<()> {
     assert_eq!(coin_type_origin.module_name, "doge");
     assert_eq!(coin_type_origin.struct_name, "DOGE");
 
-    // Check the coin object.
-    let coin = coin_object
+    // Check the gas coin object.
+    let gas_coin = gas_coin_object
         .as_coin_maybe()
-        .expect("should be a coin object");
+        .expect("should be a gas coin object");
     assert_eq!(
-        coin_object.owner.get_owner_address().unwrap().to_string(),
+        gas_coin_object
+            .owner
+            .get_owner_address()
+            .unwrap()
+            .to_string(),
         alias_id.to_string()
     );
-    assert_eq!(coin.balance, Balance::new(1_000_000));
+    assert_eq!(gas_coin.balance, Balance::new(1_000_000));
 
-    // Check the minted coin object.
-    let minted_coin = minted_coin_object
+    // Check the native token coin object.
+    let native_token_coin = native_token_coin_object
         .as_coin_maybe()
-        .expect("should be a coin object");
-    assert_eq!(minted_coin_object.owner, IotaAddress::ZERO);
-    assert_eq!(minted_coin.balance, Balance::new(u64::MAX - 1));
+        .expect("should be a native token coin object");
+    assert_eq!(native_token_coin_object.owner, IotaAddress::ZERO);
+    assert_eq!(native_token_coin.balance, Balance::new(u64::MAX - 1));
 
     // Check the coin metadata object.
     let coin_metadata = coin_metadata_object
@@ -308,20 +316,24 @@ fn coin_ownership() -> Result<()> {
 
     let (
         _package_object,
-        coin_object,
-        minted_coin_object,
+        gas_coin_object,
+        native_token_coin_object,
         _coin_metadata_object,
         max_supply_policy_object,
     ) = migrate_foundry(header, foundry)?;
 
-    // Check the owner of the coin object.
+    // Check the owner of the gas coin object.
     assert_eq!(
-        coin_object.owner.get_owner_address().unwrap().to_string(),
+        gas_coin_object
+            .owner
+            .get_owner_address()
+            .unwrap()
+            .to_string(),
         alias_id.to_string()
     );
 
-    // Check the owner of the minted coin object.
-    assert_eq!(minted_coin_object.owner, IotaAddress::ZERO);
+    // Check the owner of the native token coin object.
+    assert_eq!(native_token_coin_object.owner, IotaAddress::ZERO);
 
     // Check the owner of the max supply policy object.
     assert_eq!(
@@ -355,8 +367,8 @@ fn create_gas_coin() {
     // * The package
     // * Coin metadata
     // * MaxSupplyPolicy
-    // * The total supply coin
-    // * The foundry gas coin
+    // * The total supply native token coin
+    // * The gas coin
     assert_eq!(objects.len(), 5);
 
     // Extract the package object.

--- a/crates/iota-genesis-builder/src/stardust/migration/verification/alias.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/alias.rs
@@ -165,16 +165,19 @@ pub(super) fn verify_alias_output(
 
     verify_parent(output.governor_address(), storage)?;
 
-    ensure!(created_objects.coin().is_err(), "unexpected coin found");
+    ensure!(
+        created_objects.gas_coin().is_err(),
+        "unexpected gas coin found"
+    );
+
+    ensure!(
+        created_objects.native_token_coin().is_err(),
+        "unexpected native token coin found"
+    );
 
     ensure!(
         created_objects.coin_metadata().is_err(),
         "unexpected coin metadata found"
-    );
-
-    ensure!(
-        created_objects.minted_coin().is_err(),
-        "unexpected minted coin found"
     );
 
     ensure!(

--- a/crates/iota-genesis-builder/src/stardust/migration/verification/basic.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/basic.rs
@@ -89,7 +89,10 @@ pub(super) fn verify_basic_output(
     // If the output has multiple unlock conditions, then a genesis object should
     // have been created.
     if output.unlock_conditions().len() > 1 {
-        ensure!(created_objects.coin().is_err(), "unexpected coin created");
+        ensure!(
+            created_objects.gas_coin().is_err(),
+            "unexpected gas coin created"
+        );
 
         let created_output_obj = created_objects.output().and_then(|id| {
             storage
@@ -170,19 +173,19 @@ pub(super) fn verify_basic_output(
             "unexpected output object created for simple deposit"
         );
 
-        // Coin value and owner
-        let created_coin_obj = created_objects.coin().and_then(|id| {
+        // Gas coin value and owner
+        let created_gas_coin_obj = created_objects.gas_coin().and_then(|id| {
             storage
                 .get_object(id)
-                .ok_or_else(|| anyhow!("missing coin"))
+                .ok_or_else(|| anyhow!("missing gas coin"))
         })?;
-        let created_coin = created_coin_obj
+        let created_gas_coin = created_gas_coin_obj
             .as_coin_maybe()
-            .ok_or_else(|| anyhow!("expected a coin"))?;
+            .ok_or_else(|| anyhow!("expected a gas coin"))?;
 
-        verify_address_owner(output.address(), created_coin_obj, "coin")?;
-        verify_coin(output.amount(), &created_coin)?;
-        *total_value += created_coin.value();
+        verify_address_owner(output.address(), created_gas_coin_obj, "gas coin")?;
+        verify_coin(output.amount(), &created_gas_coin)?;
+        *total_value += created_gas_coin.value();
 
         // Native Tokens
         verify_native_tokens::<(TypeTag, Coin)>(
@@ -197,13 +200,13 @@ pub(super) fn verify_basic_output(
     verify_parent(output.address(), storage)?;
 
     ensure!(
-        created_objects.coin_metadata().is_err(),
-        "unexpected coin metadata found"
+        created_objects.native_token_coin().is_err(),
+        "unexpected native token coin found"
     );
 
     ensure!(
-        created_objects.minted_coin().is_err(),
-        "unexpected minted coin found"
+        created_objects.coin_metadata().is_err(),
+        "unexpected coin metadata found"
     );
 
     ensure!(

--- a/crates/iota-genesis-builder/src/stardust/migration/verification/created_objects.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/created_objects.rs
@@ -8,12 +8,12 @@ use iota_types::base_types::ObjectID;
 #[derive(Default)]
 pub struct CreatedObjects {
     output: Option<ObjectID>,
-    coin: Option<ObjectID>,
+    gas_coin: Option<ObjectID>,
+    native_token_coin: Option<ObjectID>,
     coin_metadata: Option<ObjectID>,
     package: Option<ObjectID>,
     max_supply_policy: Option<ObjectID>,
     native_tokens: Option<Vec<ObjectID>>,
-    minted_coin: Option<ObjectID>,
 }
 
 impl CreatedObjects {
@@ -31,17 +31,31 @@ impl CreatedObjects {
         Ok(())
     }
 
-    pub fn coin(&self) -> Result<&ObjectID> {
-        self.coin
+    pub fn gas_coin(&self) -> Result<&ObjectID> {
+        self.gas_coin
             .as_ref()
-            .ok_or_else(|| anyhow!("no created coin object"))
+            .ok_or_else(|| anyhow!("no created gas coin object"))
     }
 
-    pub(crate) fn set_coin(&mut self, id: ObjectID) -> Result<()> {
-        if let Some(id) = self.coin {
-            bail!("coin already set: {id}")
+    pub(crate) fn set_gas_coin(&mut self, id: ObjectID) -> Result<()> {
+        if let Some(id) = self.gas_coin {
+            bail!("gas coin already set: {id}")
         }
-        self.coin.replace(id);
+        self.gas_coin.replace(id);
+        Ok(())
+    }
+
+    pub fn native_token_coin(&self) -> Result<&ObjectID> {
+        self.native_token_coin
+            .as_ref()
+            .ok_or_else(|| anyhow!("no native token coin object"))
+    }
+
+    pub(crate) fn set_native_token_coin(&mut self, id: ObjectID) -> Result<()> {
+        if let Some(id) = self.native_token_coin {
+            bail!("native token coin already set: {id}")
+        }
+        self.native_token_coin.replace(id);
         Ok(())
     }
 
@@ -98,20 +112,6 @@ impl CreatedObjects {
             bail!("native tokens already set: {id:?}")
         }
         self.native_tokens.replace(ids);
-        Ok(())
-    }
-
-    pub fn minted_coin(&self) -> Result<&ObjectID> {
-        self.minted_coin
-            .as_ref()
-            .ok_or_else(|| anyhow!("no minted coin object"))
-    }
-
-    pub(crate) fn set_minted_coin(&mut self, id: ObjectID) -> Result<()> {
-        if let Some(id) = self.minted_coin {
-            bail!("minted coin already set: {id}")
-        }
-        self.minted_coin.replace(id);
         Ok(())
     }
 }

--- a/crates/iota-genesis-builder/src/stardust/migration/verification/foundry.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/foundry.rs
@@ -43,49 +43,49 @@ pub(super) fn verify_foundry_output(
         .expect("foundry outputs always have an immutable alias address")
         .address();
 
-    // Coin value and owner
-    let created_coin_obj = created_objects.coin().and_then(|id| {
+    // Gas coin value and owner
+    let created_gas_coin_obj = created_objects.gas_coin().and_then(|id| {
         storage
             .get_object(id)
-            .ok_or_else(|| anyhow!("missing coin"))
+            .ok_or_else(|| anyhow!("missing gas coin"))
     })?;
-    let created_coin = created_coin_obj
+    let created_gas_coin = created_gas_coin_obj
         .as_coin_maybe()
-        .ok_or_else(|| anyhow!("expected a coin"))?;
+        .ok_or_else(|| anyhow!("expected a gas coin"))?;
 
-    verify_address_owner(alias_address, created_coin_obj, "coin")?;
-    verify_coin(output.amount(), &created_coin)?;
-    *total_value += created_coin.value();
+    verify_address_owner(alias_address, created_gas_coin_obj, "gas coin")?;
+    verify_coin(output.amount(), &created_gas_coin)?;
+    *total_value += created_gas_coin.value();
 
-    // Minted coin value
-    let minted_coin_id = created_objects.minted_coin()?;
-    let minted_coin_obj = storage
-        .get_object(minted_coin_id)
-        .ok_or_else(|| anyhow!("missing coin"))?;
-    let minted_coin = minted_coin_obj
+    // Native token coin value
+    let native_token_coin_id = created_objects.native_token_coin()?;
+    let native_token_coin_obj = storage
+        .get_object(native_token_coin_id)
+        .ok_or_else(|| anyhow!("missing native token coin"))?;
+    let native_token_coin = native_token_coin_obj
         .as_coin_maybe()
-        .ok_or_else(|| anyhow!("expected a coin"))?;
+        .ok_or_else(|| anyhow!("expected a native token coin"))?;
 
-    // Minted coins are transferred to `0x0`
+    // The minted native token coin should be owned by `0x0`
     let expected_owner = Owner::AddressOwner(IotaAddress::default());
     ensure!(
-        minted_coin_obj.owner == expected_owner,
-        "minted coin owner mismatch: found {}, expected {}",
-        minted_coin_obj.owner,
+        native_token_coin_obj.owner == expected_owner,
+        "native token coin owner mismatch: found {}, expected {}",
+        native_token_coin_obj.owner,
         expected_owner
     );
 
     ensure!(
-        foundry_data.minted_coin_id == *minted_coin_id,
+        foundry_data.native_token_coin_id == *native_token_coin_id,
         "coin ID mismatch: found {}, expected {}",
-        foundry_data.minted_coin_id,
-        minted_coin_id
+        foundry_data.native_token_coin_id,
+        native_token_coin_id
     );
 
     ensure!(
-        minted_coin.value() == foundry_data.minted_value,
+        native_token_coin.value() == foundry_data.minted_value,
         "minted coin amount mismatch: found {}, expected {}",
-        minted_coin.value(),
+        native_token_coin.value(),
         foundry_data.minted_value
     );
 
@@ -153,7 +153,7 @@ pub(super) fn verify_foundry_output(
     );
 
     // Coin Metadata
-    let minted_coin = created_objects
+    let coin_metadata = created_objects
         .coin_metadata()
         .and_then(|id| {
             storage
@@ -164,31 +164,31 @@ pub(super) fn verify_foundry_output(
         .ok_or_else(|| anyhow!("expected a coin metadata"))?;
 
     ensure!(
-        minted_coin.decimals == expected_package_data.module().decimals,
+        coin_metadata.decimals == expected_package_data.module().decimals,
         "coin decimals mismatch: expected {}, found {}",
         expected_package_data.module().decimals,
-        minted_coin.decimals
+        coin_metadata.decimals
     );
     ensure!(
-        minted_coin.name == expected_package_data.module().coin_name,
+        coin_metadata.name == expected_package_data.module().coin_name,
         "coin name mismatch: expected {}, found {}",
         expected_package_data.module().coin_name,
-        minted_coin.name
+        coin_metadata.name
     );
     ensure!(
-        minted_coin.symbol == expected_package_data.module().symbol,
+        coin_metadata.symbol == expected_package_data.module().symbol,
         "coin symbol mismatch: expected {}, found {}",
         expected_package_data.module().symbol,
-        minted_coin.symbol
+        coin_metadata.symbol
     );
     ensure!(
-        minted_coin.description == expected_package_data.module().coin_description,
+        coin_metadata.description == expected_package_data.module().coin_description,
         "coin description mismatch: expected {}, found {}",
         expected_package_data.module().coin_description,
-        minted_coin.description
+        coin_metadata.description
     );
     ensure!(
-        minted_coin.icon_url
+        coin_metadata.icon_url
             == expected_package_data
                 .module()
                 .icon_url
@@ -196,7 +196,7 @@ pub(super) fn verify_foundry_output(
                 .map(|u| u.to_string()),
         "coin icon url mismatch: expected {:?}, found {:?}",
         expected_package_data.module().icon_url,
-        minted_coin.icon_url
+        coin_metadata.icon_url
     );
 
     // Maximum Supply

--- a/crates/iota-genesis-builder/src/stardust/migration/verification/nft.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/nft.rs
@@ -149,16 +149,19 @@ pub(super) fn verify_nft_output(
 
     verify_parent(output.address(), storage)?;
 
-    ensure!(created_objects.coin().is_err(), "unexpected coin found");
+    ensure!(
+        created_objects.gas_coin().is_err(),
+        "unexpected gas coin found"
+    );
+
+    ensure!(
+        created_objects.native_token_coin().is_err(),
+        "unexpected native token coin found"
+    );
 
     ensure!(
         created_objects.coin_metadata().is_err(),
         "unexpected coin metadata found"
-    );
-
-    ensure!(
-        created_objects.minted_coin().is_err(),
-        "unexpected minted coin found"
     );
 
     ensure!(


### PR DESCRIPTION
# Description of change

The `coin` field in `CreatedObjects` is and should only be used to reflect gas coins. This PR renames this field to `gas_coin` to make this more clear. Furthermore, we rename `minted_coin` to `native_token_coin` which reflects the native token coin minted by the foundry.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/503

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo test` in `iota-genesis-builder`

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
