### PR TITLE
feat(iota-genesis-builder): Remove migration tx digests from Genesis

### DIFF
--- a/crates/iota-config/src/genesis.rs
+++ b/crates/iota-config/src/genesis.rs
@@ -21,7 +21,6 @@ use iota_types::{
     committee::{Committee, CommitteeWithNetworkMetadata, EpochId, ProtocolVersion},
     crypto::DefaultHash,
     deny_list::{get_coin_deny_list, PerTypeDenyList},
-    digests::TransactionDigest,
     effects::{TransactionEffects, TransactionEvents},
     error::IotaResult,
     iota_system_state::{
@@ -47,7 +46,6 @@ pub struct Genesis {
     effects: TransactionEffects,
     events: TransactionEvents,
     objects: Vec<Object>,
-    migration_txs_digests: Vec<TransactionDigest>,
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
@@ -58,7 +56,6 @@ pub struct UnsignedGenesis {
     pub effects: TransactionEffects,
     pub events: TransactionEvents,
     pub objects: Vec<Object>,
-    pub migration_txs_digests: Vec<TransactionDigest>,
 }
 
 // Hand implement PartialEq in order to get around the fact that AuthSigs don't
@@ -78,7 +75,6 @@ impl PartialEq for Genesis {
             && self.transaction == other.transaction
             && self.effects == other.effects
             && self.objects == other.objects
-            && self.migration_txs_digests == other.migration_txs_digests
     }
 }
 
@@ -92,7 +88,6 @@ impl Genesis {
         effects: TransactionEffects,
         events: TransactionEvents,
         objects: Vec<Object>,
-        migration_txs_digests: Vec<TransactionDigest>,
     ) -> Self {
         Self {
             checkpoint,
@@ -101,12 +96,7 @@ impl Genesis {
             effects,
             events,
             objects,
-            migration_txs_digests,
         }
-    }
-
-    pub fn migration_txs_digests(&self) -> &[TransactionDigest] {
-        &self.migration_txs_digests
     }
 
     pub fn into_objects(self) -> Vec<Object> {
@@ -173,7 +163,7 @@ impl Genesis {
     }
 
     pub fn is_vanilla(&self) -> bool {
-        self.migration_txs_digests.is_empty()
+        self.checkpoint_contents.size() == 1
     }
 
     pub fn iota_system_object(&self) -> IotaSystemState {
@@ -240,7 +230,6 @@ impl Serialize for Genesis {
             effects: &'a TransactionEffects,
             events: &'a TransactionEvents,
             objects: &'a [Object],
-            migration_txs_digests: &'a [TransactionDigest],
         }
 
         let raw_genesis = RawGenesis {
@@ -250,7 +239,6 @@ impl Serialize for Genesis {
             effects: &self.effects,
             events: &self.events,
             objects: &self.objects,
-            migration_txs_digests: &self.migration_txs_digests,
         };
 
         if serializer.is_human_readable() {
@@ -278,7 +266,6 @@ impl<'de> Deserialize<'de> for Genesis {
             effects: TransactionEffects,
             events: TransactionEvents,
             objects: Vec<Object>,
-            migration_txs_digests: Vec<TransactionDigest>,
         }
 
         let raw_genesis = if deserializer.is_human_readable() {
@@ -296,7 +283,6 @@ impl<'de> Deserialize<'de> for Genesis {
             effects: raw_genesis.effects,
             events: raw_genesis.events,
             objects: raw_genesis.objects,
-            migration_txs_digests: raw_genesis.migration_txs_digests,
         })
     }
 }

--- a/crates/iota-config/src/migration_tx_data.rs
+++ b/crates/iota-config/src/migration_tx_data.rs
@@ -45,6 +45,10 @@ impl MigrationTxData {
         &self.inner
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, anyhow::Error> {
         let path = path.as_ref();
         trace!("Reading Migration transaction data from {}", path.display());

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -324,7 +324,7 @@ impl Builder {
             &mut self.genesis_stake,
             &mut self.migration_objects,
         );
-        self.migration_tx_data = if !unsigned_genesis.migration_txs_digests.is_empty() {
+        self.migration_tx_data = if !migration_tx_data.is_empty() {
             Some(migration_tx_data)
         } else {
             None
@@ -367,7 +367,6 @@ impl Builder {
             effects,
             events,
             objects,
-            migration_txs_digests,
         } = self
             .built_genesis
             .take()
@@ -389,7 +388,6 @@ impl Builder {
                 effects,
                 events,
                 objects,
-                migration_txs_digests,
             ),
             self.migration_tx_data,
         )
@@ -1028,7 +1026,6 @@ fn build_unsigned_genesis_data<'info>(
             effects: genesis_effects,
             events: genesis_events,
             objects: genesis_objects,
-            migration_txs_digests,
         },
         MigrationTxData::new(txs_data),
     )


### PR DESCRIPTION
The use of migration transaction digests was reduntant in the `Genesis` as they are included in the `CheckpointContents` together with TransactionEffects digest.