### PR TITLE
fix(indexer-analytics): Adjust indexer-analytics compose configuration

### DIFF
--- a/crates/iota-indexer/src/lib.rs
+++ b/crates/iota-indexer/src/lib.rs
@@ -141,7 +141,7 @@ impl Default for IndexerConfig {
     fn default() -> Self {
         Self {
             db_url: Some(secrecy::Secret::new(
-                "postgres://postgres:postgres@localhost:5432/iota_indexer".to_string(),
+                "postgres://postgres:postgrespw@localhost:5432/iota_indexer".to_string(),
             )),
             db_user_name: None,
             db_password: None,

--- a/docker/pg-services-local/docker-compose.yaml
+++ b/docker/pg-services-local/docker-compose.yaml
@@ -102,9 +102,10 @@ services:
       - RUST_BACKTRACE=1
       - RUST_LOG=info
       - RPC_WORKER_THREAD=12
+      - ADDRESS_PROCESSOR_BATCH_SIZE=500
     command:
       - /usr/local/bin/iota-indexer
-      - --db-url=postgres://iota_indexer:iota_indexer@postgres:5432/iota_indexer
+      - --db-url=postgres://postgres:postgrespw@postgres:5432/iota_indexer
       - --rpc-client-url=http://local-network:9000
       - --client-metric-port=9181
       - --analytical-worker


### PR DESCRIPTION
# Description of change

This PR fixes the compose configuration for the `indexer-analytics` consisting of following issues:

1) after the rebase, an invalid DB URL was passed to the docker compose configuration for the indexer-analytics service, so the worker could not connect to the indexer database
2) corrects the default DB URL for the `IndexerConfig` and sets it to 
`postgres://postgres:postgrespw@postgres:5432/iota_indexer`
which in general is used as default for other services
3) reduces the `ADDRESS_PROCESSOR_BATCH_SIZE` to `500`.

The `ADDRESS_PROCESSOR_BATCH_SIZE` specifies the number of transactions to be processed in each batch. It is used as a threshold to determine when the processor should start processing a new batch of transactions for the address metric.
Reducing it to `500` ensures that the address API calls work relatively quickly once the services have been set up, however but also makes sure that the processor is not called too often. This value should be eventually adjusted if network conditions change (e.g. more transactions).

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/3180

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

```
docker-compose up --force-recreate -d indexer-analytics
docker compose up -d
```

### Sample API request

```bash
$ curl -sX POST http://localhost:9005 -H "Content-Type: application/json" -H "Client-Sdk-Type: typescript" -H "Client-Sdk-Version: 0.2.0" -H "Client-Target-Api-Version: 0.2.0" -d '{"jsonrpc":"2.0","id":1,"method":"iotax_getLatestAddressMetrics","params":[]}' | jq .
```

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "checkpoint": 4146,
    "epoch": 7,
    "timestampMs": 1729003889883,
    "cumulativeAddresses": 412,
    "cumulativeActiveAddresses": 1,
    "dailyActiveAddresses": 1
  }
}
```
## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
