### PR TITLE
fix(docs): Removed custom-indexer URLs and added admonition

### DIFF
--- a/docs/content/developer/advanced/custom-indexer.mdx
+++ b/docs/content/developer/advanced/custom-indexer.mdx
@@ -31,12 +31,18 @@ Data ingestion for your indexer supports several checkpoint stream sources.
 
 ### Remote Reader
 
-The most straightforward stream source is to subscribe to a remote store of checkpoint contents. IOTA provides the following buckets:
+The most straightforward stream source is to subscribe to a remote store of checkpoint contents.
 
-- Testnet: <CodeBlock>{Networks.iota_move_testnet.indexerRpc}</CodeBlock>
-- Devnet: <CodeBlock>{Networks.iota_move_devnet.indexerRpc}</CodeBlock> 
+:::info Unavailable
 
-The checkpoint files are stored in the following format: <code>{Networks.iota_move_testnet.indexerRpc+`/<checkpoint_id>.chk`}</code>. You can download the checkpoint file by sending an HTTP GET request to the relevant URL. Try it yourself for checkpoint 1 at [{Networks.iota_move_testnet.indexerRpc}/1.chk](https://indexer.testnet.iota.cafe/1.chk).
+The IOTA Foundation does not provide this service at the moment.
+
+:::
+
+The checkpoint files are stored in the following format:
+
+<code>{Networks.iota_move_testnet.indexerRpc+`/<checkpoint_id>.chk`}</code>. You can download the checkpoint file by
+sending an HTTP GET request to the relevant URL.
 
 ```mermaid
 flowchart LR


### PR DESCRIPTION
# Description of change

Remove the URLs in the custom indexer dev docs as they are not available at the moment.

## Type of change

- Documentation Fix

## How the change has been tested

Docs were built locally.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
