### PR TITLE
feat(iota-types): staking params were changed according new requirements

### DIFF
--- a/crates/iota-types/src/governance.rs
+++ b/crates/iota-types/src/governance.rs
@@ -22,22 +22,22 @@ pub const MAX_VALIDATOR_COUNT: u64 = 150;
 
 /// Lower-bound on the amount of stake required to become a validator.
 ///
-/// 30 million IOTA
-pub const MIN_VALIDATOR_JOINING_STAKE_MICROS: u64 = 30_000_000 * MICROS_PER_IOTA;
+/// 2 million IOTA
+pub const MIN_VALIDATOR_JOINING_STAKE_MICROS: u64 = 2_000_000 * MICROS_PER_IOTA;
 
 /// Validators with stake amount below `validator_low_stake_threshold` are
 /// considered to have low stake and will be escorted out of the validator set
 /// after being below this threshold for more than
 /// `validator_low_stake_grace_period` number of epochs.
 ///
-/// 20 million IOTA
-pub const VALIDATOR_LOW_STAKE_THRESHOLD_MICROS: u64 = 20_000_000 * MICROS_PER_IOTA;
+/// 1.5 million IOTA
+pub const VALIDATOR_LOW_STAKE_THRESHOLD_MICROS: u64 = 1_500_000 * MICROS_PER_IOTA;
 
 /// Validators with stake below `validator_very_low_stake_threshold` will be
 /// removed immediately at epoch change, no grace period.
 ///
-/// 15 million IOTA
-pub const VALIDATOR_VERY_LOW_STAKE_THRESHOLD_MICROS: u64 = 15_000_000 * MICROS_PER_IOTA;
+/// 1 million IOTA
+pub const VALIDATOR_VERY_LOW_STAKE_THRESHOLD_MICROS: u64 = 1_000_000 * MICROS_PER_IOTA;
 
 /// A validator can have stake below `validator_low_stake_threshold`
 /// for this many epochs before being kicked out.


### PR DESCRIPTION
# Description of change

The parameters were set according to the following table:

Parameter | Type | Value 
-- | -- | --
MIN_VALIDATOR_JOINING_STAKE | Protocol Parameter | 2M IOTA
VALIDATOR_LOW_STAKE_THRESHOLD | Protocol Parameter | 1.5M IOTA
VALIDATOR_LOW_STAKE_GRACE_PERIOD | Protocol Parameter | 7 epochs*
VALIDATOR_VERY_LOW_STAKE_THRESHOLD | Protocol Parameter | 1M IOTA
MAX_VALIDATOR_COUNT | Protocol Parameter | 150*

## Links to any relevant issues

fixes #944 
