### PR TITLE
feat(iota): ignore chain id when using `--dump-bytecode-as-base64`

### DIFF
--- a/crates/iota-move/src/build.rs
+++ b/crates/iota-move/src/build.rs
@@ -26,6 +26,11 @@ pub struct Build {
     /// Whether we are printing in base64.
     #[clap(long, global = true)]
     pub dump_bytecode_as_base64: bool,
+    /// Don't specialize the package to the active chain when dumping bytecode as Base64. This
+    /// allows building to proceed without a network connection or active environment, but it
+    /// will not be able to automatically determine the addresses of its dependencies.
+    #[arg(long, global = true, requires = "dump_bytecode_as_base64")]
+    pub ignore_chain: bool,
     /// If true, generate struct layout schemas for
     /// all struct types passed into `entry` functions declared by modules in
     /// this package These layout schemas can be consumed by clients (e.g.,

--- a/crates/iota-move/src/build.rs
+++ b/crates/iota-move/src/build.rs
@@ -26,9 +26,10 @@ pub struct Build {
     /// Whether we are printing in base64.
     #[clap(long, global = true)]
     pub dump_bytecode_as_base64: bool,
-    /// Don't specialize the package to the active chain when dumping bytecode as Base64. This
-    /// allows building to proceed without a network connection or active environment, but it
-    /// will not be able to automatically determine the addresses of its dependencies.
+    /// Don't specialize the package to the active chain when dumping bytecode
+    /// as Base64. This allows building to proceed without a network
+    /// connection or active environment, but it will not be able to
+    /// automatically determine the addresses of its dependencies.
     #[arg(long, global = true, requires = "dump_bytecode_as_base64")]
     pub ignore_chain: bool,
     /// If true, generate struct layout schemas for

--- a/crates/iota-move/src/build.rs
+++ b/crates/iota-move/src/build.rs
@@ -27,16 +27,15 @@ pub struct Build {
     #[clap(long, global = true)]
     pub dump_bytecode_as_base64: bool,
     /// Don't specialize the package to the active chain when dumping bytecode
-    /// as Base64. This allows building to proceed without a network
-    /// connection or active environment, but it will not be able to
-    /// automatically determine the addresses of its dependencies.
+    /// as Base64. This allows building to proceed without a network connection
+    /// or active environment, but it will not be able to automatically
+    /// determine the addresses of its dependencies.
     #[arg(long, global = true, requires = "dump_bytecode_as_base64")]
     pub ignore_chain: bool,
-    /// If true, generate struct layout schemas for
-    /// all struct types passed into `entry` functions declared by modules in
-    /// this package These layout schemas can be consumed by clients (e.g.,
-    /// the TypeScript SDK) to enable serialization/deserialization of
-    /// transaction arguments and events.
+    /// If true, generate struct layout schemas for all struct types passed into
+    /// `entry` functions declared by modules in this package These layout
+    /// schemas can be consumed by clients (e.g., the TypeScript SDK) to enable
+    /// serialization/deserialization of transaction arguments and events.
     #[clap(long, global = true)]
     pub generate_struct_layouts: bool,
     /// The chain ID, if resolved. Required when the dump_bytecode_as_base64 is

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -511,8 +511,8 @@ impl IotaCommand {
                             // `iota move build` does not ordinarily require a network connection.
                             // The exception is when --dump-bytecode-as-base64 is specified: In this
                             // case, we should resolve the correct addresses for the respective
-                            // chain (e.g., testnet, mainnet) from the
-                            // Move.lock under automated address management.
+                            // chain (e.g., testnet, mainnet) from the Move.lock under automated
+                            // address management.
                             let config = client_config
                                 .unwrap_or(iota_config_dir()?.join(IOTA_CLIENT_CONFIG));
                             prompt_if_no_config(&config, false, true).await?;

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -511,15 +511,14 @@ impl IotaCommand {
                             // `iota move build` does not ordinarily require a network connection.
                             // The exception is when --dump-bytecode-as-base64 is specified: In this
                             // case, we should resolve the correct addresses for the respective
-                            // chain (e.g., testnet, mainnet) from the Move.lock under automated
-                            // address management.
+                            // chain (e.g., testnet, mainnet) from the
+                            // Move.lock under automated address management.
                             let config = client_config
                                 .unwrap_or(iota_config_dir()?.join(IOTA_CLIENT_CONFIG));
                             prompt_if_no_config(&config, false, true).await?;
                             let context = WalletContext::new(&config, None, None)?;
                             let client = context.get_client().await?;
-                            let chain_id = client.read_api().get_chain_identifier().await.ok();
-                            build.chain_id = chain_id.clone();
+                            build.chain_id = client.read_api().get_chain_identifier().await.ok();
                         }
                     }
                     _ => (),

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -505,18 +505,22 @@ impl IotaCommand {
             } => {
                 match &mut cmd {
                     iota_move::Command::Build(build) if build.dump_bytecode_as_base64 => {
-                        // `iota move build` does not ordinarily require a network connection.
-                        // The exception is when --dump-bytecode-as-base64 is specified: In this
-                        // case, we should resolve the correct addresses for the respective chain
-                        // (e.g., testnet, mainnet) from the Move.lock under automated address
-                        // management.
-                        let config =
-                            client_config.unwrap_or(iota_config_dir()?.join(IOTA_CLIENT_CONFIG));
-                        prompt_if_no_config(&config, false, true).await?;
-                        let context = WalletContext::new(&config, None, None)?;
-                        let client = context.get_client().await?;
-                        let chain_id = client.read_api().get_chain_identifier().await.ok();
-                        build.chain_id = chain_id.clone();
+                        if build.ignore_chain {
+                            build.chain_id = None;
+                        } else {
+                            // `iota move build` does not ordinarily require a network connection.
+                            // The exception is when --dump-bytecode-as-base64 is specified: In this
+                            // case, we should resolve the correct addresses for the respective
+                            // chain (e.g., testnet, mainnet) from the
+                            // Move.lock under automated address management.
+                            let config = client_config
+                                .unwrap_or(iota_config_dir()?.join(IOTA_CLIENT_CONFIG));
+                            prompt_if_no_config(&config, false, true).await?;
+                            let context = WalletContext::new(&config, None, None)?;
+                            let client = context.get_client().await?;
+                            let chain_id = client.read_api().get_chain_identifier().await.ok();
+                            build.chain_id = chain_id.clone();
+                        }
                     }
                     _ => (),
                 };

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -4383,6 +4383,7 @@ async fn test_move_new() -> Result<(), anyhow::Error> {
         build_config: move_package::BuildConfig::default(),
         cmd: iota_move::Command::Build(iota_move::build::Build {
             chain_id: None,
+            ignore_chain: false,
             dump_bytecode_as_base64: false,
             generate_struct_layouts: false,
             with_unpublished_dependencies: false,


### PR DESCRIPTION
# Description of change

Ignore chain id when using `--dump-bytecode-as-base64` in `iota move build`

Allow iota move build --dump-bytecode-as-base64 to not need to read the chain from client.yaml by adding a flag --ignore-chain. This allows building to proceed without a network connection or active environment, but it will not be able to automatically determine the addresses of its dependencies.
NB: --ignore-chain depends on dump-bytecode-as-base64, so it cannot be used on its own.

Replicating https://github.com/MystenLabs/sui/pull/20475

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running `iota move build --dump-bytecode-as-base64 --ignore-chain`
```
UPDATING GIT DEPENDENCY https://github.com/iotaledger/iota.git
INCLUDING DEPENDENCY Iota
INCLUDING DEPENDENCY MoveStdlib
BUILDING first_package
{"modules":["oRzrCwYAAAAKAQAIAggQAxgpBEECBUMrB256COgBQAqoAhIMugJmDaADBgAHAQoBDgEPAAEMAAAACAABAwQAAwICAAAFAAEAAAYCAwAADAIDAAANBAMAAAkFBgABCAAHAAIOCwEBCAMLCAkABgoBBwgDAAEGCAABAwEGCAEEBwgBAwMHCAMBCAABCAIBBggDAQUBCAECCQAFBUZvcmdlBVN3b3JkCVR4Q29udGV4dANVSUQCaWQEaW5pdAVtYWdpYwlteV9tb2R1bGUDbmV3CW5ld19zd29yZAZvYmplY3QGc2VuZGVyCHN0cmVuZ3RoDnN3b3Jkc19jcmVhdGVkCHRyYW5zZmVyCnR4X2NvbnRleHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAIDBAgCBgMMAwECAgQIAg0DAAAAAAEJCgARBQYAAAAAAAAAABIBCwAuEQc4AAIBAQAAAQQLABAAFAICAQAAAQQLABABFAIDAQAAAQQLABACFAIEAQAAAQ4KABACFAYBAAAAAAAAABYLAA8CFQsDEQULAQsCEgACAAEAAgEBAA=="],"dependencies":["0x0000000000000000000000000000000000000000000000000000000000000002","0x0000000000000000000000000000000000000000000000000000000000000001"],"digest":[161,165,63,66,81,176,143,56,249,67,149,186,243,14,190,55,242,49,46,113,128,70,206,195,29,110,225,147,209,77,71,86]}
```
