### PR TITLE
feat(workflows): add release_move_ide.yml

### DIFF
--- a/.github/workflows/release_move_ide.yml
+++ b/.github/workflows/release_move_ide.yml
@@ -1,0 +1,152 @@
+name: Release Move IDE to VS Marketplace
+
+on:
+  ## Allow triggering this workflow manually via GitHub CLI/web
+  workflow_dispatch:
+  push:
+    branches:
+      - "dev-tools/publish-move-ide"
+
+env:
+  CARGO_TERM_COLOR: always
+  # Disable incremental compilation.
+  #
+  # Incremental compilation is useful as part of an edit-build-test-edit cycle,
+  # as it lets the compiler avoid recompiling code that hasn't changed. However,
+  # on CI, we're not making small edits; we're almost always building the entire
+  # project from scratch. Thus, incremental compilation on CI actually
+  # introduces *additional* overhead to support making future builds
+  # faster...but no future builds will ever occur in any given CI environment.
+  #
+  # See https://matklad.github.io/2021/09/04/fast-rust-builds.html#ci-workflow
+  # for details.
+  CARGO_INCREMENTAL: 0
+  # Allow more retries for network requests in cargo (downloading crates) and
+  # rustup (installing toolchains). This should help to reduce flaky CI failures
+  # from transient network timeouts or other issues.
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+  # Don't emit giant backtraces in the CI logs.
+  RUST_BACKTRACE: short
+  TMP_BUILD_DIR: "./tmp/"
+
+jobs:
+  build-move-analyzer:
+    name: Build move-analyzer
+    strategy:
+      matrix:
+        os: [
+          self-hosted, # ubuntu-x86_64
+          macos-latest, # macos-arm64
+          macos-latest-large, # macos-x86_64
+          windows-latest, # windows-x86_64
+        ]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # pin@v4
+      - name: Set os/arch variables (Windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: bash
+        run: |
+          export arch=$(uname -m)
+          export os_type="windows-${arch}"
+          echo "os_type=${os_type}" >> $GITHUB_ENV
+          echo "extention=$(echo ".exe")" >> $GITHUB_ENV
+
+      - name: Set os/arch variables (self hosted ubuntu)
+        if: ${{ matrix.os == 'self-hosted' }}
+        shell: bash
+        run: |
+          export arch=$(uname -m)
+          export os_type="linux-${arch}"
+          echo "os_type=${os_type}" >> $GITHUB_ENV
+
+      - name: Set os/arch variables
+        if: ${{ matrix.os == 'macos-latest' }}
+        shell: bash
+        run: |
+          export arch=$(uname -m)
+          export system_os=$(echo ${{ matrix.os }} | cut -d- -f1)
+          export os_type="${system_os}-${arch}"
+          echo "os_type=${system_os}-${arch}" >> $GITHUB_ENV
+
+      - name: Install nexttest (Windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        uses: taiki-e/install-action@375e0c7f08a66b8c2ba7e7eef31a6f91043a81b0 # pin@v2
+        with:
+          tool: nextest
+
+      - name: Cargo build for ${{ matrix.os }} platform
+        shell: bash
+        run: |
+          [ -f ~/.cargo/env ] && source ~/.cargo/env ; cargo build --bin move-analyzer --release
+
+      # Filenames need to match external-crates/move/crates/move-analyzer/editors/code/scripts/create_from_local.sh
+      - name: Rename binaries for ${{ matrix.os }}
+        shell: bash
+        run: |
+          if [ ${{ matrix.os }} == "macos-latest" ]; then
+            OS_TARGET="macos-arm64"
+          elif [ ${{ matrix.os }} == "macos-latest-large" ]; then
+            OS_TARGET="macos-x86_64"
+          elif [ ${{ matrix.os }} == "windows-latest" ]; then
+            OS_TARGET="windows-x86_64"
+          elif [ ${{ matrix.os }} == "self-hosted" ]; then
+            OS_TARGET="ubuntu-x86_64"
+          else
+            echo "Unknown OS" ${{ matrix.os }}
+            exit 1
+          fi
+
+          mkdir -p ${{ env.TMP_BUILD_DIR }}
+          mv ./target/release/move-analyzer${{ env.extention }} ${{ env.TMP_BUILD_DIR }}/move-analyzer-$OS_TARGET${{ env.extention }}
+
+      - name: Print built file
+        run: ls -R ${{ env.TMP_BUILD_DIR }}
+
+      - name: Upload move-analyzer binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}-move-analyzer
+          path: ${{ env.TMP_BUILD_DIR }}
+          if-no-files-found: error
+
+  build-and-publish-vs-code-extension:
+    name: Build and publish VS Code extension with move-analyzer binaries
+    needs: build-move-analyzer
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # Pin v4.1.1
+        with:
+          ref: ${{ github.event.inputs.iota_repo_ref || github.ref }}
+
+      - name: Download move-analyzer binaries
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: "external-crates/move/crates/move-analyzer/editors/code/move-analyzer-binaries"
+
+      - name: Print downloaded binaries
+        run: ls -R external-crates/move/crates/move-analyzer/editors/code/move-analyzer-binaries
+
+      - name: Setup Node
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # pin@v4.0.2
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        working-directory: ./external-crates/move/crates/move-analyzer/editors/code
+        run: |
+          npm install
+          npm install --save-dev @types/node @types/semver
+          npm install -g vsce
+          sudo apt install zsh -y
+
+      - name: Build and publish VS Code extension with move-analyzer binaries
+        working-directory: external-crates/move/crates/move-analyzer/editors/code/
+        run: |
+          # Set the Personal Access Token to publish to the Visual Studio Marketplace
+          export VSCE_PAT=${{ secrets.VS_MARKETPLACE_TOKEN }}
+          ./scripts/create_from_local.sh -pub move-analyzer-binaries

--- a/.github/workflows/release_move_ide.yml
+++ b/.github/workflows/release_move_ide.yml
@@ -3,9 +3,6 @@ name: Release Move IDE to VS Marketplace
 on:
   ## Allow triggering this workflow manually via GitHub CLI/web
   workflow_dispatch:
-  push:
-    branches:
-      - "dev-tools/publish-move-ide"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release_move_ide.yml
+++ b/.github/workflows/release_move_ide.yml
@@ -68,12 +68,6 @@ jobs:
           export os_type="${system_os}-${arch}"
           echo "os_type=${system_os}-${arch}" >> $GITHUB_ENV
 
-      - name: Install nexttest (Windows)
-        if: ${{ matrix.os == 'windows-latest' }}
-        uses: taiki-e/install-action@375e0c7f08a66b8c2ba7e7eef31a6f91043a81b0 # pin@v2
-        with:
-          tool: nextest
-
       - name: Cargo build for ${{ matrix.os }} platform
         shell: bash
         run: |

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -23,6 +23,7 @@
   "keywords": [
     "move",
     "Iota",
+    "iotaledger",
     "IOTA Foundation"
   ],
   "main": "./out/src/main.js",
@@ -124,13 +125,13 @@
     "menus": {
       "commandPalette": [
         {
-          "command": "iota.serverVersion"
+          "command": "iota-move.serverVersion"
         },
         {
-          "command": "iota.build"
+          "command": "iota-move.build"
         },
         {
-          "command": "iota.test"
+          "command": "iota-move.test"
         }
       ]
     }

--- a/external-crates/move/crates/move-analyzer/editors/code/scripts/create_from_local.sh
+++ b/external-crates/move/crates/move-analyzer/editors/code/scripts/create_from_local.sh
@@ -3,9 +3,6 @@
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 
-# This script is meant to be executed on MacOS (hence zsh use - to get associative arrays otherwise
-# unavailable in the bundled bash version).
-
 set -e
 
 usage() {

--- a/external-crates/move/crates/move-analyzer/editors/code/scripts/create_from_local.sh
+++ b/external-crates/move/crates/move-analyzer/editors/code/scripts/create_from_local.sh
@@ -1,0 +1,114 @@
+#!/bin/zsh
+# Copyright (c) Mysten Labs, Inc.
+# Modifications Copyright (c) 2024 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+# This script is meant to be executed on MacOS (hence zsh use - to get associative arrays otherwise
+# unavailable in the bundled bash version).
+
+set -e
+
+usage() {
+    SCRIPT_NAME=$(basename "$1")
+    >&2 echo "Usage: $SCRIPT_NAME  -pkg|-pub [-h] BINDIR"
+    >&2 echo ""
+    >&2 echo "Options:"
+    >&2 echo " -pub          Publish extensions for all targets"
+    >&2 echo " -pkg          Package extensions for all targets"
+    >&2 echo " -h            Print this message"
+    >&2 echo " BINDIR        Directory containing pre-built IOTA move-analyzer binaries"
+}
+
+clean_tmp_dir() {
+  test -d "$TMP_DIR" && rm -fr "$TMP_DIR"
+}
+
+if [[ "$@" == "" ]]; then
+    usage $0
+    exit 1
+fi
+
+BIN_DIR=""
+for cmd in "$@"
+do
+    if [[ "$cmd" == "-h" ]]; then
+        usage $0
+        exit 0
+    elif [[ "$cmd" == "-pkg" ]]; then
+        OP="package"
+        OPTS="-omove-VSCODE_OS.vsix"
+    elif [[ "$cmd" == "-pub" ]]; then
+        OP="publish"
+        OPTS=""
+    else
+        BIN_DIR=$cmd
+
+        if [[ ! -d "$BIN_DIR" ]]; then
+            echo IOTA binary directory $BIN_DIR does not exist
+            usage $0
+            exit 1
+        fi
+    fi
+done
+
+if [[ $BIN_DIR == "" ]]; then
+    # directory storing IOTA binaries have not been defined
+    usage $0
+    exit 1
+fi
+
+# a map from os version identifiers in IOTA's binary distribution to os version identifiers
+# representing VSCode's target platforms used for creating platform-specific plugin distributions
+declare -A SUPPORTED_OS
+SUPPORTED_OS[macos-arm64]=darwin-arm64
+SUPPORTED_OS[macos-x86_64]=darwin-x64
+SUPPORTED_OS[ubuntu-x86_64]=linux-x64
+SUPPORTED_OS[windows-x86_64]=win32-x64
+
+TMP_DIR=$( mktemp -d -t vscode-createXXX )
+trap "clean_tmp_dir $TMP_DIR" EXIT
+
+BIN_FILES=($BIN_DIR/*)
+
+if (( ${#BIN_FILES[@]} != 4 )); then
+    echo "IOTA binary directory $BIN_DIR should only contain binaries for the four supported platforms"
+    exit 1
+fi
+
+
+for IOTA_MOVE_ANALYZER_BIN in "${BIN_FILES[@]}"; do
+    # Extract just the file name
+    FILE_NAME=${IOTA_MOVE_ANALYZER_BIN##*/}
+    # Get the OS target
+    OS_TARGET="${FILE_NAME#move-analyzer-}"
+    # Remove ".exe" for Windows
+    OS_TARGET="${OS_TARGET%.exe}"
+
+    if [[ ! -v SUPPORTED_OS[$OS_TARGET] ]]; then
+        echo "Found IOTA binary archive for a platform that is not supported: $IOTA_MOVE_ANALYZER_BIN"
+        echo "Supported platforms:"
+        for PLATFORM in ${(k)SUPPORTED_OS}; do
+            echo "\t$PLATFORM"
+        done
+        exit 1
+    fi
+
+    # copy move-analyzer binary to the appropriate location where it's picked up when bundling the
+    # extension
+    LANG_SERVER_DIR="language-server"
+    # remove existing one to have only the binary for the target OS
+    rm -rf $LANG_SERVER_DIR
+    mkdir $LANG_SERVER_DIR
+
+    cp $IOTA_MOVE_ANALYZER_BIN $LANG_SERVER_DIR
+
+    VSCODE_OS=${SUPPORTED_OS[$DIST_OS]}
+    vsce "$OP" ${OPTS//VSCODE_OS/$VSCODE_OS} --target "$VSCODE_OS"
+
+    rm -rf $LANG_SERVER_DIR
+
+done
+
+
+# build a "generic" version of the extension that does not bundle the move-analyzer binary
+vsce "$OP" ${OPTS//VSCODE_OS/generic}

--- a/external-crates/move/crates/move-analyzer/editors/code/scripts/create_from_local.sh
+++ b/external-crates/move/crates/move-analyzer/editors/code/scripts/create_from_local.sh
@@ -77,6 +77,7 @@ fi
 
 
 for IOTA_MOVE_ANALYZER_BIN in "${BIN_FILES[@]}"; do
+    echo "Processing" $IOTA_MOVE_ANALYZER_BIN
     # Extract just the file name
     FILE_NAME=${IOTA_MOVE_ANALYZER_BIN##*/}
     # Get the OS target
@@ -100,9 +101,16 @@ for IOTA_MOVE_ANALYZER_BIN in "${BIN_FILES[@]}"; do
     rm -rf $LANG_SERVER_DIR
     mkdir $LANG_SERVER_DIR
 
-    cp $IOTA_MOVE_ANALYZER_BIN $LANG_SERVER_DIR
+    # Copy renamed
+    if [[ "$IOTA_MOVE_ANALYZER_BIN" == *.exe ]]; then
+        cp $IOTA_MOVE_ANALYZER_BIN $LANG_SERVER_DIR/move-analyzer.exe
+    else
+        cp $IOTA_MOVE_ANALYZER_BIN $LANG_SERVER_DIR/move-analyzer
+        # Make binaries executable
+        chmod +x $LANG_SERVER_DIR/move-analyzer
+    fi
 
-    VSCODE_OS=${SUPPORTED_OS[$DIST_OS]}
+    VSCODE_OS=${SUPPORTED_OS[$OS_TARGET]}
     vsce "$OP" ${OPTS//VSCODE_OS/$VSCODE_OS} --target "$VSCODE_OS"
 
     rm -rf $LANG_SERVER_DIR

--- a/external-crates/move/crates/move-analyzer/editors/code/src/context.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/src/context.ts
@@ -359,7 +359,7 @@ export class Context {
                 await vscode.window.showInformationMessage(
                     `The move-analyzer binary at the user-specified path ('${this.configuration.serverPath}') ` +
                     'is not working. See troubleshooting instructions in the README file accompanying ' +
-                    'Move VSCode extension by IOTA Foundation in the VSCode marketplace',
+                    'Move VSCode extension by iotaledger in the VSCode marketplace',
                     { modal: true },
                     items,
                 );
@@ -410,7 +410,7 @@ export class Context {
             await vscode.window.showErrorMessage(
                 'Pre-built move-analyzer binary is not available for this platform. ' +
                 'Follow the instructions to manually install the language server in the README ' +
-                'file accompanying Move VSCode extension by IOTA Foundation in the VSCode marketplace',
+                'file accompanying Move VSCode extension by iotaledger in the VSCode marketplace',
                 { modal: true },
                 items,
             );


### PR DESCRIPTION
# Description of change

Add `release_move_ide.yml` with `create_from_local.sh` so we can publish the IOTA Move Visual Studio extension to the VS Marketplace.
It first builds the move analyzer binaries for macos (arm64+x86_64), ubuntu and windows and then creates the VS extension for each of them + one generic without a binary. For the generic one users have to build the move-analyzer binary themselves.
Also applied some minor patches from @valeriyr 

TODO: 
- [x] Update confluence workflows page when it's approved

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/4288

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running in the CI on this branch https://github.com/iotaledger/iota/actions/runs/12198732055?pr=4332
https://marketplace.visualstudio.com/items?itemName=iotaledger.iota-move :tada:
