### PR TITLE
fix[docs]: Swizzle CodeBlock to allow multiple CodeBlocks to coexist

### DIFF
--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -186,8 +186,8 @@ const config = {
       type: "text/css",
     },
   ],
-  themes: ["@docusaurus/theme-live-codeblock", "@docusaurus/theme-mermaid", 'docusaurus-theme-search-typesense',
-    '@saucelabs/theme-github-codeblock'],
+  themes: ["@docusaurus/theme-mermaid", 'docusaurus-theme-search-typesense', 
+    '@saucelabs/theme-github-codeblock', '@docusaurus/theme-live-codeblock'],
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({

--- a/docs/site/src/theme/CodeBlock/index.tsx
+++ b/docs/site/src/theme/CodeBlock/index.tsx
@@ -1,0 +1,28 @@
+/**
+ * SWIZZLED VERSION: 3.5.2
+ * REASONS:
+ *  - Add check for reference CodeBlock so it can coexist with the original CodeBlock and the live code block
+ */
+import React from 'react';
+import CodeBlock from '@theme-original/CodeBlock';
+import ReferenceCodeBlock from '@saucelabs/theme-github-codeblock/build/theme/ReferenceCodeBlock';
+import type CodeBlockType from '@theme/CodeBlock';
+import type {WrapperProps} from '@docusaurus/types';
+
+type Props = WrapperProps<typeof CodeBlockType>;
+
+export default function CodeBlockWrapper(props: Props): JSX.Element {
+  if (props.reference || props.metastring?.split(' ').includes('reference')) {
+    return (
+      <>
+        <ReferenceCodeBlock {...props} />
+      </>
+    );
+  } else {
+    return (
+      <>
+        <CodeBlock {...props} />
+      </>
+    );
+  }
+}

--- a/docs/site/src/theme/CodeBlock/index.tsx
+++ b/docs/site/src/theme/CodeBlock/index.tsx
@@ -21,10 +21,9 @@ function isReferenceCodeBlockType(props: object): props is ReferenceCodeBlockPro
 // If it isn't, we just return the live plugin CodeBlock which will check,
 // if the CodeBlock is a live CodeBlock or the original CodeBlock
 export default function CodeBlockWrapper(props: ReferenceCodeBlockProps | Props): JSX.Element {
-    return (
-      <>
-       {isReferenceCodeBlockType(props) ?  <ReferenceCodeBlock {...props} /> :  <CodeBlock {...props} />}
-      </>
-    );
-  }
+  return (
+    <>
+      {isReferenceCodeBlockType(props) ?  <ReferenceCodeBlock {...props} /> :  <CodeBlock {...props} />}
+    </>
+  );
 }

--- a/docs/site/src/theme/CodeBlock/index.tsx
+++ b/docs/site/src/theme/CodeBlock/index.tsx
@@ -6,13 +6,22 @@
 import React from 'react';
 import CodeBlock from '@theme-original/CodeBlock';
 import ReferenceCodeBlock from '@saucelabs/theme-github-codeblock/build/theme/ReferenceCodeBlock';
+import { ReferenceCodeBlockProps } from '@saucelabs/theme-github-codeblock/build/theme/types';
 import type CodeBlockType from '@theme/CodeBlock';
 import type {WrapperProps} from '@docusaurus/types';
 
 type Props = WrapperProps<typeof CodeBlockType>;
 
-export default function CodeBlockWrapper(props: Props): JSX.Element {
-  if (props.reference || props.metastring?.split(' ').includes('reference')) {
+function isReferenceCodeBlockType(props: object): props is ReferenceCodeBlockProps {
+  return 'reference' in props 
+    || ('metastring' in props && typeof props.metastring === 'string' && props.metastring.split(' ').includes('reference'));
+}
+
+// Wrap CodeBlock to check if the Code Block is a reference code block
+// IF it isn't, we just return the live theme CodeBlock which will check,
+// if the code block is a live code block or the original code block
+export default function CodeBlockWrapper(props: ReferenceCodeBlockProps | Props): JSX.Element {
+  if (isReferenceCodeBlockType(props)) {
     return (
       <>
         <ReferenceCodeBlock {...props} />

--- a/docs/site/src/theme/CodeBlock/index.tsx
+++ b/docs/site/src/theme/CodeBlock/index.tsx
@@ -17,9 +17,9 @@ function isReferenceCodeBlockType(props: object): props is ReferenceCodeBlockPro
     || ('metastring' in props && typeof props.metastring === 'string' && props.metastring.split(' ').includes('reference'));
 }
 
-// Wrap CodeBlock to check if the Code Block is a reference code block
-// IF it isn't, we just return the live theme CodeBlock which will check,
-// if the code block is a live code block or the original code block
+// Wrap CodeBlock to check if it is a reference (saucepans) CodeBlock.
+// If it isn't, we just return the live plugin CodeBlock which will check,
+// if the CodeBlock is a live CodeBlock or the original CodeBlock
 export default function CodeBlockWrapper(props: ReferenceCodeBlockProps | Props): JSX.Element {
   if (isReferenceCodeBlockType(props)) {
     return (

--- a/docs/site/src/theme/CodeBlock/index.tsx
+++ b/docs/site/src/theme/CodeBlock/index.tsx
@@ -21,16 +21,9 @@ function isReferenceCodeBlockType(props: object): props is ReferenceCodeBlockPro
 // If it isn't, we just return the live plugin CodeBlock which will check,
 // if the CodeBlock is a live CodeBlock or the original CodeBlock
 export default function CodeBlockWrapper(props: ReferenceCodeBlockProps | Props): JSX.Element {
-  if (isReferenceCodeBlockType(props)) {
     return (
       <>
-        <ReferenceCodeBlock {...props} />
-      </>
-    );
-  } else {
-    return (
-      <>
-        <CodeBlock {...props} />
+       {isReferenceCodeBlockType(props) ?  <ReferenceCodeBlock {...props} /> :  <CodeBlock {...props} />}
       </>
     );
   }


### PR DESCRIPTION
# Description of change

Swizzle ejected the CodeBlock so we can use multiple CodeBlock plugins

## Links to any relevant issues

Fixes #4403.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested locally

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
