### PR TITLE
fix(iota-genesis-builder): reduce genesis.blob size

### DIFF
--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -52,7 +52,8 @@ use iota_types::{
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     stardust::stardust_to_iota_address,
     timelock::{
-        stardust_upgrade_label::STARDUST_UPGRADE_LABEL_VALUE, timelock::is_timelock, timelocked_staked_iota::TimelockedStakedIota
+        stardust_upgrade_label::STARDUST_UPGRADE_LABEL_VALUE,
+        timelocked_staked_iota::TimelockedStakedIota,
     },
     transaction::{
         CallArg, CheckedInputObjects, Command, InputObjectKind, ObjectArg, ObjectReadResult,
@@ -315,10 +316,12 @@ impl Builder {
                 .into_iter()
                 .map(|(id, _, _)| id),
         );
-        let mut timelock_objects = self.migration_objects.take_timelock_objects(self.genesis_stake
-            .take_timelocks_to_burn()
-            .into_iter()
-            .map(|(id, _, _)| id),);
+        let mut timelock_objects = self.migration_objects.take_timelock_objects(
+            self.genesis_stake
+                .take_timelocks_to_burn()
+                .into_iter()
+                .map(|(id, _, _)| id),
+        );
 
         timelock_objects.extend(self.objects.values().cloned());
 

--- a/crates/iota-genesis-builder/src/stardust/migration/migration.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/migration.rs
@@ -324,15 +324,19 @@ impl MigrationObjects {
     }
 
     /// Take timelock objects.
-    pub fn take_timelock_objects(&mut self, objects: impl IntoIterator<Item = ObjectID>) -> Vec<Object> {
+    pub fn take_timelock_objects(
+        &mut self,
+        objects: impl IntoIterator<Item = ObjectID>,
+    ) -> Vec<Object> {
         let timelocks: HashSet<_> = objects.into_iter().collect();
-    
-        let (timelocks_result, remaining): (Vec<Object>, Vec<Object>) = self.inner
+
+        let (timelocks_result, remaining): (Vec<Object>, Vec<Object>) = self
+            .inner
             .drain(..)
             .partition(|object| timelocks.contains(&object.id()));
-        
+
         self.inner = remaining;
-    
+
         timelocks_result
     }
 

--- a/crates/iota-genesis-builder/src/stardust/migration/migration.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/migration.rs
@@ -323,6 +323,19 @@ impl MigrationObjects {
         std::mem::take(&mut self.inner)
     }
 
+    /// Take timelock objects.
+    pub fn take_timelock_objects(&mut self, objects: impl IntoIterator<Item = ObjectID>) -> Vec<Object> {
+        let timelocks: HashSet<_> = objects.into_iter().collect();
+    
+        let (timelocks_result, remaining): (Vec<Object>, Vec<Object>) = self.inner
+            .drain(..)
+            .partition(|object| timelocks.contains(&object.id()));
+        
+        self.inner = remaining;
+    
+        timelocks_result
+    }
+
     /// Checks if inner is empty.
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()


### PR DESCRIPTION
# Description of change

Reduce genesis.blob size from 6gb to 366KB by excluding migrated objects

## Links to any relevant issues

Fix #2735 .

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

`cargo run --release --bin iota genesis --working-dir test_iota_config -f --with-faucet --num-validators 1 --remote-migration-snapshots https://stardust-objects.s3.eu-central-1.amazonaws.com/iota/alphanet/latest/stardust_object_snapshot.bin.gz`