### PR TITLE
fix(iota-execution): digest arg type set to vec<u8> according to authorize_upgrade signature

### DIFF
--- a/crates/iota-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/iota-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -48,13 +48,13 @@ macro_rules! move_call {
     }
 }
 
-fn build_upgrade_test_modules(test_dir: &str) -> ([u8; 32], Vec<Vec<u8>>) {
+fn build_upgrade_test_modules(test_dir: &str) -> (Vec<u8>, Vec<Vec<u8>>) {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.extend(["src", "unit_tests", "data", "move_upgrade", test_dir]);
     let with_unpublished_deps = false;
     let package = BuildConfig::new_for_testing().build(&path).unwrap();
     (
-        package.get_package_digest(with_unpublished_deps),
+        package.get_package_digest(with_unpublished_deps).to_vec(),
         package.get_package_bytes(with_unpublished_deps),
     )
 }
@@ -178,7 +178,7 @@ impl UpgradeStateRunner {
     pub async fn upgrade(
         &mut self,
         policy: u8,
-        digest: [u8; 32],
+        digest: Vec<u8>,
         modules: Vec<Vec<u8>>,
         dep_ids: Vec<ObjectID>,
     ) -> TransactionEffects {
@@ -395,8 +395,8 @@ async fn test_upgrade_incompatible() {
 async fn test_upgrade_package_incorrect_digest() {
     let mut runner = UpgradeStateRunner::new("move_upgrade/base").await;
     let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
-    let bad_digest = [0; 32];
-
+    let bad_digest = vec![0; digest.len()];
+    
     let effects = runner
         .upgrade(UpgradePolicy::COMPATIBLE, bad_digest, modules, vec![])
         .await;

--- a/crates/iota-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/iota-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -396,7 +396,7 @@ async fn test_upgrade_package_incorrect_digest() {
     let mut runner = UpgradeStateRunner::new("move_upgrade/base").await;
     let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
     let bad_digest = vec![0; digest.len()];
-    
+
     let effects = runner
         .upgrade(UpgradePolicy::COMPATIBLE, bad_digest, modules, vec![])
         .await;

--- a/crates/iota-core/tests/staged/iota.yaml
+++ b/crates/iota-core/tests/staged/iota.yaml
@@ -748,9 +748,7 @@ PackageUpgradeError:
       DigestDoesNotMatch:
         STRUCT:
           - digest:
-              TUPLEARRAY:
-                CONTENT: U8
-                SIZE: 32
+              SEQ: U8
     4:
       UnknownUpgradePolicy:
         STRUCT:

--- a/crates/iota-types/src/execution_status.rs
+++ b/crates/iota-types/src/execution_status.rs
@@ -280,7 +280,7 @@ pub enum PackageUpgradeError {
     #[error("New package is incompatible with previous version")]
     IncompatibleUpgrade,
     #[error("Digest in upgrade ticket and computed digest disagree")]
-    DigestDoesNotMatch { digest: [u8; 32] },
+    DigestDoesNotMatch { digest: Vec<u8> },
     #[error("Upgrade policy {policy} is not a valid upgrade policy")]
     UnknownUpgradePolicy { policy: u8 },
     #[error("Package ID {package_id} does not match package ID in upgrade ticket {ticket_id}")]

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -599,8 +599,8 @@ mod checked {
 
         // Check digest.
         let computed_digest =
-            MovePackage::compute_digest_for_modules_and_deps(&module_bytes, &dep_ids);
-        if computed_digest != upgrade_ticket.digest.as_ref() {
+            MovePackage::compute_digest_for_modules_and_deps(&module_bytes, &dep_ids).into();
+        if computed_digest != upgrade_ticket.digest {
             return Err(ExecutionError::from_kind(
                 ExecutionErrorKind::PackageUpgradeError {
                     upgrade_error: PackageUpgradeError::DigestDoesNotMatch {

--- a/iota-execution/v0/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/v0/iota-adapter/src/programmable_transactions/execution.rs
@@ -581,8 +581,8 @@ mod checked {
 
         // Check digest.
         let computed_digest =
-            MovePackage::compute_digest_for_modules_and_deps(&module_bytes, &dep_ids);
-        if computed_digest != upgrade_ticket.digest.as_ref() {
+            MovePackage::compute_digest_for_modules_and_deps(&module_bytes, &dep_ids).into();
+        if computed_digest != upgrade_ticket.digest {
             return Err(ExecutionError::from_kind(
                 ExecutionErrorKind::PackageUpgradeError {
                     upgrade_error: PackageUpgradeError::DigestDoesNotMatch {


### PR DESCRIPTION
# Description of change

All tests invoke `package::authorize_upgrade` inside that has following signature;

```
    public fun authorize_upgrade(
        cap: &mut UpgradeCap,
        policy: u8,
        digest: vector<u8>
    )
```
So if we're passing a digest as simple array  - `builder.pure(digest).unwrap();` it will cause an error:
```
Failure {
    error: CommandArgumentError {
        arg_idx: 2,
        kind: InvalidBCSBytes,
    },
    command: Some(
        0,
    ),
}
```

Setting the digest type as a vector resolves the type mismatch during serialization

## Links to any relevant issues

Fix #3537 .

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`cargo test move_package_upgrade_tests`