### PR TITLE
fix(iota-genesis-builder, iota-config): include information about the migrated objects without including them into genesis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5366,9 +5366,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bcs",
  "clap",
  "derivative",
  "fastcrypto",
+ "flate2",
  "futures",
  "iota-config",
  "iota-core",

--- a/crates/iota-cluster-test/Cargo.toml
+++ b/crates/iota-cluster-test/Cargo.toml
@@ -9,9 +9,11 @@ publish = false
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }
 async-trait.workspace = true
+bcs.workspace = true
 clap.workspace = true
 derivative.workspace = true
 fastcrypto.workspace = true
+flate2.workspace = true
 futures.workspace = true
 jsonrpsee.workspace = true
 prometheus.workspace = true

--- a/crates/iota-config/src/genesis.rs
+++ b/crates/iota-config/src/genesis.rs
@@ -16,7 +16,7 @@ use fastcrypto::{
 };
 use iota_types::{
     authenticator_state::{get_authenticator_state, AuthenticatorStateInner},
-    base_types::{IotaAddress, ObjectID},
+    base_types::{IotaAddress, ObjectID, ObjectRef},
     clock::Clock,
     committee::{Committee, CommitteeWithNetworkMetadata, EpochId, ProtocolVersion},
     crypto::DefaultHash,
@@ -46,6 +46,9 @@ pub struct Genesis {
     effects: TransactionEffects,
     events: TransactionEvents,
     objects: Vec<Object>,
+    migrated_object_refs: Vec<ObjectRef>,
+    migrated_objects_ref_to_split: Vec<(ObjectRef, u64, IotaAddress)>,
+    migrated_objects_ref_to_burn: Vec<ObjectRef>,
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
@@ -56,6 +59,9 @@ pub struct UnsignedGenesis {
     pub effects: TransactionEffects,
     pub events: TransactionEvents,
     pub objects: Vec<Object>,
+    pub migrated_object_refs: Vec<ObjectRef>,
+    pub migrated_objects_ref_to_split: Vec<(ObjectRef, u64, IotaAddress)>,
+    pub migrated_objects_ref_to_burn: Vec<ObjectRef>,
 }
 
 // Hand implement PartialEq in order to get around the fact that AuthSigs don't
@@ -88,6 +94,9 @@ impl Genesis {
         effects: TransactionEffects,
         events: TransactionEvents,
         objects: Vec<Object>,
+        migrated_object_refs: Vec<ObjectRef>,
+        migrated_objects_ref_to_split: Vec<(ObjectRef, u64, IotaAddress)>,
+        migrated_objects_ref_to_burn: Vec<ObjectRef>,
     ) -> Self {
         Self {
             checkpoint,
@@ -96,6 +105,9 @@ impl Genesis {
             effects,
             events,
             objects,
+            migrated_object_refs,
+            migrated_objects_ref_to_split,
+            migrated_objects_ref_to_burn,
         }
     }
 
@@ -226,6 +238,9 @@ impl Serialize for Genesis {
             effects: &'a TransactionEffects,
             events: &'a TransactionEvents,
             objects: &'a [Object],
+            migrated_object_refs: &'a Vec<ObjectRef>,
+            migrated_objects_ref_to_split: &'a Vec<(ObjectRef, u64, IotaAddress)>,
+            migrated_objects_ref_to_burn: &'a Vec<ObjectRef>,
         }
 
         let raw_genesis = RawGenesis {
@@ -235,6 +250,9 @@ impl Serialize for Genesis {
             effects: &self.effects,
             events: &self.events,
             objects: &self.objects,
+            migrated_object_refs: &self.migrated_object_refs,
+            migrated_objects_ref_to_split: &self.migrated_objects_ref_to_split,
+            migrated_objects_ref_to_burn: &self.migrated_objects_ref_to_burn,
         };
 
         if serializer.is_human_readable() {
@@ -262,6 +280,9 @@ impl<'de> Deserialize<'de> for Genesis {
             effects: TransactionEffects,
             events: TransactionEvents,
             objects: Vec<Object>,
+            migrated_object_refs: Vec<ObjectRef>,
+            migrated_objects_ref_to_split: Vec<(ObjectRef, u64, IotaAddress)>,
+            migrated_objects_ref_to_burn: Vec<ObjectRef>,
         }
 
         let raw_genesis = if deserializer.is_human_readable() {
@@ -279,6 +300,9 @@ impl<'de> Deserialize<'de> for Genesis {
             effects: raw_genesis.effects,
             events: raw_genesis.events,
             objects: raw_genesis.objects,
+            migrated_object_refs: raw_genesis.migrated_object_refs,
+            migrated_objects_ref_to_split: raw_genesis.migrated_objects_ref_to_split,
+            migrated_objects_ref_to_burn: raw_genesis.migrated_objects_ref_to_burn,
         })
     }
 }

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -334,7 +334,7 @@ impl Builder {
         let migrated_objects_ref_to_split: Vec<(ObjectRef, u64, IotaAddress)> =
             self.genesis_stake.take_timelocks_to_split_by_ref().to_vec();
         let migrated_objects_ref_to_burn: Vec<ObjectRef> =
-            self.genesis_stake.take_timelocks_to_split_by_ref().to_vec();
+            self.genesis_stake.take_timelocks_to_burn_by_ref().to_vec();
 
         // Finally build the genesis data
         self.built_genesis = Some(build_unsigned_genesis_data(

--- a/crates/iota-genesis-builder/src/stake.rs
+++ b/crates/iota-genesis-builder/src/stake.rs
@@ -40,11 +40,21 @@ impl GenesisStake {
         std::mem::take(&mut self.timelocks_to_burn)
     }
 
+    /// Take the inner timelock objects that must be burned by ref.
+    pub fn take_timelocks_to_burn_by_ref(&self) -> &Vec<ObjectRef> {
+        &self.timelocks_to_burn
+    }
+
     /// Take the inner timelock objects that must be split.
     ///
     /// This follows the semantics of [`std::mem::take`].
     pub fn take_timelocks_to_split(&mut self) -> Vec<(ObjectRef, u64, IotaAddress)> {
         std::mem::take(&mut self.timelocks_to_split)
+    }
+
+    /// Take the inner timelock objects that must be split by ref.
+    pub fn take_timelocks_to_split_by_ref(&self) -> &Vec<(ObjectRef, u64, IotaAddress)> {
+        &self.timelocks_to_split
     }
 
     pub fn is_empty(&self) -> bool {

--- a/crates/iota-genesis-builder/src/stardust/migration/migration.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/migration.rs
@@ -323,6 +323,11 @@ impl MigrationObjects {
         std::mem::take(&mut self.inner)
     }
 
+    /// Take the inner migration objects by ref
+    pub fn objects(&mut self) -> &Vec<Object> {
+        &self.inner
+    }
+
     /// Take timelock objects.
     pub fn take_timelock_objects(
         &mut self,
@@ -332,7 +337,7 @@ impl MigrationObjects {
         let (timelocks_result, remaining): (Vec<Object>, Vec<Object>) = self
             .inner
             .drain(..)
-            .partition(|object| timelocks.contains(&object.id()));
+            .partition(|obj| timelocks.contains(&obj.id()));
         self.inner = remaining;
         timelocks_result
     }


### PR DESCRIPTION
# Description of change

Build the node DB with migrated objects that are not contained in the genesis blob.
Now genesis takes up around 500 MB of disk space.

## Links to any relevant issues
Fix #2736 .

## Type of change
Choose a type of change, and delete any options that are not relevant.
- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested
`cargo run --release --bin iota genesis --working-dir test_iota_config -f --with-faucet --num-validators 1 --remote-migration-snapshots https://stardust-objects.s3.eu-central-1.amazonaws.com/iota/alphanet/latest/stardust_object_snapshot.bin.gz`

```
cargo build --release --bin iota-test-validator
./target/release/iota-test-validator --config-dir test_iota_config
```