### PR TITLE
feat(iota-genesis-builder): get balance of gas-coin like objects

### DIFF
--- a/crates/iota-genesis-builder/src/stardust/types/coin_kind.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/coin_kind.rs
@@ -1,0 +1,194 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Coin kinds introduced with the stardust models.
+//!
+//! We define as coin kinds objects that hold some kind of `Balance`
+//! and comply with the `Coin` type layout:
+//!
+//! ```rust
+//! struct T {
+//!     id: UID,
+//!     balance: Balance,
+//!     ....
+//! }
+//! ```
+
+use std::mem::size_of;
+
+use iota_types::{
+    balance::Balance,
+    gas_coin::GAS,
+    object::{Object, ID_END_INDEX},
+    timelock::timelock::TimeLock,
+};
+
+use crate::stardust::types::{output::BasicOutput, AliasOutput, NftOutput};
+
+/// Infer whether the object is a kind of gas coin.
+pub fn is_gas_coin_kind(object: &Object) -> bool {
+    let Some(struct_tag) = object.struct_tag() else {
+        return false;
+    };
+    struct_tag == AliasOutput::tag()
+        || struct_tag == BasicOutput::type_()
+        || struct_tag == NftOutput::tag()
+        || struct_tag == TimeLock::<Balance>::type_(Balance::type_(GAS::type_tag()).into())
+        || object.is_gas_coin()
+}
+
+/// Return the `Balance` of a gas-coin kind.
+///
+/// Useful to avoid deserialization of the entire object.
+pub fn get_gas_balance_maybe(object: &Object) -> Option<Balance> {
+    if !is_gas_coin_kind(object) {
+        return None;
+    }
+    let Some(inner) = object.data.try_as_move() else {
+        return None;
+    };
+    bcs::from_bytes(&inner.contents()[ID_END_INDEX..][..size_of::<Balance>()]).ok()
+}
+
+#[cfg(test)]
+mod tests {
+
+    use iota_protocol_config::ProtocolConfig;
+    use iota_types::{
+        base_types::{IotaAddress, ObjectID, TxContext},
+        id::UID,
+        object::Owner,
+    };
+
+    use super::*;
+    use crate::stardust::types::timelock::to_genesis_object;
+
+    fn nft_output(balance: u64) -> anyhow::Result<Object> {
+        let id = UID::new(ObjectID::random());
+        let iota = Balance::new(balance);
+        let output = NftOutput {
+            id,
+            iota,
+            native_tokens: Default::default(),
+            storage_deposit_return: Default::default(),
+            timelock: Default::default(),
+            expiration: Default::default(),
+        };
+        Ok(output.to_genesis_object(
+            IotaAddress::ZERO,
+            &ProtocolConfig::get_for_min_version(),
+            &TxContext::random_for_testing_only(),
+            1.into(),
+        )?)
+    }
+
+    #[test]
+    fn is_coin_kind_nft_output() {
+        let object = nft_output(100).unwrap();
+        assert!(is_gas_coin_kind(&object));
+    }
+
+    #[test]
+    fn get_gas_balance_nft_output() {
+        let value = 100;
+        let object = nft_output(value).unwrap();
+        let gas_coin_balance = get_gas_balance_maybe(&object).unwrap();
+        assert_eq!(gas_coin_balance.value(), value);
+    }
+
+    fn alias_output(balance: u64) -> anyhow::Result<Object> {
+        let id = UID::new(ObjectID::random());
+        let iota = Balance::new(balance);
+        let output = AliasOutput {
+            id,
+            iota,
+            native_tokens: Default::default(),
+        };
+        Ok(output.to_genesis_object(
+            Owner::AddressOwner(IotaAddress::ZERO),
+            &ProtocolConfig::get_for_min_version(),
+            &TxContext::random_for_testing_only(),
+            1.into(),
+        )?)
+    }
+
+    #[test]
+    fn is_coin_kind_alias_output() {
+        let object = alias_output(100).unwrap();
+        assert!(is_gas_coin_kind(&object));
+    }
+
+    #[test]
+    fn get_gas_balance_alias_output() {
+        let value = 100;
+        let object = alias_output(value).unwrap();
+        let gas_coin_balance = get_gas_balance_maybe(&object).unwrap();
+        assert_eq!(gas_coin_balance.value(), value);
+    }
+
+    fn basic_output(balance: u64) -> anyhow::Result<Object> {
+        let id = UID::new(ObjectID::random());
+        let iota = Balance::new(balance);
+        let output = BasicOutput {
+            id,
+            iota,
+            native_tokens: Default::default(),
+            storage_deposit_return: Default::default(),
+            timelock: Default::default(),
+            expiration: Default::default(),
+            metadata: Default::default(),
+            tag: Default::default(),
+            sender: Default::default(),
+        };
+        Ok(output.to_genesis_object(
+            IotaAddress::ZERO,
+            &ProtocolConfig::get_for_min_version(),
+            &TxContext::random_for_testing_only(),
+            1.into(),
+        )?)
+    }
+
+    #[test]
+    fn is_coin_kind_basic_output() {
+        let object = basic_output(100).unwrap();
+        assert!(is_gas_coin_kind(&object));
+    }
+
+    #[test]
+    fn get_gas_balance_basic_output() {
+        let value = 100;
+        let object = basic_output(value).unwrap();
+        let gas_coin_balance = get_gas_balance_maybe(&object).unwrap();
+        assert_eq!(gas_coin_balance.value(), value);
+    }
+
+    fn timelock(balance: u64) -> anyhow::Result<Object> {
+        let id = UID::new(ObjectID::random());
+        let balance = Balance::new(balance);
+        let expiration_timestamp_ms = 10;
+        let label = None;
+
+        let timelock = TimeLock::new(id, balance, expiration_timestamp_ms, label);
+        Ok(to_genesis_object(
+            timelock,
+            IotaAddress::ZERO,
+            &ProtocolConfig::get_for_min_version(),
+            &TxContext::random_for_testing_only(),
+            1.into(),
+        )?)
+    }
+
+    #[test]
+    fn is_coin_kind_timelock() {
+        let object = timelock(100).unwrap();
+        assert!(is_gas_coin_kind(&object));
+    }
+
+    #[test]
+    fn get_gas_balance_timelock() {
+        let value = 100;
+        let object = timelock(value).unwrap();
+        let gas_coin_balance = get_gas_balance_maybe(&object).unwrap();
+        assert_eq!(gas_coin_balance.value(), value);
+    }
+}

--- a/crates/iota-genesis-builder/src/stardust/types/mod.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/mod.rs
@@ -4,6 +4,7 @@
 pub mod address;
 pub mod alias;
 pub mod capped_coin;
+pub mod coin_kind;
 pub mod foundry;
 pub mod nft;
 pub mod output;


### PR DESCRIPTION
# Description of change

Exposes functions that enable filtering the gas-coin like stardust objects, and getting their balance without the need for deserialization of the entire object

## Links to any relevant issues

Resolves #605 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo test -p iota-genesis-builder -j2 coin_kind`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
