### PR TITLE
chore(tests): disable bridge tests

### DIFF
--- a/crates/iota-bridge-cli/src/lib.rs
+++ b/crates/iota-bridge-cli/src/lib.rs
@@ -726,6 +726,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_encode_call_data() {
         let abi_json =
             std::fs::read_to_string("../iota-bridge/abi/tests/mock_iota_bridge_v2.json").unwrap();

--- a/crates/iota-e2e-tests/tests/bridge_tests.rs
+++ b/crates/iota-e2e-tests/tests/bridge_tests.rs
@@ -13,6 +13,7 @@ use iota_types::{
 use test_cluster::TestClusterBuilder;
 
 #[sim_test]
+#[ignore = "https://github.com/iotaledger/iota/issues/3224"]
 async fn test_create_bridge_state_object() {
     let test_cluster = TestClusterBuilder::new()
         .with_protocol_version((BRIDGE_ENABLE_PROTOCOL_VERSION - 1).into())
@@ -55,6 +56,7 @@ async fn test_create_bridge_state_object() {
 }
 
 #[tokio::test]
+#[ignore = "https://github.com/iotaledger/iota/issues/3224"]
 async fn test_committee_registration() {
     telemetry_subscribers::init_for_testing();
     let mut bridge_keys = vec![];
@@ -89,6 +91,7 @@ async fn test_committee_registration() {
 }
 
 #[tokio::test]
+#[ignore = "https://github.com/iotaledger/iota/issues/3224"]
 async fn test_bridge_api_compatibility() {
     let test_cluster: test_cluster::TestCluster = TestClusterBuilder::new()
         .with_protocol_version(BRIDGE_ENABLE_PROTOCOL_VERSION.into())


### PR DESCRIPTION
# Description of change

This PR disables all tests that involve the bridge for now, because we disabled the feature in the protocol.

## Links to any relevant issues

#3224

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Not tested, it only disables broken tests.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
