### PR TITLE
feat(ci): Build nightly indexer

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 80
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [self-hosted]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 80
     strategy:
       matrix:
-        os: [self-hosted]
+        os: [ubuntu-20.04]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -76,7 +76,7 @@ jobs:
       - name: cargo build (release) for ${{ matrix.os }} platform
         shell: bash
         run: |
-          [ -f ~/.cargo/env ] && source ~/.cargo/env ; cargo build --release --bin iota --bin iota-test-validator
+          [ -f ~/.cargo/env ] && source ~/.cargo/env ; cargo build --release --bin iota --bin iota-test-validator --bin iota-indexer
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -85,3 +85,4 @@ jobs:
           path: |
             ./target/release/iota
             ./target/release/iota-test-validator
+            ./target/release/iota-indexer


### PR DESCRIPTION
Closes https://github.com/iotaledger/iota/issues/1625

https://github.com/iotaledger/iota/actions/runs/10262209988

why not? :) it might be useful if for any reason we need to run a node locally, the explorer uses some methods from the extended api.