### PR TITLE
fix: use workspace dependencies for custom-indexer since it is now added to the root Cargo.toml, else it takes the latest tag from git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2668,22 +2668,10 @@ version = "0.1.0"
 dependencies = [
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "insta",
- "iota-network-stack 0.8.0-alpha",
+ "iota-network-stack",
  "rand 0.8.5",
  "serde",
- "shared-crypto 0.8.0-alpha",
-]
-
-[[package]]
-name = "consensus-config"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "iota-network-stack 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "rand 0.8.5",
- "serde",
- "shared-crypto 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
+ "shared-crypto",
 ]
 
 [[package]]
@@ -2697,7 +2685,7 @@ dependencies = [
  "bcs",
  "bytes",
  "cfg-if",
- "consensus-config 0.1.0",
+ "consensus-config",
  "dashmap",
  "enum_dispatch",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
@@ -2707,10 +2695,10 @@ dependencies = [
  "hyper-rustls 0.27.3",
  "hyper-util",
  "iota-common",
- "iota-macros 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
- "iota-network-stack 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
+ "iota-macros",
+ "iota-metrics",
+ "iota-network-stack",
+ "iota-protocol-config",
  "iota-tls",
  "itertools 0.13.0",
  "nom",
@@ -2722,10 +2710,10 @@ dependencies = [
  "rstest",
  "rustls 0.23.18",
  "serde",
- "shared-crypto 0.8.0-alpha",
+ "shared-crypto",
  "strum_macros 0.26.4",
  "tap",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2737,7 +2725,7 @@ dependencies = [
  "tower 0.4.13",
  "tower-http",
  "tracing",
- "typed-store 0.8.0-alpha",
+ "typed-store",
 ]
 
 [[package]]
@@ -3206,8 +3194,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "iota-data-ingestion-core 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
+ "iota-data-ingestion-core",
+ "iota-types",
  "prometheus",
  "tokio",
 ]
@@ -3707,13 +3695,13 @@ dependencies = [
  "anyhow",
  "bcs",
  "bip32",
- "iota-keys 0.8.0-alpha",
- "iota-move-build 0.8.0-alpha",
+ "iota-keys",
+ "iota-move-build",
  "iota-sdk 0.8.0-alpha",
- "move-binary-format 0.0.3",
- "move-core-types 0.0.4",
+ "move-binary-format",
+ "move-core-types",
  "serde_json",
- "shared-crypto 0.8.0-alpha",
+ "shared-crypto",
  "tokio",
 ]
 
@@ -3984,14 +3972,6 @@ dependencies = [
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-dependencies = [
- "serde_yaml",
-]
-
-[[package]]
-name = "enum-compat-util"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
 dependencies = [
  "serde_yaml",
 ]
@@ -5977,41 +5957,41 @@ dependencies = [
  "inquire",
  "insta",
  "iota-bridge",
- "iota-config 0.8.0-alpha",
- "iota-execution 0.1.0",
+ "iota-config",
+ "iota-execution",
  "iota-faucet",
  "iota-genesis-builder",
  "iota-graphql-rpc",
  "iota-indexer",
- "iota-json 0.8.0-alpha",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-keys 0.8.0-alpha",
- "iota-macros 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
+ "iota-json",
+ "iota-json-rpc-types",
+ "iota-keys",
+ "iota-macros",
+ "iota-metrics",
  "iota-move",
- "iota-move-build 0.8.0-alpha",
- "iota-package-management 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
+ "iota-move-build",
+ "iota-package-management",
+ "iota-protocol-config",
  "iota-replay",
  "iota-sdk 0.8.0-alpha",
- "iota-simulator 0.8.0-alpha",
+ "iota-simulator",
  "iota-source-validation",
  "iota-swarm",
  "iota-swarm-config",
  "iota-test-transaction-builder",
- "iota-transaction-builder 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
+ "iota-transaction-builder",
+ "iota-types",
  "json_to_table",
  "miette",
  "move-analyzer",
- "move-binary-format 0.0.3",
- "move-bytecode-verifier-meter 0.1.0",
+ "move-binary-format",
+ "move-bytecode-verifier-meter",
  "move-cli",
- "move-command-line-common 0.1.0",
- "move-core-types 0.0.4",
- "move-package 0.1.0",
- "move-vm-config 0.1.0",
- "move-vm-profiler 0.1.0",
+ "move-command-line-common",
+ "move-core-types",
+ "move-package",
+ "move-vm-config",
+ "move-vm-profiler",
  "msim",
  "num-bigint 0.4.6",
  "prometheus",
@@ -6023,14 +6003,14 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "shared-crypto 0.8.0-alpha",
+ "shared-crypto",
  "shell-words",
  "shlex",
  "signature 1.6.4",
  "strum 0.26.3",
  "tabled",
  "tap",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tempfile",
  "test-cluster",
  "thiserror",
@@ -6049,50 +6029,22 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
- "iota-macros 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
- "iota-move-natives-latest 0.1.0",
- "iota-protocol-config 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
- "iota-verifier-latest 0.1.0",
+ "iota-macros",
+ "iota-metrics",
+ "iota-move-natives-latest",
+ "iota-protocol-config",
+ "iota-types",
+ "iota-verifier-latest",
  "leb128",
- "move-binary-format 0.0.3",
- "move-bytecode-utils 0.1.0",
- "move-bytecode-verifier 0.1.0",
- "move-bytecode-verifier-meter 0.1.0",
- "move-core-types 0.0.4",
- "move-vm-config 0.1.0",
- "move-vm-profiler 0.1.0",
- "move-vm-runtime 0.1.0",
- "move-vm-types 0.1.0",
- "parking_lot 0.12.3",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "iota-adapter-latest"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "bcs",
- "iota-macros 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-metrics 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-move-natives-latest 0.1.0 (git+https://github.com/iotaledger/iota)",
- "iota-protocol-config 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-verifier-latest 0.1.0 (git+https://github.com/iotaledger/iota)",
- "leb128",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-verifier-meter 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-vm-config 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-vm-profiler 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-vm-runtime 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-vm-types 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-bytecode-verifier",
+ "move-bytecode-verifier-meter",
+ "move-core-types",
+ "move-vm-config",
+ "move-vm-profiler",
+ "move-vm-runtime",
+ "move-vm-types",
  "parking_lot 0.12.3",
  "serde",
  "tracing",
@@ -6125,18 +6077,18 @@ dependencies = [
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "gcp-bigquery-client",
  "iota-analytics-indexer-derive",
- "iota-config 0.8.0-alpha",
- "iota-data-ingestion-core 0.8.0-alpha",
+ "iota-config",
+ "iota-data-ingestion-core",
  "iota-indexer",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
- "iota-package-resolver 0.8.0-alpha",
- "iota-rest-api 0.8.0-alpha",
- "iota-storage 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
- "move-binary-format 0.0.3",
- "move-bytecode-utils 0.1.0",
- "move-core-types 0.0.4",
+ "iota-json-rpc-types",
+ "iota-metrics",
+ "iota-package-resolver",
+ "iota-rest-api",
+ "iota-storage",
+ "iota-types",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
  "num_enum",
  "object_store 0.10.2",
  "parquet",
@@ -6147,13 +6099,13 @@ dependencies = [
  "snowflake-api",
  "strum 0.26.3",
  "tap",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tempfile",
  "thiserror",
  "tokio",
  "tokio-stream",
  "tracing",
- "typed-store 0.8.0-alpha",
+ "typed-store",
  "url",
 ]
 
@@ -6177,16 +6129,16 @@ dependencies = [
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "futures",
  "indicatif",
- "iota-config 0.8.0-alpha",
- "iota-macros 0.8.0-alpha",
- "iota-simulator 0.8.0-alpha",
- "iota-storage 0.8.0-alpha",
+ "iota-config",
+ "iota-macros",
+ "iota-simulator",
+ "iota-storage",
  "iota-swarm-config",
- "iota-types 0.8.0-alpha",
+ "iota-types",
  "more-asserts",
- "move-binary-format 0.0.3",
- "move-core-types 0.0.4",
- "move-package 0.1.0",
+ "move-binary-format",
+ "move-core-types",
+ "move-package",
  "num_enum",
  "object_store 0.10.2",
  "prometheus",
@@ -6203,8 +6155,8 @@ name = "iota-authority-aggregation"
 version = "0.8.0-alpha"
 dependencies = [
  "futures",
- "iota-metrics 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
+ "iota-metrics",
+ "iota-types",
  "tokio",
  "tracing",
 ]
@@ -6224,10 +6176,10 @@ dependencies = [
  "crossterm 0.25.0",
  "eyre",
  "futures",
- "iota-config 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
+ "iota-config",
+ "iota-metrics",
  "iota-swarm-config",
- "iota-types 0.8.0-alpha",
+ "iota-types",
  "prettytable-rs",
  "prometheus-parse",
  "reqwest 0.12.7",
@@ -6254,25 +6206,25 @@ dependencies = [
  "futures",
  "hdrhistogram",
  "indicatif",
- "iota-config 0.8.0-alpha",
+ "iota-config",
  "iota-core",
- "iota-framework 0.8.0-alpha",
+ "iota-framework",
  "iota-framework-snapshot",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-keys 0.8.0-alpha",
- "iota-macros 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
+ "iota-json-rpc-types",
+ "iota-keys",
+ "iota-macros",
+ "iota-metrics",
  "iota-network",
- "iota-protocol-config 0.8.0-alpha",
+ "iota-protocol-config",
  "iota-sdk 0.8.0-alpha",
- "iota-simulator 0.8.0-alpha",
- "iota-storage 0.8.0-alpha",
+ "iota-simulator",
+ "iota-storage",
  "iota-surfer",
  "iota-swarm-config",
  "iota-test-transaction-builder",
- "iota-types 0.8.0-alpha",
+ "iota-types",
  "itertools 0.13.0",
- "move-core-types 0.0.4",
+ "move-core-types",
  "prometheus",
  "rand 0.8.5",
  "regex",
@@ -6282,12 +6234,12 @@ dependencies = [
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "sysinfo",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "test-cluster",
  "tokio",
  "tokio-util 0.7.12",
  "tracing",
- "typed-store 0.8.0-alpha",
+ "typed-store",
 ]
 
 [[package]]
@@ -6309,17 +6261,17 @@ dependencies = [
  "futures",
  "hex-literal 0.3.4",
  "iota-authority-aggregation",
- "iota-config 0.8.0-alpha",
- "iota-json-rpc-api 0.8.0-alpha",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-keys 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
+ "iota-config",
+ "iota-json-rpc-api",
+ "iota-json-rpc-types",
+ "iota-keys",
+ "iota-metrics",
  "iota-sdk 0.8.0-alpha",
  "iota-test-transaction-builder",
- "iota-types 0.8.0-alpha",
+ "iota-types",
  "lru 0.12.4",
  "maplit",
- "move-core-types 0.0.4",
+ "move-core-types",
  "num_enum",
  "once_cell",
  "prometheus",
@@ -6328,14 +6280,14 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with 3.9.0",
- "shared-crypto 0.8.0-alpha",
+ "shared-crypto",
  "tap",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tempfile",
  "test-cluster",
  "tokio",
  "tracing",
- "typed-store 0.8.0-alpha",
+ "typed-store",
  "url",
 ]
 
@@ -6349,18 +6301,18 @@ dependencies = [
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "futures",
  "iota-bridge",
- "iota-config 0.8.0-alpha",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-keys 0.8.0-alpha",
+ "iota-config",
+ "iota-json-rpc-types",
+ "iota-keys",
  "iota-sdk 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
- "move-core-types 0.0.4",
+ "iota-types",
+ "move-core-types",
  "reqwest 0.12.7",
  "serde",
  "serde_json",
  "serde_with 3.9.0",
- "shared-crypto 0.8.0-alpha",
- "telemetry-subscribers 0.8.0-alpha",
+ "shared-crypto",
+ "telemetry-subscribers",
  "tokio",
  "tracing",
 ]
@@ -6378,19 +6330,19 @@ dependencies = [
  "ethers",
  "futures",
  "iota-bridge",
- "iota-config 0.8.0-alpha",
- "iota-data-ingestion-core 0.8.0-alpha",
+ "iota-config",
+ "iota-data-ingestion-core",
  "iota-indexer-builder",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
+ "iota-json-rpc-types",
+ "iota-metrics",
  "iota-sdk 0.8.0-alpha",
  "iota-test-transaction-builder",
- "iota-types 0.8.0-alpha",
+ "iota-types",
  "prometheus",
  "serde",
  "serde_yaml",
  "tap",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tokio",
  "tracing",
 ]
@@ -6406,28 +6358,28 @@ dependencies = [
  "diesel",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "futures",
- "iota-config 0.8.0-alpha",
+ "iota-config",
  "iota-core",
  "iota-faucet",
  "iota-genesis-builder",
  "iota-graphql-rpc",
  "iota-indexer",
- "iota-json 0.8.0-alpha",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-keys 0.8.0-alpha",
+ "iota-json",
+ "iota-json-rpc-types",
+ "iota-keys",
  "iota-sdk 0.8.0-alpha",
  "iota-swarm",
  "iota-swarm-config",
  "iota-test-transaction-builder",
- "iota-types 0.8.0-alpha",
+ "iota-types",
  "jsonrpsee",
- "move-core-types 0.0.4",
+ "move-core-types",
  "prometheus",
  "regex",
  "reqwest 0.12.7",
  "serde_json",
- "shared-crypto 0.8.0-alpha",
- "telemetry-subscribers 0.8.0-alpha",
+ "shared-crypto",
+ "telemetry-subscribers",
  "tempfile",
  "test-cluster",
  "tokio",
@@ -6452,42 +6404,14 @@ dependencies = [
  "anyhow",
  "bcs",
  "clap",
- "consensus-config 0.1.0",
+ "consensus-config",
  "csv",
  "dirs 5.0.1",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "iota-genesis-common 0.8.0-alpha",
- "iota-keys 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
- "object_store 0.10.2",
- "once_cell",
- "prometheus",
- "rand 0.8.5",
- "reqwest 0.12.7",
- "serde",
- "serde_with 3.9.0",
- "serde_yaml",
- "tracing",
-]
-
-[[package]]
-name = "iota-config"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anemo",
- "anyhow",
- "bcs",
- "clap",
- "consensus-config 0.1.0 (git+https://github.com/iotaledger/iota)",
- "csv",
- "dirs 5.0.1",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "iota-genesis-common 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-keys 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-protocol-config 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
+ "iota-genesis-common",
+ "iota-keys",
+ "iota-protocol-config",
+ "iota-types",
  "object_store 0.10.2",
  "once_cell",
  "prometheus",
@@ -6512,7 +6436,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
- "consensus-config 0.1.0",
+ "consensus-config",
  "consensus-core",
  "count-min-sketch",
  "criterion",
@@ -6532,35 +6456,35 @@ dependencies = [
  "iota-archival",
  "iota-authority-aggregation",
  "iota-common",
- "iota-config 0.8.0-alpha",
- "iota-execution 0.1.0",
- "iota-framework 0.8.0-alpha",
+ "iota-config",
+ "iota-execution",
+ "iota-framework",
  "iota-genesis-builder",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-macros 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
+ "iota-json-rpc-types",
+ "iota-macros",
+ "iota-metrics",
  "iota-move",
- "iota-move-build 0.8.0-alpha",
+ "iota-move-build",
  "iota-network",
- "iota-network-stack 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
- "iota-simulator 0.8.0-alpha",
- "iota-storage 0.8.0-alpha",
+ "iota-network-stack",
+ "iota-protocol-config",
+ "iota-simulator",
+ "iota-storage",
  "iota-swarm-config",
  "iota-test-transaction-builder",
  "iota-transaction-checks",
- "iota-types 0.8.0-alpha",
+ "iota-types",
  "itertools 0.13.0",
  "jsonrpsee",
  "lru 0.12.4",
  "mockall",
  "moka",
  "more-asserts",
- "move-binary-format 0.0.3",
- "move-bytecode-utils 0.1.0",
- "move-core-types 0.0.4",
- "move-package 0.1.0",
- "move-symbol-pool 0.1.0",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
+ "move-package",
+ "move-symbol-pool",
  "nonempty",
  "num-bigint 0.4.6",
  "num_cpus",
@@ -6582,11 +6506,11 @@ dependencies = [
  "serde_json",
  "serde_with 3.9.0",
  "serde_yaml",
- "shared-crypto 0.8.0-alpha",
+ "shared-crypto",
  "signature 1.6.4",
  "static_assertions",
  "tap",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tempfile",
  "test-cluster",
  "test-fuzz",
@@ -6596,8 +6520,8 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "twox-hash",
- "typed-store 0.8.0-alpha",
- "typed-store-derive 0.8.0-alpha",
+ "typed-store",
+ "typed-store-derive",
  "zeroize",
 ]
 
@@ -6608,13 +6532,13 @@ dependencies = [
  "anyhow",
  "bcs",
  "insta",
- "iota-config 0.8.0-alpha",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-move-build 0.8.0-alpha",
+ "iota-config",
+ "iota-json-rpc-types",
+ "iota-move-build",
  "iota-swarm-config",
  "iota-test-transaction-builder",
- "iota-types 0.8.0-alpha",
- "move-disassembler 0.1.0",
+ "iota-types",
+ "move-disassembler",
  "serde",
  "strum 0.26.3",
  "test-cluster",
@@ -6672,10 +6596,10 @@ dependencies = [
  "bytes",
  "futures",
  "iota-archival",
- "iota-data-ingestion-core 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
- "iota-storage 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
+ "iota-data-ingestion-core",
+ "iota-metrics",
+ "iota-storage",
+ "iota-types",
  "notify",
  "object_store 0.10.2",
  "prometheus",
@@ -6683,7 +6607,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tempfile",
  "tokio",
  "tracing",
@@ -6699,42 +6623,15 @@ dependencies = [
  "backoff",
  "bcs",
  "futures",
- "iota-metrics 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
- "iota-rest-api 0.8.0-alpha",
- "iota-storage 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
+ "iota-metrics",
+ "iota-protocol-config",
+ "iota-rest-api",
+ "iota-storage",
+ "iota-types",
  "notify",
  "object_store 0.10.2",
  "prometheus",
  "rand 0.8.5",
- "serde",
- "serde_json",
- "tap",
- "tempfile",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "iota-data-ingestion-core"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "async-trait",
- "backoff",
- "bcs",
- "futures",
- "iota-metrics 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-protocol-config 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-rest-api 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-storage 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "notify",
- "object_store 0.10.2",
- "prometheus",
  "serde",
  "serde_json",
  "tap",
@@ -6762,33 +6659,33 @@ dependencies = [
  "insta",
  "iota",
  "iota-bridge",
- "iota-config 0.8.0-alpha",
+ "iota-config",
  "iota-core",
- "iota-framework 0.8.0-alpha",
+ "iota-framework",
  "iota-genesis-builder",
  "iota-json-rpc",
- "iota-json-rpc-api 0.8.0-alpha",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-keys 0.8.0-alpha",
- "iota-macros 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
- "iota-move-build 0.8.0-alpha",
+ "iota-json-rpc-api",
+ "iota-json-rpc-types",
+ "iota-keys",
+ "iota-macros",
+ "iota-metrics",
+ "iota-move-build",
  "iota-network",
  "iota-node",
- "iota-protocol-config 0.8.0-alpha",
- "iota-rest-api 0.8.0-alpha",
+ "iota-protocol-config",
+ "iota-rest-api",
  "iota-sdk 0.8.0-alpha",
- "iota-simulator 0.8.0-alpha",
- "iota-storage 0.8.0-alpha",
+ "iota-simulator",
+ "iota-storage",
  "iota-swarm",
  "iota-swarm-config",
  "iota-test-transaction-builder",
  "iota-tool",
- "iota-types 0.8.0-alpha",
+ "iota-types",
  "jsonrpsee",
- "move-binary-format 0.0.3",
- "move-core-types 0.0.4",
- "move-package 0.1.0",
+ "move-binary-format",
+ "move-core-types",
+ "move-package",
  "p256 0.13.2",
  "passkey-authenticator",
  "passkey-client",
@@ -6797,8 +6694,8 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "shared-crypto 0.8.0-alpha",
- "telemetry-subscribers 0.8.0-alpha",
+ "shared-crypto",
+ "telemetry-subscribers",
  "tempfile",
  "test-cluster",
  "tokio",
@@ -6814,46 +6711,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "iota-enum-compat-util"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "serde_yaml",
-]
-
-[[package]]
 name = "iota-execution"
 version = "0.1.0"
 dependencies = [
  "cargo_metadata 0.15.4",
- "iota-adapter-latest 0.1.0",
- "iota-move-natives-latest 0.1.0",
- "iota-protocol-config 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
- "iota-verifier-latest 0.1.0",
- "move-binary-format 0.0.3",
- "move-bytecode-verifier 0.1.0",
- "move-bytecode-verifier-meter 0.1.0",
- "move-vm-config 0.1.0",
- "move-vm-runtime 0.1.0",
+ "iota-adapter-latest",
+ "iota-move-natives-latest",
+ "iota-protocol-config",
+ "iota-types",
+ "iota-verifier-latest",
+ "move-binary-format",
+ "move-bytecode-verifier",
+ "move-bytecode-verifier-meter",
+ "move-vm-config",
+ "move-vm-runtime",
  "petgraph 0.6.5",
-]
-
-[[package]]
-name = "iota-execution"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "iota-adapter-latest 0.1.0 (git+https://github.com/iotaledger/iota)",
- "iota-move-natives-latest 0.1.0 (git+https://github.com/iotaledger/iota)",
- "iota-protocol-config 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-verifier-latest 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-verifier-meter 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-vm-config 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-vm-runtime 0.1.0 (git+https://github.com/iotaledger/iota)",
 ]
 
 [[package]]
@@ -6881,20 +6753,20 @@ dependencies = [
  "eyre",
  "futures",
  "http 1.1.0",
- "iota-config 0.8.0-alpha",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-keys 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
+ "iota-config",
+ "iota-json-rpc-types",
+ "iota-keys",
+ "iota-metrics",
  "iota-sdk 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
+ "iota-types",
  "parking_lot 0.12.3",
  "prometheus",
  "rocksdb",
  "scopeguard",
  "serde",
- "shared-crypto 0.8.0-alpha",
+ "shared-crypto",
  "tap",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tempfile",
  "test-cluster",
  "thiserror",
@@ -6903,7 +6775,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "ttl_cache",
- "typed-store 0.8.0-alpha",
+ "typed-store",
  "uuid 1.10.0",
 ]
 
@@ -6914,31 +6786,17 @@ dependencies = [
  "anyhow",
  "bcs",
  "capitalize",
- "iota-move-build 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
- "move-binary-format 0.0.3",
- "move-compiler 0.0.1",
- "move-core-types 0.0.4",
- "move-package 0.1.0",
+ "iota-move-build",
+ "iota-types",
+ "move-binary-format",
+ "move-compiler",
+ "move-core-types",
+ "move-package",
  "once_cell",
  "regex",
  "serde",
  "serde_json",
  "tempfile",
- "tracing",
-]
-
-[[package]]
-name = "iota-framework"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "bcs",
- "iota-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "once_cell",
- "serde",
  "tracing",
 ]
 
@@ -6949,9 +6807,9 @@ dependencies = [
  "anyhow",
  "bcs",
  "bin-version",
- "iota-framework 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
+ "iota-framework",
+ "iota-protocol-config",
+ "iota-types",
  "serde",
  "serde_json",
  "tokio",
@@ -6962,17 +6820,17 @@ name = "iota-framework-tests"
 version = "0.8.0-alpha"
 dependencies = [
  "datatest-stable",
- "iota-adapter-latest 0.1.0",
- "iota-framework 0.8.0-alpha",
+ "iota-adapter-latest",
+ "iota-framework",
  "iota-move",
- "iota-move-build 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
- "iota-verifier-latest 0.1.0",
- "move-bytecode-verifier 0.1.0",
- "move-bytecode-verifier-meter 0.1.0",
+ "iota-move-build",
+ "iota-protocol-config",
+ "iota-types",
+ "iota-verifier-latest",
+ "move-bytecode-verifier",
+ "move-bytecode-verifier-meter",
  "move-cli",
- "move-package 0.1.0",
+ "move-package",
  "move-unit-test",
  "prometheus",
 ]
@@ -6990,25 +6848,25 @@ dependencies = [
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "flate2",
  "fs_extra",
- "iota-adapter-latest 0.1.0",
- "iota-config 0.8.0-alpha",
- "iota-execution 0.1.0",
- "iota-framework 0.8.0-alpha",
+ "iota-adapter-latest",
+ "iota-config",
+ "iota-execution",
+ "iota-framework",
  "iota-framework-snapshot",
- "iota-genesis-common 0.8.0-alpha",
- "iota-move-build 0.8.0-alpha",
- "iota-move-natives-latest 0.1.0",
- "iota-protocol-config 0.8.0-alpha",
+ "iota-genesis-common",
+ "iota-move-build",
+ "iota-move-natives-latest",
+ "iota-protocol-config",
  "iota-sdk 1.1.5",
- "iota-simulator 0.8.0-alpha",
+ "iota-simulator",
  "iota-swarm-config",
- "iota-types 0.8.0-alpha",
+ "iota-types",
  "itertools 0.13.0",
- "move-binary-format 0.0.3",
- "move-compiler 0.0.1",
- "move-core-types 0.0.4",
- "move-package 0.1.0",
- "move-vm-runtime 0.1.0",
+ "move-binary-format",
+ "move-compiler",
+ "move-core-types",
+ "move-package",
+ "move-vm-runtime",
  "packable",
  "prefix-hex",
  "prometheus",
@@ -7022,7 +6880,7 @@ dependencies = [
  "serde_json",
  "serde_with 3.9.0",
  "serde_yaml",
- "shared-crypto 0.8.0-alpha",
+ "shared-crypto",
  "tempfile",
  "thiserror",
  "tokio",
@@ -7034,20 +6892,9 @@ dependencies = [
 name = "iota-genesis-common"
 version = "0.8.0-alpha"
 dependencies = [
- "iota-execution 0.1.0",
- "iota-protocol-config 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
- "prometheus",
-]
-
-[[package]]
-name = "iota-genesis-common"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "iota-execution 0.1.0 (git+https://github.com/iotaledger/iota)",
- "iota-protocol-config 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
+ "iota-execution",
+ "iota-protocol-config",
+ "iota-types",
  "prometheus",
 ]
 
@@ -7099,29 +6946,29 @@ dependencies = [
  "hyper 1.4.1",
  "im",
  "insta",
- "iota-framework 0.8.0-alpha",
+ "iota-framework",
  "iota-graphql-config",
  "iota-graphql-rpc-client",
  "iota-graphql-rpc-headers",
  "iota-indexer",
  "iota-json-rpc",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
- "iota-network-stack 0.8.0-alpha",
- "iota-package-resolver 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
- "iota-rest-api 0.8.0-alpha",
+ "iota-json-rpc-types",
+ "iota-metrics",
+ "iota-network-stack",
+ "iota-package-resolver",
+ "iota-protocol-config",
+ "iota-rest-api",
  "iota-sdk 0.8.0-alpha",
  "iota-swarm-config",
  "iota-test-transaction-builder",
- "iota-types 0.8.0-alpha",
+ "iota-types",
  "itertools 0.13.0",
  "lru 0.12.4",
- "move-binary-format 0.0.3",
- "move-bytecode-utils 0.1.0",
- "move-core-types 0.0.4",
- "move-disassembler 0.1.0",
- "move-ir-types 0.1.0",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
+ "move-disassembler",
+ "move-ir-types",
  "once_cell",
  "prometheus",
  "rand 0.8.5",
@@ -7132,11 +6979,11 @@ dependencies = [
  "serde_with 3.9.0",
  "serde_yaml",
  "serial_test",
- "shared-crypto 0.8.0-alpha",
+ "shared-crypto",
  "similar",
  "simulacrum",
  "tap",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tempfile",
  "test-cluster",
  "thiserror",
@@ -7188,30 +7035,30 @@ dependencies = [
  "downcast",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "futures",
- "iota-config 0.8.0-alpha",
- "iota-data-ingestion-core 0.8.0-alpha",
+ "iota-config",
+ "iota-data-ingestion-core",
  "iota-genesis-builder",
- "iota-json 0.8.0-alpha",
+ "iota-json",
  "iota-json-rpc",
- "iota-json-rpc-api 0.8.0-alpha",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-keys 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
- "iota-move-build 0.8.0-alpha",
- "iota-open-rpc 0.8.0-alpha",
- "iota-package-resolver 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
- "iota-rest-api 0.8.0-alpha",
+ "iota-json-rpc-api",
+ "iota-json-rpc-types",
+ "iota-keys",
+ "iota-metrics",
+ "iota-move-build",
+ "iota-open-rpc",
+ "iota-package-resolver",
+ "iota-protocol-config",
+ "iota-rest-api",
  "iota-sdk 0.8.0-alpha",
  "iota-swarm-config",
  "iota-test-transaction-builder",
- "iota-transaction-builder 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
+ "iota-transaction-builder",
+ "iota-types",
  "itertools 0.13.0",
  "jsonrpsee",
- "move-binary-format 0.0.3",
- "move-bytecode-utils 0.1.0",
- "move-core-types 0.0.4",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
  "mysqlclient-sys",
  "prometheus",
  "rand 0.8.5",
@@ -7223,7 +7070,7 @@ dependencies = [
  "serde_with 3.9.0",
  "simulacrum",
  "tap",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tempfile",
  "test-cluster",
  "thiserror",
@@ -7239,11 +7086,11 @@ version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
- "iota-data-ingestion-core 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
+ "iota-data-ingestion-core",
+ "iota-metrics",
+ "iota-types",
  "prometheus",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tokio",
  "tracing",
 ]
@@ -7255,33 +7102,16 @@ dependencies = [
  "anyhow",
  "bcs",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "iota-framework 0.8.0-alpha",
- "iota-move-build 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
- "move-binary-format 0.0.3",
- "move-bytecode-utils 0.1.0",
- "move-core-types 0.0.4",
+ "iota-framework",
+ "iota-move-build",
+ "iota-types",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
  "schemars",
  "serde",
  "serde_json",
  "test-fuzz",
-]
-
-[[package]]
-name = "iota-json"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "bcs",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "iota-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "schemars",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -7301,41 +7131,41 @@ dependencies = [
  "http-body 1.0.1",
  "hyper 1.4.1",
  "indexmap 2.5.0",
- "iota-config 0.8.0-alpha",
+ "iota-config",
  "iota-core",
- "iota-json 0.8.0-alpha",
- "iota-json-rpc-api 0.8.0-alpha",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
- "iota-open-rpc 0.8.0-alpha",
- "iota-open-rpc-macros 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
- "iota-storage 0.8.0-alpha",
- "iota-transaction-builder 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
+ "iota-json",
+ "iota-json-rpc-api",
+ "iota-json-rpc-types",
+ "iota-metrics",
+ "iota-open-rpc",
+ "iota-open-rpc-macros",
+ "iota-protocol-config",
+ "iota-storage",
+ "iota-transaction-builder",
+ "iota-types",
  "itertools 0.13.0",
  "jsonrpsee",
  "mockall",
- "move-binary-format 0.0.3",
- "move-bytecode-utils 0.1.0",
- "move-core-types 0.0.4",
- "move-package 0.1.0",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
+ "move-package",
  "once_cell",
  "prometheus",
  "serde",
  "serde_json",
- "shared-crypto 0.8.0-alpha",
+ "shared-crypto",
  "signature 1.6.4",
  "statrs",
  "tap",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "thiserror",
  "tokio",
  "tokio-util 0.7.12",
  "tower 0.4.13",
  "tower-http",
  "tracing",
- "typed-store-error 0.8.0-alpha",
+ "typed-store-error",
 ]
 
 [[package]]
@@ -7344,32 +7174,12 @@ version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "iota-json 0.8.0-alpha",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
- "iota-open-rpc 0.8.0-alpha",
- "iota-open-rpc-macros 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
- "jsonrpsee",
- "once_cell",
- "prometheus",
- "tap",
- "tracing",
-]
-
-[[package]]
-name = "iota-json-rpc-api"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "iota-json 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-json-rpc-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-metrics 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-open-rpc 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-open-rpc-macros 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
+ "iota-json",
+ "iota-json-rpc-types",
+ "iota-metrics",
+ "iota-open-rpc",
+ "iota-open-rpc-macros",
+ "iota-types",
  "jsonrpsee",
  "once_cell",
  "prometheus",
@@ -7385,31 +7195,31 @@ dependencies = [
  "async-trait",
  "bcs",
  "hyper 1.4.1",
- "iota-config 0.8.0-alpha",
+ "iota-config",
  "iota-core",
- "iota-json 0.8.0-alpha",
+ "iota-json",
  "iota-json-rpc",
- "iota-json-rpc-api 0.8.0-alpha",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-keys 0.8.0-alpha",
- "iota-macros 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
- "iota-move-build 0.8.0-alpha",
- "iota-open-rpc 0.8.0-alpha",
- "iota-open-rpc-macros 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
+ "iota-json-rpc-api",
+ "iota-json-rpc-types",
+ "iota-keys",
+ "iota-macros",
+ "iota-metrics",
+ "iota-move-build",
+ "iota-open-rpc",
+ "iota-open-rpc-macros",
+ "iota-protocol-config",
  "iota-sdk 0.8.0-alpha",
- "iota-simulator 0.8.0-alpha",
+ "iota-simulator",
  "iota-swarm-config",
  "iota-test-transaction-builder",
- "iota-types 0.8.0-alpha",
+ "iota-types",
  "jsonrpsee",
- "move-core-types 0.0.4",
- "move-package 0.1.0",
+ "move-core-types",
+ "move-package",
  "prometheus",
  "rand 0.8.5",
  "reqwest 0.12.7",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "test-cluster",
  "tokio",
  "tracing",
@@ -7424,48 +7234,18 @@ dependencies = [
  "colored",
  "enum_dispatch",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "iota-enum-compat-util 0.8.0-alpha",
- "iota-json 0.8.0-alpha",
- "iota-macros 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
- "iota-package-resolver 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
+ "iota-enum-compat-util",
+ "iota-json",
+ "iota-macros",
+ "iota-metrics",
+ "iota-package-resolver",
+ "iota-protocol-config",
+ "iota-types",
  "itertools 0.13.0",
  "json_to_table",
- "move-binary-format 0.0.3",
- "move-bytecode-utils 0.1.0",
- "move-core-types 0.0.4",
- "schemars",
- "serde",
- "serde_json",
- "serde_with 3.9.0",
- "tabled",
- "tracing",
-]
-
-[[package]]
-name = "iota-json-rpc-types"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "bcs",
- "colored",
- "enum_dispatch",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "iota-enum-compat-util 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-json 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-macros 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-metrics 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-package-resolver 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-protocol-config 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "itertools 0.13.0",
- "json_to_table",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
  "schemars",
  "serde",
  "serde_json",
@@ -7481,34 +7261,15 @@ dependencies = [
  "anyhow",
  "bip32",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "iota-types 0.8.0-alpha",
+ "iota-types",
  "rand 0.8.5",
  "regex",
  "serde",
  "serde_json",
- "shared-crypto 0.8.0-alpha",
+ "shared-crypto",
  "signature 1.6.4",
  "slip10_ed25519",
  "tempfile",
- "tiny-bip39",
-]
-
-[[package]]
-name = "iota-keys"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "bip32",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "iota-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "rand 0.8.5",
- "regex",
- "serde",
- "serde_json",
- "shared-crypto 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "signature 1.6.4",
- "slip10_ed25519",
  "tiny-bip39",
 ]
 
@@ -7521,15 +7282,15 @@ dependencies = [
  "bcs",
  "bytes",
  "clap",
- "iota-config 0.8.0-alpha",
- "iota-json 0.8.0-alpha",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-package-resolver 0.8.0-alpha",
- "iota-rest-api 0.8.0-alpha",
+ "iota-config",
+ "iota-json",
+ "iota-json-rpc-types",
+ "iota-package-resolver",
+ "iota-rest-api",
  "iota-sdk 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
- "move-binary-format 0.0.3",
- "move-core-types 0.0.4",
+ "iota-types",
+ "move-binary-format",
+ "move-core-types",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -7541,18 +7302,7 @@ name = "iota-macros"
 version = "0.8.0-alpha"
 dependencies = [
  "futures",
- "iota-proc-macros 0.8.0-alpha",
- "once_cell",
- "tracing",
-]
-
-[[package]]
-name = "iota-macros"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "futures",
- "iota-proc-macros 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
+ "iota-proc-macros",
  "once_cell",
  "tracing",
 ]
@@ -7573,7 +7323,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "strum 0.26.3",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tokio",
  "tracing",
 ]
@@ -7592,31 +7342,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.3",
  "prometheus",
- "prometheus-closure-metric 0.8.0-alpha",
- "scopeguard",
- "simple-server-timing-header",
- "tap",
- "tokio",
- "tracing",
- "uuid 1.10.0",
-]
-
-[[package]]
-name = "iota-metrics"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anemo",
- "anemo-tower",
- "async-trait",
- "axum",
- "bytes",
- "dashmap",
- "futures",
- "once_cell",
- "parking_lot 0.12.3",
- "prometheus",
- "prometheus-closure-metric 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
+ "prometheus-closure-metric",
  "scopeguard",
  "simple-server-timing-header",
  "tap",
@@ -7637,27 +7363,27 @@ dependencies = [
  "const-str",
  "futures",
  "git-version",
- "iota-macros 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
- "iota-move-build 0.8.0-alpha",
- "iota-move-natives-latest 0.1.0",
- "iota-protocol-config 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
+ "iota-macros",
+ "iota-metrics",
+ "iota-move-build",
+ "iota-move-natives-latest",
+ "iota-protocol-config",
+ "iota-types",
  "jemalloc-ctl",
- "move-binary-format 0.0.3",
+ "move-binary-format",
  "move-cli",
- "move-compiler 0.0.1",
- "move-disassembler 0.1.0",
- "move-ir-types 0.1.0",
- "move-package 0.1.0",
+ "move-compiler",
+ "move-disassembler",
+ "move-ir-types",
+ "move-package",
  "move-unit-test",
- "move-vm-runtime 0.1.0",
+ "move-vm-runtime",
  "once_cell",
  "prometheus",
  "rand 0.8.5",
  "serde_json",
  "serde_yaml",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tempfile",
  "tokio",
  "tracing",
@@ -7669,43 +7395,19 @@ version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "iota-package-management 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
- "iota-verifier-latest 0.1.0",
- "move-binary-format 0.0.3",
- "move-bytecode-utils 0.1.0",
- "move-bytecode-verifier 0.1.0",
- "move-command-line-common 0.1.0",
- "move-compiler 0.0.1",
- "move-core-types 0.0.4",
- "move-ir-types 0.1.0",
- "move-package 0.1.0",
- "move-symbol-pool 0.1.0",
- "serde-reflection",
- "tempfile",
-]
-
-[[package]]
-name = "iota-move-build"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "iota-package-management 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-protocol-config 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-verifier-latest 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-command-line-common 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-compiler 0.0.1 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-ir-types 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-package 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-symbol-pool 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "iota-package-management",
+ "iota-protocol-config",
+ "iota-types",
+ "iota-verifier-latest",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-bytecode-verifier",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-ir-types",
+ "move-package",
+ "move-symbol-pool",
  "serde-reflection",
  "tempfile",
 ]
@@ -7729,36 +7431,13 @@ dependencies = [
  "fastcrypto-vdf",
  "fastcrypto-zkp",
  "indexmap 2.5.0",
- "iota-protocol-config 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
- "move-binary-format 0.0.3",
- "move-core-types 0.0.4",
- "move-stdlib-natives 0.1.1",
- "move-vm-runtime 0.1.0",
- "move-vm-types 0.1.0",
- "rand 0.8.5",
- "smallvec",
- "tracing",
-]
-
-[[package]]
-name = "iota-move-natives-latest"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "bcs",
- "better_any",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "fastcrypto-vdf",
- "fastcrypto-zkp",
- "indexmap 2.5.0",
- "iota-protocol-config 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-stdlib-natives 0.1.1 (git+https://github.com/iotaledger/iota)",
- "move-vm-runtime 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-vm-types 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "iota-protocol-config",
+ "iota-types",
+ "move-binary-format",
+ "move-core-types",
+ "move-stdlib-natives",
+ "move-vm-runtime",
+ "move-vm-types",
  "rand 0.8.5",
  "smallvec",
  "tracing",
@@ -7782,18 +7461,18 @@ dependencies = [
  "futures",
  "governor",
  "iota-archival",
- "iota-config 0.8.0-alpha",
- "iota-macros 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
- "iota-network-stack 0.8.0-alpha",
- "iota-storage 0.8.0-alpha",
+ "iota-config",
+ "iota-macros",
+ "iota-metrics",
+ "iota-network-stack",
+ "iota-storage",
  "iota-swarm-config",
- "iota-types 0.8.0-alpha",
+ "iota-types",
  "prometheus",
  "rand 0.8.5",
  "serde",
  "tap",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tempfile",
  "tokio",
  "tonic",
@@ -7805,30 +7484,6 @@ dependencies = [
 [[package]]
 name = "iota-network-stack"
 version = "0.8.0-alpha"
-dependencies = [
- "anemo",
- "bcs",
- "bytes",
- "eyre",
- "futures",
- "http 1.1.0",
- "multiaddr",
- "pin-project-lite",
- "serde",
- "snap",
- "tokio",
- "tokio-stream",
- "tonic",
- "tonic-health",
- "tower 0.4.13",
- "tower-http",
- "tracing",
-]
-
-[[package]]
-name = "iota-network-stack"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
 dependencies = [
  "anemo",
  "bcs",
@@ -7870,32 +7525,32 @@ dependencies = [
  "humantime",
  "iota-archival",
  "iota-common",
- "iota-config 0.8.0-alpha",
+ "iota-config",
  "iota-core",
  "iota-json-rpc",
- "iota-json-rpc-api 0.8.0-alpha",
- "iota-macros 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
+ "iota-json-rpc-api",
+ "iota-macros",
+ "iota-metrics",
  "iota-network",
- "iota-network-stack 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
- "iota-rest-api 0.8.0-alpha",
- "iota-simulator 0.8.0-alpha",
+ "iota-network-stack",
+ "iota-protocol-config",
+ "iota-rest-api",
+ "iota-simulator",
  "iota-snapshot",
- "iota-storage 0.8.0-alpha",
+ "iota-storage",
  "iota-tls",
- "iota-types 0.8.0-alpha",
- "move-vm-profiler 0.1.0",
+ "iota-types",
+ "move-vm-profiler",
  "prometheus",
  "reqwest 0.12.7",
  "serde",
  "snap",
  "tap",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tokio",
  "tower 0.4.13",
  "tracing",
- "typed-store 0.8.0-alpha",
+ "typed-store",
  "url",
 ]
 
@@ -7907,13 +7562,13 @@ dependencies = [
  "bcs",
  "clap",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "iota-json 0.8.0-alpha",
+ "iota-json",
  "iota-json-rpc",
- "iota-json-rpc-api 0.8.0-alpha",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
- "move-core-types 0.0.4",
+ "iota-json-rpc-api",
+ "iota-json-rpc-types",
+ "iota-protocol-config",
+ "iota-types",
+ "move-core-types",
  "pretty_assertions",
  "rand 0.8.5",
  "schemars",
@@ -7924,32 +7579,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "iota-open-rpc"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "schemars",
- "serde",
- "serde_json",
- "versions",
-]
-
-[[package]]
 name = "iota-open-rpc-macros"
 version = "0.8.0-alpha"
-dependencies = [
- "derive-syn-parse",
- "itertools 0.13.0",
- "proc-macro2 1.0.86",
- "quote 1.0.37",
- "syn 1.0.109",
- "unescape",
-]
-
-[[package]]
-name = "iota-open-rpc-macros"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -7968,8 +7599,8 @@ dependencies = [
  "cynic",
  "cynic-codegen",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "iota-types 0.8.0-alpha",
- "move-core-types 0.0.4",
+ "iota-types",
+ "move-core-types",
  "reqwest 0.12.7",
  "serde",
  "serde_json",
@@ -7981,28 +7612,12 @@ name = "iota-package-management"
 version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
- "iota-json-rpc-types 0.8.0-alpha",
+ "iota-json-rpc-types",
  "iota-sdk 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
- "move-core-types 0.0.4",
- "move-package 0.1.0",
- "move-symbol-pool 0.1.0",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "iota-package-management"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "iota-json-rpc-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-sdk 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-package 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-symbol-pool 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "iota-types",
+ "move-core-types",
+ "move-package",
+ "move-symbol-pool",
  "thiserror",
  "tracing",
 ]
@@ -8016,13 +7631,13 @@ dependencies = [
  "eyre",
  "hyper 1.4.1",
  "insta",
- "iota-move-build 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
+ "iota-move-build",
+ "iota-types",
  "lru 0.12.4",
- "move-binary-format 0.0.3",
- "move-command-line-common 0.1.0",
- "move-compiler 0.0.1",
- "move-core-types 0.0.4",
+ "move-binary-format",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
  "serde",
  "serde_json",
  "thiserror",
@@ -8031,37 +7646,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "iota-package-resolver"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "async-trait",
- "bcs",
- "eyre",
- "iota-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "lru 0.12.4",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-command-line-common 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "serde",
- "thiserror",
- "tokio",
-]
-
-[[package]]
 name = "iota-proc-macros"
 version = "0.8.0-alpha"
-dependencies = [
- "msim-macros",
- "proc-macro2 1.0.86",
- "quote 1.0.37",
- "syn 2.0.77",
-]
-
-[[package]]
-name = "iota-proc-macros"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
 dependencies = [
  "msim-macros",
  "proc-macro2 1.0.86",
@@ -8075,22 +7661,8 @@ version = "0.8.0-alpha"
 dependencies = [
  "clap",
  "insta",
- "iota-protocol-config-macros 0.8.0-alpha",
- "move-vm-config 0.1.0",
- "schemars",
- "serde",
- "serde_with 3.9.0",
- "tracing",
-]
-
-[[package]]
-name = "iota-protocol-config"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "clap",
- "iota-protocol-config-macros 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "move-vm-config 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "iota-protocol-config-macros",
+ "move-vm-config",
  "schemars",
  "serde",
  "serde_with 3.9.0",
@@ -8100,16 +7672,6 @@ dependencies = [
 [[package]]
 name = "iota-protocol-config-macros"
 version = "0.8.0-alpha"
-dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.37",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "iota-protocol-config-macros"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
@@ -8132,9 +7694,9 @@ dependencies = [
  "git-version",
  "hex",
  "hyper 1.4.1",
- "iota-metrics 0.8.0-alpha",
+ "iota-metrics",
  "iota-tls",
- "iota-types 0.8.0-alpha",
+ "iota-types",
  "itertools 0.13.0",
  "mime",
  "multiaddr",
@@ -8152,7 +7714,7 @@ dependencies = [
  "serde_with 3.9.0",
  "serde_yaml",
  "snap",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tokio",
  "tower 0.4.13",
  "tower-http",
@@ -8171,23 +7733,23 @@ dependencies = [
  "clap",
  "futures",
  "http 1.1.0",
- "iota-config 0.8.0-alpha",
+ "iota-config",
  "iota-core",
- "iota-execution 0.1.0",
- "iota-framework 0.8.0-alpha",
- "iota-json-rpc-api 0.8.0-alpha",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
+ "iota-execution",
+ "iota-framework",
+ "iota-json-rpc-api",
+ "iota-json-rpc-types",
+ "iota-protocol-config",
  "iota-sdk 0.8.0-alpha",
- "iota-storage 0.8.0-alpha",
+ "iota-storage",
  "iota-transaction-checks",
- "iota-types 0.8.0-alpha",
+ "iota-types",
  "jsonrpsee",
  "lru 0.12.4",
- "move-binary-format 0.0.3",
- "move-bytecode-utils 0.1.0",
- "move-core-types 0.0.4",
- "move-vm-config 0.1.0",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
+ "move-vm-config",
  "parking_lot 0.12.3",
  "prometheus",
  "rand 0.8.5",
@@ -8196,7 +7758,7 @@ dependencies = [
  "serde_json",
  "serde_with 3.9.0",
  "serde_yaml",
- "shared-crypto 0.8.0-alpha",
+ "shared-crypto",
  "shellexpand",
  "similar",
  "tabled",
@@ -8217,41 +7779,10 @@ dependencies = [
  "bcs",
  "diffy",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "iota-network-stack 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
+ "iota-network-stack",
+ "iota-protocol-config",
  "iota-rust-sdk",
- "iota-types 0.8.0-alpha",
- "itertools 0.13.0",
- "mime",
- "openapiv3",
- "prometheus",
- "rand 0.8.5",
- "reqwest 0.12.7",
- "schemars",
- "serde",
- "serde_json",
- "serde_with 3.9.0",
- "serde_yaml",
- "tap",
- "thiserror",
- "tokio",
- "url",
-]
-
-[[package]]
-name = "iota-rest-api"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "async-trait",
- "axum",
- "bcs",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "iota-network-stack 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-protocol-config 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-rust-sdk",
- "iota-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
+ "iota-types",
  "itertools 0.13.0",
  "mime",
  "openapiv3",
@@ -8283,32 +7814,32 @@ dependencies = [
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "futures",
  "hyper 1.4.1",
- "iota-config 0.8.0-alpha",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-keys 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
- "iota-move-build 0.8.0-alpha",
+ "iota-config",
+ "iota-json-rpc-types",
+ "iota-keys",
+ "iota-metrics",
+ "iota-move-build",
  "iota-node",
  "iota-sdk 0.8.0-alpha",
  "iota-swarm-config",
- "iota-types 0.8.0-alpha",
- "move-core-types 0.0.4",
+ "iota-types",
+ "move-core-types",
  "once_cell",
  "rand 0.8.5",
  "reqwest 0.12.7",
  "serde",
  "serde_json",
- "shared-crypto 0.8.0-alpha",
+ "shared-crypto",
  "signature 1.6.4",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tempfile",
  "test-cluster",
  "thiserror",
  "tokio",
  "tracing",
- "typed-store 0.8.0-alpha",
+ "typed-store",
 ]
 
 [[package]]
@@ -8321,17 +7852,17 @@ dependencies = [
  "dashmap",
  "dirs 5.0.1",
  "futures",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-keys 0.8.0-alpha",
+ "iota-json-rpc-types",
+ "iota-keys",
  "iota-sdk 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
+ "iota-types",
  "itertools 0.13.0",
  "serde",
  "serde_json",
- "shared-crypto 0.8.0-alpha",
+ "shared-crypto",
  "shellexpand",
  "strum 0.26.3",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tokio",
  "tracing",
 ]
@@ -8371,59 +7902,24 @@ dependencies = [
  "futures",
  "futures-core",
  "getset",
- "iota-config 0.8.0-alpha",
- "iota-json 0.8.0-alpha",
- "iota-json-rpc-api 0.8.0-alpha",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-keys 0.8.0-alpha",
- "iota-move-build 0.8.0-alpha",
- "iota-transaction-builder 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
+ "iota-config",
+ "iota-json",
+ "iota-json-rpc-api",
+ "iota-json-rpc-types",
+ "iota-keys",
+ "iota-move-build",
+ "iota-transaction-builder",
+ "iota-types",
  "jsonrpsee",
- "move-core-types 0.0.4",
+ "move-core-types",
  "rand 0.8.5",
  "reqwest 0.12.7",
  "rustls 0.23.18",
  "serde",
  "serde_json",
  "serde_with 3.9.0",
- "shared-crypto 0.8.0-alpha",
+ "shared-crypto",
  "tempfile",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "iota-sdk"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.21.7",
- "bcs",
- "clap",
- "colored",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "futures",
- "futures-core",
- "getset",
- "iota-config 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-json 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-json-rpc-api 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-json-rpc-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-keys 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-transaction-builder 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "jsonrpsee",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "reqwest 0.12.7",
- "rustls 0.23.18",
- "serde",
- "serde_json",
- "serde_with 3.9.0",
- "shared-crypto 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
  "thiserror",
  "tokio",
  "tracing",
@@ -8477,38 +7973,15 @@ dependencies = [
  "anemo-tower",
  "bcs",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "iota-framework 0.8.0-alpha",
- "iota-move-build 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
+ "iota-framework",
+ "iota-move-build",
+ "iota-types",
  "lru 0.12.4",
- "move-package 0.1.0",
+ "move-package",
  "msim",
  "rand 0.8.5",
  "serde",
- "telemetry-subscribers 0.8.0-alpha",
- "tempfile",
- "tower 0.4.13",
- "tracing",
-]
-
-[[package]]
-name = "iota-simulator"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anemo",
- "anemo-tower",
- "bcs",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "iota-framework 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-move-build 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "lru 0.12.4",
- "move-package 0.1.0 (git+https://github.com/iotaledger/iota)",
- "msim",
- "rand 0.8.5",
- "serde",
- "telemetry-subscribers 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
+ "telemetry-subscribers",
  "tempfile",
  "tower 0.4.13",
  "tracing",
@@ -8523,28 +7996,28 @@ dependencies = [
  "clap",
  "fs_extra",
  "futures",
- "iota-config 0.8.0-alpha",
+ "iota-config",
  "iota-core",
- "iota-macros 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
- "iota-move-build 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
- "iota-simulator 0.8.0-alpha",
- "iota-storage 0.8.0-alpha",
+ "iota-macros",
+ "iota-metrics",
+ "iota-move-build",
+ "iota-protocol-config",
+ "iota-simulator",
+ "iota-storage",
  "iota-test-transaction-builder",
  "iota-transaction-checks",
- "iota-types 0.8.0-alpha",
- "move-binary-format 0.0.3",
- "move-bytecode-utils 0.1.0",
- "move-core-types 0.0.4",
- "move-package 0.1.0",
- "move-symbol-pool 0.1.0",
+ "iota-types",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
+ "move-package",
+ "move-symbol-pool",
  "once_cell",
  "prometheus",
  "serde",
  "serde_json",
  "strum 0.26.3",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tokio",
  "tracing",
 ]
@@ -8561,11 +8034,11 @@ dependencies = [
  "futures",
  "indicatif",
  "integer-encoding",
- "iota-config 0.8.0-alpha",
+ "iota-config",
  "iota-core",
- "iota-protocol-config 0.8.0-alpha",
- "iota-storage 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
+ "iota-protocol-config",
+ "iota-storage",
+ "iota-types",
  "num_enum",
  "object_store 0.10.2",
  "prometheus",
@@ -8586,19 +8059,19 @@ dependencies = [
  "expect-test",
  "flate2",
  "futures",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-move-build 0.8.0-alpha",
- "iota-package-management 0.8.0-alpha",
+ "iota-json-rpc-types",
+ "iota-move-build",
+ "iota-package-management",
  "iota-sdk 0.8.0-alpha",
  "iota-test-transaction-builder",
- "iota-types 0.8.0-alpha",
- "move-binary-format 0.0.3",
- "move-bytecode-source-map 0.1.0",
- "move-command-line-common 0.1.0",
- "move-compiler 0.0.1",
- "move-core-types 0.0.4",
- "move-package 0.1.0",
- "move-symbol-pool 0.1.0",
+ "iota-types",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-package",
+ "move-symbol-pool",
  "rand 0.8.5",
  "tar",
  "tempfile",
@@ -8623,21 +8096,21 @@ dependencies = [
  "git-version",
  "hyper 1.4.1",
  "iota",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
+ "iota-json-rpc-types",
+ "iota-metrics",
  "iota-move",
- "iota-move-build 0.8.0-alpha",
+ "iota-move-build",
  "iota-sdk 0.8.0-alpha",
  "iota-source-validation",
  "jsonrpsee",
- "move-compiler 0.0.1",
- "move-core-types 0.0.4",
- "move-package 0.1.0",
- "move-symbol-pool 0.1.0",
+ "move-compiler",
+ "move-core-types",
+ "move-package",
+ "move-symbol-pool",
  "prometheus",
  "reqwest 0.12.7",
  "serde",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tempfile",
  "test-cluster",
  "tokio",
@@ -8669,19 +8142,19 @@ dependencies = [
  "hyper-rustls 0.27.3",
  "indicatif",
  "integer-encoding",
- "iota-config 0.8.0-alpha",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-macros 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
- "iota-simulator 0.8.0-alpha",
+ "iota-config",
+ "iota-json-rpc-types",
+ "iota-macros",
+ "iota-metrics",
+ "iota-protocol-config",
+ "iota-simulator",
  "iota-test-transaction-builder",
- "iota-types 0.8.0-alpha",
+ "iota-types",
  "itertools 0.13.0",
  "lru 0.12.4",
- "move-binary-format 0.0.3",
- "move-bytecode-utils 0.1.0",
- "move-core-types 0.0.4",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
  "num_enum",
  "object_store 0.10.2",
  "once_cell",
@@ -8693,63 +8166,11 @@ dependencies = [
  "serde",
  "serde_json",
  "tap",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tempfile",
  "tokio",
  "tracing",
- "typed-store 0.8.0-alpha",
- "url",
- "zstd 0.13.2",
-]
-
-[[package]]
-name = "iota-storage"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "async-trait",
- "axum",
- "backoff",
- "base64-url",
- "bcs",
- "byteorder",
- "bytes",
- "chrono",
- "clap",
- "eyre",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "futures",
- "hyper 1.4.1",
- "hyper-rustls 0.27.3",
- "indicatif",
- "integer-encoding",
- "iota-config 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-json-rpc-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-metrics 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-protocol-config 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-simulator 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "itertools 0.13.0",
- "lru 0.12.4",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "num_enum",
- "object_store 0.10.2",
- "parking_lot 0.12.3",
- "percent-encoding",
- "prometheus",
- "reqwest 0.12.7",
- "rustls 0.23.18",
- "serde",
- "serde_json",
- "tap",
- "telemetry-subscribers 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "tempfile",
- "tokio",
- "tracing",
- "typed-store 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
+ "typed-store",
  "url",
  "zstd 0.13.2",
 ]
@@ -8764,20 +8185,20 @@ dependencies = [
  "futures",
  "indexmap 2.5.0",
  "iota-core",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-macros 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
- "iota-move-build 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
- "iota-simulator 0.8.0-alpha",
+ "iota-json-rpc-types",
+ "iota-macros",
+ "iota-metrics",
+ "iota-move-build",
+ "iota-protocol-config",
+ "iota-simulator",
  "iota-swarm-config",
- "iota-types 0.8.0-alpha",
- "move-binary-format 0.0.3",
- "move-core-types 0.0.4",
- "move-package 0.1.0",
+ "iota-types",
+ "move-binary-format",
+ "move-core-types",
+ "move-package",
  "prometheus",
  "rand 0.8.5",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "test-cluster",
  "tokio",
  "tracing",
@@ -8789,19 +8210,19 @@ version = "0.8.0-alpha"
 dependencies = [
  "anyhow",
  "futures",
- "iota-config 0.8.0-alpha",
- "iota-macros 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
- "iota-network-stack 0.8.0-alpha",
+ "iota-config",
+ "iota-macros",
+ "iota-metrics",
+ "iota-network-stack",
  "iota-node",
- "iota-protocol-config 0.8.0-alpha",
- "iota-simulator 0.8.0-alpha",
+ "iota-protocol-config",
+ "iota-simulator",
  "iota-swarm-config",
- "iota-types 0.8.0-alpha",
+ "iota-types",
  "prometheus",
  "rand 0.8.5",
  "tap",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tempfile",
  "tokio",
  "tonic-health",
@@ -8817,20 +8238,20 @@ dependencies = [
  "bcs",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "insta",
- "iota-config 0.8.0-alpha",
- "iota-execution 0.1.0",
+ "iota-config",
+ "iota-execution",
  "iota-genesis-builder",
- "iota-macros 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
- "iota-simulator 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
- "move-bytecode-utils 0.1.0",
+ "iota-macros",
+ "iota-protocol-config",
+ "iota-simulator",
+ "iota-types",
+ "move-bytecode-utils",
  "prometheus",
  "rand 0.8.5",
  "serde",
  "serde_with 3.9.0",
  "serde_yaml",
- "shared-crypto 0.8.0-alpha",
+ "shared-crypto",
  "tempfile",
  "tracing",
 ]
@@ -8841,11 +8262,11 @@ version = "0.8.0-alpha"
 dependencies = [
  "bcs",
  "iota-genesis-builder",
- "iota-move-build 0.8.0-alpha",
+ "iota-move-build",
  "iota-sdk 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
- "move-core-types 0.0.4",
- "shared-crypto 0.8.0-alpha",
+ "iota-types",
+ "move-core-types",
+ "shared-crypto",
 ]
 
 [[package]]
@@ -8887,18 +8308,18 @@ dependencies = [
  "hex",
  "indicatif",
  "iota-archival",
- "iota-config 0.8.0-alpha",
+ "iota-config",
  "iota-core",
  "iota-network",
  "iota-package-dump",
- "iota-protocol-config 0.8.0-alpha",
+ "iota-protocol-config",
  "iota-replay",
  "iota-sdk 0.8.0-alpha",
  "iota-snapshot",
- "iota-storage 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
+ "iota-storage",
+ "iota-types",
  "itertools 0.13.0",
- "move-core-types 0.0.4",
+ "move-core-types",
  "num_cpus",
  "object_store 0.10.2",
  "prometheus",
@@ -8907,11 +8328,11 @@ dependencies = [
  "serde_json",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tempfile",
  "tokio",
  "tracing",
- "typed-store 0.8.0-alpha",
+ "typed-store",
 ]
 
 [[package]]
@@ -8922,29 +8343,12 @@ dependencies = [
  "async-trait",
  "bcs",
  "futures",
- "iota-json 0.8.0-alpha",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
- "move-binary-format 0.0.3",
- "move-core-types 0.0.4",
-]
-
-[[package]]
-name = "iota-transaction-builder"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "async-trait",
- "bcs",
- "futures",
- "iota-json 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-json-rpc-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-protocol-config 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
+ "iota-json",
+ "iota-json-rpc-types",
+ "iota-protocol-config",
+ "iota-types",
+ "move-binary-format",
+ "move-core-types",
 ]
 
 [[package]]
@@ -8952,11 +8356,11 @@ name = "iota-transaction-checks"
 version = "0.8.0-alpha"
 dependencies = [
  "fastcrypto-zkp",
- "iota-config 0.8.0-alpha",
- "iota-execution 0.1.0",
- "iota-macros 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
+ "iota-config",
+ "iota-execution",
+ "iota-macros",
+ "iota-protocol-config",
+ "iota-types",
  "once_cell",
  "tracing",
 ]
@@ -8974,28 +8378,28 @@ dependencies = [
  "eyre",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "futures",
- "iota-config 0.8.0-alpha",
+ "iota-config",
  "iota-core",
- "iota-framework 0.8.0-alpha",
+ "iota-framework",
  "iota-framework-snapshot",
  "iota-graphql-rpc",
  "iota-json-rpc",
- "iota-json-rpc-api 0.8.0-alpha",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
- "iota-rest-api 0.8.0-alpha",
- "iota-storage 0.8.0-alpha",
+ "iota-json-rpc-api",
+ "iota-json-rpc-types",
+ "iota-protocol-config",
+ "iota-rest-api",
+ "iota-storage",
  "iota-swarm-config",
- "iota-types 0.8.0-alpha",
- "move-binary-format 0.0.3",
- "move-bytecode-utils 0.1.0",
- "move-command-line-common 0.1.0",
- "move-compiler 0.0.1",
- "move-core-types 0.0.4",
+ "iota-types",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
  "move-stdlib",
- "move-symbol-pool 0.1.0",
+ "move-symbol-pool",
  "move-transactional-test-runner",
- "move-vm-runtime 0.1.0",
+ "move-vm-runtime",
  "msim",
  "once_cell",
  "rand 0.8.5",
@@ -9003,11 +8407,11 @@ dependencies = [
  "rocksdb",
  "serde_json",
  "simulacrum",
- "telemetry-subscribers 0.8.0-alpha",
+ "telemetry-subscribers",
  "tempfile",
  "tokio",
- "typed-store 0.8.0-alpha",
- "typed-store-derive 0.8.0-alpha",
+ "typed-store",
+ "typed-store-derive",
 ]
 
 [[package]]
@@ -9022,7 +8426,7 @@ dependencies = [
  "bincode",
  "byteorder",
  "chrono",
- "consensus-config 0.1.0",
+ "consensus-config",
  "coset",
  "criterion",
  "derive_more 1.0.0",
@@ -9035,25 +8439,25 @@ dependencies = [
  "hex",
  "im",
  "indexmap 2.5.0",
- "iota-enum-compat-util 0.8.0-alpha",
- "iota-macros 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
- "iota-network-stack 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
+ "iota-enum-compat-util",
+ "iota-macros",
+ "iota-metrics",
+ "iota-network-stack",
+ "iota-protocol-config",
  "iota-rust-sdk",
  "iota-sdk 1.1.5",
  "iota-util-mem",
  "itertools 0.13.0",
  "lru 0.12.4",
- "move-binary-format 0.0.3",
- "move-bytecode-utils 0.1.0",
- "move-command-line-common 0.1.0",
- "move-core-types 0.0.4",
- "move-disassembler 0.1.0",
- "move-ir-types 0.1.0",
- "move-vm-profiler 0.1.0",
- "move-vm-test-utils 0.1.0",
- "move-vm-types 0.1.0",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-command-line-common",
+ "move-core-types",
+ "move-disassembler",
+ "move-ir-types",
+ "move-vm-profiler",
+ "move-vm-test-utils",
+ "move-vm-types",
  "nonempty",
  "num-bigint 0.4.6",
  "num-rational",
@@ -9077,7 +8481,7 @@ dependencies = [
  "serde_json",
  "serde_with 3.9.0",
  "serde_yaml",
- "shared-crypto 0.8.0-alpha",
+ "shared-crypto",
  "signature 1.6.4",
  "static_assertions",
  "strum 0.26.3",
@@ -9087,78 +8491,8 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing",
- "typed-store-error 0.8.0-alpha",
+ "typed-store-error",
  "url",
-]
-
-[[package]]
-name = "iota-types"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anemo",
- "anyhow",
- "async-trait",
- "bcs",
- "better_any",
- "bincode",
- "byteorder",
- "chrono",
- "consensus-config 0.1.0 (git+https://github.com/iotaledger/iota)",
- "derive_more 1.0.0",
- "enum_dispatch",
- "eyre",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "fastcrypto-tbls",
- "fastcrypto-zkp",
- "hex",
- "im",
- "indexmap 2.5.0",
- "iota-enum-compat-util 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-macros 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-metrics 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-network-stack 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-protocol-config 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-rust-sdk",
- "iota-sdk 1.1.5",
- "itertools 0.13.0",
- "lru 0.12.4",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-command-line-common 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-disassembler 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-ir-types 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-vm-profiler 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-vm-test-utils 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-vm-types 0.1.0 (git+https://github.com/iotaledger/iota)",
- "nonempty",
- "num-bigint 0.4.6",
- "num-rational",
- "num-traits",
- "num_enum",
- "once_cell",
- "packable",
- "parking_lot 0.12.3",
- "passkey-types",
- "prometheus",
- "rand 0.8.5",
- "roaring",
- "schemars",
- "serde",
- "serde-name",
- "serde_json",
- "serde_with 3.9.0",
- "shared-crypto 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "signature 1.6.4",
- "static_assertions",
- "strum 0.26.3",
- "strum_macros 0.26.4",
- "tap",
- "thiserror",
- "tonic",
- "tracing",
- "typed-store-error 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
 ]
 
 [[package]]
@@ -9168,11 +8502,11 @@ dependencies = [
  "anyhow",
  "datatest-stable",
  "insta",
- "iota-move-build 0.8.0-alpha",
- "move-binary-format 0.0.3",
- "move-command-line-common 0.1.0",
- "move-compiler 0.0.1",
- "move-package 0.1.0",
+ "iota-move-build",
+ "move-binary-format",
+ "move-command-line-common",
+ "move-compiler",
+ "move-package",
 ]
 
 [[package]]
@@ -9206,31 +8540,15 @@ dependencies = [
 name = "iota-verifier-latest"
 version = "0.1.0"
 dependencies = [
- "iota-protocol-config 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
- "move-abstract-interpreter 0.1.0",
- "move-abstract-stack 0.0.1",
- "move-binary-format 0.0.3",
- "move-bytecode-utils 0.1.0",
- "move-bytecode-verifier-meter 0.1.0",
- "move-core-types 0.0.4",
- "move-vm-config 0.1.0",
-]
-
-[[package]]
-name = "iota-verifier-latest"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "iota-protocol-config 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "iota-types 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "move-abstract-interpreter 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-abstract-stack 0.0.1 (git+https://github.com/iotaledger/iota)",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-verifier-meter 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-vm-config 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "iota-protocol-config",
+ "iota-types",
+ "move-abstract-interpreter",
+ "move-abstract-stack",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-bytecode-verifier-meter",
+ "move-core-types",
+ "move-vm-config",
 ]
 
 [[package]]
@@ -10300,27 +9618,13 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 name = "move-abstract-interpreter"
 version = "0.1.0"
 dependencies = [
- "move-binary-format 0.0.3",
- "move-bytecode-verifier-meter 0.1.0",
-]
-
-[[package]]
-name = "move-abstract-interpreter"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-verifier-meter 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "move-binary-format",
+ "move-bytecode-verifier-meter",
 ]
 
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-
-[[package]]
-name = "move-abstract-stack"
-version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
 
 [[package]]
 name = "move-analyzer"
@@ -10336,11 +9640,11 @@ dependencies = [
  "itertools 0.10.5",
  "lsp-server",
  "lsp-types",
- "move-command-line-common 0.1.0",
- "move-compiler 0.0.1",
- "move-ir-types 0.1.0",
- "move-package 0.1.0",
- "move-symbol-pool 0.1.0",
+ "move-command-line-common",
+ "move-compiler",
+ "move-ir-types",
+ "move-package",
+ "move-symbol-pool",
  "once_cell",
  "serde",
  "serde_json",
@@ -10356,9 +9660,9 @@ version = "0.0.3"
 dependencies = [
  "anyhow",
  "arbitrary",
- "enum-compat-util 0.1.0",
- "move-core-types 0.0.4",
- "move-proc-macros 0.1.0",
+ "enum-compat-util",
+ "move-core-types",
+ "move-proc-macros",
  "proptest",
  "proptest-derive",
  "ref-cast",
@@ -10367,27 +9671,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "move-binary-format"
-version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "enum-compat-util 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-proc-macros 0.1.0 (git+https://github.com/iotaledger/iota)",
- "ref-cast",
- "serde",
- "variant_count",
-]
-
-[[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-
-[[package]]
-name = "move-borrow-graph"
-version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
 
 [[package]]
 name = "move-bytecode-source-map"
@@ -10395,26 +9680,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
- "move-binary-format 0.0.3",
- "move-command-line-common 0.1.0",
- "move-core-types 0.0.4",
- "move-ir-types 0.1.0",
- "move-symbol-pool 0.1.0",
- "serde",
-]
-
-[[package]]
-name = "move-bytecode-source-map"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "bcs",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-command-line-common 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-ir-types 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-symbol-pool 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "move-binary-format",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-types",
+ "move-symbol-pool",
  "serde",
 ]
 
@@ -10423,21 +9693,8 @@ name = "move-bytecode-utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "move-binary-format 0.0.3",
- "move-core-types 0.0.4",
- "petgraph 0.5.1",
- "serde",
- "serde-reflection",
-]
-
-[[package]]
-name = "move-bytecode-utils"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
+ "move-binary-format",
+ "move-core-types",
  "petgraph 0.5.1",
  "serde",
  "serde-reflection",
@@ -10447,28 +9704,13 @@ dependencies = [
 name = "move-bytecode-verifier"
 version = "0.1.0"
 dependencies = [
- "move-abstract-interpreter 0.1.0",
- "move-abstract-stack 0.0.1",
- "move-binary-format 0.0.3",
- "move-borrow-graph 0.0.1",
- "move-bytecode-verifier-meter 0.1.0",
- "move-core-types 0.0.4",
- "move-vm-config 0.1.0",
- "petgraph 0.5.1",
-]
-
-[[package]]
-name = "move-bytecode-verifier"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "move-abstract-interpreter 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-abstract-stack 0.0.1 (git+https://github.com/iotaledger/iota)",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-borrow-graph 0.0.1 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-verifier-meter 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-vm-config 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "move-abstract-interpreter",
+ "move-abstract-stack",
+ "move-binary-format",
+ "move-borrow-graph",
+ "move-bytecode-verifier-meter",
+ "move-core-types",
+ "move-vm-config",
  "petgraph 0.5.1",
 ]
 
@@ -10476,19 +9718,9 @@ dependencies = [
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
 dependencies = [
- "move-binary-format 0.0.3",
- "move-core-types 0.0.4",
- "move-vm-config 0.1.0",
-]
-
-[[package]]
-name = "move-bytecode-verifier-meter"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-vm-config 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-config",
 ]
 
 [[package]]
@@ -10498,9 +9730,9 @@ dependencies = [
  "anyhow",
  "clap",
  "crossterm 0.25.0",
- "move-binary-format 0.0.3",
- "move-bytecode-source-map 0.1.0",
- "move-disassembler 0.1.0",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-disassembler",
  "regex",
  "tui",
 ]
@@ -10515,24 +9747,24 @@ dependencies = [
  "codespan-reporting",
  "colored",
  "difference",
- "move-binary-format 0.0.3",
- "move-bytecode-utils 0.1.0",
- "move-bytecode-verifier 0.1.0",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-bytecode-verifier",
  "move-bytecode-viewer",
- "move-command-line-common 0.1.0",
- "move-compiler 0.0.1",
- "move-core-types 0.0.4",
- "move-coverage 0.1.0",
- "move-disassembler 0.1.0",
- "move-docgen 0.1.0",
- "move-ir-types 0.1.0",
- "move-package 0.1.0",
- "move-stdlib-natives 0.1.1",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-coverage",
+ "move-disassembler",
+ "move-docgen",
+ "move-ir-types",
+ "move-package",
+ "move-stdlib-natives",
  "move-unit-test",
- "move-vm-profiler 0.1.0",
- "move-vm-runtime 0.1.0",
- "move-vm-test-utils 0.1.0",
- "move-vm-types 0.1.0",
+ "move-vm-profiler",
+ "move-vm-runtime",
+ "move-vm-test-utils",
+ "move-vm-types",
  "serde_yaml",
  "tempfile",
  "toml_edit 0.14.4",
@@ -10548,28 +9780,8 @@ dependencies = [
  "difference",
  "dirs-next",
  "hex",
- "move-binary-format 0.0.3",
- "move-core-types 0.0.4",
- "num-bigint 0.4.6",
- "once_cell",
- "serde",
- "sha2 0.9.9",
- "vfs",
- "walkdir",
-]
-
-[[package]]
-name = "move-command-line-common"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "bcs",
- "difference",
- "dirs-next",
- "hex",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
+ "move-binary-format",
+ "move-core-types",
  "num-bigint 0.4.6",
  "once_cell",
  "serde",
@@ -10589,48 +9801,16 @@ dependencies = [
  "dunce",
  "hex",
  "lsp-types",
- "move-binary-format 0.0.3",
- "move-borrow-graph 0.0.1",
- "move-bytecode-source-map 0.1.0",
- "move-bytecode-verifier 0.1.0",
- "move-command-line-common 0.1.0",
- "move-core-types 0.0.4",
- "move-ir-to-bytecode 0.1.0",
- "move-ir-types 0.1.0",
- "move-proc-macros 0.1.0",
- "move-symbol-pool 0.1.0",
- "once_cell",
- "petgraph 0.5.1",
- "regex",
- "serde",
- "serde_json",
- "similar",
- "stacker",
- "vfs",
-]
-
-[[package]]
-name = "move-compiler"
-version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "bcs",
- "clap",
- "codespan-reporting",
- "dunce",
- "hex",
- "lsp-types",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-borrow-graph 0.0.1 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-command-line-common 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-ir-to-bytecode 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-ir-types 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-proc-macros 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-symbol-pool 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "move-binary-format",
+ "move-borrow-graph",
+ "move-bytecode-source-map",
+ "move-bytecode-verifier",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-to-bytecode",
+ "move-ir-types",
+ "move-proc-macros",
+ "move-symbol-pool",
  "once_cell",
  "petgraph 0.5.1",
  "regex",
@@ -10648,11 +9828,11 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "bcs",
- "enum-compat-util 0.1.0",
+ "enum-compat-util",
  "ethnum",
  "hex",
  "leb128",
- "move-proc-macros 0.1.0",
+ "move-proc-macros",
  "num",
  "once_cell",
  "primitive-types 0.10.1",
@@ -10667,29 +9847,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "move-core-types"
-version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "bcs",
- "enum-compat-util 0.1.0 (git+https://github.com/iotaledger/iota)",
- "ethnum",
- "hex",
- "leb128",
- "move-proc-macros 0.1.0 (git+https://github.com/iotaledger/iota)",
- "num",
- "once_cell",
- "primitive-types 0.10.1",
- "rand 0.8.5",
- "ref-cast",
- "serde",
- "serde_bytes",
- "thiserror",
- "uint",
-]
-
-[[package]]
 name = "move-coverage"
 version = "0.1.0"
 dependencies = [
@@ -10698,32 +9855,12 @@ dependencies = [
  "clap",
  "codespan",
  "colored",
- "move-abstract-interpreter 0.1.0",
- "move-binary-format 0.0.3",
- "move-bytecode-source-map 0.1.0",
- "move-command-line-common 0.1.0",
- "move-core-types 0.0.4",
- "move-ir-types 0.1.0",
- "petgraph 0.5.1",
- "serde",
-]
-
-[[package]]
-name = "move-coverage"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "bcs",
- "clap",
- "codespan",
- "colored",
- "move-abstract-interpreter 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-command-line-common 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-ir-types 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "move-abstract-interpreter",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-types",
  "petgraph 0.5.1",
  "serde",
 ]
@@ -10737,34 +9874,14 @@ dependencies = [
  "clap",
  "colored",
  "hex",
- "move-abstract-interpreter 0.1.0",
- "move-binary-format 0.0.3",
- "move-bytecode-source-map 0.1.0",
- "move-command-line-common 0.1.0",
- "move-compiler 0.0.1",
- "move-core-types 0.0.4",
- "move-coverage 0.1.0",
- "move-ir-types 0.1.0",
-]
-
-[[package]]
-name = "move-disassembler"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "bcs",
- "clap",
- "colored",
- "hex",
- "move-abstract-interpreter 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-command-line-common 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-compiler 0.0.1 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-coverage 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-ir-types 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "move-abstract-interpreter",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-coverage",
+ "move-ir-types",
 ]
 
 [[package]]
@@ -10776,26 +9893,8 @@ dependencies = [
  "codespan-reporting",
  "itertools 0.10.5",
  "log",
- "move-compiler 0.0.1",
- "move-model 0.1.0",
- "num",
- "once_cell",
- "regex",
- "serde",
-]
-
-[[package]]
-name = "move-docgen"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "codespan",
- "codespan-reporting",
- "itertools 0.10.5",
- "log",
- "move-compiler 0.0.1 (git+https://github.com/iotaledger/iota)",
- "move-model 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "move-compiler",
+ "move-model",
  "num",
  "once_cell",
  "regex",
@@ -10809,13 +9908,13 @@ dependencies = [
  "anyhow",
  "bcs",
  "clap",
- "move-abstract-interpreter 0.1.0",
- "move-binary-format 0.0.3",
- "move-bytecode-source-map 0.1.0",
- "move-bytecode-verifier 0.1.0",
- "move-command-line-common 0.1.0",
- "move-core-types 0.0.4",
- "move-ir-to-bytecode 0.1.0",
+ "move-abstract-interpreter",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-bytecode-verifier",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-to-bytecode",
  "serde_json",
 ]
 
@@ -10826,31 +9925,13 @@ dependencies = [
  "anyhow",
  "codespan-reporting",
  "log",
- "move-binary-format 0.0.3",
- "move-bytecode-source-map 0.1.0",
- "move-command-line-common 0.1.0",
- "move-core-types 0.0.4",
- "move-ir-to-bytecode-syntax 0.1.0",
- "move-ir-types 0.1.0",
- "move-symbol-pool 0.1.0",
- "ouroboros 0.17.2",
-]
-
-[[package]]
-name = "move-ir-to-bytecode"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "codespan-reporting",
- "log",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-command-line-common 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-ir-to-bytecode-syntax 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-ir-types 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-symbol-pool 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-to-bytecode-syntax",
+ "move-ir-types",
+ "move-symbol-pool",
  "ouroboros 0.17.2",
 ]
 
@@ -10860,23 +9941,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "hex",
- "move-command-line-common 0.1.0",
- "move-core-types 0.0.4",
- "move-ir-types 0.1.0",
- "move-symbol-pool 0.1.0",
-]
-
-[[package]]
-name = "move-ir-to-bytecode-syntax"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "hex",
- "move-command-line-common 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-ir-types 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-symbol-pool 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-types",
+ "move-symbol-pool",
 ]
 
 [[package]]
@@ -10884,22 +9952,9 @@ name = "move-ir-types"
 version = "0.1.0"
 dependencies = [
  "hex",
- "move-command-line-common 0.1.0",
- "move-core-types 0.0.4",
- "move-symbol-pool 0.1.0",
- "once_cell",
- "serde",
-]
-
-[[package]]
-name = "move-ir-types"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "hex",
- "move-command-line-common 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-symbol-pool 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "move-command-line-common",
+ "move-core-types",
+ "move-symbol-pool",
  "once_cell",
  "serde",
 ]
@@ -10913,38 +9968,14 @@ dependencies = [
  "codespan-reporting",
  "itertools 0.10.5",
  "log",
- "move-binary-format 0.0.3",
- "move-bytecode-source-map 0.1.0",
- "move-command-line-common 0.1.0",
- "move-compiler 0.0.1",
- "move-core-types 0.0.4",
- "move-disassembler 0.1.0",
- "move-ir-types 0.1.0",
- "move-symbol-pool 0.1.0",
- "num",
- "once_cell",
- "regex",
- "serde",
-]
-
-[[package]]
-name = "move-model"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "codespan",
- "codespan-reporting",
- "itertools 0.10.5",
- "log",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-command-line-common 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-compiler 0.0.1 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-disassembler 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-ir-types 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-symbol-pool 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-disassembler",
+ "move-ir-types",
+ "move-symbol-pool",
  "num",
  "once_cell",
  "regex",
@@ -10959,49 +9990,15 @@ dependencies = [
  "clap",
  "colored",
  "itertools 0.10.5",
- "move-binary-format 0.0.3",
- "move-bytecode-source-map 0.1.0",
- "move-bytecode-utils 0.1.0",
- "move-command-line-common 0.1.0",
- "move-compiler 0.0.1",
- "move-core-types 0.0.4",
- "move-docgen 0.1.0",
- "move-model 0.1.0",
- "move-symbol-pool 0.1.0",
- "named-lock",
- "once_cell",
- "petgraph 0.5.1",
- "regex",
- "serde",
- "serde_yaml",
- "sha2 0.9.9",
- "tempfile",
- "toml 0.5.11",
- "toml_edit 0.14.4",
- "treeline",
- "vfs",
- "walkdir",
- "whoami",
-]
-
-[[package]]
-name = "move-package"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "clap",
- "colored",
- "itertools 0.10.5",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-command-line-common 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-compiler 0.0.1 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-docgen 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-model 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-symbol-pool 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-bytecode-utils",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-docgen",
+ "move-model",
+ "move-symbol-pool",
  "named-lock",
  "once_cell",
  "petgraph 0.5.1",
@@ -11021,15 +10018,6 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-dependencies = [
- "quote 1.0.37",
- "syn 2.0.77",
-]
-
-[[package]]
-name = "move-proc-macros"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
 dependencies = [
  "quote 1.0.37",
  "syn 2.0.77",
@@ -11044,10 +10032,10 @@ dependencies = [
  "codespan-reporting",
  "itertools 0.10.5",
  "log",
- "move-command-line-common 0.1.0",
- "move-compiler 0.0.1",
- "move-docgen 0.1.0",
- "move-model 0.1.0",
+ "move-command-line-common",
+ "move-compiler",
+ "move-docgen",
+ "move-model",
  "move-stackless-bytecode",
  "once_cell",
  "serde",
@@ -11065,11 +10053,11 @@ dependencies = [
  "im",
  "itertools 0.10.5",
  "log",
- "move-binary-format 0.0.3",
- "move-command-line-common 0.1.0",
- "move-compiler 0.0.1",
- "move-core-types 0.0.4",
- "move-model 0.1.0",
+ "move-binary-format",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-model",
  "num",
  "petgraph 0.5.1",
  "serde",
@@ -11082,10 +10070,10 @@ dependencies = [
  "anyhow",
  "hex",
  "log",
- "move-binary-format 0.0.3",
- "move-command-line-common 0.1.0",
- "move-core-types 0.0.4",
- "move-docgen 0.1.0",
+ "move-binary-format",
+ "move-command-line-common",
+ "move-core-types",
+ "move-docgen",
  "move-prover",
  "sha2 0.9.9",
  "walkdir",
@@ -11096,25 +10084,10 @@ name = "move-stdlib-natives"
 version = "0.1.1"
 dependencies = [
  "hex",
- "move-binary-format 0.0.3",
- "move-core-types 0.0.4",
- "move-vm-runtime 0.1.0",
- "move-vm-types 0.1.0",
- "sha2 0.9.9",
- "sha3 0.9.1",
- "smallvec",
-]
-
-[[package]]
-name = "move-stdlib-natives"
-version = "0.1.1"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "hex",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-vm-runtime 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-vm-types 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-runtime",
+ "move-vm-types",
  "sha2 0.9.9",
  "sha3 0.9.1",
  "smallvec",
@@ -11123,16 +10096,6 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-dependencies = [
- "once_cell",
- "phf",
- "serde",
-]
-
-[[package]]
-name = "move-symbol-pool"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
 dependencies = [
  "once_cell",
  "phf",
@@ -11146,22 +10109,22 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
- "move-binary-format 0.0.3",
- "move-bytecode-source-map 0.1.0",
+ "move-binary-format",
+ "move-bytecode-source-map",
  "move-cli",
- "move-command-line-common 0.1.0",
- "move-compiler 0.0.1",
- "move-core-types 0.0.4",
- "move-disassembler 0.1.0",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-disassembler",
  "move-ir-compiler",
- "move-ir-types 0.1.0",
+ "move-ir-types",
  "move-stdlib",
- "move-stdlib-natives 0.1.1",
- "move-symbol-pool 0.1.0",
- "move-vm-config 0.1.0",
- "move-vm-runtime 0.1.0",
- "move-vm-test-utils 0.1.0",
- "move-vm-types 0.1.0",
+ "move-stdlib-natives",
+ "move-symbol-pool",
+ "move-vm-config",
+ "move-vm-runtime",
+ "move-vm-test-utils",
+ "move-vm-types",
  "once_cell",
  "rayon",
  "regex",
@@ -11179,18 +10142,18 @@ dependencies = [
  "clap",
  "codespan-reporting",
  "colored",
- "move-binary-format 0.0.3",
- "move-bytecode-utils 0.1.0",
- "move-command-line-common 0.1.0",
- "move-compiler 0.0.1",
- "move-core-types 0.0.4",
- "move-ir-types 0.1.0",
- "move-stdlib-natives 0.1.1",
- "move-symbol-pool 0.1.0",
- "move-vm-profiler 0.1.0",
- "move-vm-runtime 0.1.0",
- "move-vm-test-utils 0.1.0",
- "move-vm-types 0.1.0",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-ir-types",
+ "move-stdlib-natives",
+ "move-symbol-pool",
+ "move-vm-profiler",
+ "move-vm-runtime",
+ "move-vm-test-utils",
+ "move-vm-types",
  "once_cell",
  "rand 0.8.5",
  "rayon",
@@ -11201,16 +10164,7 @@ dependencies = [
 name = "move-vm-config"
 version = "0.1.0"
 dependencies = [
- "move-binary-format 0.0.3",
- "once_cell",
-]
-
-[[package]]
-name = "move-vm-config"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
+ "move-binary-format",
  "once_cell",
 ]
 
@@ -11218,7 +10172,7 @@ dependencies = [
 name = "move-vm-profiler"
 version = "0.1.0"
 dependencies = [
- "move-vm-config 0.1.0",
+ "move-vm-config",
  "once_cell",
  "serde",
  "serde_json",
@@ -11226,46 +10180,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "move-vm-profiler"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "move-vm-config 0.1.0 (git+https://github.com/iotaledger/iota)",
- "once_cell",
- "serde",
-]
-
-[[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
 dependencies = [
  "better_any",
  "fail",
- "move-binary-format 0.0.3",
- "move-bytecode-verifier 0.1.0",
- "move-core-types 0.0.4",
- "move-vm-config 0.1.0",
- "move-vm-profiler 0.1.0",
- "move-vm-types 0.1.0",
- "once_cell",
- "parking_lot 0.11.2",
- "smallvec",
- "tracing",
-]
-
-[[package]]
-name = "move-vm-runtime"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "better_any",
- "fail",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-vm-config 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-vm-profiler 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-vm-types 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "move-binary-format",
+ "move-bytecode-verifier",
+ "move-core-types",
+ "move-vm-config",
+ "move-vm-profiler",
+ "move-vm-types",
  "once_cell",
  "parking_lot 0.11.2",
  "smallvec",
@@ -11277,24 +10202,10 @@ name = "move-vm-test-utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "move-binary-format 0.0.3",
- "move-core-types 0.0.4",
- "move-vm-profiler 0.1.0",
- "move-vm-types 0.1.0",
- "once_cell",
- "serde",
-]
-
-[[package]]
-name = "move-vm-test-utils"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "anyhow",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-vm-profiler 0.1.0 (git+https://github.com/iotaledger/iota)",
- "move-vm-types 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-profiler",
+ "move-vm-types",
  "once_cell",
  "serde",
 ]
@@ -11304,22 +10215,9 @@ name = "move-vm-types"
 version = "0.1.0"
 dependencies = [
  "bcs",
- "move-binary-format 0.0.3",
- "move-core-types 0.0.4",
- "move-vm-profiler 0.1.0",
- "serde",
- "smallvec",
-]
-
-[[package]]
-name = "move-vm-types"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "bcs",
- "move-binary-format 0.0.3 (git+https://github.com/iotaledger/iota)",
- "move-core-types 0.0.4 (git+https://github.com/iotaledger/iota)",
- "move-vm-profiler 0.1.0 (git+https://github.com/iotaledger/iota)",
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-profiler",
  "serde",
  "smallvec",
 ]
@@ -13136,16 +12034,6 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "0.8.0-alpha"
-dependencies = [
- "anyhow",
- "prometheus",
- "protobuf",
-]
-
-[[package]]
-name = "prometheus-closure-metric"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -14986,18 +13874,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shared-crypto"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "bcs",
- "eyre",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "serde",
- "serde_repr",
-]
-
-[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15131,24 +14007,24 @@ dependencies = [
  "bcs",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "futures",
- "iota-config 0.8.0-alpha",
- "iota-execution 0.1.0",
- "iota-framework 0.8.0-alpha",
+ "iota-config",
+ "iota-execution",
+ "iota-framework",
  "iota-genesis-builder",
- "iota-keys 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
- "iota-storage 0.8.0-alpha",
+ "iota-keys",
+ "iota-protocol-config",
+ "iota-storage",
  "iota-swarm-config",
  "iota-transaction-checks",
- "iota-types 0.8.0-alpha",
- "move-binary-format 0.0.3",
- "move-bytecode-utils 0.1.0",
- "move-core-types 0.0.4",
+ "iota-types",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
  "once_cell",
  "prometheus",
  "rand 0.8.5",
  "serde",
- "shared-crypto 0.8.0-alpha",
+ "shared-crypto",
  "tracing",
 ]
 
@@ -15877,32 +14753,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "telemetry-subscribers"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "atomic_float",
- "bytes",
- "bytes-varint",
- "clap",
- "crossterm 0.25.0",
- "futures",
- "once_cell",
- "opentelemetry 0.24.0",
- "opentelemetry-otlp",
- "opentelemetry-proto",
- "opentelemetry_sdk",
- "prometheus",
- "prost",
- "tokio",
- "tonic",
- "tracing",
- "tracing-appender",
- "tracing-opentelemetry",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15971,26 +14821,26 @@ dependencies = [
  "fastcrypto-zkp",
  "futures",
  "iota-bridge",
- "iota-config 0.8.0-alpha",
+ "iota-config",
  "iota-core",
- "iota-framework 0.8.0-alpha",
+ "iota-framework",
  "iota-genesis-builder",
  "iota-json-rpc",
- "iota-json-rpc-api 0.8.0-alpha",
- "iota-json-rpc-types 0.8.0-alpha",
- "iota-keys 0.8.0-alpha",
- "iota-macros 0.8.0-alpha",
- "iota-metrics 0.8.0-alpha",
+ "iota-json-rpc-api",
+ "iota-json-rpc-types",
+ "iota-keys",
+ "iota-macros",
+ "iota-metrics",
  "iota-node",
- "iota-protocol-config 0.8.0-alpha",
+ "iota-protocol-config",
  "iota-sdk 0.8.0-alpha",
- "iota-simulator 0.8.0-alpha",
+ "iota-simulator",
  "iota-swarm",
  "iota-swarm-config",
  "iota-test-transaction-builder",
- "iota-types 0.8.0-alpha",
+ "iota-types",
  "jsonrpsee",
- "move-binary-format 0.0.3",
+ "move-binary-format",
  "prometheus",
  "rand 0.8.5",
  "tokio",
@@ -16124,12 +14974,12 @@ dependencies = [
  "clap",
  "dirs 5.0.1",
  "fastcrypto 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "iota-keys 0.8.0-alpha",
+ "iota-keys",
  "iota-sdk 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
- "move-core-types 0.0.4",
+ "iota-types",
+ "move-core-types",
  "serde",
- "shared-crypto 0.8.0-alpha",
+ "shared-crypto",
  "tokio",
 ]
 
@@ -16735,10 +15585,10 @@ name = "transaction-fuzzer"
 version = "0.8.0-alpha"
 dependencies = [
  "iota-core",
- "iota-move-build 0.8.0-alpha",
- "iota-protocol-config 0.8.0-alpha",
- "iota-types 0.8.0-alpha",
- "move-core-types 0.0.4",
+ "iota-move-build",
+ "iota-protocol-config",
+ "iota-types",
+ "move-core-types",
  "once_cell",
  "proptest",
  "proptest-derive",
@@ -16847,7 +15697,7 @@ dependencies = [
  "eyre",
  "fdlimit",
  "hdrhistogram",
- "iota-macros 0.8.0-alpha",
+ "iota-macros",
  "itertools 0.13.0",
  "msim",
  "once_cell",
@@ -16862,41 +15712,12 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "typed-store-derive 0.8.0-alpha",
- "typed-store-error 0.8.0-alpha",
+ "typed-store-derive",
+ "typed-store-error",
  "uint",
 ]
 
 [[package]]
-name = "typed-store"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "async-trait",
- "bcs",
- "bincode",
- "collectable",
- "eyre",
- "fdlimit",
- "hdrhistogram",
- "iota-macros 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "itertools 0.13.0",
- "msim",
- "once_cell",
- "ouroboros 0.18.4",
- "prometheus",
- "rand 0.8.5",
- "rocksdb",
- "serde",
- "tap",
- "thiserror",
- "tokio",
- "tracing",
- "typed-store-derive 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
- "typed-store-error 0.8.0-alpha (git+https://github.com/iotaledger/iota)",
-]
-
-[[package]]
 name = "typed-store-derive"
 version = "0.8.0-alpha"
 dependencies = [
@@ -16907,28 +15728,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "typed-store-derive"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
-dependencies = [
- "itertools 0.13.0",
- "proc-macro2 1.0.86",
- "quote 1.0.37",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "typed-store-error"
 version = "0.8.0-alpha"
-dependencies = [
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "typed-store-error"
-version = "0.8.0-alpha"
-source = "git+https://github.com/iotaledger/iota#385e36aa3fe1c3bf920b43d1e9f5b3226a9e5e71"
 dependencies = [
  "serde",
  "thiserror",

--- a/examples/custom-indexer/rust/Cargo.toml
+++ b/examples/custom-indexer/rust/Cargo.toml
@@ -6,14 +6,14 @@ license = "Apache-2.0"
 
 [dependencies]
 # external dependencies
-anyhow = "1.0.86"
-async-trait = "0.1.81"
-prometheus = "0.13.3"
-tokio = { version = "1.38.0", features = ["full"] }
+anyhow.workspace = true
+async-trait.workspace = true
+prometheus.workspace = true
+tokio.workspace = true
 
 # internal dependencies
-iota_data_ingestion_core = { git = "https://github.com/iotaledger/iota", package = "iota-data-ingestion-core" }
-iota_types = { git = "https://github.com/iotaledger/iota", package = "iota-types" }
+iota-data-ingestion-core.workspace = true
+iota-types.workspace = true
 
 [[bin]]
 name = "local_reader"


### PR DESCRIPTION
# Description of change

Fixed workspace dependencies that introduced duplicates when bumping versions. The issue arose because #4609 added those examples to the workspace Cargo.toml