### PR TITLE
feat(iota-json-rpc-tests): add governance api tests

### DIFF
--- a/crates/iota-json-rpc-tests/README.md
+++ b/crates/iota-json-rpc-tests/README.md
@@ -47,16 +47,16 @@ That is, expect for the `WriteApi` methods that serve requests relayed by `iota-
 - [ ] `query_objects`
 - [ ] `get_total_transactions`
 
-### `GovernanceReadApi` (5/8)
+### `GovernanceReadApi` (8/8)
 
 - [x] `get_stakes_by_ids`
 - [x] `get_stakes`
 - [x] `get_timelocked_stakes_by_ids`
 - [x] `get_timelocked_stakes`
-- [ ] `get_committee_info`
+- [x] `get_committee_info`
 - [x] `get_latest_iota_system_state`
-- [ ] `get_reference_gas_price`
-- [ ] `get_validators_apy`
+- [x] `get_reference_gas_price`
+- [x] `get_validators_apy`
 
 ### `IndexerApi` (2/9)
 

--- a/crates/iota-json-rpc-tests/tests/governance_api.rs
+++ b/crates/iota-json-rpc-tests/tests/governance_api.rs
@@ -595,7 +595,7 @@ async fn test_timelocked_unstaking() -> Result<(), anyhow::Error> {
 #[sim_test]
 async fn get_committee_info() {
     let cluster = TestClusterBuilder::new()
-        .with_epoch_duration_ms(10000)
+        .with_epoch_duration_ms(1000)
         .build()
         .await;
 
@@ -623,8 +623,8 @@ async fn get_committee_info() {
 
     assert!(response.is_err());
 
-    // Sleep for 20 seconds
-    sleep(Duration::from_millis(20000)).await;
+    // Sleep for 5 seconds
+    sleep(Duration::from_millis(5000)).await;
 
     // Test with specified epoch 1
     let response = client.get_committee_info(Some(1.into())).await.unwrap();
@@ -656,5 +656,5 @@ async fn get_validators_apy() {
 
     assert_eq!(epoch, 0);
     assert_eq!(apys.len(), 4);
-    assert_eq!(apys.iter().find(|apy| apy.apy == 0.0).is_some(), true);
+    assert!(apys.iter().any(|apy| apy.apy == 0.0));
 }

--- a/crates/iota-json-rpc-tests/tests/governance_api.rs
+++ b/crates/iota-json-rpc-tests/tests/governance_api.rs
@@ -108,7 +108,7 @@ async fn test_staking() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[ignore]
+#[ignore = "https://github.com/iotaledger/iota/issues/3007"]
 #[sim_test]
 async fn test_unstaking() -> Result<(), anyhow::Error> {
     let cluster = TestClusterBuilder::new()
@@ -397,7 +397,7 @@ async fn test_timelocked_staking() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[ignore]
+#[ignore = "https://github.com/iotaledger/iota/issues/3007"]
 #[sim_test]
 async fn test_timelocked_unstaking() -> Result<(), anyhow::Error> {
     // Create a cluster
@@ -600,7 +600,6 @@ async fn get_committee_info() {
         .await;
 
     let client = cluster.rpc_client();
-    let address = cluster.get_address_0();
 
     // Test with no specified epoch
     let response = client.get_committee_info(None).await.unwrap();

--- a/crates/iota-json-rpc-tests/tests/governance_api.rs
+++ b/crates/iota-json-rpc-tests/tests/governance_api.rs
@@ -594,23 +594,26 @@ async fn test_timelocked_unstaking() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn get_committee_info() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_epoch_duration_ms(10000)
+        .build()
+        .await;
 
     let client = cluster.rpc_client();
     let address = cluster.get_address_0();
 
     // Test with no specified epoch
-    let indexer_response = client.get_committee_info(None).await.unwrap();
+    let response = client.get_committee_info(None).await.unwrap();
 
-    let (epoch_id, validators) = (indexer_response.epoch, indexer_response.validators);
+    let (epoch_id, validators) = (response.epoch, response.validators);
 
     assert!(epoch_id == 0);
     assert_eq!(validators.len(), 4);
 
     // Test with specified epoch 0
-    let indexer_response = client.get_committee_info(Some(0.into())).await.unwrap();
+    let response = client.get_committee_info(Some(0.into())).await.unwrap();
 
-    let (epoch_id, validators) = (indexer_response.epoch, indexer_response.validators);
+    let (epoch_id, validators) = (response.epoch, response.validators);
 
     assert!(epoch_id == 0);
     assert_eq!(validators.len(), 4);
@@ -619,6 +622,17 @@ async fn get_committee_info() {
     let response = client.get_committee_info(Some(1.into())).await;
 
     assert!(response.is_err());
+
+    // Sleep for 20 seconds
+    sleep(Duration::from_millis(20000)).await;
+
+    // Test with specified epoch 1
+    let response = client.get_committee_info(Some(1.into())).await.unwrap();
+
+    let (epoch_id, validators) = (response.epoch, response.validators);
+
+    assert!(epoch_id == 1);
+    assert_eq!(validators.len(), 4);
 }
 
 #[sim_test]

--- a/crates/iota-json-rpc-tests/tests/governance_api.rs
+++ b/crates/iota-json-rpc-tests/tests/governance_api.rs
@@ -595,7 +595,7 @@ async fn test_timelocked_unstaking() -> Result<(), anyhow::Error> {
 #[sim_test]
 async fn get_committee_info() {
     let cluster = TestClusterBuilder::new()
-        .with_epoch_duration_ms(1000)
+        .with_epoch_duration_ms(2000)
         .build()
         .await;
 


### PR DESCRIPTION
# Description of change

Added the remaining `GovernanceApi` tests for the `iota-json-rpc-tests` crate.

It appeared that there is an issue in the unstaking and timelocked unstaking feature. The `test_unstaking` test and 
`test_timelocked_unstaking` test provide coverage for the issue. Both tests have been ignored for now as further investigation is needed as it seems to be a more underlying issue to solve - which is outside of scope of this PR. Related tracking issue: https://github.com/iotaledger/iota/issues/3007

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/2917

## Type of change

- Tests

## How the change has been tested

`cargo simtest -p iota-json-rpc-tests --test governance_api`

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
