### PR TITLE
fix(docs/iota): fix commands and tables, remove useless whitespaces

### DIFF
--- a/crates/iota-keys/src/keystore.rs
+++ b/crates/iota-keys/src/keystore.rs
@@ -151,12 +151,12 @@ impl Display for Keystore {
         let mut writer = String::new();
         match self {
             Keystore::File(file) => {
-                writeln!(writer, "Keystore Type : File")?;
+                writeln!(writer, "Keystore Type: File")?;
                 write!(writer, "Keystore Path : {:?}", file.path)?;
                 write!(f, "{}", writer)
             }
             Keystore::InMem(_) => {
-                writeln!(writer, "Keystore Type : InMem")?;
+                writeln!(writer, "Keystore Type: InMem")?;
                 write!(f, "{}", writer)
             }
         }

--- a/crates/iota-sdk/src/error.rs
+++ b/crates/iota-sdk/src/error.rs
@@ -15,14 +15,14 @@ pub enum Error {
     Rpc(#[from] jsonrpsee::core::ClientError),
     #[error(transparent)]
     BcsSerialization(#[from] bcs::Error),
-    #[error("Subscription error : {0}")]
+    #[error("Subscription error: {0}")]
     Subscription(String),
     #[error("Failed to confirm tx status for {0:?} within {1} seconds.")]
     FailToConfirmTransactionStatus(TransactionDigest, u64),
     #[error("Data error: {0}")]
     Data(String),
     #[error(
-        "Client/Server api version mismatch, client api version : {client_version}, server api version : {server_version}"
+        "Client/Server api version mismatch, client api version: {client_version}, server api version: {server_version}"
     )]
     ServerVersionMismatch {
         client_version: String,

--- a/crates/iota-sdk/src/iota_client_config.rs
+++ b/crates/iota-sdk/src/iota_client_config.rs
@@ -116,7 +116,7 @@ impl IotaEnv {
 impl Display for IotaEnv {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut writer = String::new();
-        writeln!(writer, "Active environment : {}", self.alias)?;
+        writeln!(writer, "Active environment: {}", self.alias)?;
         write!(writer, "RPC URL: {}", self.rpc)?;
         if let Some(ws) = &self.ws {
             writeln!(writer)?;
@@ -134,7 +134,7 @@ impl Display for IotaClientConfig {
 
         writeln!(
             writer,
-            "Managed addresses : {}",
+            "Managed addresses: {}",
             self.keystore.addresses().len()
         )?;
         write!(writer, "Active address: ")?;

--- a/crates/iota/src/client_ptb/ptb.rs
+++ b/crates/iota/src/client_ptb/ptb.rs
@@ -347,10 +347,10 @@ pub fn ptb_description() -> clap::Command {
         .value_names(["INTO_COIN", "[COIN OBJECTS]"]))
         .arg(arg!(
             --"move-call" <MOVE_CALL>
-            "Make a move call to a function."
+            "Make a Move call to a function."
         )
         .long_help(
-            "Make a move call to a function.\
+            "Make a Move call to a function.\
             \n\nExamples:\
             \n --move-call std::option::is_none <u64> none\
             \n --assign a none\
@@ -396,7 +396,7 @@ pub fn ptb_description() -> clap::Command {
         ).value_hint(ValueHint::DirPath))
         .arg(arg!(
             --"upgrade" <MOVE_PACKAGE_PATH>
-            "Upgrade the move package. It takes as input the folder where the package exists."
+            "Upgrade the Move package. It takes as input the folder where the package exists."
         ).value_hint(ValueHint::DirPath))
         .arg(arg!(
             --"preview"

--- a/crates/iota/src/console.rs
+++ b/crates/iota/src/console.rs
@@ -47,14 +47,14 @@ pub async fn start_console(
         version.push('-');
         version.push_str(git_rev);
     }
-    writeln!(out, "--- Iota Console {version} ---")?;
+    writeln!(out, "--- IOTA Console {version} ---")?;
     writeln!(out)?;
     writeln!(out, "{}", context.config.deref())?;
 
     let client = context.get_client().await?;
     writeln!(
         out,
-        "Connecting to Iota full node. API version {}",
+        "Connecting to IOTA full node. API version {}",
         client.api_version()
     )?;
 
@@ -76,7 +76,7 @@ pub async fn start_console(
     }
 
     writeln!(out)?;
-    writeln!(out, "Welcome to the Iota interactive console.")?;
+    writeln!(out, "Welcome to the IOTA interactive console.")?;
     writeln!(out)?;
 
     let mut shell = Shell::new(

--- a/docs/content/references/cli/console.mdx
+++ b/docs/content/references/cli/console.mdx
@@ -20,15 +20,14 @@ For all available commands, consult the [IOTA Client CLI docs](./client.mdx). To
    / // __ \/ __/ __ `/  / /   / __ \/ __ \/ ___/ __ \/ / _ \
  _/ // /_/ / /_/ /_/ /  / /___/ /_/ / / / (__  ) /_/ / /  __/
 /___/\____/\__/\__,_/   \____/\____/_/ /_/____/\____/_/\___/ 
---- IOTA Console 1.14.0 ---
+--- IOTA Console 0.1.2 ---
 
-Managed addresses : 2
+Managed addresses: 2
 Active address: 0x3...235
-Keystore Type : File
-Keystore Path : Some("/Users/user/.iota/iota_config/iota.keystore")
-Active environment : testnet
+Keystore Type: File
+Keystore Path: Some("/Users/user/.iota/iota_config/iota.keystore")
+Active environment: testnet
 RPC URL: https://fullnode.testnet.iota.io:443
-[warn] Client/Server api version mismatch, client api version : 1.14.0, server api version : 1.13.0
 Connecting to IOTA full node. API version 1.13.0
 
 Available RPC methods: ["iota_devInspectTransactionBlock", "iota_dryRunTransactionBlock", "iota_executeTransactionBlock", 
@@ -42,7 +41,7 @@ Available RPC methods: ["iota_devInspectTransactionBlock", "iota_dryRunTransacti
 "iotax_getTotalSupply", "iotax_getValidatorsApy", "iotax_queryEvents", "iotax_queryTransactionBlocks", "iotax_resolveNameServiceAddress", 
 "iotax_resolveNameServiceNames", "iotax_subscribeEvent", "iotax_subscribeTransaction", "unsafe_batchTransaction", "unsafe_mergeCoins", 
 "unsafe_moveCall", "unsafe_pay", "unsafe_payAllIOTA", "unsafe_payIOTA", "unsafe_publish", "unsafe_requestAddStake", 
-"unsafe_requestWithdrawStake", "unsafe_splitCoin", "unsafe_splitCoinEqual", "unsafe_transferObject", "unsafe_transferIOTA"]
+"unsafe_requestWithdrawStake", "unsafe_splitCoin", "unsafe_splitCoinEqual", "unsafe_transferIOTA", "unsafe_transferObject"]
 
 Welcome to the IOTA interactive console.
 

--- a/docs/content/references/cli/console.mdx
+++ b/docs/content/references/cli/console.mdx
@@ -20,7 +20,7 @@ For all available commands, consult the [IOTA Client CLI docs](./client.mdx). To
    / // __ \/ __/ __ `/  / /   / __ \/ __ \/ ___/ __ \/ / _ \
  _/ // /_/ / /_/ /_/ /  / /___/ /_/ / / / (__  ) /_/ / /  __/
 /___/\____/\__/\__,_/   \____/\____/_/ /_/____/\____/_/\___/ 
---- IOTA Console 0.1.2 ---
+--- IOTA Console 0.1.3 ---
 
 Managed addresses: 2
 Active address: 0x3...235

--- a/docs/content/references/cli/move.mdx
+++ b/docs/content/references/cli/move.mdx
@@ -14,34 +14,38 @@ The IOTA CLI `move` command provides several commands for working with Move sour
 Typing `iota move --help` into your terminal or console displays the following information on available commands.
 
 ```
+Tool to build and test Move applications
+
 Usage: iota move [OPTIONS] <COMMAND>
 
 Commands:
-  build
-  coverage 	Inspect test coverage for this package. A previous test run with the `--coverage` flag must have previously been run
-  disassemble
-  new      	Create a new Move package with name `name` at `path`. If `path` is not provided the package will be created in the directory `name`
-  prove    	Run the Move Prover on the package at `path`. If no path is provided defaults to current directory. Use `.. prove .. -- <options>` to pass on options to the
-               	prover
-  test     	Run Move unit tests in this package
-  help     	Print this message or the help of the given subcommand(s)
+  build           
+  coverage        Inspect test coverage for this package. A previous test run with the `--coverage` flag must have previously been run
+  disassemble     
+  manage-package  Record addresses (Object IDs) for where this package is published on chain (this command sets variables in Move.lock)
+  migrate         Migrate to Move 2024 for the package at `path`. If no path is provided defaults to current directory
+  new             Create a new Move package with name `name` at `path`. If `path` is not provided the package will be created in the directory `name`
+  test            Run Move unit tests in this package
+  help            Print this message or the help of the given subcommand(s)
 
 Options:
-  -p, --path <PACKAGE_PATH>                 	Path to a package which the command should be run with respect to
-  -d, --dev                                 	Compile in 'dev' mode. The 'dev-addresses' and 'dev-dependencies' fields will be used if this flag is set. This flag is useful for
-                                            	development of packages that expose named addresses that are not set to a specific value
-  	--test                                	Compile in 'test' mode. The 'dev-addresses' and 'dev-dependencies' fields will be used along with any code in the 'tests' directory
-  	--doc                                 	Generate documentation for packages
-  	--abi                                 	Generate ABIs for packages
-  	--install-dir <INSTALL_DIR>           	Installation directory for compiled artifacts. Defaults to current directory
-  	--force                               	Force recompilation of all packages
-  	--fetch-deps-only                     	Only fetch dependency repos to MOVE_HOME
-  	--skip-fetch-latest-git-deps          	Skip fetching latest git dependencies
-  	--default-move-flavor <DEFAULT_FLAVOR>	Default flavor for move compilation, if not specified in the package's config
-  	--default-move-edition <DEFAULT_EDITION>  Default edition for move compilation, if not specified in the package's config
-  	--dependencies-are-root               	If set, dependency packages are treated as root packages. Notably, this will remove warning suppression in dependency packages
-  -h, --help                                	Print help
-  -V, --version                             	Print version
+  -p, --path <PACKAGE_PATH>                     Path to a package which the command should be run with respect to
+  -d, --dev                                     Compile in 'dev' mode. The 'dev-addresses' and 'dev-dependencies' fields will be used if this flag is set. This flag is useful for development of packages that expose named addresses that are not set to a specific value
+      --test                                    Compile in 'test' mode. The 'dev-addresses' and 'dev-dependencies' fields will be used along with any code in the 'tests' directory
+      --doc                                     Generate documentation for packages
+      --install-dir <INSTALL_DIR>               Installation directory for compiled artifacts. Defaults to current directory
+      --force                                   Force recompilation of all packages
+      --fetch-deps-only                         Only fetch dependency repos to MOVE_HOME
+      --skip-fetch-latest-git-deps              Skip fetching latest git dependencies
+      --default-move-flavor <DEFAULT_FLAVOR>    Default flavor for move compilation, if not specified in the package's config
+      --default-move-edition <DEFAULT_EDITION>  Default edition for move compilation, if not specified in the package's config
+      --dependencies-are-root                   If set, dependency packages are treated as root packages. Notably, this will remove warning suppression in dependency packages
+      --silence-warnings                        If set, ignore any compiler warnings
+      --warnings-are-errors                     If set, warnings become errors
+      --no-lint                                 If `true`, disable linters
+      --lint                                    If `true`, enables extra linters
+  -h, --help                                    Print help
+  -V, --version                                 Print version
 ```
 
 ## Examples
@@ -141,23 +145,25 @@ $ iota move build --help
 Usage: iota move build [OPTIONS]
 
 Options:
-  -p, --path <PACKAGE_PATH>                 	Path to a package which the command should be run with respect to
-  	--with-unpublished-dependencies       	Include the contents of packages in dependencies that haven't been published (only relevant when dumping bytecode as base64)
-  -d, --dev                                 	Compile in 'dev' mode. The 'dev-addresses' and 'dev-dependencies' fields will be used if this flag is set. This flag is useful for development
-                                            	of packages that expose named addresses that are not set to a specific value
-  	--dump-bytecode-as-base64             	Whether we are printing in base64
-  	--generate-struct-layouts             	If true, generate struct layout schemas for all struct types passed into `entry` functions declared by modules in this package These layout
-                                            	schemas can be consumed by clients (e.g., the TypeScript SDK) to enable serialization/deserialization of transaction arguments and events
-  	--test                                	Compile in 'test' mode. The 'dev-addresses' and 'dev-dependencies' fields will be used along with any code in the 'tests' directory
-  	--doc                                 	Generate documentation for packages
-  	--lint                                	If `true`, enable linters
-  	--abi                                 	Generate ABIs for packages
-  	--install-dir <INSTALL_DIR>           	Installation directory for compiled artifacts. Defaults to current directory
-  	--force                               	Force recompilation of all packages
-  	--fetch-deps-only                     	Only fetch dependency repos to MOVE_HOME
-  	--skip-fetch-latest-git-deps          	Skip fetching latest git dependencies
-  	--default-move-flavor <DEFAULT_FLAVOR>	Default flavor for move compilation, if not specified in the package's config
-  	--default-move-edition <DEFAULT_EDITION>  Default edition for move compilation, if not specified in the package's config
-  	--dependencies-are-root               	If set, dependency packages are treated as root packages. Notably, this will remove warning suppression in dependency packages
-  -h, --help                                	Print help
+  -p, --path <PACKAGE_PATH>                     Path to a package which the command should be run with respect to
+      --with-unpublished-dependencies           Include the contents of packages in dependencies that haven't been published (only relevant when dumping bytecode as base64)
+  -d, --dev                                     Compile in 'dev' mode. The 'dev-addresses' and 'dev-dependencies' fields will be used if this flag is set. This flag is useful for development of packages that expose named addresses that are not set to a specific value
+      --dump-bytecode-as-base64                 Whether we are printing in base64
+      --generate-struct-layouts                 If true, generate struct layout schemas for all struct types passed into `entry` functions declared by modules in this package These layout schemas can be consumed by clients (e.g., the TypeScript SDK) to enable serialization/deserialization of transaction
+                                                arguments and events
+      --test                                    Compile in 'test' mode. The 'dev-addresses' and 'dev-dependencies' fields will be used along with any code in the 'tests' directory
+      --doc                                     Generate documentation for packages
+      --install-dir <INSTALL_DIR>               Installation directory for compiled artifacts. Defaults to current directory
+      --force                                   Force recompilation of all packages
+      --fetch-deps-only                         Only fetch dependency repos to MOVE_HOME
+      --skip-fetch-latest-git-deps              Skip fetching latest git dependencies
+      --default-move-flavor <DEFAULT_FLAVOR>    Default flavor for move compilation, if not specified in the package's config
+      --default-move-edition <DEFAULT_EDITION>  Default edition for move compilation, if not specified in the package's config
+      --dependencies-are-root                   If set, dependency packages are treated as root packages. Notably, this will remove warning suppression in dependency packages
+      --silence-warnings                        If set, ignore any compiler warnings
+      --warnings-are-errors                     If set, warnings become errors
+      --no-lint                                 If `true`, disable linters
+      --lint                                    If `true`, enables extra linters
+  -h, --help                                    Print help
+  -V, --version                                 Print version
 ```

--- a/docs/content/references/cli/ptb.mdx
+++ b/docs/content/references/cli/ptb.mdx
@@ -12,25 +12,27 @@ The `client ptb` command allows you to specify the transactions for execution in
 The following list itemizes all the available args for the `iota client ptb` command. Use the `--help` for a long help version that includes some examples on how to use this command.
 
 ```
-Build, preview, and execute PTBs. Depending on your shell, you might have to use quotes around arrays or other passed values. Use --help to see examples for how to use the core functionality of this command.
+Build, preview, and execute programmable transaction blocks. Depending on your shell, you might have to use quotes around arrays or other passed values. Use --help to see examples for how to use the core functionality of this command.
 
 Usage: iota client ptb [OPTIONS]
 
 Options:
       --assign <NAME> <VALUE>                                         Assign a value to a variable name to use later in the PTB.
       --gas-coin <ID>                                                 The object ID of the gas coin to use. If not specified, it will try to use the first gas coin that it finds that has at least the requested gas-budget balance.
-      --gas-budget <NANOS>                                             The gas budget for the transaction, in NANOS.
+      --gas-budget <MICROS>                                           The gas budget for the transaction, in MICROS.
       --make-move-vec <TYPE> <[VALUES]>                               Given n-values of the same type, it constructs a vector. For non objects or an empty vector, the type tag must be specified.
       --merge-coins <INTO_COIN> <[COIN OBJECTS]>                      Merge N coins into the provided coin.
       --move-call <PACKAGE::MODULE::FUNCTION> <TYPE> <FUNCTION_ARGS>  Make a move call to a function.
       --split-coins <COIN> <[AMOUNT]>                                 Split the coin into N coins as per the given array of amounts.
       --transfer-objects <[OBJECTS]> <TO>                             Transfer objects to the specified address.
-      --publish <MOVE_PACKAGE_PATH>                                   Publish the move package. It takes as input the folder where the package exists.
+      --publish <MOVE_PACKAGE_PATH>                                   Publish the Move package. It takes as input the folder where the package exists.
       --upgrade <MOVE_PACKAGE_PATH>                                   Upgrade the move package. It takes as input the folder where the package exists.
       --preview                                                       Preview the list of PTB transactions instead of executing them.
+      --serialize-unsigned-transaction                                Instead of executing the transaction, serialize the bcs bytes of the unsigned transaction data using base64 encoding.
+      --serialize-signed-transaction                                  Instead of executing the transaction, serialize the bcs bytes of the signed transaction data using base64 encoding.
       --summary                                                       Show only a short summary (digest, execution status, gas cost). Do not use this flag when you need all the transaction data and the execution effects.
       --warn-shadows                                                  Enable shadow warning when the same variable name is declared multiple times. Off by default.
-      --json                                                          Return command outputs in json format
+      --json                                                          Return command outputs in json format.
   -h, --help                                                          Print help (see more with '--help')
 ```
 

--- a/docs/content/references/cli/ptb.mdx
+++ b/docs/content/references/cli/ptb.mdx
@@ -22,11 +22,11 @@ Options:
       --gas-budget <MICROS>                                           The gas budget for the transaction, in MICROS.
       --make-move-vec <TYPE> <[VALUES]>                               Given n-values of the same type, it constructs a vector. For non objects or an empty vector, the type tag must be specified.
       --merge-coins <INTO_COIN> <[COIN OBJECTS]>                      Merge N coins into the provided coin.
-      --move-call <PACKAGE::MODULE::FUNCTION> <TYPE> <FUNCTION_ARGS>  Make a move call to a function.
+      --move-call <PACKAGE::MODULE::FUNCTION> <TYPE> <FUNCTION_ARGS>  Make a Move call to a function.
       --split-coins <COIN> <[AMOUNT]>                                 Split the coin into N coins as per the given array of amounts.
       --transfer-objects <[OBJECTS]> <TO>                             Transfer objects to the specified address.
       --publish <MOVE_PACKAGE_PATH>                                   Publish the Move package. It takes as input the folder where the package exists.
-      --upgrade <MOVE_PACKAGE_PATH>                                   Upgrade the move package. It takes as input the folder where the package exists.
+      --upgrade <MOVE_PACKAGE_PATH>                                   Upgrade the Move package. It takes as input the folder where the package exists.
       --preview                                                       Preview the list of PTB transactions instead of executing them.
       --serialize-unsigned-transaction                                Instead of executing the transaction, serialize the bcs bytes of the unsigned transaction data using base64 encoding.
       --serialize-signed-transaction                                  Instead of executing the transaction, serialize the bcs bytes of the signed transaction data using base64 encoding.
@@ -137,7 +137,7 @@ iota client ptb \
 
 ### Split, destroy, and merge coins
 
-The following example showcases how to split a gas coin into multiple coins, make a move call to destroy one or more of the new coins, and finally merge the coins that were not destroyed back into the gas coin. It also showcases how to use framework name resolution (for example, `iota::coin` instead of `0x2::coin`) and how to refer to different values in an array using the `.` syntax.
+The following example showcases how to split a gas coin into multiple coins, make a Move call to destroy one or more of the new coins, and finally merge the coins that were not destroyed back into the gas coin. It also showcases how to use framework name resolution (for example, `iota::coin` instead of `0x2::coin`) and how to refer to different values in an array using the `.` syntax.
 
 ```bash
 # Split off from gas

--- a/docs/content/references/cli/validator.mdx
+++ b/docs/content/references/cli/validator.mdx
@@ -12,24 +12,23 @@ Typing `iota validator --help` into your terminal or console displays the follow
 Usage: iota validator [OPTIONS] [COMMAND]
 
 Commands:
-  make-validator-info          	 
-  become-candidate             	 
-  join-committee               	 
-  leave-committee              	 
-  display-metadata             	 
-  update-metadata              	 
-  update-gas-price              	Update gas price that is used to calculate Reference Gas Price
-  report-validator              	Report or un-report a validator
-  serialize-payload-pop         	Serialize the payload that is used to generate Proof of Possession. This is useful to take the payload offline for an Authority protocol
-                                    	keypair to sign
+  make-validator-info               
+  become-candidate                  
+  join-committee                    
+  leave-committee                   
+  display-metadata                  
+  update-metadata                   
+  update-gas-price                  Update gas price that is used to calculate Reference Gas Price
+  report-validator                  Report or un-report a validator
+  serialize-payload-pop             Serialize the payload that is used to generate Proof of Possession. This is useful to take the payload offline for an Authority protocol keypair to sign
   display-gas-price-update-raw-txn  Print out the serialized data of a transaction that sets the gas price quote for a validator
-  help                          	Print this message or the help of the given subcommand(s)
+  help                              Print this message or the help of the given subcommand(s)
 
 Options:
-  	--client.config <CONFIG>  Sets the file storing the state of our user accounts (an empty one will be created if missing)
-  	--json                	Return command outputs in json format
-  -y, --yes                	 
-  -h, --help                	Print help
+    --client.config <CONFIG>  Sets the file storing the state of our user accounts (an empty one will be created if missing)
+    --json                  Return command outputs in json format
+  -y, --yes                   
+  -h, --help                  Print help
 ```
 
 ## Examples
@@ -39,7 +38,7 @@ The following examples demonstrate some of the most often used commands.
 ### Update gas price for next epoch
 
 ```shell
-$ iota validator  update-gas-price 500
+$ iota validator update-gas-price 500
 ```
 
 
@@ -53,90 +52,90 @@ $ iota validator  update-gas-price 500
 A8z83EqjmgwRNFV6sme6A5tTTTQPjiLgiW76neyvhLud
 
 ----- Transaction Data ----
-╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ Transaction Data                                                                                                                                                                                                                                                                                                                                                                                                                   	 │
-├────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Sender: 0xf...3d9                                                                                                                                                                                                                                                                                                                                                         	                                                         │
-│ Gas Owner: 0xf...3d9                                                                                                                                                                                                                                                                                                                                                      	                                                         │
-│ Gas Budget: 200000000 NANOS                                                                                                                                                                                                                                                                                                                                                                                                         	 │
-│ Gas Price: 1000 NANOS                                                                                                                                                                                                                                                                                                                                                                                                               	 │
-│ Gas Payment:                                                                                                                                                                                                                                                                                                                                                                                                                       	 │
-│  ┌──                                                                                                                                                                                                                                                                                                                                                                                                                               	 │
-│  │ ID: 0x8...19e                                                                                                                                                                                                                                                                                                                                                          	                                                         │
-│  │ Version: 1                                                                                                                                                                                                                                                                                                                                                                                                                      	 │
-│  │ Digest: 8UEiGYe3KL3S6JPs8uP2sbbx7sMCtzi8yJJ6SyTe9V1x                                                                                                                                                                                                                                                                                                                                                                            	 │
-│  └──                                                                                                                                                                                                                                                                                                                                                                                                                               	 │
-│                                                                                                                                                                                                                                                                                                                                                                                                                                    	 │
-│ Transaction Kind : Programmable                                                                                                                                                                                                                                                                                                                                                                                                    	 │
-│ Inputs: [Object(SharedObject { object_id: 0x0...005, initial_shared_version: SequenceNumber(1), mutable: true }), Object(ImmOrOwnedObject { object_id: 0x4...dbe, version: SequenceNumber(1), digest: o#82z9UUX9iD2Mq9zvciD56kmmDYqjF3iwaFadi3Mk16eJ }), Pure(IOTAPureValue { value_type: Some(U64), value: "500" })]                                                                                                                   │
-│ Commands: [                                                                                                                                                                                                                                                                                                                                                                                                                        	 │
-│   MoveCall(0x0...003::iota_system::request_set_gas_price(Input(0),Input(1),Input(2))),                                                                                                                                                                                                                                                                                     	                                                         │
-│ ]                                                                                                                                                                                                                                                                                                                                                                                                                                  	 │
-│                                                                                                                                                                                                                                                                                                                                                                                                                                    	 │
-│                                                                                                                                                                                                                                                                                                                                                                                                                                    	 │
-│ Signatures:                                                                                                                                                                                                                                                                                                                                                                                                                        	 │
-│	j2FE7GNkHm9+ey0zTQrgfaTXJgGu1vYWmivrVxbUfP56vIrxMFA4XxqEyw7Q8pM1FR+JDPgCsE1kgZRGH6TZDg==                                                                                                                                                                                                                                                                                                                                        	 │
-│                                                                                                                                                                                                                                                                                                                                                                                                                                    	 │
-╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ Transaction Data                                                                                                                                                                                                                                                                                                      │
+├───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ Sender: 0xf...3d9                                                                                                                                                                                                                                                                                                     │
+│ Gas Owner: 0xf...3d9                                                                                                                                                                                                                                                                                                  │
+│ Gas Budget: 200000000 NANOS                                                                                                                                                                                                                                                                                           │
+│ Gas Price: 1000 NANOS                                                                                                                                                                                                                                                                                                 │
+│ Gas Payment:                                                                                                                                                                                                                                                                                                          │
+│  ┌──                                                                                                                                                                                                                                                                                                                  │
+│  │ ID: 0x8...19e                                                                                                                                                                                                                                                                                                      │
+│  │ Version: 1                                                                                                                                                                                                                                                                                                         │
+│  │ Digest: 8UEiGYe3KL3S6JPs8uP2sbbx7sMCtzi8yJJ6SyTe9V1x                                                                                                                                                                                                                                                               │
+│  └──                                                                                                                                                                                                                                                                                                                  │
+│                                                                                                                                                                                                                                                                                                                       │
+│ Transaction Kind : Programmable                                                                                                                                                                                                                                                                                       │
+│ Inputs: [Object(SharedObject { object_id: 0x0...005, initial_shared_version: SequenceNumber(1), mutable: true }), Object(ImmOrOwnedObject { object_id: 0x4...dbe, version: SequenceNumber(1), digest: o#82z9UUX9iD2Mq9zvciD56kmmDYqjF3iwaFadi3Mk16eJ }), Pure(IOTAPureValue { value_type: Some(U64), value: "500" })] │
+│ Commands: [                                                                                                                                                                                                                                                                                                           │
+│   MoveCall(0x0...003::iota_system::request_set_gas_price(Input(0),Input(1),Input(2))),                                                                                                                                                                                                                                │
+│ ]                                                                                                                                                                                                                                                                                                                     │
+│                                                                                                                                                                                                                                                                                                                       │
+│                                                                                                                                                                                                                                                                                                                       │
+│ Signatures:                                                                                                                                                                                                                                                                                                           │
+│  j2FE7GNkHm9+ey0zTQrgfaTXJgGu1vYWmivrVxbUfP56vIrxMFA4XxqEyw7Q8pM1FR+JDPgCsE1kgZRGH6TZDg==                                                                                                                                                                                                                             │
+│                                                                                                                                                                                                                                                                                                                       │
+╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ----- Transaction Effects ----
-╭───────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ Transaction Effects                                                                           	│
-├───────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Digest: A8z83EqjmgwRNFV6sme6A5tTTTQPjiLgiW76neyvhLud                                          	│
-│ Status: Success                                                                               	│
-│ Executed Epoch: 5                                                                             	│
-│                                                                                               	│
-│ Mutated Objects:                                                                              	│
-│  ┌──                                                                                          	│
-│  │ ID: 0x0...005                     	                                                            │
-│  │ Owner: Shared                                                                              	│
-│  │ Version: 16                                                                                	│
-│  │ Digest: ER2L6MxrqKNAsaRd9pWdMwvLzXG3ocGQnytnP9s5QLeh                                       	│
-│  └──                                                                                          	│
-│  ┌──                                                                                          	│
-│  │ ID: 0x4...dbe                     	                                                            │
-│  │ Owner: Account Address ( 0xf45...3d9 )                                                         │
-│  │ Version: 16                                                                                	│
-│  │ Digest: 4yDkecsKPe8SnacWdECmq1yVDt7MzvpXCxbRGs74PGaB                                       	│
-│  └──                                                                                          	│
-│  ┌──                                                                                          	│
-│  │ ID: 0x5...8d1                     	                                                            │
-│  │ Owner: Object ID: ( 0x000...005 )   	                                                        │
-│  │ Version: 16                                                                                	│
-│  │ Digest: BBu5zHWWX7nnb1XcFu5VLVnKZEU6AqRRarDDjEeBtqWy                                       	│
-│  └──                                                                                          	│
-│  ┌──                                                                                          	│
-│  │ ID: 0x8...19e                     	                                                            │
-│  │ Owner: Account Address ( 0xf45...3d9 )                                                         │
-│  │ Version: 16                                                                                	│
-│  │ Digest: 4WQp6FYctutMFzf6f2EX68xut71AMubewJ6c7GxpzX7e                                       	│
-│  └──                                                                                          	│
-│                                                                                               	│
-│ Shared Objects:                                                                               	│
-│  ┌──                                                                                          	│
-│  │ ID: 0x0...005                     	                                                            │ 
-│  │ Version: 15                                                                                	│
-│  │ Digest: 6vdobiuiDQpJguDxVbbMNW5ddRqEFkP67C3FWrAVYYuZ                                       	│
-│  └──                                                                                          	│
-│                                                                                               	│
-│ Gas Object:                                                                                   	│
-│  ┌──                                                                                          	│
-│  │ ID: 0x8...19e                     	                                                            │
-│  │ Owner: Account Address ( 0xf45...3d9 )                                                         │
-│  │ Version: 16                                                                                	│
-│  │ Digest: 4WQp6FYctutMFzf6f2EX68xut71AMubewJ6c7GxpzX7e                                       	│
-│  └──                                                                                          	│
-│                                                                                               	│
-│ Gas Cost Summary:                                                                             	│
-│	Storage Cost: 31479200                                                                     	    │
-│	Computation Cost: 1000000                                                                  	    │
-│	Storage Rebate: 0                                                                          	    │
-│	Non-refundable Storage Fee: 0                                                              	    │
-│                                                                                               	│
-│ Transaction Dependencies:                                                                     	│
-│	2gqHgPZbjTkDWM9GnVuWU5kT9z2SWN2ggwK3ryxf8aUX                                               	    │
-│	EmW6DhJWRACNZAvupiTNVacZFLoZxbNJ88mrKVv9DeiJ                                               	    │
-╰───────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────────────────────────────────────╮
+│ Transaction Effects                                     │
+├─────────────────────────────────────────────────────────┤
+│ Digest: A8z83EqjmgwRNFV6sme6A5tTTTQPjiLgiW76neyvhLud    │
+│ Status: Success                                         │
+│ Executed Epoch: 5                                       │
+│                                                         │
+│ Mutated Objects:                                        │
+│  ┌──                                                    │
+│  │ ID: 0x0...005                                        │
+│  │ Owner: Shared                                        │
+│  │ Version: 16                                          │
+│  │ Digest: ER2L6MxrqKNAsaRd9pWdMwvLzXG3ocGQnytnP9s5QLeh │
+│  └──                                                    │
+│  ┌──                                                    │
+│  │ ID: 0x4...dbe                                        │
+│  │ Owner: Account Address ( 0xf45...3d9 )               │
+│  │ Version: 16                                          │
+│  │ Digest: 4yDkecsKPe8SnacWdECmq1yVDt7MzvpXCxbRGs74PGaB │
+│  └──                                                    │
+│  ┌──                                                    │
+│  │ ID: 0x5...8d1                                        │
+│  │ Owner: Object ID: ( 0x000...005 )                    │
+│  │ Version: 16                                          │
+│  │ Digest: BBu5zHWWX7nnb1XcFu5VLVnKZEU6AqRRarDDjEeBtqWy │
+│  └──                                                    │
+│  ┌──                                                    │
+│  │ ID: 0x8...19e                                        │
+│  │ Owner: Account Address ( 0xf45...3d9 )               │
+│  │ Version: 16                                          │
+│  │ Digest: 4WQp6FYctutMFzf6f2EX68xut71AMubewJ6c7GxpzX7e │
+│  └──                                                    │
+│                                                         │
+│ Shared Objects:                                         │
+│  ┌──                                                    │
+│  │ ID: 0x0...005                                        │ 
+│  │ Version: 15                                          │
+│  │ Digest: 6vdobiuiDQpJguDxVbbMNW5ddRqEFkP67C3FWrAVYYuZ │
+│  └──                                                    │
+│                                                         │
+│ Gas Object:                                             │
+│  ┌──                                                    │
+│  │ ID: 0x8...19e                                        │
+│  │ Owner: Account Address ( 0xf45...3d9 )               │
+│  │ Version: 16                                          │
+│  │ Digest: 4WQp6FYctutMFzf6f2EX68xut71AMubewJ6c7GxpzX7e │
+│  └──                                                    │
+│                                                         │
+│ Gas Cost Summary:                                       │
+│  Storage Cost: 31479200                                 │
+│  Computation Cost: 1000000                              │
+│  Storage Rebate: 0                                      │
+│  Non-refundable Storage Fee: 0                          │
+│                                                         │
+│ Transaction Dependencies:                               │
+│  2gqHgPZbjTkDWM9GnVuWU5kT9z2SWN2ggwK3ryxf8aUX           │
+│  EmW6DhJWRACNZAvupiTNVacZFLoZxbNJ88mrKVv9DeiJ           │
+╰─────────────────────────────────────────────────────────╯
 ```
 
 </details>
@@ -151,7 +150,7 @@ $ iota validator request_set_gas_price --args 0x5 \"42\" --gas-budget GAS-BUDGET
 ### Display the validator information
 
 ```shell
-$ iota validator display-metadata 0x3...de5
+$ iota validator display-metadata 0x8359fff1dc629bad933cf1781564a6d98a7277ac391e70bd0af7e050b3927573  --json true
 ```
 
 
@@ -161,261 +160,48 @@ $ iota validator display-metadata 0x3...de5
   </summary>
 
 ```shell
-0x3...de5's valdiator status: Active
-IOTAValidatorSummary {
-	iota_address: 0x3...de5,
-	protocol_pubkey_bytes: [
-    	167,
-    	93,
-    	42,
-    	177,
-    	79,
-    	244,
-    	192,
-    	168,
-    	26,
-    	242,
-    	55,
-    	119,
-    	232,
-    	131,
-    	191,
-    	112,
-    	92,
-    	219,
-    	204,
-    	109,
-    	234,
-    	107,
-    	124,
-    	116,
-    	79,
-    	200,
-    	221,
-    	159,
-    	185,
-    	142,
-    	173,
-    	161,
-    	122,
-    	214,
-    	113,
-    	183,
-    	240,
-    	124,
-    	205,
-    	8,
-    	157,
-    	110,
-    	31,
-    	85,
-    	16,
-    	106,
-    	16,
-    	34,
-    	9,
-    	254,
-    	125,
-    	36,
-    	83,
-    	125,
-    	35,
-    	231,
-    	245,
-    	203,
-    	204,
-    	43,
-    	137,
-    	70,
-    	229,
-    	201,
-    	64,
-    	157,
-    	189,
-    	203,
-    	220,
-    	222,
-    	1,
-    	121,
-    	138,
-    	139,
-    	41,
-    	108,
-    	106,
-    	57,
-    	116,
-    	212,
-    	208,
-    	249,
-    	215,
-    	18,
-    	22,
-    	237,
-    	214,
-    	179,
-    	71,
-    	192,
-    	93,
-    	89,
-    	255,
-    	51,
-    	56,
-    	158,
-	],
-	network_pubkey_bytes: [
-    	118,
-    	14,
-    	165,
-    	223,
-    	145,
-    	150,
-    	130,
-    	74,
-    	212,
-    	160,
-    	218,
-    	170,
-    	134,
-    	2,
-    	206,
-    	72,
-    	228,
-    	87,
-    	35,
-    	114,
-    	40,
-    	217,
-    	206,
-    	35,
-    	29,
-    	194,
-    	81,
-    	61,
-    	186,
-    	215,
-    	56,
-    	215,
-	],
-	worker_pubkey_bytes: [
-    	84,
-    	171,
-    	204,
-    	100,
-    	81,
-    	92,
-    	16,
-    	207,
-    	151,
-    	167,
-    	70,
-    	138,
-    	104,
-    	92,
-    	100,
-    	75,
-    	53,
-    	47,
-    	212,
-    	209,
-    	92,
-    	2,
-    	109,
-    	120,
-    	66,
-    	146,
-    	180,
-    	116,
-    	144,
-    	22,
-    	139,
-    	57,
-	],
-	proof_of_possession_bytes: [
-    	137,
-    	134,
-    	236,
-    	79,
-    	232,
-    	146,
-    	206,
-    	45,
-    	136,
-    	245,
-    	8,
-    	42,
-    	114,
-    	154,
-    	128,
-    	148,
-    	60,
-    	137,
-    	214,
-    	92,
-    	177,
-    	46,
-    	118,
-    	246,
-    	37,
-    	159,
-    	183,
-    	233,
-    	122,
-    	49,
-    	121,
-    	227,
-    	136,
-    	76,
-    	48,
-    	122,
-    	119,
-    	187,
-    	194,
-    	169,
-    	114,
-    	7,
-    	16,
-    	225,
-    	104,
-    	211,
-    	100,
-    	198,
-	],
-	name: "Staked",
-	description: "The leading provider of staking infrastructure",
-	image_url: "https://avatars.githubusercontent.com/u/38704373",
-	project_url: "https://staked.us/",
-	net_address: "/dns/iota-mainnet.prod-eks-eu-west-1.staked.cloud/tcp/8080/http",
-	p2p_address: "/dns/iota-mainnet-udp.prod-eks-eu-west-1.staked.cloud/udp/8084",
-	primary_address: "/dns/iota-mainnet-udp.prod-eks-eu-west-1.staked.cloud/udp/8081",
-	worker_address: "/dns/iota-mainnet-udp.prod-eks-eu-west-1.staked.cloud/udp/8082",
-	next_epoch_protocol_pubkey_bytes: None,
-	next_epoch_proof_of_possession: None,
-	next_epoch_network_pubkey_bytes: None,
-	next_epoch_worker_pubkey_bytes: None,
-	next_epoch_net_address: None,
-	next_epoch_p2p_address: None,
-	next_epoch_primary_address: None,
-	next_epoch_worker_address: None,
-	voting_power: 53,
-	operation_cap_id: 0x4...217,
-	gas_price: 1000,
-	commission_rate: 1000,
-	next_epoch_stake: 42223548570491465,
-	next_epoch_gas_price: 1000,
-	next_epoch_commission_rate: 1000,
-	staking_pool_id: 0xc...932,
-	staking_pool_activation_epoch: Some(
-    	0,
-	),
-	staking_pool_deactivation_epoch: None,
-	staking_pool_iota_balance: 42926894529549497,
-	rewards_pool: 1047712965206377,
-	pool_token_balance: 41704322845739375,
-	pending_stake: 0,
-	pending_total_iota_withdraw: 703345959058032,
-	pending_pool_token_withdraw: 683314441220777,
-	exchange_rates_id: 0x5...65d,
-	exchange_rates_size: 231,
+0x8359fff1dc629bad933cf1781564a6d98a7277ac391e70bd0af7e050b3927573's valdiator status: Active
+{
+  "iotaAddress": "0x8359fff1dc629bad933cf1781564a6d98a7277ac391e70bd0af7e050b3927573",
+  "protocolPubkeyBytes": "lUhBLNuc6bosReVt+jv+BXZboiOjZQyT5tfJbMS1StEyBmPmF7TTuGl2vy/S8zKWGSEbPKPapz46phPZgFRy7TjXEdt6XjBHf/bkEg1atucEzAMPT/6cIx2G5We7wlXK",
+  "networkPubkeyBytes": "1JiYHZHJFtuxim7woWhPGdBIe4QPoyvLVgpCRRZwUWg=",
+  "workerPubkeyBytes": "XhjH8q+isy4LP4GS1txLJYl+KQ9kV7b5dnu6C2x4XIk=",
+  "proofOfPossessionBytes": "ovRMD5206HPBOoTfx+TgB5NXIKpbra4AuJRVGFSaaFbP2hAAZBDWpP1OD0Nyackf",
+  "name": "validator-2.r.iota-rebased-alphanet",
+  "description": "validator-2.r.iota-rebased-alphanet",
+  "imageUrl": "",
+  "projectUrl": "",
+  "netAddress": "/dns/validator-2.r.iota-rebased-alphanet.iota.cafe/tcp/8080/http",
+  "p2pAddress": "/dns/validator-2.r.iota-rebased-alphanet.iota.cafe/udp/8084",
+  "primaryAddress": "/dns/validator-2.r.iota-rebased-alphanet.iota.cafe/udp/8081",
+  "workerAddress": "/dns/validator-2.r.iota-rebased-alphanet.iota.cafe/udp/8082",
+  "nextEpochProtocolPubkeyBytes": null,
+  "nextEpochProofOfPossession": null,
+  "nextEpochNetworkPubkeyBytes": null,
+  "nextEpochWorkerPubkeyBytes": null,
+  "nextEpochNetAddress": null,
+  "nextEpochP2pAddress": null,
+  "nextEpochPrimaryAddress": null,
+  "nextEpochWorkerAddress": null,
+  "votingPower": "2500",
+  "operationCapId": "0xa88b6ac306932c77f7bc228690c35104ab8b4cd4a174ace5296d01581ae4f2d5",
+  "gasPrice": "1000",
+  "commissionRate": "200",
+  "nextEpochStake": "2958750000000000",
+  "nextEpochGasPrice": "1000",
+  "nextEpochCommissionRate": "200",
+  "stakingPoolId": "0x4fb963ec2cb115ae2e13818e38f71d3ec8c6c2b892000fe6c119bf518b9b1a85",
+  "stakingPoolActivationEpoch": "0",
+  "stakingPoolDeactivationEpoch": null,
+  "stakingPoolIotaBalance": "2958750000000000",
+  "rewardsPool": "939575000000000",
+  "poolTokenBalance": "2015128472804164",
+  "pendingStake": "0",
+  "pendingTotalIotaWithdraw": "0",
+  "pendingPoolTokenWithdraw": "0",
+  "exchangeRatesId": "0x456fd6d5a041d8c5de2998b4bf8a0cff2217132ae5de0c7017975fa82470ed43",
+  "exchangeRatesSize": "6"
+}
 ```
 </details>
 
@@ -437,85 +223,85 @@ $ iota validator report-validator  0xf...3d9
 8jVYrpuRBmdSLP37MsQGRqUqE3kE2m8XiSS4TG4aJwXf
 
 ----- Transaction Data ----
-╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ Transaction Data                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        	 │
-├────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Sender: 0xf...3d9                                                                                                                                                                                                                                                                                                                                                                                                                             	                                                         │
-│ Gas Owner: 0xf...3d9                                                                                                                                                                                                                                                                                                                                                                                                                          	                                                         │
-│ Gas Budget: 200000000 NANOS                                                                                                                                                                                                                                                                                                                                                                                                                                                                             	 │
-│ Gas Price: 1000 NANOS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   	 │
-│ Gas Payment:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           	 │
-│  ┌──                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   	 │
-│  │ ID: 0x8...19e                                                                                                                                                                                                                                                                                                                                                                                                                              	                                                         │
-│  │ Version: 16                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         	 │
-│  │ Digest: 4WQp6FYctutMFzf6f2EX68xut71AMubewJ6c7GxpzX7e                                                                                                                                                                                                                                                                                                                                                                                                                                                	 │
-│  └──                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   	 │
-│                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        	 │
-│ Transaction Kind : Programmable                                                                                                                                                                                                                                                                                                                                                                                                                                                                        	 │
-│ Inputs: [Object(SharedObject { object_id: 0x0...005, initial_shared_version: SequenceNumber(1), mutable: true }), Object(ImmOrOwnedObject { object_id: 0x4...dbe, version: SequenceNumber(16), digest: o#4yDkecsKPe8SnacWdECmq1yVDt7MzvpXCxbRGs74PGaB }), Pure(IOTAPureValue { value_type: Some(Address), value: "0xf...3d9" })]                                                                                                                                                                            │
-│ Commands: [                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            	 │
-│   MoveCall(0x0...003::iota_system::report_validator(Input(0),Input(1),Input(2))),                                                                                                                                                                                                                                                                                                                                                              	                                                         │
-│ ]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      	 │
-│                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        	 │
-│                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        	 │
-│ Signatures:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            	 │
-│	7lJ9ezA1qjGk7nyFCESgLlg/tkVSy46dDkRgJzwgWP3qA+kAjJV8YVWFjJf2r6aLgWgCZCKnka9bkcp1V5jBAA==                                                                                                                                                                                                                                                                                                                                                                                                            	 │
-│                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        	 │
-╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ Transaction Data                                                                                                                                                                                                                                                                                                                 │
+├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ Sender: 0xf...3d9                                                                                                                                                                                                                                                                                                                │
+│ Gas Owner: 0xf...3d9                                                                                                                                                                                                                                                                                                             │
+│ Gas Budget: 200000000 NANOS                                                                                                                                                                                                                                                                                                      │
+│ Gas Price: 1000 NANOS                                                                                                                                                                                                                                                                                                            │
+│ Gas Payment:                                                                                                                                                                                                                                                                                                                     │
+│  ┌──                                                                                                                                                                                                                                                                                                                             │
+│  │ ID: 0x8...19e                                                                                                                                                                                                                                                                                                                 │
+│  │ Version: 16                                                                                                                                                                                                                                                                                                                   │
+│  │ Digest: 4WQp6FYctutMFzf6f2EX68xut71AMubewJ6c7GxpzX7e                                                                                                                                                                                                                                                                          │
+│  └──                                                                                                                                                                                                                                                                                                                             │
+│                                                                                                                                                                                                                                                                                                                                  │
+│ Transaction Kind : Programmable                                                                                                                                                                                                                                                                                                  │
+│ Inputs: [Object(SharedObject { object_id: 0x0...005, initial_shared_version: SequenceNumber(1), mutable: true }), Object(ImmOrOwnedObject { object_id: 0x4...dbe, version: SequenceNumber(16), digest: o#4yDkecsKPe8SnacWdECmq1yVDt7MzvpXCxbRGs74PGaB }), Pure(IOTAPureValue { value_type: Some(Address), value: "0xf...3d9" })] │
+│ Commands: [                                                                                                                                                                                                                                                                                                                      │
+│   MoveCall(0x0...003::iota_system::report_validator(Input(0),Input(1),Input(2))),                                                                                                                                                                                                                                                │
+│ ]                                                                                                                                                                                                                                                                                                                                │
+│                                                                                                                                                                                                                                                                                                                                  │
+│                                                                                                                                                                                                                                                                                                                                  │
+│ Signatures:                                                                                                                                                                                                                                                                                                                      │
+│  7lJ9ezA1qjGk7nyFCESgLlg/tkVSy46dDkRgJzwgWP3qA+kAjJV8YVWFjJf2r6aLgWgCZCKnka9bkcp1V5jBAA==                                                                                                                                                                                                                                        │
+│                                                                                                                                                                                                                                                                                                                                  │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ----- Transaction Effects ----
-╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ Transaction Effects                                                                                                                                                                                                                                                                              	   │
-├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Digest: 8jVYrpuRBmdSLP37MsQGRqUqE3kE2m8XiSS4TG4aJwXf                                                                                                                                                                                                                                             	   │
+╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ Transaction Effects                                                                                                                                                                                                                                                                                   │
+├───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ Digest: 8jVYrpuRBmdSLP37MsQGRqUqE3kE2m8XiSS4TG4aJwXf                                                                                                                                                                                                                                                  │
 │ Status: Failure { error: "MoveAbort(MoveLocation { module: ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000003, name: Identifier(\"iota_system_state_inner\") }, function: 16, instruction: 12, function_name: Some(\"report_validator_impl\") }, 3) in command 0" } │
-│ Executed Epoch: 8                                                                                                                                                                                                                                                                                	   │
-│                                                                                                                                                                                                                                                                                                  	   │
-│ Mutated Objects:                                                                                                                                                                                                                                                                                 	   │
-│  ┌──                                                                                                                                                                                                                                                                                             	   │
-│  │ ID: 0x0...005                                                                                                                                                                                                                        	                                                           │
-│  │ Owner: Shared                                                                                                                                                                                                                                                                                 	   │
-│  │ Version: 25                                                                                                                                                                                                                                                                                   	   │
-│  │ Digest: 5N5zyTyFCqAkyz44FGrpr6cYdXcwk4eUCHKzyAZqehMB                                                                                                                                                                                                                                          	   │
-│  └──                                                                                                                                                                                                                                                                                             	   │
-│  ┌──                                                                                                                                                                                                                                                                                             	   │
-│  │ ID: 0x4...dbe                                                                                                                                                                                                                        	                                                           │
-│  │ Owner: Account Address ( 0xf...3d9 )                                                                                                                                                                                                 	                                                           │
-│  │ Version: 25                                                                                                                                                                                                                                                                                       │
-│  │ Digest: HCEr5bcJhKo5jfRx2gsXxGSkpcq6tm8nFGSxxwoPpkNz                                                                                                                                                                                                                                          	   │
-│  └──                                                                                                                                                                                                                                                                                             	   │
-│  ┌──                                                                                                                                                                                                                                                                                             	   │
-│  │ ID: 0x8...19e                                                                                                                                                                                                                        	                                                           │
-│  │ Owner: Account Address ( 0xf...3d9 )                                                                                                                                                                                                 	                                                           │
-│  │ Version: 25                                                                                                                                                                                                                                                                                   	   │
-│  │ Digest: BTzMmVABwEKXoiLsTZ79Li97Eo6HPtNtWTvib8Eq1yrH                                                                                                                                                                                                                                          	   │
-│  └──                                                                                                                                                                                                                                                                                             	   │
-│                                                                                                                                                                                                                                                                                                  	   │
-│ Shared Objects:                                                                                                                                                                                                                                                                                  	   │
-│  ┌──                                                                                                                                                                                                                                                                                             	   │
-│  │ ID: 0x0...005                                                                                                                                                                                                                        	                                                      	   │
-│  │ Version: 24                                                                                                                                                                                                                                                                                   	   │
-│  │ Digest: BiS4pKAX3KGXbJrk4oZijy6ggKHDZJd9qPUDWxLEoNR1                                                                                                                                                                                                                                          	   │
-│  └──                                                                                                                                                                                                                                                                                             	   │
-│                                                                                                                                                                                                                                                                                                  	   │
-│ Gas Object:                                                                                                                                                                                                                                                                                      	   │
-│  ┌──                                                                                                                                                                                                                                                                                             	   │
-│  │ ID: 0x8...19e                                                                                                                                                                                                                        	                                                      	   │
-│  │ Owner: Account Address ( 0xf...3d9 )                                                                                                                                                                                                 	                                                      	   │
-│  │ Version: 25                                                                                                                                                                                                                                                                                   	   │
-│  │ Digest: BTzMmVABwEKXoiLsTZ79Li97Eo6HPtNtWTvib8Eq1yrH                                                                                                                                                                                                                                          	   │
-│  └──                                                                                                                                                                                                                                                                                             	   │
-│                                                                                                                                                                                                                                                                                                  	   │
-│ Gas Cost Summary:                                                                                                                                                                                                                                                                                	   │
-│	Storage Cost: 4195200                                                                                                                                                                                                                                                                         	   │
-│	Computation Cost: 1000000                                                                                                                                                                                                                                                                     	   │
-│	Storage Rebate: 31164408                                                                                                                                                                                                                                                                      	   │
-│	Non-refundable Storage Fee: 314792                                                                                                                                                                                                                                                            	   │
-│                                                                                                                                                                                                                                                                                                  	   │
-│ Transaction Dependencies:                                                                                                                                                                                                                                                                        	   │
-│	2gqHgPZbjTkDWM9GnVuWU5kT9z2SWN2ggwK3ryxf8aUX                                                                                                                                                                                                                                                  	   │
-│	A8z83EqjmgwRNFV6sme6A5tTTTQPjiLgiW76neyvhLud                                                                                                                                                                                                                                                  	   │
-│	B8p4pVC5pzFQRVpZ73nZfAWMt7sL4iH4x4AbDviYWuzF                                                                                                                                                                                                                                                  	   │
-╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+│ Executed Epoch: 8                                                                                                                                                                                                                                                                                     │
+│                                                                                                                                                                                                                                                                                                       │
+│ Mutated Objects:                                                                                                                                                                                                                                                                                      │
+│  ┌──                                                                                                                                                                                                                                                                                                  │
+│  │ ID: 0x0...005                                                                                                                                                                                                                                                                                      │
+│  │ Owner: Shared                                                                                                                                                                                                                                                                                      │
+│  │ Version: 25                                                                                                                                                                                                                                                                                        │
+│  │ Digest: 5N5zyTyFCqAkyz44FGrpr6cYdXcwk4eUCHKzyAZqehMB                                                                                                                                                                                                                                               │
+│  └──                                                                                                                                                                                                                                                                                                  │
+│  ┌──                                                                                                                                                                                                                                                                                                  │
+│  │ ID: 0x4...dbe                                                                                                                                                                                                                                                                                      │
+│  │ Owner: Account Address ( 0xf...3d9 )                                                                                                                                                                                                                                                               │
+│  │ Version: 25                                                                                                                                                                                                                                                                                        │
+│  │ Digest: HCEr5bcJhKo5jfRx2gsXxGSkpcq6tm8nFGSxxwoPpkNz                                                                                                                                                                                                                                               │
+│  └──                                                                                                                                                                                                                                                                                                  │
+│  ┌──                                                                                                                                                                                                                                                                                                  │
+│  │ ID: 0x8...19e                                                                                                                                                                                                                                                                                      │
+│  │ Owner: Account Address ( 0xf...3d9 )                                                                                                                                                                                                                                                               │
+│  │ Version: 25                                                                                                                                                                                                                                                                                        │
+│  │ Digest: BTzMmVABwEKXoiLsTZ79Li97Eo6HPtNtWTvib8Eq1yrH                                                                                                                                                                                                                                               │
+│  └──                                                                                                                                                                                                                                                                                                  │
+│                                                                                                                                                                                                                                                                                                       │
+│ Shared Objects:                                                                                                                                                                                                                                                                                       │
+│  ┌──                                                                                                                                                                                                                                                                                                  │
+│  │ ID: 0x0...005                                                                                                                                                                                                                                                                                      │
+│  │ Version: 24                                                                                                                                                                                                                                                                                        │
+│  │ Digest: BiS4pKAX3KGXbJrk4oZijy6ggKHDZJd9qPUDWxLEoNR1                                                                                                                                                                                                                                               │
+│  └──                                                                                                                                                                                                                                                                                                  │
+│                                                                                                                                                                                                                                                                                                       │
+│ Gas Object:                                                                                                                                                                                                                                                                                           │
+│  ┌──                                                                                                                                                                                                                                                                                                  │
+│  │ ID: 0x8...19e                                                                                                                                                                                                                                                                                      │
+│  │ Owner: Account Address ( 0xf...3d9 )                                                                                                                                                                                                                                                               │
+│  │ Version: 25                                                                                                                                                                                                                                                                                        │
+│  │ Digest: BTzMmVABwEKXoiLsTZ79Li97Eo6HPtNtWTvib8Eq1yrH                                                                                                                                                                                                                                               │
+│  └──                                                                                                                                                                                                                                                                                                  │
+│                                                                                                                                                                                                                                                                                                       │
+│ Gas Cost Summary:                                                                                                                                                                                                                                                                                     │
+│  Storage Cost: 4195200                                                                                                                                                                                                                                                                                │
+│  Computation Cost: 1000000                                                                                                                                                                                                                                                                            │
+│  Storage Rebate: 31164408                                                                                                                                                                                                                                                                             │
+│  Non-refundable Storage Fee: 314792                                                                                                                                                                                                                                                                   │
+│                                                                                                                                                                                                                                                                                                       │
+│ Transaction Dependencies:                                                                                                                                                                                                                                                                             │
+│  2gqHgPZbjTkDWM9GnVuWU5kT9z2SWN2ggwK3ryxf8aUX                                                                                                                                                                                                                                                         │
+│  A8z83EqjmgwRNFV6sme6A5tTTTQPjiLgiW76neyvhLud                                                                                                                                                                                                                                                         │
+│  B8p4pVC5pzFQRVpZ73nZfAWMt7sL4iH4x4AbDviYWuzF                                                                                                                                                                                                                                                         │
+╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 </details>
@@ -535,10 +321,11 @@ Arguments:
   <reportee-address>  The IOTA Address of the validator is being reported or un-reported
 
 Options:
-  	--operation-cap-id <operation-cap-id>  Optional when sender is reporter validator itself and it holds the Cap object. Required when sender is not the reporter validator itself.
-                                         	Validator's OperationCap ID can be found by using the `display-metadata` subcommand
-  	--undo-report <undo-report>        	If true, undo an existing report [possible values: true, false]
-  	--gas-budget <gas-budget>          	Gas budget for this transaction
-  	--json                             	Return command outputs in json format
-  -h, --help                             	Print help
+      --operation-cap-id <operation-cap-id>  Optional when sender is reporter validator itself and it holds the Cap object. Required when sender is not the reporter validator itself. Validator's
+                                             OperationCap ID can be found by using the `display-metadata` subcommand
+      --undo-report <undo-report>            If true, undo an existing report [possible values: true, false]
+      --gas-budget <gas-budget>              Gas budget for this transaction
+      --json                                 Return command outputs in json format
+  -h, --help                                 Print help
+  -V, --version                              Print version
 ```

--- a/docs/content/references/cli/validator.mdx
+++ b/docs/content/references/cli/validator.mdx
@@ -9,6 +9,8 @@ The IOTA CLI `validator` command provides command-level access to validator feat
 Typing `iota validator --help` into your terminal or console displays the following information on available commands.
 
 ```shell
+A tool for validators and validator candidates
+
 Usage: iota validator [OPTIONS] [COMMAND]
 
 Commands:
@@ -25,10 +27,11 @@ Commands:
   help                              Print this message or the help of the given subcommand(s)
 
 Options:
-    --client.config <CONFIG>  Sets the file storing the state of our user accounts (an empty one will be created if missing)
-    --json                  Return command outputs in json format
-  -y, --yes                   
-  -h, --help                  Print help
+      --client.config <CONFIG>  Sets the file storing the state of our user accounts (an empty one will be created if missing)
+      --json                    Return command outputs in json format
+  -y, --yes                     
+  -h, --help                    Print help
+  -V, --version                 Print version
 ```
 
 ## Examples


### PR DESCRIPTION
# Description of change

Fix commands and tables, remove useless whitespaces, changed IOTAValidatorSummary to use the JSON output as the arrays are really long otherwise

## Links to any relevant issues

https://github.com/iotaledger/iota/issues/1613

## Type of change

- Documentation Fix

## How the change has been tested

Running cli commands
