### PR TITLE
chore(dependencies): Update `iota-rust-sdk` hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7564,7 +7564,7 @@ dependencies = [
 [[package]]
 name = "iota-rust-sdk"
 version = "0.0.0"
-source = "git+ssh://git@github.com/iotaledger/iota-rust-sdk.git?rev=be2b0fc40ae2be0ea6d33700d32435383b94b76b#be2b0fc40ae2be0ea6d33700d32435383b94b76b"
+source = "git+ssh://git@github.com/iotaledger/iota-rust-sdk.git?rev=f273b232560b0a893b845c1d1018b3aec9c41004#f273b232560b0a893b845c1d1018b3aec9c41004"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -384,7 +384,7 @@ anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "dbb5a074
 anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "dbb5a074c2d25660525ab5d36d65ff0cb8051949" }
 
 # core-types with json format for REST api
-iota-sdk2 = { package = "iota-rust-sdk", git = "ssh://git@github.com/iotaledger/iota-rust-sdk.git", rev = "be2b0fc40ae2be0ea6d33700d32435383b94b76b", features = ["hash", "serde", "schemars"] }
+iota-sdk2 = { package = "iota-rust-sdk", git = "ssh://git@github.com/iotaledger/iota-rust-sdk.git", rev = "f273b232560b0a893b845c1d1018b3aec9c41004", features = ["hash", "serde", "schemars"] }
 
 ### Workspace Members ###
 bin-version = { path = "crates/bin-version" }


### PR DESCRIPTION
# Description of change

Updates the `iota-rust-sdk` dependency to include https://github.com/iotaledger/iota-rust-sdk/pull/4