### PR TITLE
remove(iota-core): Remove multiple versions for PendingCheckpoint and AuthorityEpochTables related to randomness generation changes

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -97,7 +97,7 @@ use crate::{
     },
     checkpoints::{
         BuilderCheckpointSummary, CheckpointHeight, CheckpointServiceNotify, EpochStats,
-        PendingCheckpoint, PendingCheckpointContents, PendingCheckpointInfo,
+        PendingCheckpoint, PendingCheckpointContentsV1, PendingCheckpointInfo,
     },
     consensus_handler::{
         ConsensusCommitInfo, SequencedConsensusTransaction, SequencedConsensusTransactionKey,
@@ -2754,7 +2754,7 @@ impl AuthorityPerEpochStore {
                 checkpoint_roots.push(consensus_commit_prologue_root);
             }
             checkpoint_roots.extend(roots.into_iter());
-            let pending_checkpoint = PendingCheckpoint::V1(PendingCheckpointContents {
+            let pending_checkpoint = PendingCheckpoint::V1(PendingCheckpointContentsV1 {
                 roots: checkpoint_roots,
                 details: PendingCheckpointInfo {
                     timestamp_ms: consensus_commit_info.timestamp,
@@ -2777,7 +2777,7 @@ impl AuthorityPerEpochStore {
                 ));
             }
             if randomness_round.is_some() || (dkg_failed && !randomness_roots.is_empty()) {
-                let pending_checkpoint = PendingCheckpoint::V1(PendingCheckpointContents {
+                let pending_checkpoint = PendingCheckpoint::V1(PendingCheckpointContentsV1 {
                     roots: randomness_roots.into_iter().collect(),
                     details: PendingCheckpointInfo {
                         timestamp_ms: consensus_commit_info.timestamp,

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3690,7 +3690,7 @@ impl AuthorityPerEpochStore {
         // single batch. This means that upon restart we can use
         // BuilderCheckpointSummary::commit_height from the last built summary
         // to resume building checkpoints.
-        let mut batch = self.tables()?.pending_checkpoints.batch();
+        let mut batch = self.tables()?.pending_checkpoints_v2.batch();
         for (position_in_commit, (summary, transactions)) in content_info.into_iter().enumerate() {
             let sequence_number = summary.sequence_number;
             let summary = BuilderCheckpointSummary {

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -97,7 +97,7 @@ use crate::{
     },
     checkpoints::{
         BuilderCheckpointSummary, CheckpointHeight, CheckpointServiceNotify, EpochStats,
-        PendingCheckpointInfo, PendingCheckpoint, PendingCheckpointContents,
+        PendingCheckpoint, PendingCheckpointContents, PendingCheckpointInfo,
     },
     consensus_handler::{
         ConsensusCommitInfo, SequencedConsensusTransaction, SequencedConsensusTransactionKey,
@@ -1618,7 +1618,7 @@ impl AuthorityPerEpochStore {
         cache_reader: &dyn ObjectCacheRead,
         certificates: &[VerifiedExecutableTransaction],
     ) -> IotaResult {
-        let mut db_batch = self.tables()?.assigned_shared_object_versions.batch();
+        let mut db_batch = self.tables()?.assigned_shared_object_versions_v2.batch();
         let assigned_versions = SharedObjVerManager::assign_versions_from_consensus(
             self,
             cache_reader,
@@ -1803,7 +1803,7 @@ impl AuthorityPerEpochStore {
             cache_reader,
         )
         .await?;
-        let mut db_batch = self.tables()?.assigned_shared_object_versions.batch();
+        let mut db_batch = self.tables()?.assigned_shared_object_versions_v2.batch();
         self.set_assigned_shared_object_versions_with_db_batch(versions, &mut db_batch)
             .await?;
         db_batch.write()?;

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -895,6 +895,12 @@ impl AuthorityPerEpochStore {
             randomness_manager: OnceCell::new(),
             randomness_reporter: OnceCell::new(),
         });
+
+        // until randomness_state_enabled is not removed we need to make sure it is
+        // always enabled as depreciated versions of pending_checkpoints and
+        // assigned_shared_object_versions has been removed
+        assert!(s.randomness_state_enabled());
+
         s.update_buffer_stake_metric();
         s
     }

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1624,7 +1624,7 @@ impl AuthorityPerEpochStore {
         cache_reader: &dyn ObjectCacheRead,
         certificates: &[VerifiedExecutableTransaction],
     ) -> IotaResult {
-        let mut db_batch = self.tables()?.assigned_shared_object_versions_v2.batch();
+        let mut db_batch = self.tables()?.assigned_shared_object_versions.batch();
         let assigned_versions = SharedObjVerManager::assign_versions_from_consensus(
             self,
             cache_reader,
@@ -1809,7 +1809,7 @@ impl AuthorityPerEpochStore {
             cache_reader,
         )
         .await?;
-        let mut db_batch = self.tables()?.assigned_shared_object_versions_v2.batch();
+        let mut db_batch = self.tables()?.assigned_shared_object_versions.batch();
         self.set_assigned_shared_object_versions_with_db_batch(versions, &mut db_batch)
             .await?;
         db_batch.write()?;

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -896,11 +896,6 @@ impl AuthorityPerEpochStore {
             randomness_reporter: OnceCell::new(),
         });
 
-        // until randomness_state_enabled is not removed we need to make sure it is
-        // always enabled as depreciated versions of pending_checkpoints and
-        // assigned_shared_object_versions has been removed
-        assert!(s.randomness_state_enabled());
-
         s.update_buffer_stake_metric();
         s
     }

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -102,36 +102,36 @@ pub struct PendingCheckpointInfo {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum PendingCheckpointV2 {
+pub enum PendingCheckpoint {
     // This is an enum for future upgradability, though at the moment there is only one variant.
-    V2(PendingCheckpointV2Contents),
+    V1(PendingCheckpointContents),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct PendingCheckpointV2Contents {
+pub struct PendingCheckpointContents {
     pub roots: Vec<TransactionKey>,
     pub details: PendingCheckpointInfo,
 }
 
-impl PendingCheckpointV2 {
-    pub fn as_v2(&self) -> &PendingCheckpointV2Contents {
+impl PendingCheckpoint {
+    pub fn as_v1(&self) -> &PendingCheckpointContents {
         match self {
-            PendingCheckpointV2::V2(contents) => contents,
+            PendingCheckpoint::V1(contents) => contents,
         }
     }
 
-    pub fn into_v2(self) -> PendingCheckpointV2Contents {
+    pub fn into_v1(self) -> PendingCheckpointContents {
         match self {
-            PendingCheckpointV2::V2(contents) => contents,
+            PendingCheckpoint::V1(contents) => contents,
         }
     }
 
     pub fn roots(&self) -> &Vec<TransactionKey> {
-        &self.as_v2().roots
+        &self.as_v1().roots
     }
 
     pub fn details(&self) -> &PendingCheckpointInfo {
-        &self.as_v2().details
+        &self.as_v1().details
     }
 
     pub fn height(&self) -> CheckpointHeight {
@@ -1019,7 +1019,7 @@ impl CheckpointBuilder {
     }
 
     #[instrument(level = "debug", skip_all, fields(last_height = pendings.last().unwrap().details().checkpoint_height))]
-    async fn make_checkpoint(&self, pendings: Vec<PendingCheckpointV2>) -> anyhow::Result<()> {
+    async fn make_checkpoint(&self, pendings: Vec<PendingCheckpoint>) -> anyhow::Result<()> {
         let last_details = pendings.last().unwrap().details().clone();
 
         // Keeps track of the effects that are already included in the current
@@ -1033,7 +1033,7 @@ impl CheckpointBuilder {
         // Transactions will be recorded in the checkpoint in this order.
         let mut sorted_tx_effects_included_in_checkpoint = Vec::new();
         for pending_checkpoint in pendings.into_iter() {
-            let pending = pending_checkpoint.into_v2();
+            let pending = pending_checkpoint.into_v1();
             let txn_in_checkpoint = self
                 .resolve_checkpoint_transactions(pending.roots, &mut effects_in_current_checkpoint)
                 .await?;
@@ -2299,7 +2299,7 @@ impl CheckpointService {
     fn write_and_notify_checkpoint_for_testing(
         &self,
         epoch_store: &AuthorityPerEpochStore,
-        checkpoint: PendingCheckpointV2,
+        checkpoint: PendingCheckpoint,
     ) -> IotaResult {
         use crate::authority::authority_per_epoch_store::ConsensusCommitOutput;
 
@@ -2726,8 +2726,8 @@ mod tests {
         }
     }
 
-    fn p(i: u64, t: Vec<u8>, timestamp_ms: u64) -> PendingCheckpointV2 {
-        PendingCheckpointV2::V2(PendingCheckpointV2Contents {
+    fn p(i: u64, t: Vec<u8>, timestamp_ms: u64) -> PendingCheckpoint {
+        PendingCheckpoint::V1(PendingCheckpointContents {
             roots: t
                 .into_iter()
                 .map(|t| TransactionKey::Digest(d(t)))

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -104,23 +104,23 @@ pub struct PendingCheckpointInfo {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum PendingCheckpoint {
     // This is an enum for future upgradability, though at the moment there is only one variant.
-    V1(PendingCheckpointContents),
+    V1(PendingCheckpointContentsV1),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct PendingCheckpointContents {
+pub struct PendingCheckpointContentsV1 {
     pub roots: Vec<TransactionKey>,
     pub details: PendingCheckpointInfo,
 }
 
 impl PendingCheckpoint {
-    pub fn as_v1(&self) -> &PendingCheckpointContents {
+    pub fn as_v1(&self) -> &PendingCheckpointContentsV1 {
         match self {
             PendingCheckpoint::V1(contents) => contents,
         }
     }
 
-    pub fn into_v1(self) -> PendingCheckpointContents {
+    pub fn into_v1(self) -> PendingCheckpointContentsV1 {
         match self {
             PendingCheckpoint::V1(contents) => contents,
         }
@@ -2727,7 +2727,7 @@ mod tests {
     }
 
     fn p(i: u64, t: Vec<u8>, timestamp_ms: u64) -> PendingCheckpoint {
-        PendingCheckpoint::V1(PendingCheckpointContents {
+        PendingCheckpoint::V1(PendingCheckpointContentsV1 {
             roots: t
                 .into_iter()
                 .map(|t| TransactionKey::Digest(d(t)))

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -102,12 +102,6 @@ pub struct PendingCheckpointInfo {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct PendingCheckpoint {
-    pub roots: Vec<TransactionDigest>,
-    pub details: PendingCheckpointInfo,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum PendingCheckpointV2 {
     // This is an enum for future upgradability, though at the moment there is only one variant.
     V2(PendingCheckpointV2Contents),
@@ -129,18 +123,6 @@ impl PendingCheckpointV2 {
     pub fn into_v2(self) -> PendingCheckpointV2Contents {
         match self {
             PendingCheckpointV2::V2(contents) => contents,
-        }
-    }
-
-    pub fn expect_v1(self) -> PendingCheckpoint {
-        let v2 = self.into_v2();
-        PendingCheckpoint {
-            roots: v2
-                .roots
-                .into_iter()
-                .map(|root| *root.unwrap_digest())
-                .collect(),
-            details: v2.details,
         }
     }
 
@@ -2395,27 +2377,6 @@ impl CheckpointServiceNotify for CheckpointServiceNoop {
 
     fn notify_checkpoint(&self) -> IotaResult {
         Ok(())
-    }
-}
-
-impl PendingCheckpoint {
-    pub fn height(&self) -> CheckpointHeight {
-        self.details.checkpoint_height
-    }
-}
-
-impl PendingCheckpointV2 {}
-
-impl From<PendingCheckpoint> for PendingCheckpointV2 {
-    fn from(value: PendingCheckpoint) -> Self {
-        PendingCheckpointV2::V2(PendingCheckpointV2Contents {
-            roots: value
-                .roots
-                .into_iter()
-                .map(TransactionKey::Digest)
-                .collect(),
-            details: value.details,
-        })
     }
 }
 


### PR DESCRIPTION
# Description of change

Removing old version of `PendingCheckpointV2`, this version was introduced with randomness generation. Old version `PendingCheckpoint` was used only when `epoch_store.randomness_state_enabled()` was satisfied.

- `PendingCheckpoint` was removed, and `PendingCheckpointV2` was renamed to `PendingCheckpoint` along with corresponding methods.
- removed  `assigned_shared_object_versions` tables and renamed `assigned_shared_object_versions_v2` to `assigned_shared_object_versions`
- removed `pending_checkpoints` tables and renamed `pending_checkpoints_v2` to `pending_checkpoints`
- added assert in `AuthorityEpochTables::new` to make sure that node will not be run with randomness state is not enabled, until we remove randomness config param

## Links to any relevant issues
Close #3177 #3249 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How the change has been tested


## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
