### PR TITLE
feat(iota-indexer): Refactor ExtendedApi tests in indexer to use shared test cluster

### DIFF
--- a/crates/iota-cluster-test/src/cluster.rs
+++ b/crates/iota-cluster-test/src/cluster.rs
@@ -265,6 +265,7 @@ impl Cluster for LocalNewCluster {
                 fullnode_url.clone(),
                 ReaderWriterConfig::writer_mode(None),
                 data_ingestion_path.clone(),
+                None,
             )
             .await;
 
@@ -274,6 +275,7 @@ impl Cluster for LocalNewCluster {
                 fullnode_url.clone(),
                 ReaderWriterConfig::reader_mode(indexer_address.to_string()),
                 data_ingestion_path,
+                None,
             )
             .await;
         }

--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -69,6 +69,7 @@ pub async fn start_cluster(
         Some(db_url),
         val_fn.rpc_url().to_string(),
         ReaderWriterConfig::writer_mode(None),
+        None,
         // reset_database
         true,
         Some(data_ingestion_path),

--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -134,6 +134,7 @@ pub async fn serve_executor(
         Some(db_url),
         format!("http://{}", executor_server_url),
         ReaderWriterConfig::writer_mode(snapshot_config.clone()),
+        Some(&graphql_connection_config.db_name()),
         // reset_database
         true,
         Some(data_ingestion_path),

--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -69,11 +69,11 @@ pub async fn start_cluster(
         Some(db_url),
         val_fn.rpc_url().to_string(),
         ReaderWriterConfig::writer_mode(None),
-        None,
         // reset_database
         true,
         Some(data_ingestion_path),
         cancellation_token.clone(),
+        None,
     )
     .await;
 
@@ -134,11 +134,11 @@ pub async fn serve_executor(
         Some(db_url),
         format!("http://{}", executor_server_url),
         ReaderWriterConfig::writer_mode(snapshot_config.clone()),
-        Some(&graphql_connection_config.db_name()),
         // reset_database
         true,
         Some(data_ingestion_path),
         cancellation_token.clone(),
+        Some(&graphql_connection_config.db_name()),
     )
     .await;
 

--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -104,7 +104,7 @@ The crate provides following tests currently:
 # run tests requiring only postgres integration
 cargo test --features pg_integration -- --test-threads 1
 # run rpc tests with shared runtime
-cargo test --features shared_test_runtime
+cargo test --features shared_test_runtime -- --test-threads 1
 ```
 
 For a better testing experience is possible to use [nextest](https://nexte.st/)

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -45,7 +45,7 @@ pub async fn start_test_indexer<T: R2D2Connection + Send + 'static>(
     rpc_url: String,
     reader_writer_config: ReaderWriterConfig,
     data_ingestion_path: PathBuf,
-    new_database: Option<String>,
+    new_database: Option<&str>,
 ) -> (PgIndexerStore<T>, JoinHandle<Result<(), IndexerError>>) {
     start_test_indexer_impl(
         db_url,
@@ -67,6 +67,7 @@ pub async fn start_test_indexer_impl<T: R2D2Connection + 'static>(
     db_url: Option<String>,
     rpc_url: String,
     reader_writer_config: ReaderWriterConfig,
+    new_database: Option<&str>,
     reset_database: bool,
     data_ingestion_path: Option<PathBuf>,
     cancel: CancellationToken,
@@ -139,6 +140,7 @@ pub async fn start_test_indexer_impl<T: R2D2Connection + 'static>(
 pub fn create_pg_store<T: R2D2Connection + Send + 'static>(
     db_url: Secret<String>,
     reset_database: bool,
+    new_database: Option<&str>
 ) -> PgIndexerStore<T> {
     // Reduce the connection pool size to 10 for testing
     // to prevent maxing out

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -51,11 +51,11 @@ pub async fn start_test_indexer<T: R2D2Connection + Send + 'static>(
         db_url,
         rpc_url,
         reader_writer_config,
-        new_database,
         // reset_database
         false,
         Some(data_ingestion_path),
         CancellationToken::new(),
+        new_database,
     )
     .await
 }
@@ -67,17 +67,22 @@ pub async fn start_test_indexer_impl<T: R2D2Connection + 'static>(
     db_url: Option<String>,
     rpc_url: String,
     reader_writer_config: ReaderWriterConfig,
-    new_database: Option<&str>,
-    reset_database: bool,
+    mut reset_database: bool,
     data_ingestion_path: Option<PathBuf>,
     cancel: CancellationToken,
+    new_database: Option<&str>,
 ) -> (PgIndexerStore<T>, JoinHandle<Result<(), IndexerError>>) {
-    let db_url = db_url.unwrap_or_else(|| {
+    let mut db_url = db_url.unwrap_or_else(|| {
         let pg_host = env::var("POSTGRES_HOST").unwrap_or_else(|_| "localhost".into());
         let pg_port = env::var("POSTGRES_PORT").unwrap_or_else(|_| "32770".into());
         let pw = env::var("POSTGRES_PASSWORD").unwrap_or_else(|_| "postgrespw".into());
         format!("postgres://postgres:{pw}@{pg_host}:{pg_port}")
     });
+
+    if let Some(new_database) = new_database {
+        db_url = replace_db_name(&db_url, new_database).0;
+        reset_database = true;
+    };
 
     let mut config = IndexerConfig {
         db_url: Some(db_url.clone().into()),
@@ -140,7 +145,6 @@ pub async fn start_test_indexer_impl<T: R2D2Connection + 'static>(
 pub fn create_pg_store<T: R2D2Connection + Send + 'static>(
     db_url: Secret<String>,
     reset_database: bool,
-    new_database: Option<&str>
 ) -> PgIndexerStore<T> {
     // Reduce the connection pool size to 10 for testing
     // to prevent maxing out

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -45,11 +45,13 @@ pub async fn start_test_indexer<T: R2D2Connection + Send + 'static>(
     rpc_url: String,
     reader_writer_config: ReaderWriterConfig,
     data_ingestion_path: PathBuf,
+    new_database: Option<String>,
 ) -> (PgIndexerStore<T>, JoinHandle<Result<(), IndexerError>>) {
     start_test_indexer_impl(
         db_url,
         rpc_url,
         reader_writer_config,
+        new_database,
         // reset_database
         false,
         Some(data_ingestion_path),

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    net::{SocketAddr},
+    net::SocketAddr,
     path::PathBuf,
     sync::{Arc, OnceLock},
     time::Duration,
@@ -36,7 +36,8 @@ use tempfile::tempdir;
 use test_cluster::{TestCluster, TestClusterBuilder};
 use tokio::{runtime::Runtime, task::JoinHandle};
 
-const DEFAULT_DB_URL: &str = "postgres://postgres:postgrespw@localhost:5432/iota_indexer";
+const POSTGRES_URL: &str = "postgres://postgres:postgrespw@localhost:5432";
+const DEFAULT_DB: &str = "iota_indexer";
 const DEFAULT_INDEXER_IP: &str = "127.0.0.1";
 const DEFAULT_INDEXER_PORT: u16 = 9005;
 const DEFAULT_SERVER_PORT: u16 = 3000;
@@ -128,7 +129,7 @@ pub async fn start_test_cluster_with_read_write_indexer(
 
     // start indexer in write mode
     let (pg_store, _pg_store_handle) = start_test_indexer(
-        Some(DEFAULT_DB_URL.to_owned()),
+        Some(get_indexer_db_url(None)),
         cluster.rpc_url().to_string(),
         ReaderWriterConfig::writer_mode(None),
         temp.clone(),
@@ -145,6 +146,13 @@ pub async fn start_test_cluster_with_read_write_indexer(
         .unwrap();
 
     (cluster, pg_store, rpc_client)
+}
+
+fn get_indexer_db_url(database_name: Option<String>) -> String {
+    database_name.map_or_else(
+        || format!("{POSTGRES_URL}/{DEFAULT_DB}"),
+        |db_name| format!("{POSTGRES_URL}/{db_name}"),
+    )
 }
 
 /// Wait for the indexer to catch up to the given checkpoint sequence number
@@ -233,18 +241,9 @@ pub async fn indexer_wait_for_transaction(
     .expect("Timeout waiting for indexer to catchup to given transaction");
 }
 
-fn replace_db_name(db_url: &str, new_db_name: &str) -> String {
-    let pos = db_url.rfind('/').expect("Unable to find / in db_url");
-    format!("{}/{}", &db_url[..pos], new_db_name)
-}
-
 /// Start an Indexer instance in `Read` mode
 fn start_indexer_reader(fullnode_rpc_url: impl Into<String>, data_ingestion_path: PathBuf, database_name: Option<String>) -> u16 {
-    let db_url = match database_name {
-        Some(database_name) => replace_db_name(DEFAULT_DB_URL, &database_name),
-        None => DEFAULT_DB_URL.to_owned(),
-    };
-
+    let db_url = get_indexer_db_url(database_name);
     let port = get_available_port(DEFAULT_INDEXER_IP);
     let config = IndexerConfig {
         db_url: Some(db_url.clone()),
@@ -302,7 +301,7 @@ pub async fn start_simulacrum_rest_api_with_write_indexer(
     });
     // Starts indexer
     let (pg_store, pg_handle) = start_test_indexer(
-        Some(DEFAULT_DB_URL.to_owned()),
+        Some(get_indexer_db_url(None)),
         format!("http://{}", server_url),
         ReaderWriterConfig::writer_mode(None),
         data_ingestion_path,
@@ -322,13 +321,18 @@ pub async fn start_simulacrum_rest_api_with_read_write_indexer(
     JoinHandle<Result<(), IndexerError>>,
     HttpClient,
 ) {
-    let server_url = new_local_tcp_socket_for_testing();
-    let (server_handle, pg_store, pg_handle) =
-        start_simulacrum_rest_api_with_write_indexer(sim, data_ingestion_path.clone(), Some(server_url), database_name.clone())
-            .await;
+    let simulacrum_server_url = new_local_tcp_socket_for_testing();
+    let (server_handle, pg_store, pg_handle) = start_simulacrum_rest_api_with_write_indexer(
+        sim,
+        data_ingestion_path.clone()
+        Some(simulacrum_server_url),
+        database_name.clone(),
+    )
+    .await;
 
     // start indexer in read mode
-    let indexer_port = start_indexer_reader(format!("http://{}", server_url), data_ingestion_path, database_name);
+    let indexer_port =
+        start_indexer_reader(format!("http://{}", simulacrum_server_url), data_ingestion_path, database_name);
 
     // create an RPC client by using the indexer url
     let rpc_client = HttpClientBuilder::default()

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -54,9 +54,9 @@ mod ingestion_tests {
 
         let (_, pg_store, _) = start_simulacrum_rest_api_with_write_indexer(
             Arc::new(sim),
-            data_ingestion_path
+            data_ingestion_path,
             None,
-            Some("indexer_ingestion_tests_db".to_string()),
+            Some("indexer_ingestion_tests_db"),
         )
         .await;
 
@@ -102,8 +102,13 @@ mod ingestion_tests {
         // Create a checkpoint which should include the transaction we executed.
         let _ = sim.create_checkpoint();
 
-        let (_, pg_store, _) =
-            start_simulacrum_rest_api_with_write_indexer(Arc::new(sim), data_ingestion_path).await;
+        let (_, pg_store, _) = start_simulacrum_rest_api_with_write_indexer(
+            Arc::new(sim),
+            data_ingestion_path,
+            None,
+            Some("indexer_ingestion_tests_db"),
+        )
+        .await;
 
         indexer_wait_for_checkpoint(&pg_store, 1).await;
 

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -52,8 +52,13 @@ mod ingestion_tests {
         // Create a checkpoint which should include the transaction we executed.
         let checkpoint = sim.create_checkpoint();
 
-        let (_, pg_store, _) =
-            start_simulacrum_rest_api_with_write_indexer(Arc::new(sim), data_ingestion_path).await;
+        let (_, pg_store, _) = start_simulacrum_rest_api_with_write_indexer(
+            Arc::new(sim),
+            data_ingestion_path
+            None,
+            Some("indexer_ingestion_tests_db".to_string()),
+        )
+        .await;
 
         indexer_wait_for_checkpoint(&pg_store, 1).await;
 

--- a/crates/iota-indexer/tests/rpc-tests/extended_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/extended_api.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::OnceLock};
 
 use iota_json::{call_args, type_args};
 use iota_json_rpc_api::{
@@ -18,431 +18,404 @@ use iota_types::{
     quorum_driver_types::ExecuteTransactionRequestType,
     storage::ReadStore,
 };
-use serial_test::serial;
 use simulacrum::Simulacrum;
 use tempfile::tempdir;
 use test_cluster::TestCluster;
 
 use crate::common::{
-    indexer_wait_for_checkpoint, start_simulacrum_rest_api_with_read_write_indexer,
-    start_test_cluster_with_read_write_indexer,
+    indexer_wait_for_checkpoint, ApiTestSetup, InitializedSimulacrumEnv,
+    SimulacrumApiTestEnvDefinition,
 };
 
-#[tokio::test]
-#[serial]
-async fn get_epochs() {
+static EXTENDED_API_SHARED_SIMULACRUM_INITIALIZED_ENV: OnceLock<InitializedSimulacrumEnv> =
+    OnceLock::new();
+
+fn get_or_init_shared_extended_api_simulacrum_env() -> &'static InitializedSimulacrumEnv {
     let data_ingestion_path = tempdir().unwrap().into_path();
-    let mut sim = Simulacrum::new();
+    let extended_api_env = SimulacrumApiTestEnvDefinition {
+        unique_env_name: "extended_api".to_string(),
+        env_initializer: Box::new(|| {
+            let mut sim = Simulacrum::new();
     sim.set_data_ingestion_path(data_ingestion_path.clone());
 
-    execute_simulacrum_transactions(&mut sim, 15);
-    add_checkpoints(&mut sim, 300);
+            execute_simulacrum_transactions(&mut sim, 15);
+            add_checkpoints(&mut sim, 300);
     sim.advance_epoch();
 
-    execute_simulacrum_transactions(&mut sim, 10);
-    add_checkpoints(&mut sim, 300);
+            execute_simulacrum_transactions(&mut sim, 10);
+            add_checkpoints(&mut sim, 300);
     sim.advance_epoch();
 
-    execute_simulacrum_transactions(&mut sim, 5);
-    add_checkpoints(&mut sim, 300);
+            execute_simulacrum_transactions(&mut sim, 5);
+            add_checkpoints(&mut sim, 300);
 
-    let last_checkpoint = sim.get_latest_checkpoint().unwrap();
-
-    let (_, pg_store, _, indexer_client) =
-        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim), data_ingestion_path).await;
-    indexer_wait_for_checkpoint(&pg_store, last_checkpoint.sequence_number).await;
-
-    let epochs = indexer_client.get_epochs(None, None, None).await.unwrap();
-
-    assert_eq!(epochs.data.len(), 3);
-    assert!(!epochs.has_next_page);
-
-    let end_of_epoch_info = epochs.data[0].end_of_epoch_info.as_ref().unwrap();
-    assert_eq!(epochs.data[0].epoch, 0);
-    assert_eq!(epochs.data[0].first_checkpoint_id, 0);
-    assert_eq!(epochs.data[0].epoch_total_transactions, 17);
-    assert_eq!(end_of_epoch_info.last_checkpoint_id, 301);
-
-    let end_of_epoch_info = epochs.data[1].end_of_epoch_info.as_ref().unwrap();
-    assert_eq!(epochs.data[1].epoch, 1);
-    assert_eq!(epochs.data[1].first_checkpoint_id, 302);
-    assert_eq!(epochs.data[1].epoch_total_transactions, 11);
-    assert_eq!(end_of_epoch_info.last_checkpoint_id, 602);
-
-    assert_eq!(epochs.data[2].epoch, 2);
-    assert_eq!(epochs.data[2].first_checkpoint_id, 603);
-    assert_eq!(epochs.data[2].epoch_total_transactions, 0);
-    assert!(epochs.data[2].end_of_epoch_info.is_none());
+            sim
+        }),
+    };
+    extended_api_env.get_or_init_env(&EXTENDED_API_SHARED_SIMULACRUM_INITIALIZED_ENV)
 }
 
-#[tokio::test]
-#[serial]
-async fn get_epochs_descending() {
-    let data_ingestion_path = tempdir().unwrap().into_path();
-    let mut sim = Simulacrum::new();
-    sim.set_data_ingestion_path(data_ingestion_path.clone());
+#[test]
+fn get_epochs() {
+    let InitializedSimulacrumEnv {
+        runtime,
+        sim,
+        store,
+        client,
+    } = get_or_init_shared_extended_api_simulacrum_env();
 
-    execute_simulacrum_transactions(&mut sim, 15);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch();
+    runtime.block_on(async move {
+        let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        indexer_wait_for_checkpoint(&store, last_checkpoint.sequence_number).await;
 
-    execute_simulacrum_transactions(&mut sim, 10);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch();
+        let epochs = client.get_epochs(None, None, None).await.unwrap();
 
-    execute_simulacrum_transactions(&mut sim, 5);
-    add_checkpoints(&mut sim, 300);
+        assert_eq!(epochs.data.len(), 3);
+        assert!(!epochs.has_next_page);
 
-    let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        let end_of_epoch_info = epochs.data[0].end_of_epoch_info.as_ref().unwrap();
+        assert_eq!(epochs.data[0].epoch, 0);
+        assert_eq!(epochs.data[0].first_checkpoint_id, 0);
+        assert_eq!(epochs.data[0].epoch_total_transactions, 17);
+        assert_eq!(end_of_epoch_info.last_checkpoint_id, 301);
 
-    let (_, pg_store, _, indexer_client) =
-        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim), data_ingestion_path).await;
-    indexer_wait_for_checkpoint(&pg_store, last_checkpoint.sequence_number).await;
+        let end_of_epoch_info = epochs.data[1].end_of_epoch_info.as_ref().unwrap();
+        assert_eq!(epochs.data[1].epoch, 1);
+        assert_eq!(epochs.data[1].first_checkpoint_id, 302);
+        assert_eq!(epochs.data[1].epoch_total_transactions, 11);
+        assert_eq!(end_of_epoch_info.last_checkpoint_id, 602);
 
-    let epochs = indexer_client
-        .get_epochs(None, None, Some(true))
-        .await
-        .unwrap();
-
-    let actual_epochs_order = epochs
-        .data
-        .iter()
-        .map(|epoch| epoch.epoch)
-        .collect::<Vec<u64>>();
-
-    assert_eq!(epochs.data.len(), 3);
-    assert!(!epochs.has_next_page);
-    assert_eq!(actual_epochs_order, [2, 1, 0])
+        assert_eq!(epochs.data[2].epoch, 2);
+        assert_eq!(epochs.data[2].first_checkpoint_id, 603);
+        assert_eq!(epochs.data[2].epoch_total_transactions, 0);
+        assert!(epochs.data[2].end_of_epoch_info.is_none());
+    });
 }
 
-#[tokio::test]
-#[serial]
-async fn get_epochs_paging() {
-    let data_ingestion_path = tempdir().unwrap().into_path();
-    let mut sim = Simulacrum::new();
-    sim.set_data_ingestion_path(data_ingestion_path.clone());
+#[test]
+fn get_epochs_descending() {
+    let InitializedSimulacrumEnv {
+        runtime,
+        sim,
+        store,
+        client,
+    } = get_or_init_shared_extended_api_simulacrum_env();
 
-    execute_simulacrum_transactions(&mut sim, 15);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch();
+    runtime.block_on(async move {
+        let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        indexer_wait_for_checkpoint(&store, last_checkpoint.sequence_number).await;
 
-    execute_simulacrum_transactions(&mut sim, 10);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch();
+        let epochs = client.get_epochs(None, None, Some(true)).await.unwrap();
 
-    execute_simulacrum_transactions(&mut sim, 5);
-    add_checkpoints(&mut sim, 300);
+        let actual_epochs_order = epochs
+            .data
+            .iter()
+            .map(|epoch| epoch.epoch)
+            .collect::<Vec<u64>>();
 
-    let last_checkpoint = sim.get_latest_checkpoint().unwrap();
-
-    let (_, pg_store, _, indexer_client) =
-        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim), data_ingestion_path).await;
-    indexer_wait_for_checkpoint(&pg_store, last_checkpoint.sequence_number).await;
-
-    let epochs = indexer_client
-        .get_epochs(None, Some(2), None)
-        .await
-        .unwrap();
-    let actual_epochs_order = epochs
-        .data
-        .iter()
-        .map(|epoch| epoch.epoch)
-        .collect::<Vec<u64>>();
-
-    assert_eq!(epochs.data.len(), 2);
-    assert!(epochs.has_next_page);
-    assert_eq!(epochs.next_cursor, Some(1.into()));
-    assert_eq!(actual_epochs_order, [0, 1]);
-
-    let epochs = indexer_client
-        .get_epochs(Some(1.into()), Some(2), None)
-        .await
-        .unwrap();
-    let actual_epochs_order = epochs
-        .data
-        .iter()
-        .map(|epoch| epoch.epoch)
-        .collect::<Vec<u64>>();
-
-    assert_eq!(epochs.data.len(), 1);
-    assert!(!epochs.has_next_page);
-    assert_eq!(epochs.next_cursor, Some(2.into()));
-    assert_eq!(actual_epochs_order, [2]);
+        assert_eq!(epochs.data.len(), 3);
+        assert!(!epochs.has_next_page);
+        assert_eq!(actual_epochs_order, [2, 1, 0])
+    });
 }
 
-#[tokio::test]
-#[serial]
-async fn get_epoch_metrics() {
-    let data_ingestion_path = tempdir().unwrap().into_path();
-    let mut sim = Simulacrum::new();
-    sim.set_data_ingestion_path(data_ingestion_path.clone());
+#[test]
+fn get_epochs_paging() {
+    let InitializedSimulacrumEnv {
+        runtime,
+        sim,
+        store,
+        client,
+    } = get_or_init_shared_extended_api_simulacrum_env();
 
-    execute_simulacrum_transactions(&mut sim, 15);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch();
+    runtime.block_on(async move {
+        let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        indexer_wait_for_checkpoint(&store, last_checkpoint.sequence_number).await;
 
-    execute_simulacrum_transactions(&mut sim, 10);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch();
+        let epochs = client.get_epochs(None, Some(2), None).await.unwrap();
+        let actual_epochs_order = epochs
+            .data
+            .iter()
+            .map(|epoch| epoch.epoch)
+            .collect::<Vec<u64>>();
 
-    execute_simulacrum_transactions(&mut sim, 5);
-    add_checkpoints(&mut sim, 300);
+        assert_eq!(epochs.data.len(), 2);
+        assert!(epochs.has_next_page);
+        assert_eq!(epochs.next_cursor, Some(1.into()));
+        assert_eq!(actual_epochs_order, [0, 1]);
 
-    let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        let epochs = client
+            .get_epochs(Some(1.into()), Some(2), None)
+            .await
+            .unwrap();
+        let actual_epochs_order = epochs
+            .data
+            .iter()
+            .map(|epoch| epoch.epoch)
+            .collect::<Vec<u64>>();
 
-    let (_, pg_store, _, indexer_client) =
-        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim), data_ingestion_path).await;
-    indexer_wait_for_checkpoint(&pg_store, last_checkpoint.sequence_number).await;
-
-    let epoch_metrics = indexer_client
-        .get_epoch_metrics(None, None, None)
-        .await
-        .unwrap();
-
-    assert_eq!(epoch_metrics.data.len(), 3);
-    assert!(!epoch_metrics.has_next_page);
-
-    let end_of_epoch_info = epoch_metrics.data[0].end_of_epoch_info.as_ref().unwrap();
-    assert_eq!(epoch_metrics.data[0].epoch, 0);
-    assert_eq!(epoch_metrics.data[0].first_checkpoint_id, 0);
-    assert_eq!(epoch_metrics.data[0].epoch_total_transactions, 17);
-    assert_eq!(end_of_epoch_info.last_checkpoint_id, 301);
-
-    let end_of_epoch_info = epoch_metrics.data[1].end_of_epoch_info.as_ref().unwrap();
-    assert_eq!(epoch_metrics.data[1].epoch, 1);
-    assert_eq!(epoch_metrics.data[1].first_checkpoint_id, 302);
-    assert_eq!(epoch_metrics.data[1].epoch_total_transactions, 11);
-    assert_eq!(end_of_epoch_info.last_checkpoint_id, 602);
-
-    assert_eq!(epoch_metrics.data[2].epoch, 2);
-    assert_eq!(epoch_metrics.data[2].first_checkpoint_id, 603);
-    assert_eq!(epoch_metrics.data[2].epoch_total_transactions, 0);
-    assert!(epoch_metrics.data[2].end_of_epoch_info.is_none());
+        assert_eq!(epochs.data.len(), 1);
+        assert!(!epochs.has_next_page);
+        assert_eq!(epochs.next_cursor, Some(2.into()));
+        assert_eq!(actual_epochs_order, [2]);
+    });
 }
 
-#[tokio::test]
-#[serial]
-async fn get_epoch_metrics_descending() {
-    let data_ingestion_path = tempdir().unwrap().into_path();
-    let mut sim = Simulacrum::new();
-    sim.set_data_ingestion_path(data_ingestion_path.clone());
+#[test]
+fn get_epoch_metrics() {
+    let InitializedSimulacrumEnv {
+        runtime,
+        sim,
+        store,
+        client,
+    } = get_or_init_shared_extended_api_simulacrum_env();
 
-    execute_simulacrum_transactions(&mut sim, 15);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch();
+    runtime.block_on(async move {
+        let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        indexer_wait_for_checkpoint(&store, last_checkpoint.sequence_number).await;
 
-    execute_simulacrum_transactions(&mut sim, 10);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch();
+        let epoch_metrics = client.get_epoch_metrics(None, None, None).await.unwrap();
 
-    execute_simulacrum_transactions(&mut sim, 5);
-    add_checkpoints(&mut sim, 300);
+        assert_eq!(epoch_metrics.data.len(), 3);
+        assert!(!epoch_metrics.has_next_page);
 
-    let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        let end_of_epoch_info = epoch_metrics.data[0].end_of_epoch_info.as_ref().unwrap();
+        assert_eq!(epoch_metrics.data[0].epoch, 0);
+        assert_eq!(epoch_metrics.data[0].first_checkpoint_id, 0);
+        assert_eq!(epoch_metrics.data[0].epoch_total_transactions, 17);
+        assert_eq!(end_of_epoch_info.last_checkpoint_id, 301);
 
-    let (_, pg_store, _, indexer_client) =
-        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim), data_ingestion_path).await;
-    indexer_wait_for_checkpoint(&pg_store, last_checkpoint.sequence_number).await;
+        let end_of_epoch_info = epoch_metrics.data[1].end_of_epoch_info.as_ref().unwrap();
+        assert_eq!(epoch_metrics.data[1].epoch, 1);
+        assert_eq!(epoch_metrics.data[1].first_checkpoint_id, 302);
+        assert_eq!(epoch_metrics.data[1].epoch_total_transactions, 11);
+        assert_eq!(end_of_epoch_info.last_checkpoint_id, 602);
 
-    let epochs = indexer_client
-        .get_epoch_metrics(None, None, Some(true))
-        .await
-        .unwrap();
-
-    let actual_epochs_order = epochs
-        .data
-        .iter()
-        .map(|epoch| epoch.epoch)
-        .collect::<Vec<u64>>();
-
-    assert_eq!(epochs.data.len(), 3);
-    assert!(!epochs.has_next_page);
-    assert_eq!(actual_epochs_order, [2, 1, 0])
+        assert_eq!(epoch_metrics.data[2].epoch, 2);
+        assert_eq!(epoch_metrics.data[2].first_checkpoint_id, 603);
+        assert_eq!(epoch_metrics.data[2].epoch_total_transactions, 0);
+        assert!(epoch_metrics.data[2].end_of_epoch_info.is_none());
+    });
 }
 
-#[tokio::test]
-#[serial]
-async fn get_epoch_metrics_paging() {
-    let data_ingestion_path = tempdir().unwrap().into_path();
-    let mut sim = Simulacrum::new();
-    sim.set_data_ingestion_path(data_ingestion_path.clone());
+#[test]
+fn get_epoch_metrics_descending() {
+    let InitializedSimulacrumEnv {
+        runtime,
+        sim,
+        store,
+        client,
+    } = get_or_init_shared_extended_api_simulacrum_env();
 
-    execute_simulacrum_transactions(&mut sim, 15);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch();
+    runtime.block_on(async move {
+        let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        indexer_wait_for_checkpoint(&store, last_checkpoint.sequence_number).await;
 
-    execute_simulacrum_transactions(&mut sim, 10);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch();
+        let epochs = client
+            .get_epoch_metrics(None, None, Some(true))
+            .await
+            .unwrap();
 
-    execute_simulacrum_transactions(&mut sim, 5);
-    add_checkpoints(&mut sim, 300);
+        let actual_epochs_order = epochs
+            .data
+            .iter()
+            .map(|epoch| epoch.epoch)
+            .collect::<Vec<u64>>();
 
-    let last_checkpoint = sim.get_latest_checkpoint().unwrap();
-
-    let (_, pg_store, _, indexer_client) =
-        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim), data_ingestion_path).await;
-    indexer_wait_for_checkpoint(&pg_store, last_checkpoint.sequence_number).await;
-
-    let epochs = indexer_client
-        .get_epoch_metrics(None, Some(2), None)
-        .await
-        .unwrap();
-    let actual_epochs_order = epochs
-        .data
-        .iter()
-        .map(|epoch| epoch.epoch)
-        .collect::<Vec<u64>>();
-
-    assert_eq!(epochs.data.len(), 2);
-    assert!(epochs.has_next_page);
-    assert_eq!(epochs.next_cursor, Some(1.into()));
-    assert_eq!(actual_epochs_order, [0, 1]);
-
-    let epochs = indexer_client
-        .get_epoch_metrics(Some(1.into()), Some(2), None)
-        .await
-        .unwrap();
-    let actual_epochs_order = epochs
-        .data
-        .iter()
-        .map(|epoch| epoch.epoch)
-        .collect::<Vec<u64>>();
-
-    assert_eq!(epochs.data.len(), 1);
-    assert!(!epochs.has_next_page);
-    assert_eq!(epochs.next_cursor, Some(2.into()));
-    assert_eq!(actual_epochs_order, [2]);
+        assert_eq!(epochs.data.len(), 3);
+        assert!(!epochs.has_next_page);
+        assert_eq!(actual_epochs_order, [2, 1, 0]);
+    });
 }
 
-#[tokio::test]
-#[serial]
-async fn get_current_epoch() {
-    let data_ingestion_path = tempdir().unwrap().into_path();
-    let mut sim = Simulacrum::new();
-    sim.set_data_ingestion_path(data_ingestion_path.clone());
+#[test]
+fn get_epoch_metrics_paging() {
+    let InitializedSimulacrumEnv {
+        runtime,
+        sim,
+        store,
+        client,
+    } = get_or_init_shared_extended_api_simulacrum_env();
 
-    execute_simulacrum_transactions(&mut sim, 15);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch();
+    runtime.block_on(async move {
+        let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        indexer_wait_for_checkpoint(&store, last_checkpoint.sequence_number).await;
 
-    execute_simulacrum_transactions(&mut sim, 10);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch();
+        let epochs = client.get_epoch_metrics(None, Some(2), None).await.unwrap();
+        let actual_epochs_order = epochs
+            .data
+            .iter()
+            .map(|epoch| epoch.epoch)
+            .collect::<Vec<u64>>();
 
-    execute_simulacrum_transactions(&mut sim, 5);
-    add_checkpoints(&mut sim, 300);
+        assert_eq!(epochs.data.len(), 2);
+        assert!(epochs.has_next_page);
+        assert_eq!(epochs.next_cursor, Some(1.into()));
+        assert_eq!(actual_epochs_order, [0, 1]);
 
-    let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        let epochs = client
+            .get_epoch_metrics(Some(1.into()), Some(2), None)
+            .await
+            .unwrap();
+        let actual_epochs_order = epochs
+            .data
+            .iter()
+            .map(|epoch| epoch.epoch)
+            .collect::<Vec<u64>>();
 
-    let (_, pg_store, _, indexer_client) =
-        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim), data_ingestion_path).await;
-    indexer_wait_for_checkpoint(&pg_store, last_checkpoint.sequence_number).await;
+        assert_eq!(epochs.data.len(), 1);
+        assert!(!epochs.has_next_page);
+        assert_eq!(epochs.next_cursor, Some(2.into()));
+        assert_eq!(actual_epochs_order, [2]);
+    });
+}
 
-    let current_epoch = indexer_client.get_current_epoch().await.unwrap();
+#[test]
+fn get_current_epoch() {
+    let InitializedSimulacrumEnv {
+        runtime,
+        sim,
+        store,
+        client,
+    } = get_or_init_shared_extended_api_simulacrum_env();
 
-    assert_eq!(current_epoch.epoch, 2);
-    assert_eq!(current_epoch.first_checkpoint_id, 603);
-    assert_eq!(current_epoch.epoch_total_transactions, 0);
-    assert!(current_epoch.end_of_epoch_info.is_none());
+    runtime.block_on(async move {
+        let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        indexer_wait_for_checkpoint(&store, last_checkpoint.sequence_number).await;
+
+        let current_epoch = client.get_current_epoch().await.unwrap();
+
+        assert_eq!(current_epoch.epoch, 2);
+        assert_eq!(current_epoch.first_checkpoint_id, 603);
+        assert_eq!(current_epoch.epoch_total_transactions, 0);
+        assert!(current_epoch.end_of_epoch_info.is_none());
+    });
 }
 
 #[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2371642744"]
-#[tokio::test]
-#[serial]
-async fn get_network_metrics() {
-    let (_, pg_store, indexer_client) = start_test_cluster_with_read_write_indexer(None).await;
-    indexer_wait_for_checkpoint(&pg_store, 10).await;
+#[test]
+fn get_network_metrics() {
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        ..
+    } = ApiTestSetup::get_or_init();
 
-    let network_metrics = indexer_client.get_network_metrics().await.unwrap();
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(&store, 10).await;
 
-    println!("{:#?}", network_metrics);
+        let network_metrics = client.get_network_metrics().await.unwrap();
+
+        println!("{:#?}", network_metrics);
+    });
 }
 
 #[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2371642744"]
-#[tokio::test]
-#[serial]
-async fn get_move_call_metrics() {
-    let (cluster, pg_store, indexer_client) =
-        start_test_cluster_with_read_write_indexer(None).await;
+#[test]
+fn get_move_call_metrics() {
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        cluster,
+        ..
+    } = ApiTestSetup::get_or_init();
 
-    execute_move_fn(&cluster).await.unwrap();
+    runtime.block_on(async move {
+        execute_move_fn(&cluster).await.unwrap();
 
-    let latest_checkpoint_sn = cluster
-        .rpc_client()
-        .get_latest_checkpoint_sequence_number()
-        .await
-        .unwrap();
-    indexer_wait_for_checkpoint(&pg_store, latest_checkpoint_sn.into_inner()).await;
+        let latest_checkpoint_sn = cluster
+            .rpc_client()
+            .get_latest_checkpoint_sequence_number()
+            .await
+            .unwrap();
+        indexer_wait_for_checkpoint(&store, latest_checkpoint_sn.into_inner()).await;
 
-    let move_call_metrics = indexer_client.get_move_call_metrics().await.unwrap();
+        let move_call_metrics = client.get_move_call_metrics().await.unwrap();
 
-    // TODO: Why is the move call not included in the stats?
-    assert_eq!(move_call_metrics.rank_3_days.len(), 0);
-    assert_eq!(move_call_metrics.rank_7_days.len(), 0);
-    assert_eq!(move_call_metrics.rank_30_days.len(), 0);
+        // TODO: Why is the move call not included in the stats?
+        assert_eq!(move_call_metrics.rank_3_days.len(), 0);
+        assert_eq!(move_call_metrics.rank_7_days.len(), 0);
+        assert_eq!(move_call_metrics.rank_30_days.len(), 0);
+    });
 }
 
 #[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2371642744"]
-#[tokio::test]
-#[serial]
-async fn get_latest_address_metrics() {
-    let (_, pg_store, indexer_client) = start_test_cluster_with_read_write_indexer(None).await;
-    indexer_wait_for_checkpoint(&pg_store, 10).await;
+#[test]
+fn get_latest_address_metrics() {
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        ..
+    } = ApiTestSetup::get_or_init();
 
-    let address_metrics = indexer_client.get_latest_address_metrics().await.unwrap();
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(&store, 10).await;
 
-    println!("{:#?}", address_metrics);
+        let address_metrics = client.get_latest_address_metrics().await.unwrap();
+
+        println!("{:#?}", address_metrics);
+    });
 }
 
 #[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2371642744"]
-#[tokio::test]
-#[serial]
-async fn get_checkpoint_address_metrics() {
-    let (_, pg_store, indexer_client) = start_test_cluster_with_read_write_indexer(None).await;
-    indexer_wait_for_checkpoint(&pg_store, 10).await;
+#[test]
+fn get_checkpoint_address_metrics() {
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        ..
+    } = ApiTestSetup::get_or_init();
 
-    let address_metrics = indexer_client
-        .get_checkpoint_address_metrics(0)
-        .await
-        .unwrap();
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(&store, 10).await;
 
-    println!("{:#?}", address_metrics);
+        let address_metrics = client.get_checkpoint_address_metrics(0).await.unwrap();
+
+        println!("{:#?}", address_metrics);
+    });
 }
 
 #[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2371642744"]
-#[tokio::test]
-#[serial]
-async fn get_all_epoch_address_metrics() {
-    let (_, pg_store, indexer_client) = start_test_cluster_with_read_write_indexer(None).await;
-    indexer_wait_for_checkpoint(&pg_store, 10).await;
+#[test]
+fn get_all_epoch_address_metrics() {
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        ..
+    } = ApiTestSetup::get_or_init();
 
-    let address_metrics = indexer_client
-        .get_all_epoch_address_metrics(None)
-        .await
-        .unwrap();
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(&store, 10).await;
 
-    println!("{:#?}", address_metrics);
+        let address_metrics = client.get_all_epoch_address_metrics(None).await.unwrap();
+
+        println!("{:#?}", address_metrics);
+    });
 }
 
-#[tokio::test]
-#[serial]
-async fn get_total_transactions() {
-    let data_ingestion_path = tempdir().unwrap().into_path();
-    let mut sim = Simulacrum::new();
-    sim.set_data_ingestion_path(data_ingestion_path.clone());
-    execute_simulacrum_transactions(&mut sim, 5);
+#[test]
+fn get_total_transactions() {
+    let InitializedSimulacrumEnv {
+        runtime,
+        sim,
+        store,
+        client,
+    } = get_or_init_shared_extended_api_simulacrum_env();
 
-    let latest_checkpoint = sim.create_checkpoint();
-    let total_transactions_count = latest_checkpoint.network_total_transactions;
+    runtime.block_on(async move {
+        let latest_checkpoint = sim.get_latest_checkpoint().unwrap();
+        let total_transactions_count = latest_checkpoint.network_total_transactions;
+        indexer_wait_for_checkpoint(&store, latest_checkpoint.sequence_number).await;
 
-    let (_, pg_store, _, indexer_client) =
-        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim), data_ingestion_path).await;
-    indexer_wait_for_checkpoint(&pg_store, latest_checkpoint.sequence_number).await;
-
-    let transactions_cnt = indexer_client.get_total_transactions().await.unwrap();
-    assert_eq!(transactions_cnt.into_inner(), total_transactions_count);
-    assert_eq!(transactions_cnt.into_inner(), 6);
+        let transactions_cnt = client.get_total_transactions().await.unwrap();
+        assert_eq!(transactions_cnt.into_inner(), total_transactions_count);
+        assert_eq!(transactions_cnt.into_inner(), 33);
+    });
 }
 
 async fn execute_move_fn(cluster: &TestCluster) -> Result<(), anyhow::Error> {

--- a/crates/iota-indexer/tests/rpc-tests/extended_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/extended_api.rs
@@ -22,19 +22,16 @@ use simulacrum::Simulacrum;
 use tempfile::tempdir;
 use test_cluster::TestCluster;
 
-use crate::common::{
-    indexer_wait_for_checkpoint, ApiTestSetup, InitializedSimulacrumEnv,
-    SimulacrumApiTestEnvDefinition,
-};
+use crate::common::{ApiTestSetup, SimulacrumTestSetup, indexer_wait_for_checkpoint};
 
-static EXTENDED_API_SHARED_SIMULACRUM_INITIALIZED_ENV: OnceLock<InitializedSimulacrumEnv> =
+static EXTENDED_API_SHARED_SIMULACRUM_INITIALIZED_ENV: OnceLock<SimulacrumTestSetup> =
     OnceLock::new();
 
-fn get_or_init_shared_extended_api_simulacrum_env() -> &'static InitializedSimulacrumEnv {
+fn get_or_init_shared_extended_api_simulacrum_env() -> &'static SimulacrumTestSetup {
     let data_ingestion_path = tempdir().unwrap().into_path();
-    let extended_api_env = SimulacrumApiTestEnvDefinition {
-        unique_env_name: "extended_api".to_string(),
-        env_initializer: Box::new(|| {
+    SimulacrumTestSetup::get_or_init(
+        "extended_api",
+        || {
             let mut sim = Simulacrum::new();
     sim.set_data_ingestion_path(data_ingestion_path.clone());
 
@@ -50,14 +47,14 @@ fn get_or_init_shared_extended_api_simulacrum_env() -> &'static InitializedSimul
             add_checkpoints(&mut sim, 300);
 
             sim
-        }),
-    };
-    extended_api_env.get_or_init_env(&EXTENDED_API_SHARED_SIMULACRUM_INITIALIZED_ENV)
+        },
+        &EXTENDED_API_SHARED_SIMULACRUM_INITIALIZED_ENV,
+    )
 }
 
 #[test]
 fn get_epochs() {
-    let InitializedSimulacrumEnv {
+    let SimulacrumTestSetup {
         runtime,
         sim,
         store,
@@ -94,7 +91,7 @@ fn get_epochs() {
 
 #[test]
 fn get_epochs_descending() {
-    let InitializedSimulacrumEnv {
+    let SimulacrumTestSetup {
         runtime,
         sim,
         store,
@@ -121,7 +118,7 @@ fn get_epochs_descending() {
 
 #[test]
 fn get_epochs_paging() {
-    let InitializedSimulacrumEnv {
+    let SimulacrumTestSetup {
         runtime,
         sim,
         store,
@@ -163,7 +160,7 @@ fn get_epochs_paging() {
 
 #[test]
 fn get_epoch_metrics() {
-    let InitializedSimulacrumEnv {
+    let SimulacrumTestSetup {
         runtime,
         sim,
         store,
@@ -200,7 +197,7 @@ fn get_epoch_metrics() {
 
 #[test]
 fn get_epoch_metrics_descending() {
-    let InitializedSimulacrumEnv {
+    let SimulacrumTestSetup {
         runtime,
         sim,
         store,
@@ -230,7 +227,7 @@ fn get_epoch_metrics_descending() {
 
 #[test]
 fn get_epoch_metrics_paging() {
-    let InitializedSimulacrumEnv {
+    let SimulacrumTestSetup {
         runtime,
         sim,
         store,
@@ -272,7 +269,7 @@ fn get_epoch_metrics_paging() {
 
 #[test]
 fn get_current_epoch() {
-    let InitializedSimulacrumEnv {
+    let SimulacrumTestSetup {
         runtime,
         sim,
         store,
@@ -400,7 +397,7 @@ fn get_all_epoch_address_metrics() {
 
 #[test]
 fn get_total_transactions() {
-    let InitializedSimulacrumEnv {
+    let SimulacrumTestSetup {
         runtime,
         sim,
         store,

--- a/crates/iota-indexer/tests/rpc-tests/extended_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/extended_api.rs
@@ -28,20 +28,19 @@ static EXTENDED_API_SHARED_SIMULACRUM_INITIALIZED_ENV: OnceLock<SimulacrumTestSe
     OnceLock::new();
 
 fn get_or_init_shared_extended_api_simulacrum_env() -> &'static SimulacrumTestSetup {
-    let data_ingestion_path = tempdir().unwrap().into_path();
     SimulacrumTestSetup::get_or_init(
         "extended_api",
-        || {
+        |data_ingestion_path| {
             let mut sim = Simulacrum::new();
-    sim.set_data_ingestion_path(data_ingestion_path.clone());
+            sim.set_data_ingestion_path(data_ingestion_path);
 
             execute_simulacrum_transactions(&mut sim, 15);
             add_checkpoints(&mut sim, 300);
-    sim.advance_epoch();
+            sim.advance_epoch();
 
             execute_simulacrum_transactions(&mut sim, 10);
             add_checkpoints(&mut sim, 300);
-    sim.advance_epoch();
+            sim.advance_epoch();
 
             execute_simulacrum_transactions(&mut sim, 5);
             add_checkpoints(&mut sim, 300);

--- a/crates/iota-indexer/tests/rpc-tests/main.rs
+++ b/crates/iota-indexer/tests/rpc-tests/main.rs
@@ -4,7 +4,7 @@
 #[allow(dead_code)]
 #[path = "../common/mod.rs"]
 mod common;
-#[cfg(feature = "pg_integration")]
+#[cfg(feature = "shared_test_runtime")]
 mod extended_api;
 #[cfg(feature = "shared_test_runtime")]
 mod governance_api;


### PR DESCRIPTION
# Description of change

Introduce shared simulacrum cluster, to use in extended api tests.

With this PR execution of all tests in iota-indexer takes 30 seconds.

With this change the tests are using `shared_test_indexer_db` for tests with shared cluster, `simulacrum_env_db_extended_api` for extended_api tests with shared simulacrum and `indexer_ingestion_tests_db` for ingestion tests in iota-indexer.

Test indexer reader is always run on some free port, instead of a hardcoded one.

Simulacrum fullnode rpc api is run on free port by default, instead of hardcoded one.

In general it allows to have several simulacrum envs and indexers to be running next to each other without conflict.

## Links to any relevant issues

fixes #2951  

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo test --profile simulator --features shared_test_runtime --test rpc-tests`

`cargo test --profile simulator --features pg_integration --test ingestion_tests -- --test-threads=1`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
