### PR TITLE
feat(iota-sdk): Add `build_mainnet` fn for convenience

### DIFF
--- a/crates/iota-sdk/README.md
+++ b/crates/iota-sdk/README.md
@@ -27,6 +27,10 @@ async fn main() -> Result<(), anyhow::Error> {
     let iota_devnet = IotaClientBuilder::default().build_devnet().await?;
     println!("Iota devnet version: {}", iota_devnet.api_version());
 
+    // Iota mainnet -- https://api.mainnet.iota.cafe
+    let iota_mainnet = IotaClientBuilder::default().build_mainnet().await?;
+    println!("Iota mainnet version: {}", iota_mainnet.api_version());
+
     Ok(())
 }
 ```

--- a/crates/iota-sdk/README.md
+++ b/crates/iota-sdk/README.md
@@ -19,17 +19,17 @@ use iota_sdk::IotaClientBuilder;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    // Iota testnet -- https://api.testnet.iota.cafe
+    // IOTA testnet -- https://api.testnet.iota.cafe
     let iota_testnet = IotaClientBuilder::default().build_testnet().await?;
-    println!("Iota testnet version: {}", iota_testnet.api_version());
+    println!("IOTA testnet version: {}", iota_testnet.api_version());
 
-     // Iota devnet -- https://api.devnet.iota.cafe
+     // IOTA devnet -- https://api.devnet.iota.cafe
     let iota_devnet = IotaClientBuilder::default().build_devnet().await?;
-    println!("Iota devnet version: {}", iota_devnet.api_version());
+    println!("IOTA devnet version: {}", iota_devnet.api_version());
 
-    // Iota mainnet -- https://api.mainnet.iota.cafe
+    // IOTA mainnet -- https://api.mainnet.iota.cafe
     let iota_mainnet = IotaClientBuilder::default().build_mainnet().await?;
-    println!("Iota mainnet version: {}", iota_mainnet.api_version());
+    println!("IOTA mainnet version: {}", iota_mainnet.api_version());
 
     Ok(())
 }

--- a/crates/iota-sdk/examples/iota_client.rs
+++ b/crates/iota-sdk/examples/iota_client.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // IOTA devnet -- https://api.devnet.iota.cafe
     let devnet_client = IotaClientBuilder::default().build_devnet().await?;
-    println!("Iota devnet version: {}", devnet_client.api_version());
+    println!("IOTA devnet version: {}", devnet_client.api_version());
 
     // IOTA testnet -- https://api.testnet.iota.cafe
     let testnet_client = IotaClientBuilder::default().build_testnet().await?;

--- a/crates/iota-sdk/examples/iota_client.rs
+++ b/crates/iota-sdk/examples/iota_client.rs
@@ -34,8 +34,15 @@ async fn main() -> Result<(), anyhow::Error> {
     let testnet_client = IotaClientBuilder::default().build_testnet().await?;
     println!("IOTA testnet version: {}", testnet_client.api_version());
 
-    println!("{:?}", local_client.available_rpc_methods());
-    println!("{:?}", local_client.available_subscriptions());
+    // IOTA mainnet -- https://api.mainnet.iota.cafe
+    let mainnet_client = IotaClientBuilder::default().build_mainnet().await?;
+    println!("IOTA mainnet version: {}", mainnet_client.api_version());
+
+    println!("rpc methods: {:?}", testnet_client.available_rpc_methods());
+    println!(
+        "available subscriptions: {:?}",
+        testnet_client.available_subscriptions()
+    );
 
     Ok(())
 }

--- a/crates/iota-sdk/src/lib.rs
+++ b/crates/iota-sdk/src/lib.rs
@@ -122,6 +122,7 @@ pub const IOTA_DEVNET_URL: &str = "https://api.devnet.iota.cafe";
 pub const IOTA_DEVNET_GAS_URL: &str = "https://faucet.devnet.iota.cafe/v1/gas";
 pub const IOTA_TESTNET_URL: &str = "https://api.testnet.iota.cafe";
 pub const IOTA_TESTNET_GAS_URL: &str = "https://faucet.testnet.iota.cafe/v1/gas";
+pub const IOTA_MAINNET_URL: &str = "https://api.mainnet.iota.cafe";
 
 /// Builder for creating an [IotaClient] for connecting to the Iota network.
 ///
@@ -352,6 +353,28 @@ impl IotaClientBuilder {
     /// ```
     pub async fn build_testnet(self) -> IotaRpcResult<IotaClient> {
         self.build(IOTA_TESTNET_URL).await
+    }
+
+    /// Returns an [IotaClient] object that is ready to interact with the Iota
+    /// mainnet.
+    ///
+    /// For connecting to a custom URI, use the `build` function instead.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use sui_sdk::IotaClientBuilder;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), anyhow::Error> {
+    ///     let sui = IotaClientBuilder::default().build_mainnet().await?;
+    ///
+    ///     println!("{:?}", iota.api_version());
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn build_mainnet(self) -> IotaRpcResult<IotaClient> {
+        self.build(IOTA_MAINNET_URL).await
     }
 
     /// Return the server information as a `ServerInfo` structure.

--- a/crates/iota-sdk/src/lib.rs
+++ b/crates/iota-sdk/src/lib.rs
@@ -355,7 +355,7 @@ impl IotaClientBuilder {
         self.build(IOTA_TESTNET_URL).await
     }
 
-    /// Returns an [IotaClient] object that is ready to interact with the Iota
+    /// Returns an [IotaClient] object that is ready to interact with the IOTA
     /// mainnet.
     ///
     /// For connecting to a custom URI, use the `build` function instead.
@@ -363,11 +363,11 @@ impl IotaClientBuilder {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use sui_sdk::IotaClientBuilder;
+    /// use iota_sdk::IotaClientBuilder;
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), anyhow::Error> {
-    ///     let sui = IotaClientBuilder::default().build_mainnet().await?;
+    ///     let iota = IotaClientBuilder::default().build_mainnet().await?;
     ///
     ///     println!("{:?}", iota.api_version());
     ///     Ok(())


### PR DESCRIPTION
# Description of change

Adds a new function `build_mainnet` corresponding to the mainnet RPC node for the `IotaClientBuilder` type.

## Links to any relevant issues

https://github.com/MystenLabs/sui/pull/20640
