### PR TITLE
fix: Only add a faucet account to the`TestCluster` if there was no `NetworkConfig` provided

### DIFF
--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -137,7 +137,7 @@ pub struct TestCluster {
     pub fullnode_handle: FullNodeHandle,
     pub bridge_authority_keys: Option<Vec<BridgeAuthorityKeyPair>>,
     pub bridge_server_ports: Option<Vec<u16>>,
-    faucet: Faucet,
+    faucet: Option<Faucet>,
 }
 
 impl TestCluster {
@@ -813,7 +813,7 @@ impl TestCluster {
         amount: Option<u64>,
         funding_address: IotaAddress,
     ) -> ObjectRef {
-        let Faucet { address, keypair } = &self.faucet;
+        let Faucet { address, keypair } = &self.faucet.as_ref().expect("cannot work with a `NetworkConfig`");
 
         let keypair = &*keypair.lock().await;
 
@@ -1302,13 +1302,24 @@ impl TestClusterBuilder {
     }
 
     pub async fn build(mut self) -> TestCluster {
-        // Add a faucet address
-        let (faucet_address, faucet_keypair): (IotaAddress, AccountKeyPair) = get_key_pair();
-        let accounts = &mut self.get_or_init_genesis_config().accounts;
-        accounts.push(AccountConfig {
-            address: Some(faucet_address),
-            gas_amounts: vec![DEFAULT_GAS_AMOUNT],
-        });
+        // We can add a faucet account to the `GenesisConfig` if there was no `NetworkConfig` provided.
+        // Only either a `GenesisConfig` or a `NetworkConfig` can be used to configure and build the cluster.
+        let faucet = if self.network_config.is_none() {
+            let (faucet_address, faucet_keypair): (IotaAddress, AccountKeyPair) = get_key_pair();
+
+            let accounts = &mut self.get_or_init_genesis_config().accounts;
+            accounts.push(AccountConfig {
+                address: Some(faucet_address),
+                gas_amounts: vec![DEFAULT_GAS_AMOUNT],
+            });
+
+            Some(Faucet {
+                address: faucet_address,
+                keypair: Arc::new(tokio::sync::Mutex::new(IotaKeyPair::Ed25519(
+                    faucet_keypair.into(),
+                )))
+            })
+        } else { None };
 
         // All test clusters receive a continuous stream of random JWKs.
         // If we later use zklogin authenticated transactions in tests we will need to
@@ -1372,12 +1383,7 @@ impl TestClusterBuilder {
             fullnode_handle,
             bridge_authority_keys: None,
             bridge_server_ports: None,
-            faucet: Faucet {
-                address: faucet_address,
-                keypair: Arc::new(tokio::sync::Mutex::new(IotaKeyPair::Ed25519(
-                    faucet_keypair,
-                ))),
-            },
+            faucet,
         }
     }
 

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -813,7 +813,7 @@ impl TestCluster {
         amount: Option<u64>,
         funding_address: IotaAddress,
     ) -> ObjectRef {
-        let Faucet { address, keypair } = &self.faucet.as_ref().expect("Cannot initialize faucet: incompatible with `NetworkConfig`.");
+        let Faucet { address, keypair } = &self.faucet.as_ref().expect("Faucet not initialized: incompatible with `NetworkConfig`.");
 
         let keypair = &*keypair.lock().await;
 

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -813,7 +813,7 @@ impl TestCluster {
         amount: Option<u64>,
         funding_address: IotaAddress,
     ) -> ObjectRef {
-        let Faucet { address, keypair } = &self.faucet.as_ref().expect("cannot work with a `NetworkConfig`");
+        let Faucet { address, keypair } = &self.faucet.as_ref().expect("Cannot initialize faucet: incompatible with `NetworkConfig`.");
 
         let keypair = &*keypair.lock().await;
 

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -813,7 +813,10 @@ impl TestCluster {
         amount: Option<u64>,
         funding_address: IotaAddress,
     ) -> ObjectRef {
-        let Faucet { address, keypair } = &self.faucet.as_ref().expect("Faucet not initialized: incompatible with `NetworkConfig`.");
+        let Faucet { address, keypair } = &self
+            .faucet
+            .as_ref()
+            .expect("Faucet not initialized: incompatible with `NetworkConfig`.");
 
         let keypair = &*keypair.lock().await;
 
@@ -1302,8 +1305,9 @@ impl TestClusterBuilder {
     }
 
     pub async fn build(mut self) -> TestCluster {
-        // We can add a faucet account to the `GenesisConfig` if there was no `NetworkConfig` provided.
-        // Only either a `GenesisConfig` or a `NetworkConfig` can be used to configure and build the cluster.
+        // We can add a faucet account to the `GenesisConfig` if there was no
+        // `NetworkConfig` provided. Only either a `GenesisConfig` or a
+        // `NetworkConfig` can be used to configure and build the cluster.
         let faucet = if self.network_config.is_none() {
             let (faucet_address, faucet_keypair): (IotaAddress, AccountKeyPair) = get_key_pair();
 
@@ -1317,9 +1321,11 @@ impl TestClusterBuilder {
                 address: faucet_address,
                 keypair: Arc::new(tokio::sync::Mutex::new(IotaKeyPair::Ed25519(
                     faucet_keypair.into(),
-                )))
+                ))),
             })
-        } else { None };
+        } else {
+            None
+        };
 
         // All test clusters receive a continuous stream of random JWKs.
         // If we later use zklogin authenticated transactions in tests we will need to

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -1308,24 +1308,20 @@ impl TestClusterBuilder {
         // We can add a faucet account to the `GenesisConfig` if there was no
         // `NetworkConfig` provided. Only either a `GenesisConfig` or a
         // `NetworkConfig` can be used to configure and build the cluster.
-        let faucet = if self.network_config.is_none() {
+        let faucet = self.network_config.is_none().then(|| {
             let (faucet_address, faucet_keypair): (IotaAddress, AccountKeyPair) = get_key_pair();
-
             let accounts = &mut self.get_or_init_genesis_config().accounts;
             accounts.push(AccountConfig {
                 address: Some(faucet_address),
                 gas_amounts: vec![DEFAULT_GAS_AMOUNT],
             });
-
-            Some(Faucet {
+            Faucet {
                 address: faucet_address,
                 keypair: Arc::new(tokio::sync::Mutex::new(IotaKeyPair::Ed25519(
                     faucet_keypair,
                 ))),
-            })
-        } else {
-            None
-        };
+            }
+        });
 
         // All test clusters receive a continuous stream of random JWKs.
         // If we later use zklogin authenticated transactions in tests we will need to

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -1320,7 +1320,7 @@ impl TestClusterBuilder {
             Some(Faucet {
                 address: faucet_address,
                 keypair: Arc::new(tokio::sync::Mutex::new(IotaKeyPair::Ed25519(
-                    faucet_keypair.into(),
+                    faucet_keypair,
                 ))),
             })
         } else {


### PR DESCRIPTION
# Description of change

Adds the faucet to the `TestCluster` if there was no `NetworkConfig` provided.
Only either a `GenesisConfig` or a `NetworkConfig` can be used to configure and build the cluster.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/3930

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`cargo test --test traffic_control_tests --all-features`

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
