### PR TITLE
fix(iota-rest-api): remove wrong comment

### DIFF
--- a/crates/iota-rest-api/src/types.rs
+++ b/crates/iota-rest-api/src/types.rs
@@ -25,7 +25,6 @@ pub struct JsonObject {
     pub version: u64,
     /// Base64 string representing the object digest
     pub digest: ObjectDigest,
-    // Default to be None because otherwise it will be repeated for the getOwnedObjects endpoint
     /// The owner of this object.
     pub owner: Owner,
     /// The digest of the transaction that created or last mutated this object.


### PR DESCRIPTION
# Description of change

Remove wrong comment, there is no Option for this field.
Probably was copied over from the `struct IotaObjectData` where it is an Option

## Links to any relevant issues

Closes https://github.com/iotaledger/iota/issues/1261

## Type of change

- Documentation Fix

