### PR TITLE
chore(ci): move `execution-cut` lower in the hierarchy

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -62,6 +62,5 @@ jobs:
     if: |
       !cancelled() && !failure() && inputs.isRust && github.event.pull_request.draft == false
     needs:
-      - rust-tests
-      - external-tests
+      - rust-lints
     uses: ./.github/workflows/_execution_cut.yml


### PR DESCRIPTION
Move the `execution-cut` job lower in the hierarchy because it was after all the tests and has never been triggered yet because of it. It's actually a fairly cheap job so it can be done earlier.