### PR TITLE
chore(docker): building images with latest rust release

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -65,6 +65,7 @@ jobs:
           platforms: linux/amd64
           tags: ${{ steps.meta-node.outputs.tags }}
           push: true
+          pull: true
 
   build-iota-indexer:
     if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.iota_indexer == 'true' || github.event_name == 'release' }}
@@ -109,6 +110,7 @@ jobs:
           platforms: linux/amd64
           tags: ${{ steps.meta-indexer.outputs.tags }}
           push: true
+          pull: true
 
   build-iota-tools:
     if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.iota_tools == 'true' || github.event_name == 'release' }}
@@ -153,3 +155,4 @@ jobs:
           platforms: linux/amd64
           tags: ${{ steps.meta-tools.outputs.tags }}
           push: true
+          pull: true

--- a/docker/iota-graphql-rpc/Dockerfile
+++ b/docker/iota-graphql-rpc/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.75-bullseye AS builder
+FROM rust:bullseye AS builder
 ARG PROFILE=release
 ENV PROFILE=$PROFILE
 ARG GIT_REVISION

--- a/docker/iota-indexer/Dockerfile
+++ b/docker/iota-indexer/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.75-bullseye AS builder
+FROM rust:bullseye AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/iota-node/Dockerfile
+++ b/docker/iota-node/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.75-bullseye AS builder
+FROM rust:bullseye AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/iota-tools/Dockerfile
+++ b/docker/iota-tools/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.75-bullseye AS builder
+FROM rust:bullseye AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION


### PR DESCRIPTION
# Description of change

Using the latest Rust release to build the Docker images for release. 
Otherwise, this issue causes the GitHub action to fail, in https://github.com/iotaledger/iota/actions/runs/10165485104

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Testing with `act` locally
