### PR TITLE
fix(iota-indexer): handle missing events gracefully

### DIFF
--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -1113,13 +1113,18 @@ impl IndexerReader {
                 event_seq,
             )
         } else if descending_order {
-            let max_tx_seq: i64 = self.run_query(|conn| {
-                events::dsl::events
-                    .select(events::tx_sequence_number)
-                    .order(events::dsl::tx_sequence_number.desc())
-                    .first::<i64>(conn)
-            })?;
-            (max_tx_seq + 1, 0)
+            let max_tx_seq = self
+                .run_query(|conn| {
+                    events::dsl::events
+                        .select(events::tx_sequence_number)
+                        .order(events::dsl::tx_sequence_number.desc())
+                        .first::<i64>(conn)
+                        .optional()
+                })?
+                .map(|max_tx_seq| max_tx_seq + 1)
+                .unwrap_or(-1);
+
+            (max_tx_seq, 0)
         } else {
             (-1, 0)
         };

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -1121,8 +1121,7 @@ impl IndexerReader {
                         .first::<i64>(conn)
                         .optional()
                 })?
-                .map(|max_tx_seq| max_tx_seq + 1)
-                .unwrap_or(-1);
+                .map_or(-1, |max_tx_seq| max_tx_seq + 1);
 
             (max_tx_seq, 0)
         } else {


### PR DESCRIPTION
# Description of change

When requesting all events on indexer RPC if no events are present in the Postgres table then it fails with `Record not found` error, since is not clearly an issue per se we handle this error gracefully

## Links to any relevant issues

fixes #1814 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

started a local network and used `iota-sdk` making the query:

```rust
use iota_sdk::{rpc_types::EventFilter, IotaClientBuilder};

const LOCAL_INDEXER: &str = "http://localhost:9005";

#[tokio::main]
async fn main() -> Result<(), anyhow::Error> {

    let client = IotaClientBuilder::default().build(LOCAL_INDEXER).await?;

    let query_events = client
        .event_api()
        .query_events(EventFilter::All(vec![]), None, None, false)
        .await?;
    println!("{:?}", query_events);
    Ok(())
}
```
it give sti result which is expected
```
Error: ErrorObject { code: InternalError, message: "Indexer does not support the feature with error: `This type of EventFilter is not supported.`", data: None }

Caused by:
    ErrorObject { code: InternalError, message: "Indexer does not support the feature with error: `This type of EventFilter is not supported.`", data: None }
```
instead of this
```
Error: ErrorObject { code: InternalError, message: "Indexer failed to read PostgresDB with error: `Record not found`", data: None }

Caused by:
    ErrorObject { code: InternalError, message: "Indexer failed to read PostgresDB with error: `Record not found`", data: None }
```
## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
