### PR TITLE
fix(node) Fix tests with randomness enabled

### DIFF
--- a/crates/iota-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/iota-core/src/unit_tests/execution_driver_tests.rs
@@ -299,16 +299,8 @@ async fn execute_shared_on_first_three_authorities(
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
-#[ignore = "https://github.com/iotaledger/iota/issues/3382"]
 async fn test_execution_with_dependencies() {
     telemetry_subscribers::init_for_testing();
-
-    // Disable randomness, it can't be constructed with fake authorities in this
-    // test anyway.
-    // let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-    //    config.set_random_beacon_for_testing(false);
-    //    config
-    //});
 
     // ---- Initialize a network with three accounts, each with 10 gas objects.
 
@@ -486,16 +478,8 @@ async fn try_sign_on_first_three_authorities(
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
-#[ignore = "https://github.com/iotaledger/iota/issues/3382"]
 async fn test_per_object_overload() {
     telemetry_subscribers::init_for_testing();
-
-    // Disable randomness, it can't be constructed with fake authorities in this
-    // test anyway.
-    // let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-    //    config.set_random_beacon_for_testing(false);
-    //    config
-    //});
 
     // Initialize a network with 1 account and 2000 gas objects.
     let (addr, key): (_, AccountKeyPair) = get_key_pair();
@@ -617,16 +601,8 @@ async fn test_per_object_overload() {
 }
 
 #[tokio::test]
-#[ignore = "https://github.com/iotaledger/iota/issues/3382"]
 async fn test_txn_age_overload() {
     telemetry_subscribers::init_for_testing();
-
-    // Disable randomness, it can't be constructed with fake authorities in this
-    // test anyway.
-    // let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
-    //    config.set_random_beacon_for_testing(false);
-    //    config
-    //});
 
     // Initialize a network with 1 account and 3 gas objects.
     let (addr, key): (_, AccountKeyPair) = get_key_pair();


### PR DESCRIPTION
# Description of change

Fix tests that were failing after randomness_enabled flag was removed. 
The problem was that `authority_key` wasn't correctly propagated thoughout the config initialization, which later made cration of `RandomnessManager` fail, because a different authority key was used.

## Links to any relevant issues

Closes #3382 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Ran the tests

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
