### PR TITLE
fix(wallet): VisualAssetCard size for image with broken url.

### DIFF
--- a/apps/wallet/src/ui/app/components/nft-display/index.tsx
+++ b/apps/wallet/src/ui/app/components/nft-display/index.tsx
@@ -52,7 +52,7 @@ export function NFTDisplayCard({
     return (
         <div className={nftDisplayCardStyles({ isHoverable, wideView })}>
             <Loading loading={isPending}>
-                <div className="flex flex-col justify-center gap-sm text-center">
+                <div className="flex w-full flex-col justify-center gap-sm text-center">
                     {objectData?.data && isOwnerToken ? (
                         <Kiosk object={objectData} />
                     ) : (


### PR DESCRIPTION
Closes #2745

![CleanShot1](https://github.com/user-attachments/assets/8f9ca658-f8dc-4650-a6a4-2e3d1309535a)
