### PR TITLE
fix(move-stdlib-v0): fixed the `check_that_docs_are_updated` test

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -19,7 +19,8 @@
     "crates/iota-light-client/example_config/20873329.yaml",
     "narwhal/node/tests/staged/narwhal.yaml",
     "**/pnpm-lock.yaml",
-    "external-crates/move/crates/move-stdlib/**/docs/**/*.md"
+    "external-crates/move/crates/move-stdlib/**/docs/**/*.md",
+    "external-crates/move/move-execution/v0/crates/move-stdlib/**/docs/**/*.md"
   ],
   "toml": {
     "lineWidth": 80

--- a/external-crates/move/move-execution/v0/crates/move-stdlib/docs/ascii.md
+++ b/external-crates/move/move-execution/v0/crates/move-stdlib/docs/ascii.md
@@ -1,3 +1,4 @@
+
 <a name="0x1_ascii"></a>
 
 # Module `0x1::ascii`
@@ -5,24 +6,28 @@
 The <code>ASCII</code> module defines basic string and char newtypes in Move that verify
 that characters are valid ASCII, and that strings consist of only valid ASCII characters.
 
-- [Struct `String`](#0x1_ascii_String)
-- [Struct `Char`](#0x1_ascii_Char)
-- [Constants](#@Constants_0)
-- [Function `char`](#0x1_ascii_char)
-- [Function `string`](#0x1_ascii_string)
-- [Function `try_string`](#0x1_ascii_try_string)
-- [Function `all_characters_printable`](#0x1_ascii_all_characters_printable)
-- [Function `push_char`](#0x1_ascii_push_char)
-- [Function `pop_char`](#0x1_ascii_pop_char)
-- [Function `length`](#0x1_ascii_length)
-- [Function `as_bytes`](#0x1_ascii_as_bytes)
-- [Function `into_bytes`](#0x1_ascii_into_bytes)
-- [Function `byte`](#0x1_ascii_byte)
-- [Function `is_valid_char`](#0x1_ascii_is_valid_char)
-- [Function `is_printable_char`](#0x1_ascii_is_printable_char)
+
+-  [Struct `String`](#0x1_ascii_String)
+-  [Struct `Char`](#0x1_ascii_Char)
+-  [Constants](#@Constants_0)
+-  [Function `char`](#0x1_ascii_char)
+-  [Function `string`](#0x1_ascii_string)
+-  [Function `try_string`](#0x1_ascii_try_string)
+-  [Function `all_characters_printable`](#0x1_ascii_all_characters_printable)
+-  [Function `push_char`](#0x1_ascii_push_char)
+-  [Function `pop_char`](#0x1_ascii_pop_char)
+-  [Function `length`](#0x1_ascii_length)
+-  [Function `as_bytes`](#0x1_ascii_as_bytes)
+-  [Function `into_bytes`](#0x1_ascii_into_bytes)
+-  [Function `byte`](#0x1_ascii_byte)
+-  [Function `is_valid_char`](#0x1_ascii_is_valid_char)
+-  [Function `is_printable_char`](#0x1_ascii_is_printable_char)
+
 
 <pre><code><b>use</b> <a href="option.md#0x1_option">0x1::option</a>;
 </code></pre>
+
+
 
 <a name="0x1_ascii_String"></a>
 
@@ -34,11 +39,15 @@ be printable. To determine if a <code><a href="ascii.md#0x1_ascii_String">String
 characters you should use the <code>all_characters_printable</code> predicate
 defined in this module.
 
+
 <pre><code><b>struct</b> <a href="ascii.md#0x1_ascii_String">String</a> <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
+
+
 <details>
 <summary>Fields</summary>
+
 
 <dl>
 <dt>
@@ -49,6 +58,7 @@ defined in this module.
 </dd>
 </dl>
 
+
 </details>
 
 <a name="0x1_ascii_Char"></a>
@@ -57,11 +67,15 @@ defined in this module.
 
 An ASCII character.
 
+
 <pre><code><b>struct</b> <a href="ascii.md#0x1_ascii_Char">Char</a> <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
+
+
 <details>
 <summary>Fields</summary>
+
 
 <dl>
 <dt>
@@ -72,18 +86,23 @@ An ASCII character.
 </dd>
 </dl>
 
+
 </details>
 
 <a name="@Constants_0"></a>
 
 ## Constants
 
+
 <a name="0x1_ascii_EINVALID_ASCII_CHARACTER"></a>
 
 An invalid ASCII character was encountered when creating an ASCII string.
 
+
 <pre><code><b>const</b> <a href="ascii.md#0x1_ascii_EINVALID_ASCII_CHARACTER">EINVALID_ASCII_CHARACTER</a>: u64 = 65536;
 </code></pre>
+
+
 
 <a name="0x1_ascii_char"></a>
 
@@ -91,17 +110,23 @@ An invalid ASCII character was encountered when creating an ASCII string.
 
 Convert a <code>byte</code> into a <code><a href="ascii.md#0x1_ascii_Char">Char</a></code> that is checked to make sure it is valid ASCII.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_char">char</a>(byte: u8): <a href="ascii.md#0x1_ascii_Char">ascii::Char</a>
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_char">char</a>(byte: u8): <a href="ascii.md#0x1_ascii_Char">Char</a> {
     <b>assert</b>!(<a href="ascii.md#0x1_ascii_is_valid_char">is_valid_char</a>(byte), <a href="ascii.md#0x1_ascii_EINVALID_ASCII_CHARACTER">EINVALID_ASCII_CHARACTER</a>);
     <a href="ascii.md#0x1_ascii_Char">Char</a> { byte }
 }
 </code></pre>
+
+
 
 </details>
 
@@ -112,11 +137,15 @@ Convert a <code>byte</code> into a <code><a href="ascii.md#0x1_ascii_Char">Char<
 Convert a vector of bytes <code>bytes</code> into an <code><a href="ascii.md#0x1_ascii_String">String</a></code>. Aborts if
 <code>bytes</code> contains non-ASCII characters.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string">string</a>(bytes: <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="ascii.md#0x1_ascii_String">ascii::String</a>
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string">string</a>(bytes: <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="ascii.md#0x1_ascii_String">String</a> {
    <b>let</b> x = <a href="ascii.md#0x1_ascii_try_string">try_string</a>(bytes);
@@ -128,6 +157,8 @@ Convert a vector of bytes <code>bytes</code> into an <code><a href="ascii.md#0x1
 }
 </code></pre>
 
+
+
 </details>
 
 <a name="0x1_ascii_try_string"></a>
@@ -138,11 +169,15 @@ Convert a vector of bytes <code>bytes</code> into an <code><a href="ascii.md#0x1
 <code>Some(&lt;ascii_string&gt;)</code> if the <code>bytes</code> contains all valid ASCII
 characters. Otherwise returns <code>None</code>.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_try_string">try_string</a>(bytes: <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="option.md#0x1_option_Option">option::Option</a>&lt;<a href="ascii.md#0x1_ascii_String">ascii::String</a>&gt;
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_try_string">try_string</a>(bytes: <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;): Option&lt;<a href="ascii.md#0x1_ascii_String">String</a>&gt; {
     <b>let</b> len = <a href="vector.md#0x1_vector_length">vector::length</a>(&bytes);
@@ -156,6 +191,8 @@ characters. Otherwise returns <code>None</code>.
 }
 </code></pre>
 
+
+
 </details>
 
 <a name="0x1_ascii_all_characters_printable"></a>
@@ -165,11 +202,15 @@ characters. Otherwise returns <code>None</code>.
 Returns <code><b>true</b></code> if all characters in <code><a href="string.md#0x1_string">string</a></code> are printable characters
 Returns <code><b>false</b></code> otherwise. Not all <code><a href="ascii.md#0x1_ascii_String">String</a></code>s are printable strings.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_all_characters_printable">all_characters_printable</a>(<a href="string.md#0x1_string">string</a>: &<a href="ascii.md#0x1_ascii_String">ascii::String</a>): bool
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_all_characters_printable">all_characters_printable</a>(<a href="string.md#0x1_string">string</a>: &<a href="ascii.md#0x1_ascii_String">String</a>): bool {
     <b>let</b> len = <a href="vector.md#0x1_vector_length">vector::length</a>(&<a href="string.md#0x1_string">string</a>.bytes);
@@ -183,22 +224,31 @@ Returns <code><b>false</b></code> otherwise. Not all <code><a href="ascii.md#0x1
 }
 </code></pre>
 
+
+
 </details>
 
 <a name="0x1_ascii_push_char"></a>
 
 ## Function `push_char`
 
+
+
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_push_char">push_char</a>(<a href="string.md#0x1_string">string</a>: &<b>mut</b> <a href="ascii.md#0x1_ascii_String">ascii::String</a>, char: <a href="ascii.md#0x1_ascii_Char">ascii::Char</a>)
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_push_char">push_char</a>(<a href="string.md#0x1_string">string</a>: &<b>mut</b> <a href="ascii.md#0x1_ascii_String">String</a>, char: <a href="ascii.md#0x1_ascii_Char">Char</a>) {
     <a href="vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> <a href="string.md#0x1_string">string</a>.bytes, char.byte);
 }
 </code></pre>
+
+
 
 </details>
 
@@ -206,16 +256,23 @@ Returns <code><b>false</b></code> otherwise. Not all <code><a href="ascii.md#0x1
 
 ## Function `pop_char`
 
+
+
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_pop_char">pop_char</a>(<a href="string.md#0x1_string">string</a>: &<b>mut</b> <a href="ascii.md#0x1_ascii_String">ascii::String</a>): <a href="ascii.md#0x1_ascii_Char">ascii::Char</a>
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_pop_char">pop_char</a>(<a href="string.md#0x1_string">string</a>: &<b>mut</b> <a href="ascii.md#0x1_ascii_String">String</a>): <a href="ascii.md#0x1_ascii_Char">Char</a> {
     <a href="ascii.md#0x1_ascii_Char">Char</a> { byte: <a href="vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> <a href="string.md#0x1_string">string</a>.bytes) }
 }
 </code></pre>
+
+
 
 </details>
 
@@ -223,16 +280,23 @@ Returns <code><b>false</b></code> otherwise. Not all <code><a href="ascii.md#0x1
 
 ## Function `length`
 
+
+
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_length">length</a>(<a href="string.md#0x1_string">string</a>: &<a href="ascii.md#0x1_ascii_String">ascii::String</a>): u64
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_length">length</a>(<a href="string.md#0x1_string">string</a>: &<a href="ascii.md#0x1_ascii_String">String</a>): u64 {
     <a href="vector.md#0x1_vector_length">vector::length</a>(<a href="ascii.md#0x1_ascii_as_bytes">as_bytes</a>(<a href="string.md#0x1_string">string</a>))
 }
 </code></pre>
+
+
 
 </details>
 
@@ -242,16 +306,22 @@ Returns <code><b>false</b></code> otherwise. Not all <code><a href="ascii.md#0x1
 
 Get the inner bytes of the <code><a href="string.md#0x1_string">string</a></code> as a reference
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_as_bytes">as_bytes</a>(<a href="string.md#0x1_string">string</a>: &<a href="ascii.md#0x1_ascii_String">ascii::String</a>): &<a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_as_bytes">as_bytes</a>(<a href="string.md#0x1_string">string</a>: &<a href="ascii.md#0x1_ascii_String">String</a>): &<a href="vector.md#0x1_vector">vector</a>&lt;u8&gt; {
    &<a href="string.md#0x1_string">string</a>.bytes
 }
 </code></pre>
+
+
 
 </details>
 
@@ -261,17 +331,23 @@ Get the inner bytes of the <code><a href="string.md#0x1_string">string</a></code
 
 Unpack the <code><a href="string.md#0x1_string">string</a></code> to get its backing bytes
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_into_bytes">into_bytes</a>(<a href="string.md#0x1_string">string</a>: <a href="ascii.md#0x1_ascii_String">ascii::String</a>): <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_into_bytes">into_bytes</a>(<a href="string.md#0x1_string">string</a>: <a href="ascii.md#0x1_ascii_String">String</a>): <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt; {
    <b>let</b> <a href="ascii.md#0x1_ascii_String">String</a> { bytes } = <a href="string.md#0x1_string">string</a>;
    bytes
 }
 </code></pre>
+
+
 
 </details>
 
@@ -281,17 +357,23 @@ Unpack the <code><a href="string.md#0x1_string">string</a></code> to get its bac
 
 Unpack the <code>char</code> into its underlying byte.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_byte">byte</a>(char: <a href="ascii.md#0x1_ascii_Char">ascii::Char</a>): u8
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_byte">byte</a>(char: <a href="ascii.md#0x1_ascii_Char">Char</a>): u8 {
    <b>let</b> <a href="ascii.md#0x1_ascii_Char">Char</a> { byte } = char;
    byte
 }
 </code></pre>
+
+
 
 </details>
 
@@ -301,16 +383,22 @@ Unpack the <code>char</code> into its underlying byte.
 
 Returns <code><b>true</b></code> if <code>b</code> is a valid ASCII character. Returns <code><b>false</b></code> otherwise.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_is_valid_char">is_valid_char</a>(b: u8): bool
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_is_valid_char">is_valid_char</a>(b: u8): bool {
    b &lt;= 0x7F
 }
 </code></pre>
+
+
 
 </details>
 
@@ -320,11 +408,15 @@ Returns <code><b>true</b></code> if <code>b</code> is a valid ASCII character. R
 
 Returns <code><b>true</b></code> if <code>byte</code> is an printable ASCII character. Returns <code><b>false</b></code> otherwise.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_is_printable_char">is_printable_char</a>(byte: u8): bool
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="ascii.md#0x1_ascii_is_printable_char">is_printable_char</a>(byte: u8): bool {
    byte &gt;= 0x20 && // Disallow metacharacters
@@ -332,6 +424,9 @@ Returns <code><b>true</b></code> if <code>byte</code> is an printable ASCII char
 }
 </code></pre>
 
+
+
 </details>
+
 
 [//]: # ("File containing references which can be used from documentation")

--- a/external-crates/move/move-execution/v0/crates/move-stdlib/docs/bcs.md
+++ b/external-crates/move/move-execution/v0/crates/move-stdlib/docs/bcs.md
@@ -1,3 +1,4 @@
+
 <a name="0x1_bcs"></a>
 
 # Module `0x1::bcs`
@@ -7,9 +8,13 @@ Serialization). BCS is the binary encoding for Move resources and other non-modu
 published on-chain. See https://github.com/diem/bcs#binary-canonical-serialization-bcs for more
 details on BCS.
 
-- [Function `to_bytes`](#0x1_bcs_to_bytes)
+
+-  [Function `to_bytes`](#0x1_bcs_to_bytes)
+
 
 <pre><code></code></pre>
+
+
 
 <a name="0x1_bcs_to_bytes"></a>
 
@@ -17,15 +22,22 @@ details on BCS.
 
 Return the binary representation of <code>v</code> in BCS (Binary Canonical Serialization) format
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="bcs.md#0x1_bcs_to_bytes">to_bytes</a>&lt;MoveValue&gt;(v: &MoveValue): <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="bcs.md#0x1_bcs_to_bytes">to_bytes</a>&lt;MoveValue&gt;(v: &MoveValue): <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;;
 </code></pre>
 
+
+
 </details>
+
 
 [//]: # ("File containing references which can be used from documentation")

--- a/external-crates/move/move-execution/v0/crates/move-stdlib/docs/bit_vector.md
+++ b/external-crates/move/move-execution/v0/crates/move-stdlib/docs/bit_vector.md
@@ -1,28 +1,39 @@
+
 <a name="0x1_bit_vector"></a>
 
 # Module `0x1::bit_vector`
 
-- [Struct `BitVector`](#0x1_bit_vector_BitVector)
-- [Constants](#@Constants_0)
-- [Function `new`](#0x1_bit_vector_new)
-- [Function `set`](#0x1_bit_vector_set)
-- [Function `unset`](#0x1_bit_vector_unset)
-- [Function `shift_left`](#0x1_bit_vector_shift_left)
-- [Function `is_index_set`](#0x1_bit_vector_is_index_set)
-- [Function `length`](#0x1_bit_vector_length)
-- [Function `longest_set_sequence_starting_at`](#0x1_bit_vector_longest_set_sequence_starting_at)
+
+
+-  [Struct `BitVector`](#0x1_bit_vector_BitVector)
+-  [Constants](#@Constants_0)
+-  [Function `new`](#0x1_bit_vector_new)
+-  [Function `set`](#0x1_bit_vector_set)
+-  [Function `unset`](#0x1_bit_vector_unset)
+-  [Function `shift_left`](#0x1_bit_vector_shift_left)
+-  [Function `is_index_set`](#0x1_bit_vector_is_index_set)
+-  [Function `length`](#0x1_bit_vector_length)
+-  [Function `longest_set_sequence_starting_at`](#0x1_bit_vector_longest_set_sequence_starting_at)
+
 
 <pre><code></code></pre>
+
+
 
 <a name="0x1_bit_vector_BitVector"></a>
 
 ## Struct `BitVector`
 
+
+
 <pre><code><b>struct</b> <a href="bit_vector.md#0x1_bit_vector_BitVector">BitVector</a> <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
+
+
 <details>
 <summary>Fields</summary>
+
 
 <dl>
 <dt>
@@ -39,42 +50,58 @@
 </dd>
 </dl>
 
+
 </details>
 
 <a name="@Constants_0"></a>
 
 ## Constants
 
+
 <a name="0x1_bit_vector_EINDEX"></a>
 
 The provided index is out of bounds
 
+
 <pre><code><b>const</b> <a href="bit_vector.md#0x1_bit_vector_EINDEX">EINDEX</a>: u64 = 131072;
 </code></pre>
+
+
 
 <a name="0x1_bit_vector_ELENGTH"></a>
 
 An invalid length of bitvector was given
 
+
 <pre><code><b>const</b> <a href="bit_vector.md#0x1_bit_vector_ELENGTH">ELENGTH</a>: u64 = 131073;
 </code></pre>
+
+
 
 <a name="0x1_bit_vector_MAX_SIZE"></a>
 
 The maximum allowed bitvector size
 
+
 <pre><code><b>const</b> <a href="bit_vector.md#0x1_bit_vector_MAX_SIZE">MAX_SIZE</a>: u64 = 1024;
 </code></pre>
+
+
 
 <a name="0x1_bit_vector_new"></a>
 
 ## Function `new`
 
+
+
 <pre><code><b>public</b> <b>fun</b> <a href="bit_vector.md#0x1_bit_vector_new">new</a>(length: u64): <a href="bit_vector.md#0x1_bit_vector_BitVector">bit_vector::BitVector</a>
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="bit_vector.md#0x1_bit_vector_new">new</a>(length: u64): <a href="bit_vector.md#0x1_bit_vector_BitVector">BitVector</a> {
     <b>assert</b>!(length &gt; 0, <a href="bit_vector.md#0x1_bit_vector_ELENGTH">ELENGTH</a>);
@@ -93,6 +120,8 @@ The maximum allowed bitvector size
 }
 </code></pre>
 
+
+
 </details>
 
 <a name="0x1_bit_vector_set"></a>
@@ -101,11 +130,15 @@ The maximum allowed bitvector size
 
 Set the bit at <code>bit_index</code> in the <code>bitvector</code> regardless of its previous state.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="bit_vector.md#0x1_bit_vector_set">set</a>(bitvector: &<b>mut</b> <a href="bit_vector.md#0x1_bit_vector_BitVector">bit_vector::BitVector</a>, bit_index: u64)
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="bit_vector.md#0x1_bit_vector_set">set</a>(bitvector: &<b>mut</b> <a href="bit_vector.md#0x1_bit_vector_BitVector">BitVector</a>, bit_index: u64) {
     <b>assert</b>!(bit_index &lt; <a href="vector.md#0x1_vector_length">vector::length</a>(&bitvector.bit_field), <a href="bit_vector.md#0x1_bit_vector_EINDEX">EINDEX</a>);
@@ -113,6 +146,8 @@ Set the bit at <code>bit_index</code> in the <code>bitvector</code> regardless o
     *x = <b>true</b>;
 }
 </code></pre>
+
+
 
 </details>
 
@@ -122,11 +157,15 @@ Set the bit at <code>bit_index</code> in the <code>bitvector</code> regardless o
 
 Unset the bit at <code>bit_index</code> in the <code>bitvector</code> regardless of its previous state.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="bit_vector.md#0x1_bit_vector_unset">unset</a>(bitvector: &<b>mut</b> <a href="bit_vector.md#0x1_bit_vector_BitVector">bit_vector::BitVector</a>, bit_index: u64)
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="bit_vector.md#0x1_bit_vector_unset">unset</a>(bitvector: &<b>mut</b> <a href="bit_vector.md#0x1_bit_vector_BitVector">BitVector</a>, bit_index: u64) {
     <b>assert</b>!(bit_index &lt; <a href="vector.md#0x1_vector_length">vector::length</a>(&bitvector.bit_field), <a href="bit_vector.md#0x1_bit_vector_EINDEX">EINDEX</a>);
@@ -134,6 +173,8 @@ Unset the bit at <code>bit_index</code> in the <code>bitvector</code> regardless
     *x = <b>false</b>;
 }
 </code></pre>
+
+
 
 </details>
 
@@ -144,11 +185,15 @@ Unset the bit at <code>bit_index</code> in the <code>bitvector</code> regardless
 Shift the <code>bitvector</code> left by <code>amount</code>. If <code>amount</code> is greater than the
 bitvector's length the bitvector will be zeroed out.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="bit_vector.md#0x1_bit_vector_shift_left">shift_left</a>(bitvector: &<b>mut</b> <a href="bit_vector.md#0x1_bit_vector_BitVector">bit_vector::BitVector</a>, amount: u64)
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="bit_vector.md#0x1_bit_vector_shift_left">shift_left</a>(bitvector: &<b>mut</b> <a href="bit_vector.md#0x1_bit_vector_BitVector">BitVector</a>, amount: u64) {
     <b>if</b> (amount &gt;= bitvector.length) {
@@ -178,6 +223,8 @@ bitvector's length the bitvector will be zeroed out.
 }
 </code></pre>
 
+
+
 </details>
 
 <a name="0x1_bit_vector_is_index_set"></a>
@@ -187,17 +234,23 @@ bitvector's length the bitvector will be zeroed out.
 Return the value of the bit at <code>bit_index</code> in the <code>bitvector</code>. <code><b>true</b></code>
 represents "1" and <code><b>false</b></code> represents a 0
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="bit_vector.md#0x1_bit_vector_is_index_set">is_index_set</a>(bitvector: &<a href="bit_vector.md#0x1_bit_vector_BitVector">bit_vector::BitVector</a>, bit_index: u64): bool
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="bit_vector.md#0x1_bit_vector_is_index_set">is_index_set</a>(bitvector: &<a href="bit_vector.md#0x1_bit_vector_BitVector">BitVector</a>, bit_index: u64): bool {
     <b>assert</b>!(bit_index &lt; <a href="vector.md#0x1_vector_length">vector::length</a>(&bitvector.bit_field), <a href="bit_vector.md#0x1_bit_vector_EINDEX">EINDEX</a>);
     *<a href="vector.md#0x1_vector_borrow">vector::borrow</a>(&bitvector.bit_field, bit_index)
 }
 </code></pre>
+
+
 
 </details>
 
@@ -207,16 +260,22 @@ represents "1" and <code><b>false</b></code> represents a 0
 
 Return the length (number of usable bits) of this bitvector
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="bit_vector.md#0x1_bit_vector_length">length</a>(bitvector: &<a href="bit_vector.md#0x1_bit_vector_BitVector">bit_vector::BitVector</a>): u64
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="bit_vector.md#0x1_bit_vector_length">length</a>(bitvector: &<a href="bit_vector.md#0x1_bit_vector_BitVector">BitVector</a>): u64 {
     <a href="vector.md#0x1_vector_length">vector::length</a>(&bitvector.bit_field)
 }
 </code></pre>
+
+
 
 </details>
 
@@ -228,11 +287,15 @@ Returns the length of the longest sequence of set bits starting at (and
 including) <code>start_index</code> in the <code>bitvector</code>. If there is no such
 sequence, then <code>0</code> is returned.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="bit_vector.md#0x1_bit_vector_longest_set_sequence_starting_at">longest_set_sequence_starting_at</a>(bitvector: &<a href="bit_vector.md#0x1_bit_vector_BitVector">bit_vector::BitVector</a>, start_index: u64): u64
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="bit_vector.md#0x1_bit_vector_longest_set_sequence_starting_at">longest_set_sequence_starting_at</a>(bitvector: &<a href="bit_vector.md#0x1_bit_vector_BitVector">BitVector</a>, start_index: u64): u64 {
     <b>assert</b>!(start_index &lt; bitvector.length, <a href="bit_vector.md#0x1_bit_vector_EINDEX">EINDEX</a>);
@@ -248,6 +311,9 @@ sequence, then <code>0</code> is returned.
 }
 </code></pre>
 
+
+
 </details>
+
 
 [//]: # ("File containing references which can be used from documentation")

--- a/external-crates/move/move-execution/v0/crates/move-stdlib/docs/error.md
+++ b/external-crates/move/move-execution/v0/crates/move-stdlib/docs/error.md
@@ -1,3 +1,4 @@
+
 <a name="0x1_error"></a>
 
 # Module `0x1::error`
@@ -6,7 +7,7 @@ This module defines a set of canonical error codes which are optional to use by 
 <code><b>abort</b></code> and <code><b>assert</b>!</code> features.
 
 Canonical error codes use the 3 lowest bytes of the u64 abort code range (the upper 5 bytes are free for other use).
-Of those, the highest byte represents the _error category_ and the lower two bytes the _error reason_.
+Of those, the highest byte represents the *error category* and the lower two bytes the *error reason*.
 Given an error category <code>0x1</code> and a reason <code>0x3</code>, a canonical abort code looks as <code>0x10003</code>.
 
 A module can use a canonical code with a constant declaration of the following form:
@@ -24,117 +25,161 @@ from Unix error codes [see here](https://cloud.google.com/apis/design/errors#han
 associated HTTP error code which can be used in REST apis. The mapping from error code to http code is not 1:1;
 error codes here are a bit richer than HTTP codes.
 
-- [Constants](#@Constants_0)
-- [Function `canonical`](#0x1_error_canonical)
-- [Function `invalid_argument`](#0x1_error_invalid_argument)
-- [Function `out_of_range`](#0x1_error_out_of_range)
-- [Function `invalid_state`](#0x1_error_invalid_state)
-- [Function `unauthenticated`](#0x1_error_unauthenticated)
-- [Function `permission_denied`](#0x1_error_permission_denied)
-- [Function `not_found`](#0x1_error_not_found)
-- [Function `aborted`](#0x1_error_aborted)
-- [Function `already_exists`](#0x1_error_already_exists)
-- [Function `resource_exhausted`](#0x1_error_resource_exhausted)
-- [Function `internal`](#0x1_error_internal)
-- [Function `not_implemented`](#0x1_error_not_implemented)
-- [Function `unavailable`](#0x1_error_unavailable)
+
+-  [Constants](#@Constants_0)
+-  [Function `canonical`](#0x1_error_canonical)
+-  [Function `invalid_argument`](#0x1_error_invalid_argument)
+-  [Function `out_of_range`](#0x1_error_out_of_range)
+-  [Function `invalid_state`](#0x1_error_invalid_state)
+-  [Function `unauthenticated`](#0x1_error_unauthenticated)
+-  [Function `permission_denied`](#0x1_error_permission_denied)
+-  [Function `not_found`](#0x1_error_not_found)
+-  [Function `aborted`](#0x1_error_aborted)
+-  [Function `already_exists`](#0x1_error_already_exists)
+-  [Function `resource_exhausted`](#0x1_error_resource_exhausted)
+-  [Function `internal`](#0x1_error_internal)
+-  [Function `not_implemented`](#0x1_error_not_implemented)
+-  [Function `unavailable`](#0x1_error_unavailable)
+
 
 <pre><code></code></pre>
+
+
 
 <a name="@Constants_0"></a>
 
 ## Constants
 
+
 <a name="0x1_error_ABORTED"></a>
 
 Concurrency conflict, such as read-modify-write conflict (http: 409)
 
+
 <pre><code><b>const</b> <a href="error.md#0x1_error_ABORTED">ABORTED</a>: u64 = 7;
 </code></pre>
+
+
 
 <a name="0x1_error_ALREADY_EXISTS"></a>
 
 The resource that a client tried to create already exists (http: 409)
 
+
 <pre><code><b>const</b> <a href="error.md#0x1_error_ALREADY_EXISTS">ALREADY_EXISTS</a>: u64 = 8;
 </code></pre>
+
+
 
 <a name="0x1_error_CANCELLED"></a>
 
 Request cancelled by the client (http: 499)
 
+
 <pre><code><b>const</b> <a href="error.md#0x1_error_CANCELLED">CANCELLED</a>: u64 = 10;
 </code></pre>
+
+
 
 <a name="0x1_error_INTERNAL"></a>
 
 Internal error (http: 500)
 
+
 <pre><code><b>const</b> <a href="error.md#0x1_error_INTERNAL">INTERNAL</a>: u64 = 11;
 </code></pre>
+
+
 
 <a name="0x1_error_INVALID_ARGUMENT"></a>
 
 Caller specified an invalid argument (http: 400)
 
+
 <pre><code><b>const</b> <a href="error.md#0x1_error_INVALID_ARGUMENT">INVALID_ARGUMENT</a>: u64 = 1;
 </code></pre>
+
+
 
 <a name="0x1_error_INVALID_STATE"></a>
 
 The system is not in a state where the operation can be performed (http: 400)
 
+
 <pre><code><b>const</b> <a href="error.md#0x1_error_INVALID_STATE">INVALID_STATE</a>: u64 = 3;
 </code></pre>
+
+
 
 <a name="0x1_error_NOT_FOUND"></a>
 
 A specified resource is not found (http: 404)
 
+
 <pre><code><b>const</b> <a href="error.md#0x1_error_NOT_FOUND">NOT_FOUND</a>: u64 = 6;
 </code></pre>
+
+
 
 <a name="0x1_error_NOT_IMPLEMENTED"></a>
 
 Feature not implemented (http: 501)
 
+
 <pre><code><b>const</b> <a href="error.md#0x1_error_NOT_IMPLEMENTED">NOT_IMPLEMENTED</a>: u64 = 12;
 </code></pre>
+
+
 
 <a name="0x1_error_OUT_OF_RANGE"></a>
 
 An input or result of a computation is out of range (http: 400)
 
+
 <pre><code><b>const</b> <a href="error.md#0x1_error_OUT_OF_RANGE">OUT_OF_RANGE</a>: u64 = 2;
 </code></pre>
+
+
 
 <a name="0x1_error_PERMISSION_DENIED"></a>
 
 client does not have sufficient permission (http: 403)
 
+
 <pre><code><b>const</b> <a href="error.md#0x1_error_PERMISSION_DENIED">PERMISSION_DENIED</a>: u64 = 5;
 </code></pre>
+
+
 
 <a name="0x1_error_RESOURCE_EXHAUSTED"></a>
 
 Out of gas or other forms of quota (http: 429)
 
+
 <pre><code><b>const</b> <a href="error.md#0x1_error_RESOURCE_EXHAUSTED">RESOURCE_EXHAUSTED</a>: u64 = 9;
 </code></pre>
+
+
 
 <a name="0x1_error_UNAUTHENTICATED"></a>
 
 Request not authenticated due to missing, invalid, or expired auth token (http: 401)
 
+
 <pre><code><b>const</b> <a href="error.md#0x1_error_UNAUTHENTICATED">UNAUTHENTICATED</a>: u64 = 4;
 </code></pre>
+
+
 
 <a name="0x1_error_UNAVAILABLE"></a>
 
 The service is currently unavailable. Indicates that a retry could solve the issue (http: 503)
 
+
 <pre><code><b>const</b> <a href="error.md#0x1_error_UNAVAILABLE">UNAVAILABLE</a>: u64 = 13;
 </code></pre>
+
+
 
 <a name="0x1_error_canonical"></a>
 
@@ -142,16 +187,22 @@ The service is currently unavailable. Indicates that a retry could solve the iss
 
 Construct a canonical error code from a category and a reason.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_canonical">canonical</a>(category: u64, reason: u64): u64
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_canonical">canonical</a>(category: u64, reason: u64): u64 {
   (category &lt;&lt; 16) + reason
 }
 </code></pre>
+
+
 
 </details>
 
@@ -161,14 +212,20 @@ Construct a canonical error code from a category and a reason.
 
 Functions to construct a canonical error code of the given category.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_invalid_argument">invalid_argument</a>(r: u64): u64
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_invalid_argument">invalid_argument</a>(r: u64): u64 {  <a href="error.md#0x1_error_canonical">canonical</a>(<a href="error.md#0x1_error_INVALID_ARGUMENT">INVALID_ARGUMENT</a>, r) }
 </code></pre>
+
+
 
 </details>
 
@@ -176,14 +233,21 @@ Functions to construct a canonical error code of the given category.
 
 ## Function `out_of_range`
 
+
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_out_of_range">out_of_range</a>(r: u64): u64
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_out_of_range">out_of_range</a>(r: u64): u64 {  <a href="error.md#0x1_error_canonical">canonical</a>(<a href="error.md#0x1_error_OUT_OF_RANGE">OUT_OF_RANGE</a>, r) }
 </code></pre>
+
+
 
 </details>
 
@@ -191,14 +255,21 @@ Functions to construct a canonical error code of the given category.
 
 ## Function `invalid_state`
 
+
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_invalid_state">invalid_state</a>(r: u64): u64
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_invalid_state">invalid_state</a>(r: u64): u64 {  <a href="error.md#0x1_error_canonical">canonical</a>(<a href="error.md#0x1_error_INVALID_STATE">INVALID_STATE</a>, r) }
 </code></pre>
+
+
 
 </details>
 
@@ -206,14 +277,21 @@ Functions to construct a canonical error code of the given category.
 
 ## Function `unauthenticated`
 
+
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_unauthenticated">unauthenticated</a>(r: u64): u64
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_unauthenticated">unauthenticated</a>(r: u64): u64 { <a href="error.md#0x1_error_canonical">canonical</a>(<a href="error.md#0x1_error_UNAUTHENTICATED">UNAUTHENTICATED</a>, r) }
 </code></pre>
+
+
 
 </details>
 
@@ -221,14 +299,21 @@ Functions to construct a canonical error code of the given category.
 
 ## Function `permission_denied`
 
+
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_permission_denied">permission_denied</a>(r: u64): u64
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_permission_denied">permission_denied</a>(r: u64): u64 { <a href="error.md#0x1_error_canonical">canonical</a>(<a href="error.md#0x1_error_PERMISSION_DENIED">PERMISSION_DENIED</a>, r) }
 </code></pre>
+
+
 
 </details>
 
@@ -236,14 +321,21 @@ Functions to construct a canonical error code of the given category.
 
 ## Function `not_found`
 
+
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_not_found">not_found</a>(r: u64): u64
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_not_found">not_found</a>(r: u64): u64 { <a href="error.md#0x1_error_canonical">canonical</a>(<a href="error.md#0x1_error_NOT_FOUND">NOT_FOUND</a>, r) }
 </code></pre>
+
+
 
 </details>
 
@@ -251,14 +343,21 @@ Functions to construct a canonical error code of the given category.
 
 ## Function `aborted`
 
+
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_aborted">aborted</a>(r: u64): u64
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_aborted">aborted</a>(r: u64): u64 { <a href="error.md#0x1_error_canonical">canonical</a>(<a href="error.md#0x1_error_ABORTED">ABORTED</a>, r) }
 </code></pre>
+
+
 
 </details>
 
@@ -266,14 +365,21 @@ Functions to construct a canonical error code of the given category.
 
 ## Function `already_exists`
 
+
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_already_exists">already_exists</a>(r: u64): u64
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_already_exists">already_exists</a>(r: u64): u64 { <a href="error.md#0x1_error_canonical">canonical</a>(<a href="error.md#0x1_error_ALREADY_EXISTS">ALREADY_EXISTS</a>, r) }
 </code></pre>
+
+
 
 </details>
 
@@ -281,14 +387,21 @@ Functions to construct a canonical error code of the given category.
 
 ## Function `resource_exhausted`
 
+
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_resource_exhausted">resource_exhausted</a>(r: u64): u64
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_resource_exhausted">resource_exhausted</a>(r: u64): u64 {  <a href="error.md#0x1_error_canonical">canonical</a>(<a href="error.md#0x1_error_RESOURCE_EXHAUSTED">RESOURCE_EXHAUSTED</a>, r) }
 </code></pre>
+
+
 
 </details>
 
@@ -296,14 +409,21 @@ Functions to construct a canonical error code of the given category.
 
 ## Function `internal`
 
+
+
 <pre><code><b>public</b> <b>fun</b> <b>internal</b>(r: u64): u64
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>public</b> <b>fun</b> <b>internal</b>(r: u64): u64 {  <a href="error.md#0x1_error_canonical">canonical</a>(<a href="error.md#0x1_error_INTERNAL">INTERNAL</a>, r) }
 </code></pre>
+
+
 
 </details>
 
@@ -311,14 +431,21 @@ Functions to construct a canonical error code of the given category.
 
 ## Function `not_implemented`
 
+
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_not_implemented">not_implemented</a>(r: u64): u64
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_not_implemented">not_implemented</a>(r: u64): u64 {  <a href="error.md#0x1_error_canonical">canonical</a>(<a href="error.md#0x1_error_NOT_IMPLEMENTED">NOT_IMPLEMENTED</a>, r) }
 </code></pre>
+
+
 
 </details>
 
@@ -326,15 +453,23 @@ Functions to construct a canonical error code of the given category.
 
 ## Function `unavailable`
 
+
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_unavailable">unavailable</a>(r: u64): u64
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="error.md#0x1_error_unavailable">unavailable</a>(r: u64): u64 { <a href="error.md#0x1_error_canonical">canonical</a>(<a href="error.md#0x1_error_UNAVAILABLE">UNAVAILABLE</a>, r) }
 </code></pre>
 
+
+
 </details>
+
 
 [//]: # ("File containing references which can be used from documentation")

--- a/external-crates/move/move-execution/v0/crates/move-stdlib/docs/fixed_point32.md
+++ b/external-crates/move/move-execution/v0/crates/move-stdlib/docs/fixed_point32.md
@@ -1,3 +1,4 @@
+
 <a name="0x1_fixed_point32"></a>
 
 # Module `0x1::fixed_point32`
@@ -5,22 +6,26 @@
 Defines a fixed-point numeric type with a 32-bit integer part and
 a 32-bit fractional part.
 
-- [Struct `FixedPoint32`](#0x1_fixed_point32_FixedPoint32)
-- [Constants](#@Constants_0)
-- [Function `multiply_u64`](#0x1_fixed_point32_multiply_u64)
-- [Function `divide_u64`](#0x1_fixed_point32_divide_u64)
-- [Function `create_from_rational`](#0x1_fixed_point32_create_from_rational)
-- [Function `create_from_raw_value`](#0x1_fixed_point32_create_from_raw_value)
-- [Function `get_raw_value`](#0x1_fixed_point32_get_raw_value)
-- [Function `is_zero`](#0x1_fixed_point32_is_zero)
-- [Function `min`](#0x1_fixed_point32_min)
-- [Function `max`](#0x1_fixed_point32_max)
-- [Function `create_from_u64`](#0x1_fixed_point32_create_from_u64)
-- [Function `floor`](#0x1_fixed_point32_floor)
-- [Function `ceil`](#0x1_fixed_point32_ceil)
-- [Function `round`](#0x1_fixed_point32_round)
+
+-  [Struct `FixedPoint32`](#0x1_fixed_point32_FixedPoint32)
+-  [Constants](#@Constants_0)
+-  [Function `multiply_u64`](#0x1_fixed_point32_multiply_u64)
+-  [Function `divide_u64`](#0x1_fixed_point32_divide_u64)
+-  [Function `create_from_rational`](#0x1_fixed_point32_create_from_rational)
+-  [Function `create_from_raw_value`](#0x1_fixed_point32_create_from_raw_value)
+-  [Function `get_raw_value`](#0x1_fixed_point32_get_raw_value)
+-  [Function `is_zero`](#0x1_fixed_point32_is_zero)
+-  [Function `min`](#0x1_fixed_point32_min)
+-  [Function `max`](#0x1_fixed_point32_max)
+-  [Function `create_from_u64`](#0x1_fixed_point32_create_from_u64)
+-  [Function `floor`](#0x1_fixed_point32_floor)
+-  [Function `ceil`](#0x1_fixed_point32_ceil)
+-  [Function `round`](#0x1_fixed_point32_round)
+
 
 <pre><code></code></pre>
+
+
 
 <a name="0x1_fixed_point32_FixedPoint32"></a>
 
@@ -36,11 +41,15 @@ floating-point has less than 16 decimal digits of precision, so
 be careful about using floating-point to convert these values to
 decimal.
 
+
 <pre><code><b>struct</b> <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">FixedPoint32</a> <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
+
+
 <details>
 <summary>Fields</summary>
+
 
 <dl>
 <dt>
@@ -51,53 +60,73 @@ decimal.
 </dd>
 </dl>
 
+
 </details>
 
 <a name="@Constants_0"></a>
 
 ## Constants
 
+
 <a name="0x1_fixed_point32_EDENOMINATOR"></a>
 
 The denominator provided was zero
 
+
 <pre><code><b>const</b> <a href="fixed_point32.md#0x1_fixed_point32_EDENOMINATOR">EDENOMINATOR</a>: u64 = 65537;
 </code></pre>
+
+
 
 <a name="0x1_fixed_point32_EDIVISION"></a>
 
 The quotient value would be too large to be held in a <code>u64</code>
 
+
 <pre><code><b>const</b> <a href="fixed_point32.md#0x1_fixed_point32_EDIVISION">EDIVISION</a>: u64 = 131074;
 </code></pre>
+
+
 
 <a name="0x1_fixed_point32_EDIVISION_BY_ZERO"></a>
 
 A division by zero was encountered
 
+
 <pre><code><b>const</b> <a href="fixed_point32.md#0x1_fixed_point32_EDIVISION_BY_ZERO">EDIVISION_BY_ZERO</a>: u64 = 65540;
 </code></pre>
+
+
 
 <a name="0x1_fixed_point32_EMULTIPLICATION"></a>
 
 The multiplied value would be too large to be held in a <code>u64</code>
 
+
 <pre><code><b>const</b> <a href="fixed_point32.md#0x1_fixed_point32_EMULTIPLICATION">EMULTIPLICATION</a>: u64 = 131075;
 </code></pre>
+
+
 
 <a name="0x1_fixed_point32_ERATIO_OUT_OF_RANGE"></a>
 
 The computed ratio when converting to a <code><a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">FixedPoint32</a></code> would be unrepresentable
 
+
 <pre><code><b>const</b> <a href="fixed_point32.md#0x1_fixed_point32_ERATIO_OUT_OF_RANGE">ERATIO_OUT_OF_RANGE</a>: u64 = 131077;
 </code></pre>
+
+
 
 <a name="0x1_fixed_point32_MAX_U64"></a>
 
 > TODO: This is a basic constant and should be provided somewhere centrally in the framework.
 
+
 <pre><code><b>const</b> <a href="fixed_point32.md#0x1_fixed_point32_MAX_U64">MAX_U64</a>: u128 = 18446744073709551615;
 </code></pre>
+
+
 
 <a name="0x1_fixed_point32_multiply_u64"></a>
 
@@ -107,11 +136,15 @@ Multiply a u64 integer by a fixed-point number, truncating any
 fractional part of the product. This will abort if the product
 overflows.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_multiply_u64">multiply_u64</a>(val: u64, multiplier: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">fixed_point32::FixedPoint32</a>): u64
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_multiply_u64">multiply_u64</a>(val: u64, multiplier: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">FixedPoint32</a>): u64 {
     // The product of two 64 bit values <b>has</b> 128 bits, so perform the
@@ -127,6 +160,8 @@ overflows.
 }
 </code></pre>
 
+
+
 </details>
 
 <a name="0x1_fixed_point32_divide_u64"></a>
@@ -137,11 +172,15 @@ Divide a u64 integer by a fixed-point number, truncating any
 fractional part of the quotient. This will abort if the divisor
 is zero or if the quotient overflows.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_divide_u64">divide_u64</a>(val: u64, divisor: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">fixed_point32::FixedPoint32</a>): u64
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_divide_u64">divide_u64</a>(val: u64, divisor: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">FixedPoint32</a>): u64 {
     // Check for division by zero.
@@ -157,6 +196,8 @@ is zero or if the quotient overflows.
     (quotient <b>as</b> u64)
 }
 </code></pre>
+
+
 
 </details>
 
@@ -175,11 +216,15 @@ point, you can use a denominator of 10^N to avoid numbers where the
 very small imprecision in the binary representation could change the
 rounding, e.g., 0.0125 will round down to 0.012 instead of up to 0.013.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_create_from_rational">create_from_rational</a>(numerator: u64, denominator: u64): <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">fixed_point32::FixedPoint32</a>
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_create_from_rational">create_from_rational</a>(numerator: u64, denominator: u64): <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">FixedPoint32</a> {
     // If the denominator is zero, this will <b>abort</b>.
@@ -198,6 +243,8 @@ rounding, e.g., 0.0125 will round down to 0.012 instead of up to 0.013.
 }
 </code></pre>
 
+
+
 </details>
 
 <a name="0x1_fixed_point32_create_from_raw_value"></a>
@@ -206,16 +253,22 @@ rounding, e.g., 0.0125 will round down to 0.012 instead of up to 0.013.
 
 Create a fixedpoint value from a raw value.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_create_from_raw_value">create_from_raw_value</a>(value: u64): <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">fixed_point32::FixedPoint32</a>
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_create_from_raw_value">create_from_raw_value</a>(value: u64): <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">FixedPoint32</a> {
     <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">FixedPoint32</a> { value }
 }
 </code></pre>
+
+
 
 </details>
 
@@ -227,16 +280,22 @@ Accessor for the raw u64 value. Other less common operations, such as
 adding or subtracting FixedPoint32 values, can be done using the raw
 values directly.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_get_raw_value">get_raw_value</a>(num: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">fixed_point32::FixedPoint32</a>): u64
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_get_raw_value">get_raw_value</a>(num: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">FixedPoint32</a>): u64 {
     num.value
 }
 </code></pre>
+
+
 
 </details>
 
@@ -246,16 +305,22 @@ values directly.
 
 Returns true if the ratio is zero.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_is_zero">is_zero</a>(num: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">fixed_point32::FixedPoint32</a>): bool
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_is_zero">is_zero</a>(num: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">FixedPoint32</a>): bool {
     num.value == 0
 }
 </code></pre>
+
+
 
 </details>
 
@@ -265,11 +330,15 @@ Returns true if the ratio is zero.
 
 Returns the smaller of the two FixedPoint32 numbers.
 
+
 <pre><code><b>public</b> <b>fun</b> <b>min</b>(num1: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">fixed_point32::FixedPoint32</a>, num2: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">fixed_point32::FixedPoint32</a>): <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">fixed_point32::FixedPoint32</a>
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <b>min</b>(num1: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">FixedPoint32</a>, num2: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">FixedPoint32</a>): <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">FixedPoint32</a> {
     <b>if</b> (num1.value &lt; num2.value) {
@@ -280,6 +349,8 @@ Returns the smaller of the two FixedPoint32 numbers.
 }
 </code></pre>
 
+
+
 </details>
 
 <a name="0x1_fixed_point32_max"></a>
@@ -288,11 +359,15 @@ Returns the smaller of the two FixedPoint32 numbers.
 
 Returns the larger of the two FixedPoint32 numbers.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_max">max</a>(num1: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">fixed_point32::FixedPoint32</a>, num2: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">fixed_point32::FixedPoint32</a>): <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">fixed_point32::FixedPoint32</a>
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_max">max</a>(num1: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">FixedPoint32</a>, num2: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">FixedPoint32</a>): <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">FixedPoint32</a> {
     <b>if</b> (num1.value &gt; num2.value) {
@@ -303,6 +378,8 @@ Returns the larger of the two FixedPoint32 numbers.
 }
 </code></pre>
 
+
+
 </details>
 
 <a name="0x1_fixed_point32_create_from_u64"></a>
@@ -311,11 +388,15 @@ Returns the larger of the two FixedPoint32 numbers.
 
 Create a fixedpoint value from a u64 value.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_create_from_u64">create_from_u64</a>(val: u64): <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">fixed_point32::FixedPoint32</a>
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_create_from_u64">create_from_u64</a>(val: u64): <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">FixedPoint32</a> {
     <b>let</b> value = (val <b>as</b> u128) &lt;&lt; 32;
@@ -323,6 +404,8 @@ Create a fixedpoint value from a u64 value.
     <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">FixedPoint32</a>{value: (value <b>as</b> u64)}
 }
 </code></pre>
+
+
 
 </details>
 
@@ -332,16 +415,22 @@ Create a fixedpoint value from a u64 value.
 
 Returns the largest integer less than or equal to a given number.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_floor">floor</a>(num: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">fixed_point32::FixedPoint32</a>): u64
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_floor">floor</a>(num: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">FixedPoint32</a>): u64 {
     num.value &gt;&gt; 32
 }
 </code></pre>
+
+
 
 </details>
 
@@ -351,11 +440,15 @@ Returns the largest integer less than or equal to a given number.
 
 Rounds up the given FixedPoint32 to the next largest integer.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_ceil">ceil</a>(num: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">fixed_point32::FixedPoint32</a>): u64
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_ceil">ceil</a>(num: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">FixedPoint32</a>): u64 {
     <b>let</b> floored_num = <a href="fixed_point32.md#0x1_fixed_point32_floor">floor</a>(num) &lt;&lt; 32;
@@ -367,6 +460,8 @@ Rounds up the given FixedPoint32 to the next largest integer.
 }
 </code></pre>
 
+
+
 </details>
 
 <a name="0x1_fixed_point32_round"></a>
@@ -375,11 +470,15 @@ Rounds up the given FixedPoint32 to the next largest integer.
 
 Returns the value of a FixedPoint32 to the nearest integer.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_round">round</a>(num: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">fixed_point32::FixedPoint32</a>): u64
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="fixed_point32.md#0x1_fixed_point32_round">round</a>(num: <a href="fixed_point32.md#0x1_fixed_point32_FixedPoint32">FixedPoint32</a>): u64 {
     <b>let</b> floored_num = <a href="fixed_point32.md#0x1_fixed_point32_floor">floor</a>(num) &lt;&lt; 32;
@@ -392,6 +491,9 @@ Returns the value of a FixedPoint32 to the nearest integer.
 }
 </code></pre>
 
+
+
 </details>
+
 
 [//]: # ("File containing references which can be used from documentation")

--- a/external-crates/move/move-execution/v0/crates/move-stdlib/docs/hash.md
+++ b/external-crates/move/move-execution/v0/crates/move-stdlib/docs/hash.md
@@ -1,3 +1,4 @@
+
 <a name="0x1_hash"></a>
 
 # Module `0x1::hash`
@@ -7,23 +8,34 @@ Module which defines SHA hashes for byte vectors.
 The functions in this module are natively declared both in the Move runtime
 as in the Move prover's prelude.
 
-- [Function `sha2_256`](#0x1_hash_sha2_256)
-- [Function `sha3_256`](#0x1_hash_sha3_256)
+
+-  [Function `sha2_256`](#0x1_hash_sha2_256)
+-  [Function `sha3_256`](#0x1_hash_sha3_256)
+
 
 <pre><code></code></pre>
+
+
 
 <a name="0x1_hash_sha2_256"></a>
 
 ## Function `sha2_256`
 
+
+
 <pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_hash_sha2_256">sha2_256</a>(data: <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="hash.md#0x1_hash_sha2_256">sha2_256</a>(data: <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;;
 </code></pre>
+
+
 
 </details>
 
@@ -31,15 +43,23 @@ as in the Move prover's prelude.
 
 ## Function `sha3_256`
 
+
+
 <pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_hash_sha3_256">sha3_256</a>(data: <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="hash.md#0x1_hash_sha3_256">sha3_256</a>(data: <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;;
 </code></pre>
 
+
+
 </details>
+
 
 [//]: # ("File containing references which can be used from documentation")

--- a/external-crates/move/move-execution/v0/crates/move-stdlib/docs/option.md
+++ b/external-crates/move/move-execution/v0/crates/move-stdlib/docs/option.md
@@ -1,31 +1,36 @@
+
 <a name="0x1_option"></a>
 
 # Module `0x1::option`
 
 This module defines the Option type and its methods to represent and handle an optional value.
 
-- [Struct `Option`](#0x1_option_Option)
-- [Constants](#@Constants_0)
-- [Function `none`](#0x1_option_none)
-- [Function `some`](#0x1_option_some)
-- [Function `is_none`](#0x1_option_is_none)
-- [Function `is_some`](#0x1_option_is_some)
-- [Function `contains`](#0x1_option_contains)
-- [Function `borrow`](#0x1_option_borrow)
-- [Function `borrow_with_default`](#0x1_option_borrow_with_default)
-- [Function `get_with_default`](#0x1_option_get_with_default)
-- [Function `fill`](#0x1_option_fill)
-- [Function `extract`](#0x1_option_extract)
-- [Function `borrow_mut`](#0x1_option_borrow_mut)
-- [Function `swap`](#0x1_option_swap)
-- [Function `swap_or_fill`](#0x1_option_swap_or_fill)
-- [Function `destroy_with_default`](#0x1_option_destroy_with_default)
-- [Function `destroy_some`](#0x1_option_destroy_some)
-- [Function `destroy_none`](#0x1_option_destroy_none)
-- [Function `to_vec`](#0x1_option_to_vec)
+
+-  [Struct `Option`](#0x1_option_Option)
+-  [Constants](#@Constants_0)
+-  [Function `none`](#0x1_option_none)
+-  [Function `some`](#0x1_option_some)
+-  [Function `is_none`](#0x1_option_is_none)
+-  [Function `is_some`](#0x1_option_is_some)
+-  [Function `contains`](#0x1_option_contains)
+-  [Function `borrow`](#0x1_option_borrow)
+-  [Function `borrow_with_default`](#0x1_option_borrow_with_default)
+-  [Function `get_with_default`](#0x1_option_get_with_default)
+-  [Function `fill`](#0x1_option_fill)
+-  [Function `extract`](#0x1_option_extract)
+-  [Function `borrow_mut`](#0x1_option_borrow_mut)
+-  [Function `swap`](#0x1_option_swap)
+-  [Function `swap_or_fill`](#0x1_option_swap_or_fill)
+-  [Function `destroy_with_default`](#0x1_option_destroy_with_default)
+-  [Function `destroy_some`](#0x1_option_destroy_some)
+-  [Function `destroy_none`](#0x1_option_destroy_none)
+-  [Function `to_vec`](#0x1_option_to_vec)
+
 
 <pre><code><b>use</b> <a href="vector.md#0x1_vector">0x1::vector</a>;
 </code></pre>
+
+
 
 <a name="0x1_option_Option"></a>
 
@@ -34,11 +39,15 @@ This module defines the Option type and its methods to represent and handle an o
 Abstraction of a value that may or may not be present. Implemented with a vector of size
 zero or one because Move bytecode does not have ADTs.
 
+
 <pre><code><b>struct</b> <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt; <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
+
+
 <details>
 <summary>Fields</summary>
+
 
 <dl>
 <dt>
@@ -49,27 +58,35 @@ zero or one because Move bytecode does not have ADTs.
 </dd>
 </dl>
 
+
 </details>
 
 <a name="@Constants_0"></a>
 
 ## Constants
 
+
 <a name="0x1_option_EOPTION_IS_SET"></a>
 
 The <code><a href="option.md#0x1_option_Option">Option</a></code> is in an invalid state for the operation attempted.
 The <code><a href="option.md#0x1_option_Option">Option</a></code> is <code>Some</code> while it should be <code>None</code>.
 
+
 <pre><code><b>const</b> <a href="option.md#0x1_option_EOPTION_IS_SET">EOPTION_IS_SET</a>: u64 = 262144;
 </code></pre>
+
+
 
 <a name="0x1_option_EOPTION_NOT_SET"></a>
 
 The <code><a href="option.md#0x1_option_Option">Option</a></code> is in an invalid state for the operation attempted.
 The <code><a href="option.md#0x1_option_Option">Option</a></code> is <code>None</code> while it should be <code>Some</code>.
 
+
 <pre><code><b>const</b> <a href="option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>: u64 = 262145;
 </code></pre>
+
+
 
 <a name="0x1_option_none"></a>
 
@@ -77,16 +94,22 @@ The <code><a href="option.md#0x1_option_Option">Option</a></code> is <code>None<
 
 Return an empty <code><a href="option.md#0x1_option_Option">Option</a></code>
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_none">none</a>&lt;Element&gt;(): <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_none">none</a>&lt;Element&gt;(): <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt; {
     <a href="option.md#0x1_option_Option">Option</a> { vec: <a href="vector.md#0x1_vector_empty">vector::empty</a>() }
 }
 </code></pre>
+
+
 
 </details>
 
@@ -96,16 +119,22 @@ Return an empty <code><a href="option.md#0x1_option_Option">Option</a></code>
 
 Return an <code><a href="option.md#0x1_option_Option">Option</a></code> containing <code>e</code>
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_some">some</a>&lt;Element&gt;(e: Element): <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_some">some</a>&lt;Element&gt;(e: Element): <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt; {
     <a href="option.md#0x1_option_Option">Option</a> { vec: <a href="vector.md#0x1_vector_singleton">vector::singleton</a>(e) }
 }
 </code></pre>
+
+
 
 </details>
 
@@ -115,16 +144,22 @@ Return an <code><a href="option.md#0x1_option_Option">Option</a></code> containi
 
 Return true if <code>t</code> does not hold a value
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_is_none">is_none</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): bool
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_is_none">is_none</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): bool {
     <a href="vector.md#0x1_vector_is_empty">vector::is_empty</a>(&t.vec)
 }
 </code></pre>
+
+
 
 </details>
 
@@ -134,16 +169,22 @@ Return true if <code>t</code> does not hold a value
 
 Return true if <code>t</code> holds a value
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_is_some">is_some</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): bool
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_is_some">is_some</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): bool {
     !<a href="vector.md#0x1_vector_is_empty">vector::is_empty</a>(&t.vec)
 }
 </code></pre>
+
+
 
 </details>
 
@@ -154,16 +195,22 @@ Return true if <code>t</code> holds a value
 Return true if the value in <code>t</code> is equal to <code>e_ref</code>
 Always returns <code><b>false</b></code> if <code>t</code> does not hold a value
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_contains">contains</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e_ref: &Element): bool
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_contains">contains</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, e_ref: &Element): bool {
     <a href="vector.md#0x1_vector_contains">vector::contains</a>(&t.vec, e_ref)
 }
 </code></pre>
+
+
 
 </details>
 
@@ -174,17 +221,23 @@ Always returns <code><b>false</b></code> if <code>t</code> does not hold a value
 Return an immutable reference to the value inside <code>t</code>
 Aborts if <code>t</code> does not hold a value
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow">borrow</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): &Element
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow">borrow</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): &Element {
     <b>assert</b>!(<a href="option.md#0x1_option_is_some">is_some</a>(t), <a href="option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
     <a href="vector.md#0x1_vector_borrow">vector::borrow</a>(&t.vec, 0)
 }
 </code></pre>
+
+
 
 </details>
 
@@ -195,11 +248,15 @@ Aborts if <code>t</code> does not hold a value
 Return a reference to the value inside <code>t</code> if it holds one
 Return <code>default_ref</code> if <code>t</code> does not hold a value
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow_with_default">borrow_with_default</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default_ref: &Element): &Element
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow_with_default">borrow_with_default</a>&lt;Element&gt;(t: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, default_ref: &Element): &Element {
     <b>let</b> vec_ref = &t.vec;
@@ -207,6 +264,8 @@ Return <code>default_ref</code> if <code>t</code> does not hold a value
     <b>else</b> <a href="vector.md#0x1_vector_borrow">vector::borrow</a>(vec_ref, 0)
 }
 </code></pre>
+
+
 
 </details>
 
@@ -217,11 +276,15 @@ Return <code>default_ref</code> if <code>t</code> does not hold a value
 Return the value inside <code>t</code> if it holds one
 Return <code>default</code> if <code>t</code> does not hold a value
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_get_with_default">get_with_default</a>&lt;Element: <b>copy</b>, drop&gt;(t: &<a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default: Element): Element
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_get_with_default">get_with_default</a>&lt;Element: <b>copy</b> + drop&gt;(
     t: &<a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;,
@@ -233,6 +296,8 @@ Return <code>default</code> if <code>t</code> does not hold a value
 }
 </code></pre>
 
+
+
 </details>
 
 <a name="0x1_option_fill"></a>
@@ -242,11 +307,15 @@ Return <code>default</code> if <code>t</code> does not hold a value
 Convert the none option <code>t</code> to a some option by adding <code>e</code>.
 Aborts if <code>t</code> already holds a value
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_fill">fill</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element)
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_fill">fill</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, e: Element) {
     <b>let</b> vec_ref = &<b>mut</b> t.vec;
@@ -254,6 +323,8 @@ Aborts if <code>t</code> already holds a value
     <b>else</b> <b>abort</b> <a href="option.md#0x1_option_EOPTION_IS_SET">EOPTION_IS_SET</a>
 }
 </code></pre>
+
+
 
 </details>
 
@@ -264,17 +335,23 @@ Aborts if <code>t</code> already holds a value
 Convert a <code>some</code> option to a <code>none</code> by removing and returning the value stored inside <code>t</code>
 Aborts if <code>t</code> does not hold a value
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_extract">extract</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): Element
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_extract">extract</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): Element {
     <b>assert</b>!(<a href="option.md#0x1_option_is_some">is_some</a>(t), <a href="option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
     <a href="vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> t.vec)
 }
 </code></pre>
+
+
 
 </details>
 
@@ -285,17 +362,23 @@ Aborts if <code>t</code> does not hold a value
 Return a mutable reference to the value inside <code>t</code>
 Aborts if <code>t</code> does not hold a value
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow_mut">borrow_mut</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): &<b>mut</b> Element
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_borrow_mut">borrow_mut</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): &<b>mut</b> Element {
     <b>assert</b>!(<a href="option.md#0x1_option_is_some">is_some</a>(t), <a href="option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
     <a href="vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> t.vec, 0)
 }
 </code></pre>
+
+
 
 </details>
 
@@ -306,11 +389,15 @@ Aborts if <code>t</code> does not hold a value
 Swap the old value inside <code>t</code> with <code>e</code> and return the old value
 Aborts if <code>t</code> does not hold a value
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_swap">swap</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element): Element
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_swap">swap</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, e: Element): Element {
     <b>assert</b>!(<a href="option.md#0x1_option_is_some">is_some</a>(t), <a href="option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
@@ -320,6 +407,8 @@ Aborts if <code>t</code> does not hold a value
     old_value
 }
 </code></pre>
+
+
 
 </details>
 
@@ -331,11 +420,15 @@ Swap the old value inside <code>t</code> with <code>e</code> and return the old 
 or if there is no old value, fill it with <code>e</code>.
 Different from swap(), swap_or_fill() allows for <code>t</code> not holding a value.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_swap_or_fill">swap_or_fill</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, e: Element): <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_swap_or_fill">swap_or_fill</a>&lt;Element&gt;(t: &<b>mut</b> <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, e: Element): <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt; {
     <b>let</b> vec_ref = &<b>mut</b> t.vec;
@@ -346,6 +439,8 @@ Different from swap(), swap_or_fill() allows for <code>t</code> not holding a va
 }
 </code></pre>
 
+
+
 </details>
 
 <a name="0x1_option_destroy_with_default"></a>
@@ -354,11 +449,15 @@ Different from swap(), swap_or_fill() allows for <code>t</code> not holding a va
 
 Destroys <code>t.</code> If <code>t</code> holds a value, return it. Returns <code>default</code> otherwise
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_with_default">destroy_with_default</a>&lt;Element: drop&gt;(t: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;, default: Element): Element
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_with_default">destroy_with_default</a>&lt;Element: drop&gt;(t: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;, default: Element): Element {
     <b>let</b> <a href="option.md#0x1_option_Option">Option</a> { vec } = t;
@@ -366,6 +465,8 @@ Destroys <code>t.</code> If <code>t</code> holds a value, return it. Returns <co
     <b>else</b> <a href="vector.md#0x1_vector_pop_back">vector::pop_back</a>(&<b>mut</b> vec)
 }
 </code></pre>
+
+
 
 </details>
 
@@ -376,11 +477,15 @@ Destroys <code>t.</code> If <code>t</code> holds a value, return it. Returns <co
 Unpack <code>t</code> and return its contents
 Aborts if <code>t</code> does not hold a value
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_some">destroy_some</a>&lt;Element&gt;(t: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): Element
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_some">destroy_some</a>&lt;Element&gt;(t: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): Element {
     <b>assert</b>!(<a href="option.md#0x1_option_is_some">is_some</a>(&t), <a href="option.md#0x1_option_EOPTION_NOT_SET">EOPTION_NOT_SET</a>);
@@ -391,6 +496,8 @@ Aborts if <code>t</code> does not hold a value
 }
 </code></pre>
 
+
+
 </details>
 
 <a name="0x1_option_destroy_none"></a>
@@ -400,11 +507,15 @@ Aborts if <code>t</code> does not hold a value
 Unpack <code>t</code>
 Aborts if <code>t</code> holds a value
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_none">destroy_none</a>&lt;Element&gt;(t: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;)
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_destroy_none">destroy_none</a>&lt;Element&gt;(t: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;) {
     <b>assert</b>!(<a href="option.md#0x1_option_is_none">is_none</a>(&t), <a href="option.md#0x1_option_EOPTION_IS_SET">EOPTION_IS_SET</a>);
@@ -412,6 +523,8 @@ Aborts if <code>t</code> holds a value
     <a href="vector.md#0x1_vector_destroy_empty">vector::destroy_empty</a>(vec)
 }
 </code></pre>
+
+
 
 </details>
 
@@ -422,11 +535,15 @@ Aborts if <code>t</code> holds a value
 Convert <code>t</code> into a vector of length 1 if it is <code>Some</code>,
 and an empty vector otherwise
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_to_vec">to_vec</a>&lt;Element&gt;(t: <a href="option.md#0x1_option_Option">option::Option</a>&lt;Element&gt;): <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="option.md#0x1_option_to_vec">to_vec</a>&lt;Element&gt;(t: <a href="option.md#0x1_option_Option">Option</a>&lt;Element&gt;): <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt; {
     <b>let</b> <a href="option.md#0x1_option_Option">Option</a> { vec } = t;
@@ -434,6 +551,9 @@ and an empty vector otherwise
 }
 </code></pre>
 
+
+
 </details>
+
 
 [//]: # ("File containing references which can be used from documentation")

--- a/external-crates/move/move-execution/v0/crates/move-stdlib/docs/overview.md
+++ b/external-crates/move/move-execution/v0/crates/move-stdlib/docs/overview.md
@@ -1,23 +1,28 @@
+
 <a name="@Move_Stdlib_Modules_0"></a>
 
 # Move Stdlib Modules
 
+
 This is the root document for the Move stdlib module documentation. The Move stdlib provides modules that can be used to access or interact with core language features.
+
 
 <a name="@Index_1"></a>
 
 ## Index
 
-- [`0x1::ascii`](ascii.md#0x1_ascii)
-- [`0x1::bcs`](bcs.md#0x1_bcs)
-- [`0x1::bit_vector`](bit_vector.md#0x1_bit_vector)
-- [`0x1::error`](error.md#0x1_error)
-- [`0x1::fixed_point32`](fixed_point32.md#0x1_fixed_point32)
-- [`0x1::hash`](hash.md#0x1_hash)
-- [`0x1::option`](option.md#0x1_option)
-- [`0x1::signer`](signer.md#0x1_signer)
-- [`0x1::string`](string.md#0x1_string)
-- [`0x1::type_name`](type_name.md#0x1_type_name)
-- [`0x1::vector`](vector.md#0x1_vector)
+
+-  [`0x1::ascii`](ascii.md#0x1_ascii)
+-  [`0x1::bcs`](bcs.md#0x1_bcs)
+-  [`0x1::bit_vector`](bit_vector.md#0x1_bit_vector)
+-  [`0x1::error`](error.md#0x1_error)
+-  [`0x1::fixed_point32`](fixed_point32.md#0x1_fixed_point32)
+-  [`0x1::hash`](hash.md#0x1_hash)
+-  [`0x1::option`](option.md#0x1_option)
+-  [`0x1::signer`](signer.md#0x1_signer)
+-  [`0x1::string`](string.md#0x1_string)
+-  [`0x1::type_name`](type_name.md#0x1_type_name)
+-  [`0x1::vector`](vector.md#0x1_vector)
+
 
 [//]: # ("File containing references which can be used from documentation")

--- a/external-crates/move/move-execution/v0/crates/move-stdlib/docs/signer.md
+++ b/external-crates/move/move-execution/v0/crates/move-stdlib/docs/signer.md
@@ -1,24 +1,37 @@
+
 <a name="0x1_signer"></a>
 
 # Module `0x1::signer`
 
-- [Function `borrow_address`](#0x1_signer_borrow_address)
-- [Function `address_of`](#0x1_signer_address_of)
+
+
+-  [Function `borrow_address`](#0x1_signer_borrow_address)
+-  [Function `address_of`](#0x1_signer_address_of)
+
 
 <pre><code></code></pre>
+
+
 
 <a name="0x1_signer_borrow_address"></a>
 
 ## Function `borrow_address`
 
+
+
 <pre><code><b>public</b> <b>fun</b> <a href="signer.md#0x1_signer_borrow_address">borrow_address</a>(s: &<a href="signer.md#0x1_signer">signer</a>): &<b>address</b>
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="signer.md#0x1_signer_borrow_address">borrow_address</a>(s: &<a href="signer.md#0x1_signer">signer</a>): &<b>address</b>;
 </code></pre>
+
+
 
 </details>
 
@@ -26,17 +39,25 @@
 
 ## Function `address_of`
 
+
+
 <pre><code><b>public</b> <b>fun</b> <a href="signer.md#0x1_signer_address_of">address_of</a>(s: &<a href="signer.md#0x1_signer">signer</a>): <b>address</b>
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="signer.md#0x1_signer_address_of">address_of</a>(s: &<a href="signer.md#0x1_signer">signer</a>): <b>address</b> {
     *<a href="signer.md#0x1_signer_borrow_address">borrow_address</a>(s)
 }
 </code></pre>
 
+
+
 </details>
+
 
 [//]: # ("File containing references which can be used from documentation")

--- a/external-crates/move/move-execution/v0/crates/move-stdlib/docs/string.md
+++ b/external-crates/move/move-execution/v0/crates/move-stdlib/docs/string.md
@@ -1,29 +1,34 @@
+
 <a name="0x1_string"></a>
 
 # Module `0x1::string`
 
 The <code><a href="string.md#0x1_string">string</a></code> module defines the <code><a href="string.md#0x1_string_String">String</a></code> type which represents UTF8 encoded strings.
 
-- [Struct `String`](#0x1_string_String)
-- [Constants](#@Constants_0)
-- [Function `utf8`](#0x1_string_utf8)
-- [Function `try_utf8`](#0x1_string_try_utf8)
-- [Function `bytes`](#0x1_string_bytes)
-- [Function `is_empty`](#0x1_string_is_empty)
-- [Function `length`](#0x1_string_length)
-- [Function `append`](#0x1_string_append)
-- [Function `append_utf8`](#0x1_string_append_utf8)
-- [Function `insert`](#0x1_string_insert)
-- [Function `sub_string`](#0x1_string_sub_string)
-- [Function `index_of`](#0x1_string_index_of)
-- [Function `internal_check_utf8`](#0x1_string_internal_check_utf8)
-- [Function `internal_is_char_boundary`](#0x1_string_internal_is_char_boundary)
-- [Function `internal_sub_string`](#0x1_string_internal_sub_string)
-- [Function `internal_index_of`](#0x1_string_internal_index_of)
+
+-  [Struct `String`](#0x1_string_String)
+-  [Constants](#@Constants_0)
+-  [Function `utf8`](#0x1_string_utf8)
+-  [Function `try_utf8`](#0x1_string_try_utf8)
+-  [Function `bytes`](#0x1_string_bytes)
+-  [Function `is_empty`](#0x1_string_is_empty)
+-  [Function `length`](#0x1_string_length)
+-  [Function `append`](#0x1_string_append)
+-  [Function `append_utf8`](#0x1_string_append_utf8)
+-  [Function `insert`](#0x1_string_insert)
+-  [Function `sub_string`](#0x1_string_sub_string)
+-  [Function `index_of`](#0x1_string_index_of)
+-  [Function `internal_check_utf8`](#0x1_string_internal_check_utf8)
+-  [Function `internal_is_char_boundary`](#0x1_string_internal_is_char_boundary)
+-  [Function `internal_sub_string`](#0x1_string_internal_sub_string)
+-  [Function `internal_index_of`](#0x1_string_internal_index_of)
+
 
 <pre><code><b>use</b> <a href="option.md#0x1_option">0x1::option</a>;
 <b>use</b> <a href="vector.md#0x1_vector">0x1::vector</a>;
 </code></pre>
+
+
 
 <a name="0x1_string_String"></a>
 
@@ -31,11 +36,15 @@ The <code><a href="string.md#0x1_string">string</a></code> module defines the <c
 
 A <code><a href="string.md#0x1_string_String">String</a></code> holds a sequence of bytes which is guaranteed to be in utf8 format.
 
+
 <pre><code><b>struct</b> <a href="string.md#0x1_string_String">String</a> <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
+
+
 <details>
 <summary>Fields</summary>
+
 
 <dl>
 <dt>
@@ -46,25 +55,33 @@ A <code><a href="string.md#0x1_string_String">String</a></code> holds a sequence
 </dd>
 </dl>
 
+
 </details>
 
 <a name="@Constants_0"></a>
 
 ## Constants
 
+
 <a name="0x1_string_EINVALID_INDEX"></a>
 
 Index out of range.
 
+
 <pre><code><b>const</b> <a href="string.md#0x1_string_EINVALID_INDEX">EINVALID_INDEX</a>: u64 = 2;
 </code></pre>
+
+
 
 <a name="0x1_string_EINVALID_UTF8"></a>
 
 An invalid UTF8 encoding.
 
+
 <pre><code><b>const</b> <a href="string.md#0x1_string_EINVALID_UTF8">EINVALID_UTF8</a>: u64 = 1;
 </code></pre>
+
+
 
 <a name="0x1_string_utf8"></a>
 
@@ -72,17 +89,23 @@ An invalid UTF8 encoding.
 
 Creates a new string from a sequence of bytes. Aborts if the bytes do not represent valid utf8.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_utf8">utf8</a>(bytes: <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="string.md#0x1_string_String">string::String</a>
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_utf8">utf8</a>(bytes: <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="string.md#0x1_string_String">String</a> {
     <b>assert</b>!(<a href="string.md#0x1_string_internal_check_utf8">internal_check_utf8</a>(&bytes), <a href="string.md#0x1_string_EINVALID_UTF8">EINVALID_UTF8</a>);
     <a href="string.md#0x1_string_String">String</a>{bytes}
 }
 </code></pre>
+
+
 
 </details>
 
@@ -92,11 +115,15 @@ Creates a new string from a sequence of bytes. Aborts if the bytes do not repres
 
 Tries to create a new string from a sequence of bytes.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_try_utf8">try_utf8</a>(bytes: <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="option.md#0x1_option_Option">option::Option</a>&lt;<a href="string.md#0x1_string_String">string::String</a>&gt;
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_try_utf8">try_utf8</a>(bytes: <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;): Option&lt;<a href="string.md#0x1_string_String">String</a>&gt; {
     <b>if</b> (<a href="string.md#0x1_string_internal_check_utf8">internal_check_utf8</a>(&bytes)) {
@@ -107,6 +134,8 @@ Tries to create a new string from a sequence of bytes.
 }
 </code></pre>
 
+
+
 </details>
 
 <a name="0x1_string_bytes"></a>
@@ -115,16 +144,22 @@ Tries to create a new string from a sequence of bytes.
 
 Returns a reference to the underlying byte vector.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_bytes">bytes</a>(s: &<a href="string.md#0x1_string_String">string::String</a>): &<a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_bytes">bytes</a>(s: &<a href="string.md#0x1_string_String">String</a>): &<a href="vector.md#0x1_vector">vector</a>&lt;u8&gt; {
     &s.bytes
 }
 </code></pre>
+
+
 
 </details>
 
@@ -134,16 +169,22 @@ Returns a reference to the underlying byte vector.
 
 Checks whether this string is empty.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_is_empty">is_empty</a>(s: &<a href="string.md#0x1_string_String">string::String</a>): bool
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_is_empty">is_empty</a>(s: &<a href="string.md#0x1_string_String">String</a>): bool {
     <a href="vector.md#0x1_vector_is_empty">vector::is_empty</a>(&s.bytes)
 }
 </code></pre>
+
+
 
 </details>
 
@@ -153,16 +194,22 @@ Checks whether this string is empty.
 
 Returns the length of this string, in bytes.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_length">length</a>(s: &<a href="string.md#0x1_string_String">string::String</a>): u64
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_length">length</a>(s: &<a href="string.md#0x1_string_String">String</a>): u64 {
     <a href="vector.md#0x1_vector_length">vector::length</a>(&s.bytes)
 }
 </code></pre>
+
+
 
 </details>
 
@@ -172,16 +219,22 @@ Returns the length of this string, in bytes.
 
 Appends a string.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_append">append</a>(s: &<b>mut</b> <a href="string.md#0x1_string_String">string::String</a>, r: <a href="string.md#0x1_string_String">string::String</a>)
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_append">append</a>(s: &<b>mut</b> <a href="string.md#0x1_string_String">String</a>, r: <a href="string.md#0x1_string_String">String</a>) {
     <a href="vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> s.bytes, r.bytes)
 }
 </code></pre>
+
+
 
 </details>
 
@@ -191,16 +244,22 @@ Appends a string.
 
 Appends bytes which must be in valid utf8 format.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_append_utf8">append_utf8</a>(s: &<b>mut</b> <a href="string.md#0x1_string_String">string::String</a>, bytes: <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;)
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_append_utf8">append_utf8</a>(s: &<b>mut</b> <a href="string.md#0x1_string_String">String</a>, bytes: <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
     <a href="string.md#0x1_string_append">append</a>(s, <a href="string.md#0x1_string_utf8">utf8</a>(bytes))
 }
 </code></pre>
+
+
 
 </details>
 
@@ -211,11 +270,15 @@ Appends bytes which must be in valid utf8 format.
 Insert the other string at the byte index in given string. The index must be at a valid utf8 char
 boundary.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_insert">insert</a>(s: &<b>mut</b> <a href="string.md#0x1_string_String">string::String</a>, at: u64, o: <a href="string.md#0x1_string_String">string::String</a>)
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_insert">insert</a>(s: &<b>mut</b> <a href="string.md#0x1_string_String">String</a>, at: u64, o: <a href="string.md#0x1_string_String">String</a>) {
     <b>let</b> bytes = &s.bytes;
@@ -229,6 +292,8 @@ boundary.
 }
 </code></pre>
 
+
+
 </details>
 
 <a name="0x1_string_sub_string"></a>
@@ -239,11 +304,15 @@ Returns a sub-string using the given byte indices, where <code>i</code> is the f
 of the first byte not included (or the length of the string). The indices must be at valid utf8 char boundaries,
 guaranteeing that the result is valid utf8.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_sub_string">sub_string</a>(s: &<a href="string.md#0x1_string_String">string::String</a>, i: u64, j: u64): <a href="string.md#0x1_string_String">string::String</a>
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_sub_string">sub_string</a>(s: &<a href="string.md#0x1_string_String">String</a>, i: u64, j: u64): <a href="string.md#0x1_string_String">String</a> {
     <b>let</b> bytes = &s.bytes;
@@ -256,6 +325,8 @@ guaranteeing that the result is valid utf8.
 }
 </code></pre>
 
+
+
 </details>
 
 <a name="0x1_string_index_of"></a>
@@ -264,16 +335,22 @@ guaranteeing that the result is valid utf8.
 
 Computes the index of the first occurrence of a string. Returns <code><a href="string.md#0x1_string_length">length</a>(s)</code> if no occurrence found.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_index_of">index_of</a>(s: &<a href="string.md#0x1_string_String">string::String</a>, r: &<a href="string.md#0x1_string_String">string::String</a>): u64
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="string.md#0x1_string_index_of">index_of</a>(s: &<a href="string.md#0x1_string_String">String</a>, r: &<a href="string.md#0x1_string_String">String</a>): u64 {
     <a href="string.md#0x1_string_internal_index_of">internal_index_of</a>(&s.bytes, &r.bytes)
 }
 </code></pre>
+
+
 
 </details>
 
@@ -281,14 +358,21 @@ Computes the index of the first occurrence of a string. Returns <code><a href="s
 
 ## Function `internal_check_utf8`
 
+
+
 <pre><code><b>fun</b> <a href="string.md#0x1_string_internal_check_utf8">internal_check_utf8</a>(v: &<a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;): bool
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>native</b> <b>fun</b> <a href="string.md#0x1_string_internal_check_utf8">internal_check_utf8</a>(v: &<a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;): bool;
 </code></pre>
+
+
 
 </details>
 
@@ -296,14 +380,21 @@ Computes the index of the first occurrence of a string. Returns <code><a href="s
 
 ## Function `internal_is_char_boundary`
 
+
+
 <pre><code><b>fun</b> <a href="string.md#0x1_string_internal_is_char_boundary">internal_is_char_boundary</a>(v: &<a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;, i: u64): bool
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>native</b> <b>fun</b> <a href="string.md#0x1_string_internal_is_char_boundary">internal_is_char_boundary</a>(v: &<a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;, i: u64): bool;
 </code></pre>
+
+
 
 </details>
 
@@ -311,14 +402,21 @@ Computes the index of the first occurrence of a string. Returns <code><a href="s
 
 ## Function `internal_sub_string`
 
+
+
 <pre><code><b>fun</b> <a href="string.md#0x1_string_internal_sub_string">internal_sub_string</a>(v: &<a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;, i: u64, j: u64): <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>native</b> <b>fun</b> <a href="string.md#0x1_string_internal_sub_string">internal_sub_string</a>(v: &<a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;, i: u64, j: u64): <a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;;
 </code></pre>
+
+
 
 </details>
 
@@ -326,15 +424,23 @@ Computes the index of the first occurrence of a string. Returns <code><a href="s
 
 ## Function `internal_index_of`
 
+
+
 <pre><code><b>fun</b> <a href="string.md#0x1_string_internal_index_of">internal_index_of</a>(v: &<a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;, r: &<a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;): u64
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>native</b> <b>fun</b> <a href="string.md#0x1_string_internal_index_of">internal_index_of</a>(v: &<a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;, r: &<a href="vector.md#0x1_vector">vector</a>&lt;u8&gt;): u64;
 </code></pre>
 
+
+
 </details>
+
 
 [//]: # ("File containing references which can be used from documentation")

--- a/external-crates/move/move-execution/v0/crates/move-stdlib/docs/type_name.md
+++ b/external-crates/move/move-execution/v0/crates/move-stdlib/docs/type_name.md
@@ -1,27 +1,37 @@
+
 <a name="0x1_type_name"></a>
 
 # Module `0x1::type_name`
 
 Functionality for converting Move types into values. Use with care!
 
-- [Struct `TypeName`](#0x1_type_name_TypeName)
-- [Function `get`](#0x1_type_name_get)
-- [Function `get_with_original_ids`](#0x1_type_name_get_with_original_ids)
-- [Function `borrow_string`](#0x1_type_name_borrow_string)
-- [Function `into_string`](#0x1_type_name_into_string)
+
+-  [Struct `TypeName`](#0x1_type_name_TypeName)
+-  [Function `get`](#0x1_type_name_get)
+-  [Function `get_with_original_ids`](#0x1_type_name_get_with_original_ids)
+-  [Function `borrow_string`](#0x1_type_name_borrow_string)
+-  [Function `into_string`](#0x1_type_name_into_string)
+
 
 <pre><code><b>use</b> <a href="ascii.md#0x1_ascii">0x1::ascii</a>;
 </code></pre>
+
+
 
 <a name="0x1_type_name_TypeName"></a>
 
 ## Struct `TypeName`
 
+
+
 <pre><code><b>struct</b> <a href="type_name.md#0x1_type_name_TypeName">TypeName</a> <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
+
+
 <details>
 <summary>Fields</summary>
+
 
 <dl>
 <dt>
@@ -38,25 +48,32 @@ Functionality for converting Move types into values. Use with care!
 </dd>
 </dl>
 
+
 </details>
 
 <a name="0x1_type_name_get"></a>
 
 ## Function `get`
 
-Return a value representation of the type <code>T</code>. Package IDs
+Return a value representation of the type <code>T</code>.  Package IDs
 that appear in fully qualified type names in the output from
 this function are defining IDs (the ID of the package in
 storage that first introduced the type).
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="type_name.md#0x1_type_name_get">get</a>&lt;T&gt;(): <a href="type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="type_name.md#0x1_type_name_get">get</a>&lt;T&gt;(): <a href="type_name.md#0x1_type_name_TypeName">TypeName</a>;
 </code></pre>
+
+
 
 </details>
 
@@ -64,20 +81,26 @@ storage that first introduced the type).
 
 ## Function `get_with_original_ids`
 
-Return a value representation of the type <code>T</code>. Package IDs
+Return a value representation of the type <code>T</code>.  Package IDs
 that appear in fully qualified type names in the output from
 this function are original IDs (the ID of the first version of
 the package, even if the type in question was introduced in a
 later upgrade).
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="type_name.md#0x1_type_name_get_with_original_ids">get_with_original_ids</a>&lt;T&gt;(): <a href="type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="type_name.md#0x1_type_name_get_with_original_ids">get_with_original_ids</a>&lt;T&gt;(): <a href="type_name.md#0x1_type_name_TypeName">TypeName</a>;
 </code></pre>
+
+
 
 </details>
 
@@ -87,16 +110,22 @@ later upgrade).
 
 Get the String representation of <code>self</code>
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="type_name.md#0x1_type_name_borrow_string">borrow_string</a>(self: &<a href="type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>): &<a href="ascii.md#0x1_ascii_String">ascii::String</a>
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="type_name.md#0x1_type_name_borrow_string">borrow_string</a>(self: &<a href="type_name.md#0x1_type_name_TypeName">TypeName</a>): &String {
     &self.name
 }
 </code></pre>
+
+
 
 </details>
 
@@ -106,17 +135,24 @@ Get the String representation of <code>self</code>
 
 Convert <code>self</code> into its inner String
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="type_name.md#0x1_type_name_into_string">into_string</a>(self: <a href="type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>): <a href="ascii.md#0x1_ascii_String">ascii::String</a>
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="type_name.md#0x1_type_name_into_string">into_string</a>(self: <a href="type_name.md#0x1_type_name_TypeName">TypeName</a>): String {
     self.name
 }
 </code></pre>
 
+
+
 </details>
+
 
 [//]: # ("File containing references which can be used from documentation")

--- a/external-crates/move/move-execution/v0/crates/move-stdlib/docs/vector.md
+++ b/external-crates/move/move-execution/v0/crates/move-stdlib/docs/vector.md
@@ -1,3 +1,4 @@
+
 <a name="0x1_vector"></a>
 
 # Module `0x1::vector`
@@ -5,37 +6,45 @@
 A variable-sized container that can hold any type. Indexing is 0-based, and
 vectors are growable. This module has many native functions.
 
-- [Constants](#@Constants_0)
-- [Function `empty`](#0x1_vector_empty)
-- [Function `length`](#0x1_vector_length)
-- [Function `borrow`](#0x1_vector_borrow)
-- [Function `push_back`](#0x1_vector_push_back)
-- [Function `borrow_mut`](#0x1_vector_borrow_mut)
-- [Function `pop_back`](#0x1_vector_pop_back)
-- [Function `destroy_empty`](#0x1_vector_destroy_empty)
-- [Function `swap`](#0x1_vector_swap)
-- [Function `singleton`](#0x1_vector_singleton)
-- [Function `reverse`](#0x1_vector_reverse)
-- [Function `append`](#0x1_vector_append)
-- [Function `is_empty`](#0x1_vector_is_empty)
-- [Function `contains`](#0x1_vector_contains)
-- [Function `index_of`](#0x1_vector_index_of)
-- [Function `remove`](#0x1_vector_remove)
-- [Function `insert`](#0x1_vector_insert)
-- [Function `swap_remove`](#0x1_vector_swap_remove)
+
+-  [Constants](#@Constants_0)
+-  [Function `empty`](#0x1_vector_empty)
+-  [Function `length`](#0x1_vector_length)
+-  [Function `borrow`](#0x1_vector_borrow)
+-  [Function `push_back`](#0x1_vector_push_back)
+-  [Function `borrow_mut`](#0x1_vector_borrow_mut)
+-  [Function `pop_back`](#0x1_vector_pop_back)
+-  [Function `destroy_empty`](#0x1_vector_destroy_empty)
+-  [Function `swap`](#0x1_vector_swap)
+-  [Function `singleton`](#0x1_vector_singleton)
+-  [Function `reverse`](#0x1_vector_reverse)
+-  [Function `append`](#0x1_vector_append)
+-  [Function `is_empty`](#0x1_vector_is_empty)
+-  [Function `contains`](#0x1_vector_contains)
+-  [Function `index_of`](#0x1_vector_index_of)
+-  [Function `remove`](#0x1_vector_remove)
+-  [Function `insert`](#0x1_vector_insert)
+-  [Function `swap_remove`](#0x1_vector_swap_remove)
+
 
 <pre><code></code></pre>
+
+
 
 <a name="@Constants_0"></a>
 
 ## Constants
 
+
 <a name="0x1_vector_EINDEX_OUT_OF_BOUNDS"></a>
 
 The index into the vector is out of bounds
 
+
 <pre><code><b>const</b> <a href="vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>: u64 = 131072;
 </code></pre>
+
+
 
 <a name="0x1_vector_empty"></a>
 
@@ -43,14 +52,20 @@ The index into the vector is out of bounds
 
 Create an empty vector.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_empty">empty</a>&lt;Element&gt;(): <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_empty">empty</a>&lt;Element&gt;(): <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;;
 </code></pre>
+
+
 
 </details>
 
@@ -60,14 +75,20 @@ Create an empty vector.
 
 Return the length of the vector.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_length">length</a>&lt;Element&gt;(v: &<a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;): u64
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_length">length</a>&lt;Element&gt;(v: &<a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;): u64;
 </code></pre>
+
+
 
 </details>
 
@@ -78,14 +99,20 @@ Return the length of the vector.
 Acquire an immutable reference to the <code>i</code>th element of the vector <code>v</code>.
 Aborts if <code>i</code> is out of bounds.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_borrow">borrow</a>&lt;Element&gt;(v: &<a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): &Element
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_borrow">borrow</a>&lt;Element&gt;(v: &<a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): &Element;
 </code></pre>
+
+
 
 </details>
 
@@ -95,14 +122,20 @@ Aborts if <code>i</code> is out of bounds.
 
 Add element <code>e</code> to the end of the vector <code>v</code>.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_push_back">push_back</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: Element)
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_push_back">push_back</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: Element);
 </code></pre>
+
+
 
 </details>
 
@@ -113,14 +146,20 @@ Add element <code>e</code> to the end of the vector <code>v</code>.
 Return a mutable reference to the <code>i</code>th element in the vector <code>v</code>.
 Aborts if <code>i</code> is out of bounds.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_borrow_mut">borrow_mut</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): &<b>mut</b> Element
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_borrow_mut">borrow_mut</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): &<b>mut</b> Element;
 </code></pre>
+
+
 
 </details>
 
@@ -131,14 +170,20 @@ Aborts if <code>i</code> is out of bounds.
 Pop an element from the end of vector <code>v</code>.
 Aborts if <code>v</code> is empty.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_pop_back">pop_back</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;): Element
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_pop_back">pop_back</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;): Element;
 </code></pre>
+
+
 
 </details>
 
@@ -149,14 +194,20 @@ Aborts if <code>v</code> is empty.
 Destroy the vector <code>v</code>.
 Aborts if <code>v</code> is not empty.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_destroy_empty">destroy_empty</a>&lt;Element&gt;(v: <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;)
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_destroy_empty">destroy_empty</a>&lt;Element&gt;(v: <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;);
 </code></pre>
+
+
 
 </details>
 
@@ -167,14 +218,20 @@ Aborts if <code>v</code> is not empty.
 Swaps the elements at the <code>i</code>th and <code>j</code>th indices in the vector <code>v</code>.
 Aborts if <code>i</code> or <code>j</code> is out of bounds.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_swap">swap</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64, j: u64)
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_swap">swap</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64, j: u64);
 </code></pre>
+
+
 
 </details>
 
@@ -184,11 +241,15 @@ Aborts if <code>i</code> or <code>j</code> is out of bounds.
 
 Return an vector of size one containing element <code>e</code>.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_singleton">singleton</a>&lt;Element&gt;(e: Element): <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_singleton">singleton</a>&lt;Element&gt;(e: Element): <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt; {
     <b>let</b> v = <a href="vector.md#0x1_vector_empty">empty</a>();
@@ -196,6 +257,8 @@ Return an vector of size one containing element <code>e</code>.
     v
 }
 </code></pre>
+
+
 
 </details>
 
@@ -205,11 +268,15 @@ Return an vector of size one containing element <code>e</code>.
 
 Reverses the order of the elements in the vector <code>v</code> in place.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_reverse">reverse</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;)
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_reverse">reverse</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;) {
     <b>let</b> len = <a href="vector.md#0x1_vector_length">length</a>(v);
@@ -225,6 +292,8 @@ Reverses the order of the elements in the vector <code>v</code> in place.
 }
 </code></pre>
 
+
+
 </details>
 
 <a name="0x1_vector_append"></a>
@@ -233,11 +302,15 @@ Reverses the order of the elements in the vector <code>v</code> in place.
 
 Pushes all of the elements of the <code>other</code> vector into the <code>lhs</code> vector.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_append">append</a>&lt;Element&gt;(lhs: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, other: <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;)
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_append">append</a>&lt;Element&gt;(lhs: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, other: <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;) {
     <a href="vector.md#0x1_vector_reverse">reverse</a>(&<b>mut</b> other);
@@ -245,6 +318,8 @@ Pushes all of the elements of the <code>other</code> vector into the <code>lhs</
     <a href="vector.md#0x1_vector_destroy_empty">destroy_empty</a>(other);
 }
 </code></pre>
+
+
 
 </details>
 
@@ -254,16 +329,22 @@ Pushes all of the elements of the <code>other</code> vector into the <code>lhs</
 
 Return <code><b>true</b></code> if the vector <code>v</code> has no elements and <code><b>false</b></code> otherwise.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_is_empty">is_empty</a>&lt;Element&gt;(v: &<a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;): bool
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_is_empty">is_empty</a>&lt;Element&gt;(v: &<a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;): bool {
     <a href="vector.md#0x1_vector_length">length</a>(v) == 0
 }
 </code></pre>
+
+
 
 </details>
 
@@ -274,11 +355,15 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 Return true if <code>e</code> is in the vector <code>v</code>.
 Otherwise, returns false.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_contains">contains</a>&lt;Element&gt;(v: &<a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: &Element): bool
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_contains">contains</a>&lt;Element&gt;(v: &<a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: &Element): bool {
     <b>let</b> i = 0;
@@ -291,6 +376,8 @@ Otherwise, returns false.
 }
 </code></pre>
 
+
+
 </details>
 
 <a name="0x1_vector_index_of"></a>
@@ -300,11 +387,15 @@ Otherwise, returns false.
 Return <code>(<b>true</b>, i)</code> if <code>e</code> is in the vector <code>v</code> at index <code>i</code>.
 Otherwise, returns <code>(<b>false</b>, 0)</code>.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_index_of">index_of</a>&lt;Element&gt;(v: &<a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: &Element): (bool, u64)
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_index_of">index_of</a>&lt;Element&gt;(v: &<a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: &Element): (bool, u64) {
     <b>let</b> i = 0;
@@ -317,6 +408,8 @@ Otherwise, returns <code>(<b>false</b>, 0)</code>.
 }
 </code></pre>
 
+
+
 </details>
 
 <a name="0x1_vector_remove"></a>
@@ -327,11 +420,15 @@ Remove the <code>i</code>th element of the vector <code>v</code>, shifting all s
 This is O(n) and preserves ordering of elements in the vector.
 Aborts if <code>i</code> is out of bounds.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_remove">remove</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): Element
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_remove">remove</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): Element {
     <b>let</b> len = <a href="vector.md#0x1_vector_length">length</a>(v);
@@ -343,6 +440,8 @@ Aborts if <code>i</code> is out of bounds.
     <a href="vector.md#0x1_vector_pop_back">pop_back</a>(v)
 }
 </code></pre>
+
+
 
 </details>
 
@@ -356,11 +455,15 @@ If <code>i == <a href="vector.md#0x1_vector_length">length</a>(v)</code>, this a
 This is O(n) and preserves ordering of elements in the vector.
 Aborts if <code>i &gt; <a href="vector.md#0x1_vector_length">length</a>(v)</code>
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_insert">insert</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: Element, i: u64)
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_insert">insert</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: Element, i: u64) {
     <b>let</b> len = <a href="vector.md#0x1_vector_length">length</a>(v);
@@ -375,6 +478,8 @@ Aborts if <code>i &gt; <a href="vector.md#0x1_vector_length">length</a>(v)</code
 }
 </code></pre>
 
+
+
 </details>
 
 <a name="0x1_vector_swap_remove"></a>
@@ -385,11 +490,15 @@ Swap the <code>i</code>th element of the vector <code>v</code> with the last ele
 This is O(1), but does not preserve ordering of elements in the vector.
 Aborts if <code>i</code> is out of bounds.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_swap_remove">swap_remove</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): Element
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_swap_remove">swap_remove</a>&lt;Element&gt;(v: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): Element {
     <b>assert</b>!(!<a href="vector.md#0x1_vector_is_empty">is_empty</a>(v), <a href="vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>);
@@ -399,6 +508,9 @@ Aborts if <code>i</code> is out of bounds.
 }
 </code></pre>
 
+
+
 </details>
+
 
 [//]: # ("File containing references which can be used from documentation")

--- a/external-crates/move/move-execution/v0/crates/move-stdlib/nursery/docs/compare.md
+++ b/external-crates/move/move-execution/v0/crates/move-stdlib/nursery/docs/compare.md
@@ -1,34 +1,52 @@
+
 <a name="0x1_compare"></a>
 
 # Module `0x1::compare`
 
 Utilities for comparing Move values based on their representation in BCS.
 
-- [Constants](#@Constants_0)
-- [Function `cmp_bcs_bytes`](#0x1_compare_cmp_bcs_bytes)
-- [Function `cmp_u8`](#0x1_compare_cmp_u8)
-- [Function `cmp_u64`](#0x1_compare_cmp_u64)
+
+-  [Constants](#@Constants_0)
+-  [Function `cmp_bcs_bytes`](#0x1_compare_cmp_bcs_bytes)
+-  [Function `cmp_u8`](#0x1_compare_cmp_u8)
+-  [Function `cmp_u64`](#0x1_compare_cmp_u64)
+
 
 <pre><code></code></pre>
+
+
 
 <a name="@Constants_0"></a>
 
 ## Constants
 
+
 <a name="0x1_compare_EQUAL"></a>
+
+
 
 <pre><code><b>const</b> <a href="compare.md#0x1_compare_EQUAL">EQUAL</a>: u8 = 0;
 </code></pre>
 
+
+
 <a name="0x1_compare_GREATER_THAN"></a>
+
+
 
 <pre><code><b>const</b> <a href="compare.md#0x1_compare_GREATER_THAN">GREATER_THAN</a>: u8 = 2;
 </code></pre>
 
+
+
 <a name="0x1_compare_LESS_THAN"></a>
+
+
 
 <pre><code><b>const</b> <a href="compare.md#0x1_compare_LESS_THAN">LESS_THAN</a>: u8 = 1;
 </code></pre>
+
+
 
 <a name="0x1_compare_cmp_bcs_bytes"></a>
 
@@ -42,15 +60,14 @@ This function is designed to compare BCS (Binary Canonical Serialization)-encode
 (i.e., vectors produced by <code>bcs::to_bytes</code>). A typical client will call
 <code><a href="compare.md#0x1_compare_cmp_bcs_bytes">compare::cmp_bcs_bytes</a>(bcs::to_bytes(&t1), bcs::to_bytes(&t2))</code>. The comparison provides the
 following guarantees w.r.t the original values t1 and t2:
-
 - <code><a href="compare.md#0x1_compare_cmp_bcs_bytes">cmp_bcs_bytes</a>(bcs(t1), bcs(t2)) == <a href="compare.md#0x1_compare_LESS_THAN">LESS_THAN</a></code> iff <code><a href="compare.md#0x1_compare_cmp_bcs_bytes">cmp_bcs_bytes</a>(t2, t1) == <a href="compare.md#0x1_compare_GREATER_THAN">GREATER_THAN</a></code>
 - <code>compare::cmp&lt;T&gt;(t1, t2) == <a href="compare.md#0x1_compare_EQUAL">EQUAL</a></code> iff <code>t1 == t2</code> and (similarly)
-  <code>compare::cmp&lt;T&gt;(t1, t2) != <a href="compare.md#0x1_compare_EQUAL">EQUAL</a></code> iff <code>t1 != t2</code>, where <code>==</code> and <code>!=</code> denote the Move
-  bytecode operations for polymorphic equality.
+<code>compare::cmp&lt;T&gt;(t1, t2) != <a href="compare.md#0x1_compare_EQUAL">EQUAL</a></code> iff <code>t1 != t2</code>, where <code>==</code> and <code>!=</code> denote the Move
+bytecode operations for polymorphic equality.
 - for all primitive types <code>T</code> with <code>&lt;</code> and <code>&gt;</code> comparison operators exposed in Move bytecode
-  (<code>u8</code>, <code>u16</code>, <code>u32</code>, <code>u64</code>, <code>u128</code>, <code>u256</code>), we have
-  <code>compare_bcs_bytes(bcs(t1), bcs(t2)) == <a href="compare.md#0x1_compare_LESS_THAN">LESS_THAN</a></code> iff <code>t1 &lt; t2</code> and (similarly)
-  <code>compare_bcs_bytes(bcs(t1), bcs(t2)) == <a href="compare.md#0x1_compare_LESS_THAN">LESS_THAN</a></code> iff <code>t1 &gt; t2</code>.
+(<code>u8</code>, <code>u16</code>, <code>u32</code>, <code>u64</code>, <code>u128</code>, <code>u256</code>), we have
+<code>compare_bcs_bytes(bcs(t1), bcs(t2)) == <a href="compare.md#0x1_compare_LESS_THAN">LESS_THAN</a></code> iff <code>t1 &lt; t2</code> and (similarly)
+<code>compare_bcs_bytes(bcs(t1), bcs(t2)) == <a href="compare.md#0x1_compare_LESS_THAN">LESS_THAN</a></code> iff <code>t1 &gt; t2</code>.
 
 For all other types, the order is whatever the BCS encoding of the type and the comparison
 strategy above gives you. One case where the order might be surprising is the <code><b>address</b></code>
@@ -61,15 +78,19 @@ to left, byte-by-byte comparison means that (for example)
 <code>compare_bcs_bytes(bcs(0x100), bcs(0x001)) == <a href="compare.md#0x1_compare_LESS_THAN">LESS_THAN</a></code> (as you probably wouldn't expect).
 Keep this in mind when using this function to compare addresses.
 
-<pre><code><b>public</b> <b>fun</b> <a href="compare.md#0x1_compare_cmp_bcs_bytes">cmp_bcs_bytes</a>(v1: &<a href="">vector</a>&lt;u8&gt;, v2: &<a href="">vector</a>&lt;u8&gt;): u8
+
+<pre><code><b>public</b> <b>fun</b> <a href="compare.md#0x1_compare_cmp_bcs_bytes">cmp_bcs_bytes</a>(v1: &<a href="dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, v2: &<a href="dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): u8
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
-<pre><code><b>public</b> <b>fun</b> <a href="compare.md#0x1_compare_cmp_bcs_bytes">cmp_bcs_bytes</a>(v1: &<a href="">vector</a>&lt;u8&gt;, v2: &<a href="">vector</a>&lt;u8&gt;): u8 {
-    <b>let</b> i1 = <a href="_length">vector::length</a>(v1);
-    <b>let</b> i2 = <a href="_length">vector::length</a>(v2);
+
+<pre><code><b>public</b> <b>fun</b> <a href="compare.md#0x1_compare_cmp_bcs_bytes">cmp_bcs_bytes</a>(v1: &<a href="dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;, v2: &<a href="dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;u8&gt;): u8 {
+    <b>let</b> i1 = <a href="dependencies/move-stdlib/vector.md#0x1_vector_length">vector::length</a>(v1);
+    <b>let</b> i2 = <a href="dependencies/move-stdlib/vector.md#0x1_vector_length">vector::length</a>(v2);
     <b>let</b> len_cmp = <a href="compare.md#0x1_compare_cmp_u64">cmp_u64</a>(i1, i2);
 
     // BCS uses little endian encoding for all integer types, so we <b>choose</b> <b>to</b> <a href="compare.md#0x1_compare">compare</a> from left
@@ -78,7 +99,7 @@ Keep this in mind when using this function to compare addresses.
     <b>while</b> (i1 &gt; 0 && i2 &gt; 0) {
         i1 = i1 - 1;
         i2 = i2 - 1;
-        <b>let</b> elem_cmp = <a href="compare.md#0x1_compare_cmp_u8">cmp_u8</a>(*<a href="_borrow">vector::borrow</a>(v1, i1), *<a href="_borrow">vector::borrow</a>(v2, i2));
+        <b>let</b> elem_cmp = <a href="compare.md#0x1_compare_cmp_u8">cmp_u8</a>(*<a href="dependencies/move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(v1, i1), *<a href="dependencies/move-stdlib/vector.md#0x1_vector_borrow">vector::borrow</a>(v2, i2));
         <b>if</b> (elem_cmp != 0) <b>return</b> elem_cmp
         // <b>else</b>, <a href="compare.md#0x1_compare">compare</a> next element
     };
@@ -86,6 +107,8 @@ Keep this in mind when using this function to compare addresses.
     len_cmp
 }
 </code></pre>
+
+
 
 </details>
 
@@ -95,11 +118,15 @@ Keep this in mind when using this function to compare addresses.
 
 Compare two <code>u8</code>'s
 
+
 <pre><code><b>fun</b> <a href="compare.md#0x1_compare_cmp_u8">cmp_u8</a>(i1: u8, i2: u8): u8
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>fun</b> <a href="compare.md#0x1_compare_cmp_u8">cmp_u8</a>(i1: u8, i2: u8): u8 {
     <b>if</b> (i1 == i2) <a href="compare.md#0x1_compare_EQUAL">EQUAL</a>
@@ -107,6 +134,8 @@ Compare two <code>u8</code>'s
     <b>else</b> <a href="compare.md#0x1_compare_GREATER_THAN">GREATER_THAN</a>
 }
 </code></pre>
+
+
 
 </details>
 
@@ -116,11 +145,15 @@ Compare two <code>u8</code>'s
 
 Compare two <code>u64</code>'s
 
+
 <pre><code><b>fun</b> <a href="compare.md#0x1_compare_cmp_u64">cmp_u64</a>(i1: u64, i2: u64): u8
 </code></pre>
 
+
+
 <details>
 <summary>Implementation</summary>
+
 
 <pre><code><b>fun</b> <a href="compare.md#0x1_compare_cmp_u64">cmp_u64</a>(i1: u64, i2: u64): u8 {
     <b>if</b> (i1 == i2) <a href="compare.md#0x1_compare_EQUAL">EQUAL</a>
@@ -128,5 +161,7 @@ Compare two <code>u64</code>'s
     <b>else</b> <a href="compare.md#0x1_compare_GREATER_THAN">GREATER_THAN</a>
 }
 </code></pre>
+
+
 
 </details>

--- a/external-crates/move/move-execution/v0/crates/move-stdlib/nursery/docs/debug.md
+++ b/external-crates/move/move-execution/v0/crates/move-stdlib/nursery/docs/debug.md
@@ -1,13 +1,18 @@
+
 <a name="0x1_debug"></a>
 
 # Module `0x1::debug`
 
 Module providing debug functionality.
 
-- [Function `print`](#0x1_debug_print)
-- [Function `print_stack_trace`](#0x1_debug_print_stack_trace)
+
+-  [Function `print`](#0x1_debug_print)
+-  [Function `print_stack_trace`](#0x1_debug_print_stack_trace)
+
 
 <pre><code></code></pre>
+
+
 
 <a name="0x1_debug_print"></a>
 
@@ -15,14 +20,20 @@ Module providing debug functionality.
 
 Pretty-prints any Move value. For a Move struct, includes its field names, their types and their values.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="debug.md#0x1_debug_print">print</a>&lt;T&gt;(x: &T)
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="debug.md#0x1_debug_print">print</a>&lt;T&gt;(x: &T);
 </code></pre>
+
+
 
 </details>
 
@@ -32,13 +43,19 @@ Pretty-prints any Move value. For a Move struct, includes its field names, their
 
 Prints the calling function's stack trace.
 
+
 <pre><code><b>public</b> <b>fun</b> <a href="debug.md#0x1_debug_print_stack_trace">print_stack_trace</a>()
 </code></pre>
+
+
 
 <details>
 <summary>Implementation</summary>
 
+
 <pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="debug.md#0x1_debug_print_stack_trace">print_stack_trace</a>();
 </code></pre>
+
+
 
 </details>

--- a/external-crates/move/move-execution/v0/crates/move-stdlib/nursery/docs/dependencies/move-stdlib/vector.md
+++ b/external-crates/move/move-execution/v0/crates/move-stdlib/nursery/docs/dependencies/move-stdlib/vector.md
@@ -1,0 +1,513 @@
+
+<a name="0x1_vector"></a>
+
+# Module `0x1::vector`
+
+A variable-sized container that can hold any type. Indexing is 0-based, and
+vectors are growable. This module has many native functions.
+
+
+-  [Constants](#@Constants_0)
+-  [Function `empty`](#0x1_vector_empty)
+-  [Function `length`](#0x1_vector_length)
+-  [Function `borrow`](#0x1_vector_borrow)
+-  [Function `push_back`](#0x1_vector_push_back)
+-  [Function `borrow_mut`](#0x1_vector_borrow_mut)
+-  [Function `pop_back`](#0x1_vector_pop_back)
+-  [Function `destroy_empty`](#0x1_vector_destroy_empty)
+-  [Function `swap`](#0x1_vector_swap)
+-  [Function `singleton`](#0x1_vector_singleton)
+-  [Function `reverse`](#0x1_vector_reverse)
+-  [Function `append`](#0x1_vector_append)
+-  [Function `is_empty`](#0x1_vector_is_empty)
+-  [Function `contains`](#0x1_vector_contains)
+-  [Function `index_of`](#0x1_vector_index_of)
+-  [Function `remove`](#0x1_vector_remove)
+-  [Function `insert`](#0x1_vector_insert)
+-  [Function `swap_remove`](#0x1_vector_swap_remove)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x1_vector_EINDEX_OUT_OF_BOUNDS"></a>
+
+The index into the vector is out of bounds
+
+
+<pre><code><b>const</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>: u64 = 131072;
+</code></pre>
+
+
+
+<a name="0x1_vector_empty"></a>
+
+## Function `empty`
+
+Create an empty vector.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_empty">empty</a>&lt;Element&gt;(): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_empty">empty</a>&lt;Element&gt;(): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vector_length"></a>
+
+## Function `length`
+
+Return the length of the vector.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_length">length</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_length">length</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;): u64;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vector_borrow"></a>
+
+## Function `borrow`
+
+Acquire an immutable reference to the <code>i</code>th element of the vector <code>v</code>.
+Aborts if <code>i</code> is out of bounds.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_borrow">borrow</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): &Element
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_borrow">borrow</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): &Element;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vector_push_back"></a>
+
+## Function `push_back`
+
+Add element <code>e</code> to the end of the vector <code>v</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_push_back">push_back</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: Element)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_push_back">push_back</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: Element);
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vector_borrow_mut"></a>
+
+## Function `borrow_mut`
+
+Return a mutable reference to the <code>i</code>th element in the vector <code>v</code>.
+Aborts if <code>i</code> is out of bounds.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_borrow_mut">borrow_mut</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): &<b>mut</b> Element
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_borrow_mut">borrow_mut</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): &<b>mut</b> Element;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vector_pop_back"></a>
+
+## Function `pop_back`
+
+Pop an element from the end of vector <code>v</code>.
+Aborts if <code>v</code> is empty.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_pop_back">pop_back</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;): Element
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_pop_back">pop_back</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;): Element;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vector_destroy_empty"></a>
+
+## Function `destroy_empty`
+
+Destroy the vector <code>v</code>.
+Aborts if <code>v</code> is not empty.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_destroy_empty">destroy_empty</a>&lt;Element&gt;(v: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_destroy_empty">destroy_empty</a>&lt;Element&gt;(v: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;);
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vector_swap"></a>
+
+## Function `swap`
+
+Swaps the elements at the <code>i</code>th and <code>j</code>th indices in the vector <code>v</code>.
+Aborts if <code>i</code> or <code>j</code> is out of bounds.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_swap">swap</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64, j: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_swap">swap</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64, j: u64);
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vector_singleton"></a>
+
+## Function `singleton`
+
+Return an vector of size one containing element <code>e</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_singleton">singleton</a>&lt;Element&gt;(e: Element): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_singleton">singleton</a>&lt;Element&gt;(e: Element): <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt; {
+    <b>let</b> v = <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_empty">empty</a>();
+    <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_push_back">push_back</a>(&<b>mut</b> v, e);
+    v
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vector_reverse"></a>
+
+## Function `reverse`
+
+Reverses the order of the elements in the vector <code>v</code> in place.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_reverse">reverse</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_reverse">reverse</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;) {
+    <b>let</b> len = <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_length">length</a>(v);
+    <b>if</b> (len == 0) <b>return</b> ();
+
+    <b>let</b> front_index = 0;
+    <b>let</b> back_index = len -1;
+    <b>while</b> (front_index &lt; back_index) {
+        <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_swap">swap</a>(v, front_index, back_index);
+        front_index = front_index + 1;
+        back_index = back_index - 1;
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vector_append"></a>
+
+## Function `append`
+
+Pushes all of the elements of the <code>other</code> vector into the <code>lhs</code> vector.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_append">append</a>&lt;Element&gt;(lhs: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, other: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_append">append</a>&lt;Element&gt;(lhs: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, other: <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;) {
+    <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_reverse">reverse</a>(&<b>mut</b> other);
+    <b>while</b> (!<a href="../../dependencies/move-stdlib/vector.md#0x1_vector_is_empty">is_empty</a>(&other)) <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_push_back">push_back</a>(lhs, <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_pop_back">pop_back</a>(&<b>mut</b> other));
+    <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_destroy_empty">destroy_empty</a>(other);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vector_is_empty"></a>
+
+## Function `is_empty`
+
+Return <code><b>true</b></code> if the vector <code>v</code> has no elements and <code><b>false</b></code> otherwise.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_is_empty">is_empty</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_is_empty">is_empty</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;): bool {
+    <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_length">length</a>(v) == 0
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vector_contains"></a>
+
+## Function `contains`
+
+Return true if <code>e</code> is in the vector <code>v</code>.
+Otherwise, returns false.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_contains">contains</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: &Element): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_contains">contains</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: &Element): bool {
+    <b>let</b> i = 0;
+    <b>let</b> len = <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_length">length</a>(v);
+    <b>while</b> (i &lt; len) {
+        <b>if</b> (<a href="../../dependencies/move-stdlib/vector.md#0x1_vector_borrow">borrow</a>(v, i) == e) <b>return</b> <b>true</b>;
+        i = i + 1;
+    };
+    <b>false</b>
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vector_index_of"></a>
+
+## Function `index_of`
+
+Return <code>(<b>true</b>, i)</code> if <code>e</code> is in the vector <code>v</code> at index <code>i</code>.
+Otherwise, returns <code>(<b>false</b>, 0)</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_index_of">index_of</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: &Element): (bool, u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_index_of">index_of</a>&lt;Element&gt;(v: &<a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: &Element): (bool, u64) {
+    <b>let</b> i = 0;
+    <b>let</b> len = <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_length">length</a>(v);
+    <b>while</b> (i &lt; len) {
+        <b>if</b> (<a href="../../dependencies/move-stdlib/vector.md#0x1_vector_borrow">borrow</a>(v, i) == e) <b>return</b> (<b>true</b>, i);
+        i = i + 1;
+    };
+    (<b>false</b>, 0)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vector_remove"></a>
+
+## Function `remove`
+
+Remove the <code>i</code>th element of the vector <code>v</code>, shifting all subsequent elements.
+This is O(n) and preserves ordering of elements in the vector.
+Aborts if <code>i</code> is out of bounds.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_remove">remove</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): Element
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_remove">remove</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): Element {
+    <b>let</b> len = <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_length">length</a>(v);
+    // i out of bounds; <b>abort</b>
+    <b>if</b> (i &gt;= len) <b>abort</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>;
+
+    len = len - 1;
+    <b>while</b> (i &lt; len) <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_swap">swap</a>(v, i, { i = i + 1; i });
+    <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_pop_back">pop_back</a>(v)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vector_insert"></a>
+
+## Function `insert`
+
+Insert <code>e</code> at position <code>i</code> in the vector <code>v</code>.
+If <code>i</code> is in bounds, this shifts the old <code>v[i]</code> and all subsequent elements to the right.
+If <code>i == <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_length">length</a>(v)</code>, this adds <code>e</code> to the end of the vector.
+This is O(n) and preserves ordering of elements in the vector.
+Aborts if <code>i &gt; <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_length">length</a>(v)</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_insert">insert</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: Element, i: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_insert">insert</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, e: Element, i: u64) {
+    <b>let</b> len = <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_length">length</a>(v);
+    // i too big <b>abort</b>
+    <b>if</b> (i &gt; len) <b>abort</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>;
+
+    <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_push_back">push_back</a>(v, e);
+    <b>while</b> (i &lt; len) {
+        <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_swap">swap</a>(v, i, len);
+        i = i + 1
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_vector_swap_remove"></a>
+
+## Function `swap_remove`
+
+Swap the <code>i</code>th element of the vector <code>v</code> with the last element and then pop the vector.
+This is O(1), but does not preserve ordering of elements in the vector.
+Aborts if <code>i</code> is out of bounds.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_swap_remove">swap_remove</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): Element
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_swap_remove">swap_remove</a>&lt;Element&gt;(v: &<b>mut</b> <a href="../../dependencies/move-stdlib/vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): Element {
+    <b>assert</b>!(!<a href="../../dependencies/move-stdlib/vector.md#0x1_vector_is_empty">is_empty</a>(v), <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>);
+    <b>let</b> last_idx = <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_length">length</a>(v) - 1;
+    <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_swap">swap</a>(v, i, last_idx);
+    <a href="../../dependencies/move-stdlib/vector.md#0x1_vector_pop_back">pop_back</a>(v)
+}
+</code></pre>
+
+
+
+</details>


### PR DESCRIPTION
# Description of change

Regenerated the documentation and added `move-stdlib-v0` to the dprint excludes list.

## Links to any relevant issues

fixes #2004 

## How the change has been tested

Run `cargo nextest run` in the `./external-crates/move` directory.

