### PR TITLE
feat(types, json-rpc, indexer): Create a Display event for StakedIota

### DIFF
--- a/crates/iota-json-rpc/src/read_api.rs
+++ b/crates/iota-json-rpc/src/read_api.rs
@@ -32,6 +32,7 @@ use iota_types::{
     display::DisplayVersionUpdatedEvent,
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     error::{IotaError, IotaObjectResponseError},
+    governance::{StakedIota, staked_iota_display_version_update_event},
     iota_serde::BigInt,
     messages_checkpoint::{
         CheckpointContents, CheckpointContentsDigest, CheckpointSequenceNumber, CheckpointSummary,
@@ -1142,9 +1143,13 @@ async fn get_display_fields(
             error: None,
         });
     };
-    if let Some(display_object) =
-        get_display_object_by_type(kv_store, fullnode_api, &object_type).await?
-    {
+    if let Some(display_object) = {
+        if StakedIota::is_staked_iota(&object_type) {
+            Some(staked_iota_display_version_update_event())
+        } else {
+            get_display_object_by_type(kv_store, fullnode_api, &object_type).await?
+        }
+    } {
         return get_rendered_fields(display_object.fields, &layout);
     }
     Ok(DisplayFieldsResponse {

--- a/crates/iota-types/src/governance.rs
+++ b/crates/iota-types/src/governance.rs
@@ -9,7 +9,9 @@ use crate::{
     IOTA_SYSTEM_ADDRESS,
     balance::Balance,
     base_types::ObjectID,
+    collection_types::{Entry, VecMap},
     committee::EpochId,
+    display::DisplayVersionUpdatedEvent,
     error::IotaError,
     gas_coin::NANOS_PER_IOTA,
     id::{ID, UID},
@@ -114,5 +116,27 @@ impl TryFrom<&Object> for StakedIota {
         Err(IotaError::Type {
             error: format!("Object type is not a StakedIota: {:?}", object),
         })
+    }
+}
+
+pub fn staked_iota_display_version_update_event() -> DisplayVersionUpdatedEvent {
+    let id = ID::new(ObjectID::ZERO);
+    let version = 0_u16;
+    let contents = vec![
+        Entry {
+            key: "name".to_string(),
+            value: "staked_iota".to_string(),
+        },
+        Entry {
+            key: "image_url".to_string(),
+            value: "https://d315pvdvxi2gex.cloudfront.net/d96a337f84c5c900f31e08803.svg"
+                .to_string(),
+        },
+    ];
+    let fields = VecMap { contents };
+    DisplayVersionUpdatedEvent {
+        id,
+        version,
+        fields,
     }
 }


### PR DESCRIPTION
This PR won't be merged, it's a draft used to show an alternative approach to the display objects for system types issue #3087 

It can be tested in a local explorer connected to a fullnode or an indexer by querying a StakedIota object (e.g., each validator holds one) 



<img width="1278" alt="Screenshot 2024-11-13 at 12 51 04" src="https://github.com/user-attachments/assets/a53e1622-d2a7-47ba-849e-39f3354ac1a4">
