### PR TITLE
feat(iota-genesis-builder): sort timelock objects for delegation

### DIFF
--- a/crates/iota-genesis-builder/src/stake.rs
+++ b/crates/iota-genesis-builder/src/stake.rs
@@ -138,7 +138,7 @@ pub fn delegate_genesis_stake(
     migration_objects: &MigrationObjects,
     amount_nanos: u64,
 ) -> anyhow::Result<GenesisStake> {
-    let timelocks_pool = migration_objects.get_timelocks_by_owner(delegator);
+    let timelocks_pool = migration_objects.get_sorted_timelocks_by_owner(delegator);
     let gas_coins_pool = migration_objects.get_gas_coins_by_owner(delegator);
     if timelocks_pool.is_none() && gas_coins_pool.is_none() {
         anyhow::bail!("no timelocks or gas-coin objects found for delegator {delegator:?}");

--- a/crates/iota-genesis-builder/src/stardust/migration/migration.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/migration.rs
@@ -4,6 +4,7 @@
 //! Contains the logic for the migration process.
 
 use std::{
+    cmp::Reverse,
     collections::{HashMap, HashSet},
     io::{prelude::Write, BufWriter},
 };
@@ -307,12 +308,13 @@ impl MigrationObjects {
     pub fn get_sorted_timelocks_by_owner(&self, address: IotaAddress) -> Option<Vec<&Object>> {
         self.get_timelocks_by_owner(address).map(|mut timelocks| {
             timelocks.sort_by_cached_key(|object| {
-                object
-                    .to_rust::<TimeLock<Balance>>()
-                    .expect("this should be a TimeLock object")
-                    .expiration_timestamp_ms()
+                Reverse(
+                    object
+                        .to_rust::<TimeLock<Balance>>()
+                        .expect("this should be a TimeLock object")
+                        .expiration_timestamp_ms(),
+                )
             });
-            timelocks.reverse();
             timelocks
         })
     }

--- a/crates/iota-genesis-builder/src/stardust/migration/migration.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/migration.rs
@@ -14,12 +14,13 @@ use iota_move_build::CompiledPackage;
 use iota_protocol_config::ProtocolVersion;
 use iota_sdk::types::block::output::{FoundryOutput, Output, OutputId};
 use iota_types::{
+    balance::Balance,
     base_types::{IotaAddress, ObjectID, TxContext},
     crypto::DefaultHash,
     digests::TransactionDigest,
     epoch_data::EpochData,
     object::Object,
-    timelock::timelock::is_timelocked_balance,
+    timelock::timelock::{is_timelocked_balance, TimeLock},
     IOTA_FRAMEWORK_PACKAGE_ID, IOTA_SYSTEM_PACKAGE_ID, MOVE_STDLIB_PACKAGE_ID, STARDUST_PACKAGE_ID,
     TIMELOCK_PACKAGE_ID,
 };
@@ -295,6 +296,25 @@ impl MigrationObjects {
     /// Checks if inner is empty.
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
+    }
+
+    /// Get [`TimeLock`] objects created during the migration.
+    ///
+    /// The query is filtered by the object owner.
+    ///
+    /// The returned objects are ordered by expiration timestamp, in descending
+    /// order.
+    pub fn get_sorted_timelocks_by_owner(&self, address: IotaAddress) -> Option<Vec<&Object>> {
+        self.get_timelocks_by_owner(address).map(|mut timelocks| {
+            timelocks.sort_by_cached_key(|object| {
+                object
+                    .to_rust::<TimeLock<Balance>>()
+                    .expect("this should be a TimeLock object")
+                    .expiration_timestamp_ms()
+            });
+            timelocks.reverse();
+            timelocks
+        })
     }
 
     /// Get [`TimeLock`] objects created during the migration.


### PR DESCRIPTION
# Description of change

This patch sorts timelock objects for delegation by expiration time in descending order.

## Links to any relevant issues

Fixes #904 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo check -p iota-genesis-builder`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
