### PR TITLE
refactor(iota-core): Remove incorrect `AuthorityState ::state` comment

### DIFF
--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -142,9 +142,6 @@ pub enum StopReason {
 
 pub struct CheckpointExecutor {
     mailbox: broadcast::Receiver<VerifiedCheckpoint>,
-    // TODO: AuthorityState is only needed because we have to call
-    // deprecated_insert_finalized_transactions once that code is fully deprecated we can
-    // remove this
     state: Arc<AuthorityState>,
     checkpoint_store: Arc<CheckpointStore>,
     object_cache_reader: Arc<dyn ObjectCacheRead>,


### PR DESCRIPTION
# Description of change

Remove the incorrect comment.

The `TODO` comment to remove the `AuthorityState ::state` was written in this Sui commit [d6a9015](https://github.com/MystenLabs/sui/commit/d6a9015f16050ad1a00906f0c4914dc9d4347384) at Jan 27, 2024.
However, the `AuthorityState ::state` is then used in `object_cache_reader` and `transaction_cache_reader`  in the later Sui Commit [6243a15](https://github.com/MystenLabs/sui/commit/6243a15f0d580cb28621344c551a1588040c6209) at May 17, 2024. In addition, the `transaction_manager` which is cloned from `AuthorityState ::state` is also used to call the `enqueue_with_expected_effects_digest` method.

Thus the `AuthorityState::state` should not be removed, and the incorrect TODO comment should be removed.

## Links to any relevant issues

Part of https://github.com/iotaledger/iota/issues/2092

## Type of change

- Enhancement

## How the change has been tested

Ran the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
