### PR TITLE
refactor(iota-indexer): restore db schema for ExtendedApi

### DIFF
--- a/crates/iota-indexer/migrations/00000000000000_diesel_initial_setup/down.sql
+++ b/crates/iota-indexer/migrations/00000000000000_diesel_initial_setup/down.sql
@@ -1,5 +1,10 @@
 -- This file should undo anything in `up.sql`
 
+-- These views are placed on top because they depend on tables, if dropping the tables first and then the views it will result in an error.
+-- We could use CASCADE or placing them on top before dropping teh tables
+DROP VIEW network_metrics;
+DROP VIEW real_time_tps;
+
 -- Diesel
 DROP FUNCTION IF EXISTS diesel_manage_updated_at(_tbl regclass);
 DROP FUNCTION IF EXISTS diesel_set_updated_at();
@@ -44,3 +49,12 @@ DROP TABLE IF EXISTS display;
 
 DROP FUNCTION IF EXISTS query_cost(TEXT);
 DROP PROCEDURE IF EXISTS advance_partition;
+
+-- Extended Api metrics for the explorer
+DROP TABLE IF EXISTS tx_count_metrics;
+DROP TABLE IF EXISTS move_calls;
+DROP TABLE IF EXISTS move_call_metrics;
+DROP TABLE IF EXISTS addresses;
+DROP TABLE IF EXISTS active_addresses;
+DROP TABLE IF EXISTS address_metrics;
+DROP TABLE IF EXISTS epoch_peak_tps;

--- a/crates/iota-indexer/migrations/00000000000000_diesel_initial_setup/down.sql
+++ b/crates/iota-indexer/migrations/00000000000000_diesel_initial_setup/down.sql
@@ -1,7 +1,7 @@
 -- This file should undo anything in `up.sql`
 
 -- These views are placed on top because they depend on tables, if dropping the tables first and then the views it will result in an error.
--- We could use CASCADE or placing them on top before dropping teh tables
+-- We could use CASCADE or placing them on top before dropping the tables
 DROP VIEW network_metrics;
 DROP VIEW real_time_tps;
 

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -4,6 +4,37 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
+    active_addresses (address) {
+        address -> Bytea,
+        first_appearance_tx -> Int8,
+        first_appearance_time -> Int8,
+        last_appearance_tx -> Int8,
+        last_appearance_time -> Int8,
+    }
+}
+
+diesel::table! {
+    address_metrics (checkpoint) {
+        checkpoint -> Int8,
+        epoch -> Int8,
+        timestamp_ms -> Int8,
+        cumulative_addresses -> Int8,
+        cumulative_active_addresses -> Int8,
+        daily_active_addresses -> Int8,
+    }
+}
+
+diesel::table! {
+    addresses (address) {
+        address -> Bytea,
+        first_appearance_tx -> Int8,
+        first_appearance_time -> Int8,
+        last_appearance_tx -> Int8,
+        last_appearance_time -> Int8,
+    }
+}
+
+diesel::table! {
     checkpoints (sequence_number) {
         sequence_number -> Int8,
         checkpoint_digest -> Bytea,
@@ -30,6 +61,14 @@ diesel::table! {
         id -> Bytea,
         version -> Int2,
         bcs -> Bytea,
+    }
+}
+
+diesel::table! {
+    epoch_peak_tps (epoch) {
+        epoch -> Int8,
+        peak_tps -> Float8,
+        peak_tps_30d -> Float8,
     }
 }
 
@@ -68,6 +107,29 @@ diesel::table! {
         event_type -> Text,
         timestamp_ms -> Int8,
         bcs -> Bytea,
+    }
+}
+
+diesel::table! {
+    move_call_metrics (id) {
+        id -> Int8,
+        epoch -> Int8,
+        day -> Int8,
+        move_package -> Text,
+        move_module -> Text,
+        move_function -> Text,
+        count -> Int8,
+    }
+}
+
+diesel::table! {
+    move_calls (transaction_sequence_number, move_package, move_module, move_function) {
+        transaction_sequence_number -> Int8,
+        checkpoint_sequence_number -> Int8,
+        epoch -> Int8,
+        move_package -> Bytea,
+        move_module -> Text,
+        move_function -> Text,
     }
 }
 
@@ -206,6 +268,17 @@ diesel::table! {
 }
 
 diesel::table! {
+    tx_count_metrics (checkpoint_sequence_number) {
+        checkpoint_sequence_number -> Int8,
+        epoch -> Int8,
+        timestamp_ms -> Int8,
+        total_transaction_blocks -> Int8,
+        total_successful_transaction_blocks -> Int8,
+        total_successful_transactions -> Int8,
+    }
+}
+
+diesel::table! {
     tx_input_objects (object_id, tx_sequence_number) {
         tx_sequence_number -> Int8,
         object_id -> Bytea,
@@ -227,10 +300,16 @@ diesel::table! {
 }
 
 diesel::allow_tables_to_appear_in_same_query!(
+    active_addresses,
+    address_metrics,
+    addresses,
     checkpoints,
     display,
+    epoch_peak_tps,
     epochs,
     events,
+    move_call_metrics,
+    move_calls,
     objects,
     objects_history,
     objects_history_partition_0,
@@ -240,6 +319,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     transactions_partition_0,
     tx_calls,
     tx_changed_objects,
+    tx_count_metrics,
     tx_input_objects,
     tx_recipients,
     tx_senders,


### PR DESCRIPTION
# Description of change

Restore database schemas needed for the ExtendedApi metric endpoints for the explorer

## Links to any relevant issues

fixes #1848 

## Type of change

Choose a type of change, and delete any options that are not relevant.
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested
Added the new tables and checked if the generated `schema.rs` had the same values as the old [`schema.rs`](https://github.com/iotaledger/iota/commit/37ec59d05193d2b94fd5a38673eae49dd1eb9ef4#diff-8adb840139951c3d86d3daac883557392a7d8a378cb7f137f64811e71fa09566)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
