### PR TITLE
feat(iota): add faucet_amount param to IotaCommand::Start

### DIFF
--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -198,6 +198,11 @@ pub enum IotaCommand {
         )]
         with_faucet: Option<String>,
 
+        /// Set the amount of nanos that the faucet will put in an object.
+        /// Defaults to `200000000000`(200 IOTA).
+        #[clap(long)]
+        faucet_amount: Option<u64>,
+
         #[cfg(feature = "indexer")]
         #[clap(flatten)]
         indexer_feature_args: IndexerFeatureArgs,
@@ -370,6 +375,7 @@ impl IotaCommand {
                 config_dir,
                 force_regenesis,
                 with_faucet,
+                faucet_amount,
                 #[cfg(feature = "indexer")]
                 indexer_feature_args,
                 fullnode_rpc_port,
@@ -381,6 +387,7 @@ impl IotaCommand {
                 start(
                     config_dir.clone(),
                     with_faucet,
+                    faucet_amount,
                     #[cfg(feature = "indexer")]
                     indexer_feature_args,
                     force_regenesis,
@@ -594,6 +601,7 @@ impl IotaCommand {
 async fn start(
     config_dir: Option<PathBuf>,
     with_faucet: Option<String>,
+    faucet_amount: Option<u64>,
     #[cfg(feature = "indexer")] indexer_feature_args: IndexerFeatureArgs,
     force_regenesis: bool,
     epoch_duration_ms: Option<u64>,
@@ -808,7 +816,7 @@ async fn start(
             host_ip,
             port: faucet_address.port(),
             num_coins: DEFAULT_FAUCET_NUM_COINS,
-            amount: DEFAULT_FAUCET_NANOS_AMOUNT,
+            amount: faucet_amount.unwrap_or(DEFAULT_FAUCET_NANOS_AMOUNT),
             ..Default::default()
         };
 

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -148,6 +148,7 @@ async fn test_start() -> Result<(), anyhow::Error> {
             no_full_node: false,
             force_regenesis: false,
             with_faucet: None,
+            faucet_amount: None,
             fullnode_rpc_port: 9000,
             epoch_duration_ms: None,
             #[cfg(feature = "indexer")]

--- a/nre/validator_tool.md
+++ b/nre/validator_tool.md
@@ -200,24 +200,15 @@ Serialized payload: $PAYLOAD_TO_SIGN
 
 ## Test becoming a validator in a local network
 
-#### Modify faucet amount
+#### Start a local network with larger faucet amount
 
-Modify the `crates/iota/src/iota_commands.rs` file, so a single faucet request provides enough coins to become a validator.
-Change the `DEFAULT_FAUCET_NANOS_AMOUNT` const from `200_000_000_000` to `2_600_000_000_000_000`:
-
-```bash
-sed -i 's/200_000_000_000/2_600_000_000_000_000/g' crates/iota/src/iota_commands.rs
-```
-
-#### Start a local network with the modified faucet
+Set a larger faucet amount, so a single faucet request provides enough coins to become a validator.
 
 ```bash
-cargo run --bin iota start --force-regenesis --with-faucet
+iota start --force-regenesis --with-faucet --faucet-amount 2600000000000000
 ```
 
 #### Request coins from the faucet
-
-Using the installed iota CLI from [#preparation](#preparation), switch to the local network:
 
 ```bash
 iota client switch --env localnet


### PR DESCRIPTION
# Description of change

Add faucet_amount param to IotaCommand::Start so the faucet can provide larger amounts at once, which can be useful for tests such as becoming a validator in a network.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/3482

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running `iota start --force-regenesis --with-faucet --faucet-amount 2600000000000000` and getting funds from the faucet 