### PR TITLE
refactor(iota-proc-macros): update sim_test documentation

### DIFF
--- a/crates/iota-proc-macros/src/lib.rs
+++ b/crates/iota-proc-macros/src/lib.rs
@@ -181,14 +181,16 @@ pub fn iota_test(args: TokenStream, item: TokenStream) -> TokenStream {
     result.into()
 }
 
-/// The sim_test macro will invoke `#[msim::test]` if the simulator config var
-/// is enabled.
+/// The `sim_test` macro will invoke `#[msim::test]` if the simulator config var
+/// (`msim`) is enabled.
 ///
-/// Otherwise, it will emit an ignored test - if forcibly run, the ignored test
-/// will panic.
+/// On this premise, this macro can be used in order to pass any
+/// simulator-specific arguments, such as `check_determinism`,
+/// which is not understood by tokio.
 ///
-/// This macro must be used in order to pass any simulator-specific arguments,
-/// such as `check_determinism`, which is not understood by tokio.
+/// If the simulator config var is disabled, tests will run via
+/// `#[tokio::test]`, unless disabled by setting the environment variable
+/// `IOTA_SKIP_SIMTESTS`.
 #[proc_macro_attribute]
 pub fn sim_test(args: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as syn::ItemFn);


### PR DESCRIPTION
# Description of change

A small documentation update that sheds light on why tests with the `sim_test` attribute run even when invoking `cargo nextest run` with no other configuration (i.e. setting the `--cfg msim` rust flag).

## Links to any relevant issues

Fixes #2020

Discovered while working on #1561 

## Type of change

- Documentation Fix

## How the change has been tested

Run 
```
$ cargo nextest run -p iota-json-rpc-tests
```