### PR TITLE
fix(iota): ignore test_move_new until the repo is public

### DIFF
--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -4170,6 +4170,7 @@ async fn test_faucet() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+#[ignore = "until the repo is public https://github.com/iotaledger/iota/issues/3741"]
 #[tokio::test]
 async fn test_move_new() -> Result<(), anyhow::Error> {
     let current_dir = std::env::current_dir()?;


### PR DESCRIPTION
Ignore test_move_new until the repo is public as it can't fetch the dependency now
https://github.com/iotaledger/iota/issues/3741