### PR TITLE
feat(tooling-general): Allow trigger preview workflows manually

### DIFF
--- a/.github/workflows/apps-explorer-preview.deploy.yml
+++ b/.github/workflows/apps-explorer-preview.deploy.yml
@@ -5,6 +5,7 @@ env:
   VERCEL_PROJECT_ID: ${{ secrets.EXPLORER_VERCEL_PROJECT_ID }}
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:

--- a/.github/workflows/apps-ui-kit-preview.deploy.yml
+++ b/.github/workflows/apps-ui-kit-preview.deploy.yml
@@ -5,6 +5,7 @@ env:
   VERCEL_PROJECT_ID: ${{ secrets.APPS_UI_KIT_VERCEL_PROJECT_ID }}
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:

--- a/.github/workflows/apps-wallet-dashboard-preview.deploy.yml
+++ b/.github/workflows/apps-wallet-dashboard-preview.deploy.yml
@@ -5,6 +5,7 @@ env:
   VERCEL_PROJECT_ID: ${{ secrets.WALLET_DASHBOARD_VERCEL_PROJECT_ID }}
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:


### PR DESCRIPTION
Closes https://github.com/iotaledger/iota/issues/2027

I think this might be useful to easily trigger changes on demand. I wanted to see how the explorer would look like with after changing something in the ui kit but I couldn't as it didn't deploy a preview automatically neither I could do it manually, until now