### PR TITLE
feat(iota-indexer): Extended api tests for iota-indexer

### DIFF
--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -124,6 +124,12 @@ pub mod pg_integration {
         })
     }
 
+    pub fn get_default_fullnode_rpc_api_addr() -> SocketAddr {
+        format!("127.0.0.1:{}", DEFAULT_SERVER_PORT)
+            .parse()
+            .unwrap()
+    }
+
     /// Set up a test indexer fetching from a REST endpoint served by the given
     /// Simulacrum.
     pub async fn start_simulacrum_rest_api_with_write_indexer(
@@ -133,9 +139,7 @@ pub mod pg_integration {
         PgIndexerStore,
         JoinHandle<Result<(), IndexerError>>,
     ) {
-        let server_url: SocketAddr = format!("127.0.0.1:{}", DEFAULT_SERVER_PORT)
-            .parse()
-            .unwrap();
+        let server_url = get_default_fullnode_rpc_api_addr();
 
         let server_handle = tokio::spawn(async move {
             let chain_id = (*sim
@@ -167,40 +171,20 @@ pub mod pg_integration {
         JoinHandle<Result<(), IndexerError>>,
         HttpClient,
     ) {
-        let server_url: SocketAddr = format!("127.0.0.1:{}", DEFAULT_SERVER_PORT)
-            .parse()
-            .unwrap();
-    
-        let server_handle = tokio::spawn(async move {
-            let chain_id = (*sim
-                .get_checkpoint_by_sequence_number(0)
-                .unwrap()
-                .unwrap()
-                .digest())
-            .into();
-    
-            iota_rest_api::RestService::new_without_version(sim, chain_id)
-                .start_service(server_url, Some("/rest".to_owned()))
-                .await;
-        });
-        // Starts indexer
-        let (pg_store, pg_handle) = start_test_indexer(
-            Some(DEFAULT_DB_URL.to_owned()),
-            format!("http://{}", server_url),
-            ReaderWriterConfig::writer_mode(None),
-        )
-        .await;
-    
+        let server_url = get_default_fullnode_rpc_api_addr();
+        let (server_handle, pg_store, pg_handle) =
+            start_simulacrum_rest_api_with_write_indexer(sim).await;
+
         // start indexer in read mode
         start_indexer_reader(format!("http://{}", server_url));
-    
+
         // create an RPC client by using the indexer url
         let rpc_client = HttpClientBuilder::default()
             .build(format!(
                 "http://{DEFAULT_INDEXER_IP}:{DEFAULT_INDEXER_PORT}"
             ))
             .unwrap();
-    
+
         (server_handle, pg_store, pg_handle, rpc_client)
     }
 }

--- a/crates/iota-indexer/tests/rpc-tests/extended_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/extended_api.rs
@@ -395,22 +395,17 @@ async fn test_get_total_transactions() {
 }
 
 fn add_test_epochs_to_simulacrum(mut sim: &mut Simulacrum, tx_counts_in_epochs: &[u32]) {
-    let (counts_in_finished_epochs, current_epoch_tx_count) = match tx_counts_in_epochs {
-        [counts_in_finished_epochs @ .., current_epoch_tx_count] => {
-            (counts_in_finished_epochs, current_epoch_tx_count)
+    if let [counts_in_finished_epochs @ .., current_epoch_tx_count] = tx_counts_in_epochs {
+        for tx_count in counts_in_finished_epochs {
+            execute_simulacrum_transactions(&mut sim, *tx_count);
+            sim.advance_epoch(false);
         }
-        [] => {
-            return;
-        }
-    };
 
-    for tx_count in counts_in_finished_epochs {
-        execute_simulacrum_transactions(&mut sim, *tx_count);
-        sim.advance_epoch(false);
+        execute_simulacrum_transactions(&mut sim, *current_epoch_tx_count);
+        sim.create_checkpoint();
+    } else {
+        return;
     }
-
-    execute_simulacrum_transactions(&mut sim, *current_epoch_tx_count);
-    sim.create_checkpoint();
 }
 
 async fn execute_move_fn(cluster: &TestCluster) -> Result<(), anyhow::Error> {

--- a/crates/iota-indexer/tests/rpc-tests/extended_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/extended_api.rs
@@ -1,47 +1,31 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::str::FromStr;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{str::FromStr, sync::Arc};
 
-use iota_config::node::RunWithRange;
-use iota_json::call_args;
-use iota_json::type_args;
-use iota_json_rpc_api::{ExtendedApiClient, IndexerApiClient, ReadApiClient};
-use iota_json_rpc_types::EndOfEpochInfo;
-use iota_json_rpc_types::EpochInfo;
-use iota_json_rpc_types::EpochMetrics;
-use iota_json_rpc_types::IotaTransactionBlockResponse;
-use iota_json_rpc_types::MoveCallMetrics;
-use iota_json_rpc_types::Page;
+use iota_json::{call_args, type_args};
+use iota_json_rpc_api::{
+    ExtendedApiClient, IndexerApiClient, ReadApiClient, TransactionBuilderClient, WriteApiClient,
+};
 use iota_json_rpc_types::{
-    CheckpointId, IotaGetPastObjectRequest, IotaObjectDataOptions, IotaObjectResponse,
-    IotaObjectResponseQuery, IotaTransactionBlockResponseOptions,
+    EndOfEpochInfo, EpochInfo, EpochMetrics, IotaObjectDataOptions, IotaObjectResponseQuery,
+    IotaTransactionBlockResponseOptions, TransactionBlockBytes,
 };
-
-use iota_json_rpc_api::TransactionBuilderClient;
-use iota_json_rpc_api::WriteApiClient;
-use iota_json_rpc_types::TransactionBlockBytes;
-use iota_types::base_types::IotaAddress;
-use iota_types::gas_coin::GAS;
-use iota_types::iota_serde::BigInt;
-use iota_types::quorum_driver_types::ExecuteTransactionRequestType;
-use iota_types::storage::ReadStore;
-use iota_types::IOTA_FRAMEWORK_ADDRESS;
 use iota_types::{
-    base_types::{ObjectID, SequenceNumber},
-    digests::TransactionDigest,
-    error::IotaObjectResponseError,
-};
-
-use crate::common::pg_integration::{
-    indexer_wait_for_checkpoint, rpc_call_error_msg_matches,
-    start_simulacrum_rest_api_with_read_write_indexer, start_test_cluster_with_read_write_indexer,
+    base_types::{IotaAddress, ObjectID},
+    gas_coin::GAS,
+    quorum_driver_types::ExecuteTransactionRequestType,
+    storage::ReadStore,
+    IOTA_FRAMEWORK_ADDRESS,
 };
 use serial_test::serial;
 use simulacrum::Simulacrum;
-use test_cluster::{TestCluster, TestClusterBuilder};
+use test_cluster::TestCluster;
+
+use crate::common::pg_integration::{
+    indexer_wait_for_checkpoint, start_simulacrum_rest_api_with_read_write_indexer,
+    start_test_cluster_with_read_write_indexer,
+};
 
 #[tokio::test]
 #[serial]
@@ -319,8 +303,7 @@ async fn test_get_current_epoch() {
 #[tokio::test]
 #[serial]
 async fn test_get_network_metrics() {
-    let (cluster, pg_store, indexer_client) =
-        start_test_cluster_with_read_write_indexer(None).await;
+    let (_, pg_store, indexer_client) = start_test_cluster_with_read_write_indexer(None).await;
     indexer_wait_for_checkpoint(&pg_store, 10).await;
 
     let network_metrics = indexer_client.get_network_metrics().await.unwrap();
@@ -355,8 +338,7 @@ async fn test_get_move_call_metrics() {
 #[tokio::test]
 #[serial]
 async fn test_get_latest_address_metrics() {
-    let (cluster, pg_store, indexer_client) =
-        start_test_cluster_with_read_write_indexer(None).await;
+    let (_, pg_store, indexer_client) = start_test_cluster_with_read_write_indexer(None).await;
     indexer_wait_for_checkpoint(&pg_store, 10).await;
 
     let address_metrics = indexer_client.get_latest_address_metrics().await.unwrap();
@@ -368,8 +350,7 @@ async fn test_get_latest_address_metrics() {
 #[tokio::test]
 #[serial]
 async fn test_get_checkpoint_address_metrics() {
-    let (cluster, pg_store, indexer_client) =
-        start_test_cluster_with_read_write_indexer(None).await;
+    let (_, pg_store, indexer_client) = start_test_cluster_with_read_write_indexer(None).await;
     indexer_wait_for_checkpoint(&pg_store, 10).await;
 
     let address_metrics = indexer_client
@@ -384,8 +365,7 @@ async fn test_get_checkpoint_address_metrics() {
 #[tokio::test]
 #[serial]
 async fn test_get_all_epoch_address_metrics() {
-    let (cluster, pg_store, indexer_client) =
-        start_test_cluster_with_read_write_indexer(None).await;
+    let (_, pg_store, indexer_client) = start_test_cluster_with_read_write_indexer(None).await;
     indexer_wait_for_checkpoint(&pg_store, 10).await;
 
     let address_metrics = indexer_client

--- a/crates/iota-indexer/tests/rpc-tests/extended_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/extended_api.rs
@@ -299,7 +299,7 @@ async fn test_get_current_epoch() {
     ));
 }
 
-#[ignore]
+#[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2368524531"]
 #[tokio::test]
 #[serial]
 async fn test_get_network_metrics() {
@@ -334,7 +334,7 @@ async fn test_get_move_call_metrics() {
     assert_eq!(move_call_metrics.rank_30_days.len(), 0);
 }
 
-#[ignore]
+#[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2368524531"]
 #[tokio::test]
 #[serial]
 async fn test_get_latest_address_metrics() {
@@ -346,7 +346,7 @@ async fn test_get_latest_address_metrics() {
     println!("{:#?}", address_metrics);
 }
 
-#[ignore]
+#[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2368524531"]
 #[tokio::test]
 #[serial]
 async fn test_get_checkpoint_address_metrics() {
@@ -361,7 +361,7 @@ async fn test_get_checkpoint_address_metrics() {
     println!("{:#?}", address_metrics);
 }
 
-#[ignore]
+#[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2368524531"]
 #[tokio::test]
 #[serial]
 async fn test_get_all_epoch_address_metrics() {

--- a/crates/iota-indexer/tests/rpc-tests/extended_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/extended_api.rs
@@ -1,0 +1,505 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use iota_config::node::RunWithRange;
+use iota_json::call_args;
+use iota_json::type_args;
+use iota_json_rpc_api::{ExtendedApiClient, IndexerApiClient, ReadApiClient};
+use iota_json_rpc_types::EndOfEpochInfo;
+use iota_json_rpc_types::EpochInfo;
+use iota_json_rpc_types::EpochMetrics;
+use iota_json_rpc_types::IotaTransactionBlockResponse;
+use iota_json_rpc_types::MoveCallMetrics;
+use iota_json_rpc_types::Page;
+use iota_json_rpc_types::{
+    CheckpointId, IotaGetPastObjectRequest, IotaObjectDataOptions, IotaObjectResponse,
+    IotaObjectResponseQuery, IotaTransactionBlockResponseOptions,
+};
+
+use iota_json_rpc_api::TransactionBuilderClient;
+use iota_json_rpc_api::WriteApiClient;
+use iota_json_rpc_types::TransactionBlockBytes;
+use iota_types::base_types::IotaAddress;
+use iota_types::gas_coin::GAS;
+use iota_types::iota_serde::BigInt;
+use iota_types::quorum_driver_types::ExecuteTransactionRequestType;
+use iota_types::storage::ReadStore;
+use iota_types::IOTA_FRAMEWORK_ADDRESS;
+use iota_types::{
+    base_types::{ObjectID, SequenceNumber},
+    digests::TransactionDigest,
+    error::IotaObjectResponseError,
+};
+
+use crate::common::pg_integration::{
+    indexer_wait_for_checkpoint, rpc_call_error_msg_matches,
+    start_simulacrum_rest_api_with_read_write_indexer, start_test_cluster_with_read_write_indexer,
+};
+use serial_test::serial;
+use simulacrum::Simulacrum;
+use test_cluster::{TestCluster, TestClusterBuilder};
+
+#[tokio::test]
+#[serial]
+async fn test_get_epochs() {
+    let mut sim = Simulacrum::new();
+    _add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
+    let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+
+    let (_, pg_store, _, indexer_client) =
+        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim)).await;
+    indexer_wait_for_checkpoint(&pg_store, last_checkpoint.sequence_number).await;
+
+    let epochs = indexer_client.get_epochs(None, None, None).await.unwrap();
+
+    assert_eq!(epochs.data.len(), 3);
+    assert_eq!(epochs.has_next_page, false);
+    assert!(matches!(
+        epochs.data[0],
+        EpochInfo {
+            epoch: 0,
+            first_checkpoint_id: 0,
+            epoch_total_transactions: 17, // 15 + 1 for genesis + 1 for end of epoch
+            end_of_epoch_info: Some(EndOfEpochInfo {
+                last_checkpoint_id: 1,
+                ..
+            }),
+            ..
+        }
+    ));
+    assert!(matches!(
+        epochs.data[1],
+        EpochInfo {
+            epoch: 1,
+            first_checkpoint_id: 2,
+            epoch_total_transactions: 28, // 17 from previous epoch + 10 + 1 for end of epoch
+            end_of_epoch_info: Some(EndOfEpochInfo {
+                last_checkpoint_id: 2,
+                ..
+            }),
+            ..
+        }
+    ));
+    assert!(matches!(
+        epochs.data[2],
+        EpochInfo {
+            epoch: 2,
+            first_checkpoint_id: 3,
+            epoch_total_transactions: 0, // set to 0 for ongoing epoch, is it intended?
+            end_of_epoch_info: None,
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_get_epochs_descending() {
+    let mut sim = Simulacrum::new();
+    _add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
+    let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+
+    let (_, pg_store, _, indexer_client) =
+        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim)).await;
+    indexer_wait_for_checkpoint(&pg_store, last_checkpoint.sequence_number).await;
+
+    let epochs = indexer_client
+        .get_epochs(None, None, Some(true))
+        .await
+        .unwrap();
+
+    let actual_epochs_order = epochs
+        .data
+        .iter()
+        .map(|epoch| epoch.epoch)
+        .collect::<Vec<u64>>();
+
+    assert_eq!(epochs.data.len(), 3);
+    assert_eq!(epochs.has_next_page, false);
+    assert_eq!(actual_epochs_order, [2, 1, 0])
+}
+
+#[tokio::test]
+#[serial]
+async fn test_get_epochs_paging() {
+    let mut sim = Simulacrum::new();
+    _add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
+    let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+
+    let (_, pg_store, _, indexer_client) =
+        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim)).await;
+    indexer_wait_for_checkpoint(&pg_store, last_checkpoint.sequence_number).await;
+
+    let epochs = indexer_client
+        .get_epochs(None, Some(2), None)
+        .await
+        .unwrap();
+    let actual_epochs_order = epochs
+        .data
+        .iter()
+        .map(|epoch| epoch.epoch)
+        .collect::<Vec<u64>>();
+
+    assert_eq!(epochs.data.len(), 2);
+    assert_eq!(epochs.has_next_page, true);
+    assert_eq!(epochs.next_cursor, Some(1.into()));
+    assert_eq!(actual_epochs_order, [0, 1]);
+
+    let epochs = indexer_client
+        .get_epochs(Some(1.into()), Some(2), None)
+        .await
+        .unwrap();
+    let actual_epochs_order = epochs
+        .data
+        .iter()
+        .map(|epoch| epoch.epoch)
+        .collect::<Vec<u64>>();
+
+    assert_eq!(epochs.data.len(), 1);
+    assert_eq!(epochs.has_next_page, false);
+    assert_eq!(epochs.next_cursor, Some(2.into()));
+    assert_eq!(actual_epochs_order, [2]);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_get_epoch_metrics() {
+    let mut sim = Simulacrum::new();
+    _add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
+    let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+
+    let (_, pg_store, _, indexer_client) =
+        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim)).await;
+    indexer_wait_for_checkpoint(&pg_store, last_checkpoint.sequence_number).await;
+
+    let epoch_metrics = indexer_client
+        .get_epoch_metrics(None, None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(epoch_metrics.data.len(), 3);
+    assert_eq!(epoch_metrics.has_next_page, false);
+    assert!(matches!(
+        epoch_metrics.data[0],
+        EpochMetrics {
+            epoch: 0,
+            first_checkpoint_id: 0,
+            epoch_total_transactions: 17, // 15 + 1 for genesis + 1 for end of epoch
+            end_of_epoch_info: Some(EndOfEpochInfo {
+                last_checkpoint_id: 1,
+                ..
+            }),
+            ..
+        }
+    ));
+    assert!(matches!(
+        epoch_metrics.data[1],
+        EpochMetrics {
+            epoch: 1,
+            first_checkpoint_id: 2,
+            epoch_total_transactions: 28, // 17 from previous epoch + 10 + 1 for end of epoch
+            end_of_epoch_info: Some(EndOfEpochInfo {
+                last_checkpoint_id: 2,
+                ..
+            }),
+            ..
+        }
+    ));
+    assert!(matches!(
+        epoch_metrics.data[2],
+        EpochMetrics {
+            epoch: 2,
+            first_checkpoint_id: 3,
+            epoch_total_transactions: 0, // set to 0 for ongoing epoch, is it intended?
+            end_of_epoch_info: None,
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_get_epoch_metrics_descending() {
+    let mut sim = Simulacrum::new();
+    _add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
+    let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+
+    let (_, pg_store, _, indexer_client) =
+        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim)).await;
+    indexer_wait_for_checkpoint(&pg_store, last_checkpoint.sequence_number).await;
+
+    let epochs = indexer_client
+        .get_epoch_metrics(None, None, Some(true))
+        .await
+        .unwrap();
+
+    let actual_epochs_order = epochs
+        .data
+        .iter()
+        .map(|epoch| epoch.epoch)
+        .collect::<Vec<u64>>();
+
+    assert_eq!(epochs.data.len(), 3);
+    assert_eq!(epochs.has_next_page, false);
+    assert_eq!(actual_epochs_order, [2, 1, 0])
+}
+
+#[tokio::test]
+#[serial]
+async fn test_get_epoch_metrics_paging() {
+    let mut sim = Simulacrum::new();
+    _add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
+    let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+
+    let (_, pg_store, _, indexer_client) =
+        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim)).await;
+    indexer_wait_for_checkpoint(&pg_store, last_checkpoint.sequence_number).await;
+
+    let epochs = indexer_client
+        .get_epoch_metrics(None, Some(2), None)
+        .await
+        .unwrap();
+    let actual_epochs_order = epochs
+        .data
+        .iter()
+        .map(|epoch| epoch.epoch)
+        .collect::<Vec<u64>>();
+
+    assert_eq!(epochs.data.len(), 2);
+    assert_eq!(epochs.has_next_page, true);
+    assert_eq!(epochs.next_cursor, Some(1.into()));
+    assert_eq!(actual_epochs_order, [0, 1]);
+
+    let epochs = indexer_client
+        .get_epoch_metrics(Some(1.into()), Some(2), None)
+        .await
+        .unwrap();
+    let actual_epochs_order = epochs
+        .data
+        .iter()
+        .map(|epoch| epoch.epoch)
+        .collect::<Vec<u64>>();
+
+    assert_eq!(epochs.data.len(), 1);
+    assert_eq!(epochs.has_next_page, false);
+    assert_eq!(epochs.next_cursor, Some(2.into()));
+    assert_eq!(actual_epochs_order, [2]);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_get_current_epoch() {
+    let mut sim = Simulacrum::new();
+    _add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
+    let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+
+    let (_, pg_store, _, indexer_client) =
+        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim)).await;
+    indexer_wait_for_checkpoint(&pg_store, last_checkpoint.sequence_number).await;
+
+    let current_epoch = indexer_client.get_current_epoch().await.unwrap();
+
+    assert!(matches!(
+        current_epoch,
+        EpochInfo {
+            epoch: 2,
+            first_checkpoint_id: 3,
+            epoch_total_transactions: 0, // set to 0 for ongoing epoch, is it intended?
+            end_of_epoch_info: None,
+            ..
+        }
+    ));
+}
+
+#[ignore]
+#[tokio::test]
+#[serial]
+async fn test_get_network_metrics() {
+    let (cluster, pg_store, indexer_client) =
+        start_test_cluster_with_read_write_indexer(None).await;
+    indexer_wait_for_checkpoint(&pg_store, 10).await;
+
+    let network_metrics = indexer_client.get_network_metrics().await.unwrap();
+
+    println!("{:#?}", network_metrics);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_get_move_call_metrics() {
+    let (cluster, pg_store, indexer_client) =
+        start_test_cluster_with_read_write_indexer(None).await;
+
+    _execute_move_fn(&cluster).await.unwrap();
+
+    let latest_checkpoint_sn = cluster
+        .rpc_client()
+        .get_latest_checkpoint_sequence_number()
+        .await
+        .unwrap();
+    indexer_wait_for_checkpoint(&pg_store, latest_checkpoint_sn.into_inner()).await;
+
+    let move_call_metrics = indexer_client.get_move_call_metrics().await.unwrap();
+
+    // TODO: Why is the move call not included in the stats?
+    assert_eq!(move_call_metrics.rank_3_days.len(), 0);
+    assert_eq!(move_call_metrics.rank_7_days.len(), 0);
+    assert_eq!(move_call_metrics.rank_30_days.len(), 0);
+}
+
+#[ignore]
+#[tokio::test]
+#[serial]
+async fn test_get_latest_address_metrics() {
+    let (cluster, pg_store, indexer_client) =
+        start_test_cluster_with_read_write_indexer(None).await;
+    indexer_wait_for_checkpoint(&pg_store, 10).await;
+
+    let address_metrics = indexer_client.get_latest_address_metrics().await.unwrap();
+
+    println!("{:#?}", address_metrics);
+}
+
+#[ignore]
+#[tokio::test]
+#[serial]
+async fn test_get_checkpoint_address_metrics() {
+    let (cluster, pg_store, indexer_client) =
+        start_test_cluster_with_read_write_indexer(None).await;
+    indexer_wait_for_checkpoint(&pg_store, 10).await;
+
+    let address_metrics = indexer_client
+        .get_checkpoint_address_metrics(0)
+        .await
+        .unwrap();
+
+    println!("{:#?}", address_metrics);
+}
+
+#[ignore]
+#[tokio::test]
+#[serial]
+async fn test_get_all_epoch_address_metrics() {
+    let (cluster, pg_store, indexer_client) =
+        start_test_cluster_with_read_write_indexer(None).await;
+    indexer_wait_for_checkpoint(&pg_store, 10).await;
+
+    let address_metrics = indexer_client
+        .get_all_epoch_address_metrics(None)
+        .await
+        .unwrap();
+
+    println!("{:#?}", address_metrics);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_get_total_transactions() {
+    let mut sim = Simulacrum::new();
+    _execute_simulacrum_transactions(&mut sim, 5);
+
+    let latest_checkpoint = sim.create_checkpoint();
+    let total_transactions_count = latest_checkpoint.network_total_transactions;
+
+    let (_, pg_store, _, indexer_client) =
+        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim)).await;
+    indexer_wait_for_checkpoint(&pg_store, latest_checkpoint.sequence_number).await;
+
+    let transactions_cnt = indexer_client.get_total_transactions().await.unwrap();
+    assert_eq!(transactions_cnt.into_inner(), total_transactions_count);
+    assert_eq!(transactions_cnt.into_inner(), 6);
+}
+
+fn _add_test_epochs_to_simulacrum(mut sim: &mut Simulacrum, tx_counts_in_epochs: &[u32]) {
+    let (counts_in_finished_epochs, current_epoch_tx_count) = match tx_counts_in_epochs {
+        [counts_in_finished_epochs @ .., current_epoch_tx_count] => {
+            (counts_in_finished_epochs, current_epoch_tx_count)
+        }
+        [] => {
+            return;
+        }
+    };
+
+    for tx_count in counts_in_finished_epochs {
+        _execute_simulacrum_transactions(&mut sim, *tx_count);
+        sim.advance_epoch(false);
+    }
+
+    _execute_simulacrum_transactions(&mut sim, *current_epoch_tx_count);
+    sim.create_checkpoint();
+}
+
+async fn _execute_move_fn(cluster: &TestCluster) -> Result<(), anyhow::Error> {
+    let http_client = cluster.rpc_client();
+    let address = cluster.get_address_0();
+
+    let objects = http_client
+        .get_owned_objects(
+            address,
+            Some(IotaObjectResponseQuery::new_with_options(
+                IotaObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
+            None,
+            None,
+        )
+        .await?
+        .data;
+
+    let gas = objects.first().unwrap().object().unwrap();
+    let coin = &objects[1].object()?;
+
+    // now do the call
+    let package_id = ObjectID::new(IOTA_FRAMEWORK_ADDRESS.into_bytes());
+    let module = "pay".to_string();
+    let function = "split".to_string();
+
+    let transaction_bytes: TransactionBlockBytes = http_client
+        .move_call(
+            address,
+            package_id,
+            module,
+            function,
+            type_args![GAS::type_tag()]?,
+            call_args!(coin.object_id, 10)?,
+            Some(gas.object_id),
+            10_000_000.into(),
+            None,
+        )
+        .await?;
+
+    let tx = cluster
+        .wallet
+        .sign_transaction(&transaction_bytes.to_data()?);
+
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
+
+    let tx_response = http_client
+        .execute_transaction_block(
+            tx_bytes,
+            signatures,
+            Some(IotaTransactionBlockResponseOptions::new().with_effects()),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await?;
+    assert!(tx_response.status_ok().unwrap_or(false));
+    Ok(())
+}
+
+fn _execute_simulacrum_transaction(sim: &mut Simulacrum) {
+    let transfer_recipient = IotaAddress::random_for_testing_only();
+    let (transaction, _) = sim.transfer_txn(transfer_recipient);
+    sim.execute_transaction(transaction.clone()).unwrap();
+}
+
+fn _execute_simulacrum_transactions(sim: &mut Simulacrum, transactions_count: u32) {
+    for _ in 0..transactions_count {
+        _execute_simulacrum_transaction(sim);
+    }
+}

--- a/crates/iota-indexer/tests/rpc-tests/extended_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/extended_api.rs
@@ -299,7 +299,7 @@ async fn get_current_epoch() {
     ));
 }
 
-#[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2368524531"]
+#[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2371642744"]
 #[tokio::test]
 #[serial]
 async fn get_network_metrics() {
@@ -311,6 +311,7 @@ async fn get_network_metrics() {
     println!("{:#?}", network_metrics);
 }
 
+#[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2371642744"]
 #[tokio::test]
 #[serial]
 async fn get_move_call_metrics() {
@@ -334,7 +335,7 @@ async fn get_move_call_metrics() {
     assert_eq!(move_call_metrics.rank_30_days.len(), 0);
 }
 
-#[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2368524531"]
+#[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2371642744"]
 #[tokio::test]
 #[serial]
 async fn get_latest_address_metrics() {
@@ -346,7 +347,7 @@ async fn get_latest_address_metrics() {
     println!("{:#?}", address_metrics);
 }
 
-#[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2368524531"]
+#[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2371642744"]
 #[tokio::test]
 #[serial]
 async fn get_checkpoint_address_metrics() {
@@ -361,7 +362,7 @@ async fn get_checkpoint_address_metrics() {
     println!("{:#?}", address_metrics);
 }
 
-#[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2368524531"]
+#[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2371642744"]
 #[tokio::test]
 #[serial]
 async fn get_all_epoch_address_metrics() {

--- a/crates/iota-indexer/tests/rpc-tests/extended_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/extended_api.rs
@@ -42,42 +42,23 @@ async fn get_epochs() {
 
     assert_eq!(epochs.data.len(), 3);
     assert_eq!(epochs.has_next_page, false);
-    assert!(matches!(
-        epochs.data[0],
-        EpochInfo {
-            epoch: 0,
-            first_checkpoint_id: 0,
-            epoch_total_transactions: 17, // 15 + 1 for genesis + 1 for end of epoch
-            end_of_epoch_info: Some(EndOfEpochInfo {
-                last_checkpoint_id: 1,
-                ..
-            }),
-            ..
-        }
-    ));
-    assert!(matches!(
-        epochs.data[1],
-        EpochInfo {
-            epoch: 1,
-            first_checkpoint_id: 2,
-            epoch_total_transactions: 28, // 17 from previous epoch + 10 + 1 for end of epoch
-            end_of_epoch_info: Some(EndOfEpochInfo {
-                last_checkpoint_id: 2,
-                ..
-            }),
-            ..
-        }
-    ));
-    assert!(matches!(
-        epochs.data[2],
-        EpochInfo {
-            epoch: 2,
-            first_checkpoint_id: 3,
-            epoch_total_transactions: 0, // set to 0 for ongoing epoch, is it intended?
-            end_of_epoch_info: None,
-            ..
-        }
-    ));
+
+    let end_of_epoch_info = epochs.data[0].end_of_epoch_info.as_ref().unwrap();
+    assert_eq!(epochs.data[0].epoch, 0);
+    assert_eq!(epochs.data[0].first_checkpoint_id, 0);
+    assert_eq!(epochs.data[0].epoch_total_transactions, 17);
+    assert_eq!(end_of_epoch_info.last_checkpoint_id, 1);
+
+    let end_of_epoch_info = epochs.data[1].end_of_epoch_info.as_ref().unwrap();
+    assert_eq!(epochs.data[1].epoch, 1);
+    assert_eq!(epochs.data[1].first_checkpoint_id, 2);
+    assert_eq!(epochs.data[1].epoch_total_transactions, 28);
+    assert_eq!(end_of_epoch_info.last_checkpoint_id, 2);
+
+    assert_eq!(epochs.data[2].epoch, 2);
+    assert_eq!(epochs.data[2].first_checkpoint_id, 3);
+    assert_eq!(epochs.data[2].epoch_total_transactions, 0);
+    assert!(epochs.data[2].end_of_epoch_info.is_none());
 }
 
 #[tokio::test]
@@ -167,42 +148,23 @@ async fn get_epoch_metrics() {
 
     assert_eq!(epoch_metrics.data.len(), 3);
     assert_eq!(epoch_metrics.has_next_page, false);
-    assert!(matches!(
-        epoch_metrics.data[0],
-        EpochMetrics {
-            epoch: 0,
-            first_checkpoint_id: 0,
-            epoch_total_transactions: 17, // 15 + 1 for genesis + 1 for end of epoch
-            end_of_epoch_info: Some(EndOfEpochInfo {
-                last_checkpoint_id: 1,
-                ..
-            }),
-            ..
-        }
-    ));
-    assert!(matches!(
-        epoch_metrics.data[1],
-        EpochMetrics {
-            epoch: 1,
-            first_checkpoint_id: 2,
-            epoch_total_transactions: 28, // 17 from previous epoch + 10 + 1 for end of epoch
-            end_of_epoch_info: Some(EndOfEpochInfo {
-                last_checkpoint_id: 2,
-                ..
-            }),
-            ..
-        }
-    ));
-    assert!(matches!(
-        epoch_metrics.data[2],
-        EpochMetrics {
-            epoch: 2,
-            first_checkpoint_id: 3,
-            epoch_total_transactions: 0, // set to 0 for ongoing epoch, is it intended?
-            end_of_epoch_info: None,
-            ..
-        }
-    ));
+
+    let end_of_epoch_info = epoch_metrics.data[0].end_of_epoch_info.as_ref().unwrap();
+    assert_eq!(epoch_metrics.data[0].epoch, 0);
+    assert_eq!(epoch_metrics.data[0].first_checkpoint_id, 0);
+    assert_eq!(epoch_metrics.data[0].epoch_total_transactions, 17);
+    assert_eq!(end_of_epoch_info.last_checkpoint_id, 1);
+
+    let end_of_epoch_info = epoch_metrics.data[1].end_of_epoch_info.as_ref().unwrap();
+    assert_eq!(epoch_metrics.data[1].epoch, 1);
+    assert_eq!(epoch_metrics.data[1].first_checkpoint_id, 2);
+    assert_eq!(epoch_metrics.data[1].epoch_total_transactions, 28);
+    assert_eq!(end_of_epoch_info.last_checkpoint_id, 2);
+
+    assert_eq!(epoch_metrics.data[2].epoch, 2);
+    assert_eq!(epoch_metrics.data[2].first_checkpoint_id, 3);
+    assert_eq!(epoch_metrics.data[2].epoch_total_transactions, 0);
+    assert!(epoch_metrics.data[2].end_of_epoch_info.is_none());
 }
 
 #[tokio::test]
@@ -287,16 +249,10 @@ async fn get_current_epoch() {
 
     let current_epoch = indexer_client.get_current_epoch().await.unwrap();
 
-    assert!(matches!(
-        current_epoch,
-        EpochInfo {
-            epoch: 2,
-            first_checkpoint_id: 3,
-            epoch_total_transactions: 0, // set to 0 for ongoing epoch, is it intended?
-            end_of_epoch_info: None,
-            ..
-        }
-    ));
+    assert_eq!(current_epoch.epoch, 2);
+    assert_eq!(current_epoch.first_checkpoint_id, 3);
+    assert_eq!(current_epoch.epoch_total_transactions, 0);
+    assert!(current_epoch.end_of_epoch_info.is_none());
 }
 
 #[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2371642744"]

--- a/crates/iota-indexer/tests/rpc-tests/extended_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/extended_api.rs
@@ -31,7 +31,7 @@ use crate::common::pg_integration::{
 #[serial]
 async fn test_get_epochs() {
     let mut sim = Simulacrum::new();
-    _add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
+    add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
     let last_checkpoint = sim.get_latest_checkpoint().unwrap();
 
     let (_, pg_store, _, indexer_client) =
@@ -84,7 +84,7 @@ async fn test_get_epochs() {
 #[serial]
 async fn test_get_epochs_descending() {
     let mut sim = Simulacrum::new();
-    _add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
+    add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
     let last_checkpoint = sim.get_latest_checkpoint().unwrap();
 
     let (_, pg_store, _, indexer_client) =
@@ -111,7 +111,7 @@ async fn test_get_epochs_descending() {
 #[serial]
 async fn test_get_epochs_paging() {
     let mut sim = Simulacrum::new();
-    _add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
+    add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
     let last_checkpoint = sim.get_latest_checkpoint().unwrap();
 
     let (_, pg_store, _, indexer_client) =
@@ -153,7 +153,7 @@ async fn test_get_epochs_paging() {
 #[serial]
 async fn test_get_epoch_metrics() {
     let mut sim = Simulacrum::new();
-    _add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
+    add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
     let last_checkpoint = sim.get_latest_checkpoint().unwrap();
 
     let (_, pg_store, _, indexer_client) =
@@ -209,7 +209,7 @@ async fn test_get_epoch_metrics() {
 #[serial]
 async fn test_get_epoch_metrics_descending() {
     let mut sim = Simulacrum::new();
-    _add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
+    add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
     let last_checkpoint = sim.get_latest_checkpoint().unwrap();
 
     let (_, pg_store, _, indexer_client) =
@@ -236,7 +236,7 @@ async fn test_get_epoch_metrics_descending() {
 #[serial]
 async fn test_get_epoch_metrics_paging() {
     let mut sim = Simulacrum::new();
-    _add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
+    add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
     let last_checkpoint = sim.get_latest_checkpoint().unwrap();
 
     let (_, pg_store, _, indexer_client) =
@@ -278,7 +278,7 @@ async fn test_get_epoch_metrics_paging() {
 #[serial]
 async fn test_get_current_epoch() {
     let mut sim = Simulacrum::new();
-    _add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
+    add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
     let last_checkpoint = sim.get_latest_checkpoint().unwrap();
 
     let (_, pg_store, _, indexer_client) =
@@ -317,7 +317,7 @@ async fn test_get_move_call_metrics() {
     let (cluster, pg_store, indexer_client) =
         start_test_cluster_with_read_write_indexer(None).await;
 
-    _execute_move_fn(&cluster).await.unwrap();
+    execute_move_fn(&cluster).await.unwrap();
 
     let latest_checkpoint_sn = cluster
         .rpc_client()
@@ -380,7 +380,7 @@ async fn test_get_all_epoch_address_metrics() {
 #[serial]
 async fn test_get_total_transactions() {
     let mut sim = Simulacrum::new();
-    _execute_simulacrum_transactions(&mut sim, 5);
+    execute_simulacrum_transactions(&mut sim, 5);
 
     let latest_checkpoint = sim.create_checkpoint();
     let total_transactions_count = latest_checkpoint.network_total_transactions;
@@ -394,7 +394,7 @@ async fn test_get_total_transactions() {
     assert_eq!(transactions_cnt.into_inner(), 6);
 }
 
-fn _add_test_epochs_to_simulacrum(mut sim: &mut Simulacrum, tx_counts_in_epochs: &[u32]) {
+fn add_test_epochs_to_simulacrum(mut sim: &mut Simulacrum, tx_counts_in_epochs: &[u32]) {
     let (counts_in_finished_epochs, current_epoch_tx_count) = match tx_counts_in_epochs {
         [counts_in_finished_epochs @ .., current_epoch_tx_count] => {
             (counts_in_finished_epochs, current_epoch_tx_count)
@@ -405,15 +405,15 @@ fn _add_test_epochs_to_simulacrum(mut sim: &mut Simulacrum, tx_counts_in_epochs:
     };
 
     for tx_count in counts_in_finished_epochs {
-        _execute_simulacrum_transactions(&mut sim, *tx_count);
+        execute_simulacrum_transactions(&mut sim, *tx_count);
         sim.advance_epoch(false);
     }
 
-    _execute_simulacrum_transactions(&mut sim, *current_epoch_tx_count);
+    execute_simulacrum_transactions(&mut sim, *current_epoch_tx_count);
     sim.create_checkpoint();
 }
 
-async fn _execute_move_fn(cluster: &TestCluster) -> Result<(), anyhow::Error> {
+async fn execute_move_fn(cluster: &TestCluster) -> Result<(), anyhow::Error> {
     let http_client = cluster.rpc_client();
     let address = cluster.get_address_0();
 
@@ -472,14 +472,14 @@ async fn _execute_move_fn(cluster: &TestCluster) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-fn _execute_simulacrum_transaction(sim: &mut Simulacrum) {
+fn execute_simulacrum_transaction(sim: &mut Simulacrum) {
     let transfer_recipient = IotaAddress::random_for_testing_only();
     let (transaction, _) = sim.transfer_txn(transfer_recipient);
     sim.execute_transaction(transaction.clone()).unwrap();
 }
 
-fn _execute_simulacrum_transactions(sim: &mut Simulacrum, transactions_count: u32) {
+fn execute_simulacrum_transactions(sim: &mut Simulacrum, transactions_count: u32) {
     for _ in 0..transactions_count {
-        _execute_simulacrum_transaction(sim);
+        execute_simulacrum_transaction(sim);
     }
 }

--- a/crates/iota-indexer/tests/rpc-tests/extended_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/extended_api.rs
@@ -29,7 +29,7 @@ use crate::common::pg_integration::{
 
 #[tokio::test]
 #[serial]
-async fn test_get_epochs() {
+async fn get_epochs() {
     let mut sim = Simulacrum::new();
     add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
     let last_checkpoint = sim.get_latest_checkpoint().unwrap();
@@ -82,7 +82,7 @@ async fn test_get_epochs() {
 
 #[tokio::test]
 #[serial]
-async fn test_get_epochs_descending() {
+async fn get_epochs_descending() {
     let mut sim = Simulacrum::new();
     add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
     let last_checkpoint = sim.get_latest_checkpoint().unwrap();
@@ -109,7 +109,7 @@ async fn test_get_epochs_descending() {
 
 #[tokio::test]
 #[serial]
-async fn test_get_epochs_paging() {
+async fn get_epochs_paging() {
     let mut sim = Simulacrum::new();
     add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
     let last_checkpoint = sim.get_latest_checkpoint().unwrap();
@@ -151,7 +151,7 @@ async fn test_get_epochs_paging() {
 
 #[tokio::test]
 #[serial]
-async fn test_get_epoch_metrics() {
+async fn get_epoch_metrics() {
     let mut sim = Simulacrum::new();
     add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
     let last_checkpoint = sim.get_latest_checkpoint().unwrap();
@@ -207,7 +207,7 @@ async fn test_get_epoch_metrics() {
 
 #[tokio::test]
 #[serial]
-async fn test_get_epoch_metrics_descending() {
+async fn get_epoch_metrics_descending() {
     let mut sim = Simulacrum::new();
     add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
     let last_checkpoint = sim.get_latest_checkpoint().unwrap();
@@ -234,7 +234,7 @@ async fn test_get_epoch_metrics_descending() {
 
 #[tokio::test]
 #[serial]
-async fn test_get_epoch_metrics_paging() {
+async fn get_epoch_metrics_paging() {
     let mut sim = Simulacrum::new();
     add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
     let last_checkpoint = sim.get_latest_checkpoint().unwrap();
@@ -276,7 +276,7 @@ async fn test_get_epoch_metrics_paging() {
 
 #[tokio::test]
 #[serial]
-async fn test_get_current_epoch() {
+async fn get_current_epoch() {
     let mut sim = Simulacrum::new();
     add_test_epochs_to_simulacrum(&mut sim, &[15, 10, 5]);
     let last_checkpoint = sim.get_latest_checkpoint().unwrap();
@@ -302,7 +302,7 @@ async fn test_get_current_epoch() {
 #[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2368524531"]
 #[tokio::test]
 #[serial]
-async fn test_get_network_metrics() {
+async fn get_network_metrics() {
     let (_, pg_store, indexer_client) = start_test_cluster_with_read_write_indexer(None).await;
     indexer_wait_for_checkpoint(&pg_store, 10).await;
 
@@ -313,7 +313,7 @@ async fn test_get_network_metrics() {
 
 #[tokio::test]
 #[serial]
-async fn test_get_move_call_metrics() {
+async fn get_move_call_metrics() {
     let (cluster, pg_store, indexer_client) =
         start_test_cluster_with_read_write_indexer(None).await;
 
@@ -337,7 +337,7 @@ async fn test_get_move_call_metrics() {
 #[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2368524531"]
 #[tokio::test]
 #[serial]
-async fn test_get_latest_address_metrics() {
+async fn get_latest_address_metrics() {
     let (_, pg_store, indexer_client) = start_test_cluster_with_read_write_indexer(None).await;
     indexer_wait_for_checkpoint(&pg_store, 10).await;
 
@@ -349,7 +349,7 @@ async fn test_get_latest_address_metrics() {
 #[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2368524531"]
 #[tokio::test]
 #[serial]
-async fn test_get_checkpoint_address_metrics() {
+async fn get_checkpoint_address_metrics() {
     let (_, pg_store, indexer_client) = start_test_cluster_with_read_write_indexer(None).await;
     indexer_wait_for_checkpoint(&pg_store, 10).await;
 
@@ -364,7 +364,7 @@ async fn test_get_checkpoint_address_metrics() {
 #[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2368524531"]
 #[tokio::test]
 #[serial]
-async fn test_get_all_epoch_address_metrics() {
+async fn get_all_epoch_address_metrics() {
     let (_, pg_store, indexer_client) = start_test_cluster_with_read_write_indexer(None).await;
     indexer_wait_for_checkpoint(&pg_store, 10).await;
 
@@ -378,7 +378,7 @@ async fn test_get_all_epoch_address_metrics() {
 
 #[tokio::test]
 #[serial]
-async fn test_get_total_transactions() {
+async fn get_total_transactions() {
     let mut sim = Simulacrum::new();
     execute_simulacrum_transactions(&mut sim, 5);
 

--- a/crates/iota-indexer/tests/rpc-tests/main.rs
+++ b/crates/iota-indexer/tests/rpc-tests/main.rs
@@ -6,6 +6,6 @@
 mod common;
 
 #[cfg(feature = "pg_integration")]
-mod read_api;
-#[cfg(feature = "pg_integration")]
 mod extended_api;
+#[cfg(feature = "pg_integration")]
+mod read_api;

--- a/crates/iota-indexer/tests/rpc-tests/main.rs
+++ b/crates/iota-indexer/tests/rpc-tests/main.rs
@@ -7,3 +7,5 @@ mod common;
 
 #[cfg(feature = "pg_integration")]
 mod read_api;
+#[cfg(feature = "pg_integration")]
+mod extended_api;


### PR DESCRIPTION
# Description of change

Added tests for `ExtendedApi` in `iota-indexer`.

Only non metric related endpoints are tested in this PR.
Tests for metric related endpoints will be tackled in a separate PR.

## Links to any relevant issues

fixes #2197

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Ran `cargo nextest run --features pg_integration --test-threads 1` locally

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
