### PR TITLE
fix(iota): build swarm in blocking task in `iota start`

### DIFF
--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -726,7 +726,7 @@ async fn start(
             .with_fullnode_rpc_addr(fullnode_url);
     }
 
-    let mut swarm = swarm_builder.build();
+    let mut swarm = tokio::task::spawn_blocking(move || swarm_builder.build()).await?;
     swarm.launch().await?;
     // Let nodes connect to one another
     tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;


### PR DESCRIPTION
# Description of change

Fixes a spurious bug in `iota start`.

More specifically

```
$ cargo run --bin iota -- start --force-regenesis --remote-migration-snapshots https://stardust-objects.s3.eu-central-1.amazonaws.com/iota/alphanet/test/stardust_object_snapshot.bin.gz
```

would fail because downloading the snapshot requires a blocking task.

## Links to any relevant issues

Discovered while working on #2968 