### PR TITLE
chore(iota): remove cargo default comment

### DIFF
--- a/crates/iota-open-rpc-macros/Cargo.toml
+++ b/crates/iota-open-rpc-macros/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 license = "Apache-2.0"
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 proc-macro = true
 

--- a/crates/iota-package-resolver/Cargo.toml
+++ b/crates/iota-package-resolver/Cargo.toml
@@ -6,8 +6,6 @@ edition = "2021"
 license = "Apache-2.0"
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 async-trait.workspace = true
 bcs.workspace = true

--- a/crates/iota-snapshot/Cargo.toml
+++ b/crates/iota-snapshot/Cargo.toml
@@ -6,8 +6,6 @@ edition = "2021"
 license = "Apache-2.0"
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 anyhow.workspace = true
 bcs.workspace = true

--- a/external-crates/move/crates/move-ir-types/Cargo.toml
+++ b/external-crates/move/crates/move-ir-types/Cargo.toml
@@ -9,8 +9,6 @@ license = "Apache-2.0"
 publish = false
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 serde.workspace = true
 hex.workspace = true

--- a/external-crates/move/crates/move-stdlib/Cargo.toml
+++ b/external-crates/move/crates/move-stdlib/Cargo.toml
@@ -9,7 +9,6 @@ homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 move-errmapgen.workspace = true
 move-docgen.workspace = true

--- a/external-crates/move/crates/move-vm-integration-tests/Cargo.toml
+++ b/external-crates/move/crates/move-vm-integration-tests/Cargo.toml
@@ -9,8 +9,6 @@ license = "Apache-2.0"
 publish = false
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 anyhow.workspace = true
 fail = { workspace = true, features = ["failpoints"] }

--- a/external-crates/move/crates/move-vm-runtime/Cargo.toml
+++ b/external-crates/move/crates/move-vm-runtime/Cargo.toml
@@ -9,8 +9,6 @@ license = "Apache-2.0"
 publish = false
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 better_any.workspace = true
 fail.workspace = true

--- a/external-crates/move/crates/move-vm-test-utils/Cargo.toml
+++ b/external-crates/move/crates/move-vm-test-utils/Cargo.toml
@@ -9,8 +9,6 @@ license = "Apache-2.0"
 publish = false
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 anyhow.workspace = true
 once_cell.workspace = true
@@ -22,6 +20,6 @@ move-vm-types.workspace = true
 move-vm-profiler.workspace = true
 
 [features]
-default = [ ]
+default = []
 tiered-gas = []
 gas-profiler = []

--- a/external-crates/move/move-execution/v0/crates/move-stdlib/Cargo.toml
+++ b/external-crates/move/move-execution/v0/crates/move-stdlib/Cargo.toml
@@ -9,7 +9,6 @@ homepage = "https://diem.com"
 license = "Apache-2.0"
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 move-errmapgen.workspace = true
 move-docgen.workspace = true

--- a/external-crates/move/move-execution/v0/crates/move-vm-runtime/Cargo.toml
+++ b/external-crates/move/move-execution/v0/crates/move-vm-runtime/Cargo.toml
@@ -9,8 +9,6 @@ license = "Apache-2.0"
 publish = false
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 better_any.workspace = true
 fail.workspace = true


### PR DESCRIPTION
Just a bit of consistency as this has been removed everywhere except from a few crates.