### PR TITLE
fix(move-analyzer): fix crash if open a standalone Move file

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -1199,20 +1199,21 @@ impl SymbolicatorRunner {
                     };
                     if let Some(starting_path) = starting_path_opt {
                         let root_dir = Self::root_dir(&starting_path);
-                        if root_dir.is_none() && !missing_manifests.contains(&starting_path) {
-                            eprintln!("reporting missing manifest");
+                        if root_dir.is_none() {
+                            if !missing_manifests.contains(&starting_path) {
+                                eprintln!("reporting missing manifest");
 
-                            // report missing manifest file only once to avoid cluttering IDE's UI
-                            // in cases when developer indeed intended
-                            // to open a standalone file that was
-                            // not meant to compile
-                            missing_manifests.insert(starting_path);
-                            if let Err(err) = sender.send(Err(anyhow!(
-                                "Unable to find package manifest. Make sure that
-                            the source files are located in a sub-directory of a package containing
-                            a Move.toml file. "
-                            ))) {
-                                eprintln!("could not pass missing manifest error: {:?}", err);
+                                // report missing manifest file only once to avoid cluttering IDE's UI in
+                                // cases when developer indeed intended to open a standalone file that was
+                                // not meant to compile
+                                missing_manifests.insert(starting_path);
+                                if let Err(err) = sender.send(Err(anyhow!(
+                                    "Unable to find package manifest. Make sure that
+                                    the source files are located in a sub-directory of a package containing
+                                    a Move.toml file. "
+                                ))) {
+                                    eprintln!("could not pass missing manifest error: {:?}", err);
+                                }
                             }
                             continue;
                         }


### PR DESCRIPTION
# Description of change

Since the upstream pulling is postponed it is better to push this simple change to fix the crash and update the extension.

This change is a part of the following upstream PR which is mentioned in the issue:
https://github.com/MystenLabs/sui/pull/20510

## Links to any relevant issues

fixes #4387 
