### PR TITLE
refactor!(iota): add init-token-distribution-schedule subcommand

### DIFF
--- a/crates/iota/genesis.md
+++ b/crates/iota/genesis.md
@@ -94,12 +94,10 @@ stake to validators.
 The resulting distribution schedule is amended only if any migration sources are
 passed in the "Build Genesis" step.
 
-The `pre_minted_supply` of the network can also be set.
 
 ```
 $ iota genesis-ceremony init-token-distribution-schedule \
-    --token-allocations-path <path-to-token-allocations-csv-file> \
-    --pre-minted-supply <# of iota coins in nanos>
+    --token-allocations-path <path-to-token-allocations-csv-file>
 $ git add .
 $ git commit -m "initialize token distribution schedule"
 $ git push

--- a/crates/iota/genesis.md
+++ b/crates/iota/genesis.md
@@ -88,7 +88,7 @@ recipient-address,amount-nanos,staked-with-validator,staked-with-timelock-expira
 <validator-2-address>,1500000000000000,<validator-2-address>,
 ```
 
-This is useful for allocating funds for a faucet, for distributing the initial
+This is useful for allocating funds for a faucet, or for distributing the initial
 stake to validators.
 
 The resulting distribution schedule is amended only if any migration sources are

--- a/crates/iota/genesis.md
+++ b/crates/iota/genesis.md
@@ -83,7 +83,7 @@ Set the initial token-distribution schedule through a csv file. E.g.
 
 ```csv
 recipient-address,amount-nanos,staked-with-validator,staked-with-timelock-expiration
-<faucet-address>,1500000000000000,
+<faucet-address>,1500000000000000,,
 <validator-1-address>,1500000000000000,<validator-1-address>,
 <validator-2-address>,1500000000000000,<validator-2-address>,
 ```

--- a/crates/iota/genesis.md
+++ b/crates/iota/genesis.md
@@ -98,7 +98,7 @@ The `pre_minted_supply` of the network can also be set.
 
 ```
 $ iota genesis-ceremony init-token-distribution-schedule \
-    --token_allocations_path <path-to-token-allocations-csv-file> \
+    --token-allocations-path <path-to-token-allocations-csv-file> \
     --pre-minted-supply <# of iota coins in nanos>
 $ git add .
 $ git commit -m "initialize token distribution schedule"

--- a/crates/iota/genesis.md
+++ b/crates/iota/genesis.md
@@ -77,16 +77,31 @@ $ iota genesis-ceremony add-validator \
     --project-url https://www.iota.org
 ```
 
-3. Add token allocation for the faucet
+3. Initialize token-distribution schedule
 
-Add allocation for any faucet that might have been launched.
+Set the initial token-distribution schedule through a csv file. E.g.
+
+```csv
+recipient-address,amount-nanos,staked-with-validator,staked-with-timelock-expiration
+<faucet-address>,1500000000000000,
+<validator-1-address>,1500000000000000,<validator-1-address>,
+<validator-2-address>,1500000000000000,<validator-2-address>,
+```
+
+This is useful for allocating funds for a faucet, for distributing the initial
+stake to validators.
+
+The resulting distribution schedule is amended only if any migration sources are
+passed in the "Build Genesis" step.
+
+The `pre_minted_supply` of the network can also be set.
 
 ```
-$ iota genesis-ceremony add-token-allocation \
-    --recipient-address <IotaAddress> \
-    --amount-nanos <# of iota coins>
+$ iota genesis-ceremony init-token-distribution-schedule \
+    --token_allocations_path <path-to-token-allocations-csv-file> \
+    --pre-minted-supply <# of iota coins in nanos>
 $ git add .
-$ git commit -m "add faucet token allocation"
+$ git commit -m "initialize token distribution schedule"
 $ git push
 ```
 

--- a/crates/iota/genesis.md
+++ b/crates/iota/genesis.md
@@ -94,7 +94,6 @@ stake to validators.
 The resulting distribution schedule is amended only if any migration sources are
 passed in the "Build Genesis" step.
 
-
 ```
 $ iota genesis-ceremony init-token-distribution-schedule \
     --token-allocations-path <path-to-token-allocations-csv-file>

--- a/crates/iota/src/genesis_ceremony.rs
+++ b/crates/iota/src/genesis_ceremony.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::PathBuf;
+use std::{fs::File, path::PathBuf};
 
 use anyhow::Result;
 use camino::Utf8PathBuf;
@@ -10,7 +10,7 @@ use clap::Parser;
 use fastcrypto::encoding::{Encoding, Hex};
 use iota_config::{
     IOTA_GENESIS_FILENAME,
-    genesis::{TokenAllocation, TokenDistributionScheduleBuilder, UnsignedGenesis},
+    genesis::{TokenDistributionScheduleBuilder, UnsignedGenesis},
 };
 use iota_genesis_builder::{
     Builder, GENESIS_BUILDER_PARAMETERS_FILE, SnapshotSource, SnapshotUrl,
@@ -95,12 +95,20 @@ pub enum CeremonyCommand {
         #[clap(long)]
         project_url: Option<String>,
     },
-    /// Add token allocation for the given address.
-    AddTokenAllocation {
-        #[clap(long)]
-        recipient_address: IotaAddress,
-        #[clap(long)]
-        amount_nanos: u64,
+    /// Initialize token distribution schedule.
+    InitTokenDistributionSchedule {
+        #[clap(
+            long,
+            help = "The amount of any pre-minted supply",
+            default_value_t = 0
+        )]
+        pre_minted_supply: u64,
+        #[clap(
+            long,
+            help = "The path to the csv file with the token allocations",
+            name = "token_allocations.csv"
+        )]
+        token_allocations_path: PathBuf,
     },
     /// List the current validators in the Genesis builder.
     ListValidators,
@@ -158,21 +166,21 @@ pub async fn run(cmd: Ceremony) -> Result<()> {
             );
         }
 
-        CeremonyCommand::AddTokenAllocation {
-            recipient_address,
-            amount_nanos,
+        CeremonyCommand::InitTokenDistributionSchedule {
+            pre_minted_supply,
+            token_allocations_path,
         } => {
             let mut builder = Builder::load(&dir).await?;
-            let token_allocation = TokenAllocation {
-                recipient_address,
-                amount_nanos,
-                staked_with_validator: None,
-                staked_with_timelock_expiration: None,
-            };
             let mut schedule_builder = TokenDistributionScheduleBuilder::new();
-            schedule_builder.add_allocation(token_allocation);
-            builder = builder.with_token_distribution_schedule(schedule_builder.build());
+            schedule_builder.set_pre_minted_supply(pre_minted_supply);
 
+            let token_allocations_csv = File::open(token_allocations_path)?;
+            let mut reader = csv::Reader::from_reader(token_allocations_csv);
+            for allocation in reader.deserialize() {
+                schedule_builder.add_allocation(allocation?);
+            }
+
+            builder = builder.with_token_distribution_schedule(schedule_builder.build());
             builder.save(dir)?;
         }
 

--- a/crates/iota/src/genesis_ceremony.rs
+++ b/crates/iota/src/genesis_ceremony.rs
@@ -99,12 +99,6 @@ pub enum CeremonyCommand {
     InitTokenDistributionSchedule {
         #[clap(
             long,
-            help = "The amount of any pre-minted supply",
-            default_value_t = 0
-        )]
-        pre_minted_supply: u64,
-        #[clap(
-            long,
             help = "The path to the csv file with the token allocations",
             name = "token_allocations.csv"
         )]
@@ -167,12 +161,10 @@ pub async fn run(cmd: Ceremony) -> Result<()> {
         }
 
         CeremonyCommand::InitTokenDistributionSchedule {
-            pre_minted_supply,
             token_allocations_path,
         } => {
             let mut builder = Builder::load(&dir).await?;
             let mut schedule_builder = TokenDistributionScheduleBuilder::new();
-            schedule_builder.set_pre_minted_supply(pre_minted_supply);
 
             let token_allocations_csv = File::open(token_allocations_path)?;
             let mut reader = csv::Reader::from_reader(token_allocations_csv);

--- a/crates/iota/src/genesis_ceremony.rs
+++ b/crates/iota/src/genesis_ceremony.rs
@@ -113,12 +113,7 @@ pub enum CeremonyCommand {
         )]
         #[arg(num_args(0..))]
         local_migration_snapshots: Vec<PathBuf>,
-        #[clap(
-            long,
-            name = "iota|<full-url>",
-            help = "Remote migration snapshots.",
-            default_values_t = vec![SnapshotUrl::Iota],
-        )]
+        #[clap(long, name = "iota|<full-url>", help = "Remote migration snapshots.")]
         #[arg(num_args(0..))]
         remote_migration_snapshots: Vec<SnapshotUrl>,
     },

--- a/docs/content/references/cli/ceremony.mdx
+++ b/docs/content/references/cli/ceremony.mdx
@@ -149,9 +149,6 @@ The `pre_minted_supply` of the network can also be set.
 $ iota genesis-ceremony init-token-distribution-schedule \
     --token-allocations-path <path-to-token-allocations-csv-file> \
     --pre-minted-supply <# of iota coins in nanos>
-$ git add .
-$ git commit -m "initialize token distribution schedule"
-$ git push
 ```
 
 ### Validate the Genesis State

--- a/docs/content/references/cli/ceremony.mdx
+++ b/docs/content/references/cli/ceremony.mdx
@@ -147,7 +147,7 @@ The `pre_minted_supply` of the network can also be set.
 
 ```shell
 $ iota genesis-ceremony init-token-distribution-schedule \
-    --token_allocations_path <path-to-token-allocations-csv-file> \
+    --token-allocations-path <path-to-token-allocations-csv-file> \
     --pre-minted-supply <# of iota coins in nanos>
 $ git add .
 $ git commit -m "initialize token distribution schedule"

--- a/docs/content/references/cli/ceremony.mdx
+++ b/docs/content/references/cli/ceremony.mdx
@@ -143,12 +143,9 @@ stake to validators.
 The resulting distribution schedule is amended only if any migration sources are
 passed in the "Build the Unsigned Checkpoint" step.
 
-The `pre_minted_supply` of the network can also be set.
-
 ```shell
 $ iota genesis-ceremony init-token-distribution-schedule \
-    --token-allocations-path <path-to-token-allocations-csv-file> \
-    --pre-minted-supply <# of iota coins in nanos>
+    --token-allocations-path <path-to-token-allocations-csv-file>
 ```
 
 ### Validate the Genesis State

--- a/docs/content/references/cli/ceremony.mdx
+++ b/docs/content/references/cli/ceremony.mdx
@@ -132,7 +132,7 @@ Set the initial token-distribution schedule through a csv file. E.g.
 
 ```csv
 recipient-address,amount-nanos,staked-with-validator,staked-with-timelock-expiration
-<faucet-address>,1500000000000000,
+<faucet-address>,1500000000000000,,
 <validator-1-address>,1500000000000000,<validator-1-address>,
 <validator-2-address>,1500000000000000,<validator-2-address>,
 ```

--- a/docs/content/references/cli/ceremony.mdx
+++ b/docs/content/references/cli/ceremony.mdx
@@ -3,7 +3,7 @@ title: IOTA Genesis Ceremony CLI
 description: The IOTA Genesis Ceremony CLI provides commands for building a Genesis blob file.
 ---
 
-The IOTA CLI `genesis-ceremony` command allows the orchestration of an IOTA Genesis Ceremony, 
+The IOTA CLI `genesis-ceremony` command allows the orchestration of an IOTA Genesis Ceremony,
 where multiple remote validators can sign a genesis blob. Each step persists in a file structure
 that can be shared (for instance, via GitHub) with the validators.
 
@@ -41,7 +41,7 @@ The following example demonstrates how to build a genesis blob.
 
 ### Initialize the Genesis Builder
 
-This command creates a structure in the file system to persist the genesis builder. 
+This command creates a structure in the file system to persist the genesis builder.
 Afterward, the below commands can be used to set additional configurations.
 
 ```shell
@@ -126,15 +126,32 @@ validator1     0xba55e3ce221bb7edfbbef4d59b68893f5550b6302a9456b738ad8cf06919be0
 
 </details>
 
-### Add Token Allocation
+### Initialize token-distribution schedule
 
-This command allocates tokens to a given address for the genesis transaction, 
-and can be used to provide tokens to the faucet address.
+Set the initial token-distribution schedule through a csv file. E.g.
+
+```csv
+recipient-address,amount-nanos,staked-with-validator,staked-with-timelock-expiration
+<faucet-address>,1500000000000000,
+<validator-1-address>,1500000000000000,<validator-1-address>,
+<validator-2-address>,1500000000000000,<validator-2-address>,
+```
+
+This is useful for allocating funds for a faucet, or for distributing the initial
+stake to validators.
+
+The resulting distribution schedule is amended only if any migration sources are
+passed in the "Build the Unsigned Checkpoint" step.
+
+The `pre_minted_supply` of the network can also be set.
 
 ```shell
-iota genesis-ceremony add-token-allocation \
-    --recipient-address 0x923f43e0d325cd298c28a148858bb755921cfb032deeb0d2fb7772d6b4b168e0 \
-    --amount-nanos 1500000000000000
+$ iota genesis-ceremony init-token-distribution-schedule \
+    --token_allocations_path <path-to-token-allocations-csv-file> \
+    --pre-minted-supply <# of iota coins in nanos>
+$ git add .
+$ git commit -m "initialize token distribution schedule"
+$ git push
 ```
 
 ### Validate the Genesis State
@@ -153,7 +170,7 @@ iota genesis-ceremony build-unsigned-checkpoint
 
 ### Examine the Genesis Checkpoint
 
-This command opens the Genesis Inspector, a responsive command-line tool which allows viewing various 
+This command opens the Genesis Inspector, a responsive command-line tool which allows viewing various
 attributes of the current built checkpoint.
 
 ```shell

--- a/docs/content/references/cli/ceremony.mdx
+++ b/docs/content/references/cli/ceremony.mdx
@@ -126,9 +126,9 @@ validator1     0xba55e3ce221bb7edfbbef4d59b68893f5550b6302a9456b738ad8cf06919be0
 
 </details>
 
-### Initialize token-distribution schedule
+### Initialize the Token Distribution Schedule
 
-Set the initial token-distribution schedule through a csv file. E.g.
+Set the initial token distribution schedule through a `.csv` file:
 
 ```csv
 recipient-address,amount-nanos,staked-with-validator,staked-with-timelock-expiration
@@ -141,7 +141,7 @@ This is useful for allocating funds for a faucet, or for distributing the initia
 stake to validators.
 
 The resulting distribution schedule is amended only if any migration sources are
-passed in the "Build the Unsigned Checkpoint" step.
+passed in the [Build the Unsigned Checkpoint](#build-the-unsigned-checkpoint) step.
 
 ```shell
 $ iota genesis-ceremony init-token-distribution-schedule \


### PR DESCRIPTION
# Description of change

This patch replaces the `add-token-allocation` subcommand of `iota genesis-ceremony` with the more generic `init-token-distribution-schedule`.

It also makes migration sources optional in the ceremony, and updates the `genesis.md` file.

## Links to any relevant issues

Resolves #3810 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

`$ cargo test -p iota ceremony`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
