### PR TITLE
fix(iota-genesis-builder): Fix timelock timestamp verification

### DIFF
--- a/crates/iota-genesis-builder/src/stardust/migration/verification/basic.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/basic.rs
@@ -53,11 +53,13 @@ pub(super) fn verify_basic_output(
             .ok_or_else(|| anyhow!("invalid timelock object"))?;
 
         // Locked timestamp
+        let output_timelock_timestamp =
+            output.unlock_conditions().timelock().unwrap().timestamp() as u64 * 1000;
         ensure!(
-            created_timelock.expiration_timestamp_ms() == target_milestone_timestamp as u64,
+            created_timelock.expiration_timestamp_ms() == output_timelock_timestamp,
             "timelock timestamp mismatch: found {}, expected {}",
             created_timelock.expiration_timestamp_ms(),
-            target_milestone_timestamp
+            output_timelock_timestamp
         );
 
         // Amount


### PR DESCRIPTION
# Description of change

Instead of checking the the basic output `TimeLock` timestamp [against](https://github.com/iotaledger/iota/blob/ffcbd4dbeb188cf52936107dd75a53ac154e4e28/crates/iota-genesis-builder/src/stardust/migration/verification/basic.rs#L57) the `target_milestone_timestamp` we need to check it against the timestamp from the related output.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/826

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`cargo test`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
