### PR TITLE
Minor change into README.md file

### DIFF
--- a/apps/explorer/README.md
+++ b/apps/explorer/README.md
@@ -19,7 +19,7 @@ $ pnpm install
 To start the explorer dev server, you can run the following command:
 
 ```
-pnpm explorer dev
+pnpm run dev
 ```
 
 This will start the dev server on port 3000, which should be accessible on http://localhost:3000/


### PR DESCRIPTION
Fix command to run explorer dev server. Must have been a type and nobody noticed.

Although, I've run into another issue. I'm unable to compile locally after following guide in the README file. There seems to be a lot of dependency issues with @iota packages. It might be due that nobody tested to download explorer project directly and install all other dependencies via pnpm only. 

<img width="923" alt="Screenshot 2024-11-21 at 10 13 47 PM" src="https://github.com/user-attachments/assets/be065682-047b-475e-97b9-6236c7f53903">

