### PR TITLE
fix(iota-genesis-builder): address_swap_map_path becomes optional

### DIFF
--- a/crates/iota-genesis-builder/src/main.rs
+++ b/crates/iota-genesis-builder/src/main.rs
@@ -46,7 +46,7 @@ enum Snapshot {
             long,
             help = "Path to the address swap map file. This must be a CSV file with two columns, where an entry contains in the first column an IotaAddress present in the Hornet full-snapshot and in the second column an IotaAddress that will be used for the swap."
         )]
-        address_swap_map_path: String,
+        address_swap_map_path: Option<String>,
         #[clap(long, value_parser = clap::value_parser!(MigrationTargetNetwork), help = "Target network for migration")]
         target_network: MigrationTargetNetwork,
     },
@@ -84,7 +84,11 @@ fn main() -> Result<()> {
         CoinType::Iota => scale_amount_for_iota(snapshot_parser.total_supply()?)?,
     };
 
-    let address_swap_map = AddressSwapMap::from_csv(&address_swap_map_path)?;
+    let address_swap_map = if let Some(address_swap_map_path) = address_swap_map_path {
+        AddressSwapMap::from_csv(&address_swap_map_path)?
+    } else {
+        AddressSwapMap::default()
+    };
     // Prepare the migration using the parser output stream
     let migration = Migration::new(
         snapshot_parser.target_milestone_timestamp(),


### PR DESCRIPTION
# Description of change

Make address swap map optional only in main.rs(in order to avoid unnecessary code complexity).

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo run --bin iota-genesis-builder -- --disable-global-snapshot-verification iota --address-swap-map-path /Users/pk/Downloads/address_swap.csv --snapshot-path test-latest-full_snapshot.bin --target-network alphanetv0`
or
`cargo run --bin iota-genesis-builder -- --disable-global-snapshot-verification iota --snapshot-path test-latest-full_snapshot.bin --target-network alphanetv0`