### PR TITLE
fix(iota-rosetta): fix test_pay_with_gas_budget_fail

### DIFF
--- a/crates/iota-rosetta/tests/gas_budget_tests.rs
+++ b/crates/iota-rosetta/tests/gas_budget_tests.rs
@@ -167,7 +167,7 @@ async fn test_pay_with_gas_budget_fail() {
         TransactionIdentifierResponseResult::Error(rosetta_submit_gas_error) => {
             assert_eq!(rosetta_submit_gas_error, RosettaSubmitGasError {
                 code: 11,
-                message: "Transaction dry run error".to_string(),
+                message: "Transaction dry run".to_string(),
                 description: None,
                 retriable: false,
                 details: RosettaSubmitGasErrorDetails {


### PR DESCRIPTION
# Description of change

Fix the error comparison that failed because of https://github.com/iotaledger/iota/pull/3570

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/3634

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running the test