### PR TITLE
fix(iota-e2e-tests): Reintroduce randomness test with correct semantics

### DIFF
--- a/crates/iota-e2e-tests/tests/randomness_tests.rs
+++ b/crates/iota-e2e-tests/tests/randomness_tests.rs
@@ -1,0 +1,27 @@
+// Copyright (c) 2021, Facebook, Inc. and its affiliates
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_macros::sim_test;
+use iota_types::IOTA_RANDOMNESS_STATE_OBJECT_ID;
+use test_cluster::TestClusterBuilder;
+
+#[sim_test]
+async fn test_create_randomness_state_object() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_protocol_version(1.into())
+        .with_epoch_duration_ms(10000)
+        .build()
+        .await;
+
+    for h in &test_cluster.all_node_handles() {
+        h.with(|node| {
+            node.state()
+                .get_object_cache_reader()
+                .get_latest_object_ref_or_tombstone(IOTA_RANDOMNESS_STATE_OBJECT_ID)
+                .unwrap()
+                .expect("randomness state object should exist");
+        });
+    }
+}

--- a/crates/iota-e2e-tests/tests/randomness_tests.rs
+++ b/crates/iota-e2e-tests/tests/randomness_tests.rs
@@ -8,7 +8,7 @@ use iota_types::IOTA_RANDOMNESS_STATE_OBJECT_ID;
 use test_cluster::TestClusterBuilder;
 
 #[sim_test]
-async fn test_create_randomness_state_object() {
+async fn test_check_randomness_state_object_exists() {
     let test_cluster = TestClusterBuilder::new()
         .with_protocol_version(1.into())
         .with_epoch_duration_ms(10000)


### PR DESCRIPTION
# Description of change

In #3424 the randomness e2e test was removed. This was not necessary as it was only needed to change the assumption of the test, i.e., that the randomness state was not created during genesis.

## Links to any relevant issues

Fixes #3388 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

- `cargo test --package iota-e2e-tests --test randomness_tests -- test_create_randomness_state_object --exact --show-output`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
