### PR TITLE
fix(iota): properly set `iota keytool` command --alias option

### DIFF
--- a/crates/iota/src/keytool.rs
+++ b/crates/iota/src/keytool.rs
@@ -589,8 +589,15 @@ impl KeyToolCommand {
             } => match IotaKeyPair::decode(&input_string) {
                 Ok(ikp) => {
                     info!("Importing Bech32 encoded private key to keystore");
-                    let key = Key::from(&ikp);
-                    keystore.add_key(alias, ikp)?;
+                    let mut key = Key::from(&ikp);
+                    keystore.add_key(alias.clone(), ikp)?;
+
+                    let alias = match alias {
+                        Some(x) => x,
+                        None => keystore.get_alias_by_address(&key.iota_address)?,
+                    };
+
+                    key.alias = Some(alias);
                     CommandOutput::Import(key)
                 }
                 Err(_) => {
@@ -603,7 +610,7 @@ impl KeyToolCommand {
                                     seed.len()
                                 ));
                             }
-                            keystore.import_from_seed(&seed, key_scheme, derivation_path, alias)?
+                            keystore.import_from_seed(&seed, key_scheme, derivation_path, alias.clone())?
                         }
                         Err(_) => {
                             info!("Importing mnemonic to keystore");
@@ -611,13 +618,20 @@ impl KeyToolCommand {
                                 &input_string,
                                 key_scheme,
                                 derivation_path,
-                                alias,
+                                alias.clone(),
                             )?
                         }
                     };
 
                     let ikp = keystore.get_key(&iota_address)?;
-                    let key = Key::from(ikp);
+                    let mut key = Key::from(ikp);
+
+                    let alias = match alias {
+                        Some(x) => x,
+                        None => keystore.get_alias_by_address(&key.iota_address)?,
+                    };
+
+                    key.alias = Some(alias);
                     CommandOutput::Import(key)
                 }
             },

--- a/crates/iota/src/keytool.rs
+++ b/crates/iota/src/keytool.rs
@@ -590,10 +590,10 @@ impl KeyToolCommand {
                 Ok(ikp) => {
                     info!("Importing Bech32 encoded private key to keystore");
                     let mut key = Key::from(&ikp);
-                    
+
                     keystore.add_key(alias, ikp)?;
                     key.alias = Some(keystore.get_alias_by_address(&key.iota_address)?);
-                    
+
                     CommandOutput::Import(key)
                 }
                 Err(_) => {
@@ -606,7 +606,7 @@ impl KeyToolCommand {
                                     seed.len()
                                 ));
                             }
-                            keystore.import_from_seed(&seed, key_scheme, derivation_path, alias.clone())?
+                            keystore.import_from_seed(&seed, key_scheme, derivation_path, alias)?
                         }
                         Err(_) => {
                             info!("Importing mnemonic to keystore");
@@ -623,7 +623,7 @@ impl KeyToolCommand {
                     let mut key = Key::from(ikp);
 
                     key.alias = Some(keystore.get_alias_by_address(&key.iota_address)?);
-                    
+
                     CommandOutput::Import(key)
                 }
             },

--- a/crates/iota/src/keytool.rs
+++ b/crates/iota/src/keytool.rs
@@ -590,14 +590,10 @@ impl KeyToolCommand {
                 Ok(ikp) => {
                     info!("Importing Bech32 encoded private key to keystore");
                     let mut key = Key::from(&ikp);
-                    keystore.add_key(alias.clone(), ikp)?;
-
-                    let alias = match alias {
-                        Some(x) => x,
-                        None => keystore.get_alias_by_address(&key.iota_address)?,
-                    };
-
-                    key.alias = Some(alias);
+                    
+                    keystore.add_key(alias, ikp)?;
+                    key.alias = Some(keystore.get_alias_by_address(&key.iota_address)?);
+                    
                     CommandOutput::Import(key)
                 }
                 Err(_) => {
@@ -618,7 +614,7 @@ impl KeyToolCommand {
                                 &input_string,
                                 key_scheme,
                                 derivation_path,
-                                alias.clone(),
+                                alias,
                             )?
                         }
                     };
@@ -626,12 +622,8 @@ impl KeyToolCommand {
                     let ikp = keystore.get_key(&iota_address)?;
                     let mut key = Key::from(ikp);
 
-                    let alias = match alias {
-                        Some(x) => x,
-                        None => keystore.get_alias_by_address(&key.iota_address)?,
-                    };
-
-                    key.alias = Some(alias);
+                    key.alias = Some(keystore.get_alias_by_address(&key.iota_address)?);
+                    
                     CommandOutput::Import(key)
                 }
             },


### PR DESCRIPTION
Before (note the alias absence):
```
thibault@Mac ~/i/iota (develop)> ./target/debug/iota keytool import "iotaprivkey1qzwu593jfmlhv0ezssjfxusz66uyepkh3sugttw6d0hxusm2lhvz6hez0nc" ed25519 "m/44'/4218'/0'/0'/0'" --alias tibo0
Keys saved as Bech32.
╭─────────────────┬──────────────────────────────────────────────────────────────────────╮
│ alias           │                                                                      │
│ iotaAddress     │  0x814ff3221087c184f3f6fe918523a5e08fdf1c60d249b7bd6b8c25d226695c5d  │
│ publicBase64Key │  ZsgMWzuewt2lo77QqUhUGPizwM1oAPDNTcuHVBkkSQw=                        │
│ keyScheme       │  ed25519                                                             │
│ flag            │  0                                                                   │
│ peerId          │  66c80c5b3b9ec2dda5a3bed0a9485418f8b3c0cd6800f0cd4dcb87541924490c    │
╰─────────────────┴──────────────────────────────────────────────────────────────────────╯
thibault@Mac ~/i/iota (develop)> ./target/debug/iota keytool import "horse crush buffalo business safe captain help stone notice music minor wage" ed25519 "m/44'/4218'/0'/0'/0'" --alias tibo1
Keys saved as Bech32.
╭─────────────────┬──────────────────────────────────────────────────────────────────────╮
│ alias           │                                                                      │
│ iotaAddress     │  0x26aea848fec38527761f798f3714cd5f9cc6c97324bbfeb2886570871dabf7ea  │
│ publicBase64Key │  RlEChpc2nXjURyVyoAT0ZtSgAmi5tbLnvqHsAHYrTlE=                        │
│ keyScheme       │  ed25519                                                             │
│ flag            │  0                                                                   │
│ peerId          │  4651028697369d78d4472572a004f466d4a00268b9b5b2e7bea1ec00762b4e51    │
╰─────────────────┴──────────────────────────────────────────────────────────────────────╯
```

After (note the alias presence):
```
thibault@Mac ~/i/iota (fix-keytool-missing-alias)> ./target/debug/iota keytool import "iotaprivkey1qzwu593jfmlhv0ezssjfxusz66uyepkh3sugttw6d0hxusm2lhvz6hez0nc" ed25519 "m/44'/4218'/0'/0'/0'" --alias tibo0
Keys saved as Bech32.
╭─────────────────┬──────────────────────────────────────────────────────────────────────╮
│ alias           │  tibo0                                                               │
│ iotaAddress     │  0x814ff3221087c184f3f6fe918523a5e08fdf1c60d249b7bd6b8c25d226695c5d  │
│ publicBase64Key │  ZsgMWzuewt2lo77QqUhUGPizwM1oAPDNTcuHVBkkSQw=                        │
│ keyScheme       │  ed25519                                                             │
│ flag            │  0                                                                   │
│ peerId          │  66c80c5b3b9ec2dda5a3bed0a9485418f8b3c0cd6800f0cd4dcb87541924490c    │
╰─────────────────┴──────────────────────────────────────────────────────────────────────╯
thibault@Mac ~/i/iota (fix-keytool-missing-alias)> ./target/debug/iota keytool import "horse crush buffalo business safe captain help stone notice music minor wage" ed25519 "m/44'/4218'/0'/0'/0'" --alias tibo1
Keys saved as Bech32.
╭─────────────────┬──────────────────────────────────────────────────────────────────────╮
│ alias           │  tibo1                                                               │
│ iotaAddress     │  0x26aea848fec38527761f798f3714cd5f9cc6c97324bbfeb2886570871dabf7ea  │
│ publicBase64Key │  RlEChpc2nXjURyVyoAT0ZtSgAmi5tbLnvqHsAHYrTlE=                        │
│ keyScheme       │  ed25519                                                             │
│ flag            │  0                                                                   │
│ peerId          │  4651028697369d78d4472572a004f466d4a00268b9b5b2e7bea1ec00762b4e51    │
╰─────────────────┴──────────────────────────────────────────────────────────────────────╯
```
https://github.com/MystenLabs/sui/pull/20111