### PR TITLE
feat(iota-graphql-rpc): expose treasury cap id

### DIFF
--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -1169,6 +1169,10 @@ type Epoch {
 	"""
 	iotaTotalSupply: Int
 	"""
+	The treasury-cap id.
+	"""
+	iotaTreasuryCapId: IotaAddress
+	"""
 	Details of the system that are decided during genesis.
 	"""
 	systemParameters: SystemParameters

--- a/crates/iota-graphql-rpc/src/types/system_state_summary.rs
+++ b/crates/iota-graphql-rpc/src/types/system_state_summary.rs
@@ -6,8 +6,8 @@ use async_graphql::*;
 use iota_types::iota_system_state::iota_system_state_summary::IotaSystemStateSummary as NativeSystemStateSummary;
 
 use crate::types::{
-    big_int::BigInt, gas::GasCostSummary, safe_mode::SafeMode, storage_fund::StorageFund,
-    system_parameters::SystemParameters, uint53::UInt53,
+    big_int::BigInt, gas::GasCostSummary, iota_address::IotaAddress, safe_mode::SafeMode,
+    storage_fund::StorageFund, system_parameters::SystemParameters, uint53::UInt53,
 };
 
 #[derive(Clone, Debug)]
@@ -57,6 +57,11 @@ impl SystemStateSummary {
     /// The total IOTA supply.
     async fn iota_total_supply(&self) -> Option<u64> {
         Some(self.native.iota_total_supply)
+    }
+
+    /// The treasury-cap id.
+    async fn iota_treasury_cap_id(&self) -> Option<IotaAddress> {
+        Some(self.native.iota_treasury_cap_id.into())
     }
 
     /// Details of the system that are decided during genesis.

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -1173,6 +1173,10 @@ type Epoch {
 	"""
 	iotaTotalSupply: Int
 	"""
+	The treasury-cap id.
+	"""
+	iotaTreasuryCapId: IotaAddress
+	"""
 	Details of the system that are decided during genesis.
 	"""
 	systemParameters: SystemParameters


### PR DESCRIPTION
# Description of change

This patch exposes the `iotaTreasuryCapId` field of `Epoch` information in GraphQL.
 
## Links to any relevant issues

Fixes #3451 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

```
$ cargo nextest run -p iota-graphql-rpc
```

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
