### PR TITLE
fix(iota-json-rpc-tests): Fix move utils e2e tests

### DIFF
--- a/crates/iota-json-rpc-tests/tests/move_utils.rs
+++ b/crates/iota-json-rpc-tests/tests/move_utils.rs
@@ -132,7 +132,6 @@ async fn get_normalized_move_module() -> Result<(), anyhow::Error> {
         [
             "Coin",
             "CoinMetadata",
-            "CurrencyCreated",
             "DenyCapV1",
             "RegulatedCoinMetadata",
             "TreasuryCap",

--- a/crates/iota-json-rpc-tests/tests/move_utils.rs
+++ b/crates/iota-json-rpc-tests/tests/move_utils.rs
@@ -140,6 +140,7 @@ async fn get_normalized_move_module() -> Result<(), anyhow::Error> {
         .map(|s| s.to_string())
         .collect::<HashSet<String>>(),
     );
+
     assert_eq!(
         move_module
             .exposed_functions
@@ -175,7 +176,6 @@ async fn get_normalized_move_module() -> Result<(), anyhow::Error> {
             "mint_balance",
             "put",
             "split",
-            "supply",
             "supply_immut",
             "supply_mut",
             "take",

--- a/crates/iota-json-rpc-tests/tests/move_utils.rs
+++ b/crates/iota-json-rpc-tests/tests/move_utils.rs
@@ -139,7 +139,6 @@ async fn get_normalized_move_module() -> Result<(), anyhow::Error> {
         .map(|s| s.to_string())
         .collect::<HashSet<String>>(),
     );
-
     assert_eq!(
         move_module
             .exposed_functions

--- a/crates/iota-json-rpc-tests/tests/move_utils.rs
+++ b/crates/iota-json-rpc-tests/tests/move_utils.rs
@@ -54,7 +54,6 @@ async fn get_normalized_move_modules_by_package() -> Result<(), anyhow::Error> {
             "kiosk_extension",
             "labeler",
             "linked_table",
-            "math",
             "object",
             "object_bag",
             "object_table",


### PR DESCRIPTION
# Description of change

Update the expected values in the tests `get_normalized_move_module` and `get_normalized_move_modules_by_package`. The following elements have been removed from the codebase and should be reflected in the tests:
* `math` module
* `supply` method
* `CurrencyCreated` struct

## Links to any relevant issues

Part of #3321 

## Type of change

- Bug fix

## Change checklist

- [ ] I have checked that new and existing unit tests pass locally with my changes
