### PR TITLE
feat(iota-indexer): add test for indexer_api

### DIFF
--- a/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
@@ -141,10 +141,6 @@ async fn query_events_supported_events() {
         let result = indexer_client
             .query_events(event_filter, None, None, None)
             .await;
-
-        assert!(!rpc_call_error_msg_matches(
-            result,
-            r#"{"code":-32603,"message": "Indexer does not support the feature with error: `This type of EventFilter is not supported.`"}"#,
-        ));
+        assert!(result.is_ok());
     }
 }

--- a/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
@@ -76,77 +76,75 @@ async fn query_events_unsupported_events() {
     // Get the current time in milliseconds since the UNIX epoch
     let now_millis = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
-        .expect("Time went backwards")
+        .unwrap()
         .as_millis();
 
     // Subtract 10 minutes from the current time
     let ten_minutes_ago = now_millis - (10 * 60 * 1000); // 600 seconds = 10 minutes
 
     let unsupported_filters = vec![
-        (EventFilter::All(vec![]), true),
-        (EventFilter::Any(vec![]), true),
-        (
-            EventFilter::And(
-                Box::new(EventFilter::Any(vec![])),
-                Box::new(EventFilter::Any(vec![])),
-            ),
-            true,
+        EventFilter::All(vec![]),
+        EventFilter::Any(vec![]),
+        EventFilter::And(
+            Box::new(EventFilter::Any(vec![])),
+            Box::new(EventFilter::Any(vec![])),
         ),
-        (
-            EventFilter::Or(
-                Box::new(EventFilter::Any(vec![])),
-                Box::new(EventFilter::Any(vec![])),
-            ),
-            true,
+        EventFilter::Or(
+            Box::new(EventFilter::Any(vec![])),
+            Box::new(EventFilter::Any(vec![])),
         ),
-        (
-            EventFilter::TimeRange {
-                start_time: ten_minutes_ago as u64,
-                end_time: now_millis as u64,
-            },
-            true,
-        ),
-        (
-            EventFilter::MoveEventField {
-                path: String::default(),
-                value: serde_json::Value::Bool(true),
-            },
-            true,
-        ),
-        (EventFilter::Sender(IotaAddress::ZERO), false),
-        (EventFilter::Transaction(TransactionDigest::ZERO), false),
-        (EventFilter::Package(ObjectID::ZERO), false),
-        (
-            EventFilter::MoveEventModule {
-                package: ObjectID::ZERO,
-                module: "x".parse().unwrap(),
-            },
-            false,
-        ),
-        (
-            EventFilter::MoveEventType("0xabcd::MyModule::Foo".parse().unwrap()),
-            false,
-        ),
-        (
-            EventFilter::MoveModule {
-                package: ObjectID::ZERO,
-                module: "x".parse().unwrap(),
-            },
-            false,
-        ),
+        EventFilter::TimeRange {
+            start_time: ten_minutes_ago as u64,
+            end_time: now_millis as u64,
+        },
+        EventFilter::MoveEventField {
+            path: String::default(),
+            value: serde_json::Value::Bool(true),
+        },
     ];
 
-    for (event_filter, expected) in unsupported_filters {
+    for event_filter in unsupported_filters {
         let result = indexer_client
             .query_events(event_filter, None, None, None)
             .await;
 
-        assert_eq!(
-            expected,
-            rpc_call_error_msg_matches(
-                result,
-                r#"{"code":-32603,"message": "Indexer does not support the feature with error: `This type of EventFilter is not supported.`"}"#,
-            )
-        );
+        assert!(rpc_call_error_msg_matches(
+            result,
+            r#"{"code":-32603,"message": "Indexer does not support the feature with error: `This type of EventFilter is not supported.`"}"#,
+        ));
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn query_events_supported_events() {
+    let (_cluster, pg_store, indexer_client) =
+        start_test_cluster_with_read_write_indexer(None).await;
+    indexer_wait_for_checkpoint(&pg_store, 1).await;
+
+    let supported_filters = vec![
+        EventFilter::Sender(IotaAddress::ZERO),
+        EventFilter::Transaction(TransactionDigest::ZERO),
+        EventFilter::Package(ObjectID::ZERO),
+        EventFilter::MoveEventModule {
+            package: ObjectID::ZERO,
+            module: "x".parse().unwrap(),
+        },
+        EventFilter::MoveEventType("0xabcd::MyModule::Foo".parse().unwrap()),
+        EventFilter::MoveModule {
+            package: ObjectID::ZERO,
+            module: "x".parse().unwrap(),
+        },
+    ];
+
+    for event_filter in supported_filters {
+        let result = indexer_client
+            .query_events(event_filter, None, None, None)
+            .await;
+
+        assert!(!rpc_call_error_msg_matches(
+            result,
+            r#"{"code":-32603,"message": "Indexer does not support the feature with error: `This type of EventFilter is not supported.`"}"#,
+        ));
     }
 }

--- a/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
@@ -1,0 +1,152 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{str::FromStr, time::SystemTime};
+
+use iota_json_rpc_api::IndexerApiClient;
+use iota_json_rpc_types::{EventFilter, EventPage};
+use iota_types::{
+    base_types::{IotaAddress, ObjectID},
+    digests::TransactionDigest,
+};
+use serial_test::serial;
+
+use crate::common::pg_integration::{
+    indexer_wait_for_checkpoint, rpc_call_error_msg_matches,
+    start_test_cluster_with_read_write_indexer,
+};
+
+#[tokio::test]
+#[serial]
+async fn query_events_no_events_descending() {
+    let (_cluster, pg_store, indexer_client) =
+        start_test_cluster_with_read_write_indexer(None).await;
+    indexer_wait_for_checkpoint(&pg_store, 1).await;
+
+    let indexer_events = indexer_client
+        .query_events(
+            EventFilter::Sender(
+                IotaAddress::from_str(
+                    "0x9a934a2644c4ca2decbe3d126d80720429c5e31896aa756765afa23ae2cb4b99",
+                )
+                .unwrap(),
+            ),
+            None,
+            None,
+            Some(true),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(indexer_events, EventPage::empty())
+}
+
+#[tokio::test]
+#[serial]
+async fn query_events_no_events_ascending() {
+    let (_cluster, pg_store, indexer_client) =
+        start_test_cluster_with_read_write_indexer(None).await;
+    indexer_wait_for_checkpoint(&pg_store, 1).await;
+
+    let indexer_events = indexer_client
+        .query_events(
+            EventFilter::Sender(
+                IotaAddress::from_str(
+                    "0x9a934a2644c4ca2decbe3d126d80720429c5e31896aa756765afa23ae2cb4b99",
+                )
+                .unwrap(),
+            ),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(indexer_events, EventPage::empty())
+}
+
+#[tokio::test]
+#[serial]
+async fn query_events_unsupported_events() {
+    let (_cluster, pg_store, indexer_client) =
+        start_test_cluster_with_read_write_indexer(None).await;
+    indexer_wait_for_checkpoint(&pg_store, 1).await;
+
+    // Get the current time in milliseconds since the UNIX epoch
+    let now_millis = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_millis();
+
+    // Subtract 10 minutes from the current time
+    let ten_minutes_ago = now_millis - (10 * 60 * 1000); // 600 seconds = 10 minutes
+
+    let unsupported_filters = vec![
+        (EventFilter::All(vec![]), true),
+        (EventFilter::Any(vec![]), true),
+        (
+            EventFilter::And(
+                Box::new(EventFilter::Any(vec![])),
+                Box::new(EventFilter::Any(vec![])),
+            ),
+            true,
+        ),
+        (
+            EventFilter::Or(
+                Box::new(EventFilter::Any(vec![])),
+                Box::new(EventFilter::Any(vec![])),
+            ),
+            true,
+        ),
+        (
+            EventFilter::TimeRange {
+                start_time: ten_minutes_ago as u64,
+                end_time: now_millis as u64,
+            },
+            true,
+        ),
+        (
+            EventFilter::MoveEventField {
+                path: String::default(),
+                value: serde_json::Value::Bool(true),
+            },
+            true,
+        ),
+        (EventFilter::Sender(IotaAddress::ZERO), false),
+        (EventFilter::Transaction(TransactionDigest::ZERO), false),
+        (EventFilter::Package(ObjectID::ZERO), false),
+        (
+            EventFilter::MoveEventModule {
+                package: ObjectID::ZERO,
+                module: "x".parse().unwrap(),
+            },
+            false,
+        ),
+        (
+            EventFilter::MoveEventType("0xabcd::MyModule::Foo".parse().unwrap()),
+            false,
+        ),
+        (
+            EventFilter::MoveModule {
+                package: ObjectID::ZERO,
+                module: "x".parse().unwrap(),
+            },
+            false,
+        ),
+    ];
+
+    for (event_filter, expected) in unsupported_filters {
+        let result = indexer_client
+            .query_events(event_filter, None, None, None)
+            .await;
+
+        assert_eq!(
+            expected,
+            rpc_call_error_msg_matches(
+                result,
+                r#"{"code":-32603,"message": "Indexer does not support the feature with error: `This type of EventFilter is not supported.`"}"#,
+            )
+        );
+    }
+}

--- a/crates/iota-indexer/tests/rpc-tests/main.rs
+++ b/crates/iota-indexer/tests/rpc-tests/main.rs
@@ -6,4 +6,7 @@
 mod common;
 
 #[cfg(feature = "pg_integration")]
+mod indexer_api;
+
+#[cfg(feature = "pg_integration")]
 mod read_api;


### PR DESCRIPTION
# Description of change

Add some test cases which checks if no events are found then it should return an empty response instead of `Record not found` error

## Links to any relevant issues

fixes #2081 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

```
docker run --name iota-indexer-tests -e POSTGRES_PASSWORD=postgrespw -e POSTGRES_USER=postgres -e POSTGRES_DB=iota_indexer -d -p 5432:5432 postgres
```

```
cargo test -p iota-indexer --test rpc-tests indexer_api --features pg_integration -- --test-threads 1
```

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code

