### PR TITLE
fix(scripts): Fix missing dependency graphs

### DIFF
--- a/scripts/dependency_graphs/create_graphs.py
+++ b/scripts/dependency_graphs/create_graphs.py
@@ -152,7 +152,7 @@ if __name__ == '__main__':
 
     # Run the cargo tree command and store the output in a string variable
     # `--prefix depth` shows the dependency depth of a package
-    # `--format ' {p}'` adds a space between depth and pacakge name
+    # `--format ' {p}'` adds a space between depth and package name
     cargo_cmd = ['cargo', 'tree', '--prefix', 'depth', '--format', ' {p}']
     if skip_dev_dependencies :
         cargo_cmd.extend(['-e','no-dev'])

--- a/scripts/dependency_graphs/create_graphs.py
+++ b/scripts/dependency_graphs/create_graphs.py
@@ -152,6 +152,7 @@ if __name__ == '__main__':
 
     # Run the cargo tree command and store the output in a string variable
     # `--prefix depth` shows the dependency depth of a package
+    # `--format ' {p}'` adds a space between depth and pacakge name
     cargo_cmd = ['cargo', 'tree', '--prefix', 'depth', '--format', ' {p}']
     if skip_dev_dependencies :
         cargo_cmd.extend(['-e','no-dev'])


### PR DESCRIPTION
# Description of change

This PR fixes the missing dependency graph of some crates (e.g., `iota-core`, `iota-node`). 
Instead of calculating the depth and skipping dev-dependency line by line, we can get the correct numbers from cargo tree with options (`-e no-dev` and `--prefix depth`).


## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

I can navigate through the dependencies via my browser. 
And there are graphs for the missing ones: `iota-node`, `iota-core` etc.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
