### PR TITLE
fix(tests): Improve handling of `node_keypair` in tests.

### DIFF
--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -20,7 +20,7 @@ use iota_macros::nondeterministic;
 use iota_types::{
     base_types::{AuthorityName, IotaAddress},
     committee::{Committee, ProtocolVersion},
-    crypto::{AccountKeyPair, AuthorityKeyPair, PublicKey, get_key_pair_from_rng},
+    crypto::{AccountKeyPair, PublicKey, get_key_pair_from_rng},
     object::Object,
     supported_protocol_versions::SupportedProtocolVersions,
     traffic_control::{PolicyConfig, RemoteFirewallConfig},
@@ -39,7 +39,6 @@ use crate::{
 pub enum CommitteeConfig {
     Size(NonZeroUsize),
     Validators(Vec<ValidatorGenesisConfig>),
-    AuthorityKeys(Vec<AuthorityKeyPair>),
     AccountKeys(Vec<AccountKeyPair>),
     /// Indicates that a committee should be deterministically generated, using
     /// the provided rng as a source of randomness as well as generating
@@ -157,10 +156,7 @@ impl<R> ConfigBuilder<R> {
         self.committee = CommitteeConfig::Validators(validators);
         self
     }
-    pub fn with_validator_authority_keys(mut self, authority_keys: Vec<AuthorityKeyPair>) -> Self {
-        self.committee = CommitteeConfig::AuthorityKeys(authority_keys);
-        self
-    }
+
     pub fn with_genesis_config(mut self, genesis_config: GenesisConfig) -> Self {
         assert!(self.genesis_config.is_none(), "Genesis config already set");
         self.genesis_config = Some(genesis_config);
@@ -354,18 +350,6 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
             }
 
             CommitteeConfig::Validators(v) => v,
-
-            CommitteeConfig::AuthorityKeys(keys) => keys
-                .into_iter()
-                .map(|authority_key| {
-                    let mut builder =
-                        ValidatorGenesisConfigBuilder::new().with_protocol_key_pair(authority_key);
-                    if let Some(rgp) = self.reference_gas_price {
-                        builder = builder.with_gas_price(rgp);
-                    }
-                    builder.build(&mut rng)
-                })
-                .collect::<Vec<_>>(),
 
             CommitteeConfig::AccountKeys(keys) => {
                 // See above re fixed protocol keys


### PR DESCRIPTION
# Description of change

Improve handling of `node_keypair` for fullnodes in test framework. Previous fix was overly complicated and it's enough to pass the `node_keypair` to the randomness manager if it exists, instead of always putting it in the genesis committee.

## Links to any relevant issues


## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Ran `dev_inspect` test and `execution_driver` test that showcased this problem. 

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
