### PR TITLE
fix(iota-graphql-rpc): Transform stored transaction for genesis

### DIFF
--- a/crates/iota-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block.rs
@@ -444,8 +444,7 @@ impl TransactionBlock {
         // the nested queries.
         for mut stored in results {
             if stored.is_genesis() {
-                let mut conn = db.inner.get_pool();
-                stored = stored.set_genesis_large_object_as_inner_data(&mut conn)?;
+                stored = stored.set_genesis_large_object_as_inner_data(db.inner.get_pool())?;
             }
 
             let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();

--- a/crates/iota-graphql-rpc/src/types/transaction_block.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block.rs
@@ -442,7 +442,12 @@ impl TransactionBlock {
         // Defer to the provided checkpoint_viewed_at, but if it is not provided, use
         // the current available range. This sets a consistent upper bound for
         // the nested queries.
-        for stored in results {
+        for mut stored in results {
+            if stored.is_genesis() {
+                let mut conn = db.inner.get_pool();
+                stored = stored.set_genesis_large_object_as_inner_data(&mut conn)?;
+            }
+
             let cursor = stored.cursor(checkpoint_viewed_at).encode_cursor();
             let inner = TransactionBlockInner::try_from(stored)?;
             let transaction = TransactionBlock {

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -100,6 +100,10 @@ impl IndexerReader {
         })
     }
 
+    pub fn get_pool(&self) -> &crate::db::PgConnectionPool {
+        &self.pool
+    }
+
     fn get_connection(&self) -> Result<PgPoolConnection, IndexerError> {
         self.pool.get().map_err(|e| {
             IndexerError::PgPoolConnectionError(format!(


### PR DESCRIPTION
# Description of change

The genesis transaction data is stored as one large object in the database. When written to the database, the stored transaction for the genesis differs from other transactions as the fields `raw_transaction`, `effects` and `object_changes` are replaced with the actual pointer to the genesis object. When reading the genesis transaction from the database (the stored transaction) these must be replaced with the actual data to not run into deserialization issues.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/2824

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Run a GraphQL instance:

```sh
cargo run --bin iota-test-validator -- --with-indexer --pg-port 5432 --pg-db-name iota_indexer --graphql-host 127.0.0.1 --graphql-port 9125
```

The following query:

```
{
  transactionBlocks {
    edges {
      node {
        digest
        bcs
      }
    }
  }
}
```
## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
