### PR TITLE
[cherry-pick] fix(iota-indexer): add fallback query to get total packages metric (#4043)

### DIFF
--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -63,7 +63,7 @@ use crate::{
     },
     schema::{
         address_metrics, checkpoints, display, epochs, events, move_call_metrics, objects,
-        objects_snapshot, transactions,
+        objects_snapshot, packages, transactions,
     },
     store::{diesel_macro::*, package_resolver::IndexerStorePackageResolver},
     types::{IndexerResult, OwnerType},
@@ -1509,10 +1509,17 @@ impl<U: R2D2Connection> IndexerReader<U> {
     }
 
     pub fn get_latest_network_metrics(&self) -> IndexerResult<NetworkMetrics> {
-        let metrics = run_query!(&self.pool, |conn| {
+        let mut metrics = run_query!(&self.pool, |conn| {
             diesel::sql_query("SELECT * FROM network_metrics;")
                 .get_result::<StoredNetworkMetrics>(conn)
         })?;
+        if metrics.total_packages == -1 {
+            // this implies that the estimate is not available in the db
+            // so we fallback to the more expensive count query
+            metrics.total_packages = run_query!(&self.pool, |conn| {
+                packages::dsl::packages.count().get_result::<i64>(conn)
+            })?;
+        }
         Ok(metrics.into())
     }
 


### PR DESCRIPTION
Origin PR: #4043 

# Description of change

This patch adds a fallback query to get the total packages metric.

The primary query relies on the [pg_class](https://www.postgresql.org/docs/15/catalog-pg-class.html) catalog and uses the `reltuples` field to get a fast estimate of the row count. However reading the documentation

>reltuples float4
> 
> Number of live rows in the table. This is only an estimate used by the planner. It is updated by [VACUUM](https://www.postgresql.org/docs/15/sql-vacuum.html), [ANALYZE](https://www.postgresql.org/docs/15/sql-analyze.html), and a few DDL commands such as [CREATE INDEX](https://www.postgresql.org/docs/15/sql-createindex.html). If the table has never yet been vacuumed or analyzed, reltuples contains -1 indicating that the row count is unknown.

It has been observed that for a vanilla network that starts with only the system packages, the query for the estimate returns `-1`, likely because the insert threshold for triggering vacuuming was not supassed (see [autovacuum](https://www.postgresql.org/docs/current/routine-vacuuming.html#AUTOVACUUM)).

Credits to @begonaalvarezd for observing the issue.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Run a local network with vanilla genesis and the indexer rpc and run the following query:

```
curl 'http://0.0.0.0:9005/'   -H 'content-type: application/json' --data-raw '{"jsonrpc":"2.0","id":3,"method":"iotax_getNetworkMetrics","params":[]}' 
```

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
