### PR TITLE
refactor(core-node): Remove `StateAccumulatorV1`and rename `StateAccumulatorV2`

### DIFF
--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -111,7 +111,7 @@ mod test {
                 ..Default::default()
             })
             .with_submit_delay_step_override_millis(3000)
-            .with_state_accumulator_v2_enabled_callback(Arc::new(|idx| idx % 2 == 0))
+            .with_state_accumulator_callback(Arc::new(|idx| idx % 2 == 0))
             .build()
             .await
             .into();

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -236,11 +236,6 @@ pub struct NodeConfig {
     #[serde(default)]
     pub execution_cache: ExecutionCacheConfig,
 
-    // step 1 in removing the old state accumulator
-    #[serde(skip)]
-    #[serde(default = "bool_true")]
-    pub state_accumulator_v2: bool,
-
     #[serde(default = "bool_true")]
     pub enable_validator_tx_finalizer: bool,
 }

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -976,15 +976,6 @@ impl AuthorityPerEpochStore {
         self.parent_path.clone()
     }
 
-    pub fn state_accumulator_v2_enabled(&self) -> bool {
-        let flag = match self.get_chain_identifier().chain() {
-            Chain::Unknown | Chain::Testnet => EpochFlag::StateAccumulatorV2EnabledTestnet,
-            Chain::Mainnet => EpochFlag::StateAccumulatorV2EnabledMainnet,
-        };
-
-        self.epoch_start_configuration.flags().contains(&flag)
-    }
-
     /// Returns `&Arc<EpochStartConfiguration>`
     /// User can treat this `Arc` as `&EpochStartConfiguration`, or clone the
     /// Arc to pass as owned object

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1364,23 +1364,6 @@ impl AuthorityPerEpochStore {
             .map_err(Into::into)
     }
 
-    /// Returns future containing the state digest for the given epoch
-    /// once available.
-    /// TODO: remove once StateAccumulatorV1 is removed
-    pub async fn notify_read_checkpoint_state_digests(
-        &self,
-        checkpoints: Vec<CheckpointSequenceNumber>,
-    ) -> IotaResult<Vec<Accumulator>> {
-        self.checkpoint_state_notify_read
-            .read(&checkpoints, |checkpoints| -> IotaResult<_> {
-                Ok(self
-                    .tables()?
-                    .state_hash_by_checkpoint
-                    .multi_get(checkpoints)?)
-            })
-            .await
-    }
-
     pub async fn notify_read_running_root(
         &self,
         checkpoint: CheckpointSequenceNumber,

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -90,7 +90,7 @@ use super::{
 use crate::{
     authority::{
         AuthorityMetrics, ResolverWrapper,
-        epoch_start_configuration::{EpochFlag, EpochStartConfiguration},
+        epoch_start_configuration::EpochStartConfiguration,
         shared_object_version_manager::{
             AssignedTxAndVersions, ConsensusSharedObjVerAssignment, SharedObjVerManager,
         },

--- a/crates/iota-core/src/authority/epoch_start_configuration.rs
+++ b/crates/iota-core/src/authority/epoch_start_configuration.rs
@@ -56,8 +56,8 @@ pub trait EpochStartConfigTrait {
 pub enum EpochFlag {
     WritebackCacheEnabled = 0,
 
-    StateAccumulatorV2EnabledTestnet = 1,
-    StateAccumulatorV2EnabledMainnet = 2,
+    StateAccumulatorV1EnabledTestnet = 1,
+    StateAccumulatorV1EnabledMainnet = 2,
 }
 
 impl EpochFlag {
@@ -83,8 +83,8 @@ impl EpochFlag {
             new_flags.push(EpochFlag::WritebackCacheEnabled);
         }
 
-        new_flags.push(EpochFlag::StateAccumulatorV2EnabledTestnet);
-        new_flags.push(EpochFlag::StateAccumulatorV2EnabledMainnet);        
+        new_flags.push(EpochFlag::StateAccumulatorV1EnabledTestnet);
+        new_flags.push(EpochFlag::StateAccumulatorV1EnabledMainnet);        
 
         new_flags
     }
@@ -96,11 +96,11 @@ impl fmt::Display for EpochFlag {
         // is used as metric key
         match self {
             EpochFlag::WritebackCacheEnabled => write!(f, "WritebackCacheEnabled"),
-            EpochFlag::StateAccumulatorV2EnabledTestnet => {
-                write!(f, "StateAccumulatorV2EnabledTestnet")
+            EpochFlag::StateAccumulatorV1EnabledTestnet => {
+                write!(f, "StateAccumulatorV1EnabledTestnet")
             }
-            EpochFlag::StateAccumulatorV2EnabledMainnet => {
-                write!(f, "StateAccumulatorV2EnabledMainnet")
+            EpochFlag::StateAccumulatorV1EnabledMainnet => {
+                write!(f, "StateAccumulatorV1EnabledMainnet")
             }
         }
     }

--- a/crates/iota-core/src/authority/epoch_start_configuration.rs
+++ b/crates/iota-core/src/authority/epoch_start_configuration.rs
@@ -71,9 +71,7 @@ impl EpochFlag {
         Self::default_flags_impl(&Default::default())
     }
 
-    fn default_flags_impl(
-        cache_config: &ExecutionCacheConfig,
-    ) -> Vec<Self> {
+    fn default_flags_impl(cache_config: &ExecutionCacheConfig) -> Vec<Self> {
         let mut new_flags = vec![];
 
         if matches!(
@@ -84,7 +82,7 @@ impl EpochFlag {
         }
 
         new_flags.push(EpochFlag::StateAccumulatorV1EnabledTestnet);
-        new_flags.push(EpochFlag::StateAccumulatorV1EnabledMainnet);        
+        new_flags.push(EpochFlag::StateAccumulatorV1EnabledMainnet);
 
         new_flags
     }

--- a/crates/iota-core/src/authority/epoch_start_configuration.rs
+++ b/crates/iota-core/src/authority/epoch_start_configuration.rs
@@ -55,9 +55,6 @@ pub trait EpochStartConfigTrait {
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum EpochFlag {
     WritebackCacheEnabled = 0,
-
-    StateAccumulatorV1EnabledTestnet = 1,
-    StateAccumulatorV1EnabledMainnet = 2,
 }
 
 impl EpochFlag {
@@ -81,9 +78,6 @@ impl EpochFlag {
             new_flags.push(EpochFlag::WritebackCacheEnabled);
         }
 
-        new_flags.push(EpochFlag::StateAccumulatorV1EnabledTestnet);
-        new_flags.push(EpochFlag::StateAccumulatorV1EnabledMainnet);
-
         new_flags
     }
 }
@@ -94,12 +88,6 @@ impl fmt::Display for EpochFlag {
         // is used as metric key
         match self {
             EpochFlag::WritebackCacheEnabled => write!(f, "WritebackCacheEnabled"),
-            EpochFlag::StateAccumulatorV1EnabledTestnet => {
-                write!(f, "StateAccumulatorV1EnabledTestnet")
-            }
-            EpochFlag::StateAccumulatorV1EnabledMainnet => {
-                write!(f, "StateAccumulatorV1EnabledMainnet")
-            }
         }
     }
 }

--- a/crates/iota-core/src/authority/epoch_start_configuration.rs
+++ b/crates/iota-core/src/authority/epoch_start_configuration.rs
@@ -62,18 +62,17 @@ pub enum EpochFlag {
 
 impl EpochFlag {
     pub fn default_flags_for_new_epoch(config: &NodeConfig) -> Vec<Self> {
-        Self::default_flags_impl(&config.execution_cache, config.state_accumulator_v2)
+        Self::default_flags_impl(&config.execution_cache)
     }
 
     /// For situations in which there is no config available (e.g. setting up a
     /// downloaded snapshot).
     pub fn default_for_no_config() -> Vec<Self> {
-        Self::default_flags_impl(&Default::default(), true)
+        Self::default_flags_impl(&Default::default())
     }
 
     fn default_flags_impl(
         cache_config: &ExecutionCacheConfig,
-        enable_state_accumulator_v2: bool,
     ) -> Vec<Self> {
         let mut new_flags = vec![];
 
@@ -84,10 +83,8 @@ impl EpochFlag {
             new_flags.push(EpochFlag::WritebackCacheEnabled);
         }
 
-        if enable_state_accumulator_v2 {
-            new_flags.push(EpochFlag::StateAccumulatorV2EnabledTestnet);
-            new_flags.push(EpochFlag::StateAccumulatorV2EnabledMainnet);
-        }
+        new_flags.push(EpochFlag::StateAccumulatorV2EnabledTestnet);
+        new_flags.push(EpochFlag::StateAccumulatorV2EnabledMainnet);        
 
         new_flags
     }

--- a/crates/iota-core/src/state_accumulator.rs
+++ b/crates/iota-core/src/state_accumulator.rs
@@ -44,13 +44,7 @@ impl StateAccumulatorMetrics {
 }
 
 pub enum StateAccumulator {
-    V1(StateAccumulatorV1),
     V2(StateAccumulatorV2),
-}
-
-pub struct StateAccumulatorV1 {
-    store: Arc<dyn AccumulatorStore>,
-    metrics: Arc<StateAccumulatorMetrics>,
 }
 
 pub struct StateAccumulatorV2 {
@@ -166,11 +160,7 @@ impl StateAccumulator {
         epoch_store: &Arc<AuthorityPerEpochStore>,
         metrics: Arc<StateAccumulatorMetrics>,
     ) -> Self {
-        if epoch_store.state_accumulator_v2_enabled() {
-            StateAccumulator::V2(StateAccumulatorV2::new(store, metrics))
-        } else {
-            StateAccumulator::V1(StateAccumulatorV1::new(store, metrics))
-        }
+        StateAccumulator::V2(StateAccumulatorV2::new(store, metrics))
     }
 
     pub fn new_for_tests(
@@ -331,92 +321,6 @@ impl StateAccumulator {
             .await?
             .digest()
             .into())
-    }
-}
-
-impl StateAccumulatorV1 {
-    pub fn new(store: Arc<dyn AccumulatorStore>, metrics: Arc<StateAccumulatorMetrics>) -> Self {
-        Self { store, metrics }
-    }
-
-    /// Unions all checkpoint accumulators at the end of the epoch to generate
-    /// the root state hash and persists it to db. This function is
-    /// idempotent. Can be called on non-consecutive epochs, e.g. to
-    /// accumulate epoch 3 after having last accumulated epoch 1.
-    pub async fn accumulate_epoch(
-        &self,
-        epoch_store: Arc<AuthorityPerEpochStore>,
-        last_checkpoint_of_epoch: CheckpointSequenceNumber,
-    ) -> IotaResult<Accumulator> {
-        let _scope = monitored_scope("AccumulateEpochV1");
-        let epoch = epoch_store.epoch();
-        if let Some((_checkpoint, acc)) = self.store.get_root_state_accumulator_for_epoch(epoch)? {
-            return Ok(acc);
-        }
-
-        // Get the next checkpoint to accumulate (first checkpoint of the epoch)
-        // by adding 1 to the highest checkpoint of the previous epoch
-        let (_highest_epoch, (next_to_accumulate, mut root_state_accumulator)) = self
-            .store
-            .get_root_state_accumulator_for_highest_epoch()?
-            .map(|(epoch, (checkpoint, acc))| {
-                (
-                    epoch,
-                    (
-                        checkpoint
-                            .checked_add(1)
-                            .expect("Overflowed u64 for epoch ID"),
-                        acc,
-                    ),
-                )
-            })
-            .unwrap_or((0, (0, Accumulator::default())));
-
-        debug!(
-            "Accumulating epoch {} from checkpoint {} to checkpoint {} (inclusive)",
-            epoch, next_to_accumulate, last_checkpoint_of_epoch
-        );
-
-        let (checkpoints, mut accumulators) = epoch_store
-            .get_accumulators_in_checkpoint_range(next_to_accumulate, last_checkpoint_of_epoch)?
-            .into_iter()
-            .unzip::<_, _, Vec<_>, Vec<_>>();
-
-        let remaining_checkpoints: Vec<_> = (next_to_accumulate..=last_checkpoint_of_epoch)
-            .filter(|seq_num| !checkpoints.contains(seq_num))
-            .collect();
-
-        if !remaining_checkpoints.is_empty() {
-            debug!(
-                "Awaiting accumulation of checkpoints {:?} for epoch {} accumulation",
-                remaining_checkpoints, epoch
-            );
-        }
-
-        let mut remaining_accumulators = epoch_store
-            .notify_read_checkpoint_state_digests(remaining_checkpoints)
-            .await
-            .expect("Failed to notify read checkpoint state digests");
-
-        accumulators.append(&mut remaining_accumulators);
-
-        assert!(accumulators.len() == (last_checkpoint_of_epoch - next_to_accumulate + 1) as usize);
-
-        for acc in accumulators {
-            root_state_accumulator.union(&acc);
-        }
-
-        self.store.insert_state_accumulator_for_epoch(
-            epoch,
-            &last_checkpoint_of_epoch,
-            &root_state_accumulator,
-        )?;
-
-        Ok(root_state_accumulator)
-    }
-
-    pub fn accumulate_effects(&self, effects: Vec<TransactionEffects>) -> Accumulator {
-        accumulate_effects(effects)
     }
 }
 

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -525,14 +525,6 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     };
                     builder = builder.with_supported_protocol_versions(supported_versions);
                 }
-                if let Some(acc_v2_config) = &self.state_accumulator_v2_enabled_config {
-                    let state_accumulator_v2_enabled: bool = match acc_v2_config {
-                        StateAccumulatorV2EnabledConfig::Global(enabled) => *enabled,
-                        StateAccumulatorV2EnabledConfig::PerValidator(func) => func(idx),
-                    };
-                    builder =
-                        builder.with_state_accumulator_v2_enabled(state_accumulator_v2_enabled);
-                }
                 if let Some(num_unpruned_validators) = self.num_unpruned_validators {
                     if idx < num_unpruned_validators {
                         builder = builder.with_unpruned_checkpoints();

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -68,12 +68,12 @@ pub enum ProtocolVersionsConfig {
     PerValidator(SupportedProtocolVersionsCallback),
 }
 
-pub type StateAccumulatorV2EnabledCallback = Arc<dyn Fn(usize) -> bool + Send + Sync + 'static>;
+pub type StateAccumulatorV1EnabledCallback = Arc<dyn Fn(usize) -> bool + Send + Sync + 'static>;
 
 #[derive(Clone)]
-pub enum StateAccumulatorV2EnabledConfig {
+pub enum StateAccumulatorV1EnabledConfig {
     Global(bool),
-    PerValidator(StateAccumulatorV2EnabledCallback),
+    PerValidator(StateAccumulatorV1EnabledCallback),
 }
 
 pub struct ConfigBuilder<R = OsRng> {
@@ -92,7 +92,7 @@ pub struct ConfigBuilder<R = OsRng> {
     firewall_config: Option<RemoteFirewallConfig>,
     max_submit_position: Option<usize>,
     submit_delay_step_override_millis: Option<u64>,
-    state_accumulator_config: Option<StateAccumulatorV2EnabledConfig>,
+    state_accumulator_config: Option<StateAccumulatorV1EnabledConfig>,
     empty_validator_genesis: bool,
 }
 
@@ -114,7 +114,7 @@ impl ConfigBuilder {
             firewall_config: None,
             max_submit_position: None,
             submit_delay_step_override_millis: None,
-            state_accumulator_config: Some(StateAccumulatorV2EnabledConfig::Global(true)),
+            state_accumulator_config: Some(StateAccumulatorV1EnabledConfig::Global(true)),
             empty_validator_genesis: false,
         }
     }
@@ -238,16 +238,16 @@ impl<R> ConfigBuilder<R> {
 
     pub fn with_state_accumulator_callback(
         mut self,
-        func: StateAccumulatorV2EnabledCallback,
+        func: StateAccumulatorV1EnabledCallback,
     ) -> Self {
         self.state_accumulator_config =
-            Some(StateAccumulatorV2EnabledConfig::PerValidator(func));
+            Some(StateAccumulatorV1EnabledConfig::PerValidator(func));
         self
     }
 
     pub fn with_state_accumulator_config(
         mut self,
-        c: StateAccumulatorV2EnabledConfig,
+        c: StateAccumulatorV1EnabledConfig,
     ) -> Self {
         self.state_accumulator_config = Some(c);
         self

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -92,7 +92,7 @@ pub struct ConfigBuilder<R = OsRng> {
     firewall_config: Option<RemoteFirewallConfig>,
     max_submit_position: Option<usize>,
     submit_delay_step_override_millis: Option<u64>,
-    state_accumulator_v2_enabled_config: Option<StateAccumulatorV2EnabledConfig>,
+    state_accumulator_config: Option<StateAccumulatorV2EnabledConfig>,
     empty_validator_genesis: bool,
 }
 
@@ -114,7 +114,7 @@ impl ConfigBuilder {
             firewall_config: None,
             max_submit_position: None,
             submit_delay_step_override_millis: None,
-            state_accumulator_v2_enabled_config: None,
+            state_accumulator_config: None,
             empty_validator_genesis: false,
         }
     }
@@ -237,7 +237,7 @@ impl<R> ConfigBuilder<R> {
     }
 
     pub fn with_state_accumulator_v2_enabled(mut self, enabled: bool) -> Self {
-        self.state_accumulator_v2_enabled_config =
+        self.state_accumulator_config =
             Some(StateAccumulatorV2EnabledConfig::Global(enabled));
         self
     }
@@ -246,16 +246,16 @@ impl<R> ConfigBuilder<R> {
         mut self,
         func: StateAccumulatorV2EnabledCallback,
     ) -> Self {
-        self.state_accumulator_v2_enabled_config =
+        self.state_accumulator_config =
             Some(StateAccumulatorV2EnabledConfig::PerValidator(func));
         self
     }
 
-    pub fn with_state_accumulator_v2_enabled_config(
+    pub fn with_state_accumulator_config(
         mut self,
         c: StateAccumulatorV2EnabledConfig,
     ) -> Self {
-        self.state_accumulator_v2_enabled_config = Some(c);
+        self.state_accumulator_config = Some(c);
         self
     }
 
@@ -304,7 +304,7 @@ impl<R> ConfigBuilder<R> {
             firewall_config: self.firewall_config,
             max_submit_position: self.max_submit_position,
             submit_delay_step_override_millis: self.submit_delay_step_override_millis,
-            state_accumulator_v2_enabled_config: self.state_accumulator_v2_enabled_config,
+            state_accumulator_config: self.state_accumulator_config,
             empty_validator_genesis: self.empty_validator_genesis,
         }
     }

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -240,15 +240,11 @@ impl<R> ConfigBuilder<R> {
         mut self,
         func: StateAccumulatorV1EnabledCallback,
     ) -> Self {
-        self.state_accumulator_config =
-            Some(StateAccumulatorV1EnabledConfig::PerValidator(func));
+        self.state_accumulator_config = Some(StateAccumulatorV1EnabledConfig::PerValidator(func));
         self
     }
 
-    pub fn with_state_accumulator_config(
-        mut self,
-        c: StateAccumulatorV1EnabledConfig,
-    ) -> Self {
+    pub fn with_state_accumulator_config(mut self, c: StateAccumulatorV1EnabledConfig) -> Self {
         self.state_accumulator_config = Some(c);
         self
     }

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -114,7 +114,7 @@ impl ConfigBuilder {
             firewall_config: None,
             max_submit_position: None,
             submit_delay_step_override_millis: None,
-            state_accumulator_config: None,
+            state_accumulator_config: Some(StateAccumulatorV2EnabledConfig::Global(true)),
             empty_validator_genesis: false,
         }
     }
@@ -233,12 +233,6 @@ impl<R> ConfigBuilder<R> {
 
     pub fn with_supported_protocol_versions_config(mut self, c: ProtocolVersionsConfig) -> Self {
         self.supported_protocol_versions_config = Some(c);
-        self
-    }
-
-    pub fn with_state_accumulator_v2_enabled(mut self, enabled: bool) -> Self {
-        self.state_accumulator_config =
-            Some(StateAccumulatorV2EnabledConfig::Global(enabled));
         self
     }
 

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -236,7 +236,7 @@ impl<R> ConfigBuilder<R> {
         self
     }
 
-    pub fn with_state_accumulator_v2_enabled_callback(
+    pub fn with_state_accumulator_callback(
         mut self,
         func: StateAccumulatorV2EnabledCallback,
     ) -> Self {

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -47,13 +47,11 @@ pub struct ValidatorConfigBuilder {
     firewall_config: Option<RemoteFirewallConfig>,
     max_submit_position: Option<usize>,
     submit_delay_step_override_millis: Option<u64>,
-    state_accumulator_v2: bool,
 }
 
 impl ValidatorConfigBuilder {
     pub fn new() -> Self {
         Self {
-            state_accumulator_v2: true,
             ..Default::default()
         }
     }
@@ -113,11 +111,6 @@ impl ValidatorConfigBuilder {
         submit_delay_step_override_millis: u64,
     ) -> Self {
         self.submit_delay_step_override_millis = Some(submit_delay_step_override_millis);
-        self
-    }
-
-    pub fn with_state_accumulator_v2_enabled(mut self, enabled: bool) -> Self {
-        self.state_accumulator_v2 = enabled;
         self
     }
 
@@ -226,7 +219,6 @@ impl ValidatorConfigBuilder {
             policy_config: self.policy_config,
             firewall_config: self.firewall_config,
             execution_cache: ExecutionCacheConfig::default(),
-            state_accumulator_v2: self.state_accumulator_v2,
             enable_validator_tx_finalizer: true,
         }
     }
@@ -515,7 +507,6 @@ impl FullnodeConfigBuilder {
             policy_config: self.policy_config,
             firewall_config: self.fw_config,
             execution_cache: ExecutionCacheConfig::default(),
-            state_accumulator_v2: true,
             // This is a validator specific feature.
             enable_validator_tx_finalizer: false,
         }

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -65,7 +65,7 @@ pub struct SwarmBuilder<R = OsRng> {
     fullnode_fw_config: Option<RemoteFirewallConfig>,
     max_submit_position: Option<usize>,
     submit_delay_step_override_millis: Option<u64>,
-    state_accumulator_v2_enabled_config: StateAccumulatorV2EnabledConfig,
+    state_accumulator_config: StateAccumulatorV2EnabledConfig,
 }
 
 impl SwarmBuilder {
@@ -93,7 +93,7 @@ impl SwarmBuilder {
             fullnode_fw_config: None,
             max_submit_position: None,
             submit_delay_step_override_millis: None,
-            state_accumulator_v2_enabled_config: StateAccumulatorV2EnabledConfig::Global(true),
+            state_accumulator_config: StateAccumulatorV2EnabledConfig::Global(true),
         }
     }
 }
@@ -123,7 +123,7 @@ impl<R> SwarmBuilder<R> {
             fullnode_fw_config: self.fullnode_fw_config,
             max_submit_position: self.max_submit_position,
             submit_delay_step_override_millis: self.submit_delay_step_override_millis,
-            state_accumulator_v2_enabled_config: self.state_accumulator_v2_enabled_config,
+            state_accumulator_config: self.state_accumulator_config,
         }
     }
 
@@ -234,11 +234,11 @@ impl<R> SwarmBuilder<R> {
         self
     }
 
-    pub fn with_state_accumulator_v2_enabled_config(
+    pub fn with_state_accumulator_config(
         mut self,
         c: StateAccumulatorV2EnabledConfig,
     ) -> Self {
-        self.state_accumulator_v2_enabled_config = c;
+        self.state_accumulator_config = c;
         self
     }
 
@@ -362,8 +362,8 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
                 .with_supported_protocol_versions_config(
                     self.supported_protocol_versions_config.clone(),
                 )
-                .with_state_accumulator_v2_enabled_config(
-                    self.state_accumulator_v2_enabled_config.clone(),
+                .with_state_accumulator_config(
+                    self.state_accumulator_config.clone(),
                 )
                 .build();
             // Populate validator genesis by pointing to the blob

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -24,7 +24,7 @@ use iota_swarm_config::{
     genesis_config::{AccountConfig, GenesisConfig, ValidatorGenesisConfig},
     network_config::NetworkConfig,
     network_config_builder::{
-        CommitteeConfig, ConfigBuilder, ProtocolVersionsConfig, StateAccumulatorV2EnabledConfig,
+        CommitteeConfig, ConfigBuilder, ProtocolVersionsConfig, StateAccumulatorV1EnabledConfig,
         SupportedProtocolVersionsCallback,
     },
     node_config_builder::FullnodeConfigBuilder,
@@ -65,7 +65,7 @@ pub struct SwarmBuilder<R = OsRng> {
     fullnode_fw_config: Option<RemoteFirewallConfig>,
     max_submit_position: Option<usize>,
     submit_delay_step_override_millis: Option<u64>,
-    state_accumulator_config: StateAccumulatorV2EnabledConfig,
+    state_accumulator_config: StateAccumulatorV1EnabledConfig,
 }
 
 impl SwarmBuilder {
@@ -93,7 +93,7 @@ impl SwarmBuilder {
             fullnode_fw_config: None,
             max_submit_position: None,
             submit_delay_step_override_millis: None,
-            state_accumulator_config: StateAccumulatorV2EnabledConfig::Global(true),
+            state_accumulator_config: StateAccumulatorV1EnabledConfig::Global(true),
         }
     }
 }
@@ -236,7 +236,7 @@ impl<R> SwarmBuilder<R> {
 
     pub fn with_state_accumulator_config(
         mut self,
-        c: StateAccumulatorV2EnabledConfig,
+        c: StateAccumulatorV1EnabledConfig,
     ) -> Self {
         self.state_accumulator_config = c;
         self

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -234,10 +234,7 @@ impl<R> SwarmBuilder<R> {
         self
     }
 
-    pub fn with_state_accumulator_config(
-        mut self,
-        c: StateAccumulatorV1EnabledConfig,
-    ) -> Self {
+    pub fn with_state_accumulator_config(mut self, c: StateAccumulatorV1EnabledConfig) -> Self {
         self.state_accumulator_config = c;
         self
     }
@@ -362,9 +359,7 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
                 .with_supported_protocol_versions_config(
                     self.supported_protocol_versions_config.clone(),
                 )
-                .with_state_accumulator_config(
-                    self.state_accumulator_config.clone(),
-                )
+                .with_state_accumulator_config(self.state_accumulator_config.clone())
                 .build();
             // Populate validator genesis by pointing to the blob
             let genesis_path = dir.join(IOTA_GENESIS_FILENAME);

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -1039,7 +1039,7 @@ pub struct TestClusterBuilder {
 
     max_submit_position: Option<usize>,
     submit_delay_step_override_millis: Option<u64>,
-    validator_state_accumulator_v2_enabled_config: StateAccumulatorV2EnabledConfig,
+    validator_state_accumulator_config: StateAccumulatorV2EnabledConfig,
 }
 
 impl TestClusterBuilder {
@@ -1067,7 +1067,7 @@ impl TestClusterBuilder {
             fullnode_fw_config: None,
             max_submit_position: None,
             submit_delay_step_override_millis: None,
-            validator_state_accumulator_v2_enabled_config: StateAccumulatorV2EnabledConfig::Global(
+            validator_state_accumulator_config: StateAccumulatorV2EnabledConfig::Global(
                 true,
             ),
         }
@@ -1194,7 +1194,7 @@ impl TestClusterBuilder {
         mut self,
         func: StateAccumulatorV2EnabledCallback,
     ) -> Self {
-        self.validator_state_accumulator_v2_enabled_config =
+        self.validator_state_accumulator_config =
             StateAccumulatorV2EnabledConfig::PerValidator(func);
         self
     }
@@ -1519,8 +1519,8 @@ impl TestClusterBuilder {
             .with_supported_protocol_versions_config(
                 self.validator_supported_protocol_versions_config.clone(),
             )
-            .with_state_accumulator_v2_enabled_config(
-                self.validator_state_accumulator_v2_enabled_config.clone(),
+            .with_state_accumulator_config(
+                self.validator_state_accumulator_config.clone(),
             )
             .with_fullnode_count(1)
             .with_fullnode_supported_protocol_versions_config(

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -56,7 +56,7 @@ use iota_swarm_config::{
     genesis_config::{AccountConfig, DEFAULT_GAS_AMOUNT, GenesisConfig, ValidatorGenesisConfig},
     network_config::{NetworkConfig, NetworkConfigLight},
     network_config_builder::{
-        ProtocolVersionsConfig, StateAccumulatorV2EnabledCallback, StateAccumulatorV2EnabledConfig,
+        ProtocolVersionsConfig, StateAccumulatorV1EnabledCallback, StateAccumulatorV1EnabledConfig,
         SupportedProtocolVersionsCallback,
     },
     node_config_builder::{FullnodeConfigBuilder, ValidatorConfigBuilder},
@@ -1039,7 +1039,7 @@ pub struct TestClusterBuilder {
 
     max_submit_position: Option<usize>,
     submit_delay_step_override_millis: Option<u64>,
-    validator_state_accumulator_config: StateAccumulatorV2EnabledConfig,
+    validator_state_accumulator_config: StateAccumulatorV1EnabledConfig,
 }
 
 impl TestClusterBuilder {
@@ -1067,7 +1067,7 @@ impl TestClusterBuilder {
             fullnode_fw_config: None,
             max_submit_position: None,
             submit_delay_step_override_millis: None,
-            validator_state_accumulator_config: StateAccumulatorV2EnabledConfig::Global(
+            validator_state_accumulator_config: StateAccumulatorV1EnabledConfig::Global(
                 true,
             ),
         }
@@ -1192,10 +1192,10 @@ impl TestClusterBuilder {
 
     pub fn with_state_accumulator_callback(
         mut self,
-        func: StateAccumulatorV2EnabledCallback,
+        func: StateAccumulatorV1EnabledCallback,
     ) -> Self {
         self.validator_state_accumulator_config =
-            StateAccumulatorV2EnabledConfig::PerValidator(func);
+            StateAccumulatorV1EnabledConfig::PerValidator(func);
         self
     }
 

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -1190,7 +1190,7 @@ impl TestClusterBuilder {
         self
     }
 
-    pub fn with_state_accumulator_v2_enabled_callback(
+    pub fn with_state_accumulator_callback(
         mut self,
         func: StateAccumulatorV2EnabledCallback,
     ) -> Self {

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -1067,9 +1067,7 @@ impl TestClusterBuilder {
             fullnode_fw_config: None,
             max_submit_position: None,
             submit_delay_step_override_millis: None,
-            validator_state_accumulator_config: StateAccumulatorV1EnabledConfig::Global(
-                true,
-            ),
+            validator_state_accumulator_config: StateAccumulatorV1EnabledConfig::Global(true),
         }
     }
 
@@ -1519,9 +1517,7 @@ impl TestClusterBuilder {
             .with_supported_protocol_versions_config(
                 self.validator_supported_protocol_versions_config.clone(),
             )
-            .with_state_accumulator_config(
-                self.validator_state_accumulator_config.clone(),
-            )
+            .with_state_accumulator_config(self.validator_state_accumulator_config.clone())
             .with_fullnode_count(1)
             .with_fullnode_supported_protocol_versions_config(
                 self.fullnode_supported_protocol_versions_config


### PR DESCRIPTION
# Description of change

- [x] Remove `StateAccumulatorV1`
  - [x] remove `notify_read_checkpoint_state_digests` (only used in `StateAccumulatorV1`)
- [x] Remove the following always `true` logic
  - [x] `state_accumulator_v2_enabled`
  - [x] `state_accumulator_v2` because it is now always `true`
  - [x] `with_state_accumulator_v2_enabled`
- [x] Rename `with_state_accumulator_v2_enabled_config` to be `with_state_accumulator_config`
  - Note that now `state_accumulator_v2` is always enabled and can be configured
- [x] Rename `state_accumulator_v2_enabled_config` to be `state_accumulator_config`
- [x] Rename `validator_state_accumulator_v2_enabled_config` to be validator_state_accumulator_config
- [x] Set the default `state_accumulator_config` to be `Global(true)`
- [x] Rename `with_state_accumulator_v2_enabled_callback` to be `with_state_accumulator_callback`

## Links to any relevant issues

Closes #3259 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

- I was running the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

