### PR TITLE
fix(CI): Fix move tests multiline command

### DIFF
--- a/.github/workflows/_move_tests.yml
+++ b/.github/workflows/_move_tests.yml
@@ -17,7 +17,6 @@ jobs:
   # to Move code but not Rust code (If there are Rust changes, they
   # will be run as part of a larger test suite).
   move-test:
-    timeout-minutes: 10
     runs-on: [self-hosted]
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -33,7 +32,6 @@ jobs:
           or test(move_tests::)'
 
   move-simtest:
-    timeout-minutes: 10
     runs-on: [self-hosted]
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1

--- a/.github/workflows/_move_tests.yml
+++ b/.github/workflows/_move_tests.yml
@@ -26,7 +26,7 @@ jobs:
           tool: nextest
       - name: Run move tests
         run: >
-          cargo nextest run -E
+          cargo nextest run --profile ci -E
           'package(iota-framework-tests)
           or (package(iota-core) and test(quorum_driver::))
           or package(iota-benchmark)

--- a/.github/workflows/_move_tests.yml
+++ b/.github/workflows/_move_tests.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           tool: nextest
       - name: Run move tests
-        run: |
+        run: >
           cargo nextest run -E
           'package(iota-framework-tests)
           or (package(iota-core) and test(quorum_driver::))
@@ -41,7 +41,7 @@ jobs:
         with:
           tool: nextest
       - name: Run move tests
-        run: |
+        run: >
           scripts/simtest/cargo-simtest simtest --profile ci -E
           'package(iota-framework-tests)
           or (package(iota-core) and test(quorum_driver::))

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -81,9 +81,6 @@ jobs:
   external-tests:
     uses: ./.github/workflows/_external_rust_tests.yml
 
-  move-tests:
-    uses: ./.github/workflows/_move_tests.yml
-
   deny:
     uses: ./.github/workflows/_cargo_deny.yml
 


### PR DESCRIPTION
# Description of change

The multiline command in `_move_tests.yml` used the wrong leading character for single commands.

Additionally, I have removed the move tests (after running them once) from `nightly.yml` as they are already covered by the normal rust tests.
