### PR TITLE
fix(docs): Add missing framework docs

### DIFF
--- a/crates/iota-framework/tests/build-system-packages.rs
+++ b/crates/iota-framework/tests/build-system-packages.rs
@@ -198,10 +198,15 @@ fn build_packages_with_move_config(
         &mut files_to_write,
     );
     create_category_file(framework_dir);
-    create_category_file(stdlib_dir);
     relocate_docs(
         framework_dir,
         &framework_pkg.package.compiled_docs.unwrap(),
+        &mut files_to_write,
+    );
+    create_category_file(stdlib_dir);
+    relocate_docs(
+        stdlib_dir,
+        &stdlib_pkg.package.compiled_docs.unwrap(),
         &mut files_to_write,
     );
     create_category_file(bridge_dir);


### PR DESCRIPTION
# Description of change

A community member reported that we don't have docs for u128, but SUI has. So I looked into it. Seems like we only documented parts of the move sodlib that were dependencies of another framework package. So I guess the deep book has u128 as dependency, hence why it didn't show up on our side.
I now also create the move sodlib docs.

## Links to any relevant issues

Fixes #4564

## Type of change

- Documentation Fix

## How the change has been tested

Run locally.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
