### PR TITLE
refactor(iota-types/authority-capabilities): Rename `AuthorityCapabilities`/`CapabilityNotification`

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -90,7 +90,7 @@ use iota_types::{
         CheckpointSummaryResponse, CheckpointTimestamp, ECMHLiveObjectSetDigest,
         VerifiedCheckpoint,
     },
-    messages_consensus::{AuthorityCapabilitiesV1, AuthorityCapabilitiesV2},
+    messages_consensus::AuthorityCapabilitiesV1,
     messages_grpc::{
         HandleTransactionResponse, LayoutGenerationOption, ObjectInfoRequest,
         ObjectInfoRequestKind, ObjectInfoResponse, TransactionInfoRequest, TransactionInfoResponse,
@@ -4386,104 +4386,12 @@ impl AuthorityState {
         Some(res)
     }
 
-    // TODO: delete once authority_capabilities_v2 is deployed everywhere
-    /// Returns the new protocol version and system packages that the network
-    /// has voted to upgrade to. If the proposed protocol version is not
-    /// supported, None is returned.
     fn is_protocol_version_supported_v1(
         current_protocol_version: ProtocolVersion,
         proposed_protocol_version: ProtocolVersion,
         protocol_config: &ProtocolConfig,
         committee: &Committee,
         capabilities: Vec<AuthorityCapabilitiesV1>,
-        mut buffer_stake_bps: u64,
-    ) -> Option<(ProtocolVersion, Vec<ObjectRef>)> {
-        if proposed_protocol_version > current_protocol_version + 1
-            && !protocol_config.advance_to_highest_supported_protocol_version()
-        {
-            return None;
-        }
-
-        if buffer_stake_bps > 10000 {
-            warn!("clamping buffer_stake_bps to 10000");
-            buffer_stake_bps = 10000;
-        }
-
-        // For each validator, gather the protocol version and system packages that it
-        // would like to upgrade to in the next epoch.
-        let mut desired_upgrades: Vec<_> = capabilities
-            .into_iter()
-            .filter_map(|mut cap| {
-                // A validator that lists no packages is voting against any change at all.
-                if cap.available_system_packages.is_empty() {
-                    return None;
-                }
-
-                cap.available_system_packages.sort();
-
-                info!(
-                    "validator {:?} supports {:?} with system packages: {:?}",
-                    cap.authority.concise(),
-                    cap.supported_protocol_versions,
-                    cap.available_system_packages,
-                );
-
-                // A validator that only supports the current protocol version is also voting
-                // against any change, because framework upgrades always require a protocol
-                // version bump.
-                cap.supported_protocol_versions
-                    .is_version_supported(proposed_protocol_version)
-                    .then_some((cap.available_system_packages, cap.authority))
-            })
-            .collect();
-
-        // There can only be one set of votes that have a majority, find one if it
-        // exists.
-        desired_upgrades.sort();
-        desired_upgrades
-            .into_iter()
-            .chunk_by(|(packages, _authority)| packages.clone())
-            .into_iter()
-            .find_map(|(packages, group)| {
-                // should have been filtered out earlier.
-                assert!(!packages.is_empty());
-
-                let mut stake_aggregator: StakeAggregator<(), true> =
-                    StakeAggregator::new(Arc::new(committee.clone()));
-
-                for (_, authority) in group {
-                    stake_aggregator.insert_generic(authority, ());
-                }
-
-                let total_votes = stake_aggregator.total_votes();
-                let quorum_threshold = committee.quorum_threshold();
-                let f = committee.total_votes() - committee.quorum_threshold();
-
-                // multiple by buffer_stake_bps / 10000, rounded up.
-                let buffer_stake = (f * buffer_stake_bps + 9999) / 10000;
-                let effective_threshold = quorum_threshold + buffer_stake;
-
-                info!(
-                    ?total_votes,
-                    ?quorum_threshold,
-                    ?buffer_stake_bps,
-                    ?effective_threshold,
-                    ?proposed_protocol_version,
-                    ?packages,
-                    "support for upgrade"
-                );
-
-                let has_support = total_votes >= effective_threshold;
-                has_support.then_some((proposed_protocol_version, packages))
-            })
-    }
-
-    fn is_protocol_version_supported_v2(
-        current_protocol_version: ProtocolVersion,
-        proposed_protocol_version: ProtocolVersion,
-        protocol_config: &ProtocolConfig,
-        committee: &Committee,
-        capabilities: Vec<AuthorityCapabilitiesV2>,
         mut buffer_stake_bps: u64,
     ) -> Option<(ProtocolVersion, Vec<ObjectRef>)> {
         if proposed_protocol_version > current_protocol_version + 1
@@ -4567,10 +4475,6 @@ impl AuthorityState {
             })
     }
 
-    // TODO: delete once authority_capabilities_v2 is deployed everywhere
-    /// Selects the highest supported protocol version and system packages that
-    /// the network has voted to upgrade to. If no upgrade is supported,
-    /// returns the current protocol version and system packages.
     fn choose_protocol_version_and_system_packages_v1(
         current_protocol_version: ProtocolVersion,
         protocol_config: &ProtocolConfig,
@@ -4581,35 +4485,10 @@ impl AuthorityState {
         let mut next_protocol_version = current_protocol_version;
         let mut system_packages = vec![];
 
-        while let Some((version, packages)) = Self::is_protocol_version_supported_v1(
-            current_protocol_version,
-            next_protocol_version + 1,
-            protocol_config,
-            committee,
-            capabilities.clone(),
-            buffer_stake_bps,
-        ) {
-            next_protocol_version = version;
-            system_packages = packages;
-        }
-
-        (next_protocol_version, system_packages)
-    }
-
-    fn choose_protocol_version_and_system_packages_v2(
-        current_protocol_version: ProtocolVersion,
-        protocol_config: &ProtocolConfig,
-        committee: &Committee,
-        capabilities: Vec<AuthorityCapabilitiesV2>,
-        buffer_stake_bps: u64,
-    ) -> (ProtocolVersion, Vec<ObjectRef>) {
-        let mut next_protocol_version = current_protocol_version;
-        let mut system_packages = vec![];
-
         // Finds the highest supported protocol version and system packages by
         // incrementing the proposed protocol version by one until no further
         // upgrades are supported.
-        while let Some((version, packages)) = Self::is_protocol_version_supported_v2(
+        while let Some((version, packages)) = Self::is_protocol_version_supported_v1(
             current_protocol_version,
             next_protocol_version + 1,
             protocol_config,
@@ -4791,17 +4670,7 @@ impl AuthorityState {
         let buffer_stake_bps = epoch_store.get_effective_buffer_stake_bps();
 
         let (next_epoch_protocol_version, next_epoch_system_packages) =
-            if epoch_store.protocol_config().authority_capabilities_v2() {
-                Self::choose_protocol_version_and_system_packages_v2(
-                    epoch_store.protocol_version(),
-                    epoch_store.protocol_config(),
-                    epoch_store.committee(),
-                    epoch_store
-                        .get_capabilities_v2()
-                        .expect("read capabilities from db cannot fail"),
-                    buffer_stake_bps,
-                )
-            } else {
+            if epoch_store.protocol_config().authority_capabilities_v1() {
                 Self::choose_protocol_version_and_system_packages_v1(
                     epoch_store.protocol_version(),
                     epoch_store.protocol_config(),
@@ -4811,6 +4680,12 @@ impl AuthorityState {
                         .expect("read capabilities from db cannot fail"),
                     buffer_stake_bps,
                 )
+            } else {
+                error!(
+                    "Unsupported protocol_config {:?}",
+                    epoch_store.protocol_config()
+                );
+                return Err(anyhow!("Unsupported protocol configuration"));
             };
 
         // since system packages are created during the current epoch, they should abide

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -4682,10 +4682,10 @@ impl AuthorityState {
                 )
             } else {
                 error!(
-                    "Unsupported protocol_config {:?}",
+                    "authority_capabilities_v1 not enabled with protocol_config {:?}",
                     epoch_store.protocol_config()
                 );
-                return Err(anyhow!("Unsupported protocol configuration"));
+                return Err(anyhow!("authority_capabilities_v1 not enabled"));
             };
 
         // since system packages are created during the current epoch, they should abide

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -4670,23 +4670,15 @@ impl AuthorityState {
         let buffer_stake_bps = epoch_store.get_effective_buffer_stake_bps();
 
         let (next_epoch_protocol_version, next_epoch_system_packages) =
-            if epoch_store.protocol_config().authority_capabilities_v1() {
-                Self::choose_protocol_version_and_system_packages_v1(
-                    epoch_store.protocol_version(),
-                    epoch_store.protocol_config(),
-                    epoch_store.committee(),
-                    epoch_store
-                        .get_capabilities_v1()
-                        .expect("read capabilities from db cannot fail"),
-                    buffer_stake_bps,
-                )
-            } else {
-                error!(
-                    "authority_capabilities_v1 not enabled with protocol_config {:?}",
-                    epoch_store.protocol_config()
-                );
-                return Err(anyhow!("authority_capabilities_v1 not enabled"));
-            };
+            Self::choose_protocol_version_and_system_packages_v1(
+                epoch_store.protocol_version(),
+                epoch_store.protocol_config(),
+                epoch_store.committee(),
+                epoch_store
+                    .get_capabilities_v1()
+                    .expect("read capabilities from db cannot fail"),
+                buffer_stake_bps,
+            );
 
         // since system packages are created during the current epoch, they should abide
         // by the rules of the current epoch, including the current epoch's max

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -50,9 +50,8 @@ use iota_types::{
         CheckpointContents, CheckpointSequenceNumber, CheckpointSignatureMessage, CheckpointSummary,
     },
     messages_consensus::{
-        AuthorityCapabilitiesV1, AuthorityCapabilitiesV2, ConsensusTransaction,
-        ConsensusTransactionKey, ConsensusTransactionKind, VersionedDkgConfirmation,
-        check_total_jwk_size,
+        AuthorityCapabilitiesV1, ConsensusTransaction, ConsensusTransactionKey,
+        ConsensusTransactionKind, VersionedDkgConfirmation, check_total_jwk_size,
     },
     signature::GenericSignature,
     storage::{BackingPackageStore, GetSharedLocks, InputKey, ObjectStore},
@@ -571,8 +570,7 @@ pub struct AuthorityEpochTables {
     pub running_root_accumulators: DBMap<CheckpointSequenceNumber, Accumulator>,
 
     /// Record of the capabilities advertised by each authority.
-    authority_capabilities: DBMap<AuthorityName, AuthorityCapabilitiesV1>,
-    authority_capabilities_v2: DBMap<AuthorityName, AuthorityCapabilitiesV2>,
+    authority_capabilities_v1: DBMap<AuthorityName, AuthorityCapabilitiesV1>,
 
     /// Contains a single key, which overrides the value of
     /// ProtocolConfig::buffer_stake_for_protocol_upgrade_bps
@@ -2204,14 +2202,14 @@ impl AuthorityPerEpochStore {
     }
 
     /// Record most recently advertised capabilities of all authorities
-    pub fn record_capabilities(&self, capabilities: &AuthorityCapabilitiesV1) -> IotaResult {
-        info!("received capabilities {:?}", capabilities);
+    pub fn record_capabilities_v1(&self, capabilities: &AuthorityCapabilitiesV1) -> IotaResult {
+        info!("received capabilities v1 {:?}", capabilities);
         let authority = &capabilities.authority;
         let tables = self.tables()?;
 
         // Read-compare-write pattern assumes we are only called from the consensus
         // handler task.
-        if let Some(cap) = tables.authority_capabilities.get(authority)? {
+        if let Some(cap) = tables.authority_capabilities_v1.get(authority)? {
             if cap.generation >= capabilities.generation {
                 debug!(
                     "ignoring new capabilities {:?} in favor of previous capabilities {:?}",
@@ -2221,50 +2219,16 @@ impl AuthorityPerEpochStore {
             }
         }
         tables
-            .authority_capabilities
-            .insert(authority, capabilities)?;
-        Ok(())
-    }
-
-    /// Record most recently advertised capabilities of all authorities
-    pub fn record_capabilities_v2(&self, capabilities: &AuthorityCapabilitiesV2) -> IotaResult {
-        info!("received capabilities v2 {:?}", capabilities);
-        let authority = &capabilities.authority;
-        let tables = self.tables()?;
-
-        // Read-compare-write pattern assumes we are only called from the consensus
-        // handler task.
-        if let Some(cap) = tables.authority_capabilities_v2.get(authority)? {
-            if cap.generation >= capabilities.generation {
-                debug!(
-                    "ignoring new capabilities {:?} in favor of previous capabilities {:?}",
-                    capabilities, cap
-                );
-                return Ok(());
-            }
-        }
-        tables
-            .authority_capabilities_v2
+            .authority_capabilities_v1
             .insert(authority, capabilities)?;
         Ok(())
     }
 
     pub fn get_capabilities_v1(&self) -> IotaResult<Vec<AuthorityCapabilitiesV1>> {
-        assert!(!self.protocol_config.authority_capabilities_v2());
+        assert!(self.protocol_config.authority_capabilities_v1());
         let result: Result<Vec<AuthorityCapabilitiesV1>, TypedStoreError> = self
             .tables()?
-            .authority_capabilities
-            .values()
-            .map_into()
-            .collect();
-        Ok(result?)
-    }
-
-    pub fn get_capabilities_v2(&self) -> IotaResult<Vec<AuthorityCapabilitiesV2>> {
-        assert!(self.protocol_config.authority_capabilities_v2());
-        let result: Result<Vec<AuthorityCapabilitiesV2>, TypedStoreError> = self
-            .tables()?
-            .authority_capabilities_v2
+            .authority_capabilities_v1
             .values()
             .map_into()
             .collect();
@@ -2534,15 +2498,7 @@ impl AuthorityPerEpochStore {
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind:
-                    ConsensusTransactionKind::CapabilityNotification(AuthorityCapabilitiesV1 {
-                        authority,
-                        ..
-                    }),
-                ..
-            })
-            | SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind:
-                    ConsensusTransactionKind::CapabilityNotificationV2(AuthorityCapabilitiesV2 {
+                    ConsensusTransactionKind::CapabilityNotificationV1(AuthorityCapabilitiesV1 {
                         authority,
                         ..
                     }),
@@ -3617,30 +3573,7 @@ impl AuthorityPerEpochStore {
                 panic!("process_consensus_transaction called with end-of-publish transaction");
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::CapabilityNotification(capabilities),
-                ..
-            }) => {
-                // Records capabilities for the authority.
-                let authority = capabilities.authority;
-                if self
-                    .get_reconfig_state_read_lock_guard()
-                    .should_accept_consensus_certs()
-                {
-                    debug!(
-                        "Received CapabilityNotification from {:?}",
-                        authority.concise()
-                    );
-                    self.record_capabilities(capabilities)?;
-                } else {
-                    debug!(
-                        "Ignoring CapabilityNotification from {:?} because of end of epoch",
-                        authority.concise()
-                    );
-                }
-                Ok(ConsensusCertificateResult::ConsensusMessage)
-            }
-            SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::CapabilityNotificationV2(capabilities),
+                kind: ConsensusTransactionKind::CapabilityNotificationV1(capabilities),
                 ..
             }) => {
                 let authority = capabilities.authority;
@@ -3649,13 +3582,13 @@ impl AuthorityPerEpochStore {
                     .should_accept_consensus_certs()
                 {
                     debug!(
-                        "Received CapabilityNotificationV2 from {:?}",
+                        "Received CapabilityNotificationV1 from {:?}",
                         authority.concise()
                     );
-                    self.record_capabilities_v2(capabilities)?;
+                    self.record_capabilities_v1(capabilities)?;
                 } else {
                     debug!(
-                        "Ignoring CapabilityNotificationV2 from {:?} because of end of epoch",
+                        "Ignoring CapabilityNotificationV1 from {:?} because of end of epoch",
                         authority.concise()
                     );
                 }

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2225,7 +2225,6 @@ impl AuthorityPerEpochStore {
     }
 
     pub fn get_capabilities_v1(&self) -> IotaResult<Vec<AuthorityCapabilitiesV1>> {
-        assert!(self.protocol_config.authority_capabilities_v1());
         let result: Result<Vec<AuthorityCapabilitiesV1>, TypedStoreError> = self
             .tables()?
             .authority_capabilities_v1

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -739,8 +739,7 @@ impl ConsensusAdapter {
             && matches!(
                 transactions[0].kind,
                 ConsensusTransactionKind::EndOfPublish(_)
-                    | ConsensusTransactionKind::CapabilityNotification(_)
-                    | ConsensusTransactionKind::CapabilityNotificationV2(_)
+                    | ConsensusTransactionKind::CapabilityNotificationV1(_)
                     | ConsensusTransactionKind::RandomnessDkgMessage(_, _)
                     | ConsensusTransactionKind::RandomnessDkgConfirmation(_, _)
             ) {

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -887,7 +887,7 @@ mod tests {
             AuthorityCapabilitiesV1, ConsensusTransaction, ConsensusTransactionKind,
         },
         object::Object,
-        supported_protocol_versions::SupportedProtocolVersions,
+        supported_protocol_versions::SupportedProtocolVersionsWithHashes,
         transaction::{
             CertifiedTransaction, SenderSignedData, TransactionData, TransactionDataAPI,
         },

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -579,8 +579,7 @@ pub(crate) fn classify(transaction: &ConsensusTransaction) -> &'static str {
         }
         ConsensusTransactionKind::CheckpointSignature(_) => "checkpoint_signature",
         ConsensusTransactionKind::EndOfPublish(_) => "end_of_publish",
-        ConsensusTransactionKind::CapabilityNotification(_) => "capability_notification",
-        ConsensusTransactionKind::CapabilityNotificationV2(_) => "capability_notification_v2",
+        ConsensusTransactionKind::CapabilityNotificationV1(_) => "capability_notification_v1",
         ConsensusTransactionKind::NewJWKFetched(_, _, _) => "new_jwk_fetched",
         ConsensusTransactionKind::RandomnessStateUpdate(_, _) => "randomness_state_update",
         ConsensusTransactionKind::RandomnessDkgMessage(_, _) => "randomness_dkg_message",
@@ -883,6 +882,7 @@ mod tests {
     use iota_types::{
         base_types::{AuthorityName, IotaAddress, random_object_ref},
         committee::Committee,
+        iota_system_state::epoch_start_iota_system_state::EpochStartSystemStateTrait,
         messages_consensus::{
             AuthorityCapabilitiesV1, ConsensusTransaction, ConsensusTransactionKind,
         },
@@ -1094,9 +1094,6 @@ mod tests {
                 ConsensusTransactionKind::EndOfPublish(authority) => {
                     format!("eop({})", authority.0[0])
                 }
-                ConsensusTransactionKind::CapabilityNotification(cap) => {
-                    format!("cap({})", cap.generation)
-                }
                 ConsensusTransactionKind::UserTransaction(txn) => {
                     format!("user({})", txn.transaction_data().gas_price())
                 }
@@ -1113,11 +1110,13 @@ mod tests {
     }
 
     fn cap_txn(generation: u64) -> VerifiedSequencedConsensusTransaction {
-        txn(ConsensusTransactionKind::CapabilityNotification(
+        txn(ConsensusTransactionKind::CapabilityNotificationV1(
             AuthorityCapabilitiesV1 {
                 authority: Default::default(),
                 generation,
-                supported_protocol_versions: SupportedProtocolVersions::SYSTEM_DEFAULT,
+                supported_protocol_versions: SupportedProtocolVersionsWithHashes {
+                    versions: vec![],
+                },
                 available_system_packages: vec![],
             },
         ))

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -86,11 +86,9 @@ impl IotaTxValidator {
                     }
                 }
 
-                ConsensusTransactionKind::CapabilityNotification(_) => {}
-
                 ConsensusTransactionKind::EndOfPublish(_)
                 | ConsensusTransactionKind::NewJWKFetched(_, _, _)
-                | ConsensusTransactionKind::CapabilityNotificationV2(_)
+                | ConsensusTransactionKind::CapabilityNotificationV1(_)
                 | ConsensusTransactionKind::RandomnessStateUpdate(_, _) => {}
             }
         }

--- a/crates/iota-core/src/mysticeti_adapter.rs
+++ b/crates/iota-core/src/mysticeti_adapter.rs
@@ -117,8 +117,7 @@ impl SubmitToConsensus for LazyMysticetiClient {
             && matches!(
                 transactions[0].kind,
                 ConsensusTransactionKind::EndOfPublish(_)
-                    | ConsensusTransactionKind::CapabilityNotification(_)
-                    | ConsensusTransactionKind::CapabilityNotificationV2(_)
+                    | ConsensusTransactionKind::CapabilityNotificationV1(_)
                     | ConsensusTransactionKind::RandomnessDkgMessage(_, _)
                     | ConsensusTransactionKind::RandomnessDkgConfirmation(_, _)
             )

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -30,7 +30,7 @@ use iota_types::{
     execution_status::{ExecutionFailureStatus, ExecutionStatus},
     gas_coin::GasCoin,
     iota_system_state::IotaSystemStateWrapper,
-    messages_consensus::{AuthorityCapabilitiesV2, ConsensusDeterminedVersionAssignments},
+    messages_consensus::{AuthorityCapabilitiesV1, ConsensusDeterminedVersionAssignments},
     object::{Data, GAS_VALUE_FOR_TESTING, OBJECT_START_VERSION, Owner},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     randomness_state::get_randomness_state_obj_initial_shared_version,
@@ -5000,7 +5000,7 @@ fn test_choose_next_system_packages() {
 
     macro_rules! make_capabilities {
         ($v: expr, $name: expr, $packages: expr) => {
-            AuthorityCapabilitiesV2::new(
+            AuthorityCapabilitiesV1::new(
                 $name,
                 Chain::Unknown,
                 SupportedProtocolVersions::new_for_testing(1, $v),
@@ -5009,7 +5009,7 @@ fn test_choose_next_system_packages() {
         };
 
         ($v: expr, $name: expr, $packages: expr, $digest: expr) => {{
-            let mut cap = AuthorityCapabilitiesV2::new(
+            let mut cap = AuthorityCapabilitiesV1::new(
                 $name,
                 Chain::Unknown,
                 SupportedProtocolVersions::new_for_testing(1, $v),
@@ -5043,7 +5043,7 @@ fn test_choose_next_system_packages() {
 
     assert_eq!(
         (ver(1), vec![]),
-        AuthorityState::choose_protocol_version_and_system_packages_v2(
+        AuthorityState::choose_protocol_version_and_system_packages_v1(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,
@@ -5062,7 +5062,7 @@ fn test_choose_next_system_packages() {
 
     assert_eq!(
         (ver(1), vec![]),
-        AuthorityState::choose_protocol_version_and_system_packages_v2(
+        AuthorityState::choose_protocol_version_and_system_packages_v1(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,
@@ -5076,7 +5076,7 @@ fn test_choose_next_system_packages() {
 
     assert_eq!(
         (ver(2), sort(vec![o1, o2])),
-        AuthorityState::choose_protocol_version_and_system_packages_v2(
+        AuthorityState::choose_protocol_version_and_system_packages_v1(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,
@@ -5095,7 +5095,7 @@ fn test_choose_next_system_packages() {
 
     assert_eq!(
         (ver(1), vec![]),
-        AuthorityState::choose_protocol_version_and_system_packages_v2(
+        AuthorityState::choose_protocol_version_and_system_packages_v1(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,
@@ -5114,7 +5114,7 @@ fn test_choose_next_system_packages() {
 
     assert_eq!(
         (ver(2), sort(vec![o1, o2])),
-        AuthorityState::choose_protocol_version_and_system_packages_v2(
+        AuthorityState::choose_protocol_version_and_system_packages_v1(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,
@@ -5133,7 +5133,7 @@ fn test_choose_next_system_packages() {
 
     assert_eq!(
         (ver(1), vec![]),
-        AuthorityState::choose_protocol_version_and_system_packages_v2(
+        AuthorityState::choose_protocol_version_and_system_packages_v1(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,
@@ -5153,7 +5153,7 @@ fn test_choose_next_system_packages() {
 
     assert_eq!(
         (ver(2), sort(vec![o1, o2])),
-        AuthorityState::choose_protocol_version_and_system_packages_v2(
+        AuthorityState::choose_protocol_version_and_system_packages_v1(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,
@@ -5172,7 +5172,7 @@ fn test_choose_next_system_packages() {
 
     assert_eq!(
         (ver(1), vec![]),
-        AuthorityState::choose_protocol_version_and_system_packages_v2(
+        AuthorityState::choose_protocol_version_and_system_packages_v1(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,
@@ -5193,7 +5193,7 @@ fn test_choose_next_system_packages() {
 
     assert_eq!(
         (ver(3), sort(vec![o1, o2])),
-        AuthorityState::choose_protocol_version_and_system_packages_v2(
+        AuthorityState::choose_protocol_version_and_system_packages_v1(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,
@@ -5213,7 +5213,7 @@ fn test_choose_next_system_packages() {
     // upgrade to 3 which is the highest supported version
     assert_eq!(
         (ver(3), sort(vec![o1, o2])),
-        AuthorityState::choose_protocol_version_and_system_packages_v2(
+        AuthorityState::choose_protocol_version_and_system_packages_v1(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,
@@ -5235,7 +5235,7 @@ fn test_choose_next_system_packages() {
     // won't happen until everyone moves to 3.
     assert_eq!(
         (ver(1), sort(vec![])),
-        AuthorityState::choose_protocol_version_and_system_packages_v2(
+        AuthorityState::choose_protocol_version_and_system_packages_v1(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,
@@ -5257,7 +5257,7 @@ fn test_choose_next_system_packages() {
 
     assert_eq!(
         (ver(1), sort(vec![])),
-        AuthorityState::choose_protocol_version_and_system_packages_v2(
+        AuthorityState::choose_protocol_version_and_system_packages_v1(
             ProtocolVersion::MIN,
             &protocol_config,
             &committee,

--- a/crates/iota-node/src/admin.rs
+++ b/crates/iota-node/src/admin.rs
@@ -243,14 +243,9 @@ async fn set_filter(
 async fn capabilities(State(state): State<Arc<AppState>>) -> (StatusCode, String) {
     let epoch_store = state.node.state().load_epoch_store_one_call_per_task();
 
-    // Only one of v1 or v2 will be populated at a time
+    // Only one of capability's versions will be populated at a time
     let capabilities = epoch_store.get_capabilities_v1();
     let mut output = String::new();
-    for capability in capabilities.unwrap_or_default() {
-        output.push_str(&format!("{:?}\n", capability));
-    }
-
-    let capabilities = epoch_store.get_capabilities_v2();
     for capability in capabilities.unwrap_or_default() {
         output.push_str(&format!("{:?}\n", capability));
     }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -103,10 +103,7 @@ use iota_types::{
         IotaSystemState, IotaSystemStateTrait,
         epoch_start_iota_system_state::{EpochStartSystemState, EpochStartSystemStateTrait},
     },
-    messages_consensus::{
-        AuthorityCapabilitiesV1, AuthorityCapabilitiesV2, ConsensusTransaction,
-        check_total_jwk_size,
-    },
+    messages_consensus::{AuthorityCapabilitiesV1, ConsensusTransaction, check_total_jwk_size},
     quorum_driver_types::QuorumDriverEffectsQueueResult,
     supported_protocol_versions::SupportedProtocolVersions,
 };
@@ -1545,32 +1542,20 @@ impl IotaNode {
 
                 let config = cur_epoch_store.protocol_config();
                 let binary_config = to_binary_config(config);
-                let transaction = if config.authority_capabilities_v2() {
-                    ConsensusTransaction::new_capability_notification_v2(
-                        AuthorityCapabilitiesV2::new(
-                            self.state.name,
-                            cur_epoch_store.get_chain_identifier().chain(),
-                            self.config
-                                .supported_protocol_versions
-                                .expect("Supported versions should be populated")
-                                // no need to send digests of versions less than the current version
-                                .truncate_below(config.version),
-                            self.state
-                                .get_available_system_packages(&binary_config)
-                                .await,
-                        ),
-                    )
-                } else {
-                    ConsensusTransaction::new_capability_notification(AuthorityCapabilitiesV1::new(
+                let transaction = ConsensusTransaction::new_capability_notification_v1(
+                    AuthorityCapabilitiesV1::new(
                         self.state.name,
+                        cur_epoch_store.get_chain_identifier().chain(),
                         self.config
                             .supported_protocol_versions
-                            .expect("Supported versions should be populated"),
+                            .expect("Supported versions should be populated")
+                            // no need to send digests of versions less than the current version
+                            .truncate_below(config.version),
                         self.state
                             .get_available_system_packages(&binary_config)
                             .await,
-                    ))
-                };
+                    ),
+                );
                 info!(?transaction, "submitting capabilities to consensus");
                 components
                     .consensus_adapter

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1300,7 +1300,6 @@
                 "advance_epoch_start_time_in_safe_mode": true,
                 "advance_to_highest_supported_protocol_version": true,
                 "allow_receiving_object_id": true,
-                "authority_capabilities_v1": true,
                 "ban_entry_init": true,
                 "bridge": true,
                 "commit_root_state_digest": true,

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1300,7 +1300,7 @@
                 "advance_epoch_start_time_in_safe_mode": true,
                 "advance_to_highest_supported_protocol_version": true,
                 "allow_receiving_object_id": true,
-                "authority_capabilities_v2": true,
+                "authority_capabilities_v1": true,
                 "ban_entry_init": true,
                 "bridge": true,
                 "commit_root_state_digest": true,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -359,10 +359,6 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     passkey_auth: bool,
 
-    // Use AuthorityCapabilitiesV1
-    #[serde(skip_serializing_if = "is_false")]
-    authority_capabilities_v1: bool,
-
     // Rethrow type layout errors during serialization instead of trying to convert them.
     #[serde(skip_serializing_if = "is_false")]
     rethrow_serialization_type_layout_errors: bool,
@@ -1436,10 +1432,6 @@ impl ProtocolConfig {
         self.feature_flags.passkey_auth
     }
 
-    pub fn authority_capabilities_v1(&self) -> bool {
-        self.feature_flags.authority_capabilities_v1
-    }
-
     pub fn max_transaction_size_bytes(&self) -> u64 {
         // Provide a default value if protocol config version is too low.
         self.consensus_max_transaction_size_bytes
@@ -2112,8 +2104,6 @@ impl ProtocolConfig {
             cfg.vdf_hash_to_input_cost = Some(100);
 
             cfg.feature_flags.passkey_auth = true;
-
-            cfg.feature_flags.authority_capabilities_v1 = true;
         }
 
         // TODO: remove the never_loop attribute when the version 2 is added.

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -359,9 +359,9 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     passkey_auth: bool,
 
-    // Use AuthorityCapabilitiesV2
+    // Use AuthorityCapabilitiesV1
     #[serde(skip_serializing_if = "is_false")]
-    authority_capabilities_v2: bool,
+    authority_capabilities_v1: bool,
 
     // Rethrow type layout errors during serialization instead of trying to convert them.
     #[serde(skip_serializing_if = "is_false")]
@@ -1436,8 +1436,8 @@ impl ProtocolConfig {
         self.feature_flags.passkey_auth
     }
 
-    pub fn authority_capabilities_v2(&self) -> bool {
-        self.feature_flags.authority_capabilities_v2
+    pub fn authority_capabilities_v1(&self) -> bool {
+        self.feature_flags.authority_capabilities_v1
     }
 
     pub fn max_transaction_size_bytes(&self) -> u64 {
@@ -2113,7 +2113,7 @@ impl ProtocolConfig {
 
             cfg.feature_flags.passkey_auth = true;
 
-            cfg.feature_flags.authority_capabilities_v2 = true;
+            cfg.feature_flags.authority_capabilities_v1 = true;
         }
 
         // TODO: remove the never_loop attribute when the version 2 is added.

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -62,7 +62,6 @@ feature_flags:
   soft_bundle: true
   enable_coin_deny_list_v2: true
   passkey_auth: true
-  authority_capabilities_v1: true
   rethrow_serialization_type_layout_errors: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -62,7 +62,7 @@ feature_flags:
   soft_bundle: true
   enable_coin_deny_list_v2: true
   passkey_auth: true
-  authority_capabilities_v2: true
+  authority_capabilities_v1: true
   rethrow_serialization_type_layout_errors: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -162,7 +162,7 @@ pub struct AuthorityCapabilitiesV1 {
     pub generation: u64,
 
     /// ProtocolVersions that the authority supports.
-    pub supported_protocol_versions: SupportedProtocolVersions,
+    pub supported_protocol_versions: SupportedProtocolVersionsWithHashes,
 
     /// The ObjectRefs of all versions of system packages that the validator
     /// possesses. Used to determine whether to do a framework/movestdlib
@@ -185,65 +185,6 @@ impl Debug for AuthorityCapabilitiesV1 {
 }
 
 impl AuthorityCapabilitiesV1 {
-    pub fn new(
-        authority: AuthorityName,
-        supported_protocol_versions: SupportedProtocolVersions,
-        available_system_packages: Vec<ObjectRef>,
-    ) -> Self {
-        let generation = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("Iota did not exist prior to 1970")
-            .as_millis()
-            .try_into()
-            .expect("This build of iota is not supported in the year 500,000,000");
-        Self {
-            authority,
-            generation,
-            supported_protocol_versions,
-            available_system_packages,
-        }
-    }
-}
-
-/// Used to advertise capabilities of each authority via consensus. This allows
-/// validators to negotiate the creation of the ChangeEpoch transaction.
-#[derive(Serialize, Deserialize, Clone, Hash)]
-pub struct AuthorityCapabilitiesV2 {
-    /// Originating authority - must match transaction source authority from
-    /// consensus.
-    pub authority: AuthorityName,
-    /// Generation number set by sending authority. Used to determine which of
-    /// multiple AuthorityCapabilities messages from the same authority is
-    /// the most recent.
-    ///
-    /// (Currently, we just set this to the current time in milliseconds since
-    /// the epoch, but this should not be interpreted as a timestamp.)
-    pub generation: u64,
-
-    /// ProtocolVersions that the authority supports.
-    pub supported_protocol_versions: SupportedProtocolVersionsWithHashes,
-
-    /// The ObjectRefs of all versions of system packages that the validator
-    /// possesses. Used to determine whether to do a framework/movestdlib
-    /// upgrade.
-    pub available_system_packages: Vec<ObjectRef>,
-}
-
-impl Debug for AuthorityCapabilitiesV2 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AuthorityCapabilities")
-            .field("authority", &self.authority.concise())
-            .field("generation", &self.generation)
-            .field(
-                "supported_protocol_versions",
-                &self.supported_protocol_versions,
-            )
-            .field("available_system_packages", &self.available_system_packages)
-            .finish()
-    }
-}
-
-impl AuthorityCapabilitiesV2 {
     pub fn new(
         authority: AuthorityName,
         chain: Chain,
@@ -275,8 +216,6 @@ pub enum ConsensusTransactionKind {
     CheckpointSignature(Box<CheckpointSignatureMessage>),
     EndOfPublish(AuthorityName),
 
-    CapabilityNotification(AuthorityCapabilitiesV1),
-
     NewJWKFetched(AuthorityName, JwkId, JWK),
     RandomnessStateUpdate(u64, Vec<u8>), // deprecated
     // DKG is used to generate keys for use in the random beacon protocol.
@@ -288,7 +227,7 @@ pub enum ConsensusTransactionKind {
     // process. Contents are a serialized `fastcrypto_tbls::dkg::Confirmation`.
     RandomnessDkgConfirmation(AuthorityName, Vec<u8>),
 
-    CapabilityNotificationV2(AuthorityCapabilitiesV2),
+    CapabilityNotificationV1(AuthorityCapabilitiesV1),
 }
 
 impl ConsensusTransactionKind {
@@ -425,23 +364,13 @@ impl ConsensusTransaction {
         }
     }
 
-    pub fn new_capability_notification(capabilities: AuthorityCapabilitiesV1) -> Self {
+    pub fn new_capability_notification_v1(capabilities: AuthorityCapabilitiesV1) -> Self {
         let mut hasher = DefaultHasher::new();
         capabilities.hash(&mut hasher);
         let tracking_id = hasher.finish().to_le_bytes();
         Self {
             tracking_id,
-            kind: ConsensusTransactionKind::CapabilityNotification(capabilities),
-        }
-    }
-
-    pub fn new_capability_notification_v2(capabilities: AuthorityCapabilitiesV2) -> Self {
-        let mut hasher = DefaultHasher::new();
-        capabilities.hash(&mut hasher);
-        let tracking_id = hasher.finish().to_le_bytes();
-        Self {
-            tracking_id,
-            kind: ConsensusTransactionKind::CapabilityNotificationV2(capabilities),
+            kind: ConsensusTransactionKind::CapabilityNotificationV1(capabilities),
         }
     }
 
@@ -521,10 +450,7 @@ impl ConsensusTransaction {
             ConsensusTransactionKind::EndOfPublish(authority) => {
                 ConsensusTransactionKey::EndOfPublish(*authority)
             }
-            ConsensusTransactionKind::CapabilityNotification(cap) => {
-                ConsensusTransactionKey::CapabilityNotification(cap.authority, cap.generation)
-            }
-            ConsensusTransactionKind::CapabilityNotificationV2(cap) => {
+            ConsensusTransactionKind::CapabilityNotificationV1(cap) => {
                 ConsensusTransactionKey::CapabilityNotification(cap.authority, cap.generation)
             }
             ConsensusTransactionKind::NewJWKFetched(authority, id, key) => {


### PR DESCRIPTION
Closes #3097

# Description of change

This PR modifies the followings 
- Renamed `CapabilityNotificationV2` to be `CapabilityNotificationV1`
- Renamed  `AuthorityCapabilitiesV2` to be `AuthorityCapabilitiesV1`
- Removed the associated codes with old versions of `CapabilityNotification` and `AuthorityCapabilities`

Note that the `ConsensusTransactionKey::CapabilityNotification` has no versions, only `ConsensusTransactionKind` has versions. See the original `ConsensusTransactionKey` enum below for more details
```rust
pub enum ConsensusTransactionKey {
    Certificate(TransactionDigest),
    CheckpointSignature(AuthorityName, CheckpointSequenceNumber),
    EndOfPublish(AuthorityName),
    CapabilityNotification(AuthorityName, u64 /* generation */),
    // Key must include both id and jwk, because honest validators could be given multiple jwks
    // for the same id by malfunctioning providers.
    NewJWKFetched(Box<(AuthorityName, JwkId, JWK)>),
    RandomnessDkgMessage(AuthorityName),
    RandomnessDkgConfirmation(AuthorityName),
}
```

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

I was running the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes