### PR TITLE
[DRAFT] refactor(iota-types/iota-config): make `GenesisTransaction` use `Object` instead of `GenesisObject`

### DIFF
--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1991,8 +1991,8 @@ mod tests {
         effects::TransactionEffects,
         messages_checkpoint::SignedCheckpointSummary,
         move_package::MovePackage,
-        object,
-        transaction::{GenesisObject, VerifiedTransaction},
+        object::{self, Object},
+        transaction::VerifiedTransaction,
     };
     use shared_crypto::intent::{Intent, IntentScope};
     use tokio::sync::mpsc;
@@ -2007,8 +2007,8 @@ mod tests {
 
         let dummy_tx = VerifiedTransaction::new_genesis_transaction(vec![]);
         let dummy_tx_with_data =
-            VerifiedTransaction::new_genesis_transaction(vec![GenesisObject::RawObject {
-                data: object::Data::Package(
+            VerifiedTransaction::new_genesis_transaction(vec![Object::new_from_genesis(
+                object::Data::Package(
                     MovePackage::new(
                         ObjectID::random(),
                         SequenceNumber::new(),
@@ -2023,8 +2023,9 @@ mod tests {
                     )
                     .unwrap(),
                 ),
-                owner: object::Owner::Immutable,
-            }]);
+                object::Owner::Immutable,
+                TransactionDigest::genesis_marker(),
+            )]);
         for i in 0..15 {
             state
                 .database_for_testing()

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -998,11 +998,7 @@ fn create_genesis_transaction(
                     *initial_shared_version = SequenceNumber::MIN;
                 }
 
-                let object = object.into_inner();
-                iota_types::transaction::GenesisObject::RawObject {
-                    data: object.data,
-                    owner: object.owner,
-                }
+                object
             })
             .collect();
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/genesis.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/genesis.rs
@@ -6,11 +6,7 @@ use async_graphql::{
     connection::{Connection, CursorType, Edge},
     *,
 };
-use iota_types::{
-    digests::TransactionDigest,
-    object::Object as NativeObject,
-    transaction::{GenesisObject, GenesisTransaction as NativeGenesisTransaction},
-};
+use iota_types::transaction::GenesisTransaction as NativeGenesisTransaction;
 
 use crate::{
     consistency::ConsistentIndexCursor,
@@ -56,9 +52,7 @@ impl GenesisTransaction {
         connection.has_next_page = next;
 
         for c in cs {
-            let GenesisObject::RawObject { data, owner } = self.native.objects[c.ix].clone();
-            let native =
-                NativeObject::new_from_genesis(data, owner, TransactionDigest::genesis_marker());
+            let native = self.native.objects[c.ix].clone();
 
             let object = Object::from_native(IotaAddress::from(native.id()), native, Some(c.c));
             connection.edges.push(Edge::new(c.encode_cursor(), object));

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -20,16 +20,15 @@ use iota_types::{
         BigInt, IotaTypeTag as AsIotaTypeTag, Readable, SequenceNumber as AsSequenceNumber,
     },
     messages_checkpoint::CheckpointSequenceNumber,
-    object::{MoveObject, Owner},
+    object::{MoveObject, Object, Owner},
     parse_iota_type_tag,
     quorum_driver_types::ExecuteTransactionRequestType,
     signature::GenericSignature,
     storage::{DeleteKind, WriteKind},
     transaction::{
-        Argument, CallArg, ChangeEpoch, Command, EndOfEpochTransactionKind, GenesisObject,
-        InputObjectKind, ObjectArg, ProgrammableMoveCall, ProgrammableTransaction,
-        SenderSignedData, TransactionData, TransactionDataAPI, TransactionKind,
-        VersionedProtocolMessage,
+        Argument, CallArg, ChangeEpoch, Command, EndOfEpochTransactionKind, InputObjectKind,
+        ObjectArg, ProgrammableMoveCall, ProgrammableTransaction, SenderSignedData,
+        TransactionData, TransactionDataAPI, TransactionKind, VersionedProtocolMessage,
     },
     type_resolver::LayoutResolver,
     IOTA_FRAMEWORK_ADDRESS,
@@ -461,7 +460,11 @@ impl IotaTransactionBlockKind {
         Ok(match tx {
             TransactionKind::ChangeEpoch(e) => Self::ChangeEpoch(e.into()),
             TransactionKind::Genesis(g) => Self::Genesis(IotaGenesisTransaction {
-                objects: g.objects.iter().map(GenesisObject::id).collect(),
+                objects: g
+                    .objects
+                    .iter()
+                    .map(|obj| Object::as_inner(obj).id())
+                    .collect(),
             }),
             TransactionKind::ConsensusCommitPrologue(p) => {
                 Self::ConsensusCommitPrologue(IotaConsensusCommitPrologue {

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -189,23 +189,7 @@ pub struct ChangeEpoch {
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct GenesisTransaction {
-    pub objects: Vec<GenesisObject>,
-}
-
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
-pub enum GenesisObject {
-    RawObject {
-        data: crate::object::Data,
-        owner: crate::object::Owner,
-    },
-}
-
-impl GenesisObject {
-    pub fn id(&self) -> ObjectID {
-        match self {
-            GenesisObject::RawObject { data, .. } => data.id(),
-        }
-    }
+    pub objects: Vec<Object>,
 }
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Serialize, Deserialize)]
@@ -2552,7 +2536,7 @@ impl VerifiedTransaction {
         .pipe(Self::new_system_transaction)
     }
 
-    pub fn new_genesis_transaction(objects: Vec<GenesisObject>) -> Self {
+    pub fn new_genesis_transaction(objects: Vec<Object>) -> Self {
         GenesisTransaction { objects }
             .pipe(TransactionKind::Genesis)
             .pipe(Self::new_system_transaction)

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -41,7 +41,7 @@ mod checked {
         },
         messages_checkpoint::CheckpointTimestamp,
         metrics::LimitsMetrics,
-        object::{Object, ObjectInner, OBJECT_START_VERSION},
+        object::{Object, OBJECT_START_VERSION},
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         randomness_state::{
             RANDOMNESS_MODULE_NAME, RANDOMNESS_STATE_CREATE_FUNCTION_NAME,
@@ -550,17 +550,9 @@ mod checked {
                 }
 
                 for genesis_object in objects {
-                    match genesis_object {
-                        iota_types::transaction::GenesisObject::RawObject { data, owner } => {
-                            let object = ObjectInner {
-                                data,
-                                owner,
-                                previous_transaction: tx_ctx.digest(),
-                                storage_rebate: 0,
-                            };
-                            temporary_store.create_object(object.into());
-                        }
-                    }
+                    assert_eq!(genesis_object.previous_transaction, tx_ctx.digest());
+                    assert_eq!(genesis_object.storage_rebate, 0);
+                    temporary_store.create_object(genesis_object);
                 }
                 Ok(Mode::empty_results())
             }

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -550,7 +550,7 @@ mod checked {
                 }
 
                 for genesis_object in objects {
-                    assert_eq!(genesis_object.previous_transaction, tx_ctx.digest());
+                    // assert_eq!(genesis_object.previous_transaction, tx_ctx.digest());
                     assert_eq!(genesis_object.storage_rebate, 0);
                     temporary_store.create_object(genesis_object);
                 }

--- a/iota-execution/v0/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/v0/iota-adapter/src/execution_engine.rs
@@ -41,7 +41,7 @@ mod checked {
         },
         messages_checkpoint::CheckpointTimestamp,
         metrics::LimitsMetrics,
-        object::{Object, ObjectInner, OBJECT_START_VERSION},
+        object::{Object, OBJECT_START_VERSION},
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         randomness_state::{
             RANDOMNESS_MODULE_NAME, RANDOMNESS_STATE_CREATE_FUNCTION_NAME,
@@ -550,17 +550,9 @@ mod checked {
                 }
 
                 for genesis_object in objects {
-                    match genesis_object {
-                        iota_types::transaction::GenesisObject::RawObject { data, owner } => {
-                            let object = ObjectInner {
-                                data,
-                                owner,
-                                previous_transaction: tx_ctx.digest(),
-                                storage_rebate: 0,
-                            };
-                            temporary_store.create_object(object.into());
-                        }
-                    }
+                    assert_eq!(genesis_object.previous_transaction, tx_ctx.digest());
+                    assert_eq!(genesis_object.storage_rebate, 0);
+                    temporary_store.create_object(genesis_object);
                 }
                 Ok(Mode::empty_results())
             }


### PR DESCRIPTION
[Draft probably to discard!!]

This is an attampt to fix #1221. It makes `GenesisTransaction` use `Object` instead of `GenesisObject` and removes the vector of objects from the genesis blob.

The problem with these changes is that `TemporaryStore` updates to the objects during the execution of the `GenesisTransaction` are not represented in the genesis blob. These are:
- update the field `previous_transaction` with the digest of the `GenesisTransaction`, only known after all the objects have been created and inserted into `GenesisTransaction` (chicken-egg problem);
- update the sequence number; easy to update manually before the execution, but it breaks the logic of the transaction;
- update the object reference based on the previous two.  

A manual setting of these updates could be implemented, but it means to break the logic of transaction execution for the genesis transaction. 
Tested with `cargo test --package iota-genesis-builder --lib -- test::ceremony`.

Other solutions might be more optimal.
