### PR TITLE
fix(docs): re-remove openrpc download temporary

### DIFF
--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "dev": "docusaurus graphql-to-doc; rm '../content/references/iota-api/iota-graphql/reference/generated.md'; node src/utils/getopenrpcspecs.js; git clean -Xdf ../content/references/iota-evm/; ./scripts/get-iota-evm-references.sh; docusaurus start",
-    "build": "docusaurus graphql-to-doc; rm '../content/references/iota-api/iota-graphql/reference/generated.md'; node src/utils/getopenrpcspecs.js; git clean -Xdf ../content/references/iota-evm/; ./scripts/get-iota-evm-references.sh; docusaurus build",
+    "dev": "docusaurus graphql-to-doc; rm '../content/references/iota-api/iota-graphql/reference/generated.md'; git clean -Xdf ../content/references/iota-evm/; ./scripts/get-iota-evm-references.sh; docusaurus start",
+    "build": "docusaurus graphql-to-doc; rm '../content/references/iota-api/iota-graphql/reference/generated.md'; git clean -Xdf ../content/references/iota-evm/; ./scripts/get-iota-evm-references.sh; docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
# Description of change

Seems like one of our latest updates to `develop` in https://github.com/iotaledger/iota/pull/626 did add the openrpc download again. But this will currently not work. So I re-removed it here temporary :trollface: 

## Type of change

- Documentation Fix

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
