### PR TITLE
chore(consensus-core): move `MockCoreThreadDispatcher` to tests

### DIFF
--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -771,7 +771,7 @@ mod tests {
         commit_syncer::CommitSyncer,
         commit_vote_monitor::CommitVoteMonitor,
         context::Context,
-        core_thread::MockCoreThreadDispatcher,
+        core_thread::tests::MockCoreThreadDispatcher,
         dag_state::DagState,
         error::ConsensusResult,
         network::{BlockStream, NetworkClient},

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -1088,7 +1088,7 @@ mod tests {
         commit::{CommitRange, CommitVote, TrustedCommit},
         commit_vote_monitor::CommitVoteMonitor,
         context::Context,
-        core_thread::{CoreThreadDispatcher, MockCoreThreadDispatcher},
+        core_thread::{CoreThreadDispatcher, tests::MockCoreThreadDispatcher},
         dag_state::DagState,
         error::{ConsensusError, ConsensusResult},
         network::{BlockStream, NetworkClient},


### PR DESCRIPTION
`MockCoreThreadDispatcher` is only used for tests so I moved it there. It became a warning in stable Rust.