### PR TITLE
fix(iota-genesis-builder): Pass total supply info to migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6727,6 +6727,7 @@ dependencies = [
  "iota-protocol-config",
  "iota-sdk 1.1.4",
  "iota-simulator",
+ "iota-swarm-config",
  "iota-types",
  "itertools 0.11.0",
  "move-binary-format",

--- a/crates/iota-genesis-builder/examples/build_stardust_genesis.rs
+++ b/crates/iota-genesis-builder/examples/build_stardust_genesis.rs
@@ -3,13 +3,11 @@
 
 //! Creating a genesis blob out of a local stardust objects snapshot.
 
-use iota_genesis_builder::Builder;
+use iota_genesis_builder::{Builder, OBJECT_SNAPSHOT_FILE_PATH};
 use iota_swarm_config::genesis_config::ValidatorGenesisConfigBuilder;
 use rand::rngs::OsRng;
 use tracing::Level;
 use tracing_subscriber::FmtSubscriber;
-
-use iota_genesis_builder::OBJECT_SNAPSHOT_FILE_PATH;
 
 fn main() -> anyhow::Result<()> {
     // Initialize tracing

--- a/crates/iota-genesis-builder/src/main.rs
+++ b/crates/iota-genesis-builder/src/main.rs
@@ -32,7 +32,7 @@ fn main() -> anyhow::Result<()> {
     let parser = FullSnapshotParser::new(file)?;
 
     // Prepare the migration using the parser output stream
-    let migration = Migration::new(parser.header.target_milestone_timestamp())?;
+    let migration = Migration::new(parser.target_milestone_timestamp(), parser.total_supply()?)?;
     // Prepare the compressor writer for the objects snapshot
     let object_snapshot_writer = brotli::CompressorWriter::new(
         File::create(OBJECT_SNAPSHOT_FILE_PATH)?,

--- a/crates/iota-genesis-builder/src/stardust/error.rs
+++ b/crates/iota-genesis-builder/src/stardust/error.rs
@@ -35,7 +35,7 @@ pub enum StardustError {
     MeltingTokensMustNotBeGreaterThanMintedTokens,
     #[error("circulating supply must not be greater than maximum supply")]
     CirculatingSupplyMustNotBeGreaterThanMaximumSupply,
-    #[error("stardust snapshot parameters not found")]
+    #[error("hornet stardust snapshot parameters not found")]
     HornetSnapshotParametersNotFound,
 }
 

--- a/crates/iota-genesis-builder/src/stardust/error.rs
+++ b/crates/iota-genesis-builder/src/stardust/error.rs
@@ -35,6 +35,8 @@ pub enum StardustError {
     MeltingTokensMustNotBeGreaterThanMintedTokens,
     #[error("circulating supply must not be greater than maximum supply")]
     CirculatingSupplyMustNotBeGreaterThanMaximumSupply,
+    #[error("stardust snapshot parameters not found")]
+    HornetSnapshotParametersNotFound,
 }
 
 impl From<Infallible> for StardustError {

--- a/crates/iota-genesis-builder/src/stardust/parse.rs
+++ b/crates/iota-genesis-builder/src/stardust/parse.rs
@@ -42,10 +42,12 @@ impl<R: Read> FullSnapshotParser<R> {
         })
     }
 
+    /// Provide the target milestone timestamp extracted from the snapshot header.
     pub fn target_milestone_timestamp(&self) -> u32 {
         self.header.target_milestone_timestamp()
     }
 
+    /// Provide the network main token total supply through the snapshot protocol parameters.
     pub fn total_supply(&self) -> Result<u64> {
         if let MilestoneOption::Parameters(params) = self.header.parameters_milestone_option() {
             let protocol_params = <ProtocolParameters as packable::PackableExt>::unpack_unverified(

--- a/crates/iota-genesis-builder/src/stardust/parse.rs
+++ b/crates/iota-genesis-builder/src/stardust/parse.rs
@@ -5,10 +5,15 @@
 use std::io::{BufReader, Read};
 
 use anyhow::Result;
-use iota_sdk::types::block::{output::Output, protocol::ProtocolParameters};
+use iota_sdk::types::block::{
+    output::Output, payload::milestone::MilestoneOption, protocol::ProtocolParameters,
+};
 use packable::{unpacker::IoUnpacker, Packable};
 
-use super::types::snapshot::{FullSnapshotHeader, OutputHeader};
+use super::{
+    error::StardustError,
+    types::snapshot::{FullSnapshotHeader, OutputHeader},
+};
 
 /// Parse a full-snapshot using a [`BufReader`] internally.
 pub struct FullSnapshotParser<R: Read> {
@@ -35,5 +40,21 @@ impl<R: Read> FullSnapshotParser<R> {
                 Output::unpack::<_, true>(&mut self.reader, &ProtocolParameters::default())?,
             ))
         })
+    }
+
+    pub fn target_milestone_timestamp(&self) -> u32 {
+        self.header.target_milestone_timestamp()
+    }
+
+    pub fn total_supply(&self) -> Result<u64> {
+        if let MilestoneOption::Parameters(params) = self.header.parameters_milestone_option() {
+            let protocol_params = <ProtocolParameters as packable::PackableExt>::unpack_unverified(
+                params.binary_parameters(),
+            )
+            .expect("invalid protocol params");
+            Ok(protocol_params.token_supply())
+        } else {
+            Err(StardustError::HornetSnapshotParametersNotFound.into())
+        }
     }
 }

--- a/crates/iota-genesis-builder/src/stardust/parse.rs
+++ b/crates/iota-genesis-builder/src/stardust/parse.rs
@@ -42,12 +42,14 @@ impl<R: Read> FullSnapshotParser<R> {
         })
     }
 
-    /// Provide the target milestone timestamp extracted from the snapshot header.
+    /// Provide the target milestone timestamp extracted from the snapshot
+    /// header.
     pub fn target_milestone_timestamp(&self) -> u32 {
         self.header.target_milestone_timestamp()
     }
 
-    /// Provide the network main token total supply through the snapshot protocol parameters.
+    /// Provide the network main token total supply through the snapshot
+    /// protocol parameters.
     pub fn total_supply(&self) -> Result<u64> {
         if let MilestoneOption::Parameters(params) = self.header.parameters_milestone_option() {
             let protocol_params = <ProtocolParameters as packable::PackableExt>::unpack_unverified(


### PR DESCRIPTION
# Description of change

Fixes #628 
The total supply is taken from the parsed Hornet snapshot, through the header.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)