### PR TITLE
refactor(iota-genesis-builder): extend handling of multiple migration snapshot sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5718,6 +5718,7 @@ dependencies = [
  "tokio",
  "tracing",
  "unescape",
+ "url",
 ]
 
 [[package]]
@@ -6029,6 +6030,7 @@ dependencies = [
  "iota-config",
  "iota-core",
  "iota-faucet",
+ "iota-genesis-builder",
  "iota-graphql-rpc",
  "iota-indexer",
  "iota-json",

--- a/crates/iota-cluster-test/Cargo.toml
+++ b/crates/iota-cluster-test/Cargo.toml
@@ -28,6 +28,7 @@ iota.workspace = true
 iota-config.workspace = true
 iota-core.workspace = true
 iota-faucet.workspace = true
+iota-genesis-builder.workspace = true
 iota-graphql-rpc.workspace = true
 iota-indexer.workspace = true
 iota-json.workspace = true

--- a/crates/iota-cluster-test/src/cluster.rs
+++ b/crates/iota-cluster-test/src/cluster.rs
@@ -9,6 +9,7 @@ use iota_config::{
     genesis::Genesis, Config, PersistedConfig, IOTA_GENESIS_FILENAME, IOTA_KEYSTORE_FILENAME,
     IOTA_NETWORK_CONFIG,
 };
+use iota_genesis_builder::SnapshotSource;
 use iota_graphql_rpc::{
     config::ConnectionConfig, test_infra::cluster::start_graphql_server_with_fn_rpc,
 };
@@ -215,7 +216,19 @@ impl Cluster for LocalNewCluster {
             cluster_builder = cluster_builder.with_config_dir(config_dir);
         } else {
             // Let the faucet account hold 1000 gas objects on genesis
-            let genesis_config = GenesisConfig::custom_genesis(1, 100);
+            let mut genesis_config = GenesisConfig::custom_genesis(1, 100);
+            // Add any migration sources
+            let local_snapshots = options
+                .local_migration_snapshots
+                .iter()
+                .cloned()
+                .map(SnapshotSource::Local);
+            let remote_snapshots = options
+                .remote_migration_snapshots
+                .iter()
+                .cloned()
+                .map(SnapshotSource::S3);
+            genesis_config.migration_sources = local_snapshots.chain(remote_snapshots).collect();
             // Custom genesis should be build here where we add the extra accounts
             cluster_builder = cluster_builder.set_genesis_config(genesis_config);
 

--- a/crates/iota-cluster-test/src/config.rs
+++ b/crates/iota-cluster-test/src/config.rs
@@ -5,6 +5,7 @@
 use std::{fmt, path::PathBuf};
 
 use clap::*;
+use iota_genesis_builder::SnapshotUrl;
 use regex::Regex;
 
 #[derive(Parser, Clone, ValueEnum, Debug)]
@@ -42,6 +43,14 @@ pub struct ClusterTestOpt {
     /// URL for the indexer RPC server
     #[clap(long)]
     pub graphql_address: Option<String>,
+    /// Locations for local migration snapshots.
+    #[clap(long, name = "path")]
+    #[arg(num_args(0..))]
+    pub local_migration_snapshots: Vec<PathBuf>,
+    /// Remote migration snapshots.
+    #[clap(long, name = "iota|smr|<full-url>")]
+    #[arg(num_args(0..))]
+    pub remote_migration_snapshots: Vec<SnapshotUrl>,
 }
 
 fn obfuscated_pg_address(val: &Option<String>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -70,6 +79,8 @@ impl ClusterTestOpt {
             pg_address: None,
             config_dir: None,
             graphql_address: None,
+            local_migration_snapshots: Default::default(),
+            remote_migration_snapshots: Default::default(),
         }
     }
 }

--- a/crates/iota-cluster-test/src/lib.rs
+++ b/crates/iota-cluster-test/src/lib.rs
@@ -46,6 +46,8 @@ pub mod helper;
 pub mod test_case;
 pub mod wallet_client;
 
+pub use iota_genesis_builder::SnapshotUrl as MigrationSnapshotUrl;
+
 #[allow(unused)]
 pub struct TestContext {
     /// Cluster handle that allows access to various components in a cluster

--- a/crates/iota-genesis-builder/examples/build_stardust_genesis_from_s3.rs
+++ b/crates/iota-genesis-builder/examples/build_stardust_genesis_from_s3.rs
@@ -19,13 +19,13 @@ fn main() -> anyhow::Result<()> {
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
     info!("Reading IOTA snapshot from {}", IOTA_OBJECT_SNAPSHOT_URL);
-    let iota_snapshot_reader = Builder::read_snapshot_from_s3(SnapshotUrl::Iota)?;
+    let iota_snapshot_reader = SnapshotUrl::Iota.to_reader()?;
 
     info!(
         "Reading Shimmer snapshot from {}",
         SHIMMER_OBJECT_SNAPSHOT_URL
     );
-    let shimmer_snapshot_reader = Builder::read_snapshot_from_s3(SnapshotUrl::Shimmer)?;
+    let shimmer_snapshot_reader = SnapshotUrl::Shimmer.to_reader()?;
 
     // Start building
     info!("Building the genesis..");

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -6,7 +6,8 @@ use std::{
     collections::{BTreeMap, HashSet},
     fs::{self, File},
     io::{prelude::Read, BufReader, BufWriter},
-    path::Path,
+    path::{Path, PathBuf},
+    str::FromStr,
     sync::Arc,
 };
 
@@ -61,6 +62,7 @@ use iota_types::{
 };
 use move_binary_format::CompiledModule;
 use move_core_types::ident_str;
+use serde::{Deserialize, Serialize};
 use shared_crypto::intent::{Intent, IntentMessage, IntentScope};
 use stake::{delegate_genesis_stake, GenesisStake};
 use stardust::migration::MigrationObjects;
@@ -121,6 +123,13 @@ impl Builder {
             migration_objects: Default::default(),
             genesis_stake: Default::default(),
         }
+    }
+
+    /// Add stardust and shimmer objects into genesis.
+    pub fn with_migrated_state(self) -> anyhow::Result<Self> {
+        tracing::info!("Adding migrated state...");
+        self.add_migration_objects(SnapshotUrl::Iota.to_reader()?)?
+            .add_migration_objects(SnapshotUrl::Shimmer.to_reader()?)
     }
 
     /// Checks if the genesis to be built is vanilla or if it includes Stardust
@@ -206,15 +215,9 @@ impl Builder {
     }
 
     pub fn add_migration_objects(mut self, reader: impl Read) -> anyhow::Result<Self> {
-        self.migration_objects = MigrationObjects::new(bcs::from_reader(reader)?);
+        self.migration_objects
+            .extend(bcs::from_reader::<Vec<_>>(reader)?);
         Ok(self)
-    }
-
-    /// Reads a gzip compressed object snapshot from the S3.
-    pub fn read_snapshot_from_s3(url: SnapshotUrl) -> anyhow::Result<impl Read> {
-        Ok(GzDecoder::new(BufReader::new(reqwest::blocking::get(
-            url.to_url(),
-        )?)))
     }
 
     pub fn unsigned_genesis_checkpoint(&self) -> Option<UnsignedGenesis> {
@@ -1383,11 +1386,44 @@ pub fn split_timelocks(
     Ok(())
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum SnapshotSource {
+    Local(PathBuf),
+    S3(SnapshotUrl),
+}
+
+impl SnapshotSource {
+    /// Convert to a reader.
+    pub fn to_reader(&self) -> anyhow::Result<Box<dyn Read>> {
+        Ok(match self {
+            SnapshotSource::Local(path) => Box::new(BufReader::new(File::open(path)?)),
+            SnapshotSource::S3(snapshot_url) => Box::new(snapshot_url.to_reader()?),
+        })
+    }
+}
+
 /// The URLs to download Iota or Shimmer object snapshots.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum SnapshotUrl {
     Iota,
     Shimmer,
+    /// Custom migration snapshot for testing purposes.
+    Test(Url),
+}
+
+impl FromStr for SnapshotUrl {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(url) = reqwest::Url::from_str(s) {
+            return Ok(Self::Test(url));
+        }
+        Ok(match s.to_lowercase().as_str() {
+            "iota" => Self::Iota,
+            "smr" | "shimmer" => Self::Shimmer,
+            e => bail!("unsupported snapshot url: {e}"),
+        })
+    }
 }
 
 impl SnapshotUrl {
@@ -1396,7 +1432,15 @@ impl SnapshotUrl {
         match self {
             Self::Iota => Url::parse(IOTA_OBJECT_SNAPSHOT_URL).expect("should be valid URL"),
             Self::Shimmer => Url::parse(SHIMMER_OBJECT_SNAPSHOT_URL).expect("should be valid URL"),
+            Self::Test(url) => url.clone(),
         }
+    }
+
+    /// Convert a gzip decoder to read the compressed object snapshot from S3.
+    pub fn to_reader(&self) -> anyhow::Result<impl Read> {
+        Ok(GzDecoder::new(BufReader::new(reqwest::blocking::get(
+            self.to_url(),
+        )?)))
     }
 }
 

--- a/crates/iota-genesis-builder/src/stardust/migration/migration.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/migration.rs
@@ -268,18 +268,22 @@ pub struct MigrationObjects {
     owner_gas_coin: HashMap<IotaAddress, Vec<usize>>,
 }
 
-impl MigrationObjects {
-    pub fn new(objects: Vec<Object>) -> Self {
-        let mut owner_timelock: HashMap<IotaAddress, Vec<usize>> = Default::default();
-        let mut owner_gas_coin: HashMap<IotaAddress, Vec<usize>> = Default::default();
-        for (i, tag, object) in objects.iter().enumerate().filter_map(|(i, object)| {
-            let tag = object.struct_tag()?;
-            Some((i, tag, object))
-        }) {
-            let index = if is_timelocked_balance(&tag) {
-                &mut owner_timelock
+impl Extend<Object> for MigrationObjects {
+    fn extend<T: IntoIterator<Item = Object>>(&mut self, iter: T) {
+        let last_current_ix = self.inner.len();
+        self.inner.extend(iter);
+        for (i, tag, object) in self.inner[last_current_ix..]
+            .iter()
+            .zip(last_current_ix..)
+            .filter_map(|(object, i)| {
+                let tag = object.struct_tag()?;
+                Some((i, tag, object))
+            })
+        {
+            let owner_object_map = if is_timelocked_balance(&tag) {
+                &mut self.owner_timelock
             } else if object.is_gas_coin() {
-                &mut owner_gas_coin
+                &mut self.owner_gas_coin
             } else {
                 continue;
             };
@@ -287,16 +291,19 @@ impl MigrationObjects {
                 .owner
                 .get_owner_address()
                 .expect("timelocks should have an address owner");
-            index
+            owner_object_map
                 .entry(owner)
                 .and_modify(|object_ixs| object_ixs.push(i))
                 .or_insert_with(|| vec![i]);
         }
-        Self {
-            inner: objects,
-            owner_timelock,
-            owner_gas_coin,
-        }
+    }
+}
+
+impl MigrationObjects {
+    pub fn new(objects: Vec<Object>) -> Self {
+        let mut migration_objects = Self::default();
+        migration_objects.extend(objects);
+        migration_objects
     }
 
     /// Evict the objects with the specified ids

--- a/crates/iota-swarm-config/src/genesis_config.rs
+++ b/crates/iota-swarm-config/src/genesis_config.rs
@@ -12,7 +12,10 @@ use iota_config::{
     node::{DEFAULT_COMMISSION_RATE, DEFAULT_VALIDATOR_GAS_PRICE},
     Config,
 };
-use iota_genesis_builder::validator_info::{GenesisValidatorInfo, ValidatorInfo};
+use iota_genesis_builder::{
+    validator_info::{GenesisValidatorInfo, ValidatorInfo},
+    SnapshotSource,
+};
 use iota_types::{
     base_types::IotaAddress,
     crypto::{
@@ -227,6 +230,7 @@ pub struct GenesisConfig {
     pub validator_config_info: Option<Vec<ValidatorGenesisConfig>>,
     pub parameters: GenesisCeremonyParameters,
     pub accounts: Vec<AccountConfig>,
+    pub migration_sources: Vec<SnapshotSource>,
 }
 
 impl Config for GenesisConfig {}
@@ -411,6 +415,7 @@ impl GenesisConfig {
             validator_config_info: Some(validator_config_info),
             parameters,
             accounts: account_configs,
+            migration_sources: Default::default(),
         }
     }
 

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -356,6 +356,17 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
             let mut builder = iota_genesis_builder::Builder::new()
                 .with_parameters(genesis_config.parameters)
                 .add_objects(self.additional_objects);
+            for source in &genesis_config.migration_sources {
+                let reader = source
+                    .to_reader()
+                    .expect("migration source should be readable");
+                builder = builder
+                    .add_migration_objects(reader)
+                    .expect("migrated stated should be added without errors");
+            }
+            if !genesis_config.migration_sources.is_empty() {
+                tracing::info!("Added migrated state");
+            }
 
             for (i, validator) in validators.iter().enumerate() {
                 let name = validator

--- a/crates/iota-test-validator/src/main.rs
+++ b/crates/iota-test-validator/src/main.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 
 use anyhow::Result;
 use axum::{
@@ -17,6 +17,7 @@ use iota_cluster_test::{
     cluster::{Cluster, LocalNewCluster},
     config::{ClusterTestOpt, Env},
     faucet::{FaucetClient, FaucetClientFactory},
+    MigrationSnapshotUrl,
 };
 use iota_faucet::{
     BatchFaucetResponse, BatchStatusFaucetResponse, FaucetError, FaucetRequest, FaucetResponse,
@@ -95,6 +96,16 @@ struct Args {
     /// if we should run indexer
     #[clap(long)]
     pub with_indexer: bool,
+
+    /// Locations for local migration snapshots.
+    #[clap(long, name = "path")]
+    #[arg(num_args(0..))]
+    pub local_migration_snapshots: Vec<PathBuf>,
+
+    /// Remote migration snapshots.
+    #[clap(long, name = "iota|smr|<full-url>")]
+    #[arg(num_args(0..))]
+    pub remote_migration_snapshots: Vec<MigrationSnapshotUrl>,
 }
 
 #[tokio::main]
@@ -120,6 +131,8 @@ async fn main() -> Result<()> {
         faucet_host,
         faucet_port,
         with_indexer,
+        local_migration_snapshots,
+        remote_migration_snapshots,
     } = args;
 
     // We don't pass epoch duration if we have a genesis config.
@@ -148,6 +161,8 @@ async fn main() -> Result<()> {
         epoch_duration_ms,
         config_dir,
         graphql_address: graphql_port.map(|p| format!("{}:{}", graphql_host, p)),
+        local_migration_snapshots,
+        remote_migration_snapshots,
     };
 
     println!("Starting Iota validator with config: {:#?}", cluster_config);

--- a/crates/iota/Cargo.toml
+++ b/crates/iota/Cargo.toml
@@ -40,6 +40,7 @@ tap.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
+url.workspace = true
 
 iota-config.workspace = true
 iota-execution = { path = "../../iota-execution" }

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -82,6 +82,8 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
         benchmark_ips: None,
         with_faucet: false,
         num_validators: DEFAULT_NUMBER_OF_AUTHORITIES,
+        local_migration_snapshots: vec![],
+        remote_migration_snapshots: vec![],
     }
     .execute()
     .await?;
@@ -122,6 +124,8 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
         benchmark_ips: None,
         with_faucet: false,
         num_validators: DEFAULT_NUMBER_OF_AUTHORITIES,
+        local_migration_snapshots: vec![],
+        remote_migration_snapshots: vec![],
     }
     .execute()
     .await;


### PR DESCRIPTION
# Description of change

This patch extends the `iota-genesis-builder` lib in handling multiple snapshot sources.

## Links to any relevant issues

Part of #963 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo clippy -p iota-genesis-buidler`