### PR TITLE
feat(iota-framework/stardust): make stardust models are generic

### DIFF
--- a/crates/iota-framework/docs/stardust/address_unlock_condition.md
+++ b/crates/iota-framework/docs/stardust/address_unlock_condition.md
@@ -32,7 +32,7 @@ title: Module `0x107a::address_unlock_condition`
 Unlock a <code>BasicOutput</code> locked to the alias address.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_basic">unlock_alias_address_owned_basic</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_Alias">alias::Alias</a>, output_to_unlock: <a href="../iota-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="basic_output.md#0x107a_basic_output_BasicOutput">basic_output::BasicOutput</a>&gt;): <a href="basic_output.md#0x107a_basic_output_BasicOutput">basic_output::BasicOutput</a>
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_basic">unlock_alias_address_owned_basic</a>&lt;T&gt;(self: &<b>mut</b> <a href="alias.md#0x107a_alias_Alias">alias::Alias</a>, output_to_unlock: <a href="../iota-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="basic_output.md#0x107a_basic_output_BasicOutput">basic_output::BasicOutput</a>&lt;T&gt;&gt;): <a href="basic_output.md#0x107a_basic_output_BasicOutput">basic_output::BasicOutput</a>&lt;T&gt;
 </code></pre>
 
 
@@ -41,10 +41,10 @@ Unlock a <code>BasicOutput</code> locked to the alias address.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_basic">unlock_alias_address_owned_basic</a>(
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_basic">unlock_alias_address_owned_basic</a>&lt;T&gt;(
   self: &<b>mut</b> Alias,
-  output_to_unlock: Receiving&lt;BasicOutput&gt;
-): BasicOutput {
+  output_to_unlock: Receiving&lt;BasicOutput&lt;T&gt;&gt;
+): BasicOutput&lt;T&gt; {
     <a href="basic_output.md#0x107a_basic_output_receive">basic_output::receive</a>(self.id(), output_to_unlock)
 }
 </code></pre>
@@ -60,7 +60,7 @@ Unlock a <code>BasicOutput</code> locked to the alias address.
 Unlock an <code>NftOutput</code> locked to the alias address.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_nft">unlock_alias_address_owned_nft</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_Alias">alias::Alias</a>, output_to_unlock: <a href="../iota-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>&gt;): <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_nft">unlock_alias_address_owned_nft</a>&lt;T&gt;(self: &<b>mut</b> <a href="alias.md#0x107a_alias_Alias">alias::Alias</a>, output_to_unlock: <a href="../iota-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>&lt;T&gt;&gt;): <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>&lt;T&gt;
 </code></pre>
 
 
@@ -69,10 +69,10 @@ Unlock an <code>NftOutput</code> locked to the alias address.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_nft">unlock_alias_address_owned_nft</a>(
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_nft">unlock_alias_address_owned_nft</a>&lt;T&gt;(
   self: &<b>mut</b> Alias,
-  output_to_unlock: Receiving&lt;NftOutput&gt;,
-): NftOutput {
+  output_to_unlock: Receiving&lt;NftOutput&lt;T&gt;&gt;,
+): NftOutput&lt;T&gt; {
     <a href="nft_output.md#0x107a_nft_output_receive">nft_output::receive</a>(self.id(), output_to_unlock)
 }
 </code></pre>
@@ -88,7 +88,7 @@ Unlock an <code>NftOutput</code> locked to the alias address.
 Unlock an <code>AliasOutput</code> locked to the alias address.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_alias">unlock_alias_address_owned_alias</a>(self: &<b>mut</b> <a href="alias.md#0x107a_alias_Alias">alias::Alias</a>, output_to_unlock: <a href="../iota-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>&gt;): <a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_alias">unlock_alias_address_owned_alias</a>&lt;T&gt;(self: &<b>mut</b> <a href="alias.md#0x107a_alias_Alias">alias::Alias</a>, output_to_unlock: <a href="../iota-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>&lt;T&gt;&gt;): <a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>&lt;T&gt;
 </code></pre>
 
 
@@ -97,10 +97,10 @@ Unlock an <code>AliasOutput</code> locked to the alias address.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_alias">unlock_alias_address_owned_alias</a>(
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_alias_address_owned_alias">unlock_alias_address_owned_alias</a>&lt;T&gt;(
   self: &<b>mut</b> Alias,
-  output_to_unlock: Receiving&lt;AliasOutput&gt;,
-): AliasOutput {
+  output_to_unlock: Receiving&lt;AliasOutput&lt;T&gt;&gt;,
+): AliasOutput&lt;T&gt; {
     <a href="alias_output.md#0x107a_alias_output_receive">alias_output::receive</a>(self.id(), output_to_unlock)
 }
 </code></pre>
@@ -144,7 +144,7 @@ Unlock a <code>TreasuryCap</code> locked to the alias address.
 Unlock a <code>BasicOutput</code> locked to the <code>Nft</code> address.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_basic">unlock_nft_address_owned_basic</a>(self: &<b>mut</b> <a href="nft.md#0x107a_nft_Nft">nft::Nft</a>, output_to_unlock: <a href="../iota-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="basic_output.md#0x107a_basic_output_BasicOutput">basic_output::BasicOutput</a>&gt;): <a href="basic_output.md#0x107a_basic_output_BasicOutput">basic_output::BasicOutput</a>
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_basic">unlock_nft_address_owned_basic</a>&lt;T&gt;(self: &<b>mut</b> <a href="nft.md#0x107a_nft_Nft">nft::Nft</a>, output_to_unlock: <a href="../iota-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="basic_output.md#0x107a_basic_output_BasicOutput">basic_output::BasicOutput</a>&lt;T&gt;&gt;): <a href="basic_output.md#0x107a_basic_output_BasicOutput">basic_output::BasicOutput</a>&lt;T&gt;
 </code></pre>
 
 
@@ -153,10 +153,10 @@ Unlock a <code>BasicOutput</code> locked to the <code>Nft</code> address.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_basic">unlock_nft_address_owned_basic</a>(
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_basic">unlock_nft_address_owned_basic</a>&lt;T&gt;(
   self: &<b>mut</b> Nft,
-  output_to_unlock: Receiving&lt;BasicOutput&gt;,
-): BasicOutput {
+  output_to_unlock: Receiving&lt;BasicOutput&lt;T&gt;&gt;,
+): BasicOutput&lt;T&gt; {
     <a href="basic_output.md#0x107a_basic_output_receive">basic_output::receive</a>(self.id(), output_to_unlock)
 }
 </code></pre>
@@ -172,7 +172,7 @@ Unlock a <code>BasicOutput</code> locked to the <code>Nft</code> address.
 Unlock an <code>NftOutput</code> locked to the <code>Nft</code> address.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_nft">unlock_nft_address_owned_nft</a>(self: &<b>mut</b> <a href="nft.md#0x107a_nft_Nft">nft::Nft</a>, output_to_unlock: <a href="../iota-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>&gt;): <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_nft">unlock_nft_address_owned_nft</a>&lt;T&gt;(self: &<b>mut</b> <a href="nft.md#0x107a_nft_Nft">nft::Nft</a>, output_to_unlock: <a href="../iota-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>&lt;T&gt;&gt;): <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>&lt;T&gt;
 </code></pre>
 
 
@@ -181,10 +181,10 @@ Unlock an <code>NftOutput</code> locked to the <code>Nft</code> address.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_nft">unlock_nft_address_owned_nft</a>(
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_nft">unlock_nft_address_owned_nft</a>&lt;T&gt;(
   self: &<b>mut</b> Nft,
-  output_to_unlock: Receiving&lt;NftOutput&gt;,
-): NftOutput {
+  output_to_unlock: Receiving&lt;NftOutput&lt;T&gt;&gt;,
+): NftOutput&lt;T&gt; {
     <a href="nft_output.md#0x107a_nft_output_receive">nft_output::receive</a>(self.id(), output_to_unlock)
 }
 </code></pre>
@@ -200,7 +200,7 @@ Unlock an <code>NftOutput</code> locked to the <code>Nft</code> address.
 Unlock an <code>AliasOutput</code> locked to the <code>Nft</code> address.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_alias">unlock_nft_address_owned_alias</a>(self: &<b>mut</b> <a href="nft.md#0x107a_nft_Nft">nft::Nft</a>, output_to_unlock: <a href="../iota-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>&gt;): <a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_alias">unlock_nft_address_owned_alias</a>&lt;T&gt;(self: &<b>mut</b> <a href="nft.md#0x107a_nft_Nft">nft::Nft</a>, output_to_unlock: <a href="../iota-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>&lt;T&gt;&gt;): <a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>&lt;T&gt;
 </code></pre>
 
 
@@ -209,10 +209,10 @@ Unlock an <code>AliasOutput</code> locked to the <code>Nft</code> address.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_alias">unlock_nft_address_owned_alias</a>(
+<pre><code><b>public</b> <b>fun</b> <a href="address_unlock_condition.md#0x107a_address_unlock_condition_unlock_nft_address_owned_alias">unlock_nft_address_owned_alias</a>&lt;T&gt;(
   self: &<b>mut</b> Nft,
-  output_to_unlock: Receiving&lt;AliasOutput&gt;,
-): AliasOutput {
+  output_to_unlock: Receiving&lt;AliasOutput&lt;T&gt;&gt;,
+): AliasOutput&lt;T&gt; {
     <a href="alias_output.md#0x107a_alias_output_receive">alias_output::receive</a>(self.id(), output_to_unlock)
 }
 </code></pre>

--- a/crates/iota-framework/docs/stardust/alias_output.md
+++ b/crates/iota-framework/docs/stardust/alias_output.md
@@ -49,7 +49,7 @@ Owned Object controlled by the Governor Address.
 <code><a href="../iota-framework/balance.md#0x2_balance">balance</a>: <a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;</code>
 </dt>
 <dd>
- The amount of IOTA coins held by the output.
+ The amount of coins held by the output.
 </dd>
 <dt>
 <code>native_tokens: <a href="../iota-framework/bag.md#0x2_bag_Bag">bag::Bag</a></code>
@@ -83,7 +83,7 @@ The Alias dynamic object field name.
 ## Function `extract_assets`
 
 The function extracts assets from a legacy <code><a href="alias_output.md#0x107a_alias_output_AliasOutput">AliasOutput</a></code>.
-- returns the IOTA Balance,
+- returns the coin Balance,
 - the native tokens Bag,
 - and the <code>Alias</code> object that persists the AliasID=ObjectID from Stardust.
 
@@ -102,7 +102,7 @@ The function extracts assets from a legacy <code><a href="alias_output.md#0x107a
     <b>let</b> <a href="alias.md#0x107a_alias">alias</a> = <a href="alias_output.md#0x107a_alias_output_load_alias">load_alias</a>(&<b>mut</b> output);
 
     // Unpack the output into its basic part.
-    <b>let</b> <a href="alias_output.md#0x107a_alias_output_AliasOutput">AliasOutput</a>&lt;T&gt; {
+    <b>let</b> <a href="alias_output.md#0x107a_alias_output_AliasOutput">AliasOutput</a> {
         id,
         <a href="../iota-framework/balance.md#0x2_balance">balance</a>,
         native_tokens

--- a/crates/iota-framework/docs/stardust/alias_output.md
+++ b/crates/iota-framework/docs/stardust/alias_output.md
@@ -16,7 +16,6 @@ title: Module `0x107a::alias_output`
 <b>use</b> <a href="../iota-framework/bag.md#0x2_bag">0x2::bag</a>;
 <b>use</b> <a href="../iota-framework/balance.md#0x2_balance">0x2::balance</a>;
 <b>use</b> <a href="../iota-framework/dynamic_object_field.md#0x2_dynamic_object_field">0x2::dynamic_object_field</a>;
-<b>use</b> <a href="../iota-framework/iota.md#0x2_iota">0x2::iota</a>;
 <b>use</b> <a href="../iota-framework/object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="../iota-framework/transfer.md#0x2_transfer">0x2::transfer</a>;
 </code></pre>
@@ -30,7 +29,7 @@ title: Module `0x107a::alias_output`
 Owned Object controlled by the Governor Address.
 
 
-<pre><code><b>struct</b> <a href="alias_output.md#0x107a_alias_output_AliasOutput">AliasOutput</a> <b>has</b> key
+<pre><code><b>struct</b> <a href="alias_output.md#0x107a_alias_output_AliasOutput">AliasOutput</a>&lt;T&gt; <b>has</b> key
 </code></pre>
 
 
@@ -47,7 +46,7 @@ Owned Object controlled by the Governor Address.
  This is a "random" UID, not the AliasID from Stardust.
 </dd>
 <dt>
-<code><a href="../iota-framework/iota.md#0x2_iota">iota</a>: <a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../iota-framework/iota.md#0x2_iota_IOTA">iota::IOTA</a>&gt;</code>
+<code><a href="../iota-framework/balance.md#0x2_balance">balance</a>: <a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;</code>
 </dt>
 <dd>
  The amount of IOTA coins held by the output.
@@ -89,7 +88,7 @@ The function extracts assets from a legacy <code><a href="alias_output.md#0x107a
 - and the <code>Alias</code> object that persists the AliasID=ObjectID from Stardust.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="alias_output.md#0x107a_alias_output_extract_assets">extract_assets</a>(output: <a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>): (<a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../iota-framework/iota.md#0x2_iota_IOTA">iota::IOTA</a>&gt;, <a href="../iota-framework/bag.md#0x2_bag_Bag">bag::Bag</a>, <a href="alias.md#0x107a_alias_Alias">alias::Alias</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="alias_output.md#0x107a_alias_output_extract_assets">extract_assets</a>&lt;T&gt;(output: <a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>&lt;T&gt;): (<a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, <a href="../iota-framework/bag.md#0x2_bag_Bag">bag::Bag</a>, <a href="alias.md#0x107a_alias_Alias">alias::Alias</a>)
 </code></pre>
 
 
@@ -98,21 +97,21 @@ The function extracts assets from a legacy <code><a href="alias_output.md#0x107a
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="alias_output.md#0x107a_alias_output_extract_assets">extract_assets</a>(<b>mut</b> output: <a href="alias_output.md#0x107a_alias_output_AliasOutput">AliasOutput</a>): (Balance&lt;IOTA&gt;, Bag, Alias) {
+<pre><code><b>public</b> <b>fun</b> <a href="alias_output.md#0x107a_alias_output_extract_assets">extract_assets</a>&lt;T&gt;(<b>mut</b> output: <a href="alias_output.md#0x107a_alias_output_AliasOutput">AliasOutput</a>&lt;T&gt;): (Balance&lt;T&gt;, Bag, Alias) {
     // Load the related <a href="alias.md#0x107a_alias">alias</a> <a href="../iota-framework/object.md#0x2_object">object</a>.
     <b>let</b> <a href="alias.md#0x107a_alias">alias</a> = <a href="alias_output.md#0x107a_alias_output_load_alias">load_alias</a>(&<b>mut</b> output);
 
     // Unpack the output into its basic part.
-    <b>let</b> <a href="alias_output.md#0x107a_alias_output_AliasOutput">AliasOutput</a> {
+    <b>let</b> <a href="alias_output.md#0x107a_alias_output_AliasOutput">AliasOutput</a>&lt;T&gt; {
         id,
-        <a href="../iota-framework/iota.md#0x2_iota">iota</a>,
+        <a href="../iota-framework/balance.md#0x2_balance">balance</a>,
         native_tokens
     } = output;
 
     // Delete the output.
     <a href="../iota-framework/object.md#0x2_object_delete">object::delete</a>(id);
 
-    (<a href="../iota-framework/iota.md#0x2_iota">iota</a>, native_tokens, <a href="alias.md#0x107a_alias">alias</a>)
+    (<a href="../iota-framework/balance.md#0x2_balance">balance</a>, native_tokens, <a href="alias.md#0x107a_alias">alias</a>)
 }
 </code></pre>
 
@@ -128,7 +127,7 @@ Utility function to receive an <code><a href="alias_output.md#0x107a_alias_outpu
 Other modules in the Stardust package can call this function to receive an <code><a href="alias_output.md#0x107a_alias_output_AliasOutput">AliasOutput</a></code> object (nft).
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="alias_output.md#0x107a_alias_output_receive">receive</a>(parent: &<b>mut</b> <a href="../iota-framework/object.md#0x2_object_UID">object::UID</a>, output: <a href="../iota-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>&gt;): <a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="alias_output.md#0x107a_alias_output_receive">receive</a>&lt;T&gt;(parent: &<b>mut</b> <a href="../iota-framework/object.md#0x2_object_UID">object::UID</a>, output: <a href="../iota-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>&lt;T&gt;&gt;): <a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>&lt;T&gt;
 </code></pre>
 
 
@@ -137,7 +136,7 @@ Other modules in the Stardust package can call this function to receive an <code
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../iota-framework/package.md#0x2_package">package</a>) <b>fun</b> <a href="alias_output.md#0x107a_alias_output_receive">receive</a>(parent: &<b>mut</b> UID, output: Receiving&lt;<a href="alias_output.md#0x107a_alias_output_AliasOutput">AliasOutput</a>&gt;) : <a href="alias_output.md#0x107a_alias_output_AliasOutput">AliasOutput</a> {
+<pre><code><b>public</b>(<a href="../iota-framework/package.md#0x2_package">package</a>) <b>fun</b> <a href="alias_output.md#0x107a_alias_output_receive">receive</a>&lt;T&gt;(parent: &<b>mut</b> UID, output: Receiving&lt;<a href="alias_output.md#0x107a_alias_output_AliasOutput">AliasOutput</a>&lt;T&gt;&gt;) : <a href="alias_output.md#0x107a_alias_output_AliasOutput">AliasOutput</a>&lt;T&gt; {
     <a href="../iota-framework/transfer.md#0x2_transfer_receive">transfer::receive</a>(parent, output)
 }
 </code></pre>
@@ -153,7 +152,7 @@ Other modules in the Stardust package can call this function to receive an <code
 Utility function to attach an <code>Alias</code> to an <code><a href="alias_output.md#0x107a_alias_output_AliasOutput">AliasOutput</a></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="alias_output.md#0x107a_alias_output_attach_alias">attach_alias</a>(output: &<b>mut</b> <a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>, <a href="alias.md#0x107a_alias">alias</a>: <a href="alias.md#0x107a_alias_Alias">alias::Alias</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="alias_output.md#0x107a_alias_output_attach_alias">attach_alias</a>&lt;T&gt;(output: &<b>mut</b> <a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>&lt;T&gt;, <a href="alias.md#0x107a_alias">alias</a>: <a href="alias.md#0x107a_alias_Alias">alias::Alias</a>)
 </code></pre>
 
 
@@ -162,7 +161,7 @@ Utility function to attach an <code>Alias</code> to an <code><a href="alias_outp
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="alias_output.md#0x107a_alias_output_attach_alias">attach_alias</a>(output: &<b>mut</b> <a href="alias_output.md#0x107a_alias_output_AliasOutput">AliasOutput</a>, <a href="alias.md#0x107a_alias">alias</a>: Alias) {
+<pre><code><b>public</b> <b>fun</b> <a href="alias_output.md#0x107a_alias_output_attach_alias">attach_alias</a>&lt;T&gt;(output: &<b>mut</b> <a href="alias_output.md#0x107a_alias_output_AliasOutput">AliasOutput</a>&lt;T&gt;, <a href="alias.md#0x107a_alias">alias</a>: Alias) {
     <a href="../iota-framework/dynamic_object_field.md#0x2_dynamic_object_field_add">dynamic_object_field::add</a>(&<b>mut</b> output.id, <a href="alias_output.md#0x107a_alias_output_ALIAS_NAME">ALIAS_NAME</a>, <a href="alias.md#0x107a_alias">alias</a>)
 }
 </code></pre>
@@ -178,7 +177,7 @@ Utility function to attach an <code>Alias</code> to an <code><a href="alias_outp
 Loads the <code>Alias</code> object from the dynamic object field.
 
 
-<pre><code><b>fun</b> <a href="alias_output.md#0x107a_alias_output_load_alias">load_alias</a>(output: &<b>mut</b> <a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>): <a href="alias.md#0x107a_alias_Alias">alias::Alias</a>
+<pre><code><b>fun</b> <a href="alias_output.md#0x107a_alias_output_load_alias">load_alias</a>&lt;T&gt;(output: &<b>mut</b> <a href="alias_output.md#0x107a_alias_output_AliasOutput">alias_output::AliasOutput</a>&lt;T&gt;): <a href="alias.md#0x107a_alias_Alias">alias::Alias</a>
 </code></pre>
 
 
@@ -187,7 +186,7 @@ Loads the <code>Alias</code> object from the dynamic object field.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="alias_output.md#0x107a_alias_output_load_alias">load_alias</a>(output: &<b>mut</b> <a href="alias_output.md#0x107a_alias_output_AliasOutput">AliasOutput</a>): Alias {
+<pre><code><b>fun</b> <a href="alias_output.md#0x107a_alias_output_load_alias">load_alias</a>&lt;T&gt;(output: &<b>mut</b> <a href="alias_output.md#0x107a_alias_output_AliasOutput">AliasOutput</a>&lt;T&gt;): Alias {
     <a href="../iota-framework/dynamic_object_field.md#0x2_dynamic_object_field_remove">dynamic_object_field::remove</a>(&<b>mut</b> output.id, <a href="alias_output.md#0x107a_alias_output_ALIAS_NAME">ALIAS_NAME</a>)
 }
 </code></pre>

--- a/crates/iota-framework/docs/stardust/basic_output.md
+++ b/crates/iota-framework/docs/stardust/basic_output.md
@@ -15,7 +15,6 @@ title: Module `0x107a::basic_output`
 <b>use</b> <a href="../move-stdlib/option.md#0x1_option">0x1::option</a>;
 <b>use</b> <a href="../iota-framework/bag.md#0x2_bag">0x2::bag</a>;
 <b>use</b> <a href="../iota-framework/balance.md#0x2_balance">0x2::balance</a>;
-<b>use</b> <a href="../iota-framework/iota.md#0x2_iota">0x2::iota</a>;
 <b>use</b> <a href="../iota-framework/object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="../iota-framework/transfer.md#0x2_transfer">0x2::transfer</a>;
 <b>use</b> <a href="../iota-framework/tx_context.md#0x2_tx_context">0x2::tx_context</a>;
@@ -35,7 +34,7 @@ way to handle the two possible addresses that can unlock the output.
 -  or you can call <code>receive</code> in other models to receive a <code><a href="basic_output.md#0x107a_basic_output_BasicOutput">BasicOutput</a></code>.
 
 
-<pre><code><b>struct</b> <a href="basic_output.md#0x107a_basic_output_BasicOutput">BasicOutput</a> <b>has</b> key
+<pre><code><b>struct</b> <a href="basic_output.md#0x107a_basic_output_BasicOutput">BasicOutput</a>&lt;T&gt; <b>has</b> key
 </code></pre>
 
 
@@ -52,7 +51,7 @@ way to handle the two possible addresses that can unlock the output.
  Hash of the <code>outputId</code> that was migrated.
 </dd>
 <dt>
-<code><a href="../iota-framework/iota.md#0x2_iota">iota</a>: <a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../iota-framework/iota.md#0x2_iota_IOTA">iota::IOTA</a>&gt;</code>
+<code><a href="../iota-framework/balance.md#0x2_balance">balance</a>: <a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;</code>
 </dt>
 <dd>
  The amount of IOTA coins held by the output.
@@ -115,7 +114,7 @@ Extract the assets stored inside the output, respecting the unlock conditions.
 - Remaining assets (IOTA coins and native tokens) will be returned.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="basic_output.md#0x107a_basic_output_extract_assets">extract_assets</a>(output: <a href="basic_output.md#0x107a_basic_output_BasicOutput">basic_output::BasicOutput</a>, ctx: &<b>mut</b> <a href="../iota-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): (<a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../iota-framework/iota.md#0x2_iota_IOTA">iota::IOTA</a>&gt;, <a href="../iota-framework/bag.md#0x2_bag_Bag">bag::Bag</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="basic_output.md#0x107a_basic_output_extract_assets">extract_assets</a>&lt;T&gt;(output: <a href="basic_output.md#0x107a_basic_output_BasicOutput">basic_output::BasicOutput</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="../iota-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): (<a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, <a href="../iota-framework/bag.md#0x2_bag_Bag">bag::Bag</a>)
 </code></pre>
 
 
@@ -124,11 +123,11 @@ Extract the assets stored inside the output, respecting the unlock conditions.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="basic_output.md#0x107a_basic_output_extract_assets">extract_assets</a>(output: <a href="basic_output.md#0x107a_basic_output_BasicOutput">BasicOutput</a>, ctx: &<b>mut</b> TxContext) : (Balance&lt;IOTA&gt;, Bag) {
+<pre><code><b>public</b> <b>fun</b> <a href="basic_output.md#0x107a_basic_output_extract_assets">extract_assets</a>&lt;T&gt;(output: <a href="basic_output.md#0x107a_basic_output_BasicOutput">BasicOutput</a>&lt;T&gt;, ctx: &<b>mut</b> TxContext) : (Balance&lt;T&gt;, Bag) {
     // Unpack the output into its basic part.
     <b>let</b> <a href="basic_output.md#0x107a_basic_output_BasicOutput">BasicOutput</a> {
         id,
-        <a href="../iota-framework/iota.md#0x2_iota">iota</a>: <b>mut</b> <a href="../iota-framework/iota.md#0x2_iota">iota</a>,
+        <a href="../iota-framework/balance.md#0x2_balance">balance</a>: <b>mut</b> <a href="../iota-framework/balance.md#0x2_balance">balance</a>,
         native_tokens,
         storage_deposit_return_uc: <b>mut</b> storage_deposit_return_uc,
         timelock_uc: <b>mut</b> timelock_uc,
@@ -150,7 +149,7 @@ Extract the assets stored inside the output, respecting the unlock conditions.
 
     // If the output <b>has</b> an storage deposit <b>return</b> unlock condition, then we need <b>to</b> <b>return</b> the deposit.
     <b>if</b> (storage_deposit_return_uc.is_some()) {
-        storage_deposit_return_uc.extract().unlock(&<b>mut</b> <a href="../iota-framework/iota.md#0x2_iota">iota</a>, ctx);
+        storage_deposit_return_uc.extract().unlock(&<b>mut</b> <a href="../iota-framework/balance.md#0x2_balance">balance</a>, ctx);
     };
 
     // Destroy the unlock conditions.
@@ -161,7 +160,7 @@ Extract the assets stored inside the output, respecting the unlock conditions.
     // Delete the output.
     <a href="../iota-framework/object.md#0x2_object_delete">object::delete</a>(id);
 
-    <b>return</b> (<a href="../iota-framework/iota.md#0x2_iota">iota</a>, native_tokens)
+    <b>return</b> (<a href="../iota-framework/balance.md#0x2_balance">balance</a>, native_tokens)
 }
 </code></pre>
 
@@ -179,7 +178,7 @@ The private receiver must be implemented in its defining module (here).
 Other modules in the Stardust package can call this function to receive a basic output (alias, NFT).
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="basic_output.md#0x107a_basic_output_receive">receive</a>(parent: &<b>mut</b> <a href="../iota-framework/object.md#0x2_object_UID">object::UID</a>, output: <a href="../iota-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="basic_output.md#0x107a_basic_output_BasicOutput">basic_output::BasicOutput</a>&gt;): <a href="basic_output.md#0x107a_basic_output_BasicOutput">basic_output::BasicOutput</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="basic_output.md#0x107a_basic_output_receive">receive</a>&lt;T&gt;(parent: &<b>mut</b> <a href="../iota-framework/object.md#0x2_object_UID">object::UID</a>, output: <a href="../iota-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="basic_output.md#0x107a_basic_output_BasicOutput">basic_output::BasicOutput</a>&lt;T&gt;&gt;): <a href="basic_output.md#0x107a_basic_output_BasicOutput">basic_output::BasicOutput</a>&lt;T&gt;
 </code></pre>
 
 
@@ -188,7 +187,7 @@ Other modules in the Stardust package can call this function to receive a basic 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../iota-framework/package.md#0x2_package">package</a>) <b>fun</b> <a href="basic_output.md#0x107a_basic_output_receive">receive</a>(parent: &<b>mut</b> UID, output: Receiving&lt;<a href="basic_output.md#0x107a_basic_output_BasicOutput">BasicOutput</a>&gt;) : <a href="basic_output.md#0x107a_basic_output_BasicOutput">BasicOutput</a> {
+<pre><code><b>public</b>(<a href="../iota-framework/package.md#0x2_package">package</a>) <b>fun</b> <a href="basic_output.md#0x107a_basic_output_receive">receive</a>&lt;T&gt;(parent: &<b>mut</b> UID, output: Receiving&lt;<a href="basic_output.md#0x107a_basic_output_BasicOutput">BasicOutput</a>&lt;T&gt;&gt;) : <a href="basic_output.md#0x107a_basic_output_BasicOutput">BasicOutput</a>&lt;T&gt; {
     <a href="../iota-framework/transfer.md#0x2_transfer_receive">transfer::receive</a>(parent, output)
 }
 </code></pre>

--- a/crates/iota-framework/docs/stardust/basic_output.md
+++ b/crates/iota-framework/docs/stardust/basic_output.md
@@ -54,7 +54,7 @@ way to handle the two possible addresses that can unlock the output.
 <code><a href="../iota-framework/balance.md#0x2_balance">balance</a>: <a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;</code>
 </dt>
 <dd>
- The amount of IOTA coins held by the output.
+ The amount of coins held by the output.
 </dd>
 <dt>
 <code>native_tokens: <a href="../iota-framework/bag.md#0x2_bag_Bag">bag::Bag</a></code>
@@ -111,7 +111,7 @@ way to handle the two possible addresses that can unlock the output.
 Extract the assets stored inside the output, respecting the unlock conditions.
 - The object will be deleted.
 - The <code>StorageDepositReturnUnlockCondition</code> will return the deposit.
-- Remaining assets (IOTA coins and native tokens) will be returned.
+- Remaining assets (coins and native tokens) will be returned.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="basic_output.md#0x107a_basic_output_extract_assets">extract_assets</a>&lt;T&gt;(output: <a href="basic_output.md#0x107a_basic_output_BasicOutput">basic_output::BasicOutput</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="../iota-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): (<a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, <a href="../iota-framework/bag.md#0x2_bag_Bag">bag::Bag</a>)

--- a/crates/iota-framework/docs/stardust/nft_output.md
+++ b/crates/iota-framework/docs/stardust/nft_output.md
@@ -20,7 +20,6 @@ title: Module `0x107a::nft_output`
 <b>use</b> <a href="../iota-framework/bag.md#0x2_bag">0x2::bag</a>;
 <b>use</b> <a href="../iota-framework/balance.md#0x2_balance">0x2::balance</a>;
 <b>use</b> <a href="../iota-framework/dynamic_object_field.md#0x2_dynamic_object_field">0x2::dynamic_object_field</a>;
-<b>use</b> <a href="../iota-framework/iota.md#0x2_iota">0x2::iota</a>;
 <b>use</b> <a href="../iota-framework/object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="../iota-framework/transfer.md#0x2_transfer">0x2::transfer</a>;
 <b>use</b> <a href="../iota-framework/tx_context.md#0x2_tx_context">0x2::tx_context</a>;
@@ -35,7 +34,7 @@ title: Module `0x107a::nft_output`
 The Stardust NFT output representation.
 
 
-<pre><code><b>struct</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">NftOutput</a> <b>has</b> key
+<pre><code><b>struct</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">NftOutput</a>&lt;T&gt; <b>has</b> key
 </code></pre>
 
 
@@ -52,10 +51,10 @@ The Stardust NFT output representation.
  This is a "random" UID, not the NFTID from Stardust.
 </dd>
 <dt>
-<code><a href="../iota-framework/iota.md#0x2_iota">iota</a>: <a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../iota-framework/iota.md#0x2_iota_IOTA">iota::IOTA</a>&gt;</code>
+<code><a href="../iota-framework/balance.md#0x2_balance">balance</a>: <a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;</code>
 </dt>
 <dd>
- The amount of IOTA tokens held by the output.
+ The amount of coin tokens held by the output.
 </dd>
 <dt>
 <code>native_tokens: <a href="../iota-framework/bag.md#0x2_bag_Bag">bag::Bag</a></code>
@@ -109,7 +108,7 @@ The NFT dynamic field name.
 The function extracts assets from a legacy NFT output.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="nft_output.md#0x107a_nft_output_extract_assets">extract_assets</a>(output: <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>, ctx: &<b>mut</b> <a href="../iota-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): (<a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../iota-framework/iota.md#0x2_iota_IOTA">iota::IOTA</a>&gt;, <a href="../iota-framework/bag.md#0x2_bag_Bag">bag::Bag</a>, <a href="nft.md#0x107a_nft_Nft">nft::Nft</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="nft_output.md#0x107a_nft_output_extract_assets">extract_assets</a>&lt;T&gt;(output: <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="../iota-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): (<a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, <a href="../iota-framework/bag.md#0x2_bag_Bag">bag::Bag</a>, <a href="nft.md#0x107a_nft_Nft">nft::Nft</a>)
 </code></pre>
 
 
@@ -118,14 +117,14 @@ The function extracts assets from a legacy NFT output.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="nft_output.md#0x107a_nft_output_extract_assets">extract_assets</a>(<b>mut</b> output: <a href="nft_output.md#0x107a_nft_output_NftOutput">NftOutput</a>, ctx: &<b>mut</b> TxContext): (Balance&lt;IOTA&gt;, Bag, Nft) {
+<pre><code><b>public</b> <b>fun</b> <a href="nft_output.md#0x107a_nft_output_extract_assets">extract_assets</a>&lt;T&gt;(<b>mut</b> output: <a href="nft_output.md#0x107a_nft_output_NftOutput">NftOutput</a>&lt;T&gt;, ctx: &<b>mut</b> TxContext): (Balance&lt;T&gt;, Bag, Nft) {
     // Load the related Nft <a href="../iota-framework/object.md#0x2_object">object</a>.
     <b>let</b> <a href="nft.md#0x107a_nft">nft</a> = <a href="nft_output.md#0x107a_nft_output_load_nft">load_nft</a>(&<b>mut</b> output);
 
     // Unpuck the output.
     <b>let</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">NftOutput</a> {
         id,
-        <a href="../iota-framework/iota.md#0x2_iota">iota</a>: <b>mut</b> <a href="../iota-framework/iota.md#0x2_iota">iota</a>,
+        <a href="../iota-framework/balance.md#0x2_balance">balance</a>: <b>mut</b> <a href="../iota-framework/balance.md#0x2_balance">balance</a>,
         native_tokens,
         storage_deposit_return_uc: <b>mut</b> storage_deposit_return_uc,
         timelock_uc: <b>mut</b> timelock_uc,
@@ -144,7 +143,7 @@ The function extracts assets from a legacy NFT output.
 
     // If the output <b>has</b> a storage deposit <b>return</b> unlock condition, then we need <b>to</b> <b>return</b> the deposit.
     <b>if</b> (storage_deposit_return_uc.is_some()) {
-        storage_deposit_return_uc.extract().unlock(&<b>mut</b> <a href="../iota-framework/iota.md#0x2_iota">iota</a>, ctx);
+        storage_deposit_return_uc.extract().unlock(&<b>mut</b> <a href="../iota-framework/balance.md#0x2_balance">balance</a>, ctx);
     };
 
     // Destroy the output.
@@ -154,7 +153,7 @@ The function extracts assets from a legacy NFT output.
 
     <a href="../iota-framework/object.md#0x2_object_delete">object::delete</a>(id);
 
-    <b>return</b> (<a href="../iota-framework/iota.md#0x2_iota">iota</a>, native_tokens, <a href="nft.md#0x107a_nft">nft</a>)
+    <b>return</b> (<a href="../iota-framework/balance.md#0x2_balance">balance</a>, native_tokens, <a href="nft.md#0x107a_nft">nft</a>)
 }
 </code></pre>
 
@@ -169,7 +168,7 @@ The function extracts assets from a legacy NFT output.
 Loads the related <code>Nft</code> object.
 
 
-<pre><code><b>fun</b> <a href="nft_output.md#0x107a_nft_output_load_nft">load_nft</a>(output: &<b>mut</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>): <a href="nft.md#0x107a_nft_Nft">nft::Nft</a>
+<pre><code><b>fun</b> <a href="nft_output.md#0x107a_nft_output_load_nft">load_nft</a>&lt;T&gt;(output: &<b>mut</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>&lt;T&gt;): <a href="nft.md#0x107a_nft_Nft">nft::Nft</a>
 </code></pre>
 
 
@@ -178,7 +177,7 @@ Loads the related <code>Nft</code> object.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="nft_output.md#0x107a_nft_output_load_nft">load_nft</a>(output: &<b>mut</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">NftOutput</a>): Nft {
+<pre><code><b>fun</b> <a href="nft_output.md#0x107a_nft_output_load_nft">load_nft</a>&lt;T&gt;(output: &<b>mut</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">NftOutput</a>&lt;T&gt;): Nft {
     <a href="../iota-framework/dynamic_object_field.md#0x2_dynamic_object_field_remove">dynamic_object_field::remove</a>(&<b>mut</b> output.id, <a href="nft_output.md#0x107a_nft_output_NFT_NAME">NFT_NAME</a>)
 }
 </code></pre>
@@ -194,7 +193,7 @@ Loads the related <code>Nft</code> object.
 Utility function to attach an <code>Alias</code> to an <code>AliasOutput</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="nft_output.md#0x107a_nft_output_attach_nft">attach_nft</a>(output: &<b>mut</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>, <a href="nft.md#0x107a_nft">nft</a>: <a href="nft.md#0x107a_nft_Nft">nft::Nft</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="nft_output.md#0x107a_nft_output_attach_nft">attach_nft</a>&lt;T&gt;(output: &<b>mut</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>&lt;T&gt;, <a href="nft.md#0x107a_nft">nft</a>: <a href="nft.md#0x107a_nft_Nft">nft::Nft</a>)
 </code></pre>
 
 
@@ -203,7 +202,7 @@ Utility function to attach an <code>Alias</code> to an <code>AliasOutput</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="nft_output.md#0x107a_nft_output_attach_nft">attach_nft</a>(output: &<b>mut</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">NftOutput</a>, <a href="nft.md#0x107a_nft">nft</a>: Nft) {
+<pre><code><b>public</b> <b>fun</b> <a href="nft_output.md#0x107a_nft_output_attach_nft">attach_nft</a>&lt;T&gt;(output: &<b>mut</b> <a href="nft_output.md#0x107a_nft_output_NftOutput">NftOutput</a>&lt;T&gt;, <a href="nft.md#0x107a_nft">nft</a>: Nft) {
     <a href="../iota-framework/dynamic_object_field.md#0x2_dynamic_object_field_add">dynamic_object_field::add</a>(&<b>mut</b> output.id, <a href="nft_output.md#0x107a_nft_output_NFT_NAME">NFT_NAME</a>, <a href="nft.md#0x107a_nft">nft</a>)
 }
 </code></pre>
@@ -220,7 +219,7 @@ Utility function to receive an <code><a href="nft_output.md#0x107a_nft_output_Nf
 Other modules in the stardust package can call this function to receive an <code><a href="nft_output.md#0x107a_nft_output_NftOutput">NftOutput</a></code> (alias).
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="nft_output.md#0x107a_nft_output_receive">receive</a>(parent: &<b>mut</b> <a href="../iota-framework/object.md#0x2_object_UID">object::UID</a>, <a href="nft.md#0x107a_nft">nft</a>: <a href="../iota-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>&gt;): <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="nft_output.md#0x107a_nft_output_receive">receive</a>&lt;T&gt;(parent: &<b>mut</b> <a href="../iota-framework/object.md#0x2_object_UID">object::UID</a>, <a href="nft.md#0x107a_nft">nft</a>: <a href="../iota-framework/transfer.md#0x2_transfer_Receiving">transfer::Receiving</a>&lt;<a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>&lt;T&gt;&gt;): <a href="nft_output.md#0x107a_nft_output_NftOutput">nft_output::NftOutput</a>&lt;T&gt;
 </code></pre>
 
 
@@ -229,7 +228,7 @@ Other modules in the stardust package can call this function to receive an <code
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../iota-framework/package.md#0x2_package">package</a>) <b>fun</b> <a href="nft_output.md#0x107a_nft_output_receive">receive</a>(parent: &<b>mut</b> UID, <a href="nft.md#0x107a_nft">nft</a>: Receiving&lt;<a href="nft_output.md#0x107a_nft_output_NftOutput">NftOutput</a>&gt;) : <a href="nft_output.md#0x107a_nft_output_NftOutput">NftOutput</a> {
+<pre><code><b>public</b>(<a href="../iota-framework/package.md#0x2_package">package</a>) <b>fun</b> <a href="nft_output.md#0x107a_nft_output_receive">receive</a>&lt;T&gt;(parent: &<b>mut</b> UID, <a href="nft.md#0x107a_nft">nft</a>: Receiving&lt;<a href="nft_output.md#0x107a_nft_output_NftOutput">NftOutput</a>&lt;T&gt;&gt;) : <a href="nft_output.md#0x107a_nft_output_NftOutput">NftOutput</a>&lt;T&gt; {
     <a href="../iota-framework/transfer.md#0x2_transfer_receive">transfer::receive</a>(parent, <a href="nft.md#0x107a_nft">nft</a>)
 }
 </code></pre>

--- a/crates/iota-framework/docs/stardust/nft_output.md
+++ b/crates/iota-framework/docs/stardust/nft_output.md
@@ -54,7 +54,7 @@ The Stardust NFT output representation.
 <code><a href="../iota-framework/balance.md#0x2_balance">balance</a>: <a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;</code>
 </dt>
 <dd>
- The amount of coin tokens held by the output.
+ The amount of coins held by the output.
 </dd>
 <dt>
 <code>native_tokens: <a href="../iota-framework/bag.md#0x2_bag_Bag">bag::Bag</a></code>

--- a/crates/iota-framework/docs/stardust/storage_deposit_return_unlock_condition.md
+++ b/crates/iota-framework/docs/stardust/storage_deposit_return_unlock_condition.md
@@ -12,7 +12,6 @@ title: Module `0x107a::storage_deposit_return_unlock_condition`
 
 <pre><code><b>use</b> <a href="../iota-framework/balance.md#0x2_balance">0x2::balance</a>;
 <b>use</b> <a href="../iota-framework/coin.md#0x2_coin">0x2::coin</a>;
-<b>use</b> <a href="../iota-framework/iota.md#0x2_iota">0x2::iota</a>;
 <b>use</b> <a href="../iota-framework/transfer.md#0x2_transfer">0x2::transfer</a>;
 <b>use</b> <a href="../iota-framework/tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 </code></pre>
@@ -60,7 +59,7 @@ The Stardust storage deposit return unlock condition.
 Check the unlock condition.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="storage_deposit_return_unlock_condition.md#0x107a_storage_deposit_return_unlock_condition_unlock">unlock</a>(condition: <a href="storage_deposit_return_unlock_condition.md#0x107a_storage_deposit_return_unlock_condition_StorageDepositReturnUnlockCondition">storage_deposit_return_unlock_condition::StorageDepositReturnUnlockCondition</a>, funding: &<b>mut</b> <a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../iota-framework/iota.md#0x2_iota_IOTA">iota::IOTA</a>&gt;, ctx: &<b>mut</b> <a href="../iota-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="storage_deposit_return_unlock_condition.md#0x107a_storage_deposit_return_unlock_condition_unlock">unlock</a>&lt;T&gt;(condition: <a href="storage_deposit_return_unlock_condition.md#0x107a_storage_deposit_return_unlock_condition_StorageDepositReturnUnlockCondition">storage_deposit_return_unlock_condition::StorageDepositReturnUnlockCondition</a>, funding: &<b>mut</b> <a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="../iota-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -69,7 +68,7 @@ Check the unlock condition.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="storage_deposit_return_unlock_condition.md#0x107a_storage_deposit_return_unlock_condition_unlock">unlock</a>(condition: <a href="storage_deposit_return_unlock_condition.md#0x107a_storage_deposit_return_unlock_condition_StorageDepositReturnUnlockCondition">StorageDepositReturnUnlockCondition</a>, funding: &<b>mut</b> Balance&lt;IOTA&gt;, ctx: &<b>mut</b> TxContext) {
+<pre><code><b>public</b> <b>fun</b> <a href="storage_deposit_return_unlock_condition.md#0x107a_storage_deposit_return_unlock_condition_unlock">unlock</a>&lt;T&gt;(condition: <a href="storage_deposit_return_unlock_condition.md#0x107a_storage_deposit_return_unlock_condition_StorageDepositReturnUnlockCondition">StorageDepositReturnUnlockCondition</a>, funding: &<b>mut</b> Balance&lt;T&gt;, ctx: &<b>mut</b> TxContext) {
     // Aborts <b>if</b> `funding` is not enough.
     <b>let</b> return_balance = funding.split(condition.<a href="storage_deposit_return_unlock_condition.md#0x107a_storage_deposit_return_unlock_condition_return_amount">return_amount</a>());
 

--- a/crates/iota-framework/docs/stardust/storage_deposit_return_unlock_condition.md
+++ b/crates/iota-framework/docs/stardust/storage_deposit_return_unlock_condition.md
@@ -45,7 +45,7 @@ The Stardust storage deposit return unlock condition.
 <code>return_amount: u64</code>
 </dt>
 <dd>
- The amount of IOTA coins the consuming transaction should deposit to the address defined in Return Address.
+ The amount of coins the consuming transaction should deposit to the address defined in Return Address.
 </dd>
 </dl>
 

--- a/crates/iota-framework/packages/stardust/Move.lock
+++ b/crates/iota-framework/packages/stardust/Move.lock
@@ -2,17 +2,13 @@
 
 [move]
 version = 0
-manifest_digest = "6C1F0F55CC88971254EA38AAC647E0C39D902AAF2D67AC59A332B50B8EDDE68E"
+manifest_digest = "F765D9C4B0BEDE16AA303BACAA154B71B076DC93A5084B5BA06457803766F21F"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 
 dependencies = [
-  { name = "MoveStdlib" },
   { name = "Iota" },
+  { name = "MoveStdlib" },
 ]
-
-[[move.package]]
-name = "MoveStdlib"
-source = { local = "../move-stdlib" }
 
 [[move.package]]
 name = "Iota"
@@ -21,6 +17,10 @@ source = { local = "../iota-framework" }
 dependencies = [
   { name = "MoveStdlib" },
 ]
+
+[[move.package]]
+name = "MoveStdlib"
+source = { local = "../move-stdlib" }
 
 [move.toolchain-version]
 compiler-version = "1.22.0"

--- a/crates/iota-framework/packages/stardust/design.md
+++ b/crates/iota-framework/packages/stardust/design.md
@@ -2,7 +2,8 @@
 
 ## Migrating Basic Outputs
 
-Every Basic Output has an `Address Unlock` and an `IOTA` balance (u64). Depending on what other fields we have, we will create different objects.
+Every Basic Output has an `Address Unlock` and some `coin` balance (u64). Depending on what other fields we have, we will create different objects.
+For an instance `coin` is `IOTA` here:
 
 [Decision graph on what to do with a basic output during migration](./basic_migration_graph.svg)
 

--- a/crates/iota-framework/packages/stardust/sources/alias/alias_output.move
+++ b/crates/iota-framework/packages/stardust/sources/alias/alias_output.move
@@ -6,7 +6,6 @@ module stardust::alias_output {
     use iota::bag::Bag;
     use iota::balance::Balance;
     use iota::dynamic_object_field;
-    use iota::iota::IOTA;
     use iota::transfer::Receiving;
 
     use stardust::alias::Alias;
@@ -15,12 +14,12 @@ module stardust::alias_output {
     const ALIAS_NAME: vector<u8> = b"alias";
 
     /// Owned Object controlled by the Governor Address.
-    public struct AliasOutput has key {
+    public struct AliasOutput<phantom T> has key {
         /// This is a "random" UID, not the AliasID from Stardust.
         id: UID,
 
         /// The amount of IOTA coins held by the output.
-        iota: Balance<IOTA>,
+        balance: Balance<T>,
 
         /// The `Bag` holds native tokens, key-ed by the stringified type of the asset.
         /// Example: key: "0xabcded::soon::SOON", value: Balance<0xabcded::soon::SOON>.
@@ -33,54 +32,54 @@ module stardust::alias_output {
     ///    - returns the IOTA Balance,
     ///    - the native tokens Bag,
     ///    - and the `Alias` object that persists the AliasID=ObjectID from Stardust.
-    public fun extract_assets(mut output: AliasOutput): (Balance<IOTA>, Bag, Alias) {
+    public fun extract_assets<T>(mut output: AliasOutput<T>): (Balance<T>, Bag, Alias) {
         // Load the related alias object.
         let alias = load_alias(&mut output);
 
         // Unpack the output into its basic part.
-        let AliasOutput {
+        let AliasOutput<T> {
             id,
-            iota,
+            balance,
             native_tokens
         } = output;
 
         // Delete the output.
         object::delete(id);
 
-        (iota, native_tokens, alias)
+        (balance, native_tokens, alias)
     }
 
     // === Public-Package Functions ===
 
     /// Utility function to receive an `AliasOutput` object in other Stardust modules.
     /// Other modules in the Stardust package can call this function to receive an `AliasOutput` object (nft).
-    public(package) fun receive(parent: &mut UID, output: Receiving<AliasOutput>) : AliasOutput {
+    public(package) fun receive<T>(parent: &mut UID, output: Receiving<AliasOutput<T>>) : AliasOutput<T> {
         transfer::receive(parent, output)
     }
 
     /// Utility function to attach an `Alias` to an `AliasOutput`.
-    public fun attach_alias(output: &mut AliasOutput, alias: Alias) {
+    public fun attach_alias<T>(output: &mut AliasOutput<T>, alias: Alias) {
         dynamic_object_field::add(&mut output.id, ALIAS_NAME, alias)
     }
 
     // === Private Functions ===
 
     /// Loads the `Alias` object from the dynamic object field.
-    fun load_alias(output: &mut AliasOutput): Alias {
+    fun load_alias<T>(output: &mut AliasOutput<T>): Alias {
         dynamic_object_field::remove(&mut output.id, ALIAS_NAME)
     }
 
     // === Test Functions ===
 
     #[test_only]
-    public fun create_for_testing(
-        iota: Balance<IOTA>,
+    public fun create_for_testing<T>(
+        balance: Balance<T>,
         native_tokens: Bag,
         ctx: &mut TxContext
-    ): AliasOutput  {
-        AliasOutput {
+    ): AliasOutput<T>  {
+        AliasOutput<T> {
             id: object::new(ctx),
-            iota,
+            balance,
             native_tokens,
         }
     }

--- a/crates/iota-framework/packages/stardust/sources/alias/alias_output.move
+++ b/crates/iota-framework/packages/stardust/sources/alias/alias_output.move
@@ -18,7 +18,7 @@ module stardust::alias_output {
         /// This is a "random" UID, not the AliasID from Stardust.
         id: UID,
 
-        /// The amount of IOTA coins held by the output.
+        /// The amount of coins held by the output.
         balance: Balance<T>,
 
         /// The `Bag` holds native tokens, key-ed by the stringified type of the asset.
@@ -29,7 +29,7 @@ module stardust::alias_output {
     // === Public-Mutative Functions ===
     
     /// The function extracts assets from a legacy `AliasOutput`.
-    ///    - returns the IOTA Balance,
+    ///    - returns the coin Balance,
     ///    - the native tokens Bag,
     ///    - and the `Alias` object that persists the AliasID=ObjectID from Stardust.
     public fun extract_assets<T>(mut output: AliasOutput<T>): (Balance<T>, Bag, Alias) {
@@ -37,7 +37,7 @@ module stardust::alias_output {
         let alias = load_alias(&mut output);
 
         // Unpack the output into its basic part.
-        let AliasOutput<T> {
+        let AliasOutput {
             id,
             balance,
             native_tokens

--- a/crates/iota-framework/packages/stardust/sources/basic/basic_output.move
+++ b/crates/iota-framework/packages/stardust/sources/basic/basic_output.move
@@ -26,7 +26,7 @@ module stardust::basic_output {
         /// Hash of the `outputId` that was migrated.
         id: UID,
 
-        /// The amount of IOTA coins held by the output.
+        /// The amount of coins held by the output.
         balance: Balance<T>,
 
         /// The `Bag` holds native tokens, key-ed by the stringified type of the asset.
@@ -55,7 +55,7 @@ module stardust::basic_output {
     /// Extract the assets stored inside the output, respecting the unlock conditions.
     ///  - The object will be deleted.
     ///  - The `StorageDepositReturnUnlockCondition` will return the deposit.
-    ///  - Remaining assets (IOTA coins and native tokens) will be returned.
+    ///  - Remaining assets (coins and native tokens) will be returned.
     public fun extract_assets<T>(output: BasicOutput<T>, ctx: &mut TxContext) : (Balance<T>, Bag) {
         // Unpack the output into its basic part.
         let BasicOutput {

--- a/crates/iota-framework/packages/stardust/sources/basic/basic_output.move
+++ b/crates/iota-framework/packages/stardust/sources/basic/basic_output.move
@@ -7,7 +7,6 @@ module stardust::basic_output {
     // Iota imports.
     use iota::bag::Bag;
     use iota::balance::Balance;
-    use iota::iota::IOTA;
     use iota::transfer::Receiving;
 
     // Package imports.
@@ -23,12 +22,12 @@ module stardust::basic_output {
     ///   - notice that there is no `store` ability and there is no custom transfer function:
     ///       -  you can call `extract_assets`,
     ///       -  or you can call `receive` in other models to receive a `BasicOutput`.
-    public struct BasicOutput has key {
+    public struct BasicOutput<phantom T> has key {
         /// Hash of the `outputId` that was migrated.
         id: UID,
 
         /// The amount of IOTA coins held by the output.
-        iota: Balance<IOTA>,
+        balance: Balance<T>,
 
         /// The `Bag` holds native tokens, key-ed by the stringified type of the asset.
         /// Example: key: "0xabcded::soon::SOON", value: Balance<0xabcded::soon::SOON>.
@@ -57,11 +56,11 @@ module stardust::basic_output {
     ///  - The object will be deleted.
     ///  - The `StorageDepositReturnUnlockCondition` will return the deposit.
     ///  - Remaining assets (IOTA coins and native tokens) will be returned.
-    public fun extract_assets(output: BasicOutput, ctx: &mut TxContext) : (Balance<IOTA>, Bag) {
+    public fun extract_assets<T>(output: BasicOutput<T>, ctx: &mut TxContext) : (Balance<T>, Bag) {
         // Unpack the output into its basic part.
         let BasicOutput {
             id,
-            iota: mut iota,
+            balance: mut balance,
             native_tokens,
             storage_deposit_return_uc: mut storage_deposit_return_uc,
             timelock_uc: mut timelock_uc,
@@ -83,7 +82,7 @@ module stardust::basic_output {
 
         // If the output has an storage deposit return unlock condition, then we need to return the deposit.
         if (storage_deposit_return_uc.is_some()) {
-            storage_deposit_return_uc.extract().unlock(&mut iota, ctx);
+            storage_deposit_return_uc.extract().unlock(&mut balance, ctx);
         };
 
         // Destroy the unlock conditions.
@@ -94,7 +93,7 @@ module stardust::basic_output {
         // Delete the output.
         object::delete(id);
 
-        return (iota, native_tokens)
+        return (balance, native_tokens)
     }
 
     // === Public-Package Functions ===
@@ -103,7 +102,7 @@ module stardust::basic_output {
     /// Since `BasicOutput` only has `key`, it can not be received via `public_receive`.
     /// The private receiver must be implemented in its defining module (here).
     /// Other modules in the Stardust package can call this function to receive a basic output (alias, NFT).
-    public(package) fun receive(parent: &mut UID, output: Receiving<BasicOutput>) : BasicOutput {
+    public(package) fun receive<T>(parent: &mut UID, output: Receiving<BasicOutput<T>>) : BasicOutput<T> {
         transfer::receive(parent, output)
     }
 
@@ -111,8 +110,8 @@ module stardust::basic_output {
 
     // test only function to create a basic output
     #[test_only]
-    public fun create_for_testing(
-        iota: Balance<IOTA>,
+    public fun create_for_testing<T>(
+        balance: Balance<T>,
         native_tokens: Bag,
         storage_deposit_return_uc: Option<StorageDepositReturnUnlockCondition>,
         timelock_uc: Option<TimelockUnlockCondition>,
@@ -121,10 +120,10 @@ module stardust::basic_output {
         tag: Option<vector<u8>>,
         sender: Option<address>,
         ctx: &mut TxContext
-    ): BasicOutput {
-        BasicOutput {
+    ): BasicOutput<T> {
+        BasicOutput<T> {
             id: object::new(ctx),
-            iota,
+            balance,
             native_tokens,
             storage_deposit_return_uc,
             timelock_uc,

--- a/crates/iota-framework/packages/stardust/sources/nft/nft_output.move
+++ b/crates/iota-framework/packages/stardust/sources/nft/nft_output.move
@@ -6,7 +6,6 @@ module stardust::nft_output {
     use iota::bag::Bag;
     use iota::balance::Balance;
     use iota::dynamic_object_field;
-    use iota::iota::IOTA;
     use iota::transfer::Receiving;
 
     use stardust::nft::Nft;
@@ -19,12 +18,12 @@ module stardust::nft_output {
     const NFT_NAME: vector<u8> = b"nft";
 
     /// The Stardust NFT output representation.
-    public struct NftOutput has key {
+    public struct NftOutput<phantom T> has key {
         /// This is a "random" UID, not the NFTID from Stardust.
         id: UID,
 
-        /// The amount of IOTA tokens held by the output.
-        iota: Balance<IOTA>,
+        /// The amount of coin tokens held by the output.
+        balance: Balance<T>,
 
         /// The `Bag` holds native tokens, key-ed by the stringified type of the asset.
         /// Example: key: "0xabcded::soon::SOON", value: Balance<0xabcded::soon::SOON>.
@@ -39,14 +38,14 @@ module stardust::nft_output {
     }
 
     /// The function extracts assets from a legacy NFT output.
-    public fun extract_assets(mut output: NftOutput, ctx: &mut TxContext): (Balance<IOTA>, Bag, Nft) {
+    public fun extract_assets<T>(mut output: NftOutput<T>, ctx: &mut TxContext): (Balance<T>, Bag, Nft) {
         // Load the related Nft object.
         let nft = load_nft(&mut output);
 
         // Unpuck the output.
         let NftOutput {
             id,
-            iota: mut iota,
+            balance: mut balance,
             native_tokens,
             storage_deposit_return_uc: mut storage_deposit_return_uc,
             timelock_uc: mut timelock_uc,
@@ -65,7 +64,7 @@ module stardust::nft_output {
 
         // If the output has a storage deposit return unlock condition, then we need to return the deposit.
         if (storage_deposit_return_uc.is_some()) {
-            storage_deposit_return_uc.extract().unlock(&mut iota, ctx);
+            storage_deposit_return_uc.extract().unlock(&mut balance, ctx);
         };
 
         // Destroy the output.
@@ -75,41 +74,41 @@ module stardust::nft_output {
 
         object::delete(id);
 
-        return (iota, native_tokens, nft)
+        return (balance, native_tokens, nft)
     }
 
     /// Loads the related `Nft` object.
-    fun load_nft(output: &mut NftOutput): Nft {
+    fun load_nft<T>(output: &mut NftOutput<T>): Nft {
         dynamic_object_field::remove(&mut output.id, NFT_NAME)
     }
 
     // === Public-Package Functions ===
 
     /// Utility function to attach an `Alias` to an `AliasOutput`.
-    public fun attach_nft(output: &mut NftOutput, nft: Nft) {
+    public fun attach_nft<T>(output: &mut NftOutput<T>, nft: Nft) {
         dynamic_object_field::add(&mut output.id, NFT_NAME, nft)
     }
 
     /// Utility function to receive an `NftOutput` in other Stardust modules.
     /// Other modules in the stardust package can call this function to receive an `NftOutput` (alias).
-    public(package) fun receive(parent: &mut UID, nft: Receiving<NftOutput>) : NftOutput {
+    public(package) fun receive<T>(parent: &mut UID, nft: Receiving<NftOutput<T>>) : NftOutput<T> {
         transfer::receive(parent, nft)
     }
 
     // === Test Functions ===
 
     #[test_only]
-    public fun create_for_testing(
-        iota: Balance<IOTA>,
+    public fun create_for_testing<T>(
+        balance: Balance<T>,
         native_tokens: Bag,
         storage_deposit_return_uc: Option<StorageDepositReturnUnlockCondition>,
         timelock_uc: Option<TimelockUnlockCondition>,
         expiration_uc: Option<ExpirationUnlockCondition>,
         ctx: &mut TxContext,
-    ): NftOutput {
-        NftOutput {
+    ): NftOutput<T> {
+        NftOutput<T> {
             id: object::new(ctx),
-            iota,
+            balance,
             native_tokens,
             storage_deposit_return_uc,
             timelock_uc,

--- a/crates/iota-framework/packages/stardust/sources/nft/nft_output.move
+++ b/crates/iota-framework/packages/stardust/sources/nft/nft_output.move
@@ -22,7 +22,7 @@ module stardust::nft_output {
         /// This is a "random" UID, not the NFTID from Stardust.
         id: UID,
 
-        /// The amount of coin tokens held by the output.
+        /// The amount of coins held by the output.
         balance: Balance<T>,
 
         /// The `Bag` holds native tokens, key-ed by the stringified type of the asset.

--- a/crates/iota-framework/packages/stardust/sources/unlock_condition/address_unlock_condition.move
+++ b/crates/iota-framework/packages/stardust/sources/unlock_condition/address_unlock_condition.move
@@ -15,26 +15,26 @@ module stardust::address_unlock_condition {
     // === Receiving on Alias Address/AliasID as ObjectID ===
 
     /// Unlock a `BasicOutput` locked to the alias address.
-    public fun unlock_alias_address_owned_basic(
+    public fun unlock_alias_address_owned_basic<T>(
       self: &mut Alias,
-      output_to_unlock: Receiving<BasicOutput>
-    ): BasicOutput {
+      output_to_unlock: Receiving<BasicOutput<T>>
+    ): BasicOutput<T> {
         basic_output::receive(self.id(), output_to_unlock)
     }
 
     /// Unlock an `NftOutput` locked to the alias address.
-    public fun unlock_alias_address_owned_nft(
+    public fun unlock_alias_address_owned_nft<T>(
       self: &mut Alias,
-      output_to_unlock: Receiving<NftOutput>,
-    ): NftOutput {
+      output_to_unlock: Receiving<NftOutput<T>>,
+    ): NftOutput<T> {
         nft_output::receive(self.id(), output_to_unlock)
     }
 
     /// Unlock an `AliasOutput` locked to the alias address.
-    public fun unlock_alias_address_owned_alias(
+    public fun unlock_alias_address_owned_alias<T>(
       self: &mut Alias,
-      output_to_unlock: Receiving<AliasOutput>,
-    ): AliasOutput {
+      output_to_unlock: Receiving<AliasOutput<T>>,
+    ): AliasOutput<T> {
         alias_output::receive(self.id(), output_to_unlock)
     }
 
@@ -51,26 +51,26 @@ module stardust::address_unlock_condition {
     // === Receiving on NFT Address/NFTID as ObjectID ===
 
     /// Unlock a `BasicOutput` locked to the `Nft` address.
-    public fun unlock_nft_address_owned_basic(
+    public fun unlock_nft_address_owned_basic<T>(
       self: &mut Nft,
-      output_to_unlock: Receiving<BasicOutput>,
-    ): BasicOutput {
+      output_to_unlock: Receiving<BasicOutput<T>>,
+    ): BasicOutput<T> {
         basic_output::receive(self.id(), output_to_unlock)
     }
 
     /// Unlock an `NftOutput` locked to the `Nft` address.
-    public fun unlock_nft_address_owned_nft(
+    public fun unlock_nft_address_owned_nft<T>(
       self: &mut Nft,
-      output_to_unlock: Receiving<NftOutput>,
-    ): NftOutput {
+      output_to_unlock: Receiving<NftOutput<T>>,
+    ): NftOutput<T> {
         nft_output::receive(self.id(), output_to_unlock)
     }
 
     /// Unlock an `AliasOutput` locked to the `Nft` address.
-    public fun unlock_nft_address_owned_alias(
+    public fun unlock_nft_address_owned_alias<T>(
       self: &mut Nft,
-      output_to_unlock: Receiving<AliasOutput>,
-    ): AliasOutput {
+      output_to_unlock: Receiving<AliasOutput<T>>,
+    ): AliasOutput<T> {
         alias_output::receive(self.id(), output_to_unlock)
     }
 }

--- a/crates/iota-framework/packages/stardust/sources/unlock_condition/storage_deposit_return_unlock_condition.move
+++ b/crates/iota-framework/packages/stardust/sources/unlock_condition/storage_deposit_return_unlock_condition.move
@@ -11,7 +11,7 @@ module stardust::storage_deposit_return_unlock_condition {
     public struct StorageDepositReturnUnlockCondition has store {
         /// The address to which the consuming transaction should deposit the amount defined in Return Amount.
         return_address: address,
-        /// The amount of IOTA coins the consuming transaction should deposit to the address defined in Return Address.
+        /// The amount of coins the consuming transaction should deposit to the address defined in Return Address.
         return_amount: u64,
     }
 

--- a/crates/iota-framework/packages/stardust/sources/unlock_condition/storage_deposit_return_unlock_condition.move
+++ b/crates/iota-framework/packages/stardust/sources/unlock_condition/storage_deposit_return_unlock_condition.move
@@ -5,7 +5,6 @@ module stardust::storage_deposit_return_unlock_condition {
 
     use iota::balance::{Balance, split};
     use iota::coin::from_balance;
-    use iota::iota::IOTA;
     use iota::transfer::public_transfer;
 
     /// The Stardust storage deposit return unlock condition.
@@ -17,7 +16,7 @@ module stardust::storage_deposit_return_unlock_condition {
     }
 
     /// Check the unlock condition.
-    public fun unlock(condition: StorageDepositReturnUnlockCondition, funding: &mut Balance<IOTA>, ctx: &mut TxContext) {
+    public fun unlock<T>(condition: StorageDepositReturnUnlockCondition, funding: &mut Balance<T>, ctx: &mut TxContext) {
         // Aborts if `funding` is not enough.
         let return_balance = funding.split(condition.return_amount());
 

--- a/crates/iota-framework/packages/stardust/tests/alias_tests.move
+++ b/crates/iota-framework/packages/stardust/tests/alias_tests.move
@@ -44,9 +44,6 @@ module stardust::alias_tests {
             0,
         );
 
-        // Mint some tokens.
-        let iota = balance::create_for_testing<IOTA>(initial_iota_in_output);
-
         let test_a_balance = balance::create_for_testing<TEST_A>(initial_testA_in_output);
         let test_b_balance = balance::create_for_testing<TEST_B>(initial_testB_in_output);
 
@@ -58,7 +55,7 @@ module stardust::alias_tests {
 
         // Create an `AliasOutput`.
         let mut alias_output = alias_output::create_for_testing(
-            iota,
+            balance::create_for_testing<IOTA>(initial_iota_in_output),
             native_tokens,
             &mut ctx,
         );

--- a/crates/iota-framework/packages/stardust/tests/basic_tests.move
+++ b/crates/iota-framework/packages/stardust/tests/basic_tests.move
@@ -54,7 +54,7 @@ module stardust::basic_tests {
         );
 
         // Mint some tokens.
-        let iota = balance::create_for_testing<IOTA>(initial_iota_in_output);
+        let balance = balance::create_for_testing<IOTA>(initial_iota_in_output);
 
         let test_a_balance = balance::create_for_testing<TEST_A>(initial_testA_in_output);
         let test_b_balance = balance::create_for_testing<TEST_B>(initial_testB_in_output);
@@ -66,7 +66,7 @@ module stardust::basic_tests {
         native_tokens.add(type_name::get<TEST_B>().into_string(), test_b_balance);
 
         let output = basic_output::create_for_testing(
-            iota,
+            balance,
             native_tokens,
             option::some(storage_deposit_return_unlock_condition::create_for_testing(sdruc_return_address, sdruc_return_amount)),
             option::some(timelock_unlock_condition::create_for_testing(timelocked_until)),

--- a/crates/iota-framework/packages/stardust/tests/basic_tests.move
+++ b/crates/iota-framework/packages/stardust/tests/basic_tests.move
@@ -53,9 +53,6 @@ module stardust::basic_tests {
             0,
         );
 
-        // Mint some tokens.
-        let balance = balance::create_for_testing<IOTA>(initial_iota_in_output);
-
         let test_a_balance = balance::create_for_testing<TEST_A>(initial_testA_in_output);
         let test_b_balance = balance::create_for_testing<TEST_B>(initial_testB_in_output);
 
@@ -66,7 +63,7 @@ module stardust::basic_tests {
         native_tokens.add(type_name::get<TEST_B>().into_string(), test_b_balance);
 
         let output = basic_output::create_for_testing(
-            balance,
+            balance::create_for_testing<IOTA>(initial_iota_in_output),
             native_tokens,
             option::some(storage_deposit_return_unlock_condition::create_for_testing(sdruc_return_address, sdruc_return_amount)),
             option::some(timelock_unlock_condition::create_for_testing(timelocked_until)),

--- a/crates/iota-framework/packages/stardust/tests/nft_tests.move
+++ b/crates/iota-framework/packages/stardust/tests/nft_tests.move
@@ -43,7 +43,7 @@ module stardust::nft_tests {
         native_tokens.add(type_name::get<TEST_A>().into_string(), test_a_balance);
         native_tokens.add(type_name::get<TEST_B>().into_string(), test_b_balance);
 
-        let mut nft_output = nft_output::create_for_testing(
+        let mut nft_output = nft_output::create_for_testing<IOTA>(
             balance::create_for_testing(10000),
             native_tokens,
             option::some(storage_deposit_return_unlock_condition::create_for_testing(@0xB, 1000)),

--- a/crates/iota-framework/packages/stardust/tests/nft_tests.move
+++ b/crates/iota-framework/packages/stardust/tests/nft_tests.move
@@ -43,8 +43,8 @@ module stardust::nft_tests {
         native_tokens.add(type_name::get<TEST_A>().into_string(), test_a_balance);
         native_tokens.add(type_name::get<TEST_B>().into_string(), test_b_balance);
 
-        let mut nft_output = nft_output::create_for_testing<IOTA>(
-            balance::create_for_testing(10000),
+        let mut nft_output = nft_output::create_for_testing(
+            balance::create_for_testing<IOTA>(10000),
             native_tokens,
             option::some(storage_deposit_return_unlock_condition::create_for_testing(@0xB, 1000)),
             option::some(timelock_unlock_condition::create_for_testing(5)),

--- a/crates/iota-framework/packages/stardust/tests/unlock_condition/address_unlock_condition_tests.move
+++ b/crates/iota-framework/packages/stardust/tests/unlock_condition/address_unlock_condition_tests.move
@@ -44,9 +44,9 @@ module stardust::address_unlock_condition_tests {
             0,
         );
 
-        let mut alias_output = alias_output::create_for_testing(
+        let mut alias_output = alias_output::create_for_testing<IOTA>(
             // iota
-            balance::create_for_testing<IOTA>(initial_iota_in_output),
+            balance::create_for_testing(initial_iota_in_output),
             // tokens
             bag::new(&mut ctx),
             &mut ctx,

--- a/crates/iota-framework/packages/stardust/tests/unlock_condition/address_unlock_condition_tests.move
+++ b/crates/iota-framework/packages/stardust/tests/unlock_condition/address_unlock_condition_tests.move
@@ -44,9 +44,9 @@ module stardust::address_unlock_condition_tests {
             0,
         );
 
-        let mut alias_output = alias_output::create_for_testing<IOTA>(
+        let mut alias_output = alias_output::create_for_testing(
             // iota
-            balance::create_for_testing(initial_iota_in_output),
+            balance::create_for_testing<IOTA>(initial_iota_in_output),
             // tokens
             bag::new(&mut ctx),
             &mut ctx,
@@ -73,7 +73,6 @@ module stardust::address_unlock_condition_tests {
         alias_output.attach_alias(alias);
 
         // `BasicOutput` owned by the alias.
-        let basic_iota_balance = balance::create_for_testing<IOTA>(initial_iota_in_output);
         let timelocked_until = 5;
         let expiration_after = 20;
         let sdruc_return_address = @0xB;
@@ -81,7 +80,7 @@ module stardust::address_unlock_condition_tests {
         let expiration_return_address = @0xC;
 
         let basic_output = basic_output::create_for_testing(
-            basic_iota_balance,
+            balance::create_for_testing<IOTA>(initial_iota_in_output),
             bag::new(&mut ctx),
             option::some(storage_deposit_return_unlock_condition::create_for_testing(sdruc_return_address, sdruc_return_amount)),
             option::some(timelock_unlock_condition::create_for_testing(timelocked_until)),


### PR DESCRIPTION
Stardust models have turned into generic
Rename iota variables to more general - "balance"

# Description of change

Stardust models(especially outputs) have generic balance field in order to apply not only IOTA coin.

## Links to any relevant issues

Fixes #577 .

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected) **possibly**? 

## How the change has been tested

Run existing unit tests for iota/crates/iota-framework/packages/stardust