### PR TITLE
refactor(iota-core): Remove old versions: CheckpointResponse and CheckpointRequest.

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2583,7 +2583,7 @@ impl AuthorityState {
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub fn handle_checkpoint_request_v2(
+    pub fn handle_checkpoint_request(
         &self,
         request: &CheckpointRequest,
     ) -> IotaResult<CheckpointResponse> {

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -84,8 +84,8 @@ use iota_types::{
     message_envelope::Message,
     messages_checkpoint::{
         CertifiedCheckpointSummary, CheckpointCommitment, CheckpointContents,
-        CheckpointContentsDigest, CheckpointDigest, CheckpointRequest, CheckpointRequestV2,
-        CheckpointResponse, CheckpointResponseV2, CheckpointSequenceNumber, CheckpointSummary,
+        CheckpointContentsDigest, CheckpointDigest, CheckpointRequestV2,
+        CheckpointResponseV2, CheckpointSequenceNumber, CheckpointSummary,
         CheckpointSummaryResponse, CheckpointTimestamp, ECMHLiveObjectSetDigest,
         VerifiedCheckpoint,
     },
@@ -2583,29 +2583,6 @@ impl AuthorityState {
         })
     }
 
-    #[instrument(level = "trace", skip_all)]
-    pub fn handle_checkpoint_request(
-        &self,
-        request: &CheckpointRequest,
-    ) -> IotaResult<CheckpointResponse> {
-        let summary = match request.sequence_number {
-            Some(seq) => self
-                .checkpoint_store
-                .get_checkpoint_by_sequence_number(seq)?,
-            None => self.checkpoint_store.get_latest_certified_checkpoint(),
-        }
-        .map(|v| v.into_inner());
-        let contents = match &summary {
-            Some(s) => self
-                .checkpoint_store
-                .get_checkpoint_contents(&s.content_digest)?,
-            None => None,
-        };
-        Ok(CheckpointResponse {
-            checkpoint: summary,
-            contents,
-        })
-    }
 
     #[instrument(level = "trace", skip_all)]
     pub fn handle_checkpoint_request_v2(

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -84,10 +84,9 @@ use iota_types::{
     message_envelope::Message,
     messages_checkpoint::{
         CertifiedCheckpointSummary, CheckpointCommitment, CheckpointContents,
-        CheckpointContentsDigest, CheckpointDigest, CheckpointRequestV2,
-        CheckpointResponseV2, CheckpointSequenceNumber, CheckpointSummary,
-        CheckpointSummaryResponse, CheckpointTimestamp, ECMHLiveObjectSetDigest,
-        VerifiedCheckpoint,
+        CheckpointContentsDigest, CheckpointDigest, CheckpointRequest, CheckpointResponse,
+        CheckpointSequenceNumber, CheckpointSummary, CheckpointSummaryResponse,
+        CheckpointTimestamp, ECMHLiveObjectSetDigest, VerifiedCheckpoint,
     },
     messages_consensus::{AuthorityCapabilitiesV1, AuthorityCapabilitiesV2},
     messages_grpc::{
@@ -2583,12 +2582,11 @@ impl AuthorityState {
         })
     }
 
-
     #[instrument(level = "trace", skip_all)]
     pub fn handle_checkpoint_request_v2(
         &self,
-        request: &CheckpointRequestV2,
-    ) -> IotaResult<CheckpointResponseV2> {
+        request: &CheckpointRequest,
+    ) -> IotaResult<CheckpointResponse> {
         let summary = if request.certified {
             let summary = match request.sequence_number {
                 Some(seq) => self
@@ -2613,7 +2611,7 @@ impl AuthorityState {
                 .get_checkpoint_contents(&s.content_digest())?,
             None => None,
         };
-        Ok(CheckpointResponseV2 {
+        Ok(CheckpointResponse {
             checkpoint: summary,
             contents,
         })

--- a/crates/iota-core/src/authority_client.rs
+++ b/crates/iota-core/src/authority_client.rs
@@ -18,9 +18,7 @@ use iota_types::{
     committee::CommitteeWithNetworkMetadata,
     error::{IotaError, IotaResult},
     iota_system_state::IotaSystemState,
-    messages_checkpoint::{
-        CheckpointRequestV2, CheckpointResponseV2,
-    },
+    messages_checkpoint::{CheckpointRequest, CheckpointResponse},
     messages_grpc::{
         HandleCertificateRequestV3, HandleCertificateResponseV2, HandleCertificateResponseV3,
         HandleSoftBundleCertificatesRequestV3, HandleSoftBundleCertificatesResponseV3,
@@ -75,11 +73,11 @@ pub trait AuthorityAPI {
         request: TransactionInfoRequest,
     ) -> Result<TransactionInfoResponse, IotaError>;
 
-    /// Handles a `CheckpointRequestV2` for this account.
-    async fn handle_checkpoint_v2(
+    /// Handles a `CheckpointRequest` for this account.
+    async fn handle_checkpoint(
         &self,
-        request: CheckpointRequestV2,
-    ) -> Result<CheckpointResponseV2, IotaError>;
+        request: CheckpointRequest,
+    ) -> Result<CheckpointResponse, IotaError>;
 
     // This API is exclusively used by the benchmark code.
     // Hence it's OK to return a fixed system state type.
@@ -225,13 +223,13 @@ impl AuthorityAPI for NetworkAuthorityClient {
             .map_err(Into::into)
     }
 
-    /// Handles a `CheckpointRequestV2` for this account.
-    async fn handle_checkpoint_v2(
+    /// Handles a `CheckpointRequest` for this account.
+    async fn handle_checkpoint(
         &self,
-        request: CheckpointRequestV2,
-    ) -> Result<CheckpointResponseV2, IotaError> {
+        request: CheckpointRequest,
+    ) -> Result<CheckpointResponse, IotaError> {
         self.client()?
-            .checkpoint_v2(request)
+            .checkpoint(request)
             .await
             .map(tonic::Response::into_inner)
             .map_err(Into::into)

--- a/crates/iota-core/src/authority_client.rs
+++ b/crates/iota-core/src/authority_client.rs
@@ -19,7 +19,7 @@ use iota_types::{
     error::{IotaError, IotaResult},
     iota_system_state::IotaSystemState,
     messages_checkpoint::{
-        CheckpointRequest, CheckpointRequestV2, CheckpointResponse, CheckpointResponseV2,
+        CheckpointRequestV2, CheckpointResponseV2,
     },
     messages_grpc::{
         HandleCertificateRequestV3, HandleCertificateResponseV2, HandleCertificateResponseV3,
@@ -74,12 +74,6 @@ pub trait AuthorityAPI {
         &self,
         request: TransactionInfoRequest,
     ) -> Result<TransactionInfoResponse, IotaError>;
-
-    /// Handles a `CheckpointRequest` for this account.
-    async fn handle_checkpoint(
-        &self,
-        request: CheckpointRequest,
-    ) -> Result<CheckpointResponse, IotaError>;
 
     /// Handles a `CheckpointRequestV2` for this account.
     async fn handle_checkpoint_v2(
@@ -226,18 +220,6 @@ impl AuthorityAPI for NetworkAuthorityClient {
     ) -> Result<TransactionInfoResponse, IotaError> {
         self.client()?
             .transaction_info(request)
-            .await
-            .map(tonic::Response::into_inner)
-            .map_err(Into::into)
-    }
-
-    /// Handles a `CheckpointRequest` for this account.
-    async fn handle_checkpoint(
-        &self,
-        request: CheckpointRequest,
-    ) -> Result<CheckpointResponse, IotaError> {
-        self.client()?
-            .checkpoint(request)
             .await
             .map(tonic::Response::into_inner)
             .map_err(Into::into)

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -921,7 +921,7 @@ impl ValidatorService {
         request: tonic::Request<CheckpointRequest>,
     ) -> WrappedServiceResponse<CheckpointResponse> {
         let request = request.into_inner();
-        let response = self.state.handle_checkpoint_request_v2(&request)?;
+        let response = self.state.handle_checkpoint_request(&request)?;
         Ok((tonic::Response::new(response), Weight::one()))
     }
 

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -24,7 +24,7 @@ use iota_types::{
     fp_ensure,
     iota_system_state::IotaSystemState,
     messages_checkpoint::{
-        CheckpointRequest, CheckpointRequestV2, CheckpointResponse, CheckpointResponseV2,
+        CheckpointRequestV2, CheckpointResponseV2,
     },
     messages_consensus::ConsensusTransaction,
     messages_grpc::{
@@ -918,14 +918,6 @@ impl ValidatorService {
         Ok((tonic::Response::new(response), Weight::one()))
     }
 
-    async fn checkpoint_impl(
-        &self,
-        request: tonic::Request<CheckpointRequest>,
-    ) -> WrappedServiceResponse<CheckpointResponse> {
-        let request = request.into_inner();
-        let response = self.state.handle_checkpoint_request(&request)?;
-        Ok((tonic::Response::new(response), Weight::one()))
-    }
 
     async fn checkpoint_v2_impl(
         &self,
@@ -1203,14 +1195,6 @@ impl Validator for ValidatorService {
         request: tonic::Request<TransactionInfoRequest>,
     ) -> Result<tonic::Response<TransactionInfoResponse>, tonic::Status> {
         handle_with_decoration!(self, transaction_info_impl, request)
-    }
-
-    /// Handles a `CheckpointRequest` request.
-    async fn checkpoint(
-        &self,
-        request: tonic::Request<CheckpointRequest>,
-    ) -> Result<tonic::Response<CheckpointResponse>, tonic::Status> {
-        handle_with_decoration!(self, checkpoint_impl, request)
     }
 
     /// Handles a `CheckpointRequestV2` request.

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -23,9 +23,7 @@ use iota_types::{
     error::*,
     fp_ensure,
     iota_system_state::IotaSystemState,
-    messages_checkpoint::{
-        CheckpointRequestV2, CheckpointResponseV2,
-    },
+    messages_checkpoint::{CheckpointRequest, CheckpointResponse},
     messages_consensus::ConsensusTransaction,
     messages_grpc::{
         HandleCertificateRequestV3, HandleCertificateResponseV2, HandleCertificateResponseV3,
@@ -918,11 +916,10 @@ impl ValidatorService {
         Ok((tonic::Response::new(response), Weight::one()))
     }
 
-
-    async fn checkpoint_v2_impl(
+    async fn checkpoint_impl(
         &self,
-        request: tonic::Request<CheckpointRequestV2>,
-    ) -> WrappedServiceResponse<CheckpointResponseV2> {
+        request: tonic::Request<CheckpointRequest>,
+    ) -> WrappedServiceResponse<CheckpointResponse> {
         let request = request.into_inner();
         let response = self.state.handle_checkpoint_request_v2(&request)?;
         Ok((tonic::Response::new(response), Weight::one()))
@@ -1197,12 +1194,12 @@ impl Validator for ValidatorService {
         handle_with_decoration!(self, transaction_info_impl, request)
     }
 
-    /// Handles a `CheckpointRequestV2` request.
-    async fn checkpoint_v2(
+    /// Handles a `CheckpointRequest` request.
+    async fn checkpoint(
         &self,
-        request: tonic::Request<CheckpointRequestV2>,
-    ) -> Result<tonic::Response<CheckpointResponseV2>, tonic::Status> {
-        handle_with_decoration!(self, checkpoint_v2_impl, request)
+        request: tonic::Request<CheckpointRequest>,
+    ) -> Result<tonic::Response<CheckpointResponse>, tonic::Status> {
+        handle_with_decoration!(self, checkpoint_impl, request)
     }
 
     /// Gets the `IotaSystemState` response.

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -42,8 +42,8 @@ use iota_types::{
     },
     message_envelope::Message,
     messages_checkpoint::{
-        CertifiedCheckpointSummary, CheckpointCommitment, CheckpointContents, CheckpointRequestV2,
-        CheckpointResponseV2, CheckpointSequenceNumber, CheckpointSignatureMessage,
+        CertifiedCheckpointSummary, CheckpointCommitment, CheckpointContents, CheckpointRequest,
+        CheckpointResponse, CheckpointSequenceNumber, CheckpointSignatureMessage,
         CheckpointSummary, CheckpointSummaryResponse, CheckpointTimestamp, EndOfEpochData,
         FullCheckpointContents, SignedCheckpointSummary, TrustedCheckpoint, VerifiedCheckpoint,
         VerifiedCheckpointContents,
@@ -2095,12 +2095,12 @@ async fn diagnose_split_brain(
             let client = network_clients
                 .get(&validator)
                 .expect("Failed to get network client");
-            let request = CheckpointRequestV2 {
+            let request = CheckpointRequest {
                 sequence_number: Some(local_summary.sequence_number),
                 request_content: true,
                 certified: false,
             };
-            client.handle_checkpoint_v2(request)
+            client.handle_checkpoint(request)
         })
         .collect::<Vec<_>>();
 
@@ -2111,17 +2111,17 @@ async fn diagnose_split_brain(
         .zip(digest_name_pair)
         .filter_map(|(response, (digest, name))| match response {
             Ok(response) => match response {
-                CheckpointResponseV2 {
+                CheckpointResponse {
                     checkpoint: Some(CheckpointSummaryResponse::Pending(summary)),
                     contents: Some(contents),
                 } => Some((*name, *digest, summary, contents)),
-                CheckpointResponseV2 {
+                CheckpointResponse {
                     checkpoint: Some(CheckpointSummaryResponse::Certified(_)),
                     contents: _,
                 } => {
                     panic!("Expected pending checkpoint, but got certified checkpoint");
                 }
-                CheckpointResponseV2 {
+                CheckpointResponse {
                     checkpoint: None,
                     contents: _,
                 } => {
@@ -2131,7 +2131,7 @@ async fn diagnose_split_brain(
                     );
                     None
                 }
-                CheckpointResponseV2 {
+                CheckpointResponse {
                     checkpoint: _,
                     contents: None,
                 } => {

--- a/crates/iota-core/src/test_authority_clients.rs
+++ b/crates/iota-core/src/test_authority_clients.rs
@@ -17,9 +17,7 @@ use iota_types::{
     effects::TransactionEffectsAPI,
     error::{IotaError, IotaResult},
     iota_system_state::IotaSystemState,
-    messages_checkpoint::{
-        CheckpointRequestV2, CheckpointResponseV2,
-    },
+    messages_checkpoint::{CheckpointRequest, CheckpointResponse},
     messages_grpc::{
         HandleCertificateRequestV3, HandleCertificateResponseV2, HandleCertificateResponseV3,
         HandleSoftBundleCertificatesRequestV3, HandleSoftBundleCertificatesResponseV3,
@@ -146,10 +144,10 @@ impl AuthorityAPI for LocalAuthorityClient {
         state.handle_transaction_info_request(request).await
     }
 
-    async fn handle_checkpoint_v2(
+    async fn handle_checkpoint(
         &self,
-        request: CheckpointRequestV2,
-    ) -> Result<CheckpointResponseV2, IotaError> {
+        request: CheckpointRequest,
+    ) -> Result<CheckpointResponse, IotaError> {
         let state = self.state.clone();
 
         state.handle_checkpoint_request_v2(&request)
@@ -339,10 +337,10 @@ impl AuthorityAPI for MockAuthorityApi {
         })
     }
 
-    async fn handle_checkpoint_v2(
+    async fn handle_checkpoint(
         &self,
-        _request: CheckpointRequestV2,
-    ) -> Result<CheckpointResponseV2, IotaError> {
+        _request: CheckpointRequest,
+    ) -> Result<CheckpointResponse, IotaError> {
         unimplemented!();
     }
 
@@ -417,10 +415,10 @@ impl AuthorityAPI for HandleTransactionTestAuthorityClient {
         unimplemented!()
     }
 
-    async fn handle_checkpoint_v2(
+    async fn handle_checkpoint(
         &self,
-        _request: CheckpointRequestV2,
-    ) -> Result<CheckpointResponseV2, IotaError> {
+        _request: CheckpointRequest,
+    ) -> Result<CheckpointResponse, IotaError> {
         unimplemented!()
     }
 

--- a/crates/iota-core/src/test_authority_clients.rs
+++ b/crates/iota-core/src/test_authority_clients.rs
@@ -18,7 +18,7 @@ use iota_types::{
     error::{IotaError, IotaResult},
     iota_system_state::IotaSystemState,
     messages_checkpoint::{
-        CheckpointRequest, CheckpointRequestV2, CheckpointResponse, CheckpointResponseV2,
+        CheckpointRequestV2, CheckpointResponseV2,
     },
     messages_grpc::{
         HandleCertificateRequestV3, HandleCertificateResponseV2, HandleCertificateResponseV3,
@@ -144,15 +144,6 @@ impl AuthorityAPI for LocalAuthorityClient {
     ) -> Result<TransactionInfoResponse, IotaError> {
         let state = self.state.clone();
         state.handle_transaction_info_request(request).await
-    }
-
-    async fn handle_checkpoint(
-        &self,
-        request: CheckpointRequest,
-    ) -> Result<CheckpointResponse, IotaError> {
-        let state = self.state.clone();
-
-        state.handle_checkpoint_request(&request)
     }
 
     async fn handle_checkpoint_v2(
@@ -348,13 +339,6 @@ impl AuthorityAPI for MockAuthorityApi {
         })
     }
 
-    async fn handle_checkpoint(
-        &self,
-        _request: CheckpointRequest,
-    ) -> Result<CheckpointResponse, IotaError> {
-        unimplemented!();
-    }
-
     async fn handle_checkpoint_v2(
         &self,
         _request: CheckpointRequestV2,
@@ -430,13 +414,6 @@ impl AuthorityAPI for HandleTransactionTestAuthorityClient {
         &self,
         _request: TransactionInfoRequest,
     ) -> Result<TransactionInfoResponse, IotaError> {
-        unimplemented!()
-    }
-
-    async fn handle_checkpoint(
-        &self,
-        _request: CheckpointRequest,
-    ) -> Result<CheckpointResponse, IotaError> {
         unimplemented!()
     }
 

--- a/crates/iota-core/src/test_authority_clients.rs
+++ b/crates/iota-core/src/test_authority_clients.rs
@@ -150,7 +150,7 @@ impl AuthorityAPI for LocalAuthorityClient {
     ) -> Result<CheckpointResponse, IotaError> {
         let state = self.state.clone();
 
-        state.handle_checkpoint_request_v2(&request)
+        state.handle_checkpoint_request(&request)
     }
 
     async fn handle_system_state_object(

--- a/crates/iota-core/src/validator_tx_finalizer.rs
+++ b/crates/iota-core/src/validator_tx_finalizer.rs
@@ -289,9 +289,7 @@ mod tests {
         error::IotaError,
         executable_transaction::VerifiedExecutableTransaction,
         iota_system_state::IotaSystemState,
-        messages_checkpoint::{
-            CheckpointRequestV2, CheckpointResponseV2,
-        },
+        messages_checkpoint::{CheckpointRequest, CheckpointResponse},
         messages_grpc::{
             HandleCertificateRequestV3, HandleCertificateResponseV2, HandleCertificateResponseV3,
             HandleSoftBundleCertificatesRequestV3, HandleSoftBundleCertificatesResponseV3,
@@ -399,10 +397,10 @@ mod tests {
             unimplemented!()
         }
 
-        async fn handle_checkpoint_v2(
+        async fn handle_checkpoint(
             &self,
-            _request: CheckpointRequestV2,
-        ) -> Result<CheckpointResponseV2, IotaError> {
+            _request: CheckpointRequest,
+        ) -> Result<CheckpointResponse, IotaError> {
             unimplemented!()
         }
 

--- a/crates/iota-core/src/validator_tx_finalizer.rs
+++ b/crates/iota-core/src/validator_tx_finalizer.rs
@@ -290,7 +290,7 @@ mod tests {
         executable_transaction::VerifiedExecutableTransaction,
         iota_system_state::IotaSystemState,
         messages_checkpoint::{
-            CheckpointRequest, CheckpointRequestV2, CheckpointResponse, CheckpointResponseV2,
+            CheckpointRequestV2, CheckpointResponseV2,
         },
         messages_grpc::{
             HandleCertificateRequestV3, HandleCertificateResponseV2, HandleCertificateResponseV3,
@@ -396,13 +396,6 @@ mod tests {
             &self,
             _request: TransactionInfoRequest,
         ) -> Result<TransactionInfoResponse, IotaError> {
-            unimplemented!()
-        }
-
-        async fn handle_checkpoint(
-            &self,
-            _request: CheckpointRequest,
-        ) -> Result<CheckpointResponse, IotaError> {
             unimplemented!()
         }
 

--- a/crates/iota-network/build.rs
+++ b/crates/iota-network/build.rs
@@ -89,10 +89,10 @@ fn main() -> Result<()> {
         )
         .method(
             Method::builder()
-                .name("checkpoint_v2")
-                .route_name("CheckpointV2")
-                .input_type("iota_types::messages_checkpoint::CheckpointRequestV2")
-                .output_type("iota_types::messages_checkpoint::CheckpointResponseV2")
+                .name("checkpoint")
+                .route_name("Checkpoint")
+                .input_type("iota_types::messages_checkpoint::CheckpointRequest")
+                .output_type("iota_types::messages_checkpoint::CheckpointResponse")
                 .codec_path(codec_path)
                 .build(),
         )

--- a/crates/iota-network/build.rs
+++ b/crates/iota-network/build.rs
@@ -89,15 +89,6 @@ fn main() -> Result<()> {
         )
         .method(
             Method::builder()
-                .name("checkpoint")
-                .route_name("Checkpoint")
-                .input_type("iota_types::messages_checkpoint::CheckpointRequest")
-                .output_type("iota_types::messages_checkpoint::CheckpointResponse")
-                .codec_path(codec_path)
-                .build(),
-        )
-        .method(
-            Method::builder()
                 .name("checkpoint_v2")
                 .route_name("CheckpointV2")
                 .input_type("iota_types::messages_checkpoint::CheckpointRequestV2")

--- a/crates/iota-tool/src/commands.rs
+++ b/crates/iota-tool/src/commands.rs
@@ -21,7 +21,7 @@ use iota_sdk::{IotaClient, IotaClientBuilder, rpc_types::IotaTransactionBlockRes
 use iota_types::{
     base_types::*,
     crypto::AuthorityPublicKeyBytes,
-    messages_checkpoint::{CheckpointRequestV2, CheckpointResponseV2, CheckpointSequenceNumber},
+    messages_checkpoint::{CheckpointRequest, CheckpointResponse, CheckpointSequenceNumber},
     messages_grpc::TransactionInfoRequest,
     transaction::{SenderSignedData, Transaction},
 };
@@ -636,14 +636,14 @@ impl ToolCommand {
 
                 for (name, (_, client)) in clients {
                     let resp = client
-                        .handle_checkpoint_v2(CheckpointRequestV2 {
+                        .handle_checkpoint(CheckpointRequest {
                             sequence_number,
                             request_content: true,
                             certified: true,
                         })
                         .await
                         .unwrap();
-                    let CheckpointResponseV2 {
+                    let CheckpointResponse {
                         checkpoint,
                         contents,
                     } = resp;

--- a/crates/iota-tool/src/commands.rs
+++ b/crates/iota-tool/src/commands.rs
@@ -21,7 +21,7 @@ use iota_sdk::{IotaClient, IotaClientBuilder, rpc_types::IotaTransactionBlockRes
 use iota_types::{
     base_types::*,
     crypto::AuthorityPublicKeyBytes,
-    messages_checkpoint::{CheckpointRequest, CheckpointResponse, CheckpointSequenceNumber},
+    messages_checkpoint::{CheckpointRequestV2, CheckpointResponseV2, CheckpointSequenceNumber},
     messages_grpc::TransactionInfoRequest,
     transaction::{SenderSignedData, Transaction},
 };
@@ -636,13 +636,14 @@ impl ToolCommand {
 
                 for (name, (_, client)) in clients {
                     let resp = client
-                        .handle_checkpoint(CheckpointRequest {
+                        .handle_checkpoint_v2(CheckpointRequestV2 {
                             sequence_number,
                             request_content: true,
+                            certified: true,
                         })
                         .await
                         .unwrap();
-                    let CheckpointResponse {
+                    let CheckpointResponseV2 {
                         checkpoint,
                         contents,
                     } = resp;

--- a/crates/iota-types/src/messages_checkpoint.rs
+++ b/crates/iota-types/src/messages_checkpoint.rs
@@ -47,7 +47,7 @@ pub type CheckpointTimestamp = u64;
 use iota_metrics::histogram::Histogram;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CheckpointRequestV2 {
+pub struct CheckpointRequest {
     /// if a sequence number is specified, return the checkpoint with that
     /// sequence number; otherwise if None returns the latest checkpoint
     /// stored (authenticated or pending, depending on the value of
@@ -78,7 +78,7 @@ impl CheckpointSummaryResponse {
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CheckpointResponseV2 {
+pub struct CheckpointResponse {
     pub checkpoint: Option<CheckpointSummaryResponse>,
     pub contents: Option<CheckpointContents>,
 }

--- a/crates/iota-types/src/messages_checkpoint.rs
+++ b/crates/iota-types/src/messages_checkpoint.rs
@@ -47,17 +47,6 @@ pub type CheckpointTimestamp = u64;
 use iota_metrics::histogram::Histogram;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CheckpointRequest {
-    /// if a sequence number is specified, return the checkpoint with that
-    /// sequence number; otherwise if None returns the latest authenticated
-    /// checkpoint stored.
-    pub sequence_number: Option<CheckpointSequenceNumber>,
-    // A flag, if true also return the contents of the
-    // checkpoint besides the meta-data.
-    pub request_content: bool,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CheckpointRequestV2 {
     /// if a sequence number is specified, return the checkpoint with that
     /// sequence number; otherwise if None returns the latest checkpoint
@@ -85,13 +74,6 @@ impl CheckpointSummaryResponse {
             Self::Pending(s) => s.content_digest,
         }
     }
-}
-
-#[allow(clippy::large_enum_variant)]
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CheckpointResponse {
-    pub checkpoint: Option<CertifiedCheckpointSummary>,
-    pub contents: Option<CheckpointContents>,
 }
 
 #[allow(clippy::large_enum_variant)]


### PR DESCRIPTION
# Description of change

Closes #3103 

Removed all references of old versions:
 - `CheckpointRequest`
 - `CheckpointResponse`
 and corresponding methods and RPC definitions, note that:
 - I removed `handle_checkpoint` from safe_client, as the existing functions were outdated, and there are no usages for v2
 - iota-tool was using outdated version, replaced with v2
 
Renamed all v2 to no-suffix:
 - `CheckpointRequestV2` to `CheckpointRequest`
 - `CheckpointResponseV2` to `CheckpointResponse`


## Type of change

Choose a type of change, and delete any options that are not relevant.
- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How the change has been tested
Local tesnet

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
