### PR TITLE
iota-indexer: Add staking tests for TransactionBuilder API

### DIFF
--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -9,10 +9,7 @@ use std::{
 };
 
 use diesel::PgConnection;
-use iota_config::{
-    local_ip_utils::{get_available_port, new_local_tcp_socket_for_testing},
-    node::RunWithRange,
-};
+use iota_config::local_ip_utils::{get_available_port, new_local_tcp_socket_for_testing};
 use iota_indexer::{
     IndexerConfig,
     errors::IndexerError,
@@ -26,7 +23,6 @@ use iota_metrics::init_metrics;
 use iota_types::{
     base_types::{ObjectID, SequenceNumber},
     digests::TransactionDigest,
-    object::Object,
 };
 use jsonrpsee::{
     http_client::{HttpClient, HttpClientBuilder},
@@ -58,12 +54,9 @@ impl ApiTestSetup {
         GLOBAL_API_TEST_SETUP.get_or_init(|| {
             let runtime = tokio::runtime::Runtime::new().unwrap();
 
-            let (cluster, store, client) =
-                runtime.block_on(start_test_cluster_with_read_write_indexer(
-                    None,
-                    Some("shared_test_indexer_db"),
-                    None,
-                ));
+            let (cluster, store, client) = runtime.block_on(
+                start_test_cluster_with_read_write_indexer(Some("shared_test_indexer_db"), None),
+            );
 
             Self {
                 runtime,
@@ -117,23 +110,15 @@ impl SimulacrumTestSetup {
 /// Start a [`TestCluster`][`test_cluster::TestCluster`] with a `Read` &
 /// `Write` indexer
 pub async fn start_test_cluster_with_read_write_indexer(
-    stop_cluster_after_checkpoint_seq: Option<u64>,
     database_name: Option<&str>,
-    objects: Option<Vec<Object>>,
+    cluster_builder_modifier: Option<Box<dyn FnOnce(TestClusterBuilder) -> TestClusterBuilder>>,
 ) -> (TestCluster, PgIndexerStore<PgConnection>, HttpClient) {
     let temp = tempdir().unwrap().into_path();
     let mut builder = TestClusterBuilder::new().with_data_ingestion_dir(temp.clone());
 
-    // run the cluster until the declared checkpoint sequence number
-    if let Some(stop_cluster_after_checkpoint_seq) = stop_cluster_after_checkpoint_seq {
-        builder = builder.with_fullnode_run_with_range(Some(RunWithRange::Checkpoint(
-            stop_cluster_after_checkpoint_seq,
-        )));
+    if let Some(cluster_builder_modifier) = cluster_builder_modifier {
+        builder = cluster_builder_modifier(builder);
     };
-
-    if let Some(objects) = objects {
-        builder = builder.with_objects(objects);
-    }
 
     let cluster = builder.build().await;
 

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -111,13 +111,13 @@ impl SimulacrumTestSetup {
 /// `Write` indexer
 pub async fn start_test_cluster_with_read_write_indexer(
     database_name: Option<&str>,
-    cluster_builder_modifier: Option<Box<dyn FnOnce(TestClusterBuilder) -> TestClusterBuilder>>,
+    builder_modifier: Option<Box<dyn FnOnce(TestClusterBuilder) -> TestClusterBuilder>>,
 ) -> (TestCluster, PgIndexerStore<PgConnection>, HttpClient) {
     let temp = tempdir().unwrap().into_path();
     let mut builder = TestClusterBuilder::new().with_data_ingestion_dir(temp.clone());
 
-    if let Some(cluster_builder_modifier) = cluster_builder_modifier {
-        builder = cluster_builder_modifier(builder);
+    if let Some(builder_modifier) = builder_modifier {
+        builder = builder_modifier(builder);
     };
 
     let cluster = builder.build().await;

--- a/crates/iota-indexer/tests/rpc-tests/governance_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/governance_api.rs
@@ -30,7 +30,7 @@ fn test_staking() {
 
     runtime.block_on(async move {
         let (cluster, store, client) =
-            &start_test_cluster_with_read_write_indexer(None, Some("test_staking"), None).await;
+            &start_test_cluster_with_read_write_indexer(Some("test_staking"), None).await;
 
         indexer_wait_for_checkpoint(store, 1).await;
 
@@ -107,7 +107,7 @@ fn test_unstaking() {
 
     runtime.block_on(async move {
         let (cluster, store, client) =
-            &start_test_cluster_with_read_write_indexer(None, Some("test_unstaking"), None).await;
+            &start_test_cluster_with_read_write_indexer(Some("test_unstaking"), None).await;
 
         indexer_wait_for_checkpoint(store, 1).await;
 
@@ -210,12 +210,9 @@ fn test_timelocked_staking() {
     let ApiTestSetup { runtime, .. } = ApiTestSetup::get_or_init();
 
     runtime.block_on(async move {
-        let (cluster, store, client) = &start_test_cluster_with_read_write_indexer(
-            None,
-            Some("test_timelocked_staking"),
-            None,
-        )
-        .await;
+        let (cluster, store, client) =
+            &start_test_cluster_with_read_write_indexer(Some("test_timelocked_staking"), None)
+                .await;
 
         indexer_wait_for_checkpoint(store, 1).await;
 
@@ -322,12 +319,9 @@ fn test_timelocked_unstaking() {
     let ApiTestSetup { runtime, .. } = ApiTestSetup::get_or_init();
 
     runtime.block_on(async move {
-        let (cluster, store, client) = &start_test_cluster_with_read_write_indexer(
-            None,
-            Some("test_timelocked_unstaking"),
-            None,
-        )
-        .await;
+        let (cluster, store, client) =
+            &start_test_cluster_with_read_write_indexer(Some("test_timelocked_unstaking"), None)
+                .await;
 
         indexer_wait_for_checkpoint(store, 1).await;
 

--- a/crates/iota-indexer/tests/rpc-tests/transaction_builder.rs
+++ b/crates/iota-indexer/tests/rpc-tests/transaction_builder.rs
@@ -6,23 +6,37 @@ use std::str::FromStr;
 use diesel::PgConnection;
 use iota_indexer::store::PgIndexerStore;
 use iota_json::{call_args, type_args};
-use iota_json_rpc_api::{CoinReadApiClient, ReadApiClient, TransactionBuilderClient};
-use iota_json_rpc_types::{
-    IotaObjectDataOptions, MoveCallParams, RPCTransactionRequestParams, TransactionBlockBytes,
-    TransferObjectParams,
+use iota_json_rpc_api::{
+    CoinReadApiClient, GovernanceReadApiClient, IndexerApiClient, ReadApiClient,
+    TransactionBuilderClient,
 };
+use iota_json_rpc_types::{
+    IotaObjectDataOptions, IotaObjectResponseQuery, MoveCallParams, ObjectsPage,
+    RPCTransactionRequestParams, StakeStatus, TransactionBlockBytes, TransferObjectParams,
+};
+use iota_protocol_config::ProtocolConfig;
+use iota_swarm_config::genesis_config::AccountConfig;
 use iota_types::{
     IOTA_FRAMEWORK_ADDRESS,
-    base_types::{IotaAddress, ObjectID},
+    base_types::{IotaAddress, MoveObjectType, ObjectID},
     crypto::{AccountKeyPair, get_key_pair},
+    digests::TransactionDigest,
     gas_coin::GAS,
-    object::Owner,
+    id::UID,
+    object::{Data, MoveObject, OBJECT_START_VERSION, ObjectInner, Owner},
+    timelock::{
+        label::label_struct_tag_to_string, stardust_upgrade_label::stardust_upgrade_label_type,
+        timelock::TimeLock,
+    },
     utils::to_sender_signed_transaction,
 };
 use jsonrpsee::http_client::HttpClient;
 use test_cluster::TestCluster;
 
-use crate::common::{ApiTestSetup, indexer_wait_for_object, indexer_wait_for_transaction};
+use crate::common::{
+    ApiTestSetup, indexer_wait_for_checkpoint, indexer_wait_for_object,
+    indexer_wait_for_transaction, start_test_cluster_with_read_write_indexer,
+};
 const FUNDED_BALANCE_PER_COIN: u64 = 10_000_000_000;
 
 #[test]
@@ -432,6 +446,203 @@ fn batch_transaction() {
         .unwrap();
 }
 
+#[test]
+fn request_add_stake() {
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        cluster,
+    } = ApiTestSetup::get_or_init();
+
+    runtime
+        .block_on(async move {
+            let (address, keypair): (_, AccountKeyPair) = get_key_pair();
+            let coins = create_coins_and_wait_for_indexer(cluster, client, address, 4).await;
+            let gas = coins[3];
+            let coins_to_stake = coins[..3].to_vec();
+            let validator = get_validator(client).await;
+            let stake_amount = FUNDED_BALANCE_PER_COIN * 3 - 10_000;
+
+            let tx_bytes: TransactionBlockBytes = client
+                .request_add_stake(
+                    address,
+                    coins_to_stake,
+                    Some(stake_amount.into()),
+                    validator,
+                    Some(gas),
+                    100_000_000.into(),
+                )
+                .await
+                .unwrap();
+            execute_tx_and_wait_for_indexer(client, cluster, store, tx_bytes, &keypair).await;
+
+            let staked_iota = client.get_stakes(address).await.unwrap();
+
+            assert_eq!(1, staked_iota.len());
+            let staked_iota = &staked_iota[0];
+            assert_eq!(validator, staked_iota.validator_address);
+
+            assert_eq!(1, staked_iota.stakes.len());
+            let stake = &staked_iota.stakes[0];
+            assert!(matches!(stake.status, StakeStatus::Pending));
+            assert_eq!(stake.principal, stake_amount);
+
+            Ok::<(), anyhow::Error>(())
+        })
+        .unwrap();
+}
+
+#[test]
+fn request_withdraw_stake() {
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        cluster,
+    } = ApiTestSetup::get_or_init();
+
+    runtime
+        .block_on(async move {
+            let (address, keypair): (_, AccountKeyPair) = get_key_pair();
+            let coins = create_coins_and_wait_for_indexer(cluster, client, address, 4).await;
+            let gas = coins[3];
+            let coins_to_stake = coins[..3].to_vec();
+            let validator = get_validator(client).await;
+            let stake_amount = FUNDED_BALANCE_PER_COIN * 3 - 10_000;
+
+            let tx_bytes: TransactionBlockBytes = client
+                .request_add_stake(
+                    address,
+                    coins_to_stake,
+                    Some(stake_amount.into()),
+                    validator,
+                    Some(gas),
+                    100_000_000.into(),
+                )
+                .await
+                .unwrap();
+            execute_tx_and_wait_for_indexer(client, cluster, store, tx_bytes, &keypair).await;
+
+            let staked_iota = client.get_stakes(address).await.unwrap();
+            let stake = &staked_iota[0].stakes[0];
+            assert!(matches!(stake.status, StakeStatus::Pending));
+
+            let tx_bytes: TransactionBlockBytes = client
+                .request_withdraw_stake(
+                    address,
+                    stake.staked_iota_id,
+                    Some(gas),
+                    100_000_000.into(),
+                )
+                .await
+                .unwrap();
+            execute_tx_and_wait_for_indexer(client, cluster, store, tx_bytes, &keypair).await;
+
+            let staked_iota = client.get_stakes(address).await.unwrap();
+            assert!(staked_iota.is_empty());
+
+            Ok::<(), anyhow::Error>(())
+        })
+        .unwrap();
+}
+
+#[test]
+fn request_add_timelocked_stake() {
+    let ApiTestSetup { runtime, .. } = ApiTestSetup::get_or_init();
+
+    runtime
+        .block_on(async move {
+            let (address, keypair): (_, AccountKeyPair) = get_key_pair();
+            let (cluster, store, client, timelocked_balance) = create_cluster_with_timelocked_iota(
+                address,
+                "transaction_builder_request_add_timelocked_stake",
+            )
+            .await;
+            indexer_wait_for_checkpoint(&store, 1).await;
+
+            let coin = get_gas_object_id(&client, address).await;
+            let validator = get_validator(&client).await;
+
+            let tx_bytes: TransactionBlockBytes = client
+                .request_add_timelocked_stake(
+                    address,
+                    timelocked_balance,
+                    validator,
+                    coin,
+                    100_000_000.into(),
+                )
+                .await
+                .unwrap();
+            execute_tx_and_wait_for_indexer(&client, &cluster, &store, tx_bytes, &keypair).await;
+
+            let staked_iota = client.get_timelocked_stakes(address).await.unwrap();
+
+            assert_eq!(1, staked_iota.len());
+            let staked_iota = &staked_iota[0];
+            assert_eq!(validator, staked_iota.validator_address);
+
+            assert_eq!(1, staked_iota.stakes.len());
+            let stake = &staked_iota.stakes[0];
+            assert!(matches!(stake.status, StakeStatus::Pending));
+
+            Ok::<(), anyhow::Error>(())
+        })
+        .unwrap();
+}
+
+#[test]
+fn request_withdraw_timelocked_stake() {
+    let ApiTestSetup { runtime, .. } = ApiTestSetup::get_or_init();
+
+    runtime
+        .block_on(async move {
+            let (address, keypair): (_, AccountKeyPair) = get_key_pair();
+            let (cluster, store, client, timelocked_balance) = create_cluster_with_timelocked_iota(
+                address,
+                "transaction_builder_request_withdraw_timelocked_stake",
+            )
+            .await;
+            indexer_wait_for_checkpoint(&store, 1).await;
+
+            let coin = get_gas_object_id(&client, address).await;
+            let validator = get_validator(&client).await;
+
+            let tx_bytes: TransactionBlockBytes = client
+                .request_add_timelocked_stake(
+                    address,
+                    timelocked_balance,
+                    validator,
+                    coin,
+                    100_000_000.into(),
+                )
+                .await
+                .unwrap();
+            execute_tx_and_wait_for_indexer(&client, &cluster, &store, tx_bytes, &keypair).await;
+
+            let staked_iota = client.get_timelocked_stakes(address).await.unwrap();
+            let stake = &staked_iota[0].stakes[0];
+            assert!(matches!(stake.status, StakeStatus::Pending));
+
+            let tx_bytes: TransactionBlockBytes = client
+                .request_withdraw_timelocked_stake(
+                    address,
+                    stake.timelocked_staked_iota_id,
+                    coin,
+                    100_000_000.into(),
+                )
+                .await
+                .unwrap();
+            execute_tx_and_wait_for_indexer(&client, &cluster, &store, tx_bytes, &keypair).await;
+
+            let staked_iota = client.get_timelocked_stakes(address).await.unwrap();
+            assert!(staked_iota.is_empty());
+
+            Ok::<(), anyhow::Error>(())
+        })
+        .unwrap();
+}
+
 async fn execute_tx_and_wait_for_indexer(
     indexer_client: &HttpClient,
     cluster: &TestCluster,
@@ -474,4 +685,101 @@ async fn create_coins_and_wait_for_indexer(
         coins.push(coin.0);
     }
     coins
+}
+
+async fn create_cluster_with_timelocked_iota(
+    address: IotaAddress,
+    indexer_db_name: &str,
+) -> (
+    TestCluster,
+    PgIndexerStore<PgConnection>,
+    HttpClient,
+    ObjectID,
+) {
+    let principal = 100_000_000_000;
+    let expiration_timestamp_ms = u64::MAX;
+    let label = Option::Some(label_struct_tag_to_string(stardust_upgrade_label_type()));
+
+    let timelock_iota = unsafe {
+        MoveObject::new_from_execution(
+            MoveObjectType::timelocked_iota_balance(),
+            false,
+            OBJECT_START_VERSION,
+            TimeLock::<iota_types::balance::Balance>::new(
+                UID::new(ObjectID::random()),
+                iota_types::balance::Balance::new(principal),
+                expiration_timestamp_ms,
+                label.clone(),
+            )
+            .to_bcs_bytes(),
+            &ProtocolConfig::get_for_min_version(),
+        )
+        .unwrap()
+    };
+    let timelock_iota = ObjectInner {
+        owner: Owner::AddressOwner(address),
+        data: Data::Move(timelock_iota),
+        previous_transaction: TransactionDigest::genesis_marker(),
+        storage_rebate: 0,
+    };
+
+    let (cluster, store, client) = start_test_cluster_with_read_write_indexer(
+        Some(indexer_db_name),
+        Some(Box::new(move |builder| {
+            builder
+                .with_accounts(
+                    [AccountConfig {
+                        address: Some(address),
+                        gas_amounts: [1_000_000_000].into(),
+                    }]
+                    .into(),
+                )
+                .with_objects([timelock_iota.into()])
+        })),
+    )
+    .await;
+
+    let fullnode_client = cluster.rpc_client();
+
+    let objects: ObjectsPage = fullnode_client
+        .get_owned_objects(
+            address,
+            Some(IotaObjectResponseQuery::new_with_options(
+                IotaObjectDataOptions::full_content(),
+            )),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(2, objects.data.len());
+
+    let timelocked_balance = objects
+        .data
+        .into_iter()
+        .find(|o| !o.data.as_ref().unwrap().is_gas_coin())
+        .unwrap()
+        .object()
+        .unwrap()
+        .object_id;
+
+    (cluster, store, client, timelocked_balance)
+}
+
+async fn get_validator(client: &HttpClient) -> IotaAddress {
+    client
+        .get_latest_iota_system_state()
+        .await
+        .unwrap()
+        .active_validators[0]
+        .iota_address
+}
+
+async fn get_gas_object_id(client: &HttpClient, address: IotaAddress) -> ObjectID {
+    client
+        .get_coins(address, None, None, None)
+        .await
+        .unwrap()
+        .data[0]
+        .coin_object_id
 }


### PR DESCRIPTION
# Description of change

Add staking tests for TransactionBuilder API

## Links to any relevant issues

Fixes #3811

## Type of change

Tests

## How the change has been tested

`cargo test -j2 --profile simulator --features shared_test_runtime --test rpc-tests transaction_builder`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
