### PR TITLE
fix(devx): Replace cargo run with cargo build in iota full node guides

### DIFF
--- a/docs/content/operator/iota-full-node/source.mdx
+++ b/docs/content/operator/iota-full-node/source.mdx
@@ -134,7 +134,7 @@ cp crates/iota-config/data/fullnode-template.yaml fullnode.yaml
 Run the following command to compile the `iota-node`.
 
 ```shell
-cargo run --release --bin iota-node
+cargo build --release --bin iota-node
 ```
 
 ## 4. Start Services
@@ -208,7 +208,7 @@ Use the following steps to update your Full node:
 6. Recompile your IOTA Full node:
 
     ```bash
-    cargo run --release --bin iota-node
+    cargo build --release --bin iota-node
     ```
 
 7. Restart your IOTA Full node:

--- a/docs/content/references/exchange-integration-guide.mdx
+++ b/docs/content/references/exchange-integration-guide.mdx
@@ -82,7 +82,7 @@ Use the steps in this section to install and configure a IOTA Full node directly
     `genesis-file-location: "/iota-fullnode-folder/genesis.blob"`
 1.  Start you IOTA Full node:
     ```bash
-    cargo build --release --bin iota-node -- --config-path fullnode.yaml
+    cargo run --release --bin iota-node -- --config-path fullnode.yaml
     ```
 
 ## Set up IOTA addresses

--- a/docs/content/references/exchange-integration-guide.mdx
+++ b/docs/content/references/exchange-integration-guide.mdx
@@ -82,7 +82,7 @@ Use the steps in this section to install and configure a IOTA Full node directly
     `genesis-file-location: "/iota-fullnode-folder/genesis.blob"`
 1.  Start you IOTA Full node:
     ```bash
-    cargo run --release --bin iota-node -- --config-path fullnode.yaml
+    cargo build --release --bin iota-node -- --config-path fullnode.yaml
     ```
 
 ## Set up IOTA addresses


### PR DESCRIPTION
# Description of change

Replaced `cargo run --release --bin iota-node` with `cargo build --release  --bin iota-node`

## Links to any relevant issues

Fixes https://github.com/iotaledger/devx/issues/515

## Type of change

- Documentation Fix

## How the change has been tested

Docs were built locally.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
