### PR TITLE
fix(iota-genesis-builder): link pre_minted_supply to number of migration sources

### DIFF
--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -47,7 +47,7 @@ use iota_types::{
     effects::{TransactionEffects, TransactionEvents},
     epoch_data::EpochData,
     event::Event,
-    gas_coin::{GAS, GasCoin},
+    gas_coin::{GAS, GasCoin, STARDUST_TOTAL_SUPPLY_NANOS},
     governance::StakedIota,
     id::UID,
     in_memory_storage::InMemoryStorage,
@@ -284,6 +284,8 @@ impl Builder {
     fn resolve_token_distribution_schedule(&mut self) -> TokenDistributionSchedule {
         let validator_addresses = self.validators.values().map(|v| v.info.iota_address());
         let token_distribution_schedule = self.token_distribution_schedule.take();
+        let stardust_total_supply_nanos =
+            self.migration_sources.len() as u64 * STARDUST_TOTAL_SUPPLY_NANOS;
         if self.genesis_stake.is_empty() {
             token_distribution_schedule.unwrap_or_else(|| {
                 TokenDistributionSchedule::new_for_validators_with_default_allocation(
@@ -296,10 +298,14 @@ impl Builder {
                 schedule
             } else {
                 self.genesis_stake
-                    .extend_token_distribution_schedule_without_migration(schedule)
+                    .extend_token_distribution_schedule_without_migration(
+                        schedule,
+                        stardust_total_supply_nanos,
+                    )
             }
         } else {
-            self.genesis_stake.to_token_distribution_schedule()
+            self.genesis_stake
+                .to_token_distribution_schedule(stardust_total_supply_nanos)
         }
     }
 

--- a/crates/iota-genesis-builder/src/stake.rs
+++ b/crates/iota-genesis-builder/src/stake.rs
@@ -7,7 +7,6 @@ use iota_config::genesis::{
 };
 use iota_types::{
     base_types::{IotaAddress, ObjectRef},
-    gas_coin::STARDUST_TOTAL_SUPPLY_NANOS,
     object::Object,
     stardust::coin_kind::get_gas_balance_maybe,
 };
@@ -63,10 +62,13 @@ impl GenesisStake {
 
     /// Create a new valid [`TokenDistributionSchedule`] from the
     /// inner token allocations.
-    pub fn to_token_distribution_schedule(&self) -> TokenDistributionSchedule {
+    pub fn to_token_distribution_schedule(
+        &self,
+        total_supply_nanos: u64,
+    ) -> TokenDistributionSchedule {
         let mut builder = TokenDistributionScheduleBuilder::new();
 
-        let pre_minted_supply = self.calculate_pre_minted_supply();
+        let pre_minted_supply = self.calculate_pre_minted_supply(total_supply_nanos);
 
         builder.set_pre_minted_supply(pre_minted_supply);
 
@@ -88,18 +90,20 @@ impl GenesisStake {
     pub fn extend_token_distribution_schedule_without_migration(
         &self,
         mut schedule_without_migration: TokenDistributionSchedule,
+        total_supply_nanos: u64,
     ) -> TokenDistributionSchedule {
         schedule_without_migration
             .allocations
             .extend(self.token_allocation.clone());
-        schedule_without_migration.pre_minted_supply = self.calculate_pre_minted_supply();
+        schedule_without_migration.pre_minted_supply =
+            self.calculate_pre_minted_supply(total_supply_nanos);
         schedule_without_migration.validate();
         schedule_without_migration
     }
 
     /// Calculates the part of the IOTA supply that is pre-minted.
-    fn calculate_pre_minted_supply(&self) -> u64 {
-        STARDUST_TOTAL_SUPPLY_NANOS - self.sum_token_allocation()
+    fn calculate_pre_minted_supply(&self, total_supply_nanos: u64) -> u64 {
+        total_supply_nanos - self.sum_token_allocation()
     }
 }
 


### PR DESCRIPTION
# Description of change

This patches uses the number of `migration_sources` in `iota_genesis_builder` to calculate correctly the total iota supply of the migration object set.

## Links to any relevant issues

Fixes #3950 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Built genesis with both `iota` and test data and verified the `pre_minted_supply`.