### PR TITLE
Sc platform/localnet/pass snapshot sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5718,6 +5718,7 @@ dependencies = [
  "tokio",
  "tracing",
  "unescape",
+ "url",
 ]
 
 [[package]]
@@ -6029,6 +6030,7 @@ dependencies = [
  "iota-config",
  "iota-core",
  "iota-faucet",
+ "iota-genesis-builder",
  "iota-graphql-rpc",
  "iota-indexer",
  "iota-json",

--- a/crates/iota-cluster-test/Cargo.toml
+++ b/crates/iota-cluster-test/Cargo.toml
@@ -28,6 +28,7 @@ iota.workspace = true
 iota-config.workspace = true
 iota-core.workspace = true
 iota-faucet.workspace = true
+iota-genesis-builder.workspace = true
 iota-graphql-rpc.workspace = true
 iota-indexer.workspace = true
 iota-json.workspace = true

--- a/crates/iota-cluster-test/src/cluster.rs
+++ b/crates/iota-cluster-test/src/cluster.rs
@@ -9,6 +9,7 @@ use iota_config::{
     genesis::Genesis, Config, PersistedConfig, IOTA_GENESIS_FILENAME, IOTA_KEYSTORE_FILENAME,
     IOTA_NETWORK_CONFIG,
 };
+use iota_genesis_builder::SnapshotSource;
 use iota_graphql_rpc::{
     config::ConnectionConfig, test_infra::cluster::start_graphql_server_with_fn_rpc,
 };
@@ -215,7 +216,19 @@ impl Cluster for LocalNewCluster {
             cluster_builder = cluster_builder.with_config_dir(config_dir);
         } else {
             // Let the faucet account hold 1000 gas objects on genesis
-            let genesis_config = GenesisConfig::custom_genesis(1, 100);
+            let mut genesis_config = GenesisConfig::custom_genesis(1, 100);
+            // Add any migration sources
+            let local_snapshots = options
+                .local_migration_snapshots
+                .iter()
+                .cloned()
+                .map(SnapshotSource::Local);
+            let remote_snapshots = options
+                .remote_migration_snapshots
+                .iter()
+                .cloned()
+                .map(SnapshotSource::S3);
+            genesis_config.migration_sources = local_snapshots.chain(remote_snapshots).collect();
             // Custom genesis should be build here where we add the extra accounts
             cluster_builder = cluster_builder.set_genesis_config(genesis_config);
 

--- a/crates/iota-cluster-test/src/config.rs
+++ b/crates/iota-cluster-test/src/config.rs
@@ -5,6 +5,7 @@
 use std::{fmt, path::PathBuf};
 
 use clap::*;
+use iota_genesis_builder::SnapshotUrl;
 use regex::Regex;
 
 #[derive(Parser, Clone, ValueEnum, Debug)]
@@ -42,6 +43,14 @@ pub struct ClusterTestOpt {
     /// URL for the indexer RPC server
     #[clap(long)]
     pub graphql_address: Option<String>,
+    /// Locations for local migration snapshots.
+    #[clap(long, name = "path")]
+    #[arg(num_args(0..))]
+    pub local_migration_snapshots: Vec<PathBuf>,
+    /// Remote migration snapshots.
+    #[clap(long, name = "iota|smr|<full-url>")]
+    #[arg(num_args(0..))]
+    pub remote_migration_snapshots: Vec<SnapshotUrl>,
 }
 
 fn obfuscated_pg_address(val: &Option<String>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -70,6 +79,8 @@ impl ClusterTestOpt {
             pg_address: None,
             config_dir: None,
             graphql_address: None,
+            local_migration_snapshots: Default::default(),
+            remote_migration_snapshots: Default::default(),
         }
     }
 }

--- a/crates/iota-cluster-test/src/lib.rs
+++ b/crates/iota-cluster-test/src/lib.rs
@@ -46,6 +46,8 @@ pub mod helper;
 pub mod test_case;
 pub mod wallet_client;
 
+pub use iota_genesis_builder::SnapshotUrl as MigrationSnapshotUrl;
+
 #[allow(unused)]
 pub struct TestContext {
     /// Cluster handle that allows access to various components in a cluster

--- a/crates/iota-swarm-config/src/genesis_config.rs
+++ b/crates/iota-swarm-config/src/genesis_config.rs
@@ -12,7 +12,10 @@ use iota_config::{
     node::{DEFAULT_COMMISSION_RATE, DEFAULT_VALIDATOR_GAS_PRICE},
     Config,
 };
-use iota_genesis_builder::validator_info::{GenesisValidatorInfo, ValidatorInfo};
+use iota_genesis_builder::{
+    validator_info::{GenesisValidatorInfo, ValidatorInfo},
+    SnapshotSource,
+};
 use iota_types::{
     base_types::IotaAddress,
     crypto::{
@@ -227,6 +230,7 @@ pub struct GenesisConfig {
     pub validator_config_info: Option<Vec<ValidatorGenesisConfig>>,
     pub parameters: GenesisCeremonyParameters,
     pub accounts: Vec<AccountConfig>,
+    pub migration_sources: Vec<SnapshotSource>,
 }
 
 impl Config for GenesisConfig {}
@@ -411,6 +415,7 @@ impl GenesisConfig {
             validator_config_info: Some(validator_config_info),
             parameters,
             accounts: account_configs,
+            migration_sources: Default::default(),
         }
     }
 

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -356,6 +356,17 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
             let mut builder = iota_genesis_builder::Builder::new()
                 .with_parameters(genesis_config.parameters)
                 .add_objects(self.additional_objects);
+            for source in &genesis_config.migration_sources {
+                let reader = source
+                    .to_reader()
+                    .expect("migration source should be readable");
+                builder = builder
+                    .add_migration_objects(reader)
+                    .expect("migrated stated should be added without errors");
+            }
+            if !genesis_config.migration_sources.is_empty() {
+                tracing::info!("Added migrated state");
+            }
 
             for (i, validator) in validators.iter().enumerate() {
                 let name = validator

--- a/crates/iota-test-validator/src/main.rs
+++ b/crates/iota-test-validator/src/main.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 
 use anyhow::Result;
 use axum::{
@@ -17,6 +17,7 @@ use iota_cluster_test::{
     cluster::{Cluster, LocalNewCluster},
     config::{ClusterTestOpt, Env},
     faucet::{FaucetClient, FaucetClientFactory},
+    MigrationSnapshotUrl,
 };
 use iota_faucet::{
     BatchFaucetResponse, BatchStatusFaucetResponse, FaucetError, FaucetRequest, FaucetResponse,
@@ -95,6 +96,16 @@ struct Args {
     /// if we should run indexer
     #[clap(long)]
     pub with_indexer: bool,
+
+    /// Locations for local migration snapshots.
+    #[clap(long, name = "path")]
+    #[arg(num_args(0..))]
+    pub local_migration_snapshots: Vec<PathBuf>,
+
+    /// Remote migration snapshots.
+    #[clap(long, name = "iota|smr|<full-url>")]
+    #[arg(num_args(0..))]
+    pub remote_migration_snapshots: Vec<MigrationSnapshotUrl>,
 }
 
 #[tokio::main]
@@ -120,6 +131,8 @@ async fn main() -> Result<()> {
         faucet_host,
         faucet_port,
         with_indexer,
+        local_migration_snapshots,
+        remote_migration_snapshots,
     } = args;
 
     // We don't pass epoch duration if we have a genesis config.
@@ -148,6 +161,8 @@ async fn main() -> Result<()> {
         epoch_duration_ms,
         config_dir,
         graphql_address: graphql_port.map(|p| format!("{}:{}", graphql_host, p)),
+        local_migration_snapshots,
+        remote_migration_snapshots,
     };
 
     println!("Starting Iota validator with config: {:#?}", cluster_config);

--- a/crates/iota/Cargo.toml
+++ b/crates/iota/Cargo.toml
@@ -40,6 +40,7 @@ tap.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
+url.workspace = true
 
 iota-config.workspace = true
 iota-execution = { path = "../../iota-execution" }

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -82,6 +82,8 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
         benchmark_ips: None,
         with_faucet: false,
         num_validators: 1,
+        local_migration_snapshots: vec![],
+        remote_migration_snapshots: vec![],
     }
     .execute()
     .await?;
@@ -122,6 +124,8 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
         benchmark_ips: None,
         with_faucet: false,
         num_validators: 1,
+        local_migration_snapshots: vec![],
+        remote_migration_snapshots: vec![],
     }
     .execute()
     .await;


### PR DESCRIPTION
# Description of change

This patch allows passing multiple migration snapshot sources to populate the migration genesis objects in local networks. This affects `iota genesis` and `iota-test-validator` that now both accept the following optional arguments:

```
      --local-migration-snapshots [<path>...]
          The path to a local migration snapshot.
      --remote-migration-snapshots [<iota|smr|<full-url>>...]
          The remote migration snapshot
```

## Links to any relevant issues

Part of #963 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

1. `cargo build --release --bin iota`
2. `cargo builds --release --bin iota-test-validator`
3. `target/release/iota genesis --working-dir test_iota_config -f --with-faucet --num-validators 1 --local-migration-snapshots <path-to-uncompressed-snapshot.bin> `
     - with `--remote-migration-snapshots smr iota` the Shimmer/Iota snapshots from S3 can be added
4. `target/release/iota-test-validator -c test_iota_config`, or
5. `target/release/iota start --network.config iota_test_config/network.yaml --no--full-node`

> [!NOTE]
> If you attempt to load the S3 full snapshots, know that until #1123 is closed genesis creation will return an error while trying to delegate state to validators.