### PR TITLE
remove(node): remove `enable_effects_v2` feature flag

### DIFF
--- a/crates/iota-core/src/authority/authority_test_utils.rs
+++ b/crates/iota-core/src/authority/authority_test_utils.rs
@@ -130,10 +130,7 @@ pub async fn execute_certificate_with_execution_error(
     // wrong inside the VM
     let (result, execution_error_opt) = authority.try_execute_for_test(&certificate).await?;
     let state_after = state_acc.accumulate_cached_live_object_set_for_testing();
-    let effects_acc = state_acc.accumulate_effects(
-        vec![result.inner().data().clone()],
-        epoch_store.protocol_config(),
-    );
+    let effects_acc = state_acc.accumulate_effects(vec![result.inner().data().clone()]);
     state.union(&effects_acc);
 
     assert_eq!(state_after.digest(), state.digest());

--- a/crates/iota-core/src/test_utils.rs
+++ b/crates/iota-core/src/test_utils.rs
@@ -84,10 +84,7 @@ pub async fn send_and_confirm_transaction(
     let mut state = state_acc.accumulate_live_object_set();
     let (result, _execution_error_opt) = authority.try_execute_for_test(&certificate).await?;
     let state_after = state_acc.accumulate_live_object_set();
-    let effects_acc = state_acc.accumulate_effects(
-        vec![result.inner().data().clone()],
-        epoch_store.protocol_config(),
-    );
+    let effects_acc = state_acc.accumulate_effects(vec![result.inner().data().clone()]);
     state.union(&effects_acc);
 
     assert_eq!(state_after.digest(), state.digest());

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1304,7 +1304,6 @@
                 "disable_invariant_violation_check_in_swap_loc": true,
                 "enable_coin_deny_list": true,
                 "enable_coin_deny_list_v2": true,
-                "enable_effects_v2": true,
                 "enable_group_ops_native_function_msm": true,
                 "enable_group_ops_native_functions": true,
                 "enable_jwk_consensus_updates": false,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -155,9 +155,6 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     bridge: bool,
 
-    #[serde(skip_serializing_if = "is_false")]
-    enable_effects_v2: bool,
-
     // Enable throughput aware consensus submission
     #[serde(skip_serializing_if = "is_false")]
     throughput_aware_consensus_submission: bool,
@@ -1116,10 +1113,6 @@ impl ProtocolConfig {
         self.bridge_should_try_to_finalize_committee.unwrap_or(true)
     }
 
-    pub fn enable_effects_v2(&self) -> bool {
-        self.feature_flags.enable_effects_v2
-    }
-
     pub fn accept_zklogin_in_multisig(&self) -> bool {
         self.feature_flags.accept_zklogin_in_multisig
     }
@@ -1774,7 +1767,6 @@ impl ProtocolConfig {
         cfg.feature_flags.consensus_transaction_ordering = ConsensusTransactionOrdering::ByGasPrice;
         cfg.feature_flags.loaded_child_object_format = true;
         cfg.feature_flags.loaded_child_object_format_type = true;
-        cfg.feature_flags.enable_effects_v2 = true;
 
         cfg.feature_flags.recompute_has_public_transfer_in_execution = true;
         cfg.feature_flags.shared_object_deletion = true;

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -12,7 +12,6 @@ feature_flags:
   loaded_child_object_format: true
   loaded_child_object_format_type: true
   random_beacon: true
-  enable_effects_v2: true
   recompute_has_public_transfer_in_execution: true
   hardened_otw_check: true
   allow_receiving_object_id: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -12,7 +12,6 @@ feature_flags:
   loaded_child_object_format: true
   loaded_child_object_format_type: true
   random_beacon: true
-  enable_effects_v2: true
   recompute_has_public_transfer_in_execution: true
   hardened_otw_check: true
   allow_receiving_object_id: true

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -12,7 +12,6 @@ feature_flags:
   loaded_child_object_format: true
   loaded_child_object_format_type: true
   random_beacon: true
-  enable_effects_v2: true
   recompute_has_public_transfer_in_execution: true
   hardened_otw_check: true
   allow_receiving_object_id: true

--- a/iota-execution/latest/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/latest/iota-adapter/src/temporary_store.rs
@@ -244,8 +244,6 @@ impl<'backing> TemporaryStore<'backing> {
             }
         }
 
-        assert!(self.protocol_config.enable_effects_v2());
-
         // In the case of special transactions that don't require a gas object,
         // we don't really care about the effects to gas, just use the input for it.
         // Gas coins are guaranteed to be at least size 1 and if more than 1

--- a/iota-execution/v0/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/v0/iota-adapter/src/temporary_store.rs
@@ -244,8 +244,6 @@ impl<'backing> TemporaryStore<'backing> {
             }
         }
 
-        assert!(self.protocol_config.enable_effects_v2());
-
         // In the case of special transactions that don't require a gas object,
         // we don't really care about the effects to gas, just use the input for it.
         // Gas coins are guaranteed to be at least size 1 and if more than 1


### PR DESCRIPTION
# Description of change

This PR removes the deprecated protocol feature flag `enable_effects_v2`. 
We don't need the backwards compatibility to former protocol versions.

## Links to any relevant issues

#3253

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
