### PR TITLE
fix(iota-indexer): ensure iota-indexer functionality

### DIFF
--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -91,7 +91,7 @@ To run the tests, a running postgres instance is required. The crate provides fo
 - integration tests (see [ingestion_tests](tests/ingestion_tests.rs)) to make sure the indexer correctly indexes transaction data from a full node by comparing the data in the database with the data received from the fullnode.
 
 ```sh
-cargo test --features pg_integration
+cargo nextest --features pg_integration --test-threads 1
 ```
 
 ## Steps to run locally with TiDB (experimental)

--- a/crates/iota-json-rpc/src/lib.rs
+++ b/crates/iota-json-rpc/src/lib.rs
@@ -20,11 +20,11 @@ use iota_json_rpc_api::{
 };
 use iota_open_rpc::{Module, Project};
 use iota_types::traffic_control::{PolicyConfig, RemoteFirewallConfig};
-use tokio_util::sync::CancellationToken;
 use jsonrpsee::{types::ErrorObjectOwned, Extensions, RpcModule};
 pub use object_changes::*;
 use prometheus::Registry;
 use tokio::runtime::Handle;
+use tokio_util::sync::CancellationToken;
 use tower_http::{
     cors::{AllowOrigin, CorsLayer},
     trace::TraceLayer,
@@ -236,9 +236,12 @@ impl JsonRpcServerBuilder {
         })?;
 
         let fut = async move {
-            axum::serve(listener, app.into_make_service())
-                .await
-                .unwrap();
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .unwrap();
             if let Some(cancel) = cancel {
                 // Signal that the server is shutting down, so other tasks can clean-up.
                 cancel.cancel();


### PR DESCRIPTION
# Description of change

This patch fixes the server builder in `iota-json-rpc` so that the `iota-indexer` works as expected.

It also updates the test instructions in `iota-indexer`.

## Links to any relevant issues

Fixes #2481 

## How the change has been tested

* All variants of the `iota-indexer` service (`fullnode-sync`, `rpc-worker`, `analytical-worker`) have been started successfully using the `docker/pg-services-local` configuration.
* `cargo nextest run -p iota-indexer --features pg_integration --test-threads 1`

The database has been manually checked for the expected results, and it has been verified that the genesis checkpoint is indexed successfully.

Later checkpoints are not indexed on account of #2780 