### PR TITLE
fix(cli): Fix CLI Faucet test

### DIFF
--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -26,7 +26,7 @@ use iota::{
     key_identity::{KeyIdentity, get_identity_address},
 };
 use iota_config::{
-    Config, IOTA_CLIENT_CONFIG, IOTA_FULLNODE_CONFIG, IOTA_GENESIS_FILENAME,
+    IOTA_CLIENT_CONFIG, IOTA_FULLNODE_CONFIG, IOTA_GENESIS_FILENAME,
     IOTA_KEYSTORE_ALIASES_FILENAME, IOTA_KEYSTORE_FILENAME, IOTA_NETWORK_CONFIG, PersistedConfig,
 };
 use iota_json::IotaJsonValue;
@@ -4144,15 +4144,7 @@ async fn test_faucet() -> Result<(), anyhow::Error> {
 
     // Wait for the faucet to be up
     sleep(Duration::from_secs(1)).await;
-
-    let wallet_config = tmp.path().join("walletconfig");
-    let mut keystore = iota_keys::keystore::FileBasedKeystore::new(&tmp.path().join("keystore"))?;
-    keystore
-        .generate_and_add_new_key(SignatureScheme::ED25519, None, None, None)
-        .unwrap();
-    let mut client_config = IotaClientConfig::new(keystore.into());
-    client_config.add_env(iota_sdk::iota_client_config::IotaEnv::localnet());
-    client_config.save(&wallet_config)?;
+    let wallet_config = test_cluster.swarm.dir().join(IOTA_CLIENT_CONFIG);
     let mut context = WalletContext::new(&wallet_config, None, None)?;
 
     let faucet_result = IotaClientCommands::Faucet {


### PR DESCRIPTION
# Description of change

The client context is created with different parameters than the original context return by the function that creates the test cluster, making the command fail when performing a request. The change consists of loading the original config again and using it with the Faucet request command. 

Closes [#3764](https://github.com/iotaledger/iota/issues/3764) 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`cargo simtest --color always  --package iota --test cli_tests -- test_faucet`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
