### PR TITLE
fix(docs): Fix autogenerated api docs to support Docusaurus

### DIFF
--- a/docs/site/src/components/API/api-ref/method.js
+++ b/docs/site/src/components/API/api-ref/method.js
@@ -4,6 +4,7 @@
 
 import React, { useRef } from "react";
 import { useHistory } from "@docusaurus/router";
+import Heading from "@theme/Heading";
 import Parameters from "./parameters";
 import Result from "./result";
 import Examples from "./examples";
@@ -38,14 +39,15 @@ const Method = (props) => {
             key={`div-${api.replaceAll(/\s/g, "-").toLowerCase()}`}
             ref={parentScrollContainerRef()}
           >
-            <h2
+            <Heading
+              as="h2"
               id={`${api.replaceAll(/\s/g, "-").toLowerCase()}`}
               className="border-0 border-b border-solid border-iota-blue-dark dark:border-iota-blue scroll-mt-32 text-3xl text-iota-blue-dark dark:text-iota-blue font-bold mt-12 after:content-['_#'] after:hidden after:hover:inline after:opacity-20 cursor-pointer"
               onClick={handleClick}
               key={api.replaceAll(/\s/g, "-").toLowerCase()}
             >
               {api}
-            </h2>
+            </Heading>
             <ScrollSpy parentScrollContainerRef={parentScrollContainerRef()}>
               {json["methods"]
                 .filter((method) => method.tags[0].name === api)
@@ -68,13 +70,15 @@ const Method = (props) => {
                       id={`${method.name.toLowerCase()}`}
                       onClick={handleClick}
                     >
-                      <h3
+                      <Heading
+                        as="h3"
                         className="text-2xl font-bold after:content-['_#'] after:hidden after:hover:inline after:opacity-20 cursor-pointer"
                         key={`link-${method.name.toLowerCase()}`}
+                        id={`${method.name.toLowerCase()}`}
                         onClick={null}
                       >
                         {method.name}
-                      </h3>
+                      </Heading>
 
                       {method.deprecated && (
                         <div className="p-4 bg-iota-issue rounded-lg font-bold mt-4">

--- a/docs/site/src/components/API/index.js
+++ b/docs/site/src/components/API/index.js
@@ -4,6 +4,7 @@
 
 import React, { useState, useEffect } from "react";
 import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
+import Heading from "@theme/Heading";
 import RefNav from "./api-ref/refnav";
 import Methods from "./api-ref/method";
 
@@ -88,9 +89,9 @@ const Rpc = () => {
       <main className="flex-grow w-3/4">
         <div className="mx-8">
           <div className="">
-            <h1 className="fixed bg-white dark:bg-ifm-background-color-dark w-full py-4 top-14">
+            <Heading as="h1" className="fixed bg-white dark:bg-ifm-background-color-dark w-full py-4 top-14">
               IOTA JSON-RPC Reference - Version: {openrpc.info.version}
-            </h1>
+            </Heading>
             <ScrollSpy>
               <div className="">
                 <p className="pt-24">{openrpc.info.description}</p>


### PR DESCRIPTION
# Description of change

Headers are not registered by Docusaurus (and therefore not valid anchors for the broken anchor check) if you don't use the Docusaurus `Heading` component. So I fixed that

## Links to any relevant issues

Related to #1067.

## Type of change

- Documentation Fix

## How the change has been tested

Tested locally

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
