### PR TITLE
refactor(iota-rest-api): disable http2 in client

### DIFF
--- a/crates/iota-rest-api/src/client/sdk.rs
+++ b/crates/iota-rest-api/src/client/sdk.rs
@@ -54,7 +54,6 @@ impl Client {
 
         let inner = reqwest::ClientBuilder::new()
             .user_agent(USER_AGENT)
-            .http2_prior_knowledge()
             .build()?;
 
         Self {


### PR DESCRIPTION
# Description of change

This patch disables forced `http2` requests in the `iota-rest-api` service, as they are in effect not supported by the service started in `iota-node`.

