### PR TITLE
refactor(iota-genesis-builder): alias,nft, basic output are generic

### DIFF
--- a/crates/iota-genesis-builder/src/stardust/migration/executor.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/executor.rs
@@ -24,6 +24,7 @@ use iota_types::{
     collection_types::Bag,
     dynamic_field::Field,
     execution_mode,
+    gas_coin::GAS,
     id::UID,
     in_memory_storage::InMemoryStorage,
     inner_temporary_store::InnerTemporaryStore,
@@ -354,7 +355,7 @@ impl Executor {
                 STARDUST_PACKAGE_ID,
                 ident_str!("alias_output").into(),
                 ident_str!("attach_alias").into(),
-                vec![],
+                vec![GAS::type_tag()],
                 vec![alias_output_arg, alias_arg],
             );
 
@@ -675,7 +676,7 @@ impl Executor {
                 STARDUST_PACKAGE_ID,
                 ident_str!("nft_output").into(),
                 ident_str!("attach_nft").into(),
-                vec![],
+                vec![GAS::type_tag()],
                 vec![nft_output_arg, nft_arg],
             );
 

--- a/crates/iota-genesis-builder/src/stardust/migration/tests/alias.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/tests/alias.rs
@@ -21,6 +21,7 @@ use iota_sdk::{
 use iota_types::{
     base_types::ObjectID,
     dynamic_field::{derive_dynamic_field_id, DynamicFieldInfo},
+    gas_coin::GAS,
     id::UID,
     object::{Object, Owner},
     TypeTag,
@@ -72,7 +73,7 @@ fn migrate_alias(
         .unwrap();
     assert_eq!(
         alias_output_object.struct_tag().unwrap(),
-        AliasOutput::tag()
+        AliasOutput::tag(GAS::type_tag())
     );
 
     // Version is set to 1 when the alias is created based on the computed lamport
@@ -130,7 +131,7 @@ fn alias_migration_with_full_features() {
     let expected_alias = Alias::try_from_stardust(alias_object_id, &stardust_alias).unwrap();
 
     // The bag is tested separately.
-    assert_eq!(stardust_alias.amount(), alias_output.iota.value());
+    assert_eq!(stardust_alias.amount(), alias_output.balance.value());
     // The ID is newly generated, so we don't know the exact value, but it should
     // not be zero.
     assert_ne!(alias_output.id, UID::new(ObjectID::ZERO));

--- a/crates/iota-genesis-builder/src/stardust/migration/tests/mod.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/tests/mod.rs
@@ -124,7 +124,7 @@ fn object_migration_with_object_owner(
             STARDUST_PACKAGE_ID,
             output_owner_module_name.into(),
             ident_str!("extract_assets").into(),
-            vec![],
+            vec![GAS::type_tag()],
             vec![owner_arg],
         );
 
@@ -140,7 +140,7 @@ fn object_migration_with_object_owner(
             STARDUST_PACKAGE_ID,
             ident_str!("address_unlock_condition").into(),
             unlock_condition_function.into(),
-            vec![],
+            vec![GAS::type_tag()],
             vec![owned_arg, receiving_owned_arg],
         );
 
@@ -173,7 +173,7 @@ fn object_migration_with_object_owner(
             STARDUST_PACKAGE_ID,
             output_owned_module_name.into(),
             ident_str!("extract_assets").into(),
-            vec![],
+            vec![GAS::type_tag()],
             vec![received_owned_output],
         );
         let Argument::Result(result_idx) = extracted_assets else {
@@ -264,7 +264,7 @@ fn extract_native_token_from_bag(
             STARDUST_PACKAGE_ID,
             module_name.into(),
             ident_str!("extract_assets").into(),
-            vec![],
+            vec![GAS::type_tag()],
             vec![inner_object_arg],
         );
 
@@ -430,7 +430,7 @@ fn unlock_object_test(
             STARDUST_PACKAGE_ID,
             module_name.into(),
             ident_str!("extract_assets").into(),
-            vec![],
+            vec![GAS::type_tag()],
             vec![inner_object_arg],
         );
 

--- a/crates/iota-genesis-builder/src/stardust/migration/tests/nft.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/tests/nft.rs
@@ -29,6 +29,7 @@ use iota_types::{
     base_types::{IotaAddress, ObjectID},
     collection_types::VecMap,
     dynamic_field::{derive_dynamic_field_id, DynamicFieldInfo},
+    gas_coin::GAS,
     id::UID,
     object::{Object, Owner},
     TypeTag,
@@ -87,7 +88,7 @@ fn migrate_nft(
         nft_output_object
             .struct_tag()
             .ok_or_else(|| anyhow!("missing struct tag on output nft object"))?,
-        NftOutput::tag()
+        NftOutput::tag(GAS::type_tag())
     );
 
     // Version is set to 1 when the nft is created based on the computed lamport
@@ -153,7 +154,7 @@ fn nft_migration_with_full_features() {
     let expected_nft = Nft::try_from_stardust(nft_object_id, &stardust_nft).unwrap();
 
     // The bag is tested separately.
-    assert_eq!(stardust_nft.amount(), nft_output.iota.value());
+    assert_eq!(stardust_nft.amount(), nft_output.balance.value());
     // The ID is newly generated, so we don't know the exact value, but it should
     // not be zero.
     assert_ne!(nft_output.id, UID::new(ObjectID::ZERO));

--- a/crates/iota-genesis-builder/src/stardust/migration/verification/alias.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/alias.rs
@@ -87,9 +87,9 @@ pub(super) fn verify_alias_output(
 
     // Amount
     ensure!(
-        created_output.iota.value() == output.amount(),
+        created_output.balance.value() == output.amount(),
         "amount mismatch: found {}, expected {}",
-        created_output.iota.value(),
+        created_output.balance.value(),
         output.amount()
     );
 

--- a/crates/iota-genesis-builder/src/stardust/migration/verification/basic.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/basic.rs
@@ -112,9 +112,9 @@ pub(super) fn verify_basic_output(
 
         // Amount
         ensure!(
-            created_output.iota.value() == output.amount(),
+            created_output.balance.value() == output.amount(),
             "amount mismatch: found {}, expected {}",
-            created_output.iota.value(),
+            created_output.balance.value(),
             output.amount()
         );
 

--- a/crates/iota-genesis-builder/src/stardust/migration/verification/nft.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/nft.rs
@@ -87,9 +87,9 @@ pub(super) fn verify_nft_output(
 
     // Amount
     ensure!(
-        created_output.iota.value() == output.amount(),
+        created_output.balance.value() == output.amount(),
         "amount mismatch: found {}, expected {}",
-        created_output.iota.value(),
+        created_output.balance.value(),
         output.amount()
     );
 

--- a/crates/iota-genesis-builder/src/stardust/types/alias.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/alias.rs
@@ -152,6 +152,7 @@ pub struct AliasOutput {
 }
 
 impl AliasOutput {
+    /// Returns the struct tag of the AliasOutput struct
     pub fn tag(type_param: TypeTag) -> StructTag {
         StructTag {
             address: STARDUST_PACKAGE_ID.into(),

--- a/crates/iota-genesis-builder/src/stardust/types/coin_kind.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/coin_kind.rs
@@ -31,7 +31,7 @@ pub fn is_gas_coin_kind(object: &Object) -> bool {
         return false;
     };
     struct_tag == AliasOutput::tag(GAS::type_tag())
-        || struct_tag == BasicOutput::type_(GAS::type_tag())
+        || struct_tag == BasicOutput::tag(GAS::type_tag())
         || struct_tag == NftOutput::tag(GAS::type_tag())
         || struct_tag == TimeLock::<Balance>::type_(Balance::type_(GAS::type_tag()).into())
         || object.is_gas_coin()

--- a/crates/iota-genesis-builder/src/stardust/types/coin_kind.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/coin_kind.rs
@@ -30,9 +30,9 @@ pub fn is_gas_coin_kind(object: &Object) -> bool {
     let Some(struct_tag) = object.struct_tag() else {
         return false;
     };
-    struct_tag == AliasOutput::tag()
-        || struct_tag == BasicOutput::type_()
-        || struct_tag == NftOutput::tag()
+    struct_tag == AliasOutput::tag(GAS::type_tag())
+        || struct_tag == BasicOutput::type_(GAS::type_tag())
+        || struct_tag == NftOutput::tag(GAS::type_tag())
         || struct_tag == TimeLock::<Balance>::type_(Balance::type_(GAS::type_tag()).into())
         || object.is_gas_coin()
 }
@@ -44,9 +44,7 @@ pub fn get_gas_balance_maybe(object: &Object) -> Option<Balance> {
     if !is_gas_coin_kind(object) {
         return None;
     }
-    let Some(inner) = object.data.try_as_move() else {
-        return None;
-    };
+    let inner = object.data.try_as_move()?;
     bcs::from_bytes(&inner.contents()[ID_END_INDEX..][..size_of::<Balance>()]).ok()
 }
 
@@ -65,10 +63,10 @@ mod tests {
 
     fn nft_output(balance: u64) -> anyhow::Result<Object> {
         let id = UID::new(ObjectID::random());
-        let iota = Balance::new(balance);
+        let balance = Balance::new(balance);
         let output = NftOutput {
             id,
-            iota,
+            balance,
             native_tokens: Default::default(),
             storage_deposit_return: Default::default(),
             timelock: Default::default(),
@@ -98,10 +96,10 @@ mod tests {
 
     fn alias_output(balance: u64) -> anyhow::Result<Object> {
         let id = UID::new(ObjectID::random());
-        let iota = Balance::new(balance);
+        let balance = Balance::new(balance);
         let output = AliasOutput {
             id,
-            iota,
+            balance,
             native_tokens: Default::default(),
         };
         output.to_genesis_object(
@@ -128,10 +126,10 @@ mod tests {
 
     fn basic_output(balance: u64) -> anyhow::Result<Object> {
         let id = UID::new(ObjectID::random());
-        let iota = Balance::new(balance);
+        let balance = Balance::new(balance);
         let output = BasicOutput {
             id,
-            iota,
+            balance,
             native_tokens: Default::default(),
             storage_deposit_return: Default::default(),
             timelock: Default::default(),

--- a/crates/iota-genesis-builder/src/stardust/types/nft.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/nft.rs
@@ -254,6 +254,7 @@ pub struct Nft {
 }
 
 impl Nft {
+    /// Returns the struct tag of the NftOutput struct
     pub fn tag() -> StructTag {
         StructTag {
             address: STARDUST_PACKAGE_ID.into(),

--- a/crates/iota-genesis-builder/src/stardust/types/nft.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/nft.rs
@@ -10,9 +10,10 @@ use iota_types::{
     balance::Balance,
     base_types::{IotaAddress, ObjectID, SequenceNumber, TxContext},
     collection_types::{Bag, Entry, VecMap},
+    gas_coin::GAS,
     id::UID,
     object::{Data, MoveObject, Object, Owner},
-    STARDUST_PACKAGE_ID,
+    TypeTag, STARDUST_PACKAGE_ID,
 };
 use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructTag};
 use num_rational::Ratio;
@@ -382,7 +383,7 @@ pub struct NftOutput {
     pub id: UID,
 
     /// The amount of IOTA coins held by the output.
-    pub iota: Balance,
+    pub balance: Balance,
     /// The `Bag` holds native tokens, key-ed by the stringified type of the
     /// asset. Example: key: "0xabcded::soon::SOON", value:
     /// Balance<0xabcded::soon::SOON>.
@@ -397,12 +398,12 @@ pub struct NftOutput {
 }
 
 impl NftOutput {
-    pub fn tag() -> StructTag {
+    pub fn tag(type_param: TypeTag) -> StructTag {
         StructTag {
             address: STARDUST_PACKAGE_ID.into(),
             module: NFT_OUTPUT_MODULE_NAME.to_owned(),
             name: NFT_OUTPUT_STRUCT_NAME.to_owned(),
-            type_params: Vec::new(),
+            type_params: vec![type_param],
         }
     }
 
@@ -416,7 +417,7 @@ impl NftOutput {
         let unlock_conditions = nft.unlock_conditions();
         Ok(NftOutput {
             id: UID::new(object_id),
-            iota: Balance::new(nft.amount()),
+            balance: Balance::new(nft.amount()),
             native_tokens,
             storage_deposit_return: unlock_conditions
                 .storage_deposit_return()
@@ -442,7 +443,7 @@ impl NftOutput {
             // Safety: we know from the definition of `NftOutput` in the stardust package
             // that it does not have public transfer (`store` ability is absent).
             MoveObject::new_from_execution(
-                NftOutput::tag().into(),
+                NftOutput::tag(GAS::type_tag()).into(),
                 false,
                 version,
                 bcs::to_bytes(&self)?,

--- a/crates/iota-genesis-builder/src/stardust/types/output.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/output.rs
@@ -12,9 +12,10 @@ use iota_types::{
     base_types::{IotaAddress, MoveObjectType, ObjectID, SequenceNumber, TxContext},
     coin::Coin,
     collection_types::Bag,
+    gas_coin::GAS,
     id::UID,
     object::{Data, MoveObject, Object, Owner},
-    STARDUST_PACKAGE_ID,
+    TypeTag, STARDUST_PACKAGE_ID,
 };
 use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructTag};
 use schemars::JsonSchema;
@@ -115,8 +116,8 @@ pub struct BasicOutput {
     /// Hash of the `OutputId` that was migrated.
     pub id: UID,
 
-    /// The amount of IOTA coins held by the output.
-    pub iota: Balance,
+    /// The amount of coins held by the output.
+    pub balance: Balance,
 
     /// The `Bag` holds native tokens, key-ed by the stringified type of the
     /// asset. Example: key: "0xabcded::soon::SOON", value:
@@ -149,7 +150,7 @@ impl BasicOutput {
         output: &iota_sdk::types::block::output::BasicOutput,
     ) -> Result<Self> {
         let id = UID::new(ObjectID::new(header.output_id().hash()));
-        let iota = Balance::new(output.amount());
+        let balance = Balance::new(output.amount());
         let native_tokens = Default::default();
         let unlock_conditions = output.unlock_conditions();
         let storage_deposit_return = unlock_conditions
@@ -165,7 +166,7 @@ impl BasicOutput {
 
         Ok(BasicOutput {
             id,
-            iota,
+            balance,
             native_tokens,
             storage_deposit_return,
             timelock,
@@ -176,12 +177,12 @@ impl BasicOutput {
         })
     }
 
-    pub fn type_() -> StructTag {
+    pub fn type_(type_param: TypeTag) -> StructTag {
         StructTag {
             address: STARDUST_PACKAGE_ID.into(),
             module: BASIC_OUTPUT_MODULE_NAME.to_owned(),
             name: BASIC_OUTPUT_STRUCT_NAME.to_owned(),
-            type_params: Vec::new(),
+            type_params: vec![type_param],
         }
     }
 
@@ -203,7 +204,7 @@ impl BasicOutput {
             // Safety: we know from the definition of `BasicOutput` in the stardust package
             // that it is not publicly transferable (`store` ability is absent).
             MoveObject::new_from_execution(
-                Self::type_().into(),
+                Self::type_(GAS::type_tag()).into(),
                 false,
                 version,
                 bcs::to_bytes(self)?,
@@ -235,7 +236,7 @@ impl BasicOutput {
         create_gas_coin(
             self.id,
             owner,
-            self.iota.value(),
+            self.balance.value(),
             tx_context,
             version,
             protocol_config,

--- a/crates/iota-genesis-builder/src/stardust/types/output.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/output.rs
@@ -177,7 +177,7 @@ impl BasicOutput {
         })
     }
 
-    pub fn type_(type_param: TypeTag) -> StructTag {
+    pub fn tag(type_param: TypeTag) -> StructTag {
         StructTag {
             address: STARDUST_PACKAGE_ID.into(),
             module: BASIC_OUTPUT_MODULE_NAME.to_owned(),
@@ -204,7 +204,7 @@ impl BasicOutput {
             // Safety: we know from the definition of `BasicOutput` in the stardust package
             // that it is not publicly transferable (`store` ability is absent).
             MoveObject::new_from_execution(
-                Self::type_(GAS::type_tag()).into(),
+                BasicOutput::tag(GAS::type_tag()).into(),
                 false,
                 version,
                 bcs::to_bytes(self)?,

--- a/crates/iota-genesis-builder/src/stardust/types/output.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/output.rs
@@ -177,6 +177,7 @@ impl BasicOutput {
         })
     }
 
+    /// Returns the struct tag of the BasicOutput struct
     pub fn tag(type_param: TypeTag) -> StructTag {
         StructTag {
             address: STARDUST_PACKAGE_ID.into(),


### PR DESCRIPTION
Tag function has additional argument type_param: TypeTag 
iota-genesis-builder tests are fixed.
Some minor variables renaming(iota to balance)

# Description of change

Rust models(especially outputs) have updated tag function to handle different TypeTag.
It helps VM to handle struct type correctly.

## Links to any relevant issues

Fixes #610 .

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Run existing unit tests for iota-genesis-builder
