### PR TITLE
feat: bump iota to v0.8.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,7 +1831,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "const-str",
  "git-version",
@@ -3669,14 +3669,14 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "docs-examples"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
  "bip32",
  "iota-keys",
  "iota-move-build",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "move-binary-format",
  "move-core-types",
  "serde_json",
@@ -5714,7 +5714,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "iota"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5759,7 +5759,7 @@ dependencies = [
  "iota-package-management",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "iota-simulator",
  "iota-source-validation",
  "iota-swarm",
@@ -5838,7 +5838,7 @@ dependencies = [
 
 [[package]]
 name = "iota-adapter-transactional-tests"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -5846,7 +5846,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "arrow",
@@ -5897,7 +5897,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer-derive"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
@@ -5906,7 +5906,7 @@ dependencies = [
 
 [[package]]
 name = "iota-archival"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -5938,7 +5938,7 @@ dependencies = [
 
 [[package]]
 name = "iota-authority-aggregation"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "futures",
  "iota-metrics",
@@ -5949,7 +5949,7 @@ dependencies = [
 
 [[package]]
 name = "iota-aws-orchestrator"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -5980,7 +5980,7 @@ dependencies = [
 
 [[package]]
 name = "iota-benchmark"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6002,7 +6002,7 @@ dependencies = [
  "iota-metrics",
  "iota-network",
  "iota-protocol-config",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "iota-simulator",
  "iota-storage",
  "iota-surfer",
@@ -6030,7 +6030,7 @@ dependencies = [
 
 [[package]]
 name = "iota-bridge"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6052,7 +6052,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-keys",
  "iota-metrics",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "iota-test-transaction-builder",
  "iota-types",
  "lru 0.12.4",
@@ -6079,7 +6079,7 @@ dependencies = [
 
 [[package]]
 name = "iota-bridge-cli"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -6090,7 +6090,7 @@ dependencies = [
  "iota-config",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "iota-types",
  "move-core-types",
  "reqwest 0.12.7",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "iota-bridge-indexer"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6121,7 +6121,7 @@ dependencies = [
  "iota-indexer-builder",
  "iota-json-rpc-types",
  "iota-metrics",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "iota-test-transaction-builder",
  "iota-types",
  "prometheus",
@@ -6135,7 +6135,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cluster-test"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6153,7 +6153,7 @@ dependencies = [
  "iota-json",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "iota-swarm",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -6175,7 +6175,7 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "futures",
  "parking_lot 0.12.3",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -6211,7 +6211,7 @@ dependencies = [
 
 [[package]]
 name = "iota-core"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -6313,7 +6313,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cost"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6402,7 +6402,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion-core"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6429,7 +6429,7 @@ dependencies = [
 
 [[package]]
 name = "iota-e2e-tests"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6460,7 +6460,7 @@ dependencies = [
  "iota-node",
  "iota-protocol-config",
  "iota-rest-api",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "iota-simulator",
  "iota-storage",
  "iota-swarm",
@@ -6491,7 +6491,7 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "serde_yaml",
 ]
@@ -6529,7 +6529,7 @@ dependencies = [
 
 [[package]]
 name = "iota-faucet"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6543,7 +6543,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-keys",
  "iota-metrics",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "iota-types",
  "parking_lot 0.12.3",
  "prometheus",
@@ -6567,7 +6567,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6588,7 +6588,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-tests"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "datatest-stable",
  "iota-adapter-latest",
@@ -6623,7 +6623,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-builder"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6675,7 +6675,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -6685,7 +6685,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-config"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "quote 1.0.37",
  "syn 1.0.109",
@@ -6693,7 +6693,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-e2e-tests"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "datatest-stable",
  "iota-graphql-rpc",
@@ -6704,7 +6704,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6743,7 +6743,7 @@ dependencies = [
  "iota-package-resolver",
  "iota-protocol-config",
  "iota-rest-api",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "iota-swarm-config",
  "iota-test-transaction-builder",
  "iota-types",
@@ -6783,7 +6783,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-client"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6798,14 +6798,14 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-headers"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "axum",
 ]
 
 [[package]]
 name = "iota-indexer"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6834,7 +6834,7 @@ dependencies = [
  "iota-package-resolver",
  "iota-protocol-config",
  "iota-rest-api",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "iota-swarm-config",
  "iota-test-transaction-builder",
  "iota-transaction-builder",
@@ -6867,7 +6867,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer-builder"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6882,7 +6882,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6901,7 +6901,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6955,7 +6955,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -6974,7 +6974,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-tests"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6993,7 +6993,7 @@ dependencies = [
  "iota-open-rpc",
  "iota-open-rpc-macros",
  "iota-protocol-config",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "iota-simulator",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -7012,7 +7012,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7041,7 +7041,7 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "bip32",
@@ -7060,7 +7060,7 @@ dependencies = [
 
 [[package]]
 name = "iota-light-client"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7072,7 +7072,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-package-resolver",
  "iota-rest-api",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "iota-types",
  "move-binary-format",
  "move-core-types",
@@ -7084,7 +7084,7 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -7094,7 +7094,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metric-checker"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "backoff",
@@ -7115,7 +7115,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7138,7 +7138,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "better_any",
@@ -7176,7 +7176,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -7199,7 +7199,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-lsp"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "bin-version",
  "clap",
@@ -7230,7 +7230,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -7268,7 +7268,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anemo",
  "bcs",
@@ -7291,7 +7291,7 @@ dependencies = [
 
 [[package]]
 name = "iota-node"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7341,7 +7341,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7365,7 +7365,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -7377,7 +7377,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-dump"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7394,11 +7394,11 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "iota-json-rpc-types",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "iota-types",
  "move-core-types",
  "move-package",
@@ -7409,7 +7409,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7432,7 +7432,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "msim-macros",
  "proc-macro2 1.0.86",
@@ -7442,7 +7442,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "clap",
  "insta",
@@ -7456,7 +7456,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
@@ -7465,7 +7465,7 @@ dependencies = [
 
 [[package]]
 name = "iota-replay"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7481,7 +7481,7 @@ dependencies = [
  "iota-json-rpc-api",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "iota-storage",
  "iota-transaction-checks",
  "iota-types",
@@ -7512,7 +7512,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7543,7 +7543,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rosetta"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7561,7 +7561,7 @@ dependencies = [
  "iota-metrics",
  "iota-move-build",
  "iota-node",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "iota-swarm-config",
  "iota-types",
  "move-core-types",
@@ -7585,7 +7585,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rpc-loadgen"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7595,7 +7595,7 @@ dependencies = [
  "futures",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "iota-types",
  "itertools 0.13.0",
  "serde",
@@ -7630,7 +7630,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7708,7 +7708,7 @@ dependencies = [
 
 [[package]]
 name = "iota-simulator"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7730,7 +7730,7 @@ dependencies = [
 
 [[package]]
 name = "iota-single-node-benchmark"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7765,7 +7765,7 @@ dependencies = [
 
 [[package]]
 name = "iota-snapshot"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7793,7 +7793,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "colored",
@@ -7803,7 +7803,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "iota-test-transaction-builder",
  "iota-types",
  "move-binary-format",
@@ -7825,7 +7825,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation-service"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "axum",
@@ -7841,7 +7841,7 @@ dependencies = [
  "iota-metrics",
  "iota-move",
  "iota-move-build",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "iota-source-validation",
  "jsonrpsee",
  "move-compiler",
@@ -7864,7 +7864,7 @@ dependencies = [
 
 [[package]]
 name = "iota-storage"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7918,7 +7918,7 @@ dependencies = [
 
 [[package]]
 name = "iota-surfer"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7947,7 +7947,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "futures",
@@ -7972,7 +7972,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm-config"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -7999,12 +7999,12 @@ dependencies = [
 
 [[package]]
 name = "iota-test-transaction-builder"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "bcs",
  "iota-genesis-builder",
  "iota-move-build",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "iota-types",
  "move-core-types",
  "shared-crypto",
@@ -8012,7 +8012,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "axum",
@@ -8033,7 +8033,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tool"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -8055,7 +8055,7 @@ dependencies = [
  "iota-package-dump",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "iota-snapshot",
  "iota-storage",
  "iota-types",
@@ -8078,7 +8078,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8094,7 +8094,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-checks"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "fastcrypto-zkp",
  "iota-config",
@@ -8108,7 +8108,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transactional-test-runner"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8157,7 +8157,7 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8238,7 +8238,7 @@ dependencies = [
 
 [[package]]
 name = "iota-upgrade-compatibility-transactional-tests"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "datatest-stable",
@@ -8252,7 +8252,7 @@ dependencies = [
 
 [[package]]
 name = "iota-util-mem"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "cfg-if",
  "ed25519-consensus",
@@ -8270,7 +8270,7 @@ dependencies = [
 
 [[package]]
 name = "iota-util-mem-derive"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "proc-macro2 1.0.86",
  "syn 1.0.109",
@@ -8294,7 +8294,7 @@ dependencies = [
 
 [[package]]
 name = "iota-verifier-transactional-tests"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -11765,7 +11765,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -13568,7 +13568,7 @@ dependencies = [
 
 [[package]]
 name = "shared-crypto"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "bcs",
  "eyre",
@@ -13704,7 +13704,7 @@ dependencies = [
 
 [[package]]
 name = "simulacrum"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14420,7 +14420,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry-subscribers"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -14496,7 +14496,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-cluster"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14516,7 +14516,7 @@ dependencies = [
  "iota-metrics",
  "iota-node",
  "iota-protocol-config",
- "iota-sdk 0.7.0-alpha",
+ "iota-sdk 0.8.0-alpha",
  "iota-simulator",
  "iota-swarm",
  "iota-swarm-config",
@@ -15237,7 +15237,7 @@ dependencies = [
 
 [[package]]
 name = "transaction-fuzzer"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "iota-core",
  "iota-move-build",
@@ -15343,7 +15343,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "async-trait",
  "bcs",
@@ -15374,7 +15374,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-derive"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2 1.0.86",
@@ -15384,7 +15384,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "serde",
  "thiserror",
@@ -15392,7 +15392,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-workspace-hack"
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 dependencies = [
  "libc",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by iota-core, iota-faucet, iota-node, iota-tools, iota-sdk, iota-move-build, and iota crates.
-version = "0.7.0-alpha"
+version = "0.8.0-alpha"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/crates/iota-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/iota-graphql-e2e-tests/tests/call/simple.exp
@@ -375,7 +375,7 @@ Response: {
   "data": {
     "serviceConfig": {
       "availableVersions": [
-        "0.7"
+        "0.8"
       ]
     }
   }

--- a/crates/iota-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/iota-graphql-e2e-tests/tests/call/simple.exp
@@ -114,11 +114,11 @@ task 15, lines 64-69:
 Headers: {
     "content-type": "application/json",
     "content-length": "157",
-    "x-iota-rpc-version": "0.7.0-testing-no-sha",
+    "x-iota-rpc-version": "0.8.0-testing-no-sha",
     "vary": "origin, access-control-request-method, access-control-request-headers",
     "access-control-allow-origin": "*",
 }
-Service version: 0.7.0-testing-no-sha
+Service version: 0.8.0-testing-no-sha
 Response: {
   "data": {
     "checkpoint": {

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/iotaledger/iota/main/LICENSE"
     },
-    "version": "0.7.0-alpha"
+    "version": "0.8.0-alpha"
   },
   "methods": [
     {


### PR DESCRIPTION
# Description of change

Bumping iota to the `0.8.0-alpha`, which contains protocol version 2.