### PR TITLE
refactor(node): reduce log levels for too detailed information

### DIFF
--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -181,7 +181,7 @@ impl CommitObserver {
         let utc_now = self.context.clock.timestamp_utc_ms();
 
         for commit in committed {
-            info!(
+            debug!(
                 "Consensus commit {} with leader {} has {} blocks",
                 commit.commit_ref,
                 commit.leader,

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -513,7 +513,7 @@ impl Core {
         // Now acknowledge the transactions for their inclusion to block
         ack_transactions(verified_block.reference());
 
-        info!("Created block {:?}", verified_block);
+        debug!("Created block {:?}", verified_block);
 
         self.context
             .metrics
@@ -596,7 +596,7 @@ impl Core {
                 let Some(last_decided) = decided_leaders.last().cloned() else {
                     break;
                 };
-                tracing::info!(
+                tracing::debug!(
                     "Decided {} leaders and {commits_until_update} commits can be made before next leader schedule change",
                     decided_leaders.len()
                 );
@@ -627,7 +627,7 @@ impl Core {
                 if sequenced_leaders.is_empty() {
                     break;
                 }
-                tracing::info!(
+                tracing::debug!(
                     "Committing {} leaders: {}",
                     sequenced_leaders.len(),
                     sequenced_leaders

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -329,7 +329,7 @@ impl CheckpointExecutor {
 
                 received = self.mailbox.recv() => match received {
                     Ok(checkpoint) => {
-                        info!(
+                        debug!(
                             sequence_number = ?checkpoint.sequence_number,
                             "Received checkpoint summary from state sync"
                         );

--- a/crates/iota-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_output.rs
@@ -166,7 +166,7 @@ impl CertifiedCheckpointOutput for LogCheckpointOutput {
         &self,
         summary: &CertifiedCheckpointSummary,
     ) -> IotaResult {
-        info!(
+        debug!(
             "Certified checkpoint with sequence {} and digest {}",
             summary.sequence_number,
             summary.digest()
@@ -192,7 +192,7 @@ impl CertifiedCheckpointOutput for SendCheckpointToStateSync {
         &self,
         summary: &CertifiedCheckpointSummary,
     ) -> IotaResult {
-        info!(
+        debug!(
             "Certified checkpoint with sequence {} and digest {}",
             summary.sequence_number,
             summary.digest()

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1352,7 +1352,7 @@ impl CheckpointBuilder {
             }
         }
         let last_checkpoint_seq = last_checkpoint.as_ref().map(|(seq, _)| *seq);
-        info!(
+        debug!(
             next_checkpoint_seq = last_checkpoint_seq.unwrap_or_default() + 1,
             checkpoint_timestamp = details.timestamp_ms,
             "Creating checkpoint(s) for {} transactions",

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -197,7 +197,7 @@ fn update_index_and_hash(
     let hash = hasher.finish();
     // Log hash every 1000th transaction of the subdag
     if index.transaction_index % 1000 == 0 {
-        info!(
+        debug!(
             "Integrity hash for consensus output at subdag {} transaction {} is {:016x}",
             index.sub_dag_index, index.transaction_index, hash
         );
@@ -278,7 +278,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             timestamp
         };
 
-        info!(
+        debug!(
             %consensus_output,
             epoch = ?self.epoch_store.epoch(),
             "Received consensus output"

--- a/crates/iota-core/src/state_accumulator.rs
+++ b/crates/iota-core/src/state_accumulator.rs
@@ -685,7 +685,7 @@ impl StateAccumulatorV2 {
         checkpoint_acc: Option<Accumulator>,
     ) -> IotaResult {
         let _scope = monitored_scope("AccumulateRunningRoot");
-        tracing::info!(
+        tracing::debug!(
             "accumulating running root for checkpoint {}",
             checkpoint_seq_num
         );


### PR DESCRIPTION
Closes #3093 
This PR reduces the current info-level log volume by about 90%.

Details follow:

- The frequency of dumping the following info logs are too high
  - ~ 36.66/s for `iota_core::checkpoints::checkpoint_executor: Received checkpoint summary...`
  - ~ 64.68/s for `consensus_core::core: Committing ...`
  - ~ 64.89/s for `consensus_core::commit_observer: Consensus commit`
    - it is also already recorded in report metrics
  - ~ 64.89/s for `iota_core::consensus_handler: Received consensus output...`
  - ~ 64.89/s for `iota_core::consensus_handler: Integrity...`
     - It is logged every 1000th transaction only, but the frequency is still too high.
  - ~ 65.07/s for `consensus_core::core: Decided...`
  - ~ 16.53/s for `iota_core::checkpoints: Creating checkpoint(s)...`
  - ~ 27.16/s for `iota_core::state_accumulator: accumulating running root...`
  - ~ 64.92/s for `consensus_core::core: Created block`
  - ~ 16.36/s for `iota_core::checkpoints::checkpoint_output: Certified checkpoint with sequence...`
  - ~ 16.53/s for `iota_core::checkpoints::checkpoint_output: Creating checkpoint CheckpointDigest...`

The frequency for the following info-level log
```
iota_core::checkpoints::checkpoint_output: Creating checkpoint {:?} at epoch {}, sequence {}, previous digest {:?}, transactions count {}, content digest {:?}, end_of_epoch_data {:?}`
```
is about 16.53/s, but its level is remained the same, because it contains important information.