### PR TITLE
refactor(iota-framework/iota-system): Remove multiple versions from the iota-system types

### DIFF
--- a/crates/iota-framework/packages/iota-system/Move.lock
+++ b/crates/iota-framework/packages/iota-system/Move.lock
@@ -23,6 +23,6 @@ name = "MoveStdlib"
 source = { local = "../move-stdlib" }
 
 [move.toolchain-version]
-compiler-version = "0.1.6"
+compiler-version = "0.1.2"
 edition = "legacy"
 flavor = "iota"

--- a/crates/iota-framework/packages/iota-system/Move.lock
+++ b/crates/iota-framework/packages/iota-system/Move.lock
@@ -23,6 +23,6 @@ name = "MoveStdlib"
 source = { local = "../move-stdlib" }
 
 [move.toolchain-version]
-compiler-version = "0.1.2"
+compiler-version = "0.1.6"
 edition = "legacy"
 flavor = "iota"

--- a/crates/iota-framework/packages/iota-system/sources/iota_system.move
+++ b/crates/iota-framework/packages/iota-system/sources/iota_system.move
@@ -14,7 +14,7 @@
 /// To properly upgrade the `IotaSystemStateInnerV1` type, we need to ship a new framework that does the following:
 /// 1. Define a new `IotaSystemStateInner`type (e.g. `IotaSystemStateInnerV2`).
 /// 2. Define a data migration function that migrates the old (e.g., `IotaSystemStateInnerV1`) to the new one (e.g. IotaSystemStateInnerV2).
-/// 3. Replace all uses of `IotaSystemStateInnerV1` with `IotaSystemStateInnerV1` in both iota_system.move and iota_system_state_inner.move,
+/// 3. Replace all uses of `IotaSystemStateInnerV1` with `IotaSystemStateInnerV2` in both iota_system.move and iota_system_state_inner.move,
 ///    with the exception of the `iota_system_state_inner::create` function, which should always return the genesis type.
 /// 4. Inside `load_inner_maybe_upgrade` function, check the current version in the wrapper, and if it's not the latest version,
 ///   call the data migration function to upgrade the inner object. Make sure to also update the version in the wrapper.

--- a/crates/iota-framework/packages/iota-system/sources/iota_system.move
+++ b/crates/iota-framework/packages/iota-system/sources/iota_system.move
@@ -34,10 +34,10 @@
 /// 4. In validator_wrapper::upgrade_to_latest, check the current version in the wrapper, and if it's not the latest version,
 ///  call the data migration function to upgrade it.
 /// In Rust, we also need to add a new case in `get_validator_from_table`.
-/// Note that it is possible to upgrade IotaSystemStateInnerV1without upgrading Validator, but not the other way around.
+/// Note that it is possible to upgrade IotaSystemStateInnerV1 without upgrading Validator, but not the other way around.
 /// And when we only upgrade IotaSystemStateInnerV1, the version of Validator in the wrapper will not be updated, and hence may become
 /// inconsistent with the version of IotaSystemStateInnerV1 . This is fine as long as we don't use the Validator version to determine
-/// the IotaSystemStateInnerV1version, or vice versa.
+/// the IotaSystemStateInnerV1 version, or vice versa.
 
 module iota_system::iota_system {
     use iota::balance::Balance;

--- a/crates/iota-framework/packages/iota-system/sources/iota_system.move
+++ b/crates/iota-framework/packages/iota-system/sources/iota_system.move
@@ -3,24 +3,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Iota System State Type Upgrade Guide
-/// `IotaSystemState` is a thin wrapper around `IotaSystemStateInner` that provides a versioned interface.
-/// The `IotaSystemState` object has a fixed ID 0x5, and the `IotaSystemStateInner` object is stored as a dynamic field.
-/// There are a few different ways to upgrade the `IotaSystemStateInner` type:
+/// `IotaSystemState` is a thin wrapper around `IotaSystemStateInnerV1` that provides a versioned interface.
+/// The `IotaSystemState` object has a fixed ID 0x5, and the `IotaSystemStateInnerV1` object is stored as a dynamic field.
+/// There are a few different ways to upgrade the `IotaSystemStateInnerV1` type:
 ///
 /// The simplest and one that doesn't involve a real upgrade is to just add dynamic fields to the `extra_fields` field
-/// of `IotaSystemStateInner` or any of its sub type. This is useful when we are in a rush, or making a small change,
+/// of `IotaSystemStateInnerV1` or any of its sub type. This is useful when we are in a rush, or making a small change,
 /// or still experimenting a new field.
 ///
-/// To properly upgrade the `IotaSystemStateInner` type, we need to ship a new framework that does the following:
-/// 1. Define a new `IotaSystemStateInner`type (e.g. `IotaSystemStateInnerV2`).
-/// 2. Define a data migration function that migrates the old `IotaSystemStateInner` to the new one (i.e. IotaSystemStateInnerV2).
-/// 3. Replace all uses of `IotaSystemStateInner` with `IotaSystemStateInnerV2` in both iota_system.move and iota_system_state_inner.move,
+/// To properly upgrade the `IotaSystemStateInnerV1` type, we need to ship a new framework that does the following:
+/// 1. Define a new `IotaSystemStateInnerV1`type (e.g. `IotaSystemStateInnerV1`).
+/// 2. Define a data migration function that migrates the old   to the new one (i.e. IotaSystemStateInnerV1).
+/// 3. Replace all uses of `IotaSystemStateInnerV1` with `IotaSystemStateInnerV1` in both iota_system.move and iota_system_state_inner.move,
 ///    with the exception of the `iota_system_state_inner::create` function, which should always return the genesis type.
 /// 4. Inside `load_inner_maybe_upgrade` function, check the current version in the wrapper, and if it's not the latest version,
 ///   call the data migration function to upgrade the inner object. Make sure to also update the version in the wrapper.
 /// A detailed example can be found in iota/tests/framework_upgrades/mock_iota_systems/shallow_upgrade.
 /// Along with the Move change, we also need to update the Rust code to support the new type. This includes:
-/// 1. Define a new `IotaSystemStateInner` struct type that matches the new Move type, and implement the IotaSystemStateTrait.
+/// 1. Define a new `IotaSystemStateInnerV1` struct type that matches the new Move type, and implement the IotaSystemStateTrait.
 /// 2. Update the `IotaSystemState` struct to include the new version as a new enum variant.
 /// 3. Update the `get_iota_system_state` function to handle the new version.
 /// To test that the upgrade will be successful, we need to modify `iota_system_state_production_upgrade_test` test in
@@ -28,16 +28,16 @@
 /// put the new framework in a new directory, and run the test to exercise the upgrade.
 ///
 /// To upgrade Validator type, besides everything above, we also need to:
-/// 1. Define a new Validator type (e.g. ValidatorV2).
-/// 2. Define a data migration function that migrates the old Validator to the new one (i.e. ValidatorV2).
-/// 3. Replace all uses of Validator with ValidatorV2 except the genesis creation function.
+/// 1. Define a new Validator type (e.g. ValidatorV1).
+/// 2. Define a data migration function that migrates the old Validator to the new one (i.e. ValidatorV1).
+/// 3. Replace all uses of Validator with ValidatorV1 except the genesis creation function.
 /// 4. In validator_wrapper::upgrade_to_latest, check the current version in the wrapper, and if it's not the latest version,
 ///  call the data migration function to upgrade it.
 /// In Rust, we also need to add a new case in `get_validator_from_table`.
-/// Note that it is possible to upgrade IotaSystemStateInner without upgrading Validator, but not the other way around.
-/// And when we only upgrade IotaSystemStateInner, the version of Validator in the wrapper will not be updated, and hence may become
-/// inconsistent with the version of IotaSystemStateInner. This is fine as long as we don't use the Validator version to determine
-/// the IotaSystemStateInner version, or vice versa.
+/// Note that it is possible to upgrade IotaSystemStateInnerV1without upgrading Validator, but not the other way around.
+/// And when we only upgrade IotaSystemStateInnerV1, the version of Validator in the wrapper will not be updated, and hence may become
+/// inconsistent with the version of IotaSystemStateInnerV1 . This is fine as long as we don't use the Validator version to determine
+/// the IotaSystemStateInnerV1version, or vice versa.
 
 module iota_system::iota_system {
     use iota::balance::Balance;
@@ -49,12 +49,12 @@ module iota_system::iota_system {
     use iota::timelock::SystemTimelockCap;
     use iota_system::validator::Validator;
     use iota_system::validator_cap::UnverifiedValidatorOperationCap;
-    use iota_system::iota_system_state_inner::{Self, SystemParameters, IotaSystemStateInner, IotaSystemStateInnerV2};
+    use iota_system::iota_system_state_inner::{Self, SystemParametersV1, IotaSystemStateInnerV1};
     use iota_system::staking_pool::PoolTokenExchangeRate;
     use iota::dynamic_field;
 
     #[test_only] use iota::balance;
-    #[test_only] use iota_system::validator_set::ValidatorSet;
+    #[test_only] use iota_system::validator_set::ValidatorSetV1;
     #[test_only] use iota::vec_set::VecSet;
 
     /* friend iota_system::genesis; */
@@ -85,7 +85,7 @@ module iota_system::iota_system {
         storage_fund: Balance<IOTA>,
         protocol_version: u64,
         epoch_start_timestamp_ms: u64,
-        parameters: SystemParameters,
+        parameters: SystemParametersV1,
         system_timelock_cap: SystemTimelockCap,
         ctx: &mut TxContext,
     ) {
@@ -574,23 +574,16 @@ module iota_system::iota_system {
         storage_rebate
     }
 
-    fun load_system_state(self: &mut IotaSystemState): &IotaSystemStateInnerV2 {
+    fun load_system_state(self: &mut IotaSystemState): &IotaSystemStateInnerV1  {
         load_inner_maybe_upgrade(self)
     }
 
-    fun load_system_state_mut(self: &mut IotaSystemState): &mut IotaSystemStateInnerV2 {
+    fun load_system_state_mut(self: &mut IotaSystemState): &mut IotaSystemStateInnerV1  {
         load_inner_maybe_upgrade(self)
     }
 
-    fun load_inner_maybe_upgrade(self: &mut IotaSystemState): &mut IotaSystemStateInnerV2 {
-        if (self.version == 1) {
-          let v1: IotaSystemStateInner = dynamic_field::remove(&mut self.id, self.version);
-          let v2 = v1.v1_to_v2();
-          self.version = 2;
-          dynamic_field::add(&mut self.id, self.version, v2);
-        };
-
-        let inner: &mut IotaSystemStateInnerV2 = dynamic_field::borrow_mut(
+    fun load_inner_maybe_upgrade(self: &mut IotaSystemState): &mut IotaSystemStateInnerV1  {
+        let inner: &mut IotaSystemStateInnerV1  = dynamic_field::borrow_mut(
             &mut self.id,
             self.version
         );
@@ -652,7 +645,7 @@ module iota_system::iota_system {
 
     #[test_only]
     /// Return the current validator set
-    public fun validators(wrapper: &mut IotaSystemState): &ValidatorSet {
+    public fun validators(wrapper: &mut IotaSystemState): &ValidatorSetV1 {
         let self = load_system_state(wrapper);
         self.validators()
     }

--- a/crates/iota-framework/packages/iota-system/sources/iota_system.move
+++ b/crates/iota-framework/packages/iota-system/sources/iota_system.move
@@ -12,7 +12,7 @@
 /// or still experimenting a new field.
 ///
 /// To properly upgrade the `IotaSystemStateInnerV1` type, we need to ship a new framework that does the following:
-/// 1. Define a new `IotaSystemStateInnerV1`type (e.g. `IotaSystemStateInnerV1`).
+/// 1. Define a new `IotaSystemStateInner`type (e.g. `IotaSystemStateInnerV2`).
 /// 2. Define a data migration function that migrates the old   to the new one (i.e. IotaSystemStateInnerV1).
 /// 3. Replace all uses of `IotaSystemStateInnerV1` with `IotaSystemStateInnerV1` in both iota_system.move and iota_system_state_inner.move,
 ///    with the exception of the `iota_system_state_inner::create` function, which should always return the genesis type.

--- a/crates/iota-framework/packages/iota-system/sources/iota_system.move
+++ b/crates/iota-framework/packages/iota-system/sources/iota_system.move
@@ -28,9 +28,9 @@
 /// put the new framework in a new directory, and run the test to exercise the upgrade.
 ///
 /// To upgrade Validator type, besides everything above, we also need to:
-/// 1. Define a new Validator type (e.g. ValidatorV1).
-/// 2. Define a data migration function that migrates the old Validator to the new one (i.e. ValidatorV1).
-/// 3. Replace all uses of Validator with ValidatorV1 except the genesis creation function.
+/// 1. Define a new Validator type (e.g. ValidatorV2).
+/// 2. Define a data migration function that migrates the old ValidatorV1 to the new one (i.e. ValidatorV2).
+/// 3. Replace all uses of ValidatorV1 with ValidatorV2 except the genesis creation function.
 /// 4. In validator_wrapper::upgrade_to_latest, check the current version in the wrapper, and if it's not the latest version,
 ///  call the data migration function to upgrade it.
 /// In Rust, we also need to add a new case in `get_validator_from_table`.

--- a/crates/iota-framework/packages/iota-system/sources/iota_system.move
+++ b/crates/iota-framework/packages/iota-system/sources/iota_system.move
@@ -13,7 +13,7 @@
 ///
 /// To properly upgrade the `IotaSystemStateInnerV1` type, we need to ship a new framework that does the following:
 /// 1. Define a new `IotaSystemStateInner`type (e.g. `IotaSystemStateInnerV2`).
-/// 2. Define a data migration function that migrates the old   to the new one (i.e. IotaSystemStateInnerV1).
+/// 2. Define a data migration function that migrates the old (e.g., `IotaSystemStateInnerV1`) to the new one (e.g. IotaSystemStateInnerV2).
 /// 3. Replace all uses of `IotaSystemStateInnerV1` with `IotaSystemStateInnerV1` in both iota_system.move and iota_system_state_inner.move,
 ///    with the exception of the `iota_system_state_inner::create` function, which should always return the genesis type.
 /// 4. Inside `load_inner_maybe_upgrade` function, check the current version in the wrapper, and if it's not the latest version,

--- a/crates/iota-framework/packages/iota-system/sources/iota_system.move
+++ b/crates/iota-framework/packages/iota-system/sources/iota_system.move
@@ -20,7 +20,7 @@
 ///   call the data migration function to upgrade the inner object. Make sure to also update the version in the wrapper.
 /// A detailed example can be found in iota/tests/framework_upgrades/mock_iota_systems/shallow_upgrade.
 /// Along with the Move change, we also need to update the Rust code to support the new type. This includes:
-/// 1. Define a new `IotaSystemStateInnerV1` struct type that matches the new Move type, and implement the IotaSystemStateTrait.
+/// 1. Define a new IotaSystemStateInner struct type that matches the new Move type, and implement the IotaSystemStateTrait.
 /// 2. Update the `IotaSystemState` struct to include the new version as a new enum variant.
 /// 3. Update the `get_iota_system_state` function to handle the new version.
 /// To test that the upgrade will be successful, we need to modify `iota_system_state_production_upgrade_test` test in

--- a/crates/iota-framework/packages/iota-system/sources/validator_set.move
+++ b/crates/iota-framework/packages/iota-system/sources/validator_set.move
@@ -30,7 +30,7 @@ module iota_system::validator_set {
     /* #[test_only] */
     /* friend iota_system::stake_tests; */
 
-    public struct ValidatorSet has store {
+    public struct ValidatorSetV1 has store {
         /// Total amount of stake from all active validators at the beginning of the epoch.
         total_stake: u64,
 
@@ -67,23 +67,9 @@ module iota_system::validator_set {
         extra_fields: Bag,
     }
 
-    #[allow(unused_field)]
     /// Event containing staking and rewards related information of
     /// each validator, emitted during epoch advancement.
-    public struct ValidatorEpochInfoEvent has copy, drop {
-        epoch: u64,
-        validator_address: address,
-        reference_gas_survey_quote: u64,
-        stake: u64,
-        commission_rate: u64,
-        pool_staking_reward: u64,
-        pool_token_exchange_rate: PoolTokenExchangeRate,
-        tallying_rule_reporters: vector<address>,
-        tallying_rule_global_score: u64,
-    }
-
-    /// V2 of ValidatorEpochInfoEvent containing more information about the validator.
-    public struct ValidatorEpochInfoEventV2 has copy, drop {
+    public struct ValidatorEpochInfoEventV1 has copy, drop {
         epoch: u64,
         validator_address: address,
         reference_gas_survey_quote: u64,
@@ -143,7 +129,7 @@ module iota_system::validator_set {
 
     // ==== initialization at genesis ====
 
-    public(package) fun new(init_active_validators: vector<Validator>, ctx: &mut TxContext): ValidatorSet {
+    public(package) fun new(init_active_validators: vector<Validator>, ctx: &mut TxContext): ValidatorSetV1 {
         let total_stake = calculate_total_stakes(&init_active_validators);
         let mut staking_pool_mappings = table::new(ctx);
         let num_validators = init_active_validators.length();
@@ -153,7 +139,7 @@ module iota_system::validator_set {
             staking_pool_mappings.add(staking_pool_id(validator), iota_address(validator));
             i = i + 1;
         };
-        let mut validators = ValidatorSet {
+        let mut validators = ValidatorSetV1 {
             total_stake,
             active_validators: init_active_validators,
             pending_active_validators: table_vec::empty(ctx),
@@ -173,7 +159,7 @@ module iota_system::validator_set {
 
     /// Called by `iota_system` to add a new validator candidate.
     public(package) fun request_add_validator_candidate(
-        self: &mut ValidatorSet,
+        self: &mut ValidatorSetV1,
         validator: Validator,
         ctx: &mut TxContext,
     ) {
@@ -200,7 +186,7 @@ module iota_system::validator_set {
     }
 
     /// Called by `iota_system` to remove a validator candidate, and move them to `inactive_validators`.
-    public(package) fun request_remove_validator_candidate(self: &mut ValidatorSet, ctx: &mut TxContext) {
+    public(package) fun request_remove_validator_candidate(self: &mut ValidatorSetV1, ctx: &mut TxContext) {
         let validator_address = ctx.sender();
          assert!(
             self.validator_candidates.contains(validator_address),
@@ -227,7 +213,7 @@ module iota_system::validator_set {
 
     /// Called by `iota_system` to add a new validator to `pending_active_validators`, which will be
     /// processed at the end of epoch.
-    public(package) fun request_add_validator(self: &mut ValidatorSet, min_joining_stake_amount: u64, ctx: &TxContext) {
+    public(package) fun request_add_validator(self: &mut ValidatorSetV1, min_joining_stake_amount: u64, ctx: &TxContext) {
         let validator_address = ctx.sender();
         assert!(
             self.validator_candidates.contains(validator_address),
@@ -246,7 +232,7 @@ module iota_system::validator_set {
         self.pending_active_validators.push_back(validator);
     }
 
-    public(package) fun assert_no_pending_or_active_duplicates(self: &ValidatorSet, validator: &Validator) {
+    public(package) fun assert_no_pending_or_active_duplicates(self: &ValidatorSetV1, validator: &Validator) {
         // Validator here must be active or pending, and thus must be identified as duplicate exactly once.
         assert!(
             count_duplicates_vec(&self.active_validators, validator) +
@@ -260,7 +246,7 @@ module iota_system::validator_set {
     /// will be processed at the end of epoch.
     /// Only an active validator can request to be removed.
     public(package) fun request_remove_validator(
-        self: &mut ValidatorSet,
+        self: &mut ValidatorSetV1,
         ctx: &TxContext,
     ) {
         let validator_address = ctx.sender();
@@ -282,7 +268,7 @@ module iota_system::validator_set {
     /// of the epoch.
     /// Aborts in case the staking amount is smaller than MIN_STAKING_THRESHOLD
     public(package) fun request_add_stake(
-        self: &mut ValidatorSet,
+        self: &mut ValidatorSetV1,
         validator_address: address,
         stake: Balance<IOTA>,
         ctx: &mut TxContext,
@@ -300,7 +286,7 @@ module iota_system::validator_set {
     /// 2. If the `staked_iota` was staked with a validator that is no longer active,
     ///    the stake and any rewards corresponding to it will be immediately processed.
     public(package) fun request_withdraw_stake(
-        self: &mut ValidatorSet,
+        self: &mut ValidatorSetV1,
         staked_iota: StakedIota,
         ctx: &TxContext,
     ) : Balance<IOTA> {
@@ -320,7 +306,7 @@ module iota_system::validator_set {
     // ==== validator config setting functions ====
 
     public(package) fun request_set_commission_rate(
-        self: &mut ValidatorSet,
+        self: &mut ValidatorSetV1,
         new_commission_rate: u64,
         ctx: &TxContext,
     ) {
@@ -340,7 +326,7 @@ module iota_system::validator_set {
     ///   4. Process pending validator application and withdraws.
     ///   5. At the end, we calculate the total stake for the new epoch.
     public(package) fun advance_epoch(
-        self: &mut ValidatorSet,
+        self: &mut ValidatorSetV1,
         total_validator_rewards: &mut Balance<IOTA>,
         validator_report_records: &mut VecMap<address, VecSet<address>>,
         reward_slashing_rate: u64,
@@ -429,7 +415,7 @@ module iota_system::validator_set {
     }
 
     fun update_and_process_low_stake_departures(
-        self: &mut ValidatorSet,
+        self: &mut ValidatorSetV1,
         low_stake_threshold: u64,
         very_low_stake_threshold: u64,
         low_stake_grace_period: u64,
@@ -475,7 +461,7 @@ module iota_system::validator_set {
 
     /// Effectutate pending next epoch metadata if they are staged.
     fun effectuate_staged_metadata(
-        self: &mut ValidatorSet,
+        self: &mut ValidatorSetV1,
     ) {
         let num_validators = self.active_validators.length();
         let mut i = 0;
@@ -490,7 +476,7 @@ module iota_system::validator_set {
     /// Derive the reference gas price based on the gas price quote submitted by each validator.
     /// The returned gas price should be greater than or equal to 2/3 of the validators submitted
     /// gas price, weighted by stake.
-    public fun derive_reference_gas_price(self: &ValidatorSet): u64 {
+    public fun derive_reference_gas_price(self: &ValidatorSetV1): u64 {
         let vs = &self.active_validators;
         let num_validators = vs.length();
         let mut entries = vector[];
@@ -517,31 +503,31 @@ module iota_system::validator_set {
 
     // ==== getter functions ====
 
-    public fun total_stake(self: &ValidatorSet): u64 {
+    public fun total_stake(self: &ValidatorSetV1): u64 {
         self.total_stake
     }
 
-    public fun validator_total_stake_amount(self: &ValidatorSet, validator_address: address): u64 {
+    public fun validator_total_stake_amount(self: &ValidatorSetV1, validator_address: address): u64 {
         let validator = get_validator_ref(&self.active_validators, validator_address);
         validator.total_stake_amount()
     }
 
-    public fun validator_stake_amount(self: &ValidatorSet, validator_address: address): u64 {
+    public fun validator_stake_amount(self: &ValidatorSetV1, validator_address: address): u64 {
         let validator = get_validator_ref(&self.active_validators, validator_address);
         validator.stake_amount()
     }
 
-    public fun validator_staking_pool_id(self: &ValidatorSet, validator_address: address): ID {
+    public fun validator_staking_pool_id(self: &ValidatorSetV1, validator_address: address): ID {
         let validator = get_validator_ref(&self.active_validators, validator_address);
         validator.staking_pool_id()
     }
 
-    public fun staking_pool_mappings(self: &ValidatorSet): &Table<ID, address> {
+    public fun staking_pool_mappings(self: &ValidatorSetV1): &Table<ID, address> {
         &self.staking_pool_mappings
     }
 
     public(package) fun pool_exchange_rates(
-        self: &mut ValidatorSet, pool_id: &ID
+        self: &mut ValidatorSetV1, pool_id: &ID
     ) : &Table<u64, PoolTokenExchangeRate> {
         let validator =
             // If the pool id is recorded in the mapping, then it must be either candidate or active.
@@ -556,13 +542,13 @@ module iota_system::validator_set {
     }
 
     /// Get the total number of validators in the next epoch.
-    public(package) fun next_epoch_validator_count(self: &ValidatorSet): u64 {
+    public(package) fun next_epoch_validator_count(self: &ValidatorSetV1): u64 {
         self.active_validators.length() - self.pending_removals.length() + self.pending_active_validators.length()
     }
 
     /// Returns true iff the address exists in active validators.
     public(package) fun is_active_validator_by_iota_address(
-        self: &ValidatorSet,
+        self: &ValidatorSetV1,
         validator_address: address,
     ): bool {
        find_validator(&self.active_validators, validator_address).is_some()
@@ -573,7 +559,7 @@ module iota_system::validator_set {
     /// Checks whether `new_validator` is duplicate with any currently active validators.
     /// It differs from `is_active_validator_by_iota_address` in that the former checks
     /// only the iota address but this function looks at more metadata.
-    fun is_duplicate_with_active_validator(self: &ValidatorSet, new_validator: &Validator): bool {
+    fun is_duplicate_with_active_validator(self: &ValidatorSetV1, new_validator: &Validator): bool {
         is_duplicate_validator(&self.active_validators, new_validator)
     }
 
@@ -596,7 +582,7 @@ module iota_system::validator_set {
     }
 
     /// Checks whether `new_validator` is duplicate with any currently pending validators.
-    fun is_duplicate_with_pending_validator(self: &ValidatorSet, new_validator: &Validator): bool {
+    fun is_duplicate_with_pending_validator(self: &ValidatorSetV1, new_validator: &Validator): bool {
         count_duplicates_tablevec(&self.pending_active_validators, new_validator) > 0
     }
 
@@ -615,7 +601,7 @@ module iota_system::validator_set {
     }
 
     /// Get mutable reference to either a candidate or an active validator by address.
-    fun get_candidate_or_active_validator_mut(self: &mut ValidatorSet, validator_address: address): &mut Validator {
+    fun get_candidate_or_active_validator_mut(self: &mut ValidatorSetV1, validator_address: address): &mut Validator {
         if (self.validator_candidates.contains(validator_address)) {
             let wrapper = &mut self.validator_candidates[validator_address];
             return wrapper.load_validator_maybe_upgrade()
@@ -687,7 +673,7 @@ module iota_system::validator_set {
     /// Note: this function should be called carefully, only after verifying the transaction
     /// sender has the ability to modify the `Validator`.
     fun get_active_or_pending_or_candidate_validator_mut(
-        self: &mut ValidatorSet,
+        self: &mut ValidatorSetV1,
         validator_address: address,
         include_candidate: bool,
     ): &mut Validator {
@@ -708,7 +694,7 @@ module iota_system::validator_set {
     }
 
     public(package) fun get_validator_mut_with_verified_cap(
-        self: &mut ValidatorSet,
+        self: &mut ValidatorSetV1,
         verified_cap: &ValidatorOperationCap,
         include_candidate: bool,
     ): &mut Validator {
@@ -716,7 +702,7 @@ module iota_system::validator_set {
     }
 
     public(package) fun get_validator_mut_with_ctx(
-        self: &mut ValidatorSet,
+        self: &mut ValidatorSetV1,
         ctx: &TxContext,
     ): &mut Validator {
         let validator_address = ctx.sender();
@@ -724,7 +710,7 @@ module iota_system::validator_set {
     }
 
     public(package) fun get_validator_mut_with_ctx_including_candidates(
-        self: &mut ValidatorSet,
+        self: &mut ValidatorSetV1,
         ctx: &TxContext,
     ): &mut Validator {
         let validator_address = ctx.sender();
@@ -742,7 +728,7 @@ module iota_system::validator_set {
     }
 
     public(package) fun get_active_or_pending_or_candidate_validator_ref(
-        self: &mut ValidatorSet,
+        self: &mut ValidatorSetV1,
         validator_address: address,
         which_validator: u8,
     ): &Validator {
@@ -760,7 +746,7 @@ module iota_system::validator_set {
     }
 
     public fun get_active_validator_ref(
-        self: &ValidatorSet,
+        self: &ValidatorSetV1,
         validator_address: address,
     ): &Validator {
         let mut validator_index_opt = find_validator(&self.active_validators, validator_address);
@@ -770,7 +756,7 @@ module iota_system::validator_set {
     }
 
     public fun get_pending_validator_ref(
-        self: &ValidatorSet,
+        self: &ValidatorSetV1,
         validator_address: address,
     ): &Validator {
         let mut validator_index_opt = find_validator_from_table_vec(&self.pending_active_validators, validator_address);
@@ -781,7 +767,7 @@ module iota_system::validator_set {
 
     #[test_only]
     public fun get_candidate_validator_ref(
-        self: &ValidatorSet,
+        self: &ValidatorSetV1,
         validator_address: address,
     ): &Validator {
         self.validator_candidates[validator_address].get_inner_validator_ref()
@@ -791,7 +777,7 @@ module iota_system::validator_set {
     /// If `active_validator_only` is true, only verify the Cap for an active validator.
     /// Otherwise, verify the Cap for au either active or pending validator.
     public(package) fun verify_cap(
-        self: &mut ValidatorSet,
+        self: &mut ValidatorSetV1,
         cap: &UnverifiedValidatorOperationCap,
         which_validator: u8,
     ): ValidatorOperationCap {
@@ -808,7 +794,7 @@ module iota_system::validator_set {
     /// Process the pending withdraw requests. For each pending request, the validator
     /// is removed from `validators` and its staking pool is put into the `inactive_validators` table.
     fun process_pending_removals(
-        self: &mut ValidatorSet,
+        self: &mut ValidatorSetV1,
         validator_report_records: &mut VecMap<address, VecSet<address>>,
         ctx: &mut TxContext,
     ) {
@@ -821,7 +807,7 @@ module iota_system::validator_set {
     }
 
     fun process_validator_departure(
-        self: &mut ValidatorSet,
+        self: &mut ValidatorSetV1,
         mut validator: Validator,
         validator_report_records: &mut VecMap<address, VecSet<address>>,
         is_voluntary: bool,
@@ -886,7 +872,7 @@ module iota_system::validator_set {
 
     /// Process the pending new validators. They are activated and inserted into `validators`.
     fun process_pending_validators(
-        self: &mut ValidatorSet, new_epoch: u64,
+        self: &mut ValidatorSetV1, new_epoch: u64,
     ) {
         while (!self.pending_active_validators.is_empty()) {
             let mut validator = self.pending_active_validators.pop_back();
@@ -990,7 +976,7 @@ module iota_system::validator_set {
     /// Process the validator report records of the epoch and return the addresses of the
     /// non-performant validators according to the input threshold.
     fun compute_slashed_validators(
-        self: &ValidatorSet,
+        self: &ValidatorSetV1,
         mut validator_report_records: VecMap<address, VecSet<address>>,
     ): vector<address> {
         let mut slashed_validators = vector[];
@@ -1140,7 +1126,7 @@ module iota_system::validator_set {
                 if (slashed_validators.contains(&validator_address)) 0
                 else 1;
             event::emit(
-                ValidatorEpochInfoEventV2 {
+                ValidatorEpochInfoEventV1 {
                     epoch: new_epoch,
                     validator_address,
                     reference_gas_survey_quote: v.gas_price(),
@@ -1171,21 +1157,21 @@ module iota_system::validator_set {
     }
 
     /// Return the active validators in `self`
-    public fun active_validators(self: &ValidatorSet): &vector<Validator> {
+    public fun active_validators(self: &ValidatorSetV1): &vector<Validator> {
         &self.active_validators
     }
 
     /// Returns true if the `addr` is a validator candidate.
-    public fun is_validator_candidate(self: &ValidatorSet, addr: address): bool {
+    public fun is_validator_candidate(self: &ValidatorSetV1, addr: address): bool {
         self.validator_candidates.contains(addr)
     }
 
     /// Returns true if the staking pool identified by `staking_pool_id` is of an inactive validator.
-    public fun is_inactive_validator(self: &ValidatorSet, staking_pool_id: ID): bool {
+    public fun is_inactive_validator(self: &ValidatorSetV1, staking_pool_id: ID): bool {
         self.inactive_validators.contains(staking_pool_id)
     }
 
-    public(package) fun active_validator_addresses(self: &ValidatorSet): vector<address> {
+    public(package) fun active_validator_addresses(self: &ValidatorSetV1): vector<address> {
         let vs = &self.active_validators;
         let mut res = vector[];
         let mut i = 0;

--- a/crates/iota-framework/packages/iota-system/sources/voting_power.move
+++ b/crates/iota-framework/packages/iota-system/sources/voting_power.move
@@ -12,14 +12,7 @@ module iota_system::voting_power {
     /* #[test_only] */
     /* friend iota_system::voting_power_tests; */
 
-    #[allow(unused_field)]
-    /// Deprecated. Use VotingPowerInfoV2 instead.
-    public struct VotingPowerInfo has drop {
-        validator_index: u64,
-        voting_power: u64,
-    }
-
-    public struct VotingPowerInfoV2 has drop {
+    public struct VotingPowerInfoV1 has drop {
         validator_index: u64,
         voting_power: u64,
         stake: u64,
@@ -68,7 +61,7 @@ module iota_system::voting_power {
     fun init_voting_power_info(
         validators: &vector<Validator>,
         threshold: u64,
-    ): (vector<VotingPowerInfoV2>, u64) {
+    ): (vector<VotingPowerInfoV1>, u64) {
         let total_stake = total_stake(validators);
         let mut i = 0;
         let len = validators.length();
@@ -79,7 +72,7 @@ module iota_system::voting_power {
             let stake = validator.total_stake();
             let adjusted_stake = stake as u128 * (TOTAL_VOTING_POWER as u128) / (total_stake as u128);
             let voting_power = math::min(adjusted_stake as u64, threshold);
-            let info = VotingPowerInfoV2 {
+            let info = VotingPowerInfoV1 {
                 validator_index: i,
                 voting_power,
                 stake,
@@ -105,7 +98,7 @@ module iota_system::voting_power {
 
     /// Insert `new_info` to `info_list` as part of insertion sort, such that `info_list` is always sorted
     /// using stake, in descending order.
-    fun insert(info_list: &mut vector<VotingPowerInfoV2>, new_info: VotingPowerInfoV2) {
+    fun insert(info_list: &mut vector<VotingPowerInfoV1>, new_info: VotingPowerInfoV1) {
         let mut i = 0;
         let len = info_list.length();
         while (i < len && info_list[i].stake > new_info.stake) {
@@ -115,7 +108,7 @@ module iota_system::voting_power {
     }
 
     /// Distribute remaining_power to validators that are not capped at threshold.
-    fun adjust_voting_power(info_list: &mut vector<VotingPowerInfoV2>, threshold: u64, mut remaining_power: u64) {
+    fun adjust_voting_power(info_list: &mut vector<VotingPowerInfoV1>, threshold: u64, mut remaining_power: u64) {
         let mut i = 0;
         let len = info_list.length();
         while (i < len && remaining_power > 0) {
@@ -135,9 +128,9 @@ module iota_system::voting_power {
     }
 
     /// Update validators with the decided voting power.
-    fun update_voting_power(validators: &mut vector<Validator>, mut info_list: vector<VotingPowerInfoV2>) {
+    fun update_voting_power(validators: &mut vector<Validator>, mut info_list: vector<VotingPowerInfoV1>) {
         while (!info_list.is_empty()) {
-            let VotingPowerInfoV2 {
+            let VotingPowerInfoV1 {
                 validator_index,
                 voting_power,
                 stake: _,

--- a/crates/iota-framework/packages/iota-system/tests/timelocked_delegation_tests.move
+++ b/crates/iota-framework/packages/iota-system/tests/timelocked_delegation_tests.move
@@ -15,7 +15,7 @@ module iota_system::timelocked_stake_tests {
 
     use iota_system::iota_system::IotaSystemState;
     use iota_system::staking_pool::{Self, PoolTokenExchangeRate};
-    use iota_system::validator_set::{Self, ValidatorSet};
+    use iota_system::validator_set::{Self, ValidatorSetV1};
     use iota_system::governance_test_utils::{
         add_validator,
         add_validator_candidate,
@@ -1115,7 +1115,7 @@ module iota_system::timelocked_stake_tests {
         scenario.has_most_recent_for_sender<Coin<IOTA>>()
     }
 
-    fun is_active_validator_by_iota_address(set: &ValidatorSet, validator_address: address): bool {
+    fun is_active_validator_by_iota_address(set: &ValidatorSetV1, validator_address: address): bool {
         let validators = set.active_validators();
         let length = validators.length();
         let mut i = 0;

--- a/crates/iota-framework/packages/iota-system/tests/validator_set_tests.move
+++ b/crates/iota-framework/packages/iota-system/tests/validator_set_tests.move
@@ -8,7 +8,7 @@ module iota_system::validator_set_tests {
     use iota::coin;
     use iota_system::staking_pool::StakedIota;
     use iota_system::validator::{Self, Validator, staking_pool_id};
-    use iota_system::validator_set::{Self, ValidatorSet, active_validator_addresses};
+    use iota_system::validator_set::{Self, ValidatorSetV1, active_validator_addresses};
     use iota::test_scenario::{Self, Scenario};
     use iota::test_utils::{Self, assert_eq};
     use iota::vec_map;
@@ -430,7 +430,7 @@ module iota_system::validator_set_tests {
         ascii_bytes.to_ascii_string().into_bytes()
     }
 
-    fun advance_epoch_with_dummy_rewards(validator_set: &mut ValidatorSet, scenario: &mut Scenario) {
+    fun advance_epoch_with_dummy_rewards(validator_set: &mut ValidatorSetV1, scenario: &mut Scenario) {
         scenario.next_epoch(@0x0);
         let mut dummy_computation_reward = balance::zero();
 
@@ -448,7 +448,7 @@ module iota_system::validator_set_tests {
     }
 
     fun advance_epoch_with_low_stake_params(
-        validator_set: &mut ValidatorSet,
+        validator_set: &mut ValidatorSetV1,
         low_stake_threshold: u64,
         very_low_stake_threshold: u64,
         low_stake_grace_period: u64,
@@ -469,7 +469,7 @@ module iota_system::validator_set_tests {
         dummy_computation_reward.destroy_zero();
     }
 
-    fun add_and_activate_validator(validator_set: &mut ValidatorSet, validator: Validator, scenario: &mut Scenario) {
+    fun add_and_activate_validator(validator_set: &mut ValidatorSetV1, validator: Validator, scenario: &mut Scenario) {
         scenario.next_tx(validator.iota_address());
         let ctx = scenario.ctx();
         validator_set.request_add_validator_candidate(validator, ctx);


### PR DESCRIPTION

# Description of change

Reduce amount of versioned types V2 to V1
Types list:

- IotaSystemStateInnerV1
- ValidatorV1
- SystemParametersV1
- ValidatorSetV1
- VotingPowerInfoV1

## Links to any relevant issues

Fix #2089 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Run:

`iota move test --path ./crates/iota-framework/packages/iota-system`