### PR TITLE
fix(core): Wait for all previous commits to be sent to consensus handler at startup

### DIFF
--- a/consensus/core/src/commit_consumer.rs
+++ b/consensus/core/src/commit_consumer.rs
@@ -2,9 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::{Arc, atomic::AtomicU32};
+use std::sync::{Arc, RwLock};
 
 use iota_metrics::monitored_mpsc::UnboundedSender;
+use tokio::sync::watch;
 
 use crate::{CommitIndex, CommittedSubDag};
 
@@ -39,24 +40,65 @@ impl CommitConsumer {
 }
 
 pub struct CommitConsumerMonitor {
-    highest_handled_commit: AtomicU32,
+    // highest commit that has been handled by IOTA
+    highest_handled_commit: watch::Sender<u32>,
+
+    // the highest commit found in local storage at startup
+    highest_observed_commit_at_startup: RwLock<u32>,
 }
 
 impl CommitConsumerMonitor {
     pub(crate) fn new(last_handled_commit: CommitIndex) -> Self {
         Self {
-            highest_handled_commit: AtomicU32::new(last_handled_commit),
+            highest_handled_commit: watch::Sender::new(last_handled_commit),
+            highest_observed_commit_at_startup: RwLock::new(0),
         }
     }
 
     pub(crate) fn highest_handled_commit(&self) -> CommitIndex {
-        self.highest_handled_commit
-            .load(std::sync::atomic::Ordering::Acquire)
+        *self.highest_handled_commit.borrow()
     }
 
     pub fn set_highest_handled_commit(&self, highest_handled_commit: CommitIndex) {
         self.highest_handled_commit
-            .store(highest_handled_commit, std::sync::atomic::Ordering::Release);
+            .send_replace(highest_handled_commit);
+    }
+
+    pub fn highest_observed_commit_at_startup(&self) -> CommitIndex {
+        *self.highest_observed_commit_at_startup.read().unwrap()
+    }
+
+    pub fn set_highest_observed_commit_at_startup(
+        &self,
+        highest_observed_commit_at_startup: CommitIndex,
+    ) {
+        let highest_handled_commit = self.highest_handled_commit();
+        assert!(
+            highest_observed_commit_at_startup >= highest_handled_commit,
+            "we cannot have handled a commit that we do not know about: {} < {}",
+            highest_observed_commit_at_startup,
+            highest_handled_commit,
+        );
+
+        let mut commit = self.highest_observed_commit_at_startup.write().unwrap();
+
+        assert!(
+            *commit == 0,
+            "highest_known_commit_at_startup can only be set once"
+        );
+        *commit = highest_observed_commit_at_startup;
+    }
+
+    pub(crate) async fn replay_complete(&self) {
+        let highest_observed_commit_at_startup = self.highest_observed_commit_at_startup();
+        let mut rx = self.highest_handled_commit.subscribe();
+        loop {
+            let highest_handled = *rx.borrow_and_update();
+            if highest_handled >= highest_observed_commit_at_startup {
+                return;
+            }
+            rx.changed().await.unwrap();
+        }
     }
 }
 

--- a/crates/iota-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/iota-core/src/consensus_manager/mysticeti_manager.rs
@@ -183,8 +183,8 @@ impl ConsensusManagerTrait for MysticetiManager {
 
         let registry_id = self.registry_service.add(registry.clone());
 
-        self.authority
-            .swap(Some(Arc::new((authority, registry_id))));
+        let registered_authority = Arc::new((authority, registry_id));
+        self.authority.swap(Some(registered_authority.clone()));
 
         // Initialize the client to send transactions to this Mysticeti instance.
         self.client.set(client);
@@ -193,6 +193,9 @@ impl ConsensusManagerTrait for MysticetiManager {
         let handler = MysticetiConsensusHandler::new(consensus_handler, commit_receiver, monitor);
         let mut consensus_handler = self.consensus_handler.lock().await;
         *consensus_handler = Some(handler);
+
+        // Wait until all locally available commits have been processed
+        registered_authority.0.replay_complete().await;
     }
 
     async fn shutdown(&self) {


### PR DESCRIPTION
# Description of change

Merge bug fix from upstream: https://github.com/MystenLabs/sui/commit/494f2520a063a6b725a9e393c0dc45b37072b55f

This is necessary for proper crash recovery with data quarantining, as we will need to wait until all previously-built checkpoints have been rebuilt before starting CheckpointExecutor.

## Links to any relevant issues

Close #4685 

## Type of change

- Bug fix 

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked that new and existing unit tests pass locally with my changes
