### PR TITLE
Add iota-indexer RPC tests to CI

### DIFF
--- a/.github/workflows/_rust_tests.yml
+++ b/.github/workflows/_rust_tests.yml
@@ -244,3 +244,4 @@ jobs:
           cargo nextest run --no-fail-fast --test-threads 8 --package iota-graphql-e2e-tests --features pg_integration
           cargo nextest run --no-fail-fast --test-threads 1 --package iota-cluster-test --test local_cluster_test --features pg_integration
           cargo nextest run --no-fail-fast --test-threads 1 --package iota-indexer --test ingestion_tests --features pg_integration
+          cargo test --profile simulator --package iota-indexer --test rpc-tests --features shared_test_runtime


### PR DESCRIPTION
# Description of change

Adds `iota-indexer` RPC tests to the CI.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/3590

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

I locally ran the required `cargo test --profile simulator --package iota-indexer --test rpc-tests --features shared_test_runtime` command.

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
