### PR TITLE
fix(ui-kit): only call onClick if `Card` is not disabled

### DIFF
--- a/apps/ui-kit/src/lib/components/molecules/card/Card.tsx
+++ b/apps/ui-kit/src/lib/components/molecules/card/Card.tsx
@@ -46,9 +46,14 @@ export function Card({
     children,
     testId,
 }: CardProps) {
+    function handleOnClick() {
+        if (!isDisabled) {
+            onClick?.();
+        }
+    }
     return (
         <div
-            onClick={onClick}
+            onClick={handleOnClick}
             className={cx(
                 'relative inline-flex w-full items-center gap-3 rounded-xl px-sm py-xs',
                 CARD_TYPE_CLASSES[type],


### PR DESCRIPTION
# Description of change

Stake `card` in the wallet app is still clickable, even with the card disabled.

## Links to any relevant issues

Fixes #4418


## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)


## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
