### PR TITLE
fix(iota-framework/tests): add tests checking leftovers burning

### DIFF
--- a/crates/iota-framework/packages/iota-system/tests/rewards_distribution_tests.move
+++ b/crates/iota-framework/packages/iota-system/tests/rewards_distribution_tests.move
@@ -529,8 +529,7 @@ module iota_system::rewards_distribution_tests {
         // To get the leftover, we have to slash every validator. This way, the computation reward will remain as leftover.
         slash_all_validators(scenario);
 
-        // Pass 1700 IOTA as computation reward(for an instance).
-        // It should be larger than total supply.
+        // Pass 1700 IOTA as computation reward which is larger than the total supply of 1000 IOTA.
         advance_epoch_with_reward_amounts_and_slashing_rates(
             1000, 1700, 10_000, scenario
         );

--- a/crates/iota-framework/packages/iota-system/tests/rewards_distribution_tests.move
+++ b/crates/iota-framework/packages/iota-system/tests/rewards_distribution_tests.move
@@ -512,10 +512,8 @@ module iota_system::rewards_distribution_tests {
 
         scenario.next_tx(@0x0);
         // The total supply of 1000 IOTA should be reduced by 700 IOTA because the 700 IOTA becomes leftover and should be burned.
-        let mut system_state = scenario.take_shared<IotaSystemState>();
-        assert_eq(system_state.get_iota_supply(), 300 * MICROS_PER_IOTA);
+        assert_eq(total_supply(scenario), 300 * MICROS_PER_IOTA);
 
-        test_scenario::return_shared(system_state);
         scenario_val.end();
     }
 
@@ -549,11 +547,11 @@ module iota_system::rewards_distribution_tests {
         destroy(storage_rebate);
 
         scenario.next_tx(@0x0);
-        let mut system_state = scenario.take_shared<IotaSystemState>();
-        // Total supply after leftover has burned.
-        assert_eq(system_state.get_iota_supply(), 999_999_999_999);
 
-        test_scenario::return_shared(system_state);
+        // Total supply after leftover has burned.
+        // The 999,999,999,999 is obtained by subtracting the leftover from the total supply: 1,000,000,000,000 - 1 = 999,999,999,999.
+        assert_eq(total_supply(scenario), 999_999_999_999);
+
         scenario_val.end();
     }
 

--- a/crates/iota-framework/packages/iota-system/tests/rewards_distribution_tests.move
+++ b/crates/iota-framework/packages/iota-system/tests/rewards_distribution_tests.move
@@ -537,8 +537,6 @@ module iota_system::rewards_distribution_tests {
 
         scenario.next_tx(@0x0);
         let mut system_state = scenario.take_shared<IotaSystemState>();
-        assert_eq(system_state.get_iota_supply(), 100 * MICROS_PER_IOTA);
-
         test_scenario::return_shared(system_state);
         scenario_val.end();
     }

--- a/crates/iota-framework/packages/iota-system/tests/rewards_distribution_tests.move
+++ b/crates/iota-framework/packages/iota-system/tests/rewards_distribution_tests.move
@@ -535,9 +535,6 @@ module iota_system::rewards_distribution_tests {
             1000, 1700, 10_000, scenario
         );
 
-        scenario.next_tx(@0x0);
-        let mut system_state = scenario.take_shared<IotaSystemState>();
-        test_scenario::return_shared(system_state);
         scenario_val.end();
     }
 

--- a/crates/iota-framework/packages/iota-system/tests/rewards_distribution_tests.move
+++ b/crates/iota-framework/packages/iota-system/tests/rewards_distribution_tests.move
@@ -511,7 +511,7 @@ module iota_system::rewards_distribution_tests {
         );
 
         scenario.next_tx(@0x0);
-        // The total supply should be reduced by 700 IOTA because the 700 IOTA becomes leftover and should be burned.
+        // The total supply of 1000 IOTA should be reduced by 700 IOTA because the 700 IOTA becomes leftover and should be burned.
         let mut system_state = scenario.take_shared<IotaSystemState>();
         assert_eq(system_state.get_iota_supply(), 300 * MICROS_PER_IOTA);
 


### PR DESCRIPTION
# Description of change

Few tests for leftover burning check have been added.

## Links to any relevant issues

Fixes #1016 .

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`iota move test --path crates/iota-framework/packages/iota-system/Move.toml
`