### PR TITLE
fix(general): fix copyright

### DIFF
--- a/crates/iota-aws-orchestrator/assets/plot.py
+++ b/crates/iota-aws-orchestrator/assets/plot.py
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/crates/iota-graphql-rpc/schema/draft_target_schema.graphql
+++ b/crates/iota-graphql-rpc/schema/draft_target_schema.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/crates/iota-rosetta/docker/iota-rosetta-devnet/build.sh
+++ b/crates/iota-rosetta/docker/iota-rosetta-devnet/build.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/crates/iota-rosetta/docker/iota-rosetta-local/build.sh
+++ b/crates/iota-rosetta/docker/iota-rosetta-local/build.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/crates/transaction-fuzzer/scripts/coin_factory_gen.py
+++ b/crates/transaction-fuzzer/scripts/coin_factory_gen.py
@@ -8,20 +8,19 @@ import os
 
 NUM_VARIANTS = 64
 
-factory_file = os.path.join(os.path.dirname(__file__), os.pardir, "data", "coin_factory", "sources", "coin_factory.move")
+factory_file = os.path.join(os.path.dirname(
+    __file__), os.pardir, "data", "coin_factory", "sources", "coin_factory.move")
 
 with open(factory_file, 'w') as f:
     f.write("// Copyright (c) Mysten Labs, Inc.\n")
+    f.write("// Modifications Copyright (c) 2024 IOTA Stiftung\n")
     f.write("// SPDX-License-Identifier: Apache-2.0\n")
-
-     f.write("// Modifications Copyright (c) 2024 IOTA Stiftung
-     f.write("// SPDX-License-Identifier: Apache-2.0
 
     f.write("module coiner::coin_factory {\n")
     f.write("    use std::option;\n")
     f.write("    use iota::coin::{Self, Coin, TreasuryCap};\n")
     f.write("    use iota::transfer;\n")
-    f.write("    use std::vector;\n");
+    f.write("    use std::vector;\n")
     f.write("    use iota::tx_context::{Self, TxContext};\n")
     f.write("\n")
     f.write("    struct COIN_FACTORY has drop {}\n")
@@ -29,34 +28,37 @@ with open(factory_file, 'w') as f:
     f.write("    fun init(witness: COIN_FACTORY, ctx: &mut TxContext) {\n")
     f.write("        let (treasury, metadata) = coin::create_currency(witness, 6, b\"COIN_FACTORY\", b\"\", b\"\", option::none(), ctx);\n")
     f.write("        // this actually does not make any sense in real life (metadata should actually be frozen)\n")
-    f.write("        // but makes it easier to find package object in effects (as it will be the only immutable\n")
+    f.write(
+        "        // but makes it easier to find package object in effects (as it will be the only immutable\n")
     f.write("        // object if metadata is not frozen)\n")
     f.write("        transfer::public_share_object(metadata);\n")
     f.write("        transfer::public_transfer(treasury, tx_context::sender(ctx))\n")
     f.write("    }\n")
-    f.write("\n");
-    f.write("    public fun mint_vec(\n");
-    f.write("        cap: &mut TreasuryCap<COIN_FACTORY>,\n");
-    f.write("        value: u64,\n");
-    f.write("        size: u64,\n");
-    f.write("        ctx: &mut TxContext\n");
-    f.write("    ): vector<Coin<COIN_FACTORY>> {\n");
-    f.write("        let v = vector::empty<Coin<COIN_FACTORY>>();\n");
-    f.write("        let i = 0;\n");
-    f.write("        while (i < size) {\n");
-    f.write("            vector::push_back(&mut v, coin::mint(cap, value, ctx));\n");
-    f.write("            i = i + 1;\n");
-    f.write("        };\n");
-    f.write("        v\n");
-    f.write("    }\n\n");
-
+    f.write("\n")
+    f.write("    public fun mint_vec(\n")
+    f.write("        cap: &mut TreasuryCap<COIN_FACTORY>,\n")
+    f.write("        value: u64,\n")
+    f.write("        size: u64,\n")
+    f.write("        ctx: &mut TxContext\n")
+    f.write("    ): vector<Coin<COIN_FACTORY>> {\n")
+    f.write("        let v = vector::empty<Coin<COIN_FACTORY>>();\n")
+    f.write("        let i = 0;\n")
+    f.write("        while (i < size) {\n")
+    f.write("            vector::push_back(&mut v, coin::mint(cap, value, ctx));\n")
+    f.write("            i = i + 1;\n")
+    f.write("        };\n")
+    f.write("        v\n")
+    f.write("    }\n\n")
 
     for i in range(1, NUM_VARIANTS + 1):
-        f.write("    public fun unpack_" + str(i) +"(v: &mut vector<Coin<COIN_FACTORY>>): (\n")
-        f.write(',\n'.join([x for x in ["         Coin<COIN_FACTORY>"] for j in range(i)]))
+        f.write("    public fun unpack_" + str(i) +
+                "(v: &mut vector<Coin<COIN_FACTORY>>): (\n")
+        f.write(',\n'.join(
+            [x for x in ["         Coin<COIN_FACTORY>"] for j in range(i)]))
         f.write("\n    ) {\n")
         f.write("        (\n")
-        f.write(',\n'.join([x for x in ["         vector::pop_back(v)"] for j in range(i)]))
+        f.write(',\n'.join(
+            [x for x in ["         vector::pop_back(v)"] for j in range(i)]))
         f.write("\n        )\n")
         f.write("    }\n\n")
 

--- a/crates/transaction-fuzzer/scripts/coin_factory_gen.py
+++ b/crates/transaction-fuzzer/scripts/coin_factory_gen.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) Mysten Labs, Inc.
+# Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 
 # Generates ../data/coin_factory/sources/coin_factory.move to create NUM_VARIANTS of a function returning an N-tuple of coins

--- a/dapps/regulated-token/publish.sh
+++ b/dapps/regulated-token/publish.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/docker/deterministic-canary/build.sh
+++ b/docker/deterministic-canary/build.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/docker/fullnode-x/fullnode/entry.sh
+++ b/docker/fullnode-x/fullnode/entry.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/docker/fullnode-x/indexer/indexer.sh
+++ b/docker/fullnode-x/indexer/indexer.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/docker/iota-graphql-rpc/build.sh
+++ b/docker/iota-graphql-rpc/build.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/docker/iota-indexer/build.sh
+++ b/docker/iota-indexer/build.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/docker/iota-node-deterministic/build.sh
+++ b/docker/iota-node-deterministic/build.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/docker/iota-node/build.sh
+++ b/docker/iota-node/build.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/docker/iota-services/build.sh
+++ b/docker/iota-services/build.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/docker/iota-source-service/build.sh
+++ b/docker/iota-source-service/build.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/docker/iota-tools/build.sh
+++ b/docker/iota-tools/build.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/external-crates/move/crates/move-analyzer/editors/code/scripts/create.sh
+++ b/external-crates/move/crates/move-analyzer/editors/code/scripts/create.sh
@@ -1,7 +1,5 @@
 #!/bin/zsh
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/external-crates/move/crates/move-analyzer/prettier-plugin/scripts/treesitter-wasm-gen.sh
+++ b/external-crates/move/crates/move-analyzer/prettier-plugin/scripts/treesitter-wasm-gen.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/narwhal/Docker/build.sh
+++ b/narwhal/Docker/build.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/narwhal/Docker/entry.sh
+++ b/narwhal/Docker/entry.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/narwhal/Docker/gen.validators.sh
+++ b/narwhal/Docker/gen.validators.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 set -e

--- a/narwhal/Docker/scripts/gen.committee.py
+++ b/narwhal/Docker/scripts/gen.committee.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 """Generate a committee.json file
@@ -34,7 +32,6 @@ def main():
     for i in range(args.n):
         k = open("{}/validator-{:02d}/network-key.json".format(args.d, i)).read()
         network_keys.append(json.loads(k))
-
 
     temp = {}
     for i, (k, nk) in enumerate(zip(keys, network_keys)):

--- a/narwhal/Docker/scripts/gen.compose.py
+++ b/narwhal/Docker/scripts/gen.compose.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 """Create a docker-compose.yaml file to stdout for --num # of nodes

--- a/narwhal/Docker/scripts/gen.workers.py
+++ b/narwhal/Docker/scripts/gen.workers.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 """Generate a workers.json file

--- a/narwhal/benchmark/benchmark/aggregate.py
+++ b/narwhal/benchmark/benchmark/aggregate.py
@@ -1,7 +1,5 @@
 # Copyright(C) Facebook, Inc. and its affiliates.
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 from re import search

--- a/narwhal/benchmark/benchmark/commands.py
+++ b/narwhal/benchmark/benchmark/commands.py
@@ -1,7 +1,5 @@
 # Copyright(C) Facebook, Inc. and its affiliates.
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 from os.path import join
@@ -47,7 +45,7 @@ class CommandMaker:
     def generate_network_key(filename):
         assert isinstance(filename, str)
         return f'./narwhal-node generate_network_keys --filename {filename}'
-     
+
     @staticmethod
     def run_primary(primary_keys, primary_network_keys, worker_keys, committee, workers, store, parameters, debug=False):
         assert isinstance(primary_keys, str)

--- a/narwhal/benchmark/benchmark/config.py
+++ b/narwhal/benchmark/benchmark/config.py
@@ -1,7 +1,5 @@
 # Copyright(C) Facebook, Inc. and its affiliates.
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 from json import dump, load
@@ -11,6 +9,7 @@ from benchmark.utils import multiaddr_to_url_data
 
 class ConfigError(Exception):
     pass
+
 
 class WorkerCache:
     ''' The worker cache looks as follows:

--- a/narwhal/benchmark/benchmark/full_demo.py
+++ b/narwhal/benchmark/benchmark/full_demo.py
@@ -1,7 +1,5 @@
 # Copyright(C) Facebook, Inc. and its affiliates.
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 import subprocess
@@ -97,7 +95,8 @@ class Demo:
                 pk = subprocess.check_output(cmd_pk, encoding='utf-8').strip()
                 primary_network_names += [pk]
 
-            committee = LocalCommittee(primary_names, primary_network_names, self.BASE_PORT)
+            committee = LocalCommittee(
+                primary_names, primary_network_names, self.BASE_PORT)
             committee.print(PathMaker.committee_file())
 
             worker_names = []

--- a/narwhal/benchmark/benchmark/instance.py
+++ b/narwhal/benchmark/benchmark/instance.py
@@ -1,7 +1,5 @@
 # Copyright(C) Facebook, Inc. and its affiliates.
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 import boto3

--- a/narwhal/benchmark/benchmark/local.py
+++ b/narwhal/benchmark/benchmark/local.py
@@ -1,7 +1,5 @@
 # Copyright(C) Facebook, Inc. and its affiliates.
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 import subprocess

--- a/narwhal/benchmark/benchmark/logs.py
+++ b/narwhal/benchmark/benchmark/logs.py
@@ -1,7 +1,5 @@
 # Copyright(C) Facebook, Inc. and its affiliates.
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime, timezone

--- a/narwhal/benchmark/benchmark/plot.py
+++ b/narwhal/benchmark/benchmark/plot.py
@@ -1,7 +1,5 @@
 # Copyright(C) Facebook, Inc. and its affiliates.
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 from re import findall, search, split

--- a/narwhal/benchmark/benchmark/remote.py
+++ b/narwhal/benchmark/benchmark/remote.py
@@ -1,7 +1,5 @@
 # Copyright(C) Facebook, Inc. and its affiliates.
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 from collections import OrderedDict

--- a/narwhal/benchmark/benchmark/seed.py
+++ b/narwhal/benchmark/benchmark/seed.py
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 import subprocess

--- a/narwhal/benchmark/benchmark/settings.py
+++ b/narwhal/benchmark/benchmark/settings.py
@@ -1,7 +1,5 @@
 # Copyright(C) Facebook, Inc. and its affiliates.
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 from json import load, JSONDecodeError

--- a/narwhal/benchmark/benchmark/utils.py
+++ b/narwhal/benchmark/benchmark/utils.py
@@ -1,7 +1,5 @@
 # Copyright (c) 2021, Facebook, Inc. and its affiliates.
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 import multiaddr

--- a/narwhal/benchmark/data/paper-data/plot-script.py
+++ b/narwhal/benchmark/data/paper-data/plot-script.py
@@ -1,7 +1,5 @@
 # Copyright(C) Facebook, Inc. and its affiliates.
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/narwhal/benchmark/data/paper-data/summary-plot.py
+++ b/narwhal/benchmark/data/paper-data/summary-plot.py
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 import matplotlib.pyplot as plt

--- a/narwhal/benchmark/fabfile.py
+++ b/narwhal/benchmark/fabfile.py
@@ -1,7 +1,5 @@
 # Copyright(C) Facebook, Inc. and its affiliates.
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 from fabric import task

--- a/narwhal/scripts/changed-files.sh
+++ b/narwhal/scripts/changed-files.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/narwhal/scripts/update_dependencies.sh
+++ b/narwhal/scripts/update_dependencies.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/nre/download_and_verify_private_binary.sh
+++ b/nre/download_and_verify_private_binary.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/nre/download_private.sh
+++ b/nre/download_private.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/bench_sweep.py
+++ b/scripts/bench_sweep.py
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 from time import sleep
@@ -11,6 +9,7 @@ from string import Template
 
 cmd_template = Template(
     "../target/release/bench microbench latency --period-us $period_us --chunk-size $chunk_size --num-chunks $num_chunks")
+
 
 def get_avg_latency(period_us, chunk_size, num_chunks):
     cmd = cmd_template.substitute(
@@ -33,6 +32,7 @@ def plot(vals):
     plt.ylabel("Latency (ms)")
     plt.xlabel("Throughput")
     plt.show()
+
 
 lats = []
 for i in range(10):

--- a/scripts/changed-files.sh
+++ b/scripts/changed-files.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/check-framework-compat.sh
+++ b/scripts/check-framework-compat.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/scripts/compatibility/check-protocol-compatibility.sh
+++ b/scripts/compatibility/check-protocol-compatibility.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/compatibility/fullnode-sync.sh
+++ b/scripts/compatibility/fullnode-sync.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/compatibility/monitor_synced.py
+++ b/scripts/compatibility/monitor_synced.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/compatibility/split-cluster-check.sh
+++ b/scripts/compatibility/split-cluster-check.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/dependency.py
+++ b/scripts/dependency.py
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 
@@ -10,6 +8,7 @@ import re
 
 ROOT = os.path.join(os.path.dirname(__file__), "../")
 PATTERN = None
+
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -31,6 +30,7 @@ def parse_args():
     upgrade_group.add_argument("--rev")
     upgrade_group.add_argument("--branch")
     return parser.parse_args()
+
 
 def scan_file(file, process_line, depth=0):
     new_content = []
@@ -63,6 +63,7 @@ def try_match_line(line):
             extra = m.group(2).replace(',', ', ').replace('=', ' = ')
         return (name, extra)
     return None
+
 
 def switch_to_local(project):
     default_path_map = {
@@ -122,6 +123,7 @@ def switch_to_local(project):
 
 def upgrade_revision(project, repo, rev, branch):
     assert (args.rev is None) != (args.branch is None)
+
     def process_line(line, _):
         m = try_match_line(line)
         if m:
@@ -138,10 +140,11 @@ def upgrade_revision(project, repo, rev, branch):
 
 
 args = parse_args()
-assert(args.project == "move" or args.project == "narwhal")
+assert (args.project == "move" or args.project == "narwhal")
 
 PATTERN = re.compile(
-    '(.+)={git="https://github.com/.+/' + args.project + '",(?:rev|branch)="[^"]+"(,.*)?}'
+    '(.+)={git="https://github.com/.+/' +
+    args.project + '",(?:rev|branch)="[^"]+"(,.*)?}'
 )
 
 if args.command == "local":

--- a/scripts/execution_layer.py
+++ b/scripts/execution_layer.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/scripts/lldb_frame_sizes.py
+++ b/scripts/lldb_frame_sizes.py
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 
@@ -17,10 +15,11 @@ import lldb
 #     (lldb) command script import ./iota/scripts/lldb_frame_sizes
 #     Loaded "frame-sizes" command.
 #     (lldb) ...
-#     
+#
 #     Process XXXXX stopped
 #     ...
 #     (lldb) frame-sizes
+
 
 def frame_sizes(debugger, command, result, internal_dict):
     """Estimates the sizes of stack frames in the current backtrace.
@@ -58,6 +57,7 @@ def frame_sizes(debugger, command, result, internal_dict):
             ),
             file=result,
         )
+
 
 def __lldb_init_module(debugger, internal_dict):
     debugger.HandleCommand(

--- a/scripts/rotate_snapshots.py
+++ b/scripts/rotate_snapshots.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 
@@ -30,12 +28,13 @@ def usage():
     print(
         f'   --dir=<iota-base-dir>   Base directory for iota. Must contain /snapshots and /instances dirs')
     print('  --help                 Print this help message')
-    
+
 
 def is_referenced(root_dir, filepath):
     instances_dir = os.path.join(root_dir, 'instances')
     try:
-        result = subprocess.check_output(['find', '-L', instances_dir, '-samefile', filepath])
+        result = subprocess.check_output(
+            ['find', '-L', instances_dir, '-samefile', filepath])
     except subprocess.CalledProcessError as e:
         print(f'find command failed with error {e.returncode}: {e.output}')
         exit(1)
@@ -63,21 +62,24 @@ def main(argv):
         elif opt == '--dir':
             root_dir = arg
             env = arg
-    
+
     os.chdir(root_dir)
     snapshots_dir = os.path.join(root_dir, 'snapshots')
     contents = os.listdir(snapshots_dir)
     epoch_dirs = [path for path in contents if 'epoch_' in path]
     epochs = [int(epoch_dir.split('epoch_')[1]) for epoch_dir in epoch_dirs]
     latest_epoch = max(epochs)
-    paths_to_rotate = [epoch_dir for epoch_dir in epoch_dirs if str(latest_epoch) not in epoch_dir]
+    paths_to_rotate = [epoch_dir for epoch_dir in epoch_dirs if str(
+        latest_epoch) not in epoch_dir]
     for path in paths_to_rotate:
         snapshot_path = os.path.join(snapshots_dir, path)
         if not is_referenced(root_dir, snapshot_path):
-            print(f'Old snapshot at {snapshot_path} is not referenced by any running processes. Deleting...')
+            print(
+                f'Old snapshot at {snapshot_path} is not referenced by any running processes. Deleting...')
             shutil.rmtree(snapshot_path, ignore_errors=True)
     print('Finished rotating snapshots on host')
     exit(0)
+
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/scripts/update_all_snapshots.sh
+++ b/scripts/update_all_snapshots.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/scripts/update_fastcrypto.sh
+++ b/scripts/update_fastcrypto.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/update_move.sh
+++ b/scripts/update_move.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/update_narwhal.sh
+++ b/scripts/update_narwhal.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/checkpoint.graphql
+++ b/sdk/graphql-transport/src/queries/checkpoint.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/devInspectTransactionBlock.graphql
+++ b/sdk/graphql-transport/src/queries/devInspectTransactionBlock.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/dryRunTransactionBlock.graphql
+++ b/sdk/graphql-transport/src/queries/dryRunTransactionBlock.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/executeTransactionBlock.graphql
+++ b/sdk/graphql-transport/src/queries/executeTransactionBlock.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/getAllBalances.graphql
+++ b/sdk/graphql-transport/src/queries/getAllBalances.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/getBalance.graphql
+++ b/sdk/graphql-transport/src/queries/getBalance.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/getChainIdentifier.graphql
+++ b/sdk/graphql-transport/src/queries/getChainIdentifier.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/getCoinMetadata.graphql
+++ b/sdk/graphql-transport/src/queries/getCoinMetadata.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/getCoins.graphql
+++ b/sdk/graphql-transport/src/queries/getCoins.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/getCommitteeInfo.graphql
+++ b/sdk/graphql-transport/src/queries/getCommitteeInfo.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/getCurrentEpoch.graphql
+++ b/sdk/graphql-transport/src/queries/getCurrentEpoch.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/getDynamicFieldObject.graphql
+++ b/sdk/graphql-transport/src/queries/getDynamicFieldObject.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/getDynamicFields.graphql
+++ b/sdk/graphql-transport/src/queries/getDynamicFields.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/getLatestCheckpointSequenceNumber.graphql
+++ b/sdk/graphql-transport/src/queries/getLatestCheckpointSequenceNumber.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/getLatestIotaSystemState.graphql
+++ b/sdk/graphql-transport/src/queries/getLatestIotaSystemState.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/getMoveFunctionArgTypes.graphql
+++ b/sdk/graphql-transport/src/queries/getMoveFunctionArgTypes.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/getNormalizedMoveFunction.graphql
+++ b/sdk/graphql-transport/src/queries/getNormalizedMoveFunction.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/getNormalizedMoveModule.graphql
+++ b/sdk/graphql-transport/src/queries/getNormalizedMoveModule.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/getNormalizedMoveModulesByPackage.graphql
+++ b/sdk/graphql-transport/src/queries/getNormalizedMoveModulesByPackage.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/getNormalizedMoveStruct.graphql
+++ b/sdk/graphql-transport/src/queries/getNormalizedMoveStruct.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/getProtocolConfig.graphql
+++ b/sdk/graphql-transport/src/queries/getProtocolConfig.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/getReferenceGasPrice.graphql
+++ b/sdk/graphql-transport/src/queries/getReferenceGasPrice.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/getTotalSupply.graphql
+++ b/sdk/graphql-transport/src/queries/getTotalSupply.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/getTotalTransactionBlocks.graphql
+++ b/sdk/graphql-transport/src/queries/getTotalTransactionBlocks.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/getValidatorsApy.graphql
+++ b/sdk/graphql-transport/src/queries/getValidatorsApy.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/nameService.graphql
+++ b/sdk/graphql-transport/src/queries/nameService.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/objects.graphql
+++ b/sdk/graphql-transport/src/queries/objects.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/queryEvents.graphql
+++ b/sdk/graphql-transport/src/queries/queryEvents.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/stakes.graphql
+++ b/sdk/graphql-transport/src/queries/stakes.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/graphql-transport/src/queries/transactions.graphql
+++ b/sdk/graphql-transport/src/queries/transactions.graphql
@@ -1,6 +1,4 @@
 # Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
# Description of change

Removed duplicated SPDX-License-Identifier lines.
Fix copyright in coin_factory_gen.py as it was wrong there from the rename script

## Links to any relevant issues

Partially addresses https://github.com/iotaledger/iota/issues/806

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`python3 scripts/coin_factory_gen.py`
