### PR TITLE
Fix: Docker builds

### DIFF
--- a/docker/iota-graphql-rpc/build.sh
+++ b/docker/iota-graphql-rpc/build.sh
@@ -29,7 +29,7 @@ echo "build date: \t$BUILD_DATE"
 echo "git revision: \t$GIT_REVISION"
 echo
 
-docker build -f "$DOCKERFILE" "$REPO_ROOT" \
+docker build --ssh default -f "$DOCKERFILE" "$REPO_ROOT" \
 	--build-arg GIT_REVISION="$GIT_REVISION" \
 	--build-arg BUILD_DATE="$BUILD_DATE" \
 	--build-arg PROFILE="$PROFILE" \

--- a/docker/iota-indexer/build.sh
+++ b/docker/iota-indexer/build.sh
@@ -20,7 +20,7 @@ echo "build date: \t$BUILD_DATE"
 echo "git revision: \t$GIT_REVISION"
 echo
 
-docker build -f "$DOCKERFILE" "$REPO_ROOT" \
+docker build --ssh default -f "$DOCKERFILE" "$REPO_ROOT" \
 	--build-arg GIT_REVISION="$GIT_REVISION" \
 	--build-arg BUILD_DATE="$BUILD_DATE" \
 	"$@"

--- a/docker/iota-node/build.sh
+++ b/docker/iota-node/build.sh
@@ -29,7 +29,7 @@ echo "build date: \t$BUILD_DATE"
 echo "git revision: \t$GIT_REVISION"
 echo
 
-docker build -f "$DOCKERFILE" "$REPO_ROOT" \
+docker build --ssh default -f "$DOCKERFILE" "$REPO_ROOT" \
 	--build-arg GIT_REVISION="$GIT_REVISION" \
 	--build-arg BUILD_DATE="$BUILD_DATE" \
 	--build-arg PROFILE="$PROFILE" \

--- a/docker/iota-source-service/Dockerfile
+++ b/docker/iota-source-service/Dockerfile
@@ -4,7 +4,23 @@ ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
 RUN apt-get update && apt-get install -y cmake clang
 
-FROM chef AS builder 
+FROM chef AS builder
+
+# TODO: Remove when iota-sim is public https://github.com/iotaledger/iota/issues/2149
+RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+RUN --mount=type=ssh <<EOT
+  set -e
+  echo "Setting Git SSH protocol"
+  (
+    set +e
+    ssh -T git@github.com
+    if [ ! "$?" = "1" ]; then
+      echo "No GitHub SSH key loaded, exiting..."
+      exit 1
+    fi
+  )
+EOT
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 # Build application
 COPY Cargo.toml Cargo.lock ./
@@ -15,7 +31,7 @@ COPY narwhal narwhal
 COPY external-crates external-crates
 COPY docs docs
 
-RUN cargo build --release \
+RUN cargo --mount=type=ssh build --release \
     --bin iota-source-validation-service
 
 # Production Image

--- a/docker/iota-source-service/Dockerfile
+++ b/docker/iota-source-service/Dockerfile
@@ -31,7 +31,7 @@ COPY narwhal narwhal
 COPY external-crates external-crates
 COPY docs docs
 
-RUN cargo --mount=type=ssh build --release \
+RUN --mount=type=ssh cargo build --release \
     --bin iota-source-validation-service
 
 # Production Image

--- a/docker/iota-source-service/build.sh
+++ b/docker/iota-source-service/build.sh
@@ -20,7 +20,7 @@ echo "build date: \t$BUILD_DATE"
 echo "git revision: \t$GIT_REVISION"
 echo
 
-docker build -f "$DOCKERFILE" "$REPO_ROOT" \
+docker build --ssh default -f "$DOCKERFILE" "$REPO_ROOT" \
 	--build-arg GIT_REVISION="$GIT_REVISION" \
 	--build-arg BUILD_DATE="$BUILD_DATE" \
 	"$@"

--- a/docker/iota-test-validator/Dockerfile
+++ b/docker/iota-test-validator/Dockerfile
@@ -9,6 +9,22 @@ ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "$WORKDIR/iota"
 RUN apt-get update && apt-get install -y cmake clang libpq5 libpq-dev
 
+# TODO: Remove when iota-sim is public https://github.com/iotaledger/iota/issues/2149
+RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+RUN --mount=type=ssh <<EOT
+  set -e
+  echo "Setting Git SSH protocol"
+  (
+    set +e
+    ssh -T git@github.com
+    if [ ! "$?" = "1" ]; then
+      echo "No GitHub SSH key loaded, exiting..."
+      exit 1
+    fi
+  )
+EOT
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+
 COPY Cargo.toml Cargo.lock ./
 COPY consensus consensus
 COPY crates crates
@@ -17,7 +33,7 @@ COPY narwhal narwhal
 COPY external-crates external-crates
 COPY docs docs
 
-RUN cargo build --profile ${PROFILE} --bin iota-test-validator
+RUN --mount=type=ssh cargo build --profile ${PROFILE} --bin iota-test-validator
 RUN mv target/$(if [ $PROFILE = "dev" ]; then echo "debug"; else echo "release";fi)/iota-test-validator ./
 
 # Production Image

--- a/docker/iota-test-validator/build.sh
+++ b/docker/iota-test-validator/build.sh
@@ -20,7 +20,7 @@ echo "build date: \t$BUILD_DATE"
 echo "git revision: \t$GIT_REVISION"
 echo
 
-docker build -f "$DOCKERFILE" "$REPO_ROOT" \
+docker build --ssh default -f "$DOCKERFILE" "$REPO_ROOT" \
 	--build-arg GIT_REVISION="$GIT_REVISION" \
 	--build-arg BUILD_DATE="$BUILD_DATE" \
         --target runtime \

--- a/docker/iota-tools/build.sh
+++ b/docker/iota-tools/build.sh
@@ -20,7 +20,7 @@ echo "build date: \t$BUILD_DATE"
 echo "git revision: \t$GIT_REVISION"
 echo
 
-docker build -f "$DOCKERFILE" "$REPO_ROOT" \
+docker build --ssh default -f "$DOCKERFILE" "$REPO_ROOT" \
 	--build-arg GIT_REVISION="$GIT_REVISION" \
 	--build-arg BUILD_DATE="$BUILD_DATE" \
         --target runtime \

--- a/docker/pg-services-local/README.md
+++ b/docker/pg-services-local/README.md
@@ -15,6 +15,21 @@ configuration.
 
 ## Start the services
 
+In current images when cargo is compiling it relies on `iota-sim` which is a private repository, it can be cloned only through ssh.
+As a temporary workaround [until this issue will be closed](https://github.com/iotaledger/iota/issues/2149), before starting services
+we need to build them first, even though `docker compose up -d` does automatically build the images in this case it will fail because an explicit ssh mount is needed.
+
+Before proceeding make sure to follow these steps [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#adding-your-ssh-key-to-the-ssh-agent)
+
+> [!NOTE]
+> If you're on MacOS and using Docker Desktop make sure to choose file sharing implementation for your containers from `VirtioFS` to `gRPC FUSE`
+> as dedcribed in this [issue](https://github.com/docker/for-mac/issues/7204#issuecomment-1969109233)
+
+```
+$ docker compose build --ssh default
+$ docker compose up -d
+```
+
 ### `iota-indexer` rpc worker
 
 ```

--- a/narwhal/Docker/Dockerfile
+++ b/narwhal/Docker/Dockerfile
@@ -9,6 +9,22 @@ ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "$WORKDIR/iota"
 RUN apt-get update && apt-get install -y cmake clang
 
+# TODO: Remove when iota-sim is public https://github.com/iotaledger/iota/issues/2149
+RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+RUN --mount=type=ssh <<EOT
+  set -e
+  echo "Setting Git SSH protocol"
+  (
+    set +e
+    ssh -T git@github.com
+    if [ ! "$?" = "1" ]; then
+      echo "No GitHub SSH key loaded, exiting..."
+      exit 1
+    fi
+  )
+EOT
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+
 COPY Cargo.toml Cargo.lock ./
 COPY consensus consensus
 COPY crates crates
@@ -17,8 +33,8 @@ COPY narwhal narwhal
 COPY external-crates external-crates
 COPY docs docs
 
-RUN cargo build --profile ${PROFILE} --bin narwhal-node
-RUN cargo build --profile ${PROFILE} --features=benchmark --bin narwhal-benchmark-client
+RUN --mount=type=ssh cargo build --profile ${PROFILE} --bin narwhal-node
+RUN --mount=type=ssh cargo build --profile ${PROFILE} --features=benchmark --bin narwhal-benchmark-client
 
 # Production Image
 FROM debian:bullseye-slim AS runtime

--- a/narwhal/Docker/build.sh
+++ b/narwhal/Docker/build.sh
@@ -20,7 +20,7 @@ echo "build date: \t$BUILD_DATE"
 echo "git revision: \t$GIT_REVISION"
 echo
 
-docker build -f "$DOCKERFILE" "$REPO_ROOT" \
+docker build --ssh default -f "$DOCKERFILE" "$REPO_ROOT" \
 	--build-arg GIT_REVISION="$GIT_REVISION" \
 	--build-arg BUILD_DATE="$BUILD_DATE" \
 	"$@"


### PR DESCRIPTION
# Description of change

This PR continues the work of #2246 by adding the same logic to the remaining Dockerfiles.

Added ssh mounts to `build.sh` scripts and `Dockerfiles` to successfully build Docker images

## Links to any relevant issues
fixes #2232 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested
- Tested the successful build of the following crates by running the `build.sh` script:
  - iota-test-validator
  - iota-indexer
  - iota-graphql-rpc
  - iota-node
  - iota-source-servicea
  - iota-tools
  - narwhal

- Build images again inside `docker/pg-services-local` by using `docker compose build --ssh default` and afterwards ran the local network with `docker compose up -d`

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
