### PR TITLE
Refactor Indexer caching for `exchange_rates` and `validators_apys` to use instance-level caches, fixing cargo test failures

### DIFF
--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -104,7 +104,7 @@ The crate provides following tests currently:
 # run tests requiring only postgres integration
 cargo test --features pg_integration -- --test-threads 1
 # run rpc tests with shared runtime
-cargo test --features shared_test_runtime -- --test-threads 1
+cargo test --features shared_test_runtime
 ```
 
 For a better testing experience is possible to use [nextest](https://nexte.st/)

--- a/crates/iota-indexer/tests/rpc-tests/extended_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/extended_api.rs
@@ -19,7 +19,6 @@ use iota_types::{
     storage::ReadStore,
 };
 use simulacrum::Simulacrum;
-use tempfile::tempdir;
 use test_cluster::TestCluster;
 
 use crate::common::{ApiTestSetup, SimulacrumTestSetup, indexer_wait_for_checkpoint};


### PR DESCRIPTION
# Description of change

This PR addresses an issue in `iota-indexer` where global caches in the `exchange_rates` and `validators_apys` functions cause test failures when running `cargo test` with dedicated clusters (own `TestCluster` per test). By refactoring these functions to use instance-level caches, we prevent test interference and ensure that tests can run in parallel without conflicts.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/3773

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`cargo test --features shared_test_runtime -- --nocapture`

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
