### PR TITLE
Use same pattern for force_new_epoch in query_validator_epoch_info_event as in other tests

### DIFF
--- a/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
@@ -30,8 +30,9 @@ use move_core_types::{
 };
 
 use crate::common::{
-    ApiTestSetup, indexer_wait_for_checkpoint, indexer_wait_for_object,
-    indexer_wait_for_transaction, rpc_call_error_msg_matches,
+    ApiTestSetup, indexer_wait_for_checkpoint, indexer_wait_for_latest_checkpoint,
+    indexer_wait_for_object, indexer_wait_for_transaction, rpc_call_error_msg_matches,
+    start_test_cluster_with_read_write_indexer,
 };
 
 #[test]
@@ -187,17 +188,15 @@ fn query_events_supported_events() {
 
 #[test]
 fn query_validator_epoch_info_event() {
-    let ApiTestSetup {
-        runtime,
-        store,
-        client,
-        cluster,
-    } = ApiTestSetup::get_or_init();
+    let ApiTestSetup { runtime, .. } = ApiTestSetup::get_or_init();
 
     runtime.block_on(async move {
+        let (cluster, store, client) =
+            &start_test_cluster_with_read_write_indexer(Some("query_validator_epoch_info_event"), None).await;
         indexer_wait_for_checkpoint(store, 1).await;
 
         cluster.force_new_epoch().await;
+        indexer_wait_for_latest_checkpoint(store, cluster).await;
 
         let result = client.query_events(EventFilter::MoveEventType("0x0000000000000000000000000000000000000000000000000000000000000003::validator_set::ValidatorEpochInfoEventV1".parse().unwrap()), None, None, None).await;
         assert!(result.is_ok());

--- a/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
@@ -186,34 +186,64 @@ fn query_events_supported_events() {
     });
 }
 
-#[test]
-fn query_validator_epoch_info_event() {
-    let ApiTestSetup { runtime, .. } = ApiTestSetup::get_or_init();
+#[tokio::test]
+async fn query_validator_epoch_info_event() {
+    let (cluster, store, client) =
+        &start_test_cluster_with_read_write_indexer(Some("query_validator_epoch_info_event"), None)
+            .await;
+    indexer_wait_for_checkpoint(store, 1).await;
 
-    runtime.block_on(async move {
-        let (cluster, store, client) =
-            &start_test_cluster_with_read_write_indexer(Some("query_validator_epoch_info_event"), None).await;
-        indexer_wait_for_checkpoint(store, 1).await;
+    cluster.force_new_epoch().await;
+    indexer_wait_for_latest_checkpoint(store, cluster).await;
 
-        cluster.force_new_epoch().await;
-        indexer_wait_for_latest_checkpoint(store, cluster).await;
+    let result = client.query_events(EventFilter::MoveEventType("0x0000000000000000000000000000000000000000000000000000000000000003::validator_set::ValidatorEpochInfoEventV1".parse().unwrap()), None, None, None).await;
+    assert!(result.is_ok());
+    assert!(!result.unwrap().data.is_empty());
 
-        let result = client.query_events(EventFilter::MoveEventType("0x0000000000000000000000000000000000000000000000000000000000000003::validator_set::ValidatorEpochInfoEventV1".parse().unwrap()), None, None, None).await;
-        assert!(result.is_ok());
-        assert!(!result.unwrap().data.is_empty());
+    let result = client
+        .query_events(
+            EventFilter::MoveEventType(
+                "0x3::validator_set::ValidatorEpochInfoEventV1"
+                    .parse()
+                    .unwrap(),
+            ),
+            None,
+            None,
+            None,
+        )
+        .await;
+    assert!(result.is_ok());
+    assert!(!result.unwrap().data.is_empty());
 
-        let result = client.query_events(EventFilter::MoveEventType("0x3::validator_set::ValidatorEpochInfoEventV1".parse().unwrap()), None, None, None).await;
-        assert!(result.is_ok());
-        assert!(!result.unwrap().data.is_empty());
+    let result = client
+        .query_events(
+            EventFilter::MoveEventType(
+                "0x0003::validator_set::ValidatorEpochInfoEventV1"
+                    .parse()
+                    .unwrap(),
+            ),
+            None,
+            None,
+            None,
+        )
+        .await;
+    assert!(result.is_ok());
+    assert!(!result.unwrap().data.is_empty());
 
-        let result = client.query_events(EventFilter::MoveEventType("0x0003::validator_set::ValidatorEpochInfoEventV1".parse().unwrap()), None, None, None).await;
-        assert!(result.is_ok());
-        assert!(!result.unwrap().data.is_empty());
-
-        let result = client.query_events(EventFilter::MoveEventType("0x1::validator_set::ValidatorEpochInfoEventV1".parse().unwrap()), None, None, None).await;
-        assert!(result.is_ok());
-        assert!(result.unwrap().data.is_empty());
-    });
+    let result = client
+        .query_events(
+            EventFilter::MoveEventType(
+                "0x1::validator_set::ValidatorEpochInfoEventV1"
+                    .parse()
+                    .unwrap(),
+            ),
+            None,
+            None,
+            None,
+        )
+        .await;
+    assert!(result.is_ok());
+    assert!(result.unwrap().data.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
# Description of change

In all tests that use `force_new_epoch` function we create a separate test cluster and wait for new checkpoint being present in indexer after epoch change.

Aligned `query_validator_epoch_info_event` test to also be structured that way.
This should improve stability of the test.

## Links to any relevant issues

fixes #4499

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`cargo test -j2 --profile=simulator --features shared_test_runtime --test rpc-tests`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
