### PR TITLE
chore(CI): Update generated test data

### DIFF
--- a/crates/iota-core/tests/staged/iota.yaml
+++ b/crates/iota-core/tests/staged/iota.yaml
@@ -453,7 +453,7 @@ ExecutionFailureStatus:
     29:
       CertificateDenied: UNIT
     30:
-      IotaMoveVerificationTimedout: UNIT
+      IotaMoveVerificationTimeout: UNIT
     31:
       SharedObjectOperationNotAllowed: UNIT
     32:

--- a/crates/iota-types/tests/staged/exec_failure_status.yaml
+++ b/crates/iota-types/tests/staged/exec_failure_status.yaml
@@ -29,7 +29,7 @@
 27: PackageUpgradeError
 28: WrittenObjectsTooLarge
 29: CertificateDenied
-30: IotaMoveVerificationTimedout
+30: IotaMoveVerificationTimeout
 31: SharedObjectOperationNotAllowed
 32: InputObjectDeleted
 33: ExecutionCancelledDueToSharedObjectCongestion


### PR DESCRIPTION
# Description of change

Updates tests data after renaming `IotaMoveVerificationTimedout` -> `IotaMoveVerificationTimeout` in #3803