### PR TITLE
fix(iota-genesis-builder): Handle unexpected objects whose object ID is an ed25519 address

### DIFF
--- a/crates/iota-genesis-builder/src/stardust/migration/verification/alias.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/alias.rs
@@ -161,7 +161,7 @@ pub(super) fn verify_alias_output(
         created_alias.immutable_metadata.as_ref(),
     )?;
 
-    verify_parent(output.governor_address(), storage)?;
+    verify_parent(&output_id, output.governor_address(), storage)?;
 
     ensure!(created_objects.coin().is_err(), "unexpected coin found");
 

--- a/crates/iota-genesis-builder/src/stardust/migration/verification/basic.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/basic.rs
@@ -203,7 +203,7 @@ pub(super) fn verify_basic_output(
         )?;
     }
 
-    verify_parent(output.address(), storage)?;
+    verify_parent(&output_id, output.address(), storage)?;
 
     ensure!(
         created_objects.native_token_coin().is_err(),

--- a/crates/iota-genesis-builder/src/stardust/migration/verification/foundry.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/foundry.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 
 use anyhow::{anyhow, ensure, Result};
-use iota_sdk::types::block::output::{FoundryOutput, TokenId};
+use iota_sdk::types::block::output::{FoundryOutput, OutputId, TokenId};
 use iota_types::{
     base_types::IotaAddress, coin_manager::CoinManager, in_memory_storage::InMemoryStorage,
     object::Owner, Identifier,
@@ -27,6 +27,7 @@ use crate::stardust::{
 };
 
 pub(super) fn verify_foundry_output(
+    output_id: OutputId,
     output: &FoundryOutput,
     created_objects: &CreatedObjects,
     foundry_data: &HashMap<TokenId, FoundryLedgerData>,
@@ -240,7 +241,7 @@ pub(super) fn verify_foundry_output(
         "coin manager treasury cap",
     )?;
 
-    verify_parent(alias_address, storage)?;
+    verify_parent(&output_id, alias_address, storage)?;
 
     ensure!(
         created_objects.output().is_err(),

--- a/crates/iota-genesis-builder/src/stardust/migration/verification/mod.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/mod.rs
@@ -78,6 +78,7 @@ fn verify_output(
             total_value,
         ),
         Output::Foundry(output) => foundry::verify_foundry_output(
+            header.output_id(),
             output,
             created_objects,
             foundry_data,

--- a/crates/iota-genesis-builder/src/stardust/migration/verification/nft.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/nft.rs
@@ -145,7 +145,7 @@ pub(super) fn verify_nft_output(
         created_nft.immutable_metadata
     );
 
-    verify_parent(output.address(), storage)?;
+    verify_parent(&output_id, output.address(), storage)?;
 
     ensure!(created_objects.coin().is_err(), "unexpected coin found");
 


### PR DESCRIPTION
# Description of change

We agreed that if an unexpected object exists whose object ID is an ed25519 address, we should check the related output and migrated objects manually and not directly abort migration/verification.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/822

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`cargo run -- shimmer --snapshot-path shimmer_snapshot.bin --target-network alphanet`

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
