### PR TITLE
refactor(narwhal-types): Clean narwhal type versioning

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1693,7 +1693,6 @@ impl ProtocolConfig {
         cfg.feature_flags
             .advance_to_highest_supported_protocol_version = true;
         cfg.feature_flags.consensus_transaction_ordering = ConsensusTransactionOrdering::ByGasPrice;
-
         cfg.feature_flags.recompute_has_public_transfer_in_execution = true;
         cfg.feature_flags.shared_object_deletion = true;
         cfg.feature_flags.hardened_otw_check = true;

--- a/narwhal/types/src/tests/batch_serde.rs
+++ b/narwhal/types/src/tests/batch_serde.rs
@@ -5,13 +5,13 @@
 use serde_test::{Token, assert_tokens};
 
 use crate::{
-    Batch, BatchV2, MetadataV1, VersionedMetadata, serde::batch_serde::Token::NewtypeVariant,
+    Batch, BatchV1, MetadataV1, VersionedMetadata, serde::batch_serde::Token::NewtypeVariant,
 };
 #[test]
 fn test_serde_batch() {
     let tx = || vec![1; 5];
 
-    let batch = Batch::V2(BatchV2 {
+    let batch = Batch::V1(BatchV1 {
         transactions: (0..2).map(|_| tx()).collect(),
         versioned_metadata: VersionedMetadata::V1(MetadataV1 {
             created_at: 1666205365890,
@@ -25,7 +25,7 @@ fn test_serde_batch() {
             variant: "V2",
         },
         Token::Struct {
-            name: "BatchV2",
+            name: "BatchV1",
             len: 2,
         },
         Token::Str("transactions"),

--- a/narwhal/types/src/tests/batch_serde.rs
+++ b/narwhal/types/src/tests/batch_serde.rs
@@ -22,7 +22,7 @@ fn test_serde_batch() {
     assert_tokens(&batch, &[
         NewtypeVariant {
             name: "Batch",
-            variant: "V2",
+            variant: "V1",
         },
         Token::Struct {
             name: "BatchV1",


### PR DESCRIPTION
# Description of change

Clean up narwhal types

- [x] Renamed `Batch::V2` and `BatchV2` to be `Batch::V1` and `BatchV1`
- [x] Renamed `Certificate::V2` and `CertificateV2` to be `Certificate::V1` and `CertificateV1`

Note that the `ConsensusCommit` is indirectly used in `ConsensusOutput`, where current iota-core uses it. Might just keep them for now.

## Links to any relevant issues

Fix https://github.com/iotaledger/iota/issues/2096

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

- I was running the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
