### PR TITLE
refactor(iota-metrics): Remove channel_with_total

### DIFF
--- a/crates/iota-metrics/src/metered_channel.rs
+++ b/crates/iota-metrics/src/metered_channel.rs
@@ -378,28 +378,6 @@ pub fn channel<T>(size: usize, gauge: &IntGauge) -> (Sender<T>, Receiver<T>) {
     )
 }
 
-/// Deprecated: use `monitored_mpsc::channel` instead.
-#[track_caller]
-pub fn channel_with_total<T>(
-    size: usize,
-    gauge: &IntGauge,
-    total_gauge: &IntCounter,
-) -> (Sender<T>, Receiver<T>) {
-    gauge.set(0);
-    let (sender, receiver) = mpsc::channel(size);
-    (
-        Sender {
-            inner: sender,
-            gauge: gauge.clone(),
-        },
-        Receiver {
-            inner: receiver,
-            gauge: gauge.clone(),
-            total: Some(total_gauge.clone()),
-        },
-    )
-}
-
 /// Defines an asynchronous method `with_permit` for working with a permit to
 /// send a message.
 #[async_trait]

--- a/crates/iota-metrics/src/tests/metered_channel_tests.rs
+++ b/crates/iota-metrics/src/tests/metered_channel_tests.rs
@@ -7,10 +7,10 @@ use futures::{
     FutureExt,
     task::{Context, Poll, noop_waker},
 };
-use prometheus::{IntCounter, IntGauge};
+use prometheus::IntGauge;
 use tokio::sync::mpsc::error::TrySendError;
 
-use super::{channel, channel_with_total};
+use super::channel;
 
 #[tokio::test]
 async fn test_send() {
@@ -24,22 +24,6 @@ async fn test_send() {
     let received_item = rx.recv().await.unwrap();
     assert_eq!(received_item, item);
     assert_eq!(counter.get(), 0);
-}
-
-#[tokio::test]
-async fn test_total() {
-    let counter = IntGauge::new("TEST_COUNTER", "test").unwrap();
-    let counter_total = IntCounter::new("TEST_TOTAL", "test_total").unwrap();
-    let (tx, mut rx) = channel_with_total(8, &counter, &counter_total);
-
-    assert_eq!(counter.get(), 0);
-    let item = 42;
-    tx.send(item).await.unwrap();
-    assert_eq!(counter.get(), 1);
-    let received_item = rx.recv().await.unwrap();
-    assert_eq!(received_item, item);
-    assert_eq!(counter.get(), 0);
-    assert_eq!(counter_total.get(), 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Description of change

Remove deprecated and unused `channel_with_total`.

## Links to any relevant issues

Part of #2092

## Type of change

- Enhancement

## Change checklist


- [ ] I have followed the contribution guidelines for this project
- [ ] I have checked that new and existing unit tests pass locally with my changes
