### PR TITLE
refactor(core-node): rename `ExecutionResultsV2` to `ExecutionResultsV1`

### DIFF
--- a/crates/iota-core/src/traffic_controller/nodefw_client.rs
+++ b/crates/iota-core/src/traffic_controller/nodefw_client.rs
@@ -33,7 +33,7 @@ impl NodeFWClient {
     pub async fn block_addresses(&self, addresses: BlockAddresses) -> Result<(), reqwest::Error> {
         let response = self
             .client
-            .post(&format!("{}/block_addresses", self.remote_fw_url))
+            .post(format!("{}/block_addresses", self.remote_fw_url))
             .json(&addresses)
             .send()
             .await?;
@@ -45,7 +45,7 @@ impl NodeFWClient {
 
     pub async fn list_addresses(&self) -> Result<BlockAddresses, reqwest::Error> {
         self.client
-            .get(&format!("{}/list_addresses", self.remote_fw_url))
+            .get(format!("{}/list_addresses", self.remote_fw_url))
             .send()
             .await?
             .error_for_status()?

--- a/crates/iota-source-validation/src/toolchain.rs
+++ b/crates/iota-source-validation/src/toolchain.rs
@@ -256,9 +256,9 @@ fn download_and_compile(
         let mut dest_binary = dest_version.clone();
         dest_binary.extend(["target", "release"]);
         if platform == "windows-x86_64" {
-            dest_binary.push(&format!("iota-{platform}.exe"));
+            dest_binary.push(format!("iota-{platform}.exe"));
         } else {
-            dest_binary.push(&format!("iota-{platform}"));
+            dest_binary.push(format!("iota-{platform}"));
         }
         let dest_binary_os = OsStr::new(dest_binary.as_path());
         set_executable_permission(dest_binary_os)?;

--- a/crates/iota-types/src/execution.rs
+++ b/crates/iota-types/src/execution.rs
@@ -14,7 +14,7 @@ use crate::{
     event::Event,
     is_system_package,
     object::{Data, Object, Owner},
-    storage::{BackingPackageStore, ObjectChange},
+    storage::BackingPackageStore,
     transaction::Argument,
 };
 

--- a/crates/iota-types/src/execution.rs
+++ b/crates/iota-types/src/execution.rs
@@ -55,14 +55,14 @@ impl<T> TypeLayoutStore for T where T: BackingPackageStore {}
 
 #[derive(Debug)]
 pub enum ExecutionResults {
-    V2(ExecutionResultsV2),
+    V2(ExecutionResultsV1),
 }
 
 /// Used by iota-execution v1 and above, to capture the execution results from
 /// Move. The results represent the primitive information that can then be used
-/// to construct both transaction effects V1 and V2.
+/// to construct both transaction effect V1.
 #[derive(Debug, Default)]
-pub struct ExecutionResultsV2 {
+pub struct ExecutionResultsV1 {
     /// All objects written regardless of whether they were mutated, created, or
     /// unwrapped.
     pub written_objects: BTreeMap<ObjectID, Object>,
@@ -87,7 +87,7 @@ pub type ExecutionResult = (
     Vec<(Vec<u8>, TypeTag)>,
 );
 
-impl ExecutionResultsV2 {
+impl ExecutionResultsV1 {
     pub fn drop_writes(&mut self) {
         self.written_objects.clear();
         self.modified_objects.clear();

--- a/crates/iota-types/src/execution.rs
+++ b/crates/iota-types/src/execution.rs
@@ -55,14 +55,7 @@ impl<T> TypeLayoutStore for T where T: BackingPackageStore {}
 
 #[derive(Debug)]
 pub enum ExecutionResults {
-    V1(ExecutionResultsV1),
     V2(ExecutionResultsV2),
-}
-
-#[derive(Debug)]
-pub struct ExecutionResultsV1 {
-    pub object_changes: BTreeMap<ObjectID, ObjectChange>,
-    pub user_events: Vec<Event>,
 }
 
 /// Used by iota-execution v1 and above, to capture the execution results from

--- a/crates/iota-types/src/execution.rs
+++ b/crates/iota-types/src/execution.rs
@@ -55,7 +55,7 @@ impl<T> TypeLayoutStore for T where T: BackingPackageStore {}
 
 #[derive(Debug)]
 pub enum ExecutionResults {
-    V2(ExecutionResultsV1),
+    V1(ExecutionResultsV1),
 }
 
 /// Used by iota-execution v1 and above, to capture the execution results from

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -38,7 +38,7 @@ mod checked {
         digests::{ChainIdentifier, get_mainnet_chain_identifier, get_testnet_chain_identifier},
         effects::TransactionEffects,
         error::{ExecutionError, ExecutionErrorKind},
-        execution::{ExecutionResults, ExecutionResultsV2, is_certificate_denied},
+        execution::{ExecutionResults, ExecutionResultsV1, is_certificate_denied},
         execution_config_utils::to_binary_config,
         execution_status::{CongestedObjects, ExecutionStatus},
         gas::{GasCostSummary, IotaGasStatus},
@@ -624,8 +624,8 @@ mod checked {
                     }
                 }
 
-                temporary_store.record_execution_results(ExecutionResults::V2(
-                    ExecutionResultsV2 {
+                temporary_store.record_execution_results(ExecutionResults::V1(
+                    ExecutionResultsV1 {
                         user_events: events,
                         ..Default::default()
                     },

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
@@ -22,7 +22,7 @@ mod checked {
         coin::Coin,
         error::{ExecutionError, ExecutionErrorKind, command_argument_error},
         event::Event,
-        execution::{ExecutionResults, ExecutionResultsV2},
+        execution::{ExecutionResults, ExecutionResultsV1},
         execution_status::CommandArgumentError,
         metrics::LimitsMetrics,
         move_package::MovePackage,
@@ -841,7 +841,7 @@ mod checked {
                 })
                 .collect();
 
-            Ok(ExecutionResults::V2(ExecutionResultsV2 {
+            Ok(ExecutionResults::V1(ExecutionResultsV1 {
                 written_objects,
                 modified_objects: loaded_runtime_objects
                     .into_iter()

--- a/iota-execution/latest/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/latest/iota-adapter/src/temporary_store.rs
@@ -16,7 +16,7 @@ use iota_types::{
     effects::{EffectsObjectChange, TransactionEffects, TransactionEvents},
     error::{ExecutionError, IotaError, IotaResult},
     execution::{
-        DynamicallyLoadedObjectMetadata, ExecutionResults, ExecutionResultsV2, SharedInput,
+        DynamicallyLoadedObjectMetadata, ExecutionResults, ExecutionResultsV1, SharedInput,
     },
     execution_config_utils::to_binary_config,
     execution_status::ExecutionStatus,
@@ -53,7 +53,7 @@ pub struct TemporaryStore<'backing> {
     /// this store.
     lamport_timestamp: SequenceNumber,
     mutable_input_refs: BTreeMap<ObjectID, (VersionDigest, Owner)>, // Inputs that are mutable
-    execution_results: ExecutionResultsV2,
+    execution_results: ExecutionResultsV1,
     /// Objects that were loaded during execution (dynamic fields + received
     /// objects).
     loaded_runtime_objects: BTreeMap<ObjectID, DynamicallyLoadedObjectMetadata>,
@@ -117,7 +117,7 @@ impl<'backing> TemporaryStore<'backing> {
             input_objects: objects,
             lamport_timestamp,
             mutable_input_refs,
-            execution_results: ExecutionResultsV2::default(),
+            execution_results: ExecutionResultsV1::default(),
             protocol_config,
             loaded_runtime_objects: BTreeMap::new(),
             wrapped_object_containers: BTreeMap::new(),
@@ -1025,11 +1025,10 @@ impl<'backing> Storage for TemporaryStore<'backing> {
         TemporaryStore::read_object(self, id)
     }
 
-    /// Take execution results v2, and translate it back to be compatible with
-    /// effects v1.
+    /// Take execution results v1.
     fn record_execution_results(&mut self, results: ExecutionResults) {
-        let ExecutionResults::V2(results) = results else {
-            panic!("ExecutionResults::V2 expected in iota-execution v1 and above");
+        let ExecutionResults::V1(results) = results else {
+            panic!("ExecutionResults::V1 expected in iota-execution v1 and above");
         };
         // It's important to merge instead of override results because it's
         // possible to execute PT more than once during tx execution.

--- a/iota-execution/latest/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/latest/iota-adapter/src/temporary_store.rs
@@ -1027,9 +1027,8 @@ impl<'backing> Storage for TemporaryStore<'backing> {
 
     /// Take execution results v1.
     fn record_execution_results(&mut self, results: ExecutionResults) {
-        let ExecutionResults::V1(results) = results else {
-            panic!("ExecutionResults::V1 expected in iota-execution v1 and above");
-        };
+        let ExecutionResults::V1(results) = results;
+
         // It's important to merge instead of override results because it's
         // possible to execute PT more than once during tx execution.
         self.execution_results.merge_results(results);

--- a/iota-execution/v0/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/v0/iota-adapter/src/execution_engine.rs
@@ -38,7 +38,7 @@ mod checked {
         digests::{ChainIdentifier, get_mainnet_chain_identifier, get_testnet_chain_identifier},
         effects::TransactionEffects,
         error::{ExecutionError, ExecutionErrorKind},
-        execution::{ExecutionResults, ExecutionResultsV2, is_certificate_denied},
+        execution::{ExecutionResults, ExecutionResultsV1, is_certificate_denied},
         execution_config_utils::to_binary_config,
         execution_status::{CongestedObjects, ExecutionStatus},
         gas::{GasCostSummary, IotaGasStatus},
@@ -577,8 +577,8 @@ mod checked {
                     }
                 }
 
-                temporary_store.record_execution_results(ExecutionResults::V2(
-                    ExecutionResultsV2 {
+                temporary_store.record_execution_results(ExecutionResults::V1(
+                    ExecutionResultsV1 {
                         user_events: events,
                         ..Default::default()
                     },

--- a/iota-execution/v0/iota-adapter/src/programmable_transactions/context.rs
+++ b/iota-execution/v0/iota-adapter/src/programmable_transactions/context.rs
@@ -22,7 +22,7 @@ mod checked {
         coin::Coin,
         error::{ExecutionError, ExecutionErrorKind, command_argument_error},
         event::Event,
-        execution::{ExecutionResults, ExecutionResultsV2},
+        execution::{ExecutionResults, ExecutionResultsV1},
         execution_status::CommandArgumentError,
         metrics::LimitsMetrics,
         move_package::MovePackage,
@@ -834,7 +834,7 @@ mod checked {
                 })
                 .collect();
 
-            Ok(ExecutionResults::V2(ExecutionResultsV2 {
+            Ok(ExecutionResults::V1(ExecutionResultsV1 {
                 written_objects,
                 modified_objects: loaded_runtime_objects
                     .into_iter()

--- a/iota-execution/v0/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/v0/iota-adapter/src/temporary_store.rs
@@ -16,7 +16,7 @@ use iota_types::{
     effects::{EffectsObjectChange, TransactionEffects, TransactionEvents},
     error::{ExecutionError, IotaError, IotaResult},
     execution::{
-        DynamicallyLoadedObjectMetadata, ExecutionResults, ExecutionResultsV2, SharedInput,
+        DynamicallyLoadedObjectMetadata, ExecutionResults, ExecutionResultsV1, SharedInput,
     },
     execution_config_utils::to_binary_config,
     execution_status::ExecutionStatus,
@@ -53,7 +53,7 @@ pub struct TemporaryStore<'backing> {
     /// this store.
     lamport_timestamp: SequenceNumber,
     mutable_input_refs: BTreeMap<ObjectID, (VersionDigest, Owner)>, // Inputs that are mutable
-    execution_results: ExecutionResultsV2,
+    execution_results: ExecutionResultsV1,
     /// Objects that were loaded during execution (dynamic fields + received
     /// objects).
     loaded_runtime_objects: BTreeMap<ObjectID, DynamicallyLoadedObjectMetadata>,
@@ -117,7 +117,7 @@ impl<'backing> TemporaryStore<'backing> {
             input_objects: objects,
             lamport_timestamp,
             mutable_input_refs,
-            execution_results: ExecutionResultsV2::default(),
+            execution_results: ExecutionResultsV1::default(),
             protocol_config,
             loaded_runtime_objects: BTreeMap::new(),
             wrapped_object_containers: BTreeMap::new(),
@@ -1025,11 +1025,10 @@ impl<'backing> Storage for TemporaryStore<'backing> {
         TemporaryStore::read_object(self, id)
     }
 
-    /// Take execution results v2, and translate it back to be compatible with
-    /// effects v1.
+    /// Take execution results v1.
     fn record_execution_results(&mut self, results: ExecutionResults) {
-        let ExecutionResults::V2(results) = results else {
-            panic!("ExecutionResults::V2 expected in iota-execution v1 and above");
+        let ExecutionResults::V1(results) = results else {
+            panic!("ExecutionResults::V1 expected in iota-execution v1 and above");
         };
         // It's important to merge instead of override results because it's
         // possible to execute PT more than once during tx execution.

--- a/iota-execution/v0/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/v0/iota-adapter/src/temporary_store.rs
@@ -1027,9 +1027,8 @@ impl<'backing> Storage for TemporaryStore<'backing> {
 
     /// Take execution results v1.
     fn record_execution_results(&mut self, results: ExecutionResults) {
-        let ExecutionResults::V1(results) = results else {
-            panic!("ExecutionResults::V1 expected in iota-execution v1 and above");
-        };
+        let ExecutionResults::V1(results) = results;
+
         // It's important to merge instead of override results because it's
         // possible to execute PT more than once during tx execution.
         self.execution_results.merge_results(results);


### PR DESCRIPTION
# Description of change

- [x] Rename ExecutionResults::V2 to be V1
- [x] Remove ExecutionResultsV1

## Links to any relevant issues

Closes #3267 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

I was running the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
