### PR TITLE
refactor(iota-framework/deny-list): Rename deny_list_v1 and deny_list_v2

### DIFF
--- a/crates/iota-adapter-transactional-tests/tests/deny_list_v2/coin_deny_and_undeny_receiver.move
+++ b/crates/iota-adapter-transactional-tests/tests/deny_list_v2/coin_deny_and_undeny_receiver.move
@@ -39,7 +39,7 @@ module test::regulated_coin {
 //# run iota::pay::split_and_transfer --args object(1,0) 1 @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Deny account B.
-//# run iota::coin::deny_list_v2_add --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_add --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Transfer the regulated coin to @B still works normally.
 //# run iota::pay::split_and_transfer --args object(1,0) 1 @B --type-args test::regulated_coin::REGULATED_COIN --sender A
@@ -50,7 +50,7 @@ module test::regulated_coin {
 //# run iota::pay::split_and_transfer --args object(1,0) 1 @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Undeny account B.
-//# run iota::coin::deny_list_v2_remove --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_remove --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Transfer the regulated coin to @B still does not work.
 //# run iota::pay::split_and_transfer --args object(1,0) 1 @B --type-args test::regulated_coin::REGULATED_COIN --sender A

--- a/crates/iota-adapter-transactional-tests/tests/deny_list_v2/coin_deny_and_undeny_sender.move
+++ b/crates/iota-adapter-transactional-tests/tests/deny_list_v2/coin_deny_and_undeny_sender.move
@@ -41,7 +41,7 @@ module test::regulated_coin {
         addr: address,
         expected: bool,
     ) {
-        let status = coin::deny_list_v2_contains_next_epoch<REGULATED_COIN>(deny_list, addr);
+        let status = coin::deny_list_with_config_key_v1_contains_next_epoch<REGULATED_COIN>(deny_list, addr);
         assert!(status == expected, 0);
     }
 }
@@ -53,7 +53,7 @@ module test::regulated_coin {
 //# run iota::pay::split_and_transfer --args object(1,0) 1 @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Deny account B.
-//# run iota::coin::deny_list_v2_add --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_add --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Assert that the address is denied.
 //# run test::regulated_coin::assert_address_deny_status --args immshared(0x403) @B true --sender A
@@ -65,7 +65,7 @@ module test::regulated_coin {
 //# run iota::pay::split_and_transfer --args object(3,0) 1 @A --type-args test::regulated_coin::REGULATED_COIN --sender B
 
 // Undeny account B.
-//# run iota::coin::deny_list_v2_remove --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_remove --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Assert that the address is no longer denied.
 //# run test::regulated_coin::assert_address_deny_status --args immshared(0x403) @B false --sender A

--- a/crates/iota-adapter-transactional-tests/tests/deny_list_v2/coin_deny_multiple_coin_types.move
+++ b/crates/iota-adapter-transactional-tests/tests/deny_list_v2/coin_deny_multiple_coin_types.move
@@ -65,7 +65,7 @@ module test::regulated_coin2 {
 //# view-object 1,1
 
 // Deny account A for coin2.
-//# run iota::coin::deny_list_v2_add --args object(0x403) object(1,5) @A --type-args test::regulated_coin2::REGULATED_COIN2 --sender A
+//# run iota::coin::deny_list_with_config_key_v1_add --args object(0x403) object(1,5) @A --type-args test::regulated_coin2::REGULATED_COIN2 --sender A
 
 //# programmable --sender A --inputs object(1,0) object(1,1) @A
 //> TransferObjects([Input(0), Input(1)], Input(2))

--- a/crates/iota-adapter-transactional-tests/tests/deny_list_v2/coin_global_pause.move
+++ b/crates/iota-adapter-transactional-tests/tests/deny_list_v2/coin_global_pause.move
@@ -65,7 +65,7 @@ module test::regulated_coin {
         expected: bool,
     ) {
         let status =
-            coin::deny_list_v2_is_global_pause_enabled_next_epoch<REGULATED_COIN>(deny_list);
+            coin::deny_list_with_config_key_v1_is_global_pause_enabled_next_epoch<REGULATED_COIN>(deny_list);
         assert!(status == expected, 0);
     }
 }
@@ -80,7 +80,7 @@ module test::regulated_coin {
 //# run test::regulated_coin::partial_wrap --args object(1,0) --sender A
 
 // Enable global pause.
-//# run iota::coin::deny_list_v2_enable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_enable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Assert that global pause is enabled.
 //# run test::regulated_coin::assert_global_pause_status --args immshared(0x403) true --sender A
@@ -111,7 +111,7 @@ module test::regulated_coin {
 //# run test::regulated_coin::assert_global_pause_status --args immshared(0x403) true --sender A
 
 // Disable global pause.
-//# run iota::coin::deny_list_v2_disable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_disable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Assert that global pause is disabled.
 //# run test::regulated_coin::assert_global_pause_status --args immshared(0x403) false --sender A

--- a/crates/iota-adapter-transactional-tests/tests/deny_list_v2/delete_setting_object_same_epoch.move
+++ b/crates/iota-adapter-transactional-tests/tests/deny_list_v2/delete_setting_object_same_epoch.move
@@ -37,7 +37,7 @@ module test::regulated_coin {
         addr: address,
         expected: bool,
     ) {
-        let status = coin::deny_list_v2_contains_next_epoch<REGULATED_COIN>(deny_list, addr);
+        let status = coin::deny_list_with_config_key_v1_contains_next_epoch<REGULATED_COIN>(deny_list, addr);
         assert!(status == expected, 0);
     }
 
@@ -46,16 +46,16 @@ module test::regulated_coin {
         expected: bool,
     ) {
         let status =
-            coin::deny_list_v2_is_global_pause_enabled_next_epoch<REGULATED_COIN>(deny_list);
+            coin::deny_list_with_config_key_v1_is_global_pause_enabled_next_epoch<REGULATED_COIN>(deny_list);
         assert!(status == expected, 0);
     }
 }
 
 // Deny account B.
-//# run iota::coin::deny_list_v2_add --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_add --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Enable global pause.
-//# run iota::coin::deny_list_v2_enable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_enable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // View the setting objects
 //# view-object 2,1
@@ -63,10 +63,10 @@ module test::regulated_coin {
 //# view-object 3,0
 
 // Undeny account B.
-//# run iota::coin::deny_list_v2_remove --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_remove --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Disable global pause.
-//# run iota::coin::deny_list_v2_disable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_disable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Verify the setting objects are deleted
 //# view-object 2,1

--- a/crates/iota-adapter-transactional-tests/tests/deny_list_v2/delete_setting_object_set_once.move
+++ b/crates/iota-adapter-transactional-tests/tests/deny_list_v2/delete_setting_object_set_once.move
@@ -37,7 +37,7 @@ module test::regulated_coin {
         addr: address,
         expected: bool,
     ) {
-        let status = coin::deny_list_v2_contains_next_epoch<REGULATED_COIN>(deny_list, addr);
+        let status = coin::deny_list_with_config_key_v1_contains_next_epoch<REGULATED_COIN>(deny_list, addr);
         assert!(status == expected, 0);
     }
 
@@ -46,16 +46,16 @@ module test::regulated_coin {
         expected: bool,
     ) {
         let status =
-            coin::deny_list_v2_is_global_pause_enabled_next_epoch<REGULATED_COIN>(deny_list);
+            coin::deny_list_with_config_key_v1_is_global_pause_enabled_next_epoch<REGULATED_COIN>(deny_list);
         assert!(status == expected, 0);
     }
 }
 
 // Deny account B.
-//# run iota::coin::deny_list_v2_add --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_add --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Enable global pause.
-//# run iota::coin::deny_list_v2_enable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_enable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // View the setting objects
 //# view-object 2,1
@@ -65,10 +65,10 @@ module test::regulated_coin {
 //# advance-epoch
 
 // Undeny account B.
-//# run iota::coin::deny_list_v2_remove --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_remove --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Disable global pause.
-//# run iota::coin::deny_list_v2_disable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_disable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Verify the setting objects are still present
 //# view-object 2,1
@@ -78,10 +78,10 @@ module test::regulated_coin {
 //# advance-epoch
 
 // Undeny account B.
-//# run iota::coin::deny_list_v2_remove --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_remove --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Disable global pause.
-//# run iota::coin::deny_list_v2_disable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_disable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Verify the setting objects are deleted
 //# view-object 2,1

--- a/crates/iota-adapter-transactional-tests/tests/deny_list_v2/delete_setting_object_set_twice.move
+++ b/crates/iota-adapter-transactional-tests/tests/deny_list_v2/delete_setting_object_set_twice.move
@@ -37,7 +37,7 @@ module test::regulated_coin {
         addr: address,
         expected: bool,
     ) {
-        let status = coin::deny_list_v2_contains_next_epoch<REGULATED_COIN>(deny_list, addr);
+        let status = coin::deny_list_with_config_key_v1_contains_next_epoch<REGULATED_COIN>(deny_list, addr);
         assert!(status == expected, 0);
     }
 
@@ -46,16 +46,16 @@ module test::regulated_coin {
         expected: bool,
     ) {
         let status =
-            coin::deny_list_v2_is_global_pause_enabled_next_epoch<REGULATED_COIN>(deny_list);
+            coin::deny_list_with_config_key_v1_is_global_pause_enabled_next_epoch<REGULATED_COIN>(deny_list);
         assert!(status == expected, 0);
     }
 }
 
 // Deny account B.
-//# run iota::coin::deny_list_v2_add --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_add --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Enable global pause.
-//# run iota::coin::deny_list_v2_enable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_enable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // View the setting objects
 //# view-object 2,1
@@ -65,10 +65,10 @@ module test::regulated_coin {
 //# advance-epoch
 
 // Deny account B.
-//# run iota::coin::deny_list_v2_add --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_add --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Enable global pause.
-//# run iota::coin::deny_list_v2_enable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_enable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // View the setting objects
 //# view-object 2,1
@@ -78,10 +78,10 @@ module test::regulated_coin {
 //# advance-epoch
 
 // Undeny account B.
-//# run iota::coin::deny_list_v2_remove --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_remove --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Disable global pause.
-//# run iota::coin::deny_list_v2_disable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_disable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Verify the setting objects are still present
 //# view-object 2,1
@@ -91,10 +91,10 @@ module test::regulated_coin {
 //# advance-epoch
 
 // Undeny account B.
-//# run iota::coin::deny_list_v2_remove --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_remove --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Disable global pause.
-//# run iota::coin::deny_list_v2_disable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_disable_global_pause --args object(0x403) object(1,2) --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Verify the setting objects are deleted
 //# view-object 2,1

--- a/crates/iota-adapter-transactional-tests/tests/deny_list_v2/double_add.move
+++ b/crates/iota-adapter-transactional-tests/tests/deny_list_v2/double_add.move
@@ -37,7 +37,7 @@ module test::regulated_coin {
         addr: address,
         expected: bool,
     ) {
-        let status = coin::deny_list_v2_contains_next_epoch<REGULATED_COIN>(deny_list, addr);
+        let status = coin::deny_list_with_config_key_v1_contains_next_epoch<REGULATED_COIN>(deny_list, addr);
         assert!(status == expected, 0);
     }
 }
@@ -46,10 +46,10 @@ module test::regulated_coin {
 //# run iota::pay::split_and_transfer --args object(1,0) 1 @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Deny account B.
-//# run iota::coin::deny_list_v2_add --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_add --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Deny account B a second time. This should not change anything.
-//# run iota::coin::deny_list_v2_add --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_add --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Assert that the address is denied.
 //# run test::regulated_coin::assert_address_deny_status --args immshared(0x403) @B true --sender A
@@ -61,7 +61,7 @@ module test::regulated_coin {
 //# run iota::pay::split_and_transfer --args object(2,0) 1 @A --type-args test::regulated_coin::REGULATED_COIN --sender B
 
 // Undeny account B.
-//# run iota::coin::deny_list_v2_remove --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+//# run iota::coin::deny_list_with_config_key_v1_remove --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 
 // Assert that the address is no longer denied.
 //# run test::regulated_coin::assert_address_deny_status --args immshared(0x403) @B false --sender A

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -57,8 +57,8 @@ use iota_types::{
     base_types::*,
     committee::{Committee, EpochId, ProtocolVersion},
     crypto::{AuthoritySignInfo, AuthoritySignature, RandomnessRound, Signer, default_hash},
-    deny_list_v1::check_coin_deny_list_v1,
-    deny_list_v2::check_coin_deny_list_v2_during_signing,
+    deny_list_v1::check_global_coin_deny_list,
+    deny_list_with_config_key_v1::check_coin_deny_list_during_signing,
     digests::{ChainIdentifier, TransactionEventsDigest},
     dynamic_field::{DynamicFieldInfo, DynamicFieldName, DynamicFieldType},
     effects::{
@@ -885,7 +885,7 @@ impl AuthorityState {
             )?;
 
         if epoch_store.coin_deny_list_v1_enabled() {
-            check_coin_deny_list_v1(
+            check_global_coin_deny_list(
                 tx_data.sender(),
                 &checked_input_objects,
                 &receiving_objects,
@@ -893,8 +893,11 @@ impl AuthorityState {
             )?;
         }
 
-        if epoch_store.protocol_config().enable_coin_deny_list_v2() {
-            check_coin_deny_list_v2_during_signing(
+        if epoch_store
+            .protocol_config()
+            .enable_coin_deny_list_with_config_key_v1()
+        {
+            check_coin_deny_list_during_signing(
                 tx_data.sender(),
                 &checked_input_objects,
                 &receiving_objects,

--- a/crates/iota-core/src/unit_tests/data/coin_deny_list_with_config_key_v1/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/coin_deny_list_with_config_key_v1/Move.toml
@@ -1,5 +1,5 @@
 [package]
-name = "coin_deny_list_v2"
+name = "coin_deny_list_with_config_key_v1"
 version = "0.0.1"
 edition = "2024.beta"
 
@@ -7,4 +7,4 @@ edition = "2024.beta"
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }
 
 [addresses]
-coin_deny_list_v2 = "0x0"
+coin_deny_list_with_config_key_v1 = "0x0"

--- a/crates/iota-core/src/unit_tests/data/coin_deny_list_with_config_key_v1/sources/regulated_coin.move
+++ b/crates/iota-core/src/unit_tests/data/coin_deny_list_with_config_key_v1/sources/regulated_coin.move
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-module coin_deny_list_v2::regulated_coin {
+module coin_deny_list_with_config_key_v1::regulated_coin {
     use iota::coin;
 
     public struct REGULATED_COIN has drop {}

--- a/crates/iota-e2e-tests/tests/per_epoch_config_stress_tests.rs
+++ b/crates/iota-e2e-tests/tests/per_epoch_config_stress_tests.rs
@@ -103,9 +103,9 @@ async fn create_deny_tx(test_env: Arc<TestEnv>, gas: ObjectRef) -> TransactionDa
             IOTA_FRAMEWORK_PACKAGE_ID,
             "coin",
             if deny {
-                "deny_list_v2_add"
+                "deny_list_with_config_key_v1_add"
             } else {
-                "deny_list_v2_remove"
+                "deny_list_with_config_key_v1_remove"
             },
             vec![
                 CallArg::Object(ObjectArg::SharedObject {

--- a/crates/iota-framework/packages/iota-framework/sources/coin.move
+++ b/crates/iota-framework/packages/iota-framework/sources/coin.move
@@ -331,7 +331,7 @@ module iota::coin {
     /// Adds the given address to the deny list, preventing it from interacting with the specified
     /// coin type as an input to a transaction. Additionally at the start of the next epoch, the
     /// address will be unable to receive objects of this coin type.
-    public fun deny_list_v2_add<T>(
+    public fun deny_list_with_config_key_v1_add<T>(
         deny_list: &mut DenyList,
         _deny_cap: &mut DenyCapV2<T>,
         addr: address,
@@ -341,10 +341,10 @@ module iota::coin {
         deny_list.v2_add(DENY_LIST_COIN_INDEX, ty, addr, ctx)
     }
 
-    /// Removes an address from the deny list. Similar to `deny_list_v2_add`, the effect for input
+    /// Removes an address from the deny list. Similar to `deny_list_with_config_key_v1_add`, the effect for input
     /// objects will be immediate, but the effect for receiving objects will be delayed until the
     /// next epoch.
-    public fun deny_list_v2_remove<T>(
+    public fun deny_list_with_config_key_v1_remove<T>(
         deny_list: &mut DenyList,
         _deny_cap: &mut DenyCapV2<T>,
         addr: address,
@@ -356,7 +356,7 @@ module iota::coin {
 
     /// Check if the deny list contains the given address for the current epoch. Denied addresses
     /// in the current epoch will be unable to receive objects of this coin type.
-    public fun deny_list_v2_contains_current_epoch<T>(
+    public fun deny_list_with_config_key_v1_contains_current_epoch<T>(
         deny_list: &DenyList,
         addr: address,
         ctx: &TxContext,
@@ -368,7 +368,7 @@ module iota::coin {
     /// Check if the deny list contains the given address for the next epoch. Denied addresses in
     /// the next epoch will immediately be unable to use objects of this coin type as inputs. At the
     /// start of the next epoch, the address will be unable to receive objects of this coin type.
-    public fun deny_list_v2_contains_next_epoch<T>(
+    public fun deny_list_with_config_key_v1_contains_next_epoch<T>(
         deny_list: &DenyList,
         addr: address,
     ): bool {
@@ -380,7 +380,7 @@ module iota::coin {
     /// from using objects of this coin type as inputs. At the start of the next epoch, all
     /// addresses will be unable to receive objects of this coin type.
     #[allow(unused_mut_parameter)]
-    public fun deny_list_v2_enable_global_pause<T>(
+    public fun deny_list_with_config_key_v1_enable_global_pause<T>(
         deny_list: &mut DenyList,
         deny_cap: &mut DenyCapV2<T>,
         ctx: &mut TxContext,
@@ -394,7 +394,7 @@ module iota::coin {
     /// to resume using objects of this coin type as inputs. However, receiving objects of this coin
     /// type will still be paused until the start of the next epoch.
     #[allow(unused_mut_parameter)]
-    public fun deny_list_v2_disable_global_pause<T>(
+    public fun deny_list_with_config_key_v1_disable_global_pause<T>(
         deny_list: &mut DenyList,
         deny_cap: &mut DenyCapV2<T>,
         ctx: &mut TxContext,
@@ -405,7 +405,7 @@ module iota::coin {
     }
 
     /// Check if the global pause is enabled for the given coin type in the current epoch.
-    public fun deny_list_v2_is_global_pause_enabled_current_epoch<T>(
+    public fun deny_list_with_config_key_v1_is_global_pause_enabled_current_epoch<T>(
         deny_list: &DenyList,
         ctx: &TxContext,
     ): bool {
@@ -414,7 +414,7 @@ module iota::coin {
     }
 
     /// Check if the global pause is enabled for the given coin type in the next epoch.
-    public fun deny_list_v2_is_global_pause_enabled_next_epoch<T>(
+    public fun deny_list_with_config_key_v1_is_global_pause_enabled_next_epoch<T>(
         deny_list: &DenyList,
     ): bool {
         let ty = type_name::get_with_original_ids<T>().into_string().into_bytes();
@@ -567,7 +567,7 @@ module iota::coin {
 
     /// Adds the given address to the deny list, preventing it
     /// from interacting with the specified coin type as an input to a transaction.
-    #[deprecated(note = b"Use `migrate_regulated_currency_to_v2` to migrate to v2 and then use `deny_list_v2_add`")]
+    #[deprecated(note = b"Use `migrate_regulated_currency_to_v2` to migrate to v2 and then use `deny_list_with_config_key_v1_add`")]
     public fun deny_list_add<T>(
        deny_list: &mut DenyList,
        _deny_cap: &mut DenyCap<T>,
@@ -585,7 +585,7 @@ module iota::coin {
 
     /// Removes an address from the deny list.
     /// Aborts with `ENotFrozen` if the address is not already in the list.
-    #[deprecated(note = b"Use `migrate_regulated_currency_to_v2` to migrate to v2 and then use `deny_list_v2_remove`")]
+    #[deprecated(note = b"Use `migrate_regulated_currency_to_v2` to migrate to v2 and then use `deny_list_with_config_key_v1_remove`")]
     public fun deny_list_remove<T>(
        deny_list: &mut DenyList,
        _deny_cap: &mut DenyCap<T>,
@@ -603,7 +603,7 @@ module iota::coin {
 
     /// Returns true iff the given address is denied for the given coin type. It will
     /// return false if given a non-coin type.
-    #[deprecated(note = b"Use `migrate_regulated_currency_to_v2` to migrate to v2 and then use `deny_list_v2_contains_next_epoch` or `deny_list_v2_contains_current_epoch`")]
+    #[deprecated(note = b"Use `migrate_regulated_currency_to_v2` to migrate to v2 and then use `deny_list_with_config_key_v1_contains_next_epoch` or `deny_list_with_config_key_v1_contains_current_epoch`")]
     public fun deny_list_contains<T>(
        deny_list: &DenyList,
        addr: address,

--- a/crates/iota-framework/packages/iota-framework/tests/coin_tests.move
+++ b/crates/iota-framework/packages/iota-framework/tests/coin_tests.move
@@ -22,8 +22,8 @@ module iota::coin_tests {
         ctx: &TxContext,
     ) {
         use iota::coin::{
-            deny_list_v2_contains_next_epoch as contains_next_epoch,
-            deny_list_v2_contains_current_epoch as contains_current_epoch,
+            deny_list_with_config_key_v1_contains_next_epoch as contains_next_epoch,
+            deny_list_with_config_key_v1_contains_current_epoch as contains_current_epoch,
         };
         assert!(contains_current_epoch<COIN_TESTS>(deny_list, addr, ctx) == contains_current_epoch);
         assert!(contains_next_epoch<COIN_TESTS>(deny_list, addr) == contains_next_epoch);
@@ -36,8 +36,8 @@ module iota::coin_tests {
         ctx: &TxContext,
     ) {
         use iota::coin::{
-            deny_list_v2_is_global_pause_enabled_next_epoch as is_global_pause_enabled_next_epoch,
-            deny_list_v2_is_global_pause_enabled_current_epoch
+            deny_list_with_config_key_v1_is_global_pause_enabled_next_epoch as is_global_pause_enabled_next_epoch,
+            deny_list_with_config_key_v1_is_global_pause_enabled_current_epoch
                 as is_global_pause_enabled_current_epoch,
         };
         assert!(
@@ -214,10 +214,10 @@ module iota::coin_tests {
     }
 
     #[test]
-    fun deny_list_v2() {
+    fun deny_list_with_config_key_v1() {
         use iota::coin::{
-            deny_list_v2_add as add,
-            deny_list_v2_remove as remove,
+            deny_list_with_config_key_v1_add as add,
+            deny_list_with_config_key_v1_remove as remove,
         };
         let mut scenario = test_scenario::begin(@0);
         deny_list::create_for_test(scenario.ctx());
@@ -289,12 +289,12 @@ module iota::coin_tests {
     }
 
     #[test]
-    fun deny_list_v2_global_pause() {
+    fun deny_list_with_config_key_v1_global_pause() {
         use iota::coin::{
-            deny_list_v2_add as add,
-            deny_list_v2_remove as remove,
-            deny_list_v2_enable_global_pause as enable_global_pause,
-            deny_list_v2_disable_global_pause as disable_global_pause,
+            deny_list_with_config_key_v1_add as add,
+            deny_list_with_config_key_v1_remove as remove,
+            deny_list_with_config_key_v1_enable_global_pause as enable_global_pause,
+            deny_list_with_config_key_v1_disable_global_pause as disable_global_pause,
         };
         let mut scenario = test_scenario::begin(@0);
         deny_list::create_for_test(scenario.ctx());
@@ -366,10 +366,10 @@ module iota::coin_tests {
     }
 
     #[test]
-    fun deny_list_v2_double_add() {
+    fun deny_list_with_config_key_v1_double_add() {
         use iota::coin::{
-            deny_list_v2_add as add,
-            deny_list_v2_remove as remove,
+            deny_list_with_config_key_v1_add as add,
+            deny_list_with_config_key_v1_remove as remove,
         };
         let mut scenario = test_scenario::begin(@0);
         deny_list::create_for_test(scenario.ctx());
@@ -406,7 +406,7 @@ module iota::coin_tests {
     }
 
     #[test, expected_failure(abort_code = iota::coin::EGlobalPauseNotAllowed)]
-    fun deny_list_v2_global_pause_not_allowed_enable() {
+    fun deny_list_with_config_key_v1_global_pause_not_allowed_enable() {
         let mut scenario = test_scenario::begin(@0);
         deny_list::create_for_test(scenario.ctx());
         scenario.next_tx(TEST_ADDR);
@@ -423,12 +423,12 @@ module iota::coin_tests {
             scenario.ctx(),
         );
         let mut deny_list: deny_list::DenyList = scenario.take_shared();
-        coin::deny_list_v2_enable_global_pause(&mut deny_list, &mut deny_cap, scenario.ctx());
+        coin::deny_list_with_config_key_v1_enable_global_pause(&mut deny_list, &mut deny_cap, scenario.ctx());
         abort 0
     }
 
     #[test, expected_failure(abort_code = iota::coin::EGlobalPauseNotAllowed)]
-    fun deny_list_v2_global_pause_not_allowed_disable() {
+    fun deny_list_with_config_key_v1_global_pause_not_allowed_disable() {
         let mut scenario = test_scenario::begin(@0);
         deny_list::create_for_test(scenario.ctx());
         scenario.next_tx(TEST_ADDR);
@@ -445,7 +445,7 @@ module iota::coin_tests {
             scenario.ctx(),
         );
         let mut deny_list: deny_list::DenyList = scenario.take_shared();
-        coin::deny_list_v2_disable_global_pause(&mut deny_list, &mut deny_cap, scenario.ctx());
+        coin::deny_list_with_config_key_v1_disable_global_pause(&mut deny_list, &mut deny_cap, scenario.ctx());
         abort 0
     }
 
@@ -559,15 +559,15 @@ module iota::coin_tests {
         };
         scenario.next_tx(TEST_ADDR);
         let mut deny_list: deny_list::DenyList = scenario.take_shared();
-        coin::deny_list_v2_enable_global_pause(&mut deny_list, &mut deny_cap_v2, scenario.ctx());
+        coin::deny_list_with_config_key_v1_enable_global_pause(&mut deny_list, &mut deny_cap_v2, scenario.ctx());
         abort 0
     }
 
     #[test]
-    fun deny_list_v2_add_remove() {
+    fun deny_list_with_config_key_v1_add_remove() {
         use iota::coin::{
-            deny_list_v2_add as add,
-            deny_list_v2_remove as remove,
+            deny_list_with_config_key_v1_add as add,
+            deny_list_with_config_key_v1_remove as remove,
         };
         let mut scenario = test_scenario::begin(@0);
         deny_list::create_for_test(scenario.ctx());

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1309,7 +1309,7 @@
                 "disallow_adding_abilities_on_upgrade": true,
                 "disallow_change_struct_type_params_on_upgrade": true,
                 "enable_coin_deny_list": true,
-                "enable_coin_deny_list_v2": true,
+                "enable_coin_deny_list_with_config_key_v1": true,
                 "enable_effects_v2": true,
                 "enable_group_ops_native_function_msm": true,
                 "enable_group_ops_native_functions": true,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -353,7 +353,7 @@ struct FeatureFlags {
 
     // If true, enable the coin deny list V2.
     #[serde(skip_serializing_if = "is_false")]
-    enable_coin_deny_list_v2: bool,
+    enable_coin_deny_list_with_config_key_v1: bool,
 
     // Enable passkey auth (SIP-9)
     #[serde(skip_serializing_if = "is_false")]
@@ -1372,8 +1372,8 @@ impl ProtocolConfig {
         self.feature_flags.enable_coin_deny_list
     }
 
-    pub fn enable_coin_deny_list_v2(&self) -> bool {
-        self.feature_flags.enable_coin_deny_list_v2
+    pub fn enable_coin_deny_list_with_config_key_v1(&self) -> bool {
+        self.feature_flags.enable_coin_deny_list_with_config_key_v1
     }
 
     pub fn enable_group_ops_native_functions(&self) -> bool {
@@ -2082,7 +2082,7 @@ impl ProtocolConfig {
 
         cfg.feature_flags.mysticeti_num_leaders_per_round = Some(1);
 
-        cfg.feature_flags.enable_coin_deny_list_v2 = true;
+        cfg.feature_flags.enable_coin_deny_list_with_config_key_v1 = true;
 
         // Enable soft bundle.
         cfg.feature_flags.soft_bundle = true;

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -57,7 +57,7 @@ feature_flags:
   prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
   mysticeti_num_leaders_per_round: 1
   soft_bundle: true
-  enable_coin_deny_list_v2: true
+  enable_coin_deny_list_with_config_key_v1: true
   rethrow_serialization_type_layout_errors: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -57,7 +57,7 @@ feature_flags:
   prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
   mysticeti_num_leaders_per_round: 1
   soft_bundle: true
-  enable_coin_deny_list_v2: true
+  enable_coin_deny_list_with_config_key_v1: true
   rethrow_serialization_type_layout_errors: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -60,7 +60,7 @@ feature_flags:
   prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
   mysticeti_num_leaders_per_round: 1
   soft_bundle: true
-  enable_coin_deny_list_v2: true
+  enable_coin_deny_list_with_config_key_v1: true
   passkey_auth: true
   authority_capabilities_v2: true
   rethrow_serialization_type_layout_errors: true

--- a/crates/iota-types/src/deny_list_v1.rs
+++ b/crates/iota-types/src/deny_list_v1.rs
@@ -55,7 +55,7 @@ pub struct PerTypeDenyList {
 /// Checks coin denylist v1 at signing time.
 /// It checks that none of the coin types in the transaction are denied for the
 /// sender.
-pub fn check_coin_deny_list_v1(
+pub fn check_global_coin_deny_list(
     sender: IotaAddress,
     input_objects: &CheckedInputObjects,
     receiving_objects: &ReceivingObjects,
@@ -71,7 +71,7 @@ pub fn check_coin_deny_list_v1(
             return Ok(());
         }
     };
-    check_deny_list_v1_impl(deny_list, sender, coin_types, object_store)
+    check_global_deny_list_impl(deny_list, sender, coin_types, object_store)
 }
 
 /// Returns all unique coin types in canonical string form from the input
@@ -97,7 +97,7 @@ pub(crate) fn input_object_coin_types_for_denylist_check(
         .collect()
 }
 
-fn check_deny_list_v1_impl(
+fn check_global_deny_list_impl(
     deny_list: PerTypeDenyList,
     address: IotaAddress,
     coin_types: BTreeSet<String>,

--- a/crates/iota-types/src/deny_list_with_config_key_v1.rs
+++ b/crates/iota-types/src/deny_list_with_config_key_v1.rs
@@ -108,7 +108,7 @@ impl MoveTypeTagTrait for GlobalPauseKey {
     }
 }
 
-pub fn check_coin_deny_list_v2_during_signing(
+pub fn check_coin_deny_list_during_signing(
     address: IotaAddress,
     input_objects: &CheckedInputObjects,
     receiving_objects: &ReceivingObjects,
@@ -116,7 +116,7 @@ pub fn check_coin_deny_list_v2_during_signing(
 ) -> UserInputResult {
     let coin_types = input_object_coin_types_for_denylist_check(input_objects, receiving_objects);
     for coin_type in coin_types {
-        let Some(deny_list) = get_per_type_coin_deny_list_v2(&coin_type, object_store) else {
+        let Some(deny_list) = get_per_type_coin_deny_list(&coin_type, object_store) else {
             continue;
         };
         if check_global_pause(&deny_list, object_store, None) {
@@ -132,7 +132,7 @@ pub fn check_coin_deny_list_v2_during_signing(
 /// Returns 1) whether the coin deny list check passed,
 ///         2) the deny lists checked
 ///         2) the number of regulated coin owners checked.
-pub fn check_coin_deny_list_v2_during_execution(
+pub fn check_coin_deny_list_during_execution(
     written_objects: &BTreeMap<ObjectID, Object>,
     cur_epoch: EpochId,
     object_store: &dyn ObjectStore,
@@ -157,7 +157,7 @@ pub fn check_coin_deny_list_v2_during_execution(
     let new_regulated_coin_owners = new_coin_owners
         .into_iter()
         .filter_map(|(coin_type, owners)| {
-            let deny_list_config = get_per_type_coin_deny_list_v2(&coin_type, object_store)?;
+            let deny_list_config = get_per_type_coin_deny_list(&coin_type, object_store)?;
             Some((coin_type, (deny_list_config, owners)))
         })
         .collect::<BTreeMap<_, _>>();
@@ -203,7 +203,7 @@ fn check_new_regulated_coin_owners(
     Ok(())
 }
 
-pub fn get_per_type_coin_deny_list_v2(
+pub fn get_per_type_coin_deny_list(
     coin_type: &String,
     object_store: &dyn ObjectStore,
 ) -> Option<Config> {

--- a/crates/iota-types/src/lib.rs
+++ b/crates/iota-types/src/lib.rs
@@ -44,7 +44,7 @@ pub mod committee;
 pub mod config;
 pub mod crypto;
 pub mod deny_list_v1;
-pub mod deny_list_v2;
+pub mod deny_list_with_config_key_v1;
 pub mod digests;
 pub mod display;
 pub mod dynamic_field;

--- a/examples/move/coin/sources/regcoin.move
+++ b/examples/move/coin/sources/regcoin.move
@@ -32,7 +32,7 @@ module examples::regcoin {
         denyaddy: address,
         ctx: &mut TxContext,
     ) {
-        coin::deny_list_v2_add(denylist, denycap, denyaddy, ctx);
+        coin::deny_list_with_config_key_v1_add(denylist, denycap, denyaddy, ctx);
     }
 
     public fun remove_addr_from_deny_list(
@@ -41,6 +41,6 @@ module examples::regcoin {
         denyaddy: address,
         ctx: &mut TxContext,
     ) {
-        coin::deny_list_v2_remove(denylist, denycap, denyaddy, ctx);
+        coin::deny_list_with_config_key_v1_remove(denylist, denycap, denyaddy, ctx);
     }
 }

--- a/iota-execution/latest/iota-adapter/src/gas_charger.rs
+++ b/iota-execution/latest/iota-adapter/src/gas_charger.rs
@@ -11,7 +11,7 @@ pub mod checked {
     use iota_protocol_config::ProtocolConfig;
     use iota_types::{
         base_types::{ObjectID, ObjectRef},
-        deny_list_v2::CONFIG_SETTING_DYNAMIC_FIELD_SIZE_FOR_GAS,
+        deny_list_with_config_key_v1::CONFIG_SETTING_DYNAMIC_FIELD_SIZE_FOR_GAS,
         digests::TransactionDigest,
         error::ExecutionError,
         gas::{GasCostSummary, IotaGasStatus, deduct_gas},

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
@@ -844,7 +844,7 @@ mod checked {
                 }
             }
 
-            if protocol_config.enable_coin_deny_list_v2() {
+            if protocol_config.enable_coin_deny_list_with_config_key_v1() {
                 let DenyListResult {
                     result,
                     num_non_gas_coin_owners,

--- a/iota-execution/latest/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/latest/iota-adapter/src/temporary_store.rs
@@ -12,7 +12,7 @@ use iota_types::{
         IotaAddress, ObjectID, ObjectRef, SequenceNumber, TransactionDigest, VersionDigest,
     },
     committee::EpochId,
-    deny_list_v2::check_coin_deny_list_v2_during_execution,
+    deny_list_with_config_key_v1::check_coin_deny_list_during_execution,
     effects::{EffectsObjectChange, TransactionEffects, TransactionEvents},
     error::{ExecutionError, IotaError, IotaResult},
     execution::{
@@ -1061,7 +1061,7 @@ impl<'backing> Storage for TemporaryStore<'backing> {
     }
 
     fn check_coin_deny_list(&self, written_objects: &BTreeMap<ObjectID, Object>) -> DenyListResult {
-        let result = check_coin_deny_list_v2_during_execution(
+        let result = check_coin_deny_list_during_execution(
             written_objects,
             self.cur_epoch,
             self.store.as_object_store(),

--- a/iota-execution/v0/iota-adapter/src/gas_charger.rs
+++ b/iota-execution/v0/iota-adapter/src/gas_charger.rs
@@ -11,7 +11,7 @@ pub mod checked {
     use iota_protocol_config::ProtocolConfig;
     use iota_types::{
         base_types::{ObjectID, ObjectRef},
-        deny_list_v2::CONFIG_SETTING_DYNAMIC_FIELD_SIZE_FOR_GAS,
+        deny_list_with_config_key_v1::CONFIG_SETTING_DYNAMIC_FIELD_SIZE_FOR_GAS,
         digests::TransactionDigest,
         error::ExecutionError,
         gas::{GasCostSummary, IotaGasStatus, deduct_gas},

--- a/iota-execution/v0/iota-adapter/src/programmable_transactions/context.rs
+++ b/iota-execution/v0/iota-adapter/src/programmable_transactions/context.rs
@@ -838,7 +838,7 @@ mod checked {
                 }
             }
 
-            if protocol_config.enable_coin_deny_list_v2() {
+            if protocol_config.enable_coin_deny_list_with_config_key_v1() {
                 let DenyListResult {
                     result,
                     num_non_gas_coin_owners,

--- a/iota-execution/v0/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/v0/iota-adapter/src/temporary_store.rs
@@ -12,7 +12,7 @@ use iota_types::{
         IotaAddress, ObjectID, ObjectRef, SequenceNumber, TransactionDigest, VersionDigest,
     },
     committee::EpochId,
-    deny_list_v2::check_coin_deny_list_v2_during_execution,
+    deny_list_with_config_key_v1::check_coin_deny_list_during_execution,
     effects::{EffectsObjectChange, TransactionEffects, TransactionEvents},
     error::{ExecutionError, IotaError, IotaResult},
     execution::{
@@ -1061,7 +1061,7 @@ impl<'backing> Storage for TemporaryStore<'backing> {
     }
 
     fn check_coin_deny_list(&self, written_objects: &BTreeMap<ObjectID, Object>) -> DenyListResult {
-        let result = check_coin_deny_list_v2_during_execution(
+        let result = check_coin_deny_list_during_execution(
             written_objects,
             self.cur_epoch,
             self.store.as_object_store(),


### PR DESCRIPTION
# Description of change

Instead of merging deny_list_v1 and deny_list_v2 into one `deny_list.rs` file which might introduce unnecessary effort, we do the followings.

- [x] `deny_list_v1` remains the same
- [x] Renamed `deny_list_v2` to be `deny_list_with_config_key_v1`

### `deny_list_v1.rs`
  Note: No need of versioning for the functions anymore because all of them is under `deny_list_v1` module
  - [x] `check_coin_deny_list_v1` -> `check_global_coin_deny_list`
    - Renamed it to be `check_global_coin_deny_list` because it retrieves the deny list by calling get_deny_list_root_object, while in the `check_coin_deny_list_v2_during_signing` the deny list is fetched for each individual coin type.
  - [x] `check_deny_list_v1_impl` -> `check_global_deny_list_impl`
    - Added the `global` keyword to the function name to be consistent with the `check_global_coin_deny_list`.

### `deny_list_with_config_key_v1` (the old `deny_list_v2.rs`)
Note: No need of versioning for the functions anymore because all of them are only under `deny_list_v2` module
  - [x] `check_coin_deny_list_v2_during_signing` -> `check_coin_deny_list_during_signing`
  - [x] `check_coin_deny_list_v2_during_execution` -> `check_coin_deny_list_during_execution`
  - [x] `get_per_type_coin_deny_list_v2` -> `get_per_type_coin_deny_list`

### MISC
- [x]  `enable_coin_deny_list_v2` ->` enable_coin_deny_list_with_config_key_v1`

## Links to any relevant issues

Closes #3095

## Type of change

Choose a type of change, and delete any options that are not relevant.
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

- I was running the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`
- Passed total 509 Move unit tests for `iota-framework` by `./iota move test --path crates/iota-framework/packages/iota-framework/Move.toml`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
