### PR TITLE
feat(iota-protocol-config): disable zkLogin and jwk consensus updates

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -2007,7 +2007,6 @@ impl ProtocolConfig {
             .advance_to_highest_supported_protocol_version = true;
         cfg.feature_flags.narwhal_versioned_metadata = true;
         cfg.feature_flags.commit_root_state_digest = true;
-        cfg.feature_flags.zklogin_auth = true;
         cfg.feature_flags.consensus_transaction_ordering = ConsensusTransactionOrdering::ByGasPrice;
         cfg.feature_flags.simplified_unwrap_then_delete = true;
         cfg.feature_flags.upgraded_multisig_supported = true;
@@ -2017,10 +2016,9 @@ impl ProtocolConfig {
         cfg.feature_flags.loaded_child_object_format_type = true;
         cfg.feature_flags.simple_conservation_checks = true;
         cfg.feature_flags.end_of_epoch_transaction_supported = true;
-        cfg.feature_flags.enable_jwk_consensus_updates = true;
         cfg.feature_flags.receive_objects = true;
         cfg.feature_flags.enable_effects_v2 = true;
-        cfg.feature_flags.verify_legacy_zklogin_address = true;
+
         cfg.feature_flags.narwhal_certificate_v2 = true;
         cfg.feature_flags.recompute_has_public_transfer_in_execution = true;
         cfg.feature_flags.shared_object_deletion = true;
@@ -2032,10 +2030,18 @@ impl ProtocolConfig {
         // Enable group ops and all networks (but not msm)
         cfg.feature_flags.enable_group_ops_native_functions = true;
 
-        // zklogin_supported_providers config is deprecated, zklogin
-        // signature verifier will use the fetched jwk map to determine
-        // whether the provider is supported based on node config.
-        cfg.feature_flags.zklogin_supported_providers = BTreeSet::default();
+        // zkLogin related flags
+        {
+            cfg.feature_flags.zklogin_auth = false;
+            cfg.feature_flags.enable_jwk_consensus_updates = false;
+            // zklogin_supported_providers config is deprecated, zklogin
+            // signature verifier will use the fetched jwk map to determine
+            // whether the provider is supported based on node config.
+            cfg.feature_flags.zklogin_supported_providers = BTreeSet::default();
+            cfg.feature_flags.zklogin_max_epoch_upper_bound_delta = Some(30);
+            cfg.feature_flags.accept_zklogin_in_multisig = false;
+            cfg.feature_flags.verify_legacy_zklogin_address = true;
+        }
 
         // Following flags are implied by the execution version.
         // Once support for earlier protocol versions is dropped, these flags can be
@@ -2047,8 +2053,6 @@ impl ProtocolConfig {
         cfg.feature_flags.loaded_child_objects_fixed = true;
         cfg.feature_flags.ban_entry_init = true;
 
-        cfg.feature_flags.zklogin_max_epoch_upper_bound_delta = Some(30);
-
         // Enable consensus digest in consensus commit prologue on all networks..
         cfg.feature_flags.include_consensus_digest_in_prologue = true;
         // Enable Mysticeti on mainnet.
@@ -2057,8 +2061,6 @@ impl ProtocolConfig {
         cfg.feature_flags.consensus_network = ConsensusNetwork::Tonic;
         // Enable leader scoring & schedule change on mainnet for mysticeti.
         cfg.feature_flags.mysticeti_leader_scoring_and_schedule = true;
-
-        cfg.feature_flags.accept_zklogin_in_multisig = true;
 
         // Enable resharing at same initial version
         cfg.feature_flags.reshare_at_same_initial_version = true;

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -19,7 +19,6 @@ feature_flags:
   disallow_change_struct_type_params_on_upgrade: true
   no_extraneous_module_bytes: true
   narwhal_versioned_metadata: true
-  zklogin_auth: true
   consensus_transaction_ordering: ByGasPrice
   simplified_unwrap_then_delete: true
   upgraded_multisig_supported: true
@@ -27,7 +26,6 @@ feature_flags:
   shared_object_deletion: true
   narwhal_new_leader_election_schedule: true
   loaded_child_object_format: true
-  enable_jwk_consensus_updates: true
   end_of_epoch_transaction_supported: true
   simple_conservation_checks: true
   loaded_child_object_format_type: true
@@ -37,7 +35,6 @@ feature_flags:
   narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true
   recompute_has_public_transfer_in_execution: true
-  accept_zklogin_in_multisig: true
   include_consensus_digest_in_prologue: true
   hardened_otw_check: true
   allow_receiving_object_id: true
@@ -45,7 +42,6 @@ feature_flags:
   enable_group_ops_native_functions: true
   reject_mutable_random_on_entry_functions: true
   per_object_congestion_control_mode: TotalTxCount
-  consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30
   mysticeti_leader_scoring_and_schedule: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -19,7 +19,6 @@ feature_flags:
   disallow_change_struct_type_params_on_upgrade: true
   no_extraneous_module_bytes: true
   narwhal_versioned_metadata: true
-  zklogin_auth: true
   consensus_transaction_ordering: ByGasPrice
   simplified_unwrap_then_delete: true
   upgraded_multisig_supported: true
@@ -27,7 +26,6 @@ feature_flags:
   shared_object_deletion: true
   narwhal_new_leader_election_schedule: true
   loaded_child_object_format: true
-  enable_jwk_consensus_updates: true
   end_of_epoch_transaction_supported: true
   simple_conservation_checks: true
   loaded_child_object_format_type: true
@@ -37,7 +35,6 @@ feature_flags:
   narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true
   recompute_has_public_transfer_in_execution: true
-  accept_zklogin_in_multisig: true
   include_consensus_digest_in_prologue: true
   hardened_otw_check: true
   allow_receiving_object_id: true
@@ -45,7 +42,6 @@ feature_flags:
   enable_group_ops_native_functions: true
   reject_mutable_random_on_entry_functions: true
   per_object_congestion_control_mode: TotalTxCount
-  consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30
   mysticeti_leader_scoring_and_schedule: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -19,7 +19,6 @@ feature_flags:
   disallow_change_struct_type_params_on_upgrade: true
   no_extraneous_module_bytes: true
   narwhal_versioned_metadata: true
-  zklogin_auth: true
   consensus_transaction_ordering: ByGasPrice
   simplified_unwrap_then_delete: true
   upgraded_multisig_supported: true
@@ -27,7 +26,6 @@ feature_flags:
   shared_object_deletion: true
   narwhal_new_leader_election_schedule: true
   loaded_child_object_format: true
-  enable_jwk_consensus_updates: true
   end_of_epoch_transaction_supported: true
   simple_conservation_checks: true
   loaded_child_object_format_type: true
@@ -37,7 +35,6 @@ feature_flags:
   narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true
   recompute_has_public_transfer_in_execution: true
-  accept_zklogin_in_multisig: true
   include_consensus_digest_in_prologue: true
   hardened_otw_check: true
   allow_receiving_object_id: true
@@ -47,7 +44,6 @@ feature_flags:
   enable_group_ops_native_function_msm: true
   reject_mutable_random_on_entry_functions: true
   per_object_congestion_control_mode: TotalTxCount
-  consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30
   mysticeti_leader_scoring_and_schedule: true


### PR DESCRIPTION
# Description of change

This PR disables zkLogin and the jwk consensus updates which in turn disables the jwk update task.
I also grouped all the zkLogin related feature flags.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo run --bin iota start --force-regenesis --with-faucet` runs successfully.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
