### PR TITLE
Swap iota-test-validator with iota in docker

### DIFF
--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set env
         run: |
           echo "VITE_IOTA_BIN=$PWD/target/debug/iota" >> $GITHUB_ENV
-        echo "E2E_RUN_LOCAL_NET_CMD=(RUST_LOG=info RUST_BACKTRACE=1 $(echo $PWD/target/debug/iota) start --with-indexer --pg-port 5432 --pg-db-name iota_indexer_v2 --with-graphql 127.0.0.1:9125)" >> $GITHUB_ENV
+        echo "E2E_RUN_LOCAL_NET_CMD=(RUST_LOG=info RUST_BACKTRACE=1 $(echo $PWD/target/debug/iota) start --with-indexer --pg-port 5432 --pg-db-name iota_indexer_v2 --with-graphql=127.0.0.1:9125)" >> $GITHUB_ENV
 
       - name: Run TS SDK e2e tests
         if: inputs.isTypescriptSDK || inputs.isRust

--- a/docker/iota/Dockerfile
+++ b/docker/iota/Dockerfile
@@ -6,7 +6,8 @@ FROM rust:bullseye AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
-WORKDIR "$WORKDIR/iota"
+ARG CARGO_BUILD_FEATURES
+WORKDIR "/iota"
 
 RUN apt-get update && apt-get install -y cmake clang libpq5 libpq-dev
 
@@ -35,17 +36,16 @@ COPY external-crates external-crates
 COPY docs docs
 
 # TODO: Remove "--mount=type=ssh" when iota-sim is public https://github.com/iotaledger/iota/issues/2149
-RUN --mount=type=ssh cargo build --profile ${PROFILE} --bin iota-test-validator
-RUN mv target/$(if [ $PROFILE = "dev" ]; then echo "debug"; else echo "release";fi)/iota-test-validator ./
+RUN --mount=type=ssh cargo build --profile ${PROFILE} --bin iota --features ${CARGO_BUILD_FEATURES:=default}
+RUN mv target/$(if [ $PROFILE = "dev" ]; then echo "debug"; else echo "release";fi)/iota ./
 
 # Production Image
 FROM debian:bullseye-slim AS runtime
-WORKDIR "$WORKDIR/iota"
 
 # iota-tool needs libpq at runtime
 RUN apt-get update && apt-get install -y libpq5 libpq-dev
 
-COPY --from=builder /iota/iota-test-validator /usr/local/bin
+COPY --from=builder /iota/iota /usr/local/bin
 
 ARG BUILD_DATE
 ARG GIT_REVISION

--- a/docker/iota/build.sh
+++ b/docker/iota/build.sh
@@ -13,7 +13,7 @@ GIT_REVISION="$(git describe --always --abbrev=12 --dirty --exclude '*')"
 BUILD_DATE="$(date -u +'%Y-%m-%d')"
 
 echo
-echo "Building iota-test-validator docker image"
+echo "Building iota docker image"
 echo "Dockerfile: \t$DOCKERFILE"
 echo "docker context: $REPO_ROOT"
 echo "build date: \t$BUILD_DATE"
@@ -24,5 +24,6 @@ echo
 docker build --ssh default -f "$DOCKERFILE" "$REPO_ROOT" \
 	--build-arg GIT_REVISION="$GIT_REVISION" \
 	--build-arg BUILD_DATE="$BUILD_DATE" \
+	--build-arg CARGO_BUILD_FEATURES="$CARGO_BUILD_FEATURES" \
 	--target runtime \
 	"$@"

--- a/docker/pg-services-local/docker-compose.yaml
+++ b/docker/pg-services-local/docker-compose.yaml
@@ -1,9 +1,9 @@
 services:
   local-network:
-    image: iota-test-validator
+    image: iota
     build:
       context: ../../
-      dockerfile: docker/iota-test-validator/Dockerfile
+      dockerfile: docker/iota/Dockerfile
       args:
         - GIT_REVISION
         - BUILD_DATE
@@ -16,12 +16,13 @@ services:
       - RUST_BACKTRACE=1
       - RUST_LOG=info
     command:
-      - /usr/local/bin/iota-test-validator
-      - --fullnode-rpc-host=0.0.0.0
+      - /usr/local/bin/iota
+      - start
+      - --with-faucet=0.0.0.0:9123
       - --fullnode-rpc-port=9000
-      - --faucet-port=9123
       - --epoch-duration-ms=120000
       - --remote-migration-snapshots=https://stardust-objects.s3.eu-central-1.amazonaws.com/iota/alphanet/test/stardust_object_snapshot.bin.gz
+      - --force-regenesis
     expose:
       - 9000
     ports:


### PR DESCRIPTION
# Description of change

This patch configures the docker build for `iota` and removes the `iota-test-validator` from `docker` configurations.

It further refactors `pg-services-local` to use `iota start` from the new `iota` image.

Finally it adds a fix in the `iota start` call in `_e2e.yml` that was observed during testing `iota start` as part of this task.

## Links to any relevant issues

Fixes #2768 

## How the change has been tested

```
$ pushd docker/iota
$ ./build -t iota
$ popd
```
or
```
$ pushd docker/pg-services-local
$ docker compose build --no-cache local-network
$ popd
```

Then run the network locally with

```
$ pushd docker/pg-services-local
$ docker compose up local-network
```
