### PR TITLE
feat: add archive info for formal snapshots

### DIFF
--- a/crates/iota-tool/src/commands.rs
+++ b/crates/iota-tool/src/commands.rs
@@ -855,14 +855,11 @@ impl ToolCommand {
                         }
                     });
 
-                    let aws_virtual_hosted_style_request = env::var(
-                        "AWS_ARCHIVE_VIRTUAL_HOSTED_REQUESTS",
-                    )
-                    .ok()
-                    .and_then(|b| b.parse().ok())
-                    .unwrap_or_else(|| {
-                        matches!(network, Chain::Mainnet | Chain::Testnet)
-                    });
+                    let aws_virtual_hosted_style_request =
+                        env::var("AWS_ARCHIVE_VIRTUAL_HOSTED_REQUESTS")
+                            .ok()
+                            .and_then(|b| b.parse().ok())
+                            .unwrap_or_else(|| matches!(network, Chain::Mainnet | Chain::Testnet));
 
                     ObjectStoreConfig {
                         object_store: Some(ObjectStoreType::S3),

--- a/crates/iota-tool/src/commands.rs
+++ b/crates/iota-tool/src/commands.rs
@@ -845,17 +845,31 @@ impl ToolCommand {
                 } else {
                     // if not explicitly overridden, just default to the permissionless archive
                     // store
+                    let aws_endpoint = env::var("AWS_ARCHIVE_ENDPOINT").ok().or_else(|| {
+                        if network == Chain::Mainnet {
+                            Some("https://archive.mainnet.iota.cafe".to_string())
+                        } else if network == Chain::Testnet {
+                            Some("https://archive.testnet.iota.cafe".to_string())
+                        } else {
+                            None
+                        }
+                    });
+
+                    let aws_virtual_hosted_style_request = env::var(
+                        "AWS_ARCHIVE_VIRTUAL_HOSTED_REQUESTS",
+                    )
+                    .ok()
+                    .and_then(|b| b.parse().ok())
+                    .unwrap_or_else(|| {
+                        matches!(network, Chain::Mainnet | Chain::Testnet)
+                    });
+
                     ObjectStoreConfig {
                         object_store: Some(ObjectStoreType::S3),
                         bucket: archive_bucket.filter(|s| !s.is_empty()),
                         aws_region: Some("us-west-2".to_string()),
-                        aws_endpoint: env::var("AWS_ARCHIVE_ENDPOINT").ok(),
-                        aws_virtual_hosted_style_request: env::var(
-                            "AWS_ARCHIVE_VIRTUAL_HOSTED_REQUESTS",
-                        )
-                        .ok()
-                        .and_then(|b| b.parse().ok())
-                        .unwrap_or(false),
+                        aws_endpoint,
+                        aws_virtual_hosted_style_request,
                         object_store_connection_limit: 200,
                         no_sign_request: true,
                         ..Default::default()

--- a/crates/iota-tool/src/commands.rs
+++ b/crates/iota-tool/src/commands.rs
@@ -859,7 +859,7 @@ impl ToolCommand {
                         env::var("AWS_ARCHIVE_VIRTUAL_HOSTED_REQUESTS")
                             .ok()
                             .and_then(|b| b.parse().ok())
-                            .unwrap_or_else(|| matches!(network, Chain::Mainnet | Chain::Testnet));
+                            .unwrap_or(matches!(network, Chain::Mainnet | Chain::Testnet));
 
                     ObjectStoreConfig {
                         object_store: Some(ObjectStoreType::S3),


### PR DESCRIPTION
# Description of change

Added default variables: AWS_ARCHIVE_ENDPOINT and AWS_ARCHIVE_VIRTUAL_HOSTED_REQUESTS.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

```
# cargo run --bin iota-tool download-formal-snapshot --network testnet --latest --genesis ./testing_folder/genesis.blob --path ./testing_folder/db --num-parallel-downloads 10 --no-sign-request
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.90s
     Running `target/debug/iota-tool download-formal-snapshot --network testnet --latest --genesis ./testing_folder/genesis.blob --path ./testing_folder/db --num-parallel-downloads 10 --no-sign-request`
Beginning formal snapshot restore to end of epoch 62, network: Testnet, verification mode: Normal                                                           
[00:00:11] ████████████ 1 out of 1 .ref files done (ref files download complete)
[00:01:49] ████████████ 63/63 (Checkpoint summary sync is complete)
[00:00:05] ████████████ 1 out of 1 ref files checksummed (Checksumming complete)
[00:00:50] ████████████ 1 out of 1 ref files accumulated from snapshot (Accumulation complete)
[00:01:40] ████████████ 1 out of 1 .obj files done (Objects download complete)
[00:00:00] ████████████ 63/63 (Checkpoint summary verification is complete)
[00:00:00] ████████████ Verifying snapshot contents against root state hash (Verification complete)Successfully restored state from snapshot at end of epoch 62
```
