### PR TITLE
fix(iota-core): tests

### DIFF
--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -5004,8 +5004,7 @@ async fn test_consensus_message_processed() {
     );
 }
 
-// TODO: the following test should be enabled when we bump the protocol version.
-#[ignore]
+#[ignore = "https://github.com/iotaledger/iota/issues/2793"]
 #[test]
 fn test_choose_next_system_packages() {
     telemetry_subscribers::init_for_testing();

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -5004,6 +5004,8 @@ async fn test_consensus_message_processed() {
     );
 }
 
+// TODO: the following test should be enabled when we bump the protocol version.
+#[ignore]
 #[test]
 fn test_choose_next_system_packages() {
     telemetry_subscribers::init_for_testing();

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/missing_type_v2/sources/other_module.move
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/missing_type_v2/sources/other_module.move
@@ -3,5 +3,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module base_addr::other_module {
-    public struct X {}
 }

--- a/crates/iota-core/src/unit_tests/move_package_publish_tests.rs
+++ b/crates/iota-core/src/unit_tests/move_package_publish_tests.rs
@@ -215,7 +215,7 @@ async fn test_generate_lock_file() {
 
         [move]
         version = 2
-        manifest_digest = "8BDC303EBB7D536EAD57F37F6C73A9D6170B779731739A860581007DA95C2487"
+        manifest_digest = "78ED00C216B5A73463BD935B7AD1AB6CAF8ECA9ACD7FFCC19F3462EBD1D83EC3"
         deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
         dependencies = [
           { name = "Examples" },
@@ -229,10 +229,6 @@ async fn test_generate_lock_file() {
         dependencies = [
           { name = "Iota" },
         ]
-
-        [[move.package]]
-        name = "MoveStdlib"
-        source = { local = "../../../../../iota-framework/packages/move-stdlib" }
 
         [[move.package]]
         name = "Iota"

--- a/crates/iota-core/tests/staged/iota.yaml
+++ b/crates/iota-core/tests/staged/iota.yaml
@@ -1,3 +1,4 @@
+---
 AccountAddress:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -5,11 +6,11 @@ AccountAddress:
       SIZE: 32
 ActiveJwk:
   STRUCT:
-  - jwk_id:
-      TYPENAME: JwkId
-  - jwk:
-      TYPENAME: JWK
-  - epoch: U64
+    - jwk_id:
+        TYPENAME: JwkId
+    - jwk:
+        TYPENAME: JWK
+    - epoch: U64
 Argument:
   ENUM:
     0:
@@ -23,22 +24,22 @@ Argument:
     3:
       NestedResult:
         TUPLE:
-        - U16
-        - U16
+          - U16
+          - U16
 AuthenticatorStateExpire:
   STRUCT:
-  - min_epoch: U64
-  - authenticator_obj_initial_shared_version:
-      TYPENAME: SequenceNumber
+    - min_epoch: U64
+    - authenticator_obj_initial_shared_version:
+        TYPENAME: SequenceNumber
 AuthenticatorStateUpdate:
   STRUCT:
-  - epoch: U64
-  - round: U64
-  - new_active_jwks:
-      SEQ:
-        TYPENAME: ActiveJwk
-  - authenticator_obj_initial_shared_version:
-      TYPENAME: SequenceNumber
+    - epoch: U64
+    - round: U64
+    - new_active_jwks:
+        SEQ:
+          TYPENAME: ActiveJwk
+    - authenticator_obj_initial_shared_version:
+        TYPENAME: SequenceNumber
 AuthorityPublicKeyBytes:
   NEWTYPESTRUCT: BYTES
 CallArg:
@@ -56,22 +57,22 @@ ChainIdentifier:
     TYPENAME: CheckpointDigest
 ChangeEpoch:
   STRUCT:
-  - epoch: U64
-  - protocol_version:
-      TYPENAME: ProtocolVersion
-  - storage_charge: U64
-  - computation_charge: U64
-  - storage_rebate: U64
-  - non_refundable_storage_fee: U64
-  - epoch_start_timestamp_ms: U64
-  - system_packages:
-      SEQ:
-        TUPLE:
-        - TYPENAME: SequenceNumber
-        - SEQ:
-            SEQ: U8
-        - SEQ:
-            TYPENAME: ObjectID
+    - epoch: U64
+    - protocol_version:
+        TYPENAME: ProtocolVersion
+    - storage_charge: U64
+    - computation_charge: U64
+    - storage_rebate: U64
+    - non_refundable_storage_fee: U64
+    - epoch_start_timestamp_ms: U64
+    - system_packages:
+        SEQ:
+          TUPLE:
+            - TYPENAME: SequenceNumber
+            - SEQ:
+                SEQ: U8
+            - SEQ:
+                TYPENAME: ObjectID
 CheckpointCommitment:
   ENUM:
     0:
@@ -89,37 +90,37 @@ CheckpointContentsDigest:
     TYPENAME: Digest
 CheckpointContentsV1:
   STRUCT:
-  - transactions:
-      SEQ:
-        TYPENAME: ExecutionDigests
-  - user_signatures:
-      SEQ:
+    - transactions:
         SEQ:
-          TYPENAME: GenericSignature
+          TYPENAME: ExecutionDigests
+    - user_signatures:
+        SEQ:
+          SEQ:
+            TYPENAME: GenericSignature
 CheckpointDigest:
   NEWTYPESTRUCT:
     TYPENAME: Digest
 CheckpointSummary:
   STRUCT:
-  - epoch: U64
-  - sequence_number: U64
-  - network_total_transactions: U64
-  - content_digest:
-      TYPENAME: CheckpointContentsDigest
-  - previous_digest:
-      OPTION:
-        TYPENAME: CheckpointDigest
-  - epoch_rolling_gas_cost_summary:
-      TYPENAME: GasCostSummary
-  - timestamp_ms: U64
-  - checkpoint_commitments:
-      SEQ:
-        TYPENAME: CheckpointCommitment
-  - end_of_epoch_data:
-      OPTION:
-        TYPENAME: EndOfEpochData
-  - version_specific_data:
-      SEQ: U8
+    - epoch: U64
+    - sequence_number: U64
+    - network_total_transactions: U64
+    - content_digest:
+        TYPENAME: CheckpointContentsDigest
+    - previous_digest:
+        OPTION:
+          TYPENAME: CheckpointDigest
+    - epoch_rolling_gas_cost_summary:
+        TYPENAME: GasCostSummary
+    - timestamp_ms: U64
+    - checkpoint_commitments:
+        SEQ:
+          TYPENAME: CheckpointCommitment
+    - end_of_epoch_data:
+        OPTION:
+          TYPENAME: EndOfEpochData
+    - version_specific_data:
+        SEQ: U8
 Command:
   ENUM:
     0:
@@ -129,44 +130,44 @@ Command:
     1:
       TransferObjects:
         TUPLE:
-        - SEQ:
-            TYPENAME: Argument
-        - TYPENAME: Argument
+          - SEQ:
+              TYPENAME: Argument
+          - TYPENAME: Argument
     2:
       SplitCoins:
         TUPLE:
-        - TYPENAME: Argument
-        - SEQ:
-            TYPENAME: Argument
+          - TYPENAME: Argument
+          - SEQ:
+              TYPENAME: Argument
     3:
       MergeCoins:
         TUPLE:
-        - TYPENAME: Argument
-        - SEQ:
-            TYPENAME: Argument
+          - TYPENAME: Argument
+          - SEQ:
+              TYPENAME: Argument
     4:
       Publish:
         TUPLE:
-        - SEQ:
-            SEQ: U8
-        - SEQ:
-            TYPENAME: ObjectID
+          - SEQ:
+              SEQ: U8
+          - SEQ:
+              TYPENAME: ObjectID
     5:
       MakeMoveVec:
         TUPLE:
-        - OPTION:
-            TYPENAME: TypeTag
-        - SEQ:
-            TYPENAME: Argument
+          - OPTION:
+              TYPENAME: TypeTag
+          - SEQ:
+              TYPENAME: Argument
     6:
       Upgrade:
         TUPLE:
-        - SEQ:
-            SEQ: U8
-        - SEQ:
-            TYPENAME: ObjectID
-        - TYPENAME: ObjectID
-        - TYPENAME: Argument
+          - SEQ:
+              SEQ: U8
+          - SEQ:
+              TYPENAME: ObjectID
+          - TYPENAME: ObjectID
+          - TYPENAME: Argument
 CommandArgumentError:
   ENUM:
     0:
@@ -180,16 +181,16 @@ CommandArgumentError:
     4:
       IndexOutOfBounds:
         STRUCT:
-        - idx: U16
+          - idx: U16
     5:
       SecondaryIndexOutOfBounds:
         STRUCT:
-        - result_idx: U16
-        - secondary_idx: U16
+          - result_idx: U16
+          - secondary_idx: U16
     6:
       InvalidResultArity:
         STRUCT:
-        - result_idx: U16
+          - result_idx: U16
     7:
       InvalidGasCoinUsage: UNIT
     8:
@@ -233,9 +234,9 @@ ConsensusCommitDigest:
     TYPENAME: Digest
 ConsensusCommitPrologue:
   STRUCT:
-  - epoch: U64
-  - round: U64
-  - commit_timestamp_ms: U64
+    - epoch: U64
+    - round: U64
+    - commit_timestamp_ms: U64
 ConsensusCommitPrologueV2:
   STRUCT:
     - epoch: U64
@@ -288,34 +289,34 @@ Digest:
   NEWTYPESTRUCT: BYTES
 ECMHLiveObjectSetDigest:
   STRUCT:
-  - digest:
-      TYPENAME: Digest
+    - digest:
+        TYPENAME: Digest
 EffectsAuxDataDigest:
   NEWTYPESTRUCT:
     TYPENAME: Digest
 EffectsObjectChange:
   STRUCT:
-  - input_state:
-      TYPENAME: ObjectIn
-  - output_state:
-      TYPENAME: ObjectOut
-  - id_operation:
-      TYPENAME: IDOperation
+    - input_state:
+        TYPENAME: ObjectIn
+    - output_state:
+        TYPENAME: ObjectOut
+    - id_operation:
+        TYPENAME: IDOperation
 EmptySignInfo:
   STRUCT: []
 EndOfEpochData:
   STRUCT:
-  - nextEpochCommittee:
-      SEQ:
-        TUPLE:
-        - TYPENAME: AuthorityPublicKeyBytes
-        - U64
-  - nextEpochProtocolVersion:
-      TYPENAME: ProtocolVersion
-  - epochCommitments:
-      SEQ:
-        TYPENAME: CheckpointCommitment
-  - epochSupplyChange: I64
+    - nextEpochCommittee:
+        SEQ:
+          TUPLE:
+            - TYPENAME: AuthorityPublicKeyBytes
+            - U64
+    - nextEpochProtocolVersion:
+        TYPENAME: ProtocolVersion
+    - epochCommitments:
+        SEQ:
+          TYPENAME: CheckpointCommitment
+    - epochSupplyChange: I64
 EndOfEpochTransactionKind:
   ENUM:
     0:
@@ -342,33 +343,33 @@ EndOfEpochTransactionKind:
           TYPENAME: SequenceNumber
 Envelope:
   STRUCT:
-  - data:
-      TYPENAME: SenderSignedData
-  - auth_signature:
-      TYPENAME: EmptySignInfo
+    - data:
+        TYPENAME: SenderSignedData
+    - auth_signature:
+        TYPENAME: EmptySignInfo
 Event:
   STRUCT:
-  - package_id:
-      TYPENAME: ObjectID
-  - transaction_module:
-      TYPENAME: Identifier
-  - sender:
-      TYPENAME: IotaAddress
-  - type_:
-      TYPENAME: StructTag
-  - contents: BYTES
+    - package_id:
+        TYPENAME: ObjectID
+    - transaction_module:
+        TYPENAME: Identifier
+    - sender:
+        TYPENAME: IotaAddress
+    - type_:
+        TYPENAME: StructTag
+    - contents: BYTES
 ExecutionData:
   STRUCT:
-  - transaction:
-      TYPENAME: Envelope
-  - effects:
-      TYPENAME: TransactionEffects
+    - transaction:
+        TYPENAME: Envelope
+    - effects:
+        TYPENAME: TransactionEffects
 ExecutionDigests:
   STRUCT:
-  - transaction:
-      TYPENAME: TransactionDigest
-  - effects:
-      TYPENAME: TransactionEffectsDigest
+    - transaction:
+        TYPENAME: TransactionDigest
+    - effects:
+        TYPENAME: TransactionEffectsDigest
 ExecutionFailureStatus:
   ENUM:
     0:
@@ -382,18 +383,18 @@ ExecutionFailureStatus:
     4:
       MoveObjectTooBig:
         STRUCT:
-        - object_size: U64
-        - max_object_size: U64
+          - object_size: U64
+          - max_object_size: U64
     5:
       MovePackageTooBig:
         STRUCT:
-        - object_size: U64
-        - max_object_size: U64
+          - object_size: U64
+          - max_object_size: U64
     6:
       CircularObjectOwnership:
         STRUCT:
-        - object:
-            TYPENAME: ObjectID
+          - object:
+              TYPENAME: ObjectID
     7:
       InsufficientCoinBalance: UNIT
     8:
@@ -409,8 +410,8 @@ ExecutionFailureStatus:
     12:
       MoveAbort:
         TUPLE:
-        - TYPENAME: MoveLocation
-        - U64
+          - TYPENAME: MoveLocation
+          - U64
     13:
       VMVerificationOrDeserializationError: UNIT
     14:
@@ -426,31 +427,31 @@ ExecutionFailureStatus:
     19:
       CommandArgumentError:
         STRUCT:
-        - arg_idx: U16
-        - kind:
-            TYPENAME: CommandArgumentError
+          - arg_idx: U16
+          - kind:
+              TYPENAME: CommandArgumentError
     20:
       TypeArgumentError:
         STRUCT:
-        - argument_idx: U16
-        - kind:
-            TYPENAME: TypeArgumentError
+          - argument_idx: U16
+          - kind:
+              TYPENAME: TypeArgumentError
     21:
       UnusedValueWithoutDrop:
         STRUCT:
-        - result_idx: U16
-        - secondary_idx: U16
+          - result_idx: U16
+          - secondary_idx: U16
     22:
       InvalidPublicFunctionReturnType:
         STRUCT:
-        - idx: U16
+          - idx: U16
     23:
       InvalidTransferObject: UNIT
     24:
       EffectsTooLarge:
         STRUCT:
-        - current_size: U64
-        - max_size: U64
+          - current_size: U64
+          - max_size: U64
     25:
       PublishUpgradeMissingDependency: UNIT
     26:
@@ -458,13 +459,13 @@ ExecutionFailureStatus:
     27:
       PackageUpgradeError:
         STRUCT:
-        - upgrade_error:
-            TYPENAME: PackageUpgradeError
+          - upgrade_error:
+              TYPENAME: PackageUpgradeError
     28:
       WrittenObjectsTooLarge:
         STRUCT:
-        - current_size: U64
-        - max_size: U64
+          - current_size: U64
+          - max_size: U64
     29:
       CertificateDenied: UNIT
     30:
@@ -497,25 +498,25 @@ ExecutionStatus:
     1:
       Failure:
         STRUCT:
-        - error:
-            TYPENAME: ExecutionFailureStatus
-        - command:
-            OPTION: U64
+          - error:
+              TYPENAME: ExecutionFailureStatus
+          - command:
+              OPTION: U64
 FullCheckpointContents:
   STRUCT:
-  - transactions:
-      SEQ:
-        TYPENAME: ExecutionData
-  - user_signatures:
-      SEQ:
+    - transactions:
         SEQ:
-          TYPENAME: GenericSignature
+          TYPENAME: ExecutionData
+    - user_signatures:
+        SEQ:
+          SEQ:
+            TYPENAME: GenericSignature
 GasCostSummary:
   STRUCT:
-  - computationCost: U64
-  - storageCost: U64
-  - storageRebate: U64
-  - nonRefundableStorageFee: U64
+    - computationCost: U64
+    - storageCost: U64
+    - storageRebate: U64
+    - nonRefundableStorageFee: U64
 GasData:
   STRUCT:
     - payment:
@@ -536,18 +537,18 @@ GenesisObject:
     0:
       RawObject:
         STRUCT:
-        - data:
-            TYPENAME: Data
-        - owner:
-            TYPENAME: Owner
+          - data:
+              TYPENAME: Data
+          - owner:
+              TYPENAME: Owner
 GenesisTransaction:
   STRUCT:
-  - objects:
-      SEQ:
-        TYPENAME: GenesisObject
-  - events:
-      SEQ:
-        TYPENAME: Event
+    - objects:
+        SEQ:
+          TYPENAME: GenesisObject
+    - events:
+        SEQ:
+          TYPENAME: Event
 IDOperation:
   ENUM:
     0:
@@ -560,15 +561,15 @@ Identifier:
   NEWTYPESTRUCT: STR
 Intent:
   STRUCT:
-  - scope: U8
-  - version: U8
-  - app_id: U8
+    - scope: U8
+    - version: U8
+    - app_id: U8
 IntentMessage:
   STRUCT:
-  - intent:
-      TYPENAME: Intent
-  - value:
-      TYPENAME: TransactionData
+    - intent:
+        TYPENAME: Intent
+    - value:
+        TYPENAME: TransactionData
 IotaAddress:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -576,40 +577,40 @@ IotaAddress:
       SIZE: 32
 JWK:
   STRUCT:
-  - kty: STR
-  - e: STR
-  - n: STR
-  - alg: STR
+    - kty: STR
+    - e: STR
+    - n: STR
+    - alg: STR
 JwkId:
   STRUCT:
-  - iss: STR
-  - kid: STR
+    - iss: STR
+    - kid: STR
 ModuleId:
   STRUCT:
-  - address:
-      TYPENAME: AccountAddress
-  - name:
-      TYPENAME: Identifier
+    - address:
+        TYPENAME: AccountAddress
+    - name:
+        TYPENAME: Identifier
 MoveLocation:
   STRUCT:
-  - module:
-      TYPENAME: ModuleId
-  - function: U16
-  - instruction: U16
-  - function_name:
-      OPTION: STR
+    - module:
+        TYPENAME: ModuleId
+    - function: U16
+    - instruction: U16
+    - function_name:
+        OPTION: STR
 MoveLocationOpt:
   NEWTYPESTRUCT:
     OPTION:
       TYPENAME: MoveLocation
 MoveObject:
   STRUCT:
-  - type_:
-      TYPENAME: MoveObjectType
-  - has_public_transfer: BOOL
-  - version:
-      TYPENAME: SequenceNumber
-  - contents: BYTES
+    - type_:
+        TYPENAME: MoveObjectType
+    - has_public_transfer: BOOL
+    - version:
+        TYPENAME: SequenceNumber
+    - contents: BYTES
 MoveObjectType:
   NEWTYPESTRUCT:
     TYPENAME: MoveObjectType_
@@ -629,63 +630,63 @@ MoveObjectType_:
           TYPENAME: TypeTag
 MovePackage:
   STRUCT:
-  - id:
-      TYPENAME: ObjectID
-  - version:
-      TYPENAME: SequenceNumber
-  - module_map:
-      MAP:
-        KEY: STR
-        VALUE: BYTES
-  - type_origin_table:
-      SEQ:
-        TYPENAME: TypeOrigin
-  - linkage_table:
-      MAP:
-        KEY:
-          TYPENAME: ObjectID
-        VALUE:
-          TYPENAME: UpgradeInfo
+    - id:
+        TYPENAME: ObjectID
+    - version:
+        TYPENAME: SequenceNumber
+    - module_map:
+        MAP:
+          KEY: STR
+          VALUE: BYTES
+    - type_origin_table:
+        SEQ:
+          TYPENAME: TypeOrigin
+    - linkage_table:
+        MAP:
+          KEY:
+            TYPENAME: ObjectID
+          VALUE:
+            TYPENAME: UpgradeInfo
 MultiSig:
   STRUCT:
-  - sigs:
-      SEQ:
-        TYPENAME: CompressedSignature
-  - bitmap: U16
-  - multisig_pk:
-      TYPENAME: MultiSigPublicKey
+    - sigs:
+        SEQ:
+          TYPENAME: CompressedSignature
+    - bitmap: U16
+    - multisig_pk:
+        TYPENAME: MultiSigPublicKey
 MultiSigPublicKey:
   STRUCT:
-  - pk_map:
-      SEQ:
-        TUPLE:
-        - TYPENAME: PublicKey
-        - U8
-  - threshold: U16
+    - pk_map:
+        SEQ:
+          TUPLE:
+            - TYPENAME: PublicKey
+            - U8
+    - threshold: U16
 ObjectArg:
   ENUM:
     0:
       ImmOrOwnedObject:
         NEWTYPE:
           TUPLE:
-          - TYPENAME: ObjectID
-          - TYPENAME: SequenceNumber
-          - TYPENAME: ObjectDigest
+            - TYPENAME: ObjectID
+            - TYPENAME: SequenceNumber
+            - TYPENAME: ObjectDigest
     1:
       SharedObject:
         STRUCT:
-        - id:
-            TYPENAME: ObjectID
-        - initial_shared_version:
-            TYPENAME: SequenceNumber
-        - mutable: BOOL
+          - id:
+              TYPENAME: ObjectID
+          - initial_shared_version:
+              TYPENAME: SequenceNumber
+          - mutable: BOOL
     2:
       Receiving:
         NEWTYPE:
           TUPLE:
-          - TYPENAME: ObjectID
-          - TYPENAME: SequenceNumber
-          - TYPENAME: ObjectDigest
+            - TYPENAME: ObjectID
+            - TYPENAME: SequenceNumber
+            - TYPENAME: ObjectDigest
 ObjectDigest:
   NEWTYPESTRUCT:
     TYPENAME: Digest
@@ -700,10 +701,10 @@ ObjectIn:
       Exist:
         NEWTYPE:
           TUPLE:
-          - TUPLE:
-            - TYPENAME: SequenceNumber
-            - TYPENAME: ObjectDigest
-          - TYPENAME: Owner
+            - TUPLE:
+                - TYPENAME: SequenceNumber
+                - TYPENAME: ObjectDigest
+            - TYPENAME: Owner
 ObjectInfoRequestKind:
   ENUM:
     0:
@@ -720,14 +721,14 @@ ObjectOut:
       ObjectWrite:
         NEWTYPE:
           TUPLE:
-          - TYPENAME: ObjectDigest
-          - TYPENAME: Owner
+            - TYPENAME: ObjectDigest
+            - TYPENAME: Owner
     2:
       PackageWrite:
         NEWTYPE:
           TUPLE:
-          - TYPENAME: SequenceNumber
-          - TYPENAME: ObjectDigest
+            - TYPENAME: SequenceNumber
+            - TYPENAME: ObjectDigest
 Owner:
   ENUM:
     0:
@@ -741,8 +742,8 @@ Owner:
     2:
       Shared:
         STRUCT:
-        - initial_shared_version:
-            TYPENAME: SequenceNumber
+          - initial_shared_version:
+              TYPENAME: SequenceNumber
     3:
       Immutable: UNIT
 PackageUpgradeError:
@@ -750,53 +751,53 @@ PackageUpgradeError:
     0:
       UnableToFetchPackage:
         STRUCT:
-        - package_id:
-            TYPENAME: ObjectID
+          - package_id:
+              TYPENAME: ObjectID
     1:
       NotAPackage:
         STRUCT:
-        - object_id:
-            TYPENAME: ObjectID
+          - object_id:
+              TYPENAME: ObjectID
     2:
       IncompatibleUpgrade: UNIT
     3:
       DigestDoesNotMatch:
         STRUCT:
-        - digest:
-            SEQ: U8
+          - digest:
+              SEQ: U8
     4:
       UnknownUpgradePolicy:
         STRUCT:
-        - policy: U8
+          - policy: U8
     5:
       PackageIDDoesNotMatch:
         STRUCT:
-        - package_id:
-            TYPENAME: ObjectID
-        - ticket_id:
-            TYPENAME: ObjectID
+          - package_id:
+              TYPENAME: ObjectID
+          - ticket_id:
+              TYPENAME: ObjectID
 ProgrammableMoveCall:
   STRUCT:
-  - package:
-      TYPENAME: ObjectID
-  - module:
-      TYPENAME: Identifier
-  - function:
-      TYPENAME: Identifier
-  - type_arguments:
-      SEQ:
-        TYPENAME: TypeTag
-  - arguments:
-      SEQ:
-        TYPENAME: Argument
+    - package:
+        TYPENAME: ObjectID
+    - module:
+        TYPENAME: Identifier
+    - function:
+        TYPENAME: Identifier
+    - type_arguments:
+        SEQ:
+          TYPENAME: TypeTag
+    - arguments:
+        SEQ:
+          TYPENAME: Argument
 ProgrammableTransaction:
   STRUCT:
-  - inputs:
-      SEQ:
-        TYPENAME: CallArg
-  - commands:
-      SEQ:
-        TYPENAME: Command
+    - inputs:
+        SEQ:
+          TYPENAME: CallArg
+    - commands:
+        SEQ:
+          TYPENAME: Command
 ProtocolVersion:
   NEWTYPESTRUCT: U64
 PublicKey:
@@ -827,24 +828,24 @@ RandomnessRound:
   NEWTYPESTRUCT: U64
 RandomnessStateUpdate:
   STRUCT:
-  - epoch: U64
-  - randomness_round:
-      TYPENAME: RandomnessRound
-  - random_bytes:
-      SEQ: U8
-  - randomness_obj_initial_shared_version:
-      TYPENAME: SequenceNumber
+    - epoch: U64
+    - randomness_round:
+        TYPENAME: RandomnessRound
+    - random_bytes:
+        SEQ: U8
+    - randomness_obj_initial_shared_version:
+        TYPENAME: SequenceNumber
 SenderSignedData:
   NEWTYPESTRUCT:
     SEQ:
       TYPENAME: SenderSignedTransaction
 SenderSignedTransaction:
   STRUCT:
-  - intent_message:
-      TYPENAME: IntentMessage
-  - tx_signatures:
-      SEQ:
-        TYPENAME: GenericSignature
+    - intent_message:
+        TYPENAME: IntentMessage
+    - tx_signatures:
+        SEQ:
+          TYPENAME: GenericSignature
 SequenceNumber:
   NEWTYPESTRUCT: U64
 StructTag:
@@ -858,11 +859,6 @@ StructTag:
     - type_args:
         SEQ:
           TYPENAME: TypeTag
-IotaAddress:
-  NEWTYPESTRUCT:
-    TUPLEARRAY:
-      CONTENT: U8
-      SIZE: 32
 TransactionData:
   ENUM:
     0:
@@ -897,111 +893,111 @@ TransactionEffectsDigest:
     TYPENAME: Digest
 TransactionEffectsV1:
   STRUCT:
-  - status:
-      TYPENAME: ExecutionStatus
-  - executed_epoch: U64
-  - gas_used:
-      TYPENAME: GasCostSummary
-  - modified_at_versions:
-      SEQ:
-        TUPLE:
-        - TYPENAME: ObjectID
-        - TYPENAME: SequenceNumber
-  - shared_objects:
-      SEQ:
-        TUPLE:
-        - TYPENAME: ObjectID
-        - TYPENAME: SequenceNumber
-        - TYPENAME: ObjectDigest
-  - transaction_digest:
-      TYPENAME: TransactionDigest
-  - created:
-      SEQ:
-        TUPLE:
-        - TUPLE:
-          - TYPENAME: ObjectID
-          - TYPENAME: SequenceNumber
-          - TYPENAME: ObjectDigest
-        - TYPENAME: Owner
-  - mutated:
-      SEQ:
-        TUPLE:
-        - TUPLE:
-          - TYPENAME: ObjectID
-          - TYPENAME: SequenceNumber
-          - TYPENAME: ObjectDigest
-        - TYPENAME: Owner
-  - unwrapped:
-      SEQ:
-        TUPLE:
-        - TUPLE:
-          - TYPENAME: ObjectID
-          - TYPENAME: SequenceNumber
-          - TYPENAME: ObjectDigest
-        - TYPENAME: Owner
-  - deleted:
-      SEQ:
-        TUPLE:
-        - TYPENAME: ObjectID
-        - TYPENAME: SequenceNumber
-        - TYPENAME: ObjectDigest
-  - unwrapped_then_deleted:
-      SEQ:
-        TUPLE:
-        - TYPENAME: ObjectID
-        - TYPENAME: SequenceNumber
-        - TYPENAME: ObjectDigest
-  - wrapped:
-      SEQ:
-        TUPLE:
-        - TYPENAME: ObjectID
-        - TYPENAME: SequenceNumber
-        - TYPENAME: ObjectDigest
-  - gas_object:
-      TUPLE:
-      - TUPLE:
-        - TYPENAME: ObjectID
-        - TYPENAME: SequenceNumber
-        - TYPENAME: ObjectDigest
-      - TYPENAME: Owner
-  - events_digest:
-      OPTION:
-        TYPENAME: TransactionEventsDigest
-  - dependencies:
-      SEQ:
+    - status:
+        TYPENAME: ExecutionStatus
+    - executed_epoch: U64
+    - gas_used:
+        TYPENAME: GasCostSummary
+    - modified_at_versions:
+        SEQ:
+          TUPLE:
+            - TYPENAME: ObjectID
+            - TYPENAME: SequenceNumber
+    - shared_objects:
+        SEQ:
+          TUPLE:
+            - TYPENAME: ObjectID
+            - TYPENAME: SequenceNumber
+            - TYPENAME: ObjectDigest
+    - transaction_digest:
         TYPENAME: TransactionDigest
+    - created:
+        SEQ:
+          TUPLE:
+            - TUPLE:
+                - TYPENAME: ObjectID
+                - TYPENAME: SequenceNumber
+                - TYPENAME: ObjectDigest
+            - TYPENAME: Owner
+    - mutated:
+        SEQ:
+          TUPLE:
+            - TUPLE:
+                - TYPENAME: ObjectID
+                - TYPENAME: SequenceNumber
+                - TYPENAME: ObjectDigest
+            - TYPENAME: Owner
+    - unwrapped:
+        SEQ:
+          TUPLE:
+            - TUPLE:
+                - TYPENAME: ObjectID
+                - TYPENAME: SequenceNumber
+                - TYPENAME: ObjectDigest
+            - TYPENAME: Owner
+    - deleted:
+        SEQ:
+          TUPLE:
+            - TYPENAME: ObjectID
+            - TYPENAME: SequenceNumber
+            - TYPENAME: ObjectDigest
+    - unwrapped_then_deleted:
+        SEQ:
+          TUPLE:
+            - TYPENAME: ObjectID
+            - TYPENAME: SequenceNumber
+            - TYPENAME: ObjectDigest
+    - wrapped:
+        SEQ:
+          TUPLE:
+            - TYPENAME: ObjectID
+            - TYPENAME: SequenceNumber
+            - TYPENAME: ObjectDigest
+    - gas_object:
+        TUPLE:
+          - TUPLE:
+              - TYPENAME: ObjectID
+              - TYPENAME: SequenceNumber
+              - TYPENAME: ObjectDigest
+          - TYPENAME: Owner
+    - events_digest:
+        OPTION:
+          TYPENAME: TransactionEventsDigest
+    - dependencies:
+        SEQ:
+          TYPENAME: TransactionDigest
 TransactionEffectsV2:
   STRUCT:
-  - status:
-      TYPENAME: ExecutionStatus
-  - executed_epoch: U64
-  - gas_used:
-      TYPENAME: GasCostSummary
-  - transaction_digest:
-      TYPENAME: TransactionDigest
-  - gas_object_index:
-      OPTION: U32
-  - events_digest:
-      OPTION:
-        TYPENAME: TransactionEventsDigest
-  - dependencies:
-      SEQ:
+    - status:
+        TYPENAME: ExecutionStatus
+    - executed_epoch: U64
+    - gas_used:
+        TYPENAME: GasCostSummary
+    - transaction_digest:
         TYPENAME: TransactionDigest
-  - lamport_version:
-      TYPENAME: SequenceNumber
-  - changed_objects:
-      SEQ:
-        TUPLE:
-        - TYPENAME: ObjectID
-        - TYPENAME: EffectsObjectChange
-  - unchanged_shared_objects:
-      SEQ:
-        TUPLE:
-        - TYPENAME: ObjectID
-        - TYPENAME: UnchangedSharedKind
-  - aux_data_digest:
-      OPTION:
-        TYPENAME: EffectsAuxDataDigest
+    - gas_object_index:
+        OPTION: U32
+    - events_digest:
+        OPTION:
+          TYPENAME: TransactionEventsDigest
+    - dependencies:
+        SEQ:
+          TYPENAME: TransactionDigest
+    - lamport_version:
+        TYPENAME: SequenceNumber
+    - changed_objects:
+        SEQ:
+          TUPLE:
+            - TYPENAME: ObjectID
+            - TYPENAME: EffectsObjectChange
+    - unchanged_shared_objects:
+        SEQ:
+          TUPLE:
+            - TYPENAME: ObjectID
+            - TYPENAME: UnchangedSharedKind
+    - aux_data_digest:
+        OPTION:
+          TYPENAME: EffectsAuxDataDigest
 TransactionEventsDigest:
   NEWTYPESTRUCT:
     TYPENAME: Digest
@@ -1114,8 +1110,8 @@ UnchangedSharedKind:
       ReadOnlyRoot:
         NEWTYPE:
           TUPLE:
-          - TYPENAME: SequenceNumber
-          - TYPENAME: ObjectDigest
+            - TYPENAME: SequenceNumber
+            - TYPENAME: ObjectDigest
     1:
       MutateDeleted:
         NEWTYPE:
@@ -1132,10 +1128,10 @@ UnchangedSharedKind:
       PerEpochConfig: UNIT
 UpgradeInfo:
   STRUCT:
-  - upgraded_id:
-      TYPENAME: ObjectID
-  - upgraded_version:
-      TYPENAME: SequenceNumber
+    - upgraded_id:
+        TYPENAME: ObjectID
+    - upgraded_version:
+        TYPENAME: SequenceNumber
 ZkLoginAuthenticatorAsBytes:
   NEWTYPESTRUCT:
     SEQ: U8


### PR DESCRIPTION
Fixes #2651 

1. `test_choose_next_system_packages` is ignored since we have only one protocol version.
2. `test_generate_lock_file` - the expected lock file content was updated.
3. `test_format` is fixed by updating the `iota.yaml` file.
4. `test_upgrade_package_missing_type` fixed the incorrectly merged related Move sources.
5. `test_congestion_control_execution_cancellation` should be run using `simtest`.
