### PR TITLE
refactor(iota-types): Remove `MOVE_VERIFIER_TAG` and `IOTA_VERIFIER_TAG`

### DIFF
--- a/crates/iota-types/src/metrics.rs
+++ b/crates/iota-types/src/metrics.rs
@@ -90,14 +90,6 @@ pub struct BytecodeVerifierMetrics {
 }
 
 impl BytecodeVerifierMetrics {
-    /// DEPRECATED in latest metered verifier, which only report overall success
-    /// or timeout.
-    pub const MOVE_VERIFIER_TAG: &'static str = "move_verifier";
-
-    /// DEPRECATED in latest metered verifier, which only report overall success
-    /// or timeout.
-    pub const IOTA_VERIFIER_TAG: &'static str = "iota_verifier";
-
     pub const OVERALL_TAG: &'static str = "overall";
     pub const SUCCESS_TAG: &'static str = "success";
     pub const TIMEOUT_TAG: &'static str = "failed";


### PR DESCRIPTION
# Description of change

Remove deprecated and unused `MOVE_VERIFIER_TAG` and `IOTA_VERIFIER_TAG`

## Links to any relevant issues

Part of #2092 

## Type of change

- Enhancement

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have checked that new and existing unit tests pass locally with my changes
