### PR TITLE
fix(core-consensus) Remove unused anemo config in consensus tests

### DIFF
--- a/consensus/config/tests/snapshots/parameters_test__parameters.snap
+++ b/consensus/config/tests/snapshots/parameters_test__parameters.snap
@@ -16,8 +16,6 @@ dag_state_cached_rounds: 500
 commit_sync_parallel_fetches: 20
 commit_sync_batch_size: 100
 commit_sync_batches_ahead: 80
-anemo:
-  excessive_message_size: 8388608
 tonic:
   keepalive_interval:
     secs: 5


### PR DESCRIPTION
Remove unused anemo config that makes tests fail