### PR TITLE
fix: ci after mysticeti cleanup

### DIFF
--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -36,7 +36,6 @@ runs:
             - ".github/workflows/_rust_tests.yml"
             - ".github/workflows/_rust_lints.yml"
             - ".github/workflows/_external_rust_tests.yml"
-            - ".github/workflows/_mysticeti_tests.yml"
             - ".github/workflows/_cargo_deny.yml"
             - "Cargo.toml"
             - "Cargo.lock"

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -58,13 +58,6 @@ jobs:
       - rust-lints
     uses: ./.github/workflows/_external_rust_tests.yml
 
-  mysticeti-tests:
-    if: |
-      !cancelled() && !failure() && inputs.isRust && github.event.pull_request.draft == false
-    needs:
-      - rust-lints
-    uses: ./.github/workflows/_mysticeti_tests.yml
-
   execution-cut:
     if: |
       !cancelled() && !failure() && inputs.isRust && github.event.pull_request.draft == false


### PR DESCRIPTION
# Description of change

Remove the mentions of `_mysticeti_tests` as #3494 removed the workflow.
