### PR TITLE
fix(devx): Add note about https for the explorer

### DIFF
--- a/docs/content/developer/getting-started/local-network.mdx
+++ b/docs/content/developer/getting-started/local-network.mdx
@@ -167,7 +167,16 @@ The response resembles the following, but with different IDs:
 ```
 
 :::tip explorer
+
 In order to use the explorer locally users can use the deployed explorer and set another endpoint like this: [https://explorer.iota.cafe/?network=http%3A%2F%2F127.0.0.1%3A9000](https://explorer.iota.cafe/?network=http%3A%2F%2F127.0.0.1%3A9000) or manually provide a Custom RPC URL on the [Explorer](https://explorer.iota.cafe/) page in the top right corner.
+
+:::
+
+:::warning HTTPS only
+
+The [IOTA Explorer](https://explorer.iota.cafe) requires a secure HTTPS connection. If your local network doesn't support HTTPS, consider [running your own instance of the Explorer]](https://github.com/iotaledger/iota/tree/develop/apps/explorer#iota-explorer).
+
+
 :::
 
 ## Install IOTA Wallet Locally

--- a/docs/content/developer/getting-started/local-network.mdx
+++ b/docs/content/developer/getting-started/local-network.mdx
@@ -174,8 +174,7 @@ In order to use the explorer locally users can use the deployed explorer and set
 
 :::warning HTTPS only
 
-The [IOTA Explorer](https://explorer.iota.cafe) requires a secure HTTPS connection. If your local network doesn't support HTTPS, consider [running your own instance of the Explorer]](https://github.com/iotaledger/iota/tree/develop/apps/explorer#iota-explorer).
-
+The [IOTA Explorer](https://explorer.iota.cafe) requires a secure HTTPS connection. If your local network doesn't support HTTPS, consider [running your own instance of the Explorer](https://github.com/iotaledger/iota/tree/develop/apps/explorer#iota-explorer).
 
 :::
 


### PR DESCRIPTION
# Description of change

Added a warning in the local network docs about the explorer requiring https for this JSON RPC

## Type of change

- Documentation Fix

## How the change has been tested

Docs were built locally.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
