### PR TITLE
chore(docs): Fix typo in hello iota faucet example

### DIFF
--- a/docs/content/references/ts-sdk/typescript/hello-iota.mdx
+++ b/docs/content/references/ts-sdk/typescript/hello-iota.mdx
@@ -53,7 +53,7 @@ Create a new `index.js` file in the root of your project with the following code
 
 ```js
 import { getFullnodeUrl, IotaClient } from '@iota/iota-sdk/client';
-import { getFaucetHost, requestIotaFromFaucetv1 } from '@iota/iota-sdk/faucet';
+import { getFaucetHost, requestIotaFromFaucetV1 } from '@iota/iota-sdk/faucet';
 import { NANOS_PER_IOTA } from '@iota/iota-sdk/utils';
 
 // replace <YOUR_IOTA_ADDRESS> with your actual address, which is in the form 0x123...
@@ -72,7 +72,7 @@ const iotaBefore = await iotaClient.getBalance({
     owner: MY_ADDRESS,
 });
 
-await requestIotaFromFaucetv1({
+await requestIotaFromFaucetV1({
     // use getFaucetHost to make sure you're using correct faucet address
     // you can also just use the address (see IOTA TypeScript SDK Quick Start for values)
     host: getFaucetHost('devnet'),


### PR DESCRIPTION
# Description of change

Fixes a typo in the `Hello IOTA` docs example, specifically the import of `requestIotaFromFaucetV1`.

## Links to any relevant issues



## Type of change

- Documentation Fix

## How the change has been tested

Minor text change, no test needed.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
