### PR TITLE
feat(iota-swarm-config): introduce NetworkConfigLight

### DIFF
--- a/crates/iota-cluster-test/src/cluster.rs
+++ b/crates/iota-cluster-test/src/cluster.rs
@@ -5,7 +5,10 @@
 use std::{net::SocketAddr, path::Path};
 
 use async_trait::async_trait;
-use iota_config::{Config, PersistedConfig, IOTA_KEYSTORE_FILENAME, IOTA_NETWORK_CONFIG};
+use iota_config::{
+    genesis::Genesis, Config, PersistedConfig, IOTA_GENESIS_FILENAME, IOTA_KEYSTORE_FILENAME,
+    IOTA_NETWORK_CONFIG,
+};
 use iota_graphql_rpc::{
     config::ConnectionConfig, test_infra::cluster::start_graphql_server_with_fn_rpc,
 };
@@ -16,7 +19,10 @@ use iota_sdk::{
     wallet_context::WalletContext,
 };
 use iota_swarm::memory::Swarm;
-use iota_swarm_config::{genesis_config::GenesisConfig, network_config::NetworkConfig};
+use iota_swarm_config::{
+    genesis_config::GenesisConfig,
+    network_config::{NetworkConfig, NetworkConfigLight},
+};
 use iota_types::{
     base_types::IotaAddress,
     crypto::{get_key_pair, AccountKeyPair, IotaKeyPair, KeypairTraits},
@@ -185,15 +191,27 @@ impl Cluster for LocalNewCluster {
             assert!(options.epoch_duration_ms.is_none());
             // Load the config of the Iota authority.
             let network_config_path = config_dir.join(IOTA_NETWORK_CONFIG);
-            let network_config: NetworkConfig = PersistedConfig::read(&network_config_path)
-                .map_err(|err| {
-                    err.context(format!(
-                        "Cannot open Iota network config file at {:?}",
-                        network_config_path
-                    ))
-                })?;
+            let NetworkConfigLight {
+                validator_configs,
+                account_keys,
+                committee_with_network: _,
+            } = PersistedConfig::read(&network_config_path).map_err(|err| {
+                err.context(format!(
+                    "Cannot open Iota network config file at {:?}",
+                    network_config_path
+                ))
+            })?;
 
+            // Add genesis objects
+            let genesis_path = config_dir.join(IOTA_GENESIS_FILENAME);
+            let genesis = Genesis::load(genesis_path)?;
+            let network_config = NetworkConfig {
+                validator_configs,
+                account_keys,
+                genesis,
+            };
             cluster_builder = cluster_builder.set_network_config(network_config);
+
             cluster_builder = cluster_builder.with_config_dir(config_dir);
         } else {
             // Let the faucet account hold 1000 gas objects on genesis

--- a/crates/iota-config/src/genesis.rs
+++ b/crates/iota-config/src/genesis.rs
@@ -100,6 +100,10 @@ impl Genesis {
         }
     }
 
+    pub fn into_objects(self) -> Vec<Object> {
+        self.objects
+    }
+
     pub fn objects(&self) -> &[Object] {
         &self.objects
     }

--- a/crates/iota-config/src/lib.rs
+++ b/crates/iota-config/src/lib.rs
@@ -4,6 +4,7 @@
 
 use std::{
     fs,
+    io::BufWriter,
     path::{Path, PathBuf},
 };
 
@@ -93,8 +94,8 @@ where
     fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), anyhow::Error> {
         let path = path.as_ref();
         trace!("Writing config to {}", path.display());
-        let config = serde_yaml::to_string(&self)?;
-        fs::write(path, config)
+        let mut write = BufWriter::new(fs::File::create(path)?);
+        serde_yaml::to_writer(&mut write, &self)
             .with_context(|| format!("Unable to save config to {}", path.display()))?;
         Ok(())
     }

--- a/crates/iota-genesis-builder/src/stardust/migration/migration.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/migration.rs
@@ -258,9 +258,9 @@ impl Migration {
 
 /// All the objects created during the migration.
 ///
-/// Internally it maintains indexes of [`TimeLock`] and [`iota_types::gas_coin::GasCoin`]
-/// objects groupped by their owners to accommodate queries of this
-/// sort.
+/// Internally it maintains indexes of [`TimeLock`] and
+/// [`iota_types::gas_coin::GasCoin`] objects groupped by their owners to
+/// accommodate queries of this sort.
 #[derive(Debug, Clone, Default)]
 pub struct MigrationObjects {
     inner: Vec<Object>,
@@ -364,7 +364,8 @@ impl MigrationObjects {
         )
     }
 
-    /// Get [`iota_types::gas_coin::GasCoin`] objects created during the migration.
+    /// Get [`iota_types::gas_coin::GasCoin`] objects created during the
+    /// migration.
     ///
     /// The query is filtered by the object owner.
     pub fn get_gas_coins_by_owner(&self, address: IotaAddress) -> Option<Vec<&Object>> {

--- a/crates/iota-swarm-config/src/network_config.rs
+++ b/crates/iota-swarm-config/src/network_config.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_config::{genesis, Config, NodeConfig};
+use iota_config::{genesis, node, Config, NodeConfig};
 use iota_types::{
     committee::CommitteeWithNetworkMetadata, crypto::AccountKeyPair, multiaddr::Multiaddr,
 };
@@ -41,5 +41,66 @@ impl NetworkConfig {
 
     pub fn into_validator_configs(self) -> Vec<NodeConfig> {
         self.validator_configs
+    }
+
+    /// Retrieve genesis information that might be present in the configured
+    /// validators.
+    pub fn get_validator_genesis(&self) -> Option<&node::Genesis> {
+        self.validator_configs
+            .first()
+            .as_ref()
+            .map(|validator| &validator.genesis)
+    }
+}
+
+/// This is the light version of [`NetworkConfig`] that does not
+/// contain the entire [`genesis::Genesis`].
+#[serde_as]
+#[derive(Debug, Deserialize, Serialize)]
+pub struct NetworkConfigLight {
+    pub validator_configs: Vec<NodeConfig>,
+    pub account_keys: Vec<AccountKeyPair>,
+    pub committee_with_network: CommitteeWithNetworkMetadata,
+}
+
+impl Config for NetworkConfigLight {}
+
+impl NetworkConfigLight {
+    pub fn new(
+        validator_configs: Vec<NodeConfig>,
+        account_keys: Vec<AccountKeyPair>,
+        genesis: &genesis::Genesis,
+    ) -> Self {
+        Self {
+            validator_configs,
+            account_keys,
+            committee_with_network: genesis.committee_with_network(),
+        }
+    }
+
+    pub fn validator_configs(&self) -> &[NodeConfig] {
+        &self.validator_configs
+    }
+
+    pub fn net_addresses(&self) -> Vec<Multiaddr> {
+        self.committee_with_network
+            .network_metadata
+            .clone()
+            .into_values()
+            .map(|n| n.network_address)
+            .collect()
+    }
+
+    pub fn into_validator_configs(self) -> Vec<NodeConfig> {
+        self.validator_configs
+    }
+
+    /// Retrieve genesis information that might be present in the configured
+    /// validators.
+    pub fn get_validator_genesis(&self) -> Option<&node::Genesis> {
+        self.validator_configs
+            .first()
+            .as_ref()
+            .map(|validator| &validator.genesis)
     }
 }

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -75,6 +75,7 @@ pub struct ConfigBuilder<R = OsRng> {
     num_unpruned_validators: Option<usize>,
     authority_overload_config: Option<AuthorityOverloadConfig>,
     data_ingestion_dir: Option<PathBuf>,
+    empty_validator_genesis: bool,
 }
 
 impl ConfigBuilder {
@@ -91,6 +92,7 @@ impl ConfigBuilder {
             num_unpruned_validators: None,
             authority_overload_config: None,
             data_ingestion_dir: None,
+            empty_validator_genesis: false,
         }
     }
 
@@ -226,6 +228,7 @@ impl<R> ConfigBuilder<R> {
             jwk_fetch_interval: self.jwk_fetch_interval,
             authority_overload_config: self.authority_overload_config,
             data_ingestion_dir: self.data_ingestion_dir,
+            empty_validator_genesis: self.empty_validator_genesis,
         }
     }
 
@@ -234,6 +237,15 @@ impl<R> ConfigBuilder<R> {
             self.genesis_config = Some(GenesisConfig::for_local_testing());
         }
         self.genesis_config.as_mut().unwrap()
+    }
+
+    /// Avoid initializing validator genesis in memory.
+    ///
+    /// This allows callers to create the genesis blob,
+    /// and use a file pointer to configure the validators.
+    pub fn with_empty_validator_genesis(mut self) -> Self {
+        self.empty_validator_genesis = true;
+        self
     }
 }
 
@@ -401,7 +413,11 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                         builder = builder.with_unpruned_checkpoints();
                     }
                 }
-                builder.build(validator, genesis.clone())
+                if self.empty_validator_genesis {
+                    builder.build_without_genesis(validator)
+                } else {
+                    builder.build(validator, genesis.clone())
+                }
             })
             .collect();
         NetworkConfig {

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -27,7 +27,7 @@ use iota_sdk::{
 use iota_swarm::memory::Swarm;
 use iota_swarm_config::{
     genesis_config::{GenesisConfig, DEFAULT_NUMBER_OF_AUTHORITIES},
-    network_config::NetworkConfig,
+    network_config::{NetworkConfig, NetworkConfigLight},
     network_config_builder::ConfigBuilder,
     node_config_builder::FullnodeConfigBuilder,
 };
@@ -93,6 +93,12 @@ pub enum IotaCommand {
             help = "Creates an extra faucet configuration for iota-test-validator persisted runs."
         )]
         with_faucet: bool,
+        #[clap(
+            long,
+            help = "The number of validators in the network.",
+            default_value_t = DEFAULT_NUMBER_OF_AUTHORITIES
+        )]
+        num_validators: usize,
     },
     GenesisCeremony(Ceremony),
     /// Iota keystore tool.
@@ -177,20 +183,40 @@ impl IotaCommand {
             } => {
                 // Auto genesis if path is none and iota directory doesn't exists.
                 if config.is_none() && !iota_config_dir()?.join(IOTA_NETWORK_CONFIG).exists() {
-                    genesis(None, None, None, false, None, None, false).await?;
+                    genesis(
+                        None,
+                        None,
+                        None,
+                        false,
+                        None,
+                        None,
+                        false,
+                        DEFAULT_NUMBER_OF_AUTHORITIES,
+                    )
+                    .await?;
                 }
 
                 // Load the config of the Iota authority.
                 let network_config_path = config
                     .clone()
                     .unwrap_or(iota_config_dir()?.join(IOTA_NETWORK_CONFIG));
-                let network_config: NetworkConfig = PersistedConfig::read(&network_config_path)
-                    .map_err(|err| {
-                        err.context(format!(
-                            "Cannot open Iota network config file at {:?}",
-                            network_config_path
-                        ))
-                    })?;
+                let NetworkConfigLight {
+                    validator_configs,
+                    account_keys,
+                    ..
+                } = PersistedConfig::read(&network_config_path).map_err(|err| {
+                    err.context(format!(
+                        "Cannot open Iota network config file at {:?}",
+                        network_config_path
+                    ))
+                })?;
+                let genesis_path = iota_config_dir()?.join(IOTA_GENESIS_FILENAME);
+                let genesis = iota_config::genesis::Genesis::load(genesis_path)?;
+                let network_config = NetworkConfig {
+                    validator_configs,
+                    account_keys,
+                    genesis,
+                };
                 let mut swarm_builder = Swarm::builder()
                     .dir(iota_config_dir()?)
                     .with_network_config(network_config);
@@ -256,6 +282,7 @@ impl IotaCommand {
                 epoch_duration_ms,
                 benchmark_ips,
                 with_faucet,
+                num_validators,
             } => {
                 genesis(
                     from_config,
@@ -265,6 +292,7 @@ impl IotaCommand {
                     epoch_duration_ms,
                     benchmark_ips,
                     with_faucet,
+                    num_validators,
                 )
                 .await
             }
@@ -342,6 +370,7 @@ async fn genesis(
     epoch_duration_ms: Option<u64>,
     benchmark_ips: Option<Vec<String>>,
     with_faucet: bool,
+    num_validators: usize,
 ) -> Result<(), anyhow::Error> {
     let iota_config_dir = &match working_dir {
         // if a directory is specified, it must exist (it
@@ -451,31 +480,34 @@ async fn genesis(
     let validator_info = genesis_conf.validator_config_info.take();
     let ssfn_info = genesis_conf.ssfn_config_info.take();
 
-    let builder = ConfigBuilder::new(iota_config_dir);
     if let Some(epoch_duration_ms) = epoch_duration_ms {
         genesis_conf.parameters.epoch_duration_ms = epoch_duration_ms;
     }
-    let mut network_config = if let Some(validators) = validator_info {
-        builder
-            .with_genesis_config(genesis_conf)
-            .with_validators(validators)
-            .build()
+    let mut builder = ConfigBuilder::new(iota_config_dir)
+        .with_genesis_config(genesis_conf)
+        .with_empty_validator_genesis();
+    builder = if let Some(validators) = validator_info {
+        builder.with_validators(validators)
     } else {
-        builder
-            .committee_size(NonZeroUsize::new(DEFAULT_NUMBER_OF_AUTHORITIES).unwrap())
-            .with_genesis_config(genesis_conf)
-            .build()
+        builder.committee_size(NonZeroUsize::new(num_validators).unwrap())
     };
-
+    let network_config = tokio::task::spawn_blocking(move || builder.build()).await?;
     let mut keystore = FileBasedKeystore::new(&keystore_path)?;
     for key in &network_config.account_keys {
         keystore.add_key(None, IotaKeyPair::Ed25519(key.copy()))?;
     }
     let active_address = keystore.addresses().pop();
 
-    network_config.genesis.save(&genesis_path)?;
+    let NetworkConfig {
+        validator_configs,
+        account_keys,
+        genesis,
+    } = network_config;
+    let mut network_config = NetworkConfigLight::new(validator_configs, account_keys, &genesis);
+    genesis.save(&genesis_path)?;
+    let genesis = iota_config::node::Genesis::new_from_file(&genesis_path);
     for validator in &mut network_config.validator_configs {
-        validator.genesis = iota_config::node::Genesis::new_from_file(&genesis_path);
+        validator.genesis = genesis.clone();
     }
 
     info!("Network genesis completed.");
@@ -487,7 +519,8 @@ async fn genesis(
     let fullnode_config = FullnodeConfigBuilder::new()
         .with_config_directory(FULL_NODE_DB_PATH.into())
         .with_rpc_addr(iota_config::node::default_json_rpc_address())
-        .build(&mut OsRng, &network_config);
+        .with_genesis(genesis.clone())
+        .build_from_parts(&mut OsRng, network_config.validator_configs(), genesis);
 
     fullnode_config.save(iota_config_dir.join(IOTA_FULLNODE_CONFIG))?;
     let mut ssfn_nodes = vec![];
@@ -496,6 +529,7 @@ async fn genesis(
             let path =
                 iota_config_dir.join(iota_config::ssfn_config_file(ssfn.p2p_address.clone(), i));
             // join base fullnode config with each SsfnGenesisConfig entry
+            let genesis = Genesis::new_from_file("/opt/iota/config/genesis.blob");
             let ssfn_config = FullnodeConfigBuilder::new()
                 .with_config_directory(FULL_NODE_DB_PATH.into())
                 .with_p2p_external_address(ssfn.p2p_address)
@@ -506,8 +540,8 @@ async fn genesis(
                 .with_metrics_address("0.0.0.0:9184".parse().unwrap())
                 .with_admin_interface_port(1337)
                 .with_json_rpc_address("0.0.0.0:9000".parse().unwrap())
-                .with_genesis(Genesis::new_from_file("/opt/iota/config/genesis.blob"))
-                .build(&mut OsRng, &network_config);
+                .with_genesis(genesis.clone())
+                .build_from_parts(&mut OsRng, network_config.validator_configs(), genesis);
             ssfn_nodes.push(ssfn_config.clone());
             ssfn_config.save(path)?;
         }

--- a/crates/iota/src/main.rs
+++ b/crates/iota/src/main.rs
@@ -87,6 +87,11 @@ async fn main() {
                 .init()
         }
 
+        IotaCommand::Start { .. } => telemetry_subscribers::TelemetryConfig::new()
+            .with_log_level("info")
+            .with_env()
+            .init(),
+
         _ => telemetry_subscribers::TelemetryConfig::new()
             .with_log_level("error")
             .with_env()

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -7,8 +7,8 @@ use std::os::unix::fs::FileExt;
 #[cfg(target_os = "windows")]
 use std::os::windows::fs::FileExt;
 use std::{
-    collections::BTreeSet, fmt::Write, fs::read_dir, io::Read, path::PathBuf, str, thread,
-    time::Duration,
+    collections::BTreeSet, fmt::Write, fs::read_dir, io::Read, path::PathBuf, str, str::FromStr,
+    thread, time::Duration,
 };
 
 use expect_test::expect;

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -81,6 +81,7 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
         epoch_duration_ms: None,
         benchmark_ips: None,
         with_faucet: false,
+        num_validators: 1,
     }
     .execute()
     .await?;
@@ -120,6 +121,7 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
         epoch_duration_ms: None,
         benchmark_ips: None,
         with_faucet: false,
+        num_validators: 1,
     }
     .execute()
     .await;

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -7,8 +7,8 @@ use std::os::unix::fs::FileExt;
 #[cfg(target_os = "windows")]
 use std::os::windows::fs::FileExt;
 use std::{
-    collections::BTreeSet, fmt::Write, fs::read_dir, io::Read, path::PathBuf, str, str::FromStr,
-    thread, time::Duration,
+    collections::BTreeSet, fmt::Write, fs::read_dir, io::Read, path::PathBuf, str, thread,
+    time::Duration,
 };
 
 use expect_test::expect;
@@ -32,8 +32,8 @@ use iota_macros::sim_test;
 use iota_move_build::{BuildConfig, IotaPackageHooks};
 use iota_sdk::{iota_client_config::IotaClientConfig, wallet_context::WalletContext};
 use iota_swarm_config::{
-    genesis_config::{AccountConfig, GenesisConfig},
-    network_config::NetworkConfig,
+    genesis_config::{AccountConfig, GenesisConfig, DEFAULT_NUMBER_OF_AUTHORITIES},
+    network_config::NetworkConfigLight,
 };
 use iota_test_transaction_builder::batch_make_transfer_transactions;
 use iota_types::{
@@ -81,7 +81,7 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
         epoch_duration_ms: None,
         benchmark_ips: None,
         with_faucet: false,
-        num_validators: 1,
+        num_validators: DEFAULT_NUMBER_OF_AUTHORITIES,
     }
     .execute()
     .await?;
@@ -101,7 +101,7 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
 
     // Check network config
     let network_conf =
-        PersistedConfig::<NetworkConfig>::read(&working_dir.join(IOTA_NETWORK_CONFIG))?;
+        PersistedConfig::<NetworkConfigLight>::read(&working_dir.join(IOTA_NETWORK_CONFIG))?;
     assert_eq!(4, network_conf.validator_configs().len());
 
     // Check wallet config
@@ -121,7 +121,7 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
         epoch_duration_ms: None,
         benchmark_ips: None,
         with_faucet: false,
-        num_validators: 1,
+        num_validators: DEFAULT_NUMBER_OF_AUTHORITIES,
     }
     .execute()
     .await;

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -158,7 +158,7 @@ impl TestCluster {
     pub async fn spawn_new_fullnode(&mut self) -> FullNodeHandle {
         self.start_fullnode_from_config(
             self.fullnode_config_builder()
-                .build(&mut OsRng, &self.swarm.config()),
+                .build(&mut OsRng, self.swarm.config()),
         )
         .await
     }

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -34,7 +34,7 @@ use iota_sdk::{
 use iota_swarm::memory::{Swarm, SwarmBuilder};
 use iota_swarm_config::{
     genesis_config::{AccountConfig, GenesisConfig, ValidatorGenesisConfig, DEFAULT_GAS_AMOUNT},
-    network_config::NetworkConfig,
+    network_config::{NetworkConfig, NetworkConfigLight},
     network_config_builder::{ProtocolVersionsConfig, SupportedProtocolVersionsCallback},
     node_config_builder::{FullnodeConfigBuilder, ValidatorConfigBuilder},
 };
@@ -158,7 +158,7 @@ impl TestCluster {
     pub async fn spawn_new_fullnode(&mut self) -> FullNodeHandle {
         self.start_fullnode_from_config(
             self.fullnode_config_builder()
-                .build(&mut OsRng, self.swarm.config()),
+                .build(&mut OsRng, &self.swarm.config()),
         )
         .await
     }
@@ -1090,7 +1090,20 @@ impl TestClusterBuilder {
         let wallet_path = dir.join(IOTA_CLIENT_CONFIG);
         let keystore_path = dir.join(IOTA_KEYSTORE_FILENAME);
 
-        swarm.config().save(network_path)?;
+        let network_config = swarm.config();
+        // Create light config to save
+        let account_keys = network_config
+            .account_keys
+            .iter()
+            .map(|kp| kp.copy())
+            .collect();
+        let network_config_light = NetworkConfigLight::new(
+            network_config.validator_configs.clone(),
+            account_keys,
+            &network_config.genesis,
+        );
+        network_config_light.save(network_path)?;
+
         let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
         for key in &swarm.config().account_keys {
             keystore.add_key(None, IotaKeyPair::Ed25519(key.copy()))?;


### PR DESCRIPTION
# Description of change

This patch mainly introduces `iota_swarm_config::network_config::NetworkConfig` to reduce the memory demands of creating network configuration including genesis for a swarm. This network configuration is used by local networks.

## Links to any relevant issues

Part of #963 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

1. Setup a temp working-dir: `mkdir ./iota_test_config`
2. Build `iota`: `cargo build --bin iota`
3. Build `iota-test-validator`: `cargo build --bin iota-test-validator`
4. Create vanilla network configuration: `target/debug/iota genesis --with-faucet --working-dir iota_test_config`
5. Start `iota-test-validator`: `target/debug/iota-test-validator -c iota_test_config`
6. Or use `iota start --network.config iota_test_config/network.yaml --no-full-node`