### PR TITLE
feat(iota): add data_ingestion_dir to iota start command

### DIFF
--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -409,6 +409,7 @@ impl IotaCommand {
                     force_regenesis,
                     epoch_duration_ms,
                     fullnode_rpc_port,
+                    #[cfg(feature = "indexer")]
                     data_ingestion_dir,
                     no_full_node,
                     local_migration_snapshots,

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -221,7 +221,7 @@ pub enum IotaCommand {
         /// directory. This is incompatible with --no-full-node.
         ///
         /// If --with-indexer is set, this defaults to a temporary directory.
-        #[cfg(feature = "indexer")] 
+        #[cfg(feature = "indexer")]
         #[clap(long, value_name = "DATA_INGESTION_DIR")]
         data_ingestion_dir: Option<PathBuf>,
 
@@ -392,7 +392,7 @@ impl IotaCommand {
                 #[cfg(feature = "indexer")]
                 indexer_feature_args,
                 fullnode_rpc_port,
-                #[cfg(feature = "indexer")] 
+                #[cfg(feature = "indexer")]
                 data_ingestion_dir,
                 no_full_node,
                 epoch_duration_ms,

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -757,9 +757,6 @@ async fn start(
             .with_network_config(network_config);
     }
 
-    #[cfg(feature = "indexer")]
-    let data_ingestion_path = tempdir()?.into_path();
-
     // the indexer requires to set the fullnode's data ingestion directory
     // note that this overrides the default configuration that is set when running
     // the genesis command, which sets data_ingestion_dir to None.
@@ -806,7 +803,7 @@ async fn start(
             Some(pg_address.clone()),
             fullnode_url.clone(),
             ReaderWriterConfig::writer_mode(None),
-            Some(data_ingestion_path.clone()),
+            data_ingestion_dir.clone(),
             None,
         )
         .await;
@@ -817,7 +814,7 @@ async fn start(
             Some(pg_address.clone()),
             fullnode_url.clone(),
             ReaderWriterConfig::reader_mode(indexer_address.to_string()),
-            Some(data_ingestion_path),
+            data_ingestion_dir,
             None,
         )
         .await;

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -222,7 +222,7 @@ pub enum IotaCommand {
         ///
         /// If --with-indexer is set, this defaults to a temporary directory.
         #[cfg(feature = "indexer")]
-        #[clap(long, value_name = "DATA_INGESTION_DIR")]
+        #[arg(long, value_name = "DATA_INGESTION_DIR")]
         data_ingestion_dir: Option<PathBuf>,
 
         /// Start the network without a fullnode

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -217,6 +217,14 @@ pub enum IotaCommand {
         #[clap(long)]
         epoch_duration_ms: Option<u64>,
 
+        /// Make the fullnode dump executed checkpoints as files to this
+        /// directory. This is incompatible with --no-full-node.
+        ///
+        /// If --with-indexer is set, this defaults to a temporary directory.
+        #[cfg(feature = "indexer")] 
+        #[clap(long, value_name = "DATA_INGESTION_DIR")]
+        data_ingestion_dir: Option<PathBuf>,
+
         /// Start the network without a fullnode
         #[clap(long = "no-full-node")]
         no_full_node: bool,
@@ -384,6 +392,8 @@ impl IotaCommand {
                 #[cfg(feature = "indexer")]
                 indexer_feature_args,
                 fullnode_rpc_port,
+                #[cfg(feature = "indexer")] 
+                data_ingestion_dir,
                 no_full_node,
                 epoch_duration_ms,
                 local_migration_snapshots,
@@ -399,6 +409,7 @@ impl IotaCommand {
                     force_regenesis,
                     epoch_duration_ms,
                     fullnode_rpc_port,
+                    data_ingestion_dir,
                     no_full_node,
                     local_migration_snapshots,
                     remote_migration_snapshots,
@@ -625,6 +636,7 @@ async fn start(
     force_regenesis: bool,
     epoch_duration_ms: Option<u64>,
     fullnode_rpc_port: u16,
+    #[cfg(feature = "indexer")] mut data_ingestion_dir: Option<PathBuf>,
     no_full_node: bool,
     local_migration_snapshots: Vec<PathBuf>,
     remote_migration_snapshots: Vec<SnapshotUrl>,
@@ -751,8 +763,13 @@ async fn start(
     // note that this overrides the default configuration that is set when running
     // the genesis command, which sets data_ingestion_dir to None.
     #[cfg(feature = "indexer")]
-    if with_indexer.is_some() {
-        swarm_builder = swarm_builder.with_data_ingestion_dir(data_ingestion_path.clone());
+    if with_indexer.is_some() && data_ingestion_dir.is_none() {
+        data_ingestion_dir = Some(tempdir()?.into_path())
+    }
+
+    #[cfg(feature = "indexer")]
+    if let Some(ref dir) = data_ingestion_dir {
+        swarm_builder = swarm_builder.with_data_ingestion_dir(dir.clone());
     }
 
     let mut fullnode_url = iota_config::node::default_json_rpc_address();

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -152,6 +152,7 @@ async fn test_start() -> Result<(), anyhow::Error> {
     if let Ok(res) = tokio::time::timeout(
         Duration::from_secs(10),
         IotaCommand::Start {
+            data_ingestion_dir: None,
             config_dir: Some(working_dir.to_path_buf()),
             no_full_node: false,
             force_regenesis: false,

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -152,6 +152,7 @@ async fn test_start() -> Result<(), anyhow::Error> {
     if let Ok(res) = tokio::time::timeout(
         Duration::from_secs(10),
         IotaCommand::Start {
+            #[cfg(feature = "indexer")]
             data_ingestion_dir: None,
             config_dir: Some(working_dir.to_path_buf()),
             no_full_node: false,


### PR DESCRIPTION
# Description of change

Add data_ingestion_dir to iota start command so one can set the folder in which executed checkpoints are saved as files.
This is useful, among other things, for testing a custom [local reader](https://docs.iota.org/developer/advanced/custom-indexer#local-reader) indexing setup with low overhead.

Porting over https://github.com/MystenLabs/sui/pull/20472

Fixes https://github.com/iotaledger/iota/issues/4918

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running `cargo run --features=indexer start --force-regenesis --with-faucet --data-ingestion-dir "data-ingestion-dir" --with-indexer` created a folder `data-ingestion-dir/` with the checkpoint files:
```
0.chk
1.chk
2.chk
...
```