### PR TITLE
feat(ci): rely on already installed dprint

### DIFF
--- a/.github/workflows/dprint.yml
+++ b/.github/workflows/dprint.yml
@@ -20,7 +20,5 @@ jobs:
     runs-on: [self-hosted]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # Pin v4.1.1
-      - name: Install dprint
-        run: cargo install dprint
       - name: Check dprint formatting
         run: dprint check


### PR DESCRIPTION
Thomas installed dprint on all our runners so we don't have to install it every time in the workflow.
30s out of the 40s of the workflow are spent installing it.