### PR TITLE
fix(devx): make Iota build on Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -27,3 +27,7 @@ rustflags = [
   "-C",
   "link-arg=/STACK:8000000",
 ]
+
+[target.x86_64-pc-windows-msvc.pq]
+rustc-link-search = ["C:\\Program Files\\PostgreSQL\\16\\lib"]
+rustc-link-lib = ["libpq"]

--- a/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
@@ -1686,12 +1686,13 @@ impl<'a> fmt::Display for SubstTOML<'a> {
 
 /// Escape a string to output in a TOML file.
 fn str_escape(s: &str) -> String {
-    format!("\"{s}\"")
+    toml::Value::String(s.to_string()).to_string()
 }
 
 /// Escape a path to output in a TOML file.
 fn path_escape(p: &Path) -> Result<String, fmt::Error> {
-    p.to_str().map(str_escape).ok_or(fmt::Error)
+    // Handle non-UTF-8 paths by escaping the lossy representation
+    Ok(str_escape(p.to_string_lossy().as_ref()))
 }
 
 fn format_deps(


### PR DESCRIPTION
# Description of change

When building Iota on Windows, one of the steps include compiling the `Movestdlib`. 
When compiling, the move compiler tries to generate a `Move.lock` file given the `Move.toml`.


However, when resolving paths on Windows, A problem occurs:
The `Move.lock` file string contains invalid Unicode characters which needs to be properly escaped.

The error when building on Windows:
```--- stderr
  thread 'main' panicked at crates\iota-framework\build.rs:160:6:
  called `Result::unwrap()` on an `Err` value: ModuleBuildFailure { error: "TOML parse error at line 8, column 25\n  |\n8 | source = { local = \"..\\move-stdlib\" }\n  |                         ^\ninvalid escape sequence\nexpected `b`, `f`, `n`, `r`, `t`, `u`, `U`, `\\`, `\"`\n" }  
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR tries to properly escape those characters.

## Links to any relevant issues



## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Locally

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
