### PR TITLE
fix(iota): Deal with migration tx data for network config

### DIFF
--- a/crates/iota-cluster-test/src/cluster.rs
+++ b/crates/iota-cluster-test/src/cluster.rs
@@ -206,7 +206,6 @@ impl Cluster for LocalNewCluster {
             // Add genesis objects
             let genesis_path = config_dir.join(IOTA_GENESIS_FILENAME);
             let genesis = Genesis::load(genesis_path)?;
-            // Load migration data
             let network_config = NetworkConfig {
                 validator_configs,
                 account_keys,

--- a/crates/iota-cluster-test/src/cluster.rs
+++ b/crates/iota-cluster-test/src/cluster.rs
@@ -6,8 +6,7 @@ use std::{net::SocketAddr, path::Path};
 
 use async_trait::async_trait;
 use iota_config::{
-    genesis::Genesis, migration_tx_data::MigrationTxData, Config, PersistedConfig,
-    IOTA_GENESIS_FILENAME, IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME, IOTA_KEYSTORE_FILENAME,
+    genesis::Genesis, Config, PersistedConfig, IOTA_GENESIS_FILENAME, IOTA_KEYSTORE_FILENAME,
     IOTA_NETWORK_CONFIG,
 };
 use iota_genesis_builder::SnapshotSource;
@@ -208,13 +207,10 @@ impl Cluster for LocalNewCluster {
             let genesis_path = config_dir.join(IOTA_GENESIS_FILENAME);
             let genesis = Genesis::load(genesis_path)?;
             // Load migration data
-            let migration_tx_data_path = config_dir.join(IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME);
-            let migration_tx_data = MigrationTxData::load(migration_tx_data_path)?;
             let network_config = NetworkConfig {
                 validator_configs,
                 account_keys,
                 genesis,
-                migration_tx_data,
             };
             cluster_builder = cluster_builder.set_network_config(network_config);
 

--- a/crates/iota-core/src/test_utils.rs
+++ b/crates/iota-core/src/test_utils.rs
@@ -260,7 +260,7 @@ async fn init_genesis(
         builder = builder.add_validator_signature(key);
     }
 
-    let (genesis, _migration_tx_data) = builder.build();
+    let (genesis, _) = builder.build();
     (genesis, key_pairs, pkg_id)
 }
 

--- a/crates/iota-genesis-builder/examples/build_stardust_genesis.rs
+++ b/crates/iota-genesis-builder/examples/build_stardust_genesis.rs
@@ -55,7 +55,7 @@ fn main() -> anyhow::Result<()> {
         builder = builder.add_validator_signature(key);
     }
 
-    let (genesis, _migration_tx_data) = builder.build();
+    let (genesis, _) = builder.build();
     // Save to file
     genesis.save("genesis.blob")?;
     Ok(())

--- a/crates/iota-genesis-builder/examples/build_stardust_genesis_from_s3.rs
+++ b/crates/iota-genesis-builder/examples/build_stardust_genesis_from_s3.rs
@@ -35,7 +35,7 @@ fn main() -> anyhow::Result<()> {
         builder = builder.add_validator_signature(key);
     }
 
-    let (_genesis, _migration_tx_data) = builder.build();
+    let (_genesis, _) = builder.build();
 
     info!("Genesis built successfully");
 

--- a/crates/iota-genesis-builder/examples/build_vanilla_genesis.rs
+++ b/crates/iota-genesis-builder/examples/build_vanilla_genesis.rs
@@ -35,7 +35,7 @@ fn main() -> anyhow::Result<()> {
         builder = builder.add_validator_signature(key);
     }
 
-    let (genesis, _migration_tx_data) = builder.build();
+    let (genesis, _) = builder.build();
     // Save to file
     genesis.save("genesis-vanilla.blob")?;
     Ok(())

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -105,7 +105,7 @@ pub struct Builder {
     migration_objects: MigrationObjects,
     genesis_stake: GenesisStake,
     migration_sources: Vec<SnapshotSource>,
-    migration_tx_data: MigrationTxData,
+    migration_tx_data: Option<MigrationTxData>,
 }
 
 impl Default for Builder {
@@ -324,9 +324,12 @@ impl Builder {
             &mut self.genesis_stake,
             &mut self.migration_objects,
         );
+        self.migration_tx_data = if !unsigned_genesis.migration_txs_effects.is_empty() {
+            Some(migration_tx_data)
+        } else {
+            None
+        };
         self.built_genesis = Some(unsigned_genesis);
-        self.migration_tx_data = migration_tx_data;
-
         self.token_distribution_schedule = Some(token_distribution_schedule);
     }
 
@@ -349,7 +352,7 @@ impl Builder {
         self.parameters.protocol_version
     }
 
-    pub fn build(mut self) -> (Genesis, MigrationTxData) {
+    pub fn build(mut self) -> (Genesis, Option<MigrationTxData>) {
         if self.built_genesis.is_none() {
             self.build_and_cache_unsigned_genesis();
         }

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -60,7 +60,7 @@ use iota_types::{
     },
     transaction::{
         CallArg, CheckedInputObjects, Command, InputObjectKind, ObjectArg, ObjectReadResult,
-        Transaction, TransactionKey,
+        Transaction,
     },
     IOTA_FRAMEWORK_PACKAGE_ID, IOTA_SYSTEM_ADDRESS,
 };

--- a/crates/iota-swarm-config/src/network_config.rs
+++ b/crates/iota-swarm-config/src/network_config.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_config::{genesis, migration_tx_data::MigrationTxData, node, Config, NodeConfig};
+use iota_config::{genesis, node, Config, NodeConfig};
 use iota_types::{
     committee::CommitteeWithNetworkMetadata, crypto::AccountKeyPair, multiaddr::Multiaddr,
 };
@@ -17,7 +17,6 @@ pub struct NetworkConfig {
     pub validator_configs: Vec<NodeConfig>,
     pub account_keys: Vec<AccountKeyPair>,
     pub genesis: genesis::Genesis,
-    pub migration_tx_data: MigrationTxData,
 }
 
 impl Config for NetworkConfig {}

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -11,7 +11,6 @@ use std::{
 
 use iota_config::{
     genesis::{TokenAllocation, TokenDistributionScheduleBuilder},
-    migration_tx_data,
     node::AuthorityOverloadConfig,
 };
 use iota_macros::nondeterministic;
@@ -353,7 +352,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
             builder.build()
         };
 
-        let (genesis, migration_tx_data) = {
+        let (genesis, _) = {
             let mut builder = iota_genesis_builder::Builder::new()
                 .with_parameters(genesis_config.parameters)
                 .add_objects(self.additional_objects);
@@ -428,7 +427,6 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
             validator_configs,
             genesis,
             account_keys,
-            migration_tx_data,
         }
     }
 }

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -12,6 +12,7 @@ use std::{
 use iota_config::{
     genesis::{TokenAllocation, TokenDistributionScheduleBuilder},
     node::AuthorityOverloadConfig,
+    IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME,
 };
 use iota_macros::nondeterministic;
 use iota_protocol_config::SupportedProtocolVersions;
@@ -352,7 +353,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
             builder.build()
         };
 
-        let (genesis, _) = {
+        let (genesis, migration_tx_data_option) = {
             let mut builder = iota_genesis_builder::Builder::new()
                 .with_parameters(genesis_config.parameters)
                 .add_objects(self.additional_objects);
@@ -378,6 +379,15 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
 
             builder.build()
         };
+
+        if let Some(migration_tx_data) = migration_tx_data_option {
+            migration_tx_data
+                .save(
+                    self.config_directory
+                        .join(IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME),
+                )
+                .expect("Should be able to save the migration data");
+        }
 
         let validator_configs = validators
             .into_iter()

--- a/crates/iota-swarm-config/tests/snapshot_tests.rs
+++ b/crates/iota-swarm-config/tests/snapshot_tests.rs
@@ -23,7 +23,6 @@ use fastcrypto::traits::KeyPair;
 use insta::assert_yaml_snapshot;
 use iota_config::{
     genesis::{GenesisCeremonyParameters, TokenDistributionScheduleBuilder},
-    migration_tx_data,
     node::{DEFAULT_COMMISSION_RATE, DEFAULT_VALIDATOR_GAS_PRICE},
 };
 use iota_genesis_builder::{validator_info::ValidatorInfo, Builder};
@@ -91,7 +90,7 @@ fn populated_genesis_snapshot_matches() {
         builder.build()
     };
 
-    let (genesis, _migration_tx_data) = Builder::new()
+    let (genesis, _) = Builder::new()
         .with_token_distribution_schedule(token_distribution_schedule)
         .add_validator(validator, pop)
         .with_parameters(GenesisCeremonyParameters {

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -15,7 +15,7 @@ use anyhow::Result;
 use futures::future::try_join_all;
 use iota_config::{
     node::{AuthorityOverloadConfig, DBCheckpointConfig, RunWithRange},
-    NodeConfig, IOTA_GENESIS_FILENAME, IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME,
+    NodeConfig, IOTA_GENESIS_FILENAME,
 };
 use iota_macros::nondeterministic;
 use iota_node::IotaNodeHandle;
@@ -301,15 +301,10 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
                 .build();
             // Populate validator genesis by pointing to the blob
             let genesis_path = dir.join(IOTA_GENESIS_FILENAME);
-            let migration_tx_data_path = dir.join(IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME);
             network_config
                 .genesis
                 .save(&genesis_path)
                 .expect("genesis should be saved successfully");
-            network_config
-                .migration_tx_data
-                .save(&migration_tx_data_path)
-                .expect("migration tx data should be saved successfully");
             for validator in &mut network_config.validator_configs {
                 validator.genesis = iota_config::node::Genesis::new_from_file(&genesis_path);
             }

--- a/crates/iota/src/genesis_ceremony.rs
+++ b/crates/iota/src/genesis_ceremony.rs
@@ -327,7 +327,7 @@ pub async fn run(cmd: Ceremony) -> Result<()> {
 
             check_protocol_version(&builder, protocol_version)?;
 
-            let (genesis, migration_tx_data) = builder.build();
+            let (genesis, migration_tx_data_option) = builder.build();
             genesis.save(dir.join(IOTA_GENESIS_FILENAME))?;
 
             println!("Successfully built {IOTA_GENESIS_FILENAME}");
@@ -335,8 +335,10 @@ pub async fn run(cmd: Ceremony) -> Result<()> {
                 "{IOTA_GENESIS_FILENAME} blake2b-256: {}",
                 Hex::encode(genesis.hash())
             );
-            migration_tx_data.save(dir.join(IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME))?;
-            println!("Successfully built {IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME}");
+            if let Some(migration_tx_data) = migration_tx_data_option {
+                migration_tx_data.save(dir.join(IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME))?;
+                println!("Successfully built {IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME}");
+            }
         }
     }
 


### PR DESCRIPTION
# Description of change

Removes the migration data from network config and then saves the file locally when the genesis is built.

## How the change has been tested

`cargo run --release --bin iota genesis --working-dir ../test_iota_config -f --with-faucet --num-validators 1 --local-migration-snapshots ../stardust_object_snapshot.bin`

