### PR TITLE
chore(iota-types,iota-cluster-test): Remove `derivative` dependency

### DIFF
--- a/.github/workflows/_cargo_deny.yml
+++ b/.github/workflows/_cargo_deny.yml
@@ -17,10 +17,12 @@ jobs:
     name: cargo deny (bans, licenses, sources)
     runs-on: [self-hosted]
     steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # pin@v4
       - run: cargo deny --manifest-path ${{ inputs.manifest-path || './Cargo.toml' }} check bans licenses sources
 
   advisories:
     name: cargo deny (advisories)
     runs-on: [self-hosted]
     steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # pin@v4
       - run: cargo deny --manifest-path ${{ inputs.manifest-path || './Cargo.toml' }} check advisories

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3462,6 +3462,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "syn 2.0.77",
+ "unicode-xid 0.2.6",
+]
+
+[[package]]
 name = "diesel"
 version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4384,7 +4405,7 @@ dependencies = [
  "cbc",
  "ctr",
  "curve25519-dalek-ng",
- "derive_more",
+ "derive_more 0.99.18",
  "digest 0.10.7",
  "ecdsa 0.16.9",
  "ed25519-consensus",
@@ -4477,7 +4498,7 @@ dependencies = [
  "ark-snark",
  "blst",
  "byte-slice-cast",
- "derive_more",
+ "derive_more 0.99.18",
  "fastcrypto",
  "ff 0.13.0",
  "im",
@@ -6119,7 +6140,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
- "derivative",
+ "derive_more 1.0.0",
  "diesel",
  "fastcrypto",
  "futures",
@@ -7655,7 +7676,7 @@ dependencies = [
  "bech32",
  "bitflags 2.6.0",
  "bytemuck",
- "derive_more",
+ "derive_more 0.99.18",
  "futures",
  "getset",
  "gloo-timers 0.3.0",
@@ -8149,8 +8170,7 @@ dependencies = [
  "consensus-config",
  "coset",
  "criterion",
- "derivative",
- "derive_more",
+ "derive_more 1.0.0",
  "enum_dispatch",
  "expect-test",
  "eyre",
@@ -13062,7 +13082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eca070c12893629e2cc820a9761bedf6ce1dcddc9852984d1dc734b8bd9bd024"
 dependencies = [
  "cfg-if",
- "derive_more",
+ "derive_more 0.99.18",
  "parity-scale-codec 3.6.12",
  "scale-info-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,7 +238,7 @@ crossterm = "0.25.0"
 csv = "1.2.1"
 dashmap = "5.5.3"
 datatest-stable = { git = "https://github.com/nextest-rs/datatest-stable.git", rev = "72db7f6d1bbe36a5407e96b9488a581f763e106f" }
-derivative = "2.2.0"
+derive_more = "1.0"
 diesel = { version = "2.1.0", features = ["chrono", "r2d2", "serde_json", "64-column-tables", "i-implement-a-third-party-backend-and-opt-into-breaking-changes"] }
 dirs = "5.0"
 ed25519-consensus = { version = "2.0.1", features = ["serde"] }

--- a/crates/iota-cluster-test/Cargo.toml
+++ b/crates/iota-cluster-test/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 anyhow = { workspace = true, features = ["backtrace"] }
 async-trait.workspace = true
 clap.workspace = true
-derivative.workspace = true
+derive_more = { workspace = true, features = ["debug"] }
 diesel.workspace = true
 fastcrypto.workspace = true
 futures.workspace = true

--- a/crates/iota-cluster-test/src/config.rs
+++ b/crates/iota-cluster-test/src/config.rs
@@ -19,8 +19,7 @@ pub enum Env {
     NewLocal,
 }
 
-#[derive(derivative::Derivative, Parser)]
-#[derivative(Debug)]
+#[derive(derive_more::Debug, Parser)]
 #[clap(name = "", rename_all = "kebab-case")]
 pub struct ClusterTestOpt {
     #[clap(value_enum)]
@@ -36,7 +35,7 @@ pub struct ClusterTestOpt {
     pub indexer_address: Option<String>,
     /// URL for the Indexer Postgres DB
     #[clap(long)]
-    #[derivative(Debug(format_with = "obfuscated_pg_address"))]
+    #[debug("{}", ObfuscatedPgAddress(pg_address))]
     pub pg_address: Option<String>,
     #[clap(long)]
     pub config_dir: Option<PathBuf>,
@@ -53,17 +52,24 @@ pub struct ClusterTestOpt {
     pub remote_migration_snapshots: Vec<SnapshotUrl>,
 }
 
-fn obfuscated_pg_address(val: &Option<String>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    match val {
-        None => write!(f, "None"),
-        Some(val) => {
-            write!(
-                f,
-                "{}",
-                Regex::new(r":.*@")
-                    .unwrap()
-                    .replace_all(val.as_str(), ":*****@")
-            )
+// This is not actually dead, but rust thinks it is because it is only used in
+// the derive macro above.
+#[allow(dead_code)]
+struct ObfuscatedPgAddress<'a>(&'a Option<String>);
+
+impl<'a> std::fmt::Display for ObfuscatedPgAddress<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            None => write!(f, "None"),
+            Some(val) => {
+                write!(
+                    f,
+                    "{}",
+                    Regex::new(r":.*@")
+                        .unwrap()
+                        .replace_all(val.as_str(), ":*****@")
+                )
+            }
         }
     }
 }

--- a/crates/iota-types/Cargo.toml
+++ b/crates/iota-types/Cargo.toml
@@ -19,8 +19,7 @@ better_any.workspace = true
 bincode.workspace = true
 byteorder.workspace = true
 chrono.workspace = true
-derivative.workspace = true
-derive_more = "0.99.17"
+derive_more = { workspace = true, features = ["as_ref", "from", "debug", "display"] }
 enum_dispatch.workspace = true
 eyre.workspace = true
 fastcrypto = { workspace = true, features = ["copy_key"] }

--- a/crates/iota-types/src/iota_system_state/iota_system_state_inner_v1.rs
+++ b/crates/iota-types/src/iota_system_state/iota_system_state_inner_v1.rs
@@ -96,14 +96,13 @@ pub struct ValidatorMetadataV1 {
     pub extra_fields: Bag,
 }
 
-#[derive(derivative::Derivative, Clone, Eq, PartialEq)]
-#[derivative(Debug)]
+#[derive(derive_more::Debug, Clone, Eq, PartialEq)]
 pub struct VerifiedValidatorMetadataV1 {
     pub iota_address: IotaAddress,
     pub authority_pubkey: AuthorityPublicKey,
     pub network_pubkey: NetworkPublicKey,
     pub protocol_pubkey: NetworkPublicKey,
-    #[derivative(Debug = "ignore")]
+    #[debug(skip)]
     pub proof_of_possession_bytes: Vec<u8>,
     pub name: String,
     pub description: String,

--- a/crates/iota-types/src/move_package.rs
+++ b/crates/iota-types/src/move_package.rs
@@ -121,11 +121,11 @@ pub struct MovePackage {
 #[repr(u8)]
 #[derive(Display, Debug, Clone, Copy)]
 pub enum UpgradePolicy {
-    #[display(fmt = "COMPATIBLE")]
+    #[display("COMPATIBLE")]
     Compatible = 0,
-    #[display(fmt = "ADDITIVE")]
+    #[display("ADDITIVE")]
     Additive = 128,
-    #[display(fmt = "DEP_ONLY")]
+    #[display("DEP_ONLY")]
     DepOnly = 192,
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -52,6 +52,8 @@ ignore = [
   "RUSTSEC-2023-0049",
   # difference is unmaintained
   "RUSTSEC-2020-0095",
+  # derivative is unmaintained
+  "RUSTSEC-2024-0388",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/deny.toml
+++ b/deny.toml
@@ -54,6 +54,8 @@ ignore = [
   "RUSTSEC-2020-0095",
   # derivative is unmaintained
   "RUSTSEC-2024-0388",
+  # instant is unmaintained
+  "RUSTSEC-2024-0384",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
# Description of change

Replaces `derivative` with `derive_more` to fix the cargo deny advisory https://rustsec.org/advisories/RUSTSEC-2024-0388.

NOTE: Simply removing the dependency doesn't work as fastcrypto uses a library that has not updated yet.

Ignores https://rustsec.org/advisories/RUSTSEC-2024-0384 and https://rustsec.org/advisories/RUSTSEC-2024-0388
