### PR TITLE
fix!(iota): remove default_value from IndexerFeatureArgs::with_indexer

### DIFF
--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -87,7 +87,6 @@ pub struct IndexerFeatureArgs {
     /// `--with-indexer=0.0.0.0:9124` The indexer will be started in writer
     /// mode and reader mode.
     #[clap(long,
-            default_value = "0.0.0.0:9124",
             default_missing_value = "0.0.0.0:9124",
             num_args = 0..=1,
             require_equals = true,


### PR DESCRIPTION
# Description of change

Remove default_value from IndexerFeatureArgs::with_indexer as it makes the indexer non optional, which then makes these checks here obsolete https://github.com/iotaledger/iota/blob/f3d9af456ede14496e04e6d97b4d2bbf4688c192/crates/iota/src/iota_commands.rs#L722 
https://github.com/iotaledger/iota/blob/f3d9af456ede14496e04e6d97b4d2bbf4688c192/crates/iota/src/iota_commands.rs#L750
and always tries to establish a connection to a postgres db and never starts a faucet if failing to do so

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/3212

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running `cargo run --features=indexer start --with-faucet --force-regenesis` without a postgres db and then `iota client faucet --url http://127.0.0.1:9123/gas`
