### PR TITLE
feat(iota-genesis-builder, iota-core): support migration transactions effects in genesis

### DIFF
--- a/crates/iota-config/src/genesis.rs
+++ b/crates/iota-config/src/genesis.rs
@@ -46,6 +46,7 @@ pub struct Genesis {
     effects: TransactionEffects,
     events: TransactionEvents,
     objects: Vec<Object>,
+    migration_txs_effects: Vec<TransactionEffects>,
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
@@ -56,6 +57,7 @@ pub struct UnsignedGenesis {
     pub effects: TransactionEffects,
     pub events: TransactionEvents,
     pub objects: Vec<Object>,
+    pub migration_txs_effects: Vec<TransactionEffects>,
 }
 
 // Hand implement PartialEq in order to get around the fact that AuthSigs don't
@@ -75,6 +77,7 @@ impl PartialEq for Genesis {
             && self.transaction == other.transaction
             && self.effects == other.effects
             && self.objects == other.objects
+            && self.migration_txs_effects == other.migration_txs_effects
     }
 }
 
@@ -88,6 +91,7 @@ impl Genesis {
         effects: TransactionEffects,
         events: TransactionEvents,
         objects: Vec<Object>,
+        migration_txs_effects: Vec<TransactionEffects>,
     ) -> Self {
         Self {
             checkpoint,
@@ -96,7 +100,12 @@ impl Genesis {
             effects,
             events,
             objects,
+            migration_txs_effects,
         }
+    }
+
+    pub fn migration_txs_effects(&self) -> &[TransactionEffects] {
+        &self.migration_txs_effects
     }
 
     pub fn into_objects(self) -> Vec<Object> {
@@ -226,6 +235,7 @@ impl Serialize for Genesis {
             effects: &'a TransactionEffects,
             events: &'a TransactionEvents,
             objects: &'a [Object],
+            migration_txs_effects: &'a [TransactionEffects],
         }
 
         let raw_genesis = RawGenesis {
@@ -235,6 +245,7 @@ impl Serialize for Genesis {
             effects: &self.effects,
             events: &self.events,
             objects: &self.objects,
+            migration_txs_effects: &self.migration_txs_effects,
         };
 
         if serializer.is_human_readable() {
@@ -262,6 +273,7 @@ impl<'de> Deserialize<'de> for Genesis {
             effects: TransactionEffects,
             events: TransactionEvents,
             objects: Vec<Object>,
+            migration_txs_effects: Vec<TransactionEffects>,
         }
 
         let raw_genesis = if deserializer.is_human_readable() {
@@ -279,6 +291,7 @@ impl<'de> Deserialize<'de> for Genesis {
             effects: raw_genesis.effects,
             events: raw_genesis.events,
             objects: raw_genesis.objects,
+            migration_txs_effects: raw_genesis.migration_txs_effects,
         })
     }
 }

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -1011,16 +1011,12 @@ fn calculate_migration_transactions(
     let avg_chunk_size = migration_objects.len() / MIGRATION_TX_MAX_AMOUNT;
     let remainder = migration_objects.len() % MIGRATION_TX_MAX_AMOUNT;
 
-    println!("CHUNK SIZE IS - {}", avg_chunk_size);
-    println!("MIGRATION OBJECTS LEN IS - {}", migration_objects.len());
-
     // For the first remainder transactions, the chunk size is chunk_size + 1.
     // For the remaining transactions, the chunk size is just chunk_size.
     let chunks =
         (0..MIGRATION_TX_MAX_AMOUNT).map(|i| avg_chunk_size + if i < remainder { 1 } else { 0 });
 
     let mut start_idx = 0;
-    let mut objects_len = 0;
     for chunk in chunks {
         let objects_per_chunk = match migration_objects.get(start_idx..start_idx + chunk) {
             Some(chunk) => chunk.to_vec(),
@@ -1039,14 +1035,7 @@ fn calculate_migration_transactions(
         migration_txs_effects.push(migration_effects);
 
         start_idx += chunk;
-        objects_len += objects.len();
     }
-
-    println!(
-        "migration_txs_effects LEN IS - {}",
-        migration_txs_effects.len()
-    );
-    println!("migration_txs_effects objects len LEN IS - {}", objects_len);
 }
 
 fn create_genesis_checkpoint(


### PR DESCRIPTION
# Description of change

Makes so that the initial migrated objects vector gets modified accordingly:

split timelock objects as indicated during the token distribution schedule creation
burn gas coin indicated in the token distribution schedule creation
burn timelock objects indicated in the token distribution schedule creation
This creates a vector of objects migration_objects that can be used to continue working on https://github.com/iotaledger/iota/issues/2879.

Accumulate migration txs effect in genesis in order to verify migration.blob data in future

## Links to any relevant issues

Fix #2879 .

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

`cargo run --release --bin iota genesis --working-dir test_iota_config -f --with-faucet --num-validators 1 --remote-migration-snapshots https://stardust-objects.s3.eu-central-1.amazonaws.com/iota/alphanet/latest/stardust_object_snapshot.bin.gz`
