### PR TITLE
fix: Change CODEOWNERS of doc configs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,6 @@
 # Everything within the SDK folder 
 /sdk/ @iotaledger/boxfish @iotaledger/l1-core @iotaledger/tooling
 
-# Docs are for DevEx to approve upon
-/docs/ @iotaledger/devx
-
 # Changes to the genesis builder should be approved by Konstantinos or Mirko at least
 /crates/iota-genesis-builder/ @kodemartin @miker83z
 
@@ -27,6 +24,12 @@ pnpm-workspace.yaml @iotaledger/boxfish @iotaledger/tooling
 prettier.config.js @iotaledger/boxfish @iotaledger/tooling
 turbo.json @iotaledger/boxfish @iotaledger/tooling
 vercel.json @iotaledger/boxfish @iotaledger/tooling
+
+# Docs are for DevEx to approve upon
+/docs/ @iotaledger/devx
+# Override ownership of Boxfish Studio and the tooling team for the following files
+/docs/**/package.json @iotaledger/devx
+/docs/**/vercel.json @iotaledger/devx
 
 # Protect this CODEOWNERS file, with some fallback in case of unavailability
 /.github/CODEOWNERS @luca-moser @lzpap @miker83z @fijter


### PR DESCRIPTION
# Description of change

Moved DX after tooling to override their ownership. This should exclude tooling and boxfish completely from the docs now

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
