### PR TITLE
chore(CI): Add check for nightly workflow and reroute slack message

### DIFF
--- a/.github/workflows/develop_ci_slack_report.yml
+++ b/.github/workflows/develop_ci_slack_report.yml
@@ -18,4 +18,4 @@ jobs:
           message_format: ":fire: *${{github.event.workflow_run.name}}* ${{github.event.workflow_run.conclusion}} <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure> author: ${{ github.event.workflow_run.head_commit.author.name }}"
           footer: "${{ github.event.workflow_run.display_title }} \n<${{github.server_url}}/${{github.repository}}/commit/${{github.event.workflow_run.head_commit.id}}>"
         env:
-          SLACK_WEBHOOK_URL: github.event.workflow_run.name == 'Nightly checks' ? ${{ secrets.DEV_BROKEN_CI_SLACK_WEBHOOK }} | ${{ secrets.DEV_BROKEN_CI_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ github.event.workflow_run.name == 'Nightly checks' }} ? ${{ secrets.DEV_BROKEN_CI_SLACK_WEBHOOK }} | ${{ secrets.DEV_BROKEN_CI_SLACK_WEBHOOK }}

--- a/.github/workflows/develop_ci_slack_report.yml
+++ b/.github/workflows/develop_ci_slack_report.yml
@@ -18,4 +18,4 @@ jobs:
           message_format: ":fire: *${{github.event.workflow_run.name}}* ${{github.event.workflow_run.conclusion}} <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure> author: ${{ github.event.workflow_run.head_commit.author.name }}"
           footer: "${{ github.event.workflow_run.display_title }} \n<${{github.server_url}}/${{github.repository}}/commit/${{github.event.workflow_run.head_commit.id}}>"
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.DEV_BROKEN_CI_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK_URL: github.event.workflow_run.name == 'Nightly checks' ? ${{ secrets.DEV_BROKEN_CI_SLACK_WEBHOOK }} | ${{ secrets.DEV_BROKEN_CI_SLACK_WEBHOOK }}

--- a/.github/workflows/develop_ci_slack_report.yml
+++ b/.github/workflows/develop_ci_slack_report.yml
@@ -18,4 +18,4 @@ jobs:
           message_format: ":fire: *${{github.event.workflow_run.name}}* ${{github.event.workflow_run.conclusion}} <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure> author: ${{ github.event.workflow_run.head_commit.author.name }}"
           footer: "${{ github.event.workflow_run.display_title }} \n<${{github.server_url}}/${{github.repository}}/commit/${{github.event.workflow_run.head_commit.id}}>"
         env:
-          SLACK_WEBHOOK_URL: ${{ github.event.workflow_run.name == 'Nightly checks' }} ? ${{ secrets.DEV_BROKEN_CI_SLACK_WEBHOOK }} | ${{ secrets.DEV_BROKEN_CI_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ github.event.workflow_run.name == 'Nightly checks' }} ? ${{ secrets.NIGHTLY_BROKEN_CI_SLACK_WEBHOOK }} | ${{ secrets.DEV_BROKEN_CI_SLACK_WEBHOOK }}

--- a/.github/workflows/develop_ci_slack_report.yml
+++ b/.github/workflows/develop_ci_slack_report.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["*"]
     types: [completed]
-    branches: [develop, "dev-tools/slack-nightly"]
+    branches: [develop]
 
 jobs:
   on-failure:

--- a/.github/workflows/develop_ci_slack_report.yml
+++ b/.github/workflows/develop_ci_slack_report.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["*"]
     types: [completed]
-    branches: [develop]
+    branches: [develop, "dev-tools/slack-nightly"]
 
 jobs:
   on-failure:


### PR DESCRIPTION
## Description 

This PR adds a check in the develop slack reporting workflow which will send the message to a different channel depending on whether the failure is from the nightly workflow.

NOTE: Currently there is no hook for this other channel, so that will be added once it is set up.