### PR TITLE
chore(ci): include external crates in coverage report

### DIFF
--- a/.github/workflows/cargo_llvm_cov.yml
+++ b/.github/workflows/cargo_llvm_cov.yml
@@ -139,8 +139,7 @@ jobs:
           echo "Creating report (lcov.info)."
           LLVM_PROFILE_FILE="merged.profdata" cargo llvm-cov report \
             --lcov \
-            --output-path lcov.info \
-            --ignore-filename-regex 'external-crates/.*'
+            --output-path lcov.info
 
           echo "Removing absolute path prefix: ${{ github.workspace }} from report."
           sed --in-place "s#${{ github.workspace }}#.#g" lcov.info


### PR DESCRIPTION
# Description of change

No longer excludes external-crates from the coverage report.

## How the change has been tested

CI