### PR TITLE
Merge from upstream: fix(node): Do not continue transaction execution attempts after epoch has ended

### DIFF
--- a/crates/iota-core/src/execution_driver.rs
+++ b/crates/iota-core/src/execution_driver.rs
@@ -109,7 +109,8 @@ pub async fn execution_process(
 
         // Certificate execution can take significant time, so run it in a separate
         // task.
-        spawn_monitored_task!(async move {
+        let epoch_store_clone = epoch_store.clone();
+        spawn_monitored_task!(epoch_store.within_alive_epoch(async move {
             let _scope = monitored_scope("ExecutionDriver::task");
             let _guard = permit;
             if let Ok(true) = authority.is_tx_already_executed(&digest) {
@@ -120,7 +121,7 @@ pub async fn execution_process(
                 fail_point_async!("transaction_execution_delay");
                 attempts += 1;
                 let res = authority
-                    .try_execute_immediately(&certificate, expected_effects_digest, &epoch_store)
+                    .try_execute_immediately(&certificate, expected_effects_digest, &epoch_store_clone)
                     .await;
                 if let Err(e) = res {
                     if attempts == EXECUTION_MAX_ATTEMPTS {
@@ -138,6 +139,6 @@ pub async fn execution_process(
                 .metrics
                 .execution_driver_executed_transactions
                 .inc();
-        }.instrument(error_span!("execution_driver", tx_digest = ?digest)));
+        }.instrument(error_span!("execution_driver", tx_digest = ?digest))));
     }
 }


### PR DESCRIPTION

# Description of change

Merging upstream changes: https://github.com/MystenLabs/sui/commit/adde1a9908fd3e5ca7cafd01544a08a22b33c717

From upstream: 
Do not continue transaction execution attempts after epoch has ended (https://github.com/MystenLabs/sui/pull/19780)
Previously, we could hit the panic here due to continually retrying a transaction from the previous epoch.

## Links to any relevant issues

Fixes: https://github.com/iotaledger/iota/issues/4677

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

