### PR TITLE
fix(ts-sdk): Update typography light theme line height

### DIFF
--- a/.changeset/warm-eagles-count.md
+++ b/.changeset/warm-eagles-count.md
@@ -1,0 +1,5 @@
+---
+'@iota/dapp-kit': patch
+---
+
+Sync typography styling in both dark and light themes

--- a/sdk/dapp-kit/src/themes/lightTheme.ts
+++ b/sdk/dapp-kit/src/themes/lightTheme.ts
@@ -55,8 +55,8 @@ export const lightTheme: ThemeVars = {
         fontFamily:
             'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
         fontStyle: 'normal',
-        lineHeight: '1.3',
-        letterSpacing: '1',
+        lineHeight: '24px',
+        letterSpacing: '0.1px',
     },
     spacing: {
         xxsmall: '4px',


### PR DESCRIPTION
Closes https://github.com/iotaledger/iota/issues/4590

Its now the same one as we have in the dark theme