### PR TITLE
fix(docs): Fix broken link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for considering making a contribution to the IOTA network or its document
 
 ## Contribute to IOTA
 
-See [IOTA Environment Setup](https://github.com/iotaledger/iota/blob/main/docs/content/guides/developer/getting-started/iota-environment.mdx) for approach to submitting code fixes and enhancements.
+See [IOTA Environment Setup](https://github.com/iotaledger/iota/blob/main/docs/content/developer/getting-started/iota-environment.mdx) for approach to submitting code fixes and enhancements.
 
 Found a bug or security vulnerability? Create a [GitHub issue](https://github.com/iotaledger/iota/issues/new/choose).
 


### PR DESCRIPTION
# Description of change

Fix broken link in CONTRIBUTING.md  

Note: I think we should also change the branch to `develop` in that link but not sure about that. 
[Update] Ok, maybe not, maybe `main` is better since it is re-directed to the current default branch.

## Type of change

- Documentation Fix

