### PR TITLE
feat(iota-indexer): Add test for dev_inspect_transaction_block

### DIFF
--- a/crates/iota-json-rpc-tests/tests/rpc_server_tests.rs
+++ b/crates/iota-json-rpc-tests/tests/rpc_server_tests.rs
@@ -25,6 +25,7 @@ use iota_json_rpc_types::{
 use iota_macros::sim_test;
 use iota_move_build::BuildConfig;
 use iota_protocol_config::ProtocolConfig;
+use iota_simulator::fastcrypto::encoding::Base64;
 use iota_swarm_config::genesis_config::{
     AccountConfig, DEFAULT_GAS_AMOUNT, DEFAULT_NUMBER_OF_OBJECT_PER_ACCOUNT,
 };
@@ -39,12 +40,14 @@ use iota_types::{
     id::UID,
     object::{Data, MoveObject, ObjectInner, Owner, OBJECT_START_VERSION},
     parse_iota_struct_tag,
+    programmable_transaction_builder::ProgrammableTransactionBuilder,
     quorum_driver_types::ExecuteTransactionRequestType,
     stardust::output::{Irc27Metadata, Nft},
     timelock::{
         label::label_struct_tag_to_string, stardust_upgrade_label::stardust_upgrade_label_type,
         timelock::TimeLock,
     },
+    transaction::TransactionKind,
     utils::to_sender_signed_transaction,
     IOTA_FRAMEWORK_ADDRESS,
 };
@@ -158,6 +161,86 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
         dryrun_response.object_changes,
         tx_response.object_changes.unwrap(),
     );
+    Ok(())
+}
+
+#[sim_test]
+async fn test_dev_inspect_transaction_block() -> Result<(), anyhow::Error> {
+    let cluster = TestClusterBuilder::new().build().await;
+    let http_client = cluster.rpc_client();
+    let address = cluster.get_address_0();
+    let other_address = cluster.get_address_1();
+
+    let objects = http_client
+        .get_owned_objects(
+            address,
+            Some(IotaObjectResponseQuery::new_with_options(
+                IotaObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
+            None,
+            None,
+        )
+        .await?
+        .data;
+
+    let obj = objects
+        .clone()
+        .first()
+        .unwrap()
+        .object()
+        .unwrap()
+        .object_ref();
+
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.transfer_object(other_address, obj).unwrap();
+        builder.finish()
+    };
+    let kind = TransactionKind::programmable(pt);
+
+    let devinspect_response = http_client
+        .dev_inspect_transaction_block(
+            address,
+            Base64::from_bytes(&bcs::to_bytes(&kind).unwrap()),
+            None,
+            None,
+            None,
+        )
+        .await?;
+
+    assert_eq!(
+        *devinspect_response.effects.status(),
+        IotaExecutionStatus::Success
+    );
+    let tx_effect_obj_reassigned = &devinspect_response
+        .effects
+        .mutated()
+        .iter().find(|o| o.reference.object_id == obj.0)
+        .unwrap();
+    assert_eq!(
+        tx_effect_obj_reassigned.owner,
+        Owner::AddressOwner(other_address)
+    );
+
+    let actual_object_info = http_client
+        .get_object(
+            obj.0,
+            Some(IotaObjectDataOptions {
+                show_owner: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        actual_object_info.data.unwrap().owner.unwrap(),
+        Owner::AddressOwner(address)
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
# Description of change

Cover `dev_inspect_transaction_block` endpoint with a basic test. To have full coverage for `WriteApi` in fullnode json rpc.

## Links to any relevant issues

fixes #2918

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Ran `cargo nextest run -p iota-json-rpc-tests test_dev_inspect`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
