### PR TITLE
feat: bump iota to v0.8.1-rc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,7 +1831,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "const-str",
  "git-version",
@@ -3690,14 +3690,14 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "docs-examples"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
  "bip32",
  "iota-keys",
  "iota-move-build",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "move-binary-format",
  "move-core-types",
  "serde_json",
@@ -5928,7 +5928,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "iota"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5973,7 +5973,7 @@ dependencies = [
  "iota-package-management",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-simulator",
  "iota-source-validation",
  "iota-swarm",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "iota-adapter-transactional-tests"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -6060,7 +6060,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "arrow",
@@ -6111,7 +6111,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer-derive"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
@@ -6120,7 +6120,7 @@ dependencies = [
 
 [[package]]
 name = "iota-archival"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6152,7 +6152,7 @@ dependencies = [
 
 [[package]]
 name = "iota-authority-aggregation"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "futures",
  "iota-metrics",
@@ -6163,7 +6163,7 @@ dependencies = [
 
 [[package]]
 name = "iota-aws-orchestrator"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6194,7 +6194,7 @@ dependencies = [
 
 [[package]]
 name = "iota-benchmark"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6216,7 +6216,7 @@ dependencies = [
  "iota-metrics",
  "iota-network",
  "iota-protocol-config",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-simulator",
  "iota-storage",
  "iota-surfer",
@@ -6244,7 +6244,7 @@ dependencies = [
 
 [[package]]
 name = "iota-bridge"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6266,7 +6266,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-keys",
  "iota-metrics",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-test-transaction-builder",
  "iota-types",
  "lru 0.12.4",
@@ -6293,7 +6293,7 @@ dependencies = [
 
 [[package]]
 name = "iota-bridge-cli"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "clap",
@@ -6304,7 +6304,7 @@ dependencies = [
  "iota-config",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-types",
  "move-core-types",
  "reqwest 0.12.7",
@@ -6319,7 +6319,7 @@ dependencies = [
 
 [[package]]
 name = "iota-bridge-indexer"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6335,7 +6335,7 @@ dependencies = [
  "iota-indexer-builder",
  "iota-json-rpc-types",
  "iota-metrics",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-test-transaction-builder",
  "iota-types",
  "prometheus",
@@ -6349,7 +6349,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cluster-test"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6367,7 +6367,7 @@ dependencies = [
  "iota-json",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-swarm",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -6389,7 +6389,7 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "futures",
  "parking_lot 0.12.3",
@@ -6398,7 +6398,7 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -6425,7 +6425,7 @@ dependencies = [
 
 [[package]]
 name = "iota-core"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -6527,7 +6527,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cost"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6582,7 +6582,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6616,7 +6616,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion-core"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "iota-e2e-tests"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6674,7 +6674,7 @@ dependencies = [
  "iota-node",
  "iota-protocol-config",
  "iota-rest-api",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-simulator",
  "iota-storage",
  "iota-swarm",
@@ -6705,7 +6705,7 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "serde_yaml",
 ]
@@ -6743,7 +6743,7 @@ dependencies = [
 
 [[package]]
 name = "iota-faucet"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6757,7 +6757,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-keys",
  "iota-metrics",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-types",
  "parking_lot 0.12.3",
  "prometheus",
@@ -6781,7 +6781,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6802,7 +6802,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6817,7 +6817,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-tests"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "datatest-stable",
  "iota-adapter-latest",
@@ -6837,7 +6837,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-builder"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6890,7 +6890,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -6900,7 +6900,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-config"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "quote 1.0.37",
  "syn 1.0.109",
@@ -6908,7 +6908,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-e2e-tests"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "datatest-stable",
  "iota-graphql-rpc",
@@ -6919,7 +6919,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6958,7 +6958,7 @@ dependencies = [
  "iota-package-resolver",
  "iota-protocol-config",
  "iota-rest-api",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-swarm-config",
  "iota-test-transaction-builder",
  "iota-types",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-client"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -7013,14 +7013,14 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-headers"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "axum",
 ]
 
 [[package]]
 name = "iota-indexer"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7049,7 +7049,7 @@ dependencies = [
  "iota-package-resolver",
  "iota-protocol-config",
  "iota-rest-api",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-swarm-config",
  "iota-test-transaction-builder",
  "iota-transaction-builder",
@@ -7082,7 +7082,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer-builder"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7097,7 +7097,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7116,7 +7116,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7170,7 +7170,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
@@ -7189,7 +7189,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-tests"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7208,7 +7208,7 @@ dependencies = [
  "iota-open-rpc",
  "iota-open-rpc-macros",
  "iota-protocol-config",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-simulator",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -7227,7 +7227,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7256,7 +7256,7 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "bip32",
@@ -7275,7 +7275,7 @@ dependencies = [
 
 [[package]]
 name = "iota-light-client"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7287,7 +7287,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-package-resolver",
  "iota-rest-api",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-types",
  "move-binary-format",
  "move-core-types",
@@ -7299,7 +7299,7 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -7309,7 +7309,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metric-checker"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "backoff",
@@ -7330,7 +7330,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7353,7 +7353,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "better_any",
@@ -7391,7 +7391,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
@@ -7414,7 +7414,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-lsp"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "bin-version",
  "clap",
@@ -7445,7 +7445,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -7483,7 +7483,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anemo",
  "bcs",
@@ -7506,7 +7506,7 @@ dependencies = [
 
 [[package]]
 name = "iota-node"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7556,7 +7556,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7580,7 +7580,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -7592,7 +7592,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-dump"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7609,11 +7609,11 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "iota-json-rpc-types",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-types",
  "move-core-types",
  "move-package",
@@ -7624,7 +7624,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7647,7 +7647,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "msim-macros",
  "proc-macro2 1.0.86",
@@ -7657,7 +7657,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "clap",
  "insta",
@@ -7671,7 +7671,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
@@ -7680,7 +7680,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proxy"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "axum",
@@ -7724,7 +7724,7 @@ dependencies = [
 
 [[package]]
 name = "iota-replay"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7740,7 +7740,7 @@ dependencies = [
  "iota-json-rpc-api",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-storage",
  "iota-transaction-checks",
  "iota-types",
@@ -7771,7 +7771,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7802,7 +7802,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rosetta"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7820,7 +7820,7 @@ dependencies = [
  "iota-metrics",
  "iota-move-build",
  "iota-node",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-swarm-config",
  "iota-types",
  "move-core-types",
@@ -7844,7 +7844,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rpc-loadgen"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7854,7 +7854,7 @@ dependencies = [
  "futures",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-types",
  "itertools 0.13.0",
  "serde",
@@ -7889,7 +7889,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7967,7 +7967,7 @@ dependencies = [
 
 [[package]]
 name = "iota-simulator"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7989,7 +7989,7 @@ dependencies = [
 
 [[package]]
 name = "iota-single-node-benchmark"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "async-trait",
  "bcs",
@@ -8024,7 +8024,7 @@ dependencies = [
 
 [[package]]
 name = "iota-snapshot"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8052,7 +8052,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "colored",
@@ -8062,7 +8062,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-test-transaction-builder",
  "iota-types",
  "move-binary-format",
@@ -8084,7 +8084,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation-service"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "axum",
@@ -8100,7 +8100,7 @@ dependencies = [
  "iota-metrics",
  "iota-move",
  "iota-move-build",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-source-validation",
  "jsonrpsee",
  "move-compiler",
@@ -8123,7 +8123,7 @@ dependencies = [
 
 [[package]]
 name = "iota-storage"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8177,7 +8177,7 @@ dependencies = [
 
 [[package]]
 name = "iota-surfer"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "async-trait",
  "bcs",
@@ -8206,7 +8206,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "futures",
@@ -8231,7 +8231,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm-config"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8258,12 +8258,12 @@ dependencies = [
 
 [[package]]
 name = "iota-test-transaction-builder"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "bcs",
  "iota-genesis-builder",
  "iota-move-build",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-types",
  "move-core-types",
  "shared-crypto",
@@ -8271,7 +8271,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "axum",
@@ -8292,7 +8292,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tool"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -8314,7 +8314,7 @@ dependencies = [
  "iota-package-dump",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-snapshot",
  "iota-storage",
  "iota-types",
@@ -8337,7 +8337,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8353,7 +8353,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-checks"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "fastcrypto-zkp",
  "iota-config",
@@ -8367,7 +8367,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transactional-test-runner"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8416,7 +8416,7 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8497,7 +8497,7 @@ dependencies = [
 
 [[package]]
 name = "iota-upgrade-compatibility-transactional-tests"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "datatest-stable",
@@ -8511,7 +8511,7 @@ dependencies = [
 
 [[package]]
 name = "iota-util-mem"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "cfg-if",
  "ed25519-consensus",
@@ -8529,7 +8529,7 @@ dependencies = [
 
 [[package]]
 name = "iota-util-mem-derive"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "proc-macro2 1.0.86",
  "syn 1.0.109",
@@ -8553,7 +8553,7 @@ dependencies = [
 
 [[package]]
 name = "iota-verifier-transactional-tests"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -12033,7 +12033,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -13864,7 +13864,7 @@ dependencies = [
 
 [[package]]
 name = "shared-crypto"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "bcs",
  "eyre",
@@ -14000,7 +14000,7 @@ dependencies = [
 
 [[package]]
 name = "simulacrum"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14727,7 +14727,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry-subscribers"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -14813,7 +14813,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-cluster"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14833,7 +14833,7 @@ dependencies = [
  "iota-metrics",
  "iota-node",
  "iota-protocol-config",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-simulator",
  "iota-swarm",
  "iota-swarm-config",
@@ -14975,7 +14975,7 @@ dependencies = [
  "dirs 5.0.1",
  "fastcrypto 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "iota-keys",
- "iota-sdk 0.8.1-beta",
+ "iota-sdk 0.8.1-rc",
  "iota-types",
  "move-core-types",
  "serde",
@@ -15582,7 +15582,7 @@ dependencies = [
 
 [[package]]
 name = "transaction-fuzzer"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "iota-core",
  "iota-move-build",
@@ -15688,7 +15688,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "async-trait",
  "bcs",
@@ -15719,7 +15719,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-derive"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2 1.0.86",
@@ -15729,7 +15729,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "serde",
  "thiserror",
@@ -15737,7 +15737,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-workspace-hack"
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 dependencies = [
  "libc",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by iota-core, iota-faucet, iota-node, iota-tools, iota-sdk, iota-move-build, and iota crates.
-version = "0.8.1-beta"
+version = "0.8.1-rc"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/iotaledger/iota/main/LICENSE"
     },
-    "version": "0.8.1-beta"
+    "version": "0.8.1-rc"
   },
   "methods": [
     {


### PR DESCRIPTION
# Description of change

Bump Iota to `v0.8.1-rc` in preparation for a testnet release.
