### PR TITLE
fix(wallet): reactivity issue determining the sourceStrategy in balance finder

### DIFF
--- a/apps/wallet/src/ui/app/pages/accounts/manage/accounts-finder/AccountsFinderView.tsx
+++ b/apps/wallet/src/ui/app/pages/accounts/manage/accounts-finder/AccountsFinderView.tsx
@@ -67,7 +67,7 @@ export function AccountsFinderView(): JSX.Element {
                       type: 'software',
                       sourceID: accountSourceId!,
                   },
-        [password, accountSourceId],
+        [password, accountSourceId, accountSourceType],
     );
     const { find } = useAccountsFinder({
         accountSourceType,


### PR DESCRIPTION
# Description of change

There is a crash if you import from mnemonic and jump into the balance finder, the issue seems to be a reacitvity issue

## Links to any relevant issues

Close https://github.com/iotaledger/iota/issues/1351


## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation Fix

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
