### PR TITLE
fix(reconfiguration-tests): Fix reconfiguration-tests (simtest)

### DIFF
--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -716,8 +716,16 @@ async fn do_test_reconfig_with_committee_change_stress() {
         let handle2 = test_cluster.spawn_new_validator(v2).await;
 
         tokio::join!(
-            test_cluster.wait_for_epoch_on_node(&handle1, Some(cur_epoch), Duration::from_secs(60)),
-            test_cluster.wait_for_epoch_on_node(&handle2, Some(cur_epoch), Duration::from_secs(60))
+            test_cluster.wait_for_epoch_on_node(
+                &handle1,
+                Some(cur_epoch),
+                Duration::from_secs(300)
+            ),
+            test_cluster.wait_for_epoch_on_node(
+                &handle2,
+                Some(cur_epoch),
+                Duration::from_secs(300)
+            )
         );
 
         test_cluster.trigger_reconfiguration().await;
@@ -726,7 +734,7 @@ async fn do_test_reconfig_with_committee_change_stress() {
             .iota_node
             .with(|node| node.state().epoch_store_for_testing().committee().clone());
         cur_epoch = committee.epoch();
-        assert_eq!(committee.num_members(), 9);
+        assert_eq!(committee.num_members(), 7);
         assert!(committee.authority_exists(&handle1.state().name));
         assert!(committee.authority_exists(&handle2.state().name));
         removed_validators


### PR DESCRIPTION
# Description of change

Fixed

- iota-e2e-tests::reconfiguration_tests test_reconfig_with_committee_change_stress
- iota-e2e-tests::reconfiguration_tests test_reconfig_with_committee_change_stress_determinism

According to the SUI repo and the latest commit in main branch ([df0cb67](https://github.com/MystenLabs/sui/blob/df0cb674415537ff628bf98f459cd500f28d4f23/crates/sui-e2e-tests/tests/reconfiguration_tests.rs#L715)), the committee members' count was corrected to be 7. Also, the time_out was increased to avoid unexpected timeout.

## Links to any relevant issues

Part of #3321

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

```bash
./scripts/simtest/cargo-simtest simtest \
  --color always \
  --package iota-e2e-tests --test reconfiguration_tests -- test_reconfig_with_committee_change_stress
```

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
