### PR TITLE
fix(iota-rest-api): return the correct IOTA coin info

### DIFF
--- a/crates/iota-rest-api/openapi/openapi.json
+++ b/crates/iota-rest-api/openapi/openapi.json
@@ -1227,6 +1227,7 @@
       "CoinTreasury": {
         "type": "object",
         "required": [
+          "id",
           "total_supply"
         ],
         "properties": {
@@ -3959,6 +3960,7 @@
           "inactive_pools_id",
           "inactive_pools_size",
           "iota_total_supply",
+          "iota_treasury_cap_id",
           "max_validator_count",
           "min_validator_joining_stake",
           "pending_active_validators_id",
@@ -4043,6 +4045,14 @@
             "description": "The current IOTA supply.",
             "type": "string",
             "format": "u64"
+          },
+          "iota_treasury_cap_id": {
+            "description": "The `TreasuryCap<IOTA>` object ID.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ObjectId"
+              }
+            ]
           },
           "max_validator_count": {
             "description": "Maximum number of active validators at any moment. We do not allow the number of validators in any epoch to go above this.",

--- a/crates/iota-rest-api/src/system.rs
+++ b/crates/iota-rest-api/src/system.rs
@@ -90,6 +90,8 @@ pub struct SystemStateSummary {
     #[serde_as(as = "iota_types::iota_serde::BigInt<u64>")]
     #[schemars(with = "crate::_schemars::U64")]
     pub iota_total_supply: u64,
+    /// The `TreasuryCap<IOTA>` object ID.
+    pub iota_treasury_cap_id: ObjectId,
     /// The storage rebates of all the objects on-chain stored in the storage
     /// fund.
     #[serde_as(as = "iota_types::iota_serde::BigInt<u64>")]
@@ -433,6 +435,7 @@ impl From<iota_types::iota_system_state::iota_system_state_summary::IotaSystemSt
             protocol_version,
             system_state_version,
             iota_total_supply,
+            iota_treasury_cap_id,
             storage_fund_total_object_storage_rebates,
             storage_fund_non_refundable_balance,
             reference_gas_price,
@@ -468,6 +471,7 @@ impl From<iota_types::iota_system_state::iota_system_state_summary::IotaSystemSt
             protocol_version,
             system_state_version,
             iota_total_supply,
+            iota_treasury_cap_id: iota_treasury_cap_id.into(),
             storage_fund_total_object_storage_rebates,
             storage_fund_non_refundable_balance,
             reference_gas_price,

--- a/crates/iota-types/src/gas_coin.rs
+++ b/crates/iota-types/src/gas_coin.rs
@@ -189,6 +189,11 @@ mod checked {
             }
         }
 
+        /// Returns the `TreasuryCap<IOTA>` object ID.
+        pub fn id(&self) -> &ObjectID {
+            self.inner.id.object_id()
+        }
+
         /// Returns the total `Supply` of `Coin<IOTA>`.
         pub fn total_supply(&self) -> &Supply {
             &self.inner.total_supply

--- a/crates/iota-types/src/iota_system_state/iota_system_state_inner_v1.rs
+++ b/crates/iota-types/src/iota_system_state/iota_system_state_inner_v1.rs
@@ -665,6 +665,7 @@ impl IotaSystemStateTrait for IotaSystemStateInnerV1 {
             protocol_version,
             system_state_version,
             iota_total_supply: iota_treasury_cap.total_supply().value,
+            iota_treasury_cap_id: iota_treasury_cap.id().to_owned(),
             storage_fund_total_object_storage_rebates: storage_fund
                 .total_object_storage_rebates
                 .value(),

--- a/crates/iota-types/src/iota_system_state/iota_system_state_inner_v2.rs
+++ b/crates/iota-types/src/iota_system_state/iota_system_state_inner_v2.rs
@@ -264,6 +264,7 @@ impl IotaSystemStateTrait for IotaSystemStateInnerV2 {
             protocol_version,
             system_state_version,
             iota_total_supply: iota_treasury_cap.total_supply().value,
+            iota_treasury_cap_id: iota_treasury_cap.id().to_owned(),
             storage_fund_total_object_storage_rebates: storage_fund
                 .total_object_storage_rebates
                 .value(),

--- a/crates/iota-types/src/iota_system_state/iota_system_state_summary.rs
+++ b/crates/iota-types/src/iota_system_state/iota_system_state_summary.rs
@@ -44,6 +44,8 @@ pub struct IotaSystemStateSummary {
     #[schemars(with = "BigInt<u64>")]
     #[serde_as(as = "Readable<BigInt<u64>, _>")]
     pub iota_total_supply: u64,
+    /// The `TreasuryCap<IOTA>` object ID.
+    pub iota_treasury_cap_id: ObjectID,
     /// The storage rebates of all the objects on-chain stored in the storage
     /// fund.
     #[schemars(with = "BigInt<u64>")]
@@ -321,6 +323,7 @@ impl Default for IotaSystemStateSummary {
             protocol_version: 1,
             system_state_version: 1,
             iota_total_supply: 0,
+            iota_treasury_cap_id: ObjectID::ZERO,
             storage_fund_total_object_storage_rebates: 0,
             storage_fund_non_refundable_balance: 0,
             reference_gas_price: 1,


### PR DESCRIPTION
Fixes #2858 