### PR TITLE
fix(docs): Typo in node docker install

### DIFF
--- a/nre/docker/README.md
+++ b/nre/docker/README.md
@@ -7,7 +7,7 @@ Tested using:
 
 ## Prerequisites and Setup
 
-1. Confirm you have either [Docker Engine](https://docs.docker.com/engine/install/) or [Docker Desktop](https://docs.docker.com/desktop/install/linux-install/) instllled, as well as [Docker Compose](https://github.com/docker/compose#linux).
+1. Confirm you have either [Docker Engine](https://docs.docker.com/engine/install/) or [Docker Desktop](https://docs.docker.com/desktop/install/linux-install/) installed, as well as [Docker Compose](https://github.com/docker/compose#linux).
 
 2. Update [validator.yaml](../config/validator.yaml) and place it in the same directory as `docker-compose.yaml`.
 


### PR DESCRIPTION
# Description of change

Fixes a typo in the docker node install docs.

## Links to any relevant issues

There are no relevant issues since this is  just an extremely small typo fix.

## Type of change

Choose a type of change, and delete any options that are not relevant.
- Documentation Fix

## How the change has been tested

Totally ran a docs setup locally to check whether the typo was gone.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
