### PR TITLE
fix(iota-node): migration transactions execution has been added

### DIFF
--- a/crates/iota-config/src/migration_tx_data.rs
+++ b/crates/iota-config/src/migration_tx_data.rs
@@ -37,10 +37,6 @@ impl MigrationTxData {
         Self { inner: txs_data }
     }
 
-    pub fn extract_txs_data(self) -> TransactionsData {
-        self.inner
-    }
-
     pub fn txs_data(&self) -> &TransactionsData {
         &self.inner
     }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -649,14 +649,14 @@ impl IotaNode {
             let genesis_tx = &genesis.transaction();
             let span = error_span!("genesis_txn", tx_digest = ?genesis_tx.digest());
             // Execute genesis transaction 
-            Self::execute_transaction_immediately(&state, &epoch_store, genesis_tx, span).await;
+            Self::execute_transaction_immediately_at_zero_epoch_checkpoint(&state, &epoch_store, genesis_tx, span).await;
  
             if let Some(migration_tx_data) = migration_tx_data {
                 for (tx_digest, (tx, _, _, _)) in migration_tx_data.txs_data() {
                     let span = error_span!("migration_txn", tx_digest = ?tx_digest);
 
                     // Execute migration transaction
-                    Self::execute_transaction_immediately(&state, &epoch_store, tx, span).await;
+                    Self::execute_transaction_immediately_at_zero_epoch_checkpoint(&state, &epoch_store, tx, span).await;
                 }
             }
         }
@@ -1803,7 +1803,7 @@ impl IotaNode {
         &self.config
     }
 
-    async fn execute_transaction_immediately(state: &Arc<AuthorityState>, epoch_store: &Arc<AuthorityPerEpochStore>, tx: &Transaction, span: tracing::Span) {
+    async fn execute_transaction_immediately_at_zero_epoch_checkpoint(state: &Arc<AuthorityState>, epoch_store: &Arc<AuthorityPerEpochStore>, tx: &Transaction, span: tracing::Span) {
         let transaction =
             iota_types::executable_transaction::VerifiedExecutableTransaction::new_unchecked(
                 iota_types::executable_transaction::ExecutableTransaction::new_from_data_and_sig(


### PR DESCRIPTION
# Description of change

Continues fixing #2903 .

Migration transactions execution has been added according to genesis transaction flow.

## Type of change
- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo run --release --bin iota genesis --working-dir test_iota_config -f --with-faucet --num-validators 1 --remote-migration-snapshots https://stardust-objects.s3.eu-central-1.amazonaws.com/iota/alphanet/latest/stardust_object_snapshot.bin.gz
`
```
cargo build --release --bin iota-test-validator
./target/release/iota-test-validator --config-dir test_iota_config
```