### PR TITLE
feat(CI): deploy wiki daily

### DIFF
--- a/.github/workflows/release-wiki.yml
+++ b/.github/workflows/release-wiki.yml
@@ -6,6 +6,8 @@ env:
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   wiki-release:

--- a/.github/workflows/release-wiki.yml
+++ b/.github/workflows/release-wiki.yml
@@ -7,7 +7,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
 jobs:
   wiki-release:


### PR DESCRIPTION
# Description of change

We can start regularly deploying the docs I think. We could also deploy on every commit on main, but tbh with the Wiki I started to get used to a "nightly" release, especially if we want to time new releases with an announcement or something like that

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
