### PR TITLE
feat(iota-node, iota-config, iota-core, genesis-builder): remove vector of objects from the migration blob

### DIFF
--- a/crates/iota-config/src/migration_tx_data.rs
+++ b/crates/iota-config/src/migration_tx_data.rs
@@ -12,21 +12,14 @@ use anyhow::{Context, Result};
 use iota_types::{
     digests::TransactionDigest,
     effects::{TransactionEffects, TransactionEvents},
-    object::Object,
-    transaction::Transaction,
+    object::{Object, ObjectInner},
+    transaction::{GenesisTransaction, Transaction, TransactionDataAPI},
 };
 use serde::{Deserialize, Serialize};
 use tracing::trace;
 
-pub type TransactionsData = BTreeMap<
-    TransactionDigest,
-    (
-        Transaction,
-        TransactionEffects,
-        TransactionEvents,
-        Vec<Object>,
-    ),
->;
+pub type TransactionsData =
+    BTreeMap<TransactionDigest, (Transaction, TransactionEffects, TransactionEvents)>;
 #[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize, Default)]
 pub struct MigrationTxData {
     inner: TransactionsData,
@@ -43,6 +36,40 @@ impl MigrationTxData {
 
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
+    }
+
+    pub fn objects_by_tx_digest(
+        &self,
+        digest: TransactionDigest,
+    ) -> Result<Vec<Object>, anyhow::Error> {
+        let mut migration_objects = Vec::new();
+
+        let (tx, _, _) = self
+            .inner
+            .get(&digest)
+            .with_context(|| format!("No transaction found for digest: {:?}", digest))?;
+        if let iota_types::transaction::TransactionKind::Genesis(GenesisTransaction {
+            objects,
+            ..
+        }) = tx.transaction_data().kind()
+        {
+            for object in objects {
+                match object {
+                    iota_types::transaction::GenesisObject::RawObject { data, owner } => {
+                        let object = ObjectInner {
+                            data: data.to_owned(),
+                            owner: owner.to_owned(),
+                            previous_transaction: tx.digest().clone(),
+                            storage_rebate: 0,
+                        };
+                        migration_objects.push(object.into());
+                    }
+                }
+            }
+        } else {
+            panic!("Wrong transaction type of migration data");
+        }
+        Ok(migration_objects)
     }
 
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, anyhow::Error> {

--- a/crates/iota-config/src/migration_tx_data.rs
+++ b/crates/iota-config/src/migration_tx_data.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     fs::File,
     io::{BufReader, BufWriter},
     path::Path,
@@ -11,12 +11,18 @@ use std::{
 use anyhow::{Context, Result};
 use iota_types::{
     digests::TransactionDigest,
-    effects::{TransactionEffects, TransactionEvents},
+    effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
+    message_envelope::Message,
+    messages_checkpoint::{CheckpointContents, CheckpointSummary},
     object::{Object, ObjectInner},
-    transaction::{GenesisTransaction, Transaction, TransactionDataAPI},
+    transaction::{
+        GenesisObject, GenesisTransaction, Transaction, TransactionDataAPI, TransactionKind,
+    },
 };
 use serde::{Deserialize, Serialize};
 use tracing::trace;
+
+use crate::genesis::{Genesis, UnsignedGenesis};
 
 pub type TransactionsData =
     BTreeMap<TransactionDigest, (Transaction, TransactionEffects, TransactionEvents)>;
@@ -48,28 +54,84 @@ impl MigrationTxData {
             .inner
             .get(&digest)
             .with_context(|| format!("No transaction found for digest: {:?}", digest))?;
-        if let iota_types::transaction::TransactionKind::Genesis(GenesisTransaction {
-            objects,
-            ..
-        }) = tx.transaction_data().kind()
+        if let TransactionKind::Genesis(GenesisTransaction { objects, .. }) =
+            tx.transaction_data().kind()
         {
-            for object in objects {
-                match object {
-                    iota_types::transaction::GenesisObject::RawObject { data, owner } => {
-                        let object = ObjectInner {
-                            data: data.to_owned(),
-                            owner: owner.to_owned(),
-                            previous_transaction: tx.digest().clone(),
-                            storage_rebate: 0,
-                        };
-                        migration_objects.push(object.into());
+            for GenesisObject::RawObject { data, owner } in objects {
+                migration_objects.push(
+                    ObjectInner {
+                        data: data.to_owned(),
+                        owner: owner.to_owned(),
+                        previous_transaction: *tx.digest(),
+                        storage_rebate: 0,
                     }
-                }
+                    .into(),
+                );
             }
         } else {
-            panic!("Wrong transaction type of migration data");
+            panic!("wrong transaction type of migration data");
         }
         Ok(migration_objects)
+    }
+
+    fn validate_from_genesis_components(
+        &self,
+        checkpoint: &CheckpointSummary,
+        contents: &CheckpointContents,
+        genesis_tx_digest: TransactionDigest,
+    ) -> anyhow::Result<()> {
+        assert_eq!(checkpoint.content_digest, *contents.digest());
+        let mut validation_digests_queue: HashSet<TransactionDigest> =
+            self.inner.keys().copied().collect();
+        for (valid_tx_digest, valid_effects_digest) in contents.iter().filter_map(|exec_digest| {
+            (exec_digest.transaction != genesis_tx_digest)
+                .then_some((&exec_digest.transaction, &exec_digest.effects))
+        }) {
+            let (tx, effects, events) = self
+                .inner
+                .get(valid_tx_digest)
+                .ok_or(anyhow::anyhow!("missing transaction digest"))?;
+
+            if &effects.digest() != valid_effects_digest
+                || effects.transaction_digest() != valid_tx_digest
+                || &tx.data().digest() != valid_tx_digest
+            {
+                anyhow::bail!("invalid transaction or effects data");
+            }
+
+            if let Some(valid_events) = effects.events_digest() {
+                if &events.digest() != valid_events {
+                    anyhow::bail!("invalid events data");
+                }
+            } else if !events.data.is_empty() {
+                anyhow::bail!("invalid events data");
+            }
+            validation_digests_queue.remove(valid_tx_digest);
+        }
+        assert!(
+            validation_digests_queue.is_empty(),
+            "the migration data is corrupted"
+        );
+        Ok(())
+    }
+
+    pub fn validate_from_genesis(&self, genesis: &Genesis) -> anyhow::Result<()> {
+        self.validate_from_genesis_components(
+            &genesis.checkpoint(),
+            genesis.checkpoint_contents(),
+            *genesis.transaction().digest(),
+        )
+    }
+
+    pub fn validate_from_unsigned_genesis(
+        &self,
+        unsigned_genesis: &UnsignedGenesis,
+    ) -> anyhow::Result<()> {
+        self.validate_from_genesis_components(
+            unsigned_genesis.checkpoint(),
+            unsigned_genesis.checkpoint_contents(),
+            *unsigned_genesis.transaction().digest(),
+        )
     }
 
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, anyhow::Error> {

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -317,7 +317,10 @@ impl NodeConfig {
     }
 
     pub fn load_migration_tx_data(&self) -> Result<migration_tx_data::MigrationTxData> {
-        self.migration_tx_data.load()
+        let migration_tx_data = self.migration_tx_data.load()?;
+        // Validate migration content in order to avoid corrupted or malicious data
+        migration_tx_data.validate_from_genesis(self.genesis.genesis()?)?;
+        Ok(migration_tx_data)
     }
 
     pub fn iota_address(&self) -> IotaAddress {

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -310,11 +310,13 @@ impl AuthorityStore {
                     .for_each(|(_, execution_digest)| {
                         let tx_digest = &execution_digest.transaction;
                         if tx_digest != genesis.transaction().digest() {
-                            if let Some((tx, effects, events, objects)) = txs_data.get(tx_digest) {
+                            if let Some((tx, effects, events)) = txs_data.get(tx_digest) {
                                 let transaction = VerifiedTransaction::new_unchecked(tx.clone());
-
+                                let objects = migration_transactions
+                                    .objects_by_tx_digest(*tx_digest)
+                                    .expect("The migration data is corrupted");
                                 store
-                                    .bulk_insert_genesis_objects(objects)
+                                    .bulk_insert_genesis_objects(&objects)
                                     .expect("Cannot bulk insert migrated objects");
 
                                 store

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -268,11 +268,11 @@ impl AuthorityStore {
         // Only initialize an empty database.
         if store
             .database_is_empty()
-            .expect("Database read should not fail at init.")
+            .expect("database read should not fail at init.")
         {
             store
                 .bulk_insert_genesis_objects(genesis.objects())
-                .expect("Cannot bulk insert genesis objects");
+                .expect("cannot bulk insert genesis objects");
 
             // insert txn and effects of genesis
             let transaction = VerifiedTransaction::new_unchecked(genesis.transaction().clone());
@@ -281,13 +281,13 @@ impl AuthorityStore {
                 .perpetual_tables
                 .transactions
                 .insert(transaction.digest(), transaction.serializable_ref())
-                .expect("Cannot insert genesis transaction");
+                .expect("cannot insert genesis transaction");
 
             store
                 .perpetual_tables
                 .effects
                 .insert(&genesis.effects().digest(), genesis.effects())
-                .expect("Cannot insert genesis effects");
+                .expect("cannot insert genesis effects");
 
             // We don't insert the effects to executed_effects yet because the genesis tx
             // hasn't but will be executed. This is important for fullnodes to
@@ -314,22 +314,22 @@ impl AuthorityStore {
                                 let transaction = VerifiedTransaction::new_unchecked(tx.clone());
                                 let objects = migration_transactions
                                     .objects_by_tx_digest(*tx_digest)
-                                    .expect("The migration data is corrupted");
+                                    .expect("the migration data is corrupted");
                                 store
                                     .bulk_insert_genesis_objects(&objects)
-                                    .expect("Cannot bulk insert migrated objects");
+                                    .expect("cannot bulk insert migrated objects");
 
                                 store
                                     .perpetual_tables
                                     .transactions
                                     .insert(transaction.digest(), transaction.serializable_ref())
-                                    .expect("Cannot insert migration transaction");
+                                    .expect("cannot insert migration transaction");
 
                                 store
                                     .perpetual_tables
                                     .effects
                                     .insert(&effects.digest(), effects)
-                                    .expect("Cannot insert migration effects");
+                                    .expect("cannot insert migration effects");
 
                                 let events = events
                                     .data

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -1052,7 +1052,7 @@ fn extract_migration_transactions_data(
             None => break,
         };
 
-        let (migration_transaction, migration_effects, migration_events, objects) =
+        let (migration_transaction, migration_effects, migration_events, _) =
             create_genesis_transaction(
                 objects_per_chunk.to_vec(),
                 vec![],
@@ -1063,12 +1063,7 @@ fn extract_migration_transactions_data(
 
         txs_data.insert(
             *migration_transaction.digest(),
-            (
-                migration_transaction,
-                migration_effects,
-                migration_events,
-                objects,
-            ),
+            (migration_transaction, migration_effects, migration_events),
         );
         start_idx += chunk;
     }
@@ -1088,7 +1083,7 @@ fn create_genesis_checkpoint(
     let mut effects_digests = vec![execution_digests];
 
     for digest in txs_data.keys() {
-        if let Some((_, effects, _, _)) = txs_data.get(digest) {
+        if let Some((_, effects, _)) = txs_data.get(digest) {
             effects_digests.push(effects.execution_digests());
         }
     }

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -713,6 +713,18 @@ impl Builder {
                 )
                 .expect("signature should be valid");
         }
+
+        // Validate migration content in order to avoid corrupted or malicious data
+        if let Some(migration_tx_data) = &self.migration_tx_data {
+            migration_tx_data
+                .validate_from_unsigned_genesis(&unsigned_genesis)
+                .expect("the migration data is corrupted");
+        } else {
+            assert!(
+                self.is_vanilla(),
+                "the genesis without migration data should be a vanilla version"
+            );
+        }
     }
 
     pub async fn load<P: AsRef<Path>>(path: P) -> anyhow::Result<Self, anyhow::Error> {

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -615,7 +615,11 @@ impl IotaNode {
                         migration_tx_data
                             .txs_data()
                             .values()
-                            .flat_map(|(_, _, _, migration_objects)| migration_objects.clone()),
+                            .flat_map(|(tx, _, _)| {
+                                migration_tx_data
+                                    .objects_by_tx_digest(*tx.digest())
+                                    .expect("The migration data is corrupted")
+                            }),
                     )
                     .collect::<Vec<_>>()
             },
@@ -659,7 +663,7 @@ impl IotaNode {
             .await;
 
             if let Some(migration_tx_data) = migration_tx_data {
-                for (tx_digest, (tx, _, _, _)) in migration_tx_data.txs_data() {
+                for (tx_digest, (tx, _, _)) in migration_tx_data.txs_data() {
                     let span = error_span!("migration_txn", tx_digest = ?tx_digest);
 
                     // Execute migration transaction

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -618,7 +618,7 @@ impl IotaNode {
                             .flat_map(|(tx, _, _)| {
                                 migration_tx_data
                                     .objects_by_tx_digest(*tx.digest())
-                                    .expect("The migration data is corrupted")
+                                    .expect("the migration data is corrupted")
                             }),
                     )
                     .collect::<Vec<_>>()


### PR DESCRIPTION
# Description of change

The `Vec<Object>` field was removed from the `migration.blob` (`MigrationTxData`) to reduce the blob size by half. 
The objects are now retrieved on the fly.

## Links to any relevant issues

Fix #3045 .

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo run --release --bin iota genesis --working-dir test_iota_config -f --with-faucet --num-validators 1 --remote-migration-snapshots https://stardust-objects.s3.eu-central-1.amazonaws.com/iota/alphanet/latest/stardust_object_snapshot.bin.gz
`
```
cargo build --release --bin iota-test-validator
./target/release/iota-test-validator --config-dir test_iota_config
```
