### PR TITLE
fix(iota-types): `elided_named_lifetimes` 1.83 compiler warning

### DIFF
--- a/crates/iota-types/src/crypto.rs
+++ b/crates/iota-types/src/crypto.rs
@@ -1390,7 +1390,7 @@ impl<const STRONG_THRESHOLD: bool> AuthorityQuorumSignInfo<STRONG_THRESHOLD> {
     pub fn authorities<'a>(
         &'a self,
         committee: &'a Committee,
-    ) -> impl Iterator<Item = IotaResult<&AuthorityName>> {
+    ) -> impl Iterator<Item = IotaResult<&'a AuthorityName>> {
         self.signers_map.iter().map(|i| {
             committee
                 .authority_by_index(i)


### PR DESCRIPTION
```
warning: elided lifetime has a name
    --> crates/iota-types/src/crypto.rs:1393:42
     |
1390 |     pub fn authorities<'a>(
     |                        -- lifetime `'a` declared here
...
1393 |     ) -> impl Iterator<Item = IotaResult<&AuthorityName>> {
     |                                          ^ this elided lifetime gets resolved as `'a`
     |
     = note: `#[warn(elided_named_lifetimes)]` on by default
```