### PR TITLE
feat(iota-genesis-builder): better display for `snapshot_test_outputs` example

### DIFF
--- a/crates/iota-genesis-builder/examples/snapshot_test_outputs.rs
+++ b/crates/iota-genesis-builder/examples/snapshot_test_outputs.rs
@@ -23,7 +23,7 @@ fn parse_snapshot<const VERIFY: bool>(path: impl AsRef<Path>) -> anyhow::Result<
     // Total supply is in IOTA, snapshot supply is Micros
     assert_eq!(total_supply, TOTAL_SUPPLY_IOTA * 1_000_000);
 
-    println!("Total supply: {total_supply}");
+    println!("Total supply: {total_supply}\n");
 
     Ok(())
 }
@@ -43,10 +43,12 @@ async fn main() -> anyhow::Result<()> {
         new_path.push_str(&current_path);
     }
 
+    println!("Before injecting test outputs");
     parse_snapshot::<false>(&current_path)?;
 
     add_snapshot_test_outputs::<false>(&current_path, &new_path).await?;
 
+    println!("After injecting test outputs");
     parse_snapshot::<false>(&new_path)?;
 
     Ok(())

--- a/crates/iota-genesis-builder/src/stardust/test_outputs/alias_ownership.rs
+++ b/crates/iota-genesis-builder/src/stardust/test_outputs/alias_ownership.rs
@@ -139,7 +139,7 @@ fn random_nft_output(
 
     let amount = rng.gen_range(1_000_000..10_000_000);
     let nft_output = NftOutputBuilder::new_with_amount(amount, NftId::new(rng.gen()))
-        .add_unlock_condition(AddressUnlockCondition::new(owner.clone()))
+        .add_unlock_condition(AddressUnlockCondition::new(owner))
         .with_immutable_features(vec![
             Feature::Metadata(MetadataFeature::new(serde_json::to_vec(&nft_metadata)?)?),
             Feature::Issuer(IssuerFeature::new(owner)),
@@ -158,7 +158,7 @@ fn random_alias_output(
 
     let amount = rng.gen_range(1_000_000..10_000_000);
     let alias_output = AliasOutputBuilder::new_with_amount(amount, AliasId::new(rng.gen()))
-        .add_unlock_condition(GovernorAddressUnlockCondition::new(owner.clone()))
+        .add_unlock_condition(GovernorAddressUnlockCondition::new(owner))
         .add_unlock_condition(StateControllerAddressUnlockCondition::new(owner))
         .finish()?;
 

--- a/crates/iota-genesis-builder/src/stardust/test_outputs/alias_ownership.rs
+++ b/crates/iota-genesis-builder/src/stardust/test_outputs/alias_ownership.rs
@@ -31,13 +31,19 @@ const COIN_TYPE: u32 = 4218;
 const OWNING_ALIAS_COUNT: u32 = 10;
 
 pub(crate) async fn outputs() -> anyhow::Result<Vec<(OutputHeader, Output)>> {
+    let randomness_seed = rand::random();
+    let mut rng = StdRng::seed_from_u64(randomness_seed);
+
+    println!("------------------------------");
+    println!("alias_ownership");
+    println!("Randomness seed: {randomness_seed}");
+    // TODO
+    println!("------------------------------\n");
+
     let mut outputs = Vec::new();
     let secret_manager = MnemonicSecretManager::try_from_mnemonic(MNEMONIC)?;
 
     // create a randomized ownership dependency tree
-    let randomness_seed = rand::random();
-    let mut rng = StdRng::seed_from_u64(randomness_seed);
-    println!("alias_ownership randomness seed: {randomness_seed}");
 
     let alias_owners = secret_manager
         .generate_ed25519_addresses(COIN_TYPE, 0, 0..OWNING_ALIAS_COUNT, None)

--- a/crates/iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs
+++ b/crates/iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs
@@ -168,8 +168,14 @@ const STARDUST_MIX: &[StardustWallet] = &[
 
 pub(crate) async fn outputs(vested_index: &mut u32) -> anyhow::Result<Vec<(OutputHeader, Output)>> {
     let randomness_seed = random::<u64>();
-    println!("stardust_mix randomness seed: {randomness_seed}");
     let mut rng = StdRng::seed_from_u64(randomness_seed);
+
+    println!("------------------------------");
+    println!("stardust_mix");
+    println!("Randomness seed: {randomness_seed}");
+    // TODO
+    println!("------------------------------\n");
+
     let mut outputs = Vec::new();
 
     let mut vested_rewards_transaction_id = [0; 32];

--- a/crates/iota-genesis-builder/src/stardust/test_outputs/vesting_schedule_entity.rs
+++ b/crates/iota-genesis-builder/src/stardust/test_outputs/vesting_schedule_entity.rs
@@ -23,13 +23,21 @@ const VESTING_WEEKS: usize = 208;
 const VESTING_WEEKS_FREQUENCY: usize = 2;
 
 pub(crate) async fn outputs(vested_index: &mut u32) -> anyhow::Result<Vec<(OutputHeader, Output)>> {
+    let randomness_seed = random::<u64>();
+    let mut rng = StdRng::seed_from_u64(randomness_seed);
+
+    println!("------------------------------");
+    println!("vesting_schedule_entity");
+    println!("Randomness seed: {randomness_seed}");
+    println!("Mnemonic: {MNEMONIC}");
+    println!(
+        "1 account, 1 address, coin type {COIN_TYPE}, {VESTING_WEEKS} vesting weeks, frequency of {VESTING_WEEKS_FREQUENCY} weeks"
+    );
+    println!("------------------------------\n");
+
     let mut outputs = Vec::new();
     let secret_manager = MnemonicSecretManager::try_from_mnemonic(MNEMONIC)?;
     let mut transaction_id = [0; 32];
-
-    let randomness_seed = random::<u64>();
-    let mut rng = StdRng::seed_from_u64(randomness_seed);
-    println!("vesting_schedule_entity randomness seed: {randomness_seed}");
 
     // Prepare a transaction ID with the vested reward prefix.
     transaction_id[0..28]

--- a/crates/iota-genesis-builder/src/stardust/test_outputs/vesting_schedule_iota_airdrop.rs
+++ b/crates/iota-genesis-builder/src/stardust/test_outputs/vesting_schedule_iota_airdrop.rs
@@ -30,16 +30,24 @@ const VESTING_WEEKS: usize = 104;
 const VESTING_WEEKS_FREQUENCY: usize = 2;
 
 pub(crate) async fn outputs(vested_index: &mut u32) -> anyhow::Result<Vec<(OutputHeader, Output)>> {
+    let randomness_seed = random::<u64>();
+    let mut rng = StdRng::seed_from_u64(randomness_seed);
+
+    println!("------------------------------");
+    println!("vesting_schedule_iota_airdrop");
+    println!("Randomness seed: {randomness_seed}");
+    println!("Mnemonic: {MNEMONIC}");
+    println!(
+        "{ADDRESSES_PER_ACCOUNT} accounts, {ADDRESSES_PER_ACCOUNT} addresses per account, coin type {COIN_TYPE}, {VESTING_WEEKS} vesting weeks, frequency of {VESTING_WEEKS_FREQUENCY} weeks"
+    );
+    println!("------------------------------\n");
+
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)?
         .as_secs() as u32;
     let mut outputs = Vec::new();
     let secret_manager = MnemonicSecretManager::try_from_mnemonic(MNEMONIC)?;
     let mut transaction_id = [0; 32];
-
-    let randomness_seed = random::<u64>();
-    let mut rng = StdRng::seed_from_u64(randomness_seed);
-    println!("vesting_schedule_iota_airdrop randomness seed: {randomness_seed}");
 
     // Prepare a transaction ID with the vested reward prefix.
     transaction_id[0..28]


### PR DESCRIPTION
Makes it easier for the tooling team to get all information without having to read the code.

Example:
```
Before injecting test outputs
Output count: 8214755
Total supply: 4600000000000000

------------------------------
alias_ownership
Randomness seed: 14818331315203029479
------------------------------

------------------------------
stardust_mix
Randomness seed: 17977789054925842959
------------------------------

------------------------------
vesting_schedule_entity
Randomness seed: 7792485459630131050
Mnemonic: chunk beach oval twist manage spread street width view pig hen oak size fix lab tent say home team cube loop van they suit
1 account, 1 address, coin type 4218, 208 vesting weeks, frequency of 2 weeks
------------------------------

------------------------------
vesting_schedule_iota_airdrop
Randomness seed: 8039842204979467773
Mnemonic: mesh dose off wage gas tent key light help girl faint catch sock trouble guard moon talk pill enemy hawk gain mix sad mimic
20 accounts, 20 addresses per account, coin type 4218, 104 vesting weeks, frequency of 2 weeks
------------------------------

After injecting test outputs
Output count: 8226432
Total supply: 4600000000000000
```