### PR TITLE
feat(iota-protocol-config): disabling storage_fund_reinvest_rate

### DIFF
--- a/crates/iota-framework/docs/iota-system/iota_system_state_inner.md
+++ b/crates/iota-framework/docs/iota-system/iota_system_state_inner.md
@@ -2110,12 +2110,6 @@ gas coins.
         <a href="iota_system_state_inner.md#0x3_iota_system_state_inner_EBpsTooLarge">EBpsTooLarge</a>,
     );
 
-    // Do not overwrite the start epoch.
-    // TODO: remove this in later upgrade.
-    // <b>if</b> (self.parameters.stake_subsidy_start_epoch &gt; 0) {
-    //     self.parameters.stake_subsidy_start_epoch = 20;
-    // };
-
     // Accumulate the gas summary during safe_mode before processing any rewards:
     <b>let</b> safe_mode_storage_rewards = self.safe_mode_storage_rewards.withdraw_all();
     storage_reward.join(safe_mode_storage_rewards);

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1358,7 +1358,7 @@ impl ProtocolConfig {
             obj_metadata_cost_non_refundable: Some(50),
             gas_model_version: Some(8),
             storage_rebate_rate: Some(9900),
-            storage_fund_reinvest_rate: Some(500),
+            storage_fund_reinvest_rate: Some(0),
             // Change reward slashing rate to 100%.
             reward_slashing_rate: Some(10000),
             storage_gas_price: Some(76),

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -120,7 +120,7 @@ gas_model_version: 8
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50
 storage_rebate_rate: 9900
-storage_fund_reinvest_rate: 500
+storage_fund_reinvest_rate: 0
 reward_slashing_rate: 10000
 storage_gas_price: 76
 max_transactions_per_checkpoint: 10000
@@ -259,3 +259,4 @@ max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
+

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -122,7 +122,7 @@ gas_model_version: 8
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50
 storage_rebate_rate: 9900
-storage_fund_reinvest_rate: 500
+storage_fund_reinvest_rate: 0
 reward_slashing_rate: 10000
 storage_gas_price: 76
 max_transactions_per_checkpoint: 10000
@@ -261,3 +261,4 @@ max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
+

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -125,7 +125,7 @@ gas_model_version: 8
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50
 storage_rebate_rate: 9900
-storage_fund_reinvest_rate: 500
+storage_fund_reinvest_rate: 0
 reward_slashing_rate: 10000
 storage_gas_price: 76
 max_transactions_per_checkpoint: 10000
@@ -268,3 +268,4 @@ random_beacon_reduction_lower_bound: 1600
 random_beacon_dkg_timeout_round: 200
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
+


### PR DESCRIPTION
# Description of change

Disabling storage_fund_reinvest_rate in iota-protocol-config.
Regenerating of iota-protocol-config snapshots.

## Links to any relevant issues

Fixes #1006

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Run tests - kinesis/crates/iota-framework/packages/iota-system