### PR TITLE
fix(docs): fix graphql URLs

### DIFF
--- a/docs/content/developer/getting-started/graphql-rpc.mdx
+++ b/docs/content/developer/getting-started/graphql-rpc.mdx
@@ -5,11 +5,11 @@ description: Intoductory guide to making queries of the IOTA RPC using the Graph
 
 The quickest way to access the GraphQL service for IOTA RPC is through the online IDE that provides a complete toolbox for fetching data and executing transactions on the network. The online IDE provides features such as auto-completion (use Ctrl+Space or just start typing), built-in documentation (Book icon, top-left), multi-tabs, and more.
 
-The online IDE is available for [Devnet](https://graphql.devnet.iota.cafe/l) and [Testnet](https://graphql.testnet.iota.cafel). This guide contains various queries that you can try directly in the IDE.
+The online IDE is available for [Devnet](https://graphql.devnet.iota.cafe) and [Testnet](https://graphql.testnet.iota.cafe). This guide contains various queries that you can try directly in the IDE.
 
 :::info
 - Any existing addresses/object IDs in these examples refer to `testnet` data only.
-- Both [devnet](https://graphql.devnet.iota.cafe/l) and [testnet](https://graphql.testnet.iota.cafel) services are rate-limited to keep network throughput optimized.
+- Both [devnet](https://graphql.devnet.iota.cafe) and [testnet](https://graphql.testnet.iota.cafe) services are rate-limited to keep network throughput optimized.
 :::
 
 For more details about some concepts used in the examples below, please see the [GraphQL concepts](../graphql-rpc.mdx) page, and consult the [reference](../../references/iota-graphql.mdx) for full documentation on the supported schema.

--- a/docs/content/developer/graphql-rpc.mdx
+++ b/docs/content/developer/graphql-rpc.mdx
@@ -24,7 +24,7 @@ The service accepts the following optional headers:
 By default, each request returns the service's version in the response header: `x-iota-rpc-version`.
 
 ```bash
-curl -i -X POST https://explorer.iota.org/testnet/graphql \
+curl -i -X POST https://graphql.testnet.iota.cafe \
      --header 'x-iota-rpc-show-usage: true'                 \
      --header 'Content-Type: application/json'             \
      --data '{
@@ -96,7 +96,7 @@ When using the online IDE, supply variables as a JSON object to the query in the
 When making a request to the GraphQL service (for example, using `curl`), pass the query and variables as two fields of a single JSON object:
 
 ```bash
- curl -X POST https://explorer.iota.org/testnet/graphql \
+ curl -X POST https://graphql.testnet.iota.cafe \
     --header 'Content-Type: application/json' \
     --data '{
      "query": "query ($epochID: Int) { epoch(id: $epochID) { referenceGasPrice } }",


### PR DESCRIPTION
# Description of change

Fix graphql URLs

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Opening the testnet page, devnet one is not found, probably not deployed yet