### PR TITLE
Fix cursor handling in get_all_coins indexer endpoint

### DIFF
--- a/crates/iota-indexer/src/apis/coin_api.rs
+++ b/crates/iota-indexer/src/apis/coin_api.rs
@@ -15,10 +15,11 @@ use iota_types::{
     balance::Supply,
     base_types::{IotaAddress, ObjectID},
     gas_coin::GAS,
+    object::ObjectRead,
 };
 use jsonrpsee::{RpcModule, core::RpcResult};
 
-use crate::indexer_reader::IndexerReader;
+use crate::{errors::IndexerError, indexer_reader::IndexerReader};
 
 pub(crate) struct CoinReadApi<T: R2D2Connection + 'static> {
     inner: IndexerReader<T>,
@@ -27,6 +28,29 @@ pub(crate) struct CoinReadApi<T: R2D2Connection + 'static> {
 impl<T: R2D2Connection> CoinReadApi<T> {
     pub fn new(inner: IndexerReader<T>) -> Self {
         Self { inner }
+    }
+
+    async fn get_coin_type_canonical_string(
+        &self,
+        object_id: ObjectID,
+    ) -> Result<String, IndexerError> {
+        let object_read = self
+            .inner
+            .get_object_read_in_blocking_task(object_id)
+            .await?;
+        if let ObjectRead::Exists(_, object, _) = object_read {
+            if let Some(type_tag) = object.coin_type_maybe() {
+                return Ok(type_tag.to_canonical_string(true));
+            }
+            return Err(IndexerError::InvalidArgument(format!(
+                "Object is not a coin: {}",
+                object_id
+            )));
+        }
+        Err(IndexerError::InvalidArgument(format!(
+            "Object not found: {}",
+            object_id
+        )))
     }
 }
 
@@ -49,10 +73,13 @@ impl<T: R2D2Connection + 'static> CoinReadApiServer for CoinReadApi<T> {
             parse_to_type_tag(coin_type)?.to_canonical_string(/* with_prefix */ true);
 
         let cursor = match cursor {
-            Some(c) => c,
+            Some(object_id) => (
+                self.get_coin_type_canonical_string(object_id).await?,
+                object_id,
+            ),
             // If cursor is not specified, we need to start from the beginning of the coin type,
-            // which is the minimal possible ObjectID.
-            None => ObjectID::ZERO,
+            // which is the minimal possible coin name and ObjectID.
+            None => (String::new(), ObjectID::ZERO),
         };
         let mut results = self
             .inner
@@ -81,10 +108,13 @@ impl<T: R2D2Connection + 'static> CoinReadApiServer for CoinReadApi<T> {
         }
 
         let cursor = match cursor {
-            Some(c) => c,
+            Some(object_id) => (
+                self.get_coin_type_canonical_string(object_id).await?,
+                object_id,
+            ),
             // If cursor is not specified, we need to start from the beginning of the coin type,
-            // which is the minimal possible ObjectID.
-            None => ObjectID::ZERO,
+            // which is the minimal possible coin name and ObjectID.
+            None => (String::new(), ObjectID::ZERO),
         };
         let mut results = self
             .inner

--- a/crates/iota-indexer/src/apis/coin_api.rs
+++ b/crates/iota-indexer/src/apis/coin_api.rs
@@ -15,11 +15,10 @@ use iota_types::{
     balance::Supply,
     base_types::{IotaAddress, ObjectID},
     gas_coin::GAS,
-    object::ObjectRead,
 };
 use jsonrpsee::{RpcModule, core::RpcResult};
 
-use crate::{errors::IndexerError, indexer_reader::IndexerReader};
+use crate::indexer_reader::IndexerReader;
 
 pub(crate) struct CoinReadApi<T: R2D2Connection + 'static> {
     inner: IndexerReader<T>,
@@ -28,29 +27,6 @@ pub(crate) struct CoinReadApi<T: R2D2Connection + 'static> {
 impl<T: R2D2Connection> CoinReadApi<T> {
     pub fn new(inner: IndexerReader<T>) -> Self {
         Self { inner }
-    }
-
-    async fn get_coin_type_canonical_string(
-        &self,
-        object_id: ObjectID,
-    ) -> Result<String, IndexerError> {
-        let object_read = self
-            .inner
-            .get_object_read_in_blocking_task(object_id)
-            .await?;
-        if let ObjectRead::Exists(_, object, _) = object_read {
-            if let Some(type_tag) = object.coin_type_maybe() {
-                return Ok(type_tag.to_canonical_string(true));
-            }
-            return Err(IndexerError::InvalidArgument(format!(
-                "Object is not a coin: {}",
-                object_id
-            )));
-        }
-        Err(IndexerError::InvalidArgument(format!(
-            "Object not found: {}",
-            object_id
-        )))
     }
 }
 
@@ -73,13 +49,10 @@ impl<T: R2D2Connection + 'static> CoinReadApiServer for CoinReadApi<T> {
             parse_to_type_tag(coin_type)?.to_canonical_string(/* with_prefix */ true);
 
         let cursor = match cursor {
-            Some(object_id) => (
-                self.get_coin_type_canonical_string(object_id).await?,
-                object_id,
-            ),
+            Some(c) => c,
             // If cursor is not specified, we need to start from the beginning of the coin type,
-            // which is the minimal possible coin name and ObjectID.
-            None => (String::new(), ObjectID::ZERO),
+            // which is the minimal possible ObjectID.
+            None => ObjectID::ZERO,
         };
         let mut results = self
             .inner
@@ -108,13 +81,10 @@ impl<T: R2D2Connection + 'static> CoinReadApiServer for CoinReadApi<T> {
         }
 
         let cursor = match cursor {
-            Some(object_id) => (
-                self.get_coin_type_canonical_string(object_id).await?,
-                object_id,
-            ),
+            Some(c) => c,
             // If cursor is not specified, we need to start from the beginning of the coin type,
-            // which is the minimal possible coin name and ObjectID.
-            None => (String::new(), ObjectID::ZERO),
+            // which is the minimal possible ObjectID.
+            None => ObjectID::ZERO,
         };
         let mut results = self
             .inner

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -1493,7 +1493,7 @@ impl<U: R2D2Connection> IndexerReader<U> {
         &self,
         owner: IotaAddress,
         coin_type: Option<String>,
-        cursor: (String, ObjectID),
+        cursor: ObjectID,
         limit: usize,
     ) -> Result<Vec<IotaCoin>, IndexerError> {
         self.spawn_blocking(move |this| this.get_owned_coins(owner, coin_type, cursor, limit))
@@ -1505,25 +1505,13 @@ impl<U: R2D2Connection> IndexerReader<U> {
         owner: IotaAddress,
         // If coin_type is None, look for all coins.
         coin_type: Option<String>,
-        cursor: (String, ObjectID),
+        cursor: ObjectID,
         limit: usize,
     ) -> Result<Vec<IotaCoin>, IndexerError> {
-        use diesel::BoolExpressionMethods;
-
-        let (coin_type_cursor, object_id_cursor) = cursor;
-
         let mut query = objects::dsl::objects
             .filter(objects::dsl::owner_type.eq(OwnerType::Address as i16))
             .filter(objects::dsl::owner_id.eq(owner.to_vec()))
-            .filter(
-                // This filter is equivalent to
-                // (objects::dsl::coin_type, objects::dsl::object_id).gt(cursor)
-                objects::dsl::coin_type
-                    .gt(coin_type_cursor.clone())
-                    .or(objects::dsl::coin_type
-                        .eq(coin_type_cursor)
-                        .and(objects::dsl::object_id.gt(object_id_cursor.to_vec()))),
-            )
+            .filter(objects::dsl::object_id.gt(cursor.to_vec()))
             .into_boxed();
         if let Some(coin_type) = coin_type {
             query = query.filter(objects::dsl::coin_type.eq(Some(coin_type)));
@@ -1531,7 +1519,7 @@ impl<U: R2D2Connection> IndexerReader<U> {
             query = query.filter(objects::dsl::coin_type.is_not_null());
         }
         query = query
-            .order((objects::dsl::coin_type.asc(), objects::dsl::object_id.asc()))
+            .order(objects::dsl::object_id.asc())
             .limit(limit as i64);
 
         let stored_objects = run_query!(&self.pool, |conn| query.load::<StoredObject>(conn))?;

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -1493,7 +1493,7 @@ impl<U: R2D2Connection> IndexerReader<U> {
         &self,
         owner: IotaAddress,
         coin_type: Option<String>,
-        cursor: ObjectID,
+        cursor: (String, ObjectID),
         limit: usize,
     ) -> Result<Vec<IotaCoin>, IndexerError> {
         self.spawn_blocking(move |this| this.get_owned_coins(owner, coin_type, cursor, limit))
@@ -1505,13 +1505,25 @@ impl<U: R2D2Connection> IndexerReader<U> {
         owner: IotaAddress,
         // If coin_type is None, look for all coins.
         coin_type: Option<String>,
-        cursor: ObjectID,
+        cursor: (String, ObjectID),
         limit: usize,
     ) -> Result<Vec<IotaCoin>, IndexerError> {
+        use diesel::BoolExpressionMethods;
+
+        let (coin_type_cursor, object_id_cursor) = cursor;
+
         let mut query = objects::dsl::objects
             .filter(objects::dsl::owner_type.eq(OwnerType::Address as i16))
             .filter(objects::dsl::owner_id.eq(owner.to_vec()))
-            .filter(objects::dsl::object_id.gt(cursor.to_vec()))
+            .filter(
+                // This filter is equivalent to
+                // (objects::dsl::coin_type, objects::dsl::object_id).gt(cursor)
+                objects::dsl::coin_type
+                    .gt(coin_type_cursor.clone())
+                    .or(objects::dsl::coin_type
+                        .eq(coin_type_cursor)
+                        .and(objects::dsl::object_id.gt(object_id_cursor.to_vec()))),
+            )
             .into_boxed();
         if let Some(coin_type) = coin_type {
             query = query.filter(objects::dsl::coin_type.eq(Some(coin_type)));

--- a/crates/iota-indexer/tests/rpc-tests/coin_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/coin_api.rs
@@ -14,7 +14,7 @@ use iota_json_rpc_types::{
 };
 use iota_move_build::BuildConfig;
 use iota_types::{
-    IOTA_FRAMEWORK_ADDRESS,
+    IOTA_CLOCK_OBJECT_ID, IOTA_FRAMEWORK_ADDRESS,
     balance::Supply,
     base_types::{IotaAddress, ObjectID},
     coin::{COIN_MODULE_NAME, TreasuryCap},
@@ -27,7 +27,7 @@ use jsonrpsee::http_client::HttpClient;
 use test_cluster::TestCluster;
 use tokio::sync::OnceCell;
 
-use crate::common::{ApiTestSetup, execute_tx_and_wait_for_indexer, indexer_wait_for_object};
+use crate::common::{ApiTestSetup, execute_tx_and_wait_for_indexer, indexer_wait_for_object, rpc_call_error_msg_matches};
 
 static COMMON_TESTING_ADDR_AND_CUSTOM_COIN_NAME: OnceCell<(IotaAddress, AccountKeyPair, String)> =
     OnceCell::const_new();
@@ -175,7 +175,6 @@ fn get_all_coins_basic_scenario() {
     });
 }
 
-#[ignore = "https://github.com/iotaledger/iota/issues/3588"]
 #[test]
 fn get_all_coins_with_cursor() {
     let ApiTestSetup {
@@ -194,20 +193,49 @@ fn get_all_coins_with_cursor() {
             .unwrap();
         let cursor = all_coins.data[3].coin_object_id; // get some coin from the middle
 
-        let (result_fullnode_all, result_indexer_all) =
-            get_all_coins_fullnode_indexer(cluster, client, *owner, None, None).await;
-
         let (result_fullnode, result_indexer) =
             get_all_coins_fullnode_indexer(cluster, client, *owner, Some(cursor), None).await;
 
-        println!("Fullnode all: {:#?}", result_fullnode_all);
-        println!("Indexer all: {:#?}", result_indexer_all);
-        println!("Fullnode: {:#?}", result_fullnode);
-        println!("Indexer: {:#?}", result_indexer);
-        println!("Cursor: {:#?}", cursor);
-
         assert!(!result_indexer.data.is_empty());
         assert_eq!(result_fullnode, result_indexer);
+    });
+}
+
+#[test]
+fn get_all_coins_bad_cursor_nonexistent_object() {
+    let ApiTestSetup {
+        runtime,
+        client,
+        cluster,
+        ..
+    } = ApiTestSetup::get_or_init();
+    runtime.block_on(async move {
+        let (owner, _) = get_or_init_addr_and_custom_coins(cluster, client).await;
+        let cursor = ObjectID::ZERO; // get some object_id that does not exist
+        let result = client.get_all_coins(*owner, Some(cursor), None).await;
+        assert!(rpc_call_error_msg_matches(
+            result,
+            r#"{"code":-32603,"message":"Invalid argument with error: `Object not found: 0x0000000000000000000000000000000000000000000000000000000000000000`"}"#,
+        ));
+    });
+}
+
+#[test]
+fn get_all_coins_bad_cursor_noncoin_object() {
+    let ApiTestSetup {
+        runtime,
+        client,
+        cluster,
+        ..
+    } = ApiTestSetup::get_or_init();
+    runtime.block_on(async move {
+        let (owner, _) = get_or_init_addr_and_custom_coins(cluster, client).await;
+        let cursor = IOTA_CLOCK_OBJECT_ID; // valid object id that is not a coin
+        let result = client.get_all_coins(*owner, Some(cursor), None).await;
+        assert!(rpc_call_error_msg_matches(
+            result,
+            r#"{"code":-32603,"message":"Invalid argument with error: `Object is not a coin: 0x0000000000000000000000000000000000000000000000000000000000000006`"}"#,
+        ));
     });
 }
 

--- a/crates/iota-indexer/tests/rpc-tests/coin_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/coin_api.rs
@@ -14,7 +14,7 @@ use iota_json_rpc_types::{
 };
 use iota_move_build::BuildConfig;
 use iota_types::{
-    IOTA_CLOCK_OBJECT_ID, IOTA_FRAMEWORK_ADDRESS,
+    IOTA_FRAMEWORK_ADDRESS,
     balance::Supply,
     base_types::{IotaAddress, ObjectID},
     coin::{COIN_MODULE_NAME, TreasuryCap},
@@ -23,11 +23,12 @@ use iota_types::{
     quorum_driver_types::ExecuteTransactionRequestType,
     utils::to_sender_signed_transaction,
 };
+use itertools::Itertools;
 use jsonrpsee::http_client::HttpClient;
 use test_cluster::TestCluster;
 use tokio::sync::OnceCell;
 
-use crate::common::{ApiTestSetup, execute_tx_and_wait_for_indexer, indexer_wait_for_object, rpc_call_error_msg_matches};
+use crate::common::{ApiTestSetup, execute_tx_and_wait_for_indexer, indexer_wait_for_object};
 
 static COMMON_TESTING_ADDR_AND_CUSTOM_COIN_NAME: OnceCell<(IotaAddress, AccountKeyPair, String)> =
     OnceCell::const_new();
@@ -171,7 +172,18 @@ fn get_all_coins_basic_scenario() {
             get_all_coins_fullnode_indexer(cluster, client, *owner, None, None).await;
 
         assert!(!result_indexer.data.is_empty());
-        assert_eq!(result_fullnode, result_indexer);
+        assert_eq!(
+            result_fullnode
+                .data
+                .iter()
+                .sorted_by_key(|coin| coin.coin_object_id)
+                .collect::<Vec<_>>(),
+            result_indexer
+                .data
+                .iter()
+                .sorted_by_key(|coin| coin.coin_object_id)
+                .collect::<Vec<_>>()
+        );
     });
 }
 
@@ -186,56 +198,25 @@ fn get_all_coins_with_cursor() {
     runtime.block_on(async move {
         let (owner, _, _) = get_or_init_addr_and_custom_coins(cluster, client).await;
 
-        let all_coins = cluster
-            .rpc_client()
-            .get_coins(*owner, None, None, None)
-            .await
-            .unwrap();
-        let cursor = all_coins.data[3].coin_object_id; // get some coin from the middle
+        let all_coins = client.get_all_coins(*owner, None, None).await.unwrap();
+        assert_eq!(all_coins.data.len(), 6);
+        assert!(!all_coins.has_next_page);
 
-        let (result_fullnode, result_indexer) =
-            get_all_coins_fullnode_indexer(cluster, client, *owner, Some(cursor), None).await;
+        let first_page_results = client.get_all_coins(*owner, None, Some(4)).await.unwrap();
+        assert!(first_page_results.has_next_page);
+        let second_page_results: iota_json_rpc_types::Page<iota_json_rpc_types::Coin, ObjectID> =
+            client
+                .get_all_coins(*owner, first_page_results.next_cursor, Some(4))
+                .await
+                .unwrap();
+        assert!(!second_page_results.has_next_page);
 
-        assert!(!result_indexer.data.is_empty());
-        assert_eq!(result_fullnode, result_indexer);
-    });
-}
-
-#[test]
-fn get_all_coins_bad_cursor_nonexistent_object() {
-    let ApiTestSetup {
-        runtime,
-        client,
-        cluster,
-        ..
-    } = ApiTestSetup::get_or_init();
-    runtime.block_on(async move {
-        let (owner, _) = get_or_init_addr_and_custom_coins(cluster, client).await;
-        let cursor = ObjectID::ZERO; // get some object_id that does not exist
-        let result = client.get_all_coins(*owner, Some(cursor), None).await;
-        assert!(rpc_call_error_msg_matches(
-            result,
-            r#"{"code":-32603,"message":"Invalid argument with error: `Object not found: 0x0000000000000000000000000000000000000000000000000000000000000000`"}"#,
-        ));
-    });
-}
-
-#[test]
-fn get_all_coins_bad_cursor_noncoin_object() {
-    let ApiTestSetup {
-        runtime,
-        client,
-        cluster,
-        ..
-    } = ApiTestSetup::get_or_init();
-    runtime.block_on(async move {
-        let (owner, _) = get_or_init_addr_and_custom_coins(cluster, client).await;
-        let cursor = IOTA_CLOCK_OBJECT_ID; // valid object id that is not a coin
-        let result = client.get_all_coins(*owner, Some(cursor), None).await;
-        assert!(rpc_call_error_msg_matches(
-            result,
-            r#"{"code":-32603,"message":"Invalid argument with error: `Object is not a coin: 0x0000000000000000000000000000000000000000000000000000000000000006`"}"#,
-        ));
+        let merged_page_contents: Vec<_> = first_page_results
+            .data
+            .into_iter()
+            .chain(second_page_results.data)
+            .collect();
+        assert_eq!(all_coins.data, merged_page_contents);
     });
 }
 
@@ -250,11 +231,21 @@ fn get_all_coins_with_limit() {
     runtime.block_on(async move {
         let (owner, _, _) = get_or_init_addr_and_custom_coins(cluster, client).await;
 
-        let (result_fullnode, result_indexer) =
-            get_all_coins_fullnode_indexer(cluster, client, *owner, None, Some(2)).await;
+        let all_coins = client.get_all_coins(*owner, None, None).await.unwrap();
+        let tested_limit = 2;
+        let expected_data = all_coins
+            .data
+            .into_iter()
+            .take(tested_limit)
+            .collect::<Vec<_>>();
 
-        assert!(!result_indexer.data.is_empty());
-        assert_eq!(result_fullnode, result_indexer);
+        let limited_result = client
+            .get_all_coins(*owner, None, Some(tested_limit))
+            .await
+            .unwrap();
+
+        assert_eq!(limited_result.data.len(), tested_limit);
+        assert_eq!(expected_data, limited_result.data);
     });
 }
 


### PR DESCRIPTION
# Description of change

Coins returned by get_all_coins endpoint were sorted by (coin_type, object_id), but only object_id was used as a cursor which resulted in bad filtering applied when using the cursor.

Fixed the issue by sorting the result by object_id only.

## Links to any relevant issues

fixes #3588

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`cargo test -j2 --profile=simulator --features shared_test_runtime --test rpc-tests`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
