### PR TITLE
chore(iota): disable code ownership of root Cargo.lock

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,3 +41,6 @@ vercel.json @iotaledger/boxfish @iotaledger/tooling
 
 # Protect this CODEOWNERS file, with some fallback in case of unavailability
 /.github/CODEOWNERS @luca-moser @lzpap @miker83z @fijter
+
+# Disable code ownership as it is generated and does not need review
+./Cargo.lock


### PR DESCRIPTION
A proposal to discuss.
This file is generated from *.toml files that are themselves under code ownership so it shouldn't require itself ownership.
This creates situations like https://github.com/iotaledger/iota/pull/1458 where a PR could have been merged by the dev-tools teams on its own but it then requires l1-core, which is just annoying for them.