### PR TITLE
Fix `StructTag` conversion for `iotax_queryEvents` Indexer-RPC method

### DIFF
--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -1161,7 +1161,8 @@ impl<U: R2D2Connection> IndexerReader<U> {
                     )
                 }
                 EventFilter::MoveEventType(struct_tag) => {
-                    format!("event_type = '{}'", struct_tag)
+                    let formatted_struct_tag = struct_tag.to_canonical_string(true);
+                    format!("event_type = '{formatted_struct_tag}'")
                 }
                 EventFilter::MoveEventModule { package, module } => {
                     let package_module_prefix = format!("{}::{}", package.to_hex_literal(), module);

--- a/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
@@ -186,6 +186,38 @@ fn query_events_supported_events() {
 }
 
 #[test]
+fn query_validator_epoch_info_event() {
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        cluster,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(store, 1).await;
+
+        cluster.force_new_epoch().await;
+
+        let result = client.query_events(EventFilter::MoveEventType("0x0000000000000000000000000000000000000000000000000000000000000003::validator_set::ValidatorEpochInfoEventV1".parse().unwrap()), None, None, None).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().data.len() > 0);
+
+        let result = client.query_events(EventFilter::MoveEventType("0x3::validator_set::ValidatorEpochInfoEventV1".parse().unwrap()), None, None, None).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().data.len() > 0);
+
+        let result = client.query_events(EventFilter::MoveEventType("0x03::validator_set::ValidatorEpochInfoEventV1".parse().unwrap()), None, None, None).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().data.len() > 0);
+
+        let result = client.query_events(EventFilter::MoveEventType("0x1::validator_set::ValidatorEpochInfoEventV1".parse().unwrap()), None, None, None).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().data.len() == 0);
+    });
+}
+
+#[test]
 fn test_get_owned_objects() -> Result<(), anyhow::Error> {
     let ApiTestSetup {
         runtime,

--- a/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
@@ -201,19 +201,19 @@ fn query_validator_epoch_info_event() {
 
         let result = client.query_events(EventFilter::MoveEventType("0x0000000000000000000000000000000000000000000000000000000000000003::validator_set::ValidatorEpochInfoEventV1".parse().unwrap()), None, None, None).await;
         assert!(result.is_ok());
-        assert!(result.unwrap().data.len() > 0);
+        assert!(!result.unwrap().data.is_empty());
 
         let result = client.query_events(EventFilter::MoveEventType("0x3::validator_set::ValidatorEpochInfoEventV1".parse().unwrap()), None, None, None).await;
         assert!(result.is_ok());
-        assert!(result.unwrap().data.len() > 0);
+        assert!(!result.unwrap().data.is_empty());
 
-        let result = client.query_events(EventFilter::MoveEventType("0x03::validator_set::ValidatorEpochInfoEventV1".parse().unwrap()), None, None, None).await;
+        let result = client.query_events(EventFilter::MoveEventType("0x0003::validator_set::ValidatorEpochInfoEventV1".parse().unwrap()), None, None, None).await;
         assert!(result.is_ok());
-        assert!(result.unwrap().data.len() > 0);
+        assert!(!result.unwrap().data.is_empty());
 
         let result = client.query_events(EventFilter::MoveEventType("0x1::validator_set::ValidatorEpochInfoEventV1".parse().unwrap()), None, None, None).await;
         assert!(result.is_ok());
-        assert!(result.unwrap().data.len() == 0);
+        assert!(result.unwrap().data.is_empty());
     });
 }
 


### PR DESCRIPTION
## Description 

Currently, there is a bug in the `iotax_queryEvents` implementation when processing `EventFilter::MoveEventType(struct_tag)`. Even if the user provides a `struct_tag` in its full canonical hex representation (including the necessary prefix), it is not converted correctly to the format expected by the database. Instead, the struct_tag is transformed into a simplified representation that does not align with the structure stored in the indexer database.

This mismatch causes the SQL query to fail in finding the relevant records, effectively preventing the retrieval of the desired event data, despite the user supplying the correct input.

While `iotax_queryEvents` makes use of following string:

https://github.com/MystenLabs/sui/blob/8bd53998f88c4619f39dcf298f699199a0071e7c/crates/sui-indexer/src/indexer_reader.rs#L1032-L1034

The indexed event is stored makes use of the full canonical string (including the prefix):

https://github.com/MystenLabs/sui/blob/8bd53998f88c4619f39dcf298f699199a0071e7c/crates/sui-indexer/src/types.rs#L134

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/4284

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

The provided test.

`cargo test --profile simulator --features shared_test_runtime --test rpc-tests indexer_api::query_validator_epoch_info_event`

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
