### PR TITLE
fix: update schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7475,6 +7475,7 @@ dependencies = [
  "fastcrypto",
  "iota-network-stack",
  "iota-protocol-config",
+ "iota-rust-sdk",
  "iota-types",
  "itertools 0.13.0",
  "mime",
@@ -7487,7 +7488,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
- "sui-sdk",
  "tap",
  "thiserror",
  "tokio",
@@ -7559,6 +7559,26 @@ dependencies = [
  "telemetry-subscribers",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "iota-rust-sdk"
+version = "0.0.0"
+source = "git+ssh://git@github.com/iotaledger/iota-rust-sdk.git?rev=be2b0fc40ae2be0ea6d33700d32435383b94b76b#be2b0fc40ae2be0ea6d33700d32435383b94b76b"
+dependencies = [
+ "base64ct",
+ "bcs",
+ "blake2",
+ "bnum",
+ "bs58 0.5.1",
+ "hex",
+ "roaring",
+ "schemars",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -8115,6 +8135,7 @@ dependencies = [
  "iota-metrics",
  "iota-network-stack",
  "iota-protocol-config",
+ "iota-rust-sdk",
  "iota-sdk 1.1.5",
  "itertools 0.13.0",
  "lru 0.12.4",
@@ -8155,7 +8176,6 @@ dependencies = [
  "static_assertions",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "sui-sdk",
  "tap",
  "thiserror",
  "tokio",
@@ -14198,26 +14218,6 @@ name = "subtle-ng"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
-
-[[package]]
-name = "sui-sdk"
-version = "0.0.0"
-source = "git+ssh://git@github.com/iotaledger/iota-rust-sdk.git?rev=bd233b6879b917fb95e17f21927c198e7a60c924#bd233b6879b917fb95e17f21927c198e7a60c924"
-dependencies = [
- "base64ct",
- "bcs",
- "blake2",
- "bnum",
- "bs58 0.5.1",
- "hex",
- "roaring",
- "schemars",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with",
- "winnow 0.6.20",
-]
 
 [[package]]
 name = "supports-color"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -384,7 +384,7 @@ anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "dbb5a074
 anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "dbb5a074c2d25660525ab5d36d65ff0cb8051949" }
 
 # core-types with json format for REST api
-iota-sdk2 = { package = "sui-sdk", git = "ssh://git@github.com/iotaledger/iota-rust-sdk.git", rev = "bd233b6879b917fb95e17f21927c198e7a60c924", features = ["hash", "serde", "schemars"] }
+iota-sdk2 = { package = "iota-rust-sdk", git = "ssh://git@github.com/iotaledger/iota-rust-sdk.git", rev = "be2b0fc40ae2be0ea6d33700d32435383b94b76b", features = ["hash", "serde", "schemars"] }
 
 ### Workspace Members ###
 bin-version = { path = "crates/bin-version" }

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1296,18 +1296,18 @@
               "maxSupportedProtocolVersion": "1",
               "protocolVersion": "1",
               "featureFlags": {
-                "accept_zklogin_in_multisig": true,
+                "accept_zklogin_in_multisig": false,
                 "advance_to_highest_supported_protocol_version": true,
                 "allow_receiving_object_id": true,
                 "authority_capabilities_v2": true,
-                "bridge": true,
+                "bridge": false,
                 "disable_invariant_violation_check_in_swap_loc": true,
                 "enable_coin_deny_list": true,
                 "enable_coin_deny_list_v2": true,
                 "enable_effects_v2": true,
                 "enable_group_ops_native_function_msm": true,
                 "enable_group_ops_native_functions": true,
-                "enable_jwk_consensus_updates": true,
+                "enable_jwk_consensus_updates": false,
                 "enable_poseidon": true,
                 "enable_vdf": true,
                 "fresh_vm_on_framework_upgrade": true,
@@ -1318,7 +1318,6 @@
                 "mysticeti_leader_scoring_and_schedule": true,
                 "mysticeti_use_committed_subdag_digest": true,
                 "no_extraneous_module_bytes": true,
-                "package_upgrades": true,
                 "passkey_auth": true,
                 "prepend_prologue_tx_in_consensus_commit_in_checkpoints": true,
                 "random_beacon": true,
@@ -1333,7 +1332,7 @@
                 "soft_bundle": true,
                 "throughput_aware_consensus_submission": false,
                 "verify_legacy_zklogin_address": true,
-                "zklogin_auth": true
+                "zklogin_auth": false
               },
               "attributes": {
                 "address_from_bytes_cost_base": {

--- a/crates/iota-rest-api/openapi/openapi.json
+++ b/crates/iota-rest-api/openapi/openapi.json
@@ -858,7 +858,7 @@
       },
       "Address": {
         "title": "Address",
-        "description": "A 32-byte Sui address, encoded as a hex string.",
+        "description": "A 32-byte Iota address, encoded as a hex string.",
         "examples": [
           "0x0000000000000000000000000000000000000000000000000000000000000002"
         ],
@@ -2235,7 +2235,7 @@
             }
           },
           {
-            "description": "Sui Move Bytecode Verification Error.",
+            "description": "Iota Move Bytecode Verification Error.",
             "type": "object",
             "required": [
               "error"
@@ -2244,7 +2244,7 @@
               "error": {
                 "type": "string",
                 "enum": [
-                  "sui_move_verification_error"
+                  "iota_move_verification_error"
                 ]
               }
             }
@@ -2615,7 +2615,7 @@
             }
           },
           {
-            "description": "Sui Move Bytecode verification timed out.",
+            "description": "Iota Move Bytecode verification timed out.",
             "type": "object",
             "required": [
               "error"
@@ -2624,7 +2624,7 @@
               "error": {
                 "type": "string",
                 "enum": [
-                  "sui_move_verification_timedout"
+                  "iota_move_verification_timedout"
                 ]
               }
             }
@@ -2757,7 +2757,7 @@
         }
       },
       "GasCostSummary": {
-        "description": "Summary of gas charges.\n\nStorage is charged independently of computation. There are 3 parts to the storage charges: `storage_cost`: it is the charge of storage at the time the transaction is executed. The cost of storage is the number of bytes of the objects being mutated multiplied by a variable storage cost per byte `storage_rebate`: this is the amount a user gets back when manipulating an object. The `storage_rebate` is the `storage_cost` for an object minus fees. `non_refundable_storage_fee`: not all the value of the object storage cost is given back to user and there is a small fraction that is kept by the system. This value tracks that charge.\n\nWhen looking at a gas cost summary the amount charged to the user is `computation_cost + storage_cost - storage_rebate` and that is the amount that is deducted from the gas coins. `non_refundable_storage_fee` is collected from the objects being mutated/deleted and it is tracked by the system in storage funds.\n\nObjects deleted, including the older versions of objects mutated, have the storage field on the objects added up to a pool of \"potential rebate\". This rebate then is reduced by the \"nonrefundable rate\" such that: `potential_rebate(storage cost of deleted/mutated objects) = storage_rebate + non_refundable_storage_fee`",
+        "description": "Summary of gas charges.\n\nStorage is charged independently of computation. There are 3 parts to the storage charges: `storage_cost`: it is the charge of storage at the time the transaction is executed.                 The cost of storage is the number of bytes of the objects being mutated                 multiplied by a variable storage cost per byte `storage_rebate`: this is the amount a user gets back when manipulating an object.                   The `storage_rebate` is the `storage_cost` for an object minus fees. `non_refundable_storage_fee`: not all the value of the object storage cost is given back to user and there is a small fraction that is kept by the system. This value tracks that charge.\n\nWhen looking at a gas cost summary the amount charged to the user is `computation_cost + storage_cost - storage_rebate` and that is the amount that is deducted from the gas coins. `non_refundable_storage_fee` is collected from the objects being mutated/deleted and it is tracked by the system in storage funds.\n\nObjects deleted, including the older versions of objects mutated, have the storage field on the objects added up to a pool of \"potential rebate\". This rebate then is reduced by the \"nonrefundable rate\" such that: `potential_rebate(storage cost of deleted/mutated objects) = storage_rebate + non_refundable_storage_fee`",
         "type": "object",
         "required": [
           "computation_cost",
@@ -2876,7 +2876,7 @@
         "title": "Identifier",
         "description": "A Move Identifier",
         "examples": [
-          "sui"
+          "iota"
         ],
         "type": "string",
         "pattern": "(?:[a-zA-Z][a-zA-Z0-9_]{0,127})|(?:_[a-zA-Z0-9_]{0,127})"
@@ -3916,7 +3916,7 @@
         "title": "StructTag",
         "description": "A Move StructTag",
         "examples": [
-          "0x2::coin::Coin<0x2::sui::SUI>"
+          "0x2::coin::Coin<0x2::iota::IOTA>"
         ],
         "type": "string"
       },


### PR DESCRIPTION
# Description of change

The `iota-rust-sdk` version was updated.
The `openrpc.json` and `openapi.json` schemas were updated.