### PR TITLE
fix(ci): use dedicated rosetta config dir

### DIFF
--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -59,6 +59,9 @@ runs:
             - "examples/**"
             - "iota_programmability/**"
             - ".github/workflows/_move_tests.yml"
+          isRosetta:
+            - ".github/scripts/rosetta/**"
+            - "crates/iota-rosetta/**"
           isExternalCrates:
             - "external-crates/move/crates/**"
           isReleaseNotesEligible:

--- a/.github/scripts/rosetta/setup.sh
+++ b/.github/scripts/rosetta/setup.sh
@@ -7,8 +7,12 @@ echo "Install binaries"
 cargo install --locked --bin iota --path crates/iota
 cargo install --locked --bin iota-rosetta --path crates/iota-rosetta
 
+echo "create dedicated config dir for IOTA genesis"
+CONFIG_DIR="~/.iota/rosetta_config"
+mkdir -p $CONFIG_DIR
+
 echo "run IOTA genesis"
-iota genesis
+iota genesis -f --working-dir $CONFIG_DIR
 
 echo "generate rosetta configuration"
 iota-rosetta generate-rosetta-cli-config --online-url http://127.0.0.1:9002 --offline-url http://127.0.0.1:9003

--- a/.github/workflows/_rosetta.yml
+++ b/.github/workflows/_rosetta.yml
@@ -1,9 +1,9 @@
-name: Rosetta tests
+name: Rosetta validation
 
 on: workflow_call
 
 concurrency:
-  group: rosetta-tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: rosetta-validation-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
 
 env:
@@ -21,7 +21,7 @@ env:
   RUSTDOCFLAGS: -D warnings
 
 jobs:
-  test:
+  validation:
     timeout-minutes: 45
     runs-on: [self-hosted]
     steps:

--- a/.github/workflows/_rosetta.yml
+++ b/.github/workflows/_rosetta.yml
@@ -1,0 +1,55 @@
+name: Rosetta tests
+
+on: workflow_call
+
+concurrency:
+  group: rosetta-tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_LOG: "error"
+  # Don't emit giant backtraces in the CI logs.
+  RUST_BACKTRACE: short
+  CARGO_INCREMENTAL: 0
+  # Allow more retries for network requests in cargo (downloading crates) and
+  # rustup (installing toolchains). This should help to reduce flaky CI failures
+  # from transient network timeouts or other issues.
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+  # RUSTFLAGS: -D warnings
+  RUSTDOCFLAGS: -D warnings
+
+jobs:
+  test:
+    timeout-minutes: 45
+    runs-on: [self-hosted]
+    steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - name: Setup environment
+        run: .github/scripts/rosetta/setup.sh
+        shell: bash
+
+      - name: Start local IOTA network
+        run: |
+          iota start --no-full-node &
+        shell: bash
+
+      - name: Start Rosetta servers
+        run: .github/scripts/rosetta/start_rosetta.sh
+        shell: bash
+
+      - name: Sleep for 20 seconds
+        run: sleep 20s
+        shell: bash
+
+      - name: Run check:construction test
+        run: |
+          ./bin/rosetta-cli --configuration-file rosetta_cli.json check:construction
+        shell: bash
+
+      - name: Run check:data test
+        run: |
+          ./bin/rosetta-cli --configuration-file rosetta_cli.json check:data
+        shell: bash

--- a/.github/workflows/_rust_tests.yml
+++ b/.github/workflows/_rust_tests.yml
@@ -159,39 +159,6 @@ jobs:
 
           eval ${command}
 
-  rosetta-validation:
-    timeout-minutes: 45
-    runs-on: [self-hosted]
-    steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-
-      - name: Setup environment
-        run: .github/scripts/rosetta/setup.sh
-        shell: bash
-
-      - name: Start local IOTA network
-        run: |
-          iota start --no-full-node &
-        shell: bash
-
-      - name: Start Rosetta servers
-        run: .github/scripts/rosetta/start_rosetta.sh
-        shell: bash
-
-      - name: Sleep for 20 seconds
-        run: sleep 20s
-        shell: bash
-
-      - name: Run check:construction test
-        run: |
-          ./bin/rosetta-cli --configuration-file rosetta_cli.json check:construction
-        shell: bash
-
-      - name: Run check:data test
-        run: |
-          ./bin/rosetta-cli --configuration-file rosetta_cli.json check:data
-        shell: bash
-
   graphql-rpc:
     name: graphql-rpc
     timeout-minutes: 45

--- a/.github/workflows/hierarchy.yml
+++ b/.github/workflows/hierarchy.yml
@@ -20,6 +20,7 @@ jobs:
     outputs:
       isRust: ${{ steps.diff.outputs.isRust }}
       isMove: ${{ steps.diff.outputs.isMove }}
+      isRosetta: ${{ steps.diff.outputs.isRosetta }}
       isDoc: ${{ steps.diff.outputs.isDoc }}
       isReleaseNotesEligible: ${{ steps.diff.outputs.isReleaseNotesEligible }}
       isExternalCrates: ${{ steps.diff.outputs.isExternalCrates }}
@@ -106,6 +107,17 @@ jobs:
     secrets: inherit
     with:
       isRust: ${{ needs.diff.outputs.isRust == 'true' }}
+
+  rosetta:
+    needs:
+      - diff
+      - dprint-format
+      - license-check
+      - typos
+    if: |
+      !cancelled() && !failure() && 
+      (needs.diff.outputs.isRosetta == 'true' || needs.diff.outputs.isRust == 'true')
+    uses: ./.github/workflows/_rosetta.yml
 
   e2e:
     if: (!cancelled() && !failure() && (!github.event.pull_request.draft || github.ref_name == 'develop'))

--- a/.github/workflows/hierarchy.yml
+++ b/.github/workflows/hierarchy.yml
@@ -115,7 +115,7 @@ jobs:
       - license-check
       - typos
     if: |
-      !cancelled() && !failure() && 
+      !cancelled() && !failure() &&
       (needs.diff.outputs.isRosetta == 'true' || needs.diff.outputs.isRust == 'true')
     uses: ./.github/workflows/_rosetta.yml
 


### PR DESCRIPTION
# Description of change

Fixes rosetta setup in the CI by forcing a dedicated config dir for `iota genesis` in `.github/scripts/rosetta/setup.sh`.

## Links to any relevant issues

Fixes #4472 

## Type of change


- Bug fix (a non-breaking change which fixes an issue)

