### PR TITLE
fix(wallet): improve fetching visual assets on higher numbered pages

### DIFF
--- a/apps/wallet/src/ui/app/pages/home/nfts/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nfts/index.tsx
@@ -127,6 +127,20 @@ function NftsPage() {
         }
     }, [ownedAssets]);
 
+    useEffect(() => {
+        // Fetch the next page if there are no visual assets, other + hidden assets are present in multiples of 50, and there are more pages to fetch
+        if (
+            hasNextPage &&
+            ownedAssets?.visual.length === 0 &&
+            ownedAssets?.other.length + ownedAssets?.hidden.length > 0 &&
+            (ownedAssets.other.length + ownedAssets.hidden.length) % 50 === 0 &&
+            !isFetchingNextPage
+        ) {
+            fetchNextPage();
+            setSelectedAssetCategory(null);
+        }
+    }, [hasNextPage, ownedAssets, isFetchingNextPage]);
+
     if (isLoading) {
         return (
             <div className="mt-1 flex w-full justify-center">


### PR DESCRIPTION
# Description of change

resolves #4532 

## How the change has been tested

1. add new mnemonic to wallet and tooling resources .env to have a clean start
2. in tooling resources create a lot of non coin objects 
ex. create stardust basic outputs with run-test-scenario script but MODIFY the script before running it by commenting out the creation of Nft outputs and alias outputs. Even the native tokens can be removed from basic outputs to keep things simple.
Run the modified script couple of times so you generate more than 50 basic output objects.
3. mint single NFT  with `pnpm mint_nft:mint` and in this way the NFT would appear in 2. or 3. page

