### PR TITLE
chore(iota): disable code ownership of root pnpm-lock.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,6 +41,6 @@ vercel.json @iotaledger/boxfish @iotaledger/tooling
 # Protect this CODEOWNERS file, with some fallback in case of unavailability
 /.github/CODEOWNERS @luca-moser @lzpap @miker83z @fijter
 
-# Disable code ownership as it is generated and does not need review
+# Disable code ownership for these auto-generated files
 /Cargo.lock
 /pnpm-lock.yaml

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,7 +23,6 @@
 .prettierignore @iotaledger/boxfish @iotaledger/tooling
 graphql.config.ts @iotaledger/boxfish @iotaledger/tooling
 package.json @iotaledger/boxfish @iotaledger/tooling
-pnpm-lock.yaml @iotaledger/boxfish @iotaledger/tooling
 pnpm-workspace.yaml @iotaledger/boxfish @iotaledger/tooling
 prettier.config.js @iotaledger/boxfish @iotaledger/tooling
 turbo.json @iotaledger/boxfish @iotaledger/tooling

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,3 +44,4 @@ vercel.json @iotaledger/boxfish @iotaledger/tooling
 
 # Disable code ownership as it is generated and does not need review
 ./Cargo.lock
+./pnpm-lock.yaml


### PR DESCRIPTION
# Description of change

Same reasons basically as in https://github.com/iotaledger/iota/pull/1460. As the ownership is already checked by changing the source files themselves it makes no sense to enable it for the lock file.