### PR TITLE
doc(fix): Correct the casing of IotaClientProvider

### DIFF
--- a/docs/content/developer/getting-started/first-app/client-tssdk.mdx
+++ b/docs/content/developer/getting-started/first-app/client-tssdk.mdx
@@ -74,10 +74,10 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
 ```
 <AlphaNet />
 
-Next, set up the `IOTAClientProvider`. This `Provider` delivers a `IOTAClient` instance from `@iota/iota-sdk` to all the hooks in dApp Kit. This provider manages which network dApp Kit connects to, and can accept configuration for multiple networks. This exercise connects to `devnet`.
+Next, set up the `IotaClientProvider`. This `Provider` delivers a `IOTAClient` instance from `@iota/iota-sdk` to all the hooks in dApp Kit. This provider manages which network dApp Kit connects to, and can accept configuration for multiple networks. This exercise connects to `devnet`.
 
 ```ts
-import { IOTAClientProvider } from '@iota/dapp-kit';
+import { IotaClientProvider } from '@iota/dapp-kit';
 import { getFullnodeUrl } from '@iota/iota-sdk/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -90,9 +90,9 @@ const networks = {
 ReactDOM.createRoot(document.getElementById('root')!).render(
 	<React.StrictMode>
 		<QueryClientProvider client={queryClient}>
-			<IOTAClientProvider networks={networks} defaultNetwork="devnet">
+			<IotaClientProvider networks={networks} defaultNetwork="devnet">
 				<App />
-			</IOTAClientProvider>
+			</IotaClientProvider>
 		</QueryClientProvider>
 	</React.StrictMode>,
 );
@@ -103,7 +103,7 @@ Finally, set up the `WalletProvider` from `@iota/dapp-kit`, and import styles fo
 ```ts
 import '@iota/dapp-kit/dist/index.css';
 
-import { IOTAClientProvider, WalletProvider } from '@iota/dapp-kit';
+import { IotaClientProvider, WalletProvider } from '@iota/dapp-kit';
 import { getFullnodeUrl } from '@iota/iota-sdk/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -116,11 +116,11 @@ const networks = {
 ReactDOM.createRoot(document.getElementById('root')!).render(
 	<React.StrictMode>
 		<QueryClientProvider client={queryClient}>
-			<IOTAClientProvider networks={networks} defaultNetwork="devnet">
+			<IotaClientProvider networks={networks} defaultNetwork="devnet">
 				<WalletProvider>
 					<App />
 				</WalletProvider>
-			</IOTAClientProvider>
+			</IotaClientProvider>
 		</QueryClientProvider>
 	</React.StrictMode>,
 );


### PR DESCRIPTION
# Description of change

The document of the Client App with IOTA TypeScript SDK has an issue that needs to be fixed, there is no definition of `IOTAClientProvider` instead of IotaClientProvider in the Dapp-kit module.

## Links to any relevant issues

 fixes #2457 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
