### PR TITLE
chore(ci): clean app deploy job names

### DIFF
--- a/.github/workflows/apps-backend-production.deploy.yml
+++ b/.github/workflows/apps-backend-production.deploy.yml
@@ -13,7 +13,7 @@ on:
       - ".github/workflows/apps-backend-production.deploy.yml"
 
 jobs:
-  deploy-preview:
+  deploy-production:
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/apps-explorer-production.deploy.yml
+++ b/.github/workflows/apps-explorer-production.deploy.yml
@@ -13,7 +13,7 @@ on:
       - ".github/workflows/apps-explorer-production.deploy.yml"
 
 jobs:
-  deploy-prod:
+  deploy-production:
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/apps-ui-kit-production.deploy.yml
+++ b/.github/workflows/apps-ui-kit-production.deploy.yml
@@ -14,7 +14,7 @@ on:
       - ".github/workflows/apps-ui-kit-production.deploy.yml"
 
 jobs:
-  deploy-preview:
+  deploy-production:
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/apps-wallet-dashboard-production.deploy.yml
+++ b/.github/workflows/apps-wallet-dashboard-production.deploy.yml
@@ -13,7 +13,7 @@ on:
       - ".github/workflows/apps-wallet-dashboard-production.deploy.yml"
 
 jobs:
-  deploy-preview:
+  deploy-production:
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
I guess `production` has been copy pasted from `preview` and the job names were not renamed.