### PR TITLE
fix(iota-genesis-builder): make test NFTs unique

### DIFF
--- a/crates/iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs
+++ b/crates/iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs
@@ -215,7 +215,7 @@ pub(crate) async fn outputs(vested_index: &mut u32) -> anyhow::Result<Vec<(Outpu
             outputs.extend(new_basic_or_nft_outputs(
                 OutputBuilder::Nft(NftOutputBuilder::new_with_amount(
                     OUTPUT_IOTA_AMOUNT,
-                    NftId::new(rng.gen()),
+                    NftId::null(),
                 )),
                 address,
                 native_tokens_for_nft_outputs,


### PR DESCRIPTION
# Description of change

Fix the test NFTs by making them unique, before the builder with the random NFT ID got used to build multiple NFT outputs, now they're all just set to null so they get a random one through the random output id.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/1129

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running `cargo run --release --example snapshot_test_outputs --features="test-outputs" latest-full_snapshot.bin` and then `cargo run --release -- --disable-global-snapshot-verification iota --snapshot-path test-latest-full_snapshot.bin --target-network alphanet`