### PR TITLE
feat(workflows): remove release-notes-check

### DIFF
--- a/.github/workflows/hierarchy.yml
+++ b/.github/workflows/hierarchy.yml
@@ -75,33 +75,6 @@ jobs:
     if: (!cancelled() && needs.diff.outputs.isDoc == 'true')
     uses: ./.github/workflows/_docs_lint.yml
 
-  release-notes-description-check:
-    name: release-notes-check
-    concurrency:
-      group: release-notes-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-      cancel-in-progress: true
-    needs: diff
-    if: (!cancelled() && needs.diff.outputs.isReleaseNotesEligible == 'true')
-    runs-on: [self-hosted]
-    steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # pin@v4
-      - name: Check Pull Request Description
-        shell: bash
-        run: |
-          export PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-          export DESCRIPTION=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/iotaledger/iota/pulls/${PR_NUMBER}" \
-            | jq --raw-output .body)
-
-          if [[ "${DESCRIPTION}" == *"[x]"*  ]]; then
-            if [[ "${DESCRIPTION}" =~ Release[[:space:]]notes[[:space:]]+.* ]]; then
-              exit 0
-            else
-              echo "At least one '[x]' was checked under 'Type of Change (Check all that apply)', you need to add a blob under the 'Release Notes' section."
-              exit 1
-            fi
-          fi
-
   turborepo:
     needs:
       - dprint-format


### PR DESCRIPTION
# Description of change

Remove release-notes-check as we don't generate our release notes this way it's checked there

## Links to any relevant issues

Closes https://github.com/iotaledger/iota/issues/4228

## Type of change

- Enhancement
