### PR TITLE
feat(iota-config/node): create a node::MigrationTxData type

### DIFF
--- a/crates/iota-config/src/migration_tx_data.rs
+++ b/crates/iota-config/src/migration_tx_data.rs
@@ -41,6 +41,10 @@ impl MigrationTxData {
         self.inner
     }
 
+    pub fn txs_data(&self) -> &TransactionsData {
+        &self.inner
+    }
+
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, anyhow::Error> {
         let path = path.as_ref();
         trace!("Reading Migration transaction data from {}", path.display());

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -795,7 +795,6 @@ fn default_authority_overload_config() -> AuthorityOverloadConfig {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq)]
 pub struct MigrationTxData {
-    #[serde(flatten)]
     location: Option<PathBuf>,
 }
 

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -32,7 +32,7 @@ use serde_with::serde_as;
 use tracing::info;
 
 use crate::{
-    certificate_deny_config::CertificateDenyConfig, genesis,
+    certificate_deny_config::CertificateDenyConfig, genesis, migration_tx_data,
     object_storage_config::ObjectStoreConfig, p2p::P2pConfig,
     transaction_deny_config::TransactionDenyConfig, Config,
 };
@@ -60,7 +60,6 @@ pub struct NodeConfig {
     pub network_key_pair: KeyPairWithPath,
 
     #[serde(default)]
-    pub migration_data_path: Option<PathBuf>,
     pub db_path: PathBuf,
     #[serde(default = "default_grpc_address")]
     pub network_address: Multiaddr,
@@ -99,6 +98,8 @@ pub struct NodeConfig {
     pub p2p_config: P2pConfig,
 
     pub genesis: Genesis,
+
+    pub migration_tx_data: MigrationTxData,
 
     #[serde(default = "default_authority_store_pruning_config")]
     pub authority_store_pruning_config: AuthorityStorePruningConfig,
@@ -291,10 +292,6 @@ impl NodeConfig {
         self.db_path.join("live")
     }
 
-    pub fn migration_data_path(&self) -> &Option<PathBuf> {
-        &self.migration_data_path
-    }
-
     pub fn db_checkpoint_path(&self) -> PathBuf {
         self.db_path.join("db_checkpoints")
     }
@@ -317,6 +314,10 @@ impl NodeConfig {
 
     pub fn genesis(&self) -> Result<&genesis::Genesis> {
         self.genesis.genesis()
+    }
+
+    pub fn migration_tx_data(&self) -> Result<&migration_tx_data::MigrationTxData> {
+        self.migration_tx_data.migration_tx_data()
     }
 
     pub fn iota_address(&self) -> IotaAddress {
@@ -790,6 +791,64 @@ impl Default for AuthorityOverloadConfig {
 
 fn default_authority_overload_config() -> AuthorityOverloadConfig {
     AuthorityOverloadConfig::default()
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq)]
+pub struct MigrationTxData {
+    #[serde(flatten)]
+    location: Option<MigrationTxDataLocation>,
+
+    #[serde(skip)]
+    migration_tx_data: once_cell::sync::OnceCell<migration_tx_data::MigrationTxData>,
+}
+
+impl MigrationTxData {
+    pub fn new(migration_tx_data: migration_tx_data::MigrationTxData) -> Self {
+        Self {
+            location: Some(MigrationTxDataLocation::InPlace { migration_tx_data }),
+            migration_tx_data: Default::default(),
+        }
+    }
+
+    pub fn new_from_file<P: Into<PathBuf>>(path: P) -> Self {
+        Self {
+            location: Some(MigrationTxDataLocation::File {
+                migration_tx_data_file_location: path.into(),
+            }),
+            migration_tx_data: Default::default(),
+        }
+    }
+
+    pub fn new_empty() -> Self {
+        Self {
+            location: None,
+            migration_tx_data: Default::default(),
+        }
+    }
+
+    pub fn migration_tx_data(&self) -> Result<&migration_tx_data::MigrationTxData> {
+        match &self.location {
+            Some(MigrationTxDataLocation::InPlace { migration_tx_data }) => Ok(migration_tx_data),
+            Some(MigrationTxDataLocation::File {
+                migration_tx_data_file_location,
+            }) => self.migration_tx_data.get_or_try_init(|| {
+                migration_tx_data::MigrationTxData::load(migration_tx_data_file_location)
+            }),
+            None => anyhow::bail!("no migration_tx_data location set"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq)]
+#[serde(untagged)]
+enum MigrationTxDataLocation {
+    InPlace {
+        migration_tx_data: migration_tx_data::MigrationTxData,
+    },
+    File {
+        #[serde(rename = "migration-tx-data-file-location")]
+        migration_tx_data_file_location: PathBuf,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq)]

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -2,6 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use core::panic;
 use std::{cmp::Ordering, iter, mem, ops::Not, sync::Arc, thread};
 
 use either::Either;
@@ -151,7 +152,7 @@ impl AuthorityStore {
         indirect_objects_threshold: usize,
         enable_epoch_iota_conservation_check: bool,
         registry: &Registry,
-        migration_tx_data: Option<MigrationTxData>,
+        migration_tx_data: Option<&MigrationTxData>,
     ) -> IotaResult<Arc<Self>> {
         let epoch_start_configuration = if perpetual_tables.database_is_empty()? {
             info!("Creating new epoch start config from genesis");
@@ -252,7 +253,7 @@ impl AuthorityStore {
         indirect_objects_threshold: usize,
         enable_epoch_iota_conservation_check: bool,
         registry: &Registry,
-        migration_tx_data: Option<MigrationTxData>,
+        migration_tx_data: Option<&MigrationTxData>,
     ) -> IotaResult<Arc<Self>> {
         let store = Arc::new(Self {
             mutex_table: MutexTable::new(NUM_SHARDS),
@@ -301,14 +302,14 @@ impl AuthorityStore {
             store.perpetual_tables.events.multi_insert(events).unwrap();
 
             if let Some(migration_transactions) = migration_tx_data {
-                let mut txs_data = migration_transactions.extract_txs_data();
+                let txs_data = migration_transactions.txs_data();
 
                 for tx_digest in genesis.migration_txs_digests() {
-                    if let Some((tx, effects, events, objects)) = txs_data.remove(&tx_digest) {
+                    if let Some((tx, effects, events, objects)) = txs_data.get(&tx_digest) {
                         let transaction = VerifiedTransaction::new_unchecked(tx.clone());
 
                         store
-                            .bulk_insert_genesis_objects(&objects)
+                            .bulk_insert_genesis_objects(objects)
                             .expect("Cannot bulk insert migrated objects");
 
                         store
@@ -320,7 +321,7 @@ impl AuthorityStore {
                         store
                             .perpetual_tables
                             .effects
-                            .insert(&effects.digest(), &effects)
+                            .insert(&effects.digest(), effects)
                             .expect("Cannot insert migration effects");
 
                         let events = events
@@ -329,14 +330,10 @@ impl AuthorityStore {
                             .enumerate()
                             .map(|(i, e)| ((events.digest(), i), e));
                         store.perpetual_tables.events.multi_insert(events).unwrap();
+                    } else {
+                        panic!("tx digest not found in migrated objects blob");
                     }
                 }
-
-                // Assert that all transactions have been successfully processed.
-                assert!(
-                    txs_data.is_empty(),
-                    "Migration data hasn't been processed correctly"
-                );
             }
         }
 

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -152,7 +152,7 @@ impl AuthorityStore {
         indirect_objects_threshold: usize,
         enable_epoch_iota_conservation_check: bool,
         registry: &Registry,
-        migration_tx_data: Option<&MigrationTxData>,
+        migration_tx_data: Option<MigrationTxData>,
     ) -> IotaResult<Arc<Self>> {
         let epoch_start_configuration = if perpetual_tables.database_is_empty()? {
             info!("Creating new epoch start config from genesis");
@@ -253,7 +253,7 @@ impl AuthorityStore {
         indirect_objects_threshold: usize,
         enable_epoch_iota_conservation_check: bool,
         registry: &Registry,
-        migration_tx_data: Option<&MigrationTxData>,
+        migration_tx_data: Option<MigrationTxData>,
     ) -> IotaResult<Arc<Self>> {
         let store = Arc::new(Self {
             mutex_table: MutexTable::new(NUM_SHARDS),
@@ -302,14 +302,14 @@ impl AuthorityStore {
             store.perpetual_tables.events.multi_insert(events).unwrap();
 
             if let Some(migration_transactions) = migration_tx_data {
-                let txs_data = migration_transactions.txs_data();
+                let mut txs_data = migration_transactions.extract_txs_data();
 
                 for tx_digest in genesis.migration_txs_digests() {
-                    if let Some((tx, effects, events, objects)) = txs_data.get(&tx_digest) {
+                    if let Some((tx, effects, events, objects)) = txs_data.remove(tx_digest) {
                         let transaction = VerifiedTransaction::new_unchecked(tx.clone());
 
                         store
-                            .bulk_insert_genesis_objects(objects)
+                            .bulk_insert_genesis_objects(&objects)
                             .expect("Cannot bulk insert migrated objects");
 
                         store
@@ -321,7 +321,7 @@ impl AuthorityStore {
                         store
                             .perpetual_tables
                             .effects
-                            .insert(&effects.digest(), effects)
+                            .insert(&effects.digest(), &effects)
                             .expect("Cannot insert migration effects");
 
                         let events = events
@@ -334,6 +334,12 @@ impl AuthorityStore {
                         panic!("tx digest not found in migrated objects blob");
                     }
                 }
+
+                // Assert that all transactions have been successfully processed.
+                assert!(
+                    txs_data.is_empty(),
+                    "Migration transaction data blob was altered"
+                );
             }
         }
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -424,15 +424,13 @@ impl IotaNode {
         DBMetrics::init(&prometheus_registry);
         iota_metrics::init_metrics(&prometheus_registry);
 
-        let mut migration_tx_data = None;
         let genesis = config.genesis()?;
-        if !genesis.is_vanilla() {
-            if let Some(migration_path) = config.migration_data_path() {
-                migration_tx_data = Some(iota_config::migration_tx_data::MigrationTxData::load(
-                    migration_path,
-                )?);
-            }
-        }
+        let migration_tx_data = if !genesis.is_vanilla() {
+            Some(config.migration_tx_data()?)
+        } else {
+            None
+        };
+
         let secret = Arc::pin(config.protocol_key_pair().copy());
         let genesis_committee = genesis.committee()?;
         let committee_store = Arc::new(CommitteeStore::new(

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -426,7 +426,7 @@ impl IotaNode {
 
         let genesis = config.genesis()?;
         let migration_tx_data = if !genesis.is_vanilla() {
-            Some(config.migration_tx_data()?)
+            Some(config.load_migration_tx_data()?)
         } else {
             None
         };


### PR DESCRIPTION
# Description of change

Created a type `MigrationTxData` in `iota_config::node` that mimics the `Genesis` type in the same file. This allows to create a unique instance of MigrationTxData for the config, by referring to the file.

