### PR TITLE
chore(tests): disable zklogin tests

### DIFF
--- a/crates/iota-core/src/unit_tests/transaction_deny_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_deny_tests.rs
@@ -191,6 +191,7 @@ async fn test_user_transaction_disabled() {
 }
 
 #[tokio::test]
+#[ignore = "https://github.com/iotaledger/iota/issues/1777"]
 async fn test_zklogin_transaction_disabled() {
     let (_, state) = setup_test(
         TransactionDenyConfigBuilder::new()

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -511,6 +511,7 @@ async fn do_transaction_test_impl(
 }
 
 #[sim_test]
+#[ignore = "https://github.com/iotaledger/iota/issues/1777"]
 async fn test_zklogin_transfer_with_bad_ephemeral_sig() {
     do_zklogin_transaction_test(
         1,
@@ -533,6 +534,7 @@ async fn test_zklogin_transfer_with_bad_ephemeral_sig() {
 }
 
 #[sim_test]
+#[ignore = "https://github.com/iotaledger/iota/issues/1777"]
 async fn test_zklogin_transfer_with_large_address_seed() {
     telemetry_subscribers::init_for_testing();
     let (
@@ -577,7 +579,8 @@ async fn test_zklogin_transfer_with_large_address_seed() {
 }
 
 #[sim_test]
-async fn zklogin_test_caching_scenarios() {
+#[ignore = "https://github.com/iotaledger/iota/issues/1777"]
+async fn test_zklogin_caching_scenarios() {
     telemetry_subscribers::init_for_testing();
     let (
         object_ids,
@@ -1170,7 +1173,8 @@ fn make_socket_addr() -> std::net::SocketAddr {
 }
 
 #[tokio::test]
-async fn zklogin_txn_fail_if_missing_jwk() {
+#[ignore = "https://github.com/iotaledger/iota/issues/1777"]
+async fn test_zklogin_txn_fail_if_missing_jwk() {
     telemetry_subscribers::init_for_testing();
 
     // Initialize an authorty state with some objects under a zklogin address.
@@ -1244,7 +1248,8 @@ async fn zklogin_txn_fail_if_missing_jwk() {
 }
 
 #[tokio::test]
-async fn zk_multisig_test() {
+#[ignore = "https://github.com/iotaledger/iota/issues/1777"]
+async fn test_zklogin_multisig() {
     telemetry_subscribers::init_for_testing();
 
     // User generate a multisig account with no zklogin signer.

--- a/crates/iota-e2e-tests/tests/multisig_tests.rs
+++ b/crates/iota-e2e-tests/tests/multisig_tests.rs
@@ -705,6 +705,7 @@ async fn test_expired_epoch_zklogin_in_multisig() {
 }
 
 #[sim_test]
+#[ignore = "https://github.com/iotaledger/iota/issues/1777"]
 async fn test_max_epoch_too_large_fail_zklogin_in_multisig() {
     use iota_protocol_config::ProtocolConfig;
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {

--- a/crates/iota-e2e-tests/tests/zklogin_tests.rs
+++ b/crates/iota-e2e-tests/tests/zklogin_tests.rs
@@ -105,7 +105,7 @@ async fn test_zklogin_feature_legacy_address_deny() {
 
 #[sim_test]
 #[ignore = "https://github.com/iotaledger/iota/issues/1777"]
-async fn test_legacy_zklogin_address_accept() {
+async fn test_zklogin_legacy_address_accept() {
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_verify_legacy_zklogin_address_for_testing(true);
         config
@@ -120,7 +120,7 @@ async fn test_legacy_zklogin_address_accept() {
 
 #[sim_test]
 #[ignore = "https://github.com/iotaledger/iota/issues/1777"]
-async fn zklogin_end_to_end_test() {
+async fn test_zklogin_end_to_end() {
     let test_cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(15000)
         .with_default_jwks()
@@ -144,7 +144,8 @@ async fn zklogin_end_to_end_test() {
 }
 
 #[sim_test]
-async fn test_max_epoch_too_large_fail_tx() {
+#[ignore = "https://github.com/iotaledger/iota/issues/1777"]
+async fn test_zklogin_max_epoch_too_large_fail_tx() {
     use iota_protocol_config::ProtocolConfig;
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_zklogin_max_epoch_upper_bound_delta_for_testing(Some(1));
@@ -171,7 +172,7 @@ async fn test_max_epoch_too_large_fail_tx() {
 
 #[sim_test]
 #[ignore = "https://github.com/iotaledger/iota/issues/1777"]
-async fn test_expired_zklogin_sig() {
+async fn test_zklogin_expired_zklogin_sig() {
     let test_cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(15000)
         .with_default_jwks()
@@ -223,7 +224,7 @@ async fn test_expired_zklogin_sig() {
 
 #[sim_test]
 #[ignore = "https://github.com/iotaledger/iota/issues/1777"]
-async fn test_auth_state_creation() {
+async fn test_zklogin_auth_state_creation() {
     // Create test cluster without auth state object in genesis
     let test_cluster = TestClusterBuilder::new()
         .with_protocol_version(23.into())
@@ -241,7 +242,7 @@ async fn test_auth_state_creation() {
 
 #[sim_test]
 #[ignore = "https://github.com/iotaledger/iota/issues/1777"]
-async fn test_create_authenticator_state_object() {
+async fn test_zklogin_create_authenticator_state_object() {
     let test_cluster = TestClusterBuilder::new()
         .with_protocol_version(23.into())
         .with_epoch_duration_ms(15000)
@@ -285,7 +286,7 @@ async fn test_create_authenticator_state_object() {
 #[cfg(msim)]
 #[sim_test]
 #[ignore = "https://github.com/iotaledger/iota/issues/1777"]
-async fn test_conflicting_jwks() {
+async fn test_zklogin_conflicting_jwks() {
     use std::{
         collections::HashSet,
         sync::{Arc, Mutex},

--- a/crates/iota-types/src/unit_tests/multisig_tests.rs
+++ b/crates/iota-types/src/unit_tests/multisig_tests.rs
@@ -336,7 +336,8 @@ fn multisig_get_indices() {
 }
 
 #[test]
-fn multisig_zklogin_scenarios() {
+#[ignore = "https://github.com/iotaledger/iota/issues/1777"]
+fn test_multisig_zklogin_scenarios() {
     // consistency test with
     // iota/sdk/typescript/test/unit/cryptography/multisig.test.ts
     let mut seed = StdRng::from_seed([0; 32]);
@@ -381,7 +382,8 @@ fn multisig_zklogin_scenarios() {
 }
 
 #[test]
-fn zklogin_in_multisig_works_with_both_addresses() {
+#[ignore = "https://github.com/iotaledger/iota/issues/1777"]
+fn test_zklogin_in_multisig_works_with_both_addresses() {
     let mut seed = StdRng::from_seed([0; 32]);
     let kp: Ed25519KeyPair = get_key_pair_from_rng(&mut seed).1;
     let ikp: IotaKeyPair = IotaKeyPair::Ed25519(kp);
@@ -480,7 +482,8 @@ fn zklogin_in_multisig_works_with_both_addresses() {
 }
 
 #[test]
-fn test_derive_multisig_address() {
+#[ignore = "https://github.com/iotaledger/iota/issues/1777"]
+fn test_zklogin_derive_multisig_address() {
     // consistency test with typescript:
     // /sdk/typescript/test/unit/cryptography/multisig.test.ts
     let pk1 = PublicKey::ZkLogin(

--- a/crates/iota-types/src/unit_tests/zk_login_authenticator_test.rs
+++ b/crates/iota-types/src/unit_tests/zk_login_authenticator_test.rs
@@ -28,7 +28,8 @@ use crate::{
 };
 
 #[test]
-fn test_serde_zk_login_signature() {
+#[ignore = "https://github.com/iotaledger/iota/issues/1777"]
+fn test_serde_zklogin_signature() {
     // consistency test with typescript:
     // sdk/typescript/test/unit/zklogin/signature.test.ts
     use fastcrypto::encoding::Encoding;
@@ -43,7 +44,8 @@ fn test_serde_zk_login_signature() {
 }
 
 #[test]
-fn test_serde_zk_public_identifier() {
+#[ignore = "https://github.com/iotaledger/iota/issues/1777"]
+fn test_serde_zklogin_public_identifier() {
     let (_, _, inputs) =
         &load_test_vectors("./src/unit_tests/zklogin_test_vectors.json").unwrap()[0];
     let modified_inputs =
@@ -95,7 +97,8 @@ fn test_serde_zk_public_identifier() {
 }
 
 #[test]
-fn zklogin_sign_personal_message() {
+#[ignore = "https://github.com/iotaledger/iota/issues/1777"]
+fn test_zklogin_sign_personal_message() {
     let data = PersonalMessage {
         message: b"hello world".to_vec(),
     };


### PR DESCRIPTION
# Description of change

This PR disables all tests that involve zklogin for now, because we disabled the feature in the protocol.

## Links to any relevant issues

#1777 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Not tested, it only disables broken tests.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
