### PR TITLE
fix(iota-source-validation-service): test_api_route works again

### DIFF
--- a/crates/iota-source-validation-service/src/main.rs
+++ b/crates/iota-source-validation-service/src/main.rs
@@ -34,7 +34,7 @@ pub async fn main() -> anyhow::Result<()> {
     let (sources, sources_list) = initialize(&package_config, tmp_dir.path()).await?;
     info!("verification complete in {:?}", start.elapsed());
 
-    let metrics_listener = tokio::net::TcpListener::bind(METRICS_HOST_PORT).await?;
+    let metrics_listener = std::net::TcpListener::bind(METRICS_HOST_PORT)?;
     let registry_service = start_prometheus_server(metrics_listener);
     let prometheus_registry = registry_service.default_registry();
     let metrics = SourceServiceMetrics::new(&prometheus_registry);

--- a/crates/iota-source-validation-service/tests/tests.rs
+++ b/crates/iota-source-validation-service/tests/tests.rs
@@ -308,7 +308,7 @@ async fn test_api_route() -> anyhow::Result<()> {
         sources_list,
     }));
 
-    serve(app_state).await.expect("Cannot start service");
+    tokio::spawn(async move { serve(app_state).await.expect("Cannot start service.") });
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let client = Client::new();
@@ -362,7 +362,7 @@ async fn test_api_route() -> anyhow::Result<()> {
 #[tokio::test]
 async fn test_metrics_route() -> anyhow::Result<()> {
     // Start metrics server
-    let metrics_listener = tokio::net::TcpListener::bind(METRICS_HOST_PORT).await?;
+    let metrics_listener = std::net::TcpListener::bind(METRICS_HOST_PORT)?;
     let registry_service = start_prometheus_server(metrics_listener);
     let prometheus_registry = registry_service.default_registry();
     SourceServiceMetrics::new(&prometheus_registry);


### PR DESCRIPTION
# Description of change

Solve some hiccups created during the merge.
`iota-source-validation-service::tests test_api_route` works again and doesn't block the CI with long runs.

## Links to any relevant issues

https://github.com/iotaledger/iota/issues/3319

## Type of change

- Bug fix (a non-breaking change which fixes an issue)


