### PR TITLE
feat(iota-indexer): Introduce ability to create more shared test clusters

### DIFF
--- a/crates/iota-cluster-test/src/cluster.rs
+++ b/crates/iota-cluster-test/src/cluster.rs
@@ -259,6 +259,7 @@ impl Cluster for LocalNewCluster {
                 Some(pg_address.clone()),
                 fullnode_url.clone(),
                 ReaderWriterConfig::writer_mode(None),
+                None,
             )
             .await;
 
@@ -267,6 +268,7 @@ impl Cluster for LocalNewCluster {
                 Some(pg_address),
                 fullnode_url.clone(),
                 ReaderWriterConfig::reader_mode(indexer_address.to_string()),
+                None,
             )
             .await;
         }

--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -130,7 +130,7 @@ pub async fn serve_executor(
         Some(db_url),
         format!("http://{}", executor_server_url),
         ReaderWriterConfig::writer_mode(snapshot_config.clone()),
-        Some(graphql_connection_config.db_name()),
+        Some(&graphql_connection_config.db_name()),
     )
     .await;
 

--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -65,6 +65,7 @@ pub async fn start_cluster(
         Some(db_url),
         val_fn.rpc_url().to_string(),
         ReaderWriterConfig::writer_mode(None),
+        None,
     )
     .await;
 

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -42,8 +42,9 @@ pub async fn start_test_indexer(
     db_url: Option<String>,
     rpc_url: String,
     reader_writer_config: ReaderWriterConfig,
+    new_database: Option<String>,
 ) -> (PgIndexerStore, JoinHandle<Result<(), IndexerError>>) {
-    start_test_indexer_impl(db_url, rpc_url, reader_writer_config, None).await
+    start_test_indexer_impl(db_url, rpc_url, reader_writer_config, new_database).await
 }
 
 pub async fn start_test_indexer_impl(

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -42,7 +42,7 @@ pub async fn start_test_indexer(
     db_url: Option<String>,
     rpc_url: String,
     reader_writer_config: ReaderWriterConfig,
-    new_database: Option<String>,
+    new_database: Option<&str>,
 ) -> (PgIndexerStore, JoinHandle<Result<(), IndexerError>>) {
     start_test_indexer_impl(db_url, rpc_url, reader_writer_config, new_database).await
 }
@@ -51,7 +51,7 @@ pub async fn start_test_indexer_impl(
     db_url: Option<String>,
     rpc_url: String,
     reader_writer_config: ReaderWriterConfig,
-    new_database: Option<String>,
+    new_database: Option<&str>,
 ) -> (PgIndexerStore, JoinHandle<Result<(), IndexerError>>) {
     let db_url = db_url.unwrap_or_else(|| {
         let pg_host = env::var("POSTGRES_HOST").unwrap_or_else(|_| "localhost".into());
@@ -124,7 +124,7 @@ pub async fn start_test_indexer_impl(
     (store, handle)
 }
 
-pub fn create_pg_store(db_url: String, new_database: Option<String>) -> PgIndexerStore {
+pub fn create_pg_store(db_url: String, new_database: Option<&str>) -> PgIndexerStore {
     // Reduce the connection pool size to 10 for testing
     // to prevent maxing out
     info!("Setting DB_POOL_SIZE to 10");
@@ -159,7 +159,7 @@ pub fn create_pg_store(db_url: String, new_database: Option<String>) -> PgIndexe
         default_conn
             .batch_execute(&format!("CREATE DATABASE {}", new_database))
             .unwrap();
-        parsed_url = replace_db_name(&parsed_url, &new_database).0;
+        parsed_url = replace_db_name(&parsed_url, new_database).0;
     }
 
     let blocking_pool =

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    net::SocketAddr,
+    net::{SocketAddr, TcpListener},
     sync::{Arc, OnceLock},
     time::Duration,
 };
@@ -46,7 +46,10 @@ impl ApiTestSetup {
             let runtime = tokio::runtime::Runtime::new().unwrap();
 
             let (cluster, store, client) =
-                runtime.block_on(start_test_cluster_with_read_write_indexer(None));
+                runtime.block_on(start_test_cluster_with_read_write_indexer(
+                    None,
+                    Some("shared_test_indexer_db".to_string()),
+                ));
 
             Self {
                 runtime,
@@ -58,10 +61,47 @@ impl ApiTestSetup {
     }
 }
 
+pub struct SimulacrumApiTestEnvDefinition {
+    pub unique_env_name: String,
+    pub env_initializer: Box<dyn Fn() -> Simulacrum>,
+}
+
+pub struct InitializedSimulacrumEnv {
+    pub runtime: Runtime,
+    pub sim: Arc<Simulacrum>,
+    pub store: PgIndexerStore,
+    /// Indexer RPC Client
+    pub client: HttpClient,
+}
+
+impl SimulacrumApiTestEnvDefinition {
+    pub fn get_or_init_env<'a>(
+        &self,
+        initialized_env_container: &'a OnceLock<InitializedSimulacrumEnv>,
+    ) -> &'a InitializedSimulacrumEnv {
+        initialized_env_container.get_or_init(|| {
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            let sim = Arc::new((self.env_initializer)());
+            let db_name = format!("simulacrum_env_db_{}", self.unique_env_name);
+            let (_, store, _, client) = runtime.block_on(
+                start_simulacrum_rest_api_with_read_write_indexer(sim.clone(), Some(db_name)),
+            );
+
+            InitializedSimulacrumEnv {
+                runtime,
+                sim,
+                store,
+                client,
+            }
+        })
+    }
+}
+
 /// Start a [`TestCluster`][`test_cluster::TestCluster`] with a `Read` &
 /// `Write` indexer
 pub async fn start_test_cluster_with_read_write_indexer(
     stop_cluster_after_checkpoint_seq: Option<u64>,
+    database_name: Option<String>,
 ) -> (TestCluster, PgIndexerStore, HttpClient) {
     let mut builder = TestClusterBuilder::new();
 
@@ -79,17 +119,16 @@ pub async fn start_test_cluster_with_read_write_indexer(
         Some(DEFAULT_DB_URL.to_owned()),
         cluster.rpc_url().to_string(),
         ReaderWriterConfig::writer_mode(None),
+        database_name.clone(),
     )
     .await;
 
     // start indexer in read mode
-    start_indexer_reader(cluster.rpc_url().to_owned());
+    let indexer_port = start_indexer_reader(cluster.rpc_url().to_owned(), database_name);
 
     // create an RPC client by using the indexer url
     let rpc_client = HttpClientBuilder::default()
-        .build(format!(
-            "http://{DEFAULT_INDEXER_IP}:{DEFAULT_INDEXER_PORT}"
-        ))
+        .build(format!("http://{DEFAULT_INDEXER_IP}:{indexer_port}"))
         .unwrap();
 
     (cluster, pg_store, rpc_client)
@@ -117,24 +156,44 @@ pub async fn indexer_wait_for_checkpoint(
     .expect("Timeout waiting for indexer to catchup to checkpoint");
 }
 
+fn get_available_port() -> u16 {
+    // Let the OS assign some available port, read it, and then make it available
+    // again.
+    // This results in a race condition, some other app can use this port in a short
+    // time window between this function call and a place where we use it
+    let tl = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    tl.local_addr().unwrap().port()
+}
+
+fn replace_db_name(db_url: &str, new_db_name: &str) -> String {
+    let pos = db_url.rfind('/').expect("Unable to find / in db_url");
+    format!("{}/{}", &db_url[..pos], new_db_name)
+}
+
 /// Start an Indexer instance in `Read` mode
-fn start_indexer_reader(fullnode_rpc_url: impl Into<String>) {
+fn start_indexer_reader(fullnode_rpc_url: impl Into<String>, database_name: Option<String>) -> u16 {
+    let db_url = match database_name {
+        Some(database_name) => replace_db_name(DEFAULT_DB_URL, &database_name),
+        None => DEFAULT_DB_URL.to_owned(),
+    };
+
+    let port = get_available_port();
     let config = IndexerConfig {
-        db_url: Some(DEFAULT_DB_URL.to_owned()),
+        db_url: Some(db_url.clone()),
         rpc_client_url: fullnode_rpc_url.into(),
         reset_db: true,
         rpc_server_worker: true,
         rpc_server_url: DEFAULT_INDEXER_IP.to_owned(),
-        rpc_server_port: DEFAULT_INDEXER_PORT,
+        rpc_server_port: port,
         ..Default::default()
     };
 
     let registry = prometheus::Registry::default();
     init_metrics(&registry);
 
-    tokio::spawn(async move {
-        Indexer::start_reader(&config, &registry, DEFAULT_DB_URL.to_owned()).await
-    });
+    tokio::spawn(async move { Indexer::start_reader(&config, &registry, db_url).await });
+
+    port
 }
 
 /// Check if provided error message does match with
@@ -153,23 +212,23 @@ pub fn rpc_call_error_msg_matches<T>(
     })
 }
 
-pub fn get_default_fullnode_rpc_api_addr() -> SocketAddr {
-    format!("127.0.0.1:{}", DEFAULT_SERVER_PORT)
-        .parse()
-        .unwrap()
+pub fn get_available_fullnode_rpc_api_addr() -> SocketAddr {
+    let port = get_available_port();
+    format!("127.0.0.1:{}", port).parse().unwrap()
 }
 
 /// Set up a test indexer fetching from a REST endpoint served by the given
 /// Simulacrum.
 pub async fn start_simulacrum_rest_api_with_write_indexer(
     sim: Arc<Simulacrum>,
+    server_url: Option<SocketAddr>,
+    database_name: Option<String>,
 ) -> (
     JoinHandle<()>,
     PgIndexerStore,
     JoinHandle<Result<(), IndexerError>>,
 ) {
-    let server_url = get_default_fullnode_rpc_api_addr();
-
+    let server_url = server_url.unwrap_or_else(get_available_fullnode_rpc_api_addr);
     let server_handle = tokio::spawn(async move {
         let chain_id = (*sim
             .get_checkpoint_by_sequence_number(0)
@@ -187,6 +246,7 @@ pub async fn start_simulacrum_rest_api_with_write_indexer(
         Some(DEFAULT_DB_URL.to_owned()),
         format!("http://{}", server_url),
         ReaderWriterConfig::writer_mode(None),
+        database_name,
     )
     .await;
     (server_handle, pg_store, pg_handle)
@@ -194,24 +254,24 @@ pub async fn start_simulacrum_rest_api_with_write_indexer(
 
 pub async fn start_simulacrum_rest_api_with_read_write_indexer(
     sim: Arc<Simulacrum>,
+    database_name: Option<String>,
 ) -> (
     JoinHandle<()>,
     PgIndexerStore,
     JoinHandle<Result<(), IndexerError>>,
     HttpClient,
 ) {
-    let server_url = get_default_fullnode_rpc_api_addr();
+    let server_url = get_available_fullnode_rpc_api_addr();
     let (server_handle, pg_store, pg_handle) =
-        start_simulacrum_rest_api_with_write_indexer(sim).await;
+        start_simulacrum_rest_api_with_write_indexer(sim, Some(server_url), database_name.clone())
+            .await;
 
     // start indexer in read mode
-    start_indexer_reader(format!("http://{}", server_url));
+    let indexer_port = start_indexer_reader(format!("http://{}", server_url), database_name);
 
     // create an RPC client by using the indexer url
     let rpc_client = HttpClientBuilder::default()
-        .build(format!(
-            "http://{DEFAULT_INDEXER_IP}:{DEFAULT_INDEXER_PORT}"
-        ))
+        .build(format!("http://{DEFAULT_INDEXER_IP}:{indexer_port}"))
         .unwrap();
 
     (server_handle, pg_store, pg_handle, rpc_client)

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    net::{SocketAddr, TcpListener},
+    net::{SocketAddr},
     sync::{Arc, OnceLock},
     time::Duration,
 };
 
-use iota_config::node::RunWithRange;
+use iota_config::{
+    local_ip_utils::{get_available_port, new_local_tcp_socket_for_testing},
+    node::RunWithRange,
+};
 use iota_indexer::{
     errors::IndexerError,
     indexer::Indexer,
@@ -156,15 +159,6 @@ pub async fn indexer_wait_for_checkpoint(
     .expect("Timeout waiting for indexer to catchup to checkpoint");
 }
 
-fn get_available_port() -> u16 {
-    // Let the OS assign some available port, read it, and then make it available
-    // again.
-    // This results in a race condition, some other app can use this port in a short
-    // time window between this function call and a place where we use it
-    let tl = TcpListener::bind(("127.0.0.1", 0)).unwrap();
-    tl.local_addr().unwrap().port()
-}
-
 fn replace_db_name(db_url: &str, new_db_name: &str) -> String {
     let pos = db_url.rfind('/').expect("Unable to find / in db_url");
     format!("{}/{}", &db_url[..pos], new_db_name)
@@ -177,7 +171,7 @@ fn start_indexer_reader(fullnode_rpc_url: impl Into<String>, database_name: Opti
         None => DEFAULT_DB_URL.to_owned(),
     };
 
-    let port = get_available_port();
+    let port = get_available_port(DEFAULT_INDEXER_IP);
     let config = IndexerConfig {
         db_url: Some(db_url.clone()),
         rpc_client_url: fullnode_rpc_url.into(),
@@ -212,11 +206,6 @@ pub fn rpc_call_error_msg_matches<T>(
     })
 }
 
-pub fn get_available_fullnode_rpc_api_addr() -> SocketAddr {
-    let port = get_available_port();
-    format!("127.0.0.1:{}", port).parse().unwrap()
-}
-
 /// Set up a test indexer fetching from a REST endpoint served by the given
 /// Simulacrum.
 pub async fn start_simulacrum_rest_api_with_write_indexer(
@@ -228,7 +217,7 @@ pub async fn start_simulacrum_rest_api_with_write_indexer(
     PgIndexerStore,
     JoinHandle<Result<(), IndexerError>>,
 ) {
-    let server_url = server_url.unwrap_or_else(get_available_fullnode_rpc_api_addr);
+    let server_url = server_url.unwrap_or_else(new_local_tcp_socket_for_testing);
     let server_handle = tokio::spawn(async move {
         let chain_id = (*sim
             .get_checkpoint_by_sequence_number(0)
@@ -261,7 +250,7 @@ pub async fn start_simulacrum_rest_api_with_read_write_indexer(
     JoinHandle<Result<(), IndexerError>>,
     HttpClient,
 ) {
-    let server_url = get_available_fullnode_rpc_api_addr();
+    let server_url = new_local_tcp_socket_for_testing();
     let (server_handle, pg_store, pg_handle) =
         start_simulacrum_rest_api_with_write_indexer(sim, Some(server_url), database_name.clone())
             .await;

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -46,7 +46,12 @@ mod ingestion_tests {
         // Create a checkpoint which should include the transaction we executed.
         let checkpoint = sim.create_checkpoint();
 
-        let (_, pg_store, _) = start_simulacrum_rest_api_with_write_indexer(Arc::new(sim)).await;
+        let (_, pg_store, _) = start_simulacrum_rest_api_with_write_indexer(
+            Arc::new(sim),
+            None,
+            Some("indexer_ingestion_tests_db".to_string()),
+        )
+        .await;
 
         // Wait for the indexer to catch up to the checkpoint.
         indexer_wait_for_checkpoint(&pg_store, 1).await;

--- a/crates/iota-indexer/tests/rpc-tests/extended_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/extended_api.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::OnceLock};
 
 use iota_json::{call_args, type_args};
 use iota_json_rpc_api::{
@@ -18,414 +18,401 @@ use iota_types::{
     storage::ReadStore,
     IOTA_FRAMEWORK_ADDRESS,
 };
-use serial_test::serial;
 use simulacrum::Simulacrum;
 use test_cluster::TestCluster;
 
 use crate::common::{
-    indexer_wait_for_checkpoint, start_simulacrum_rest_api_with_read_write_indexer,
-    start_test_cluster_with_read_write_indexer,
+    indexer_wait_for_checkpoint, ApiTestSetup, InitializedSimulacrumEnv,
+    SimulacrumApiTestEnvDefinition,
 };
 
-#[tokio::test]
-#[serial]
-async fn get_epochs() {
-    let mut sim = Simulacrum::new();
+static EXTENDED_API_SHARED_SIMULACRUM_INITIALIZED_ENV: OnceLock<InitializedSimulacrumEnv> =
+    OnceLock::new();
 
-    execute_simulacrum_transactions(&mut sim, 15);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch(false);
+fn get_or_init_shared_extended_api_simulacrum_env() -> &'static InitializedSimulacrumEnv {
+    let extended_api_env = SimulacrumApiTestEnvDefinition {
+        unique_env_name: "extended_api".to_string(),
+        env_initializer: Box::new(|| {
+            let mut sim = Simulacrum::new();
 
-    execute_simulacrum_transactions(&mut sim, 10);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch(false);
+            execute_simulacrum_transactions(&mut sim, 15);
+            add_checkpoints(&mut sim, 300);
+            sim.advance_epoch(false);
 
-    execute_simulacrum_transactions(&mut sim, 5);
-    add_checkpoints(&mut sim, 300);
+            execute_simulacrum_transactions(&mut sim, 10);
+            add_checkpoints(&mut sim, 300);
+            sim.advance_epoch(false);
 
-    let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+            execute_simulacrum_transactions(&mut sim, 5);
+            add_checkpoints(&mut sim, 300);
 
-    let (_, pg_store, _, indexer_client) =
-        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim)).await;
-    indexer_wait_for_checkpoint(&pg_store, last_checkpoint.sequence_number).await;
-
-    let epochs = indexer_client.get_epochs(None, None, None).await.unwrap();
-
-    assert_eq!(epochs.data.len(), 3);
-    assert!(!epochs.has_next_page);
-
-    let end_of_epoch_info = epochs.data[0].end_of_epoch_info.as_ref().unwrap();
-    assert_eq!(epochs.data[0].epoch, 0);
-    assert_eq!(epochs.data[0].first_checkpoint_id, 0);
-    assert_eq!(epochs.data[0].epoch_total_transactions, 17);
-    assert_eq!(end_of_epoch_info.last_checkpoint_id, 301);
-
-    let end_of_epoch_info = epochs.data[1].end_of_epoch_info.as_ref().unwrap();
-    assert_eq!(epochs.data[1].epoch, 1);
-    assert_eq!(epochs.data[1].first_checkpoint_id, 302);
-    assert_eq!(epochs.data[1].epoch_total_transactions, 11);
-    assert_eq!(end_of_epoch_info.last_checkpoint_id, 602);
-
-    assert_eq!(epochs.data[2].epoch, 2);
-    assert_eq!(epochs.data[2].first_checkpoint_id, 603);
-    assert_eq!(epochs.data[2].epoch_total_transactions, 0);
-    assert!(epochs.data[2].end_of_epoch_info.is_none());
+            sim
+        }),
+    };
+    extended_api_env.get_or_init_env(&EXTENDED_API_SHARED_SIMULACRUM_INITIALIZED_ENV)
 }
 
-#[tokio::test]
-#[serial]
-async fn get_epochs_descending() {
-    let mut sim = Simulacrum::new();
+#[test]
+fn get_epochs() {
+    let InitializedSimulacrumEnv {
+        runtime,
+        sim,
+        store,
+        client,
+    } = get_or_init_shared_extended_api_simulacrum_env();
 
-    execute_simulacrum_transactions(&mut sim, 15);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch(false);
+    runtime.block_on(async move {
+        let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        indexer_wait_for_checkpoint(&store, last_checkpoint.sequence_number).await;
 
-    execute_simulacrum_transactions(&mut sim, 10);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch(false);
+        let epochs = client.get_epochs(None, None, None).await.unwrap();
 
-    execute_simulacrum_transactions(&mut sim, 5);
-    add_checkpoints(&mut sim, 300);
+        assert_eq!(epochs.data.len(), 3);
+        assert!(!epochs.has_next_page);
 
-    let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        let end_of_epoch_info = epochs.data[0].end_of_epoch_info.as_ref().unwrap();
+        assert_eq!(epochs.data[0].epoch, 0);
+        assert_eq!(epochs.data[0].first_checkpoint_id, 0);
+        assert_eq!(epochs.data[0].epoch_total_transactions, 17);
+        assert_eq!(end_of_epoch_info.last_checkpoint_id, 301);
 
-    let (_, pg_store, _, indexer_client) =
-        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim)).await;
-    indexer_wait_for_checkpoint(&pg_store, last_checkpoint.sequence_number).await;
+        let end_of_epoch_info = epochs.data[1].end_of_epoch_info.as_ref().unwrap();
+        assert_eq!(epochs.data[1].epoch, 1);
+        assert_eq!(epochs.data[1].first_checkpoint_id, 302);
+        assert_eq!(epochs.data[1].epoch_total_transactions, 11);
+        assert_eq!(end_of_epoch_info.last_checkpoint_id, 602);
 
-    let epochs = indexer_client
-        .get_epochs(None, None, Some(true))
-        .await
-        .unwrap();
-
-    let actual_epochs_order = epochs
-        .data
-        .iter()
-        .map(|epoch| epoch.epoch)
-        .collect::<Vec<u64>>();
-
-    assert_eq!(epochs.data.len(), 3);
-    assert!(!epochs.has_next_page);
-    assert_eq!(actual_epochs_order, [2, 1, 0])
+        assert_eq!(epochs.data[2].epoch, 2);
+        assert_eq!(epochs.data[2].first_checkpoint_id, 603);
+        assert_eq!(epochs.data[2].epoch_total_transactions, 0);
+        assert!(epochs.data[2].end_of_epoch_info.is_none());
+    });
 }
 
-#[tokio::test]
-#[serial]
-async fn get_epochs_paging() {
-    let mut sim = Simulacrum::new();
+#[test]
+fn get_epochs_descending() {
+    let InitializedSimulacrumEnv {
+        runtime,
+        sim,
+        store,
+        client,
+    } = get_or_init_shared_extended_api_simulacrum_env();
 
-    execute_simulacrum_transactions(&mut sim, 15);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch(false);
+    runtime.block_on(async move {
+        let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        indexer_wait_for_checkpoint(&store, last_checkpoint.sequence_number).await;
 
-    execute_simulacrum_transactions(&mut sim, 10);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch(false);
+        let epochs = client.get_epochs(None, None, Some(true)).await.unwrap();
 
-    execute_simulacrum_transactions(&mut sim, 5);
-    add_checkpoints(&mut sim, 300);
+        let actual_epochs_order = epochs
+            .data
+            .iter()
+            .map(|epoch| epoch.epoch)
+            .collect::<Vec<u64>>();
 
-    let last_checkpoint = sim.get_latest_checkpoint().unwrap();
-
-    let (_, pg_store, _, indexer_client) =
-        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim)).await;
-    indexer_wait_for_checkpoint(&pg_store, last_checkpoint.sequence_number).await;
-
-    let epochs = indexer_client
-        .get_epochs(None, Some(2), None)
-        .await
-        .unwrap();
-    let actual_epochs_order = epochs
-        .data
-        .iter()
-        .map(|epoch| epoch.epoch)
-        .collect::<Vec<u64>>();
-
-    assert_eq!(epochs.data.len(), 2);
-    assert!(epochs.has_next_page);
-    assert_eq!(epochs.next_cursor, Some(1.into()));
-    assert_eq!(actual_epochs_order, [0, 1]);
-
-    let epochs = indexer_client
-        .get_epochs(Some(1.into()), Some(2), None)
-        .await
-        .unwrap();
-    let actual_epochs_order = epochs
-        .data
-        .iter()
-        .map(|epoch| epoch.epoch)
-        .collect::<Vec<u64>>();
-
-    assert_eq!(epochs.data.len(), 1);
-    assert!(!epochs.has_next_page);
-    assert_eq!(epochs.next_cursor, Some(2.into()));
-    assert_eq!(actual_epochs_order, [2]);
+        assert_eq!(epochs.data.len(), 3);
+        assert!(!epochs.has_next_page);
+        assert_eq!(actual_epochs_order, [2, 1, 0])
+    });
 }
 
-#[tokio::test]
-#[serial]
-async fn get_epoch_metrics() {
-    let mut sim = Simulacrum::new();
+#[test]
+fn get_epochs_paging() {
+    let InitializedSimulacrumEnv {
+        runtime,
+        sim,
+        store,
+        client,
+    } = get_or_init_shared_extended_api_simulacrum_env();
 
-    execute_simulacrum_transactions(&mut sim, 15);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch(false);
+    runtime.block_on(async move {
+        let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        indexer_wait_for_checkpoint(&store, last_checkpoint.sequence_number).await;
 
-    execute_simulacrum_transactions(&mut sim, 10);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch(false);
+        let epochs = client.get_epochs(None, Some(2), None).await.unwrap();
+        let actual_epochs_order = epochs
+            .data
+            .iter()
+            .map(|epoch| epoch.epoch)
+            .collect::<Vec<u64>>();
 
-    execute_simulacrum_transactions(&mut sim, 5);
-    add_checkpoints(&mut sim, 300);
+        assert_eq!(epochs.data.len(), 2);
+        assert!(epochs.has_next_page);
+        assert_eq!(epochs.next_cursor, Some(1.into()));
+        assert_eq!(actual_epochs_order, [0, 1]);
 
-    let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        let epochs = client
+            .get_epochs(Some(1.into()), Some(2), None)
+            .await
+            .unwrap();
+        let actual_epochs_order = epochs
+            .data
+            .iter()
+            .map(|epoch| epoch.epoch)
+            .collect::<Vec<u64>>();
 
-    let (_, pg_store, _, indexer_client) =
-        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim)).await;
-    indexer_wait_for_checkpoint(&pg_store, last_checkpoint.sequence_number).await;
-
-    let epoch_metrics = indexer_client
-        .get_epoch_metrics(None, None, None)
-        .await
-        .unwrap();
-
-    assert_eq!(epoch_metrics.data.len(), 3);
-    assert!(!epoch_metrics.has_next_page);
-
-    let end_of_epoch_info = epoch_metrics.data[0].end_of_epoch_info.as_ref().unwrap();
-    assert_eq!(epoch_metrics.data[0].epoch, 0);
-    assert_eq!(epoch_metrics.data[0].first_checkpoint_id, 0);
-    assert_eq!(epoch_metrics.data[0].epoch_total_transactions, 17);
-    assert_eq!(end_of_epoch_info.last_checkpoint_id, 301);
-
-    let end_of_epoch_info = epoch_metrics.data[1].end_of_epoch_info.as_ref().unwrap();
-    assert_eq!(epoch_metrics.data[1].epoch, 1);
-    assert_eq!(epoch_metrics.data[1].first_checkpoint_id, 302);
-    assert_eq!(epoch_metrics.data[1].epoch_total_transactions, 11);
-    assert_eq!(end_of_epoch_info.last_checkpoint_id, 602);
-
-    assert_eq!(epoch_metrics.data[2].epoch, 2);
-    assert_eq!(epoch_metrics.data[2].first_checkpoint_id, 603);
-    assert_eq!(epoch_metrics.data[2].epoch_total_transactions, 0);
-    assert!(epoch_metrics.data[2].end_of_epoch_info.is_none());
+        assert_eq!(epochs.data.len(), 1);
+        assert!(!epochs.has_next_page);
+        assert_eq!(epochs.next_cursor, Some(2.into()));
+        assert_eq!(actual_epochs_order, [2]);
+    });
 }
 
-#[tokio::test]
-#[serial]
-async fn get_epoch_metrics_descending() {
-    let mut sim = Simulacrum::new();
+#[test]
+fn get_epoch_metrics() {
+    let InitializedSimulacrumEnv {
+        runtime,
+        sim,
+        store,
+        client,
+    } = get_or_init_shared_extended_api_simulacrum_env();
 
-    execute_simulacrum_transactions(&mut sim, 15);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch(false);
+    runtime.block_on(async move {
+        let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        indexer_wait_for_checkpoint(&store, last_checkpoint.sequence_number).await;
 
-    execute_simulacrum_transactions(&mut sim, 10);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch(false);
+        let epoch_metrics = client.get_epoch_metrics(None, None, None).await.unwrap();
 
-    execute_simulacrum_transactions(&mut sim, 5);
-    add_checkpoints(&mut sim, 300);
+        assert_eq!(epoch_metrics.data.len(), 3);
+        assert!(!epoch_metrics.has_next_page);
 
-    let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        let end_of_epoch_info = epoch_metrics.data[0].end_of_epoch_info.as_ref().unwrap();
+        assert_eq!(epoch_metrics.data[0].epoch, 0);
+        assert_eq!(epoch_metrics.data[0].first_checkpoint_id, 0);
+        assert_eq!(epoch_metrics.data[0].epoch_total_transactions, 17);
+        assert_eq!(end_of_epoch_info.last_checkpoint_id, 301);
 
-    let (_, pg_store, _, indexer_client) =
-        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim)).await;
-    indexer_wait_for_checkpoint(&pg_store, last_checkpoint.sequence_number).await;
+        let end_of_epoch_info = epoch_metrics.data[1].end_of_epoch_info.as_ref().unwrap();
+        assert_eq!(epoch_metrics.data[1].epoch, 1);
+        assert_eq!(epoch_metrics.data[1].first_checkpoint_id, 302);
+        assert_eq!(epoch_metrics.data[1].epoch_total_transactions, 11);
+        assert_eq!(end_of_epoch_info.last_checkpoint_id, 602);
 
-    let epochs = indexer_client
-        .get_epoch_metrics(None, None, Some(true))
-        .await
-        .unwrap();
-
-    let actual_epochs_order = epochs
-        .data
-        .iter()
-        .map(|epoch| epoch.epoch)
-        .collect::<Vec<u64>>();
-
-    assert_eq!(epochs.data.len(), 3);
-    assert!(!epochs.has_next_page);
-    assert_eq!(actual_epochs_order, [2, 1, 0])
+        assert_eq!(epoch_metrics.data[2].epoch, 2);
+        assert_eq!(epoch_metrics.data[2].first_checkpoint_id, 603);
+        assert_eq!(epoch_metrics.data[2].epoch_total_transactions, 0);
+        assert!(epoch_metrics.data[2].end_of_epoch_info.is_none());
+    });
 }
 
-#[tokio::test]
-#[serial]
-async fn get_epoch_metrics_paging() {
-    let mut sim = Simulacrum::new();
+#[test]
+fn get_epoch_metrics_descending() {
+    let InitializedSimulacrumEnv {
+        runtime,
+        sim,
+        store,
+        client,
+    } = get_or_init_shared_extended_api_simulacrum_env();
 
-    execute_simulacrum_transactions(&mut sim, 15);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch(false);
+    runtime.block_on(async move {
+        let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        indexer_wait_for_checkpoint(&store, last_checkpoint.sequence_number).await;
 
-    execute_simulacrum_transactions(&mut sim, 10);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch(false);
+        let epochs = client
+            .get_epoch_metrics(None, None, Some(true))
+            .await
+            .unwrap();
 
-    execute_simulacrum_transactions(&mut sim, 5);
-    add_checkpoints(&mut sim, 300);
+        let actual_epochs_order = epochs
+            .data
+            .iter()
+            .map(|epoch| epoch.epoch)
+            .collect::<Vec<u64>>();
 
-    let last_checkpoint = sim.get_latest_checkpoint().unwrap();
-
-    let (_, pg_store, _, indexer_client) =
-        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim)).await;
-    indexer_wait_for_checkpoint(&pg_store, last_checkpoint.sequence_number).await;
-
-    let epochs = indexer_client
-        .get_epoch_metrics(None, Some(2), None)
-        .await
-        .unwrap();
-    let actual_epochs_order = epochs
-        .data
-        .iter()
-        .map(|epoch| epoch.epoch)
-        .collect::<Vec<u64>>();
-
-    assert_eq!(epochs.data.len(), 2);
-    assert!(epochs.has_next_page);
-    assert_eq!(epochs.next_cursor, Some(1.into()));
-    assert_eq!(actual_epochs_order, [0, 1]);
-
-    let epochs = indexer_client
-        .get_epoch_metrics(Some(1.into()), Some(2), None)
-        .await
-        .unwrap();
-    let actual_epochs_order = epochs
-        .data
-        .iter()
-        .map(|epoch| epoch.epoch)
-        .collect::<Vec<u64>>();
-
-    assert_eq!(epochs.data.len(), 1);
-    assert!(!epochs.has_next_page);
-    assert_eq!(epochs.next_cursor, Some(2.into()));
-    assert_eq!(actual_epochs_order, [2]);
+        assert_eq!(epochs.data.len(), 3);
+        assert!(!epochs.has_next_page);
+        assert_eq!(actual_epochs_order, [2, 1, 0]);
+    });
 }
 
-#[tokio::test]
-#[serial]
-async fn get_current_epoch() {
-    let mut sim = Simulacrum::new();
+#[test]
+fn get_epoch_metrics_paging() {
+    let InitializedSimulacrumEnv {
+        runtime,
+        sim,
+        store,
+        client,
+    } = get_or_init_shared_extended_api_simulacrum_env();
 
-    execute_simulacrum_transactions(&mut sim, 15);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch(false);
+    runtime.block_on(async move {
+        let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        indexer_wait_for_checkpoint(&store, last_checkpoint.sequence_number).await;
 
-    execute_simulacrum_transactions(&mut sim, 10);
-    add_checkpoints(&mut sim, 300);
-    sim.advance_epoch(false);
+        let epochs = client.get_epoch_metrics(None, Some(2), None).await.unwrap();
+        let actual_epochs_order = epochs
+            .data
+            .iter()
+            .map(|epoch| epoch.epoch)
+            .collect::<Vec<u64>>();
 
-    execute_simulacrum_transactions(&mut sim, 5);
-    add_checkpoints(&mut sim, 300);
+        assert_eq!(epochs.data.len(), 2);
+        assert!(epochs.has_next_page);
+        assert_eq!(epochs.next_cursor, Some(1.into()));
+        assert_eq!(actual_epochs_order, [0, 1]);
 
-    let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        let epochs = client
+            .get_epoch_metrics(Some(1.into()), Some(2), None)
+            .await
+            .unwrap();
+        let actual_epochs_order = epochs
+            .data
+            .iter()
+            .map(|epoch| epoch.epoch)
+            .collect::<Vec<u64>>();
 
-    let (_, pg_store, _, indexer_client) =
-        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim)).await;
-    indexer_wait_for_checkpoint(&pg_store, last_checkpoint.sequence_number).await;
+        assert_eq!(epochs.data.len(), 1);
+        assert!(!epochs.has_next_page);
+        assert_eq!(epochs.next_cursor, Some(2.into()));
+        assert_eq!(actual_epochs_order, [2]);
+    });
+}
 
-    let current_epoch = indexer_client.get_current_epoch().await.unwrap();
+#[test]
+fn get_current_epoch() {
+    let InitializedSimulacrumEnv {
+        runtime,
+        sim,
+        store,
+        client,
+    } = get_or_init_shared_extended_api_simulacrum_env();
 
-    assert_eq!(current_epoch.epoch, 2);
-    assert_eq!(current_epoch.first_checkpoint_id, 603);
-    assert_eq!(current_epoch.epoch_total_transactions, 0);
-    assert!(current_epoch.end_of_epoch_info.is_none());
+    runtime.block_on(async move {
+        let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        indexer_wait_for_checkpoint(&store, last_checkpoint.sequence_number).await;
+
+        let current_epoch = client.get_current_epoch().await.unwrap();
+
+        assert_eq!(current_epoch.epoch, 2);
+        assert_eq!(current_epoch.first_checkpoint_id, 603);
+        assert_eq!(current_epoch.epoch_total_transactions, 0);
+        assert!(current_epoch.end_of_epoch_info.is_none());
+    });
 }
 
 #[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2371642744"]
-#[tokio::test]
-#[serial]
-async fn get_network_metrics() {
-    let (_, pg_store, indexer_client) = start_test_cluster_with_read_write_indexer(None).await;
-    indexer_wait_for_checkpoint(&pg_store, 10).await;
+#[test]
+fn get_network_metrics() {
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        ..
+    } = ApiTestSetup::get_or_init();
 
-    let network_metrics = indexer_client.get_network_metrics().await.unwrap();
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(&store, 10).await;
 
-    println!("{:#?}", network_metrics);
+        let network_metrics = client.get_network_metrics().await.unwrap();
+
+        println!("{:#?}", network_metrics);
+    });
 }
 
 #[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2371642744"]
-#[tokio::test]
-#[serial]
-async fn get_move_call_metrics() {
-    let (cluster, pg_store, indexer_client) =
-        start_test_cluster_with_read_write_indexer(None).await;
+#[test]
+fn get_move_call_metrics() {
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        cluster,
+        ..
+    } = ApiTestSetup::get_or_init();
 
-    execute_move_fn(&cluster).await.unwrap();
+    runtime.block_on(async move {
+        execute_move_fn(&cluster).await.unwrap();
 
-    let latest_checkpoint_sn = cluster
-        .rpc_client()
-        .get_latest_checkpoint_sequence_number()
-        .await
-        .unwrap();
-    indexer_wait_for_checkpoint(&pg_store, latest_checkpoint_sn.into_inner()).await;
+        let latest_checkpoint_sn = cluster
+            .rpc_client()
+            .get_latest_checkpoint_sequence_number()
+            .await
+            .unwrap();
+        indexer_wait_for_checkpoint(&store, latest_checkpoint_sn.into_inner()).await;
 
-    let move_call_metrics = indexer_client.get_move_call_metrics().await.unwrap();
+        let move_call_metrics = client.get_move_call_metrics().await.unwrap();
 
-    // TODO: Why is the move call not included in the stats?
-    assert_eq!(move_call_metrics.rank_3_days.len(), 0);
-    assert_eq!(move_call_metrics.rank_7_days.len(), 0);
-    assert_eq!(move_call_metrics.rank_30_days.len(), 0);
+        // TODO: Why is the move call not included in the stats?
+        assert_eq!(move_call_metrics.rank_3_days.len(), 0);
+        assert_eq!(move_call_metrics.rank_7_days.len(), 0);
+        assert_eq!(move_call_metrics.rank_30_days.len(), 0);
+    });
 }
 
 #[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2371642744"]
-#[tokio::test]
-#[serial]
-async fn get_latest_address_metrics() {
-    let (_, pg_store, indexer_client) = start_test_cluster_with_read_write_indexer(None).await;
-    indexer_wait_for_checkpoint(&pg_store, 10).await;
+#[test]
+fn get_latest_address_metrics() {
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        ..
+    } = ApiTestSetup::get_or_init();
 
-    let address_metrics = indexer_client.get_latest_address_metrics().await.unwrap();
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(&store, 10).await;
 
-    println!("{:#?}", address_metrics);
+        let address_metrics = client.get_latest_address_metrics().await.unwrap();
+
+        println!("{:#?}", address_metrics);
+    });
 }
 
 #[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2371642744"]
-#[tokio::test]
-#[serial]
-async fn get_checkpoint_address_metrics() {
-    let (_, pg_store, indexer_client) = start_test_cluster_with_read_write_indexer(None).await;
-    indexer_wait_for_checkpoint(&pg_store, 10).await;
+#[test]
+fn get_checkpoint_address_metrics() {
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        ..
+    } = ApiTestSetup::get_or_init();
 
-    let address_metrics = indexer_client
-        .get_checkpoint_address_metrics(0)
-        .await
-        .unwrap();
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(&store, 10).await;
 
-    println!("{:#?}", address_metrics);
+        let address_metrics = client.get_checkpoint_address_metrics(0).await.unwrap();
+
+        println!("{:#?}", address_metrics);
+    });
 }
 
 #[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2371642744"]
-#[tokio::test]
-#[serial]
-async fn get_all_epoch_address_metrics() {
-    let (_, pg_store, indexer_client) = start_test_cluster_with_read_write_indexer(None).await;
-    indexer_wait_for_checkpoint(&pg_store, 10).await;
+#[test]
+fn get_all_epoch_address_metrics() {
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        ..
+    } = ApiTestSetup::get_or_init();
 
-    let address_metrics = indexer_client
-        .get_all_epoch_address_metrics(None)
-        .await
-        .unwrap();
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(&store, 10).await;
 
-    println!("{:#?}", address_metrics);
+        let address_metrics = client.get_all_epoch_address_metrics(None).await.unwrap();
+
+        println!("{:#?}", address_metrics);
+    });
 }
 
-#[tokio::test]
-#[serial]
-async fn get_total_transactions() {
-    let mut sim = Simulacrum::new();
-    execute_simulacrum_transactions(&mut sim, 5);
+#[test]
+fn get_total_transactions() {
+    let InitializedSimulacrumEnv {
+        runtime,
+        sim,
+        store,
+        client,
+    } = get_or_init_shared_extended_api_simulacrum_env();
 
-    let latest_checkpoint = sim.create_checkpoint();
-    let total_transactions_count = latest_checkpoint.network_total_transactions;
+    runtime.block_on(async move {
+        let latest_checkpoint = sim.get_latest_checkpoint().unwrap();
+        let total_transactions_count = latest_checkpoint.network_total_transactions;
+        indexer_wait_for_checkpoint(&store, latest_checkpoint.sequence_number).await;
 
-    let (_, pg_store, _, indexer_client) =
-        start_simulacrum_rest_api_with_read_write_indexer(Arc::new(sim)).await;
-    indexer_wait_for_checkpoint(&pg_store, latest_checkpoint.sequence_number).await;
-
-    let transactions_cnt = indexer_client.get_total_transactions().await.unwrap();
-    assert_eq!(transactions_cnt.into_inner(), total_transactions_count);
-    assert_eq!(transactions_cnt.into_inner(), 6);
+        let transactions_cnt = client.get_total_transactions().await.unwrap();
+        assert_eq!(transactions_cnt.into_inner(), total_transactions_count);
+        assert_eq!(transactions_cnt.into_inner(), 33);
+    });
 }
 
 async fn execute_move_fn(cluster: &TestCluster) -> Result<(), anyhow::Error> {

--- a/crates/iota-indexer/tests/rpc-tests/extended_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/extended_api.rs
@@ -12,18 +12,18 @@ use iota_json_rpc_types::{
     TransactionBlockBytes,
 };
 use iota_types::{
+    IOTA_FRAMEWORK_ADDRESS,
     base_types::{IotaAddress, ObjectID},
     gas_coin::GAS,
     quorum_driver_types::ExecuteTransactionRequestType,
     storage::ReadStore,
-    IOTA_FRAMEWORK_ADDRESS,
 };
 use simulacrum::Simulacrum;
 use test_cluster::TestCluster;
 
 use crate::common::{
-    indexer_wait_for_checkpoint, ApiTestSetup, InitializedSimulacrumEnv,
-    SimulacrumApiTestEnvDefinition,
+    InitializedClusterEnv, InitializedSimulacrumEnv, SimulacrumApiTestEnvDefinition,
+    get_or_init_global_test_env, indexer_wait_for_checkpoint,
 };
 
 static EXTENDED_API_SHARED_SIMULACRUM_INITIALIZED_ENV: OnceLock<InitializedSimulacrumEnv> =
@@ -292,12 +292,12 @@ fn get_current_epoch() {
 #[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2371642744"]
 #[test]
 fn get_network_metrics() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
 
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(&store, 10).await;
@@ -311,13 +311,13 @@ fn get_network_metrics() {
 #[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2371642744"]
 #[test]
 fn get_move_call_metrics() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         cluster,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
 
     runtime.block_on(async move {
         execute_move_fn(&cluster).await.unwrap();
@@ -341,12 +341,12 @@ fn get_move_call_metrics() {
 #[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2371642744"]
 #[test]
 fn get_latest_address_metrics() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
 
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(&store, 10).await;
@@ -360,12 +360,12 @@ fn get_latest_address_metrics() {
 #[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2371642744"]
 #[test]
 fn get_checkpoint_address_metrics() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
 
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(&store, 10).await;
@@ -379,12 +379,12 @@ fn get_checkpoint_address_metrics() {
 #[ignore = "https://github.com/iotaledger/iota/issues/2197#issuecomment-2371642744"]
 #[test]
 fn get_all_epoch_address_metrics() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
 
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(&store, 10).await;

--- a/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
@@ -10,16 +10,19 @@ use iota_types::{
     digests::TransactionDigest,
 };
 
-use crate::common::{indexer_wait_for_checkpoint, rpc_call_error_msg_matches, ApiTestSetup};
+use crate::common::{
+    InitializedClusterEnv, get_or_init_global_test_env, indexer_wait_for_checkpoint,
+    rpc_call_error_msg_matches,
+};
 
 #[test]
 fn query_events_no_events_descending() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
 
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
@@ -45,12 +48,12 @@ fn query_events_no_events_descending() {
 
 #[test]
 fn query_events_no_events_ascending() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
 
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
@@ -76,12 +79,12 @@ fn query_events_no_events_ascending() {
 
 #[test]
 fn query_events_unsupported_events() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
 
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
@@ -131,12 +134,12 @@ fn query_events_unsupported_events() {
 
 #[test]
 fn query_events_supported_events() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
 
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;

--- a/crates/iota-indexer/tests/rpc-tests/main.rs
+++ b/crates/iota-indexer/tests/rpc-tests/main.rs
@@ -5,7 +5,7 @@
 #[path = "../common/mod.rs"]
 mod common;
 
-#[cfg(feature = "pg_integration")]
+#[cfg(feature = "shared_test_runtime")]
 mod extended_api;
 
 #[cfg(feature = "shared_test_runtime")]

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -14,7 +14,10 @@ use iota_types::{
     error::IotaObjectResponseError,
 };
 
-use crate::common::{indexer_wait_for_checkpoint, rpc_call_error_msg_matches, ApiTestSetup};
+use crate::common::{
+    InitializedClusterEnv, get_or_init_global_test_env, indexer_wait_for_checkpoint,
+    rpc_call_error_msg_matches,
+};
 
 fn is_ascending(vec: &[u64]) -> bool {
     vec.windows(2).all(|window| window[0] <= window[1])
@@ -46,12 +49,12 @@ fn match_transaction_block_resp_options(
 }
 
 fn get_object_with_options(options: IotaObjectDataOptions) {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         cluster,
         store,
         client,
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
 
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
@@ -80,12 +83,12 @@ fn get_object_with_options(options: IotaObjectDataOptions) {
 }
 
 fn multi_get_objects_with_options(options: IotaObjectDataOptions) {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         cluster,
         store,
         client,
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
 
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
@@ -118,12 +121,12 @@ fn multi_get_objects_with_options(options: IotaObjectDataOptions) {
 }
 
 fn get_transaction_block_with_options(options: IotaTransactionBlockResponseOptions) {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         cluster,
         store,
         client,
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
 
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
@@ -164,12 +167,12 @@ fn get_transaction_block_with_options(options: IotaTransactionBlockResponseOptio
 }
 
 fn multi_get_transaction_blocks_with_options(options: IotaTransactionBlockResponseOptions) {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         cluster,
         store,
         client,
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 3).await;
 
@@ -214,12 +217,12 @@ fn multi_get_transaction_blocks_with_options(options: IotaTransactionBlockRespon
 
 #[test]
 fn get_checkpoint_by_seq_num() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         cluster,
         store,
         client,
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
 
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
@@ -241,12 +244,12 @@ fn get_checkpoint_by_seq_num() {
 
 #[test]
 fn get_checkpoint_by_seq_num_not_found() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
 
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
@@ -263,12 +266,12 @@ fn get_checkpoint_by_seq_num_not_found() {
 
 #[test]
 fn get_checkpoint_by_digest() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         cluster,
         store,
         client,
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
 
@@ -289,12 +292,12 @@ fn get_checkpoint_by_digest() {
 
 #[test]
 fn get_checkpoint_by_digest_not_found() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
 
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
@@ -312,12 +315,12 @@ fn get_checkpoint_by_digest_not_found() {
 
 #[test]
 fn get_checkpoints_all_ascending() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
 
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 3).await;
@@ -336,12 +339,12 @@ fn get_checkpoints_all_ascending() {
 
 #[test]
 fn get_checkpoints_all_descending() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 3).await;
 
@@ -359,12 +362,12 @@ fn get_checkpoints_all_descending() {
 
 #[test]
 fn get_checkpoints_by_cursor_and_limit_one_descending() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 3).await;
 
@@ -386,12 +389,12 @@ fn get_checkpoints_by_cursor_and_limit_one_descending() {
 
 #[test]
 fn get_checkpoints_by_cursor_and_limit_one_ascending() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 3).await;
 
@@ -413,12 +416,12 @@ fn get_checkpoints_by_cursor_and_limit_one_ascending() {
 
 #[test]
 fn get_checkpoints_by_cursor_zero_and_limit_ascending() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 3).await;
 
@@ -440,12 +443,12 @@ fn get_checkpoints_by_cursor_zero_and_limit_ascending() {
 
 #[test]
 fn get_checkpoints_by_cursor_zero_and_limit_descending() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 3).await;
 
@@ -467,12 +470,12 @@ fn get_checkpoints_by_cursor_zero_and_limit_descending() {
 
 #[test]
 fn get_checkpoints_by_cursor_and_limit_ascending() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 6).await;
 
@@ -494,12 +497,12 @@ fn get_checkpoints_by_cursor_and_limit_ascending() {
 
 #[test]
 fn get_checkpoints_by_cursor_and_limit_descending() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
 
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 3).await;
@@ -523,12 +526,12 @@ fn get_checkpoints_by_cursor_and_limit_descending() {
 
 #[test]
 fn get_checkpoints_invalid_limit() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
 
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 3).await;
@@ -544,12 +547,12 @@ fn get_checkpoints_invalid_limit() {
 
 #[test]
 fn get_object() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         cluster,
         store,
         client,
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
         let address = cluster.get_address_0();
@@ -572,12 +575,12 @@ fn get_object() {
 
 #[test]
 fn get_object_not_found() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
 
@@ -592,17 +595,14 @@ fn get_object_not_found() {
             .await
             .unwrap();
 
-        assert_eq!(
-            indexer_obj,
-            IotaObjectResponse {
-                data: None,
-                error: Some(IotaObjectResponseError::NotExists {
-                    object_id: "0x9a934a2644c4ca2decbe3d126d80720429c5e31896aa756765afa23ae2cb4b99"
-                        .parse()
-                        .unwrap()
-                })
-            }
-        )
+        assert_eq!(indexer_obj, IotaObjectResponse {
+            data: None,
+            error: Some(IotaObjectResponseError::NotExists {
+                object_id: "0x9a934a2644c4ca2decbe3d126d80720429c5e31896aa756765afa23ae2cb4b99"
+                    .parse()
+                    .unwrap()
+            })
+        })
     });
 }
 
@@ -656,12 +656,12 @@ fn get_object_with_storage_rebate() {
 
 #[test]
 fn multi_get_objects() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         cluster,
         store,
         client,
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
         let address = cluster.get_address_0();
@@ -686,12 +686,12 @@ fn multi_get_objects() {
 
 #[test]
 fn multi_get_objects_not_found() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
 
@@ -708,40 +708,35 @@ fn multi_get_objects_not_found() {
 
         let indexer_objects = client.multi_get_objects(object_ids, None).await.unwrap();
 
-        assert_eq!(
-            indexer_objects,
-            vec![
-                IotaObjectResponse {
-                    data: None,
-                    error: Some(IotaObjectResponseError::NotExists {
-                        object_id:
-                            "0x9a934a2644c4ca2decbe3d126d80720429c5e31896aa756765afa23ae2cb4b99"
-                                .parse()
-                                .unwrap()
-                    })
-                },
-                IotaObjectResponse {
-                    data: None,
-                    error: Some(IotaObjectResponseError::NotExists {
-                        object_id:
-                            "0x1a934a7644c4cf2decbe3d126d80720429c5e30896aa756765afa23af3cb4b82"
-                                .parse()
-                                .unwrap()
-                    })
-                }
-            ]
-        )
+        assert_eq!(indexer_objects, vec![
+            IotaObjectResponse {
+                data: None,
+                error: Some(IotaObjectResponseError::NotExists {
+                    object_id: "0x9a934a2644c4ca2decbe3d126d80720429c5e31896aa756765afa23ae2cb4b99"
+                        .parse()
+                        .unwrap()
+                })
+            },
+            IotaObjectResponse {
+                data: None,
+                error: Some(IotaObjectResponseError::NotExists {
+                    object_id: "0x1a934a7644c4cf2decbe3d126d80720429c5e30896aa756765afa23af3cb4b82"
+                        .parse()
+                        .unwrap()
+                })
+            }
+        ])
     });
 }
 
 #[test]
 fn multi_get_objects_found_and_not_found() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         cluster,
         store,
         client,
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
         let address = cluster.get_address_0();
@@ -837,12 +832,12 @@ fn multi_get_objects_with_storage_rebate() {
 
 #[test]
 fn get_events() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         cluster,
         store,
         client,
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
 
@@ -863,12 +858,12 @@ fn get_events() {
 
 #[test]
 fn get_events_not_found() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
 
@@ -883,12 +878,12 @@ fn get_events_not_found() {
 
 #[test]
 fn get_transaction_block() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         cluster,
         store,
         client,
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
 
@@ -908,12 +903,12 @@ fn get_transaction_block() {
 
 #[test]
 fn get_transaction_block_not_found() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
 
@@ -989,12 +984,12 @@ fn get_transaction_block_with_input() {
 
 #[test]
 fn multi_get_transaction_blocks() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         cluster,
         store,
         client,
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 3).await;
 
@@ -1088,12 +1083,12 @@ fn multi_get_transaction_blocks_with_input() {
 
 #[test]
 fn get_protocol_config() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         cluster,
         store,
         client,
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
 
@@ -1115,12 +1110,12 @@ fn get_protocol_config() {
 
 #[test]
 fn get_protocol_config_invalid_protocol_version() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
 
@@ -1137,12 +1132,12 @@ fn get_protocol_config_invalid_protocol_version() {
 
 #[test]
 fn get_chain_identifier() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         cluster,
         store,
         client,
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
 
@@ -1157,12 +1152,12 @@ fn get_chain_identifier() {
 #[test]
 fn get_total_transaction_blocks() {
     let checkpoint = 5;
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         cluster,
         store,
         client,
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
 
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, checkpoint).await;
@@ -1191,12 +1186,12 @@ fn get_total_transaction_blocks() {
 #[test]
 fn get_latest_checkpoint_sequence_number() {
     let checkpoint = 5;
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
 
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, checkpoint).await;
@@ -1221,12 +1216,12 @@ fn get_latest_checkpoint_sequence_number() {
 
 #[test]
 fn try_get_past_object() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
 
@@ -1242,12 +1237,12 @@ fn try_get_past_object() {
 
 #[test]
 fn try_multi_get_past_objects() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
 
@@ -1269,12 +1264,12 @@ fn try_multi_get_past_objects() {
 
 #[test]
 fn get_loaded_child_objects() {
-    let ApiTestSetup {
+    let InitializedClusterEnv {
         runtime,
         store,
         client,
         ..
-    } = ApiTestSetup::get_or_init();
+    } = get_or_init_global_test_env();
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, 1).await;
 


### PR DESCRIPTION
# Description of change

Introduce ability to create more shared test clusters, in a similar way that more simulacrum clusters can be created in #3018 . This PR is currently stacked on top of #3018 until it's merged.

## Links to any relevant issues

fixes #3492

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo test -j2 --profile simulator --features shared_test_runtime --test rpc-tests`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
