### PR TITLE
fix(iota): Remove `nushell` completion support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,16 +2492,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_complete_nushell"
-version = "4.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "315902e790cc6e5ddd20cbd313c1d0d49db77f191e149f96397230fb82a17677"
-dependencies = [
- "clap",
- "clap_complete",
-]
-
-[[package]]
 name = "clap_derive"
 version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5964,7 +5954,6 @@ dependencies = [
  "camino",
  "clap",
  "clap_complete",
- "clap_complete_nushell",
  "colored",
  "csv",
  "datatest-stable",

--- a/crates/iota/Cargo.toml
+++ b/crates/iota/Cargo.toml
@@ -23,7 +23,6 @@ bip32.workspace = true
 camino.workspace = true
 clap.workspace = true
 clap_complete = { version = "4.5", optional = true }
-clap_complete_nushell = { version = "4.5", optional = true }
 colored.workspace = true
 csv.workspace = true
 diesel = { workspace = true, optional = true }
@@ -130,4 +129,4 @@ harness = false
 [features]
 gas-profiler = ["iota-types/gas-profiler", "iota-execution/gas-profiler"]
 indexer = ["dep:diesel", "dep:iota-indexer", "dep:iota-graphql-rpc"]
-gen-completions = ["dep:clap_complete", "dep:clap_complete_nushell"]
+gen-completions = ["dep:clap_complete"]

--- a/crates/iota/src/completions.rs
+++ b/crates/iota/src/completions.rs
@@ -3,7 +3,6 @@
 
 use clap::{Command, CommandFactory, Parser, ValueEnum};
 use clap_complete::{Generator, Shell, generate, generate_to};
-use clap_complete_nushell::Nushell;
 use strum::{EnumIter, IntoEnumIterator};
 
 use crate::iota_commands::IotaCommand;
@@ -14,7 +13,6 @@ pub enum GenShell {
     Bash,
     Elvish,
     Fish,
-    Nushell,
     PowerShell,
     Zsh,
 }
@@ -27,7 +25,6 @@ impl Generator for GenShell {
             Self::Fish => Shell::Fish.file_name(name),
             Self::PowerShell => Shell::PowerShell.file_name(name),
             Self::Zsh => Shell::Zsh.file_name(name),
-            Self::Nushell => Nushell.file_name(name),
         }
     }
 
@@ -38,7 +35,6 @@ impl Generator for GenShell {
             Self::Fish => Shell::Fish.generate(cmd, buf),
             Self::PowerShell => Shell::PowerShell.generate(cmd, buf),
             Self::Zsh => Shell::Zsh.generate(cmd, buf),
-            Self::Nushell => Nushell.generate(cmd, buf),
         }
     }
 }


### PR DESCRIPTION
## Description 

Removes support for `nushell` completions because the current CLI definition is incompatible with it and generates an invalid completion file. The changes to fix this would be quite invasive, so it has been deemed better to remove this.