### PR TITLE
refactor(iota-json-rpc-tests): Optimise `iota-json-rpc` tests

### DIFF
--- a/crates/iota-json-rpc-tests/README.md
+++ b/crates/iota-json-rpc-tests/README.md
@@ -16,7 +16,7 @@ Certain test cases rely on the test execution model, such as `nextest` or `simte
 When running all `coin_api` tests using `cargo test`, failures may occur because the `QUERY_MAX_RESULT_LIMIT` is initialized upon first access (as a Singleton). This behavior complicates testing, as subsequent tests
 that rely on this data will be affected by the initial test's configuration. Moreover, some test cases may need different values for `QUERY_MAX_RESULT_LIMIT`, further complicating the testing process.
 
-> **NOTE**
+> [!NOTE]
 >
 > To speed up the tests running time we can use the `simulator` profile, it internally uses the `opt-level = 1` which gives about 5x speedup executing tests without slowing down build times very much.
 >

--- a/crates/iota-json-rpc-tests/README.md
+++ b/crates/iota-json-rpc-tests/README.md
@@ -16,9 +16,15 @@ Certain test cases rely on the test execution model, such as `nextest` or `simte
 When running all `coin_api` tests using `cargo test`, failures may occur because the `QUERY_MAX_RESULT_LIMIT` is initialized upon first access (as a Singleton). This behavior complicates testing, as subsequent tests
 that rely on this data will be affected by the initial test's configuration. Moreover, some test cases may need different values for `QUERY_MAX_RESULT_LIMIT`, further complicating the testing process.
 
+> **NOTE**
+>
+> To speed up the tests running time we can use the `simulator` profile, it internally uses the `opt-level = 1` which gives about 5x speedup executing tests without slowing down build times very much.
+>
+> We can use this profile for `cargo nextest` or `cargo test`, when using `cargo simtest` this profile is enabled by default
+
 ### Using `tokio`
 
-- `cargo nextest run -p iota-json-rpc-tests
+- `cargo nextest run --cargo-profile simulator -p iota-json-rpc-tests`
 
 ### Using the simulation testing framework
 


### PR DESCRIPTION


# Description of change

Added a note in the README on how to improve the execution times of the `iota-json-rpc-tests`

## Links to any relevant issues

#3105 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)


## How the change has been tested

running all tests without the profile, the execution time is around 10 min

```sh
cargo nextest run -p iota-json-rpc-tests
```

running all tests tithe the `simulator` profile, the execution is around 2 min

```sh
cargo nextest run --cargo-profile simulator -p iota-json-rpc-tests
```


## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code

