### PR TITLE
remove(node): remove unused protocol feature flags

### DIFF
--- a/crates/iota-e2e-tests/tests/multisig_tests.rs
+++ b/crates/iota-e2e-tests/tests/multisig_tests.rs
@@ -15,7 +15,7 @@ use iota_types::{
         CompressedSignature, IotaKeyPair, PublicKey, Signature, ZkLoginAuthenticatorAsBytes,
         ZkLoginPublicIdentifier, get_key_pair,
     },
-    error::{IotaError, IotaResult, UserInputError},
+    error::{IotaError, IotaResult},
     multisig::{MultiSig, MultiSigPublicKey},
     multisig_legacy::{MultiSigLegacy, MultiSigPublicKeyLegacy},
     signature::GenericSignature,
@@ -43,26 +43,7 @@ async fn do_upgraded_multisig_test() -> IotaResult {
 }
 
 #[sim_test]
-async fn test_upgraded_multisig_feature_deny() {
-    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-        config.set_upgraded_multisig_for_testing(false);
-        config
-    });
-
-    let err = do_upgraded_multisig_test().await.unwrap_err();
-
-    assert!(matches!(err, IotaError::UserInput {
-        error: UserInputError::Unsupported(..)
-    }));
-}
-
-#[sim_test]
 async fn test_upgraded_multisig_feature_allow() {
-    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-        config.set_upgraded_multisig_for_testing(true);
-        config
-    });
-
     let res = do_upgraded_multisig_test().await;
 
     // we didn't make a real transaction with a valid object, but we verify that we

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1331,7 +1331,6 @@
                 "passkey_auth": true,
                 "prepend_prologue_tx_in_consensus_commit_in_checkpoints": true,
                 "random_beacon": true,
-                "receive_objects": true,
                 "recompute_has_public_transfer_in_execution": true,
                 "record_consensus_determined_version_assignments_in_prologue": true,
                 "reject_mutable_random_on_entry_functions": true,

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1342,7 +1342,6 @@
                 "reshare_at_same_initial_version": true,
                 "resolve_abort_locations_to_package_id": true,
                 "rethrow_serialization_type_layout_errors": true,
-                "scoring_decision_with_validity_cutoff": true,
                 "shared_object_deletion": true,
                 "simple_conservation_checks": true,
                 "simplified_unwrap_then_delete": true,

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1327,7 +1327,6 @@
                 "mysticeti_use_committed_subdag_digest": true,
                 "narwhal_certificate_v2": true,
                 "narwhal_new_leader_election_schedule": true,
-                "narwhal_versioned_metadata": true,
                 "no_extraneous_module_bytes": true,
                 "package_upgrades": true,
                 "passkey_auth": true,

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1329,7 +1329,6 @@
                 "narwhal_new_leader_election_schedule": true,
                 "narwhal_versioned_metadata": true,
                 "no_extraneous_module_bytes": true,
-                "package_digest_hash_module": true,
                 "package_upgrades": true,
                 "passkey_auth": true,
                 "prepend_prologue_tx_in_consensus_commit_in_checkpoints": true,

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1306,7 +1306,6 @@
                 "commit_root_state_digest": true,
                 "consensus_order_end_of_epoch_last": true,
                 "disable_invariant_violation_check_in_swap_loc": true,
-                "disallow_adding_abilities_on_upgrade": true,
                 "disallow_change_struct_type_params_on_upgrade": true,
                 "enable_coin_deny_list": true,
                 "enable_coin_deny_list_v2": true,

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1325,7 +1325,6 @@
                 "missing_type_is_compatibility_error": true,
                 "mysticeti_leader_scoring_and_schedule": true,
                 "mysticeti_use_committed_subdag_digest": true,
-                "narwhal_certificate_v2": true,
                 "no_extraneous_module_bytes": true,
                 "package_upgrades": true,
                 "passkey_auth": true,

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1326,7 +1326,6 @@
                 "mysticeti_leader_scoring_and_schedule": true,
                 "mysticeti_use_committed_subdag_digest": true,
                 "narwhal_certificate_v2": true,
-                "narwhal_new_leader_election_schedule": true,
                 "no_extraneous_module_bytes": true,
                 "package_upgrades": true,
                 "passkey_auth": true,

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1345,7 +1345,6 @@
                 "soft_bundle": true,
                 "throughput_aware_consensus_submission": false,
                 "txn_base_cost_as_multiplier": true,
-                "upgraded_multisig_supported": true,
                 "verify_legacy_zklogin_address": true,
                 "zklogin_auth": true
               },

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -174,10 +174,6 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     shared_object_deletion: bool,
 
-    // If true, then the new algorithm for the leader election schedule will be used
-    #[serde(skip_serializing_if = "is_false")]
-    narwhal_new_leader_election_schedule: bool,
-
     // A list of supported OIDC providers that can be used for zklogin.
     #[serde(skip_serializing_if = "is_empty")]
     zklogin_supported_providers: BTreeSet<String>,
@@ -1216,10 +1212,6 @@ impl ProtocolConfig {
         self.feature_flags.shared_object_deletion
     }
 
-    pub fn narwhal_new_leader_election_schedule(&self) -> bool {
-        self.feature_flags.narwhal_new_leader_election_schedule
-    }
-
     pub fn loaded_child_object_format(&self) -> bool {
         self.feature_flags.loaded_child_object_format
     }
@@ -1970,7 +1962,6 @@ impl ProtocolConfig {
         cfg.feature_flags.consensus_transaction_ordering = ConsensusTransactionOrdering::ByGasPrice;
         cfg.feature_flags.simplified_unwrap_then_delete = true;
         cfg.feature_flags.txn_base_cost_as_multiplier = true;
-        cfg.feature_flags.narwhal_new_leader_election_schedule = true;
         cfg.feature_flags.loaded_child_object_format = true;
         cfg.feature_flags.loaded_child_object_format_type = true;
         cfg.feature_flags.simple_conservation_checks = true;
@@ -2202,11 +2193,7 @@ impl ProtocolConfig {
     pub fn set_reshare_at_same_initial_version_for_testing(&mut self, val: bool) {
         self.feature_flags.reshare_at_same_initial_version = val;
     }
-
-    pub fn set_narwhal_new_leader_election_schedule_for_testing(&mut self, val: bool) {
-        self.feature_flags.narwhal_new_leader_election_schedule = val;
-    }
-
+    
     pub fn set_receive_object_for_testing(&mut self, val: bool) {
         self.feature_flags.receive_objects = val
     }

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -127,10 +127,6 @@ struct FeatureFlags {
     // compatibility error.
     #[serde(skip_serializing_if = "is_false")]
     missing_type_is_compatibility_error: bool,
-    // If true, then the scoring decision mechanism will not get disabled when we do have more than
-    // f low scoring authorities, but it will simply flag as low scoring only up to f authorities.
-    #[serde(skip_serializing_if = "is_false")]
-    scoring_decision_with_validity_cutoff: bool,
 
     // DEPRECATED: this was an ephemeral feature flag only used by consensus handler, which has now
     // been deployed everywhere.
@@ -1181,10 +1177,6 @@ impl ProtocolConfig {
         self.feature_flags.missing_type_is_compatibility_error
     }
 
-    pub fn scoring_decision_with_validity_cutoff(&self) -> bool {
-        self.feature_flags.scoring_decision_with_validity_cutoff
-    }
-
     pub fn narwhal_versioned_metadata(&self) -> bool {
         self.feature_flags.narwhal_versioned_metadata
     }
@@ -1996,7 +1988,6 @@ impl ProtocolConfig {
 
         cfg.feature_flags.advance_epoch_start_time_in_safe_mode = true;
         cfg.feature_flags.missing_type_is_compatibility_error = true;
-        cfg.feature_flags.scoring_decision_with_validity_cutoff = true;
         cfg.feature_flags.consensus_order_end_of_epoch_last = true;
         cfg.feature_flags
             .disable_invariant_violation_check_in_swap_loc = true;

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -110,8 +110,6 @@ pub struct Error(pub String);
 struct FeatureFlags {
     // Add feature flags here, e.g.:
     // new_protocol_feature: bool,
-    #[serde(skip_serializing_if = "is_false")]
-    package_upgrades: bool,
     // If true, validators will commit to the root state digest
     // in end of epoch checkpoint proposals
     #[serde(skip_serializing_if = "is_false")]
@@ -1114,23 +1112,8 @@ impl ProtocolConfig {
     //     }
     // }
 
-    pub fn check_package_upgrades_supported(&self) -> Result<(), Error> {
-        if self.feature_flags.package_upgrades {
-            Ok(())
-        } else {
-            Err(Error(format!(
-                "package upgrades are not supported at {:?}",
-                self.version
-            )))
-        }
-    }
-
     pub fn allow_receiving_object_id(&self) -> bool {
         self.feature_flags.allow_receiving_object_id
-    }
-
-    pub fn package_upgrades_supported(&self) -> bool {
-        self.feature_flags.package_upgrades
     }
 
     pub fn check_commit_root_state_digest_supported(&self) -> bool {
@@ -1978,7 +1961,6 @@ impl ProtocolConfig {
         // Following flags are implied by the execution version.
         // Once support for earlier protocol versions is dropped, these flags can be
         // removed:
-        cfg.feature_flags.package_upgrades = true;
         cfg.feature_flags
             .disallow_change_struct_type_params_on_upgrade = true;
         cfg.feature_flags.loaded_child_objects_fixed = true;

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -197,10 +197,6 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     loaded_child_object_format_type: bool,
 
-    // Enable receiving sent objects
-    #[serde(skip_serializing_if = "is_false")]
-    receive_objects: bool,
-
     // Enable random beacon protocol
     #[serde(skip_serializing_if = "is_false")]
     random_beacon: bool,
@@ -1137,10 +1133,6 @@ impl ProtocolConfig {
         self.feature_flags.allow_receiving_object_id
     }
 
-    pub fn receiving_objects_supported(&self) -> bool {
-        self.feature_flags.receive_objects
-    }
-
     pub fn package_upgrades_supported(&self) -> bool {
         self.feature_flags.package_upgrades
     }
@@ -1966,7 +1958,6 @@ impl ProtocolConfig {
         cfg.feature_flags.loaded_child_object_format_type = true;
         cfg.feature_flags.simple_conservation_checks = true;
         cfg.feature_flags.end_of_epoch_transaction_supported = true;
-        cfg.feature_flags.receive_objects = true;
         cfg.feature_flags.enable_effects_v2 = true;
 
         cfg.feature_flags.narwhal_certificate_v2 = true;
@@ -2193,10 +2184,7 @@ impl ProtocolConfig {
     pub fn set_reshare_at_same_initial_version_for_testing(&mut self, val: bool) {
         self.feature_flags.reshare_at_same_initial_version = val;
     }
-    
-    pub fn set_receive_object_for_testing(&mut self, val: bool) {
-        self.feature_flags.receive_objects = val
-    }
+
     pub fn set_narwhal_certificate_v2_for_testing(&mut self, val: bool) {
         self.feature_flags.narwhal_certificate_v2 = val
     }

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -208,10 +208,6 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     enable_effects_v2: bool,
 
-    // If true, then use CertificateV2 in narwhal.
-    #[serde(skip_serializing_if = "is_false")]
-    narwhal_certificate_v2: bool,
-
     // If true, allow verify with legacy zklogin address
     #[serde(skip_serializing_if = "is_false")]
     verify_legacy_zklogin_address: bool,
@@ -1274,10 +1270,6 @@ impl ProtocolConfig {
         self.feature_flags.enable_effects_v2
     }
 
-    pub fn narwhal_certificate_v2(&self) -> bool {
-        self.feature_flags.narwhal_certificate_v2
-    }
-
     pub fn verify_legacy_zklogin_address(&self) -> bool {
         self.feature_flags.verify_legacy_zklogin_address
     }
@@ -1960,7 +1952,6 @@ impl ProtocolConfig {
         cfg.feature_flags.end_of_epoch_transaction_supported = true;
         cfg.feature_flags.enable_effects_v2 = true;
 
-        cfg.feature_flags.narwhal_certificate_v2 = true;
         cfg.feature_flags.recompute_has_public_transfer_in_execution = true;
         cfg.feature_flags.shared_object_deletion = true;
         cfg.feature_flags.hardened_otw_check = true;
@@ -2185,9 +2176,6 @@ impl ProtocolConfig {
         self.feature_flags.reshare_at_same_initial_version = val;
     }
 
-    pub fn set_narwhal_certificate_v2_for_testing(&mut self, val: bool) {
-        self.feature_flags.narwhal_certificate_v2 = val
-    }
     pub fn set_verify_legacy_zklogin_address_for_testing(&mut self, val: bool) {
         self.feature_flags.verify_legacy_zklogin_address = val
     }

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -143,9 +143,6 @@ struct FeatureFlags {
     // If true, disallow entry modifiers on entry functions
     #[serde(skip_serializing_if = "is_false")]
     ban_entry_init: bool,
-    // If true, hash module bytes individually when calculating package digests for upgrades
-    #[serde(skip_serializing_if = "is_false")]
-    package_digest_hash_module: bool,
     // If true, disallow changing struct type parameters during package upgrades
     #[serde(skip_serializing_if = "is_false")]
     disallow_change_struct_type_params_on_upgrade: bool,
@@ -1196,10 +1193,6 @@ impl ProtocolConfig {
         self.feature_flags.ban_entry_init
     }
 
-    pub fn package_digest_hash_module(&self) -> bool {
-        self.feature_flags.package_digest_hash_module
-    }
-
     pub fn disallow_change_struct_type_params_on_upgrade(&self) -> bool {
         self.feature_flags
             .disallow_change_struct_type_params_on_upgrade
@@ -1984,7 +1977,6 @@ impl ProtocolConfig {
         cfg.feature_flags.consensus_order_end_of_epoch_last = true;
         cfg.feature_flags
             .disable_invariant_violation_check_in_swap_loc = true;
-        cfg.feature_flags.package_digest_hash_module = true;
         cfg.feature_flags.no_extraneous_module_bytes = true;
         cfg.feature_flags
             .advance_to_highest_supported_protocol_version = true;

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -149,9 +149,6 @@ struct FeatureFlags {
     // If true, checks no extra bytes in a compiled module
     #[serde(skip_serializing_if = "is_false")]
     no_extraneous_module_bytes: bool,
-    // If true, then use the versioned metadata format in narwhal entities.
-    #[serde(skip_serializing_if = "is_false")]
-    narwhal_versioned_metadata: bool,
 
     // Enable zklogin auth
     #[serde(skip_serializing_if = "is_false")]
@@ -1171,10 +1168,6 @@ impl ProtocolConfig {
         self.feature_flags.missing_type_is_compatibility_error
     }
 
-    pub fn narwhal_versioned_metadata(&self) -> bool {
-        self.feature_flags.narwhal_versioned_metadata
-    }
-
     pub fn consensus_order_end_of_epoch_last(&self) -> bool {
         self.feature_flags.consensus_order_end_of_epoch_last
     }
@@ -1980,7 +1973,6 @@ impl ProtocolConfig {
         cfg.feature_flags.no_extraneous_module_bytes = true;
         cfg.feature_flags
             .advance_to_highest_supported_protocol_version = true;
-        cfg.feature_flags.narwhal_versioned_metadata = true;
         cfg.feature_flags.commit_root_state_digest = true;
         cfg.feature_flags.consensus_transaction_ordering = ConsensusTransactionOrdering::ByGasPrice;
         cfg.feature_flags.simplified_unwrap_then_delete = true;

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -166,9 +166,6 @@ struct FeatureFlags {
     // regardless of their previous state in the store.
     #[serde(skip_serializing_if = "is_false")]
     simplified_unwrap_then_delete: bool,
-    // Enable upgraded multisig support
-    #[serde(skip_serializing_if = "is_false")]
-    upgraded_multisig_supported: bool,
     // If true minimum txn charge is a multiplier of the gas price
     #[serde(skip_serializing_if = "is_false")]
     txn_base_cost_as_multiplier: bool,
@@ -1211,10 +1208,6 @@ impl ProtocolConfig {
         self.feature_flags.simplified_unwrap_then_delete
     }
 
-    pub fn supports_upgraded_multisig(&self) -> bool {
-        self.feature_flags.upgraded_multisig_supported
-    }
-
     pub fn txn_base_cost_as_multiplier(&self) -> bool {
         self.feature_flags.txn_base_cost_as_multiplier
     }
@@ -1976,7 +1969,6 @@ impl ProtocolConfig {
         cfg.feature_flags.commit_root_state_digest = true;
         cfg.feature_flags.consensus_transaction_ordering = ConsensusTransactionOrdering::ByGasPrice;
         cfg.feature_flags.simplified_unwrap_then_delete = true;
-        cfg.feature_flags.upgraded_multisig_supported = true;
         cfg.feature_flags.txn_base_cost_as_multiplier = true;
         cfg.feature_flags.narwhal_new_leader_election_schedule = true;
         cfg.feature_flags.loaded_child_object_format = true;
@@ -2195,9 +2187,6 @@ impl ProtocolConfig {
         self.feature_flags.random_beacon = val
     }
 
-    pub fn set_upgraded_multisig_for_testing(&mut self, val: bool) {
-        self.feature_flags.upgraded_multisig_supported = val
-    }
     pub fn set_accept_zklogin_in_multisig_for_testing(&mut self, val: bool) {
         self.feature_flags.accept_zklogin_in_multisig = val
     }

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -133,9 +133,6 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     consensus_order_end_of_epoch_last: bool,
 
-    // Disallow adding abilities to types during package upgrades.
-    #[serde(skip_serializing_if = "is_false")]
-    disallow_adding_abilities_on_upgrade: bool,
     // Disables unnecessary invariant check in the Move VM when swapping the value out of a local
     #[serde(skip_serializing_if = "is_false")]
     disable_invariant_violation_check_in_swap_loc: bool,
@@ -1185,10 +1182,6 @@ impl ProtocolConfig {
         self.feature_flags.consensus_order_end_of_epoch_last
     }
 
-    pub fn disallow_adding_abilities_on_upgrade(&self) -> bool {
-        self.feature_flags.disallow_adding_abilities_on_upgrade
-    }
-
     pub fn disable_invariant_violation_check_in_swap_loc(&self) -> bool {
         self.feature_flags
             .disable_invariant_violation_check_in_swap_loc
@@ -2037,7 +2030,6 @@ impl ProtocolConfig {
         // Once support for earlier protocol versions is dropped, these flags can be
         // removed:
         cfg.feature_flags.package_upgrades = true;
-        cfg.feature_flags.disallow_adding_abilities_on_upgrade = true;
         cfg.feature_flags
             .disallow_change_struct_type_params_on_upgrade = true;
         cfg.feature_flags.loaded_child_objects_fixed = true;

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -19,7 +19,6 @@ feature_flags:
   simplified_unwrap_then_delete: true
   txn_base_cost_as_multiplier: true
   shared_object_deletion: true
-  narwhal_new_leader_election_schedule: true
   loaded_child_object_format: true
   end_of_epoch_transaction_supported: true
   simple_conservation_checks: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -9,7 +9,6 @@ feature_flags:
   advance_epoch_start_time_in_safe_mode: true
   loaded_child_objects_fixed: true
   missing_type_is_compatibility_error: true
-  scoring_decision_with_validity_cutoff: true
   consensus_order_end_of_epoch_last: true
   disallow_adding_abilities_on_upgrade: true
   disable_invariant_violation_check_in_swap_loc: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -4,7 +4,6 @@ expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
 version: 1
 feature_flags:
-  package_upgrades: true
   commit_root_state_digest: true
   advance_epoch_start_time_in_safe_mode: true
   loaded_child_objects_fixed: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -17,7 +17,6 @@ feature_flags:
   no_extraneous_module_bytes: true
   consensus_transaction_ordering: ByGasPrice
   simplified_unwrap_then_delete: true
-  upgraded_multisig_supported: true
   txn_base_cost_as_multiplier: true
   shared_object_deletion: true
   narwhal_new_leader_election_schedule: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -10,7 +10,6 @@ feature_flags:
   loaded_child_objects_fixed: true
   missing_type_is_compatibility_error: true
   consensus_order_end_of_epoch_last: true
-  disallow_adding_abilities_on_upgrade: true
   disable_invariant_violation_check_in_swap_loc: true
   advance_to_highest_supported_protocol_version: true
   ban_entry_init: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -13,7 +13,6 @@ feature_flags:
   disable_invariant_violation_check_in_swap_loc: true
   advance_to_highest_supported_protocol_version: true
   ban_entry_init: true
-  package_digest_hash_module: true
   disallow_change_struct_type_params_on_upgrade: true
   no_extraneous_module_bytes: true
   narwhal_versioned_metadata: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -15,7 +15,6 @@ feature_flags:
   ban_entry_init: true
   disallow_change_struct_type_params_on_upgrade: true
   no_extraneous_module_bytes: true
-  narwhal_versioned_metadata: true
   consensus_transaction_ordering: ByGasPrice
   simplified_unwrap_then_delete: true
   upgraded_multisig_supported: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -23,7 +23,6 @@ feature_flags:
   end_of_epoch_transaction_supported: true
   simple_conservation_checks: true
   loaded_child_object_format_type: true
-  receive_objects: true
   random_beacon: true
   enable_effects_v2: true
   narwhal_certificate_v2: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -25,7 +25,6 @@ feature_flags:
   loaded_child_object_format_type: true
   random_beacon: true
   enable_effects_v2: true
-  narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true
   recompute_has_public_transfer_in_execution: true
   include_consensus_digest_in_prologue: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -34,7 +34,6 @@ feature_flags:
   enable_group_ops_native_functions: true
   reject_mutable_random_on_entry_functions: true
   per_object_congestion_control_mode: TotalTxCount
-  consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30
   mysticeti_leader_scoring_and_schedule: true
   reshare_at_same_initial_version: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -19,7 +19,6 @@ feature_flags:
   simplified_unwrap_then_delete: true
   txn_base_cost_as_multiplier: true
   shared_object_deletion: true
-  narwhal_new_leader_election_schedule: true
   loaded_child_object_format: true
   end_of_epoch_transaction_supported: true
   simple_conservation_checks: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -9,7 +9,6 @@ feature_flags:
   advance_epoch_start_time_in_safe_mode: true
   loaded_child_objects_fixed: true
   missing_type_is_compatibility_error: true
-  scoring_decision_with_validity_cutoff: true
   consensus_order_end_of_epoch_last: true
   disallow_adding_abilities_on_upgrade: true
   disable_invariant_violation_check_in_swap_loc: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -4,7 +4,6 @@ expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
 version: 1
 feature_flags:
-  package_upgrades: true
   commit_root_state_digest: true
   advance_epoch_start_time_in_safe_mode: true
   loaded_child_objects_fixed: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -17,7 +17,6 @@ feature_flags:
   no_extraneous_module_bytes: true
   consensus_transaction_ordering: ByGasPrice
   simplified_unwrap_then_delete: true
-  upgraded_multisig_supported: true
   txn_base_cost_as_multiplier: true
   shared_object_deletion: true
   narwhal_new_leader_election_schedule: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -10,7 +10,6 @@ feature_flags:
   loaded_child_objects_fixed: true
   missing_type_is_compatibility_error: true
   consensus_order_end_of_epoch_last: true
-  disallow_adding_abilities_on_upgrade: true
   disable_invariant_violation_check_in_swap_loc: true
   advance_to_highest_supported_protocol_version: true
   ban_entry_init: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -13,7 +13,6 @@ feature_flags:
   disable_invariant_violation_check_in_swap_loc: true
   advance_to_highest_supported_protocol_version: true
   ban_entry_init: true
-  package_digest_hash_module: true
   disallow_change_struct_type_params_on_upgrade: true
   no_extraneous_module_bytes: true
   narwhal_versioned_metadata: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -15,7 +15,6 @@ feature_flags:
   ban_entry_init: true
   disallow_change_struct_type_params_on_upgrade: true
   no_extraneous_module_bytes: true
-  narwhal_versioned_metadata: true
   consensus_transaction_ordering: ByGasPrice
   simplified_unwrap_then_delete: true
   upgraded_multisig_supported: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -23,7 +23,6 @@ feature_flags:
   end_of_epoch_transaction_supported: true
   simple_conservation_checks: true
   loaded_child_object_format_type: true
-  receive_objects: true
   random_beacon: true
   enable_effects_v2: true
   narwhal_certificate_v2: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -25,7 +25,6 @@ feature_flags:
   loaded_child_object_format_type: true
   random_beacon: true
   enable_effects_v2: true
-  narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true
   recompute_has_public_transfer_in_execution: true
   include_consensus_digest_in_prologue: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -34,7 +34,6 @@ feature_flags:
   enable_group_ops_native_functions: true
   reject_mutable_random_on_entry_functions: true
   per_object_congestion_control_mode: TotalTxCount
-  consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30
   mysticeti_leader_scoring_and_schedule: true
   reshare_at_same_initial_version: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -19,7 +19,6 @@ feature_flags:
   simplified_unwrap_then_delete: true
   txn_base_cost_as_multiplier: true
   shared_object_deletion: true
-  narwhal_new_leader_election_schedule: true
   loaded_child_object_format: true
   end_of_epoch_transaction_supported: true
   simple_conservation_checks: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -9,7 +9,6 @@ feature_flags:
   advance_epoch_start_time_in_safe_mode: true
   loaded_child_objects_fixed: true
   missing_type_is_compatibility_error: true
-  scoring_decision_with_validity_cutoff: true
   consensus_order_end_of_epoch_last: true
   disallow_adding_abilities_on_upgrade: true
   disable_invariant_violation_check_in_swap_loc: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -4,7 +4,6 @@ expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
 version: 1
 feature_flags:
-  package_upgrades: true
   commit_root_state_digest: true
   advance_epoch_start_time_in_safe_mode: true
   loaded_child_objects_fixed: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -17,7 +17,6 @@ feature_flags:
   no_extraneous_module_bytes: true
   consensus_transaction_ordering: ByGasPrice
   simplified_unwrap_then_delete: true
-  upgraded_multisig_supported: true
   txn_base_cost_as_multiplier: true
   shared_object_deletion: true
   narwhal_new_leader_election_schedule: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -10,7 +10,6 @@ feature_flags:
   loaded_child_objects_fixed: true
   missing_type_is_compatibility_error: true
   consensus_order_end_of_epoch_last: true
-  disallow_adding_abilities_on_upgrade: true
   disable_invariant_violation_check_in_swap_loc: true
   advance_to_highest_supported_protocol_version: true
   ban_entry_init: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -13,7 +13,6 @@ feature_flags:
   disable_invariant_violation_check_in_swap_loc: true
   advance_to_highest_supported_protocol_version: true
   ban_entry_init: true
-  package_digest_hash_module: true
   disallow_change_struct_type_params_on_upgrade: true
   no_extraneous_module_bytes: true
   narwhal_versioned_metadata: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -15,7 +15,6 @@ feature_flags:
   ban_entry_init: true
   disallow_change_struct_type_params_on_upgrade: true
   no_extraneous_module_bytes: true
-  narwhal_versioned_metadata: true
   consensus_transaction_ordering: ByGasPrice
   simplified_unwrap_then_delete: true
   upgraded_multisig_supported: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -23,7 +23,6 @@ feature_flags:
   end_of_epoch_transaction_supported: true
   simple_conservation_checks: true
   loaded_child_object_format_type: true
-  receive_objects: true
   random_beacon: true
   enable_effects_v2: true
   narwhal_certificate_v2: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -25,7 +25,6 @@ feature_flags:
   loaded_child_object_format_type: true
   random_beacon: true
   enable_effects_v2: true
-  narwhal_certificate_v2: true
   verify_legacy_zklogin_address: true
   recompute_has_public_transfer_in_execution: true
   include_consensus_digest_in_prologue: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -36,7 +36,6 @@ feature_flags:
   enable_group_ops_native_function_msm: true
   reject_mutable_random_on_entry_functions: true
   per_object_congestion_control_mode: TotalTxCount
-  consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30
   mysticeti_leader_scoring_and_schedule: true
   reshare_at_same_initial_version: true

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -531,15 +531,9 @@ impl CallArg {
                 );
             }
             CallArg::Object(o) => match o {
-                ObjectArg::ImmOrOwnedObject(_) | ObjectArg::SharedObject { .. } => (),
-                ObjectArg::Receiving(_) => {
-                    if !config.receiving_objects_supported() {
-                        return Err(UserInputError::Unsupported(format!(
-                            "receiving objects is not supported at {:?}",
-                            config.version
-                        )));
-                    }
-                }
+                ObjectArg::Receiving(_)
+                | ObjectArg::ImmOrOwnedObject(_)
+                | ObjectArg::SharedObject { .. } => (),
             },
         }
         Ok(())
@@ -2313,15 +2307,6 @@ impl SenderSignedData {
     fn check_user_signature_protocol_compatibility(&self, config: &ProtocolConfig) -> IotaResult {
         for sig in &self.inner().tx_signatures {
             match sig {
-                GenericSignature::MultiSig(_) => {
-                    if !config.supports_upgraded_multisig() {
-                        return Err(IotaError::UserInput {
-                            error: UserInputError::Unsupported(
-                                "upgraded multisig format not enabled on this network".to_string(),
-                            ),
-                        });
-                    }
-                }
                 GenericSignature::ZkLoginAuthenticator(_) => {
                     if !config.zklogin_auth() {
                         return Err(IotaError::UserInput {
@@ -2340,7 +2325,9 @@ impl SenderSignedData {
                         });
                     }
                 }
-                GenericSignature::Signature(_) | GenericSignature::MultiSigLegacy(_) => (),
+                GenericSignature::Signature(_)
+                | GenericSignature::MultiSig(_)
+                | GenericSignature::MultiSigLegacy(_) => (),
             }
         }
 


### PR DESCRIPTION
# Description of change

This PR removes unused protocol feature flags.

## Links to any relevant issues

#3253

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running a local node with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
