### PR TITLE
feat(iota-indexer): Add `WriteApi` tests

### DIFF
--- a/crates/iota-indexer/Cargo.toml
+++ b/crates/iota-indexer/Cargo.toml
@@ -63,6 +63,7 @@ serde_json.workspace = true
 serial_test = "2.0"
 simulacrum.workspace = true
 test-cluster.workspace = true
+fastcrypto.workspace = true
 
 [[bin]]
 name = "iota-indexer"

--- a/crates/iota-indexer/Cargo.toml
+++ b/crates/iota-indexer/Cargo.toml
@@ -53,6 +53,7 @@ pg_integration = []
 shared_test_runtime = []
 
 [dev-dependencies]
+fastcrypto.workspace = true
 iota-config.workspace = true
 iota-genesis-builder.workspace = true
 iota-keys.workspace = true
@@ -63,7 +64,6 @@ serde_json.workspace = true
 serial_test = "2.0"
 simulacrum.workspace = true
 test-cluster.workspace = true
-fastcrypto.workspace = true
 
 [[bin]]
 name = "iota-indexer"

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -141,7 +141,7 @@ pub async fn indexer_wait_for_object(
         }
     })
     .await
-    .expect("Timeout waiting for indexer to catchup to checkpoint");
+    .expect("Timeout waiting for indexer to catchup to given object's sequence number");
 }
 
 /// Start an Indexer instance in `Read` mode

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -9,14 +9,17 @@ use std::{
 
 use iota_config::node::RunWithRange;
 use iota_indexer::{
+    IndexerConfig,
     errors::IndexerError,
     indexer::Indexer,
-    store::{indexer_store::IndexerStore, PgIndexerStore},
-    test_utils::{start_test_indexer, ReaderWriterConfig},
-    IndexerConfig,
+    store::{PgIndexerStore, indexer_store::IndexerStore},
+    test_utils::{ReaderWriterConfig, start_test_indexer},
 };
 use iota_metrics::init_metrics;
-use iota_types::storage::ReadStore;
+use iota_types::{
+    base_types::{ObjectID, SequenceNumber},
+    storage::ReadStore,
+};
 use jsonrpsee::{
     http_client::{HttpClient, HttpClientBuilder},
     types::ErrorObject,
@@ -110,6 +113,30 @@ pub async fn indexer_wait_for_checkpoint(
                 .unwrap();
             cp_opt.is_none() || (cp_opt.unwrap() < checkpoint_sequence_number)
         } {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("Timeout waiting for indexer to catchup to checkpoint");
+}
+
+/// Wait for the indexer to catch up to the given object sequence number
+pub async fn indexer_wait_for_object(
+    pg_store: &PgIndexerStore,
+    object_id: ObjectID,
+    sequence_number: SequenceNumber,
+) {
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            if pg_store
+                .get_object_read(object_id, Some(sequence_number))
+                .await
+                .unwrap()
+                .object()
+                .is_ok()
+            {
+                break;
+            }
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
     })

--- a/crates/iota-indexer/tests/rpc-tests/main.rs
+++ b/crates/iota-indexer/tests/rpc-tests/main.rs
@@ -13,3 +13,6 @@ mod indexer_api;
 
 #[cfg(feature = "shared_test_runtime")]
 mod read_api;
+
+#[cfg(feature = "shared_test_runtime")]
+mod write_api;

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -103,12 +103,10 @@ fn dev_inspect_transaction_block() {
                 .effects
                 .mutated()
                 .iter()
-                .find_map(|o| { (o.reference.object_id == obj_id).then_some(o.owner) })
+                .find_map(|obj| { (obj.reference.object_id == obj_id).then_some(obj.owner) })
                 .unwrap(),
             Owner::AddressOwner(receiver)
         );
-
-        indexer_wait_for_object(store, obj_id, seq_num).await;
 
         let actual_object_info = client
             .get_object(obj_id, Some(IotaObjectDataOptions::new().with_owner()))
@@ -160,8 +158,8 @@ fn execute_transaction_block() {
             .unwrap()
             .mutated()
             .iter()
-            .find_map(|o| {
-                (o.reference.object_id == obj_id).then_some((o.reference.version, o.owner))
+            .find_map(|obj| {
+                (obj.reference.object_id == obj_id).then_some((obj.reference.version, obj.owner))
             })
             .unwrap();
 

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -1,0 +1,229 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use fastcrypto::encoding::Base64;
+use iota_json_rpc_api::{
+    IndexerApiClient, ReadApiClient, TransactionBuilderClient, WriteApiClient,
+};
+use iota_json_rpc_types::{
+    IotaExecutionStatus, IotaObjectDataOptions, IotaTransactionBlockEffectsAPI,
+    IotaTransactionBlockResponseOptions,
+};
+use iota_types::{
+    object::Owner, programmable_transaction_builder::ProgrammableTransactionBuilder,
+    quorum_driver_types::ExecuteTransactionRequestType, transaction::TransactionKind,
+};
+
+use crate::common::{ApiTestSetup, indexer_wait_for_checkpoint, indexer_wait_for_object};
+
+#[test]
+fn dev_inspect_transaction_block() {
+    let ApiTestSetup {
+        runtime,
+        cluster,
+        store,
+        client,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async {
+        indexer_wait_for_checkpoint(store, 1).await;
+
+        let sender = cluster.get_address_0();
+        let receiver = cluster.get_address_1();
+
+        let objects = cluster
+            .rpc_client()
+            .get_owned_objects(sender, None, None, None)
+            .await
+            .unwrap()
+            .data;
+
+        let (obj_id, seq_num, digest) = objects.first().unwrap().object().unwrap().object_ref();
+
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder
+            .transfer_object(receiver, (obj_id, seq_num, digest))
+            .unwrap();
+        let ptb = builder.finish();
+
+        let indexer_devinspect_results = client
+            .dev_inspect_transaction_block(
+                sender,
+                Base64::from_bytes(&bcs::to_bytes(&TransactionKind::programmable(ptb)).unwrap()),
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *indexer_devinspect_results.effects.status(),
+            IotaExecutionStatus::Success
+        );
+
+        assert_eq!(
+            indexer_devinspect_results
+                .effects
+                .mutated()
+                .iter()
+                .find_map(|o| { (o.reference.object_id == obj_id).then_some(o.owner) })
+                .unwrap(),
+            Owner::AddressOwner(receiver)
+        );
+
+        indexer_wait_for_object(store, obj_id, seq_num).await;
+
+        let actual_object_info = client
+            .get_object(obj_id, Some(IotaObjectDataOptions::new().with_owner()))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            actual_object_info.data.unwrap().owner.unwrap(),
+            Owner::AddressOwner(sender)
+        );
+    });
+}
+
+#[test]
+fn execute_transaction_block() {
+    let ApiTestSetup {
+        runtime,
+        cluster,
+        store,
+        client,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async {
+        indexer_wait_for_checkpoint(store, 1).await;
+
+        let sender = cluster.get_address_0();
+        let receiver = cluster.get_address_1();
+
+        let objects = cluster
+            .rpc_client()
+            .get_owned_objects(sender, None, None, None)
+            .await
+            .unwrap()
+            .data;
+
+        let obj_id = objects.first().unwrap().object().unwrap().object_id;
+        let gas = objects.last().unwrap().object().unwrap().object_id;
+
+        let transaction_bytes = client
+            .transfer_object(sender, obj_id, Some(gas), 10_000_000.into(), receiver)
+            .await
+            .unwrap();
+
+        let (tx_bytes, signatures) = cluster
+            .wallet
+            .sign_transaction(&transaction_bytes.to_data().unwrap())
+            .to_tx_bytes_and_signatures();
+
+        let indexer_tx_response = client
+            .execute_transaction_block(
+                tx_bytes,
+                signatures,
+                Some(IotaTransactionBlockResponseOptions::new().with_effects()),
+                Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *indexer_tx_response.effects.as_ref().unwrap().status(),
+            IotaExecutionStatus::Success
+        );
+
+        let (seq_num, owner) = indexer_tx_response
+            .effects
+            .unwrap()
+            .mutated()
+            .iter()
+            .find_map(|o| {
+                (o.reference.object_id == obj_id).then_some((o.reference.version, o.owner))
+            })
+            .unwrap();
+
+        assert_eq!(owner, Owner::AddressOwner(receiver));
+
+        indexer_wait_for_object(store, obj_id, seq_num).await;
+
+        let actual_object_info = client
+            .get_object(obj_id, Some(IotaObjectDataOptions::new().with_owner()))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            actual_object_info.data.unwrap().owner.unwrap(),
+            Owner::AddressOwner(receiver)
+        );
+    });
+}
+
+#[test]
+fn dry_run_transaction_block() {
+    let ApiTestSetup {
+        runtime,
+        cluster,
+        store,
+        client,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async {
+        indexer_wait_for_checkpoint(store, 1).await;
+
+        let sender = cluster.get_address_0();
+        let receiver = cluster.get_address_1();
+
+        let objects = cluster
+            .rpc_client()
+            .get_owned_objects(sender, None, None, None)
+            .await
+            .unwrap()
+            .data;
+
+        let obj_id = objects.first().unwrap().object().unwrap().object_id;
+        let gas = objects.last().unwrap().object().unwrap().object_id;
+
+        let transaction_bytes = client
+            .transfer_object(sender, obj_id, Some(gas), 10_000_000.into(), receiver)
+            .await
+            .unwrap();
+
+        let (tx_bytes, signatures) = cluster
+            .wallet
+            .sign_transaction(&transaction_bytes.to_data().unwrap())
+            .to_tx_bytes_and_signatures();
+
+        let dry_run_tx_block_resp = client
+            .dry_run_transaction_block(tx_bytes.clone())
+            .await
+            .unwrap();
+
+        let indexer_tx_response = client
+            .execute_transaction_block(
+                tx_bytes,
+                signatures,
+                Some(
+                    IotaTransactionBlockResponseOptions::new()
+                        .with_effects()
+                        .with_object_changes(),
+                ),
+                Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *indexer_tx_response.effects.as_ref().unwrap().status(),
+            IotaExecutionStatus::Success
+        );
+
+        assert_eq!(
+            indexer_tx_response.object_changes.unwrap(),
+            dry_run_tx_block_resp.object_changes
+        )
+    });
+}


### PR DESCRIPTION
# Description of change

Add `WriteApi` tests for the `iota-indexer`

## Links to any relevant issues

#2203 

## Type of change
- Enhancement (a non-breaking change which adds functionality)


## How the change has been tested
- Start a **postgres** instance using this command:
 ```sh
 docker run --name iota-indexer-tests -e POSTGRES_PASSWORD=postgrespw -e POSTGRES_USER=postgres -e POSTGRES_DB=iota_indexer -d -p 5432:5432 postgres
 ```

- run tests:
```sh
  cargo test -p iota-indexer --test rpc-tests write_api --features shared_test_runtime
```

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code

