### PR TITLE
fix(move-analyzer): change the publisher name

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "iota-move",
   "displayName": "IOTA Move",
   "description": "A Move language integrated development environment for IOTA.",
-  "publisher": "iota-foundation",
+  "publisher": "iotaledger",
   "icon": "images/move.png",
   "license": "Apache-2.0",
   "version": "1.0.0",

--- a/external-crates/move/crates/move-analyzer/editors/code/src/extension.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/src/extension.ts
@@ -9,7 +9,7 @@ import * as vscode from 'vscode';
 /** Information related to this extension itself, such as its identifier and version. */
 export class Extension {
     /** The string used to uniquely identify this particular extension to VS Code. */
-    readonly identifier = 'iota-foundation.iota-move';
+    readonly identifier = 'iotaledger.iota-move';
 
     private readonly extension: vscode.Extension<unknown>;
 

--- a/external-crates/move/crates/move-analyzer/editors/code/tests/ext.test.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/tests/ext.test.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 
 Mocha.suite('ext', () => {
     Mocha.test('ext_exists', () => {
-        const ext = vscode.extensions.getExtension('iota-foundation.iota-move');
+        const ext = vscode.extensions.getExtension('iotaledger.iota-move');
         assert.ok(ext);
     });
 });

--- a/external-crates/move/crates/move-analyzer/editors/code/tests/lsp.test.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/tests/lsp.test.ts
@@ -24,7 +24,7 @@ const PRIMITIVE_TYPES = ['u8', 'u16', 'u32', 'u64', 'u128', 'u256', 'bool', 'vec
 
 Mocha.suite('LSP', () => {
     Mocha.test('textDocument/documentSymbol', async () => {
-        const ext = vscode.extensions.getExtension('iota-foundation.iota-move');
+        const ext = vscode.extensions.getExtension('iotaledger.iota-move');
         assert.ok(ext);
 
         await ext.activate(); // Synchronous waiting for activation to complete
@@ -69,7 +69,7 @@ Mocha.suite('LSP', () => {
     });
 
     Mocha.test('textDocument/hover for definition in the same module', async () => {
-        const ext = vscode.extensions.getExtension('iota-foundation.iota-move');
+        const ext = vscode.extensions.getExtension('iotaledger.iota-move');
         assert.ok(ext);
 
         await ext.activate(); // Synchronous waiting for activation to complete
@@ -108,7 +108,7 @@ Mocha.suite('LSP', () => {
     });
 
     Mocha.test('textDocument/hover for definition in an external module', async () => {
-        const ext = vscode.extensions.getExtension('iota-foundation.iota-move');
+        const ext = vscode.extensions.getExtension('iotaledger.iota-move');
         assert.ok(ext);
 
         await ext.activate(); // Synchronous waiting for activation to complete
@@ -147,7 +147,7 @@ Mocha.suite('LSP', () => {
     });
 
     Mocha.test('textDocument/completion', async () => {
-        const ext = vscode.extensions.getExtension('iota-foundation.iota-move');
+        const ext = vscode.extensions.getExtension('iotaledger.iota-move');
         assert.ok(ext);
 
         await ext.activate(); // Synchronous waiting for activation to complete


### PR DESCRIPTION
# Description of change

According to issue #4241, the publisher's name is `iotaledger`.
The publisher name should be changed in the extension manifest to be consistent with the created one.

## Links to any relevant issues

fixes #4292

