### PR TITLE
chore(ci): set nextest retries to 1

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -8,7 +8,7 @@ failure-output = "immediate"
 # Show skipped tests in the CI output.
 status-level = "skip"
 # Retry failing tests in order to not block builds on flaky tests
-retries = 5
+retries = 1
 # Timeout tests after 4 minutes
 slow-timeout = { period = "60s", terminate-after = 4 }
 


### PR DESCRIPTION
We want to reduce CI time to have more runners available for important PRs. This may make more flaky tests to fail, we should list them in a issue and temporarily disable them if needed.