### PR TITLE
fix(iota-json-rpc): Add missing apy check to average_apy_from_exchange_rates

### DIFF
--- a/crates/iota-json-rpc/src/governance_api.rs
+++ b/crates/iota-json-rpc/src/governance_api.rs
@@ -460,7 +460,7 @@ pub fn average_apy_from_exchange_rates<'er>(
         .zip(rates_next)
         .filter_map(|(er, er_next)| {
             let apy = calculate_apy(er, er_next);
-            (apy > 0.0).then_some(apy)
+            (apy > 0.0 && apy < 0.1).then_some(apy)
         })
         .take(30)
         .collect::<Vec<_>>();


### PR DESCRIPTION
# Description of change

One check is missing during refactoring of apy calculation.
Adding the check back can make the apy_test pass again.

## Links to any relevant issues

Part of #3321 

## Type of change

- Bug fix 

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

- [ ] I have checked that new and existing unit tests pass locally with my changes
