### PR TITLE
feat(genesis-builder): validate migration data before taking it

### DIFF
--- a/crates/iota-config/src/genesis.rs
+++ b/crates/iota-config/src/genesis.rs
@@ -38,6 +38,8 @@ use iota_types::{
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tracing::trace;
 
+use crate::migration_tx_data::MigrationTxData;
+
 #[derive(Clone, Debug)]
 pub struct Genesis {
     checkpoint: CertifiedCheckpointSummary,
@@ -56,6 +58,11 @@ pub struct UnsignedGenesis {
     pub effects: TransactionEffects,
     pub events: TransactionEvents,
     pub objects: Vec<Object>,
+}
+
+pub struct GenesisBuildEffects {
+    pub genesis: Genesis,
+    pub migration_tx_data: Option<MigrationTxData>,
 }
 
 // Hand implement PartialEq in order to get around the fact that AuthSigs don't
@@ -626,5 +633,14 @@ impl TokenDistributionScheduleBuilder {
 
         schedule.validate();
         schedule
+    }
+}
+
+impl GenesisBuildEffects {
+    pub fn new(genesis: Genesis, migration_tx_data: Option<MigrationTxData>) -> Self {
+        Self {
+            genesis,
+            migration_tx_data,
+        }
     }
 }

--- a/crates/iota-config/src/genesis.rs
+++ b/crates/iota-config/src/genesis.rs
@@ -38,8 +38,6 @@ use iota_types::{
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tracing::trace;
 
-use crate::migration_tx_data::MigrationTxData;
-
 #[derive(Clone, Debug)]
 pub struct Genesis {
     checkpoint: CertifiedCheckpointSummary,
@@ -58,11 +56,6 @@ pub struct UnsignedGenesis {
     pub effects: TransactionEffects,
     pub events: TransactionEvents,
     pub objects: Vec<Object>,
-}
-
-pub struct GenesisBuildEffects {
-    pub genesis: Genesis,
-    pub migration_tx_data: Option<MigrationTxData>,
 }
 
 // Hand implement PartialEq in order to get around the fact that AuthSigs don't
@@ -633,14 +626,5 @@ impl TokenDistributionScheduleBuilder {
 
         schedule.validate();
         schedule
-    }
-}
-
-impl GenesisBuildEffects {
-    pub fn new(genesis: Genesis, migration_tx_data: Option<MigrationTxData>) -> Self {
-        Self {
-            genesis,
-            migration_tx_data,
-        }
     }
 }

--- a/crates/iota-core/src/test_utils.rs
+++ b/crates/iota-core/src/test_utils.rs
@@ -6,13 +6,11 @@ use std::{collections::BTreeMap, path::PathBuf, sync::Arc, time::Duration};
 
 use fastcrypto::{hash::MultisetHash, traits::KeyPair};
 use futures::future::join_all;
-use iota_config::{
-    genesis::{Genesis, GenesisBuildEffects},
-    local_ip_utils,
-    node::AuthorityOverloadConfig,
-};
+use iota_config::{genesis::Genesis, local_ip_utils, node::AuthorityOverloadConfig};
 use iota_framework::BuiltInFramework;
-use iota_genesis_builder::validator_info::ValidatorInfo;
+use iota_genesis_builder::{
+    genesis_build_effects::GenesisBuildEffects, validator_info::ValidatorInfo,
+};
 use iota_macros::nondeterministic;
 use iota_move_build::{BuildConfig, CompiledPackage, IotaPackageHooks};
 use iota_protocol_config::ProtocolConfig;

--- a/crates/iota-core/src/test_utils.rs
+++ b/crates/iota-core/src/test_utils.rs
@@ -6,7 +6,11 @@ use std::{collections::BTreeMap, path::PathBuf, sync::Arc, time::Duration};
 
 use fastcrypto::{hash::MultisetHash, traits::KeyPair};
 use futures::future::join_all;
-use iota_config::{genesis::Genesis, local_ip_utils, node::AuthorityOverloadConfig};
+use iota_config::{
+    genesis::{Genesis, GenesisBuildEffects},
+    local_ip_utils,
+    node::AuthorityOverloadConfig,
+};
 use iota_framework::BuiltInFramework;
 use iota_genesis_builder::validator_info::ValidatorInfo;
 use iota_macros::nondeterministic;
@@ -258,7 +262,7 @@ async fn init_genesis(
         builder = builder.add_validator_signature(key);
     }
 
-    let genesis = builder.build();
+    let GenesisBuildEffects { genesis, .. } = builder.build();
     (genesis, key_pairs, pkg_id)
 }
 

--- a/crates/iota-genesis-builder/src/genesis_build_effects.rs
+++ b/crates/iota-genesis-builder/src/genesis_build_effects.rs
@@ -1,0 +1,18 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_config::{genesis::Genesis, migration_tx_data::MigrationTxData};
+
+pub struct GenesisBuildEffects {
+    pub genesis: Genesis,
+    pub migration_tx_data: Option<MigrationTxData>,
+}
+
+impl GenesisBuildEffects {
+    pub fn new(genesis: Genesis, migration_tx_data: Option<MigrationTxData>) -> Self {
+        Self {
+            genesis,
+            migration_tx_data,
+        }
+    }
+}

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -15,11 +15,12 @@ use anyhow::{Context, bail};
 use camino::Utf8Path;
 use fastcrypto::{hash::HashFunction, traits::KeyPair};
 use flate2::bufread::GzDecoder;
+use genesis_build_effects::GenesisBuildEffects;
 use iota_config::{
     IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME,
     genesis::{
-        Genesis, GenesisBuildEffects, GenesisCeremonyParameters, GenesisChainParameters,
-        TokenDistributionSchedule, UnsignedGenesis,
+        Genesis, GenesisCeremonyParameters, GenesisChainParameters, TokenDistributionSchedule,
+        UnsignedGenesis,
     },
     migration_tx_data::{MigrationTxData, TransactionsData},
 };
@@ -80,6 +81,7 @@ use stardust::migration::MigrationObjects;
 use tracing::trace;
 use validator_info::{GenesisValidatorInfo, GenesisValidatorMetadata, ValidatorInfo};
 
+pub mod genesis_build_effects;
 mod stake;
 pub mod stardust;
 pub mod validator_info;

--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -722,6 +722,18 @@ impl Builder {
                 )
                 .expect("signature should be valid");
         }
+
+        // Validate migration content in order to avoid corrupted or malicious data
+        if let Some(migration_tx_data) = &self.migration_tx_data {
+            migration_tx_data
+                .validate_from_unsigned_genesis(&unsigned_genesis)
+                .expect("the migration data is corrupted");
+        } else {
+            assert!(
+                !self.contains_migrations(),
+                "genesis that contains migration should have migration data"
+            );
+        }
     }
 
     pub async fn load<P: AsRef<Path>>(path: P) -> anyhow::Result<Self, anyhow::Error> {

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -11,7 +11,7 @@ use std::{
 
 use iota_config::{
     IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME,
-    genesis::{TokenAllocation, TokenDistributionScheduleBuilder},
+    genesis::{GenesisBuildEffects, TokenAllocation, TokenDistributionScheduleBuilder},
     node::AuthorityOverloadConfig,
 };
 use iota_macros::nondeterministic;
@@ -423,7 +423,10 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
             builder.build()
         };
 
-        let (genesis, migration_tx_data_option) = {
+        let GenesisBuildEffects {
+            genesis,
+            migration_tx_data,
+        } = {
             let mut builder = iota_genesis_builder::Builder::new()
                 .with_parameters(genesis_config.parameters)
                 .add_objects(self.additional_objects);
@@ -447,11 +450,10 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                 builder = builder.add_validator_signature(&validator.key_pair);
             }
 
-            let migration_tx_data = builder.take_migration_tx_data();
-            (builder.build(), migration_tx_data)
+            builder.build()
         };
 
-        if let Some(migration_tx_data) = migration_tx_data_option {
+        if let Some(migration_tx_data) = migration_tx_data {
             migration_tx_data
                 .save(
                     self.config_directory

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -11,9 +11,10 @@ use std::{
 
 use iota_config::{
     IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME,
-    genesis::{GenesisBuildEffects, TokenAllocation, TokenDistributionScheduleBuilder},
+    genesis::{TokenAllocation, TokenDistributionScheduleBuilder},
     node::AuthorityOverloadConfig,
 };
+use iota_genesis_builder::genesis_build_effects::GenesisBuildEffects;
 use iota_macros::nondeterministic;
 use iota_types::{
     base_types::{AuthorityName, IotaAddress},

--- a/crates/iota-swarm-config/tests/snapshot_tests.rs
+++ b/crates/iota-swarm-config/tests/snapshot_tests.rs
@@ -22,7 +22,7 @@ use std::num::NonZeroUsize;
 use fastcrypto::traits::KeyPair;
 use insta::assert_yaml_snapshot;
 use iota_config::{
-    genesis::{GenesisCeremonyParameters, TokenDistributionScheduleBuilder},
+    genesis::{GenesisBuildEffects, GenesisCeremonyParameters, TokenDistributionScheduleBuilder},
     node::{DEFAULT_COMMISSION_RATE, DEFAULT_VALIDATOR_GAS_PRICE},
 };
 use iota_genesis_builder::{Builder, validator_info::ValidatorInfo};
@@ -90,7 +90,7 @@ fn populated_genesis_snapshot_matches() {
         builder.build()
     };
 
-    let genesis = Builder::new()
+    let GenesisBuildEffects { genesis, .. } = Builder::new()
         .with_token_distribution_schedule(token_distribution_schedule)
         .add_validator(validator, pop)
         .with_parameters(GenesisCeremonyParameters {

--- a/crates/iota-swarm-config/tests/snapshot_tests.rs
+++ b/crates/iota-swarm-config/tests/snapshot_tests.rs
@@ -22,10 +22,12 @@ use std::num::NonZeroUsize;
 use fastcrypto::traits::KeyPair;
 use insta::assert_yaml_snapshot;
 use iota_config::{
-    genesis::{GenesisBuildEffects, GenesisCeremonyParameters, TokenDistributionScheduleBuilder},
+    genesis::{GenesisCeremonyParameters, TokenDistributionScheduleBuilder},
     node::{DEFAULT_COMMISSION_RATE, DEFAULT_VALIDATOR_GAS_PRICE},
 };
-use iota_genesis_builder::{Builder, validator_info::ValidatorInfo};
+use iota_genesis_builder::{
+    Builder, genesis_build_effects::GenesisBuildEffects, validator_info::ValidatorInfo,
+};
 use iota_swarm_config::genesis_config::GenesisConfig;
 use iota_types::{
     base_types::IotaAddress,

--- a/crates/iota/src/genesis_ceremony.rs
+++ b/crates/iota/src/genesis_ceremony.rs
@@ -10,7 +10,9 @@ use clap::Parser;
 use fastcrypto::encoding::{Encoding, Hex};
 use iota_config::{
     IOTA_GENESIS_FILENAME,
-    genesis::{TokenAllocation, TokenDistributionScheduleBuilder, UnsignedGenesis},
+    genesis::{
+        GenesisBuildEffects, TokenAllocation, TokenDistributionScheduleBuilder, UnsignedGenesis,
+    },
 };
 use iota_genesis_builder::{Builder, GENESIS_BUILDER_PARAMETERS_FILE, SnapshotSource, SnapshotUrl};
 use iota_keys::keypair_file::{
@@ -327,7 +329,7 @@ pub async fn run(cmd: Ceremony) -> Result<()> {
 
             check_protocol_version(&builder, protocol_version)?;
 
-            let genesis = builder.build();
+            let GenesisBuildEffects { genesis, .. } = builder.build();
             genesis.save(dir.join(IOTA_GENESIS_FILENAME))?;
 
             println!("Successfully built {IOTA_GENESIS_FILENAME}");

--- a/crates/iota/src/genesis_ceremony.rs
+++ b/crates/iota/src/genesis_ceremony.rs
@@ -10,11 +10,12 @@ use clap::Parser;
 use fastcrypto::encoding::{Encoding, Hex};
 use iota_config::{
     IOTA_GENESIS_FILENAME,
-    genesis::{
-        GenesisBuildEffects, TokenAllocation, TokenDistributionScheduleBuilder, UnsignedGenesis,
-    },
+    genesis::{TokenAllocation, TokenDistributionScheduleBuilder, UnsignedGenesis},
 };
-use iota_genesis_builder::{Builder, GENESIS_BUILDER_PARAMETERS_FILE, SnapshotSource, SnapshotUrl};
+use iota_genesis_builder::{
+    Builder, GENESIS_BUILDER_PARAMETERS_FILE, SnapshotSource, SnapshotUrl,
+    genesis_build_effects::GenesisBuildEffects,
+};
 use iota_keys::keypair_file::{
     read_authority_keypair_from_file, read_keypair_from_file, read_network_keypair_from_file,
 };


### PR DESCRIPTION
# Description of change

In `crates/iota-swarm-config/src/network_config_builder.rs` the migration tx data was taken out from memory before the genesis validation https://github.com/iotaledger/iota/blob/a7f68bc338d9336f1b3b40313d3ba8ca742c2335/crates/iota-swarm-config/src/network_config_builder.rs#L450-L451

This PR allows to return genesis build effects that contain genesis and migration data after the all validation processes. 