### PR TITLE
fix(tooling-sdk): Revert making `@iota/create-dapp` public on #2844

### DIFF
--- a/sdk/create-dapp/package.json
+++ b/sdk/create-dapp/package.json
@@ -30,9 +30,6 @@
     "bugs": {
         "url": "https://github.com/iotaledger/iota/issues/new"
     },
-    "publishConfig": {
-        "access": "public"
-    },
     "devDependencies": {
         "@iota/build-scripts": "workspace:*",
         "typescript": "^5.5.3"


### PR DESCRIPTION
Reverts https://github.com/iotaledger/iota/pull/2844#discussion_r1827786113
Closes https://github.com/iotaledger/iota/issues/3869