### PR TITLE
show correct burnt amount in SystemEpochInfoEventV1

### DIFF
--- a/crates/iota-framework/packages/iota-system/sources/iota_system_state_inner.move
+++ b/crates/iota-framework/packages/iota-system/sources/iota_system_state_inner.move
@@ -758,7 +758,7 @@ module iota_system::iota_system_state_inner {
         mut computation_charges: Balance<IOTA>,
         iota_treasury_cap: &mut iota::iota::IotaTreasuryCap,
         ctx: &TxContext,
-    ): (Balance<IOTA>) {
+    ): Balance<IOTA> {
         if (computation_charges.value() < validator_target_reward) {
             let amount_to_mint = validator_target_reward - computation_charges.value();
             let balance_to_mint = iota_treasury_cap.mint_balance(amount_to_mint, ctx);

--- a/crates/iota-framework/packages/iota-system/sources/iota_system_state_inner.move
+++ b/crates/iota-framework/packages/iota-system/sources/iota_system_state_inner.move
@@ -674,11 +674,12 @@ module iota_system::iota_system_state_inner {
 
         let storage_charge_value = storage_charge.value();
         let computation_charge = computation_reward.value();
+        let mut burnt_tokens_amount = computation_charge;
 
        // Mints or burns tokens depending on the target reward.
        // Since not all rewards are distributed in case of slashed validators,
        // tokens might be minted here and burnt in the same epoch change.
-        let (mut total_validator_rewards, minted_tokens_amount, mut burnt_tokens_amount) = match_computation_reward_to_target_reward(
+        let mut total_validator_rewards = match_computation_reward_to_target_reward(
             validator_target_reward,
             computation_reward,
             &mut self.iota_treasury_cap,
@@ -704,7 +705,7 @@ module iota_system::iota_system_state_inner {
         let new_total_stake = self.validators.total_stake();
 
         let remaining_validator_rewards_amount_after_distribution = total_validator_rewards.value();
-        let total_validator_rewards_distributed = total_validator_rewards_amount_before_distribution - remaining_validator_rewards_amount_after_distribution;
+        let total_stake_rewards_distributed = total_validator_rewards_amount_before_distribution - remaining_validator_rewards_amount_after_distribution;
 
         self.protocol_version = next_protocol_version;
 
@@ -734,9 +735,9 @@ module iota_system::iota_system_state_inner {
                 storage_rebate: storage_rebate_amount,
                 storage_fund_balance: self.storage_fund.total_balance(),
                 total_gas_fees: computation_charge,
-                total_stake_rewards_distributed: total_validator_rewards_distributed,
+                total_stake_rewards_distributed,
                 burnt_tokens_amount,
-                minted_tokens_amount
+                minted_tokens_amount: validator_target_reward,
             }
         );
         self.safe_mode = false;
@@ -754,24 +755,20 @@ module iota_system::iota_system_state_inner {
     /// and the amount of computation fees burned in this epoch.
     fun match_computation_reward_to_target_reward(
         validator_target_reward: u64,
-        mut computation_reward: Balance<IOTA>,
+        mut computation_charges: Balance<IOTA>,
         iota_treasury_cap: &mut iota::iota::IotaTreasuryCap,
         ctx: &TxContext,
-    ): (Balance<IOTA>, u64, u64) {
-        let mut burnt_tokens_amount = 0;
-        let mut minted_tokens_amount = 0;
-        if (computation_reward.value() < validator_target_reward) {
-            let tokens_to_mint = validator_target_reward - computation_reward.value();
-            let new_tokens = iota_treasury_cap.mint_balance(tokens_to_mint, ctx);
-            minted_tokens_amount = new_tokens.value();
-            computation_reward.join(new_tokens);
-        } else if (computation_reward.value() > validator_target_reward) {
-            let tokens_to_burn = computation_reward.value() - validator_target_reward;
-            let rewards_to_burn = computation_reward.split(tokens_to_burn);
-            burnt_tokens_amount = rewards_to_burn.value();
-            iota_treasury_cap.burn_balance(rewards_to_burn, ctx);
+    ): (Balance<IOTA>) {
+        if (computation_charges.value() < validator_target_reward) {
+            let amount_to_mint = validator_target_reward - computation_charges.value();
+            let balance_to_mint = iota_treasury_cap.mint_balance(amount_to_mint, ctx);
+            computation_charges.join(balance_to_mint);
+        } else if (computation_charges.value() > validator_target_reward) {
+            let amount_to_burn = computation_charges.value() - validator_target_reward;
+            let balance_to_burn = computation_charges.split(amount_to_burn);
+            iota_treasury_cap.burn_balance(balance_to_burn, ctx);
         };
-        (computation_reward, minted_tokens_amount, burnt_tokens_amount)
+        computation_charges
     }
 
     /// Return the current epoch number. Useful for applications that need a coarse-grained concept of time,

--- a/crates/iota-framework/packages/iota-system/sources/iota_system_state_inner.move
+++ b/crates/iota-framework/packages/iota-system/sources/iota_system_state_inner.move
@@ -769,7 +769,7 @@ module iota_system::iota_system_state_inner {
             let balance_to_burn = computation_charges.split(actual_amount_to_burn);
             iota_treasury_cap.burn_balance(balance_to_burn, ctx);
         };
-        (computation_charges, burnt_tokens_amount, minted_tokens_amount)
+        (computation_charges, minted_tokens_amount, burnt_tokens_amount)
     }
 
     /// Return the current epoch number. Useful for applications that need a coarse-grained concept of time,


### PR DESCRIPTION
# Description of change

Show correct burned tokens amount in the `SystemEpochInfoEventV1` emitted from the advance_epoch function

## Links to any relevant issues

fixes #4114 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Review only
