### PR TITLE
fix(test): Fix simtest compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7519,9 +7519,11 @@ dependencies = [
  "msim",
  "narwhal-network",
  "rand 0.8.5",
+ "real_tokio",
  "serde",
  "telemetry-subscribers",
  "tempfile",
+ "tokio",
  "tower",
  "tracing",
 ]

--- a/crates/iota-simulator/Cargo.toml
+++ b/crates/iota-simulator/Cargo.toml
@@ -27,3 +27,5 @@ tracing.workspace = true
 
 [target.'cfg(msim)'.dependencies]
 msim.workspace = true
+tokio.workspace = true
+real_tokio = { git = "https://github.com/mystenmark/tokio-madsim-fork.git", rev = "e47aafebf98e9c1734a8848a1876d5946c44bdd1", features = ["full"] }

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -7,8 +7,8 @@ use std::os::unix::fs::FileExt;
 #[cfg(target_os = "windows")]
 use std::os::windows::fs::FileExt;
 use std::{
-    collections::BTreeSet, fmt::Write, fs::read_dir, io::Read, path::PathBuf, str, str::FromStr,
-    thread, time::Duration,
+    collections::BTreeSet, fmt::Write, fs::read_dir, io::Read, path::PathBuf, str, thread,
+    time::Duration,
 };
 
 use expect_test::expect;


### PR DESCRIPTION
# Description of change

Tests marked with `#[sim_test]` are currently failing to compile when `cfg(msim)` is enabled. This PR fixes this using a bit of a hack, explained in `iota-simulator/src/lib.rs`

```
TODO: This is a temporary fix to a problem in `msim_macros`, where it
generates code like this:

let (stop_tx, stop_rx) = ::tokio::sync::oneshot::channel();
let watchdog =
    iota_simulator::runtime::start_watchdog(rt.clone(), inner_seed, watchdog_timeout, stop_rx);

Unfortunately, this uses the local `tokio` of the caller, rather than the
`real_tokio` crate in the `msim` workspace that is expected by
`start_watchdog`. Replacing the local tokio in each crate where sim tests
are used is not a good option, as it conflicts with other crates' usage of
tokio. This solution resolves the problem by shadowing the method and
converting the channel type with an additional adapter task.
```

Are there other solutions? I think there are, but they would require forking and maintaining yet another mysten repo. Or, possibly, moving all of the sim tests to one place where the alternate tokio can be used without breaking the crates.
