### PR TITLE
refactor(iota-genesis-builder): optimize memory usage while building genesis

### DIFF
--- a/crates/iota-config/src/genesis.rs
+++ b/crates/iota-config/src/genesis.rs
@@ -4,7 +4,7 @@
 
 use std::{
     collections::HashMap,
-    fs::{self, File},
+    fs::File,
     io::{BufReader, BufWriter},
     path::Path,
 };

--- a/crates/iota-config/src/genesis.rs
+++ b/crates/iota-config/src/genesis.rs
@@ -2,7 +2,12 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, fs, path::Path};
+use std::{
+    collections::HashMap,
+    fs::{self, File},
+    io::{BufReader, BufWriter},
+    path::Path,
+};
 
 use anyhow::{Context, Result};
 use fastcrypto::{
@@ -174,17 +179,17 @@ impl Genesis {
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, anyhow::Error> {
         let path = path.as_ref();
         trace!("Reading Genesis from {}", path.display());
-        let bytes = fs::read(path)
+        let read = File::open(path)
             .with_context(|| format!("Unable to load Genesis from {}", path.display()))?;
-        bcs::from_bytes(&bytes)
+        bcs::from_reader(BufReader::new(read))
             .with_context(|| format!("Unable to parse Genesis from {}", path.display()))
     }
 
     pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), anyhow::Error> {
         let path = path.as_ref();
         trace!("Writing Genesis to {}", path.display());
-        let bytes = bcs::to_bytes(&self)?;
-        fs::write(path, bytes)
+        let mut write = BufWriter::new(File::create(path)?);
+        bcs::serialize_into(&mut write, &self)
             .with_context(|| format!("Unable to save Genesis to {}", path.display()))?;
         Ok(())
     }

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -296,7 +296,9 @@ impl Builder {
         if self.built_genesis.is_none() {
             self.build_and_cache_unsigned_genesis();
         }
-        self.built_genesis.as_ref().expect("genesis should have been built and cached")
+        self.built_genesis
+            .as_ref()
+            .expect("genesis should have been built and cached")
     }
 
     fn committee(objects: &[Object]) -> Committee {
@@ -1061,10 +1063,8 @@ fn create_genesis_objects(
         .unwrap();
     }
 
-    {
-        for object in input_objects {
-            store.insert_object(object.to_owned());
-        }
+    for object in input_objects {
+        store.insert_object(object);
     }
 
     generate_genesis_system_object(

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -169,19 +169,14 @@ impl Builder {
     }
 
     pub fn add_validator_signature(mut self, keypair: &AuthorityKeyPair) -> Self {
-        if self.built_genesis.is_none() {
-            self.build_and_cache_unsigned_genesis();
-        }
-        let UnsignedGenesis { checkpoint, .. } = self
-            .built_genesis
-            .as_ref()
-            .expect("genesis should have been built");
-
         let name = keypair.public().into();
         assert!(
             self.validators.contains_key(&name),
             "provided keypair does not correspond to a validator in the validator set"
         );
+
+        let UnsignedGenesis { checkpoint, .. } = self.get_or_build_unsigned_genesis();
+
         let checkpoint_signature = {
             let intent_msg = IntentMessage::new(
                 Intent::iota_app(IntentScope::CheckpointSummary),

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -169,7 +169,7 @@ impl Builder {
 
     pub fn add_validator_signature(mut self, keypair: &AuthorityKeyPair) -> Self {
         if self.built_genesis.is_none() {
-            self.build_and_cache_unsigned_genesis_checkpoint();
+            self.build_and_cache_unsigned_genesis();
         }
         let UnsignedGenesis { checkpoint, .. } = self
             .built_genesis
@@ -215,7 +215,7 @@ impl Builder {
         self.built_genesis.clone()
     }
 
-    fn build_and_cache_unsigned_genesis_checkpoint(&mut self) {
+    fn build_and_cache_unsigned_genesis(&mut self) {
         // Verify that all input data is valid
         self.validate_inputs().unwrap();
         let validators = self.validators.clone().into_values().collect::<Vec<_>>();
@@ -291,9 +291,9 @@ impl Builder {
         self.token_distribution_schedule = Some(token_distribution_schedule);
     }
 
-    pub fn build_unsigned_genesis_checkpoint(&mut self) -> &UnsignedGenesis {
+    pub fn get_or_build_unsigned_genesis(&mut self) -> &UnsignedGenesis {
         if self.built_genesis.is_none() {
-            self.build_and_cache_unsigned_genesis_checkpoint();
+            self.build_and_cache_unsigned_genesis();
         }
         self.built_genesis.as_ref().unwrap()
     }
@@ -310,7 +310,7 @@ impl Builder {
 
     pub fn build(mut self) -> Genesis {
         if self.built_genesis.is_none() {
-            self.build_and_cache_unsigned_genesis_checkpoint();
+            self.build_and_cache_unsigned_genesis();
         }
         let UnsignedGenesis {
             checkpoint,
@@ -737,7 +737,7 @@ impl Builder {
             );
 
             // Verify loaded genesis matches one build from the constituent parts
-            let built = builder.build_unsigned_genesis_checkpoint();
+            let built = builder.get_or_build_unsigned_genesis();
             loaded_genesis.checkpoint_contents.digest(); // cache digest before compare
             assert_eq!(
                 *built, loaded_genesis,
@@ -1399,7 +1399,7 @@ mod test {
         let pop = generate_proof_of_possession(&key, account_key.public().into());
         let mut builder = Builder::new().add_validator(validator, pop);
 
-        let genesis = builder.build_unsigned_genesis_checkpoint();
+        let genesis = builder.get_or_build_unsigned_genesis();
         for object in genesis.objects() {
             println!("ObjectID: {} Type: {:?}", object.id(), object.type_());
         }

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -296,7 +296,7 @@ impl Builder {
         if self.built_genesis.is_none() {
             self.build_and_cache_unsigned_genesis();
         }
-        self.built_genesis.as_ref().unwrap()
+        self.built_genesis.as_ref().expect("genesis should have been built and cached")
     }
 
     fn committee(objects: &[Object]) -> Committee {

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -285,7 +285,7 @@ impl Builder {
             &token_distribution_schedule,
             &self.genesis_stake.take_timelock_allocations(),
             &validators,
-            &objects,
+            objects,
         ));
 
         self.token_distribution_schedule = Some(token_distribution_schedule);
@@ -844,7 +844,7 @@ fn build_unsigned_genesis_data(
     token_distribution_schedule: &TokenDistributionSchedule,
     timelock_allocations: &[TimelockAllocation],
     validators: &[GenesisValidatorInfo],
-    objects: &[Object],
+    objects: Vec<Object>,
 ) -> UnsignedGenesis {
     if !parameters.allow_insertion_of_extra_objects && !objects.is_empty() {
         panic!(
@@ -1032,7 +1032,7 @@ fn create_genesis_transaction(
 
 fn create_genesis_objects(
     genesis_ctx: &mut TxContext,
-    input_objects: &[Object],
+    input_objects: Vec<Object>,
     validators: &[GenesisValidatorMetadata],
     parameters: &GenesisChainParameters,
     token_distribution_schedule: &TokenDistributionSchedule,

--- a/crates/iota/src/genesis_ceremony.rs
+++ b/crates/iota/src/genesis_ceremony.rs
@@ -183,7 +183,7 @@ pub fn run(cmd: Ceremony) -> Result<()> {
 
         CeremonyCommand::BuildUnsignedCheckpoint => {
             let mut builder = Builder::load(&dir)?;
-            let UnsignedGenesis { checkpoint, .. } = builder.build_unsigned_genesis_checkpoint();
+            let UnsignedGenesis { checkpoint, .. } = builder.get_or_build_unsigned_genesis();
             println!(
                 "Successfully built unsigned checkpoint: {}",
                 checkpoint.digest()


### PR DESCRIPTION
# Description of change

This patch introduces some optimizations in `Builder` methods to reduce the high memory usage of operation pertaining to building, saving, and loading `Genesis`, and loading/saving the `Builder` itself (this affects genesis ceremony).

1. Building unsigned genesis no longer clones the created and cached value.
2. Additional objects (including stardust objects) are moved from one step of the pipeline to the other.
3. `Genesis` is [de]serialized using buffered reader/writer.
4. `Builder:{load,save}` uses similar [de]serialize optimizations.

As a result the memory usage that was picking to `27GB` now dropped to `13GB`. 

Time efficiency seems to have also improved as I recorded
```
40s built time for genesis
8s for writing to disk
```
 
> [!NOTE]
> This is blocked by #741. Once the latter is merged, the target branch of this PR will change to `sc-platform/genesis-staking`. Hence it is now marked as draft.
>
> Nevertheless it can be reviewed already.

## Links to any relevant issues

Fixes #889 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

* Saving `genesis` in the `build_stardust_genesis` example.
* Saving and loading the builder with custom scripts.