### PR TITLE
feat(workflows): add workflow to report CI failures on develop to slack

### DIFF
--- a/.github/workflows/develop-ci-slack-report.yml
+++ b/.github/workflows/develop-ci-slack-report.yml
@@ -1,0 +1,21 @@
+name: Report develop CI failure to slack
+
+on:
+  workflow_run:
+    workflows: ["*"]
+    types: [completed]
+    branches: [develop]
+
+jobs:
+  on-failure:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out'
+    steps:
+      - uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ github.event.workflow_run.conclusion }}
+          notification_title: " ${{github.event.workflow_run.name}} - ${{github.event.workflow_run.conclusion}} on ${{github.event.workflow_run.head_branch}}"
+          message_format: ":fire: *${{github.event.workflow_run.name}}* ${{github.event.workflow_run.conclusion}} <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure> author: ${{ github.event.workflow_run.head_commit.author.name }}"
+          footer: "${{ github.event.workflow_run.display_title }} \n<${{github.server_url}}/${{github.repository}}/commit/${{github.event.workflow_run.head_commit.id}}>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.DEV_BROKEN_CI_SLACK_WEBHOOK }}


### PR DESCRIPTION
# Description of change

Add workflow to report CI failures on develop to slack so we have better visibility on failures there
The DEV_BROKEN_CI_SLACK_WEBHOOK secret was already added to the repo

## Links to any relevant issues

Fixes #1370 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested in another repository with failing CI, message in slack looks like this
![image](https://github.com/user-attachments/assets/609f36c2-fe16-47a8-966b-2741884b906e)


