### PR TITLE
chore(core-node)!: remove unused `EpochFlags` + special `ExecutedInEpochTable` logic

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1471,25 +1471,6 @@ impl AuthorityState {
 
         let output_keys = inner_temporary_store.get_output_keys(effects);
 
-        // Only need to sign effects if we are a validator, and if the
-        // executed_in_epoch_table is not yet enabled. TODO: once
-        // executed_in_epoch_table is enabled everywhere, we can remove the code below
-        // entirely.
-        let should_sign_effects =
-            self.is_validator(epoch_store) && !epoch_store.executed_in_epoch_table_enabled();
-
-        let effects_sig = if should_sign_effects {
-            Some(AuthoritySignInfo::new(
-                epoch_store.epoch(),
-                effects,
-                Intent::iota_app(IntentScope::TransactionEffects),
-                self.name,
-                &*self.secret,
-            ))
-        } else {
-            None
-        };
-
         // index certificate
         let _ = self
             .post_process_one_tx(certificate, effects, &inner_temporary_store, epoch_store)
@@ -1502,12 +1483,7 @@ impl AuthorityState {
         // The insertion to epoch_store is not atomic with the insertion to the
         // perpetual store. This is OK because we insert to the epoch store
         // first. And during lookups we always look up in the perpetual store first.
-        epoch_store.insert_tx_key_and_effects_signature(
-            &tx_key,
-            tx_digest,
-            &effects.digest(),
-            effects_sig.as_ref(),
-        )?;
+        epoch_store.insert_tx_key_and_digest(&tx_key, tx_digest)?;
 
         // Allow testing what happens if we crash here.
         fail_point_async!("crash");

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -380,8 +380,6 @@ pub struct AuthorityPerEpochStore {
     pub(crate) metrics: Arc<EpochMetrics>,
     epoch_start_configuration: Arc<EpochStartConfiguration>,
 
-    executed_in_epoch_table_enabled: once_cell::sync::OnceCell<bool>,
-
     /// Execution state that has to restart at each epoch change
     execution_component: ExecutionComponents,
 
@@ -935,7 +933,6 @@ impl AuthorityPerEpochStore {
             epoch_close_time: Default::default(),
             metrics,
             epoch_start_configuration,
-            executed_in_epoch_table_enabled: once_cell::sync::OnceCell::new(),
             execution_component,
             chain_identifier,
             jwk_aggregator,
@@ -1042,14 +1039,6 @@ impl AuthorityPerEpochStore {
         };
 
         self.epoch_start_configuration.flags().contains(&flag)
-    }
-
-    pub fn executed_in_epoch_table_enabled(&self) -> bool {
-        *self.executed_in_epoch_table_enabled.get_or_init(|| {
-            self.epoch_start_configuration
-                .flags()
-                .contains(&EpochFlag::ExecutedInEpochTable)
-        })
     }
 
     /// Returns `&Arc<EpochStartConfiguration>`
@@ -1267,28 +1256,15 @@ impl AuthorityPerEpochStore {
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub fn insert_tx_key_and_effects_signature(
+    pub fn insert_tx_key_and_digest(
         &self,
         tx_key: &TransactionKey,
         tx_digest: &TransactionDigest,
-        effects_digest: &TransactionEffectsDigest,
-        effects_signature: Option<&AuthoritySignInfo>,
     ) -> IotaResult {
         let tables = self.tables()?;
         let mut batch = self.tables()?.effects_signatures.batch();
 
-        if self.executed_in_epoch_table_enabled() {
-            batch.insert_batch(&tables.executed_in_epoch, [(tx_digest, ())])?;
-        }
-
-        if let Some(effects_signature) = effects_signature {
-            batch.insert_batch(&tables.effects_signatures, [(tx_digest, effects_signature)])?;
-
-            batch.insert_batch(&tables.signed_effects_digests, [(
-                tx_digest,
-                effects_digest,
-            )])?;
-        }
+        batch.insert_batch(&tables.executed_in_epoch, [(tx_digest, ())])?;
 
         if !matches!(tx_key, TransactionKey::Digest(_)) {
             batch.insert_batch(&tables.transaction_key_to_digest, [(tx_key, tx_digest)])?;
@@ -1332,11 +1308,7 @@ impl AuthorityPerEpochStore {
         digests: impl IntoIterator<Item = &'a TransactionDigest>,
     ) -> IotaResult<Vec<bool>> {
         let tables = self.tables()?;
-        if self.executed_in_epoch_table_enabled() {
-            Ok(tables.executed_in_epoch.multi_contains_keys(digests)?)
-        } else {
-            Ok(tables.effects_signatures.multi_contains_keys(digests)?)
-        }
+        Ok(tables.executed_in_epoch.multi_contains_keys(digests)?)
     }
 
     pub fn get_effects_signature(
@@ -4062,12 +4034,6 @@ impl AuthorityPerEpochStore {
     }
 
     pub(crate) fn check_all_executed_transactions_in_checkpoint(&self) {
-        if !self.executed_in_epoch_table_enabled() {
-            error!(
-                "Cannot check executed transactions in checkpoint because executed_in_epoch table is not enabled"
-            );
-            return;
-        }
         let tables = self.tables().unwrap();
 
         info!("Verifying that all executed transactions are in a checkpoint");

--- a/crates/iota-core/src/authority/epoch_start_configuration.rs
+++ b/crates/iota-core/src/authority/epoch_start_configuration.rs
@@ -54,22 +54,12 @@ pub trait EpochStartConfigTrait {
 // inconsistent with the released branch, and must be fixed.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum EpochFlag {
-    // The deprecated flags have all been in production for long enough that
-    // we can have deleted the old code paths they were guarding.
-    // We retain them here in order not to break deserialization.
-    _InMemoryCheckpointRootsDeprecated = 0,
-    _PerEpochFinalizedTransactionsDeprecated = 1,
-    _ObjectLockSplitTablesDeprecated = 2,
+    WritebackCacheEnabled = 0,
 
-    WritebackCacheEnabled = 3,
+    StateAccumulatorV2EnabledTestnet = 1,
+    StateAccumulatorV2EnabledMainnet = 2,
 
-    // This flag was "burned" because it was deployed with a broken version of the code. The
-    // new flags below are required to enable state accumulator v2
-    _StateAccumulatorV2EnabledDeprecated = 4,
-    StateAccumulatorV2EnabledTestnet = 5,
-    StateAccumulatorV2EnabledMainnet = 6,
-
-    ExecutedInEpochTable = 7,
+    ExecutedInEpochTable = 3,
 }
 
 impl EpochFlag {
@@ -110,19 +100,7 @@ impl fmt::Display for EpochFlag {
         // Important - implementation should return low cardinality values because this
         // is used as metric key
         match self {
-            EpochFlag::_InMemoryCheckpointRootsDeprecated => {
-                write!(f, "InMemoryCheckpointRoots (DEPRECATED)")
-            }
-            EpochFlag::_PerEpochFinalizedTransactionsDeprecated => {
-                write!(f, "PerEpochFinalizedTransactions (DEPRECATED)")
-            }
-            EpochFlag::_ObjectLockSplitTablesDeprecated => {
-                write!(f, "ObjectLockSplitTables (DEPRECATED)")
-            }
             EpochFlag::WritebackCacheEnabled => write!(f, "WritebackCacheEnabled"),
-            EpochFlag::_StateAccumulatorV2EnabledDeprecated => {
-                write!(f, "StateAccumulatorV2EnabledDeprecated (DEPRECATED)")
-            }
             EpochFlag::ExecutedInEpochTable => write!(f, "ExecutedInEpochTable"),
             EpochFlag::StateAccumulatorV2EnabledTestnet => {
                 write!(f, "StateAccumulatorV2EnabledTestnet")

--- a/crates/iota-core/src/authority/epoch_start_configuration.rs
+++ b/crates/iota-core/src/authority/epoch_start_configuration.rs
@@ -58,8 +58,6 @@ pub enum EpochFlag {
 
     StateAccumulatorV2EnabledTestnet = 1,
     StateAccumulatorV2EnabledMainnet = 2,
-
-    ExecutedInEpochTable = 3,
 }
 
 impl EpochFlag {
@@ -77,7 +75,7 @@ impl EpochFlag {
         cache_config: &ExecutionCacheConfig,
         enable_state_accumulator_v2: bool,
     ) -> Vec<Self> {
-        let mut new_flags = vec![EpochFlag::ExecutedInEpochTable];
+        let mut new_flags = vec![];
 
         if matches!(
             choose_execution_cache(cache_config),
@@ -101,7 +99,6 @@ impl fmt::Display for EpochFlag {
         // is used as metric key
         match self {
             EpochFlag::WritebackCacheEnabled => write!(f, "WritebackCacheEnabled"),
-            EpochFlag::ExecutedInEpochTable => write!(f, "ExecutedInEpochTable"),
             EpochFlag::StateAccumulatorV2EnabledTestnet => {
                 write!(f, "StateAccumulatorV2EnabledTestnet")
             }

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -2467,7 +2467,7 @@ mod tests {
     use iota_protocol_config::{Chain, ProtocolConfig};
     use iota_types::{
         base_types::{ObjectID, SequenceNumber, TransactionEffectsDigest},
-        crypto::{AuthoritySignInfo, Signature},
+        crypto::Signature,
         digests::TransactionEventsDigest,
         effects::{TransactionEffects, TransactionEvents},
         messages_checkpoint::SignedCheckpointSummary,
@@ -2475,7 +2475,6 @@ mod tests {
         object,
         transaction::{GenesisObject, VerifiedTransaction},
     };
-    use shared_crypto::intent::{Intent, IntentScope};
     use tokio::sync::mpsc;
 
     use super::*;
@@ -2845,18 +2844,7 @@ mod tests {
         let effects = e(digest, dependencies, gas_used);
         store.insert(digest, effects.clone());
         epoch_store
-            .insert_tx_key_and_effects_signature(
-                &TransactionKey::Digest(digest),
-                &digest,
-                &effects.digest(),
-                Some(&AuthoritySignInfo::new(
-                    epoch_store.epoch(),
-                    &effects,
-                    Intent::iota_app(IntentScope::TransactionEffects),
-                    state.name,
-                    &*state.secret,
-                )),
-            )
+            .insert_tx_key_and_digest(&TransactionKey::Digest(digest), &digest)
             .expect("Inserting cert fx and sigs should not fail");
     }
 }


### PR DESCRIPTION
# Description of change

This PR removes unused EpochFlags.
I guess we need to reset the existing networks because that is a breaking change.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

I was running the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
