### PR TITLE
chore(iota-types): Expand all type conversions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7626,7 +7626,6 @@ dependencies = [
 [[package]]
 name = "iota-rust-sdk"
 version = "0.0.0"
-source = "git+ssh://git@github.com/iotaledger/iota-rust-sdk.git?rev=ed6173d434c77604ddc93aaa1550168fdbe97b09#ed6173d434c77604ddc93aaa1550168fdbe97b09"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7626,6 +7626,7 @@ dependencies = [
 [[package]]
 name = "iota-rust-sdk"
 version = "0.0.0"
+source = "git+ssh://git@github.com/iotaledger/iota-rust-sdk.git?rev=dd7b331a5ec62fd5e810051d19f31dff90ea7e3f#dd7b331a5ec62fd5e810051d19f31dff90ea7e3f"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -419,7 +419,7 @@ iota-rosetta = { path = "crates/iota-rosetta" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
 # core-types with json format for REST api
-iota-sdk2 = { package = "iota-rust-sdk", path = "../iota-rust-sdk/crates/iota-rust-sdk", features = ["hash", "serde", "schemars"] }
+iota-sdk2 = { package = "iota-rust-sdk", git = "ssh://git@github.com/iotaledger/iota-rust-sdk.git", rev = "dd7b331a5ec62fd5e810051d19f31dff90ea7e3f", features = ["hash", "serde", "schemars"] }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -418,7 +418,7 @@ iota-rest-api = { path = "crates/iota-rest-api" }
 iota-rosetta = { path = "crates/iota-rosetta" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-# core-types with json format for REST api
+# core-types with json format for REST API
 iota-sdk2 = { package = "iota-rust-sdk", git = "ssh://git@github.com/iotaledger/iota-rust-sdk.git", rev = "dd7b331a5ec62fd5e810051d19f31dff90ea7e3f", features = ["hash", "serde", "schemars"] }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -418,8 +418,8 @@ iota-rest-api = { path = "crates/iota-rest-api" }
 iota-rosetta = { path = "crates/iota-rosetta" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
-# core-types with json format for REST API
-iota-sdk2 = { package = "iota-rust-sdk", git = "ssh://git@github.com/iotaledger/iota-rust-sdk.git", rev = "ed6173d434c77604ddc93aaa1550168fdbe97b09", features = ["hash", "serde", "schemars"] }
+# core-types with json format for REST api
+iota-sdk2 = { package = "iota-rust-sdk", path = "../iota-rust-sdk/crates/iota-rust-sdk", features = ["hash", "serde", "schemars"] }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/crates/iota-types/src/authenticator_state.rs
+++ b/crates/iota-types/src/authenticator_state.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-pub use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId};
+pub(crate) use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId};
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
 use serde::{Deserialize, Serialize};
 

--- a/crates/iota-types/src/authenticator_state.rs
+++ b/crates/iota-types/src/authenticator_state.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId};
+pub use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId};
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
 use serde::{Deserialize, Serialize};
 

--- a/crates/iota-types/src/base_types.rs
+++ b/crates/iota-types/src/base_types.rs
@@ -612,6 +612,10 @@ pub struct IotaAddress(
 impl IotaAddress {
     pub const ZERO: Self = Self([0u8; IOTA_ADDRESS_LENGTH]);
 
+    pub fn new(bytes: [u8; IOTA_ADDRESS_LENGTH]) -> Self {
+        Self(bytes)
+    }
+
     /// Convert the address to a byte buffer.
     pub fn to_vec(&self) -> Vec<u8> {
         self.0.to_vec()

--- a/crates/iota-types/src/digests.rs
+++ b/crates/iota-types/src/digests.rs
@@ -157,7 +157,7 @@ impl fmt::UpperHex for Digest {
     Deserialize,
     JsonSchema,
 )]
-pub struct ChainIdentifier(pub CheckpointDigest);
+pub struct ChainIdentifier(pub(crate) CheckpointDigest);
 
 pub static MAINNET_CHAIN_IDENTIFIER: OnceCell<ChainIdentifier> = OnceCell::new();
 pub static TESTNET_CHAIN_IDENTIFIER: OnceCell<ChainIdentifier> = OnceCell::new();
@@ -210,7 +210,7 @@ impl ChainIdentifier {
         self.0.into_inner()
     }
 
-    pub fn inner(&self) -> CheckpointDigest {
+    pub fn digest(&self) -> CheckpointDigest {
         self.0
     }
 }

--- a/crates/iota-types/src/digests.rs
+++ b/crates/iota-types/src/digests.rs
@@ -157,7 +157,7 @@ impl fmt::UpperHex for Digest {
     Deserialize,
     JsonSchema,
 )]
-pub struct ChainIdentifier(CheckpointDigest);
+pub struct ChainIdentifier(pub CheckpointDigest);
 
 pub static MAINNET_CHAIN_IDENTIFIER: OnceCell<ChainIdentifier> = OnceCell::new();
 pub static TESTNET_CHAIN_IDENTIFIER: OnceCell<ChainIdentifier> = OnceCell::new();
@@ -204,6 +204,14 @@ impl ChainIdentifier {
 
     pub fn as_bytes(&self) -> &[u8; 32] {
         self.0.inner()
+    }
+
+    pub fn into_bytes(self) -> [u8; 32] {
+        self.0.into_inner()
+    }
+
+    pub fn inner(&self) -> CheckpointDigest {
+        self.0
     }
 }
 

--- a/crates/iota-types/src/effects/effects_v1.rs
+++ b/crates/iota-types/src/effects/effects_v1.rs
@@ -31,37 +31,37 @@ use crate::{
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct TransactionEffectsV1 {
     /// The status of the execution
-    status: ExecutionStatus,
+    pub(crate) status: ExecutionStatus,
     /// The epoch when this transaction was executed.
-    executed_epoch: EpochId,
-    gas_used: GasCostSummary,
+    pub(crate) executed_epoch: EpochId,
+    pub(crate) gas_used: GasCostSummary,
     /// The transaction digest
-    transaction_digest: TransactionDigest,
+    pub(crate) transaction_digest: TransactionDigest,
     /// The updated gas object reference, as an index into the `changed_objects`
     /// vector. Having a dedicated field for convenient access.
     /// System transaction that don't require gas will leave this as None.
-    gas_object_index: Option<u32>,
+    pub(crate) gas_object_index: Option<u32>,
     /// The digest of the events emitted during execution,
     /// can be None if the transaction does not emit any event.
-    events_digest: Option<TransactionEventsDigest>,
+    pub(crate) events_digest: Option<TransactionEventsDigest>,
     /// The set of transaction digests this transaction depends on.
-    dependencies: Vec<TransactionDigest>,
+    pub(crate) dependencies: Vec<TransactionDigest>,
 
     /// The version number of all the written Move objects by this transaction.
     pub(crate) lamport_version: SequenceNumber,
     /// Objects whose state are changed in the object store.
-    changed_objects: Vec<(ObjectID, EffectsObjectChange)>,
+    pub(crate) changed_objects: Vec<(ObjectID, EffectsObjectChange)>,
     /// Shared objects that are not mutated in this transaction. Unlike owned
     /// objects, read-only shared objects' version are not committed in the
     /// transaction, and in order for a node to catch up and execute it
     /// without consensus sequencing, the version needs to be committed in
     /// the effects.
-    unchanged_shared_objects: Vec<(ObjectID, UnchangedSharedKind)>,
+    pub(crate) unchanged_shared_objects: Vec<(ObjectID, UnchangedSharedKind)>,
     /// Auxiliary data that are not protocol-critical, generated as part of the
     /// effects but are stored separately. Storing it separately allows us
     /// to avoid bloating the effects with data that are not critical.
     /// It also provides more flexibility on the format and type of the data.
-    aux_data_digest: Option<EffectsAuxDataDigest>,
+    pub(crate) aux_data_digest: Option<EffectsAuxDataDigest>,
 }
 
 impl TransactionEffectsAPI for TransactionEffectsV1 {
@@ -573,6 +573,10 @@ impl TransactionEffectsV1 {
 
     pub fn changed_objects(&self) -> &[(ObjectID, EffectsObjectChange)] {
         &self.changed_objects
+    }
+
+    pub fn aux_data_digest(&self) -> Option<EffectsAuxDataDigest> {
+        self.aux_data_digest
     }
 }
 

--- a/crates/iota-types/src/effects/mod.rs
+++ b/crates/iota-types/src/effects/mod.rs
@@ -30,7 +30,7 @@ use crate::{
     storage::WriteKind,
 };
 
-mod effects_v1;
+pub(crate) mod effects_v1;
 mod object_change;
 mod test_effects_builder;
 

--- a/crates/iota-types/src/execution_status.rs
+++ b/crates/iota-types/src/execution_status.rs
@@ -186,7 +186,7 @@ pub enum ExecutionFailureStatus {
         "Iota Move Bytecode Verification Timeout. \
         Please run the Iota Move Verifier for more information."
     )]
-    IotaMoveVerificationTimedout,
+    IotaMoveVerificationTimeout,
 
     #[error("The shared object operation is not allowed.")]
     SharedObjectOperationNotAllowed,

--- a/crates/iota-types/src/iota_sdk2_conversions.rs
+++ b/crates/iota-types/src/iota_sdk2_conversions.rs
@@ -11,42 +11,1576 @@
 //! directly to avoid going through the BCS machinery.
 
 use fastcrypto::traits::ToFromBytes;
-use iota_sdk2::types::*;
+use iota_sdk2::types::{
+    object::{MovePackage, MoveStruct},
+    *,
+};
+use move_core_types::language_storage::ModuleId;
 
-use crate::crypto::AuthorityPublicKeyBytes;
+use crate::transaction::TransactionDataAPI as _;
 
-macro_rules! bcs_convert_impl {
-    ($core:ty, $external:ty) => {
-        impl From<$core> for $external {
-            fn from(value: $core) -> Self {
-                let bytes = bcs::to_bytes(&value).unwrap();
-                bcs::from_bytes(&bytes).unwrap()
+impl From<crate::object::Object> for Object {
+    fn from(value: crate::object::Object) -> Self {
+        Self::new(
+            value.data.clone().into(),
+            value.owner.into(),
+            value.previous_transaction.into(),
+            value.storage_rebate,
+        )
+    }
+}
+
+impl From<Object> for crate::object::Object {
+    fn from(value: Object) -> Self {
+        let (owner, prev_txn) = (*value.owner(), value.previous_transaction());
+        Self::new_from_genesis(value.into_data().into(), owner.into(), prev_txn.into())
+    }
+}
+
+impl From<crate::object::Data> for ObjectData {
+    fn from(value: crate::object::Data) -> Self {
+        match value {
+            crate::object::Data::Move(move_object) => Self::Struct(move_object_to_sdk(move_object)),
+            crate::object::Data::Package(move_package) => {
+                Self::Package(move_package_to_sdk(move_package))
+            }
+        }
+    }
+}
+
+impl From<ObjectData> for crate::object::Data {
+    fn from(value: ObjectData) -> Self {
+        match value {
+            ObjectData::Struct(move_object) => Self::Move(sdk_object_to_move(move_object)),
+            ObjectData::Package(move_package) => Self::Package(sdk_package_to_move(move_package)),
+        }
+    }
+}
+
+fn move_type_tag_to_sdk(tt: move_core_types::language_storage::TypeTag) -> TypeTag {
+    use move_core_types::language_storage::TypeTag as MoveTypeTag;
+    match tt {
+        MoveTypeTag::Bool => TypeTag::Bool,
+        MoveTypeTag::U8 => TypeTag::U8,
+        MoveTypeTag::U64 => TypeTag::U64,
+        MoveTypeTag::U128 => TypeTag::U128,
+        MoveTypeTag::Address => TypeTag::Address,
+        MoveTypeTag::Signer => TypeTag::Signer,
+        MoveTypeTag::Vector(type_tag) => TypeTag::Vector(Box::new(move_type_tag_to_sdk(*type_tag))),
+        MoveTypeTag::Struct(struct_tag) => {
+            TypeTag::Struct(Box::new(move_struct_tag_to_sdk(*struct_tag)))
+        }
+        MoveTypeTag::U16 => TypeTag::U16,
+        MoveTypeTag::U32 => TypeTag::U32,
+        MoveTypeTag::U256 => TypeTag::U256,
+    }
+}
+
+fn move_struct_tag_to_sdk(st: move_core_types::language_storage::StructTag) -> StructTag {
+    StructTag {
+        address: Address::new(st.address.into_bytes()),
+        module: Identifier::new(st.module.as_str()).expect("module identifier conversion failed"),
+        name: Identifier::new(st.name.as_str()).expect("struct name identifier conversion failed"),
+        type_params: st
+            .type_params
+            .into_iter()
+            .map(|tt| move_type_tag_to_sdk(tt))
+            .collect(),
+    }
+}
+
+fn move_package_to_sdk(package: crate::move_package::MovePackage) -> MovePackage {
+    MovePackage {
+        id: package.id().into(),
+        version: package.version().value(),
+        modules: package
+            .module_map
+            .into_iter()
+            .map(|(name, bytes)| {
+                (
+                    Identifier::new(name).expect("package name identifier conversion failed"),
+                    bytes,
+                )
+            })
+            .collect(),
+        type_origin_table: package
+            .type_origin_table
+            .into_iter()
+            .map(move_type_origin_to_sdk)
+            .collect(),
+        linkage_table: package
+            .linkage_table
+            .into_iter()
+            .map(|(id, info)| (id.into(), move_upgrade_info_to_sdk(info)))
+            .collect(),
+    }
+}
+
+fn sdk_package_to_move(package: MovePackage) -> crate::move_package::MovePackage {
+    crate::move_package::MovePackage {
+        id: package.id.into(),
+        version: package.version.into(),
+        module_map: package
+            .modules
+            .into_iter()
+            .map(|(name, bytes)| (name.to_string(), bytes))
+            .collect(),
+        type_origin_table: package
+            .type_origin_table
+            .into_iter()
+            .map(sdk_type_origin_to_move)
+            .collect(),
+        linkage_table: package
+            .linkage_table
+            .into_iter()
+            .map(|(id, info)| (id.into(), sdk_upgrade_info_to_move(info)))
+            .collect(),
+    }
+}
+
+fn move_object_to_sdk(obj: crate::object::MoveObject) -> MoveStruct {
+    MoveStruct {
+        type_: move_object_type_to_sdk(obj.type_),
+        has_public_transfer: obj.has_public_transfer,
+        version: obj.version.value(),
+        contents: obj.contents,
+    }
+}
+
+fn sdk_object_to_move(obj: MoveStruct) -> crate::object::MoveObject {
+    crate::object::MoveObject {
+        type_: sdk_object_type_to_move(obj.type_),
+        has_public_transfer: obj.has_public_transfer,
+        version: obj.version.into(),
+        contents: obj.contents,
+    }
+}
+
+fn move_object_type_to_sdk(type_: crate::base_types::MoveObjectType) -> StructTag {
+    move_struct_tag_to_sdk(move_core_types::language_storage::StructTag {
+        address: type_.address(),
+        module: type_.module().to_owned(),
+        name: type_.name().to_owned(),
+        type_params: type_.type_params(),
+    })
+}
+
+fn sdk_object_type_to_move(type_: StructTag) -> crate::base_types::MoveObjectType {
+    crate::base_types::MoveObjectType::from(move_core_types::language_storage::StructTag {
+        address: move_core_types::account_address::AccountAddress::new(type_.address.into_inner()),
+        module: crate::Identifier::new(type_.module.as_str())
+            .expect("struct module name conversion failed"),
+        name: crate::Identifier::new(type_.name.as_str()).expect("struct name conversion failed"),
+        type_params: type_
+            .type_params
+            .into_iter()
+            .map(type_tag_sdk_to_core)
+            .collect(),
+    })
+}
+
+fn move_type_origin_to_sdk(origin: crate::move_package::TypeOrigin) -> TypeOrigin {
+    TypeOrigin {
+        module_name: Identifier::new(&origin.module_name)
+            .expect("module identifier conversion failed"),
+        struct_name: Identifier::new(&origin.datatype_name)
+            .expect("struct identifier conversion failed"),
+        package: origin.package.into(),
+    }
+}
+
+fn sdk_type_origin_to_move(origin: TypeOrigin) -> crate::move_package::TypeOrigin {
+    crate::move_package::TypeOrigin {
+        module_name: origin.module_name.to_string(),
+        datatype_name: origin.struct_name.to_string(),
+        package: origin.package.into(),
+    }
+}
+
+fn move_upgrade_info_to_sdk(info: crate::move_package::UpgradeInfo) -> UpgradeInfo {
+    UpgradeInfo {
+        upgraded_id: info.upgraded_id.into(),
+        upgraded_version: info.upgraded_version.value(),
+    }
+}
+
+fn sdk_upgrade_info_to_move(info: UpgradeInfo) -> crate::move_package::UpgradeInfo {
+    crate::move_package::UpgradeInfo {
+        upgraded_id: info.upgraded_id.into(),
+        upgraded_version: info.upgraded_version.into(),
+    }
+}
+
+impl From<crate::transaction::TransactionData> for Transaction {
+    fn from(value: crate::transaction::TransactionData) -> Self {
+        Self {
+            sender: Address::new(value.sender().to_inner()),
+            gas_payment: GasPayment {
+                objects: value
+                    .gas()
+                    .into_iter()
+                    .map(|(id, seq, digest)| {
+                        ObjectReference::new((*id).into(), seq.value().into(), (*digest).into())
+                    })
+                    .collect(),
+                owner: Address::new(value.gas_data().owner.to_inner()),
+                price: value.gas_data().price,
+                budget: value.gas_data().budget,
+            },
+            expiration: match value.expiration() {
+                crate::transaction::TransactionExpiration::None => TransactionExpiration::None,
+                crate::transaction::TransactionExpiration::Epoch(e) => {
+                    TransactionExpiration::Epoch(*e)
+                }
+            },
+            kind: value.into_kind().into(),
+        }
+    }
+}
+
+impl From<Transaction> for crate::transaction::TransactionData {
+    fn from(value: Transaction) -> Self {
+        Self::new_with_gas_data(
+            value.kind.into(),
+            value.sender.into(),
+            crate::transaction::GasData {
+                payment: value
+                    .gas_payment
+                    .objects
+                    .into_iter()
+                    .map(ObjectReference::into_parts)
+                    .map(|(id, seq, digest)| (id.into(), seq.into(), digest.into()))
+                    .collect(),
+                owner: value.gas_payment.owner.into(),
+                price: value.gas_payment.price,
+                budget: value.gas_payment.budget,
+            },
+        )
+    }
+}
+
+impl From<crate::transaction::TransactionKind> for TransactionKind {
+    fn from(value: crate::transaction::TransactionKind) -> Self {
+        use crate::transaction::TransactionKind as TransactionKind2;
+        match value {
+            TransactionKind2::ProgrammableTransaction(programmable_transaction) => {
+                TransactionKind::ProgrammableTransaction(ProgrammableTransaction {
+                    inputs: programmable_transaction
+                        .inputs
+                        .into_iter()
+                        .map(Into::into)
+                        .collect(),
+                    commands: programmable_transaction
+                        .commands
+                        .into_iter()
+                        .map(Into::into)
+                        .collect(),
+                })
+            }
+            TransactionKind2::Genesis(genesis_transaction) => {
+                TransactionKind::Genesis(GenesisTransaction {
+                    objects: genesis_transaction
+                        .objects
+                        .into_iter()
+                        .map(|obj| match obj {
+                            crate::transaction::GenesisObject::RawObject { data, owner } => {
+                                GenesisObject::new(data.into(), owner.into())
+                            }
+                        })
+                        .collect(),
+                })
+            }
+            TransactionKind2::ConsensusCommitPrologueV1(consensus_commit_prologue_v1) => {
+                let consensus_determined_version_assignments = match consensus_commit_prologue_v1.consensus_determined_version_assignments {
+                    crate::messages_consensus::ConsensusDeterminedVersionAssignments::CancelledTransactions(vec) =>
+                        ConsensusDeterminedVersionAssignments::CancelledTransactions {
+                            cancelled_transactions: vec.into_iter().map(|value| CancelledTransaction {
+                                digest: value.0.into(),
+                                version_assignments:
+                                    value
+                                        .1
+                                        .into_iter()
+                                        .map(|value| VersionAssignment::new(value.0.into(), value.1.value()))
+                                        .collect(),
+                            }).collect()
+                        },
+                };
+                TransactionKind::ConsensusCommitPrologueV1(ConsensusCommitPrologueV1 {
+                    epoch: consensus_commit_prologue_v1.epoch,
+                    round: consensus_commit_prologue_v1.round,
+                    sub_dag_index: consensus_commit_prologue_v1.sub_dag_index,
+                    commit_timestamp_ms: consensus_commit_prologue_v1.commit_timestamp_ms,
+                    consensus_commit_digest: consensus_commit_prologue_v1
+                        .consensus_commit_digest
+                        .into(),
+                    consensus_determined_version_assignments,
+                })
+            }
+            TransactionKind2::AuthenticatorStateUpdateV1(authenticator_state_update_v1) => {
+                TransactionKind::AuthenticatorStateUpdateV1(AuthenticatorStateUpdateV1 {
+                    epoch: authenticator_state_update_v1.epoch,
+                    round: authenticator_state_update_v1.round,
+                    new_active_jwks: authenticator_state_update_v1
+                        .new_active_jwks
+                        .into_iter()
+                        .map(|jwk| ActiveJwk {
+                            jwk_id: JwkId {
+                                iss: jwk.jwk_id.iss,
+                                kid: jwk.jwk_id.kid,
+                            },
+                            jwk: Jwk {
+                                kty: jwk.jwk.kty,
+                                e: jwk.jwk.e,
+                                n: jwk.jwk.n,
+                                alg: jwk.jwk.alg,
+                            },
+                            epoch: jwk.epoch,
+                        })
+                        .collect(),
+                    authenticator_obj_initial_shared_version: authenticator_state_update_v1
+                        .authenticator_obj_initial_shared_version
+                        .value(),
+                })
+            }
+            TransactionKind2::EndOfEpochTransaction(vec) => {
+                TransactionKind::EndOfEpoch(vec.into_iter().map(Into::into).collect())
+            }
+            TransactionKind2::RandomnessStateUpdate(randomness_state_update) => {
+                TransactionKind::RandomnessStateUpdate(RandomnessStateUpdate {
+                    epoch: randomness_state_update.epoch,
+                    randomness_round: randomness_state_update.randomness_round.0,
+                    random_bytes: randomness_state_update.random_bytes,
+                    randomness_obj_initial_shared_version: randomness_state_update
+                        .randomness_obj_initial_shared_version
+                        .value(),
+                })
+            }
+        }
+    }
+}
+
+impl From<TransactionKind> for crate::transaction::TransactionKind {
+    fn from(value: TransactionKind) -> Self {
+        match value {
+            TransactionKind::ProgrammableTransaction(programmable_transaction) => {
+                Self::ProgrammableTransaction(crate::transaction::ProgrammableTransaction {
+                    inputs: programmable_transaction
+                        .inputs
+                        .into_iter()
+                        .map(Into::into)
+                        .collect(),
+                    commands: programmable_transaction
+                        .commands
+                        .into_iter()
+                        .map(Into::into)
+                        .collect(),
+                })
+            }
+            TransactionKind::Genesis(genesis_transaction) => {
+                Self::Genesis(crate::transaction::GenesisTransaction {
+                    objects: genesis_transaction
+                        .objects
+                        .into_iter()
+                        .map(|obj| crate::transaction::GenesisObject::RawObject {
+                            data: obj.data.into(),
+                            owner: obj.owner.into(),
+                        })
+                        .collect(),
+                    events: todo!(),
+                })
+            }
+            TransactionKind::ConsensusCommitPrologueV1(consensus_commit_prologue_v1) => {
+                let consensus_determined_version_assignments = match consensus_commit_prologue_v1.consensus_determined_version_assignments {
+                    ConsensusDeterminedVersionAssignments::CancelledTransactions{ cancelled_transactions } =>
+                    crate::messages_consensus::ConsensusDeterminedVersionAssignments::CancelledTransactions(
+                        cancelled_transactions.into_iter().map(|value|
+                            (
+                                value.digest.into(),
+                                value
+                                    .version_assignments
+                                    .into_iter()
+                                    .map(|value| (value.object_id.into(), value.version.into()))
+                                    .collect()
+                            )
+                        ).collect()
+                    ),
+                };
+                Self::ConsensusCommitPrologueV1(
+                    crate::messages_consensus::ConsensusCommitPrologueV1 {
+                        epoch: consensus_commit_prologue_v1.epoch,
+                        round: consensus_commit_prologue_v1.round,
+                        sub_dag_index: consensus_commit_prologue_v1.sub_dag_index,
+                        commit_timestamp_ms: consensus_commit_prologue_v1.commit_timestamp_ms,
+                        consensus_commit_digest: consensus_commit_prologue_v1
+                            .consensus_commit_digest
+                            .into(),
+                        consensus_determined_version_assignments,
+                    },
+                )
+            }
+            TransactionKind::AuthenticatorStateUpdateV1(authenticator_state_update_v1) => {
+                Self::AuthenticatorStateUpdateV1(crate::transaction::AuthenticatorStateUpdateV1 {
+                    epoch: authenticator_state_update_v1.epoch,
+                    round: authenticator_state_update_v1.round,
+                    new_active_jwks: authenticator_state_update_v1
+                        .new_active_jwks
+                        .into_iter()
+                        .map(|jwk| crate::authenticator_state::ActiveJwk {
+                            jwk_id: crate::authenticator_state::JwkId {
+                                iss: jwk.jwk_id.iss,
+                                kid: jwk.jwk_id.kid,
+                            },
+                            jwk: crate::authenticator_state::JWK {
+                                kty: jwk.jwk.kty,
+                                e: jwk.jwk.e,
+                                n: jwk.jwk.n,
+                                alg: jwk.jwk.alg,
+                            },
+                            epoch: jwk.epoch,
+                        })
+                        .collect(),
+                    authenticator_obj_initial_shared_version: authenticator_state_update_v1
+                        .authenticator_obj_initial_shared_version
+                        .into(),
+                })
+            }
+            TransactionKind::EndOfEpoch(vec) => {
+                Self::EndOfEpochTransaction(vec.into_iter().map(Into::into).collect())
+            }
+            TransactionKind::RandomnessStateUpdate(randomness_state_update) => {
+                Self::RandomnessStateUpdate(crate::transaction::RandomnessStateUpdate {
+                    epoch: randomness_state_update.epoch,
+                    randomness_round: crate::crypto::RandomnessRound(
+                        randomness_state_update.randomness_round,
+                    ),
+                    random_bytes: randomness_state_update.random_bytes,
+                    randomness_obj_initial_shared_version: randomness_state_update
+                        .randomness_obj_initial_shared_version
+                        .into(),
+                })
+            }
+        }
+    }
+}
+
+impl From<crate::transaction::EndOfEpochTransactionKind> for EndOfEpochTransactionKind {
+    fn from(value: crate::transaction::EndOfEpochTransactionKind) -> Self {
+        match value {
+            crate::transaction::EndOfEpochTransactionKind::ChangeEpoch(change_epoch) => {
+                EndOfEpochTransactionKind::ChangeEpoch(ChangeEpoch {
+                    epoch: change_epoch.epoch,
+                    protocol_version: change_epoch.protocol_version.as_u64(),
+                    storage_charge: change_epoch.storage_charge,
+                    computation_charge: change_epoch.computation_charge,
+                    storage_rebate: change_epoch.storage_rebate,
+                    non_refundable_storage_fee: change_epoch.non_refundable_storage_fee,
+                    epoch_start_timestamp_ms: change_epoch.epoch_start_timestamp_ms,
+                    system_packages: change_epoch
+                        .system_packages
+                        .into_iter()
+                        .map(|(version, modules, dependencies)| SystemPackage {
+                            version: version.value(),
+                            modules,
+                            dependencies: dependencies.into_iter().map(Into::into).collect(),
+                        })
+                        .collect(),
+                })
+            }
+            crate::transaction::EndOfEpochTransactionKind::AuthenticatorStateCreate => {
+                EndOfEpochTransactionKind::AuthenticatorStateCreate
+            }
+            crate::transaction::EndOfEpochTransactionKind::AuthenticatorStateExpire(
+                authenticator_state_expire,
+            ) => EndOfEpochTransactionKind::AuthenticatorStateExpire(AuthenticatorStateExpire {
+                min_epoch: authenticator_state_expire.min_epoch,
+                authenticator_obj_initial_shared_version: authenticator_state_expire
+                    .authenticator_obj_initial_shared_version
+                    .value(),
+            }),
+            crate::transaction::EndOfEpochTransactionKind::BridgeStateCreate(chain_identifier) => {
+                EndOfEpochTransactionKind::BridgeStateCreate {
+                    chain_id: CheckpointDigest::new(chain_identifier.inner().into()),
+                }
+            }
+            crate::transaction::EndOfEpochTransactionKind::BridgeCommitteeInit(sequence_number) => {
+                EndOfEpochTransactionKind::BridgeCommitteeInit {
+                    bridge_object_version: sequence_number.value(),
+                }
+            }
+        }
+    }
+}
+
+impl From<EndOfEpochTransactionKind> for crate::transaction::EndOfEpochTransactionKind {
+    fn from(value: EndOfEpochTransactionKind) -> Self {
+        match value {
+            EndOfEpochTransactionKind::ChangeEpoch(change_epoch) => {
+                Self::ChangeEpoch(crate::transaction::ChangeEpoch {
+                    epoch: change_epoch.epoch,
+                    protocol_version: change_epoch.protocol_version.into(),
+                    storage_charge: change_epoch.storage_charge,
+                    computation_charge: change_epoch.computation_charge,
+                    storage_rebate: change_epoch.storage_rebate,
+                    non_refundable_storage_fee: change_epoch.non_refundable_storage_fee,
+                    epoch_start_timestamp_ms: change_epoch.epoch_start_timestamp_ms,
+                    system_packages: change_epoch
+                        .system_packages
+                        .into_iter()
+                        .map(|package| {
+                            (
+                                package.version.into(),
+                                package.modules,
+                                package.dependencies.into_iter().map(Into::into).collect(),
+                            )
+                        })
+                        .collect(),
+                })
+            }
+            EndOfEpochTransactionKind::AuthenticatorStateCreate => Self::AuthenticatorStateCreate,
+            EndOfEpochTransactionKind::AuthenticatorStateExpire(authenticator_state_expire) => {
+                Self::AuthenticatorStateExpire(crate::transaction::AuthenticatorStateExpire {
+                    min_epoch: authenticator_state_expire.min_epoch,
+                    authenticator_obj_initial_shared_version: authenticator_state_expire
+                        .authenticator_obj_initial_shared_version
+                        .into(),
+                })
+            }
+            EndOfEpochTransactionKind::BridgeStateCreate { chain_id } => {
+                Self::BridgeStateCreate(crate::digests::ChainIdentifier(chain_id.into()))
+            }
+            EndOfEpochTransactionKind::BridgeCommitteeInit {
+                bridge_object_version,
+            } => Self::BridgeCommitteeInit(bridge_object_version.into()),
+        }
+    }
+}
+
+impl From<crate::transaction::CallArg> for InputArgument {
+    fn from(value: crate::transaction::CallArg) -> Self {
+        match value {
+            crate::transaction::CallArg::Pure(vec) => Self::Pure { value: vec },
+            crate::transaction::CallArg::Object(object_arg) => match object_arg {
+                crate::transaction::ObjectArg::ImmOrOwnedObject(obj_ref) => {
+                    Self::ImmutableOrOwned(core_obj_ref_to_sdk(obj_ref))
+                }
+                crate::transaction::ObjectArg::SharedObject {
+                    id,
+                    initial_shared_version,
+                    mutable,
+                } => Self::Shared {
+                    object_id: id.into(),
+                    initial_shared_version: initial_shared_version.value(),
+                    mutable,
+                },
+                crate::transaction::ObjectArg::Receiving(obj_ref) => {
+                    Self::Receiving(core_obj_ref_to_sdk(obj_ref))
+                }
+            },
+        }
+    }
+}
+
+impl From<InputArgument> for crate::transaction::CallArg {
+    fn from(value: InputArgument) -> Self {
+        use crate::transaction::ObjectArg;
+        match value {
+            InputArgument::Pure { value } => Self::Pure(value),
+            InputArgument::ImmutableOrOwned(object_reference) => Self::Object(
+                ObjectArg::ImmOrOwnedObject(sdk_obj_ref_to_core(object_reference)),
+            ),
+            InputArgument::Shared {
+                object_id,
+                initial_shared_version,
+                mutable,
+            } => Self::Object(ObjectArg::SharedObject {
+                id: object_id.into(),
+                initial_shared_version: initial_shared_version.into(),
+                mutable,
+            }),
+            InputArgument::Receiving(object_reference) => {
+                Self::Object(ObjectArg::Receiving(sdk_obj_ref_to_core(object_reference)))
+            }
+        }
+    }
+}
+
+fn core_obj_ref_to_sdk(obj_ref: crate::base_types::ObjectRef) -> ObjectReference {
+    ObjectReference::new(obj_ref.0.into(), obj_ref.1.value(), obj_ref.2.into())
+}
+
+fn sdk_obj_ref_to_core(obj_ref: ObjectReference) -> crate::base_types::ObjectRef {
+    let (id, seq, digest) = obj_ref.into_parts();
+    (id.into(), seq.into(), digest.into())
+}
+
+impl From<crate::effects::TransactionEffects> for TransactionEffects {
+    fn from(value: crate::effects::TransactionEffects) -> Self {
+        match value {
+            crate::effects::TransactionEffects::V1(effects) => {
+                Self::V1(Box::new(TransactionEffectsV1 {
+                    epoch: effects.executed_epoch,
+                    gas_used: GasCostSummary::new(
+                        effects.gas_used.computation_cost,
+                        effects.gas_used.storage_cost,
+                        effects.gas_used.storage_rebate,
+                        effects.gas_used.non_refundable_storage_fee,
+                    ),
+                    gas_object_index: effects.gas_object_index,
+                    transaction_digest: effects.transaction_digest.into(),
+                    events_digest: effects.events_digest.map(Into::into),
+                    dependencies: effects.dependencies.into_iter().map(Into::into).collect(),
+                    lamport_version: effects.lamport_version.value(),
+                    changed_objects: effects
+                        .changed_objects
+                        .into_iter()
+                        .map(|(id, change)| ChangedObject {
+                            object_id: id.into(),
+                            change: EffectsObjectChange {
+                                input_state: match change.input_state {
+                                    crate::effects::ObjectIn::NotExist => ObjectIn::NotExist,
+                                    crate::effects::ObjectIn::Exist(((version, digest), owner)) => {
+                                        ObjectIn::Exist {
+                                            version: version.value(),
+                                            digest: digest.into(),
+                                            owner: owner.into(),
+                                        }
+                                    }
+                                },
+                                output_state: match change.output_state {
+                                    crate::effects::ObjectOut::NotExist => ObjectOut::NotExist,
+                                    crate::effects::ObjectOut::ObjectWrite((digest, owner)) => {
+                                        ObjectOut::ObjectWrite {
+                                            digest: digest.into(),
+                                            owner: owner.into(),
+                                        }
+                                    }
+                                    crate::effects::ObjectOut::PackageWrite((seq, digest)) => {
+                                        ObjectOut::PackageWrite {
+                                            version: seq.value(),
+                                            digest: digest.into(),
+                                        }
+                                    }
+                                },
+                                id_operation: match change.id_operation {
+                                    crate::effects::IDOperation::None => IdOperation::None,
+                                    crate::effects::IDOperation::Created => IdOperation::Created,
+                                    crate::effects::IDOperation::Deleted => IdOperation::Deleted,
+                                },
+                            },
+                        })
+                        .collect(),
+                    unchanged_shared_objects: effects
+                        .unchanged_shared_objects
+                        .into_iter()
+                        .map(|(id, kind)| UnchangedSharedObject {
+                            object_id: id.into(),
+                            kind: match kind {
+                                crate::effects::UnchangedSharedKind::ReadOnlyRoot((
+                                    version,
+                                    digest,
+                                )) => UnchangedSharedKind::ReadOnlyRoot {
+                                    version: version.value(),
+                                    digest: digest.into(),
+                                },
+                                crate::effects::UnchangedSharedKind::MutateDeleted(
+                                    sequence_number,
+                                ) => UnchangedSharedKind::MutateDeleted {
+                                    version: sequence_number.value(),
+                                },
+                                crate::effects::UnchangedSharedKind::ReadDeleted(
+                                    sequence_number,
+                                ) => UnchangedSharedKind::ReadDeleted {
+                                    version: sequence_number.value(),
+                                },
+                                crate::effects::UnchangedSharedKind::Cancelled(sequence_number) => {
+                                    UnchangedSharedKind::Cancelled {
+                                        version: sequence_number.value(),
+                                    }
+                                }
+                                crate::effects::UnchangedSharedKind::PerEpochConfig => {
+                                    UnchangedSharedKind::PerEpochConfig
+                                }
+                            },
+                        })
+                        .collect(),
+                    auxiliary_data_digest: effects.aux_data_digest.map(Into::into),
+                    status: effects.status.into(),
+                }))
+            }
+        }
+    }
+}
+
+impl From<TransactionEffects> for crate::effects::TransactionEffects {
+    fn from(value: TransactionEffects) -> Self {
+        match value {
+            TransactionEffects::V1(transaction_effects_v1) => {
+                crate::effects::effects_v1::TransactionEffectsV1 {
+                    status: transaction_effects_v1.status.into(),
+                    executed_epoch: transaction_effects_v1.epoch,
+                    gas_used: crate::gas::GasCostSummary::new(
+                        transaction_effects_v1.gas_used.computation_cost,
+                        transaction_effects_v1.gas_used.storage_cost,
+                        transaction_effects_v1.gas_used.storage_rebate,
+                        transaction_effects_v1.gas_used.non_refundable_storage_fee,
+                    ),
+                    transaction_digest: transaction_effects_v1.transaction_digest.into(),
+                    gas_object_index: transaction_effects_v1.gas_object_index,
+                    events_digest: transaction_effects_v1.events_digest.map(Into::into),
+                    dependencies: transaction_effects_v1
+                        .dependencies
+                        .into_iter()
+                        .map(Into::into)
+                        .collect(),
+                    lamport_version: transaction_effects_v1.lamport_version.into(),
+                    changed_objects: transaction_effects_v1
+                        .changed_objects
+                        .into_iter()
+                        .map(|obj| {
+                            (obj.object_id.into(), crate::effects::EffectsObjectChange {
+                                input_state: match obj.change.input_state {
+                                    ObjectIn::NotExist => crate::effects::ObjectIn::NotExist,
+                                    ObjectIn::Exist {
+                                        version,
+                                        digest,
+                                        owner,
+                                    } => crate::effects::ObjectIn::Exist((
+                                        (version.into(), digest.into()),
+                                        owner.into(),
+                                    )),
+                                },
+                                output_state: match obj.change.output_state {
+                                    ObjectOut::NotExist => crate::effects::ObjectOut::NotExist,
+                                    ObjectOut::ObjectWrite { digest, owner } => {
+                                        crate::effects::ObjectOut::ObjectWrite((
+                                            digest.into(),
+                                            owner.into(),
+                                        ))
+                                    }
+                                    ObjectOut::PackageWrite { version, digest } => {
+                                        crate::effects::ObjectOut::PackageWrite((
+                                            version.into(),
+                                            digest.into(),
+                                        ))
+                                    }
+                                },
+                                id_operation: match obj.change.id_operation {
+                                    IdOperation::None => crate::effects::IDOperation::None,
+                                    IdOperation::Created => crate::effects::IDOperation::Created,
+                                    IdOperation::Deleted => crate::effects::IDOperation::Deleted,
+                                },
+                            })
+                        })
+                        .collect(),
+                    unchanged_shared_objects: transaction_effects_v1
+                        .unchanged_shared_objects
+                        .into_iter()
+                        .map(|obj| {
+                            (obj.object_id.into(), match obj.kind {
+                                UnchangedSharedKind::ReadOnlyRoot { version, digest } => {
+                                    crate::effects::UnchangedSharedKind::ReadOnlyRoot((
+                                        version.into(),
+                                        digest.into(),
+                                    ))
+                                }
+                                UnchangedSharedKind::MutateDeleted { version } => {
+                                    crate::effects::UnchangedSharedKind::MutateDeleted(
+                                        version.into(),
+                                    )
+                                }
+                                UnchangedSharedKind::ReadDeleted { version } => {
+                                    crate::effects::UnchangedSharedKind::ReadDeleted(version.into())
+                                }
+                                UnchangedSharedKind::Cancelled { version } => {
+                                    crate::effects::UnchangedSharedKind::Cancelled(version.into())
+                                }
+                                UnchangedSharedKind::PerEpochConfig => {
+                                    crate::effects::UnchangedSharedKind::PerEpochConfig
+                                }
+                            })
+                        })
+                        .collect(),
+                    aux_data_digest: transaction_effects_v1.auxiliary_data_digest.map(Into::into),
+                }
+                .into()
+            }
+        }
+    }
+}
+
+macro_rules! impl_convert_digest {
+    ($name:ident) => {
+        impl From<crate::digests::$name> for $name {
+            fn from(value: crate::digests::$name) -> Self {
+                Self::new(value.into_inner())
             }
         }
 
-        impl From<$external> for $core {
-            fn from(value: $external) -> Self {
-                let bytes = bcs::to_bytes(&value).unwrap();
-                bcs::from_bytes(&bytes).unwrap()
+        impl From<$name> for crate::digests::$name {
+            fn from(value: $name) -> Self {
+                Self::new(value.into_inner())
             }
         }
     };
 }
 
-bcs_convert_impl!(crate::object::Object, Object);
-bcs_convert_impl!(crate::transaction::TransactionData, Transaction);
-bcs_convert_impl!(crate::effects::TransactionEffects, TransactionEffects);
-bcs_convert_impl!(
-    crate::messages_checkpoint::CheckpointContents,
-    CheckpointContents
-);
-bcs_convert_impl!(
-    crate::full_checkpoint_content::CheckpointData,
-    CheckpointData
-);
-bcs_convert_impl!(crate::signature::GenericSignature, UserSignature);
-bcs_convert_impl!(crate::effects::TransactionEvents, TransactionEvents);
-bcs_convert_impl!(crate::transaction::Command, Command);
+impl_convert_digest!(Digest);
+impl_convert_digest!(ObjectDigest);
+impl_convert_digest!(CheckpointDigest);
+impl_convert_digest!(TransactionDigest);
+impl_convert_digest!(TransactionEffectsDigest);
+impl_convert_digest!(TransactionEventsDigest);
+impl_convert_digest!(CheckpointContentsDigest);
+impl_convert_digest!(ConsensusCommitDigest);
+
+impl From<crate::digests::EffectsAuxDataDigest> for EffectsAuxiliaryDataDigest {
+    fn from(value: crate::digests::EffectsAuxDataDigest) -> Self {
+        Self::new(value.into_inner())
+    }
+}
+
+impl From<EffectsAuxiliaryDataDigest> for crate::digests::EffectsAuxDataDigest {
+    fn from(value: EffectsAuxiliaryDataDigest) -> Self {
+        Self::new(value.into_inner())
+    }
+}
+
+impl From<crate::execution_status::ExecutionStatus> for ExecutionStatus {
+    fn from(value: crate::execution_status::ExecutionStatus) -> Self {
+        match value {
+            crate::execution_status::ExecutionStatus::Success => Self::Success,
+            crate::execution_status::ExecutionStatus::Failure { error, command } => Self::Failure {
+                error: error.into(),
+                command: command.map(|v| v as u64),
+            },
+        }
+    }
+}
+
+impl From<ExecutionStatus> for crate::execution_status::ExecutionStatus {
+    fn from(value: ExecutionStatus) -> Self {
+        match value {
+            ExecutionStatus::Success => Self::Success,
+            ExecutionStatus::Failure { error, command } => Self::Failure {
+                error: error.into(),
+                command: command.map(|v| v as usize),
+            },
+        }
+    }
+}
+
+impl From<crate::execution_status::ExecutionFailureStatus> for ExecutionError {
+    fn from(value: crate::execution_status::ExecutionFailureStatus) -> Self {
+        use crate::execution_status::ExecutionFailureStatus;
+        match value {
+            ExecutionFailureStatus::InsufficientGas => Self::InsufficientGas,
+            ExecutionFailureStatus::InvalidGasObject => Self::InvalidGasObject,
+            ExecutionFailureStatus::InvariantViolation => Self::InvariantViolation,
+            ExecutionFailureStatus::FeatureNotYetSupported => Self::FeatureNotYetSupported,
+            ExecutionFailureStatus::MoveObjectTooBig {
+                object_size,
+                max_object_size,
+            } => Self::ObjectTooBig {
+                object_size,
+                max_object_size,
+            },
+            ExecutionFailureStatus::MovePackageTooBig {
+                object_size,
+                max_object_size,
+            } => Self::PackageTooBig {
+                object_size,
+                max_object_size,
+            },
+            ExecutionFailureStatus::CircularObjectOwnership { object } => {
+                Self::CircularObjectOwnership {
+                    object: object.into(),
+                }
+            }
+            ExecutionFailureStatus::InsufficientCoinBalance => Self::InsufficientCoinBalance,
+            ExecutionFailureStatus::CoinBalanceOverflow => Self::CoinBalanceOverflow,
+            ExecutionFailureStatus::PublishErrorNonZeroAddress => Self::PublishErrorNonZeroAddress,
+            ExecutionFailureStatus::IotaMoveVerificationError => Self::IotaMoveVerificationError,
+            ExecutionFailureStatus::MovePrimitiveRuntimeError(move_location_opt) => {
+                Self::MovePrimitiveRuntimeError {
+                    location: move_location_opt.0.map(Into::into),
+                }
+            }
+            ExecutionFailureStatus::MoveAbort(move_location, code) => Self::MoveAbort {
+                location: move_location.into(),
+                code,
+            },
+            ExecutionFailureStatus::VMVerificationOrDeserializationError => {
+                Self::VmVerificationOrDeserializationError
+            }
+            ExecutionFailureStatus::VMInvariantViolation => Self::VmInvariantViolation,
+            ExecutionFailureStatus::FunctionNotFound => Self::FunctionNotFound,
+            ExecutionFailureStatus::ArityMismatch => Self::ArityMismatch,
+            ExecutionFailureStatus::TypeArityMismatch => Self::TypeArityMismatch,
+            ExecutionFailureStatus::NonEntryFunctionInvoked => Self::NonEntryFunctionInvoked,
+            ExecutionFailureStatus::CommandArgumentError { arg_idx, kind } => {
+                use crate::execution_status::CommandArgumentError as CommandArgumentError2;
+                Self::CommandArgumentError {
+                    argument: arg_idx,
+                    kind: match kind {
+                        CommandArgumentError2::TypeMismatch => CommandArgumentError::TypeMismatch,
+                        CommandArgumentError2::InvalidBCSBytes => {
+                            CommandArgumentError::InvalidBcsBytes
+                        }
+                        CommandArgumentError2::InvalidUsageOfPureArg => {
+                            CommandArgumentError::InvalidUsageOfPureArgument
+                        }
+                        CommandArgumentError2::InvalidArgumentToPrivateEntryFunction => {
+                            CommandArgumentError::InvalidArgumentToPrivateEntryFunction
+                        }
+                        CommandArgumentError2::IndexOutOfBounds { idx } => {
+                            CommandArgumentError::IndexOutOfBounds { index: idx }
+                        }
+                        CommandArgumentError2::SecondaryIndexOutOfBounds {
+                            result_idx,
+                            secondary_idx,
+                        } => CommandArgumentError::SecondaryIndexOutOfBounds {
+                            result: result_idx,
+                            subresult: secondary_idx,
+                        },
+                        CommandArgumentError2::InvalidResultArity { result_idx } => {
+                            CommandArgumentError::InvalidResultArity { result: result_idx }
+                        }
+                        CommandArgumentError2::InvalidGasCoinUsage => {
+                            CommandArgumentError::InvalidGasCoinUsage
+                        }
+                        CommandArgumentError2::InvalidValueUsage => {
+                            CommandArgumentError::InvalidValueUsage
+                        }
+                        CommandArgumentError2::InvalidObjectByValue => {
+                            CommandArgumentError::InvalidObjectByValue
+                        }
+                        CommandArgumentError2::InvalidObjectByMutRef => {
+                            CommandArgumentError::InvalidObjectByMutRef
+                        }
+                        CommandArgumentError2::SharedObjectOperationNotAllowed => {
+                            CommandArgumentError::SharedObjectOperationNotAllowed
+                        }
+                    },
+                }
+            }
+            ExecutionFailureStatus::TypeArgumentError { argument_idx, kind } => {
+                use crate::execution_status::TypeArgumentError as TypeArgumentError2;
+                Self::TypeArgumentError {
+                    type_argument: argument_idx,
+                    kind: match kind {
+                        TypeArgumentError2::TypeNotFound => TypeArgumentError::TypeNotFound,
+                        TypeArgumentError2::ConstraintNotSatisfied => {
+                            TypeArgumentError::ConstraintNotSatisfied
+                        }
+                    },
+                }
+            }
+            ExecutionFailureStatus::UnusedValueWithoutDrop {
+                result_idx,
+                secondary_idx,
+            } => Self::UnusedValueWithoutDrop {
+                result: result_idx,
+                subresult: secondary_idx,
+            },
+            ExecutionFailureStatus::InvalidPublicFunctionReturnType { idx } => {
+                Self::InvalidPublicFunctionReturnType { index: idx }
+            }
+            ExecutionFailureStatus::InvalidTransferObject => Self::InvalidTransferObject,
+            ExecutionFailureStatus::EffectsTooLarge {
+                current_size,
+                max_size,
+            } => Self::EffectsTooLarge {
+                current_size: current_size,
+                max_size: max_size,
+            },
+            ExecutionFailureStatus::PublishUpgradeMissingDependency => {
+                Self::PublishUpgradeMissingDependency
+            }
+            ExecutionFailureStatus::PublishUpgradeDependencyDowngrade => {
+                Self::PublishUpgradeDependencyDowngrade
+            }
+            ExecutionFailureStatus::PackageUpgradeError { upgrade_error } => {
+                use crate::execution_status::PackageUpgradeError as PackageUpgradeError2;
+                Self::PackageUpgradeError {
+                    kind: match upgrade_error {
+                        PackageUpgradeError2::UnableToFetchPackage { package_id } => {
+                            PackageUpgradeError::UnableToFetchPackage {
+                                package_id: package_id.into(),
+                            }
+                        }
+                        PackageUpgradeError2::NotAPackage { object_id } => {
+                            PackageUpgradeError::NotAPackage {
+                                object_id: object_id.into(),
+                            }
+                        }
+                        PackageUpgradeError2::IncompatibleUpgrade => {
+                            PackageUpgradeError::IncompatibleUpgrade
+                        }
+                        PackageUpgradeError2::DigestDoesNotMatch { digest } => {
+                            PackageUpgradeError::DigestDoesNotMatch {
+                                digest: Digest::from_bytes(digest).expect("invalid digest bytes"),
+                            }
+                        }
+                        PackageUpgradeError2::UnknownUpgradePolicy { policy } => {
+                            PackageUpgradeError::UnknownUpgradePolicy { policy }
+                        }
+                        PackageUpgradeError2::PackageIDDoesNotMatch {
+                            package_id,
+                            ticket_id,
+                        } => PackageUpgradeError::PackageIdDoesNotMatch {
+                            package_id: package_id.into(),
+                            ticket_id: ticket_id.into(),
+                        },
+                    },
+                }
+            }
+            ExecutionFailureStatus::WrittenObjectsTooLarge {
+                current_size,
+                max_size,
+            } => Self::WrittenObjectsTooLarge {
+                object_size: current_size,
+                max_object_size: max_size,
+            },
+            ExecutionFailureStatus::CertificateDenied => Self::CertificateDenied,
+            ExecutionFailureStatus::IotaMoveVerificationTimeout => {
+                Self::IotaMoveVerificationTimeout
+            }
+            ExecutionFailureStatus::SharedObjectOperationNotAllowed => {
+                Self::SharedObjectOperationNotAllowed
+            }
+            ExecutionFailureStatus::InputObjectDeleted => Self::InputObjectDeleted,
+            ExecutionFailureStatus::ExecutionCancelledDueToSharedObjectCongestion {
+                congested_objects,
+            } => Self::ExecutionCancelledDueToSharedObjectCongestion {
+                congested_objects: congested_objects.0.into_iter().map(Into::into).collect(),
+            },
+            ExecutionFailureStatus::AddressDeniedForCoin { address, coin_type } => {
+                Self::AddressDeniedForCoin {
+                    address: address.into(),
+                    coin_type,
+                }
+            }
+            ExecutionFailureStatus::CoinTypeGlobalPause { coin_type } => {
+                Self::CoinTypeGlobalPause { coin_type }
+            }
+            ExecutionFailureStatus::ExecutionCancelledDueToRandomnessUnavailable => {
+                Self::ExecutionCancelledDueToRandomnessUnavailable
+            }
+        }
+    }
+}
+
+impl From<ExecutionError> for crate::execution_status::ExecutionFailureStatus {
+    fn from(value: ExecutionError) -> Self {
+        match value {
+            ExecutionError::InsufficientGas => Self::InsufficientGas,
+            ExecutionError::InvalidGasObject => Self::InvalidGasObject,
+            ExecutionError::InvariantViolation => Self::InvariantViolation,
+            ExecutionError::FeatureNotYetSupported => Self::FeatureNotYetSupported,
+            ExecutionError::ObjectTooBig {
+                object_size,
+                max_object_size,
+            } => Self::MoveObjectTooBig {
+                object_size,
+                max_object_size,
+            },
+            ExecutionError::PackageTooBig {
+                object_size,
+                max_object_size,
+            } => Self::MovePackageTooBig {
+                object_size,
+                max_object_size,
+            },
+            ExecutionError::CircularObjectOwnership { object } => Self::CircularObjectOwnership {
+                object: object.into(),
+            },
+            ExecutionError::InsufficientCoinBalance => Self::InsufficientCoinBalance,
+            ExecutionError::CoinBalanceOverflow => Self::CoinBalanceOverflow,
+            ExecutionError::PublishErrorNonZeroAddress => Self::PublishErrorNonZeroAddress,
+            ExecutionError::IotaMoveVerificationError => Self::IotaMoveVerificationError,
+            ExecutionError::MovePrimitiveRuntimeError { location } => {
+                Self::MovePrimitiveRuntimeError(crate::execution_status::MoveLocationOpt(
+                    location.map(Into::into),
+                ))
+            }
+            ExecutionError::MoveAbort { location, code } => Self::MoveAbort(location.into(), code),
+            ExecutionError::VmVerificationOrDeserializationError => {
+                Self::VMVerificationOrDeserializationError
+            }
+            ExecutionError::VmInvariantViolation => Self::VMInvariantViolation,
+            ExecutionError::FunctionNotFound => Self::FunctionNotFound,
+            ExecutionError::ArityMismatch => Self::ArityMismatch,
+            ExecutionError::TypeArityMismatch => Self::TypeArityMismatch,
+            ExecutionError::NonEntryFunctionInvoked => Self::NonEntryFunctionInvoked,
+            ExecutionError::CommandArgumentError { argument, kind } => {
+                use crate::execution_status::CommandArgumentError as CommandArgumentError2;
+                Self::CommandArgumentError {
+                    arg_idx: argument,
+                    kind: match kind {
+                        CommandArgumentError::TypeMismatch => CommandArgumentError2::TypeMismatch,
+                        CommandArgumentError::InvalidBcsBytes => {
+                            CommandArgumentError2::InvalidBCSBytes
+                        }
+                        CommandArgumentError::InvalidUsageOfPureArgument => {
+                            CommandArgumentError2::InvalidUsageOfPureArg
+                        }
+                        CommandArgumentError::InvalidArgumentToPrivateEntryFunction => {
+                            CommandArgumentError2::InvalidArgumentToPrivateEntryFunction
+                        }
+                        CommandArgumentError::IndexOutOfBounds { index } => {
+                            CommandArgumentError2::IndexOutOfBounds { idx: index }
+                        }
+                        CommandArgumentError::SecondaryIndexOutOfBounds { result, subresult } => {
+                            CommandArgumentError2::SecondaryIndexOutOfBounds {
+                                result_idx: result,
+                                secondary_idx: subresult,
+                            }
+                        }
+                        CommandArgumentError::InvalidResultArity { result } => {
+                            CommandArgumentError2::InvalidResultArity { result_idx: result }
+                        }
+                        CommandArgumentError::InvalidGasCoinUsage => {
+                            CommandArgumentError2::InvalidGasCoinUsage
+                        }
+                        CommandArgumentError::InvalidValueUsage => {
+                            CommandArgumentError2::InvalidValueUsage
+                        }
+                        CommandArgumentError::InvalidObjectByValue => {
+                            CommandArgumentError2::InvalidObjectByValue
+                        }
+                        CommandArgumentError::InvalidObjectByMutRef => {
+                            CommandArgumentError2::InvalidObjectByMutRef
+                        }
+                        CommandArgumentError::SharedObjectOperationNotAllowed => {
+                            CommandArgumentError2::SharedObjectOperationNotAllowed
+                        }
+                    },
+                }
+            }
+            ExecutionError::TypeArgumentError {
+                type_argument,
+                kind,
+            } => {
+                use crate::execution_status::TypeArgumentError as TypeArgumentError2;
+                Self::TypeArgumentError {
+                    argument_idx: type_argument,
+                    kind: match kind {
+                        TypeArgumentError::TypeNotFound => TypeArgumentError2::TypeNotFound,
+                        TypeArgumentError::ConstraintNotSatisfied => {
+                            TypeArgumentError2::ConstraintNotSatisfied
+                        }
+                    },
+                }
+            }
+            ExecutionError::UnusedValueWithoutDrop { result, subresult } => {
+                Self::UnusedValueWithoutDrop {
+                    result_idx: result,
+                    secondary_idx: subresult,
+                }
+            }
+            ExecutionError::InvalidPublicFunctionReturnType { index } => {
+                Self::InvalidPublicFunctionReturnType { idx: index }
+            }
+            ExecutionError::InvalidTransferObject => Self::InvalidTransferObject,
+            ExecutionError::EffectsTooLarge {
+                current_size,
+                max_size,
+            } => Self::EffectsTooLarge {
+                current_size: current_size,
+                max_size: max_size,
+            },
+            ExecutionError::PublishUpgradeMissingDependency => {
+                Self::PublishUpgradeMissingDependency
+            }
+            ExecutionError::PublishUpgradeDependencyDowngrade => {
+                Self::PublishUpgradeDependencyDowngrade
+            }
+            ExecutionError::PackageUpgradeError { kind } => {
+                use crate::execution_status::PackageUpgradeError as PackageUpgradeError2;
+                Self::PackageUpgradeError {
+                    upgrade_error: match kind {
+                        PackageUpgradeError::UnableToFetchPackage { package_id } => {
+                            PackageUpgradeError2::UnableToFetchPackage {
+                                package_id: package_id.into(),
+                            }
+                        }
+                        PackageUpgradeError::NotAPackage { object_id } => {
+                            PackageUpgradeError2::NotAPackage {
+                                object_id: object_id.into(),
+                            }
+                        }
+                        PackageUpgradeError::IncompatibleUpgrade => {
+                            PackageUpgradeError2::IncompatibleUpgrade
+                        }
+                        PackageUpgradeError::DigestDoesNotMatch { digest } => {
+                            PackageUpgradeError2::DigestDoesNotMatch {
+                                digest: digest.as_bytes().to_vec(),
+                            }
+                        }
+                        PackageUpgradeError::UnknownUpgradePolicy { policy } => {
+                            PackageUpgradeError2::UnknownUpgradePolicy { policy }
+                        }
+                        PackageUpgradeError::PackageIdDoesNotMatch {
+                            package_id,
+                            ticket_id,
+                        } => PackageUpgradeError2::PackageIDDoesNotMatch {
+                            package_id: package_id.into(),
+                            ticket_id: ticket_id.into(),
+                        },
+                    },
+                }
+            }
+            ExecutionError::WrittenObjectsTooLarge {
+                object_size,
+                max_object_size,
+            } => Self::WrittenObjectsTooLarge {
+                current_size: object_size,
+                max_size: max_object_size,
+            },
+            ExecutionError::CertificateDenied => Self::CertificateDenied,
+            ExecutionError::IotaMoveVerificationTimeout => Self::IotaMoveVerificationTimeout,
+            ExecutionError::SharedObjectOperationNotAllowed => {
+                Self::SharedObjectOperationNotAllowed
+            }
+            ExecutionError::InputObjectDeleted => Self::InputObjectDeleted,
+            ExecutionError::ExecutionCancelledDueToSharedObjectCongestion { congested_objects } => {
+                Self::ExecutionCancelledDueToSharedObjectCongestion {
+                    congested_objects: crate::execution_status::CongestedObjects(
+                        congested_objects.into_iter().map(Into::into).collect(),
+                    ),
+                }
+            }
+            ExecutionError::AddressDeniedForCoin { address, coin_type } => {
+                Self::AddressDeniedForCoin {
+                    address: address.into(),
+                    coin_type,
+                }
+            }
+            ExecutionError::CoinTypeGlobalPause { coin_type } => {
+                Self::CoinTypeGlobalPause { coin_type }
+            }
+            ExecutionError::ExecutionCancelledDueToRandomnessUnavailable => {
+                Self::ExecutionCancelledDueToRandomnessUnavailable
+            }
+        }
+    }
+}
+
+impl From<crate::execution_status::MoveLocation> for MoveLocation {
+    fn from(value: crate::execution_status::MoveLocation) -> Self {
+        Self {
+            package: ObjectId::new(value.module.address().into_bytes()),
+            module: Identifier::new(value.module.name().as_str()).expect("invalid module mame"),
+            function: value.function,
+            instruction: value.instruction,
+            function_name: value
+                .function_name
+                .map(|name| Identifier::new(name).expect("invalid function mame")),
+        }
+    }
+}
+
+impl From<MoveLocation> for crate::execution_status::MoveLocation {
+    fn from(value: MoveLocation) -> Self {
+        Self {
+            module: ModuleId::new(
+                move_core_types::account_address::AccountAddress::new(value.package.into_inner()),
+                crate::Identifier::new(value.module.as_str()).expect("invalid module mame"),
+            ),
+            function: value.function,
+            instruction: value.instruction,
+            function_name: value.function_name.map(|name| name.to_string()),
+        }
+    }
+}
+
+impl From<crate::messages_checkpoint::CheckpointContents> for CheckpointContents {
+    fn from(value: crate::messages_checkpoint::CheckpointContents) -> Self {
+        Self(
+            value
+                .into_iter_with_signatures()
+                .map(|(digests, signatures)| CheckpointTransactionInfo {
+                    transaction: digests.transaction.into(),
+                    effects: digests.effects.into(),
+                    signatures: signatures.into_iter().map(Into::into).collect(),
+                })
+                .collect(),
+        )
+    }
+}
+
+impl From<CheckpointContents> for crate::messages_checkpoint::CheckpointContents {
+    fn from(value: CheckpointContents) -> Self {
+        let (transactions, user_signatures) = value.0.into_iter().fold(
+            (Vec::new(), Vec::new()),
+            |(mut transactions, mut user_signatures), info| {
+                transactions.push(crate::base_types::ExecutionDigests {
+                    transaction: info.transaction.into(),
+                    effects: info.effects.into(),
+                });
+                user_signatures.push(info.signatures.into_iter().map(Into::into).collect());
+                (transactions, user_signatures)
+            },
+        );
+        crate::messages_checkpoint::CheckpointContents::new_with_digests_and_signatures(
+            transactions,
+            user_signatures,
+        )
+    }
+}
+
+impl From<crate::full_checkpoint_content::CheckpointData> for CheckpointData {
+    fn from(value: crate::full_checkpoint_content::CheckpointData) -> Self {
+        Self {
+            checkpoint_summary: value.checkpoint_summary.into(),
+            checkpoint_contents: value.checkpoint_contents.into(),
+            transactions: value.transactions.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<CheckpointData> for crate::full_checkpoint_content::CheckpointData {
+    fn from(value: CheckpointData) -> Self {
+        Self {
+            checkpoint_summary: value.checkpoint_summary.into(),
+            checkpoint_contents: value.checkpoint_contents.into(),
+            transactions: value.transactions.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<crate::full_checkpoint_content::CheckpointTransaction> for CheckpointTransaction {
+    fn from(value: crate::full_checkpoint_content::CheckpointTransaction) -> Self {
+        Self {
+            transaction: value.transaction.into(),
+            effects: value.effects.into(),
+            events: value.events.map(Into::into),
+            input_objects: value.input_objects.into_iter().map(Into::into).collect(),
+            output_objects: value.output_objects.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<CheckpointTransaction> for crate::full_checkpoint_content::CheckpointTransaction {
+    fn from(value: CheckpointTransaction) -> Self {
+        Self {
+            transaction: value.transaction.into(),
+            effects: value.effects.into(),
+            events: value.events.map(Into::into),
+            input_objects: value.input_objects.into_iter().map(Into::into).collect(),
+            output_objects: value.output_objects.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<crate::signature::GenericSignature> for UserSignature {
+    fn from(value: crate::signature::GenericSignature) -> Self {
+        match value {
+            crate::signature::GenericSignature::MultiSig(multi_sig) => Self::Multisig(
+                MultisigAggregatedSignature::from_serialized_bytes(multi_sig.as_bytes())
+                    .expect("invalid multisig aggregated signature"),
+            ),
+            crate::signature::GenericSignature::Signature(signature) => Self::Simple(
+                SimpleSignature::from_serialized_bytes(signature.as_bytes())
+                    .expect("invalid simple signature"),
+            ),
+            crate::signature::GenericSignature::ZkLoginAuthenticator(zk_login_authenticator) => {
+                Self::ZkLogin(Box::new(
+                    ZkLoginAuthenticator::from_serialized_bytes(zk_login_authenticator.as_bytes())
+                        .expect("invalid zklogin authenticator"),
+                ))
+            }
+            crate::signature::GenericSignature::PasskeyAuthenticator(passkey_authenticator) => {
+                Self::Passkey(
+                    PasskeyAuthenticator::from_serialized_bytes(passkey_authenticator.as_bytes())
+                        .expect("invalid passkey authenticator"),
+                )
+            }
+        }
+    }
+}
+
+impl From<UserSignature> for crate::signature::GenericSignature {
+    fn from(value: UserSignature) -> Self {
+        Self::from_bytes(&bcs::to_bytes(&value).expect("invalid signature"))
+            .expect("invalid signature")
+    }
+}
+
+impl From<crate::effects::TransactionEvents> for TransactionEvents {
+    fn from(value: crate::effects::TransactionEvents) -> Self {
+        Self(value.data.into_iter().map(Into::into).collect())
+    }
+}
+
+impl From<TransactionEvents> for crate::effects::TransactionEvents {
+    fn from(value: TransactionEvents) -> Self {
+        Self {
+            data: value.0.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<crate::event::Event> for Event {
+    fn from(value: crate::event::Event) -> Self {
+        Self {
+            package_id: value.package_id.into(),
+            module: Identifier::new(value.transaction_module.as_str())
+                .expect("invalid event module identifier"),
+            sender: value.sender.into(),
+            type_: struct_tag_core_to_sdk(value.type_),
+            contents: value.contents,
+        }
+    }
+}
+
+impl From<Event> for crate::event::Event {
+    fn from(value: Event) -> Self {
+        Self {
+            package_id: value.package_id.into(),
+            transaction_module: crate::Identifier::new(value.module.as_str())
+                .expect("invalid event module identifier"),
+            sender: value.sender.into(),
+            type_: struct_tag_sdk_to_core(value.type_),
+            contents: value.contents,
+        }
+    }
+}
+
+impl From<crate::transaction::Command> for Command {
+    fn from(value: crate::transaction::Command) -> Self {
+        use crate::transaction::Command as Command2;
+        match value {
+            Command2::MoveCall(programmable_move_call) => Self::MoveCall(MoveCall {
+                package: programmable_move_call.package.into(),
+                module: Identifier::new(programmable_move_call.module.as_str())
+                    .expect("invalid move call module identifier"),
+                function: Identifier::new(programmable_move_call.function.as_str())
+                    .expect("invalid move call function identifier"),
+                type_arguments: programmable_move_call
+                    .type_arguments
+                    .into_iter()
+                    .map(type_tag_core_to_sdk)
+                    .collect(),
+                arguments: programmable_move_call
+                    .arguments
+                    .into_iter()
+                    .map(Into::into)
+                    .collect(),
+            }),
+            Command2::TransferObjects(objects, address) => Self::TransferObjects(TransferObjects {
+                objects: objects.into_iter().map(Into::into).collect(),
+                address: address.into(),
+            }),
+            Command2::SplitCoins(coin, amounts) => Self::SplitCoins(SplitCoins {
+                coin: coin.into(),
+                amounts: amounts.into_iter().map(Into::into).collect(),
+            }),
+            Command2::MergeCoins(argument, coins_to_merge) => Self::MergeCoins(MergeCoins {
+                coin: argument.into(),
+                coins_to_merge: coins_to_merge.into_iter().map(Into::into).collect(),
+            }),
+            Command2::Publish(modules, dependencies) => Self::Publish(Publish {
+                modules,
+                dependencies: dependencies.into_iter().map(Into::into).collect(),
+            }),
+            Command2::MakeMoveVec(type_tag, elements) => Self::MakeMoveVector(MakeMoveVector {
+                type_: type_tag.map(type_tag_core_to_sdk),
+                elements: elements.into_iter().map(Into::into).collect(),
+            }),
+            Command2::Upgrade(modules, dependencies, package, ticket) => Self::Upgrade(Upgrade {
+                modules,
+                dependencies: dependencies.into_iter().map(Into::into).collect(),
+                package: package.into(),
+                ticket: ticket.into(),
+            }),
+        }
+    }
+}
+
+impl From<Command> for crate::transaction::Command {
+    fn from(value: Command) -> Self {
+        match value {
+            Command::MoveCall(move_call) => {
+                Self::MoveCall(Box::new(crate::transaction::ProgrammableMoveCall {
+                    package: move_call.package.into(),
+                    module: crate::Identifier::new(move_call.module.as_str())
+                        .expect("invalid move call module identifier"),
+                    function: crate::Identifier::new(move_call.function.as_str())
+                        .expect("invalid move call function identifier"),
+                    type_arguments: move_call
+                        .type_arguments
+                        .into_iter()
+                        .map(type_tag_sdk_to_core)
+                        .collect(),
+                    arguments: move_call.arguments.into_iter().map(Into::into).collect(),
+                }))
+            }
+            Command::TransferObjects(transfer_objects) => Self::TransferObjects(
+                transfer_objects
+                    .objects
+                    .into_iter()
+                    .map(Into::into)
+                    .collect(),
+                transfer_objects.address.into(),
+            ),
+            Command::SplitCoins(split_coins) => Self::SplitCoins(
+                split_coins.coin.into(),
+                split_coins.amounts.into_iter().map(Into::into).collect(),
+            ),
+            Command::MergeCoins(merge_coins) => Self::MergeCoins(
+                merge_coins.coin.into(),
+                merge_coins
+                    .coins_to_merge
+                    .into_iter()
+                    .map(Into::into)
+                    .collect(),
+            ),
+            Command::Publish(publish) => Self::Publish(
+                publish.modules,
+                publish.dependencies.into_iter().map(Into::into).collect(),
+            ),
+            Command::MakeMoveVector(make_move_vector) => Self::MakeMoveVec(
+                make_move_vector.type_.map(type_tag_sdk_to_core),
+                make_move_vector
+                    .elements
+                    .into_iter()
+                    .map(Into::into)
+                    .collect(),
+            ),
+            Command::Upgrade(upgrade) => Self::Upgrade(
+                upgrade.modules,
+                upgrade.dependencies.into_iter().map(Into::into).collect(),
+                upgrade.package.into(),
+                upgrade.ticket.into(),
+            ),
+        }
+    }
+}
+
+impl From<crate::transaction::Argument> for Argument {
+    fn from(value: crate::transaction::Argument) -> Self {
+        match value {
+            crate::transaction::Argument::GasCoin => Self::Gas,
+            crate::transaction::Argument::Input(idx) => Self::Input(idx),
+            crate::transaction::Argument::Result(idx) => Self::Result(idx),
+            crate::transaction::Argument::NestedResult(idx1, idx2) => {
+                Self::NestedResult(idx1, idx2)
+            }
+        }
+    }
+}
+
+impl From<Argument> for crate::transaction::Argument {
+    fn from(value: Argument) -> Self {
+        match value {
+            Argument::Gas => Self::GasCoin,
+            Argument::Input(idx) => Self::Input(idx),
+            Argument::Result(idx) => Self::Result(idx),
+            Argument::NestedResult(idx1, idx2) => Self::NestedResult(idx1, idx2),
+        }
+    }
+}
 
 impl From<crate::gas::GasCostSummary> for GasCostSummary {
     fn from(value: crate::gas::GasCostSummary) -> Self {
@@ -98,12 +1632,7 @@ impl From<EndOfEpochData> for crate::messages_checkpoint::EndOfEpochData {
             next_epoch_committee: value
                 .next_epoch_committee
                 .into_iter()
-                .map(|v| {
-                    (
-                        AuthorityPublicKeyBytes::new(v.public_key.into_inner()),
-                        v.stake,
-                    )
-                })
+                .map(|v| (v.public_key.into(), v.stake))
                 .collect(),
             next_epoch_protocol_version: value.next_epoch_protocol_version.into(),
             epoch_commitments: value
@@ -132,18 +1661,6 @@ impl From<CheckpointCommitment> for crate::messages_checkpoint::CheckpointCommit
         Self::ECMHLiveObjectSetDigest(crate::messages_checkpoint::ECMHLiveObjectSetDigest {
             digest: crate::digests::Digest::new(digest.into_inner()),
         })
-    }
-}
-
-impl From<crate::messages_checkpoint::CheckpointContentsDigest> for CheckpointContentsDigest {
-    fn from(value: crate::messages_checkpoint::CheckpointContentsDigest) -> Self {
-        Self::new(value.into_inner())
-    }
-}
-
-impl From<CheckpointContentsDigest> for crate::messages_checkpoint::CheckpointContentsDigest {
-    fn from(value: CheckpointContentsDigest) -> Self {
-        Self::new(value.into_inner())
     }
 }
 
@@ -424,42 +1941,6 @@ pub fn struct_tag_sdk_to_core(value: StructTag) -> move_core_types::language_sto
         module,
         name,
         type_params,
-    }
-}
-
-impl From<crate::messages_checkpoint::CheckpointDigest> for CheckpointDigest {
-    fn from(value: crate::messages_checkpoint::CheckpointDigest) -> Self {
-        Self::new(value.into_inner())
-    }
-}
-
-impl From<CheckpointDigest> for crate::messages_checkpoint::CheckpointDigest {
-    fn from(value: CheckpointDigest) -> Self {
-        Self::new(value.into_inner())
-    }
-}
-
-impl From<crate::digests::TransactionDigest> for TransactionDigest {
-    fn from(value: crate::digests::TransactionDigest) -> Self {
-        Self::new(value.into_inner())
-    }
-}
-
-impl From<TransactionDigest> for crate::digests::TransactionDigest {
-    fn from(value: TransactionDigest) -> Self {
-        Self::new(value.into_inner())
-    }
-}
-
-impl From<crate::digests::ObjectDigest> for ObjectDigest {
-    fn from(value: crate::digests::ObjectDigest) -> Self {
-        Self::new(value.into_inner())
-    }
-}
-
-impl From<ObjectDigest> for crate::digests::ObjectDigest {
-    fn from(value: ObjectDigest) -> Self {
-        Self::new(value.into_inner())
     }
 }
 

--- a/crates/iota-types/src/iota_sdk2_conversions.rs
+++ b/crates/iota-types/src/iota_sdk2_conversions.rs
@@ -528,7 +528,7 @@ impl From<crate::transaction::EndOfEpochTransactionKind> for EndOfEpochTransacti
             }),
             crate::transaction::EndOfEpochTransactionKind::BridgeStateCreate(chain_identifier) => {
                 EndOfEpochTransactionKind::BridgeStateCreate {
-                    chain_id: CheckpointDigest::new(chain_identifier.inner().into()),
+                    chain_id: CheckpointDigest::new(chain_identifier.digest().into()),
                 }
             }
             crate::transaction::EndOfEpochTransactionKind::BridgeCommitteeInit(sequence_number) => {

--- a/crates/iota-types/src/iota_sdk2_conversions.rs
+++ b/crates/iota-types/src/iota_sdk2_conversions.rs
@@ -87,7 +87,7 @@ fn move_struct_tag_to_sdk(st: move_core_types::language_storage::StructTag) -> S
         type_params: st
             .type_params
             .into_iter()
-            .map(|tt| move_type_tag_to_sdk(tt))
+            .map(move_type_tag_to_sdk)
             .collect(),
     }
 }
@@ -221,9 +221,9 @@ impl From<crate::transaction::TransactionData> for Transaction {
             gas_payment: GasPayment {
                 objects: value
                     .gas()
-                    .into_iter()
+                    .iter()
                     .map(|(id, seq, digest)| {
-                        ObjectReference::new((*id).into(), seq.value().into(), (*digest).into())
+                        ObjectReference::new((*id).into(), seq.value(), (*digest).into())
                     })
                     .collect(),
                 owner: Address::new(value.gas_data().owner.to_inner()),
@@ -1017,8 +1017,8 @@ impl From<crate::execution_status::ExecutionFailureStatus> for ExecutionError {
                 current_size,
                 max_size,
             } => Self::EffectsTooLarge {
-                current_size: current_size,
-                max_size: max_size,
+                current_size,
+                max_size,
             },
             ExecutionFailureStatus::PublishUpgradeMissingDependency => {
                 Self::PublishUpgradeMissingDependency
@@ -1211,8 +1211,8 @@ impl From<ExecutionError> for crate::execution_status::ExecutionFailureStatus {
                 current_size,
                 max_size,
             } => Self::EffectsTooLarge {
-                current_size: current_size,
-                max_size: max_size,
+                current_size,
+                max_size,
             },
             ExecutionError::PublishUpgradeMissingDependency => {
                 Self::PublishUpgradeMissingDependency
@@ -1295,12 +1295,12 @@ impl From<crate::execution_status::MoveLocation> for MoveLocation {
     fn from(value: crate::execution_status::MoveLocation) -> Self {
         Self {
             package: ObjectId::new(value.module.address().into_bytes()),
-            module: Identifier::new(value.module.name().as_str()).expect("invalid module mame"),
+            module: Identifier::new(value.module.name().as_str()).expect("invalid module name"),
             function: value.function,
             instruction: value.instruction,
             function_name: value
                 .function_name
-                .map(|name| Identifier::new(name).expect("invalid function mame")),
+                .map(|name| Identifier::new(name).expect("invalid function name")),
         }
     }
 }
@@ -1310,7 +1310,7 @@ impl From<MoveLocation> for crate::execution_status::MoveLocation {
         Self {
             module: ModuleId::new(
                 move_core_types::account_address::AccountAddress::new(value.package.into_inner()),
-                crate::Identifier::new(value.module.as_str()).expect("invalid module mame"),
+                crate::Identifier::new(value.module.as_str()).expect("invalid module name"),
             ),
             function: value.function,
             instruction: value.instruction,

--- a/crates/iota-types/src/messages_checkpoint.rs
+++ b/crates/iota-types/src/messages_checkpoint.rs
@@ -424,13 +424,10 @@ pub struct CheckpointContentsV1 {
 }
 
 impl CheckpointContents {
-    pub fn new_with_digests_and_signatures<T>(
-        contents: T,
+    pub fn new_with_digests_and_signatures(
+        contents: impl IntoIterator<Item = ExecutionDigests>,
         user_signatures: Vec<Vec<GenericSignature>>,
-    ) -> Self
-    where
-        T: IntoIterator<Item = ExecutionDigests>,
-    {
+    ) -> Self {
         let transactions: Vec<_> = contents.into_iter().collect();
         assert_eq!(transactions.len(), user_signatures.len());
         Self::V1(CheckpointContentsV1 {
@@ -440,10 +437,9 @@ impl CheckpointContents {
         })
     }
 
-    pub fn new_with_causally_ordered_execution_data<'a, T>(contents: T) -> Self
-    where
-        T: IntoIterator<Item = &'a VerifiedExecutionData>,
-    {
+    pub fn new_with_causally_ordered_execution_data<'a>(
+        contents: impl IntoIterator<Item = &'a VerifiedExecutionData>,
+    ) -> Self {
         let (transactions, user_signatures): (Vec<_>, Vec<_>) = contents
             .into_iter()
             .map(|data| {
@@ -462,10 +458,9 @@ impl CheckpointContents {
     }
 
     #[cfg(any(test, feature = "test-utils"))]
-    pub fn new_with_digests_only_for_tests<T>(contents: T) -> Self
-    where
-        T: IntoIterator<Item = ExecutionDigests>,
-    {
+    pub fn new_with_digests_only_for_tests(
+        contents: impl IntoIterator<Item = ExecutionDigests>,
+    ) -> Self {
         let transactions: Vec<_> = contents.into_iter().collect();
         let user_signatures = transactions.iter().map(|_| vec![]).collect();
         Self::V1(CheckpointContentsV1 {

--- a/crates/iota-types/src/move_package.rs
+++ b/crates/iota-types/src/move_package.rs
@@ -88,7 +88,7 @@ pub struct UpgradeInfo {
 #[serde_as]
 #[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize, Hash)]
 pub struct MovePackage {
-    id: ObjectID,
+    pub id: ObjectID,
     /// Most move packages are uniquely identified by their ID (i.e. there is
     /// only one version per ID), but the version is still stored because
     /// one package may be an upgrade of another (at a different ID), in
@@ -100,18 +100,18 @@ pub struct MovePackage {
     ///
     /// In all cases, packages are referred to by move calls using just their
     /// ID, and they are always loaded at their latest version.
-    version: SequenceNumber,
+    pub version: SequenceNumber,
     // TODO use session cache
     #[serde_as(as = "BTreeMap<_, Bytes>")]
-    module_map: BTreeMap<String, Vec<u8>>,
+    pub module_map: BTreeMap<String, Vec<u8>>,
 
     /// Maps struct/module to a package version where it was first defined,
     /// stored as a vector for simple serialization and deserialization.
-    type_origin_table: Vec<TypeOrigin>,
+    pub type_origin_table: Vec<TypeOrigin>,
 
     // For each dependency, maps original package ID to the info about the (upgraded) dependency
     // version that this package is using
-    linkage_table: BTreeMap<ObjectID, UpgradeInfo>,
+    pub linkage_table: BTreeMap<ObjectID, UpgradeInfo>,
 }
 
 // NB: do _not_ add `Serialize` or `Deserialize` to this enum. Convert to u8

--- a/crates/iota-types/src/move_package.rs
+++ b/crates/iota-types/src/move_package.rs
@@ -88,7 +88,7 @@ pub struct UpgradeInfo {
 #[serde_as]
 #[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize, Hash)]
 pub struct MovePackage {
-    pub id: ObjectID,
+    pub(crate) id: ObjectID,
     /// Most move packages are uniquely identified by their ID (i.e. there is
     /// only one version per ID), but the version is still stored because
     /// one package may be an upgrade of another (at a different ID), in
@@ -100,18 +100,18 @@ pub struct MovePackage {
     ///
     /// In all cases, packages are referred to by move calls using just their
     /// ID, and they are always loaded at their latest version.
-    pub version: SequenceNumber,
+    pub(crate) version: SequenceNumber,
     // TODO use session cache
     #[serde_as(as = "BTreeMap<_, Bytes>")]
-    pub module_map: BTreeMap<String, Vec<u8>>,
+    pub(crate) module_map: BTreeMap<String, Vec<u8>>,
 
     /// Maps struct/module to a package version where it was first defined,
     /// stored as a vector for simple serialization and deserialization.
-    pub type_origin_table: Vec<TypeOrigin>,
+    pub(crate) type_origin_table: Vec<TypeOrigin>,
 
     // For each dependency, maps original package ID to the info about the (upgraded) dependency
     // version that this package is using
-    pub linkage_table: BTreeMap<ObjectID, UpgradeInfo>,
+    pub(crate) linkage_table: BTreeMap<ObjectID, UpgradeInfo>,
 }
 
 // NB: do _not_ add `Serialize` or `Deserialize` to this enum. Convert to u8

--- a/crates/iota-types/src/object.rs
+++ b/crates/iota-types/src/object.rs
@@ -50,18 +50,18 @@ pub const OBJECT_START_VERSION: SequenceNumber = SequenceNumber::from_u64(1);
 #[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize, Hash)]
 pub struct MoveObject {
     /// The type of this object. Immutable
-    type_: MoveObjectType,
+    pub type_: MoveObjectType,
     /// DEPRECATED this field is no longer used to determine whether a tx can
     /// transfer this object. Instead, it is always calculated from the
     /// objects type when loaded in execution
-    has_public_transfer: bool,
+    pub has_public_transfer: bool,
     /// Number that increases each time a tx takes this object as a mutable
     /// input This is a lamport timestamp, not a sequentially increasing
     /// version
-    version: SequenceNumber,
+    pub version: SequenceNumber,
     /// BCS bytes of a Move struct value
     #[serde_as(as = "Bytes")]
-    contents: Vec<u8>,
+    pub contents: Vec<u8>,
 }
 
 /// Index marking the end of the object's ID + the beginning of its version

--- a/crates/iota-types/src/object.rs
+++ b/crates/iota-types/src/object.rs
@@ -50,18 +50,18 @@ pub const OBJECT_START_VERSION: SequenceNumber = SequenceNumber::from_u64(1);
 #[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize, Hash)]
 pub struct MoveObject {
     /// The type of this object. Immutable
-    pub type_: MoveObjectType,
+    pub(crate) type_: MoveObjectType,
     /// DEPRECATED this field is no longer used to determine whether a tx can
     /// transfer this object. Instead, it is always calculated from the
     /// objects type when loaded in execution
-    pub has_public_transfer: bool,
+    pub(crate) has_public_transfer: bool,
     /// Number that increases each time a tx takes this object as a mutable
     /// input This is a lamport timestamp, not a sequentially increasing
     /// version
-    pub version: SequenceNumber,
+    pub(crate) version: SequenceNumber,
     /// BCS bytes of a Move struct value
     #[serde_as(as = "Bytes")]
-    pub contents: Vec<u8>,
+    pub(crate) contents: Vec<u8>,
 }
 
 /// Index marking the end of the object's ID + the beginning of its version

--- a/iota-execution/latest/iota-verifier/src/lib.rs
+++ b/iota-execution/latest/iota-verifier/src/lib.rs
@@ -23,7 +23,7 @@ fn verification_failure(error: String) -> ExecutionError {
 }
 
 fn to_verification_timeout_error(error: String) -> ExecutionError {
-    ExecutionError::new_with_source(ExecutionErrorKind::IotaMoveVerificationTimedout, error)
+    ExecutionError::new_with_source(ExecutionErrorKind::IotaMoveVerificationTimeout, error)
 }
 
 /// Runs the Move verifier and checks if the error counts as a Move verifier

--- a/iota-execution/latest/iota-verifier/src/verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/verifier.rs
@@ -39,7 +39,7 @@ pub fn iota_verify_module_metered_check_timeout_only(
     if let Err(error) = iota_verify_module_metered(module, fn_info_map, meter) {
         if matches!(
             error.kind(),
-            iota_types::execution_status::ExecutionFailureStatus::IotaMoveVerificationTimedout
+            iota_types::execution_status::ExecutionFailureStatus::IotaMoveVerificationTimeout
         ) {
             return Err(error);
         }
@@ -57,7 +57,7 @@ pub fn iota_verify_module_unmetered(
         debug_assert!(
             !matches!(
                 err.kind(),
-                iota_types::execution_status::ExecutionFailureStatus::IotaMoveVerificationTimedout
+                iota_types::execution_status::ExecutionFailureStatus::IotaMoveVerificationTimeout
             ),
             "Unexpected timeout error in execution"
         );

--- a/iota-execution/v0/iota-verifier/src/lib.rs
+++ b/iota-execution/v0/iota-verifier/src/lib.rs
@@ -23,7 +23,7 @@ fn verification_failure(error: String) -> ExecutionError {
 }
 
 fn to_verification_timeout_error(error: String) -> ExecutionError {
-    ExecutionError::new_with_source(ExecutionErrorKind::IotaMoveVerificationTimedout, error)
+    ExecutionError::new_with_source(ExecutionErrorKind::IotaMoveVerificationTimeout, error)
 }
 
 /// Runs the Move verifier and checks if the error counts as a Move verifier

--- a/iota-execution/v0/iota-verifier/src/verifier.rs
+++ b/iota-execution/v0/iota-verifier/src/verifier.rs
@@ -39,7 +39,7 @@ pub fn iota_verify_module_metered_check_timeout_only(
     if let Err(error) = iota_verify_module_metered(module, fn_info_map, meter) {
         if matches!(
             error.kind(),
-            iota_types::execution_status::ExecutionFailureStatus::IotaMoveVerificationTimedout
+            iota_types::execution_status::ExecutionFailureStatus::IotaMoveVerificationTimeout
         ) {
             return Err(error);
         }
@@ -57,7 +57,7 @@ pub fn iota_verify_module_unmetered(
         debug_assert!(
             !matches!(
                 err.kind(),
-                iota_types::execution_status::ExecutionFailureStatus::IotaMoveVerificationTimedout
+                iota_types::execution_status::ExecutionFailureStatus::IotaMoveVerificationTimeout
             ),
             "Unexpected timeout error in execution"
         );


### PR DESCRIPTION
# Description of change

Adds all remaining concrete `From` impls between core types and `iota-rust-sdk` types.