### PR TITLE
chore(tests): disable jwk related tests

### DIFF
--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -3038,6 +3038,9 @@ async fn test_invalid_mutable_clock_parameter() {
 }
 
 #[tokio::test]
+#[ignore = "https://github.com/iotaledger/iota/issues/1777"]
+// If "enable_jwk_consensus_updates" is set to false, the AuthorityState is
+// never created and therefore the test will fail.
 async fn test_invalid_authenticator_state_parameter() {
     // User transactions that take the singleton AuthenticatorState object at `0x7`
     // by mutable reference will fail to sign, to prevent transactions


### PR DESCRIPTION
# Description of change

This PR disables the `test_invalid_authenticator_state_parameter` because it is based on a protocol feature `enable_jwk_consensus_updates` which we disabled for now.

## Links to any relevant issues

#1777

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Not tested, because it only skips a broken test.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes