### PR TITLE
fix(wallet): skip empty accounts while merging in accounts finder

### DIFF
--- a/apps/wallet/src/background/accounts-finder/accounts-finder.ts
+++ b/apps/wallet/src/background/accounts-finder/accounts-finder.ts
@@ -181,7 +181,6 @@ export function hasBalance(balance: CoinBalance): boolean {
 // }
 function transformToBipMap(accounts: AccountFromFinder[]) {
     const bipMap: Record<string, AddressFromFinder> = {};
-
     accounts.forEach((account) => {
         account.addresses.forEach((address) => {
             address.forEach((changeIndexObj) => {
@@ -196,7 +195,7 @@ function transformToBipMap(accounts: AccountFromFinder[]) {
 
 // Transform bipMap to list of accounts back.
 function transformFromBipMap(bipMap: Record<string, AddressFromFinder>) {
-    const accounts: AccountFromFinder[] = [];
+    let accounts: AccountFromFinder[] = [];
 
     Object.entries(bipMap).forEach(([key, address]) => {
         const [accountIndex, addressIndex, changeIndex] = key.split('-').map(Number);
@@ -217,6 +216,7 @@ function transformFromBipMap(bipMap: Record<string, AddressFromFinder>) {
         accounts[accountIndex].addresses[addressIndex][changeIndex] = address;
     });
 
+    accounts = accounts.filter((account) => !!account); // empty accounts possible when accountIndex is custom. => [empty x 100, {index: 101...}]
     return accounts;
 }
 


### PR DESCRIPTION
# Description of change

Found one case:
1. Set accountStartIndex as 5000.
2. Press "Search"

Actual result:
code throw error because we have empty elements in accounts list.
`[empty x 4999, {index: 5000, ...}]`

Expected result:
List contains only accounts;

## Links to any relevant issues

#727

## How the change has been tested

Pass random numbers to accountStartIndex and addressStartIndex.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
