### PR TITLE
fix(typed-store-workspace-hack): edition 2021

### DIFF
--- a/crates/typed-store-workspace-hack/Cargo.toml
+++ b/crates/typed-store-workspace-hack/Cargo.toml
@@ -8,6 +8,7 @@
 [package]
 name = "typed-store-workspace-hack"
 version = "0.0.0"
+edition = "2021"
 license = "Apache-2.0"
 publish = false
 


### PR DESCRIPTION
Missing edition defaults to 2015. It's a warning in `beta` which may become an error in `stable` soon with our CI settings.
The crate is generated though, but this is not something we would regenerate often or at all.