### PR TITLE
fix(iota-genesis-builder): Don't suppress BasicOutput metadata, tag, and sender features

### DIFF
--- a/crates/iota-genesis-builder/src/stardust/migration/verification/basic.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/basic.rs
@@ -86,8 +86,8 @@ pub(super) fn verify_basic_output(
         return Ok(());
     }
 
-    // If the output has multiple unlock conditions, then a genesis object should
-    // have been created.
+    // If the output has multiple unlock conditions or a metadata, tag or sender
+    // feature, then a genesis object should have been created.
     if output.unlock_conditions().expiration().is_some()
         || output
             .unlock_conditions()
@@ -96,6 +96,9 @@ pub(super) fn verify_basic_output(
         || output
             .unlock_conditions()
             .is_time_locked(target_milestone_timestamp)
+        || output.features().metadata().is_some()
+        || output.features().tag().is_some()
+        || output.features().sender().is_some()
     {
         ensure!(created_objects.coin().is_err(), "unexpected coin created");
 

--- a/crates/iota-genesis-builder/src/stardust/migration/verification/basic.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/basic.rs
@@ -96,9 +96,7 @@ pub(super) fn verify_basic_output(
         || output
             .unlock_conditions()
             .is_time_locked(target_milestone_timestamp)
-        || output.features().metadata().is_some()
-        || output.features().tag().is_some()
-        || output.features().sender().is_some()
+        || !output.features().is_empty()
     {
         ensure!(created_objects.coin().is_err(), "unexpected coin created");
 

--- a/crates/iota-types/src/stardust/output/basic.rs
+++ b/crates/iota-types/src/stardust/output/basic.rs
@@ -119,7 +119,7 @@ impl BasicOutput {
     ///
     /// Returns `true` in particular when the given milestone timestamp is equal
     /// or past the unix timestamp in a present timelock and no other unlock
-    /// condition is present.
+    /// condition or metadata, tag, sender feature is present.
     pub fn is_simple_coin(&self, target_milestone_timestamp_sec: u32) -> bool {
         !(self.expiration.is_some()
             || self.storage_deposit_return.is_some()

--- a/crates/iota-types/src/stardust/output/basic.rs
+++ b/crates/iota-types/src/stardust/output/basic.rs
@@ -20,7 +20,7 @@ use crate::{
     collection_types::Bag,
     id::UID,
     object::{Data, MoveObject, Object, Owner},
-    stardust::coin_type::CoinType,
+    stardust::{coin_type::CoinType, stardust_to_iota_address},
     TypeTag, STARDUST_PACKAGE_ID,
 };
 
@@ -89,7 +89,8 @@ impl BasicOutput {
         let sender = output
             .features()
             .sender()
-            .map(|sender| sender.address().into());
+            .map(|sender| stardust_to_iota_address(sender.address()))
+            .transpose()?;
 
         Ok(BasicOutput {
             id,

--- a/crates/iota-types/src/stardust/output/basic.rs
+++ b/crates/iota-types/src/stardust/output/basic.rs
@@ -125,11 +125,10 @@ impl BasicOutput {
             || self.storage_deposit_return.is_some()
             || self.timelock.as_ref().map_or(false, |timelock| {
                 target_milestone_timestamp_sec < timelock.unix_time
-            }
+            })
             || self.metadata.is_some()
             || self.tag.is_some()
-            || self.sender.is_some()
-        ))
+            || self.sender.is_some())
     }
 
     pub fn to_genesis_object(


### PR DESCRIPTION
# Description of change

Fixes `is_simple_coin`, which is responsible for whether a basic output is simply converted into a coin or not.
By adjusting `is_simple_coin` with checks for `metadata`, `tag`, and `sender features`, we no longer convert basic outputs that contain these fields to simple coins.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/819

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`cargo test`
Testing with snapshot not completed yet.

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
