### PR TITLE
feat(tooling-general): Opt-in precommit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
-pnpm exec lint-staged --allow-empty
+if [ "$NPM_PRECOMMIT_HOOK" = "true" ]; then
+  pnpm exec lint-staged --allow-empty
+fi


### PR DESCRIPTION
Closes https://github.com/iotaledger/iota/issues/2062

People who want to opt in would need to set `NPM_PRECOMMIT_HOOK` to `true` 
- bash: `.bashrc`
- nushell: `env.nu`