### PR TITLE
refactor(iota-e2e-tests): Rename data types

### DIFF
--- a/crates/iota-benchmark/src/lib.rs
+++ b/crates/iota-benchmark/src/lib.rs
@@ -355,7 +355,7 @@ impl ValidatorProxy for LocalValidatorAggregatorProxy {
             let ticket = self
                 .qd
                 .submit_transaction(
-                    iota_types::quorum_driver_types::ExecuteTransactionRequestV3 {
+                    iota_types::quorum_driver_types::ExecuteTransactionRequestV1 {
                         transaction: tx.clone(),
                         include_events: true,
                         include_input_objects: false,

--- a/crates/iota-core/src/quorum_driver/mod.rs
+++ b/crates/iota-core/src/quorum_driver/mod.rs
@@ -28,7 +28,7 @@ use iota_types::{
     messages_grpc::HandleCertificateRequestV3,
     messages_safe_client::PlainTransactionInfoResponse,
     quorum_driver_types::{
-        ExecuteTransactionRequestV3, QuorumDriverEffectsQueueResult, QuorumDriverError,
+        ExecuteTransactionRequestV1, QuorumDriverEffectsQueueResult, QuorumDriverError,
         QuorumDriverResponse, QuorumDriverResult,
     },
     transaction::{CertifiedTransaction, Transaction},
@@ -62,7 +62,7 @@ const TX_MAX_RETRY_TIMES: u32 = 10;
 
 #[derive(Clone)]
 pub struct QuorumDriverTask {
-    pub request: ExecuteTransactionRequestV3,
+    pub request: ExecuteTransactionRequestV1,
     pub tx_cert: Option<CertifiedTransaction>,
     pub retry_times: u32,
     pub next_retry_after: Instant,
@@ -148,7 +148,7 @@ impl<A: Clone> QuorumDriver<A> {
     /// If it has, notify failure.
     async fn enqueue_again_maybe(
         &self,
-        request: ExecuteTransactionRequestV3,
+        request: ExecuteTransactionRequestV1,
         tx_cert: Option<CertifiedTransaction>,
         old_retry_times: u32,
         client_addr: Option<SocketAddr>,
@@ -176,7 +176,7 @@ impl<A: Clone> QuorumDriver<A> {
     /// backoff duration will be at least `min_backoff_duration`.
     async fn backoff_and_enqueue(
         &self,
-        request: ExecuteTransactionRequestV3,
+        request: ExecuteTransactionRequestV1,
         tx_cert: Option<CertifiedTransaction>,
         old_retry_times: u32,
         client_addr: Option<SocketAddr>,
@@ -252,7 +252,7 @@ where
     #[instrument(level = "trace", skip_all)]
     pub async fn submit_transaction(
         &self,
-        request: ExecuteTransactionRequestV3,
+        request: ExecuteTransactionRequestV1,
     ) -> IotaResult<Registration<TransactionDigest, QuorumDriverResult>> {
         let tx_digest = request.transaction.digest();
         debug!(?tx_digest, "Received transaction execution request.");
@@ -277,7 +277,7 @@ where
     #[instrument(level = "trace", skip_all)]
     pub async fn submit_transaction_no_ticket(
         &self,
-        request: ExecuteTransactionRequestV3,
+        request: ExecuteTransactionRequestV1,
         client_addr: Option<SocketAddr>,
     ) -> IotaResult<()> {
         let tx_digest = request.transaction.digest();
@@ -691,7 +691,7 @@ where
     // TransactionOrchestrator
     pub async fn submit_transaction_no_ticket(
         &self,
-        request: ExecuteTransactionRequestV3,
+        request: ExecuteTransactionRequestV1,
         client_addr: Option<SocketAddr>,
     ) -> IotaResult<()> {
         self.quorum_driver
@@ -701,7 +701,7 @@ where
 
     pub async fn submit_transaction(
         &self,
-        request: ExecuteTransactionRequestV3,
+        request: ExecuteTransactionRequestV1,
     ) -> IotaResult<Registration<TransactionDigest, QuorumDriverResult>> {
         self.quorum_driver.submit_transaction(request).await
     }
@@ -891,7 +891,7 @@ where
 
     fn handle_error(
         quorum_driver: Arc<QuorumDriver<A>>,
-        request: ExecuteTransactionRequestV3,
+        request: ExecuteTransactionRequestV1,
         err: Option<QuorumDriverError>,
         tx_cert: Option<CertifiedTransaction>,
         old_retry_times: u32,

--- a/crates/iota-core/src/quorum_driver/tests.rs
+++ b/crates/iota-core/src/quorum_driver/tests.rs
@@ -19,7 +19,7 @@ use iota_types::{
     effects::TransactionEffectsAPI,
     object::{Object, generate_test_gas_objects},
     quorum_driver_types::{
-        ExecuteTransactionRequestV3, QuorumDriverError, QuorumDriverResponse, QuorumDriverResult,
+        ExecuteTransactionRequestV1, QuorumDriverError, QuorumDriverResponse, QuorumDriverResult,
     },
     transaction::Transaction,
 };
@@ -96,7 +96,7 @@ async fn test_quorum_driver_submit_transaction() {
         assert_eq!(*effects_cert.data().transaction_digest(), digest);
     });
     let ticket = quorum_driver_handler
-        .submit_transaction(ExecuteTransactionRequestV3::new_v2(tx))
+        .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx))
         .await
         .unwrap();
     verify_ticket_response(ticket, &digest).await;
@@ -130,7 +130,7 @@ async fn test_quorum_driver_submit_transaction_no_ticket() {
     });
     quorum_driver_handler
         .submit_transaction_no_ticket(
-            ExecuteTransactionRequestV3::new_v2(tx),
+            ExecuteTransactionRequestV1::new_v2(tx),
             Some(SocketAddr::new([127, 0, 0, 1].into(), 0)),
         )
         .await
@@ -175,7 +175,7 @@ async fn test_quorum_driver_with_given_notify_read() {
     });
     let ticket1 = notifier.register_one(&digest);
     let ticket2 = quorum_driver_handler
-        .submit_transaction(ExecuteTransactionRequestV3::new_v2(tx))
+        .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx))
         .await
         .unwrap();
     verify_ticket_response(ticket1, &digest).await;
@@ -212,7 +212,7 @@ async fn test_quorum_driver_update_validators_and_max_retry_times() {
         // This error should not happen in practice for benign validators and a working
         // client
         let ticket = quorum_driver
-            .submit_transaction(ExecuteTransactionRequestV3::new_v2(tx))
+            .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx))
             .await
             .unwrap();
         // We have a timeout here to make the test fail fast if fails
@@ -305,7 +305,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
 
     let tx2 = make_tx(&gas, sender, &keypair, rgp);
     let res = quorum_driver
-        .submit_transaction(ExecuteTransactionRequestV3::new_v2(tx2))
+        .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx2))
         .await
         .unwrap()
         .await;
@@ -357,7 +357,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
     let tx2 = make_tx(&gas, sender, &keypair, rgp);
 
     let res = quorum_driver
-        .submit_transaction(ExecuteTransactionRequestV3::new_v2(tx2))
+        .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx2))
         .await
         .unwrap()
         .await;
@@ -393,7 +393,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
     let tx2_digest = *tx2.digest();
 
     let res = quorum_driver
-        .submit_transaction(ExecuteTransactionRequestV3::new_v2(tx2))
+        .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx2))
         .await
         .unwrap()
         .await
@@ -432,7 +432,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
     let tx3 = make_tx(&gas, sender, &keypair, rgp);
 
     let res = quorum_driver
-        .submit_transaction(ExecuteTransactionRequestV3::new_v2(tx3))
+        .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx3))
         .await
         .unwrap()
         .await;
@@ -481,7 +481,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
             .is_ok()
     );
     let res = quorum_driver
-        .submit_transaction(ExecuteTransactionRequestV3::new_v2(tx2))
+        .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx2))
         .await
         .unwrap()
         .await;
@@ -531,7 +531,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
     );
 
     let res = quorum_driver
-        .submit_transaction(ExecuteTransactionRequestV3::new_v2(tx))
+        .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx))
         .await
         .unwrap()
         .await
@@ -566,7 +566,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
 
     let tx4 = make_tx(&gas, sender, &keypair, rgp);
     let res = quorum_driver
-        .submit_transaction(ExecuteTransactionRequestV3::new_v2(tx4.clone()))
+        .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx4.clone()))
         .await
         .unwrap()
         .await;
@@ -657,7 +657,7 @@ async fn test_quorum_driver_handling_overload_and_retry() {
     // Submit the transaction, and check that it shouldn't return, and the number of
     // retries is within 300s timeout / 30s retry after duration = 10 times.
     let ticket = quorum_driver_handler
-        .submit_transaction(ExecuteTransactionRequestV3::new_v2(tx))
+        .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx))
         .await
         .unwrap();
     match timeout(Duration::from_secs(300), ticket).await {

--- a/crates/iota-core/src/quorum_driver/tests.rs
+++ b/crates/iota-core/src/quorum_driver/tests.rs
@@ -96,7 +96,7 @@ async fn test_quorum_driver_submit_transaction() {
         assert_eq!(*effects_cert.data().transaction_digest(), digest);
     });
     let ticket = quorum_driver_handler
-        .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx))
+        .submit_transaction(ExecuteTransactionRequestV1::new_v1(tx))
         .await
         .unwrap();
     verify_ticket_response(ticket, &digest).await;
@@ -130,7 +130,7 @@ async fn test_quorum_driver_submit_transaction_no_ticket() {
     });
     quorum_driver_handler
         .submit_transaction_no_ticket(
-            ExecuteTransactionRequestV1::new_v2(tx),
+            ExecuteTransactionRequestV1::new_v1(tx),
             Some(SocketAddr::new([127, 0, 0, 1].into(), 0)),
         )
         .await
@@ -175,7 +175,7 @@ async fn test_quorum_driver_with_given_notify_read() {
     });
     let ticket1 = notifier.register_one(&digest);
     let ticket2 = quorum_driver_handler
-        .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx))
+        .submit_transaction(ExecuteTransactionRequestV1::new_v1(tx))
         .await
         .unwrap();
     verify_ticket_response(ticket1, &digest).await;
@@ -212,7 +212,7 @@ async fn test_quorum_driver_update_validators_and_max_retry_times() {
         // This error should not happen in practice for benign validators and a working
         // client
         let ticket = quorum_driver
-            .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx))
+            .submit_transaction(ExecuteTransactionRequestV1::new_v1(tx))
             .await
             .unwrap();
         // We have a timeout here to make the test fail fast if fails
@@ -305,7 +305,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
 
     let tx2 = make_tx(&gas, sender, &keypair, rgp);
     let res = quorum_driver
-        .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx2))
+        .submit_transaction(ExecuteTransactionRequestV1::new_v1(tx2))
         .await
         .unwrap()
         .await;
@@ -357,7 +357,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
     let tx2 = make_tx(&gas, sender, &keypair, rgp);
 
     let res = quorum_driver
-        .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx2))
+        .submit_transaction(ExecuteTransactionRequestV1::new_v1(tx2))
         .await
         .unwrap()
         .await;
@@ -393,7 +393,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
     let tx2_digest = *tx2.digest();
 
     let res = quorum_driver
-        .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx2))
+        .submit_transaction(ExecuteTransactionRequestV1::new_v1(tx2))
         .await
         .unwrap()
         .await
@@ -432,7 +432,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
     let tx3 = make_tx(&gas, sender, &keypair, rgp);
 
     let res = quorum_driver
-        .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx3))
+        .submit_transaction(ExecuteTransactionRequestV1::new_v1(tx3))
         .await
         .unwrap()
         .await;
@@ -481,7 +481,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
             .is_ok()
     );
     let res = quorum_driver
-        .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx2))
+        .submit_transaction(ExecuteTransactionRequestV1::new_v1(tx2))
         .await
         .unwrap()
         .await;
@@ -531,7 +531,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
     );
 
     let res = quorum_driver
-        .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx))
+        .submit_transaction(ExecuteTransactionRequestV1::new_v1(tx))
         .await
         .unwrap()
         .await
@@ -566,7 +566,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
 
     let tx4 = make_tx(&gas, sender, &keypair, rgp);
     let res = quorum_driver
-        .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx4.clone()))
+        .submit_transaction(ExecuteTransactionRequestV1::new_v1(tx4.clone()))
         .await
         .unwrap()
         .await;
@@ -657,7 +657,7 @@ async fn test_quorum_driver_handling_overload_and_retry() {
     // Submit the transaction, and check that it shouldn't return, and the number of
     // retries is within 300s timeout / 30s retry after duration = 10 times.
     let ticket = quorum_driver_handler
-        .submit_transaction(ExecuteTransactionRequestV1::new_v2(tx))
+        .submit_transaction(ExecuteTransactionRequestV1::new_v1(tx))
         .await
         .unwrap();
     match timeout(Duration::from_secs(300), ticket).await {

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -26,7 +26,7 @@ use iota_types::{
     executable_transaction::VerifiedExecutableTransaction,
     iota_system_state::IotaSystemState,
     quorum_driver_types::{
-        ExecuteTransactionRequestType, ExecuteTransactionRequestV3, ExecuteTransactionResponseV3,
+        ExecuteTransactionRequestType, ExecuteTransactionRequestV1, ExecuteTransactionResponseV1,
         FinalizedEffects, IsTransactionExecutedLocally, QuorumDriverEffectsQueueResult,
         QuorumDriverError, QuorumDriverResponse, QuorumDriverResult,
     },
@@ -158,10 +158,10 @@ where
     err)]
     pub async fn execute_transaction_block(
         &self,
-        request: ExecuteTransactionRequestV3,
+        request: ExecuteTransactionRequestV1,
         request_type: ExecuteTransactionRequestType,
         client_addr: Option<SocketAddr>,
-    ) -> Result<(ExecuteTransactionResponseV3, IsTransactionExecutedLocally), QuorumDriverError>
+    ) -> Result<(ExecuteTransactionResponseV1, IsTransactionExecutedLocally), QuorumDriverError>
     {
         let epoch_store = self.validator_state.load_epoch_store_one_call_per_task();
 
@@ -200,7 +200,7 @@ where
             auxiliary_data,
         } = response;
 
-        let response = ExecuteTransactionResponseV3 {
+        let response = ExecuteTransactionResponseV1 {
             effects: FinalizedEffects::new_from_effects_cert(effects_cert.into()),
             events,
             input_objects,
@@ -213,13 +213,13 @@ where
 
     // Utilize the handle_certificate_v3 validator api to request input/output
     // objects
-    #[instrument(name = "tx_orchestrator_execute_transaction_v3", level = "trace", skip_all,
+    #[instrument(name = "tx_orchestrator_execute_transaction_v1", level = "trace", skip_all,
                  fields(tx_digest = ?request.transaction.digest()))]
-    pub async fn execute_transaction_v3(
+    pub async fn execute_transaction_v1(
         &self,
-        request: ExecuteTransactionRequestV3,
+        request: ExecuteTransactionRequestV1,
         client_addr: Option<SocketAddr>,
-    ) -> Result<ExecuteTransactionResponseV3, QuorumDriverError> {
+    ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError> {
         let epoch_store = self.validator_state.load_epoch_store_one_call_per_task();
 
         let QuorumDriverResponse {
@@ -233,7 +233,7 @@ where
             .await
             .map(|(_, r)| r)?;
 
-        Ok(ExecuteTransactionResponseV3 {
+        Ok(ExecuteTransactionResponseV1 {
             effects: FinalizedEffects::new_from_effects_cert(effects_cert.into()),
             events,
             input_objects,
@@ -248,7 +248,7 @@ where
     pub async fn execute_transaction_impl(
         &self,
         epoch_store: &AuthorityPerEpochStore,
-        request: ExecuteTransactionRequestV3,
+        request: ExecuteTransactionRequestV1,
         client_addr: Option<SocketAddr>,
     ) -> Result<(VerifiedTransaction, QuorumDriverResponse), QuorumDriverError> {
         let transaction = epoch_store
@@ -319,7 +319,7 @@ where
     async fn submit(
         &self,
         transaction: VerifiedTransaction,
-        request: ExecuteTransactionRequestV3,
+        request: ExecuteTransactionRequestV1,
         client_addr: Option<SocketAddr>,
     ) -> IotaResult<impl Future<Output = IotaResult<QuorumDriverResult>> + '_> {
         let tx_digest = *transaction.digest();
@@ -536,7 +536,7 @@ where
                 // world. TODO(william) correctly extract client_addr from logs
                 if let Err(err) = quorum_driver
                     .submit_transaction_no_ticket(
-                        ExecuteTransactionRequestV3 {
+                        ExecuteTransactionRequestV1 {
                             transaction: tx,
                             include_events: true,
                             include_input_objects: false,
@@ -735,9 +735,9 @@ where
 {
     async fn execute_transaction(
         &self,
-        request: ExecuteTransactionRequestV3,
+        request: ExecuteTransactionRequestV1,
         client_addr: Option<std::net::SocketAddr>,
-    ) -> Result<ExecuteTransactionResponseV3, QuorumDriverError> {
-        self.execute_transaction_v3(request, client_addr).await
+    ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError> {
+        self.execute_transaction_v1(request, client_addr).await
     }
 }

--- a/crates/iota-e2e-tests/tests/full_node_tests.rs
+++ b/crates/iota-e2e-tests/tests/full_node_tests.rs
@@ -749,7 +749,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let digest = *txn.digest();
     let res = transaction_orchestrator
         .execute_transaction_block(
-            ExecuteTransactionRequestV1::new_v2(txn),
+            ExecuteTransactionRequestV1::new_v1(txn),
             ExecuteTransactionRequestType::WaitForLocalExecution,
             None,
         )
@@ -784,7 +784,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let digest = *txn.digest();
     let res = transaction_orchestrator
         .execute_transaction_block(
-            ExecuteTransactionRequestV1::new_v2(txn),
+            ExecuteTransactionRequestV1::new_v1(txn),
             ExecuteTransactionRequestType::WaitForEffectsCert,
             None,
         )
@@ -1194,7 +1194,7 @@ async fn test_pass_back_no_object() -> Result<(), anyhow::Error> {
     let digest = *tx.digest();
     let _res = transaction_orchestrator
         .execute_transaction_block(
-            ExecuteTransactionRequestV1::new_v2(tx),
+            ExecuteTransactionRequestV1::new_v1(tx),
             ExecuteTransactionRequestType::WaitForLocalExecution,
             None,
         )

--- a/crates/iota-e2e-tests/tests/full_node_tests.rs
+++ b/crates/iota-e2e-tests/tests/full_node_tests.rs
@@ -33,7 +33,7 @@ use iota_types::{
     object::{Object, ObjectRead, Owner, PastObjectRead},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     quorum_driver_types::{
-        ExecuteTransactionRequestType, ExecuteTransactionRequestV3, QuorumDriverResponse,
+        ExecuteTransactionRequestType, ExecuteTransactionRequestV1, QuorumDriverResponse,
     },
     storage::ObjectStore,
     transaction::{
@@ -749,7 +749,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let digest = *txn.digest();
     let res = transaction_orchestrator
         .execute_transaction_block(
-            ExecuteTransactionRequestV3::new_v2(txn),
+            ExecuteTransactionRequestV1::new_v2(txn),
             ExecuteTransactionRequestType::WaitForLocalExecution,
             None,
         )
@@ -784,7 +784,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let digest = *txn.digest();
     let res = transaction_orchestrator
         .execute_transaction_block(
-            ExecuteTransactionRequestV3::new_v2(txn),
+            ExecuteTransactionRequestV1::new_v2(txn),
             ExecuteTransactionRequestType::WaitForEffectsCert,
             None,
         )
@@ -1194,7 +1194,7 @@ async fn test_pass_back_no_object() -> Result<(), anyhow::Error> {
     let digest = *tx.digest();
     let _res = transaction_orchestrator
         .execute_transaction_block(
-            ExecuteTransactionRequestV3::new_v2(tx),
+            ExecuteTransactionRequestV1::new_v2(tx),
             ExecuteTransactionRequestType::WaitForLocalExecution,
             None,
         )

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -51,7 +51,7 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     orchestrator
         .quorum_driver()
         .submit_transaction_no_ticket(
-            ExecuteTransactionRequestV1::new_v2(txn),
+            ExecuteTransactionRequestV1::new_v1(txn),
             Some(make_socket_addr()),
         )
         .await?;
@@ -256,7 +256,7 @@ async fn test_tx_across_epoch_boundaries() {
     tokio::task::spawn(async move {
         match to
             .execute_transaction_block(
-                ExecuteTransactionRequestV1::new_v2(tx.clone()),
+                ExecuteTransactionRequestV1::new_v1(tx.clone()),
                 ExecuteTransactionRequestType::WaitForEffectsCert,
                 None,
             )
@@ -299,7 +299,7 @@ async fn execute_with_orchestrator(
     request_type: ExecuteTransactionRequestType,
 ) -> Result<(ExecuteTransactionResponseV1, IsTransactionExecutedLocally), QuorumDriverError> {
     orchestrator
-        .execute_transaction_block(ExecuteTransactionRequestV1::new_v2(txn), request_type, None)
+        .execute_transaction_block(ExecuteTransactionRequestV1::new_v1(txn), request_type, None)
         .await
 }
 

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -17,7 +17,7 @@ use iota_test_transaction_builder::{
 use iota_types::{
     effects::TransactionEffectsAPI,
     quorum_driver_types::{
-        ExecuteTransactionRequestType, ExecuteTransactionRequestV3, ExecuteTransactionResponseV3,
+        ExecuteTransactionRequestType, ExecuteTransactionRequestV1, ExecuteTransactionResponseV1,
         FinalizedEffects, IsTransactionExecutedLocally, QuorumDriverError,
     },
     transaction::Transaction,
@@ -51,7 +51,7 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     orchestrator
         .quorum_driver()
         .submit_transaction_no_ticket(
-            ExecuteTransactionRequestV3::new_v2(txn),
+            ExecuteTransactionRequestV1::new_v2(txn),
             Some(make_socket_addr()),
         )
         .await?;
@@ -256,7 +256,7 @@ async fn test_tx_across_epoch_boundaries() {
     tokio::task::spawn(async move {
         match to
             .execute_transaction_block(
-                ExecuteTransactionRequestV3::new_v2(tx.clone()),
+                ExecuteTransactionRequestV1::new_v2(tx.clone()),
                 ExecuteTransactionRequestType::WaitForEffectsCert,
                 None,
             )
@@ -297,14 +297,14 @@ async fn execute_with_orchestrator(
     orchestrator: &TransactionOrchestrator<NetworkAuthorityClient>,
     txn: Transaction,
     request_type: ExecuteTransactionRequestType,
-) -> Result<(ExecuteTransactionResponseV3, IsTransactionExecutedLocally), QuorumDriverError> {
+) -> Result<(ExecuteTransactionResponseV1, IsTransactionExecutedLocally), QuorumDriverError> {
     orchestrator
-        .execute_transaction_block(ExecuteTransactionRequestV3::new_v2(txn), request_type, None)
+        .execute_transaction_block(ExecuteTransactionRequestV1::new_v2(txn), request_type, None)
         .await
 }
 
 #[sim_test]
-async fn execute_transaction_v3() -> Result<(), anyhow::Error> {
+async fn execute_transaction_v1() -> Result<(), anyhow::Error> {
     let mut test_cluster = TestClusterBuilder::new().build().await;
     let context = &mut test_cluster.wallet;
     let handle = &test_cluster.fullnode_handle.iota_node;
@@ -321,14 +321,14 @@ async fn execute_transaction_v3() -> Result<(), anyhow::Error> {
     // Quorum driver does not execute txn locally
     let txn = txns.swap_remove(0);
 
-    let request = ExecuteTransactionRequestV3 {
+    let request = ExecuteTransactionRequestV1 {
         transaction: txn,
         include_events: true,
         include_input_objects: true,
         include_output_objects: true,
         include_auxiliary_data: false,
     };
-    let response = orchestrator.execute_transaction_v3(request, None).await?;
+    let response = orchestrator.execute_transaction_v1(request, None).await?;
     let fx = &response.effects.effects;
 
     let mut expected_input_objects = fx.modified_at_versions();
@@ -362,7 +362,7 @@ async fn execute_transaction_v3() -> Result<(), anyhow::Error> {
 }
 
 #[sim_test]
-async fn execute_transaction_v3_staking_transaction() -> Result<(), anyhow::Error> {
+async fn execute_transaction_v1_staking_transaction() -> Result<(), anyhow::Error> {
     let mut test_cluster = TestClusterBuilder::new().build().await;
     let context = &mut test_cluster.wallet;
     let handle = &test_cluster.fullnode_handle.iota_node;
@@ -380,14 +380,14 @@ async fn execute_transaction_v3_staking_transaction() -> Result<(), anyhow::Erro
         .iota_address;
     let transaction = make_staking_transaction(context, validator_address).await;
 
-    let request = ExecuteTransactionRequestV3 {
+    let request = ExecuteTransactionRequestV1 {
         transaction,
         include_events: true,
         include_input_objects: true,
         include_output_objects: true,
         include_auxiliary_data: false,
     };
-    let response = orchestrator.execute_transaction_v3(request, None).await?;
+    let response = orchestrator.execute_transaction_v1(request, None).await?;
     let fx = &response.effects.effects;
 
     let mut expected_input_objects = fx.modified_at_versions();

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -24,7 +24,7 @@ use iota_types::{
     effects::TransactionEffectsAPI,
     iota_serde::BigInt,
     quorum_driver_types::{
-        ExecuteTransactionRequestType, ExecuteTransactionRequestV3, ExecuteTransactionResponseV3,
+        ExecuteTransactionRequestType, ExecuteTransactionRequestV1, ExecuteTransactionResponseV1,
     },
     signature::GenericSignature,
     storage::PostExecutionPackageResolver,
@@ -79,7 +79,7 @@ impl TransactionExecutionApi {
         opts: Option<IotaTransactionBlockResponseOptions>,
     ) -> Result<
         (
-            ExecuteTransactionRequestV3,
+            ExecuteTransactionRequestV1,
             IotaTransactionBlockResponseOptions,
             IotaAddress,
             Vec<InputObjectKind>,
@@ -116,7 +116,7 @@ impl TransactionExecutionApi {
             None
         };
 
-        let request = ExecuteTransactionRequestV3 {
+        let request = ExecuteTransactionRequestV1 {
             transaction: txn.clone(),
             include_events: opts.show_events,
             include_input_objects: opts.show_balance_changes || opts.show_object_changes,
@@ -175,7 +175,7 @@ impl TransactionExecutionApi {
 
     async fn handle_post_orchestration(
         &self,
-        response: ExecuteTransactionResponseV3,
+        response: ExecuteTransactionResponseV1,
         is_executed_locally: bool,
         opts: IotaTransactionBlockResponseOptions,
         digest: TransactionDigest,

--- a/crates/iota-rest-api/src/transactions/execution.rs
+++ b/crates/iota-rest-api/src/transactions/execution.rs
@@ -73,7 +73,7 @@ async fn execute_transaction(
     Bcs(transaction): Bcs<SignedTransaction>,
 ) -> Result<ResponseContent<TransactionExecutionResponse>> {
     let executor = state.ok_or_else(|| anyhow::anyhow!("No Transaction Executor"))?;
-    let request = iota_types::quorum_driver_types::ExecuteTransactionRequestV3 {
+    let request = iota_types::quorum_driver_types::ExecuteTransactionRequestV1 {
         transaction: transaction.into(),
         include_events: parameters.events,
         include_input_objects: parameters.input_objects || parameters.balance_changes,
@@ -81,7 +81,7 @@ async fn execute_transaction(
         include_auxiliary_data: false,
     };
 
-    let iota_types::quorum_driver_types::ExecuteTransactionResponseV3 {
+    let iota_types::quorum_driver_types::ExecuteTransactionResponseV1 {
         effects,
         events,
         input_objects,

--- a/crates/iota-types/src/quorum_driver_types.rs
+++ b/crates/iota-types/src/quorum_driver_types.rs
@@ -148,7 +148,7 @@ impl ExecuteTransactionRequest {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct ExecuteTransactionRequestV3 {
+pub struct ExecuteTransactionRequestV1 {
     pub transaction: Transaction,
 
     pub include_events: bool,
@@ -157,18 +157,7 @@ pub struct ExecuteTransactionRequestV3 {
     pub include_auxiliary_data: bool,
 }
 
-#[derive(Clone, Debug)]
-pub struct VerifiedExecuteTransactionResponseV3 {
-    pub effects: VerifiedCertifiedTransactionEffects,
-    pub events: Option<TransactionEvents>,
-    // Input objects will only be populated in the happy path
-    pub input_objects: Option<Vec<Object>>,
-    // Output objects will only be populated in the happy path
-    pub output_objects: Option<Vec<Object>>,
-    pub auxiliary_data: Option<Vec<u8>>,
-}
-
-impl ExecuteTransactionRequestV3 {
+impl ExecuteTransactionRequestV1 {
     pub fn new_v2<T: Into<Transaction>>(transaction: T) -> Self {
         Self {
             transaction: transaction.into(),
@@ -181,7 +170,7 @@ impl ExecuteTransactionRequestV3 {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct ExecuteTransactionResponseV3 {
+pub struct ExecuteTransactionResponseV1 {
     pub effects: FinalizedEffects,
 
     pub events: Option<TransactionEvents>,

--- a/crates/iota-types/src/quorum_driver_types.rs
+++ b/crates/iota-types/src/quorum_driver_types.rs
@@ -158,7 +158,7 @@ pub struct ExecuteTransactionRequestV1 {
 }
 
 impl ExecuteTransactionRequestV1 {
-    pub fn new_v2<T: Into<Transaction>>(transaction: T) -> Self {
+    pub fn new_v1<T: Into<Transaction>>(transaction: T) -> Self {
         Self {
             transaction: transaction.into(),
             include_events: true,

--- a/crates/iota-types/src/transaction_executor.rs
+++ b/crates/iota-types/src/transaction_executor.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::quorum_driver_types::{
-    ExecuteTransactionRequestV3, ExecuteTransactionResponseV3, QuorumDriverError,
+    ExecuteTransactionRequestV1, ExecuteTransactionResponseV1, QuorumDriverError,
 };
 
 /// Trait to define the interface for how the REST service interacts with a a
@@ -12,7 +12,7 @@ use crate::quorum_driver_types::{
 pub trait TransactionExecutor: Send + Sync {
     async fn execute_transaction(
         &self,
-        request: ExecuteTransactionRequestV3,
+        request: ExecuteTransactionRequestV1,
         client_addr: Option<std::net::SocketAddr>,
-    ) -> Result<ExecuteTransactionResponseV3, QuorumDriverError>;
+    ) -> Result<ExecuteTransactionResponseV1, QuorumDriverError>;
 }


### PR DESCRIPTION
# Description of change

- [x] execute_transaction_v3 -> execute_transaction_v1
  - Note: there are no other `execute_transaction_v*` functions
- [x] ExecuteTransactionRequestV3 -> ExecuteTransactionRequestV1
  - Note: there are no other `ExecuteTransactionRequestV*` structs
- [x] ExecuteTransactionResponseV3 -> ExecuteTransactionResponseV1
  - Note: there are no other `ExecuteTransactionResponseV*` structs
- [x] Remove whole VerifiedExecuteTransactionResponseV3
  - Not used at all

## Links to any relevant issues

Closes #2145

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

- I was running the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
