### PR TITLE
feat(tooling-sdk): Support anonymous fixed size desestructured transaction results

### DIFF
--- a/.changeset/moody-worms-wonder.md
+++ b/.changeset/moody-worms-wonder.md
@@ -1,0 +1,5 @@
+---
+'@iota/iota-sdk': patch
+---
+
+Support anonymous fixed-size desestructure transaction results

--- a/sdk/typescript/src/transactions/TransactionBlock.ts
+++ b/sdk/typescript/src/transactions/TransactionBlock.ts
@@ -76,7 +76,7 @@ function createTransactionResult(index: number, maxResults?: number): Transactio
                     while (true) {
                         yield nestedResultFor(i);
                         i++;
-                        if(i == maxResults){
+                        if (i == maxResults) {
                             break;
                         }
                     }
@@ -380,8 +380,7 @@ export class TransactionBlock {
         coin: TransactionObjectArgument | string,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         amounts: (TransactionArgument | SerializedBcs<any> | number | string | bigint)[],
-
-        maxResults?: number
+        maxResults?: number,
     ) {
         return this.add(
             Transactions.SplitCoins(
@@ -394,39 +393,48 @@ export class TransactionBlock {
                         : this.#normalizeTransactionArgument(amount),
                 ),
             ),
-            maxResults
+            maxResults,
         );
     }
     mergeCoins(
         destination: TransactionObjectArgument | string,
         sources: (TransactionObjectArgument | string)[],
+        maxResults?: number,
     ) {
         return this.add(
             Transactions.MergeCoins(
                 typeof destination === 'string' ? this.object(destination) : destination,
                 sources.map((src) => (typeof src === 'string' ? this.object(src) : src)),
             ),
+            maxResults,
         );
     }
-    publish({ modules, dependencies }: { modules: number[][] | string[]; dependencies: string[] }) {
+    publish(
+        { modules, dependencies }: { modules: number[][] | string[]; dependencies: string[] },
+        maxResults?: number,
+    ) {
         return this.add(
             Transactions.Publish({
                 modules,
                 dependencies,
             }),
+            maxResults,
         );
     }
-    upgrade({
-        modules,
-        dependencies,
-        packageId,
-        ticket,
-    }: {
-        modules: number[][] | string[];
-        dependencies: string[];
-        packageId: string;
-        ticket: TransactionObjectArgument | string;
-    }) {
+    upgrade(
+        {
+            modules,
+            dependencies,
+            packageId,
+            ticket,
+        }: {
+            modules: number[][] | string[];
+            dependencies: string[];
+            packageId: string;
+            ticket: TransactionObjectArgument | string;
+        },
+        maxResults?: number,
+    ) {
         return this.add(
             Transactions.Upgrade({
                 modules,
@@ -434,30 +442,36 @@ export class TransactionBlock {
                 packageId,
                 ticket: typeof ticket === 'string' ? this.object(ticket) : ticket,
             }),
+            maxResults,
         );
     }
-    moveCall({
-        arguments: args,
-        typeArguments,
-        target,
-    }: {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        arguments?: (TransactionArgument | SerializedBcs<any>)[];
-        typeArguments?: string[];
-        target: `${string}::${string}::${string}`;
-    }) {
+    moveCall(
+        {
+            arguments: args,
+            typeArguments,
+            target,
+        }: {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            arguments?: (TransactionArgument | SerializedBcs<any>)[];
+            typeArguments?: string[];
+            target: `${string}::${string}::${string}`;
+        },
+        maxResults?: number,
+    ) {
         return this.add(
             Transactions.MoveCall({
                 arguments: args?.map((arg) => this.#normalizeTransactionArgument(arg)),
                 typeArguments,
                 target,
             }),
+            maxResults,
         );
     }
     transferObjects(
         objects: (TransactionObjectArgument | string)[],
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         address: TransactionArgument | SerializedBcs<any> | string,
+        maxResults?: number,
     ) {
         return this.add(
             Transactions.TransferObjects(
@@ -466,20 +480,25 @@ export class TransactionBlock {
                     ? this.pure.address(address)
                     : this.#normalizeTransactionArgument(address),
             ),
+            maxResults,
         );
     }
-    makeMoveVec({
-        type,
-        objects,
-    }: {
-        objects: (TransactionObjectArgument | string)[];
-        type?: string;
-    }) {
+    makeMoveVec(
+        {
+            type,
+            objects,
+        }: {
+            objects: (TransactionObjectArgument | string)[];
+            type?: string;
+        },
+        maxResults?: number,
+    ) {
         return this.add(
             Transactions.MakeMoveVec({
                 type,
                 objects: objects.map((obj) => (typeof obj === 'string' ? this.object(obj) : obj)),
             }),
+            maxResults,
         );
     }
 


### PR DESCRIPTION
Closes https://github.com/iotaledger/iota/issues/2151

### Why
Currently, the SDK will end up in an infinite loop when it attempts to desestructure an array with no known size.

Consider the following code which will never finish running (simplified).

```ts
const NUMBER_OF_SPLITS = 100;

const [...splittedCoins] = ptb.splitCoins(
  ptb.gas,
  new Array<number>(NUMBER_OF_SPLITS).fill(1_000_000),
  NUMBER_OF_SPLITS
);

// Here, transferObjects will iterate over the splittedCoins (L478)
// Which will yield the function generator returned by the `get` 
// method on the transaction result proxy in L77, and because the iterator 
// never ends unless you simply stop iterating (impossible as it is 
// calling `map()` but possible if you do a simple desestructure 
// like `[a, b, c] = objects`, this one will only yield 3 times) it never finishes.
ptb.transferObjects(splittedCoins, ptb.pure.address(address))
```
Here is the code of the transaction result proxy for the sake of the issue:
```ts

function createTransactionResult(index: number, maxResults?: number): TransactionResult {
    const baseResult: TransactionArgument = { kind: 'Result', index };

    const nestedResults: TransactionArgument[] = [];
    const nestedResultFor = (resultIndex: number): TransactionArgument =>
        (nestedResults[resultIndex] ??= {
            kind: 'NestedResult',
            index,
            resultIndex,
        });

    return new Proxy(baseResult, {
        set() {
            throw new Error(
                'The transaction result is a proxy, and does not support setting properties directly',
            );
        },
        // TODO: Instead of making this return a concrete argument, we should ideally
        // make it reference-based (so that this gets resolved at build-time), which
        // allows re-ordering transactions.
        get(target, property) {
            // This allows this transaction argument to be used in the singular form:
            if (property in target) {
                return Reflect.get(target, property);
            }

            // Support destructuring:
            if (property === Symbol.iterator) {
                return function* () {
                    let i = 0;
                    while (true) {
                        yield nestedResultFor(i);
                        i++;
                        if (i == maxResults) {
                            break;
                        }
                    }
                };
            }

            if (typeof property === 'symbol') return;

            const resultIndex = parseInt(property, 10);
            if (Number.isNaN(resultIndex) || resultIndex < 0) return;
            return nestedResultFor(resultIndex);
        },
    }) as TransactionResult;
}
```

### Solution
I had the idea of having the ability of specifying an optional max number of results to the yielding of results. So, now, if a `maxResults` number is specified, the function generator will only yield as long as the index of results has not reached the specified number.

Thus, making it possible to desestructure hundreds of transaction result objects and actually use them