### PR TITLE
Recommend IOTA Move extension for VS Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
     "recommendations": [
-        "move.move-analyzer",
+        "iotaledger.iota-move",
         "rust-lang.rust-analyzer",
         "esbenp.prettier-vscode",
         "ms-playwright.playwright",


### PR DESCRIPTION
# Description of change

Use our extension instead of the `move.move-analyzer` in the VS Code recommendations when opening the project.