### PR TITLE
chore(typed-store): Remove unused `?Sized` bounds

### DIFF
--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -11,7 +11,7 @@ use crate::TypedStoreError;
 
 pub trait Map<'a, K, V>
 where
-    K: Serialize + DeserializeOwned + ?Sized,
+    K: Serialize + DeserializeOwned,
     V: Serialize + DeserializeOwned,
 {
     type Error: Error;
@@ -156,7 +156,7 @@ where
 #[async_trait]
 pub trait AsyncMap<'a, K, V>
 where
-    K: Serialize + DeserializeOwned + ?Sized + std::marker::Sync,
+    K: Serialize + DeserializeOwned + std::marker::Sync,
     V: Serialize + DeserializeOwned + std::marker::Sync + std::marker::Send,
 {
     type Error: Error;


### PR DESCRIPTION
# Description of change

Clippy reports `needless_maybe_sized` in 1.81 for these traits where this bound is ignored by the compiler due to the always-sized `DeserializeOwned` bound.