### PR TITLE
fix(iota-indexer): Refactor `IndexerApi` top use the shared runtime for tests

### DIFF
--- a/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
@@ -86,46 +86,46 @@ fn query_events_unsupported_events() {
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
 
-    // Get the current time in milliseconds since the UNIX epoch
-    let now_millis = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_millis();
+        // Get the current time in milliseconds since the UNIX epoch
+        let now_millis = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_millis();
 
-    // Subtract 10 minutes from the current time
-    let ten_minutes_ago = now_millis - (10 * 60 * 1000); // 600 seconds = 10 minutes
+        // Subtract 10 minutes from the current time
+        let ten_minutes_ago = now_millis - (10 * 60 * 1000); // 600 seconds = 10 minutes
 
-    let unsupported_filters = vec![
-        EventFilter::All(vec![]),
-        EventFilter::Any(vec![]),
-        EventFilter::And(
-            Box::new(EventFilter::Any(vec![])),
-            Box::new(EventFilter::Any(vec![])),
-        ),
-        EventFilter::Or(
-            Box::new(EventFilter::Any(vec![])),
-            Box::new(EventFilter::Any(vec![])),
-        ),
-        EventFilter::TimeRange {
-            start_time: ten_minutes_ago as u64,
-            end_time: now_millis as u64,
-        },
-        EventFilter::MoveEventField {
-            path: String::default(),
-            value: serde_json::Value::Bool(true),
-        },
-    ];
+        let unsupported_filters = vec![
+            EventFilter::All(vec![]),
+            EventFilter::Any(vec![]),
+            EventFilter::And(
+                Box::new(EventFilter::Any(vec![])),
+                Box::new(EventFilter::Any(vec![])),
+            ),
+            EventFilter::Or(
+                Box::new(EventFilter::Any(vec![])),
+                Box::new(EventFilter::Any(vec![])),
+            ),
+            EventFilter::TimeRange {
+                start_time: ten_minutes_ago as u64,
+                end_time: now_millis as u64,
+            },
+            EventFilter::MoveEventField {
+                path: String::default(),
+                value: serde_json::Value::Bool(true),
+            },
+        ];
 
-    for event_filter in unsupported_filters {
-        let result = client
-            .query_events(event_filter, None, None, None)
-            .await;
+        for event_filter in unsupported_filters {
+            let result = client
+                .query_events(event_filter, None, None, None)
+                .await;
 
-        assert!(rpc_call_error_msg_matches(
-            result,
-            r#"{"code":-32603,"message": "Indexer does not support the feature with error: `This type of EventFilter is not supported.`"}"#,
-        ));
-    }
+            assert!(rpc_call_error_msg_matches(
+                result,
+                r#"{"code":-32603,"message": "Indexer does not support the feature with error: `This type of EventFilter is not supported.`"}"#,
+            ));
+        }
     });
 }
 

--- a/crates/iota-indexer/tests/rpc-tests/main.rs
+++ b/crates/iota-indexer/tests/rpc-tests/main.rs
@@ -8,7 +8,7 @@ mod common;
 #[cfg(feature = "pg_integration")]
 mod extended_api;
 
-#[cfg(feature = "pg_integration")]
+#[cfg(feature = "shared_test_runtime")]
 mod indexer_api;
 
 #[cfg(feature = "shared_test_runtime")]


### PR DESCRIPTION
# Description of change

Refactor `IndexerApi` top use the shared runtime for tests

## Links to any relevant issues

fixes #2960

## Type of change

- Enhancement (a non-breaking change which adds functionality)


## How the change has been tested

To start a postgres instance
```
docker run --name iota-indexer-tests -e POSTGRES_PASSWORD=postgrespw -e POSTGRES_USER=postgres -e POSTGRES_DB=iota_indexer -d -p 5432:5432 postgres
```

####  Run indexer api tests
```
cargo test -p iota-indexer  --test rpc-tests indexer_api --features shared_test_runtime
```
#### Run all rpc-tests which rely on shared runtime and check if no test is failing
```
cargo test -p iota-indexer  --test rpc-tests --features shared_test_runtime
```
## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code

