### PR TITLE
feat(ci): add docs examples in rust

### DIFF
--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -32,6 +32,7 @@ runs:
             - "external-crates/**"
             - "narwhal/**"
             - "iota-execution/**"
+            - "docs/examples/rust/**"
             - ".github/workflows/codecov.yml"
             - ".github/workflows/rust.yml"
             - ".github/workflows/external.yml"


### PR DESCRIPTION
# Description of change

This PR adds `docs/examples/rust` to the list of `isRust` in the CI actions.

## Links to any relevant issues

Fixes #1509 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Run the CI with an error in `docs/examples/rust`.