### PR TITLE
fix(tooling-ci): Fix turbo-diff

### DIFF
--- a/.github/actions/turbo-diffs/action.yml
+++ b/.github/actions/turbo-diffs/action.yml
@@ -17,7 +17,7 @@ runs:
     - id: changes
       name: Detect changes
       shell: bash
-      run: echo "packages=$(pnpm --silent dlx turbo@1 run build --filter="...[origin/develop]" --dry=json | jq -c ".packages")" >> $GITHUB_OUTPUT
+      run: echo "packages=$(pnpm --silent dlx turbo@2 run build --filter="...[origin/develop]" --dry=json | jq -c ".packages")" >> $GITHUB_OUTPUT
     - name: Print changes for easy debugging
       shell: bash
       run: echo ${{ steps.changes.outputs.packages }}


### PR DESCRIPTION
# Description of change

Fix the `turbo-diff` workflow broken by the move to turbo v2.x.x
Close https://github.com/iotaledger/iota/issues/2851