### PR TITLE
feat: Add docker configuration for checkpoints remote store

### DIFF
--- a/docker/iota-data-ingestion/Dockerfile
+++ b/docker/iota-data-ingestion/Dockerfile
@@ -1,0 +1,60 @@
+# Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
+ARG RUST_IMAGE_VERSION=bookworm
+FROM rust:${RUST_IMAGE_VERSION} AS builder
+
+ARG PROFILE=release
+ARG CARGO_BUILD_FEATURES
+# The GIT_REVISION environment variable is used during build time inside the rust crates
+ARG GIT_REVISION
+ENV GIT_REVISION=$GIT_REVISION
+
+WORKDIR "/iota"
+
+# Install build dependencies, including clang and lld for faster linking
+RUN apt update && apt install -y cmake clang lld
+
+# Configure Rust to use clang and lld as the linker
+RUN mkdir -p ~/.cargo && \
+    echo -e "[target.x86_64-unknown-linux-gnu]\nlinker = \"clang\"\nrustflags = [\"-C\", \"link-arg=-fuse-ld=lld\"]" > ~/.cargo/config.toml
+
+# Install additional dependencies
+RUN apt install -y ca-certificates
+
+# Copy in all crates, Cargo.toml, and Cargo.lock
+COPY consensus consensus
+COPY crates crates
+COPY docs docs
+COPY examples examples
+COPY external-crates external-crates
+COPY iota-execution iota-execution
+COPY Cargo.toml Cargo.lock ./
+
+RUN cargo build --profile ${PROFILE} --bin iota-data-ingestion --features ${CARGO_BUILD_FEATURES:=default}
+
+# Copy the built binary to the working directory depending on the output folder of the profile,
+# so we can copy it to the runtime image
+RUN if [ -d target/release ]; then \
+    TARGET_DIR="target/release"; \
+    elif [ -d target/debug ]; then \
+    TARGET_DIR="target/debug"; \
+    else \
+    echo "Error: No build directory found"; \
+    exit 1; \
+    fi && \
+    mv $TARGET_DIR/iota-data-ingestion ./;
+
+# Production image
+FROM debian:bookworm-slim AS runtime
+
+ARG WORKDIR="/iota"
+WORKDIR "$WORKDIR"
+
+# Install runtime dependencies and tools
+RUN apt update && apt install -y ca-certificates curl
+
+COPY --from=builder /iota/iota-data-ingestion /usr/local/bin
+
+ARG BUILD_DATE
+ARG GIT_REVISION
+LABEL build-date=$BUILD_DATE
+LABEL git-revision=$GIT_REVISION

--- a/docker/iota-data-ingestion/Dockerfile
+++ b/docker/iota-data-ingestion/Dockerfile
@@ -46,9 +46,6 @@ RUN if [ -d target/release ]; then \
 # Production image
 FROM debian:bookworm-slim AS runtime
 
-ARG WORKDIR="/iota"
-WORKDIR "$WORKDIR"
-
 # Install runtime dependencies and tools
 RUN apt update && apt install -y ca-certificates curl
 

--- a/docker/iota-data-ingestion/README.md
+++ b/docker/iota-data-ingestion/README.md
@@ -1,0 +1,97 @@
+# Checkpoint Remote Store
+
+This Docker image enables storing checkpoint blobs to a remote storage service (e.g., AWS S3). The service requires AWS credentials for proper execution.
+
+## Configuration
+
+### Environment Variables
+
+The Docker Compose service accepts an `.env` file containing the following AWS credentials:
+
+```text
+AWS_ACCESS_KEY_ID=test
+AWS_SECRET_ACCESS_KEY=test
+AWS_DEFAULT_REGION=us-east-1
+AWS_ENDPOINT_URL=http://localstack:4566  # Optional: Used for local testing with localstack
+```
+
+### Configuration File
+
+A default configuration file is provided at `config/config.yaml`, primarily configured for local testing with [localstack](https://github.com/localstack/localstack). This configuration can be customized based on your needs and is mounted into the container via Docker Compose.
+
+## Prerequisites
+
+Before starting the service, you need to set up the required AWS components. The following examples use localstack, but can be adapted for production AWS environments.
+
+### 1. Create S3 Bucket
+
+```bash
+aws --profile localstack s3 mb s3://checkpoints
+```
+
+### 2. Set up DynamoDB
+
+Create the DynamoDB table:
+
+```bash
+aws --profile localstack dynamodb create-table \
+    --table-name checkpoint-progress \
+    --attribute-definitions AttributeName=task_name,AttributeType=S \
+    --key-schema AttributeName=task_name,KeyType=HASH \
+    --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5
+```
+
+Initialize the required record:
+
+```bash
+aws --profile localstack dynamodb put-item \
+    --table-name checkpoint-progress \
+    --item '{
+        "task_name": {"S": "local-blob-storage"},
+        "nstate": {"N": "0"}
+    }'
+```
+
+### 3. Verify Resources
+
+Verify that the resources were created correctly:
+
+```bash
+aws --profile localstack s3 ls
+aws --profile localstack dynamodb list-tables
+```
+
+## Usage
+
+### Build the Docker Image
+
+Build a fresh Docker image without using cached layers:
+
+```bash
+docker compose build --no-cache
+```
+
+### Start the Service
+
+Run the container in detached mode:
+
+```bash
+docker compose up -d
+```
+
+### Stop the Service
+
+Stop and remove the container and associated resources:
+
+```bash
+docker compose down
+```
+
+## Troubleshooting
+
+- Ensure all AWS credentials are properly set in the `.env` file
+- Verify that the S3 bucket and DynamoDB table exist before starting the service
+- Check container logs if the service fails to start:
+  ```bash
+  docker compose logs
+  ```

--- a/docker/iota-data-ingestion/README.md
+++ b/docker/iota-data-ingestion/README.md
@@ -17,11 +17,75 @@ AWS_ENDPOINT_URL=http://localstack:4566  # Optional: Used for local testing with
 
 ### Configuration File
 
-A default configuration file is provided at `config/config.yaml`, primarily configured for local testing with [localstack](https://github.com/localstack/localstack). This configuration can be customized based on your needs and is mounted into the container via Docker Compose.
+A default configuration file is provided at `config/config.yaml`. This configuration can be customized based on your needs and is mounted into the container via Docker Compose.
 
-## Prerequisites
+```yaml
+# IndexerExecutor config
+#
+path: "./test-checkpoints"
+# IOTA Node Rest API URL
+remote_store_url: "http://localhost:9000/api/v1"
 
-Before starting the service, you need to set up the required AWS components. The following examples use localstack, but can be adapted for production AWS environments.
+# DynamoDbProgressStore config
+#
+progress_store:
+  aws_access_key_id: "test"
+  aws_secret_access_key: "test"
+  aws_region: "us-east-1"
+  # DynamoDB table name
+  table_name: "checkpoint-progress"
+
+# Wrokers Configs
+#
+tasks:
+  # Task unique name
+  - name: "local-blob-storage"
+    # Number of workers will process the checkpoints in parallel
+    concurrency: 1
+    # Task type
+    blob:
+      # S3 bucket where checkpoints will be stored
+      url: "s3://checkpoints"
+      # AWS S3 client config options
+      remote_store_options:
+        - ["access_key_id", "test"]
+        - ["secret_access_key", "test"]
+        - ["region", "us-east-1"]
+        # Only needed if using Localstack for local development purposes, it's preferred to be removed
+        - ["endpoint_url", "http://localhost:4566"]
+```
+
+## Usage
+
+### Build the Docker Image
+
+Build a fresh Docker image without using cached layers:
+
+```bash
+docker compose build --no-cache
+```
+
+### Start the Service
+
+Run the container in detached mode:
+
+```bash
+docker compose up -d
+```
+
+### Stop the Service
+
+Stop and remove the container and associated resources:
+
+```bash
+docker compose down
+```
+
+## Local development
+
+### Prerequisites
+
+Before starting the service, you need to set up the required AWS components. The following examples use [localstack](https://github.com/localstack/localstack), but can be adapted for production AWS environments.
 
 ### 1. Create S3 Bucket
 
@@ -59,32 +123,6 @@ Verify that the resources were created correctly:
 ```bash
 aws --profile localstack s3 ls
 aws --profile localstack dynamodb list-tables
-```
-
-## Usage
-
-### Build the Docker Image
-
-Build a fresh Docker image without using cached layers:
-
-```bash
-docker compose build --no-cache
-```
-
-### Start the Service
-
-Run the container in detached mode:
-
-```bash
-docker compose up -d
-```
-
-### Stop the Service
-
-Stop and remove the container and associated resources:
-
-```bash
-docker compose down
 ```
 
 ## Troubleshooting

--- a/docker/iota-data-ingestion/build.sh
+++ b/docker/iota-data-ingestion/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Copyright (c) 2024 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+./../utils/build-script.sh --container-name "iotaledger/checkpoints-remote-store"

--- a/docker/iota-data-ingestion/build.sh
+++ b/docker/iota-data-ingestion/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
-./../utils/build-script.sh --container-name "iotaledger/checkpoints-remote-store"
+./../utils/build-script.sh --container-name "iotaledger/iota-data-ingestion"

--- a/docker/iota-data-ingestion/config/config.yaml
+++ b/docker/iota-data-ingestion/config/config.yaml
@@ -1,0 +1,33 @@
+# IndexerExecutor config
+#
+path: "./test-checkpoints"
+# IOTA Node Rest API URL
+remote_store_url: "http://localhost:9000/api/v1"
+
+# DynamoDbProgressStore config
+#
+progress_store:
+  aws_access_key_id: "test"
+  aws_secret_access_key: "test"
+  aws_region: "us-east-1"
+  # DynamoDB table name
+  table_name: "checkpoint-progress"
+
+# Wrokers Configs
+#
+tasks:
+  # Task unique name
+  - name: "local-blob-storage"
+    # Number of workers will process the checkpoints in parallel
+    concurrency: 1
+    # Task type
+    blob:
+      # S3 bucket where checkpoints will be stored
+      url: "s3://checkpoints"
+      # AWS S3 client config options
+      remote_store_options:
+        - ["access_key_id", "test"]
+        - ["secret_access_key", "test"]
+        - ["region", "us-east-1"]
+        # Only needed if using Localstack for local development purposes, it's preferred to be removed
+        - ["endpoint_url", "http://localhost:4566"]

--- a/docker/iota-data-ingestion/docker-compose.yaml
+++ b/docker/iota-data-ingestion/docker-compose.yaml
@@ -1,0 +1,19 @@
+services:
+  checkpoints-remote-store:
+    build:
+      context: ../../
+      dockerfile: docker/iota-data-ingestion/Dockerfile
+      args:
+        - GIT_REVISION
+        - BUILD_DATE
+        - PROFILE=release
+    image: checkpoints-remote-store:latest
+    env_file:
+      - .env
+    networks:
+      iota-network:
+    volumes:
+      - ./config/config.yaml:/iota/config.yaml:r
+    command: >
+      iota-data-ingestion
+      config.yaml

--- a/docker/iota-data-ingestion/docker-compose.yaml
+++ b/docker/iota-data-ingestion/docker-compose.yaml
@@ -14,4 +14,4 @@ services:
       - ./config/config.yaml:/iota/config.yaml:r
     command: >
       iota-data-ingestion
-      config.yaml
+      /iota/config.yaml

--- a/docker/iota-data-ingestion/docker-compose.yaml
+++ b/docker/iota-data-ingestion/docker-compose.yaml
@@ -10,8 +10,6 @@ services:
     image: checkpoints-remote-store:latest
     env_file:
       - .env
-    networks:
-      iota-network:
     volumes:
       - ./config/config.yaml:/iota/config.yaml:r
     command: >


### PR DESCRIPTION
# Description of change

Provide a Docker configuration for setting up a Checkpoint remote store service. The provided use case uses [localstack](https://github.com/localstack/localstack), but it can be adapted to any production AWS environment.

## Links to any relevant issues

fixes #4907 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

- The changes have been tested by creating a unified docker network using 
```bash
docker network create iota-network
```
This network definition was added to the pg-services-local, remote checkpints store and localstack docker compose files

```yaml
networks:
  iota-network:
    external: true
    name: iota-network
```
This ensures that 3 different services can communicate wit each other other.

- Created S3 bucket and DynamoDB table as explained in the README.md

- used docker compose to run the services and made sure that checkpoints were saved to the S3 bucket

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation

