### PR TITLE
fix(e2e-tests): Increase timeout from 60s to 300s in validator_tx_finalizer_e2e_tests

### DIFF
--- a/crates/iota-e2e-tests/tests/validator_tx_finalizer_e2e_tests.rs
+++ b/crates/iota-e2e-tests/tests/validator_tx_finalizer_e2e_tests.rs
@@ -34,7 +34,7 @@ async fn test_validator_tx_finalizer_fastpath_tx() {
     // case where the other 2 wake up first, it would take 10 + 3 * 1 = 13s for
     // a validator to finalize this.
     let tx_digests = [tx_digest];
-    tokio::time::timeout(Duration::from_secs(60), async move {
+    tokio::time::timeout(Duration::from_secs(300), async move {
         for node in cluster.all_node_handles() {
             node.with_async(|n| async {
                 n.state()
@@ -73,7 +73,7 @@ async fn test_validator_tx_finalizer_consensus_tx() {
         .await
         .unwrap();
     let tx_digests = [tx_digest];
-    tokio::time::timeout(Duration::from_secs(60), async move {
+    tokio::time::timeout(Duration::from_secs(300), async move {
         for node in cluster.all_node_handles() {
             node.with_async(|n| async {
                 n.state()


### PR DESCRIPTION
This PR aims to fix 2 e2e-tests:
* iota-e2e-tests::validator_tx_finalizer_e2e_tests test_validator_tx_finalizer_consensus_tx
* iota-e2e-tests::validator_tx_finalizer_e2e_tests test_validator_tx_finalizer_fastpath_tx

The tests failed because thy're taking more than 60s to finish.

Part of #3321 

CI screenshot:
![image](https://github.com/user-attachments/assets/2760f154-4970-447c-ba4b-2af0057cbc94)

# Description of change

Please write a summary of your changes and why you made them.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #(issue)`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix

## How the change has been tested

```
./scripts/simtest/cargo-simtest simtest --no-fail-fast  --color always   --package iota-e2e-tests --test validator_tx_finalizer_e2e_tests
```

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have checked that new and existing unit tests pass locally with my changes
