### PR TITLE
refactor(iota-transactional-test-runner): document `run-graphql` syntax

### DIFF
--- a/crates/iota-transactional-test-runner/syntax.md
+++ b/crates/iota-transactional-test-runner/syntax.md
@@ -108,48 +108,24 @@ Following interpolation rules are supported:
 All of the above rules (object references, named addresses, raw Base64-encoded strings) can be used in a single query. 
 Any placeholder that cannot be mapped to a known variable, object, or address will cause an error.
 
-####  Example: Get the first transaction block with its effects and object changes
+####  Example
 
 ```
-//# run-graphql
+//# run-graphql --cursors {"c":3,"t":1,"tc":1}
 {
-  transactionBlocks(first: 1) {
+  transactionBlocks(first: 1, after: "@{cursor_0}", filter: {signAddress: "@{A}"}) {
     nodes {
-      effects {
-        objectChanges {
-          pageInfo {
-            hasPreviousPage
-            hasNextPage
-            startCursor
-            endCursor
-          }
-          edges {
-            cursor
-          }
+      sender {
+        fakeCoinBalance: balance(type: "@{P0}::fake::FAKE") {
+          totalBalance
         }
-      }
-    }
-  }
-}
-```
-
-####  Example: Get the first transaction block with its effects and object changes using a specific cursor
-
-```
-//# run-graphql --cursors {"c":1}
-{
-  transactionBlocks(first: 1) {
-    nodes {
-      effects {
-        objectChanges(first: 5, after: "@{cursor_0}") {
-          pageInfo {
-            hasPreviousPage
-            hasNextPage
-            startCursor
-            endCursor
-          }
-          edges {
-            cursor
+        allBalances: balances {
+          nodes {
+            coinType {
+              repr
+            }
+            coinObjectCount
+            totalBalance
           }
         }
       }

--- a/crates/iota-transactional-test-runner/syntax.md
+++ b/crates/iota-transactional-test-runner/syntax.md
@@ -71,6 +71,78 @@ in the respective sections.
 
 ### `run-graphql`
 
+Allows to execute GraphQL queries with optional options and returns the output.
+
+#### Syntax:
+```
+//# run-graphql [OPTIONS]
+<GraphQL-query>
+```
+
+####  Options:
+
+```
+--show-usage: Displays usage information for the command.
+--show-headers: Includes HTTP headers in the output.
+--show-service-version: Displays the version of the service handling the GraphQL query.
+--cursors <cursor-list>: Specifies a list of cursors to be used within the query. Each cursor can be referenced in the GraphQL query using @{cursor_name} syntax.
+```
+
+#### Query interpolation:
+
+The task supports placeholder interpolation within queries.
+Placeholders like `@{variable_name}` are dynamically replaced with values provided in the `--cursors` option or derived from named addresses, object enumerations, and checkpoints.
+
+####  Example: Get the first transaction block with its effects and object changes
+
+```
+//# run-graphql
+{
+  transactionBlocks(first: 1) {
+    nodes {
+      effects {
+        objectChanges {
+          pageInfo {
+            hasPreviousPage
+            hasNextPage
+            startCursor
+            endCursor
+          }
+          edges {
+            cursor
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+####  Example: Get the first transaction block with its effects and object changes using a specific cursor
+
+```
+//# run-graphql --cursors {"c":1}
+{
+  transactionBlocks(first: 1) {
+    nodes {
+      effects {
+        objectChanges(first: 5, after: "@{cursor_0}") {
+          pageInfo {
+            hasPreviousPage
+            hasNextPage
+            startCursor
+            endCursor
+          }
+          edges {
+            cursor
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ### `force-object-snapshot-catchup`
 
 ### `bench`

--- a/crates/iota-transactional-test-runner/syntax.md
+++ b/crates/iota-transactional-test-runner/syntax.md
@@ -114,7 +114,7 @@ Any placeholder or cursor that cannot be mapped to a known variable, object, or 
 #### Examples
 
 The following example query will replace the placeholder `@{cursor_0}` with the Base64-encoded [transaction block cursor](../../crates/iota-graphql-rpc/src/types/transaction_block.rs) `{"c":3,"t":1,"tc":1}` where `c` is the checkpoint sequence number, `t` is the transaction sequence number, and `tc` is the transaction checkpoint number.
-Cursor values depend on the query and the underlying schema. The cursor value above example is specific to the GraphQL `transactionBlocks` query.
+Cursor values depend on the query and the underlying schema. The cursor value above is specific to the GraphQL `transactionBlocks` query.
 `@{A}` and `@{P0}` will be replaced with the addresses `A` and `P0` respectively that were created during the initialization step.
 
 ```

--- a/crates/iota-transactional-test-runner/syntax.md
+++ b/crates/iota-transactional-test-runner/syntax.md
@@ -96,7 +96,7 @@ It supports the following placeholders:
 
 1. **Object Placeholders**
    - **Syntax**: `@{obj_x_y}` or `@{obj_x_y_opt}`
-   - Here, `(x, y)` corresponds to the transaction index and the creation index of the object within that transaction. The placeholder will be replaced with the object ID as a string (like `0xABCD...`).
+   - Here, `(x, y)` corresponds to the task index and the creation index of the object within that task. The placeholder will be replaced with the object ID as a string (like `0xABCD...`).
 
 2. **Named Address Placeholders**
    - **Syntax**: `@{NamedAddr}` or `@{NamedAddr_opt}`

--- a/crates/iota-transactional-test-runner/syntax.md
+++ b/crates/iota-transactional-test-runner/syntax.md
@@ -104,15 +104,17 @@ It supports the following placeholders:
 
 3. **Cursors**
    - **Syntax**: `//# run-graphql --cursors string1 string2 ...`
-   - Any string passed to `--cursors` will be Base64-encoded and can be accessed in the query as `@{cursor_0}`, `@{cursor_1}`, etc., in the order provided.
-   - If the string matches `@{obj_x_y}`, it pairs the object’s ID for (x, y) with the highest checkpoint; if the string matches `@{obj_x_y, checkpoint}`, it pairs the object’s ID with the provided checkpoint. It then BCS-encodes the (objectID, checkpoint) tuple and provides the Base64-encoded cursor value.
+     - Every string passed to `--cursors` will be Base64-encoded and can be accessed in the query as `@{cursor_0}`, `@{cursor_1}`, etc., in the order provided.
+     - Depending on the query, the strings passed to `--cursors` must follow the expected cursor format for the specific query.
+     - To generate cursor values from created objects at runtime, the strings passed to `--cursors` must correspond to the format `@{obj_x_y}` or `@{obj_x_y, checkpoint}`. The tuple (objectID, checkpoint) is then BCS-encoded and can be accessed in the query as `@{cursor_0}`, `@{cursor_1}`, etc. in the specified order.
 
-All of the above rules (object references, named addresses, raw Base64-encoded strings) can be used in a single query.
+All of the above rules (object placeholders, named address placeholders, cursor strings) can be used in a single query.
 Any placeholder that cannot be mapped to a known variable, object, or address will cause an error.
 
-#### Example
+#### Examples
 
-The following query will replace the placeholder `@{cursor_0}` with the base64-encoded string `{"c":3,"t":1,"tc":1}`.
+The following example query will replace the placeholder `@{cursor_0}` with the base64-encoded [transaction block cursor](../../crates/iota-graphql-rpc/src/types/transaction_block.rs) `{"c":3,"t":1,"tc":1}` where `c` is the checkpoint sequence number, `t` is the transaction sequence number, and `tc` is the transaction checkpoint number.
+Cursor values depend on the query and the underlying schema. The cursor value above example is specific to the GraphQL `transactionBlocks` query.
 `@{A}` and `@{P0}` will be replaced with the addresses `A` and `P0` respectively that were created during the initialization step.
 
 ```

--- a/crates/iota-transactional-test-runner/syntax.md
+++ b/crates/iota-transactional-test-runner/syntax.md
@@ -74,12 +74,14 @@ in the respective sections.
 Allows to execute GraphQL queries with optional options and returns the output.
 
 #### Syntax:
+
 ```
 //# run-graphql [OPTIONS]
 <GraphQL-query>
 ```
 
-####  Options:
+#### Options:
+
 ```
 --show-usage: Displays usage information for the command.
 --show-headers: Includes HTTP headers in the output.
@@ -90,8 +92,7 @@ Allows to execute GraphQL queries with optional options and returns the output.
 #### Query Interpolation
 
 The command supports **query interpolation**, allowing you to dynamically replace parts of the GraphQL query at runtime.
-
-Following interpolation rules are supported:
+It supports the following placeholders:
 
 1. **Object Placeholders**
    - **Syntax**: `@{obj_x_y}` or `@{obj_x_y_opt}`
@@ -101,14 +102,14 @@ Following interpolation rules are supported:
    - **Syntax**: `@{NamedAddr}` or `@{NamedAddr_opt}`
    - Substitutes known accounts and addresses that have been created during the initialization step, e.g. `init --protocol-version 1 --addresses P0=0x0 --accounts A B --simulator`
 
-3. **Base64-Encoded Cursors**
-   - Any string passed to `--cursors` list will be Base64-encoded and made accessible in the query as `@{cursor_0}`, `@{cursor_1}`, etc., in the order provided.
-   - If the string matches `@{obj_x_y}`, it pairs the object’s ID for (x, y) with the highest checkpoint; if the string is `@{obj_x_y,checkpoint}`, it pairs the object’s ID with the specified checkpoint. It then BCS-encodes the (objectID, checkpoint) tuple and provides the Base64-encodes the result.
+3. **Cursors**
+   - Any string passed to the `--cursors` list will be Base64-encoded and can be accessed in the query as `@{cursor_0}`, `@{cursor_1}`, etc., in the order provided.
+   - If the string matches `@{obj_x_y}`, it pairs the object’s ID for (x, y) with the highest checkpoint; if the string matches `@{obj_x_y, checkpoint}`, it pairs the object’s ID with the provided checkpoint. It then BCS-encodes the (objectID, checkpoint) tuple and provides the Base64-encoded cursor value.
 
-All of the above rules (object references, named addresses, raw Base64-encoded strings) can be used in a single query. 
+All of the above rules (object references, named addresses, raw Base64-encoded strings) can be used in a single query.
 Any placeholder that cannot be mapped to a known variable, object, or address will cause an error.
 
-####  Example
+#### Example
 
 ```
 //# run-graphql --cursors {"c":3,"t":1,"tc":1}
@@ -133,6 +134,9 @@ Any placeholder that cannot be mapped to a known variable, object, or address wi
   }
 }
 ```
+
+The above query will replace the placeholder `@{cursor_0}` with the base64-encoded string `{"c":3,"t":1,"tc":1}`.
+`@{A}` and `@{P0}` will be replaced with the addresses `A` and `P0` respectively that were created during the initialization step.
 
 ### `force-object-snapshot-catchup`
 

--- a/crates/iota-transactional-test-runner/syntax.md
+++ b/crates/iota-transactional-test-runner/syntax.md
@@ -141,6 +141,25 @@ Cursor values depend on the query and the underlying schema. The cursor value ab
 }
 ```
 
+An example of a query that generates an object cursor at runtime:
+
+```
+//# run-graphql --cursors @{obj_6_0}
+{
+  address(address: "@{A}") {
+    objects(first: 2 after: "@{cursor_0}") {
+      edges {
+        node {
+          contents {
+            json
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ### `force-object-snapshot-catchup`
 
 ### `bench`

--- a/crates/iota-transactional-test-runner/syntax.md
+++ b/crates/iota-transactional-test-runner/syntax.md
@@ -80,18 +80,33 @@ Allows to execute GraphQL queries with optional options and returns the output.
 ```
 
 ####  Options:
-
 ```
 --show-usage: Displays usage information for the command.
 --show-headers: Includes HTTP headers in the output.
 --show-service-version: Displays the version of the service handling the GraphQL query.
---cursors <cursor-list>: Specifies a list of cursors to be used within the query. Each cursor can be referenced in the GraphQL query using @{cursor_name} syntax.
+--cursors <cursor-list>: Specifies a list of cursors to be used within the query.
 ```
 
-#### Query interpolation:
+#### Query Interpolation
 
-The task supports placeholder interpolation within queries.
-Placeholders like `@{variable_name}` are dynamically replaced with values provided in the `--cursors` option or derived from named addresses, object enumerations, and checkpoints.
+The command supports **query interpolation**, allowing you to dynamically replace parts of the GraphQL query at runtime.
+
+Following interpolation rules are supported:
+
+1. **Object Placeholders**
+   - **Syntax**: `@{obj_x_y}` or `@{obj_x_y_opt}`
+   - Here, `(x, y)` corresponds to the transaction index and the creation index of the object within that transaction. The placeholder will be replaced with the object ID as a string (like `0xABCD...`).
+
+2. **Named Address Placeholders**
+   - **Syntax**: `@{NamedAddr}` or `@{NamedAddr_opt}`
+   - Substitutes known accounts and addresses that have been created during the initialization step, e.g. `init --protocol-version 1 --addresses P0=0x0 --accounts A B --simulator`
+
+3. **Base64-Encoded Cursors**
+   - Any string passed to `--cursors` list will be Base64-encoded and made accessible in the query as `@{cursor_0}`, `@{cursor_1}`, etc., in the order provided.
+   - If the string matches `@{obj_x_y}`, it pairs the object’s ID for (x, y) with the highest checkpoint; if the string is `@{obj_x_y,checkpoint}`, it pairs the object’s ID with the specified checkpoint. It then BCS-encodes the (objectID, checkpoint) tuple and provides the Base64-encodes the result.
+
+All of the above rules (object references, named addresses, raw Base64-encoded strings) can be used in a single query. 
+Any placeholder that cannot be mapped to a known variable, object, or address will cause an error.
 
 ####  Example: Get the first transaction block with its effects and object changes
 

--- a/crates/iota-transactional-test-runner/syntax.md
+++ b/crates/iota-transactional-test-runner/syntax.md
@@ -103,13 +103,17 @@ It supports the following placeholders:
    - Substitutes known accounts and addresses that have been created during the initialization step, e.g. `init --protocol-version 1 --addresses P0=0x0 --accounts A B --simulator`
 
 3. **Cursors**
-   - Any string passed to the `--cursors` list will be Base64-encoded and can be accessed in the query as `@{cursor_0}`, `@{cursor_1}`, etc., in the order provided.
+   - **Syntax**: `//# run-graphql --cursors string1 string2 ...`
+   - Any string passed to `--cursors` will be Base64-encoded and can be accessed in the query as `@{cursor_0}`, `@{cursor_1}`, etc., in the order provided.
    - If the string matches `@{obj_x_y}`, it pairs the object’s ID for (x, y) with the highest checkpoint; if the string matches `@{obj_x_y, checkpoint}`, it pairs the object’s ID with the provided checkpoint. It then BCS-encodes the (objectID, checkpoint) tuple and provides the Base64-encoded cursor value.
 
 All of the above rules (object references, named addresses, raw Base64-encoded strings) can be used in a single query.
 Any placeholder that cannot be mapped to a known variable, object, or address will cause an error.
 
 #### Example
+
+The following query will replace the placeholder `@{cursor_0}` with the base64-encoded string `{"c":3,"t":1,"tc":1}`.
+`@{A}` and `@{P0}` will be replaced with the addresses `A` and `P0` respectively that were created during the initialization step.
 
 ```
 //# run-graphql --cursors {"c":3,"t":1,"tc":1}
@@ -134,9 +138,6 @@ Any placeholder that cannot be mapped to a known variable, object, or address wi
   }
 }
 ```
-
-The above query will replace the placeholder `@{cursor_0}` with the base64-encoded string `{"c":3,"t":1,"tc":1}`.
-`@{A}` and `@{P0}` will be replaced with the addresses `A` and `P0` respectively that were created during the initialization step.
 
 ### `force-object-snapshot-catchup`
 

--- a/crates/iota-transactional-test-runner/syntax.md
+++ b/crates/iota-transactional-test-runner/syntax.md
@@ -6,11 +6,11 @@ This currently used in the following tests:
 
 ```
 $ cargo tree -i iota-transactional-test-runner
-iota-transactional-test-runner v0.1.0 (/home/kodemartin/projects/kinesis/crates/iota-transactional-test-runner)
+iota-transactional-test-runner v0.1.0 (crates/iota-transactional-test-runner)
 [dev-dependencies]
-├── iota-adapter-transactional-tests v0.1.0 (/home/kodemartin/projects/kinesis/crates/iota-adapter-transactional-tests)
-├── iota-graphql-e2e-tests v0.1.0 (/home/kodemartin/projects/kinesis/crates/iota-graphql-e2e-tests)
-└── iota-verifier-transactional-tests v0.1.0 (/home/kodemartin/projects/kinesis/crates/iota-verifier-transactional-tests)
+├── iota-adapter-transactional-tests v0.1.0 (crates/iota-adapter-transactional-tests)
+├── iota-graphql-e2e-tests v0.1.0 (crates/iota-graphql-e2e-tests)
+└── iota-verifier-transactional-tests v0.1.0 (crates/iota-verifier-transactional-tests)
 ```
 
 ## Common rules

--- a/crates/iota-transactional-test-runner/syntax.md
+++ b/crates/iota-transactional-test-runner/syntax.md
@@ -104,16 +104,16 @@ It supports the following placeholders:
 
 3. **Cursors**
    - **Syntax**: `//# run-graphql --cursors string1 string2 ...`
-     - Every string passed to `--cursors` will be Base64-encoded and can be accessed in the query as `@{cursor_0}`, `@{cursor_1}`, etc., in the order provided.
-     - Depending on the query, the strings passed to `--cursors` must follow the expected cursor format for the specific query.
-     - To generate cursor values from created objects at runtime, the strings passed to `--cursors` must correspond to the format `@{obj_x_y}` or `@{obj_x_y, checkpoint}`. The tuple (objectID, checkpoint) is then BCS-encoded and can be accessed in the query as `@{cursor_0}`, `@{cursor_1}`, etc. in the specified order.
+     - Depending on the query, the raw strings passed to `--cursors` might be required in JSON, BCS or any other format that the query expects.
+     - Each string passed is automatically Base64-encoded (as all cursor values are expected to be Base64-encoded) and can be accessed in the query as `@{cursor_0}`, `@{cursor_1}`, etc., in the order provided.
+     - To generate cursor values from objects at runtime, the strings passed must correspond to the format `@{obj_x_y}` or `@{obj_x_y, checkpoint}` and are translated to Base64-encoded object cursors.
 
 All of the above rules (object placeholders, named address placeholders, cursor strings) can be used in a single query.
-Any placeholder that cannot be mapped to a known variable, object, or address will cause an error.
+Any placeholder or cursor that cannot be mapped to a known variable, object, or address will cause an error.
 
 #### Examples
 
-The following example query will replace the placeholder `@{cursor_0}` with the base64-encoded [transaction block cursor](../../crates/iota-graphql-rpc/src/types/transaction_block.rs) `{"c":3,"t":1,"tc":1}` where `c` is the checkpoint sequence number, `t` is the transaction sequence number, and `tc` is the transaction checkpoint number.
+The following example query will replace the placeholder `@{cursor_0}` with the Base64-encoded [transaction block cursor](../../crates/iota-graphql-rpc/src/types/transaction_block.rs) `{"c":3,"t":1,"tc":1}` where `c` is the checkpoint sequence number, `t` is the transaction sequence number, and `tc` is the transaction checkpoint number.
 Cursor values depend on the query and the underlying schema. The cursor value above example is specific to the GraphQL `transactionBlocks` query.
 `@{A}` and `@{P0}` will be replaced with the addresses `A` and `P0` respectively that were created during the initialization step.
 


### PR DESCRIPTION
# Description of change

Documents the `run-graphql` syntax of the `iota-transactional-test-runner` framework.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/4201

## Type of change

- Documentation
