### PR TITLE
fix(e2e-tests): Fix reconfiguration e2e tests and msim compilation

### DIFF
--- a/crates/iota-benchmark/Cargo.toml
+++ b/crates/iota-benchmark/Cargo.toml
@@ -55,4 +55,5 @@ iota-framework.workspace = true
 iota-framework-snapshot.workspace = true
 iota-macros.workspace = true
 iota-simulator.workspace = true
+iota-surfer.workspace = true
 typed-store.workspace = true

--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -677,7 +677,7 @@ mod test {
 
         let init_framework =
             iota_framework_snapshot::load_bytecode_snapshot(starting_version).unwrap();
-        let test_cluster = Arc::new(
+        let test_cluster: Arc<TestCluster> = Arc::new(
             init_test_cluster_builder(4, 15000)
                 .with_protocol_version(ProtocolVersion::new(starting_version))
                 .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(
@@ -688,7 +688,6 @@ mod test {
                     SupportedProtocolVersions::new_for_testing(starting_version, max_ver),
                 )
                 .with_objects(init_framework.into_iter().map(|p| p.genesis_object()))
-                .with_stake_subsidy_start_epoch(10)
                 .build()
                 .await,
         );

--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -913,6 +913,15 @@ async fn add_validator_candidate(
 }
 
 async fn execute_remove_validator_tx(test_cluster: &TestCluster, handle: &IotaNodeHandle) {
+    let cur_pending_removals = test_cluster.fullnode_handle.iota_node.with(|node| {
+        node.state()
+            .get_iota_system_state_object_for_testing()
+            .unwrap()
+            .into_iota_system_state_summary()
+            .pending_removals
+            .len()
+    });
+
     let address = handle.with(|node| node.get_config().iota_address());
     let gas = test_cluster
         .wallet
@@ -928,6 +937,20 @@ async fn execute_remove_validator_tx(test_cluster: &TestCluster, handle: &IotaNo
             .build_and_sign(node.get_config().account_key_pair.keypair())
     });
     test_cluster.execute_transaction(tx).await;
+
+    // Check that the validator can be found in the removal list now.
+    test_cluster.fullnode_handle.iota_node.with(|node| {
+        let system_state = node
+            .state()
+            .get_iota_system_state_object_for_testing()
+            .unwrap();
+        let system_state_summary = system_state.into_iota_system_state_summary();
+
+        assert_eq!(
+            system_state_summary.pending_removals.len(),
+            cur_pending_removals + 1
+        );
+    });
 }
 
 /// Execute a sequence of transactions to add a validator, including adding

--- a/crates/iota-storage/Cargo.toml
+++ b/crates/iota-storage/Cargo.toml
@@ -57,9 +57,13 @@ move-bytecode-utils.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true
-axum.workspace = true
 iota-macros = { workspace = true }
 iota-test-transaction-builder.workspace = true
 iota-types = { workspace = true, features = ["test-utils"] }
 once_cell.workspace = true
 tempfile.workspace = true
+
+[target.'cfg(msim)'.dependencies]
+axum.workspace = true
+iota-simulator.workspace = true
+rustls = "0.23"

--- a/crates/iota-storage/tests/key_value_tests.rs
+++ b/crates/iota-storage/tests/key_value_tests.rs
@@ -427,7 +427,6 @@ async fn test_get_tx_from_fallback() {
 #[cfg(msim)]
 mod simtests {
     use std::{
-        net::SocketAddr,
         sync::Mutex,
         time::{Duration, Instant},
     };
@@ -441,6 +440,8 @@ mod simtests {
     use iota_macros::sim_test;
     use iota_simulator::configs::constant_latency_ms;
     use iota_storage::http_key_value_store::*;
+    use rustls::crypto::{CryptoProvider, ring};
+    use tokio::net::TcpListener;
     use tracing::info;
 
     use super::*;

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -102,6 +102,7 @@ export TMPDIR=$(mktemp -d)
 root_dir=$(git rev-parse --show-toplevel)
 export SIMTEST_STATIC_INIT_MOVE=$root_dir"/examples/move/basics"
 
+# we need to use "target.'cfg(all())'.rustflags" instead of "build.rustflags" because the latter are ignored if any "target" flags are set
 cargo ${CARGO_COMMAND[@]} \
   --config "target.'cfg(all())'.rustflags = [$RUST_FLAGS]" \
   "${cargo_patch_args[@]}" \

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -103,7 +103,7 @@ root_dir=$(git rev-parse --show-toplevel)
 export SIMTEST_STATIC_INIT_MOVE=$root_dir"/examples/move/basics"
 
 cargo ${CARGO_COMMAND[@]} \
-  --config "build.rustflags = [$RUST_FLAGS]" \
+  --config "target.'cfg(all())'.rustflags = [$RUST_FLAGS]" \
   "${cargo_patch_args[@]}" \
   "$@"
 


### PR DESCRIPTION
# Description of change


* Add removal check in `execute_remove_validator_tx`.
* Replace `build.rustflags` with `target.'cfg(all())'.rustflags` in cargo-simtest
The rustflags is set up with the rules in [link](https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags), it ignores the rustflags settings from command line if the environment(`~/.cargo/config.toml`) has rustflags already. That's why the cfg `msim` never get set in the tests. 
And currently the only way to have all the rustflags included is to  use `target.'cfg(all())'.rustflags` instead of `build.rustflags` because the latter are ignored if any target flags are set

Discussion regarding rustflags: https://github.com/rust-lang/cargo/issues/5376

## Links to any relevant issues

Part of #3321

Included changes in #3501 (@bingyanglin) 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix
- Enhancement 

## How the change has been tested

```
./scripts/simtest/cargo-simtest simtest --fail-fast --package iota-e2e-tests --test reconfiguration_tests
```

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have checked that new and existing unit tests pass locally with my changes
