### PR TITLE
fix(explorer): Fix `not a correct flattenable data` for string arguments in txs

### DIFF
--- a/apps/explorer/src/pages/transaction-result/programmable-transaction-view/utils.ts
+++ b/apps/explorer/src/pages/transaction-result/programmable-transaction-view/utils.ts
@@ -24,7 +24,7 @@ export function flattenIotaArguments(data: (IotaArgument | IotaArgument[])[]): s
                 } else if ('NestedResult' in value) {
                     return `NestedResult(${value.NestedResult[0]}, ${value.NestedResult[1]})`;
                 }
-            } else if (typeof value === 'string'){
+            } else if (typeof value === 'string') {
                 return value;
             } else {
                 throw new Error('Not a correct flattenable data');

--- a/apps/explorer/src/pages/transaction-result/programmable-transaction-view/utils.ts
+++ b/apps/explorer/src/pages/transaction-result/programmable-transaction-view/utils.ts
@@ -24,10 +24,11 @@ export function flattenIotaArguments(data: (IotaArgument | IotaArgument[])[]): s
                 } else if ('NestedResult' in value) {
                     return `NestedResult(${value.NestedResult[0]}, ${value.NestedResult[1]})`;
                 }
+            } else if (typeof value === 'string'){
+                return `Address(${value})`;
             } else {
                 throw new Error('Not a correct flattenable data');
             }
-            return '';
         })
         .join(', ');
 }

--- a/apps/explorer/src/pages/transaction-result/programmable-transaction-view/utils.ts
+++ b/apps/explorer/src/pages/transaction-result/programmable-transaction-view/utils.ts
@@ -25,7 +25,7 @@ export function flattenIotaArguments(data: (IotaArgument | IotaArgument[])[]): s
                     return `NestedResult(${value.NestedResult[0]}, ${value.NestedResult[1]})`;
                 }
             } else if (typeof value === 'string'){
-                return `Address(${value})`;
+                return value;
             } else {
                 throw new Error('Not a correct flattenable data');
             }


### PR DESCRIPTION
Closes #3318

Example tx: `9VrzcKCjdm532TiAnQPzgd6o5hDPymycobjECD1T1sDH` & `7qq4W43TqHg9tQPMvdAFW4Tz6J88KnPppBPR1hNKmQAd`