### PR TITLE
feat(iota-framework): burning leftover rewards, storage_fund doesn't earn from that

### DIFF
--- a/crates/iota-framework/docs/iota-system/iota_system_state_inner.md
+++ b/crates/iota-framework/docs/iota-system/iota_system_state_inner.md
@@ -2110,12 +2110,6 @@ gas coins.
         <a href="iota_system_state_inner.md#0x3_iota_system_state_inner_EBpsTooLarge">EBpsTooLarge</a>,
     );
 
-    // Do not overwrite the start epoch.
-    // TODO: remove this in later upgrade.
-    // <b>if</b> (self.parameters.stake_subsidy_start_epoch &gt; 0) {
-    //     self.parameters.stake_subsidy_start_epoch = 20;
-    // };
-
     // Accumulate the gas summary during safe_mode before processing any rewards:
     <b>let</b> safe_mode_storage_rewards = self.safe_mode_storage_rewards.withdraw_all();
     storage_reward.join(safe_mode_storage_rewards);
@@ -2195,16 +2189,19 @@ gas coins.
     leftover_staking_rewards.join(computation_reward);
     <b>let</b> leftover_storage_fund_inflow = leftover_staking_rewards.value();
 
+    // Burning leftover rewards
+    self.iota_treasury_cap.burn_balance(leftover_staking_rewards, ctx);
+
     <b>let</b> refunded_storage_rebate =
         self.<a href="storage_fund.md#0x3_storage_fund">storage_fund</a>.<a href="iota_system_state_inner.md#0x3_iota_system_state_inner_advance_epoch">advance_epoch</a>(
             storage_reward,
             storage_fund_reinvestment,
-            leftover_staking_rewards,
             storage_rebate_amount,
             non_refundable_storage_fee_amount,
         );
 
     <a href="../iota-framework/event.md#0x2_event_emit">event::emit</a>(
+        //TODO: Add additional information (e.g., how much was burned, how much was leftover, etc.)
         <a href="iota_system_state_inner.md#0x3_iota_system_state_inner_SystemEpochInfoEvent">SystemEpochInfoEvent</a> {
             epoch: self.epoch,
             protocol_version: self.protocol_version,

--- a/crates/iota-framework/docs/iota-system/storage_fund.md
+++ b/crates/iota-framework/docs/iota-system/storage_fund.md
@@ -94,7 +94,7 @@ Called by <code><a href="iota_system.md#0x3_iota_system">iota_system</a></code> 
 Called by <code><a href="iota_system.md#0x3_iota_system">iota_system</a></code> at epoch change times to process the inflows and outflows of storage fund.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="storage_fund.md#0x3_storage_fund_advance_epoch">advance_epoch</a>(self: &<b>mut</b> <a href="storage_fund.md#0x3_storage_fund_StorageFund">storage_fund::StorageFund</a>, storage_charges: <a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../iota-framework/iota.md#0x2_iota_IOTA">iota::IOTA</a>&gt;, storage_fund_reinvestment: <a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../iota-framework/iota.md#0x2_iota_IOTA">iota::IOTA</a>&gt;, leftover_staking_rewards: <a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../iota-framework/iota.md#0x2_iota_IOTA">iota::IOTA</a>&gt;, storage_rebate_amount: u64, non_refundable_storage_fee_amount: u64): <a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../iota-framework/iota.md#0x2_iota_IOTA">iota::IOTA</a>&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="storage_fund.md#0x3_storage_fund_advance_epoch">advance_epoch</a>(self: &<b>mut</b> <a href="storage_fund.md#0x3_storage_fund_StorageFund">storage_fund::StorageFund</a>, storage_charges: <a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../iota-framework/iota.md#0x2_iota_IOTA">iota::IOTA</a>&gt;, storage_fund_reinvestment: <a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../iota-framework/iota.md#0x2_iota_IOTA">iota::IOTA</a>&gt;, storage_rebate_amount: u64, non_refundable_storage_fee_amount: u64): <a href="../iota-framework/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../iota-framework/iota.md#0x2_iota_IOTA">iota::IOTA</a>&gt;
 </code></pre>
 
 
@@ -107,13 +107,11 @@ Called by <code><a href="iota_system.md#0x3_iota_system">iota_system</a></code> 
     self: &<b>mut</b> <a href="storage_fund.md#0x3_storage_fund_StorageFund">StorageFund</a>,
     storage_charges: Balance&lt;IOTA&gt;,
     storage_fund_reinvestment: Balance&lt;IOTA&gt;,
-    leftover_staking_rewards: Balance&lt;IOTA&gt;,
     storage_rebate_amount: u64,
     non_refundable_storage_fee_amount: u64,
 ) : Balance&lt;IOTA&gt; {
-    // Both the reinvestment and leftover rewards are not <b>to</b> be refunded so they go <b>to</b> the non-refundable <a href="../iota-framework/balance.md#0x2_balance">balance</a>.
+    // The reinvestment rewards are not <b>to</b> be refunded so they go <b>to</b> the non-refundable <a href="../iota-framework/balance.md#0x2_balance">balance</a>.
     self.non_refundable_balance.join(storage_fund_reinvestment);
-    self.non_refundable_balance.join(leftover_staking_rewards);
 
     // The storage charges for the epoch come from the storage rebate of the new objects created
     // and the new storage rebates of the objects modified during the epoch so we put the charges

--- a/crates/iota-framework/packages/iota-system/sources/iota_system_state_inner.move
+++ b/crates/iota-framework/packages/iota-system/sources/iota_system_state_inner.move
@@ -927,16 +927,19 @@ module iota_system::iota_system_state_inner {
         leftover_staking_rewards.join(computation_reward);
         let leftover_storage_fund_inflow = leftover_staking_rewards.value();
 
+        // Burning leftover rewards
+        self.iota_treasury_cap.burn_balance(leftover_staking_rewards, ctx);
+
         let refunded_storage_rebate =
             self.storage_fund.advance_epoch(
                 storage_reward,
                 storage_fund_reinvestment,
-                leftover_staking_rewards,
                 storage_rebate_amount,
                 non_refundable_storage_fee_amount,
             );
 
         event::emit(
+            //TODO: Add additional information (e.g., how much was burned, how much was leftover, etc.)
             SystemEpochInfoEvent {
                 epoch: self.epoch,
                 protocol_version: self.protocol_version,

--- a/crates/iota-framework/packages/iota-system/sources/storage_fund.move
+++ b/crates/iota-framework/packages/iota-system/sources/storage_fund.move
@@ -35,13 +35,11 @@ module iota_system::storage_fund {
         self: &mut StorageFund,
         storage_charges: Balance<IOTA>,
         storage_fund_reinvestment: Balance<IOTA>,
-        leftover_staking_rewards: Balance<IOTA>,
         storage_rebate_amount: u64,
         non_refundable_storage_fee_amount: u64,
     ) : Balance<IOTA> {
-        // Both the reinvestment and leftover rewards are not to be refunded so they go to the non-refundable balance.
+        // The reinvestment rewards are not to be refunded so they go to the non-refundable balance.
         self.non_refundable_balance.join(storage_fund_reinvestment);
-        self.non_refundable_balance.join(leftover_staking_rewards);
 
         // The storage charges for the epoch come from the storage rebate of the new objects created
         // and the new storage rebates of the objects modified during the epoch so we put the charges

--- a/crates/iota-framework/packages/iota-system/tests/rewards_distribution_tests.move
+++ b/crates/iota-framework/packages/iota-system/tests/rewards_distribution_tests.move
@@ -308,7 +308,7 @@ module iota_system::rewards_distribution_tests {
     #[test]
     fun test_everyone_slashed() {
         // This test is to make sure that if everyone is slashed, our protocol works as expected without aborting
-        // and all rewards go to the storage fund.
+        // and rewards are burned, and no tokens go to the storage fund.
         set_up_iota_system_state();
         let mut scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
@@ -327,16 +327,16 @@ module iota_system::rewards_distribution_tests {
         report_validator(VALIDATOR_ADDR_4, VALIDATOR_ADDR_1, scenario);
 
         advance_epoch_with_reward_amounts_and_slashing_rates(
-            1000, 3000, 10_000, scenario
+            1000, 500, 10_000, scenario
         );
 
         // All validators should have 0 rewards added so their stake stays the same.
         assert_validator_self_stake_amounts(validator_addrs(), vector[100 * MICROS_PER_IOTA, 200 * MICROS_PER_IOTA, 300 * MICROS_PER_IOTA, 400 * MICROS_PER_IOTA], scenario);
 
         scenario.next_tx(@0x0);
-        // Storage fund balance should increase by 4000 IOTA.
+        // Storage fund balance should be the same as before.
         let mut system_state = scenario.take_shared<IotaSystemState>();
-        assert_eq(system_state.get_storage_fund_total_balance(), 4000 * MICROS_PER_IOTA);
+        assert_eq(system_state.get_storage_fund_total_balance(), 1000 * MICROS_PER_IOTA);
 
         // The entire 1000 IOTA of storage rewards should go to the object rebate portion of the storage fund.
         assert_eq(system_state.get_storage_fund_object_rebates(), 1000 * MICROS_PER_IOTA);


### PR DESCRIPTION
# Description of change

Storage fund doesn't earn from leftover rewards.

# Links to any relevant issues

Fixes #1007 .

# Type of change

Breaking change (fix or feature that would cause existing functionality to not work as expected)

#How the change has been tested

Run tests - kinesis/crates/iota-framework/packages/iota-system