### PR TITLE
chore(docs): remove TOCInline

### DIFF
--- a/docs/content/operator/validator-operation/ansible/README.mdx
+++ b/docs/content/operator/validator-operation/ansible/README.mdx
@@ -4,9 +4,7 @@ sidebar_label: Ansible Configuration
 
 
 import Configuration from './../../../../../nre/ansible/README.md';
-import TOCInline from '@theme/TOCInline';
 
 # Ansible Configuration
 
 <Configuration />
-<TOCInline toc={toc} />

--- a/docs/content/operator/validator-operation/docker/README.mdx
+++ b/docs/content/operator/validator-operation/docker/README.mdx
@@ -2,9 +2,7 @@
 sidebar_label: Docker Configuration
 ---
 import Configuration from './../../../../../nre/docker/README.md';
-import TOCInline from '@theme/TOCInline';
 
 # System Configuration
 
 <Configuration />
-<TOCInline toc={toc} />

--- a/docs/content/operator/validator-operation/systemd/README.mdx
+++ b/docs/content/operator/validator-operation/systemd/README.mdx
@@ -2,9 +2,7 @@
 sidebar_label: Systemd Configuration
 ---
 import Configuration from './../../../../../nre/systemd/README.md';
-import TOCInline from '@theme/TOCInline';
 
 # System Configuration
 
 <Configuration />
-<TOCInline toc={toc} />

--- a/docs/content/operator/validator-operation/validator-tasks.mdx
+++ b/docs/content/operator/validator-operation/validator-tasks.mdx
@@ -1,7 +1,5 @@
 import ValidatorTasks from './../../../../nre/validator_tasks.md';
-import TOCInline from '@theme/TOCInline';
 
 # Validator Tasks
 
 <ValidatorTasks />
-<TOCInline toc={toc} />

--- a/docs/content/operator/validator-tools.mdx
+++ b/docs/content/operator/validator-tools.mdx
@@ -1,7 +1,5 @@
 import ValidatorTools from './../../../nre/validator_tool.md';
-import TOCInline from '@theme/TOCInline';
 
 # Validator Tools
 
 <ValidatorTools />
-<TOCInline toc={toc} />


### PR DESCRIPTION
# Description of change

I think this is useless. We have a TOC already provided by default

## Type of change

- Documentation Fix

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
