### PR TITLE
fix(iota-indexer): get object packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,6 +1084,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd82dba44d209fddb11c190e0a94b78651f95299598e472215667417a03ff1d"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7a4168111d7eb622a31b214057b8509c0a7e1794f44c546d742330dc793972"
+dependencies = [
+ "bindgen 0.69.5",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "aws-runtime"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,6 +1847,29 @@ dependencies = [
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.77",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.10.5",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.77",
+ "which",
 ]
 
 [[package]]
@@ -5951,6 +6001,7 @@ dependencies = [
  "iota-sdk 0.4.0",
  "iota-simulator",
  "iota-storage",
+ "iota-surfer",
  "iota-swarm-config",
  "iota-test-transaction-builder",
  "iota-types",
@@ -7850,6 +7901,7 @@ dependencies = [
  "iota-macros",
  "iota-metrics",
  "iota-protocol-config",
+ "iota-simulator",
  "iota-test-transaction-builder",
  "iota-types",
  "itertools 0.13.0",
@@ -7864,6 +7916,7 @@ dependencies = [
  "percent-encoding",
  "prometheus",
  "reqwest 0.12.7",
+ "rustls 0.23.13",
  "serde",
  "serde_json",
  "tap",
@@ -8875,7 +8928,7 @@ version = "0.11.0+8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
 dependencies = [
- "bindgen",
+ "bindgen 0.65.1",
  "bzip2-sys",
  "cc",
  "glob",
@@ -9259,6 +9312,12 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "mockall"
@@ -12957,6 +13016,7 @@ version = "0.23.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring 0.17.8",
@@ -13072,6 +13132,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
+ "aws-lc-rs",
  "ring 0.17.8",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -15894,6 +15955,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]

--- a/crates/iota-indexer/src/models/objects.rs
+++ b/crates/iota-indexer/src/models/objects.rs
@@ -294,29 +294,29 @@ impl StoredObject {
         let oref = self.get_object_ref()?;
         let object: iota_types::object::Object = self.try_into()?;
 
-        if let Some(move_object) = object.data.try_as_move().cloned() {
-            let move_type_layout = package_resolver
-                .type_layout(move_object.type_().clone().into())
-                .await
-                .map_err(|e| {
-                    IndexerError::ResolveMoveStruct(format!(
-                        "Failed to convert into object read for obj {}:{}, type: {}. Error: {e}",
-                        object.id(),
-                        object.version(),
-                        move_object.type_(),
-                    ))
-                })?;
-            let move_struct_layout = match move_type_layout {
-                MoveTypeLayout::Struct(s) => Ok(s),
-                _ => Err(IndexerError::ResolveMoveStruct(
-                    "MoveTypeLayout is not Struct".to_string(),
-                )),
-            }?;
+        let Some(move_object) = object.data.try_as_move().cloned() else {
+            return Ok(ObjectRead::Exists(oref, object, None));
+        };
 
-            return Ok(ObjectRead::Exists(oref, object, Some(move_struct_layout)));
-        }
+        let move_type_layout = package_resolver
+            .type_layout(move_object.type_().clone().into())
+            .await
+            .map_err(|e| {
+                IndexerError::ResolveMoveStruct(format!(
+                    "Failed to convert into object read for obj {}:{}, type: {}. Error: {e}",
+                    object.id(),
+                    object.version(),
+                    move_object.type_(),
+                ))
+            })?;
+        let move_struct_layout = match move_type_layout {
+            MoveTypeLayout::Struct(s) => Ok(s),
+            _ => Err(IndexerError::ResolveMoveStruct(
+                "MoveTypeLayout is not Struct".to_string(),
+            )),
+        }?;
 
-        Ok(ObjectRead::Exists(oref, object, None))
+        Ok(ObjectRead::Exists(oref, object, Some(move_struct_layout)))
     }
 
     pub async fn try_into_expectant_dynamic_field_info(


### PR DESCRIPTION


# Description of change
Fix the ability to get package objects in the indexer's `ReadApi` `get_object` RPC function

## Links to any relevant issues

#3587 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)


## How the change has been tested

Start a postgres instance

start the local network
```
cargo run --bin iota  --features indexer -- start --force-regenesis
```

make the RPC query

```sh
curl --location 'localhost:9124' \
--header 'Content-Type: application/json' \
--data '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "iota_getObject",
    "params": [
        "0x2",
        {
            "showType": true,
            "showContent": true,
            "showOwner": true,
            "showPreviousTransaction": true,
            "showStorageRebate": true,
            "showDisplay": true
        }
    ]
}'
```

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code

