### PR TITLE
fix(ui-kit): remove scrolling event on input type numbers

### DIFF
--- a/apps/ui-kit/src/lib/components/molecules/input/Input.tsx
+++ b/apps/ui-kit/src/lib/components/molecules/input/Input.tsx
@@ -156,10 +156,29 @@ function InputElement({
     inputRef: React.ForwardedRef<HTMLInputElement>;
     className: string;
 }) {
+    function preventScrollInputChange(e: React.WheelEvent<HTMLInputElement>) {
+        if (type === InputType.Number) {
+            const input = e.currentTarget;
+
+            input.blur();
+            e.stopPropagation();
+            setTimeout(() => {
+                input.focus({ preventScroll: true });
+            }, 0);
+        }
+    }
     return type === InputType.NumericFormat ? (
         <NumericFormatInput inputRef={inputRef} {...inputProps} type={type} />
     ) : (
-        <input ref={inputRef} {...inputProps} type={type} />
+        <input
+            ref={inputRef}
+            {...inputProps}
+            type={type}
+            onWheel={(e) => {
+                preventScrollInputChange(e);
+                inputProps.onWheel?.(e);
+            }}
+        />
     );
 }
 


### PR DESCRIPTION
Fixes #2109

Previously the "Send Token" inputs where numbers, but now they're text. 
The only place where this can be reproduced now is the autolock number input in the account settings