### PR TITLE
fix(ci): labeler.yml for explorer

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,6 @@
-Documentation:
+documentation:
   - changed-files:
       - any-glob-to-any-file: docs/content/**/*
-iota-explorer:
+explorer:
   - changed-files:
-      - any-glob-to-any-file: explorer/**/*
+      - any-glob-to-any-file: apps/explorer/**/*


### PR DESCRIPTION
Label `iota-explorer` doesn't exist and the glob path was wrong.