### PR TITLE
feat(iota): add IotaValidatorCommand::List command

### DIFF
--- a/crates/iota/src/validator_commands.rs
+++ b/crates/iota/src/validator_commands.rs
@@ -696,7 +696,7 @@ impl IotaValidatorCommand {
 
                 let mut builder = Builder::default();
 
-                builder.push_record(vec![
+                builder.set_header([
                     "iota address",
                     "name",
                     "staking pool balance",
@@ -711,7 +711,7 @@ impl IotaValidatorCommand {
                     ..
                 } in active_validators
                 {
-                    builder.push_record(vec![
+                    builder.push_record([
                         iota_address.to_string(),
                         name,
                         staking_pool_iota_balance.to_string(),

--- a/crates/iota/src/validator_commands.rs
+++ b/crates/iota/src/validator_commands.rs
@@ -54,6 +54,7 @@ use iota_types::{
 use move_core_types::ident_str;
 use serde::Serialize;
 use shared_crypto::intent::{Intent, IntentMessage, IntentScope};
+use tabled::{builder::Builder, settings::Style};
 use tap::tap::TapOptional;
 use url::{ParseError, Url};
 
@@ -693,20 +694,34 @@ impl IotaValidatorCommand {
                     .await?
                     .active_validators;
 
-                println!(
-                    "{:<66} | {:<12} | {:<20} | {:<10}",
-                    "iota address", "name", "staking pool balance", "pending stake"
-                );
+                let mut builder = Builder::default();
 
-                for validator in active_validators {
-                    println!(
-                        "{:<66} | {:<12} | {:<20} | {:<10}",
-                        validator.iota_address,
-                        validator.name,
-                        validator.staking_pool_iota_balance,
-                        validator.pending_stake
-                    );
+                builder.push_record(vec![
+                    "iota address",
+                    "name",
+                    "staking pool balance",
+                    "pending stake",
+                ]);
+
+                for IotaValidatorSummary {
+                    iota_address,
+                    name,
+                    staking_pool_iota_balance,
+                    pending_stake,
+                    ..
+                } in active_validators
+                {
+                    builder.push_record(vec![
+                        iota_address.to_string(),
+                        name,
+                        staking_pool_iota_balance.to_string(),
+                        pending_stake.to_string(),
+                    ]);
                 }
+
+                let table = builder.build().with(Style::rounded()).to_string();
+                println!("{table}");
+
                 IotaValidatorCommandResponse::List
             }
         });

--- a/crates/iota/src/validator_commands.rs
+++ b/crates/iota/src/validator_commands.rs
@@ -223,7 +223,7 @@ pub enum IotaValidatorCommand {
     },
     /// Get a list of the validators in the network. Use the `display-metadata`
     /// command to see the complete data for a validator.
-    Validators,
+    List,
 }
 
 #[derive(Serialize)]
@@ -250,7 +250,7 @@ pub enum IotaValidatorCommandResponse {
         execution_response: Option<IotaTransactionBlockResponse>,
         serialized_unsigned_transaction: Option<String>,
     },
-    Validators,
+    List,
 }
 
 fn make_key_files(
@@ -684,7 +684,7 @@ impl IotaValidatorCommand {
                     }
                 }
             }
-            IotaValidatorCommand::Validators => {
+            IotaValidatorCommand::List => {
                 let client = context.get_client().await?;
 
                 let active_validators = client
@@ -707,7 +707,7 @@ impl IotaValidatorCommand {
                         validator.pending_stake
                     );
                 }
-                IotaValidatorCommandResponse::Validators
+                IotaValidatorCommandResponse::List
             }
         });
         ret
@@ -987,7 +987,7 @@ impl Display for IotaValidatorCommandResponse {
                     )?;
                 }
             }
-            IotaValidatorCommandResponse::Validators => {}
+            IotaValidatorCommandResponse::List => {}
         }
         write!(f, "{}", writer.trim_end_matches('\n'))
     }


### PR DESCRIPTION
# Description of change

Add IotaValidatorCommand::List command to see all validators in a network

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/2515

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running the command in a local network:
```
iota validator list
╭────────────────────────────────────────────────────────────────────┬─────────────┬──────────────────────┬───────────────╮
│ iota address                                                       │ name        │ staking pool balance │ pending stake │
├────────────────────────────────────────────────────────────────────┼─────────────┼──────────────────────┼───────────────┤
│ 0x1a2b932d1cad44f59c982066e9c535148cde395121607363b19974c8f5cb87f7 │ validator-1 │ 3225750000000000     │ 0             │
│ 0xcdb31557d462385250937a4e78c8c55d762982063196299e98bf5a48b9991816 │ validator-0 │ 3225750000000000     │ 0             │
│ 0x081ac0babd04d8d0643aef06cdc9bd092ad8c5f0a467c69b8096dcc41ef6a33a │ validator-2 │ 3225750000000000     │ 0             │
│ 0x05175b8abd70a23b7d75ea1c6200a1f4dcd36f7e55be9b2523b78a4fb8b90d12 │ validator-3 │ 3225750000000000     │ 0             │
╰────────────────────────────────────────────────────────────────────┴─────────────┴──────────────────────┴───────────────╯
```
