### PR TITLE
chore(iota): Remove extra address generation in client commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,9 +2461,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.18"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2471,15 +2471,15 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.18"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
  "strsim 0.11.1",
- "terminal_size",
+ "terminal_size 0.4.1",
 ]
 
 [[package]]
@@ -2496,9 +2496,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clipboard-win"
@@ -9005,7 +9005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -9318,7 +9318,7 @@ dependencies = [
  "supports-color",
  "supports-hyperlinks",
  "supports-unicode",
- "terminal_size",
+ "terminal_size 0.3.0",
  "textwrap",
  "thiserror",
  "unicode-width",
@@ -14639,6 +14639,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15497,7 +15507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 


### PR DESCRIPTION
# Description of change

Removes an extra address generation in `prompt_if_no_config` when calling `iota client new-address`. This function generates a new address if none exists, but this should be done by the command. Instead, two addresses are generated. This PR fixes this by checking the command variant and skipping the extra address generation for this specific command.

## Before

```
Config file ["/Users/thibault/.iota/iota_config/client.yaml"] doesn't exist, do you want to connect to a Iota Full node server [y/N]?y
Iota Full node server URL (Defaults to Iota Testnet if not specified) : 
Select key scheme to generate keypair (0 for ed25519, 1 for secp256k1, 2: for secp256r1):
0
Keys saved as Bech32.
Generated new keypair and alias for address with scheme "ed25519" [amazing-sunstone: 0xf6dffdc2a6af842bac816180a83d31616d9dc216b8a7882a84bdcef08e6326af]
Secret Recovery Phrase : [clutch solution favorite into excuse own divert adjust attract couple uncle exile]
Keys saved as Bech32.
[warn] Client/Server api version mismatch, client api version: 0.8.0-alpha, server api version: 0.7.3-rc
╭───────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Created new keypair and saved it to keystore.                                                     │
├────────────────┬──────────────────────────────────────────────────────────────────────────────────┤
│ alias          │ peaceful-spodumene                                                               │
│ address        │ 0x4c582c8dee21d59e3a57600e1c866c49414cbfbafad1d1c7973e91b1bc7202d5               │
│ keyScheme      │ ed25519                                                                          │
│ recoveryPhrase │ original unhappy thunder gaze marriage advice raw there vocal holiday seat drama │
╰────────────────┴──────────────────────────────────────────────────────────────────────────────────╯
```

## After

```
Config file ["/Users/chloe/.iota/iota_config/client.yaml"] doesn't exist, do you want to connect to a Iota Full node server [y/N]?y
Iota Full node server URL (Defaults to Iota Testnet if not specified) : 
Keys saved as Bech32.
[warn] Client/Server api version mismatch, client api version: 0.8.0-alpha, server api version: 0.7.3-rc
╭────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Created new keypair and saved it to keystore.                                                  │
├────────────────┬───────────────────────────────────────────────────────────────────────────────┤
│ alias          │ unruffled-zircon                                                              │
│ address        │ 0x1b7242b51f96af36a4483b855092dea80be4af518c05e00995c66096aa2c828b            │
│ keyScheme      │ ed25519                                                                       │
│ recoveryPhrase │ rhythm market elephant bitter room maid ozone include snap sport sleep damage │
╰────────────────┴───────────────────────────────────────────────────────────────────────────────╯
```
