### PR TITLE
remove(node): remove `missing_type_is_compatibility_error` feature flag

### DIFF
--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1322,7 +1322,6 @@
                 "loaded_child_object_format": true,
                 "loaded_child_object_format_type": true,
                 "loaded_child_objects_fixed": true,
-                "missing_type_is_compatibility_error": true,
                 "mysticeti_leader_scoring_and_schedule": true,
                 "mysticeti_use_committed_subdag_digest": true,
                 "no_extraneous_module_bytes": true,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -121,10 +121,6 @@ struct FeatureFlags {
     // object runtime.
     #[serde(skip_serializing_if = "is_false")]
     loaded_child_objects_fixed: bool,
-    // If true, treat missing types in the upgraded modules when creating an upgraded package as a
-    // compatibility error.
-    #[serde(skip_serializing_if = "is_false")]
-    missing_type_is_compatibility_error: bool,
 
     // DEPRECATED: this was an ephemeral feature flag only used by consensus handler, which has now
     // been deployed everywhere.
@@ -1128,10 +1124,6 @@ impl ProtocolConfig {
         self.feature_flags.loaded_child_objects_fixed
     }
 
-    pub fn missing_type_is_compatibility_error(&self) -> bool {
-        self.feature_flags.missing_type_is_compatibility_error
-    }
-
     pub fn consensus_order_end_of_epoch_last(&self) -> bool {
         self.feature_flags.consensus_order_end_of_epoch_last
     }
@@ -1918,7 +1910,6 @@ impl ProtocolConfig {
         };
 
         cfg.feature_flags.advance_epoch_start_time_in_safe_mode = true;
-        cfg.feature_flags.missing_type_is_compatibility_error = true;
         cfg.feature_flags.consensus_order_end_of_epoch_last = true;
         cfg.feature_flags
             .disable_invariant_violation_check_in_swap_loc = true;

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -7,7 +7,6 @@ feature_flags:
   commit_root_state_digest: true
   advance_epoch_start_time_in_safe_mode: true
   loaded_child_objects_fixed: true
-  missing_type_is_compatibility_error: true
   consensus_order_end_of_epoch_last: true
   disable_invariant_violation_check_in_swap_loc: true
   advance_to_highest_supported_protocol_version: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -7,7 +7,6 @@ feature_flags:
   commit_root_state_digest: true
   advance_epoch_start_time_in_safe_mode: true
   loaded_child_objects_fixed: true
-  missing_type_is_compatibility_error: true
   consensus_order_end_of_epoch_last: true
   disable_invariant_violation_check_in_swap_loc: true
   advance_to_highest_supported_protocol_version: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -7,7 +7,6 @@ feature_flags:
   commit_root_state_digest: true
   advance_epoch_start_time_in_safe_mode: true
   loaded_child_objects_fixed: true
-  missing_type_is_compatibility_error: true
   consensus_order_end_of_epoch_last: true
   disable_invariant_violation_check_in_swap_loc: true
   advance_to_highest_supported_protocol_version: true


### PR DESCRIPTION
# Description of change

This PR removes the deprecated protocol feature flag `missing_type_is_compatibility_error`. 
We don't need the backwards compatibility to former protocol versions.

## Links to any relevant issues

#3253

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
