### PR TITLE
refactor(iota-benchmark): Remove deprecated CHECKPOINTS_PER_EPOCH

### DIFF
--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -839,9 +839,6 @@ mod test {
             "SIM_STRESS_TEST_NUM_VALIDATORS",
             default_num_validators,
         ));
-        if std::env::var("CHECKPOINTS_PER_EPOCH").is_ok() {
-            eprintln!("CHECKPOINTS_PER_EPOCH env var is deprecated, use EPOCH_DURATION_MS");
-        }
         let epoch_duration_ms = get_var("EPOCH_DURATION_MS", default_epoch_duration_ms);
         if epoch_duration_ms > 0 {
             builder = builder.with_epoch_duration_ms(epoch_duration_ms);


### PR DESCRIPTION
# Description of change

Remove deprecated CHECKPOINTS_PER_EPOCH.

## Links to any relevant issues

Part of #2092 

## Type of change

- Enhancement


## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have checked that new and existing unit tests pass locally with my changes
