### PR TITLE
fix(iota-framework/timelock): Add `split_and_transfer` function to `TimeLock<Balance<T>>`

### DIFF
--- a/crates/iota-framework/docs/timelock/timelocked_balance.md
+++ b/crates/iota-framework/docs/timelock/timelocked_balance.md
@@ -9,6 +9,7 @@ Utility functions for time-locked balance.
 -  [Function `join`](#0x10cf_timelocked_balance_join)
 -  [Function `join_vec`](#0x10cf_timelocked_balance_join_vec)
 -  [Function `split`](#0x10cf_timelocked_balance_split)
+-  [Function `split_and_transfer`](#0x10cf_timelocked_balance_split_and_transfer)
 
 
 <pre><code><b>use</b> <a href="timelock.md#0x10cf_timelock">0x10cf::timelock</a>;
@@ -136,6 +137,34 @@ Split a <code>TimeLock&lt;Balance&lt;T&gt;&gt;</code> and take a sub balance fro
 
     // Pack the splitted <a href="../iota-framework/balance.md#0x2_balance">balance</a> into a <a href="timelock.md#0x10cf_timelock">timelock</a>.
     <a href="timelock.md#0x10cf_timelock_pack">timelock::pack</a>(value, self.expiration_timestamp_ms(), self.label(), ctx)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x10cf_timelocked_balance_split_and_transfer"></a>
+
+## Function `split_and_transfer`
+
+Split a <code>TimeLock&lt;Balance&lt;T&gt;&gt;</code> and transfer it to the original owner.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="timelocked_balance.md#0x10cf_timelocked_balance_split_and_transfer">split_and_transfer</a>&lt;T&gt;(self: &<b>mut</b> <a href="timelock.md#0x10cf_timelock_TimeLock">timelock::TimeLock</a>&lt;<a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;&gt;, value: u64, ctx: &<b>mut</b> <a href="../iota-framework/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="timelocked_balance.md#0x10cf_timelocked_balance_split_and_transfer">split_and_transfer</a>&lt;T&gt;(self: &<b>mut</b> TimeLock&lt;Balance&lt;T&gt;&gt;, value: u64, ctx: &<b>mut</b> TxContext){
+    // Split the <a href="timelock.md#0x10cf_timelock">timelock</a>.
+    <b>let</b> splitted = <a href="timelocked_balance.md#0x10cf_timelocked_balance_split">split</a>(self, value, ctx);
+    // Transfer it <b>to</b> the sender.
+    splitted.<a href="../iota-framework/transfer.md#0x2_transfer">transfer</a>(ctx.sender())
 }
 </code></pre>
 

--- a/crates/iota-framework/packages/timelock/Move.lock
+++ b/crates/iota-framework/packages/timelock/Move.lock
@@ -2,17 +2,13 @@
 
 [move]
 version = 1
-manifest_digest = "F7B0657885F7F095E7ED4AC0F6A8772A191E3257D870D1C8A0DD84BFD1BE32E8"
+manifest_digest = "B70A186772DD522A8D8DC380E7217B09F79FE8D34CB09A27CD39E5FFA487CA30"
 deps_digest = "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3"
 dependencies = [
-  { name = "MoveStdlib" },
   { name = "Iota" },
   { name = "IotaSystem" },
+  { name = "MoveStdlib" },
 ]
-
-[[move.package]]
-name = "MoveStdlib"
-source = { local = "../move-stdlib" }
 
 [[move.package]]
 name = "Iota"
@@ -27,9 +23,13 @@ name = "IotaSystem"
 source = { local = "../iota-system" }
 
 dependencies = [
-  { name = "MoveStdlib" },
   { name = "Iota" },
+  { name = "MoveStdlib" },
 ]
+
+[[move.package]]
+name = "MoveStdlib"
+source = { local = "../move-stdlib" }
 
 [move.toolchain-version]
 compiler-version = "1.22.0"

--- a/crates/iota-framework/packages/timelock/sources/timelocked_balance.move
+++ b/crates/iota-framework/packages/timelock/sources/timelocked_balance.move
@@ -50,4 +50,13 @@ module timelock::timelocked_balance {
         // Pack the splitted balance into a timelock.
         timelock::pack(value, self.expiration_timestamp_ms(), self.label(), ctx)
     }
+
+
+    /// Split a `TimeLock<Balance<T>>` and transfer it to the original owner.
+    public fun split_and_transfer<T>(self: &mut TimeLock<Balance<T>>, value: u64, ctx: &mut TxContext){
+        // Split the timelock.
+        let splitted = split(self, value, ctx);
+        // Transfer it to the sender.
+        splitted.transfer(ctx.sender())
+    }
 }

--- a/crates/iota-framework/packages/timelock/tests/timelocked_balance_tests.move
+++ b/crates/iota-framework/packages/timelock/tests/timelocked_balance_tests.move
@@ -10,7 +10,7 @@ module timelock::timelocked_balance_tests {
     use iota::test_utils::{Self, assert_eq};
 
     use timelock::labeler::LabelerCap;
-    use timelock::timelock;
+    use timelock::timelock::{Self, TimeLock};
     use timelock::timelocked_balance;
 
     use timelock::test_label_one::{Self, TEST_LABEL_ONE};
@@ -256,6 +256,38 @@ module timelock::timelocked_balance_tests {
         assert_eq(original.locked().value(), 7);
 
         // Check the splitted timelock.
+        assert_eq(splitted.expiration_timestamp_ms(), 100);
+        assert_eq(splitted.locked().value(), 3);
+
+        // Cleanup.
+        test_utils::destroy(original);
+        test_utils::destroy(splitted);
+
+        scenario.end();
+    }
+
+    #[test]
+    fun test_split_and_transfer_timelocked_balances() {
+        // Set up a test environment.
+        let sender = @0xA;
+        let mut scenario = test_scenario::begin(sender);
+
+        // Minting some IOTA.
+        let iota = balance::create_for_testing<IOTA>(10);
+
+        // Lock the IOTA balance.
+        let mut original = timelock::lock(iota, 100, scenario.ctx());
+
+        // Split and transfer the timelock.
+        timelocked_balance::split_and_transfer(&mut original, 3, scenario.ctx());
+        scenario.next_tx(sender);
+    
+        // Check the original timelock.
+        assert_eq(original.expiration_timestamp_ms(), 100);
+        assert_eq(original.locked().value(), 7);
+
+        // Check the splitted timelock.
+        let splitted = scenario.take_from_address<TimeLock<Balance<IOTA>>>(sender);
         assert_eq(splitted.expiration_timestamp_ms(), 100);
         assert_eq(splitted.locked().value(), 3);
 


### PR DESCRIPTION
# Description of change

This PR makes so that a splitted `TimeLock<Balance<T>>`can be transferred to the original owner (`timelocked_balance::split` returns a value that cannot be transferred in a PTB).    

## Links to any relevant issues

Fixes #810 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`iota move test`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
