### PR TITLE
remove(node): remove `txn_base_cost_as_multiplier` feature flag

### DIFF
--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1341,7 +1341,6 @@
                 "simplified_unwrap_then_delete": true,
                 "soft_bundle": true,
                 "throughput_aware_consensus_submission": false,
-                "txn_base_cost_as_multiplier": true,
                 "verify_legacy_zklogin_address": true,
                 "zklogin_auth": true
               },

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -164,9 +164,6 @@ struct FeatureFlags {
     // regardless of their previous state in the store.
     #[serde(skip_serializing_if = "is_false")]
     simplified_unwrap_then_delete: bool,
-    // If true minimum txn charge is a multiplier of the gas price
-    #[serde(skip_serializing_if = "is_false")]
-    txn_base_cost_as_multiplier: bool,
 
     // If true, the ability to delete shared objects is in effect
     #[serde(skip_serializing_if = "is_false")]
@@ -1175,10 +1172,6 @@ impl ProtocolConfig {
         self.feature_flags.simplified_unwrap_then_delete
     }
 
-    pub fn txn_base_cost_as_multiplier(&self) -> bool {
-        self.feature_flags.txn_base_cost_as_multiplier
-    }
-
     pub fn shared_object_deletion(&self) -> bool {
         self.feature_flags.shared_object_deletion
     }
@@ -1928,7 +1921,6 @@ impl ProtocolConfig {
         cfg.feature_flags.commit_root_state_digest = true;
         cfg.feature_flags.consensus_transaction_ordering = ConsensusTransactionOrdering::ByGasPrice;
         cfg.feature_flags.simplified_unwrap_then_delete = true;
-        cfg.feature_flags.txn_base_cost_as_multiplier = true;
         cfg.feature_flags.loaded_child_object_format = true;
         cfg.feature_flags.loaded_child_object_format_type = true;
         cfg.feature_flags.simple_conservation_checks = true;

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -16,7 +16,6 @@ feature_flags:
   no_extraneous_module_bytes: true
   consensus_transaction_ordering: ByGasPrice
   simplified_unwrap_then_delete: true
-  txn_base_cost_as_multiplier: true
   shared_object_deletion: true
   loaded_child_object_format: true
   end_of_epoch_transaction_supported: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -16,7 +16,6 @@ feature_flags:
   no_extraneous_module_bytes: true
   consensus_transaction_ordering: ByGasPrice
   simplified_unwrap_then_delete: true
-  txn_base_cost_as_multiplier: true
   shared_object_deletion: true
   loaded_child_object_format: true
   end_of_epoch_transaction_supported: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -16,7 +16,6 @@ feature_flags:
   no_extraneous_module_bytes: true
   consensus_transaction_ordering: ByGasPrice
   simplified_unwrap_then_delete: true
-  txn_base_cost_as_multiplier: true
   shared_object_deletion: true
   loaded_child_object_format: true
   end_of_epoch_transaction_supported: true

--- a/crates/iota-types/src/gas_model/gas_predicates.rs
+++ b/crates/iota-types/src/gas_model/gas_predicates.rs
@@ -6,8 +6,6 @@
 // Predicates and utility functions based on gas versions.
 //
 
-use iota_protocol_config::ProtocolConfig;
-
 use crate::gas_model::{
     tables::{
         initial_cost_schedule_v1, initial_cost_schedule_v2, initial_cost_schedule_v3,
@@ -35,12 +33,6 @@ pub fn charge_input_as_memory(gas_model_version: u64) -> bool {
 /// If true, calculate value sizes using the legacy size calculation.
 pub fn use_legacy_abstract_size(gas_model_version: u64) -> bool {
     gas_model_version <= 7
-}
-
-// If true, use the value of txn_base_cost as a multiplier of transaction gas
-// price to determine the minimum cost of a transaction.
-pub fn txn_base_cost_as_multiplier(protocol_config: &ProtocolConfig) -> bool {
-    protocol_config.txn_base_cost_as_multiplier()
 }
 
 // If true, charge differently for package upgrades

--- a/crates/iota-types/src/gas_model/gas_v2.rs
+++ b/crates/iota-types/src/gas_model/gas_v2.rs
@@ -15,7 +15,7 @@ mod checked {
         error::{ExecutionError, ExecutionErrorKind, UserInputError, UserInputResult},
         gas::{self, GasCostSummary, IotaGasStatusAPI},
         gas_model::{
-            gas_predicates::{cost_table_for_version, txn_base_cost_as_multiplier},
+            gas_predicates::cost_table_for_version,
             tables::{GasStatus, ZERO_COST_SCHEDULE},
             units_types::CostTable,
         },
@@ -122,11 +122,7 @@ mod checked {
         pub(crate) fn new(c: &ProtocolConfig, gas_price: u64) -> Self {
             // gas_price here is the Reference Gas Price, however we may decide
             // to change it to be the price passed in the transaction
-            let min_transaction_cost = if txn_base_cost_as_multiplier(c) {
-                c.base_tx_cost_fixed() * gas_price
-            } else {
-                c.base_tx_cost_fixed()
-            };
+            let min_transaction_cost = c.base_tx_cost_fixed() * gas_price;
             Self {
                 min_transaction_cost,
                 max_gas_budget: c.max_tx_gas(),


### PR DESCRIPTION
# Description of change

This PR removes the deprecated protocol feature flag `txn_base_cost_as_multiplier`. 
We don't need the backwards compatibility to former protocol versions.

## Links to any relevant issues

#3253

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
