### PR TITLE
refactor(iota-faucet): use consts in FaucetConfig::default()

### DIFF
--- a/crates/iota-faucet/src/faucet/mod.rs
+++ b/crates/iota-faucet/src/faucet/mod.rs
@@ -137,8 +137,8 @@ impl Default for FaucetConfig {
         Self {
             port: 5003,
             host_ip: Ipv4Addr::new(127, 0, 0, 1),
-            amount: 1_000_000_000,
-            num_coins: 1,
+            amount: DEFAULT_AMOUNT,
+            num_coins: DEFAULT_NUM_OF_COINS,
             request_buffer_size: 10,
             max_request_per_second: 10,
             wallet_client_timeout_secs: 60,


### PR DESCRIPTION
# Description of change

Use consts in FaucetConfig::default() so changes to the consts are used as default and one doesn't need to do extra changes

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/2430

## Type of change

- Enhancement (a non-breaking change which adds functionality)

