### PR TITLE
fix(iota-node): lazy load migration.blob file in node

### DIFF
--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -445,11 +445,11 @@ impl IotaNode {
         iota_metrics::thread_stall_monitor::start_thread_stall_monitor();
 
         let genesis = config.genesis()?.clone();
-        let migration_tx_data = (genesis.contains_migrations()).then(|| {
-            config
-                .load_migration_tx_data()
-                .expect("missing migration transactions data")
-        });
+        let migration_tx_data = if genesis.contains_migrations() {
+            Some(config.load_migration_tx_data()?)
+        } else {
+            None
+        };
 
         let secret = Arc::pin(config.protocol_key_pair().copy());
         let genesis_committee = genesis.committee()?;

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -445,8 +445,11 @@ impl IotaNode {
         iota_metrics::thread_stall_monitor::start_thread_stall_monitor();
 
         let genesis = config.genesis()?.clone();
-        let migration_tx_data =
-            (genesis.contains_migrations()).then_some(config.load_migration_tx_data()?);
+        let migration_tx_data = (genesis.contains_migrations()).then(|| {
+            config
+                .load_migration_tx_data()
+                .expect("missing migration transactions data")
+        });
 
         let secret = Arc::pin(config.protocol_key_pair().copy());
         let genesis_committee = genesis.committee()?;


### PR DESCRIPTION
# Description of change

Fixes node startup. `then_some` was eagerly loading the migration blob, while `then` does it lazily. The former crashes the node with missing `migration.blob` even when it is not supposed to attempt loading it.

## Type of change


- Bug fix (a non-breaking change which fixes an issue)


## How the change has been tested

Running test locally that require `TestCluster`, that relies on `iota-swarm` that is running without migration.blobs

