### PR TITLE
chore(core-node): disable bridge and skip tests

### DIFF
--- a/crates/iota-bridge/src/abi.rs
+++ b/crates/iota-bridge/src/abi.rs
@@ -308,6 +308,7 @@ mod tests {
     };
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_eth_message_conversion_emergency_action_regression() -> anyhow::Result<()> {
         telemetry_subscribers::init_for_testing();
 
@@ -328,6 +329,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_eth_message_conversion_update_blocklist_action_regression() -> anyhow::Result<()> {
         telemetry_subscribers::init_for_testing();
         let pub_key_bytes = BridgeAuthorityPublicKeyBytes::from_bytes(
@@ -355,6 +357,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_eth_message_conversion_update_limit_action_regression() -> anyhow::Result<()> {
         telemetry_subscribers::init_for_testing();
         let action = LimitUpdateAction {
@@ -375,6 +378,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_eth_message_conversion_contract_upgrade_action_regression() -> anyhow::Result<()> {
         telemetry_subscribers::init_for_testing();
         let action = EvmContractUpgradeAction {
@@ -399,6 +403,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_eth_message_conversion_update_price_action_regression() -> anyhow::Result<()> {
         telemetry_subscribers::init_for_testing();
         let action = AssetPriceUpdateAction {
@@ -419,6 +424,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_eth_message_conversion_add_tokens_on_evm_action_regression() -> anyhow::Result<()> {
         let action = AddTokensOnEvmAction {
             nonce: 5,
@@ -448,6 +454,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_token_deposit_eth_log_to_iota_bridge_event_regression() -> anyhow::Result<()> {
         telemetry_subscribers::init_for_testing();
         let tx_hash = TxHash::random();
@@ -503,6 +510,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_0_iota_amount_conversion_for_eth_event() {
         let e = EthBridgeEvent::EthIotaBridgeEvents(EthIotaBridgeEvents::TokensDepositedFilter(
             TokensDepositedFilter {

--- a/crates/iota-bridge/src/action_executor.rs
+++ b/crates/iota-bridge/src/action_executor.rs
@@ -693,6 +693,7 @@ mod tests {
     };
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_onchain_execution_loop() {
         let (
             signing_tx,
@@ -900,6 +901,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_signature_aggregation_loop() {
         let (
             signing_tx,
@@ -1026,6 +1028,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_skip_request_signature_if_already_processed_on_chain() {
         let (
             signing_tx,
@@ -1096,6 +1099,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_skip_tx_submission_if_already_processed_on_chain() {
         let (
             _signing_tx,
@@ -1182,6 +1186,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_skip_tx_submission_if_bridge_is_paused() {
         let (
             _signing_tx,
@@ -1281,6 +1286,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_action_executor_handle_new_token() {
         let new_token_id = 255u8; // token id that does not exist
         let new_type_tag = TypeTag::from_str("0xbeef::beef::BEEF").unwrap();

--- a/crates/iota-bridge/src/client/bridge_authority_aggregator.rs
+++ b/crates/iota-bridge/src/client/bridge_authority_aggregator.rs
@@ -282,6 +282,7 @@ mod tests {
     };
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_bridge_auth_agg_construction() {
         telemetry_subscribers::init_for_testing();
 
@@ -331,6 +332,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_bridge_auth_agg_ok() {
         telemetry_subscribers::init_for_testing();
 
@@ -428,6 +430,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_bridge_auth_agg_more_cases() {
         telemetry_subscribers::init_for_testing();
 
@@ -530,6 +533,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_get_sigs_state() {
         telemetry_subscribers::init_for_testing();
 

--- a/crates/iota-bridge/src/client/bridge_client.rs
+++ b/crates/iota-bridge/src/client/bridge_client.rs
@@ -259,6 +259,7 @@ mod tests {
     };
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_bridge_client() {
         telemetry_subscribers::init_for_testing();
 
@@ -321,6 +322,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_bridge_client_request_sign_action() {
         telemetry_subscribers::init_for_testing();
         let registry = Registry::new();
@@ -440,6 +442,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_bridge_action_path_regression_tests() {
         let iota_tx_digest = TransactionDigest::random();
         let iota_tx_event_index = 5;

--- a/crates/iota-bridge/src/crypto.rs
+++ b/crates/iota-bridge/src/crypto.rs
@@ -202,6 +202,7 @@ mod tests {
     };
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_sign_and_verify_bridge_event_basic() -> anyhow::Result<()> {
         telemetry_subscribers::init_for_testing();
         let registry = Registry::new();
@@ -278,6 +279,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_bridge_sig_verification_regression_test() {
         telemetry_subscribers::init_for_testing();
         let registry = Registry::new();
@@ -379,6 +381,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_bridge_authority_public_key_bytes_to_eth_address() {
         let pub_key_bytes = BridgeAuthorityPublicKeyBytes::from_bytes(
             &Hex::decode("02321ede33d2c2d7a8a152f275a1484edef2098f034121a602cb7d767d38680aa4")

--- a/crates/iota-bridge/src/e2e_tests/basic.rs
+++ b/crates/iota-bridge/src/e2e_tests/basic.rs
@@ -43,6 +43,7 @@ use crate::{
 };
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[ignore = "https://github.com/iotaledger/iota/issues/3224"]
 async fn test_bridge_from_eth_to_iota_to_eth() {
     telemetry_subscribers::init_for_testing();
 
@@ -162,6 +163,7 @@ async fn test_bridge_from_eth_to_iota_to_eth() {
 // Test add new coins on both Iota and Eth
 // Also test bridge node handling `NewTokenEvent``
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[ignore = "https://github.com/iotaledger/iota/issues/3224"]
 async fn test_add_new_coins_on_iota_and_eth() {
     telemetry_subscribers::init_for_testing();
     let mut bridge_test_cluster = BridgeTestClusterBuilder::new()

--- a/crates/iota-bridge/src/e2e_tests/complex.rs
+++ b/crates/iota-bridge/src/e2e_tests/complex.rs
@@ -20,6 +20,7 @@ use crate::{
 };
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
+#[ignore = "https://github.com/iotaledger/iota/issues/3224"]
 async fn test_iota_bridge_paused() {
     telemetry_subscribers::init_for_testing();
 

--- a/crates/iota-bridge/src/encoding.rs
+++ b/crates/iota-bridge/src/encoding.rs
@@ -414,6 +414,7 @@ mod tests {
     };
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_bridge_message_encoding() -> anyhow::Result<()> {
         telemetry_subscribers::init_for_testing();
         let registry = Registry::new();
@@ -487,6 +488,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_bridge_message_encoding_regression_emitted_iota_to_eth_token_bridge_v1()
     -> anyhow::Result<()> {
         telemetry_subscribers::init_for_testing();
@@ -537,6 +539,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_bridge_message_encoding_blocklist_update_v1() {
         telemetry_subscribers::init_for_testing();
         let registry = Registry::new();
@@ -633,6 +636,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_bridge_message_encoding_emergency_action() {
         let action = BridgeAction::EmergencyAction(EmergencyAction {
             nonce: 55,
@@ -670,6 +674,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_bridge_message_encoding_limit_update_action() {
         let action = BridgeAction::LimitUpdateAction(LimitUpdateAction {
             nonce: 15,
@@ -695,6 +700,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_bridge_message_encoding_asset_price_update_action() {
         let action = BridgeAction::AssetPriceUpdateAction(AssetPriceUpdateAction {
             nonce: 266,
@@ -720,6 +726,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_bridge_message_encoding_evm_contract_upgrade_action() {
         // Calldata with only the function selector and no parameters: `function
         // initializeV2()`
@@ -858,6 +865,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_bridge_message_encoding_regression_eth_to_iota_token_bridge_v1() -> anyhow::Result<()> {
         telemetry_subscribers::init_for_testing();
         let registry = Registry::new();
@@ -908,6 +916,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_bridge_message_encoding_regression_add_coins_on_iota() -> anyhow::Result<()> {
         telemetry_subscribers::init_for_testing();
 
@@ -939,6 +948,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_bridge_message_encoding_regression_add_coins_on_evm() -> anyhow::Result<()> {
         let action = BridgeAction::AddTokensOnEvmAction(crate::types::AddTokensOnEvmAction {
             nonce: 0,

--- a/crates/iota-bridge/src/eth_client.rs
+++ b/crates/iota-bridge/src/eth_client.rs
@@ -294,6 +294,7 @@ mod tests {
     use crate::test_utils::{get_test_log_and_action, mock_last_finalized_block};
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_get_finalized_bridge_action_maybe() {
         telemetry_subscribers::init_for_testing();
         let registry = Registry::new();
@@ -368,6 +369,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_get_finalized_bridge_action_maybe_unrecognized_contract() {
         telemetry_subscribers::init_for_testing();
         let registry = Registry::new();

--- a/crates/iota-bridge/src/eth_mock_provider.rs
+++ b/crates/iota-bridge/src/eth_mock_provider.rs
@@ -104,6 +104,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_basic_responses_match() {
         let mock = EthMockProvider::new();
 
@@ -140,6 +141,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_with_provider() {
         let mock = EthMockProvider::new();
         let provider = ethers::providers::Provider::new(mock.clone());

--- a/crates/iota-bridge/src/eth_syncer.rs
+++ b/crates/iota-bridge/src/eth_syncer.rs
@@ -226,6 +226,7 @@ mod tests {
     };
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_last_finalized_block() -> anyhow::Result<()> {
         telemetry_subscribers::init_for_testing();
         let registry = Registry::new();
@@ -290,6 +291,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_multiple_addresses() -> anyhow::Result<()> {
         telemetry_subscribers::init_for_testing();
         let registry = Registry::new();
@@ -406,6 +408,7 @@ mod tests {
     /// Test that the syncer will query for logs in multiple queries if the
     /// range is too big.
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_paginated_eth_log_query() -> anyhow::Result<()> {
         telemetry_subscribers::init_for_testing();
         let registry = Registry::new();

--- a/crates/iota-bridge/src/events.rs
+++ b/crates/iota-bridge/src/events.rs
@@ -505,6 +505,7 @@ pub mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_bridge_events_when_init() {
         telemetry_subscribers::init_for_testing();
         init_all_struct_tags();
@@ -546,6 +547,7 @@ pub mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_conversion_for_committee_member_url_update_event() {
         let (_, kp): (_, BridgeAuthorityKeyPair) = get_key_pair();
         let new_url = "https://example.com:443";
@@ -574,6 +576,7 @@ pub mod tests {
     // TODO: add conversion tests for other events
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_0_iota_amount_conversion_for_iota_event() {
         let emitted_event = MoveTokenDepositedEvent {
             seq_num: 1,

--- a/crates/iota-bridge/src/iota_client.rs
+++ b/crates/iota-bridge/src/iota_client.rs
@@ -645,6 +645,7 @@ mod tests {
     };
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn get_bridge_action_by_tx_digest_and_event_idx_maybe() {
         // Note: for random events generated in this test, we only care about
         // tx_digest and event_seq, so it's ok that package and module does
@@ -760,6 +761,7 @@ mod tests {
     // TODO: we need an e2e test for this with published solidity contract and
     // committee with BridgeNodes
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_get_action_onchain_status_for_iota_to_eth_transfer() {
         telemetry_subscribers::init_for_testing();
         let mut bridge_keys = vec![];

--- a/crates/iota-bridge/src/iota_syncer.rs
+++ b/crates/iota-bridge/src/iota_syncer.rs
@@ -127,6 +127,7 @@ mod tests {
     use crate::{iota_client::IotaClient, iota_mock_client::IotaMockClient};
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_iota_syncer_basic() -> anyhow::Result<()> {
         telemetry_subscribers::init_for_testing();
         let registry = Registry::new();

--- a/crates/iota-bridge/src/iota_transaction_builder.rs
+++ b/crates/iota-bridge/src/iota_transaction_builder.rs
@@ -640,6 +640,7 @@ mod tests {
     };
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_build_iota_transaction_for_token_transfer() {
         telemetry_subscribers::init_for_testing();
         let mut bridge_keys = vec![];
@@ -718,6 +719,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_build_iota_transaction_for_emergency_op() {
         telemetry_subscribers::init_for_testing();
         let mut bridge_keys = vec![];
@@ -787,6 +789,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_build_iota_transaction_for_committee_blocklist() {
         telemetry_subscribers::init_for_testing();
         let mut bridge_keys = vec![];
@@ -873,6 +876,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_build_iota_transaction_for_limit_update() {
         telemetry_subscribers::init_for_testing();
         let mut bridge_keys = vec![];
@@ -942,6 +946,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_build_iota_transaction_for_price_update() {
         telemetry_subscribers::init_for_testing();
         let mut bridge_keys = vec![];

--- a/crates/iota-bridge/src/lib.rs
+++ b/crates/iota-bridge/src/lib.rs
@@ -90,6 +90,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_retry_with_max_elapsed_time() {
         telemetry_subscribers::init_for_testing();
         // no retry is needed, should return immediately. We give it a very small

--- a/crates/iota-bridge/src/metered_eth_provider.rs
+++ b/crates/iota-bridge/src/metered_eth_provider.rs
@@ -62,6 +62,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_metered_eth_provider() {
         let metrics = Arc::new(BridgeMetrics::new(&Registry::new()));
         let provider = new_metered_eth_provider("http://localhost:9876", metrics.clone()).unwrap();

--- a/crates/iota-bridge/src/monitor.rs
+++ b/crates/iota-bridge/src/monitor.rs
@@ -302,6 +302,7 @@ mod tests {
     };
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_get_latest_bridge_committee_with_url_update_event() {
         telemetry_subscribers::init_for_testing();
         let iota_client_mock = IotaMockClient::default();
@@ -439,6 +440,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_get_latest_bridge_committee_with_blocklist_event() {
         telemetry_subscribers::init_for_testing();
         let iota_client_mock = IotaMockClient::default();
@@ -633,6 +635,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_get_bridge_pause_status_with_emergency_event() {
         telemetry_subscribers::init_for_testing();
         let iota_client_mock = IotaMockClient::default();
@@ -704,6 +707,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_update_bridge_authority_aggregation_with_url_change_event() {
         let (
             monitor_tx,
@@ -758,6 +762,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_update_bridge_authority_aggregation_with_blocklist_event() {
         let (
             monitor_tx,
@@ -810,6 +815,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_update_bridge_pause_status_with_emergency_event() {
         let (
             monitor_tx,
@@ -851,6 +857,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_update_iota_token_type_tags() {
         let (
             monitor_tx,

--- a/crates/iota-bridge/src/node.rs
+++ b/crates/iota-bridge/src/node.rs
@@ -262,6 +262,7 @@ mod tests {
     };
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_get_eth_contracts_to_watch() {
         telemetry_subscribers::init_for_testing();
         let temp_dir = tempfile::tempdir().unwrap();
@@ -316,6 +317,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_get_iota_modules_to_watch() {
         telemetry_subscribers::init_for_testing();
         let temp_dir = tempfile::tempdir().unwrap();
@@ -402,6 +404,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_starting_bridge_node() {
         telemetry_subscribers::init_for_testing();
         let bridge_test_cluster = setup().await;
@@ -452,6 +455,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_starting_bridge_node_with_client() {
         telemetry_subscribers::init_for_testing();
         let bridge_test_cluster = setup().await;
@@ -517,6 +521,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_starting_bridge_node_with_client_and_separate_client_key() {
         telemetry_subscribers::init_for_testing();
         let bridge_test_cluster = setup().await;

--- a/crates/iota-bridge/src/orchestrator.rs
+++ b/crates/iota-bridge/src/orchestrator.rs
@@ -291,6 +291,7 @@ mod tests {
     };
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_iota_watcher_task() {
         // Note: this test may fail because of the following reasons:
         // the IotaEvent's struct tag does not match the ones in events.rs
@@ -354,6 +355,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_eth_watcher_task() {
         // Note: this test may fail because of the following reasons:
         // 1. Log and BridgeAction returned from `get_test_log_and_action` are not in
@@ -429,6 +431,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     /// Test that when orchestrator starts, all pending actions are sent to
     /// executor
     async fn test_resume_actions_in_pending_logs() {

--- a/crates/iota-bridge/src/server/governance_verifier.rs
+++ b/crates/iota-bridge/src/server/governance_verifier.rs
@@ -65,6 +65,7 @@ mod tests {
     };
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_governance_verifier() {
         let action_1 = BridgeAction::EmergencyAction(EmergencyAction {
             chain_id: BridgeChainId::EthCustom,

--- a/crates/iota-bridge/src/server/handler.rs
+++ b/crates/iota-bridge/src/server/handler.rs
@@ -371,6 +371,7 @@ mod tests {
     };
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_iota_signer_with_cache() {
         let (_, kp): (_, BridgeAuthorityKeyPair) = get_key_pair();
         let signer = Arc::new(kp);
@@ -510,6 +511,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_eth_signer_with_cache() {
         let (_, kp): (_, BridgeAuthorityKeyPair) = get_key_pair();
         let signer = Arc::new(kp);
@@ -585,6 +587,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_signer_with_governace_verifier() {
         let action_1 = BridgeAction::EmergencyAction(EmergencyAction {
             chain_id: BridgeChainId::EthCustom,

--- a/crates/iota-bridge/src/server/mod.rs
+++ b/crates/iota-bridge/src/server/mod.rs
@@ -622,6 +622,7 @@ mod tests {
     };
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_bridge_server_handle_blocklist_update_action_path() {
         let client = setup();
 
@@ -640,6 +641,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_bridge_server_handle_emergency_action_path() {
         let client = setup();
 
@@ -652,6 +654,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_bridge_server_handle_limit_update_action_path() {
         let client = setup();
 
@@ -665,6 +668,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_bridge_server_handle_asset_price_update_action_path() {
         let client = setup();
 
@@ -678,6 +682,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_bridge_server_handle_evm_contract_upgrade_action_path() {
         let client = setup();
 
@@ -701,6 +706,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_bridge_server_handle_add_tokens_on_iota_action_path() {
         let client = setup();
 
@@ -720,6 +726,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_bridge_server_handle_add_tokens_on_evm_action_path() {
         let client = setup();
 

--- a/crates/iota-bridge/src/storage.rs
+++ b/crates/iota-bridge/src/storage.rs
@@ -144,6 +144,7 @@ mod tests {
 
     // async: existing runtime is required with typed-store
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_bridge_storage_basic() {
         let temp_dir = tempfile::tempdir().unwrap();
         let store = BridgeOrchestratorTables::new(temp_dir.path());

--- a/crates/iota-bridge/src/types.rs
+++ b/crates/iota-bridge/src/types.rs
@@ -604,6 +604,7 @@ mod tests {
     };
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_bridge_committee_construction() -> anyhow::Result<()> {
         let (mut authority, _, _) = get_test_authority_and_key(8000, 9999);
         // This is ok
@@ -632,6 +633,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_bridge_committee_total_blocklisted_stake() -> anyhow::Result<()> {
         let (mut authority1, _, _) = get_test_authority_and_key(10000, 9999);
         assert_eq!(
@@ -667,6 +669,7 @@ mod tests {
 
     // Regression test to avoid accidentally change to approval threshold
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_bridge_action_approval_threshold_regression_test() -> anyhow::Result<()> {
         let action = get_test_iota_to_eth_bridge_action(None, None, None, None, None, None, None);
         assert_eq!(action.approval_threshold(), 3334);
@@ -724,6 +727,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     fn test_bridge_committee_filter_blocklisted_authorities() -> anyhow::Result<()> {
         // Note: today BridgeCommittee does not shuffle authorities
         let (authority1, _, _) = get_test_authority_and_key(5000, 9999);

--- a/crates/iota-protocol-config/README.md
+++ b/crates/iota-protocol-config/README.md
@@ -1,0 +1,15 @@
+# How to generate new protocol config snapshot files
+
+IMPORTANT: never update snapshots. only add new versions!
+
+## Prerequisites
+
+cargo install cargo-insta
+
+## Generate the new protocol config snapshot files
+
+Run `cargo test -p iota-protocol-config` to generate a new protocol config snapshot.
+The generated file will have the `.new` extension. Then run `cargo insta review` and accept
+the changes to finalize the snapshot file (it will remove the `.new` suffix).
+
+Repeat this process until all snapshot files for this version were created and the test doesn't fail anymore.

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -2098,7 +2098,7 @@ impl ProtocolConfig {
 
         cfg.feature_flags.rethrow_serialization_type_layout_errors = true;
 
-        cfg.feature_flags.bridge = true;
+        cfg.feature_flags.bridge = false;
 
         // Devnet
         if chain != Chain::Mainnet && chain != Chain::Testnet {

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -33,7 +33,6 @@ feature_flags:
   loaded_child_object_format_type: true
   receive_objects: true
   random_beacon: true
-  bridge: true
   enable_effects_v2: true
   narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -33,7 +33,6 @@ feature_flags:
   loaded_child_object_format_type: true
   receive_objects: true
   random_beacon: true
-  bridge: true
   enable_effects_v2: true
   narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -33,7 +33,6 @@ feature_flags:
   loaded_child_object_format_type: true
   receive_objects: true
   random_beacon: true
-  bridge: true
   enable_effects_v2: true
   narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true


### PR DESCRIPTION
# Description of change

We would like to deactivate the bridge for now and also skip the tests, since we do not operate the necessary infrastructure anyway.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

I was running the node locally.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
