### PR TITLE
fix(iota-genesis-builder): satisfy clippy

### DIFF
--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -43,9 +43,11 @@ use iota_types::{
     gas::IotaGasStatus,
     gas_coin::{GasCoin, GAS},
     governance::StakedIota,
+    id::UID,
     in_memory_storage::InMemoryStorage,
     inner_temporary_store::InnerTemporaryStore,
     iota_system_state::{get_iota_system_state, IotaSystemState, IotaSystemStateTrait},
+    is_system_package,
     message_envelope::Message,
     messages_checkpoint::{
         CertifiedCheckpointSummary, CheckpointContents, CheckpointSummary,
@@ -63,7 +65,7 @@ use iota_types::{
         CallArg, CheckedInputObjects, Command, InputObjectKind, ObjectArg, ObjectReadResult,
         Transaction,
     },
-    BRIDGE_ADDRESS, IOTA_BRIDGE_OBJECT_ID, IOTA_FRAMEWORK_ADDRESS, IOTA_SYSTEM_ADDRESS,
+    BRIDGE_ADDRESS, IOTA_BRIDGE_OBJECT_ID, IOTA_FRAMEWORK_PACKAGE_ID, IOTA_SYSTEM_ADDRESS,
 };
 use move_binary_format::CompiledModule;
 use move_core_types::ident_str;
@@ -953,7 +955,7 @@ fn build_unsigned_genesis_data<'info>(
     // if system packages are provided in `objects`, update them with the provided
     // bytes. This is a no-op under normal conditions and only an issue with
     // certain tests.
-    update_system_packages_from_objects(&mut system_packages, objects);
+    update_system_packages_from_objects(&mut system_packages, &objects);
 
     let mut genesis_ctx = create_genesis_context(
         &epoch_data,

--- a/crates/iota-genesis-builder/src/stardust/migration/migration.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/migration.rs
@@ -22,6 +22,7 @@ use iota_types::{
     timelock::timelock::{self, is_timelocked_balance, TimeLock},
     IOTA_FRAMEWORK_PACKAGE_ID, IOTA_SYSTEM_PACKAGE_ID, MOVE_STDLIB_PACKAGE_ID, STARDUST_PACKAGE_ID,
 };
+use move_binary_format::file_format_common::VERSION_MAX;
 use tracing::info;
 
 use crate::stardust::{
@@ -406,7 +407,7 @@ pub(super) fn package_module_bytes(pkg: &CompiledPackage) -> Result<Vec<Vec<u8>>
     pkg.get_modules()
         .map(|module| {
             let mut buf = Vec::new();
-            module.serialize(&mut buf)?;
+            module.serialize_with_version(VERSION_MAX, &mut buf)?;
             Ok(buf)
         })
         .collect::<Result<_>>()

--- a/crates/iota-genesis-builder/src/stardust/migration/verification/foundry.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/foundry.rs
@@ -137,9 +137,9 @@ pub(super) fn verify_foundry_output(
         expected_package_data.module().module_name
     );
     ensure!(
-        foundry_data.coin_type_origin.struct_name == expected_package_data.module().otw_name,
+        foundry_data.coin_type_origin.datatype_name == expected_package_data.module().otw_name,
         "foundry data OTW struct name mismatch: found {}, expected {}",
-        foundry_data.coin_type_origin.struct_name,
+        foundry_data.coin_type_origin.datatype_name,
         expected_package_data.module().otw_name
     );
 

--- a/crates/iota-genesis-builder/src/stardust/native_token/package_builder.rs
+++ b/crates/iota-genesis-builder/src/stardust/native_token/package_builder.rs
@@ -43,7 +43,7 @@ pub fn build_and_compile(package: NativeTokenPackageData) -> Result<CompiledPack
 
     // Step 4: Compile the package
     move_package::package_hooks::register_package_hooks(Box::new(IotaPackageHooks));
-    let compiled_package = BuildConfig::default().build(package_path)?;
+    let compiled_package = BuildConfig::default().build(&package_path)?;
 
     // Clean up the temporary directory
     tmp_dir.close()?;

--- a/crates/iota-json-rpc-api/src/lib.rs
+++ b/crates/iota-json-rpc-api/src/lib.rs
@@ -304,7 +304,7 @@ pub const TRANSACTION_EXECUTION_CLIENT_ERROR_CODE: i32 = -32002;
 /// Convert a jsonrpsee client error into a generic error object.
 pub fn error_object_from_rpc(rpc_err: ClientError) -> ErrorObjectOwned {
     match rpc_err {
-        ClientError::Call(e) => e.into(),
+        ClientError::Call(e) => e,
         _ => ErrorObjectOwned::owned::<()>(UNKNOWN_ERROR_CODE, rpc_err.to_string(), None),
     }
 }


### PR DESCRIPTION
# Description of change

Part of #2600

Fixes `clippy` for `iota-genesis-builder` and as a side effect for `iota-json-rpc-api`.