### PR TITLE
feat: Bump Iota to v0.1.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - uses: taiki-e/install-action@nextest
       - name: cargo test
-        run: cargo nextest run --profile ci -E 'rdeps(iota-sdk)' -p iota-sdk@1.22.0
+        run: cargo nextest run --profile ci -E 'rdeps(iota-sdk)' -p iota-sdk@0.1.1
 
   diff:
     runs-on: [self-hosted-rust]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5078,7 +5078,7 @@ dependencies = [
 
 [[package]]
 name = "iota"
-version = "1.22.0"
+version = "0.1.1"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5114,7 +5114,7 @@ dependencies = [
  "iota-move-build",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.22.0",
+ "iota-sdk 0.1.1",
  "iota-simulator",
  "iota-source-validation",
  "iota-swarm",
@@ -5219,7 +5219,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer"
-version = "1.22.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -5271,7 +5271,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer-derive"
-version = "1.22.0"
+version = "0.1.1"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
@@ -5377,7 +5377,7 @@ dependencies = [
  "iota-macros",
  "iota-network",
  "iota-protocol-config",
- "iota-sdk 1.22.0",
+ "iota-sdk 0.1.1",
  "iota-simulator",
  "iota-storage",
  "iota-swarm-config",
@@ -5423,7 +5423,7 @@ dependencies = [
  "iota-json",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 1.22.0",
+ "iota-sdk 0.1.1",
  "iota-swarm",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -5717,7 +5717,7 @@ dependencies = [
  "iota-move-build",
  "iota-node",
  "iota-protocol-config",
- "iota-sdk 1.22.0",
+ "iota-sdk 0.1.1",
  "iota-simulator",
  "iota-storage",
  "iota-swarm",
@@ -5786,7 +5786,7 @@ dependencies = [
 
 [[package]]
 name = "iota-faucet"
-version = "1.22.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -5800,7 +5800,7 @@ dependencies = [
  "iota-config",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 1.22.0",
+ "iota-sdk 0.1.1",
  "iota-types",
  "mysten-metrics",
  "parking_lot 0.12.3",
@@ -5978,7 +5978,7 @@ dependencies = [
  "iota-package-resolver",
  "iota-protocol-config",
  "iota-rest-api",
- "iota-sdk 1.22.0",
+ "iota-sdk 0.1.1",
  "iota-swarm-config",
  "iota-types",
  "lru 0.10.1",
@@ -6038,7 +6038,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer"
-version = "1.22.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6064,7 +6064,7 @@ dependencies = [
  "iota-package-resolver",
  "iota-protocol-config",
  "iota-rest-api",
- "iota-sdk 1.22.0",
+ "iota-sdk 0.1.1",
  "iota-test-transaction-builder",
  "iota-transaction-builder",
  "iota-types",
@@ -6200,7 +6200,7 @@ dependencies = [
  "iota-open-rpc",
  "iota-open-rpc-macros",
  "iota-protocol-config",
- "iota-sdk 1.22.0",
+ "iota-sdk 0.1.1",
  "iota-simulator",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -6277,7 +6277,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-package-resolver",
  "iota-rest-api",
- "iota-sdk 1.22.0",
+ "iota-sdk 0.1.1",
  "iota-types",
  "move-binary-format",
  "move-core-types",
@@ -6320,7 +6320,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move"
-version = "1.22.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6362,7 +6362,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "1.22.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "datatest-stable",
@@ -6461,7 +6461,7 @@ dependencies = [
 
 [[package]]
 name = "iota-node"
-version = "1.22.0"
+version = "0.1.1"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6509,7 +6509,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.22.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6618,7 +6618,7 @@ dependencies = [
  "iota-json-rpc-api",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.22.0",
+ "iota-sdk 0.1.1",
  "iota-storage",
  "iota-types",
  "jsonrpsee",
@@ -6683,7 +6683,7 @@ dependencies = [
  "iota-keys",
  "iota-move-build",
  "iota-node",
- "iota-sdk 1.22.0",
+ "iota-sdk 0.1.1",
  "iota-swarm-config",
  "iota-types",
  "move-core-types",
@@ -6707,7 +6707,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rpc-loadgen"
-version = "1.22.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6718,7 +6718,7 @@ dependencies = [
  "iota-json-rpc",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 1.22.0",
+ "iota-sdk 0.1.1",
  "iota-types",
  "itertools 0.13.0",
  "serde",
@@ -6727,6 +6727,42 @@ dependencies = [
  "shellexpand",
  "strum 0.26.3",
  "telemetry-subscribers",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "iota-sdk"
+version = "0.1.1"
+dependencies = [
+ "anyhow",
+ "async-recursion",
+ "async-trait",
+ "bcs",
+ "clap",
+ "colored",
+ "dirs 5.0.1",
+ "fastcrypto",
+ "futures",
+ "futures-core",
+ "iota-config",
+ "iota-json",
+ "iota-json-rpc-api",
+ "iota-json-rpc-types",
+ "iota-keys",
+ "iota-transaction-builder",
+ "iota-types",
+ "jsonrpsee",
+ "move-core-types",
+ "rand 0.8.5",
+ "reqwest 0.12.5",
+ "rustls 0.23.12",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "shared-crypto",
+ "tempfile",
+ "thiserror",
  "tokio",
  "tracing",
 ]
@@ -6769,42 +6805,6 @@ dependencies = [
  "tokio",
  "url",
  "zeroize",
-]
-
-[[package]]
-name = "iota-sdk"
-version = "1.22.0"
-dependencies = [
- "anyhow",
- "async-recursion",
- "async-trait",
- "bcs",
- "clap",
- "colored",
- "dirs 5.0.1",
- "fastcrypto",
- "futures",
- "futures-core",
- "iota-config",
- "iota-json",
- "iota-json-rpc-api",
- "iota-json-rpc-types",
- "iota-keys",
- "iota-transaction-builder",
- "iota-types",
- "jsonrpsee",
- "move-core-types",
- "rand 0.8.5",
- "reqwest 0.12.5",
- "rustls 0.23.12",
- "serde",
- "serde_json",
- "serde_with",
- "shared-crypto",
- "tempfile",
- "thiserror",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation"
-version = "1.22.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "colored",
@@ -6902,7 +6902,7 @@ dependencies = [
  "futures",
  "iota-json-rpc-types",
  "iota-move-build",
- "iota-sdk 1.22.0",
+ "iota-sdk 0.1.1",
  "iota-test-transaction-builder",
  "iota-types",
  "move-binary-format",
@@ -6938,7 +6938,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-move",
  "iota-move-build",
- "iota-sdk 1.22.0",
+ "iota-sdk 0.1.1",
  "iota-source-validation",
  "jsonrpsee",
  "move-compiler",
@@ -7021,7 +7021,7 @@ dependencies = [
 
 [[package]]
 name = "iota-surfer"
-version = "1.22.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7106,7 +7106,7 @@ dependencies = [
  "bcs",
  "iota-genesis-builder",
  "iota-move-build",
- "iota-sdk 1.22.0",
+ "iota-sdk 0.1.1",
  "iota-types",
  "move-core-types",
  "shared-crypto",
@@ -7131,7 +7131,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tool"
-version = "1.22.0"
+version = "0.1.1"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -7155,7 +7155,7 @@ dependencies = [
  "iota-network",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.22.0",
+ "iota-sdk 0.1.1",
  "iota-snapshot",
  "iota-storage",
  "iota-types",
@@ -13369,7 +13369,7 @@ dependencies = [
  "iota-macros",
  "iota-node",
  "iota-protocol-config",
- "iota-sdk 1.22.0",
+ "iota-sdk 0.1.1",
  "iota-simulator",
  "iota-swarm",
  "iota-swarm-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by iota-core, iota-faucet, iota-node, iota-tools, iota-sdk, iota-move-build, and iota crates.
-version = "1.22.0"
+version = "0.1.1"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/crates/iota-framework/packages/deepbook/Move.lock
+++ b/crates/iota-framework/packages/deepbook/Move.lock
@@ -23,6 +23,6 @@ name = "MoveStdlib"
 source = { local = "../move-stdlib" }
 
 [move.toolchain-version]
-compiler-version = "1.22.0"
+compiler-version = "0.1.1"
 edition = "legacy"
 flavor = "iota"

--- a/crates/iota-framework/packages/iota-framework/Move.lock
+++ b/crates/iota-framework/packages/iota-framework/Move.lock
@@ -14,6 +14,6 @@ name = "MoveStdlib"
 source = { local = "../move-stdlib" }
 
 [move.toolchain-version]
-compiler-version = "1.22.0"
+compiler-version = "0.1.1"
 edition = "legacy"
 flavor = "iota"

--- a/crates/iota-framework/packages/iota-system/Move.lock
+++ b/crates/iota-framework/packages/iota-system/Move.lock
@@ -23,6 +23,6 @@ name = "MoveStdlib"
 source = { local = "../move-stdlib" }
 
 [move.toolchain-version]
-compiler-version = "1.22.0"
+compiler-version = "0.1.1"
 edition = "legacy"
 flavor = "iota"

--- a/crates/iota-framework/packages/move-stdlib/Move.lock
+++ b/crates/iota-framework/packages/move-stdlib/Move.lock
@@ -6,6 +6,6 @@ manifest_digest = "774F1883683AAACD2512A2B6C01188350E10E5A035E065A8CF110CE44A564
 deps_digest = "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855"
 
 [move.toolchain-version]
-compiler-version = "1.22.0"
+compiler-version = "0.1.1"
 edition = "legacy"
 flavor = "iota"

--- a/crates/iota-framework/packages/stardust/Move.lock
+++ b/crates/iota-framework/packages/stardust/Move.lock
@@ -23,6 +23,6 @@ name = "MoveStdlib"
 source = { local = "../move-stdlib" }
 
 [move.toolchain-version]
-compiler-version = "1.22.0"
+compiler-version = "0.1.1"
 edition = "legacy"
 flavor = "iota"

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -4,15 +4,15 @@
     "title": "Iota JSON-RPC",
     "description": "Iota JSON-RPC API for interaction with Iota Full node. Make RPC calls using https://fullnode.NETWORK.iota.io:443, where NETWORK is the network you want to use (testnet, devnet, mainnet). By default, local networks use port 9000.",
     "contact": {
-      "name": "Mysten Labs",
-      "url": "https://mystenlabs.com",
-      "email": "build@mystenlabs.com"
+      "name": "IOTA Foundation",
+      "url": "https://iota.org",
+      "email": "contact@iota.org"
     },
     "license": {
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/iotaledger/iota/main/LICENSE"
     },
-    "version": "1.22.0"
+    "version": "0.1.1"
   },
   "methods": [
     {


### PR DESCRIPTION
# Description of change

Start software versioning in root `Cargo.toml` that should propegate to other crates as well (iota-core, iota-sdk, etc.)

## Notes
 - In principal a version bump shall only change the root Cargo.toml and .lock files, plus the openrpc.json spec file. Due to the latter being out of date, tests will fail on this PR until #1513 is done.


