### PR TITLE
chore(iota-core): re-enable tombstone tests (bump pprof to 0.14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "aligned-vec"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e0966165eaf052580bd70eb1b32cb3d6245774c0104d1b2793e9650bf83b52a"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3932,6 +3941,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
  "once_cell",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "equator"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c35da53b5a021d2484a7cc49b2ac7f2d840f8236a286f84202369bd338d761ea"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
+dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "syn 2.0.77",
@@ -11439,10 +11468,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "pprof"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb"
+checksum = "ebbe2f8898beba44815fdc9e5a4ae9c929e21c5dc29b0c774a15555f7f58d6d0"
 dependencies = [
+ "aligned-vec",
  "backtrace",
  "cfg-if",
  "findshlibs",

--- a/crates/iota-core/Cargo.toml
+++ b/crates/iota-core/Cargo.toml
@@ -115,7 +115,7 @@ move-symbol-pool.workspace = true
 
 [target.'cfg(not(target_env = "msvc"))'.dev-dependencies]
 # external dependencies
-pprof = { version = "0.13", features = ["cpp", "frame-pointer"] }
+pprof = { version = "0.14", features = ["cpp", "frame-pointer"] }
 test-fuzz.workspace = true
 
 # internal dependencies

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -1183,7 +1183,6 @@ mod pprof_tests {
     }
 
     #[tokio::test]
-    #[ignore = "https://github.com/iotaledger/iota/issues/958"]
     async fn ensure_no_tombstone_fragmentation_in_stack_frame_with_ignore_tombstones()
     -> Result<(), anyhow::Error> {
         // This test writes a bunch of objects to objects table, invokes pruning on it
@@ -1221,7 +1220,6 @@ mod pprof_tests {
     }
 
     #[tokio::test]
-    #[ignore = "https://github.com/iotaledger/iota/issues/958"]
     async fn ensure_no_tombstone_fragmentation_in_stack_frame_after_flush()
     -> Result<(), anyhow::Error> {
         // This test writes a bunch of objects to objects table, invokes pruning on it


### PR DESCRIPTION
Fixes https://github.com/iotaledger/iota/issues/958

Before https://github.com/iotaledger/iota/actions/runs/11898043790/job/33156671744?pr=4113
After https://github.com/iotaledger/iota/actions/runs/11899296968/job/33157821152?pr=4113