### PR TITLE
fix(iota-faucet): Fix faucet batch send status

### DIFF
--- a/crates/iota-faucet/src/faucet/simple_faucet.rs
+++ b/crates/iota-faucet/src/faucet/simple_faucet.rs
@@ -809,12 +809,16 @@ impl SimpleFaucet {
 
             request_count.insert(addy, number_of_coins as u64 + index);
 
+            // We can safely zip up `coins_slice` and `amounts` without truncating either
+            // slice, since both are checked to have the same length, according
+            // to the above code.
             let transferred_gases = coins_slice
                 .iter()
-                .map(|coin| CoinInfo {
+                .zip(amounts)
+                .map(|(coin, amount)| CoinInfo {
                     id: coin.object_id(),
                     transfer_tx_digest: res.digest,
-                    amount: self.coin_amount,
+                    amount,
                 })
                 .collect();
 


### PR DESCRIPTION
# Description of change

Fix faucet batch send status.

When using `/v1/gas` to request a gas coin from the faucet, a task ID is returned which can be used via `/v1/status/:task_id` to check the current status of the request.

The `FaucetConfig::amount` is a way to configure how many tokens the faucet pays out for a single request. However, it is inconsistently used in the code. The standalone `iota-faucet` binary uses the values from that config:

https://github.com/iotaledger/iota/blob/e8ed2e9f51ec928202acb444ae426b2c3aa54e17/crates/iota-faucet/src/main.rs#L157-L164

However, the `iota-test-validator` uses the faucet client implementation from `iota-cluster-test` which uses hardcoded values:

https://github.com/iotaledger/iota/blob/e8ed2e9f51ec928202acb444ae426b2c3aa54e17/crates/iota-cluster-test/src/faucet.rs#L187-L191

This is all fine until we check the status of the faucet request. After transferring the gas coins, `check_and_map_batch_transfer_gas_result` is called to update the status of the request. When creating the `transferred_gases` vector, containing all the object ids and corresponding amounts, the code assumes that `self.coin_amount` is used, which is initially set to `FaucetConfig::amount`. Since the latter is currently set to a default of `1_000_000_000`, and the above `iota-test-cluster` implementation uses a different value, the status check returns an incorrect response.

To fix it, the actually transferred values from `amounts` can be used instead of the configured value.

## Links to any relevant issues

fixes #767
