### PR TITLE
fix(iota-rosetta): fix tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -243,7 +243,6 @@ criterion = { version = "0.5.0", features = ["async", "async_tokio", "html_repor
 crossterm = "0.25.0"
 csv = "1.2.1"
 dashmap = "5.5.3"
-# datatest-stable = "0.1.2"
 datatest-stable = { git = "https://github.com/nextest-rs/datatest-stable.git", rev = "72db7f6d1bbe36a5407e96b9488a581f763e106f" }
 derivative = "2.2.0"
 diesel = { version = "2.1.0", features = ["chrono", "r2d2", "serde_json", "64-column-tables", "i-implement-a-third-party-backend-and-opt-into-breaking-changes"] }
@@ -310,7 +309,8 @@ serde_json = { version = "1.0.95", features = ["preserve_order"] }
 serde_with = "3.8"
 serde_yaml = "0.8.26"
 shellexpand = "3.1.0"
-signature = { version = "1.6.0", features = ["rand-preview"] }
+# datatest-stable = "0.1.2"
+signature = "1.6.0"
 similar = "2.4.0"
 smallvec = "1.10.0"
 snap = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,10 +210,7 @@ overflow-checks = true
 opt-level = 1
 
 [workspace.lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-  'cfg(msim)',
-  'cfg(fail_points)',
-] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(msim)', 'cfg(fail_points)'] }
 
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
@@ -223,25 +220,9 @@ async-graphql = "=7.0.1"
 async-recursion = "1.0.4"
 async-trait = "0.1.61"
 aws-config = "0.56"
-axum = { version = "0.7", default-features = false, features = [
-  "tokio",
-  "http1",
-  "http2",
-  "json",
-  "matched-path",
-  "original-uri",
-  "form",
-  "query",
-  "ws",
-] }
+axum = { version = "0.7", default-features = false, features = ["tokio", "http1", "http2", "json", "matched-path", "original-uri", "form", "query", "ws"] }
 axum-extra = { version = "0.9", features = ["typed-header"] }
-backoff = { version = "0.4.0", features = [
-  "futures",
-  "futures-core",
-  "pin-project-lite",
-  "tokio",
-  "tokio_1",
-] }
+backoff = { version = "0.4.0", features = ["futures", "futures-core", "pin-project-lite", "tokio", "tokio_1"] }
 base64 = "0.21.2"
 base64-url = "2"
 bcs = "0.1.4"
@@ -258,24 +239,14 @@ clap = { version = "4.4", features = ["derive", "wrap_help"] }
 colored = "2.0.0"
 comfy-table = "6.1.3"
 const-str = "0.5.3"
-criterion = { version = "0.5.0", features = [
-  "async",
-  "async_tokio",
-  "html_reports",
-] }
+criterion = { version = "0.5.0", features = ["async", "async_tokio", "html_reports"] }
 crossterm = "0.25.0"
 csv = "1.2.1"
 dashmap = "5.5.3"
 # datatest-stable = "0.1.2"
 datatest-stable = { git = "https://github.com/nextest-rs/datatest-stable.git", rev = "72db7f6d1bbe36a5407e96b9488a581f763e106f" }
 derivative = "2.2.0"
-diesel = { version = "2.1.0", features = [
-  "chrono",
-  "r2d2",
-  "serde_json",
-  "64-column-tables",
-  "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
-] }
+diesel = { version = "2.1.0", features = ["chrono", "r2d2", "serde_json", "64-column-tables", "i-implement-a-third-party-backend-and-opt-into-breaking-changes"] }
 dirs = "5.0"
 ed25519-consensus = { version = "2.0.1", features = ["serde"] }
 either = "1.8.0"
@@ -293,12 +264,7 @@ hex = "0.4.3"
 http = "1"
 humantime = "2.1.0"
 hyper = "1"
-hyper-rustls = { version = "0.27", default-features = false, features = [
-  "webpki-roots",
-  "http2",
-  "ring",
-  "tls12",
-] }
+hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-roots", "http2", "ring", "tls12"] }
 im = "15"
 indexmap = { version = "2.1.0", features = ["serde"] }
 indicatif = "0.17.2"
@@ -306,13 +272,7 @@ insta = { version = "1.21.1", features = ["redactions", "yaml", "json"] }
 integer-encoding = "3.0.1"
 itertools = "0.13.0"
 json_to_table = { git = "https://github.com/zhiburt/tabled/", rev = "e449317a1c02eb6b29e409ad6617e5d9eb7b3bd4" }
-jsonrpsee = { version = "0.24", features = [
-  "server",
-  "macros",
-  "client",
-  "ws-client",
-  "http-client",
-] }
+jsonrpsee = { version = "0.24", features = ["server", "macros", "client", "ws-client", "http-client"] }
 leb128 = "0.2.5"
 lru = "0.12"
 mockall = "0.11.4"
@@ -337,25 +297,11 @@ quote = "1.0.23"
 rand = "0.8.5"
 rayon = "1.5.3"
 regex = "1.7.1"
-reqwest = { version = "0.12", default-features = false, features = [
-  "http2",
-  "json",
-  "rustls-tls",
-] }
+reqwest = { version = "0.12", default-features = false, features = ["http2", "json", "rustls-tls"] }
 roaring = "0.10.6"
-rocksdb = { version = "0.21.0", default-features = false, features = [
-  "snappy",
-  "lz4",
-  "zstd",
-  "zlib",
-  "multi-threaded-cf",
-] }
+rocksdb = { version = "0.21.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf"] }
 rstest = "0.16.0"
-rustls = { version = "0.23", default-features = false, features = [
-  "std",
-  "tls12",
-  "ring",
-] }
+rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "ring"] }
 schemars = { version = "0.8.21", features = ["either"] }
 scopeguard = "1.1"
 serde = { version = "1.0.144", features = ["derive", "rc"] }
@@ -380,10 +326,7 @@ thiserror = "1.0.40"
 # tokio is defined at a specific version to support patching with iota-sim
 # Do not upgrade without updating https://github.com/iotaledger/iota-sim first
 tokio = "=1.39.2"
-tokio-rustls = { version = "0.26", default-features = false, features = [
-  "tls12",
-  "ring",
-] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["tls12", "ring"] }
 tokio-stream = { version = "0.1.14", features = ["sync", "net"] }
 tokio-util = "0.7.10"
 toml = { version = "0.7.4", features = ["preserve_order"] }
@@ -393,31 +336,10 @@ toml = { version = "0.7.4", features = ["preserve_order"] }
 tonic = { version = "0.12", features = ["transport"] }
 tonic-build = { version = "0.12", features = ["prost", "transport"] }
 tonic-health = "0.12"
-tower = { version = "0.4.12", features = [
-  "full",
-  "util",
-  "timeout",
-  "load-shed",
-  "limit",
-] }
-tower-http = { version = "0.5", features = [
-  "cors",
-  "full",
-  "trace",
-  "set-header",
-  "propagate-header",
-] }
+tower = { version = "0.4.12", features = ["full", "util", "timeout", "load-shed", "limit"] }
+tower-http = { version = "0.5", features = ["cors", "full", "trace", "set-header", "propagate-header"] }
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.15", default-features = false, features = [
-  "std",
-  "smallvec",
-  "fmt",
-  "ansi",
-  "time",
-  "json",
-  "registry",
-  "env-filter",
-] }
+tracing-subscriber = { version = "0.3.15", default-features = false, features = ["std", "smallvec", "fmt", "ansi", "time", "json", "registry", "env-filter"] }
 unescape = "0.1.0"
 url = "2.3.1"
 uuid = { version = "1.1.2", features = ["v4", "fast-rng"] }
@@ -443,17 +365,13 @@ move-transactional-test-runner = { path = "external-crates/move/crates/move-tran
 move-unit-test = { path = "external-crates/move/crates/move-unit-test" }
 move-vm-config = { path = "external-crates/move/crates/move-vm-config" }
 move-vm-profiler = { path = "external-crates/move/crates/move-vm-profiler" }
-move-vm-test-utils = { path = "external-crates/move/crates/move-vm-test-utils/", features = [
-  "tiered-gas",
-] }
+move-vm-test-utils = { path = "external-crates/move/crates/move-vm-test-utils/", features = ["tiered-gas"] }
 move-vm-types = { path = "external-crates/move/crates/move-vm-types" }
 
 coset = "0.3"
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597" }
 fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597" }
-fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597", features = [
-  "experimental",
-] }
+fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597", features = ["experimental"] }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597", package = "fastcrypto-zkp" }
 p256 = { version = "0.13.2", features = ["ecdsa"] }
 passkey-authenticator = { version = "0.2.0" }
@@ -466,11 +384,7 @@ anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "dbb5a074
 anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "dbb5a074c2d25660525ab5d36d65ff0cb8051949" }
 
 # core-types with json format for REST api
-iota-sdk2 = { package = "iota-rust-sdk", git = "ssh://git@github.com/iotaledger/iota-rust-sdk.git", rev = "f273b232560b0a893b845c1d1018b3aec9c41004", features = [
-  "hash",
-  "serde",
-  "schemars",
-] }
+iota-sdk2 = { package = "iota-rust-sdk", git = "ssh://git@github.com/iotaledger/iota-rust-sdk.git", rev = "f273b232560b0a893b845c1d1018b3aec9c41004", features = ["hash", "serde", "schemars"] }
 
 ### Workspace Members ###
 bin-version = { path = "crates/bin-version" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,7 +210,10 @@ overflow-checks = true
 opt-level = 1
 
 [workspace.lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(msim)', 'cfg(fail_points)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(msim)',
+  'cfg(fail_points)',
+] }
 
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
@@ -220,9 +223,25 @@ async-graphql = "=7.0.1"
 async-recursion = "1.0.4"
 async-trait = "0.1.61"
 aws-config = "0.56"
-axum = { version = "0.7", default-features = false, features = ["tokio", "http1", "http2", "json", "matched-path", "original-uri", "form", "query", "ws"] }
+axum = { version = "0.7", default-features = false, features = [
+  "tokio",
+  "http1",
+  "http2",
+  "json",
+  "matched-path",
+  "original-uri",
+  "form",
+  "query",
+  "ws",
+] }
 axum-extra = { version = "0.9", features = ["typed-header"] }
-backoff = { version = "0.4.0", features = ["futures", "futures-core", "pin-project-lite", "tokio", "tokio_1"] }
+backoff = { version = "0.4.0", features = [
+  "futures",
+  "futures-core",
+  "pin-project-lite",
+  "tokio",
+  "tokio_1",
+] }
 base64 = "0.21.2"
 base64-url = "2"
 bcs = "0.1.4"
@@ -239,14 +258,24 @@ clap = { version = "4.4", features = ["derive", "wrap_help"] }
 colored = "2.0.0"
 comfy-table = "6.1.3"
 const-str = "0.5.3"
-criterion = { version = "0.5.0", features = ["async", "async_tokio", "html_reports"] }
+criterion = { version = "0.5.0", features = [
+  "async",
+  "async_tokio",
+  "html_reports",
+] }
 crossterm = "0.25.0"
 csv = "1.2.1"
 dashmap = "5.5.3"
 # datatest-stable = "0.1.2"
 datatest-stable = { git = "https://github.com/nextest-rs/datatest-stable.git", rev = "72db7f6d1bbe36a5407e96b9488a581f763e106f" }
 derivative = "2.2.0"
-diesel = { version = "2.1.0", features = ["chrono", "r2d2", "serde_json", "64-column-tables", "i-implement-a-third-party-backend-and-opt-into-breaking-changes"] }
+diesel = { version = "2.1.0", features = [
+  "chrono",
+  "r2d2",
+  "serde_json",
+  "64-column-tables",
+  "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
+] }
 dirs = "5.0"
 ed25519-consensus = { version = "2.0.1", features = ["serde"] }
 either = "1.8.0"
@@ -264,7 +293,12 @@ hex = "0.4.3"
 http = "1"
 humantime = "2.1.0"
 hyper = "1"
-hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-roots", "http2", "ring", "tls12"] }
+hyper-rustls = { version = "0.27", default-features = false, features = [
+  "webpki-roots",
+  "http2",
+  "ring",
+  "tls12",
+] }
 im = "15"
 indexmap = { version = "2.1.0", features = ["serde"] }
 indicatif = "0.17.2"
@@ -272,7 +306,13 @@ insta = { version = "1.21.1", features = ["redactions", "yaml", "json"] }
 integer-encoding = "3.0.1"
 itertools = "0.13.0"
 json_to_table = { git = "https://github.com/zhiburt/tabled/", rev = "e449317a1c02eb6b29e409ad6617e5d9eb7b3bd4" }
-jsonrpsee = { version = "0.24", features = ["server", "macros", "client", "ws-client", "http-client"] }
+jsonrpsee = { version = "0.24", features = [
+  "server",
+  "macros",
+  "client",
+  "ws-client",
+  "http-client",
+] }
 leb128 = "0.2.5"
 lru = "0.12"
 mockall = "0.11.4"
@@ -297,11 +337,25 @@ quote = "1.0.23"
 rand = "0.8.5"
 rayon = "1.5.3"
 regex = "1.7.1"
-reqwest = { version = "0.12", default-features = false, features = ["http2", "json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = [
+  "http2",
+  "json",
+  "rustls-tls",
+] }
 roaring = "0.10.6"
-rocksdb = { version = "0.21.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf"] }
+rocksdb = { version = "0.21.0", default-features = false, features = [
+  "snappy",
+  "lz4",
+  "zstd",
+  "zlib",
+  "multi-threaded-cf",
+] }
 rstest = "0.16.0"
-rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "ring"] }
+rustls = { version = "0.23", default-features = false, features = [
+  "std",
+  "tls12",
+  "ring",
+] }
 schemars = { version = "0.8.21", features = ["either"] }
 scopeguard = "1.1"
 serde = { version = "1.0.144", features = ["derive", "rc"] }
@@ -310,7 +364,7 @@ serde_json = { version = "1.0.95", features = ["preserve_order"] }
 serde_with = "3.8"
 serde_yaml = "0.8.26"
 shellexpand = "3.1.0"
-signature = "1.6.0"
+signature = { version = "1.6.0", features = ["rand-preview"] }
 similar = "2.4.0"
 smallvec = "1.10.0"
 snap = "1.1.0"
@@ -326,7 +380,10 @@ thiserror = "1.0.40"
 # tokio is defined at a specific version to support patching with iota-sim
 # Do not upgrade without updating https://github.com/iotaledger/iota-sim first
 tokio = "=1.39.2"
-tokio-rustls = { version = "0.26", default-features = false, features = ["tls12", "ring"] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+  "tls12",
+  "ring",
+] }
 tokio-stream = { version = "0.1.14", features = ["sync", "net"] }
 tokio-util = "0.7.10"
 toml = { version = "0.7.4", features = ["preserve_order"] }
@@ -336,10 +393,31 @@ toml = { version = "0.7.4", features = ["preserve_order"] }
 tonic = { version = "0.12", features = ["transport"] }
 tonic-build = { version = "0.12", features = ["prost", "transport"] }
 tonic-health = "0.12"
-tower = { version = "0.4.12", features = ["full", "util", "timeout", "load-shed", "limit"] }
-tower-http = { version = "0.5", features = ["cors", "full", "trace", "set-header", "propagate-header"] }
+tower = { version = "0.4.12", features = [
+  "full",
+  "util",
+  "timeout",
+  "load-shed",
+  "limit",
+] }
+tower-http = { version = "0.5", features = [
+  "cors",
+  "full",
+  "trace",
+  "set-header",
+  "propagate-header",
+] }
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.15", default-features = false, features = ["std", "smallvec", "fmt", "ansi", "time", "json", "registry", "env-filter"] }
+tracing-subscriber = { version = "0.3.15", default-features = false, features = [
+  "std",
+  "smallvec",
+  "fmt",
+  "ansi",
+  "time",
+  "json",
+  "registry",
+  "env-filter",
+] }
 unescape = "0.1.0"
 url = "2.3.1"
 uuid = { version = "1.1.2", features = ["v4", "fast-rng"] }
@@ -365,13 +443,17 @@ move-transactional-test-runner = { path = "external-crates/move/crates/move-tran
 move-unit-test = { path = "external-crates/move/crates/move-unit-test" }
 move-vm-config = { path = "external-crates/move/crates/move-vm-config" }
 move-vm-profiler = { path = "external-crates/move/crates/move-vm-profiler" }
-move-vm-test-utils = { path = "external-crates/move/crates/move-vm-test-utils/", features = ["tiered-gas"] }
+move-vm-test-utils = { path = "external-crates/move/crates/move-vm-test-utils/", features = [
+  "tiered-gas",
+] }
 move-vm-types = { path = "external-crates/move/crates/move-vm-types" }
 
 coset = "0.3"
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597" }
 fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597" }
-fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597", features = ["experimental"] }
+fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597", features = [
+  "experimental",
+] }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597", package = "fastcrypto-zkp" }
 p256 = { version = "0.13.2", features = ["ecdsa"] }
 passkey-authenticator = { version = "0.2.0" }
@@ -384,7 +466,11 @@ anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "dbb5a074
 anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "dbb5a074c2d25660525ab5d36d65ff0cb8051949" }
 
 # core-types with json format for REST api
-iota-sdk2 = { package = "iota-rust-sdk", git = "ssh://git@github.com/iotaledger/iota-rust-sdk.git", rev = "f273b232560b0a893b845c1d1018b3aec9c41004", features = ["hash", "serde", "schemars"] }
+iota-sdk2 = { package = "iota-rust-sdk", git = "ssh://git@github.com/iotaledger/iota-rust-sdk.git", rev = "f273b232560b0a893b845c1d1018b3aec9c41004", features = [
+  "hash",
+  "serde",
+  "schemars",
+] }
 
 ### Workspace Members ###
 bin-version = { path = "crates/bin-version" }

--- a/crates/iota-rosetta/Cargo.toml
+++ b/crates/iota-rosetta/Cargo.toml
@@ -47,5 +47,6 @@ iota-move-build.workspace = true
 iota-sdk.workspace = true
 rand.workspace = true
 reqwest.workspace = true
+signature = { version = "1.6.0", features = ["rand-preview"] }
 tempfile.workspace = true
 test-cluster.workspace = true

--- a/crates/iota-rosetta/src/main.rs
+++ b/crates/iota-rosetta/src/main.rs
@@ -14,10 +14,7 @@ use std::{
 
 use anyhow::anyhow;
 use clap::Parser;
-use fastcrypto::{
-    encoding::{Encoding, Hex},
-    traits::EncodeDecodeBase64,
-};
+use fastcrypto::encoding::{Encoding, Hex};
 use iota_config::{
     Config, IOTA_FULLNODE_CONFIG, IOTA_KEYSTORE_FILENAME, NodeConfig, iota_config_dir,
 };
@@ -221,7 +218,7 @@ fn read_prefunded_account(path: &Path) -> Result<Vec<PrefundedAccount>, anyhow::
     let keys = kp_strings
         .iter()
         .map(|kpstr| {
-            let key = IotaKeyPair::decode_base64(kpstr);
+            let key = IotaKeyPair::decode(kpstr);
             key.map(|k| (IotaAddress::from(&k.public()), k))
         })
         .collect::<Result<BTreeMap<_, _>, _>>()

--- a/crates/iota-rosetta/tests/end_to_end_tests.rs
+++ b/crates/iota-rosetta/tests/end_to_end_tests.rs
@@ -253,7 +253,7 @@ async fn test_withdraw_stake() {
     telemetry_subscribers::init_for_testing();
 
     let test_cluster = TestClusterBuilder::new()
-        .with_epoch_duration_ms(10000)
+        .with_epoch_duration_ms(15000)
         .build()
         .await;
     let sender = test_cluster.get_address_0();


### PR DESCRIPTION
# Description of change

Fix tests, the `decode_base64()` needed to be changed to `decode()` because of https://github.com/iotaledger/iota/pull/1479
For the other test the epoch time I adjusted to the time it also waits further below
```
    // wait for epoch.
    tokio::time::sleep(Duration::from_millis(15000)).await;
```

The feature I added as it was missing when running tests in the iota-rosetta crate:
```
error[E0432]: unresolved import `signature::rand_core`
   --> crates/iota-rosetta/src/unit_tests/balance_changing_tx_tests.rs:43:16
    |
43  | use signature::rand_core::OsRng;
    |                ^^^^^^^^^ could not find `rand_core` in `signature`
```

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/3476

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running `cargo test` in crates/iota-rosetta