### PR TITLE
feat(wallet): Allow ledger address verification

### DIFF
--- a/apps/wallet/src/ui/app/pages/home/tokens/ReceiveTokensDialog.tsx
+++ b/apps/wallet/src/ui/app/pages/home/tokens/ReceiveTokensDialog.tsx
@@ -7,7 +7,10 @@ import { useCopyToClipboard } from '_hooks';
 import { QR } from '@iota/core';
 import { toast } from 'react-hot-toast';
 import { useIotaLedgerClient } from '_src/ui/app/components';
-import { isLedgerAccountSerializedUI } from '_src/background/accounts/LedgerAccount';
+import {
+    isLedgerAccountSerializedUI,
+    type LedgerAccountSerializedUI,
+} from '_src/background/accounts/LedgerAccount';
 import { useActiveAccount } from '_src/ui/app/hooks/useActiveAccount';
 
 interface ReceiveTokensDialogProps {
@@ -24,8 +27,10 @@ export function ReceiveTokensDialog({ address, open, setOpen }: ReceiveTokensDia
         copySuccessMessage: 'Address copied',
     });
 
+    const isLedger = isLedgerAccountSerializedUI(activeAccount as LedgerAccountSerializedUI);
+
     const onVerifyAddress = useCallback(async () => {
-        if (!activeAccount) {
+        if (!isLedger || !activeAccount) {
             return;
         }
 
@@ -35,7 +40,6 @@ export function ReceiveTokensDialog({ address, open, setOpen }: ReceiveTokensDia
 
         try {
             let ledgerClient = iotaLedgerClient;
-
             if (!ledgerClient) {
                 ledgerClient = await connectToLedger(true);
             }
@@ -46,7 +50,7 @@ export function ReceiveTokensDialog({ address, open, setOpen }: ReceiveTokensDia
         } catch {
             toast.error('Address verification failed!');
         }
-    }, [activeAccount, iotaLedgerClient, connectToLedger]);
+    }, [isLedger, activeAccount, iotaLedgerClient, connectToLedger]);
 
     return (
         <div className="relative">

--- a/apps/wallet/src/ui/app/pages/home/tokens/ReceiveTokensDialog.tsx
+++ b/apps/wallet/src/ui/app/pages/home/tokens/ReceiveTokensDialog.tsx
@@ -1,9 +1,17 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+import { useCallback } from 'react';
 import { Button, Address, Dialog, DialogContent, DialogBody, Header } from '@iota/apps-ui-kit';
 import { useCopyToClipboard } from '_hooks';
 import { QR } from '@iota/core';
+import { toast } from 'react-hot-toast';
+import { useIotaLedgerClient } from '_src/ui/app/components';
+import {
+    isLedgerAccountSerializedUI,
+    type LedgerAccountSerializedUI,
+} from '_src/background/accounts/LedgerAccount';
+import { useActiveAccount } from '_src/ui/app/hooks/useActiveAccount';
 
 interface ReceiveTokensDialogProps {
     address: string;
@@ -12,9 +20,38 @@ interface ReceiveTokensDialogProps {
 }
 
 export function ReceiveTokensDialog({ address, open, setOpen }: ReceiveTokensDialogProps) {
+    const activeAccount = useActiveAccount();
+    const { connectToLedger, iotaLedgerClient } = useIotaLedgerClient();
+
     const onCopy = useCopyToClipboard(address, {
         copySuccessMessage: 'Address copied',
     });
+
+    const isLedger = isLedgerAccountSerializedUI(activeAccount as LedgerAccountSerializedUI);
+
+    const onVerifyAddress = useCallback(() => {
+        if (isLedger && activeAccount) {
+            (async () => {
+                try {
+                    let ledgerClient = iotaLedgerClient;
+                    if (!ledgerClient) {
+                        ledgerClient = await connectToLedger(true);
+                    }
+
+                    const derivationPath = (activeAccount as LedgerAccountSerializedUI)
+                        .derivationPath;
+
+                    if (derivationPath) {
+                        toast.success('Please, confirm the address on your Ledger device.');
+                        await ledgerClient.getPublicKey(derivationPath, true);
+                        toast.success('Address verification successful!');
+                    }
+                } catch {
+                    toast.error('Address verification failed!');
+                }
+            })();
+        }
+    }, [isLedger, activeAccount, iotaLedgerClient, connectToLedger]);
 
     return (
         <div className="relative">
@@ -32,6 +69,11 @@ export function ReceiveTokensDialog({ address, open, setOpen }: ReceiveTokensDia
                     <div className="flex w-full flex-row justify-center gap-2 px-md--rs pb-md--rs pt-sm--rs">
                         <Button onClick={onCopy} fullWidth text="Copy Address" />
                     </div>
+                    {isLedger && (
+                        <div className="flex w-full flex-row justify-center gap-2 px-md--rs pb-md--rs pt-sm--rs">
+                            <Button onClick={onVerifyAddress} fullWidth text="Verify Address" />
+                        </div>
+                    )}
                 </DialogContent>
             </Dialog>
         </div>


### PR DESCRIPTION
# Description of change

Closes https://github.com/iotaledger/iota/issues/2932

## For tester/reviewer

Please, if testing with a real device, check this flow
- Setup a ledger wallet
- Close and re-open the wallet extension so that ledger is disconnected (unlock your account)
- Verify the address (in the receive popup), but "Reject" the address on ledger. An error toast should show
- Try to verify again and on ledger choose "Confirm"

Confirm the above flow works without issues.
Why ? I tested with speculos emulated ledger and after "rejection", when trying to verify again speculos would crash. We want to check that it's not the case with a real device.