### PR TITLE
refactor(iota-types/authenticator-state-update): Rename `AuthenticatorStateUpdate`

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1407,7 +1407,7 @@ impl AuthorityState {
         )
         .await?;
 
-        if let TransactionKind::AuthenticatorStateUpdate(auth_state) =
+        if let TransactionKind::AuthenticatorStateUpdateV1(auth_state) =
             certificate.data().transaction_data().kind()
         {
             if let Some(err) = &execution_error_opt {

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -57,7 +57,7 @@ use iota_types::{
     signature::GenericSignature,
     storage::{BackingPackageStore, GetSharedLocks, InputKey, ObjectStore},
     transaction::{
-        AuthenticatorStateUpdate, CertifiedTransaction, InputObjectKind, SenderSignedData,
+        AuthenticatorStateUpdateV1, CertifiedTransaction, InputObjectKind, SenderSignedData,
         Transaction, TransactionDataAPI, TransactionKey, TransactionKind, VerifiedCertificate,
         VerifiedSignedTransaction, VerifiedTransaction,
     },
@@ -4049,7 +4049,7 @@ impl AuthorityPerEpochStore {
             .set(self.epoch_open_time.elapsed().as_millis() as i64);
     }
 
-    pub(crate) fn update_authenticator_state(&self, update: &AuthenticatorStateUpdate) {
+    pub(crate) fn update_authenticator_state(&self, update: &AuthenticatorStateUpdateV1) {
         info!("Updating authenticator state: {:?}", update);
         for active_jwk in &update.new_active_jwks {
             let ActiveJwk { jwk_id, jwk, .. } = active_jwk;

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1389,8 +1389,8 @@ impl CheckpointBuilder {
                     TransactionKind::ConsensusCommitPrologue(_)
                     | TransactionKind::ConsensusCommitPrologueV2(_)
                     | TransactionKind::ConsensusCommitPrologueV3(_)
-                    | TransactionKind::AuthenticatorStateUpdate(_) => {
-                        // ConsensusCommitPrologue and AuthenticatorStateUpdate
+                    | TransactionKind::AuthenticatorStateUpdateV1(_) => {
+                        // ConsensusCommitPrologue and AuthenticatorStateUpdateV1
                         // are guaranteed to be
                         // processed before we reach here.
                     }

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1390,7 +1390,8 @@ impl CheckpointBuilder {
                     | TransactionKind::ConsensusCommitPrologueV2(_)
                     | TransactionKind::ConsensusCommitPrologueV3(_)
                     | TransactionKind::AuthenticatorStateUpdateV1(_) => {
-                        // ConsensusCommitPrologue and AuthenticatorStateUpdateV1
+                        // ConsensusCommitPrologue and
+                        // AuthenticatorStateUpdateV1
                         // are guaranteed to be
                         // processed before we reach here.
                     }

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -296,7 +296,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             let authenticator_state_update_transaction =
                 self.authenticator_state_update_transaction(round, new_jwks);
             debug!(
-                "adding AuthenticatorStateUpdate({:?}) tx: {:?}",
+                "adding AuthenticatorStateUpdateV1({:?}) tx: {:?}",
                 authenticator_state_update_transaction.digest(),
                 authenticator_state_update_transaction,
             );

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -26,7 +26,7 @@ use iota_types::{
     multisig::{MultiSig, MultiSigPublicKey},
     signature::GenericSignature,
     transaction::{
-        AuthenticatorStateUpdate, GenesisTransaction, TransactionDataAPI, TransactionKind,
+        AuthenticatorStateUpdateV1, GenesisTransaction, TransactionDataAPI, TransactionKind,
     },
     utils::{get_one_zklogin_inputs, load_test_vectors, to_sender_signed_transaction},
     zk_login_authenticator::ZkLoginAuthenticator,
@@ -1016,7 +1016,7 @@ async fn setup_zklogin_network(
     let gas_object_id = gas_object_ids[0];
     let jwks = parse_jwks(DEFAULT_JWK_BYTES, &OIDCProvider::Twitch)?;
     let epoch_store = authority_state.epoch_store_for_testing();
-    epoch_store.update_authenticator_state(&AuthenticatorStateUpdate {
+    epoch_store.update_authenticator_state(&AuthenticatorStateUpdateV1 {
         epoch: 0,
         round: 0,
         new_active_jwks: jwks
@@ -1192,7 +1192,7 @@ async fn zklogin_txn_fail_if_missing_jwk() {
     // Initialize an authenticator state with a Google JWK.
     let jwks = parse_jwks(DEFAULT_JWK_BYTES, &OIDCProvider::Google).unwrap();
     let epoch_store = authority_state.epoch_store_for_testing();
-    epoch_store.update_authenticator_state(&AuthenticatorStateUpdate {
+    epoch_store.update_authenticator_state(&AuthenticatorStateUpdateV1 {
         epoch: 0,
         round: 0,
         new_active_jwks: jwks
@@ -1224,7 +1224,7 @@ async fn zklogin_txn_fail_if_missing_jwk() {
     // Initialize an authenticator state with Twitch's kid as "nosuckkey".
     pub const BAD_JWK_BYTES: &[u8] = r#"{"keys":[{"alg":"RS256","e":"AQAB","kid":"nosuchkey","kty":"RSA","n":"6lq9MQ-q6hcxr7kOUp-tHlHtdcDsVLwVIw13iXUCvuDOeCi0VSuxCCUY6UmMjy53dX00ih2E4Y4UvlrmmurK0eG26b-HMNNAvCGsVXHU3RcRhVoHDaOwHwU72j7bpHn9XbP3Q3jebX6KIfNbei2MiR0Wyb8RZHE-aZhRYO8_-k9G2GycTpvc-2GBsP8VHLUKKfAs2B6sW3q3ymU6M0L-cFXkZ9fHkn9ejs-sqZPhMJxtBPBxoUIUQFTgv4VXTSv914f_YkNw-EjuwbgwXMvpyr06EyfImxHoxsZkFYB-qBYHtaMxTnFsZBr6fn8Ha2JqT1hoP7Z5r5wxDu3GQhKkHw","use":"sig"}]}"#.as_bytes();
     let jwks = parse_jwks(BAD_JWK_BYTES, &OIDCProvider::Twitch).unwrap();
-    epoch_store.update_authenticator_state(&AuthenticatorStateUpdate {
+    epoch_store.update_authenticator_state(&AuthenticatorStateUpdateV1 {
         epoch: 0,
         round: 0,
         new_active_jwks: jwks
@@ -1268,7 +1268,7 @@ async fn zk_multisig_test() {
 
     let jwks = parse_jwks(DEFAULT_JWK_BYTES, &OIDCProvider::Twitch).unwrap();
     let epoch_store = authority_state.epoch_store_for_testing();
-    epoch_store.update_authenticator_state(&AuthenticatorStateUpdate {
+    epoch_store.update_authenticator_state(&AuthenticatorStateUpdateV1 {
         epoch: 0,
         round: 0,
         new_active_jwks: jwks

--- a/crates/iota-e2e-tests/tests/zklogin_tests.rs
+++ b/crates/iota-e2e-tests/tests/zklogin_tests.rs
@@ -234,7 +234,7 @@ async fn test_auth_state_creation() {
     // Wait until we are in an epoch that has zklogin enabled, but the auth state
     // object is not created yet.
     test_cluster.wait_for_protocol_version(24.into()).await;
-    // Now wait until the auth state object is created, ie. AuthenticatorStateUpdate
+    // Now wait until the auth state object is created, ie. AuthenticatorStateUpdateV1
     // transaction happened.
     test_cluster.wait_for_authenticator_state_update().await;
 }
@@ -324,7 +324,7 @@ async fn test_conflicting_jwks() {
                     .unwrap();
                 match &tx.data().intent_message().value.kind() {
                     TransactionKind::EndOfEpochTransaction(_) => (),
-                    TransactionKind::AuthenticatorStateUpdate(update) => {
+                    TransactionKind::AuthenticatorStateUpdateV1(update) => {
                         let jwks = &mut *jwks_clone.lock().unwrap();
                         for jwk in &update.new_active_jwks {
                             jwks.push(jwk.clone());

--- a/crates/iota-e2e-tests/tests/zklogin_tests.rs
+++ b/crates/iota-e2e-tests/tests/zklogin_tests.rs
@@ -234,8 +234,8 @@ async fn test_auth_state_creation() {
     // Wait until we are in an epoch that has zklogin enabled, but the auth state
     // object is not created yet.
     test_cluster.wait_for_protocol_version(24.into()).await;
-    // Now wait until the auth state object is created, ie. AuthenticatorStateUpdateV1
-    // transaction happened.
+    // Now wait until the auth state object is created, ie.
+    // AuthenticatorStateUpdateV1 transaction happened.
     test_cluster.wait_for_authenticator_state_update().await;
 }
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/authenticator_state_update.rs
@@ -8,7 +8,7 @@ use async_graphql::{
 };
 use iota_types::{
     authenticator_state::ActiveJwk as NativeActiveJwk,
-    transaction::AuthenticatorStateUpdate as NativeAuthenticatorStateUpdateTransaction,
+    transaction::AuthenticatorStateUpdateV1 as NativeAuthenticatorStateUpdateV1Transaction,
 };
 
 use crate::{
@@ -21,8 +21,8 @@ use crate::{
 };
 
 #[derive(Clone, PartialEq, Eq)]
-pub(crate) struct AuthenticatorStateUpdateTransaction {
-    pub native: NativeAuthenticatorStateUpdateTransaction,
+pub(crate) struct AuthenticatorStateUpdateV1Transaction {
+    pub native: NativeAuthenticatorStateUpdateV1Transaction,
     /// The checkpoint sequence number this was viewed at.
     pub checkpoint_viewed_at: u64,
 }
@@ -39,7 +39,7 @@ struct ActiveJwk {
 
 /// System transaction for updating the on-chain state used by zkLogin.
 #[Object]
-impl AuthenticatorStateUpdateTransaction {
+impl AuthenticatorStateUpdateV1Transaction {
     /// Epoch of the authenticator state update transaction.
     async fn epoch(&self, ctx: &Context<'_>) -> Result<Option<Epoch>> {
         Epoch::query(ctx, Some(self.native.epoch), self.checkpoint_viewed_at)

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/end_of_epoch.rs
@@ -253,7 +253,7 @@ impl AuthenticatorStateExpireTransaction {
             .extend()
     }
 
-    /// The initial version that the AuthenticatorStateUpdate was shared at.
+    /// The initial version that the AuthenticatorStateUpdateV1 was shared at.
     async fn authenticator_obj_initial_shared_version(&self) -> UInt53 {
         self.native
             .authenticator_obj_initial_shared_version

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/mod.rs
@@ -11,7 +11,7 @@ use self::{
     randomness_state_update::RandomnessStateUpdateTransaction,
 };
 use crate::types::transaction_block_kind::{
-    authenticator_state_update::AuthenticatorStateUpdateTransaction,
+    authenticator_state_update::AuthenticatorStateUpdateV1Transaction,
     end_of_epoch::EndOfEpochTransaction, programmable::ProgrammableTransactionBlock,
 };
 
@@ -30,7 +30,7 @@ pub(crate) enum TransactionBlockKind {
     Genesis(GenesisTransaction),
     ChangeEpoch(ChangeEpochTransaction),
     Programmable(ProgrammableTransactionBlock),
-    AuthenticatorState(AuthenticatorStateUpdateTransaction),
+    AuthenticatorState(AuthenticatorStateUpdateV1Transaction),
     Randomness(RandomnessStateUpdateTransaction),
     EndOfEpoch(EndOfEpochTransaction),
 }
@@ -62,8 +62,8 @@ impl TransactionBlockKind {
             K::ConsensusCommitPrologueV3(ccp) => T::ConsensusCommitPrologue(
                 ConsensusCommitPrologueTransaction::from_v3(ccp, checkpoint_viewed_at),
             ),
-            K::AuthenticatorStateUpdate(asu) => {
-                T::AuthenticatorState(AuthenticatorStateUpdateTransaction {
+            K::AuthenticatorStateUpdateV1(asu) => {
+                T::AuthenticatorState(AuthenticatorStateUpdateV1Transaction {
                     native: asu,
                     checkpoint_viewed_at,
                 })

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -407,7 +407,7 @@ pub enum IotaTransactionBlockKind {
     /// used in future transactions
     ProgrammableTransaction(IotaProgrammableTransactionBlock),
     /// A transaction which updates global authenticator state
-    AuthenticatorStateUpdate(IotaAuthenticatorStateUpdate),
+    AuthenticatorStateUpdateV1(IotaAuthenticatorStateUpdateV1),
     /// A transaction which updates global randomness state
     RandomnessStateUpdate(IotaRandomnessStateUpdate),
     /// The transaction which occurs only at the end of the epoch
@@ -464,7 +464,7 @@ impl Display for IotaTransactionBlockKind {
                 write!(writer, "Transaction Kind: Programmable")?;
                 write!(writer, "{}", crate::displays::Pretty(p))?;
             }
-            Self::AuthenticatorStateUpdate(_) => {
+            Self::AuthenticatorStateUpdateV1(_) => {
                 writeln!(writer, "Transaction Kind: Authenticator State Update")?;
             }
             Self::RandomnessStateUpdate(_) => {
@@ -524,8 +524,8 @@ impl IotaTransactionBlockKind {
             TransactionKind::ProgrammableTransaction(p) => Self::ProgrammableTransaction(
                 IotaProgrammableTransactionBlock::try_from(p, module_cache)?,
             ),
-            TransactionKind::AuthenticatorStateUpdate(update) => {
-                Self::AuthenticatorStateUpdate(IotaAuthenticatorStateUpdate {
+            TransactionKind::AuthenticatorStateUpdateV1(update) => {
+                Self::AuthenticatorStateUpdateV1(IotaAuthenticatorStateUpdateV1 {
                     epoch: update.epoch,
                     round: update.round,
                     new_active_jwks: update
@@ -632,8 +632,8 @@ impl IotaTransactionBlockKind {
                 )
                 .await?,
             ),
-            TransactionKind::AuthenticatorStateUpdate(update) => {
-                Self::AuthenticatorStateUpdate(IotaAuthenticatorStateUpdate {
+            TransactionKind::AuthenticatorStateUpdateV1(update) => {
+                Self::AuthenticatorStateUpdateV1(IotaAuthenticatorStateUpdateV1 {
                     epoch: update.epoch,
                     round: update.round,
                     new_active_jwks: update
@@ -704,7 +704,7 @@ impl IotaTransactionBlockKind {
             Self::ConsensusCommitPrologueV2(_) => "ConsensusCommitPrologueV2",
             Self::ConsensusCommitPrologueV3(_) => "ConsensusCommitPrologueV3",
             Self::ProgrammableTransaction(_) => "ProgrammableTransaction",
-            Self::AuthenticatorStateUpdate(_) => "AuthenticatorStateUpdate",
+            Self::AuthenticatorStateUpdateV1(_) => "AuthenticatorStateUpdateV1",
             Self::RandomnessStateUpdate(_) => "RandomnessStateUpdate",
             Self::EndOfEpochTransaction(_) => "EndOfEpochTransaction",
         }
@@ -1681,7 +1681,7 @@ pub struct IotaConsensusCommitPrologueV3 {
 
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-pub struct IotaAuthenticatorStateUpdate {
+pub struct IotaAuthenticatorStateUpdateV1 {
     #[schemars(with = "BigInt<u64>")]
     #[serde_as(as = "BigInt<u64>")]
     pub epoch: u64,

--- a/crates/iota-rosetta/src/types.rs
+++ b/crates/iota-rosetta/src/types.rs
@@ -416,7 +416,7 @@ pub enum OperationType {
     Genesis,
     ConsensusCommitPrologue,
     ProgrammableTransaction,
-    AuthenticatorStateUpdate,
+    AuthenticatorStateUpdateV1,
     RandomnessStateUpdate,
     EndOfEpochTransaction,
 }
@@ -434,8 +434,8 @@ impl From<&IotaTransactionBlockKind> for OperationType {
             IotaTransactionBlockKind::ProgrammableTransaction(_) => {
                 OperationType::ProgrammableTransaction
             }
-            IotaTransactionBlockKind::AuthenticatorStateUpdate(_) => {
-                OperationType::AuthenticatorStateUpdate
+            IotaTransactionBlockKind::AuthenticatorStateUpdateV1(_) => {
+                OperationType::AuthenticatorStateUpdateV1
             }
             IotaTransactionBlockKind::RandomnessStateUpdate(_) => {
                 OperationType::RandomnessStateUpdate

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -231,7 +231,7 @@ impl AuthenticatorStateExpire {
 }
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Serialize, Deserialize)]
-pub struct AuthenticatorStateUpdate {
+pub struct AuthenticatorStateUpdateV1 {
     /// Epoch of the authenticator state update transaction
     pub epoch: u64,
     /// Consensus round of the authenticator state update
@@ -244,7 +244,7 @@ pub struct AuthenticatorStateUpdate {
     // TransactionKind.
 }
 
-impl AuthenticatorStateUpdate {
+impl AuthenticatorStateUpdateV1 {
     pub fn authenticator_obj_initial_shared_version(&self) -> SequenceNumber {
         self.authenticator_obj_initial_shared_version
     }
@@ -289,7 +289,7 @@ pub enum TransactionKind {
     ChangeEpoch(ChangeEpoch),
     Genesis(GenesisTransaction),
     ConsensusCommitPrologue(ConsensusCommitPrologue),
-    AuthenticatorStateUpdate(AuthenticatorStateUpdate),
+    AuthenticatorStateUpdateV1(AuthenticatorStateUpdateV1),
 
     /// EndOfEpochTransaction replaces ChangeEpoch with a list of transactions
     /// that are allowed to run at the end of the epoch.
@@ -1186,7 +1186,7 @@ impl TransactionKind {
             | TransactionKind::ConsensusCommitPrologue(_)
             | TransactionKind::ConsensusCommitPrologueV2(_)
             | TransactionKind::ConsensusCommitPrologueV3(_)
-            | TransactionKind::AuthenticatorStateUpdate(_)
+            | TransactionKind::AuthenticatorStateUpdateV1(_)
             | TransactionKind::RandomnessStateUpdate(_)
             | TransactionKind::EndOfEpochTransaction(_) => true,
             TransactionKind::ProgrammableTransaction(_) => false,
@@ -1243,7 +1243,7 @@ impl TransactionKind {
                     mutable: true,
                 })))
             }
-            Self::AuthenticatorStateUpdate(update) => {
+            Self::AuthenticatorStateUpdateV1(update) => {
                 Either::Left(Either::Left(iter::once(SharedInputObject {
                     id: IOTA_AUTHENTICATOR_STATE_OBJECT_ID,
                     initial_shared_version: update.authenticator_obj_initial_shared_version,
@@ -1281,7 +1281,7 @@ impl TransactionKind {
             | TransactionKind::ConsensusCommitPrologue(_)
             | TransactionKind::ConsensusCommitPrologueV2(_)
             | TransactionKind::ConsensusCommitPrologueV3(_)
-            | TransactionKind::AuthenticatorStateUpdate(_)
+            | TransactionKind::AuthenticatorStateUpdateV1(_)
             | TransactionKind::RandomnessStateUpdate(_)
             | TransactionKind::EndOfEpochTransaction(_) => vec![],
             TransactionKind::ProgrammableTransaction(pt) => pt.receiving_objects(),
@@ -1314,7 +1314,7 @@ impl TransactionKind {
                     mutable: true,
                 }]
             }
-            Self::AuthenticatorStateUpdate(update) => {
+            Self::AuthenticatorStateUpdateV1(update) => {
                 vec![InputObjectKind::SharedMoveObject {
                     id: IOTA_AUTHENTICATOR_STATE_OBJECT_ID,
                     initial_shared_version: update.authenticator_obj_initial_shared_version(),
@@ -1392,7 +1392,7 @@ impl TransactionKind {
                 }
             }
 
-            TransactionKind::AuthenticatorStateUpdate(_) => {
+            TransactionKind::AuthenticatorStateUpdateV1(_) => {
                 if !config.enable_jwk_consensus_updates() {
                     return Err(UserInputError::Unsupported(
                         "authenticator state updates not enabled".to_string(),
@@ -1441,7 +1441,7 @@ impl TransactionKind {
             Self::ConsensusCommitPrologueV2(_) => "ConsensusCommitPrologueV2",
             Self::ConsensusCommitPrologueV3(_) => "ConsensusCommitPrologueV3",
             Self::ProgrammableTransaction(_) => "ProgrammableTransaction",
-            Self::AuthenticatorStateUpdate(_) => "AuthenticatorStateUpdate",
+            Self::AuthenticatorStateUpdateV1(_) => "AuthenticatorStateUpdateV1",
             Self::RandomnessStateUpdate(_) => "RandomnessStateUpdate",
             Self::EndOfEpochTransaction(_) => "EndOfEpochTransaction",
         }
@@ -1486,7 +1486,7 @@ impl Display for TransactionKind {
                 writeln!(writer, "Transaction Kind : Programmable")?;
                 write!(writer, "{p}")?;
             }
-            Self::AuthenticatorStateUpdate(_) => {
+            Self::AuthenticatorStateUpdateV1(_) => {
                 writeln!(writer, "Transaction Kind : Authenticator State Update")?;
             }
             Self::RandomnessStateUpdate(_) => {
@@ -2595,13 +2595,13 @@ impl VerifiedTransaction {
         new_active_jwks: Vec<ActiveJwk>,
         authenticator_obj_initial_shared_version: SequenceNumber,
     ) -> Self {
-        AuthenticatorStateUpdate {
+        AuthenticatorStateUpdateV1 {
             epoch,
             round,
             new_active_jwks,
             authenticator_obj_initial_shared_version,
         }
-        .pipe(TransactionKind::AuthenticatorStateUpdate)
+        .pipe(TransactionKind::AuthenticatorStateUpdateV1)
         .pipe(Self::new_system_transaction)
     }
 

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -606,7 +606,7 @@ impl TestCluster {
                             .unwrap();
                         match &tx.data().intent_message().value.kind() {
                             TransactionKind::EndOfEpochTransaction(_) => (),
-                            TransactionKind::AuthenticatorStateUpdate(_) => break,
+                            TransactionKind::AuthenticatorStateUpdateV1(_) => break,
                             _ => panic!("{:?}", tx),
                         }
                     }

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -60,7 +60,7 @@ mod checked {
         },
         storage::{BackingStore, Storage},
         transaction::{
-            Argument, AuthenticatorStateExpire, AuthenticatorStateUpdate, CallArg, ChangeEpoch,
+            Argument, AuthenticatorStateExpire, AuthenticatorStateUpdateV1, CallArg, ChangeEpoch,
             CheckedInputObjects, Command, EndOfEpochTransactionKind, GenesisTransaction, ObjectArg,
             ProgrammableTransaction, RandomnessStateUpdate, TransactionKind,
         },
@@ -757,7 +757,7 @@ mod checked {
                     "EndOfEpochTransactionKind::ChangeEpoch should be the last transaction in the list"
                 )
             }
-            TransactionKind::AuthenticatorStateUpdate(auth_state_update) => {
+            TransactionKind::AuthenticatorStateUpdateV1(auth_state_update) => {
                 setup_authenticator_state_update(
                     auth_state_update,
                     temporary_store,
@@ -1267,7 +1267,7 @@ mod checked {
     /// arguments. It then executes the transaction using the system
     /// execution mode.
     fn setup_authenticator_state_update(
-        update: AuthenticatorStateUpdate,
+        update: AuthenticatorStateUpdateV1,
         temporary_store: &mut TemporaryStore<'_>,
         tx_ctx: &mut TxContext,
         move_vm: &Arc<MoveVM>,

--- a/iota-execution/v0/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/v0/iota-adapter/src/execution_engine.rs
@@ -60,7 +60,7 @@ mod checked {
         },
         storage::{BackingStore, Storage},
         transaction::{
-            Argument, AuthenticatorStateExpire, AuthenticatorStateUpdate, CallArg, ChangeEpoch,
+            Argument, AuthenticatorStateExpire, AuthenticatorStateUpdateV1, CallArg, ChangeEpoch,
             CheckedInputObjects, Command, EndOfEpochTransactionKind, GenesisTransaction, ObjectArg,
             ProgrammableTransaction, RandomnessStateUpdate, TransactionKind,
         },
@@ -710,7 +710,7 @@ mod checked {
                     "EndOfEpochTransactionKind::ChangeEpoch should be the last transaction in the list"
                 )
             }
-            TransactionKind::AuthenticatorStateUpdate(auth_state_update) => {
+            TransactionKind::AuthenticatorStateUpdateV1(auth_state_update) => {
                 setup_authenticator_state_update(
                     auth_state_update,
                     temporary_store,
@@ -1182,7 +1182,7 @@ mod checked {
     }
 
     fn setup_authenticator_state_update(
-        update: AuthenticatorStateUpdate,
+        update: AuthenticatorStateUpdateV1,
         temporary_store: &mut TemporaryStore<'_>,
         tx_ctx: &mut TxContext,
         move_vm: &Arc<MoveVM>,


### PR DESCRIPTION
Closes #3096 

# Description of change

This PR renames the existing `AuthenticatorStateUpdate` to be `AuthenticatorStateUpdateV1`

There might be different `AuthenticatorStateUpdate` versions in the future, as there is a comment in `iota-types/src/transaction.rs` that says adding a `AuthenticatorStateUpdateV2` to `TransactionKind` for versioning `AuthenticatorStateUpdate`.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

I was running the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
