### PR TITLE
Merge from upstream: fix(node): Hold reconfig lock while handling transaction

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -847,6 +847,9 @@ impl AuthorityState {
         transaction: VerifiedTransaction,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> IotaResult<VerifiedSignedTransaction> {
+        // Ensure that validator cannot reconfigure while we are signing the tx
+        let _execution_lock = self.execution_lock_for_signing().await;
+
         let tx_digest = transaction.digest();
         let tx_data = transaction.data().transaction_data();
 
@@ -929,16 +932,6 @@ impl AuthorityState {
             .authority_state_handle_transaction_latency
             .start_timer();
         self.metrics.tx_orders.inc();
-
-        // The should_accept_user_certs check here is best effort, because
-        // between a validator signs a tx and a cert is formed, the validator
-        // could close the window.
-        if !epoch_store
-            .get_reconfig_state_read_lock_guard()
-            .should_accept_user_certs()
-        {
-            return Err(IotaError::ValidatorHaltedAtEpochEnd);
-        }
 
         let signed = self.handle_transaction_impl(transaction, epoch_store).await;
         match signed {
@@ -2860,6 +2853,15 @@ impl AuthorityState {
                 actual_epoch: transaction.auth_sig().epoch(),
             })
         }
+    }
+
+    /// Acquires the execution lock for the duration of a transaction signing
+    /// request. This prevents reconfiguration from starting until we are
+    /// finished handling the signing request. Otherwise, in-memory lock
+    /// state could be cleared (by `ObjectLocks::clear_cached_locks`)
+    /// while we are attempting to acquire locks for the transaction.
+    pub async fn execution_lock_for_signing(&self) -> ExecutionLockReadGuard {
+        self.execution_lock.read().await
     }
 
     pub async fn execution_lock_for_reconfiguration(&self) -> ExecutionLockWriteGuard {


### PR DESCRIPTION
# Description of change

Merging upstream changes: https://github.com/MystenLabs/sui/commit/7c9b1d1f091e810e8cf22c913589a8f43c215604

**From upstream:** 
This fixes a crash where we clear all pending locks at reconfig

(https://github.com/MystenLabs/sui/blob/dec33d0a303a7f83e778fcc5a136ab9776162e68/crates/sui-core/src/execution_cache/object_locks.rs#L121)
while trying to acquire locks for a transaction.

Without this fix, the node can reconfigure while we are trying to
acquire locks for a transaction. If `clear_locks()` linked above is
called while we are trying to call `clear_cached_locks` at
https://github.com/MystenLabs/sui/blob/74d6d564970406e1b3191a07cf207af1ab6b3356/crates/sui-core/src/execution_cache/object_locks.rs#L245,
we hit the panic at
https://github.com/MystenLabs/sui/blob/74d6d564970406e1b3191a07cf207af1ab6b3356/crates/sui-core/src/execution_cache/object_locks.rs#L160

## Links to any relevant issues

Fixes: https://github.com/iotaledger/iota/issues/4684

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

cargo run --release --bin iota start --force-regenesis --with-faucet

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

