### PR TITLE
fix(iota-types): Update total supply const and rename Micros to Nanos

### DIFF
--- a/crates/iota-benchmark/src/benchmark_setup.rs
+++ b/crates/iota-benchmark/src/benchmark_setup.rs
@@ -102,7 +102,7 @@ impl Env {
                 let cluster = TestClusterBuilder::new()
                     .with_accounts(vec![AccountConfig {
                         address: Some(primary_gas_owner),
-                        // We can't use TOTAL_SUPPLY_MICROS because we need to account for validator
+                        // We can't use TOTAL_SUPPLY_NANOS because we need to account for validator
                         // stakes in genesis allocation.
                         gas_amounts: vec![TOTAL_SUPPLY_NANOS / 2],
                     }])

--- a/crates/iota-benchmark/src/benchmark_setup.rs
+++ b/crates/iota-benchmark/src/benchmark_setup.rs
@@ -9,7 +9,7 @@ use iota_swarm_config::genesis_config::AccountConfig;
 use iota_types::{
     base_types::{ConciseableName, IotaAddress, ObjectID},
     crypto::{deterministic_random_account_key, AccountKeyPair},
-    gas_coin::TOTAL_SUPPLY_MICROS,
+    gas_coin::TOTAL_SUPPLY_NANOS,
     object::Owner,
 };
 use prometheus::Registry;
@@ -104,7 +104,7 @@ impl Env {
                         address: Some(primary_gas_owner),
                         // We can't use TOTAL_SUPPLY_MICROS because we need to account for validator
                         // stakes in genesis allocation.
-                        gas_amounts: vec![TOTAL_SUPPLY_MICROS / 2],
+                        gas_amounts: vec![TOTAL_SUPPLY_NANOS / 2],
                     }])
                     .with_num_validators(committee_size)
                     .build()

--- a/crates/iota-benchmark/src/workloads/batch_payment.rs
+++ b/crates/iota-benchmark/src/workloads/batch_payment.rs
@@ -28,12 +28,12 @@ use crate::{
     ExecutionEffects, ValidatorProxy,
 };
 
-/// Value of each address's "primary coin" in micros. The first transaction
+/// Value of each address's "primary coin" in nanos. The first transaction
 /// gives each address a coin worth PRIMARY_COIN_VALUE, and all subsequent
 /// transfers send TRANSFER_AMOUNT coins each time
 const PRIMARY_COIN_VALUE: u64 = 100 * NANOS_PER_IOTA;
 
-/// Number of micros sent to each address on each batch transfer
+/// Number of nanos sent to each address on each batch transfer
 const BATCH_TRANSFER_AMOUNT: u64 = 1;
 
 const DUMMY_GAS: ObjectRef = (ObjectID::ZERO, SequenceNumber::MIN, ObjectDigest::MIN);

--- a/crates/iota-benchmark/src/workloads/batch_payment.rs
+++ b/crates/iota-benchmark/src/workloads/batch_payment.rs
@@ -10,7 +10,7 @@ use iota_types::{
     base_types::{IotaAddress, ObjectID, ObjectRef, SequenceNumber},
     crypto::get_key_pair,
     digests::ObjectDigest,
-    gas_coin::MICROS_PER_IOTA,
+    gas_coin::NANOS_PER_IOTA,
     object::Owner,
     transaction::Transaction,
 };
@@ -31,7 +31,7 @@ use crate::{
 /// Value of each address's "primary coin" in micros. The first transaction
 /// gives each address a coin worth PRIMARY_COIN_VALUE, and all subsequent
 /// transfers send TRANSFER_AMOUNT coins each time
-const PRIMARY_COIN_VALUE: u64 = 100 * MICROS_PER_IOTA;
+const PRIMARY_COIN_VALUE: u64 = 100 * NANOS_PER_IOTA;
 
 /// Number of micros sent to each address on each batch transfer
 const BATCH_TRANSFER_AMOUNT: u64 = 1;

--- a/crates/iota-benchmark/src/workloads/delegation.rs
+++ b/crates/iota-benchmark/src/workloads/delegation.rs
@@ -10,7 +10,7 @@ use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
     base_types::{IotaAddress, ObjectRef},
     crypto::{get_key_pair, AccountKeyPair},
-    gas_coin::MICROS_PER_IOTA,
+    gas_coin::NANOS_PER_IOTA,
     transaction::Transaction,
 };
 use rand::seq::IteratorRandom;
@@ -79,7 +79,7 @@ impl Payload for DelegationTestPayload {
             None => make_transfer_iota_transaction(
                 self.gas,
                 self.sender,
-                Some(MICROS_PER_IOTA),
+                Some(NANOS_PER_IOTA),
                 self.sender,
                 &self.keypair,
                 self.system_state_observer

--- a/crates/iota-benchmark/src/workloads/workload.rs
+++ b/crates/iota-benchmark/src/workloads/workload.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use iota_types::gas_coin::MICROS_PER_IOTA;
+use iota_types::gas_coin::NANOS_PER_IOTA;
 
 use crate::{
     system_state_observer::SystemStateObserver,
@@ -15,11 +15,11 @@ use crate::{
 
 // This is the maximum gas we will transfer from primary coin into any gas coin
 // for running the benchmark
-pub const MAX_GAS_FOR_TESTING: u64 = 1_000 * MICROS_PER_IOTA;
+pub const MAX_GAS_FOR_TESTING: u64 = 1_000 * NANOS_PER_IOTA;
 
 // TODO: get this information from protocol config
 // This is the maximum budget that can be set for a transaction. 50 IOTA.
-pub const MAX_BUDGET: u64 = 50 * MICROS_PER_IOTA;
+pub const MAX_BUDGET: u64 = 50 * NANOS_PER_IOTA;
 // (COIN_BYTES_SIZE * STORAGE_PRICE * STORAGE_UNITS_PER_BYTE)
 pub const STORAGE_COST_PER_COIN: u64 = 130 * 76 * 100;
 // (COUNTER_BYTES_SIZE * STORAGE_PRICE * STORAGE_UNITS_PER_BYTE)

--- a/crates/iota-config/src/genesis.rs
+++ b/crates/iota-config/src/genesis.rs
@@ -459,11 +459,11 @@ impl GenesisCeremonyParameters {
             stake_subsidy_period_length: self.stake_subsidy_period_length,
             stake_subsidy_decrease_rate: self.stake_subsidy_decrease_rate,
             max_validator_count: iota_types::governance::MAX_VALIDATOR_COUNT,
-            min_validator_joining_stake: iota_types::governance::MIN_VALIDATOR_JOINING_STAKE_MICROS,
+            min_validator_joining_stake: iota_types::governance::MIN_VALIDATOR_JOINING_STAKE_NANOS,
             validator_low_stake_threshold:
-                iota_types::governance::VALIDATOR_LOW_STAKE_THRESHOLD_MICROS,
+                iota_types::governance::VALIDATOR_LOW_STAKE_THRESHOLD_NANOS,
             validator_very_low_stake_threshold:
-                iota_types::governance::VALIDATOR_VERY_LOW_STAKE_THRESHOLD_MICROS,
+                iota_types::governance::VALIDATOR_VERY_LOW_STAKE_THRESHOLD_NANOS,
             validator_low_stake_grace_period:
                 iota_types::governance::VALIDATOR_LOW_STAKE_GRACE_PERIOD,
         }
@@ -479,13 +479,13 @@ impl Default for GenesisCeremonyParameters {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct TokenDistributionSchedule {
-    pub stake_subsidy_fund_micros: u64,
+    pub stake_subsidy_fund_nanos: u64,
     pub allocations: Vec<TokenAllocation>,
 }
 
 impl TokenDistributionSchedule {
     pub fn validate(&self) {
-        let mut total_nanos = self.stake_subsidy_fund_micros;
+        let mut total_nanos = self.stake_subsidy_fund_nanos;
 
         for allocation in &self.allocations {
             total_nanos += allocation.amount_nanos;
@@ -522,7 +522,7 @@ impl TokenDistributionSchedule {
 
         // Check that all validators have sufficient stake allocated to ensure they meet
         // the minimum stake threshold
-        let minimum_required_stake = iota_types::governance::VALIDATOR_LOW_STAKE_THRESHOLD_MICROS;
+        let minimum_required_stake = iota_types::governance::VALIDATOR_LOW_STAKE_THRESHOLD_NANOS;
         for (validator, stake) in validators {
             if stake < minimum_required_stake {
                 panic!(
@@ -536,7 +536,7 @@ impl TokenDistributionSchedule {
         validators: I,
     ) -> Self {
         let mut supply = TOTAL_SUPPLY_NANOS;
-        let default_allocation = iota_types::governance::VALIDATOR_LOW_STAKE_THRESHOLD_MICROS;
+        let default_allocation = iota_types::governance::VALIDATOR_LOW_STAKE_THRESHOLD_NANOS;
 
         let allocations = validators
             .into_iter()
@@ -551,7 +551,7 @@ impl TokenDistributionSchedule {
             .collect();
 
         let schedule = Self {
-            stake_subsidy_fund_micros: supply,
+            stake_subsidy_fund_nanos: supply,
             allocations,
         };
 
@@ -591,7 +591,7 @@ impl TokenDistributionSchedule {
         );
 
         let schedule = Self {
-            stake_subsidy_fund_micros: stake_subsidy_fund_allocation.amount_nanos,
+            stake_subsidy_fund_nanos: stake_subsidy_fund_allocation.amount_nanos,
             allocations,
         };
 
@@ -608,7 +608,7 @@ impl TokenDistributionSchedule {
 
         writer.serialize(TokenAllocation {
             recipient_address: IotaAddress::default(),
-            amount_nanos: self.stake_subsidy_fund_micros,
+            amount_nanos: self.stake_subsidy_fund_nanos,
             staked_with_validator: None,
         })?;
 
@@ -646,7 +646,7 @@ impl TokenDistributionScheduleBuilder {
         &mut self,
         validators: I,
     ) {
-        let default_allocation = iota_types::governance::VALIDATOR_LOW_STAKE_THRESHOLD_MICROS;
+        let default_allocation = iota_types::governance::VALIDATOR_LOW_STAKE_THRESHOLD_NANOS;
 
         for validator in validators {
             self.add_allocation(TokenAllocation {
@@ -664,7 +664,7 @@ impl TokenDistributionScheduleBuilder {
 
     pub fn build(&self) -> TokenDistributionSchedule {
         let schedule = TokenDistributionSchedule {
-            stake_subsidy_fund_micros: self.pool,
+            stake_subsidy_fund_nanos: self.pool,
             allocations: self.allocations.clone(),
         };
 

--- a/crates/iota-config/src/genesis.rs
+++ b/crates/iota-config/src/genesis.rs
@@ -485,15 +485,15 @@ pub struct TokenDistributionSchedule {
 
 impl TokenDistributionSchedule {
     pub fn validate(&self) {
-        let mut total_micros = self.stake_subsidy_fund_micros;
+        let mut total_nanos = self.stake_subsidy_fund_micros;
 
         for allocation in &self.allocations {
-            total_micros += allocation.amount_micros;
+            total_nanos += allocation.amount_nanos;
         }
 
-        if total_micros != TOTAL_SUPPLY_NANOS {
+        if total_nanos != TOTAL_SUPPLY_NANOS {
             panic!(
-                "TokenDistributionSchedule adds up to {total_micros} and not expected {TOTAL_SUPPLY_NANOS}"
+                "TokenDistributionSchedule adds up to {total_nanos} and not expected {TOTAL_SUPPLY_NANOS}"
             );
         }
     }
@@ -516,7 +516,7 @@ impl TokenDistributionSchedule {
                 *validators
                     .get_mut(staked_with_validator)
                     .expect("allocation must be staked with valid validator") +=
-                    allocation.amount_micros;
+                    allocation.amount_nanos;
             }
         }
 
@@ -544,7 +544,7 @@ impl TokenDistributionSchedule {
                 supply -= default_allocation;
                 TokenAllocation {
                     recipient_address: a,
-                    amount_micros: default_allocation,
+                    amount_nanos: default_allocation,
                     staked_with_validator: Some(a),
                 }
             })
@@ -574,7 +574,7 @@ impl TokenDistributionSchedule {
             reader.deserialize().collect::<Result<_, _>>()?;
         assert_eq!(
             TOTAL_SUPPLY_NANOS,
-            allocations.iter().map(|a| a.amount_micros).sum::<u64>(),
+            allocations.iter().map(|a| a.amount_nanos).sum::<u64>(),
             "Token Distribution Schedule must add up to 10B Iota",
         );
         let stake_subsidy_fund_allocation = allocations.pop().unwrap();
@@ -591,7 +591,7 @@ impl TokenDistributionSchedule {
         );
 
         let schedule = Self {
-            stake_subsidy_fund_micros: stake_subsidy_fund_allocation.amount_micros,
+            stake_subsidy_fund_micros: stake_subsidy_fund_allocation.amount_nanos,
             allocations,
         };
 
@@ -608,7 +608,7 @@ impl TokenDistributionSchedule {
 
         writer.serialize(TokenAllocation {
             recipient_address: IotaAddress::default(),
-            amount_micros: self.stake_subsidy_fund_micros,
+            amount_nanos: self.stake_subsidy_fund_micros,
             staked_with_validator: None,
         })?;
 
@@ -620,7 +620,7 @@ impl TokenDistributionSchedule {
 #[serde(rename_all = "kebab-case")]
 pub struct TokenAllocation {
     pub recipient_address: IotaAddress,
-    pub amount_micros: u64,
+    pub amount_nanos: u64,
 
     /// Indicates if this allocation should be staked at genesis and with which
     /// validator
@@ -651,14 +651,14 @@ impl TokenDistributionScheduleBuilder {
         for validator in validators {
             self.add_allocation(TokenAllocation {
                 recipient_address: validator,
-                amount_micros: default_allocation,
+                amount_nanos: default_allocation,
                 staked_with_validator: Some(validator),
             });
         }
     }
 
     pub fn add_allocation(&mut self, allocation: TokenAllocation) {
-        self.pool = self.pool.checked_sub(allocation.amount_micros).unwrap();
+        self.pool = self.pool.checked_sub(allocation.amount_nanos).unwrap();
         self.allocations.push(allocation);
     }
 

--- a/crates/iota-config/src/genesis.rs
+++ b/crates/iota-config/src/genesis.rs
@@ -18,7 +18,7 @@ use iota_types::{
     deny_list::{get_coin_deny_list, PerTypeDenyList},
     effects::{TransactionEffects, TransactionEvents},
     error::IotaResult,
-    gas_coin::TOTAL_SUPPLY_MICROS,
+    gas_coin::TOTAL_SUPPLY_NANOS,
     iota_system_state::{
         get_iota_system_state, get_iota_system_state_wrapper, IotaSystemState,
         IotaSystemStateTrait, IotaSystemStateWrapper, IotaValidatorGenesis,
@@ -435,7 +435,7 @@ impl GenesisCeremonyParameters {
 
     fn default_initial_stake_subsidy_distribution_amount() -> u64 {
         // 1M Iota
-        1_000_000 * iota_types::gas_coin::MICROS_PER_IOTA
+        1_000_000 * iota_types::gas_coin::NANOS_PER_IOTA
     }
 
     fn default_stake_subsidy_period_length() -> u64 {
@@ -491,9 +491,9 @@ impl TokenDistributionSchedule {
             total_micros += allocation.amount_micros;
         }
 
-        if total_micros != TOTAL_SUPPLY_MICROS {
+        if total_micros != TOTAL_SUPPLY_NANOS {
             panic!(
-                "TokenDistributionSchedule adds up to {total_micros} and not expected {TOTAL_SUPPLY_MICROS}"
+                "TokenDistributionSchedule adds up to {total_micros} and not expected {TOTAL_SUPPLY_NANOS}"
             );
         }
     }
@@ -535,7 +535,7 @@ impl TokenDistributionSchedule {
     pub fn new_for_validators_with_default_allocation<I: IntoIterator<Item = IotaAddress>>(
         validators: I,
     ) -> Self {
-        let mut supply = TOTAL_SUPPLY_MICROS;
+        let mut supply = TOTAL_SUPPLY_NANOS;
         let default_allocation = iota_types::governance::VALIDATOR_LOW_STAKE_THRESHOLD_MICROS;
 
         let allocations = validators
@@ -573,7 +573,7 @@ impl TokenDistributionSchedule {
         let mut allocations: Vec<TokenAllocation> =
             reader.deserialize().collect::<Result<_, _>>()?;
         assert_eq!(
-            TOTAL_SUPPLY_MICROS,
+            TOTAL_SUPPLY_NANOS,
             allocations.iter().map(|a| a.amount_micros).sum::<u64>(),
             "Token Distribution Schedule must add up to 10B Iota",
         );
@@ -637,7 +637,7 @@ impl TokenDistributionScheduleBuilder {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {
-            pool: TOTAL_SUPPLY_MICROS,
+            pool: TOTAL_SUPPLY_NANOS,
             allocations: vec![],
         }
     }

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -17,7 +17,7 @@ use iota_types::{
     error::UserInputError,
     execution::TypeLayoutStore,
     fp_bail, fp_ensure,
-    gas_coin::TOTAL_SUPPLY_MICROS,
+    gas_coin::TOTAL_SUPPLY_NANOS,
     iota_system_state::get_iota_system_state,
     message_envelope::Message,
     storage::{
@@ -1757,7 +1757,7 @@ impl AuthorityStore {
             .set(imbalance);
         self.metrics
             .iota_conservation_imbalance
-            .set((total_iota as i128 - TOTAL_SUPPLY_MICROS as i128) as i64);
+            .set((total_iota as i128 - TOTAL_SUPPLY_NANOS as i128) as i64);
 
         if let Some(expected_imbalance) = self
             .perpetual_tables

--- a/crates/iota-e2e-tests/tests/framework_upgrades/mock_iota_systems/base/sources/genesis.move
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/mock_iota_systems/base/sources/genesis.move
@@ -54,13 +54,13 @@ module iota_system::genesis {
     }
 
     struct TokenDistributionSchedule has drop {
-        stake_subsidy_fund_micros: u64,
+        stake_subsidy_fund_nanos: u64,
         allocations: vector<TokenAllocation>,
     }
 
     struct TokenAllocation has drop {
         recipient_address: address,
-        amount_micros: u64,
+        amount_nanos: u64,
         staked_with_validator: Option<address>,
     }
 
@@ -117,7 +117,7 @@ module iota_system::genesis {
         iota_system::create(
             iota_system_state_id,
             validators,
-            iota_supply,     // storage_fund
+            iota_supply, // storage_fund
             genesis_chain_parameters.protocol_version,
             genesis_chain_parameters.chain_start_timestamp_ms,
             genesis_chain_parameters.epoch_duration_ms,

--- a/crates/iota-e2e-tests/tests/framework_upgrades/mock_iota_systems/deep_upgrade/sources/genesis.move
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/mock_iota_systems/deep_upgrade/sources/genesis.move
@@ -54,13 +54,13 @@ module iota_system::genesis {
     }
 
     struct TokenDistributionSchedule has drop {
-        stake_subsidy_fund_micros: u64,
+        stake_subsidy_fund_nanos: u64,
         allocations: vector<TokenAllocation>,
     }
 
     struct TokenAllocation has drop {
         recipient_address: address,
-        amount_micros: u64,
+        amount_nanos: u64,
         staked_with_validator: Option<address>,
     }
 
@@ -117,7 +117,7 @@ module iota_system::genesis {
         iota_system::create(
             iota_system_state_id,
             validators,
-            iota_supply,     // storage_fund
+            iota_supply, // storage_fund
             genesis_chain_parameters.protocol_version,
             genesis_chain_parameters.chain_start_timestamp_ms,
             genesis_chain_parameters.epoch_duration_ms,

--- a/crates/iota-e2e-tests/tests/framework_upgrades/mock_iota_systems/safe_mode/sources/genesis.move
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/mock_iota_systems/safe_mode/sources/genesis.move
@@ -54,13 +54,13 @@ module iota_system::genesis {
     }
 
     struct TokenDistributionSchedule has drop {
-        stake_subsidy_fund_micros: u64,
+        stake_subsidy_fund_nanos: u64,
         allocations: vector<TokenAllocation>,
     }
 
     struct TokenAllocation has drop {
         recipient_address: address,
-        amount_micros: u64,
+        amount_nanos: u64,
         staked_with_validator: Option<address>,
     }
 
@@ -117,7 +117,7 @@ module iota_system::genesis {
         iota_system::create(
             iota_system_state_id,
             validators,
-            iota_supply,     // storage_fund
+            iota_supply, // storage_fund
             genesis_chain_parameters.protocol_version,
             genesis_chain_parameters.chain_start_timestamp_ms,
             genesis_chain_parameters.epoch_duration_ms,

--- a/crates/iota-e2e-tests/tests/framework_upgrades/mock_iota_systems/shallow_upgrade/sources/genesis.move
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/mock_iota_systems/shallow_upgrade/sources/genesis.move
@@ -54,13 +54,13 @@ module iota_system::genesis {
     }
 
     struct TokenDistributionSchedule has drop {
-        stake_subsidy_fund_micros: u64,
+        stake_subsidy_fund_nanos: u64,
         allocations: vector<TokenAllocation>,
     }
 
     struct TokenAllocation has drop {
         recipient_address: address,
-        amount_micros: u64,
+        amount_nanos: u64,
         staked_with_validator: Option<address>,
     }
 
@@ -117,7 +117,7 @@ module iota_system::genesis {
         iota_system::create(
             iota_system_state_id,
             validators,
-            iota_supply,     // storage_fund
+            iota_supply, // storage_fund
             genesis_chain_parameters.protocol_version,
             genesis_chain_parameters.chain_start_timestamp_ms,
             genesis_chain_parameters.epoch_duration_ms,

--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -23,7 +23,7 @@ use iota_types::{
     effects::TransactionEffectsAPI,
     error::IotaError,
     gas::GasCostSummary,
-    governance::MIN_VALIDATOR_JOINING_STAKE_MICROS,
+    governance::MIN_VALIDATOR_JOINING_STAKE_NANOS,
     iota_system_state::{
         get_validator_from_table, iota_system_state_summary::get_validator_by_pool_id,
         IotaSystemStateTrait,
@@ -880,7 +880,7 @@ async fn execute_add_validator_transactions(
         .wallet
         .gas_for_owner_budget(
             address,
-            MIN_VALIDATOR_JOINING_STAKE_MICROS,
+            MIN_VALIDATOR_JOINING_STAKE_NANOS,
             Default::default(),
         )
         .await

--- a/crates/iota-framework/docs/iota-system/genesis.md
+++ b/crates/iota-framework/docs/iota-system/genesis.md
@@ -251,7 +251,7 @@ title: Module `0x3::genesis`
 
 <dl>
 <dt>
-<code>stake_subsidy_fund_micros: u64</code>
+<code>stake_subsidy_fund_nanos: u64</code>
 </dt>
 <dd>
 
@@ -290,7 +290,7 @@ title: Module `0x3::genesis`
 
 </dd>
 <dt>
-<code>amount_micros: u64</code>
+<code>amount_nanos: u64</code>
 </dt>
 <dd>
 
@@ -361,11 +361,11 @@ all the information we need in the system.
     <b>assert</b>!(ctx.epoch() == 0, <a href="genesis.md#0x3_genesis_ENotCalledAtGenesis">ENotCalledAtGenesis</a>);
 
     <b>let</b> <a href="genesis.md#0x3_genesis_TokenDistributionSchedule">TokenDistributionSchedule</a> {
-        stake_subsidy_fund_micros,
+        stake_subsidy_fund_nanos,
         allocations,
     } = token_distribution_schedule;
 
-    <b>let</b> subsidy_fund = iota_supply.split(stake_subsidy_fund_micros);
+    <b>let</b> subsidy_fund = iota_supply.split(stake_subsidy_fund_nanos);
     <b>let</b> <a href="storage_fund.md#0x3_storage_fund">storage_fund</a> = <a href="../iota-framework/balance.md#0x2_balance_zero">balance::zero</a>();
 
     // Create all the `Validator` structs
@@ -496,15 +496,17 @@ all the information we need in the system.
     <b>while</b> (!allocations.is_empty()) {
         <b>let</b> <a href="genesis.md#0x3_genesis_TokenAllocation">TokenAllocation</a> {
             recipient_address,
-            amount_micros,
+            amount_nanos,
             staked_with_validator,
         } = allocations.pop_back();
 
-        <b>let</b> allocation_balance = iota_supply.split(amount_micros);
+        <b>let</b> allocation_balance = iota_supply.split(amount_nanos);
 
         <b>if</b> (staked_with_validator.is_some()) {
             <b>let</b> validator_address = staked_with_validator.destroy_some();
-            <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_mut">validator_set::get_validator_mut</a>(validators, validator_address);
+            <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_mut">validator_set::get_validator_mut</a>(
+                validators, validator_address
+            );
             <a href="validator.md#0x3_validator">validator</a>.request_add_stake_at_genesis(
                 allocation_balance,
                 recipient_address,

--- a/crates/iota-framework/packages/iota-system/sources/genesis.move
+++ b/crates/iota-framework/packages/iota-system/sources/genesis.move
@@ -55,13 +55,13 @@ module iota_system::genesis {
     }
 
     public struct TokenDistributionSchedule {
-        stake_subsidy_fund_micros: u64,
+        stake_subsidy_fund_nanos: u64,
         allocations: vector<TokenAllocation>,
     }
 
     public struct TokenAllocation {
         recipient_address: address,
-        amount_micros: u64,
+        amount_nanos: u64,
 
         /// Indicates if this allocation should be staked at genesis and with which validator
         staked_with_validator: Option<address>,
@@ -89,11 +89,11 @@ module iota_system::genesis {
         assert!(ctx.epoch() == 0, ENotCalledAtGenesis);
 
         let TokenDistributionSchedule {
-            stake_subsidy_fund_micros,
+            stake_subsidy_fund_nanos,
             allocations,
         } = token_distribution_schedule;
 
-        let subsidy_fund = iota_supply.split(stake_subsidy_fund_micros);
+        let subsidy_fund = iota_supply.split(stake_subsidy_fund_nanos);
         let storage_fund = balance::zero();
 
         // Create all the `Validator` structs
@@ -204,15 +204,17 @@ module iota_system::genesis {
         while (!allocations.is_empty()) {
             let TokenAllocation {
                 recipient_address,
-                amount_micros,
+                amount_nanos,
                 staked_with_validator,
             } = allocations.pop_back();
 
-            let allocation_balance = iota_supply.split(amount_micros);
+            let allocation_balance = iota_supply.split(amount_nanos);
 
             if (staked_with_validator.is_some()) {
                 let validator_address = staked_with_validator.destroy_some();
-                let validator = validator_set::get_validator_mut(validators, validator_address);
+                let validator = validator_set::get_validator_mut(
+                    validators, validator_address
+                );
                 validator.request_add_stake_at_genesis(
                     allocation_balance,
                     recipient_address,

--- a/crates/iota-genesis-builder/examples/parse_hornet_genesis_snapshot.rs
+++ b/crates/iota-genesis-builder/examples/parse_hornet_genesis_snapshot.rs
@@ -5,9 +5,8 @@
 //! and verifying the total supply.
 use std::fs::File;
 
-use iota_genesis_builder::stardust::{
-    parse::HornetGenesisSnapshotParser, types::output_header::TOTAL_SUPPLY_IOTA,
-};
+use iota_genesis_builder::stardust::parse::HornetGenesisSnapshotParser;
+use iota_types::gas_coin::TOTAL_SUPPLY_IOTA;
 
 fn main() -> anyhow::Result<()> {
     let Some(path) = std::env::args().nth(1) else {

--- a/crates/iota-genesis-builder/examples/parse_hornet_genesis_snapshot.rs
+++ b/crates/iota-genesis-builder/examples/parse_hornet_genesis_snapshot.rs
@@ -20,7 +20,7 @@ fn main() -> anyhow::Result<()> {
     let total_supply = parser.outputs().try_fold(0, |acc, output| {
         Ok::<_, anyhow::Error>(acc + output?.1.amount())
     })?;
-    // Total supply is in IOTA, snapshot supply is is Micros
+    // Total supply is in IOTA, snapshot supply is Micros
     assert_eq!(total_supply, TOTAL_SUPPLY_IOTA * 1_000_000);
     println!("Total supply: {total_supply}");
     Ok(())

--- a/crates/iota-genesis-builder/examples/parse_hornet_genesis_snapshot.rs
+++ b/crates/iota-genesis-builder/examples/parse_hornet_genesis_snapshot.rs
@@ -20,7 +20,8 @@ fn main() -> anyhow::Result<()> {
     let total_supply = parser.outputs().try_fold(0, |acc, output| {
         Ok::<_, anyhow::Error>(acc + output?.1.amount())
     })?;
-    assert_eq!(total_supply, TOTAL_SUPPLY_IOTA);
+    // Total supply is in IOTA, snapshot supply is is Micros
+    assert_eq!(total_supply, TOTAL_SUPPLY_IOTA * 1_000_000);
     println!("Total supply: {total_supply}");
     Ok(())
 }

--- a/crates/iota-genesis-builder/examples/snapshot_test_outputs.rs
+++ b/crates/iota-genesis-builder/examples/snapshot_test_outputs.rs
@@ -7,8 +7,8 @@ use std::{fs::File, path::Path};
 
 use iota_genesis_builder::stardust::{
     parse::HornetGenesisSnapshotParser, test_outputs::add_snapshot_test_outputs,
-    types::output_header::TOTAL_SUPPLY_IOTA,
 };
+use iota_types::gas_coin::TOTAL_SUPPLY_IOTA;
 
 fn parse_snapshot<P: AsRef<Path>>(path: P) -> anyhow::Result<()> {
     let file = File::open(path)?;

--- a/crates/iota-genesis-builder/examples/snapshot_test_outputs.rs
+++ b/crates/iota-genesis-builder/examples/snapshot_test_outputs.rs
@@ -20,7 +20,8 @@ fn parse_snapshot<P: AsRef<Path>>(path: P) -> anyhow::Result<()> {
         Ok::<_, anyhow::Error>(acc + output?.1.amount())
     })?;
 
-    assert_eq!(total_supply, TOTAL_SUPPLY_IOTA);
+    // Total supply is in IOTA, snapshot supply is is Micros
+    assert_eq!(total_supply, TOTAL_SUPPLY_IOTA * 1_000_000);
 
     println!("Total supply: {total_supply}");
 

--- a/crates/iota-genesis-builder/examples/snapshot_test_outputs.rs
+++ b/crates/iota-genesis-builder/examples/snapshot_test_outputs.rs
@@ -20,7 +20,7 @@ fn parse_snapshot<P: AsRef<Path>>(path: P) -> anyhow::Result<()> {
         Ok::<_, anyhow::Error>(acc + output?.1.amount())
     })?;
 
-    // Total supply is in IOTA, snapshot supply is is Micros
+    // Total supply is in IOTA, snapshot supply is Micros
     assert_eq!(total_supply, TOTAL_SUPPLY_IOTA * 1_000_000);
 
     println!("Total supply: {total_supply}");

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -497,7 +497,7 @@ impl Builder {
                             panic!("gas object owner must be address owner");
                         };
                         *owner == allocation.recipient_address
-                            && s.principal() == allocation.amount_micros
+                            && s.principal() == allocation.amount_nanos
                             && s.pool_id() == staking_pool_id
                     })
                     .map(|(k, _)| *k)
@@ -508,7 +508,7 @@ impl Builder {
                     staked_iota_object.0.owner,
                     Owner::AddressOwner(allocation.recipient_address)
                 );
-                assert_eq!(staked_iota_object.1.principal(), allocation.amount_micros);
+                assert_eq!(staked_iota_object.1.principal(), allocation.amount_nanos);
                 assert_eq!(staked_iota_object.1.pool_id(), staking_pool_id);
                 assert_eq!(staked_iota_object.1.activation_epoch(), 0);
             } else {
@@ -517,7 +517,7 @@ impl Builder {
                     .find(|(_k, (o, g))| {
                         if let Owner::AddressOwner(owner) = &o.owner {
                             *owner == allocation.recipient_address
-                                && g.value() == allocation.amount_micros
+                                && g.value() == allocation.amount_nanos
                         } else {
                             false
                         }
@@ -529,7 +529,7 @@ impl Builder {
                     gas_object.0.owner,
                     Owner::AddressOwner(allocation.recipient_address)
                 );
-                assert_eq!(gas_object.1.value(), allocation.amount_micros,);
+                assert_eq!(gas_object.1.value(), allocation.amount_nanos,);
             }
         }
 

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -471,7 +471,7 @@ impl Builder {
         let token_distribution_schedule = self.token_distribution_schedule.clone().unwrap();
         assert_eq!(
             system_state.stake_subsidy.balance.value(),
-            token_distribution_schedule.stake_subsidy_fund_micros
+            token_distribution_schedule.stake_subsidy_fund_nanos
         );
 
         let mut gas_objects: BTreeMap<ObjectID, (&Object, GasCoin)> = unsigned_genesis

--- a/crates/iota-genesis-builder/src/stardust/types/output_header.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/output_header.rs
@@ -11,9 +11,6 @@ use packable::Packable;
 
 use crate::stardust::types::output_index::OutputIndex;
 
-/// The total supply on the iota-mainnet
-pub const TOTAL_SUPPLY_IOTA: u64 = 4_600_000_000_000_000;
-
 /// The header of an [`Output`](iota_sdk::types::block::output::Output) in the
 /// snapshot
 #[derive(Debug, Clone, Packable)]

--- a/crates/iota-indexer/src/apis/coin_api.rs
+++ b/crates/iota-indexer/src/apis/coin_api.rs
@@ -13,7 +13,7 @@ use iota_open_rpc::Module;
 use iota_types::{
     balance::Supply,
     base_types::{IotaAddress, ObjectID},
-    gas_coin::{GAS, TOTAL_SUPPLY_MICROS},
+    gas_coin::{GAS, TOTAL_SUPPLY_NANOS},
 };
 use jsonrpsee::{core::RpcResult, RpcModule};
 
@@ -138,7 +138,7 @@ impl CoinReadApiServer for CoinReadApi {
         let coin_struct = parse_to_struct_tag(&coin_type)?;
         if GAS::is_gas(&coin_struct) {
             Ok(Supply {
-                value: TOTAL_SUPPLY_MICROS,
+                value: TOTAL_SUPPLY_NANOS,
             })
         } else {
             self.inner

--- a/crates/iota-json-rpc/src/coin_api.rs
+++ b/crates/iota-json-rpc/src/coin_api.rs
@@ -16,7 +16,7 @@ use iota_types::{
     base_types::{IotaAddress, ObjectID},
     coin::{CoinMetadata, TreasuryCap},
     effects::TransactionEffectsAPI,
-    gas_coin::{GAS, TOTAL_SUPPLY_MICROS},
+    gas_coin::{GAS, TOTAL_SUPPLY_NANOS},
     object::Object,
     parse_iota_struct_tag,
 };
@@ -219,7 +219,7 @@ impl CoinReadApiServer for CoinReadApi {
             let coin_struct = parse_to_struct_tag(&coin_type)?;
             Ok(if GAS::is_gas(&coin_struct) {
                 Supply {
-                    value: TOTAL_SUPPLY_MICROS,
+                    value: TOTAL_SUPPLY_NANOS,
                 }
             } else {
                 let treasury_cap_object = self

--- a/crates/iota-json-rpc/src/coin_api.rs
+++ b/crates/iota-json-rpc/src/coin_api.rs
@@ -1303,7 +1303,7 @@ mod tests {
             let response = coin_read_api.get_total_supply(coin_type.to_string()).await;
 
             let supply = response.unwrap();
-            let expected = expect!["10000000000000000000"];
+            let expected = expect!["4600000000000000000"];
             expected.assert_eq(&supply.value.to_string());
         }
 

--- a/crates/iota-json-rpc/src/coin_api.rs
+++ b/crates/iota-json-rpc/src/coin_api.rs
@@ -1287,7 +1287,7 @@ mod tests {
     }
 
     mod get_total_supply_tests {
-        use iota_types::id::UID;
+        use iota_types::{gas_coin::TOKEN_SUPPLY_NANOS, id::UID};
         use mockall::predicate;
 
         use super::{super::*, *};
@@ -1303,8 +1303,7 @@ mod tests {
             let response = coin_read_api.get_total_supply(coin_type.to_string()).await;
 
             let supply = response.unwrap();
-            let expected = expect!["4600000000000000000"];
-            expected.assert_eq(&supply.value.to_string());
+            assert_eq!(supply.value, TOKEN_SUPPLY_NANOS);
         }
 
         #[tokio::test]

--- a/crates/iota-json-rpc/src/coin_api.rs
+++ b/crates/iota-json-rpc/src/coin_api.rs
@@ -1287,7 +1287,7 @@ mod tests {
     }
 
     mod get_total_supply_tests {
-        use iota_types::{gas_coin::TOKEN_SUPPLY_NANOS, id::UID};
+        use iota_types::{gas_coin::TOTAL_SUPPLY_NANOS, id::UID};
         use mockall::predicate;
 
         use super::{super::*, *};
@@ -1303,7 +1303,7 @@ mod tests {
             let response = coin_read_api.get_total_supply(coin_type.to_string()).await;
 
             let supply = response.unwrap();
-            assert_eq!(supply.value, TOKEN_SUPPLY_NANOS);
+            assert_eq!(supply.value, TOTAL_SUPPLY_NANOS);
         }
 
         #[tokio::test]

--- a/crates/iota-swarm-config/src/genesis_config.rs
+++ b/crates/iota-swarm-config/src/genesis_config.rs
@@ -215,7 +215,7 @@ impl ValidatorGenesisConfigBuilder {
             narwhal_worker_address,
             consensus_address,
             consensus_internal_worker_address: None,
-            stake: iota_types::governance::VALIDATOR_LOW_STAKE_THRESHOLD_MICROS,
+            stake: iota_types::governance::VALIDATOR_LOW_STAKE_THRESHOLD_NANOS,
             name: None,
         }
     }
@@ -276,7 +276,7 @@ fn default_multiaddr_address() -> Multiaddr {
 }
 
 fn default_stake() -> u64 {
-    iota_types::governance::VALIDATOR_LOW_STAKE_THRESHOLD_MICROS
+    iota_types::governance::VALIDATOR_LOW_STAKE_THRESHOLD_NANOS
 }
 
 fn default_bls12381_key_pair() -> AuthorityKeyPair {

--- a/crates/iota-swarm-config/src/genesis_config.rs
+++ b/crates/iota-swarm-config/src/genesis_config.rs
@@ -257,7 +257,7 @@ impl GenesisConfig {
             account.gas_amounts.iter().for_each(|a| {
                 allocations.push(TokenAllocation {
                     recipient_address: address,
-                    amount_micros: *a,
+                    amount_nanos: *a,
                     staked_with_validator: None,
                 });
             });

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -324,12 +324,12 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                 // Give each validator some gas so they can pay for their transactions.
                 let gas_coin = TokenAllocation {
                     recipient_address: address,
-                    amount_micros: DEFAULT_GAS_AMOUNT,
+                    amount_nanos: DEFAULT_GAS_AMOUNT,
                     staked_with_validator: None,
                 };
                 let stake = TokenAllocation {
                     recipient_address: address,
-                    amount_micros: validator.stake,
+                    amount_nanos: validator.stake,
                     staked_with_validator: Some(address),
                 };
                 builder.add_allocation(gas_coin);

--- a/crates/iota-types/src/gas_coin.rs
+++ b/crates/iota-types/src/gas_coin.rs
@@ -25,16 +25,16 @@ use crate::{
     IOTA_FRAMEWORK_ADDRESS,
 };
 
-/// The number of Micros per Iota token
-pub const MICROS_PER_IOTA: u64 = 1_000_000_000;
+/// The number of Nanos per Iota token
+pub const NANOS_PER_IOTA: u64 = 1_000_000_000;
 
 /// Total supply denominated in Iota
-pub const TOTAL_SUPPLY_IOTA: u64 = 10_000_000_000;
+pub const TOTAL_SUPPLY_IOTA: u64 = 4_600_000_000;
 
 // Note: cannot use checked arithmetic here since `const unwrap` is still
 // unstable.
-/// Total supply denominated in Micros
-pub const TOTAL_SUPPLY_MICROS: u64 = TOTAL_SUPPLY_IOTA * MICROS_PER_IOTA;
+/// Total supply denominated in Nanos
+pub const TOTAL_SUPPLY_NANOS: u64 = TOTAL_SUPPLY_IOTA * NANOS_PER_IOTA;
 
 pub const GAS_MODULE_NAME: &IdentStr = ident_str!("iota");
 pub const GAS_STRUCT_NAME: &IdentStr = ident_str!("IOTA");

--- a/crates/iota-types/src/governance.rs
+++ b/crates/iota-types/src/governance.rs
@@ -10,7 +10,7 @@ use crate::{
     base_types::ObjectID,
     committee::EpochId,
     error::IotaError,
-    gas_coin::MICROS_PER_IOTA,
+    gas_coin::NANOS_PER_IOTA,
     id::{ID, UID},
     object::{Data, Object},
     IOTA_SYSTEM_ADDRESS,
@@ -23,7 +23,7 @@ pub const MAX_VALIDATOR_COUNT: u64 = 150;
 /// Lower-bound on the amount of stake required to become a validator.
 ///
 /// 30 million IOTA
-pub const MIN_VALIDATOR_JOINING_STAKE_MICROS: u64 = 30_000_000 * MICROS_PER_IOTA;
+pub const MIN_VALIDATOR_JOINING_STAKE_MICROS: u64 = 30_000_000 * NANOS_PER_IOTA;
 
 /// Validators with stake amount below `validator_low_stake_threshold` are
 /// considered to have low stake and will be escorted out of the validator set
@@ -31,13 +31,13 @@ pub const MIN_VALIDATOR_JOINING_STAKE_MICROS: u64 = 30_000_000 * MICROS_PER_IOTA
 /// `validator_low_stake_grace_period` number of epochs.
 ///
 /// 20 million IOTA
-pub const VALIDATOR_LOW_STAKE_THRESHOLD_MICROS: u64 = 20_000_000 * MICROS_PER_IOTA;
+pub const VALIDATOR_LOW_STAKE_THRESHOLD_MICROS: u64 = 20_000_000 * NANOS_PER_IOTA;
 
 /// Validators with stake below `validator_very_low_stake_threshold` will be
 /// removed immediately at epoch change, no grace period.
 ///
 /// 15 million IOTA
-pub const VALIDATOR_VERY_LOW_STAKE_THRESHOLD_MICROS: u64 = 15_000_000 * MICROS_PER_IOTA;
+pub const VALIDATOR_VERY_LOW_STAKE_THRESHOLD_MICROS: u64 = 15_000_000 * NANOS_PER_IOTA;
 
 /// A validator can have stake below `validator_low_stake_threshold`
 /// for this many epochs before being kicked out.

--- a/crates/iota-types/src/governance.rs
+++ b/crates/iota-types/src/governance.rs
@@ -23,7 +23,7 @@ pub const MAX_VALIDATOR_COUNT: u64 = 150;
 /// Lower-bound on the amount of stake required to become a validator.
 ///
 /// 30 million IOTA
-pub const MIN_VALIDATOR_JOINING_STAKE_MICROS: u64 = 30_000_000 * NANOS_PER_IOTA;
+pub const MIN_VALIDATOR_JOINING_STAKE_NANOS: u64 = 30_000_000 * NANOS_PER_IOTA;
 
 /// Validators with stake amount below `validator_low_stake_threshold` are
 /// considered to have low stake and will be escorted out of the validator set
@@ -31,13 +31,13 @@ pub const MIN_VALIDATOR_JOINING_STAKE_MICROS: u64 = 30_000_000 * NANOS_PER_IOTA;
 /// `validator_low_stake_grace_period` number of epochs.
 ///
 /// 20 million IOTA
-pub const VALIDATOR_LOW_STAKE_THRESHOLD_MICROS: u64 = 20_000_000 * NANOS_PER_IOTA;
+pub const VALIDATOR_LOW_STAKE_THRESHOLD_NANOS: u64 = 20_000_000 * NANOS_PER_IOTA;
 
 /// Validators with stake below `validator_very_low_stake_threshold` will be
 /// removed immediately at epoch change, no grace period.
 ///
 /// 15 million IOTA
-pub const VALIDATOR_VERY_LOW_STAKE_THRESHOLD_MICROS: u64 = 15_000_000 * NANOS_PER_IOTA;
+pub const VALIDATOR_VERY_LOW_STAKE_THRESHOLD_NANOS: u64 = 15_000_000 * NANOS_PER_IOTA;
 
 /// A validator can have stake below `validator_low_stake_threshold`
 /// for this many epochs before being kicked out.

--- a/crates/iota/src/genesis_inspector.rs
+++ b/crates/iota/src/genesis_inspector.rs
@@ -9,7 +9,7 @@ use iota_config::genesis::UnsignedGenesis;
 use iota_types::{
     base_types::ObjectID,
     coin::CoinMetadata,
-    gas_coin::{GasCoin, MICROS_PER_IOTA, TOTAL_SUPPLY_MICROS},
+    gas_coin::{GasCoin, NANOS_PER_IOTA, TOTAL_SUPPLY_NANOS},
     governance::StakedIota,
     iota_system_state::IotaValidatorGenesis,
     move_package::MovePackage,
@@ -269,20 +269,20 @@ fn examine_total_supply(
             println!("Owner {:?}", owner);
             println!(
                 "Total Amount of Iota/StakedIota Owned: {amount_sum} MICROS or {} IOTA:",
-                amount_sum / MICROS_PER_IOTA
+                amount_sum / NANOS_PER_IOTA
             );
             println!("{:#?}\n", coins);
         }
     }
-    assert_eq!(total_iota, TOTAL_SUPPLY_MICROS);
+    assert_eq!(total_iota, TOTAL_SUPPLY_NANOS);
     // Always print this.
     println!(
         "Total Supply of Iota: {total_iota} MICROS or {} IOTA",
-        total_iota / MICROS_PER_IOTA
+        total_iota / NANOS_PER_IOTA
     );
     println!(
         "Total Amount of StakedIota: {total_staked_iota} MICROS or {} IOTA\n",
-        total_staked_iota / MICROS_PER_IOTA
+        total_staked_iota / NANOS_PER_IOTA
     );
     if print {
         print_divider("Iota Distribution");

--- a/crates/iota/src/genesis_inspector.rs
+++ b/crates/iota/src/genesis_inspector.rs
@@ -268,7 +268,7 @@ fn examine_total_supply(
         if print {
             println!("Owner {:?}", owner);
             println!(
-                "Total Amount of Iota/StakedIota Owned: {amount_sum} MICROS or {} IOTA:",
+                "Total Amount of Iota/StakedIota Owned: {amount_sum} NANOS or {} IOTA:",
                 amount_sum / NANOS_PER_IOTA
             );
             println!("{:#?}\n", coins);
@@ -277,11 +277,11 @@ fn examine_total_supply(
     assert_eq!(total_iota, TOTAL_SUPPLY_NANOS);
     // Always print this.
     println!(
-        "Total Supply of Iota: {total_iota} MICROS or {} IOTA",
+        "Total Supply of Iota: {total_iota} NANOS or {} IOTA",
         total_iota / NANOS_PER_IOTA
     );
     println!(
-        "Total Amount of StakedIota: {total_staked_iota} MICROS or {} IOTA\n",
+        "Total Amount of StakedIota: {total_staked_iota} NANOS or {} IOTA\n",
         total_staked_iota / NANOS_PER_IOTA
     );
     if print {

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -311,16 +311,16 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         self.epoch_state.reference_gas_price()
     }
 
-    /// Request that `amount` Micros be sent to `address` from a faucet account.
+    /// Request that `amount` Nanos be sent to `address` from a faucet account.
     ///
     /// ```
-    /// use iota_types::{base_types::IotaAddress, gas_coin::MICROS_PER_IOTA};
+    /// use iota_types::{base_types::IotaAddress, gas_coin::NANOS_PER_IOTA};
     /// use simulacrum::Simulacrum;
     ///
     /// # fn main() {
     /// let mut simulacrum = Simulacrum::new();
     /// let address = IotaAddress::generate(simulacrum.rng());
-    /// simulacrum.request_gas(address, MICROS_PER_IOTA).unwrap();
+    /// simulacrum.request_gas(address, NANOS_PER_IOTA).unwrap();
     ///
     /// // `account` now has a Coin<IOTA> object with single IOTA in it.
     /// // ...
@@ -338,7 +338,7 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
                 object.is_gas_coin() && object.get_coin_value_unsafe() > amount + NANOS_PER_IOTA
             })
             .ok_or_else(|| {
-                anyhow!("unable to find a coin with enough to satisfy request for {amount} Micros")
+                anyhow!("unable to find a coin with enough to satisfy request for {amount} Nanos")
             })?;
 
         let gas_data = iota_types::transaction::GasData {

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -29,7 +29,7 @@ use iota_types::{
     digests::ConsensusCommitDigest,
     effects::TransactionEffects,
     error::ExecutionError,
-    gas_coin::{GasCoin, MICROS_PER_IOTA},
+    gas_coin::{GasCoin, NANOS_PER_IOTA},
     inner_temporary_store::InnerTemporaryStore,
     iota_system_state::epoch_start_iota_system_state::EpochStartSystemState,
     messages_checkpoint::{EndOfEpochData, VerifiedCheckpoint},
@@ -335,7 +335,7 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
             .store()
             .owned_objects(*sender)
             .find(|object| {
-                object.is_gas_coin() && object.get_coin_value_unsafe() > amount + MICROS_PER_IOTA
+                object.is_gas_coin() && object.get_coin_value_unsafe() > amount + NANOS_PER_IOTA
             })
             .ok_or_else(|| {
                 anyhow!("unable to find a coin with enough to satisfy request for {amount} Micros")
@@ -345,7 +345,7 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
             payment: vec![object.compute_object_reference()],
             owner: *sender,
             price: self.reference_gas_price(),
-            budget: MICROS_PER_IOTA,
+            budget: NANOS_PER_IOTA,
         };
 
         let pt = {

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -45,7 +45,7 @@ use iota_types::{
     crypto::{IotaKeyPair, KeypairTraits},
     effects::{TransactionEffects, TransactionEvents},
     error::IotaResult,
-    governance::MIN_VALIDATOR_JOINING_STAKE_MICROS,
+    governance::MIN_VALIDATOR_JOINING_STAKE_NANOS,
     iota_system_state::{
         epoch_start_iota_system_state::EpochStartSystemStateTrait, IotaSystemState,
         IotaSystemStateTrait,
@@ -921,7 +921,7 @@ impl TestClusterBuilder {
             .accounts
             .extend(addresses.into_iter().map(|address| AccountConfig {
                 address: Some(address),
-                gas_amounts: vec![DEFAULT_GAS_AMOUNT, MIN_VALIDATOR_JOINING_STAKE_MICROS],
+                gas_amounts: vec![DEFAULT_GAS_AMOUNT, MIN_VALIDATOR_JOINING_STAKE_NANOS],
             }));
         self
     }

--- a/crates/transaction-fuzzer/src/lib.rs
+++ b/crates/transaction-fuzzer/src/lib.rs
@@ -17,7 +17,7 @@ use iota_types::{
     base_types::{IotaAddress, ObjectID},
     crypto::{get_key_pair, AccountKeyPair},
     digests::TransactionDigest,
-    gas_coin::TOTAL_SUPPLY_MICROS,
+    gas_coin::TOTAL_SUPPLY_NANOS,
     object::{MoveObject, Object, Owner, OBJECT_START_VERSION},
     transaction::GasData,
 };
@@ -45,7 +45,7 @@ fn generate_random_gas_data(
     let mut gas_objects = vec![];
     let mut object_refs = vec![];
 
-    let max_gas_balance = TOTAL_SUPPLY_MICROS;
+    let max_gas_balance = TOTAL_SUPPLY_NANOS;
 
     let total_gas_balance = rng.gen_range(0..=max_gas_balance);
     let mut remaining_gas_balance = total_gas_balance;


### PR DESCRIPTION
# Description of change

This fixes the disparity between the const definitions between `iota.move` and `iota-types` `TOTAL_SUPPLY_IOTA`, and renames Micros to Nanos. I also removed a duplicate const from `iota-genesis-builder`.

## Links to any relevant issues

Closes #856
