### PR TITLE
fix: Feature gating for test-outputs module

### DIFF
--- a/crates/iota-genesis-builder/src/stardust/mod.rs
+++ b/crates/iota-genesis-builder/src/stardust/mod.rs
@@ -8,5 +8,6 @@
 pub mod migration;
 pub mod native_token;
 pub mod parse;
+#[cfg(feature = "test-outputs")]
 pub mod test_outputs;
 pub mod types;


### PR DESCRIPTION
# Description of change

Adds a feature gate to the `test_outputs` module to avoid build errors when the `iota-sdk/client` feature is not enabled