### PR TITLE
[refactor(iota-graphql-rpc)]: Restore and ignore ZKLogin test

### DIFF
--- a/crates/iota-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/iota-graphql-rpc/tests/e2e_tests.rs
@@ -415,6 +415,99 @@ mod tests {
         assert_eq!(sender_read, sender.to_string());
     }
 
+    #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/1777"]
+    #[serial]
+    async fn test_zklogin_sig_verify() {
+        let _guard = telemetry_subscribers::TelemetryConfig::new()
+            .with_env()
+            .init();
+
+        let connection_config = ConnectionConfig::ci_integration_test_cfg();
+        let cluster =
+            iota_graphql_rpc::test_infra::cluster::start_cluster(connection_config, None).await;
+
+        // wait for epoch to be indexed, so that current epoch and JWK are populated in
+        // db.
+        let test_cluster = cluster.validator_fullnode_handle;
+        test_cluster.wait_for_epoch(Some(1)).await;
+        test_cluster.wait_for_authenticator_state_update().await;
+
+        // now query the endpoint with a valid tx data bytes and a valid signature with
+        // the correct proof for dev env.
+        let bytes = "AAABACACAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgEBAQABAAAcpgUkGBwS5nPO79YXkjMyvaRjGS57hqxzfyd2yGtejwGbB4FfBEl+LgXSLKw6oGFBCyCGjMYZFUxCocYb6ZAnFwEAAAAAAAAAIJZw7UpW1XHubORIOaY8d2+WyBNwoJ+FEAxlsa7h7JHrHKYFJBgcEuZzzu/WF5IzMr2kYxkue4asc38ndshrXo8BAAAAAAAAABAnAAAAAAAAAA==";
+        let signature = "BQNNMTczMTgwODkxMjU5NTI0MjE3MzYzNDIyNjM3MTc5MzI3MTk0Mzc3MTc4NDQyODI0MTAxODc5NTc5ODQ3NTE5Mzk5NDI4OTgyNTEyNTBNMTEzNzM5NjY2NDU0NjkxMjI1ODIwNzQwODIyOTU5ODUzODgyNTg4NDA2ODE2MTgyNjg1OTM5NzY2OTczMjU4OTIyODA5MTU2ODEyMDcBMQMCTDU5Mzk4NzExNDczNDg4MzQ5OTczNjE3MjAxMjIyMzg5ODAxNzcxNTIzMDMyNzQzMTEwNDcyNDk5MDU5NDIzODQ5MTU3Njg2OTA4OTVMNDUzMzU2ODI3MTEzNDc4NTI3ODczMTIzNDU3MDM2MTQ4MjY1MTk5Njc0MDc5MTg4ODI4NTg2NDk2Njg4NDAzMjcxNzA0OTgxMTcwOAJNMTA1NjQzODcyODUwNzE1NTU0Njk3NTM5OTA2NjE0MTA4NDAxMTg2MzU5MjU0NjY1OTcwMzcwMTgwNTg3NzAwNDEzNDc1MTg0NjEzNjhNMTI1OTczMjM1NDcyNzc1NzkxNDQ2OTg0OTYzNzIyNDI2MTUzNjgwODU4MDEzMTMzNDMxNTU3MzU1MTEzMzAwMDM4ODQ3Njc5NTc4NTQCATEBMANNMTU3OTE1ODk0NzI1NTY4MjYyNjMyMzE2NDQ3Mjg4NzMzMzc2MjkwMTUyNjk5ODQ2OTk0MDQwNzM2MjM2MDMzNTI1Mzc2Nzg4MTMxNzFMNDU0Nzg2NjQ5OTI0ODg4MTQ0OTY3NjE2MTE1ODAyNDc0ODA2MDQ4NTM3MzI1MDAyOTQyMzkwNDExMzAxNzQyMjUzOTAzNzE2MjUyNwExMXdpYVhOeklqb2lhSFIwY0hNNkx5OXBaQzUwZDJsMFkyZ3VkSFl2YjJGMWRHZ3lJaXcCMmV5SmhiR2NpT2lKU1V6STFOaUlzSW5SNWNDSTZJa3BYVkNJc0ltdHBaQ0k2SWpFaWZRTTIwNzk0Nzg4NTU5NjIwNjY5NTk2MjA2NDU3MDIyOTY2MTc2OTg2Njg4NzI3ODc2MTI4MjIzNjI4MTEzOTE2MzgwOTI3NTAyNzM3OTExCgAAAAAAAABhAG6Bf8BLuaIEgvF8Lx2jVoRWKKRIlaLlEJxgvqwq5nDX+rvzJxYAUFd7KeQBd9upNx+CHpmINkfgj26jcHbbqAy5xu4WMO8+cRFEpkjbBruyKE9ydM++5T/87lA8waSSAA==";
+        let intent_scope = "TRANSACTION_DATA";
+        let author = "0x1ca60524181c12e673ceefd617923332bda463192e7b86ac737f2776c86b5e8f";
+        let query = r#"{ verifyZkloginSignature(bytes: $bytes, signature: $signature, intentScope: $intent_scope, author: $author ) { success, errors}}"#;
+        let variables = vec![
+            GraphqlQueryVariable {
+                name: "bytes".to_string(),
+                ty: "String!".to_string(),
+                value: json!(bytes),
+            },
+            GraphqlQueryVariable {
+                name: "signature".to_string(),
+                ty: "String!".to_string(),
+                value: json!(signature),
+            },
+            GraphqlQueryVariable {
+                name: "intent_scope".to_string(),
+                ty: "ZkLoginIntentScope!".to_string(),
+                value: json!(intent_scope),
+            },
+            GraphqlQueryVariable {
+                name: "author".to_string(),
+                ty: "IotaAddress!".to_string(),
+                value: json!(author),
+            },
+        ];
+        let res = cluster
+            .graphql_client
+            .execute_to_graphql(query.to_string(), true, variables, vec![])
+            .await
+            .unwrap();
+
+        // a valid signature with tx bytes returns success as true.
+        let binding = res.response_body().data.clone().into_json().unwrap();
+        let res = binding.get("verifyZkloginSignature").unwrap();
+        assert_eq!(res.get("success").unwrap(), true);
+
+        // set up an invalid intent scope.
+        let incorrect_intent_scope = "PERSONAL_MESSAGE";
+        let incorrect_variables = vec![
+            GraphqlQueryVariable {
+                name: "bytes".to_string(),
+                ty: "String!".to_string(),
+                value: json!(bytes),
+            },
+            GraphqlQueryVariable {
+                name: "signature".to_string(),
+                ty: "String!".to_string(),
+                value: json!(signature),
+            },
+            GraphqlQueryVariable {
+                name: "intent_scope".to_string(),
+                ty: "ZkLoginIntentScope!".to_string(),
+                value: json!(incorrect_intent_scope),
+            },
+            GraphqlQueryVariable {
+                name: "author".to_string(),
+                ty: "IotaAddress!".to_string(),
+                value: json!(author),
+            },
+        ];
+        //  returns a non-empty errors list in response
+        let res = cluster
+            .graphql_client
+            .execute_to_graphql(query.to_string(), true, incorrect_variables, vec![])
+            .await
+            .unwrap();
+        let binding = res.response_body().data.clone().into_json().unwrap();
+        let res = binding.get("verifyZkloginSignature").unwrap();
+        assert_eq!(res.get("success").unwrap(), false);
+    }
+
     // TODO: add more test cases for transaction execution/dry run in transactional
     // test runner.
     #[tokio::test]


### PR DESCRIPTION
# Description of change

Restores the previously [removed](https://github.com/iotaledger/iota/pull/2136/files#diff-b9631720c88d0d31045591b23018b92d1e2bb6e2e8b4f568c5e275177192563eL420) ZKLogin test in iota-graphql-rpc and ignores it.



## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/2249

## Type of change

- Refactor

## How the change has been tested

`cargo nextest run -p iota-graphql-rpc --features pg_integration --no-fail-fast --test-threads 1`

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
