### PR TITLE
feat(iota): alphanet genesis ceremony

### DIFF
--- a/crates/iota-genesis-builder/examples/build_stardust_genesis_from_s3.rs
+++ b/crates/iota-genesis-builder/examples/build_stardust_genesis_from_s3.rs
@@ -3,9 +3,7 @@
 
 //! Creating a genesis blob out of a remote stardust objects snapshots.
 
-use iota_genesis_builder::{
-    Builder, SnapshotUrl, IOTA_OBJECT_SNAPSHOT_URL, SHIMMER_OBJECT_SNAPSHOT_URL,
-};
+use iota_genesis_builder::{Builder, SnapshotUrl};
 use iota_swarm_config::genesis_config::ValidatorGenesisConfigBuilder;
 use rand::rngs::OsRng;
 use tracing::{info, Level};
@@ -18,20 +16,11 @@ fn main() -> anyhow::Result<()> {
         .finish();
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
-    info!("Reading IOTA snapshot from {}", IOTA_OBJECT_SNAPSHOT_URL);
-    let iota_snapshot_reader = SnapshotUrl::Iota.to_reader()?;
-
-    info!(
-        "Reading Shimmer snapshot from {}",
-        SHIMMER_OBJECT_SNAPSHOT_URL
-    );
-    let shimmer_snapshot_reader = SnapshotUrl::Shimmer.to_reader()?;
-
     // Start building
     info!("Building the genesis..");
     let mut builder = Builder::new()
-        .add_migration_objects(iota_snapshot_reader)?
-        .add_migration_objects(shimmer_snapshot_reader)?;
+        .add_migration_source(SnapshotUrl::Iota.into())
+        .add_migration_source(SnapshotUrl::Shimmer.into());
 
     let mut key_pairs = Vec::new();
     let mut rng = OsRng;

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -246,8 +246,6 @@ impl Builder {
             .unwrap();
         }
 
-        // Verify that token distribution schedule is valid
-        self.validate_token_distribution_schedule().unwrap();
         // Get the vanilla token distribution schedule or merge it with genesis stake
         let token_distribution_schedule = if self.is_vanilla() {
             if let Some(token_distribution_schedule) = &self.token_distribution_schedule {
@@ -263,6 +261,11 @@ impl Builder {
         } else {
             self.genesis_stake.to_token_distribution_schedule()
         };
+        // Verify that token distribution schedule is valid
+        token_distribution_schedule.validate();
+        token_distribution_schedule.check_all_stake_operations_are_for_valid_validators(
+            self.validators.values().map(|v| v.info.iota_address()),
+        );
 
         // If the genesis stake was created, then burn gas objects that were added to
         // the token distribution schedule, because they will be created on the

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -944,11 +944,6 @@ fn build_unsigned_genesis_data<'info>(
         .map(GenesisValidatorMetadata::from)
         .collect::<Vec<_>>();
 
-    token_distribution_schedule.validate();
-    token_distribution_schedule
-        .check_minimum_stake_for_validators(genesis_validators.iter().map(|v| v.iota_address))
-        .expect("all validators should have the required stake");
-
     let epoch_data = EpochData::new_genesis(genesis_chain_parameters.chain_start_timestamp_ms);
 
     // Get the correct system packages for our protocol version. If we cannot find

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -82,6 +82,7 @@ pub const GENESIS_BUILDER_PARAMETERS_FILE: &str = "parameters";
 const GENESIS_BUILDER_TOKEN_DISTRIBUTION_SCHEDULE_FILE: &str = "token-distribution-schedule";
 const GENESIS_BUILDER_SIGNATURE_DIR: &str = "signatures";
 const GENESIS_BUILDER_UNSIGNED_GENESIS_FILE: &str = "unsigned-genesis";
+const GENESIS_BUILDER_MIGRATION_SOURCES_FILE: &str = "migration-sources";
 
 pub const BROTLI_COMPRESSOR_BUFFER_SIZE: usize = 4096;
 /// Compression levels go from 0 to 11, where 11 has the highest compression
@@ -103,6 +104,7 @@ pub struct Builder {
     built_genesis: Option<UnsignedGenesis>,
     migration_objects: MigrationObjects,
     genesis_stake: GenesisStake,
+    migration_sources: Vec<SnapshotSource>,
 }
 
 impl Default for Builder {
@@ -122,6 +124,7 @@ impl Builder {
             built_genesis: None,
             migration_objects: Default::default(),
             genesis_stake: Default::default(),
+            migration_sources: Default::default(),
         }
     }
 
@@ -214,6 +217,11 @@ impl Builder {
         self
     }
 
+    pub fn add_migration_source(mut self, source: SnapshotSource) -> Self {
+        self.migration_sources.push(source);
+        self
+    }
+
     pub fn add_migration_objects(mut self, reader: impl Read) -> anyhow::Result<Self> {
         self.migration_objects
             .extend(bcs::from_reader::<Vec<_>>(reader)?);
@@ -224,12 +232,18 @@ impl Builder {
         self.built_genesis.clone()
     }
 
-    fn build_and_cache_unsigned_genesis(&mut self) {
-        // Verify that all input data is valid
-        self.validate_inputs().unwrap();
-        let validators = self.validators.clone().into_values().collect::<Vec<_>>();
+    fn load_migration_sources(&mut self) -> anyhow::Result<()> {
+        for source in &self.migration_sources {
+            tracing::info!("Adding migration objects from {:?}", source);
+            self.migration_objects
+                .extend(bcs::from_reader::<Vec<_>>(source.to_reader()?)?);
+        }
+        Ok(())
+    }
 
-        // If not vanilla then create genesis_stake
+    /// Create and cache the [`GenesisStake`] if the builder
+    /// contains migrated objects.
+    fn create_and_cache_genesis_stake(&mut self) -> anyhow::Result<()> {
         if !self.migration_objects.is_empty() {
             let delegator =
                 stardust_to_iota_address(Address::try_from_bech32(IF_STARDUST_ADDRESS).unwrap())
@@ -238,34 +252,57 @@ impl Builder {
             // VALIDATOR_LOW_STAKE_THRESHOLD_NANOS
             let minimum_stake = iota_types::governance::MIN_VALIDATOR_JOINING_STAKE_NANOS;
             self.genesis_stake = delegate_genesis_stake(
-                &validators,
+                self.validators.values(),
                 delegator,
                 &self.migration_objects,
                 minimum_stake,
-            )
-            .unwrap();
+            )?;
         }
+        Ok(())
+    }
 
-        // Get the vanilla token distribution schedule or merge it with genesis stake
-        let token_distribution_schedule = if self.is_vanilla() {
-            if let Some(token_distribution_schedule) = &self.token_distribution_schedule {
-                token_distribution_schedule.clone()
-            } else {
+    /// Evaluate the genesis [`TokenDistributionSchedule`].
+    fn resolve_token_distribution_schedule(&mut self) -> TokenDistributionSchedule {
+        let validator_addresses = self.validators.values().map(|v| v.info.iota_address());
+        let token_distribution_schedule = self.token_distribution_schedule.take();
+        if self.genesis_stake.is_empty() {
+            token_distribution_schedule.unwrap_or_else(|| {
                 TokenDistributionSchedule::new_for_validators_with_default_allocation(
-                    validators.iter().map(|v| v.info.iota_address()),
+                    validator_addresses,
                 )
+            })
+        } else if let Some(schedule) = token_distribution_schedule {
+            if schedule.contains_timelocked_stake() {
+                // Genesis stake is already included
+                schedule
+            } else {
+                self.genesis_stake
+                    .extend_vanilla_token_distribution_schedule(schedule)
             }
-        } else if let Some(token_distribution_schedule) = &self.token_distribution_schedule {
-            self.genesis_stake
-                .extend_vanilla_token_distribution_schedule(token_distribution_schedule.clone())
         } else {
             self.genesis_stake.to_token_distribution_schedule()
-        };
+        }
+    }
+
+    fn build_and_cache_unsigned_genesis(&mut self) {
+        // Verify that all input data is valid
+        self.validate_inputs().unwrap();
+
+        self.load_migration_sources()
+            .expect("migration sources should be loaded without errors");
+
+        self.create_and_cache_genesis_stake()
+            .expect("genesis stake should be created without errors");
+
+        // Get the vanilla token distribution schedule or merge it with genesis stake
+        let token_distribution_schedule = self.resolve_token_distribution_schedule();
         // Verify that token distribution schedule is valid
         token_distribution_schedule.validate();
-        token_distribution_schedule.check_all_stake_operations_are_for_valid_validators(
-            self.validators.values().map(|v| v.info.iota_address()),
-        );
+        token_distribution_schedule
+            .check_minimum_stake_for_validators(
+                self.validators.values().map(|v| v.info.iota_address()),
+            )
+            .expect("all validators should have the required stake");
 
         // If the genesis stake was created, then burn gas objects that were added to
         // the token distribution schedule, because they will be created on the
@@ -284,7 +321,7 @@ impl Builder {
         self.built_genesis = Some(build_unsigned_genesis_data(
             &self.parameters,
             &token_distribution_schedule,
-            &validators,
+            self.validators.values(),
             objects,
             &mut self.genesis_stake,
         ));
@@ -381,9 +418,9 @@ impl Builder {
     fn validate_token_distribution_schedule(&self) -> anyhow::Result<(), anyhow::Error> {
         if let Some(token_distribution_schedule) = &self.token_distribution_schedule {
             token_distribution_schedule.validate();
-            token_distribution_schedule.check_all_stake_operations_are_for_valid_validators(
+            token_distribution_schedule.check_minimum_stake_for_validators(
                 self.validators.values().map(|v| v.info.iota_address()),
-            );
+            )?;
         }
 
         Ok(())
@@ -709,6 +746,19 @@ impl Builder {
         ))?)
         .context("unable to deserialize genesis parameters")?;
 
+        // Load migration objects if any
+        let migration_sources_file = path.join(GENESIS_BUILDER_MIGRATION_SOURCES_FILE);
+        let migration_sources: Vec<SnapshotSource> = if migration_sources_file.exists() {
+            serde_yaml::from_slice(
+                &fs::read(migration_sources_file)
+                    .context("unable to read migration sources file")?,
+            )
+            .context("unable to deserialize migration sources")?
+        } else {
+            Default::default()
+        };
+        println!("{:?}", migration_sources);
+
         let token_distribution_schedule_file =
             path.join(GENESIS_BUILDER_TOKEN_DISTRIBUTION_SCHEDULE_FILE);
         let token_distribution_schedule = if token_distribution_schedule_file.exists() {
@@ -756,6 +806,7 @@ impl Builder {
             built_genesis: None, // Leave this as none, will build and compare below
             migration_objects: Default::default(),
             genesis_stake: Default::default(),
+            migration_sources,
         };
 
         let unsigned_genesis_file = path.join(GENESIS_BUILDER_UNSIGNED_GENESIS_FILE);
@@ -827,6 +878,11 @@ impl Builder {
             bcs::serialize_into(&mut write, &genesis)?;
         }
 
+        if !self.migration_sources.is_empty() {
+            let file = path.join(GENESIS_BUILDER_MIGRATION_SOURCES_FILE);
+            fs::write(file, serde_yaml::to_string(&self.migration_sources)?)?;
+        }
+
         Ok(())
     }
 }
@@ -870,10 +926,10 @@ fn get_genesis_protocol_config(version: ProtocolVersion) -> ProtocolConfig {
     ProtocolConfig::get_for_version(version, ChainIdentifier::default().chain())
 }
 
-fn build_unsigned_genesis_data(
+fn build_unsigned_genesis_data<'info>(
     parameters: &GenesisCeremonyParameters,
     token_distribution_schedule: &TokenDistributionSchedule,
-    validators: &[GenesisValidatorInfo],
+    validators: impl Iterator<Item = &'info GenesisValidatorInfo>,
     objects: Vec<Object>,
     genesis_stake: &mut GenesisStake,
 ) -> UnsignedGenesis {
@@ -885,15 +941,14 @@ fn build_unsigned_genesis_data(
 
     let genesis_chain_parameters = parameters.to_genesis_chain_parameters();
     let genesis_validators = validators
-        .iter()
         .cloned()
         .map(GenesisValidatorMetadata::from)
         .collect::<Vec<_>>();
 
     token_distribution_schedule.validate();
-    token_distribution_schedule.check_all_stake_operations_are_for_valid_validators(
-        genesis_validators.iter().map(|v| v.iota_address),
-    );
+    token_distribution_schedule
+        .check_minimum_stake_for_validators(genesis_validators.iter().map(|v| v.iota_address))
+        .expect("all validators should have the required stake");
 
     let epoch_data = EpochData::new_genesis(genesis_chain_parameters.chain_start_timestamp_ms);
 

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -1426,6 +1426,16 @@ pub enum SnapshotUrl {
     Test(Url),
 }
 
+impl std::fmt::Display for SnapshotUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SnapshotUrl::Iota => "iota".fmt(f),
+            SnapshotUrl::Shimmer => "smr".fmt(f),
+            SnapshotUrl::Test(url) => url.as_str().fmt(f),
+        }
+    }
+}
+
 impl FromStr for SnapshotUrl {
     type Err = anyhow::Error;
 

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -757,7 +757,6 @@ impl Builder {
         } else {
             Default::default()
         };
-        println!("{:?}", migration_sources);
 
         let token_distribution_schedule_file =
             path.join(GENESIS_BUILDER_TOKEN_DISTRIBUTION_SCHEDULE_FILE);

--- a/crates/iota-genesis-builder/src/stake.rs
+++ b/crates/iota-genesis-builder/src/stake.rs
@@ -79,9 +79,12 @@ impl GenesisStake {
     /// Extend a vanilla [`TokenDistributionSchedule`] with the
     /// inner token allocations.
     ///
-    /// ## Panic
+    /// The resulting schedule is guaranteed to contain allocations
+    /// that sum up the initial total supply of Iota in nanos.
     ///
-    /// The method panics if the resulting schedule is invalid.
+    /// ## Errors
+    ///
+    /// The method fails if the resulting schedule contains is invalid.
     pub fn extend_vanilla_token_distribution_schedule(
         &self,
         mut vanilla_schedule: TokenDistributionSchedule,
@@ -167,8 +170,8 @@ pub fn pick_objects_for_allocation<'obj>(
 /// This function iterates in turn over [`TimeLock`] and
 /// [`GasCoin`][iota_types::gas_coin::GasCoin] objects created
 /// during stardust migration that are owned by the `delegator`.
-pub fn delegate_genesis_stake(
-    validators: &[GenesisValidatorInfo],
+pub fn delegate_genesis_stake<'info>(
+    validators: impl Iterator<Item = &'info GenesisValidatorInfo>,
     delegator: IotaAddress,
     migration_objects: &MigrationObjects,
     amount_nanos: u64,

--- a/crates/iota/genesis.md
+++ b/crates/iota/genesis.md
@@ -59,17 +59,16 @@ $ git commit -m "add validator <name>'s information"
 $ git push # either to the shared workspace or another branch followed by a PR
 ```
 
-3. Add Initial Gas Objects
+3. Add token allocation for the faucet
 
-Add configuration for any initial gas objects that should be created at genesis.
+Add allocation for any faucet that might have been launched.
 
 ```
-$ iota genesis-ceremony add-gas-object \
-    --address <IotaAddress> \
-    --object-id <ObjectId> \
-    --value <# of iota coins>
+$ iota genesis-ceremony add-token-allocation \
+    --recipient-address <IotaAddress> \
+    --amount-nanos <# of iota coins>
 $ git add .
-$ git commit -m "add gas object"
+$ git commit -m "add faucet token allocation"
 $ git push
 ```
 

--- a/crates/iota/src/genesis_ceremony.rs
+++ b/crates/iota/src/genesis_ceremony.rs
@@ -244,7 +244,7 @@ pub fn run(cmd: Ceremony) -> Result<()> {
         }
 
         CeremonyCommand::BuildUnsignedCheckpoint => {
-            let mut builder = Builder::load(&dir)?;
+            let mut builder = Builder::load(&dir)?.with_migrated_state()?;
             let UnsignedGenesis { checkpoint, .. } = builder.get_or_build_unsigned_genesis();
             println!(
                 "Successfully built unsigned checkpoint: {}",

--- a/crates/iota/src/genesis_ceremony.rs
+++ b/crates/iota/src/genesis_ceremony.rs
@@ -468,7 +468,6 @@ mod test {
         let command = Ceremony {
             path: Some(dir.path().into()),
             protocol_version: MAX_PROTOCOL_VERSION,
-            protocol_version: None,
             command: CeremonyCommand::BuildUnsignedCheckpoint {
                 local_migration_snapshots: vec![],
                 remote_migration_snapshots: vec![],

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -210,6 +210,10 @@ impl IotaCommand {
                     .await?;
                 }
 
+                // Load the config of the Iota authority.
+                let network_config_path = config
+                    .clone()
+                    .unwrap_or(iota_config_dir()?.join(IOTA_NETWORK_CONFIG));
                 let NetworkConfigLight {
                     validator_configs,
                     account_keys,

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -291,7 +291,7 @@ impl IotaCommand {
                 )
                 .await
             }
-            IotaCommand::GenesisCeremony(cmd) => run(cmd),
+            IotaCommand::GenesisCeremony(cmd) => run(cmd).await,
             IotaCommand::KeyTool {
                 keystore_path,
                 json,

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -210,10 +210,6 @@ impl IotaCommand {
                     .await?;
                 }
 
-                // Load the config of the Iota authority.
-                let network_config_path = config
-                    .clone()
-                    .unwrap_or(iota_config_dir()?.join(IOTA_NETWORK_CONFIG));
                 let NetworkConfigLight {
                     validator_configs,
                     account_keys,

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -7,8 +7,8 @@ use std::os::unix::fs::FileExt;
 #[cfg(target_os = "windows")]
 use std::os::windows::fs::FileExt;
 use std::{
-    collections::BTreeSet, fmt::Write, fs::read_dir, io::Read, path::PathBuf, str, thread,
-    time::Duration,
+    collections::BTreeSet, fmt::Write, fs::read_dir, io::Read, path::PathBuf, str, str::FromStr,
+    thread, time::Duration,
 };
 
 use expect_test::expect;

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -7,8 +7,8 @@ use std::os::unix::fs::FileExt;
 #[cfg(target_os = "windows")]
 use std::os::windows::fs::FileExt;
 use std::{
-    collections::BTreeSet, fmt::Write, fs::read_dir, io::Read, path::PathBuf, str, str::FromStr,
-    thread, time::Duration,
+    collections::BTreeSet, fmt::Write, fs::read_dir, io::Read, path::PathBuf, str, thread,
+    time::Duration,
 };
 
 use expect_test::expect;


### PR DESCRIPTION
# Description of change

This patch introduces the necessary changes to perform successfully the genesis-ceremony of the alphanet network with the migrated state and faucet working. The changes can be summed up as follows:

1. Validation of the `token_distribution_schedule` in `Builder::build_and_cache_unsigned_genesis` is performed only after the genesis stake from the migrated state is merged with any cached (vanilla or not) schedule in the `Builder`. This allows to add simple token allocations (e.g. for the faucet) without requiring to satisfy the minimum stake for the validators.
2. The migrated state is now only added through the `add_migration_source` builder method, that accepts `SnapshotSource` value. This populates a new field `migration_sources` that is saved into a dedicated file with calling `Builder::save`. This allows us to reload the migrated state when calling `Builder::load`  to load the builder from disk.
3. `Builder::token_distribution_schedule` has been made more strict, allowing only schedule values that don't contain timelocked stake, in order to avoid conflicts with genesis stake delegated from the migrated state while reloading a saved `Builder`.
4. A few blocks in `Builder::build_and_cache_unsigned_genesis` have been moved into dedicated methodsto separate concerns,  and refactored to accommodate correct reloading of the `Builder`. Other utility functions have been added here and there.

## Links to any relevant issues

The genesis-ceremony has been successfully performed. So this

Resolves #138

