### PR TITLE
Fix get_all_balances returning zero objects count in fullnode

### DIFF
--- a/crates/iota-indexer/tests/rpc-tests/transaction_builder.rs
+++ b/crates/iota-indexer/tests/rpc-tests/transaction_builder.rs
@@ -28,14 +28,13 @@ use iota_types::{
         label::label_struct_tag_to_string, stardust_upgrade_label::stardust_upgrade_label_type,
         timelock::TimeLock,
     },
-    utils::to_sender_signed_transaction,
 };
 use jsonrpsee::http_client::HttpClient;
 use test_cluster::TestCluster;
 
 use crate::common::{
-    ApiTestSetup, indexer_wait_for_checkpoint, indexer_wait_for_latest_checkpoint,
-    indexer_wait_for_object, indexer_wait_for_transaction,
+    ApiTestSetup, execute_tx_and_wait_for_indexer, indexer_wait_for_checkpoint,
+    indexer_wait_for_latest_checkpoint, indexer_wait_for_object,
     start_test_cluster_with_read_write_indexer,
 };
 const FUNDED_BALANCE_PER_COIN: u64 = 10_000_000_000;
@@ -770,18 +769,6 @@ fn request_withdraw_timelocked_stake_from_active() {
             Ok::<(), anyhow::Error>(())
         })
         .unwrap();
-}
-
-async fn execute_tx_and_wait_for_indexer(
-    indexer_client: &HttpClient,
-    cluster: &TestCluster,
-    store: &PgIndexerStore<PgConnection>,
-    tx_bytes: TransactionBlockBytes,
-    keypair: &AccountKeyPair,
-) {
-    let txn = to_sender_signed_transaction(tx_bytes.to_data().unwrap(), keypair);
-    let res = cluster.wallet.execute_transaction_must_succeed(txn).await;
-    indexer_wait_for_transaction(res.digest, store, indexer_client).await;
 }
 
 async fn get_address_balances(indexer_client: &HttpClient, address: IotaAddress) -> Vec<u64> {

--- a/crates/iota-json-rpc-tests/tests/coin_api.rs
+++ b/crates/iota-json-rpc-tests/tests/coin_api.rs
@@ -28,7 +28,7 @@ use iota_types::{
     quorum_driver_types::ExecuteTransactionRequestType,
 };
 use jsonrpsee::http_client::HttpClient;
-use test_cluster::TestClusterBuilder;
+use test_cluster::{TestCluster, TestClusterBuilder};
 
 async fn create_and_mint_coins(
     http_client: &HttpClient,
@@ -717,4 +717,87 @@ async fn get_all_balances() {
         total_amount as u128, new_coin_balance.total_balance,
         "New coin should have correct balance"
     );
+}
+
+#[sim_test]
+async fn get_all_balances_after_zeroing_coins_count() {
+    let cluster = TestClusterBuilder::new().build().await;
+    let http_client = cluster.rpc_client();
+    let address = cluster.get_address_0();
+    let other_address = cluster.get_address_1();
+
+    // Get all balances
+    let balances: Vec<Balance> = http_client.get_all_balances(address).await.unwrap();
+    assert!(!balances.is_empty(), "Should have some balances");
+
+    // Check if IOTA balance exists
+    let iota_balance = balances
+        .iter()
+        .find(|b| b.coin_type == "0x2::iota::IOTA")
+        .expect("IOTA balance should exist");
+
+    assert!(
+        iota_balance.coin_object_count > 0,
+        "There should be more than 0 IOTA coins"
+    );
+
+    transfer_all_coins(&cluster, http_client, address, other_address)
+        .await
+        .unwrap();
+
+    let updated_balances: Vec<Balance> = http_client.get_all_balances(address).await.unwrap();
+    assert!(
+        updated_balances.is_empty(),
+        "Should have no balances after sending away all IOTA coins"
+    );
+}
+
+async fn transfer_all_coins(
+    cluster: &TestCluster,
+    http_client: &HttpClient,
+    from_address: IotaAddress,
+    to_address: IotaAddress,
+) -> Result<IotaTransactionBlockResponse, anyhow::Error> {
+    let coins = http_client
+        .get_coins(from_address, None, None, None)
+        .await
+        .unwrap()
+        .data
+        .iter()
+        .map(|coin| coin.coin_object_id)
+        .collect();
+
+    let transaction_bytes: TransactionBlockBytes = http_client
+        .pay_all_iota(from_address, coins, to_address, 10_000_000.into())
+        .await?;
+
+    execute_tx(cluster, http_client, transaction_bytes).await
+}
+
+async fn execute_tx(
+    cluster: &TestCluster,
+    http_client: &HttpClient,
+    transaction_bytes: TransactionBlockBytes,
+) -> Result<IotaTransactionBlockResponse, anyhow::Error> {
+    let tx = cluster
+        .wallet
+        .sign_transaction(&transaction_bytes.to_data()?);
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
+
+    let tx_response: IotaTransactionBlockResponse = http_client
+        .execute_transaction_block(
+            tx_bytes,
+            signatures,
+            Some(
+                IotaTransactionBlockResponseOptions::new()
+                    .with_effects()
+                    .with_object_changes()
+                    .with_balance_changes(),
+            ),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await?;
+    assert_eq!(tx_response.status_ok(), Some(true));
+
+    Ok(tx_response)
 }

--- a/crates/iota-storage/src/indexes.rs
+++ b/crates/iota-storage/src/indexes.rs
@@ -1367,14 +1367,10 @@ impl IndexStore {
                 })
             })
             .await
-            .map(|balances_map| {
-                Arc::new(
-                    (*balances_map)
-                        .clone()
-                        .into_iter()
-                        .filter(|(_, TotalBalance { num_coins, .. })| *num_coins > 0)
-                        .collect::<HashMap<_, _>>(),
-                )
+            .map(|mut balances_map| {
+                Arc::make_mut(&mut balances_map)
+                    .retain(|_, TotalBalance { num_coins, .. }| *num_coins > 0);
+                balances_map
             })
     }
 

--- a/crates/iota-storage/src/indexes.rs
+++ b/crates/iota-storage/src/indexes.rs
@@ -1367,6 +1367,15 @@ impl IndexStore {
                 })
             })
             .await
+            .map(|balances_map| {
+                Arc::new(
+                    (*balances_map)
+                        .clone()
+                        .into_iter()
+                        .filter(|(_, TotalBalance { num_coins, .. })| *num_coins > 0)
+                        .collect::<HashMap<_, _>>(),
+                )
+            })
     }
 
     /// Read balance for a `IotaAddress` and `CoinType` from the backend


### PR DESCRIPTION
# Description of change

Implement filtering of balances returned by `get_all_balances` to omit coins with zero objects count.

The most probable root cause of the issue was described here: https://github.com/iotaledger/iota/issues/4349#issuecomment-2595213598

## Links to any relevant issues

fixes #4349

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`cargo test --package=iota-indexer --profile=simulator --features shared_test_runtime`
`cargo nextest run --package=iota-json-rpc-tests`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
