### PR TITLE
fix(iota): remove obsolete assertion in test_genesis

### DIFF
--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -63,15 +63,6 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
     let temp_dir = tempfile::tempdir()?;
     let working_dir = temp_dir.path();
 
-    // Start network without authorities
-    let start = IotaCommand::Start {
-        config_dir: Some(working_dir.into()),
-        no_full_node: false,
-    }
-    .execute()
-    .await;
-    assert!(matches!(start, Err(..)));
-    // Genesis
     IotaCommand::Genesis {
         working_dir: Some(working_dir.to_path_buf()),
         write_config: None,


### PR DESCRIPTION
# Description of change

The test was first trying to execute the `iota start` command, expecting it to fail, because the network config file does not exist in the provided path.

With #1205, however, we accept only the configuration directory as argument, and if no network config is present we generate it.

So the test was running a test network.

We remove the `iota start` check, because it is out of the scope and outdated.



## Links to any relevant issues

No issue, this is a hotfix.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`cargo nextest run -p iota -j2 -E 'test(test_genesis)'`

