### PR TITLE
feat(iota-genesis-builder): Remove brotli compression flag in genesis builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5908,7 +5908,6 @@ dependencies = [
  "anyhow",
  "bcs",
  "bigdecimal",
- "brotli",
  "camino",
  "clap",
  "fastcrypto",

--- a/crates/iota-genesis-builder/Cargo.toml
+++ b/crates/iota-genesis-builder/Cargo.toml
@@ -34,7 +34,6 @@ tokio.workspace = true
 tracing.workspace = true
 
 bigdecimal = "0.4.3"
-brotli = "6.0.0"
 fs_extra = "1.3.0"
 iota-sdk = { version = "1.1.4", default-features = false, features = ["irc_27", "irc_30", "std"] }
 packable = { version = "0.8.3", default-features = false, features = ["io"] }

--- a/crates/iota-genesis-builder/examples/build_stardust_genesis.rs
+++ b/crates/iota-genesis-builder/examples/build_stardust_genesis.rs
@@ -16,13 +16,6 @@ use rand::rngs::OsRng;
     about = "Example Tool for generating a genesis file from a Stardust Migration Objects snapshot"
 )]
 struct Cli {
-    #[clap(
-        short,
-        long,
-        default_value_t = false,
-        help = "Decompress the input object snapshot"
-    )]
-    decompress: bool,
     #[clap(long, default_value_t = OBJECT_SNAPSHOT_FILE_PATH.to_string(), help = "Path to the Stardust Migration Objects snapshot file")]
     snapshot_path: String,
 }
@@ -34,11 +27,7 @@ fn main() -> anyhow::Result<()> {
 
     // Prepare the reader for the objects snapshot
     let path = PathBuf::from(cli.snapshot_path);
-    let object_snapshot_source = if cli.decompress {
-        SnapshotSource::LocalBrotli(path)
-    } else {
-        SnapshotSource::Local(path)
-    };
+    let object_snapshot_source = SnapshotSource::Local(path);
 
     // Start building
     let mut builder = Builder::new().add_migration_source(object_snapshot_source);

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -84,7 +84,6 @@ const GENESIS_BUILDER_SIGNATURE_DIR: &str = "signatures";
 const GENESIS_BUILDER_UNSIGNED_GENESIS_FILE: &str = "unsigned-genesis";
 const GENESIS_BUILDER_MIGRATION_SOURCES_FILE: &str = "migration-sources";
 
-pub const BROTLI_COMPRESSOR_BUFFER_SIZE: usize = 4096;
 pub const OBJECT_SNAPSHOT_FILE_PATH: &str = "stardust_object_snapshot.bin";
 pub const IOTA_OBJECT_SNAPSHOT_URL: &str = "https://stardust-objects.s3.eu-central-1.amazonaws.com/iota/alphanet/latest/stardust_object_snapshot.bin.gz";
 pub const SHIMMER_OBJECT_SNAPSHOT_URL: &str = "https://stardust-objects.s3.eu-central-1.amazonaws.com/shimmer/alphanet/latest/stardust_object_snapshot.bin.gz";
@@ -1442,8 +1441,6 @@ pub fn split_timelocks(
 pub enum SnapshotSource {
     /// Local uncompressed file.
     Local(PathBuf),
-    /// Local file compressed with brotli.
-    LocalBrotli(PathBuf),
     /// Remote file (S3) with gzip compressed file
     S3(SnapshotUrl),
 }
@@ -1454,10 +1451,6 @@ impl SnapshotSource {
         Ok(match self {
             SnapshotSource::Local(path) => Box::new(BufReader::new(File::open(path)?)),
             SnapshotSource::S3(snapshot_url) => Box::new(snapshot_url.to_reader()?),
-            SnapshotSource::LocalBrotli(path) => Box::new(brotli::Decompressor::new(
-                File::open(path)?,
-                BROTLI_COMPRESSOR_BUFFER_SIZE,
-            )),
         })
     }
 }

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -85,11 +85,6 @@ const GENESIS_BUILDER_UNSIGNED_GENESIS_FILE: &str = "unsigned-genesis";
 const GENESIS_BUILDER_MIGRATION_SOURCES_FILE: &str = "migration-sources";
 
 pub const BROTLI_COMPRESSOR_BUFFER_SIZE: usize = 4096;
-/// Compression levels go from 0 to 11, where 11 has the highest compression
-/// ratio but requires more time.
-pub const BROTLI_COMPRESSOR_QUALITY: u32 = 11;
-/// The LZ77 window size (0, 10-24) where bigger windows size improves density.
-pub const BROTLI_COMPRESSOR_LG_WINDOW_SIZE: u32 = 22;
 pub const OBJECT_SNAPSHOT_FILE_PATH: &str = "stardust_object_snapshot.bin";
 pub const IOTA_OBJECT_SNAPSHOT_URL: &str = "https://stardust-objects.s3.eu-central-1.amazonaws.com/iota/alphanet/latest/stardust_object_snapshot.bin.gz";
 pub const SHIMMER_OBJECT_SNAPSHOT_URL: &str = "https://stardust-objects.s3.eu-central-1.amazonaws.com/shimmer/alphanet/latest/stardust_object_snapshot.bin.gz";

--- a/crates/iota-genesis-builder/src/main.rs
+++ b/crates/iota-genesis-builder/src/main.rs
@@ -7,7 +7,7 @@
 use std::{
     collections::BTreeMap,
     fs::File,
-    io::{BufWriter, Write},
+    io::BufWriter,
 };
 
 use anyhow::{anyhow, Result};
@@ -18,7 +18,6 @@ use iota_genesis_builder::{
         parse::HornetSnapshotParser,
         types::output_header::OutputHeader,
     },
-    BROTLI_COMPRESSOR_BUFFER_SIZE, BROTLI_COMPRESSOR_LG_WINDOW_SIZE, BROTLI_COMPRESSOR_QUALITY,
     OBJECT_SNAPSHOT_FILE_PATH,
 };
 use iota_sdk::types::block::{
@@ -44,7 +43,6 @@ struct Cli {
         default_value_t = false,
         help = "Compress the resulting object snapshot"
     )]
-    compress: bool,
     #[clap(long, help = "Disable global snapshot verification")]
     disable_global_snapshot_verification: bool,
 }
@@ -108,16 +106,7 @@ fn main() -> Result<()> {
 
     // Prepare the writer for the objects snapshot
     let output_file = File::create(OBJECT_SNAPSHOT_FILE_PATH)?;
-    let object_snapshot_writer: Box<dyn Write> = if cli.compress {
-        Box::new(brotli::CompressorWriter::new(
-            output_file,
-            BROTLI_COMPRESSOR_BUFFER_SIZE,
-            BROTLI_COMPRESSOR_QUALITY,
-            BROTLI_COMPRESSOR_LG_WINDOW_SIZE,
-        ))
-    } else {
-        Box::new(BufWriter::new(output_file))
-    };
+    let object_snapshot_writer = BufWriter::new(output_file);
 
     match coin_type {
         CoinType::Shimmer => {

--- a/crates/iota-genesis-builder/src/main.rs
+++ b/crates/iota-genesis-builder/src/main.rs
@@ -37,12 +37,6 @@ use tracing_subscriber::FmtSubscriber;
 struct Cli {
     #[clap(subcommand)]
     snapshot: Snapshot,
-    #[clap(
-        short,
-        long,
-        default_value_t = false,
-        help = "Compress the resulting object snapshot"
-    )]
     #[clap(long, help = "Disable global snapshot verification")]
     disable_global_snapshot_verification: bool,
 }

--- a/crates/iota-genesis-builder/src/main.rs
+++ b/crates/iota-genesis-builder/src/main.rs
@@ -4,11 +4,7 @@
 //! Creating a stardust objects snapshot out of a Hornet snapshot.
 //! TIP that defines the Hornet snapshot file format:
 //! https://github.com/iotaledger/tips/blob/main/tips/TIP-0035/tip-0035.md
-use std::{
-    collections::BTreeMap,
-    fs::File,
-    io::BufWriter,
-};
+use std::{collections::BTreeMap, fs::File, io::BufWriter};
 
 use anyhow::{anyhow, Result};
 use clap::{Parser, Subcommand};


### PR DESCRIPTION
# Description of change

Removed an option to use brotli compression in iota-genesis-builder through the `--compress` flag.
The reasoning is explained here: #926

## Links to any relevant issues

fix #926 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected):
    - The `--compress` flag in `iota-genesis-builder` will no longer be accepted

## How the change has been tested

- `cargo test`
- manually checked that the command `cargo run --bin iota-genesis-builder...` executes successfully

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
