### PR TITLE
fix(external-crates): add `move-execution` to external-crates workspace members

### DIFF
--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1585,6 +1585,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-bytecode-verifier-v0"
+version = "0.1.0"
+dependencies = [
+ "hex-literal",
+ "invalid-mutations",
+ "move-abstract-stack",
+ "move-binary-format",
+ "move-borrow-graph",
+ "move-core-types",
+ "move-vm-config",
+ "petgraph",
+]
+
+[[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
 dependencies = [
@@ -2053,6 +2067,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-stdlib-v0"
+version = "0.1.1"
+dependencies = [
+ "anyhow",
+ "dir-diff",
+ "file_diff",
+ "hex",
+ "log",
+ "move-binary-format",
+ "move-cli",
+ "move-command-line-common",
+ "move-core-types",
+ "move-docgen",
+ "move-errmapgen",
+ "move-package",
+ "move-prover",
+ "move-unit-test",
+ "move-vm-runtime-v0",
+ "move-vm-types",
+ "sha2",
+ "sha3",
+ "smallvec",
+ "tempfile",
+ "walkdir",
+]
+
+[[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
 dependencies = [
@@ -2174,6 +2215,30 @@ dependencies = [
  "hex",
  "move-binary-format",
  "move-bytecode-verifier",
+ "move-compiler",
+ "move-core-types",
+ "move-ir-compiler",
+ "move-vm-config",
+ "move-vm-profiler",
+ "move-vm-types",
+ "once_cell",
+ "parking_lot 0.11.2",
+ "proptest",
+ "sha3",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "move-vm-runtime-v0"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "better_any",
+ "fail",
+ "hex",
+ "move-binary-format",
+ "move-bytecode-verifier-v0",
  "move-compiler",
  "move-core-types",
  "move-ir-compiler",

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -3,6 +3,9 @@ resolver = "2"
 
 members = [
     "crates/*",
+    "move-execution/v0/crates/move-bytecode-verifier",
+    "move-execution/v0/crates/move-vm-runtime",
+    "move-execution/v0/crates/move-stdlib",
 ]
 
 # Dependencies that should be kept in sync through the whole workspace
@@ -26,7 +29,10 @@ criterion-cpu-time = "0.1.0"
 crossbeam = "0.8"
 crossbeam-channel = "0.5.0"
 crossterm = "0.25.0"
-curve25519-dalek = { version = "0.1.0", package = "curve25519-dalek-fiat", default-features = false, features = ["std", "u64_backend"] }
+curve25519-dalek = { version = "0.1.0", package = "curve25519-dalek-fiat", default-features = false, features = [
+    "std",
+    "u64_backend",
+] }
 datatest-stable = "0.1.1"
 derivative = "2.2.0"
 difference = "2.0.0"
@@ -34,7 +40,11 @@ digest = "0.9.0"
 dir-diff = "0.3.2"
 dirs-next = "2.0.0"
 dunce = "1.0.2"
-ed25519-dalek = { version = "0.1.0", package = "ed25519-dalek-fiat", default-features = false, features = ["std", "serde", "u64_backend"] }
+ed25519-dalek = { version = "0.1.0", package = "ed25519-dalek-fiat", default-features = false, features = [
+    "std",
+    "serde",
+    "u64_backend",
+] }
 ethnum = "1.0.4"
 fail = "0.4.0"
 file_diff = "1.0.0"
@@ -45,7 +55,7 @@ hex = "0.4.3"
 hex-literal = "0.3.4"
 hkdf = "0.10.0"
 im = "15.1.0"
-internment = { version = "0.5.0", features = [ "arc"] }
+internment = { version = "0.5.0", features = ["arc"] }
 itertools = "0.10.0"
 leb128 = "0.2.5"
 libfuzzer-sys = "0.4"
@@ -65,10 +75,14 @@ paste = "1.0.5"
 pathdiff = "0.2.1"
 petgraph = "0.5.1"
 phf = { version = "0.11", features = ["macros"] }
-plotters = { version = "0.3.0", default-features = false, features = ["evcxr", "line_series", "histogram"]}
+plotters = { version = "0.3.0", default-features = false, features = [
+    "evcxr",
+    "line_series",
+    "histogram",
+] }
 pretty = "0.10.0"
 prettydiff = "0.4.0"
-primitive-types = { version = "0.10.1", features = ["impl-serde"]}
+primitive-types = { version = "0.10.1", features = ["impl-serde"] }
 proc-macro2 = "1.0.24"
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
@@ -99,7 +113,7 @@ thiserror = "1.0.24"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 tokio = { version = "1.18.2", features = ["full"] }
 toml = "0.5.8"
-toml_edit =  { version = "0.14.3", features = ["easy"] }
+toml_edit = { version = "0.14.3", features = ["easy"] }
 tracing = "0.1.26"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 treeline = "0.1.0"
@@ -110,11 +124,14 @@ variant_count = "1.1.0"
 vfs = "0.10.0"
 walkdir = "2.3.1"
 whoami = { version = "1.2.1" }
-x25519-dalek = { version = "0.1.0", package = "x25519-dalek-fiat", default-features = false, features = ["std", "u64_backend"] }
+x25519-dalek = { version = "0.1.0", package = "x25519-dalek-fiat", default-features = false, features = [
+    "std",
+    "u64_backend",
+] }
 z3tracer = "0.8.0"
 
 bytecode-interpreter-crypto = { path = "crates/bytecode-interpreter-crypto" }
-enum-compat-util = { path = "crates/enum-compat-util"}
+enum-compat-util = { path = "crates/enum-compat-util" }
 invalid-mutations = { path = "crates/invalid-mutations" }
 module-generation = { path = "crates/module-generation" }
 move-abstract-stack = { path = "crates/move-abstract-stack" }
@@ -138,7 +155,7 @@ move-ir-to-bytecode-syntax = { path = "crates/move-ir-to-bytecode-syntax" }
 move-ir-types = { path = "crates/move-ir-types" }
 move-model = { path = "crates/move-model" }
 move-package = { path = "crates/move-package" }
-move-proc-macros = { path = "crates/move-proc-macros"}
+move-proc-macros = { path = "crates/move-proc-macros" }
 move-prover = { path = "crates/move-prover" }
 move-prover-test-utils = { path = "crates/move-prover-test-utils" }
 move-read-write-set-types = { path = "crates/move-read-write-set-types" }
@@ -153,7 +170,7 @@ move-vm-profiler = { path = "crates/move-vm-profiler" }
 move-vm-runtime = { path = "crates/move-vm-runtime" }
 move-vm-test-utils = { path = "crates/move-vm-test-utils" }
 move-vm-types = { path = "crates/move-vm-types" }
-prover_bytecode = { path = "crates/move-stackless-bytecode", package="move-stackless-bytecode" }
+prover_bytecode = { path = "crates/move-stackless-bytecode", package = "move-stackless-bytecode" }
 
 [profile.bench]
 debug = true
@@ -169,6 +186,6 @@ opt-level = 3
 # use release settings to reduce memory pressure in the linking step in CI
 [profile.ci]
 inherits = "test"
-debug = 0 # for saving disk space during linking
+debug = 0           # for saving disk space during linking
 incremental = false
 codegen-units = 16

--- a/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/control_flow_v5.rs
+++ b/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/control_flow_v5.rs
@@ -39,7 +39,7 @@ pub fn verify(
 
 fn verify_fallthrough(
     current_function: FunctionDefinitionIndex,
-    code: &Vec<Bytecode>,
+    code: &[Bytecode],
 ) -> PartialVMResult<()> {
     // Check to make sure that the bytecode vector ends with a branching
     // instruction.

--- a/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/interpreter.rs
+++ b/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/interpreter.rs
@@ -1297,11 +1297,7 @@ impl Frame {
             for instruction in &code[self.pc as usize..] {
                 trace!(
                     &self.function,
-                    &self.locals,
-                    self.pc,
-                    instruction,
-                    resolver,
-                    interpreter
+                    &self.locals, self.pc, instruction, resolver, interpreter
                 );
 
                 fail_point!("move_vm::interpreter_loop", |_| {

--- a/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/tracing.rs
+++ b/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/tracing.rs
@@ -48,7 +48,6 @@ static DEBUGGING_ENABLED: Lazy<bool> =
 static LOGGING_FILE: Lazy<Mutex<File>> = Lazy::new(|| {
     Mutex::new(
         OpenOptions::new()
-            .write(true)
             .create(true)
             .append(true)
             .open(&*FILE_PATH)


### PR DESCRIPTION
Replicates https://github.com/MystenLabs/sui/pull/17130/files#diff-f4bc7020d176413d4b8fe7590870bc6bc81259781fc9a1c1f681fce00a5b7edbR6.

Running `rustfmt` from the root was failing with errors like the following because the `move-execution` crates weren't added to the `external-crates` workspace.

```
`cargo metadata` exited with an error: error: current package believes it's in a workspace when it's not:
current:   /Users/thibault/iota/iota/external-crates/move/move-execution/v0/crates/move-stdlib/Cargo.toml
workspace: /Users/thibault/iota/iota/external-crates/move/Cargo.toml

this may be fixable by adding `move-execution/v0/crates/move-stdlib` to the `workspace.members` array of the manifest located at: /Users/thibault/iota/iota/external-crates/move/Cargo.toml
Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.

This utility formats all bin and lib files of the current crate using rustfmt.
```

