### PR TITLE
fix(iota-indexer): Persist system state with epoch begin info

### DIFF
--- a/crates/iota-indexer/src/models/epoch.rs
+++ b/crates/iota-indexer/src/models/epoch.rs
@@ -71,6 +71,7 @@ impl StoredEpochInfo {
             protocol_version: e.protocol_version as i64,
             total_stake: e.total_stake as i64,
             storage_fund_balance: e.storage_fund_balance as i64,
+            system_state: e.system_state.clone(),
             ..Default::default()
         }
     }


### PR DESCRIPTION
# Description of change

This patch persists the system state along the epoch begin info in the Indexer database which is required for the `iotax_getCommitteeInfo` to work.

- [X] Reproduced the bug locally: Issuing `iotax_getCommitteeInfo` for the current epoch should make the indexer crash
- [X] Store the system state in the beginning info
- [X] Test the fix manually

As part of the `GovernanceApi` RPC tests in #2198 a test will be added for `iotax_getCommitteeInfo` to further show that the change is effective.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/2572

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

```bash
curl --location 'localhost:9124' \
--header 'Content-Type: application/json' \
--header 'client-target-api-version: 0.1.4' \
--header 'Cookie: _ddce2=d971c6ece3fbd230' \
--data '{
  "jsonrpc": "2.0",
  "id": 2,
  "method": "iotax_getCommitteeInfo",
  "params": [
    null
  ]
}'
```
```json
{"jsonrpc":"2.0","id":2,"result":{"epoch":"0","validators":[["jc/20VUECmVvSBmxMRG1LFdGqGunLzlfuv4uw4R9HoFA5iSnUf32tfIFC8cgXPnTAATJCwx0Cv/TJs5nPMKyOi0k1T4q/rKG38Zo/UBgCJ1tKxe3md02+Q0zLlSnozjU","2500"],["mfJe9h+AMrkUY2RgmCxcxvE07x3a52ZX8sv+wev8jQlzdAgN9vzw3Li8Sw2OCvXYDrv/K0xZn1T0LWMS38MUJ2B4wcw0fru+xRmL4lhRPzhrkw0CwnSagD4jMJVevRoQ","2500"],["rd7vlNiYyI5A297/kcXxBfnPLHR/tvK8N+wD1ske2y4aV4z1RL6LCTHiXyQ9WbDDDZihbOO6HWzx1/UEJpkusK2zE0sFW+gUDS218l+wDYP45CIr8B/WrJOh/0152ljy","2500"],["s/1e+1yHJAOkrRPxGZUTYG0jNUqEUkmuoVdWTCP/PBXGyeZSty10DoysuTy8wGhrDsDMDBx2C/tCtDZRn8WoBUt2UzqXqfI5h9CX75ax8lJrsgc/oQp3GZQXcjR+8nT0","2500"]]}}
```

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
