### PR TITLE
fix(devx): FIx URLs in References Overview

### DIFF
--- a/docs/content/references/references.mdx
+++ b/docs/content/references/references.mdx
@@ -11,7 +11,7 @@ Reference the IOTA framework and IOTA RPC documentation for details of the code 
 
 <Cards>
 
-<Card title="JSON-RPC" href="references/iota-api">
+<Card title="JSON-RPC" href="/references/iota-api">
 A public service that enables interacting with the IOTA network.
 </Card>
 </Cards>
@@ -21,7 +21,7 @@ A public service that enables interacting with the IOTA network.
 Move powers smart contract logic for the IOTA blockchain. Use these resources to learn Move or refresh your memory.
 
 <Cards>
-<Card title="IOTA framework" href="references/framework"/>
+<Card title="IOTA framework" href="/references/framework"/>
 <Card title="Move language" href="https://github.com/move-language/move/blob/main/language/documentation/book/src/introduction.md">
 Documentation for the Move programming language on GitHub.
 </Card>
@@ -32,13 +32,13 @@ Documentation for the Move programming language on GitHub.
 Interact directly with IOTA networks and its features using the IOTA command line interface (CLI). The CLI is divided into separate base commands that target a specific set of features.
 
 <Cards>
-<Card title="IOTA Client CLI" href="references/cli/client">
+<Card title="IOTA Client CLI" href="/references/cli/client">
 Create a client on a IOTA network to generate addresses, access networks, and more with the IOTA Client CLI.
 </Card>
-<Card title="IOTA Client PTB CLI" href="references/cli/ptb">
+<Card title="IOTA Client PTB CLI" href="/references/cli/ptb">
 Build, preview, and execute programmable transaction blocks directly from your terminal with the IOTA Client PTB CLI.
 </Card>
-<Card title="IOTA Move CLI" href="references/cli/move">
+<Card title="IOTA Move CLI" href="/references/cli/move">
 Access IOTA Move functions on chain using the IOTA Move CLI.
 </Card>
 </Cards>
@@ -48,8 +48,8 @@ Access IOTA Move functions on chain using the IOTA Move CLI.
 Official software development kits (SDKs) available for IOTA include the TypeScript SDK and Rust SDK.
 
 <Cards>
-<Card title="IOTA TypeScript SDK" href="references/ts-sdk/typescript">
+<Card title="IOTA TypeScript SDK" href="/references/ts-sdk/typescript">
 The IOTA TypeScript SDK has its own microsite. Click this box to go there.
 </Card>
-<Card title="IOTA Rust SDK" href="references/rust-sdk"/>
+<Card title="IOTA Rust SDK" href="/references/rust-sdk"/>
 </Cards>


### PR DESCRIPTION
# Description of change

Added `/` before URLs in References overview to make them absolute.


## Type of change

- Documentation Fix

## How the change has been tested

Docs were built locally.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
