### PR TITLE
feat(workflow): release iota-graphql-rpc docker image

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -20,6 +20,11 @@ on:
         description: "Release iota-tools image"
         required: false
         default: false
+      iota_graphql_rpc:
+        type: boolean
+        description: "Release iota-graphql-rpc image"
+        required: false
+        default: false
 
 jobs:
   build-iota-node:
@@ -152,6 +157,51 @@ jobs:
         with:
           context: .
           file: docker/iota-tools/Dockerfile
+          platforms: linux/amd64
+          tags: ${{ steps.meta-tools.outputs.tags }}
+          push: true
+          pull: true
+
+  build-iota-graphql-rpc:
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.iota_graphql_rpc == 'true' || github.event_name == 'release' }}
+    runs-on: self-hosted
+    environment: release
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta for iota-graphql-rpc
+        id: meta-tools
+        uses: docker/metadata-action@v5
+        with:
+          images: docker-registry.iota.org/iota-graphql-rpc
+          tags: |
+            type=raw,value={{sha}},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}},enable=${{ github.event_name == 'release' }}
+            type=match,pattern=v(\d+.\d+),suffix=-alpha,group=1,enable=${{ contains(github.ref, '-alpha') && github.event_name == 'release' }}
+            type=match,pattern=v(\d+.\d+),suffix=-beta,group=1,enable=${{ contains(github.ref, '-beta') && github.event_name == 'release' }}
+            type=match,pattern=v(\d+.\d+),suffix=-rc,group=1,enable=${{ contains(github.ref, '-rc') && github.event_name == 'release' }}
+
+      - name: Login to Docker Registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+          password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+          registry: ${{ secrets.DOCKER_REGISTRY_URL }}
+
+      - name: Build and push Docker image for iota-graphql-rpc
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/iota-graphql-rpc/Dockerfile
           platforms: linux/amd64
           tags: ${{ steps.meta-tools.outputs.tags }}
           push: true


### PR DESCRIPTION
# Description of change

Build and push the `iota-graphql-rpc` Docker image to our self-hosted Docker registry server.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested with `act`
