### PR TITLE
remove(node): remove `end_of_epoch_transaction_supported` feature flag

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -4841,34 +4841,18 @@ impl AuthorityState {
             ));
         };
 
-        let tx = if epoch_store
-            .protocol_config()
-            .end_of_epoch_transaction_supported()
-        {
-            txns.push(EndOfEpochTransactionKind::new_change_epoch(
-                next_epoch,
-                next_epoch_protocol_version,
-                gas_cost_summary.storage_cost,
-                gas_cost_summary.computation_cost,
-                gas_cost_summary.storage_rebate,
-                gas_cost_summary.non_refundable_storage_fee,
-                epoch_start_timestamp_ms,
-                next_epoch_system_package_bytes,
-            ));
+        txns.push(EndOfEpochTransactionKind::new_change_epoch(
+            next_epoch,
+            next_epoch_protocol_version,
+            gas_cost_summary.storage_cost,
+            gas_cost_summary.computation_cost,
+            gas_cost_summary.storage_rebate,
+            gas_cost_summary.non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            next_epoch_system_package_bytes,
+        ));
 
-            VerifiedTransaction::new_end_of_epoch_transaction(txns)
-        } else {
-            VerifiedTransaction::new_change_epoch(
-                next_epoch,
-                next_epoch_protocol_version,
-                gas_cost_summary.storage_cost,
-                gas_cost_summary.computation_cost,
-                gas_cost_summary.storage_rebate,
-                gas_cost_summary.non_refundable_storage_fee,
-                epoch_start_timestamp_ms,
-                next_epoch_system_package_bytes,
-            )
-        };
+        let tx = VerifiedTransaction::new_end_of_epoch_transaction(txns);
 
         let executable_tx = VerifiedExecutableTransaction::new_from_checkpoint(
             tx.clone(),

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1315,7 +1315,6 @@
                 "enable_jwk_consensus_updates": true,
                 "enable_poseidon": true,
                 "enable_vdf": true,
-                "end_of_epoch_transaction_supported": true,
                 "fresh_vm_on_framework_upgrade": true,
                 "hardened_otw_check": true,
                 "include_consensus_digest_in_prologue": true,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -183,9 +183,6 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     enable_jwk_consensus_updates: bool,
 
-    #[serde(skip_serializing_if = "is_false")]
-    end_of_epoch_transaction_supported: bool,
-
     // Perform simple conservation checks keeping into account out of gas scenarios
     // while charging for storage.
     #[serde(skip_serializing_if = "is_false")]
@@ -1188,12 +1185,7 @@ impl ProtocolConfig {
     }
 
     pub fn enable_jwk_consensus_updates(&self) -> bool {
-        let ret = self.feature_flags.enable_jwk_consensus_updates;
-        if ret {
-            // jwk updates required end-of-epoch transactions
-            assert!(self.feature_flags.end_of_epoch_transaction_supported);
-        }
-        ret
+        self.feature_flags.enable_jwk_consensus_updates
     }
 
     pub fn simple_conservation_checks(&self) -> bool {
@@ -1202,15 +1194,6 @@ impl ProtocolConfig {
 
     pub fn loaded_child_object_format_type(&self) -> bool {
         self.feature_flags.loaded_child_object_format_type
-    }
-
-    pub fn end_of_epoch_transaction_supported(&self) -> bool {
-        let ret = self.feature_flags.end_of_epoch_transaction_supported;
-        if !ret {
-            // jwk updates required end-of-epoch transactions
-            assert!(!self.feature_flags.enable_jwk_consensus_updates);
-        }
-        ret
     }
 
     pub fn recompute_has_public_transfer_in_execution(&self) -> bool {
@@ -1233,12 +1216,7 @@ impl ProtocolConfig {
     }
 
     pub fn enable_bridge(&self) -> bool {
-        let ret = self.feature_flags.bridge;
-        if ret {
-            // bridge required end-of-epoch transactions
-            assert!(self.feature_flags.end_of_epoch_transaction_supported);
-        }
-        ret
+        self.feature_flags.bridge
     }
 
     pub fn should_try_to_finalize_bridge_committee(&self) -> bool {
@@ -1932,7 +1910,6 @@ impl ProtocolConfig {
         cfg.feature_flags.loaded_child_object_format = true;
         cfg.feature_flags.loaded_child_object_format_type = true;
         cfg.feature_flags.simple_conservation_checks = true;
-        cfg.feature_flags.end_of_epoch_transaction_supported = true;
         cfg.feature_flags.enable_effects_v2 = true;
 
         cfg.feature_flags.recompute_has_public_transfer_in_execution = true;

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -19,7 +19,6 @@ feature_flags:
   txn_base_cost_as_multiplier: true
   shared_object_deletion: true
   loaded_child_object_format: true
-  end_of_epoch_transaction_supported: true
   simple_conservation_checks: true
   loaded_child_object_format_type: true
   random_beacon: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -19,7 +19,6 @@ feature_flags:
   txn_base_cost_as_multiplier: true
   shared_object_deletion: true
   loaded_child_object_format: true
-  end_of_epoch_transaction_supported: true
   simple_conservation_checks: true
   loaded_child_object_format_type: true
   random_beacon: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -19,7 +19,6 @@ feature_flags:
   txn_base_cost_as_multiplier: true
   shared_object_deletion: true
   loaded_child_object_format: true
-  end_of_epoch_transaction_supported: true
   simple_conservation_checks: true
   loaded_child_object_format_type: true
   random_beacon: true

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -1375,12 +1375,6 @@ impl TransactionKind {
                 }
             }
             TransactionKind::EndOfEpochTransaction(txns) => {
-                if !config.end_of_epoch_transaction_supported() {
-                    return Err(UserInputError::Unsupported(
-                        "EndOfEpochTransaction is not supported".to_string(),
-                    ));
-                }
-
                 for tx in txns {
                     tx.validity_check(config)?;
                 }


### PR DESCRIPTION
# Description of change

This PR removes the deprecated protocol feature flag `end_of_epoch_transaction_supported`. 
We don't need the backwards compatibility to former protocol versions.

## Links to any relevant issues

#3253

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
