### PR TITLE
feat!(iota-sdk): add default crypto provider to IotaClient

### DIFF
--- a/crates/iota-sdk/Cargo.toml
+++ b/crates/iota-sdk/Cargo.toml
@@ -16,6 +16,7 @@ futures.workspace = true
 futures-core.workspace = true
 jsonrpsee.workspace = true
 reqwest.workspace = true
+rustls.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
@@ -45,7 +46,6 @@ dirs.workspace = true
 futures.workspace = true
 futures-core.workspace = true
 rand.workspace = true
-rustls.workspace = true
 tempfile.workspace = true
 
 [[example]]

--- a/crates/iota-sdk/examples/sign_tx_guide.rs
+++ b/crates/iota-sdk/examples/sign_tx_guide.rs
@@ -34,9 +34,6 @@ use crate::utils::request_tokens_from_faucet;
 /// https://github.com/iotaledger/iota/blob/main/docs/content/guides/developer/iota-101/sign-and-send-txn.mdx
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    rustls::crypto::ring::default_provider()
-        .install_default()
-        .unwrap();
     // set up iota client for the desired network.
     let iota_client = IotaClientBuilder::default().build_testnet().await?;
 

--- a/crates/iota-sdk/examples/utils.rs
+++ b/crates/iota-sdk/examples/utils.rs
@@ -79,9 +79,6 @@ pub async fn setup_for_write() -> Result<(IotaClient, IotaAddress, IotaAddress),
 /// If there is no IOTA owned by the active address, then it will request
 /// IOTA from the faucet.
 pub async fn setup_for_read() -> Result<(IotaClient, IotaAddress), anyhow::Error> {
-    rustls::crypto::ring::default_provider()
-        .install_default()
-        .unwrap();
     let client = IotaClientBuilder::default().build_testnet().await?;
     println!("Iota testnet version is: {}", client.api_version());
     let mut wallet = retrieve_wallet()?;

--- a/crates/iota-sdk/src/lib.rs
+++ b/crates/iota-sdk/src/lib.rs
@@ -99,6 +99,7 @@ use jsonrpsee::{
     ws_client::{PingConfig, WsClient, WsClientBuilder},
 };
 use move_core_types::language_storage::StructTag;
+use rustls::crypto::{ring, CryptoProvider};
 use serde_json::Value;
 
 use crate::{
@@ -203,9 +204,9 @@ impl IotaClientBuilder {
     /// }
     /// ```
     pub async fn build(self, http: impl AsRef<str>) -> IotaRpcResult<IotaClient> {
-        rustls::crypto::ring::default_provider()
-            .install_default()
-            .ok();
+        if CryptoProvider::get_default().is_none() {
+            ring::default_provider().install_default().ok();
+        }
 
         let client_version = env!("CARGO_PKG_VERSION");
         let mut headers = HeaderMap::new();

--- a/crates/iota-sdk/src/lib.rs
+++ b/crates/iota-sdk/src/lib.rs
@@ -203,6 +203,10 @@ impl IotaClientBuilder {
     /// }
     /// ```
     pub async fn build(self, http: impl AsRef<str>) -> IotaRpcResult<IotaClient> {
+        rustls::crypto::ring::default_provider()
+            .install_default()
+            .ok();
+
         let client_version = env!("CARGO_PKG_VERSION");
         let mut headers = HeaderMap::new();
         headers.insert(


### PR DESCRIPTION
# Description of change

Add rustls as default crypto provider to IotaClient so users don't have to do it themselves and also so the CLI works

## Links to any relevant issues

Fixes #1459 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Running cli commands and running `cargo run --example programmable_transactions_api` with alphanet url
