### PR TITLE
fix(iota, iota-replay): fix test_profiler test by unignoring it and pass valid tx_digest

### DIFF
--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -727,18 +727,7 @@ impl LocalExec {
                 reason: "System transaction".to_string(),
             });
         }
-        // Before protocol version 16, the generation of effects depends on the wrapped
-        // tombstones. It is not possible to retrieve such data for replay.
-        if tx_info.protocol_version.as_u64() < 16 {
-            warn!(
-                "Protocol version ({:?}) too old: {}, skipping transaction",
-                tx_info.protocol_version, tx_digest
-            );
-            return Err(ReplayEngineError::TransactionNotSupported {
-                digest: *tx_digest,
-                reason: "Protocol version too old".to_string(),
-            });
-        }
+
         // Initialize the state necessary for execution
         // Get the input objects
         let input_objects = self.initialize_execution_env_state(tx_info).await?;

--- a/crates/iota/src/unit_tests/profiler_tests.rs
+++ b/crates/iota/src/unit_tests/profiler_tests.rs
@@ -61,7 +61,6 @@ async fn test_profiler() {
     let command_result =
         iota_replay::execute_replay_command(Some(testnet_url), false, false, None, None, cmd).await;
 
-    println!("{:?}", command_result);
     assert!(command_result.is_ok());
 
     // check that the profile was written

--- a/crates/iota/src/unit_tests/profiler_tests.rs
+++ b/crates/iota/src/unit_tests/profiler_tests.rs
@@ -36,7 +36,6 @@ fn test_macro_shows_feature_enabled() {
     }
 }
 
-#[ignore]
 #[cfg(feature = "gas-profiler")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_profiler() {
@@ -49,7 +48,7 @@ async fn test_profiler() {
     let profile_output = output_dir.path().join("profile.json");
 
     let testnet_url = "https://api.testnet.iota.cafe".to_string();
-    let tx_digest = "98KxVD14f2JgceKx4X27HaVAA2YGJ3Aazf6Y4tabpHa8".to_string();
+    let tx_digest = "7qq4W43TqHg9tQPMvdAFW4Tz6J88KnPppBPR1hNKmQAd".to_string();
 
     let cmd = ReplayToolCommand::ProfileTransaction {
         tx_digest,
@@ -62,6 +61,7 @@ async fn test_profiler() {
     let command_result =
         iota_replay::execute_replay_command(Some(testnet_url), false, false, None, None, cmd).await;
 
+    println!("{:?}", command_result);
     assert!(command_result.is_ok());
 
     // check that the profile was written


### PR DESCRIPTION
# Description of change

Protocol version check was removed because of:

> That was used by sui for their logic on tombstones, for us is already fine since protocol version 1

New digest `7qq4W43TqHg9tQPMvdAFW4Tz6J88KnPppBPR1hNKmQAd` it’s digest of generated transaction took from the iota-replay crate.

## Links to any relevant issues

Fix #4395 .

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`cargo test test_profiler --features gas-profiler --lib
`