### PR TITLE
[cherry-pick] Fix `StructTag` conversion for `iotax_queryEvents` Indexer-RPC method (#4289)

### DIFF
--- a/crates/iota-cluster-test/src/cluster.rs
+++ b/crates/iota-cluster-test/src/cluster.rs
@@ -264,7 +264,7 @@ impl Cluster for LocalNewCluster {
                 Some(pg_address.clone()),
                 fullnode_url.clone(),
                 ReaderWriterConfig::writer_mode(None),
-                data_ingestion_path.clone(),
+                Some(data_ingestion_path.clone()),
                 None,
             )
             .await;
@@ -274,7 +274,7 @@ impl Cluster for LocalNewCluster {
                 Some(pg_address),
                 fullnode_url.clone(),
                 ReaderWriterConfig::reader_mode(indexer_address.to_string()),
-                data_ingestion_path,
+                Some(data_ingestion_path),
                 None,
             )
             .await;

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -1161,7 +1161,8 @@ impl<U: R2D2Connection> IndexerReader<U> {
                     )
                 }
                 EventFilter::MoveEventType(struct_tag) => {
-                    format!("event_type = '{}'", struct_tag)
+                    let formatted_struct_tag = struct_tag.to_canonical_string(true);
+                    format!("event_type = '{formatted_struct_tag}'")
                 }
                 EventFilter::MoveEventModule { package, module } => {
                     let package_module_prefix = format!("{}::{}", package.to_hex_literal(), module);

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -114,7 +114,7 @@ pub async fn start_test_cluster_with_read_write_indexer(
     builder_modifier: Option<Box<dyn FnOnce(TestClusterBuilder) -> TestClusterBuilder>>,
 ) -> (TestCluster, PgIndexerStore<PgConnection>, HttpClient) {
     let temp = tempdir().unwrap().into_path();
-    let mut builder = TestClusterBuilder::new().with_data_ingestion_dir(temp.clone());
+    let mut builder = TestClusterBuilder::new();
 
     if let Some(builder_modifier) = builder_modifier {
         builder = builder_modifier(builder);
@@ -127,7 +127,7 @@ pub async fn start_test_cluster_with_read_write_indexer(
         Some(get_indexer_db_url(None)),
         cluster.rpc_url().to_string(),
         ReaderWriterConfig::writer_mode(None),
-        temp.clone(),
+        None,
         database_name,
     )
     .await;
@@ -305,7 +305,7 @@ pub async fn start_simulacrum_rest_api_with_write_indexer(
         Some(get_indexer_db_url(None)),
         format!("http://{}", server_url),
         ReaderWriterConfig::writer_mode(None),
-        data_ingestion_path,
+        Some(data_ingestion_path),
         database_name,
     )
     .await;

--- a/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
@@ -186,6 +186,38 @@ fn query_events_supported_events() {
 }
 
 #[test]
+fn query_validator_epoch_info_event() {
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        cluster,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(store, 1).await;
+
+        cluster.force_new_epoch().await;
+
+        let result = client.query_events(EventFilter::MoveEventType("0x0000000000000000000000000000000000000000000000000000000000000003::validator_set::ValidatorEpochInfoEventV1".parse().unwrap()), None, None, None).await;
+        assert!(result.is_ok());
+        assert!(!result.unwrap().data.is_empty());
+
+        let result = client.query_events(EventFilter::MoveEventType("0x3::validator_set::ValidatorEpochInfoEventV1".parse().unwrap()), None, None, None).await;
+        assert!(result.is_ok());
+        assert!(!result.unwrap().data.is_empty());
+
+        let result = client.query_events(EventFilter::MoveEventType("0x0003::validator_set::ValidatorEpochInfoEventV1".parse().unwrap()), None, None, None).await;
+        assert!(result.is_ok());
+        assert!(!result.unwrap().data.is_empty());
+
+        let result = client.query_events(EventFilter::MoveEventType("0x1::validator_set::ValidatorEpochInfoEventV1".parse().unwrap()), None, None, None).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().data.is_empty());
+    });
+}
+
+#[test]
 fn test_get_owned_objects() -> Result<(), anyhow::Error> {
     let ApiTestSetup {
         runtime,

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -1158,6 +1158,7 @@ fn get_total_transaction_blocks() {
 
     runtime.block_on(async move {
         indexer_wait_for_checkpoint(store, checkpoint).await;
+
         let total_transaction_blocks = client.get_total_transaction_blocks().await.unwrap();
 
         let fullnode_checkpoint = cluster

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -755,7 +755,7 @@ async fn start(
             Some(pg_address.clone()),
             fullnode_url.clone(),
             ReaderWriterConfig::writer_mode(None),
-            data_ingestion_path.clone(),
+            Some(data_ingestion_path.clone()),
             None,
         )
         .await;
@@ -766,7 +766,7 @@ async fn start(
             Some(pg_address.clone()),
             fullnode_url.clone(),
             ReaderWriterConfig::reader_mode(indexer_address.to_string()),
-            data_ingestion_path,
+            Some(data_ingestion_path),
             None,
         )
         .await;


### PR DESCRIPTION
Cherry-pick #4289 on 0.7.x