### PR TITLE
fix(iota-genesis-builder): Scale total supply amount for iota

### DIFF
--- a/crates/iota-genesis-builder/src/main.rs
+++ b/crates/iota-genesis-builder/src/main.rs
@@ -73,7 +73,7 @@ fn main() -> Result<()> {
     // Start the Hornet snapshot parser
     let snapshot_parser = HornetGenesisSnapshotParser::new(File::open(snapshot_path)?)?;
     let total_supply = match coin_type {
-        CoinType::Iota => scale_amount(snapshot_parser.total_supply()?)?,
+        CoinType::Iota => scale_amount_for_iota(snapshot_parser.total_supply()?)?,
         CoinType::Shimmer => snapshot_parser.total_supply()?,
     };
 
@@ -114,7 +114,7 @@ fn scale_output_amount_for_iota(output: &mut Output) -> Result<()> {
         Output::Basic(ref basic_output) => {
             // Update amount
             let mut builder = BasicOutputBuilder::from(basic_output)
-                .with_amount(scale_amount(basic_output.amount())?);
+                .with_amount(scale_amount_for_iota(basic_output.amount())?);
 
             // Update amount in potential storage deposit return unlock condition
             if let Some(sdr_uc) = basic_output
@@ -125,7 +125,7 @@ fn scale_output_amount_for_iota(output: &mut Output) -> Result<()> {
                 builder = builder.replace_unlock_condition(
                     StorageDepositReturnUnlockCondition::new(
                         sdr_uc.return_address(),
-                        scale_amount(sdr_uc.amount())?,
+                        scale_amount_for_iota(sdr_uc.amount())?,
                         u64::MAX,
                     )
                     .unwrap(),
@@ -136,18 +136,18 @@ fn scale_output_amount_for_iota(output: &mut Output) -> Result<()> {
         }
         Output::Alias(ref alias_output) => Output::from(
             AliasOutputBuilder::from(alias_output)
-                .with_amount(scale_amount(alias_output.amount())?)
+                .with_amount(scale_amount_for_iota(alias_output.amount())?)
                 .finish()?,
         ),
         Output::Foundry(ref foundry_output) => Output::from(
             FoundryOutputBuilder::from(foundry_output)
-                .with_amount(scale_amount(foundry_output.amount())?)
+                .with_amount(scale_amount_for_iota(foundry_output.amount())?)
                 .finish()?,
         ),
         Output::Nft(ref nft_output) => {
             // Update amount
-            let mut builder =
-                NftOutputBuilder::from(nft_output).with_amount(scale_amount(nft_output.amount())?);
+            let mut builder = NftOutputBuilder::from(nft_output)
+                .with_amount(scale_amount_for_iota(nft_output.amount())?);
 
             // Update amount in potential storage deposit return unlock condition
             if let Some(sdr_uc) = nft_output
@@ -158,7 +158,7 @@ fn scale_output_amount_for_iota(output: &mut Output) -> Result<()> {
                 builder = builder.replace_unlock_condition(
                     StorageDepositReturnUnlockCondition::new(
                         sdr_uc.return_address(),
-                        scale_amount(sdr_uc.amount())?,
+                        scale_amount_for_iota(sdr_uc.amount())?,
                         u64::MAX,
                     )
                     .unwrap(),
@@ -172,7 +172,7 @@ fn scale_output_amount_for_iota(output: &mut Output) -> Result<()> {
     Ok(())
 }
 
-fn scale_amount(amount: u64) -> Result<u64> {
+fn scale_amount_for_iota(amount: u64) -> Result<u64> {
     const IOTA_MULTIPLIER: u64 = 1000;
 
     amount

--- a/crates/iota-genesis-builder/src/main.rs
+++ b/crates/iota-genesis-builder/src/main.rs
@@ -72,11 +72,15 @@ fn main() -> Result<()> {
 
     // Start the Hornet snapshot parser
     let snapshot_parser = HornetGenesisSnapshotParser::new(File::open(snapshot_path)?)?;
+    let total_supply = match coin_type {
+        CoinType::Iota => scale_amount(snapshot_parser.total_supply()?)?,
+        CoinType::Shimmer => snapshot_parser.total_supply()?,
+    };
 
     // Prepare the migration using the parser output stream
     let migration = Migration::new(
         snapshot_parser.target_milestone_timestamp(),
-        scale_amount(snapshot_parser.total_supply()?)?,
+        total_supply,
         target_network,
         coin_type,
     )?;


### PR DESCRIPTION
# Description of change

Scales the total supply amount for IOTA that we get from the snapshot in order to avoid following verification issue:

`Error: total supply mismatch: found 4600000000000000000, expected 4600000000000000`

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/852

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

- cargo test
- verification passed

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
