### PR TITLE
chore: Fix some compiler warnings from `#[expect]` tags on msim

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1593,7 +1593,7 @@ impl AuthorityState {
         let transaction_data = &certificate.data().intent_message().value;
         let (kind, signer, gas) = transaction_data.execution_parts();
 
-        #[expect(unused_mut)]
+        #[cfg_attr(not(any(msim, fail_points)), expect(unused_mut))]
         let (inner_temp_store, _, mut effects, execution_error_opt) =
             epoch_store.executor().execute_transaction_to_effects(
                 self.get_backing_store().as_ref(),

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -163,7 +163,7 @@ impl AuthorityStore {
         let epoch_start_configuration = if perpetual_tables.database_is_empty()? {
             info!("Creating new epoch start config from genesis");
 
-            #[expect(unused_mut)]
+            #[cfg_attr(not(any(msim, fail_points)), expect(unused_mut))]
             let mut initial_epoch_flags = EpochFlag::default_flags_for_new_epoch(config);
             fail_point_arg!("initial_epoch_flags", |flags: Vec<EpochFlag>| {
                 info!("Setting initial epoch flags to {:?}", flags);

--- a/crates/iota-core/src/epoch/randomness.rs
+++ b/crates/iota-core/src/epoch/randomness.rs
@@ -426,7 +426,7 @@ impl RandomnessManager {
         info!("random beacon: created {msg:?} with dkg version {dkg_version}");
         let transaction = ConsensusTransaction::new_randomness_dkg_message(epoch_store.name, &msg);
 
-        #[expect(unused_mut)]
+        #[cfg_attr(not(any(msim, fail_points)), expect(unused_mut))]
         let mut fail_point_skip_sending = false;
         fail_point_if!("rb-dkg", || {
             // maybe skip sending in simtests
@@ -498,7 +498,7 @@ impl RandomnessManager {
                         &conf,
                     );
 
-                    #[expect(unused_mut)]
+                    #[cfg_attr(not(any(msim, fail_points)), expect(unused_mut))]
                     let mut fail_point_skip_sending = false;
                     fail_point_if!("rb-dkg", || {
                         // maybe skip sending in simtests

--- a/crates/iota-network/build.rs
+++ b/crates/iota-network/build.rs
@@ -12,6 +12,9 @@ use tonic_build::manual::{Builder, Method, Service};
 type Result<T> = ::std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 fn main() -> Result<()> {
+    println!("cargo::rustc-check-cfg=cfg(msim)");
+    println!("cargo::rustc-check-cfg=cfg(fail_points)");
+
     let out_dir = if env::var("DUMP_GENERATED_GRPC").is_ok() {
         PathBuf::from("")
     } else {

--- a/crates/iota-network/src/randomness/mod.rs
+++ b/crates/iota-network/src/randomness/mod.rs
@@ -952,7 +952,7 @@ impl RandomnessEventLoop {
         full_sig: Arc<OnceCell<RandomnessSignature>>,
     ) {
         // For simtests, we may test not sending partial signatures.
-        #[expect(unused_mut)]
+        #[cfg_attr(not(any(msim, fail_points)), expect(unused_mut))]
         let mut fail_point_skip_sending = false;
         fail_point_if!("rb-send-partial-signatures", || {
             fail_point_skip_sending = true;

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1896,7 +1896,6 @@ impl IotaNode {
             .store(new_value, Ordering::Relaxed);
     }
 
-    #[expect(unused_variables)]
     async fn fetch_jwks(
         authority: AuthorityName,
         provider: &OIDCProvider,


### PR DESCRIPTION
# Description of change

Fixes some warnings from the compiler that does not expect certain lints when compiling for `msim`.
Example of warnings it's fixing https://github.com/iotaledger/iota/actions/runs/12632863834/job/35198980076?pr=4605#step:6:1280
