### PR TITLE
remove(node): remove `soft_bundle` feature flag

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -242,9 +242,6 @@ pub struct NodeConfig {
     pub state_accumulator_v2: bool,
 
     #[serde(default = "bool_true")]
-    pub enable_soft_bundle: bool,
-
-    #[serde(default = "bool_true")]
     pub enable_validator_tx_finalizer: bool,
 }
 

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -779,21 +779,6 @@ impl ValidatorService {
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> Result<(), tonic::Status> {
         let protocol_config = epoch_store.protocol_config();
-        let node_config = &self.state.config;
-
-        // Soft Bundle MUST be enabled both in protocol config and local node config.
-        //
-        // The local node config is by default enabled, but can be turned off by the
-        // node operator. This acts an extra safety measure where a validator
-        // node have the choice to turn this feature off, without having to
-        // upgrade the entire network.
-        fp_ensure!(
-            protocol_config.soft_bundle() && node_config.enable_soft_bundle,
-            IotaError::UnsupportedFeature {
-                error: "Soft Bundle".to_string()
-            }
-            .into()
-        );
 
         // Enforce these checks per [SIP-19](https://github.com/sui-foundation/sips/blob/main/sips/sip-19.md):
         // - All certs must access at least one shared object.

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -1619,7 +1619,6 @@ async fn test_handle_soft_bundle_certificates() {
 
     let mut protocol_config =
         ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
-    protocol_config.set_enable_soft_bundle_for_testing(true);
     protocol_config.set_max_soft_bundle_size_for_testing(10);
 
     let authority = TestAuthorityBuilder::new()
@@ -1791,7 +1790,6 @@ async fn test_handle_soft_bundle_certificates_errors() {
 
     let mut protocol_config =
         ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
-    protocol_config.set_enable_soft_bundle_for_testing(true);
     protocol_config.set_max_soft_bundle_size_for_testing(3);
     let authority = TestAuthorityBuilder::new()
         .with_reference_gas_price(1000)

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1316,7 +1316,6 @@
                 "recompute_has_public_transfer_in_execution": true,
                 "rethrow_serialization_type_layout_errors": true,
                 "shared_object_deletion": true,
-                "soft_bundle": true,
                 "throughput_aware_consensus_submission": false,
                 "zklogin_auth": false
               },

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -209,10 +209,6 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "Option::is_none")]
     mysticeti_num_leaders_per_round: Option<usize>,
 
-    // Enable Soft Bundle (SIP-19).
-    #[serde(skip_serializing_if = "is_false")]
-    soft_bundle: bool,
-
     // If true, enable the coin deny list V2.
     #[serde(skip_serializing_if = "is_false")]
     enable_coin_deny_list_v2: bool,
@@ -1129,10 +1125,6 @@ impl ProtocolConfig {
         self.feature_flags.mysticeti_num_leaders_per_round
     }
 
-    pub fn soft_bundle(&self) -> bool {
-        self.feature_flags.soft_bundle
-    }
-
     pub fn passkey_auth(&self) -> bool {
         self.feature_flags.passkey_auth
     }
@@ -1736,9 +1728,6 @@ impl ProtocolConfig {
 
         cfg.feature_flags.enable_coin_deny_list_v2 = true;
 
-        // Enable soft bundle.
-        cfg.feature_flags.soft_bundle = true;
-
         cfg.feature_flags.per_object_congestion_control_mode =
             PerObjectCongestionControlMode::TotalTxCount;
 
@@ -1905,10 +1894,6 @@ impl ProtocolConfig {
 
     pub fn set_mysticeti_num_leaders_per_round_for_testing(&mut self, val: Option<usize>) {
         self.feature_flags.mysticeti_num_leaders_per_round = val;
-    }
-
-    pub fn set_enable_soft_bundle_for_testing(&mut self, val: bool) {
-        self.feature_flags.soft_bundle = val;
     }
 
     pub fn set_passkey_auth_for_testing(&mut self, val: bool) {

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_1.snap
@@ -18,7 +18,6 @@ feature_flags:
   mysticeti_leader_scoring_and_schedule: true
   mysticeti_use_committed_subdag_digest: true
   mysticeti_num_leaders_per_round: 1
-  soft_bundle: true
   enable_coin_deny_list_v2: true
   rethrow_serialization_type_layout_errors: true
 max_tx_size_bytes: 131072

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_1.snap
@@ -18,7 +18,6 @@ feature_flags:
   mysticeti_leader_scoring_and_schedule: true
   mysticeti_use_committed_subdag_digest: true
   mysticeti_num_leaders_per_round: 1
-  soft_bundle: true
   enable_coin_deny_list_v2: true
   rethrow_serialization_type_layout_errors: true
 max_tx_size_bytes: 131072

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_1.snap
@@ -21,7 +21,6 @@ feature_flags:
   mysticeti_use_committed_subdag_digest: true
   enable_vdf: true
   mysticeti_num_leaders_per_round: 1
-  soft_bundle: true
   enable_coin_deny_list_v2: true
   passkey_auth: true
   authority_capabilities_v2: true

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -227,7 +227,6 @@ impl ValidatorConfigBuilder {
             firewall_config: self.firewall_config,
             execution_cache: ExecutionCacheConfig::default(),
             state_accumulator_v2: self.state_accumulator_v2,
-            enable_soft_bundle: true,
             enable_validator_tx_finalizer: true,
         }
     }
@@ -517,7 +516,6 @@ impl FullnodeConfigBuilder {
             firewall_config: self.fw_config,
             execution_cache: ExecutionCacheConfig::default(),
             state_accumulator_v2: true,
-            enable_soft_bundle: true,
             // This is a validator specific feature.
             enable_validator_tx_finalizer: false,
         }


### PR DESCRIPTION
# Description of change

This PR removes the deprecated protocol feature flag `soft_bundle`. 
We don't need the backwards compatibility to former protocol versions.

## Links to any relevant issues

#3253

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
