### PR TITLE
Fix: Cannot find rates for staking pool

### DIFF
--- a/crates/iota-graphql-rpc/src/server/exchange_rates_task.rs
+++ b/crates/iota-graphql-rpc/src/server/exchange_rates_task.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_indexer::apis::{GovernanceReadApi, governance_api::exchange_rates};
+use iota_indexer::apis::GovernanceReadApi;
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
@@ -48,7 +48,7 @@ impl TriggerExchangeRatesTask {
                     if let Ok(latest_iota_system_state) = latest_iota_system_state {
                         let db = self.db.clone();
                         let governance_api = GovernanceReadApi::new(db.inner) ;
-                        exchange_rates(&governance_api, &latest_iota_system_state)
+                        governance_api.exchange_rates( &latest_iota_system_state)
                             .await
                             .map_err(|e| error!("Failed to fetch exchange rates: {:?}", e))
                             .ok();

--- a/crates/iota-graphql-rpc/src/types/validator.rs
+++ b/crates/iota-graphql-rpc/src/types/validator.rs
@@ -9,6 +9,7 @@ use async_graphql::{
     dataloader::Loader,
     *,
 };
+use futures::TryFutureExt;
 use iota_indexer::apis::GovernanceReadApi;
 use iota_json_rpc::governance_api::median_apy_from_exchange_rates;
 use iota_types::{
@@ -37,6 +38,7 @@ use crate::{
         validator_credentials::ValidatorCredentials,
     },
 };
+
 #[derive(Clone, Debug)]
 pub(crate) struct Validator {
     pub validator_summary: NativeIotaValidatorSummary,
@@ -75,21 +77,30 @@ impl Loader<u64> for Db {
             .map_err(|_| Error::Internal("Failed to fetch latest Iota system state".to_string()))?;
         let governance_api = GovernanceReadApi::new(self.inner.clone());
 
-        let pending_and_candidate_validators_exchange_rate = governance_api
-            .pending_and_candidate_validators_exchange_rate(&latest_iota_system_state)
-            .await
-            .map_err(|e| {
-                Error::Internal(format!(
-                    "Error fetching pending and candidate validators exchange rates. {e}"
-                ))
-            })?;
+        let (candidate_rates, pending_rates) = tokio::try_join!(
+            governance_api
+                .candidate_validators_exchange_rate(&latest_iota_system_state)
+                .map_err(|e| {
+                    Error::Internal(format!(
+                        "Error fetching candidate validators exchange rates. {e}"
+                    ))
+                }),
+            governance_api
+                .pending_validators_exchange_rate()
+                .map_err(|e| {
+                    Error::Internal(format!(
+                        "Error fetching pending validators exchange rates. {e}"
+                    ))
+                })
+        )?;
 
         let mut exchange_rates = governance_api
             .exchange_rates(&latest_iota_system_state)
             .await
             .map_err(|e| Error::Internal(format!("Error fetching exchange rates. {e}")))?;
 
-        exchange_rates.extend(pending_and_candidate_validators_exchange_rate.into_iter());
+        exchange_rates.extend(candidate_rates.into_iter());
+        exchange_rates.extend(pending_rates.into_iter());
 
         let mut results = BTreeMap::new();
 

--- a/crates/iota-graphql-rpc/src/types/validator.rs
+++ b/crates/iota-graphql-rpc/src/types/validator.rs
@@ -80,7 +80,7 @@ impl Loader<u64> for Db {
             .await
             .map_err(|e| {
                 Error::Internal(format!(
-                    "Error fetching pending validators exchange rates. {e}"
+                    "Error fetching pending and candidate validators exchange rates. {e}"
                 ))
             })?;
 

--- a/crates/iota-indexer/src/apis/governance_api.rs
+++ b/crates/iota-indexer/src/apis/governance_api.rs
@@ -345,7 +345,7 @@ impl<T: R2D2Connection + 'static> GovernanceReadApi<T> {
         Ok(exchange_rates)
     }
 
-    /// Cached exchange rates for validators for the given epoch, the cache size
+    /// Caches exchange rates for validators for the given epoch, the cache size
     /// is 1, it will be cleared when the epoch changes. Rates are in
     /// descending order by epoch.
     pub async fn exchange_rates(

--- a/crates/iota-indexer/src/apis/governance_api.rs
+++ b/crates/iota-indexer/src/apis/governance_api.rs
@@ -346,7 +346,7 @@ impl<T: R2D2Connection + 'static> GovernanceReadApi<T> {
     }
 
     /// Cached exchange rates for validators for the given epoch, the cache size
-    /// is 1, it will be cleared when the epoch changes. rates are in
+    /// is 1, it will be cleared when the epoch changes. Rates are in
     /// descending order by epoch.
     pub async fn exchange_rates(
         &self,

--- a/crates/iota-indexer/src/apis/governance_api.rs
+++ b/crates/iota-indexer/src/apis/governance_api.rs
@@ -478,24 +478,25 @@ impl<T: R2D2Connection + 'static> GovernanceReadApi<T> {
         self.validator_exchange_rates(tables).await
     }
 
-    /// Fetches validator status information from `StateRead` for validators not
-    /// included in `IotaSystemStateSummary`.
+    /// Fetches validator status information from `StateRead`.
     ///
-    /// `IotaSystemStateSummary` only contains information about `Active`
-    /// validators. To retrieve information about `Inactive`, `Candidate`, and
-    /// `Pending` validators, we need to access dynamic fields within specific
-    /// tables.
+    /// This makes sense for validators not included in
+    /// `IotaSystemStateSummary`. `IotaSystemStateSummary` only contains
+    /// information about `Active` validators. To retrieve information about
+    /// `Inactive`, `Candidate`, and `Pending` validators, we need to access
+    /// dynamic fields within specific Move tables.
     ///
-    /// To retrieve validator status information, this function utilizes a
-    /// `table_id` defined by an `ObjectID` and a `limit` to specify the number
-    /// of records to fetch. Both the `table_id` and `limit` are obtained
-    /// from `IotaSystemStateSummary`. Additionally, a `key` is extracted
-    /// from the `table_id`'s `DynamicFieldInfo` to identify the specific
-    /// validator within the table.
+    /// To retrieve validator status information, this function utilizes the
+    /// corresponding `table_id` (an `ObjectID` value) and a `limit` to specify
+    /// the number of records to fetch. Both the `table_id` and `limit` can
+    /// be obtained from `IotaSystemStateSummary` in the caller.
+    /// Additionally, keys are extracted from the table `DynamicFieldInfo`
+    /// values according to the `key` closure. This helps in identifying the
+    /// specific validator within the table.
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```text
     /// // Get inactive validators
     /// let system_state_summary = self.get_latest_iota_system_state().await?;
     /// let _ = self.validator_summary_from_system_state(
@@ -510,7 +511,7 @@ impl<T: R2D2Connection + 'static> GovernanceReadApi<T> {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```text
     /// // Get candidate validators
     /// let system_state_summary = self.get_latest_iota_system_state().await?;
     /// let _ = self.validator_summary_from_system_state(

--- a/crates/iota-json-rpc/src/governance_api.rs
+++ b/crates/iota-json-rpc/src/governance_api.rs
@@ -683,12 +683,12 @@ fn candidate_validators_exchange_rate(
 /// `Pending` validators, we need to access dynamic fields within specific
 /// tables.
 ///
-/// To retrieve validator status information, this function utilizes a
-/// `table_id` defined by an `ObjectID` and a `limit` to specify the number of
-/// records to fetch. Both the `table_id` and `limit` are obtained from
-/// `IotaSystemStateSummary`. Additionally, a `key` is extracted from the
-/// `table_id`'s `DynamicFieldInfo` to identify the specific validator within
-/// the table.
+/// To retrieve validator status information, this function utilizes the
+/// corresponding `table_id` (an `ObjectID` value) and a `limit` to specify the
+/// number of records to fetch. Both the `table_id` and `limit` can be obtained
+/// from `IotaSystemStateSummary` in the caller. Additionally, keys are
+/// extracted from the table `DynamicFieldInfo` values according to the `key`
+/// closure. This helps in identifying the specific validator within the table.
 ///
 /// # Example
 ///

--- a/crates/iota-json-rpc/src/governance_api.rs
+++ b/crates/iota-json-rpc/src/governance_api.rs
@@ -692,7 +692,7 @@ fn candidate_validators_exchange_rate(
 ///
 /// # Example
 ///
-/// ```rust
+/// ```text
 /// // Get inactive validators
 /// let system_state_summary = state.get_system_state()?.into_iota_system_state_summary();
 /// let _ = validator_summary_from_system_state(
@@ -708,7 +708,7 @@ fn candidate_validators_exchange_rate(
 ///
 /// # Example
 ///
-/// ```rust
+/// ```text
 /// // Get candidate validators
 /// let system_state_summary = state.get_system_state()?.into_iota_system_state_summary();
 /// let _ = validator_summary_from_system_state(

--- a/crates/iota-json-rpc/src/governance_api.rs
+++ b/crates/iota-json-rpc/src/governance_api.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{cmp::max, collections::BTreeMap, str::FromStr, sync::Arc};
+use std::{cmp::max, collections::BTreeMap, fmt::Debug, sync::Arc};
 
 use async_trait::async_trait;
 use cached::{SizedCache, proc_macro::cached};
@@ -17,9 +17,10 @@ use iota_json_rpc_types::{
 use iota_metrics::spawn_monitored_task;
 use iota_open_rpc::Module;
 use iota_types::{
+    MoveTypeTagTrait,
     base_types::{IotaAddress, ObjectID},
     committee::EpochId,
-    dynamic_field::get_dynamic_field_from_store,
+    dynamic_field::{DynamicFieldInfo, get_dynamic_field_from_store},
     error::{IotaError, UserInputError},
     governance::StakedIota,
     id::ID,
@@ -33,7 +34,7 @@ use iota_types::{
 };
 use itertools::Itertools;
 use jsonrpsee::{RpcModule, core::RpcResult};
-use serde::Deserialize;
+use serde::{Serialize, de::DeserializeOwned};
 use statrs::statistics::{Data, Median};
 use tracing::{info, instrument};
 
@@ -43,6 +44,9 @@ use crate::{
     error::{Error, IotaRpcInputError, RpcInterimResult},
     logger::FutureWithTracing as _,
 };
+
+type ValidatorTable = (IotaAddress, ObjectID, ObjectID, u64, bool);
+
 #[derive(Clone)]
 pub struct GovernanceReadApi {
     state: Arc<dyn StateRead>,
@@ -199,8 +203,10 @@ impl GovernanceReadApi {
         let rates = exchange_rates(&self.state, system_state_summary.epoch)
             .await?
             .into_iter()
-            // Try to find for any pending and candidate validator exchange rate
-            .chain(pending_and_candidate_validators_exchange_rate(&self.state)?.into_iter())
+            // Try to find for any candidate validator exchange rate
+            .chain(candidate_validators_exchange_rate(&self.state)?.into_iter())
+            // Try to find for any pending validator exchange rate
+            .chain(pending_validators_exchange_rate(&self.state)?.into_iter())
             .map(|rates| (rates.pool_id, rates))
             .collect::<BTreeMap<_, _>>();
 
@@ -528,54 +534,16 @@ async fn exchange_rates(
     state: &Arc<dyn StateRead>,
     _current_epoch: EpochId,
 ) -> RpcInterimResult<Vec<ValidatorExchangeRates>> {
-    let system_state = state.get_system_state()?;
-    let system_state_summary: IotaSystemStateSummary =
-        system_state.into_iota_system_state_summary();
-
-    // Get validator rate tables
-    let mut tables = vec![];
-
-    for validator in system_state_summary.active_validators {
-        tables.push((
-            validator.iota_address,
-            validator.staking_pool_id,
-            validator.exchange_rates_id,
-            validator.exchange_rates_size,
-            true,
-        ));
-    }
-
-    // Get inactive validator rate tables
-    for df in state.get_dynamic_fields(
-        system_state_summary.inactive_pools_id,
-        None,
-        system_state_summary.inactive_pools_size as usize,
-    )? {
-        let pool_id: ID =
-            bcs::from_bytes(&df.1.bcs_name).map_err(|e| IotaError::ObjectDeserialization {
-                error: e.to_string(),
-            })?;
-        let validator = get_validator_from_table(
-            state.get_object_store().as_ref(),
-            system_state_summary.inactive_pools_id,
-            &pool_id,
-        )?; // TODO(wlmyng): roll this into StateReadError
-        tables.push((
-            validator.iota_address,
-            validator.staking_pool_id,
-            validator.exchange_rates_id,
-            validator.exchange_rates_size,
-            false,
-        ));
-    }
-
-    validator_exchange_rates(state, tables)
+    Ok(active_validators_exchange_rates(state)?
+        .into_iter()
+        .chain(inactive_validators_exchange_rates(state)?.into_iter())
+        .collect())
 }
 
 /// Get validator exchange rates
 fn validator_exchange_rates(
     state: &Arc<dyn StateRead>,
-    tables: Vec<(IotaAddress, ObjectID, ObjectID, u64, bool)>,
+    tables: Vec<ValidatorTable>,
 ) -> RpcInterimResult<Vec<ValidatorExchangeRates>> {
     if tables.is_empty() {
         return Ok(vec![]);
@@ -587,8 +555,8 @@ fn validator_exchange_rates(
         let mut rates = state
             .get_dynamic_fields(exchange_rates_id, None, exchange_rates_size as usize)?
             .into_iter()
-            .map(|df| {
-                let epoch: EpochId = bcs::from_bytes(&df.1.bcs_name).map_err(|e| {
+            .map(|(_object_id, df)| {
+                let epoch: EpochId = bcs::from_bytes(&df.bcs_name).map_err(|e| {
                     IotaError::ObjectDeserialization {
                         error: e.to_string(),
                     }
@@ -617,20 +585,65 @@ fn validator_exchange_rates(
     Ok(exchange_rates)
 }
 
-/// Check if there is any `Pending` and `Candidate` validators and get its
-/// exchange rates, this two states of a validator lifecycle can manifest
-/// during an epoch or multiple ones, is essential to not cache this data,
-/// while exchange rates for `Active` and `Inactive` validators is OK to do
-/// so because those states are manifested on epoch change.
-fn pending_and_candidate_validators_exchange_rate(
+/// Check for validators in the `Active` state and get its exchange rate
+fn active_validators_exchange_rates(
+    state: &Arc<dyn StateRead>,
+) -> RpcInterimResult<Vec<ValidatorExchangeRates>> {
+    let system_state_summary = state.get_system_state()?.into_iota_system_state_summary();
+
+    let tables = system_state_summary
+        .active_validators
+        .into_iter()
+        .map(|validator| {
+            (
+                validator.iota_address,
+                validator.staking_pool_id,
+                validator.exchange_rates_id,
+                validator.exchange_rates_size,
+                true,
+            )
+        })
+        .collect();
+
+    validator_exchange_rates(state, tables)
+}
+
+/// Check for validators in the `Inactive` state and get its exchange rate
+fn inactive_validators_exchange_rates(
+    state: &Arc<dyn StateRead>,
+) -> RpcInterimResult<Vec<ValidatorExchangeRates>> {
+    let system_state_summary = state.get_system_state()?.into_iota_system_state_summary();
+
+    let tables = validator_summary_from_system_state(
+        state,
+        system_state_summary.inactive_pools_id,
+        system_state_summary.inactive_pools_size,
+        |df| {
+            bcs::from_bytes::<ID>(&df.bcs_name).map_err(|e| {
+                IotaError::ObjectDeserialization {
+                    error: e.to_string(),
+                }
+                .into()
+            })
+        },
+    )?;
+
+    validator_exchange_rates(state, tables)
+}
+
+/// Check for validators in the `Pending` state and get its exchange rate. For
+/// these validators, their exchange rates should not be cached as their state
+/// can occur during an epoch or across multiple ones. In contrast, exchange
+/// rates for `Active` and `Inactive` validators can be cached, as their state
+/// changes only at epoch change.
+fn pending_validators_exchange_rate(
     state: &Arc<dyn StateRead>,
 ) -> RpcInterimResult<Vec<ValidatorExchangeRates>> {
     let system_state = state.get_system_state()?;
     let object_store = state.get_object_store();
-    let system_state_summary = system_state.clone().into_iota_system_state_summary();
 
     // Try to find for any pending active validator
-    let mut tables = system_state
+    let tables = system_state
         .get_pending_active_validators(object_store)?
         .into_iter()
         .map(|pending_active_validator| {
@@ -642,34 +655,69 @@ fn pending_and_candidate_validators_exchange_rate(
                 false,
             )
         })
-        .collect::<Vec<(IotaAddress, ObjectID, ObjectID, u64, bool)>>();
-
-    // Try to find for validator candidate and get its exchange rates
-    for (_, df) in state.get_dynamic_fields(
-        system_state_summary.validator_candidates_id,
-        None,
-        system_state_summary.validator_candidates_size as usize,
-    )? {
-        let raw_address =
-            String::deserialize(df.name.value).map_err(|err| IotaError::from(err.to_string()))?;
-        let validator_address = IotaAddress::from_str(&raw_address)?;
-
-        let validator_summary = get_validator_from_table(
-            object_store,
-            system_state_summary.validator_candidates_id,
-            &validator_address,
-        )?;
-
-        tables.push((
-            validator_summary.iota_address,
-            validator_summary.staking_pool_id,
-            validator_summary.exchange_rates_id,
-            validator_summary.exchange_rates_size,
-            false,
-        ));
-    }
+        .collect::<Vec<ValidatorTable>>();
 
     validator_exchange_rates(state, tables)
+}
+
+/// Check for validators in the `Candidate` state and get its exchange rate. For
+/// these validators, their exchange rates should not be cached as their state
+/// can occur during an epoch or across multiple ones. In contrast, exchange
+/// rates for `Active` and `Inactive` validators can be cached, as their state
+/// changes only at epoch change.
+fn candidate_validators_exchange_rate(
+    state: &Arc<dyn StateRead>,
+) -> RpcInterimResult<Vec<ValidatorExchangeRates>> {
+    let system_state_summary = state.get_system_state()?.into_iota_system_state_summary();
+
+    // From validator_candidates_id table get validator info using as key its
+    // IotaAddress
+    let tables = validator_summary_from_system_state(
+        state,
+        system_state_summary.validator_candidates_id,
+        system_state_summary.validator_candidates_size,
+        |df| {
+            bcs::from_bytes::<IotaAddress>(&df.bcs_name).map_err(|err| {
+                IotaError::ObjectDeserialization {
+                    error: err.to_string(),
+                }
+                .into()
+            })
+        },
+    )?;
+
+    validator_exchange_rates(state, tables)
+}
+
+/// An utility function to gather `Candidate` or `Inactive` validator status
+/// information from the system state
+fn validator_summary_from_system_state<K, F>(
+    state: &Arc<dyn StateRead>,
+    table_id: ObjectID,
+    validator_size: u64,
+    key: F,
+) -> RpcInterimResult<Vec<ValidatorTable>>
+where
+    F: Fn(DynamicFieldInfo) -> RpcInterimResult<K>,
+    K: MoveTypeTagTrait + Serialize + DeserializeOwned + Debug,
+{
+    let object_store = state.get_object_store();
+
+    state
+        .get_dynamic_fields(table_id, None, validator_size as usize)?
+        .into_iter()
+        .map(|(_object_id, df)| {
+            let validator_summary = get_validator_from_table(object_store, table_id, &key(df)?)?;
+
+            Ok((
+                validator_summary.iota_address,
+                validator_summary.staking_pool_id,
+                validator_summary.exchange_rates_id,
+                validator_summary.exchange_rates_size,
+                false,
+            ))
+        })
+        .collect()
 }
 
 #[derive(Clone, Debug)]

--- a/crates/iota-json-rpc/src/governance_api.rs
+++ b/crates/iota-json-rpc/src/governance_api.rs
@@ -675,13 +675,13 @@ fn candidate_validators_exchange_rate(
     validator_exchange_rates(state, tables)
 }
 
-/// Fetches validator status information from `StateRead` for validators not
-/// included in `IotaSystemStateSummary`.
+/// Fetches validator status information from `StateRead`.
 ///
+/// This makes sense for validators not included in `IotaSystemStateSummary`.
 /// `IotaSystemStateSummary` only contains information about `Active`
 /// validators. To retrieve information about `Inactive`, `Candidate`, and
 /// `Pending` validators, we need to access dynamic fields within specific
-/// tables.
+/// Move tables.
 ///
 /// To retrieve validator status information, this function utilizes the
 /// corresponding `table_id` (an `ObjectID` value) and a `limit` to specify the


### PR DESCRIPTION
# Description of change

This PR fixes the `"Cannot find rates for staking pool: {pool_id}"` error in the following crates
- `iota-json-rpc`
- `iota-indexer`
- `iota-graphql-rpc` 

The missing piece was to include also the candidate validators into account, now it should include all the the lifecycle phases of a validator: **Candidate**, **Pending**, **Active**, **Inactive**.

## Links to any relevant issues

#2929 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

- Start postgres

```sh
docker run --rm --name CONTAINER_NAME -e POSTGRES_PASSWORD=postgrespw -e POSTGRES_USER=postgres -e POSTGRES_DB=iota_indexer -d -p 5432:5432 postgres -N 1000
```

- Start a local network
```sh
RUST_LOG=consensus=off,iota_json_rpc=info cargo run --features indexer --bin iota start --force-regenesis --with-faucet --faucet-amount 2600000000000000 --with-indexer --epoch-duration-ms 10000
```

- run this script, it will step by step execute the RPC call during all the phases of a validator: Candidate, Pending, Active

```sh
function http_request() {
    for PORT in 9000 9124
    do
        RESPONSE=$(curl http://localhost:${PORT} \
        --header 'content-type: application/json' \
        --data '{
            "jsonrpc": "2.0",
            "id": 1,
            "method": "iotax_getStakes",
            "params": {
                "owner": "'${validatorAddress}'"
            }
        }')

        echo $RESPONSE

        if echo $RESPONSE | grep -q "Cannot find rates for staking pool"; then
            echo $RESPONSE
            exit 1
        fi
    done
}

set -x
iota client switch --env localnet
iota client faucet --url http://127.0.0.1:9123/gas
sleep 2
# Create validator
iota validator make-validator-info validator0 description https://iota.org/logo.png https://www.iota.org 127.0.0.1 1000
# Ad validator as candidate, is not in pending list yet
iota validator become-candidate validator.info
sleep 2
# Delegate stakes to validator
coinObjectId=$(iota client gas --json | jq '.[0].gasCoinId')
validatorAddress=$(iota client active-address)
iota client call --package 0x3 --module iota_system --function request_add_stake --args 0x5 $coinObjectId $validatorAddress --gas-budget 10000000
sleep 2
set +x
# Request validator stakes
http_request
# Add the validator into pending list, it will become active on next epoch
set -x
iota validator join-committee
sleep 2
set +x
# Request validator stakes
http_request
# wait till the stakes will be active
set -x
sleep 10
set +x
# Request validator stakes
http_request

```

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
