### PR TITLE
Restores the update of the `latest_fullnode_checkpoint_sequence_number` indexer metric.

### DIFF
--- a/crates/iota-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/iota-indexer/src/handlers/checkpoint_handler.rs
@@ -120,6 +120,9 @@ where
     T: R2D2Connection + 'static,
 {
     async fn process_checkpoint(&self, checkpoint: CheckpointData) -> anyhow::Result<()> {
+        self.metrics
+            .latest_fullnode_checkpoint_sequence_number
+            .set(checkpoint.checkpoint_summary.sequence_number as i64);
         let time_now_ms = chrono::Utc::now().timestamp_millis();
         let cp_download_lag = time_now_ms - checkpoint.checkpoint_summary.timestamp_ms as i64;
         info!(


### PR DESCRIPTION
# Description of change

Restores the update of the `latest_fullnode_checkpoint_sequence_number` indexer metric.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/3605

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`cargo build`

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
