### PR TITLE
feat: add workflow for release docker image

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,155 @@
+name: Publish Docker Images
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      iota_node:
+        type: boolean
+        description: 'Release iota-node image'
+        required: false
+        default: false
+      iota_indexer:
+        type: boolean
+        description: 'Release iota-indexer image'
+        required: false
+        default: false
+      iota_tools:
+        type: boolean
+        description: 'Release iota-tools image'
+        required: false
+        default: false
+
+jobs:
+  build-iota-node:
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.iota_node == 'true' || github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta for iota-node
+        id: meta-node
+        uses: docker/metadata-action@v5
+        with:
+          images: docker-registry.iota.org/iota-node
+          tags: |
+              type=raw,value={{sha}},enable=${{ github.event_name == 'workflow_dispatch' }}
+              type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+              type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
+              type=semver,pattern={{major}},enable=${{ github.event_name == 'release' }}
+              type=match,pattern=v(\d+.\d+),suffix=-alpha,group=1,enable=${{ contains(github.ref, '-alpha') && github.event_name == 'release' }}
+              type=match,pattern=v(\d+.\d+),suffix=-beta,group=1,enable=${{ contains(github.ref, '-beta') && github.event_name == 'release' }}
+              type=match,pattern=v(\d+.\d+),suffix=-rc,group=1,enable=${{ contains(github.ref, '-rc') && github.event_name == 'release' }}
+
+      - name: Login to Docker Registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+          password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+          registry: ${{ secrets.DOCKER_REGISTRY_URL }}
+
+      - name: Build and push Docker image for iota-node
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/iota-node/Dockerfile
+          platforms: linux/amd64
+          tags: ${{ steps.meta-node.outputs.tags }}
+          push: true
+
+  build-iota-indexer:
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.iota_indexer == 'true' || github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta for iota-indexer
+        id: meta-indexer
+        uses: docker/metadata-action@v5
+        with:
+          images: docker-registry.iota.org/iota-indexer
+          tags: |
+              type=raw,value={{sha}},enable=${{ github.event_name == 'workflow_dispatch' }}
+              type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+              type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
+              type=semver,pattern={{major}},enable=${{ github.event_name == 'release' }}
+              type=match,pattern=v(\d+.\d+),suffix=-alpha,group=1,enable=${{ contains(github.ref, '-alpha') && github.event_name == 'release' }}
+              type=match,pattern=v(\d+.\d+),suffix=-beta,group=1,enable=${{ contains(github.ref, '-beta') && github.event_name == 'release' }}
+              type=match,pattern=v(\d+.\d+),suffix=-rc,group=1,enable=${{ contains(github.ref, '-rc') && github.event_name == 'release' }}
+
+      - name: Login to Docker Registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+          password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+          registry: ${{ secrets.DOCKER_REGISTRY_URL }}
+
+      - name: Build and push Docker image for iota-indexer
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/iota-indexer/Dockerfile
+          platforms: linux/amd64
+          tags: ${{ steps.meta-indexer.outputs.tags }}
+          push: true
+
+  build-iota-tools:
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.iota_tools == 'true' || github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta for iota-tools
+        id: meta-tools
+        uses: docker/metadata-action@v5
+        with:
+          images: docker-registry.iota.org/iota-tools
+          tags: |
+              type=raw,value={{sha}},enable=${{ github.event_name == 'workflow_dispatch' }}
+              type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+              type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
+              type=semver,pattern={{major}},enable=${{ github.event_name == 'release' }}
+              type=match,pattern=v(\d+.\d+),suffix=-alpha,group=1,enable=${{ contains(github.ref, '-alpha') && github.event_name == 'release' }}
+              type=match,pattern=v(\d+.\d+),suffix=-beta,group=1,enable=${{ contains(github.ref, '-beta') && github.event_name == 'release' }}
+              type=match,pattern=v(\d+.\d+),suffix=-rc,group=1,enable=${{ contains(github.ref, '-rc') && github.event_name == 'release' }}
+
+      - name: Login to Docker Registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+          password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+          registry: ${{ secrets.DOCKER_REGISTRY_URL }}
+
+      - name: Build and push Docker image for iota-tools
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/iota-tools/Dockerfile
+          platforms: linux/amd64
+          tags: ${{ steps.meta-tools.outputs.tags }}
+          push: true


### PR DESCRIPTION
# Description of change

Add the workflow for releasing `iota-node`, `iota-indexer`, and `iota-tools` Docker images. This workflow can be triggered by a release or manually. If you trigger the workflow manually, the tag will be the SHA of the commit.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Used `act` to test the workflow locally on my laptop.

