### PR TITLE
fix(docs): updated port list with 8081 tcp

### DIFF
--- a/nre/validator_tasks.md
+++ b/nre/validator_tasks.md
@@ -91,7 +91,7 @@ Iota Node uses the following ports by default:
 | protocol/port | reachability     | purpose                           |
 | ------------- | ---------------- | --------------------------------- |
 | TCP/8080      | inbound          | protocol/transaction interface    |
-| UDP/8081      | inbound/outbound | primary interface                 |
+| TCP/8081      | inbound/outbound | primary interface                 |
 | UDP/8084      | inbound/outbound | peer to peer state sync interface |
 | TCP/8443      | outbound         | metrics pushing                   |
 | TCP/9184      | localhost        | metrics scraping                  |


### PR DESCRIPTION
Avoid confusion in the docs where we still mentioned the 8081 UDP used by Narwhal instead of TCP for Mysticeti.