### PR TITLE
fix(iota-genesis-builder): Settle random generation of test data only snapshot

### DIFF
--- a/crates/iota-benchmark/src/embedded_reconfig_observer.rs
+++ b/crates/iota-benchmark/src/embedded_reconfig_observer.rs
@@ -55,8 +55,7 @@ impl EmbeddedReconfigObserver {
                 if new_epoch <= cur_epoch {
                     trace!(
                         cur_epoch,
-                        new_epoch,
-                        "Ignored Committee from a previous or current epoch",
+                        new_epoch, "Ignored Committee from a previous or current epoch",
                     );
                     return Ok(auth_agg);
                 }

--- a/crates/iota-core/src/checkpoints/causal_order.rs
+++ b/crates/iota-core/src/checkpoints/causal_order.rs
@@ -181,8 +181,7 @@ impl RWLockDependencyBuilder {
             for dep in reads {
                 trace!(
                     "Assuming additional dependency when constructing checkpoint {:?} -> {:?}",
-                    digest,
-                    *dep
+                    digest, *dep
                 );
                 v.insert(*dep);
             }

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -740,8 +740,7 @@ async fn handle_execution_effects(
                 if checkpoint.sequence_number > highest_seq + 1 {
                     trace!(
                         "Checkpoint {} is still executing. Highest executed = {}",
-                        checkpoint.sequence_number,
-                        highest_seq
+                        checkpoint.sequence_number, highest_seq
                     );
                     continue;
                 }

--- a/crates/iota-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_output.rs
@@ -124,8 +124,7 @@ impl CheckpointOutput for LogCheckpointOutput {
     ) -> IotaResult {
         trace!(
             "Including following transactions in checkpoint {}: {:?}",
-            summary.sequence_number,
-            contents
+            summary.sequence_number, contents
         );
         info!(
             "Creating checkpoint {:?} at epoch {}, sequence {}, previous digest {:?}, transactions count {}, content digest {:?}, end_of_epoch_data {:?}",

--- a/crates/iota-framework/build.rs
+++ b/crates/iota-framework/build.rs
@@ -234,9 +234,9 @@ fn build_packages_with_move_config(
 /// * Replace html tags and use Docusaurus components where needed.
 fn relocate_docs(prefix: &str, files: &[(String, String)], output: &mut BTreeMap<String, String>) {
     // Turn on multi-line mode so that `.` matches newlines, consume from the start
-    // of the file to beginning of the heading, then capture the heading as three different parts and
-    // replace with the yaml tag for docusaurus, add the Link import and the title anchor,
-    // so the tile can be linked to. E.g., ```
+    // of the file to beginning of the heading, then capture the heading as three
+    // different parts and replace with the yaml tag for docusaurus, add the
+    // Link import and the title anchor, so the tile can be linked to. E.g., ```
     // -<a name="0x2_display"></a>
     // -
     // -# Module `0x2::display`
@@ -267,16 +267,19 @@ fn relocate_docs(prefix: &str, files: &[(String, String)], output: &mut BTreeMap
             new_path.to_string_lossy().to_string()
         };
 
-        // Replace a-tags with Link to register anchors in Docusaurus (we have to use the `id` attribute as `name` is deprecated and not existing in Link component)
-        let content = link_from_regex.replace_all(&file_content, r#"<Link id="$1"></Link>"#);
+        // Replace a-tags with Link to register anchors in Docusaurus (we have to use
+        // the `id` attribute as `name` is deprecated and not existing in Link
+        // component)
+        let content = link_from_regex.replace_all(file_content, r#"<Link id="$1"></Link>"#);
 
-        // Replace a-tags with href for Link tags to enable link and anchor checking. We need to make sure that `to` path don't contain extensions in a later step.
+        // Replace a-tags with href for Link tags to enable link and anchor checking. We
+        // need to make sure that `to` path don't contain extensions in a later step.
         let content = link_to_regex.replace_all(&content, r#"<Link to="$1">$2</Link>"#);
 
         // Escape `{` in <code> and add new lines as this is a requirement from mdx
         let content = code_regex.replace_all(&content, |caps: &regex::Captures| {
             let code_content = caps.get(1).unwrap().as_str();
-            format!("<code>\n{}</code>", code_content.replace("{", "\\{"))
+            format!("<code>\n{}</code>", code_content.replace('{', "\\{"))
         });
 
         // Wrap types like '<IOTA>', '<T>' and more in backticks as they are seen as

--- a/crates/iota-genesis-builder/src/stardust/test_outputs/delegator_outputs.rs
+++ b/crates/iota-genesis-builder/src/stardust/test_outputs/delegator_outputs.rs
@@ -9,7 +9,7 @@ use iota_sdk::types::block::{
     },
 };
 use iota_types::timelock::timelock::VESTED_REWARD_ID_PREFIX;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, Rng};
 
 use super::to_micros;
 use crate::stardust::types::{
@@ -81,11 +81,10 @@ pub(crate) fn new_vested_output(
 }
 
 pub fn outputs(
-    randomness_seed: u64,
+    rng: &mut StdRng,
     vested_index: &mut u32,
     delegator: Ed25519Address,
 ) -> anyhow::Result<Vec<(OutputHeader, Output)>> {
-    let mut rng = StdRng::seed_from_u64(randomness_seed);
     let mut new_outputs = Vec::new();
 
     // Add gas coins to delegator
@@ -93,7 +92,7 @@ pub fn outputs(
         new_outputs.push(new_simple_basic_output(
             DELEGATOR_GAS_COIN_AMOUNT_PER_OUTPUT,
             delegator,
-            &mut rng,
+            rng,
         )?);
     }
 
@@ -104,7 +103,7 @@ pub fn outputs(
             DELEGATOR_TIMELOCKS_AMOUNT_PER_OUTPUT,
             delegator,
             Some(MERGE_TIMESTAMP_SECS + TIMELOCK_MAX_ENDING_TIME),
-            &mut rng,
+            rng,
         )?);
         *vested_index -= 1;
     }

--- a/crates/iota-genesis-builder/src/stardust/test_outputs/mod.rs
+++ b/crates/iota-genesis-builder/src/stardust/test_outputs/mod.rs
@@ -72,12 +72,13 @@ pub async fn add_snapshot_test_outputs<const VERIFY: bool>(
     let mut new_header = parser.header.clone();
     let mut vested_index = u32::MAX;
 
+    let mut rng = StdRng::seed_from_u64(randomness_seed);
     let mut new_outputs = [
-        alias_ownership::outputs(randomness_seed).await?,
-        stardust_mix::outputs(randomness_seed, &mut vested_index).await?,
-        vesting_schedule_entity::outputs(randomness_seed, &mut vested_index).await?,
-        vesting_schedule_iota_airdrop::outputs(randomness_seed, &mut vested_index).await?,
-        vesting_schedule_portfolio_mix::outputs(randomness_seed, &mut vested_index).await?,
+        alias_ownership::outputs(&mut rng).await?,
+        stardust_mix::outputs(&mut rng, &mut vested_index).await?,
+        vesting_schedule_entity::outputs(&mut rng, &mut vested_index).await?,
+        vesting_schedule_iota_airdrop::outputs(&mut rng, &mut vested_index).await?,
+        vesting_schedule_portfolio_mix::outputs(&mut rng, &mut vested_index).await?,
     ]
     .concat();
 
@@ -85,7 +86,7 @@ pub async fn add_snapshot_test_outputs<const VERIFY: bool>(
 
     new_outputs.append(&mut if let Some(delegator) = delegator.into() {
         add_only_test_outputs(
-            randomness_seed,
+            &mut rng,
             &mut vested_index,
             delegator,
             with_sampling.then_some(&mut parser),
@@ -148,19 +149,18 @@ fn add_all_previous_outputs_and_test_outputs<R: Read>(
 /// with a timelocked staking. Optionally some samples from the previous
 /// snapshot are taken too.
 fn add_only_test_outputs<R: Read>(
-    randomness_seed: u64,
+    rng: &mut StdRng,
     vested_index: &mut u32,
     delegator: Ed25519Address,
     parser: Option<&mut HornetSnapshotParser<R>>,
     new_temp_amount: u64,
 ) -> anyhow::Result<Vec<(OutputHeader, Output)>> {
-    let mut rng = StdRng::seed_from_u64(randomness_seed);
     // Needed outputs for delegator
-    let mut new_outputs = delegator_outputs::outputs(randomness_seed, vested_index, delegator)?;
+    let mut new_outputs = delegator_outputs::outputs(rng, vested_index, delegator)?;
 
     // Additional sample outputs
     if let Some(parser) = parser {
-        new_outputs.append(&mut with_sampling(parser, &mut rng)?)
+        new_outputs.append(&mut with_sampling(parser, rng)?)
     }
 
     // Add all the remainder tokens to the zero address
@@ -174,11 +174,11 @@ fn add_only_test_outputs<R: Read>(
         new_outputs.push(new_simple_basic_output(
             remainder_per_output,
             zero_address,
-            &mut rng,
+            rng,
         )?);
     }
     if difference > 0 {
-        new_outputs.push(new_simple_basic_output(difference, zero_address, &mut rng)?);
+        new_outputs.push(new_simple_basic_output(difference, zero_address, rng)?);
     }
 
     Ok(new_outputs)

--- a/crates/iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs
+++ b/crates/iota-genesis-builder/src/stardust/test_outputs/stardust_mix.rs
@@ -24,7 +24,7 @@ use iota_sdk::{
         },
     },
 };
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, Rng};
 
 use crate::stardust::{
     test_outputs::new_vested_output,
@@ -166,10 +166,9 @@ const STARDUST_MIX: &[StardustWallet] = &[
 ];
 
 pub(crate) async fn outputs(
-    randomness_seed: u64,
+    rng: &mut StdRng,
     vested_index: &mut u32,
 ) -> anyhow::Result<Vec<(OutputHeader, Output)>> {
-    let mut rng = StdRng::seed_from_u64(randomness_seed);
     let mut outputs = Vec::new();
 
     for wallet in STARDUST_MIX {
@@ -190,7 +189,7 @@ pub(crate) async fn outputs(
 
             // Random add up to 2 aliases with foundry and native tokens
             let (alias_foundry_outputs, native_tokens_for_basic_outputs) =
-                random_alias_foundry_native_token(address, &mut rng)?;
+                random_alias_foundry_native_token(address, rng)?;
             let native_tokens_for_nft_outputs = native_tokens_for_basic_outputs.clone();
             outputs.extend(alias_foundry_outputs);
 
@@ -199,14 +198,14 @@ pub(crate) async fn outputs(
                 OUTPUT_IOTA_AMOUNT,
                 address,
                 None,
-                &mut rng,
+                rng,
             )?);
             *vested_index -= 1;
             outputs.extend(new_basic_or_nft_outputs(
                 OutputBuilder::Basic(BasicOutputBuilder::new_with_amount(OUTPUT_IOTA_AMOUNT)),
                 address,
                 native_tokens_for_basic_outputs,
-                &mut rng,
+                rng,
             )?);
             outputs.extend(new_basic_or_nft_outputs(
                 OutputBuilder::Nft(NftOutputBuilder::new_with_amount(
@@ -215,7 +214,7 @@ pub(crate) async fn outputs(
                 )),
                 address,
                 native_tokens_for_nft_outputs,
-                &mut rng,
+                rng,
             )?);
         }
     }

--- a/crates/iota-genesis-builder/src/stardust/test_outputs/vesting_schedule_entity.rs
+++ b/crates/iota-genesis-builder/src/stardust/test_outputs/vesting_schedule_entity.rs
@@ -9,7 +9,7 @@ use iota_sdk::{
     client::secret::{mnemonic::MnemonicSecretManager, SecretManage},
     types::block::output::Output,
 };
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, Rng};
 
 use crate::stardust::{
     test_outputs::{new_vested_output, MERGE_TIMESTAMP_SECS},
@@ -22,13 +22,11 @@ const VESTING_WEEKS: usize = 208;
 const VESTING_WEEKS_FREQUENCY: usize = 2;
 
 pub(crate) async fn outputs(
-    randomness_seed: u64,
+    rng: &mut StdRng,
     vested_index: &mut u32,
 ) -> anyhow::Result<Vec<(OutputHeader, Output)>> {
     let mut outputs = Vec::new();
     let secret_manager = MnemonicSecretManager::try_from_mnemonic(MNEMONIC)?;
-
-    let mut rng = StdRng::seed_from_u64(randomness_seed);
 
     let address = secret_manager
         .generate_ed25519_addresses(COIN_TYPE, 0, 0..1, None)
@@ -48,7 +46,7 @@ pub(crate) async fn outputs(
         initial_unlock_amount,
         address,
         None,
-        &mut rng,
+        rng,
     )?);
     *vested_index -= 1;
 
@@ -60,7 +58,7 @@ pub(crate) async fn outputs(
             vested_amount,
             address,
             Some(timelock),
-            &mut rng,
+            rng,
         )?);
         *vested_index -= 1;
     }

--- a/crates/iota-genesis-builder/src/stardust/test_outputs/vesting_schedule_iota_airdrop.rs
+++ b/crates/iota-genesis-builder/src/stardust/test_outputs/vesting_schedule_iota_airdrop.rs
@@ -14,7 +14,7 @@ use iota_sdk::{
     client::secret::{mnemonic::MnemonicSecretManager, SecretManage},
     types::block::output::Output,
 };
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, Rng};
 
 use crate::stardust::{
     test_outputs::{new_vested_output, MERGE_TIMESTAMP_SECS},
@@ -29,7 +29,7 @@ const VESTING_WEEKS: usize = 104;
 const VESTING_WEEKS_FREQUENCY: usize = 2;
 
 pub(crate) async fn outputs(
-    randomness_seed: u64,
+    rng: &mut StdRng,
     vested_index: &mut u32,
 ) -> anyhow::Result<Vec<(OutputHeader, Output)>> {
     let now = SystemTime::now()
@@ -37,8 +37,6 @@ pub(crate) async fn outputs(
         .as_secs() as u32;
     let mut outputs = Vec::new();
     let secret_manager = MnemonicSecretManager::try_from_mnemonic(MNEMONIC)?;
-
-    let mut rng = StdRng::seed_from_u64(randomness_seed);
 
     for account_index in 0..ACCOUNTS {
         for address_index in 0..ADDRESSES_PER_ACCOUNT {
@@ -72,7 +70,7 @@ pub(crate) async fn outputs(
                     initial_unlock_amount,
                     address,
                     None,
-                    &mut rng,
+                    rng,
                 )?);
                 *vested_index -= 1;
             }
@@ -88,7 +86,7 @@ pub(crate) async fn outputs(
                         vested_amount,
                         address,
                         Some(timelock),
-                        &mut rng,
+                        rng,
                     )?);
                     *vested_index -= 1;
                 }

--- a/crates/iota-genesis-builder/src/stardust/test_outputs/vesting_schedule_portfolio_mix.rs
+++ b/crates/iota-genesis-builder/src/stardust/test_outputs/vesting_schedule_portfolio_mix.rs
@@ -15,7 +15,7 @@ use iota_sdk::{
         },
     },
 };
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, Rng};
 
 use crate::stardust::{
     test_outputs::{new_vested_output, MERGE_MILESTONE_INDEX, MERGE_TIMESTAMP_SECS},
@@ -39,13 +39,11 @@ const ADDRESSES: &[[u32; 3]] = &[
 ];
 
 pub(crate) async fn outputs(
-    randomness_seed: u64,
+    rng: &mut StdRng,
     vested_index: &mut u32,
 ) -> anyhow::Result<Vec<(OutputHeader, Output)>> {
     let mut outputs = Vec::new();
     let secret_manager = MnemonicSecretManager::try_from_mnemonic(MNEMONIC)?;
-
-    let mut rng = StdRng::seed_from_u64(randomness_seed);
 
     for [account_index, internal, address_index] in ADDRESSES {
         let address = secret_manager
@@ -59,14 +57,14 @@ pub(crate) async fn outputs(
 
         match address_index {
             0 => {
-                add_random_basic_output(&mut outputs, &mut rng, address)?;
+                add_random_basic_output(&mut outputs, rng, address)?;
             }
             1 => {
-                add_vested_outputs(&mut outputs, &mut rng, vested_index, address)?;
+                add_vested_outputs(&mut outputs, rng, vested_index, address)?;
             }
             2 => {
-                add_random_basic_output(&mut outputs, &mut rng, address)?;
-                add_vested_outputs(&mut outputs, &mut rng, vested_index, address)?;
+                add_random_basic_output(&mut outputs, rng, address)?;
+                add_vested_outputs(&mut outputs, rng, vested_index, address)?;
             }
             _ => unreachable!(),
         }


### PR DESCRIPTION
# Description of change

Fixes #1265 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

- `cargo run --release --example snapshot_only_test_outputs --features="test-outputs" ../latest-full_snapshot-iota.bin`
- `cargo run --release --bin iota-genesis-builder -- --disable-global-snapshot-verification iota --snapshot-path ../test-latest-full_snapshot-iota.bin --target-network alphanetv0`
- `cargo run --release --bin iota genesis --working-dir test_iota_config -f --with-faucet --num-validators 4 --local-migration-snapshots ./stardust_object_snapshot.bin`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
