### PR TITLE
chore(CI): Use SSH for docker builds

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -107,9 +107,17 @@ jobs:
           password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
           registry: ${{ secrets.DOCKER_REGISTRY_URL }}
 
+      - name: Set up SSH
+        uses: MrSquaare/ssh-setup-action@v3
+        with:
+          host: github.com
+          private-key: ${{ secrets.SSH_PRIVATE_KEY_IOTA_CI }}
+          private-key-name: github-ppk
+
       - name: Build and push Docker image for iota-indexer
         uses: docker/build-push-action@v5
         with:
+          ssh: default
           context: .
           file: docker/iota-indexer/Dockerfile
           platforms: linux/amd64

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Set up SSH
         uses: MrSquaare/ssh-setup-action@v3
         with:
-          host: ${{ secrets.SSH_GITHUB_KNOWN_HOSTS }}
+          host: github.com
           private-key: ${{ secrets.SSH_PRIVATE_KEY_IOTA_CI }}
           private-key-name: github-ppk
 

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Build and push Docker image for iota-indexer
         uses: docker/build-push-action@v5
         with:
-          ssh: default
+          ssh: default=${{ secrets.SSH_PRIVATE_KEY_IOTA_CI }}
           context: .
           file: docker/iota-indexer/Dockerfile
           platforms: linux/amd64

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -62,6 +62,7 @@ jobs:
           password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
           registry: ${{ secrets.DOCKER_REGISTRY_URL }}
 
+      # TODO: Remove when iota-sim is public https://github.com/iotaledger/iota/issues/2149
       - name: Set up SSH
         uses: MrSquaare/ssh-setup-action@v3
         with:
@@ -115,6 +116,7 @@ jobs:
           password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
           registry: ${{ secrets.DOCKER_REGISTRY_URL }}
 
+      # TODO: Remove when iota-sim is public https://github.com/iotaledger/iota/issues/2149
       - name: Set up SSH
         uses: MrSquaare/ssh-setup-action@v3
         with:
@@ -168,6 +170,7 @@ jobs:
           password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
           registry: ${{ secrets.DOCKER_REGISTRY_URL }}
 
+      # TODO: Remove when iota-sim is public https://github.com/iotaledger/iota/issues/2149
       - name: Set up SSH
         uses: MrSquaare/ssh-setup-action@v3
         with:
@@ -221,6 +224,7 @@ jobs:
           password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
           registry: ${{ secrets.DOCKER_REGISTRY_URL }}
 
+      # TODO: Remove when iota-sim is public https://github.com/iotaledger/iota/issues/2149
       - name: Set up SSH
         uses: MrSquaare/ssh-setup-action@v3
         with:

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Set up SSH
         uses: MrSquaare/ssh-setup-action@v3
         with:
-          host: github.com
+          host: ${{ secrets.SSH_GITHUB_KNOWN_HOSTS }}
           private-key: ${{ secrets.SSH_PRIVATE_KEY_IOTA_CI }}
           private-key-name: github-ppk
 

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           host: github.com
           private-key: ${{ secrets.SSH_PRIVATE_KEY_IOTA_CI }}
-          private-key-name: github-ppk
+          private-key-name: git
 
       - name: Build and push Docker image for iota-indexer
         uses: docker/build-push-action@v5

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Build and push Docker image for iota-indexer
         uses: docker/build-push-action@v5
         with:
-          ssh: default=${{ secrets.SSH_PRIVATE_KEY_IOTA_CI }}
+          ssh: default
           context: .
           file: docker/iota-indexer/Dockerfile
           platforms: linux/amd64

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -62,9 +62,17 @@ jobs:
           password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
           registry: ${{ secrets.DOCKER_REGISTRY_URL }}
 
+      - name: Set up SSH
+        uses: MrSquaare/ssh-setup-action@v3
+        with:
+          host: github.com
+          private-key: ${{ secrets.SSH_PRIVATE_KEY_IOTA_CI }}
+          private-key-name: github-ppk
+
       - name: Build and push Docker image for iota-node
         uses: docker/build-push-action@v5
         with:
+          ssh: default
           context: .
           file: docker/iota-node/Dockerfile
           platforms: linux/amd64
@@ -160,9 +168,17 @@ jobs:
           password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
           registry: ${{ secrets.DOCKER_REGISTRY_URL }}
 
+      - name: Set up SSH
+        uses: MrSquaare/ssh-setup-action@v3
+        with:
+          host: github.com
+          private-key: ${{ secrets.SSH_PRIVATE_KEY_IOTA_CI }}
+          private-key-name: github-ppk
+
       - name: Build and push Docker image for iota-tools
         uses: docker/build-push-action@v5
         with:
+          ssh: default
           context: .
           file: docker/iota-tools/Dockerfile
           platforms: linux/amd64
@@ -205,9 +221,17 @@ jobs:
           password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
           registry: ${{ secrets.DOCKER_REGISTRY_URL }}
 
+      - name: Set up SSH
+        uses: MrSquaare/ssh-setup-action@v3
+        with:
+          host: github.com
+          private-key: ${{ secrets.SSH_PRIVATE_KEY_IOTA_CI }}
+          private-key-name: github-ppk
+
       - name: Build and push Docker image for iota-graphql-rpc
         uses: docker/build-push-action@v5
         with:
+          ssh: default
           context: .
           file: docker/iota-graphql-rpc/Dockerfile
           platforms: linux/amd64

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           host: github.com
           private-key: ${{ secrets.SSH_PRIVATE_KEY_IOTA_CI }}
-          private-key-name: git
+          private-key-name: github-ppk
 
       - name: Build and push Docker image for iota-indexer
         uses: docker/build-push-action@v5

--- a/docker/iota-graphql-rpc/Dockerfile
+++ b/docker/iota-graphql-rpc/Dockerfile
@@ -10,6 +10,22 @@ ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "$WORKDIR/iota"
 RUN apt-get update && apt-get install -y cmake clang libpq-dev
 
+# TODO: Remove when iota-sim is public
+RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+RUN --mount=type=ssh <<EOT
+  set -e
+  echo "Setting Git SSH protocol"
+  (
+    set +e
+    ssh -T git@github.com
+    if [ ! "$?" = "1" ]; then
+      echo "No GitHub SSH key loaded, exiting..."
+      exit 1
+    fi
+  )
+EOT
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+
 COPY Cargo.toml Cargo.lock ./
 COPY consensus consensus
 COPY crates crates
@@ -18,7 +34,7 @@ COPY narwhal narwhal
 COPY external-crates external-crates
 COPY docs docs
 
-RUN cargo build --profile ${PROFILE} --bin iota-graphql-rpc
+RUN --mount=type=ssh cargo build --profile ${PROFILE} --bin iota-graphql-rpc
 RUN mv target/$(if [ $PROFILE = "dev" ]; then echo "debug"; else echo "release";fi)/iota-graphql-rpc ./
 
 

--- a/docker/iota-graphql-rpc/Dockerfile
+++ b/docker/iota-graphql-rpc/Dockerfile
@@ -10,7 +10,7 @@ ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "$WORKDIR/iota"
 RUN apt-get update && apt-get install -y cmake clang libpq-dev
 
-# TODO: Remove when iota-sim is public
+# TODO: Remove when iota-sim is public https://github.com/iotaledger/iota/issues/2149
 RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 RUN --mount=type=ssh <<EOT
   set -e

--- a/docker/iota-indexer/Dockerfile
+++ b/docker/iota-indexer/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR "$WORKDIR/iota"
 RUN apt update && apt install -y libpq5 ca-certificates libpq-dev postgresql
 
 # TODO: Remove when iota-sim is public
+RUN apk add --no-cache file git rsync openssh-client
 RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 RUN --mount=type=ssh <<EOT
   set -e
@@ -37,7 +38,7 @@ COPY narwhal narwhal
 COPY external-crates external-crates
 COPY docs docs
 
-RUN cargo build --profile ${PROFILE} --bin iota-indexer
+RUN --mount=type=ssh cargo build --profile ${PROFILE} --bin iota-indexer
 RUN mv target/$(if [ $PROFILE = "dev" ]; then echo "debug"; else echo "release";fi)/iota-indexer ./
 
 # Production Image

--- a/docker/iota-indexer/Dockerfile
+++ b/docker/iota-indexer/Dockerfile
@@ -11,6 +11,22 @@ WORKDIR "$WORKDIR/iota"
 # iota-indexer needs postgres libpq5 and ca-certificates
 RUN apt update && apt install -y libpq5 ca-certificates libpq-dev postgresql
 
+# TODO: Remove when iota-sim is public
+RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+RUN --mount=type=ssh <<EOT
+  set -e
+  echo "Setting Git SSH protocol"
+  git config --global url."git@github.com:".insteadOf "https://github.com/"
+  (
+    set +e
+    ssh -T git@github.com
+    if [ ! "$?" = "1" ]; then
+      echo "No GitHub SSH key loaded, exiting..."
+      exit 1
+    fi
+  )
+EOT
+
 RUN apt-get update && apt-get install -y cmake clang
 
 COPY Cargo.toml Cargo.lock ./

--- a/docker/iota-indexer/Dockerfile
+++ b/docker/iota-indexer/Dockerfile
@@ -16,7 +16,6 @@ RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 RUN --mount=type=ssh <<EOT
   set -e
   echo "Setting Git SSH protocol"
-  git config --global url."git@github.com:".insteadOf "https://github.com/"
   (
     set +e
     ssh -T git@github.com

--- a/docker/iota-indexer/Dockerfile
+++ b/docker/iota-indexer/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR "$WORKDIR/iota"
 # iota-indexer needs postgres libpq5 and ca-certificates
 RUN apt update && apt install -y libpq5 ca-certificates libpq-dev postgresql
 
-# TODO: Remove when iota-sim is public
+# TODO: Remove when iota-sim is public https://github.com/iotaledger/iota/issues/2149
 RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 RUN --mount=type=ssh <<EOT
   set -e

--- a/docker/iota-indexer/Dockerfile
+++ b/docker/iota-indexer/Dockerfile
@@ -12,7 +12,6 @@ WORKDIR "$WORKDIR/iota"
 RUN apt update && apt install -y libpq5 ca-certificates libpq-dev postgresql
 
 # TODO: Remove when iota-sim is public
-RUN apk add --no-cache file git rsync openssh-client
 RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 RUN --mount=type=ssh <<EOT
   set -e

--- a/docker/iota-indexer/Dockerfile
+++ b/docker/iota-indexer/Dockerfile
@@ -25,6 +25,7 @@ RUN --mount=type=ssh <<EOT
     fi
   )
 EOT
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 RUN apt-get update && apt-get install -y cmake clang
 

--- a/docker/iota-node/Dockerfile
+++ b/docker/iota-node/Dockerfile
@@ -9,6 +9,22 @@ ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "$WORKDIR/iota"
 RUN apt-get update && apt-get install -y cmake clang
 
+# TODO: Remove when iota-sim is public
+RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+RUN --mount=type=ssh <<EOT
+  set -e
+  echo "Setting Git SSH protocol"
+  (
+    set +e
+    ssh -T git@github.com
+    if [ ! "$?" = "1" ]; then
+      echo "No GitHub SSH key loaded, exiting..."
+      exit 1
+    fi
+  )
+EOT
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+
 COPY Cargo.toml Cargo.lock ./
 COPY consensus consensus
 COPY crates crates
@@ -17,7 +33,7 @@ COPY narwhal narwhal
 COPY external-crates external-crates
 COPY docs docs
 
-RUN cargo build --profile ${PROFILE} --bin iota-node
+RUN --mount=type=ssh cargo build --profile ${PROFILE} --bin iota-node
 
 # Production Image
 FROM debian:bullseye-slim AS runtime

--- a/docker/iota-node/Dockerfile
+++ b/docker/iota-node/Dockerfile
@@ -9,7 +9,7 @@ ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "$WORKDIR/iota"
 RUN apt-get update && apt-get install -y cmake clang
 
-# TODO: Remove when iota-sim is public
+# TODO: Remove when iota-sim is public https://github.com/iotaledger/iota/issues/2149
 RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 RUN --mount=type=ssh <<EOT
   set -e

--- a/docker/iota-tools/Dockerfile
+++ b/docker/iota-tools/Dockerfile
@@ -9,7 +9,7 @@ ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "$WORKDIR/iota"
 RUN apt-get update && apt-get install -y cmake clang libpq5 libpq-dev
 
-# TODO: Remove when iota-sim is public
+# TODO: Remove when iota-sim is public https://github.com/iotaledger/iota/issues/2149
 RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 RUN --mount=type=ssh <<EOT
   set -e

--- a/docker/iota-tools/Dockerfile
+++ b/docker/iota-tools/Dockerfile
@@ -9,6 +9,22 @@ ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "$WORKDIR/iota"
 RUN apt-get update && apt-get install -y cmake clang libpq5 libpq-dev
 
+# TODO: Remove when iota-sim is public
+RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+RUN --mount=type=ssh <<EOT
+  set -e
+  echo "Setting Git SSH protocol"
+  (
+    set +e
+    ssh -T git@github.com
+    if [ ! "$?" = "1" ]; then
+      echo "No GitHub SSH key loaded, exiting..."
+      exit 1
+    fi
+  )
+EOT
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+
 COPY Cargo.toml Cargo.lock ./
 COPY consensus consensus
 COPY crates crates
@@ -17,7 +33,7 @@ COPY narwhal narwhal
 COPY external-crates external-crates
 COPY docs docs
 
-RUN cargo build --profile ${PROFILE} \
+RUN --mount=type=ssh cargo build --profile ${PROFILE} \
     --bin iota-node \
     --bin iota \
     --bin iota-faucet \


### PR DESCRIPTION
# Description of change

Docker builds in the CI cannot run without SSH due to the private repository `iota-sim`. This PR adds some setup to allow this.