### PR TITLE
chore(iota-sdk): Fix doc error

### DIFF
--- a/crates/iota-sdk/src/apis/quorum_driver.rs
+++ b/crates/iota-sdk/src/apis/quorum_driver.rs
@@ -38,7 +38,7 @@ impl QuorumDriverApi {
     ///
     /// When `WaitForLocalExecution` is used, but the returned
     /// `confirmed_local_execution` is false, the client will wait for
-    /// two seconds before returning [Error::FailToConfirmTransactionStatus].
+    /// some time before returning [Error::FailToConfirmTransactionStatus].
     pub async fn execute_transaction_block(
         &self,
         tx: Transaction,

--- a/crates/iota-sdk/src/apis/quorum_driver.rs
+++ b/crates/iota-sdk/src/apis/quorum_driver.rs
@@ -37,9 +37,8 @@ impl QuorumDriverApi {
     /// [`ExecuteTransactionRequestType::WaitForLocalExecution`].
     ///
     /// When `WaitForLocalExecution` is used, but the returned
-    /// `confirmed_local_execution` is false, the client will wait a
-    /// duration defined by [WAIT_FOR_LOCAL_EXECUTION_INTERVAL]
-    /// before returning [Error::FailToConfirmTransactionStatus].
+    /// `confirmed_local_execution` is false, the client will wait for
+    /// two seconds before returning [Error::FailToConfirmTransactionStatus].
     pub async fn execute_transaction_block(
         &self,
         tx: Transaction,


### PR DESCRIPTION
# Description of change

Fixes an error in `cargo doc` because of a reference to a private constant.