### PR TITLE
fix: Override package.json ownership in external crates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,10 +7,6 @@
 # Changes to the genesis builder should be approved by Konstantinos or Mirko at least
 /crates/iota-genesis-builder/ @kodemartin @miker83z
 
-# vm-language team
-/iota-execution/ @iotaledger/vm-language
-/external-crates/ @iotaledger/vm-language
-
 # infrastructure team
 /docker/ @iotaledger/infrastructure @iotaledger/node @iotaledger/devops-admin
 /crates/iota-json-rpc*/ @iotaledger/infrastructure
@@ -60,6 +56,10 @@ pnpm-workspace.yaml @iotaledger/tooling
 prettier.config.js @iotaledger/tooling
 turbo.json @iotaledger/tooling
 vercel.json @iotaledger/tooling
+
+# vm-language team
+/iota-execution/ @iotaledger/vm-language
+/external-crates/ @iotaledger/vm-language
 
 # Docs and examples are for DevEx to approve upon
 /docs/ @iotaledger/devx

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,6 +58,7 @@ turbo.json @iotaledger/tooling
 vercel.json @iotaledger/tooling
 
 # vm-language team
+# Needs to be after package.json ownership definition to override it
 /iota-execution/ @iotaledger/vm-language
 /external-crates/ @iotaledger/vm-language
 


### PR DESCRIPTION
# Description of change

Fixes the ownership of package.json file (or any file) in `/iota-execution/ @iotaledger/vm-language` and `/external-crates/`

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

The [code owner plugin](https://marketplace.visualstudio.com/items?itemName=chdsbd.github-code-owners) told me this will work :trollface: 

<img width="171" alt="ownership of package.json in external crates" src="https://github.com/user-attachments/assets/5a3d9e25-4955-4766-a7f7-e25329f78a0d" />

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
