### PR TITLE
[cherry-pick] feat(iota/iota-sdk/iota-tool): update network URLs and docs (#4023)

### DIFF
--- a/crates/iota-sdk/README.md
+++ b/crates/iota-sdk/README.md
@@ -19,11 +19,11 @@ use iota_sdk::IotaClientBuilder;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    // Iota testnet -- https://fullnode.testnet.iota.io:443
+    // Iota testnet -- https://api.testnet.iota.cafe
     let iota_testnet = IotaClientBuilder::default().build_testnet().await?;
     println!("Iota testnet version: {}", iota_testnet.api_version());
 
-     // Iota devnet -- https://fullnode.devnet.iota.io:443
+     // Iota devnet -- https://api.devnet.iota.cafe
     let iota_devnet = IotaClientBuilder::default().build_devnet().await?;
     println!("Iota devnet version: {}", iota_devnet.api_version());
 
@@ -53,7 +53,7 @@ There are several files ending in `_api.rs` which provide code examples of the c
 
 ### Prerequisites
 
-Unless otherwise specified, most of these examples assume `Rust` and `cargo` are installed, and that there is an available internet connection. The examples connect to the IOTA testnet (`https://fullnode.testnet.iota.io:443`) and execute different APIs using the active address from the local wallet. If there is no local wallet, it will create one, generate two addresses, set one of them to be active, and it will request 1 IOTA from the testnet faucet for the active address.
+Unless otherwise specified, most of these examples assume `Rust` and `cargo` are installed, and that there is an available internet connection. The examples connect to the IOTA testnet (`https://api.testnet.iota.cafe`) and execute different APIs using the active address from the local wallet. If there is no local wallet, it will create one, generate two addresses, set one of them to be active, and it will request 1 IOTA from the testnet faucet for the active address.
 
 ### Running the existing examples
 
@@ -74,11 +74,11 @@ In the root folder of the `iota` repository (or in the `iota-sdk` crate folder),
 The `IotaClientBuilder` struct provides a connection to the JSON-RPC server that you use for all read-only operations. The default URLs to connect to the IOTA network are:
 
 - Local: http://127.0.0.1:9000
-- Devnet: https://fullnode.devnet.iota.io:443
-- Testnet: https://fullnode.testnet.iota.io:443
-- Mainnet: https://fullnode.mainnet.iota.io:443
+- Devnet: https://api.devnet.iota.cafe
+- Testnet: https://api.testnet.iota.cafe
+- Mainnet: https://api.mainnet.iota.cafe
 
-For all available servers, see [here](TODO: https://github.com/iotaledger/iota/issues/1614).
+For all available servers, see [here](https://docs.iota.org/developer/network-overview).
 
 For running a local IOTA network, please follow [this guide](https://wiki.iota.cafe/developer/getting-started/iota-install) for installing IOTA and [this guide](https://wiki.iota.cafe/developer/getting-started/local-network#start-the-local-network) for starting the local IOTA network.
 
@@ -96,11 +96,11 @@ async fn main() -> Result<(), anyhow::Error> {
     let iota_local = IotaClientBuilder::default().build_localnet().await?;
     println!("IOTA local network version: {}", iota_local.api_version());
 
-    // IOTA devnet -- https://fullnode.devnet.iota.io:443
+    // IOTA devnet -- https://api.devnet.iota.cafe
     let iota_devnet = IotaClientBuilder::default().build_devnet().await?;
     println!("IOTA devnet version: {}", iota_devnet.api_version());
 
-    // IOTA testnet -- https://fullnode.testnet.iota.io:443
+    // IOTA testnet -- https://api.testnet.iota.cafe
     let iota_testnet = IotaClientBuilder::default().build_testnet().await?;
     println!("IOTA testnet version: {}", iota_testnet.api_version());
 

--- a/crates/iota-sdk/examples/coin_read_api.rs
+++ b/crates/iota-sdk/examples/coin_read_api.rs
@@ -8,8 +8,7 @@
 //! doesn't) check if it has coins and request coins from the faucet if there
 //! aren't any. If there is no wallet, it will create a wallet and two
 //! addresses, set one address as active, and add 1 IOTA to the active address.
-//! By default, the example will use the Iota testnet network (fullnode.testnet.
-//! iota.io:443).
+//! By default, the example will use the IOTA testnet network (https://api.testnet.iota.cafe).
 //!
 //! cargo run --example coin_read_api
 

--- a/crates/iota-sdk/examples/event_api.rs
+++ b/crates/iota-sdk/examples/event_api.rs
@@ -36,8 +36,8 @@ async fn main() -> Result<(), anyhow::Error> {
     println!(" *** Query events ***\n ");
 
     let ws = IotaClientBuilder::default()
-        .ws_url("wss://rpc.testnet.iota.io:443")
-        .build("https://fullnode.testnet.iota.io:443")
+        .ws_url("wss://api.testnet.iota.cafe")
+        .build("https://api.testnet.iota.cafe")
         .await?;
     println!("WS version {:?}", ws.api_version());
 

--- a/crates/iota-sdk/examples/iota_client.rs
+++ b/crates/iota-sdk/examples/iota_client.rs
@@ -2,13 +2,13 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! This example shows the few basic ways to connect to an Iota network.
-//! There are several in-built methods for connecting to the Iota devnet,
+//! This example shows the few basic ways to connect to an IOTA network.
+//! There are several in-built methods for connecting to the IOTA devnet,
 //! testnet, and localnet (running locally), as well as a custom way for
 //! connecting to custom URLs. The example prints out the API versions of the
 //! different networks, and finally, it prints the list of available RPC methods
 //! and the list of subscriptions. Note that running this code will fail if
-//! there is no Iota network running locally on the default address:
+//! there is no IOTA network running locally on the default address:
 //! 127.0.0.1:9000
 //!
 //! cargo run --example iota_client
@@ -20,19 +20,19 @@ async fn main() -> Result<(), anyhow::Error> {
     let client = IotaClientBuilder::default()
         .build("http://127.0.0.1:9000") // local network address
         .await?;
-    println!("Iota local network version: {}", client.api_version());
+    println!("IOTA local network version: {}", client.api_version());
 
-    // local Iota network, like the above one but using the dedicated function
+    // local IOTA network, like the above one but using the dedicated function
     let local_client = IotaClientBuilder::default().build_localnet().await?;
-    println!("Iota local network version: {}", local_client.api_version());
+    println!("IOTA local network version: {}", local_client.api_version());
 
-    // Iota devnet -- https://fullnode.devnet.iota.io:443
+    // IOTA devnet -- https://api.devnet.iota.cafe
     let devnet_client = IotaClientBuilder::default().build_devnet().await?;
     println!("Iota devnet version: {}", devnet_client.api_version());
 
-    // Iota testnet -- https://fullnode.testnet.iota.io:443
+    // IOTA testnet -- https://api.testnet.iota.cafe
     let testnet_client = IotaClientBuilder::default().build_testnet().await?;
-    println!("Iota testnet version: {}", testnet_client.api_version());
+    println!("IOTA testnet version: {}", testnet_client.api_version());
 
     println!("{:?}", local_client.available_rpc_methods());
     println!("{:?}", local_client.available_subscriptions());

--- a/crates/iota-sdk/examples/read_api/transaction_subscription.rs
+++ b/crates/iota-sdk/examples/read_api/transaction_subscription.rs
@@ -16,8 +16,8 @@ use iota_sdk::IotaClientBuilder;
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     let client = IotaClientBuilder::default()
-        .ws_url("wss://rpc.testnet.iota.io:443")
-        .build("https://fullnode.testnet.iota.io:443")
+        .ws_url("wss://api.testnet.iota.cafe")
+        .build("https://api.testnet.iota.cafe")
         .await?;
     println!("WS version {:?}", client.api_version());
 

--- a/crates/iota-sdk/examples/utils.rs
+++ b/crates/iota-sdk/examples/utils.rs
@@ -38,9 +38,9 @@ struct FaucetResponse {
     error: Option<String>,
 }
 
-// const IOTA_FAUCET_BASE_URL: &str = "https://faucet.devnet.iota.io"; // devnet faucet
+// const IOTA_FAUCET_BASE_URL: &str = "https://faucet.devnet.iota.cafe"; // devnet faucet
 
-pub const IOTA_FAUCET_BASE_URL: &str = "https://faucet.testnet.iota.io"; // testnet faucet
+pub const IOTA_FAUCET_BASE_URL: &str = "https://faucet.testnet.iota.cafe"; // testnet faucet
 
 // if you use the `iota start` subcommand and use the local network; if it does
 // not work, try with port 5003. const IOTA_FAUCET_BASE_URL: &str = "http://127.0.0.1:9123";

--- a/crates/iota-sdk/src/apis/event.rs
+++ b/crates/iota-sdk/src/apis/event.rs
@@ -45,8 +45,8 @@ impl EventApi {
     /// #[tokio::main]
     /// async fn main() -> Result<(), anyhow::Error> {
     ///     let iota = IotaClientBuilder::default()
-    ///         .ws_url("wss://rpc.mainnet.iota.io:443")
-    ///         .build("https://fullnode.mainnet.iota.io:443")
+    ///         .ws_url("wss://api.mainnet.iota.cafe")
+    ///         .build("https://api.mainnet.iota.cafe")
     ///         .await?;
     ///     let mut subscribe_all = iota
     ///         .event_api()

--- a/crates/iota-sdk/src/lib.rs
+++ b/crates/iota-sdk/src/lib.rs
@@ -2,11 +2,11 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! The Iota Rust SDK
+//! The IOTA Rust SDK
 //!
 //! It aims at providing a similar SDK functionality like the one existing for
 //! [TypeScript](https://github.com/iotaledger/iota/tree/main/sdk/typescript/).
-//! Iota Rust SDK builds on top of the [JSON RPC API](https://docs.iota.io/iota-jsonrpc)
+//! IOTA Rust SDK builds on top of the [JSON RPC API](https://docs.iota.org/iota-api-ref)
 //! and therefore many of the return types are the ones specified in
 //! [iota_types].
 //!

--- a/crates/iota-tool/src/commands.rs
+++ b/crates/iota-tool/src/commands.rs
@@ -708,9 +708,9 @@ impl ToolCommand {
                 let aws_endpoint = env::var("AWS_SNAPSHOT_ENDPOINT").ok().or_else(|| {
                     if no_sign_request {
                         if network == Chain::Mainnet {
-                            Some("https://formal-snapshot.mainnet.iota.io".to_string())
+                            Some("https://dbfiles.mainnet.iota.cafe/formal".to_string())
                         } else if network == Chain::Testnet {
-                            Some("https://formal-snapshot.testnet.iota.io".to_string())
+                            Some("https://dbfiles.testnet.iota.cafe/formal".to_string())
                         } else {
                             None
                         }
@@ -941,9 +941,9 @@ impl ToolCommand {
                 let snapshot_store_config = if no_sign_request {
                     let aws_endpoint = env::var("AWS_SNAPSHOT_ENDPOINT").ok().or_else(|| {
                         if network == Chain::Mainnet {
-                            Some("https://db-snapshot.mainnet.iota.io".to_string())
+                            Some("https://dbfiles.mainnet.iota.cafe/snapshots".to_string())
                         } else if network == Chain::Testnet {
-                            Some("https://db-snapshot.testnet.iota.io".to_string())
+                            Some("https://dbfiles.testnet.iota.cafe/snapshots".to_string())
                         } else {
                             None
                         }

--- a/crates/iota/src/zklogin_commands_util.rs
+++ b/crates/iota/src/zklogin_commands_util.rs
@@ -217,10 +217,10 @@ pub async fn perform_zk_login_test_tx(
 fn get_config(network: &str) -> (&str, &str) {
     match network {
         "devnet" => (
-            "https://faucet.devnet.iota.io/gas",
-            "https://rpc.devnet.iota.io:443",
+            "https://faucet.devnet.iota.cafe/v1/gas",
+            "https://api.devnet.iota.cafe",
         ),
-        "localnet" => ("http://127.0.0.1:9123/gas", "http://127.0.0.1:9000"),
+        "localnet" => ("http://127.0.0.1:9123/v1/gas", "http://127.0.0.1:9000"),
         _ => panic!("Invalid network"),
     }
 }


### PR DESCRIPTION
# Description of change

Update network URLs and docs

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/4003

## Type of change

- Enhancement (a non-breaking change which adds functionality)
- Documentation Fix

## How the change has been tested

Only tested the local faucet v1 url with `iota client faucet --url http://127.0.0.1:9123/v1/gas`
