### PR TITLE
refactor(docker,iota-graphql-rpc): account for delay in fullnode startup

### DIFF
--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -462,7 +462,11 @@ impl ServerBuilder {
                     .max_concurrent_requests(MAX_CONCURRENT_REQUESTS)
                     .build(url)
                     .await
-                    .map_err(|e| Error::Internal(format!("Failed to create IotaClient: {}", e)))?,
+                    .map_err(|e| {
+                        Error::Internal(format!(
+                            "Failed to connect to fullnode {e}. Is the node server running?"
+                        ))
+                    })?,
             )
         } else {
             warn!(

--- a/docker/iota/Dockerfile
+++ b/docker/iota/Dockerfile
@@ -43,7 +43,7 @@ RUN mv target/$(if [ $PROFILE = "dev" ]; then echo "debug"; else echo "release";
 FROM debian:bullseye-slim AS runtime
 
 # iota-tool needs libpq at runtime
-RUN apt-get update && apt-get install -y libpq5 libpq-dev
+RUN apt-get update && apt-get install -y libpq5 libpq-dev curl
 
 COPY --from=builder /iota/iota /usr/local/bin
 

--- a/docker/pg-services-local/docker-compose.yaml
+++ b/docker/pg-services-local/docker-compose.yaml
@@ -28,6 +28,12 @@ services:
     ports:
       - "127.0.0.1:9000:9000"
       - "127.0.0.1:9123:9123"
+    healthcheck:
+      test: "curl -f http://local-network:9000/rest/"
+      interval: 1s
+      start_period: 5s
+      timeout: 2s
+      retries: 3
 
   indexer-sync:
     image: iota-indexer
@@ -140,9 +146,13 @@ services:
       - "127.0.0.1:8000:8000/tcp"
       - "127.0.0.1:9183:9181/tcp"
     depends_on:
-      - local-network
-      - postgres
-      - indexer-sync
+      local-network:
+        condition: service_healthy
+        restart: true
+      postgres:
+        condition: service_healthy
+      indexer-sync:
+        condition: service_started
 
   postgres:
     image: postgres:15


### PR DESCRIPTION
# Description of change

Fixes #3058 

## How the change has been tested

```
$ pushd docker/pg-services-local
$ docker compose up --build graphql-server
```