### PR TITLE
feat(sc-platform): Fix APY calculation and add end-to-end APY test

### DIFF
--- a/crates/iota-e2e-tests/tests/apy_test.rs
+++ b/crates/iota-e2e-tests/tests/apy_test.rs
@@ -1,0 +1,143 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use fastcrypto::ed25519::Ed25519KeyPair;
+use iota_json_rpc_api::{CoinReadApiClient, GovernanceReadApiClient};
+use iota_keys::keystore::AccountKeystore;
+use iota_macros::sim_test;
+use iota_swarm_config::genesis_config::{AccountConfig, GenesisConfig, DEFAULT_GAS_AMOUNT};
+use iota_test_transaction_builder::TestTransactionBuilder;
+use iota_types::{
+    crypto::{get_key_pair_from_rng, IotaKeyPair},
+    gas_coin::NANOS_PER_IOTA,
+};
+use test_cluster::TestClusterBuilder;
+
+/// Assuming the following parameters (in IOTAs):
+///
+/// - VALIDATOR_LOW_STAKE_THRESHOLD_NANOS = 1_500_00
+/// - COMMISSION_RATE = 2%
+/// - VALIDATOR_TARGET_REWARD = 767_000
+/// - SINGLE_VALIDATOR_REWARD = VALIDATOR_TARGET_REWARD / 4
+/// - SINGLE_VALIDATOR_COMMISSION = 0.02 * SINGLE_VALIDATOR_REWARD
+/// - STAKE = 3_500_000_000
+///
+/// After epoch 0, we expect the validator to which we staked to have:
+/// - An iota_balance of the original staked 1_500_000 plus the distributed
+///   rewards of SINGLE_VALIDATOR_REWARD - SINGLE_VALIDATOR_COMMISSION =
+///   1_687_915.
+/// - The pool should have a total stake of the originally staked 1_500_000 plus
+///   the newly staked STAKE plus the entire reward it received (=
+///   SINGLE_VALIDATOR_REWARD, since the commission is also staked) =
+///   3_501_691_750.
+/// - The new pool token balance is then given by
+/// (pool_token_epoch_0 * new_stake) / iota_balance_after_rewards = (1_500_000 *
+/// 3_501_691_750) / 1_687_915 = 3_111_849_604.
+///
+/// Finally, this gives us the exchange rate for that pool for epoch 1:
+/// iota_amount = 3_501_691_750
+/// pool_token = 3_111_849_604
+/// rate_epoch1 = pool_token / iota_amount ~= 0.8886703418122358
+///
+/// After epoch 1, we expect the validator to which we staked to have
+/// - An iota_balance of the previously staked 3_501_691_750 plus the
+///   distributed rewards of SINGLE_VALIDATOR_REWARD -
+///   SINGLE_VALIDATOR_COMMISSION = 3_501_879_665.
+/// - The pool should have a total stake of the previously staked 3_501_691_750
+///   plus the entire reward it received (= SINGLE_VALIDATOR_REWARD, since the
+///   commission is also staked) = 3_501_883_500.
+/// - The new pool token balance is then given by
+/// (pool_token_epoch_1 * new_stake) / iota_balance_after_rewards =
+/// (3_111_849_604 * 3_501_883_500) / 3_501_879_665 = 3_111_853_012.
+///
+/// Finally, this gives us the exchange rate for that pool for epoch 1:
+/// iota_amount = 3_501_883_500
+/// pool_token = 3_111_853_012
+/// rate_epoch2 = pool_token / iota_amount ~= 0.8886226547118051
+///
+/// And with those two rates we can calculate the APY:
+/// apy = ((rate_epoch1/rate_epoch2)^365) - 1 ~= 0.019779937783565904
+#[sim_test]
+async fn test_apy() {
+    // We need a large stake for low enough APY values such that they are not
+    // filtered out by the APY calculation function.
+    let stake = 3_500_000_000 * NANOS_PER_IOTA;
+    let mut rng = rand::thread_rng();
+    let mut genesis_config = GenesisConfig::for_local_testing();
+    let (address, keypair): (_, Ed25519KeyPair) = get_key_pair_from_rng(&mut rng);
+    genesis_config.accounts.extend([AccountConfig {
+        address: Some(address),
+        gas_amounts: vec![DEFAULT_GAS_AMOUNT, stake],
+    }]);
+
+    let mut test_cluster = TestClusterBuilder::new()
+        .set_genesis_config(genesis_config)
+        .with_epoch_duration_ms(10_000)
+        .build()
+        .await;
+
+    test_cluster
+        .wallet
+        .config
+        .keystore
+        .add_key(None, IotaKeyPair::Ed25519(keypair))
+        .unwrap();
+
+    let ref_gas_price = test_cluster.get_reference_gas_price().await;
+
+    let client = test_cluster.rpc_client();
+    let mut coins = client
+        .get_coins(address, None, None, None)
+        .await
+        .unwrap()
+        .data
+        .into_iter();
+    let (gas_coin, stake_coin) = {
+        let coin1 = coins.next().expect("there should be at least two coins");
+        let coin2 = coins.next().expect("there should be at least two coins");
+
+        if coin1.balance > coin2.balance {
+            (coin2, coin1)
+        } else {
+            (coin1, coin2)
+        }
+    };
+
+    let validator_address = test_cluster
+        .swarm
+        .active_validators()
+        .next()
+        .unwrap()
+        .config
+        .iota_address();
+    let transaction = TestTransactionBuilder::new(address, gas_coin.object_ref(), ref_gas_price)
+        .call_staking(stake_coin.object_ref(), validator_address)
+        .build();
+    test_cluster
+        .sign_and_execute_transaction(&transaction)
+        .await;
+
+    // Wait for two epochs with the new stake so we get two new exchange rates which
+    // are minimally needed to calculate the APY.
+    test_cluster.wait_for_epoch(None).await;
+    test_cluster.wait_for_epoch(None).await;
+
+    let http_client = test_cluster.rpc_client();
+
+    let apys = http_client
+        .get_validators_apy()
+        .await
+        .expect("call should succeed");
+
+    assert_eq!(apys.epoch, 2);
+
+    let validator_apy = apys
+        .apys
+        .iter()
+        .find(|validator_apy| validator_apy.address == validator_address)
+        .unwrap();
+
+    // See description above for the origin of this value.
+    assert!((validator_apy.apy - 0.01977).abs() < 0.01);
+}

--- a/crates/iota-e2e-tests/tests/apy_test.rs
+++ b/crates/iota-e2e-tests/tests/apy_test.rs
@@ -1,5 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2024 IOTA Stiftung
+// Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use fastcrypto::ed25519::Ed25519KeyPair;
@@ -58,6 +57,7 @@ async fn test_apy() {
     let mut test_cluster = TestClusterBuilder::new()
         .set_genesis_config(genesis_config)
         .with_epoch_duration_ms(10_000)
+        .with_num_validators(4)
         .build()
         .await;
 

--- a/crates/iota-e2e-tests/tests/apy_test.rs
+++ b/crates/iota-e2e-tests/tests/apy_test.rs
@@ -40,11 +40,8 @@ use test_cluster::TestClusterBuilder;
 /// Two exchanges rates are needed to calculate the APY in the API. Epoch 0
 /// always has an initial exchange rate set which cannot be used, so we need to
 /// calculate APY from epoch 1 and 2. Since we need epoch 0 to start staking
-/// anyway, and only have the stake of the pool at the expected number starting
-/// from epoch 1, this is totally fine.
-///
-/// Note that we don't get exactly 8% APY but slightly above, since the total
-/// stake of the pool
+/// anyway, and only have the stake of the pool at the expected number (a
+/// quarter of 3.5B IOTAs) starting from epoch 1, this is totally fine.
 #[sim_test]
 async fn test_apy() {
     // We need a large stake for low enough APY values such that they are not

--- a/crates/iota-graphql-e2e-tests/tests/validator/validator.exp
+++ b/crates/iota-graphql-e2e-tests/tests/validator/validator.exp
@@ -48,7 +48,6 @@ Response: {
         "activeValidators": {
           "nodes": [
             {
-              "apy": 1,
               "name": "validator-0"
             }
           ]
@@ -147,7 +146,6 @@ Response: {
         "activeValidators": {
           "nodes": [
             {
-              "apy": 2,
               "name": "validator-0",
               "reportRecords": {
                 "nodes": []

--- a/crates/iota-graphql-e2e-tests/tests/validator/validator.move
+++ b/crates/iota-graphql-e2e-tests/tests/validator/validator.move
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-// Test the change of APY with heavy transactions
+// Test heavy transactions.
 
 //# init --protocol-version 1 --simulator --accounts A --addresses P0=0x0
 
@@ -55,7 +55,6 @@ module P0::m {
     validatorSet {
       activeValidators {
         nodes {
-          apy
           name
         }
       }
@@ -105,7 +104,6 @@ module P0::m {
     validatorSet {
       activeValidators {
         nodes {
-          apy
           name
           reportRecords {
             nodes {


### PR DESCRIPTION
# Description of change

Removes the part of the `iota-graphql-e2e-test` test that tests the APY and creates a new APY specific test in `iota-e2e-tests`.

The APY calculation was broken before and was fixed. This fix was already done in #1186, which is not yet merged though. So parts of that fix were ported here, in particular removing the filtering of epochs based on the stake subsidy start epoch. This start epoch is now `u64::MAX` so all of the epochs would have been filtered. In any case, all of the subsidy-related things will be properly removed in #1186.
This calculation fix also fixes a bug where if `apy_counts = 0` we divide by `0` which returns `NaN`.

The reason for this change is that due to our new tokenomics the APY calculation only returns reasonable results when the total stake is fairly large. In the test clusters that the e2e tests use, those stakes are typically very small since every validator is commonly initialized to have a stake of `VALIDATOR_LOW_STAKE_THRESHOLD_NANOS`. Hence the need for a separate test that can control the total stake and produce APY values that are not filtered by `calculate_apys` in the `GovernanceApi`.

See https://github.com/iotaledger/iota/issues/1235#issuecomment-2244472458 for additional details.

Unfortunately, `iota-e2e-tests` are ignored in CI at the moment, so this test will not become part of CI tests just yet, but that's probably ok.

## Links to any relevant issues

fixes point 3 of #1235

## How the change has been tested

`cargo nextest run -p iota-e2e-tests test_apy`