### PR TITLE
feat(sc-platform): Disable stake subsidies

### DIFF
--- a/crates/iota-config/src/genesis.rs
+++ b/crates/iota-config/src/genesis.rs
@@ -371,7 +371,7 @@ pub struct GenesisCeremonyParameters {
     pub epoch_duration_ms: u64,
 
     /// The starting epoch in which stake subsidies start being paid out.
-    #[serde(default)]
+    #[serde(default = "GenesisCeremonyParameters::default_stake_subsidy_start_epoch")]
     pub stake_subsidy_start_epoch: u64,
 
     /// The amount of stake subsidy to be drawn down per distribution.
@@ -398,7 +398,7 @@ impl GenesisCeremonyParameters {
             chain_start_timestamp_ms: Self::default_timestamp_ms(),
             protocol_version: ProtocolVersion::MAX,
             allow_insertion_of_extra_objects: true,
-            stake_subsidy_start_epoch: 0,
+            stake_subsidy_start_epoch: Self::default_stake_subsidy_start_epoch(),
             epoch_duration_ms: Self::default_epoch_duration_ms(),
             stake_subsidy_initial_distribution_amount:
                 Self::default_initial_stake_subsidy_distribution_amount(),
@@ -421,6 +421,12 @@ impl GenesisCeremonyParameters {
     fn default_epoch_duration_ms() -> u64 {
         // 24 hrs
         24 * 60 * 60 * 1000
+    }
+
+    fn default_stake_subsidy_start_epoch() -> u64 {
+        // Set to highest possible value so that the stake subsidy fund never pays out
+        // rewards.
+        u64::MAX
     }
 
     fn default_initial_stake_subsidy_distribution_amount() -> u64 {

--- a/crates/iota-config/src/genesis.rs
+++ b/crates/iota-config/src/genesis.rs
@@ -424,18 +424,21 @@ impl GenesisCeremonyParameters {
     }
 
     fn default_initial_stake_subsidy_distribution_amount() -> u64 {
-        // 1M Iota
-        1_000_000 * iota_types::gas_coin::MICROS_PER_IOTA
+        // 0 IOTA in nanos
+        0
     }
 
     fn default_stake_subsidy_period_length() -> u64 {
-        // 10 distributions or epochs
-        10
+        // Set to highest possible value so that the "decrease stake subsidy amount"
+        // code path is never entered which makes it easier to reason about the
+        // stake subsidy fund.
+        u64::MAX
     }
 
     fn default_stake_subsidy_decrease_rate() -> u16 {
-        // 10% in basis points
-        1000
+        // Due to how stake_subsidy_period_length is set, this values is not important,
+        // since the distribution amount is never decreased.
+        0
     }
 
     pub fn to_genesis_chain_parameters(&self) -> GenesisChainParameters {

--- a/crates/iota-framework/docs/iota-system/iota_system_state_inner.md
+++ b/crates/iota-framework/docs/iota-system/iota_system_state_inner.md
@@ -2110,10 +2110,11 @@ gas coins.
         <a href="iota_system_state_inner.md#0x3_iota_system_state_inner_EBpsTooLarge">EBpsTooLarge</a>,
     );
 
+    // Do not overwrite the start epoch.
     // TODO: remove this in later upgrade.
-    <b>if</b> (self.parameters.stake_subsidy_start_epoch &gt; 0) {
-        self.parameters.stake_subsidy_start_epoch = 20;
-    };
+    // <b>if</b> (self.parameters.stake_subsidy_start_epoch &gt; 0) {
+    //     self.parameters.stake_subsidy_start_epoch = 20;
+    // };
 
     // Accumulate the gas summary during safe_mode before processing any rewards:
     <b>let</b> safe_mode_storage_rewards = self.safe_mode_storage_rewards.withdraw_all();

--- a/crates/iota-framework/packages/iota-system/sources/iota_system_state_inner.move
+++ b/crates/iota-framework/packages/iota-system/sources/iota_system_state_inner.move
@@ -848,12 +848,6 @@ module iota_system::iota_system_state_inner {
             EBpsTooLarge,
         );
 
-        // Do not overwrite the start epoch.
-        // TODO: remove this in later upgrade.
-        // if (self.parameters.stake_subsidy_start_epoch > 0) {
-        //     self.parameters.stake_subsidy_start_epoch = 20;
-        // };
-
         // Accumulate the gas summary during safe_mode before processing any rewards:
         let safe_mode_storage_rewards = self.safe_mode_storage_rewards.withdraw_all();
         storage_reward.join(safe_mode_storage_rewards);

--- a/crates/iota-framework/packages/iota-system/sources/iota_system_state_inner.move
+++ b/crates/iota-framework/packages/iota-system/sources/iota_system_state_inner.move
@@ -848,10 +848,11 @@ module iota_system::iota_system_state_inner {
             EBpsTooLarge,
         );
 
+        // Do not overwrite the start epoch.
         // TODO: remove this in later upgrade.
-        if (self.parameters.stake_subsidy_start_epoch > 0) {
-            self.parameters.stake_subsidy_start_epoch = 20;
-        };
+        // if (self.parameters.stake_subsidy_start_epoch > 0) {
+        //     self.parameters.stake_subsidy_start_epoch = 20;
+        // };
 
         // Accumulate the gas summary during safe_mode before processing any rewards:
         let safe_mode_storage_rewards = self.safe_mode_storage_rewards.withdraw_all();


### PR DESCRIPTION
# Description of change

Disable stake subsidies by setting parameters in such a way that the reward's paid out from the stake subsidy fund are 0.

In a later step, we can actually remove the code of the stake subsidy fund but this is avoided now to keep the tokenomics changes to a minimum.

## Links to any relevant issues

fixes #938 

## How the change has been tested

`iota-test-validator` successfully starts and advances epochs.