### PR TITLE
fix(apps-ui-kit): improve `prepublishOnly` script by adding turbo

### DIFF
--- a/apps/ui-kit/package.json
+++ b/apps/ui-kit/package.json
@@ -13,7 +13,7 @@
         "dist"
     ],
     "scripts": {
-        "prepublishOnly": "pnpm run build",
+        "prepublishOnly": "pnpm turbo run build",
         "prettier:check": "prettier -c --ignore-unknown --ignore-path=../../.prettierignore --ignore-path=.prettierignore .",
         "prettier:fix": "prettier -w --ignore-unknown --ignore-path=../../.prettierignore --ignore-path=.prettierignore .",
         "eslint:check": "eslint --max-warnings=0 .",


### PR DESCRIPTION
# Description of change

Use `turbo` to build correctly dependencies before publish.

## Links to any relevant issues

Fixes #4933 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)


## How the change has been tested

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
