### PR TITLE
remove(node): remove `loaded_child_objects_fixed` feature flag

### DIFF
--- a/crates/iota-core/src/state_accumulator.rs
+++ b/crates/iota-core/src/state_accumulator.rs
@@ -177,15 +177,11 @@ where
     } else if protocol_config.simplified_unwrap_then_delete() {
         accumulate_effects_v2(store, effects)
     } else {
-        accumulate_effects_v1(store, effects, protocol_config)
+        accumulate_effects_v1(store, effects)
     }
 }
 
-fn accumulate_effects_v1<T, S>(
-    store: S,
-    effects: Vec<TransactionEffects>,
-    protocol_config: &ProtocolConfig,
-) -> Accumulator
+fn accumulate_effects_v1<T, S>(store: S, effects: Vec<TransactionEffects>) -> Accumulator
 where
     S: std::ops::Deref<Target = T>,
     T: AccumulatorStore + ?Sized,
@@ -296,11 +292,7 @@ where
                 .expect("read cannot fail");
 
             objref.map(|(id, version, digest)| {
-                assert!(
-                    !protocol_config.loaded_child_objects_fixed() || digest.is_wrapped(),
-                    "{:?}",
-                    id
-                );
+                assert!(digest.is_wrapped(), "{:?}", id);
                 WrappedObject::new(id, version)
             })
         })

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1321,7 +1321,6 @@
                 "include_consensus_digest_in_prologue": true,
                 "loaded_child_object_format": true,
                 "loaded_child_object_format_type": true,
-                "loaded_child_objects_fixed": true,
                 "missing_type_is_compatibility_error": true,
                 "mysticeti_leader_scoring_and_schedule": true,
                 "mysticeti_use_committed_subdag_digest": true,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -117,10 +117,6 @@ struct FeatureFlags {
     // Pass epoch start time to advance_epoch safe mode function.
     #[serde(skip_serializing_if = "is_false")]
     advance_epoch_start_time_in_safe_mode: bool,
-    // If true, apply the fix to correctly capturing loaded child object versions in execution's
-    // object runtime.
-    #[serde(skip_serializing_if = "is_false")]
-    loaded_child_objects_fixed: bool,
     // If true, treat missing types in the upgraded modules when creating an upgraded package as a
     // compatibility error.
     #[serde(skip_serializing_if = "is_false")]
@@ -1124,10 +1120,6 @@ impl ProtocolConfig {
         self.feature_flags.advance_epoch_start_time_in_safe_mode
     }
 
-    pub fn loaded_child_objects_fixed(&self) -> bool {
-        self.feature_flags.loaded_child_objects_fixed
-    }
-
     pub fn missing_type_is_compatibility_error(&self) -> bool {
         self.feature_flags.missing_type_is_compatibility_error
     }
@@ -1963,7 +1955,6 @@ impl ProtocolConfig {
         // removed:
         cfg.feature_flags
             .disallow_change_struct_type_params_on_upgrade = true;
-        cfg.feature_flags.loaded_child_objects_fixed = true;
         cfg.feature_flags.ban_entry_init = true;
 
         // Enable consensus digest in consensus commit prologue on all networks..

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -6,7 +6,6 @@ version: 1
 feature_flags:
   commit_root_state_digest: true
   advance_epoch_start_time_in_safe_mode: true
-  loaded_child_objects_fixed: true
   missing_type_is_compatibility_error: true
   consensus_order_end_of_epoch_last: true
   disable_invariant_violation_check_in_swap_loc: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -6,7 +6,6 @@ version: 1
 feature_flags:
   commit_root_state_digest: true
   advance_epoch_start_time_in_safe_mode: true
-  loaded_child_objects_fixed: true
   missing_type_is_compatibility_error: true
   consensus_order_end_of_epoch_last: true
   disable_invariant_violation_check_in_swap_loc: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -6,7 +6,6 @@ version: 1
 feature_flags:
   commit_root_state_digest: true
   advance_epoch_start_time_in_safe_mode: true
-  loaded_child_objects_fixed: true
   missing_type_is_compatibility_error: true
   consensus_order_end_of_epoch_last: true
   disable_invariant_violation_check_in_swap_loc: true


### PR DESCRIPTION
# Description of change

This PR removes the deprecated protocol feature flag `loaded_child_objects_fixed`. 
We don't need the backwards compatibility to former protocol versions.

## Links to any relevant issues

#3253

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
