### PR TITLE
ci(explorer): disable explorer e2e tests

### DIFF
--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -77,7 +77,8 @@ jobs:
 
       - name: Run Explorer e2e tests
         # need to run Explorer e2e when its upstream(TS SDK and Rust) or itself is changed
-        if: inputs.isTypescriptSDK || inputs.isExplorer || inputs.isRust
+        # if: inputs.isTypescriptSDK || inputs.isExplorer || inputs.isRust
+        if: false
         run: pnpm --filter iota-explorer playwright test
       - uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -74,15 +74,3 @@ jobs:
       - name: Build explorer
         if: inputs.isTypescriptSDK || inputs.isExplorer || inputs.isRust
         run: pnpm turbo --filter=iota-explorer build
-
-      - name: Run Explorer e2e tests
-        # need to run Explorer e2e when its upstream(TS SDK and Rust) or itself is changed
-        # if: inputs.isTypescriptSDK || inputs.isExplorer || inputs.isRust
-        if: false
-        run: pnpm --filter iota-explorer playwright test
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: playwright-report-explorer
-          path: apps/explorer/playwright-report/
-          retention-days: 30


### PR DESCRIPTION
# Description of change

We need to pause the explorer e2e tests while we rebrand.

## Links to any relevant issues

Fixes #2293 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation Fix

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
