### PR TITLE
feat(iota-json-rpc-tests): Add missing TransactionBuilderApi tests for transfer/pay endpoinds for fullnode

### DIFF
--- a/crates/iota-json-rpc-tests/README.md
+++ b/crates/iota-json-rpc-tests/README.md
@@ -98,10 +98,10 @@ That is, expect for the `WriteApi` methods that serve requests relayed by `iota-
 ### `TransactionBuilder` (7/15)
 
 - [x] `transfer_object`
-- [ ] `transfer_iota`
-- [ ] `pay`
-- [ ] `pay_iota`
-- [ ] `pay_all_iota`
+- [x] `transfer_iota`
+- [x] `pay`
+- [x] `pay_iota`
+- [x] `pay_all_iota`
 - [x] `move_call`
 - [x] `publish`
 - [ ] `split_coin`
@@ -116,5 +116,5 @@ That is, expect for the `WriteApi` methods that serve requests relayed by `iota-
 ### `WriteApi` (2/3)
 
 - [x] `execute_transaction_block`
-- [ ] `dev_inspect_transaction_block`
+- [x] `dev_inspect_transaction_block`
 - [x] `dry_run_transaction_block`


### PR DESCRIPTION
# Description of change

Add missing `TransactionBuilderApi`  transfer/pay endpoinds tests in `iota-json-rpc-tests`

## Links to any relevant issues

completes half of the work from #2915

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo test -j2 --test transaction_builder_api`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
