### PR TITLE
chore(iota-indexer): fix typos in `IndexerMetrics`

### DIFF
--- a/crates/iota-indexer/src/metrics.rs
+++ b/crates/iota-indexer/src/metrics.rs
@@ -337,7 +337,7 @@ impl IndexerMetrics {
             ).unwrap(),
             fullnode_checkpoint_data_download_latency: register_histogram_with_registry!(
                 "fullnode_checkpoint_data_download_latency",
-                "Time spent in downloading checkpoint and transation for a new checkpoint from the Full Node",
+                "Time spent in downloading checkpoint and transaction for a new checkpoint from the Full Node",
                 DATA_INGESTION_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
@@ -458,7 +458,7 @@ impl IndexerMetrics {
             )
             .unwrap(),
             checkpoint_db_commit_latency_transactions_chunks_transformation: register_histogram_with_registry!(
-                "checkpoint_db_commit_latency_transactions_transaformation",
+                "checkpoint_db_commit_latency_transactions_transformation",
                 "Time spent in transactions chunks transformation prior to commit",
                 DATA_INGESTION_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,


### PR DESCRIPTION
# Description of change

This PR aims at fixing a few typos in some `IndexerMetrics` (namely, in their description that appears on Grafana).

## Links to any relevant issues

## Type of change

- Documentation Fix

## How the change has been tested

Minor text change in the metrics description that appears on Grafana, so I believe no test needed.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes