### PR TITLE
feat(docs/stardust): Add docs for basic output claim

### DIFF
--- a/docs/content/developer/stardust/claiming.mdx
+++ b/docs/content/developer/stardust/claiming.mdx
@@ -7,3 +7,103 @@
   - Demonstrates through examples for each output type the resulting move objects
   - Explains what commands need to be called in a PTB to claim the assets
   - Describes transaction sponsorship from iota addresses for shimmer claiming
+
+## IOTA tokens automatic migration 
+
+
+## Output types to Move Objects
+
+
+## Examples of Stardust asset claim transactions
+
+In the following, some examples of transactions for claiming the Stardust assets will be presented. Different commands in a [PTB](../iota-101/transactions/ptb/prog-txn-blocks.mdx) are used depending on the claiming scenario, that varies depending on the Stardust Output type and composition.
+
+### Basic Output
+
+An address can own `BasicOutput` objects that needs to be unlocked. In this case, some off-chain queries can be used to check the unlock conditions of the `BasicOutput` and asses if it can be unlocked.    
+
+<Tabs>
+<TabItem value="rs" label="Rust">
+
+```rust file=<rootDir>/docs/examples/rust/stardust/check-basic-output-unlock-conditions.rs#L20-L56
+```
+
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+TODO
+
+</TabItem>
+</Tabs>
+
+#### Claim of a Basic Output
+Once a Basic Output can be unlocked the claim of its assets can start
+
+1. The first step is to fetch the `BasicOutput` object needed to be claimed.
+
+<Tabs>
+<TabItem value="rs" label="Rust">
+
+```rust file=<rootDir>/docs/examples/rust/stardust/basic-output-claim.rs#L74-L99
+```
+
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+TODO
+
+</TabItem>
+</Tabs>
+
+
+2. Then we check the native tokens that possibily were held by this output. A `Bag` is used for holding these tokens, so in this step we are interested in obtaining the dynamic field keys that are used as bag index. In the case of the native tokens `Bag` the keys are strings representing the `OTW` used for the native token `Coin`. 
+
+<Tabs>
+<TabItem value="rs" label="Rust">
+
+```rust file=<rootDir>/docs/examples/rust/stardust/basic-output-claim.rs#L101-L128
+```
+
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+TODO
+
+</TabItem>
+</Tabs>
+
+3. Finally, a PTB can be created using the `basic_output` as input and the `Bag` keys for iterating the native tokens extracted. 
+
+<Tabs>
+<TabItem value="rs" label="Rust">
+
+```rust file=<rootDir>/docs/examples/rust/stardust/basic-output-claim.rs#L131-L195
+```
+
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+TODO
+
+</TabItem>
+</Tabs>
+
+### NFT Output
+
+#### Claim of a NFT Output
+
+#### Conversion of a NFT Output into a custom NFT
+
+### Alias Output
+
+#### Claim of a Alias Output
+
+#### Conversion of an Alias Output into a custom Object
+
+### Foundry Output
+
+#### Claim of a Foundry Output
+
+
+## Sponsoring your Shimmer claiming
+

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -36,6 +36,10 @@ name = "basic-output-claim"
 path = "stardust/basic-output-claim.rs"
 
 [[example]]
+name = "check-basic-output-unlock-conditions"
+path = "stardust/check-basic-output-unlock-conditions.rs"
+
+[[example]]
 name = "nft-migration"
 path = "stardust/nft-migration.rs"
 

--- a/docs/examples/rust/stardust/check-basic-output-unlock-conditions.rs
+++ b/docs/examples/rust/stardust/check-basic-output-unlock-conditions.rs
@@ -46,13 +46,13 @@ async fn main() -> Result<(), anyhow::Error> {
     println!("Basic Output infos: {basic_output:?}");
 
     if let Some(sdruc) = basic_output.storage_deposit_return {
-        println!("Storage Deposit Return Unlock Condition infos: {:?}", sdruc);
+        println!("Storage Deposit Return Unlock Condition infos: {sdruc:?}");
     }
     if let Some(tuc) = basic_output.timelock {
         println!("Timelocked until: {}", tuc.unix_time);
     }
     if let Some(euc) = basic_output.expiration {
-        println!("Expiration Unlock Condition infos: {:?}", euc);
+        println!("Expiration Unlock Condition infos: {euc:?}");
     }
 
     Ok(())

--- a/docs/examples/rust/stardust/check-basic-output-unlock-conditions.rs
+++ b/docs/examples/rust/stardust/check-basic-output-unlock-conditions.rs
@@ -1,0 +1,59 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Example demonstrating queries for checking the unlock conditions of a basic
+//! output. In order to work, it requires a network with test objects
+//! generated from iota-genesis-builder/src/stardust/test_outputs.
+
+use anyhow::anyhow;
+use iota_sdk::{
+    rpc_types::{IotaData, IotaObjectDataOptions},
+    types::{base_types::ObjectID, stardust::output::BasicOutput},
+    IotaClientBuilder,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    // Build an iota client for a local network
+    let iota_client = IotaClientBuilder::default().build_localnet().await?;
+
+    // This object id was fetched manually. It refers to a Basic Output object that
+    // contains some Native Tokens.
+    let basic_output_object_id = ObjectID::from_hex_literal(
+        "0xde09139ed46b9f5f876671e4403f312fad867c5ae5d300a252e4b6a6f1fa1fbd",
+    )?;
+    // Get Basic Output object
+    let basic_output_object = iota_client
+        .read_api()
+        .get_object_with_options(
+            basic_output_object_id,
+            IotaObjectDataOptions::new().with_bcs(),
+        )
+        .await?
+        .data
+        .ok_or(anyhow!("Basic output not found"))?;
+
+    // Convert the basic output object into its Rust representation
+    let basic_output = bcs::from_bytes::<BasicOutput>(
+        &basic_output_object
+            .bcs
+            .expect("should contain bcs")
+            .try_as_move()
+            .expect("should convert it to a move object")
+            .bcs_bytes,
+    )?;
+
+    println!("Basic Output infos: {:?}", basic_output);
+
+    if let Some(sdruc) = basic_output.storage_deposit_return {
+        println!("Storage Deposit Return Unlock Condition infos: {:?}", sdruc);
+    }
+    if let Some(tuc) = basic_output.timelock {
+        println!("Timelocked until: {}", tuc.unix_time);
+    }
+    if let Some(euc) = basic_output.expiration {
+        println!("Expiration Unlock Condition infos: {:?}", euc);
+    }
+
+    Ok(())
+}

--- a/docs/examples/rust/stardust/check-basic-output-unlock-conditions.rs
+++ b/docs/examples/rust/stardust/check-basic-output-unlock-conditions.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), anyhow::Error> {
             .bcs_bytes,
     )?;
 
-    println!("Basic Output infos: {:?}", basic_output);
+    println!("Basic Output infos: {basic_output:?}");
 
     if let Some(sdruc) = basic_output.storage_deposit_return {
         println!("Storage Deposit Return Unlock Condition infos: {:?}", sdruc);


### PR DESCRIPTION
# Description of change

This PR uses the rust example for claiming a Basic Output to enrigh the docs related to Stardust claimings.  It also adds a new rust example for fetching the Unlock Conditions info of a Basic Output.

## Links to any relevant issues

Fix #1331  

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
