### PR TITLE
chore(bin_version): don't concatenate GIT_REVISION if empty

### DIFF
--- a/crates/bin-version/src/lib.rs
+++ b/crates/bin-version/src/lib.rs
@@ -12,11 +12,11 @@ pub mod _hidden {
 ///
 /// Defines two global `const`s:
 ///   `GIT_REVISION`: The git revision as specified by the `GIT_REVISION` env
-/// variable provided at   compile time, or the current git revision as
-/// discovered by running `git describe`.
+/// variable provided at compile time, or the current git revision as discovered
+/// by running `git describe`.
 ///
 ///   `VERSION`: The value of the `CARGO_PKG_VERSION` environment variable
-/// concatenated with the   value of `GIT_REVISION`.
+/// concatenated with the value of `GIT_REVISION` if it is not empty.
 ///
 /// Note: This macro must only be used from a binary, if used inside a library
 /// this will fail to compile.
@@ -25,16 +25,19 @@ macro_rules! bin_version {
     () => {
         $crate::git_revision!();
 
-        const VERSION: &str =
-            $crate::_hidden::concat!(env!("CARGO_PKG_VERSION"), "-", GIT_REVISION);
+        const VERSION: &str = if GIT_REVISION.is_empty() {
+            env!("CARGO_PKG_VERSION")
+        } else {
+            $crate::_hidden::concat!(env!("CARGO_PKG_VERSION"), "-", GIT_REVISION)
+        };
     };
 }
 
 /// Defines constant that holds the git revision at build time.
 ///
 ///   `GIT_REVISION`: The git revision as specified by the `GIT_REVISION` env
-/// variable provided at   compile time, or the current git revision as
-/// discovered by running `git describe`.
+/// variable provided at compile time, or the current git revision as discovered
+/// by running `git describe`.
 ///
 /// Note: This macro must only be used from a binary, if used inside a library
 /// this will fail to compile.


### PR DESCRIPTION
Currently, `GIT_REVISION` is always concatenated to `CARGO_PKG_VERSION`, even if it is empty, which is the case when building from a release archive.

Before (archive)
```
iota 0.8.0-alpha-
```
After (archive)
```
iota 0.8.0-alpha
```
Git
```
iota 0.8.0-alpha-6b522486923f
```