### PR TITLE
Fix `iota-rest-api` compilation and tests

### DIFF
--- a/crates/iota-rest-api/openapi/openapi.json
+++ b/crates/iota-rest-api/openapi/openapi.json
@@ -858,7 +858,7 @@
       },
       "Address": {
         "title": "Address",
-        "description": "A 32-byte Iota address, encoded as a hex string.",
+        "description": "A 32-byte Sui address, encoded as a hex string.",
         "examples": [
           "0x0000000000000000000000000000000000000000000000000000000000000002"
         ],
@@ -2234,7 +2234,7 @@
             }
           },
           {
-            "description": "Iota Move Bytecode Verification Error.",
+            "description": "Sui Move Bytecode Verification Error.",
             "type": "object",
             "required": [
               "error"
@@ -2243,7 +2243,7 @@
               "error": {
                 "type": "string",
                 "enum": [
-                  "iota_move_verification_error"
+                  "sui_move_verification_error"
                 ]
               }
             }
@@ -2614,7 +2614,7 @@
             }
           },
           {
-            "description": "Iota Move Bytecode verification timed out.",
+            "description": "Sui Move Bytecode verification timed out.",
             "type": "object",
             "required": [
               "error"
@@ -2623,7 +2623,7 @@
               "error": {
                 "type": "string",
                 "enum": [
-                  "iota_move_verification_timedout"
+                  "sui_move_verification_timedout"
                 ]
               }
             }
@@ -2875,7 +2875,7 @@
         "title": "Identifier",
         "description": "A Move Identifier",
         "examples": [
-          "iota"
+          "sui"
         ],
         "type": "string",
         "pattern": "(?:[a-zA-Z][a-zA-Z0-9_]{0,127})|(?:_[a-zA-Z0-9_]{0,127})"
@@ -3915,7 +3915,7 @@
         "title": "StructTag",
         "description": "A Move StructTag",
         "examples": [
-          "0x2::coin::Coin<0x2::iota::IOTA>"
+          "0x2::coin::Coin<0x2::sui::SUI>"
         ],
         "type": "string"
       },
@@ -3958,6 +3958,7 @@
           "epoch_start_timestamp_ms",
           "inactive_pools_id",
           "inactive_pools_size",
+          "iota_total_supply",
           "max_validator_count",
           "min_validator_joining_stake",
           "pending_active_validators_id",
@@ -3968,14 +3969,8 @@
           "safe_mode",
           "safe_mode_computation_rewards",
           "safe_mode_non_refundable_storage_fee",
+          "safe_mode_storage_charges",
           "safe_mode_storage_rebates",
-          "safe_mode_storage_rewards",
-          "stake_subsidy_balance",
-          "stake_subsidy_current_distribution_amount",
-          "stake_subsidy_decrease_rate",
-          "stake_subsidy_distribution_counter",
-          "stake_subsidy_period_length",
-          "stake_subsidy_start_epoch",
           "staking_pool_mappings_id",
           "staking_pool_mappings_size",
           "storage_fund_non_refundable_balance",
@@ -4044,6 +4039,11 @@
             "type": "string",
             "format": "u64"
           },
+          "iota_total_supply": {
+            "description": "The current IOTA supply.",
+            "type": "string",
+            "format": "u64"
+          },
           "max_validator_count": {
             "description": "Maximum number of active validators at any moment. We do not allow the number of validators in any epoch to go above this.",
             "type": "string",
@@ -4100,44 +4100,13 @@
             "type": "string",
             "format": "u64"
           },
+          "safe_mode_storage_charges": {
+            "description": "Amount of storage charges accumulated (and not yet distributed) during safe mode.",
+            "type": "string",
+            "format": "u64"
+          },
           "safe_mode_storage_rebates": {
             "description": "Amount of storage rebates accumulated (and not yet burned) during safe mode.",
-            "type": "string",
-            "format": "u64"
-          },
-          "safe_mode_storage_rewards": {
-            "description": "Amount of storage rewards accumulated (and not yet distributed) during safe mode.",
-            "type": "string",
-            "format": "u64"
-          },
-          "stake_subsidy_balance": {
-            "description": "Balance of IOTA set aside for stake subsidies that will be drawn down over time.",
-            "type": "string",
-            "format": "u64"
-          },
-          "stake_subsidy_current_distribution_amount": {
-            "description": "The amount of stake subsidy to be drawn down per epoch. This amount decays and decreases over time.",
-            "type": "string",
-            "format": "u64"
-          },
-          "stake_subsidy_decrease_rate": {
-            "description": "The rate at which the distribution amount decays at the end of each period. Expressed in basis points.",
-            "type": "integer",
-            "format": "uint16",
-            "minimum": 0.0
-          },
-          "stake_subsidy_distribution_counter": {
-            "description": "This counter may be different from the current epoch number if in some epochs we decide to skip the subsidy.",
-            "type": "string",
-            "format": "u64"
-          },
-          "stake_subsidy_period_length": {
-            "description": "Number of distributions to occur before the distribution amount decays.",
-            "type": "string",
-            "format": "u64"
-          },
-          "stake_subsidy_start_epoch": {
-            "description": "The starting epoch in which stake subsidies start being paid out",
             "type": "string",
             "format": "u64"
           },

--- a/crates/iota-rest-api/src/coins.rs
+++ b/crates/iota-rest-api/src/coins.rs
@@ -172,9 +172,11 @@ pub struct CoinTreasury {
     pub total_supply: u64,
 }
 
+// TODO: needs to be fixed during the merge, the total IOTA supply should be
+// taken from the related `TreasuryCap`.
 impl CoinTreasury {
     const IOTA: Self = Self {
         id: None,
-        total_supply: iota_types::gas_coin::TOTAL_SUPPLY_NANOS,
+        total_supply: 0,
     };
 }

--- a/crates/iota-rest-api/src/error.rs
+++ b/crates/iota-rest-api/src/error.rs
@@ -57,7 +57,7 @@ impl From<iota_types::quorum_driver_types::QuorumDriverError> for RestError {
             InvalidUserSignature(err) => {
                 let message = {
                     let err = match err {
-                        IotaError::UserInputError { error } => error.to_string(),
+                        IotaError::UserInput { error } => error.to_string(),
                         _ => err.to_string(),
                     };
                     format!("Invalid user signature: {err}")
@@ -114,7 +114,7 @@ impl From<iota_types::quorum_driver_types::QuorumDriverError> for RestError {
                             // So, we take an easier route and consider them non-retryable
                             // at all. Combining this with the sorting above, clients will
                             // see the dominant error first.
-                            IotaError::UserInputError { error } => Some(error.to_string()),
+                            IotaError::UserInput { error } => Some(error.to_string()),
                             _ => {
                                 if err.is_retryable().0 {
                                     None

--- a/crates/iota-rest-api/src/system.rs
+++ b/crates/iota-rest-api/src/system.rs
@@ -86,6 +86,10 @@ pub struct SystemStateSummary {
     #[serde_as(as = "iota_types::iota_serde::BigInt<u64>")]
     #[schemars(with = "crate::_schemars::U64")]
     pub system_state_version: u64,
+    /// The current IOTA supply.
+    #[serde_as(as = "iota_types::iota_serde::BigInt<u64>")]
+    #[schemars(with = "crate::_schemars::U64")]
+    pub iota_total_supply: u64,
     /// The storage rebates of all the objects on-chain stored in the storage
     /// fund.
     #[serde_as(as = "iota_types::iota_serde::BigInt<u64>")]
@@ -106,11 +110,11 @@ pub struct SystemStateSummary {
     /// advance_epoch, and ended up executing advance_epoch_safe_mode.
     /// It can be reset once we are able to successfully execute advance_epoch.
     pub safe_mode: bool,
-    /// Amount of storage rewards accumulated (and not yet distributed) during
+    /// Amount of storage charges accumulated (and not yet distributed) during
     /// safe mode.
     #[serde_as(as = "iota_types::iota_serde::BigInt<u64>")]
     #[schemars(with = "crate::_schemars::U64")]
-    pub safe_mode_storage_rewards: u64,
+    pub safe_mode_storage_charges: u64,
     /// Amount of computation rewards accumulated (and not yet distributed)
     /// during safe mode.
     #[serde_as(as = "iota_types::iota_serde::BigInt<u64>")]
@@ -135,11 +139,6 @@ pub struct SystemStateSummary {
     #[serde_as(as = "iota_types::iota_serde::BigInt<u64>")]
     #[schemars(with = "crate::_schemars::U64")]
     pub epoch_duration_ms: u64,
-
-    /// The starting epoch in which stake subsidies start being paid out
-    #[serde_as(as = "iota_types::iota_serde::BigInt<u64>")]
-    #[schemars(with = "crate::_schemars::U64")]
-    pub stake_subsidy_start_epoch: u64,
 
     /// Maximum number of active validators at any moment.
     /// We do not allow the number of validators in any epoch to go above this.
@@ -171,30 +170,6 @@ pub struct SystemStateSummary {
     #[serde_as(as = "iota_types::iota_serde::BigInt<u64>")]
     #[schemars(with = "crate::_schemars::U64")]
     pub validator_low_stake_grace_period: u64,
-
-    // Stake subsidy information
-    /// Balance of IOTA set aside for stake subsidies that will be drawn down
-    /// over time.
-    #[serde_as(as = "iota_types::iota_serde::BigInt<u64>")]
-    #[schemars(with = "crate::_schemars::U64")]
-    pub stake_subsidy_balance: u64,
-    /// This counter may be different from the current epoch number if
-    /// in some epochs we decide to skip the subsidy.
-    #[serde_as(as = "iota_types::iota_serde::BigInt<u64>")]
-    #[schemars(with = "crate::_schemars::U64")]
-    pub stake_subsidy_distribution_counter: u64,
-    /// The amount of stake subsidy to be drawn down per epoch.
-    /// This amount decays and decreases over time.
-    #[serde_as(as = "iota_types::iota_serde::BigInt<u64>")]
-    #[schemars(with = "crate::_schemars::U64")]
-    pub stake_subsidy_current_distribution_amount: u64,
-    /// Number of distributions to occur before the distribution amount decays.
-    #[serde_as(as = "iota_types::iota_serde::BigInt<u64>")]
-    #[schemars(with = "crate::_schemars::U64")]
-    pub stake_subsidy_period_length: u64,
-    /// The rate at which the distribution amount decays at the end of each
-    /// period. Expressed in basis points.
-    pub stake_subsidy_decrease_rate: u16,
 
     // Validator set
     /// Total amount of stake from all active validators at the beginning of the
@@ -457,27 +432,22 @@ impl From<iota_types::iota_system_state::iota_system_state_summary::IotaSystemSt
             epoch,
             protocol_version,
             system_state_version,
+            iota_total_supply,
             storage_fund_total_object_storage_rebates,
             storage_fund_non_refundable_balance,
             reference_gas_price,
             safe_mode,
-            safe_mode_storage_rewards,
+            safe_mode_storage_charges,
             safe_mode_computation_rewards,
             safe_mode_storage_rebates,
             safe_mode_non_refundable_storage_fee,
             epoch_start_timestamp_ms,
             epoch_duration_ms,
-            stake_subsidy_start_epoch,
             max_validator_count,
             min_validator_joining_stake,
             validator_low_stake_threshold,
             validator_very_low_stake_threshold,
             validator_low_stake_grace_period,
-            stake_subsidy_balance,
-            stake_subsidy_distribution_counter,
-            stake_subsidy_current_distribution_amount,
-            stake_subsidy_period_length,
-            stake_subsidy_decrease_rate,
             total_stake,
             active_validators,
             pending_active_validators_id,
@@ -497,27 +467,22 @@ impl From<iota_types::iota_system_state::iota_system_state_summary::IotaSystemSt
             epoch,
             protocol_version,
             system_state_version,
+            iota_total_supply,
             storage_fund_total_object_storage_rebates,
             storage_fund_non_refundable_balance,
             reference_gas_price,
             safe_mode,
-            safe_mode_storage_rewards,
+            safe_mode_storage_charges,
             safe_mode_computation_rewards,
             safe_mode_storage_rebates,
             safe_mode_non_refundable_storage_fee,
             epoch_start_timestamp_ms,
             epoch_duration_ms,
-            stake_subsidy_start_epoch,
             max_validator_count,
             min_validator_joining_stake,
             validator_low_stake_threshold,
             validator_very_low_stake_threshold,
             validator_low_stake_grace_period,
-            stake_subsidy_balance,
-            stake_subsidy_distribution_counter,
-            stake_subsidy_current_distribution_amount,
-            stake_subsidy_period_length,
-            stake_subsidy_decrease_rate,
             total_stake,
             active_validators: active_validators.into_iter().map(Into::into).collect(),
             pending_active_validators_id: pending_active_validators_id.into(),


### PR DESCRIPTION
Fixes #2615 

1. Restored lost `SystemStateSummary` changes.
2. Updated the `openapi.json` file.

@kodemartin, please, note that some Sui types are presented in the schema. I think it happens because the `sui-rust-sdk` crate is used:
```toml
# core-types with json format for REST api
iota-sdk2 = { package = "sui-sdk", git = "https://github.com/mystenlabs/sui-rust-sdk.git", rev = "bd233b6879b917fb95e17f21927c198e7a60c924", features = [
  "hash",
  "serde",
  "schemars",
] }
```

Also, will be created a new task to fix the IOTA supply function:
```rust
// TODO: needs to be fixed during the merge, the total IOTA supply should be
// taken from the related `TreasuryCap`.
impl CoinTreasury {
    const IOTA: Self = Self {
        id: None,
-        total_supply: iota_types::gas_coin::TOTAL_SUPPLY_NANOS,
+        total_supply: 0,
    };
}
```