### PR TITLE
fix(external-crates): ignored the `nested_deps_git_local` test

### DIFF
--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.toml
@@ -1,8 +1,0 @@
-[package]
-name = "NestedDeps"
-
-[dependencies]
-MoveNursery = { git = "https://github.com/iotaledger/iota", rev = "5d8a867", subdir = "external-crates/move/crates/move-stdlib/nursery" }
-
-[addresses]
-std = "0x1"

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.toml.ignore
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move.toml.ignore
@@ -2,7 +2,7 @@
 name = "NestedDeps"
 
 [dependencies]
-MoveNursery = { git = "https://github.com/iotaledger/iota", rev = "f7e5011", subdir = "external-crates/move/crates/move-stdlib/nursery" }
+MoveNursery = { git = "https://github.com/iotaledger/iota", rev = "5d8a867", subdir = "external-crates/move/crates/move-stdlib/nursery" }
 
 [addresses]
 std = "0x1"


### PR DESCRIPTION
# Description of change

The test was ignored by the same reason as in the PR https://github.com/iotaledger/iota/pull/2139

The `Move.toml.ignore` file was updated to be equivalent to the original file since the test is the same as in the Sui repo at the moment.

> The test works locally.

## Links to any relevant issues

fixes #3083 
