### PR TITLE
feat(iota-protocol-config): set storage_rebate_rate to 100%

### DIFF
--- a/crates/iota-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
+++ b/crates/iota-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
@@ -18,8 +18,8 @@ expression: common_costs_actual
   "SharedCounterAssertValue": {
     "computationCost": "1000000",
     "storageCost": "2591600",
-    "storageRebate": "1587564",
-    "nonRefundableStorageFee": "16036"
+    "storageRebate": "1603600",
+    "nonRefundableStorageFee": "0"
   },
   "SharedCounterCreate": {
     "computationCost": "1000000",
@@ -30,8 +30,8 @@ expression: common_costs_actual
   "SharedCounterIncrement": {
     "computationCost": "1000000",
     "storageCost": "2591600",
-    "storageRebate": "1587564",
-    "nonRefundableStorageFee": "16036"
+    "storageRebate": "1603600",
+    "nonRefundableStorageFee": "0"
   },
   "SplitCoin": {
     "computationCost": "1000000",

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1361,7 +1361,7 @@ impl ProtocolConfig {
             obj_data_cost_refundable: Some(100),
             obj_metadata_cost_non_refundable: Some(50),
             gas_model_version: Some(8),
-            storage_rebate_rate: Some(9900),
+            storage_rebate_rate: Some(10000),
             storage_fund_reinvest_rate: Some(0),
             // Change reward slashing rate to 100%.
             reward_slashing_rate: Some(10000),

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -260,4 +260,3 @@ max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
-

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -119,7 +119,7 @@ obj_access_cost_verify_per_byte: 200
 gas_model_version: 8
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50
-storage_rebate_rate: 9900
+storage_rebate_rate: 10000
 storage_fund_reinvest_rate: 0
 reward_slashing_rate: 10000
 storage_gas_price: 76
@@ -260,3 +260,4 @@ max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
+

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -260,3 +260,4 @@ max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
+

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -262,3 +262,4 @@ max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
+

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -262,4 +262,3 @@ max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
-

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -121,7 +121,7 @@ obj_access_cost_verify_per_byte: 200
 gas_model_version: 8
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50
-storage_rebate_rate: 9900
+storage_rebate_rate: 10000
 storage_fund_reinvest_rate: 0
 reward_slashing_rate: 10000
 storage_gas_price: 76
@@ -262,3 +262,4 @@ max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
+

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -124,7 +124,7 @@ obj_access_cost_verify_per_byte: 200
 gas_model_version: 8
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50
-storage_rebate_rate: 9900
+storage_rebate_rate: 10000
 storage_fund_reinvest_rate: 0
 reward_slashing_rate: 10000
 storage_gas_price: 76
@@ -269,3 +269,4 @@ random_beacon_reduction_lower_bound: 1600
 random_beacon_dkg_timeout_round: 200
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
+

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -269,4 +269,3 @@ random_beacon_reduction_lower_bound: 1600
 random_beacon_dkg_timeout_round: 200
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
-

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -269,3 +269,4 @@ random_beacon_reduction_lower_bound: 1600
 random_beacon_dkg_timeout_round: 200
 consensus_max_transaction_size_bytes: 262144
 consensus_max_transactions_in_block_bytes: 6291456
+


### PR DESCRIPTION
# Description of change

Set storage_rebate_rate to 100%(so now it will return all rewards back)
Framework snapshot were regenerated.

## Links to any relevant issues

Fixes #1069 .

## Type of change
 
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Run tests - kinesis/crates/iota-framework/packages/iota-system

```
cargo insta test -p iota-cost --review
cargo insta test -p iota-config --review
```