### PR TITLE
fix(docs): re-enable move syntax highlighting

### DIFF
--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -291,7 +291,7 @@ const config = {
       prism: {
         theme: themes.vsLight,
         darkTheme: themes.vsDark,
-        additionalLanguages: ["rust", "typescript", "solidity"],
+        additionalLanguages: ["rust", "typescript", "solidity", "move"],
       },
       imageZoom: {
         selector: '.markdown img',

--- a/docs/site/src/theme/prism-include-languages.js
+++ b/docs/site/src/theme/prism-include-languages.js
@@ -18,8 +18,15 @@ export default function prismIncludeLanguages(PrismObject) {
     }
     // custom style for toml files
     require('./prism-toml');
+
+    if (lang === 'move') {
+      // custom style for move files
+      require('./prism-move.js');
+    }
+    else {
     // eslint-disable-next-line global-require, import/no-dynamic-require
     require(`prismjs/components/prism-${lang}`);
+    }
   });
   delete globalThis.Prism;
 }


### PR DESCRIPTION
# Description of change

Re-enable move syntax highlighting in docs

## Links to any relevant issues


## Type of change

Choose a type of change, and delete any options that are not relevant.

- Documentation Fix

## How the change has been tested

Docs built locally

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
