### PR TITLE
fix(docs/references/cli/ptb): remove 0xdee9 (deepbook) mention

### DIFF
--- a/docs/content/references/cli/ptb.mdx
+++ b/docs/content/references/cli/ptb.mdx
@@ -76,7 +76,7 @@ iota client ptb \
 
 :::tip
 
-CLI PTB uses name resolution for common packages like `iota`, `std`, so you can use them directly instead of their addresses: `0x2`, `0x1`.
+CLI PTB uses name resolution for common packages like `iota`, `std`, so you can use them directly instead of their addresses: `0x2` or `0x1`.
 
 :::
 

--- a/docs/content/references/cli/ptb.mdx
+++ b/docs/content/references/cli/ptb.mdx
@@ -76,7 +76,7 @@ iota client ptb \
 
 :::tip
 
-CLI PTB uses name resolution for common packages like `iota`, `std`, so you can use them directly instead of their addresses: `0x2`, `0x1`, or `0xdee9`.
+CLI PTB uses name resolution for common packages like `iota`, `std`, so you can use them directly instead of their addresses: `0x2`, `0x1`.
 
 :::
 


### PR DESCRIPTION
# Description of change

Remove 0xdee9 (deepbook) mention as it's currently not enabled

## Links to any relevant issues

https://github.com/iotaledger/iota/issues/1613

## Type of change

- Documentation Fix
