### PR TITLE
refactor(tooling-ui-kit): Clean up `Select`

### DIFF
--- a/apps/ui-kit/src/lib/components/molecules/select/Select.tsx
+++ b/apps/ui-kit/src/lib/components/molecules/select/Select.tsx
@@ -15,7 +15,11 @@ export type SelectOption =
     | { id: string; renderLabel: () => React.JSX.Element }
     | { id: string; label: React.ReactNode };
 
-interface SelectProps extends Pick<React.HTMLProps<HTMLSelectElement>, 'disabled' | 'value'> {
+interface SelectProps extends Pick<React.HTMLProps<HTMLSelectElement>, 'disabled'> {
+    /**
+     * The selected option value.
+     */
+    value?: string;
     /**
      * The field label.
      */
@@ -67,16 +71,9 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
         ref,
     ) => {
         const [isOpen, setIsOpen] = useState<boolean>(false);
-        const [selectedValue, setSelectedValue] = useState<SelectOption>(
-            findValueByProps(value, options),
-        );
+        const selectedValue = findValueByProps(value, options);
 
         const selectorText = selectedValue || placeholder;
-
-        useEffect(() => {
-            const newValue = findValueByProps(value, options);
-            setSelectedValue(newValue);
-        }, [value, options]);
 
         useEffect(() => {
             if (disabled && isOpen) {
@@ -97,7 +94,6 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
         }
 
         function handleOptionClick(option: SelectOption) {
-            setSelectedValue(option);
             closeDropdown();
             onValueChange?.(typeof option === 'string' ? option : option.id);
         }

--- a/apps/ui-kit/src/storybook/stories/molecules/Select.stories.tsx
+++ b/apps/ui-kit/src/storybook/stories/molecules/Select.stories.tsx
@@ -33,19 +33,26 @@ export const Default: Story = {
         },
     },
     render: (args) => {
+        const [selected, setSelected] = useState('iota');
         const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined);
 
         const onChange = (id: string) => {
             if (id === 'Invalid Option') {
                 setErrorMessage('Invalid Option Selected');
             } else {
+                setSelected(id);
                 setErrorMessage(undefined);
             }
         };
 
         return (
             <div className="h-60">
-                <Select {...args} onValueChange={onChange} errorMessage={errorMessage} />
+                <Select
+                    {...args}
+                    value={selected}
+                    onValueChange={onChange}
+                    errorMessage={errorMessage}
+                />
             </div>
         );
     },

--- a/apps/ui-kit/src/storybook/stories/molecules/Select.stories.tsx
+++ b/apps/ui-kit/src/storybook/stories/molecules/Select.stories.tsx
@@ -33,7 +33,7 @@ export const Default: Story = {
         },
     },
     render: (args) => {
-        const [selected, setSelected] = useState('iota');
+        const [selected, setSelected] = useState('Option 1');
         const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined);
 
         const onChange = (id: string) => {

--- a/apps/ui-kit/src/storybook/stories/molecules/Select.stories.tsx
+++ b/apps/ui-kit/src/storybook/stories/molecules/Select.stories.tsx
@@ -58,6 +58,8 @@ export const CustomOptions: Story = {
         options: [],
     },
     render: ({ options, ...args }) => {
+        const [selected, setSelected] = useState('iota');
+
         const customOptions: SelectOption[] = [
             {
                 id: 'iota',
@@ -81,7 +83,12 @@ export const CustomOptions: Story = {
 
         return (
             <div className="h-60">
-                <Select {...args} options={customOptions} />
+                <Select
+                    {...args}
+                    value={selected}
+                    onValueChange={setSelected}
+                    options={customOptions}
+                />
             </div>
         );
     },


### PR DESCRIPTION
Closes https://github.com/iotaledger/iota/issues/2229

1. We cannot accept anything else other than `string` for the current value as otherwise this will break the equality check of `option.id` in `findValueByProps` because `option.id` can only be string

2. We don't need to have an inner selected value as we already receive it from the props.