### PR TITLE
fix(workflows): don't require SSH secrets anymore

### DIFF
--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -5,11 +5,6 @@ on:
     inputs:
       isRust:
         type: boolean
-    secrets:
-      SSH_PRIVATE_KEY_IOTA_CI:
-        required: true
-      SSH_GITHUB_KNOWN_HOSTS:
-        required: true
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
# Description of change

The keys were added when the repos were private, but since the repos are public now, they SSH keys aren't needed anymore and should be removed as PRs from other forks will fail if they don't create secrets with the same name

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/4198

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
