### PR TITLE
fix(iota-genesis-builder): save and load migration sources correctly

### DIFF
--- a/crates/iota-genesis-builder/Cargo.toml
+++ b/crates/iota-genesis-builder/Cargo.toml
@@ -29,8 +29,8 @@ serde_json.workspace = true
 serde_with.workspace = true
 serde_yaml.workspace = true
 tempfile.workspace = true
-tokio.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
 tracing.workspace = true
 
 bigdecimal = "0.4.3"

--- a/crates/iota-genesis-builder/Cargo.toml
+++ b/crates/iota-genesis-builder/Cargo.toml
@@ -29,6 +29,7 @@ serde_json.workspace = true
 serde_with.workspace = true
 serde_yaml.workspace = true
 tempfile.workspace = true
+tokio.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -756,7 +756,7 @@ impl Builder {
         // Load migration objects if any
         let migration_sources_file = path.join(GENESIS_BUILDER_MIGRATION_SOURCES_FILE);
         let migration_sources: Vec<SnapshotSource> = if migration_sources_file.exists() {
-            serde_yaml::from_slice(
+            serde_json::from_slice(
                 &fs::read(migration_sources_file)
                     .context("unable to read migration sources file")?,
             )
@@ -886,7 +886,7 @@ impl Builder {
 
         if !self.migration_sources.is_empty() {
             let file = path.join(GENESIS_BUILDER_MIGRATION_SOURCES_FILE);
-            fs::write(file, serde_yaml::to_string(&self.migration_sources)?)?;
+            fs::write(file, serde_json::to_string(&self.migration_sources)?)?;
         }
 
         Ok(())

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -737,7 +737,7 @@ impl Builder {
         }
     }
 
-    pub fn load<P: AsRef<Path>>(path: P) -> anyhow::Result<Self, anyhow::Error> {
+    pub async fn load<P: AsRef<Path>>(path: P) -> anyhow::Result<Self, anyhow::Error> {
         let path = path.as_ref();
         let path: &Utf8Path = path.try_into()?;
         trace!("Reading Genesis Builder from {}", path);
@@ -817,8 +817,9 @@ impl Builder {
 
         let unsigned_genesis_file = path.join(GENESIS_BUILDER_UNSIGNED_GENESIS_FILE);
         if unsigned_genesis_file.exists() {
+            let reader = BufReader::new(File::open(unsigned_genesis_file)?);
             let loaded_genesis: UnsignedGenesis =
-                bcs::from_reader(BufReader::new(File::open(unsigned_genesis_file)?))?;
+                tokio::task::spawn_blocking(move || bcs::from_reader(reader)).await??;
 
             // If we have a built genesis, then we must have a token_distribution_schedule
             // present as well.
@@ -828,10 +829,14 @@ impl Builder {
             );
 
             // Verify loaded genesis matches one build from the constituent parts
-            let built = builder.get_or_build_unsigned_genesis();
+            builder = tokio::task::spawn_blocking(move || {
+                builder.get_or_build_unsigned_genesis();
+                builder
+            })
+            .await?;
             loaded_genesis.checkpoint_contents.digest(); // cache digest before compare
             assert!(
-                *built == loaded_genesis,
+                *builder.get_or_build_unsigned_genesis() == loaded_genesis,
                 "loaded genesis does not match built genesis"
             );
 
@@ -1577,9 +1582,9 @@ mod test {
         std::io::Write::write_all(&mut std::io::stdout(), &output).unwrap();
     }
 
-    #[test]
+    #[tokio::test]
     #[cfg_attr(msim, ignore)]
-    fn ceremony() {
+    async fn ceremony() {
         let dir = tempfile::TempDir::new().unwrap();
 
         let key: AuthorityKeyPair = get_key_pair_from_rng(&mut rand::rngs::OsRng).1;
@@ -1610,6 +1615,6 @@ mod test {
             println!("ObjectID: {} Type: {:?}", object.id(), object.type_());
         }
         builder.save(dir.path()).unwrap();
-        Builder::load(dir.path()).unwrap();
+        Builder::load(dir.path()).await.unwrap();
     }
 }

--- a/crates/iota/src/genesis_ceremony.rs
+++ b/crates/iota/src/genesis_ceremony.rs
@@ -156,7 +156,7 @@ pub async fn run(cmd: Ceremony) -> Result<()> {
         }
 
         CeremonyCommand::ValidateState => {
-            let builder = Builder::load(&dir)?;
+            let builder = Builder::load(&dir).await?;
             builder.validate()?;
             println!(
                 "Successfully validated ceremony builder at {}",
@@ -168,7 +168,7 @@ pub async fn run(cmd: Ceremony) -> Result<()> {
             recipient_address,
             amount_nanos,
         } => {
-            let mut builder = Builder::load(&dir)?;
+            let mut builder = Builder::load(&dir).await?;
             let token_allocation = TokenAllocation {
                 recipient_address,
                 amount_nanos,
@@ -196,7 +196,7 @@ pub async fn run(cmd: Ceremony) -> Result<()> {
             image_url,
             project_url,
         } => {
-            let mut builder = Builder::load(&dir)?;
+            let mut builder = Builder::load(&dir).await?;
             let keypair: AuthorityKeyPair = read_authority_keypair_from_file(validator_key_file)?;
             let account_keypair: IotaKeyPair = read_keypair_from_file(account_key_file)?;
             let worker_keypair: NetworkKeyPair = read_network_keypair_from_file(worker_key_file)?;
@@ -226,7 +226,7 @@ pub async fn run(cmd: Ceremony) -> Result<()> {
         }
 
         CeremonyCommand::ListValidators => {
-            let builder = Builder::load(&dir)?;
+            let builder = Builder::load(&dir).await?;
 
             let mut validators = builder
                 .validators()
@@ -270,7 +270,7 @@ pub async fn run(cmd: Ceremony) -> Result<()> {
                 .into_iter()
                 .map(SnapshotSource::S3);
 
-            let mut builder = Builder::load(&dir)?;
+            let mut builder = Builder::load(&dir).await?;
             for source in local_snapshots.chain(remote_snapshots) {
                 builder = builder.add_migration_source(source);
             }
@@ -287,7 +287,7 @@ pub async fn run(cmd: Ceremony) -> Result<()> {
         }
 
         CeremonyCommand::ExamineGenesisCheckpoint => {
-            let builder = Builder::load(&dir)?;
+            let builder = Builder::load(&dir).await?;
 
             let Some(unsigned_genesis) = builder.unsigned_genesis_checkpoint() else {
                 return Err(anyhow::anyhow!(
@@ -301,7 +301,7 @@ pub async fn run(cmd: Ceremony) -> Result<()> {
         CeremonyCommand::VerifyAndSign { key_file } => {
             let keypair: AuthorityKeyPair = read_authority_keypair_from_file(key_file)?;
 
-            let mut builder = Builder::load(&dir)?;
+            let mut builder = Builder::load(&dir).await?;
 
             check_protocol_version(&builder, protocol_version)?;
 
@@ -323,7 +323,8 @@ pub async fn run(cmd: Ceremony) -> Result<()> {
         }
 
         CeremonyCommand::Finalize => {
-            let builder = Builder::load(&dir)?;
+            let builder = Builder::load(&dir).await?;
+
             check_protocol_version(&builder, protocol_version)?;
 
             let genesis = builder.build();


### PR DESCRIPTION
# Description of change

This patch fixes a serialization bug while calling `iota_genesis_builder::Builder::save`. Namely, when we set a `SnapshotUrl::Test(Url)` value as a migration source to the builder, `Builder::save` tries to serialize the migration sources in YAML which fails with the following error:

```
serializing nested enums in YAML is not supported yet
```

To fix this we simply opted in serializing in JSON.

In addition, this patch fixes a related bug that arises when calling `Builder::load`  from within an asynchronous runtime. Namely, `Builder::load` tries to rebuild genesis from the deserialized migration sources, and thus calls the `reqwest::blocking::get` which should be called as a blocking task, otherwise we get this error

```
Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.
```

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested
```
cargo test -j2 -p iota ceremony
```

After applying this patch

```diff
diff --git a/crates/iota/src/genesis_ceremony.rs b/crates/iota/src/genesis_ceremony.rs
index 0e74e90b2d..ef6a4b42a8 100644
--- a/crates/iota/src/genesis_ceremony.rs
+++ b/crates/iota/src/genesis_ceremony.rs
@@ -466,12 +466,15 @@ mod test {
         }
 
         // Build the unsigned checkpoint
+        const TEST_SNAPSHOT_URL: &str = "https://stardust-objects.s3.eu-central-1.amazonaws.com/iota/alphanet/test/stardust_object_snapshot.bin.gz";
         let command = Ceremony {
             path: Some(dir.path().into()),
             protocol_version: MAX_PROTOCOL_VERSION,
             command: CeremonyCommand::BuildUnsignedCheckpoint {
                 local_migration_snapshots: vec![],
-                remote_migration_snapshots: vec![],
+                remote_migration_snapshots: vec![SnapshotUrl::Test(
+                    TEST_SNAPSHOT_URL.parse().unwrap(),
+                )],
             },
         };
```

and
 
```
cargo test -j2 -p iota-genesis-builder ceremony
```
