### PR TITLE
feat(iota-sdk): Use default request type

### DIFF
--- a/crates/iota-sdk/src/apis/quorum_driver.rs
+++ b/crates/iota-sdk/src/apis/quorum_driver.rs
@@ -58,7 +58,9 @@ impl QuorumDriverApi {
                 tx_bytes.clone(),
                 signatures.clone(),
                 Some(options.clone()),
-                Some(request_type.clone()),
+                // Ignore the request type as we emulate WaitForLocalExecution below.
+                // It will default to WaitForEffectsCert on the RPC nodes.
+                None,
             )
             .await?;
 


### PR DESCRIPTION
# Description of change

Use default request type on RPC nodes in SDK quorum driver API `execute_transaction_block`.

# Related

https://github.com/MystenLabs/sui/pull/19373

