### PR TITLE
[iota-faucet] Enable the use of batched mode on faucet

### DIFF
--- a/crates/iota-faucet/src/faucet/simple_faucet.rs
+++ b/crates/iota-faucet/src/faucet/simple_faucet.rs
@@ -137,9 +137,8 @@ impl SimpleFaucet {
         );
 
         // Split the coins eventually into two pools: one for the gas pool and one for
-        // the batch pool. The batch pool will only be populated if the batch
-        // feature is enabled and the gas pool will serve as a fallback in case the
-        // batch pool is empty.
+        // the batch pool. The batch pool will only be populated if the batch feature is
+        // enabled.
         let split_point = if config.batch_enabled {
             if coins.len() > 1 {
                 1 // At least one coin goes to the gas pool the rest to the batch pool

--- a/crates/iota-faucet/src/faucet/simple_faucet.rs
+++ b/crates/iota-faucet/src/faucet/simple_faucet.rs
@@ -135,9 +135,12 @@ impl SimpleFaucet {
         // the normal queue
         let split_point = if coins.len() > 10 {
             coins.len() / 2
+        } else if coins.len() > 1 {
+            coins.len() - 1 // At least one coin goes to the batch pool
         } else {
-            coins.len()
+            coins.len() // All coins go to the gas pool if there's only one coin
         };
+
         // Put half of the coins in the old faucet impl queue, and put half in the other
         // queue for batch coins. In the test cases we create an account with 5
         // coins so we just let this run with a minimum of 5 coins
@@ -946,6 +949,7 @@ impl Faucet for SimpleFaucet {
         {
             return Err(FaucetError::BatchSendQueueFull);
         }
+
         let mut task_map = self.task_id_cache.lock().await;
         task_map.insert(
             id,
@@ -1035,6 +1039,7 @@ pub async fn batch_transfer_gases(
         "Batch transfer attempted of size: {:?}", total_requests
     );
     let total_iota_needed: u64 = requests.iter().flat_map(|(_, _, amounts)| amounts).sum();
+
     // This loop is utilized to grab a coin that is large enough for the request
     loop {
         let gas_coin_response = faucet

--- a/crates/iota-faucet/src/faucet/simple_faucet.rs
+++ b/crates/iota-faucet/src/faucet/simple_faucet.rs
@@ -1306,7 +1306,10 @@ mod tests {
     #[tokio::test]
     async fn test_batch_transfer_interface() {
         let test_cluster = TestClusterBuilder::new().build().await;
-        let config: FaucetConfig = Default::default();
+        let config: FaucetConfig = FaucetConfig {
+            batch_enabled: true,
+            ..Default::default()
+        };
         let coin_amount = config.amount;
         let prom_registry = Registry::new();
         let tmp = tempfile::tempdir().unwrap();
@@ -1906,7 +1909,10 @@ mod tests {
     #[tokio::test]
     async fn test_amounts_transferred_on_batch() {
         let test_cluster = TestClusterBuilder::new().build().await;
-        let config: FaucetConfig = Default::default();
+        let config: FaucetConfig = FaucetConfig {
+            batch_enabled: true,
+            ..Default::default()
+        };
         let address = test_cluster.get_address_0();
         let mut context = test_cluster.wallet;
         let gas_coins = context

--- a/crates/iota-faucet/src/faucet/simple_faucet.rs
+++ b/crates/iota-faucet/src/faucet/simple_faucet.rs
@@ -149,9 +149,6 @@ impl SimpleFaucet {
             coins.len() // All coins go to the gas pool if batch is disabled
         };
 
-        // Put half of the coins in the old faucet impl queue, and put half in the other
-        // queue for batch coins. In the test cases we create an account with 5
-        // coins so we just let this run with a minimum of 5 coins
         for (coins_processed, coin) in coins.iter().enumerate() {
             let coin_id = *coin.id();
             if let Some(write_ahead_log::Entry {

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -4205,8 +4205,10 @@ async fn test_faucet_batch() -> Result<(), anyhow::Error> {
 
     let tmp = tempfile::tempdir().unwrap();
     let prom_registry = prometheus::Registry::new();
-    let mut config = iota_faucet::FaucetConfig::default();
-    config.batch_enabled = true;
+    let config = iota_faucet::FaucetConfig {
+        batch_enabled: true,
+        ..Default::default()
+    };
 
     let prometheus_registry = prometheus::Registry::new();
     let app_state = std::sync::Arc::new(iota_faucet::AppState {

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -4177,6 +4177,11 @@ async fn test_faucet() -> Result<(), anyhow::Error> {
     .execute(&mut context)
     .await?;
 
+    if let IotaClientCommandResult::NoOutput = faucet_result {
+    } else {
+        unreachable!("Invalid response");
+    };
+
     sleep(Duration::from_secs(5)).await;
 
     let gas_objects_after = context
@@ -4185,11 +4190,6 @@ async fn test_faucet() -> Result<(), anyhow::Error> {
         .unwrap()
         .len();
     assert_eq!(gas_objects_after, 1);
-
-    if let IotaClientCommandResult::NoOutput = faucet_result {
-    } else {
-        unreachable!("Invalid response");
-    };
 
     Ok(())
 }


### PR DESCRIPTION
# Description of change

Enables the use of batched mode on the faucet.
It appeared that if only 5 coins are provided to the faucet (which is the default for the wallet context) all coins will be added to the default gas queue available at `/gas` and not to the batch queue at `/v1/gas`. This logic has been refactored.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/4065

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Provided a test for batch send.

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
