### PR TITLE
chore(*): Remove `test-utils` feature from `iota-types`

### DIFF
--- a/crates/iota-archival/Cargo.toml
+++ b/crates/iota-archival/Cargo.toml
@@ -26,7 +26,7 @@ tracing.workspace = true
 # internal dependencies
 iota-config.workspace = true
 iota-storage.workspace = true
-iota-types = { workspace = true, features = ["test-utils"] }
+iota-types.workspace = true
 
 [dev-dependencies]
 # external dependencies

--- a/crates/iota-bridge-indexer/Cargo.toml
+++ b/crates/iota-bridge-indexer/Cargo.toml
@@ -36,7 +36,6 @@ telemetry-subscribers.workspace = true
 
 [dev-dependencies]
 iota-test-transaction-builder.workspace = true
-iota-types = { workspace = true, features = ["test-utils"] }
 
 [[bin]]
 name = "bridge-indexer"

--- a/crates/iota-bridge/Cargo.toml
+++ b/crates/iota-bridge/Cargo.toml
@@ -57,8 +57,4 @@ hex-literal = "0.3.4"
 maplit = "1.0.2"
 
 # internal dependencies
-iota-config.workspace = true
-iota-json-rpc-types = { workspace = true, features = ["test-utils"] }
-iota-test-transaction-builder.workspace = true
-iota-types = { workspace = true, features = ["test-utils"] }
 test-cluster.workspace = true

--- a/crates/iota-config/Cargo.toml
+++ b/crates/iota-config/Cargo.toml
@@ -34,6 +34,3 @@ iota-genesis-common.workspace = true
 iota-keys.workspace = true
 iota-protocol-config.workspace = true
 iota-types.workspace = true
-
-[dev-dependencies]
-iota-types = { workspace = true, features = ["test-utils"] }

--- a/crates/iota-core/Cargo.toml
+++ b/crates/iota-core/Cargo.toml
@@ -110,8 +110,6 @@ tower.workspace = true
 # internal dependencies
 iota-move.workspace = true
 iota-test-transaction-builder.workspace = true
-iota-types = { workspace = true, features = ["test-utils"] }
-move-symbol-pool.workspace = true
 
 [target.'cfg(not(target_env = "msvc"))'.dev-dependencies]
 # external dependencies

--- a/crates/iota-data-ingestion-core/Cargo.toml
+++ b/crates/iota-data-ingestion-core/Cargo.toml
@@ -35,6 +35,3 @@ iota-types.workspace = true
 [dev-dependencies]
 # external dependencies
 rand.workspace = true
-
-# internal dependencies
-iota-types = { workspace = true, features = ["test-utils"] }

--- a/crates/iota-data-ingestion-core/Cargo.toml
+++ b/crates/iota-data-ingestion-core/Cargo.toml
@@ -33,5 +33,4 @@ iota-storage.workspace = true
 iota-types.workspace = true
 
 [dev-dependencies]
-# external dependencies
 rand.workspace = true

--- a/crates/iota-data-ingestion/Cargo.toml
+++ b/crates/iota-data-ingestion/Cargo.toml
@@ -42,6 +42,3 @@ telemetry-subscribers.workspace = true
 # external dependencies
 rand.workspace = true
 tempfile.workspace = true
-
-# internal dependencies
-iota-types = { workspace = true, features = ["test-utils"] }

--- a/crates/iota-data-ingestion/Cargo.toml
+++ b/crates/iota-data-ingestion/Cargo.toml
@@ -39,6 +39,5 @@ iota-types.workspace = true
 telemetry-subscribers.workspace = true
 
 [dev-dependencies]
-# external dependencies
 rand.workspace = true
 tempfile.workspace = true

--- a/crates/iota-genesis-builder/Cargo.toml
+++ b/crates/iota-genesis-builder/Cargo.toml
@@ -69,7 +69,6 @@ tokio = { workspace = true, features = ["macros"] }
 
 # internal dependencies
 iota-swarm-config.workspace = true
-iota-types = { workspace = true, features = ["test-utils"] }
 
 [features]
 test-outputs = ["iota-sdk/client"]

--- a/crates/iota-json-rpc-types/Cargo.toml
+++ b/crates/iota-json-rpc-types/Cargo.toml
@@ -33,9 +33,3 @@ iota-types.workspace = true
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true
 move-core-types.workspace = true
-
-[dev-dependencies]
-iota-types = { workspace = true, features = ["test-utils"] }
-
-[features]
-test-utils = ["iota-types/test-utils"]

--- a/crates/iota-json-rpc-types/src/iota_event.rs
+++ b/crates/iota-json-rpc-types/src/iota_event.rs
@@ -2,9 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(any(feature = "test-utils", test))]
-use std::str::FromStr;
-use std::{fmt, fmt::Display};
+use std::{fmt, fmt::Display, str::FromStr};
 
 use fastcrypto::encoding::{Base58, Base64};
 use iota_metrics::monitored_scope;
@@ -161,7 +159,6 @@ impl Display for IotaEvent {
     }
 }
 
-#[cfg(any(feature = "test-utils", test))]
 impl IotaEvent {
     pub fn random_for_testing() -> Self {
         Self {

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -871,7 +871,6 @@ impl IotaTransactionBlockEffectsAPI for IotaTransactionBlockEffectsV1 {
 }
 
 impl IotaTransactionBlockEffects {
-    #[cfg(any(feature = "test-utils", test))]
     pub fn new_for_testing(
         transaction_digest: TransactionDigest,
         status: IotaExecutionStatus,

--- a/crates/iota-json-rpc/Cargo.toml
+++ b/crates/iota-json-rpc/Cargo.toml
@@ -62,5 +62,4 @@ expect-test.workspace = true
 mockall.workspace = true
 
 # internal dependencies
-iota-types = { workspace = true, features = ["test-utils"] }
 telemetry-subscribers.workspace = true

--- a/crates/iota-json/Cargo.toml
+++ b/crates/iota-json/Cargo.toml
@@ -28,4 +28,3 @@ test-fuzz.workspace = true
 # internal dependencies
 iota-framework.workspace = true
 iota-move-build.workspace = true
-iota-types = { workspace = true, features = ["test-utils"] }

--- a/crates/iota-open-rpc/Cargo.toml
+++ b/crates/iota-open-rpc/Cargo.toml
@@ -31,7 +31,7 @@ iota-json-rpc.workspace = true
 iota-json-rpc-api.workspace = true
 iota-json-rpc-types.workspace = true
 iota-protocol-config.workspace = true
-iota-types = { workspace = true, features = ["test-utils"] }
+iota-types.workspace = true
 move-core-types.workspace = true
 
 [[example]]

--- a/crates/iota-proxy/Cargo.toml
+++ b/crates/iota-proxy/Cargo.toml
@@ -48,7 +48,6 @@ iota-types.workspace = true
 telemetry-subscribers.workspace = true
 
 [dev-dependencies]
-# external dependencies
 axum-server.workspace = true
 mime = "0.3"
 serde_json.workspace = true

--- a/crates/iota-proxy/Cargo.toml
+++ b/crates/iota-proxy/Cargo.toml
@@ -54,8 +54,5 @@ mime = "0.3"
 serde_json.workspace = true
 tower.workspace = true
 
-# internal dependencies
-iota-types = { workspace = true, features = ["test-utils"] }
-
 [build-dependencies]
 prost-build = "0.13.1"

--- a/crates/iota-rpc-loadgen/Cargo.toml
+++ b/crates/iota-rpc-loadgen/Cargo.toml
@@ -26,7 +26,7 @@ tracing.workspace = true
 iota-json-rpc-types.workspace = true
 iota-keys.workspace = true
 iota-sdk.workspace = true
-iota-types = { workspace = true, features = ["test-utils"] }
+iota-types.workspace = true
 shared-crypto.workspace = true
 telemetry-subscribers.workspace = true
 

--- a/crates/iota-single-node-benchmark/Cargo.toml
+++ b/crates/iota-single-node-benchmark/Cargo.toml
@@ -17,7 +17,7 @@ prometheus.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 strum.workspace = true
-tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
+tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 
 # internal dependencies
@@ -27,7 +27,7 @@ iota-move-build.workspace = true
 iota-storage.workspace = true
 iota-test-transaction-builder.workspace = true
 iota-transaction-checks.workspace = true
-iota-types = { workspace = true, features = ["test-utils"] }
+iota-types.workspace = true
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true
 move-core-types.workspace = true

--- a/crates/iota-storage/Cargo.toml
+++ b/crates/iota-storage/Cargo.toml
@@ -65,7 +65,6 @@ tempfile.workspace = true
 # internal dependencies
 iota-macros.workspace = true
 iota-test-transaction-builder.workspace = true
-iota-types = { workspace = true, features = ["test-utils"] }
 
 [target.'cfg(msim)'.dependencies]
 # external dependencies

--- a/crates/iota-transactional-test-runner/Cargo.toml
+++ b/crates/iota-transactional-test-runner/Cargo.toml
@@ -42,7 +42,7 @@ iota-protocol-config.workspace = true
 iota-rest-api.workspace = true
 iota-storage.workspace = true
 iota-swarm-config.workspace = true
-iota-types = { workspace = true, features = ["test-utils"] }
+iota-types.workspace = true
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true
 move-command-line-common.workspace = true

--- a/crates/iota-types/Cargo.toml
+++ b/crates/iota-types/Cargo.toml
@@ -103,7 +103,6 @@ harness = false
 
 [features]
 default = []
-test-utils = []
 gas-profiler = [
   "move-vm-profiler/gas-profiler",
   "move-vm-test-utils/gas-profiler",

--- a/crates/iota-types/src/base_types.rs
+++ b/crates/iota-types/src/base_types.rs
@@ -69,7 +69,6 @@ pub use crate::{
 };
 
 #[cfg(test)]
-#[cfg(feature = "test-utils")]
 #[path = "unit_tests/base_types_tests.rs"]
 mod base_types_tests;
 
@@ -150,7 +149,6 @@ pub fn random_object_ref() -> ObjectRef {
     )
 }
 
-#[cfg(any(feature = "test-utils", test))]
 pub fn update_object_ref_for_testing(object_ref: ObjectRef) -> ObjectRef {
     (
         object_ref.0,
@@ -624,7 +622,6 @@ impl IotaAddress {
         self.0.to_vec()
     }
 
-    #[cfg(any(feature = "test-utils", test))]
     /// Return a random IotaAddress.
     pub fn random_for_testing_only() -> Self {
         AccountAddress::random().into()
@@ -822,7 +819,6 @@ impl fmt::Debug for IotaAddress {
     }
 }
 
-#[cfg(any(test, feature = "test-utils"))]
 /// Generate a fake IotaAddress with repeated one byte.
 pub fn dbg_addr(name: u8) -> IotaAddress {
     let addr = [name; IOTA_ADDRESS_LENGTH];
@@ -1054,7 +1050,6 @@ impl TxContext {
         Ok(())
     }
 
-    #[cfg(feature = "test-utils")]
     // Generate a random TxContext for testing.
     pub fn random_for_testing_only() -> Self {
         Self::new(
@@ -1064,7 +1059,6 @@ impl TxContext {
         )
     }
 
-    #[cfg(feature = "test-utils")]
     /// Generate a TxContext for testing with a specific sender.
     pub fn with_sender_for_testing_only(sender: &IotaAddress) -> Self {
         Self::new(sender, &TransactionDigest::random(), &EpochData::new_test())
@@ -1388,7 +1382,6 @@ impl std::ops::Deref for ObjectID {
     }
 }
 
-#[cfg(feature = "test-utils")]
 /// Generate a fake ObjectID with repeated one byte.
 pub fn dbg_object_id(name: u8) -> ObjectID {
     ObjectID::new([name; ObjectID::LENGTH])

--- a/crates/iota-types/src/crypto.rs
+++ b/crates/iota-types/src/crypto.rs
@@ -64,7 +64,6 @@ use crate::{
 mod crypto_tests;
 
 #[cfg(test)]
-#[cfg(feature = "test-utils")]
 #[path = "unit_tests/intent_tests.rs"]
 mod intent_tests;
 

--- a/crates/iota-types/src/gas_coin.rs
+++ b/crates/iota-types/src/gas_coin.rs
@@ -122,12 +122,10 @@ mod checked {
             Coin::layout(TypeTag::Struct(Box::new(GAS::type_())))
         }
 
-        #[cfg(any(feature = "test-utils", test))]
         pub fn new_for_testing(value: u64) -> Self {
             Self::new(ObjectID::random(), value)
         }
 
-        #[cfg(any(feature = "test-utils", test))]
         pub fn new_for_testing_with_id(id: ObjectID, value: u64) -> Self {
             Self::new(id, value)
         }

--- a/crates/iota-types/src/lib.rs
+++ b/crates/iota-types/src/lib.rs
@@ -95,7 +95,6 @@ pub mod versioned;
 pub mod zk_login_authenticator;
 pub mod zk_login_util;
 
-#[cfg(any(test, feature = "test-utils"))]
 #[path = "./unit_tests/utils.rs"]
 pub mod utils;
 

--- a/crates/iota-types/src/messages_checkpoint.rs
+++ b/crates/iota-types/src/messages_checkpoint.rs
@@ -456,7 +456,6 @@ impl CheckpointContents {
         })
     }
 
-    #[cfg(any(test, feature = "test-utils"))]
     pub fn new_with_digests_only_for_tests(
         contents: impl IntoIterator<Item = ExecutionDigests>,
     ) -> Self {
@@ -769,7 +768,6 @@ pub struct CheckpointVersionSpecificDataV1 {
 }
 
 #[cfg(test)]
-#[cfg(feature = "test-utils")]
 mod tests {
     use fastcrypto::traits::KeyPair;
     use rand::{SeedableRng, prelude::StdRng};

--- a/crates/iota-types/src/stardust/coin_kind.rs
+++ b/crates/iota-types/src/stardust/coin_kind.rs
@@ -48,9 +48,7 @@ pub fn get_gas_balance_maybe(object: &Object) -> Option<Balance> {
 }
 
 #[cfg(test)]
-#[cfg(feature = "test-utils")]
 mod tests {
-
     use iota_protocol_config::ProtocolConfig;
 
     use crate::{

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -75,7 +75,6 @@ pub const DEFAULT_VALIDATOR_GAS_PRICE: u64 = 1000;
 const BLOCKED_MOVE_FUNCTIONS: [(ObjectID, &str, &str); 0] = [];
 
 #[cfg(test)]
-#[cfg(feature = "test-utils")]
 #[path = "unit_tests/messages_tests.rs"]
 mod messages_tests;
 

--- a/crates/iota-types/src/zk_login_authenticator.rs
+++ b/crates/iota-types/src/zk_login_authenticator.rs
@@ -95,15 +95,12 @@ impl ZkLoginAuthenticator {
         self.max_epoch
     }
 
-    #[cfg(feature = "test-utils")]
     pub fn user_signature_mut_for_testing(&mut self) -> &mut Signature {
         &mut self.user_signature
     }
-    #[cfg(feature = "test-utils")]
     pub fn max_epoch_mut_for_testing(&mut self) -> &mut EpochId {
         &mut self.max_epoch
     }
-    #[cfg(feature = "test-utils")]
     pub fn zk_login_inputs_mut_for_testing(&mut self) -> &mut ZkLoginInputs {
         &mut self.inputs
     }

--- a/crates/simulacrum/Cargo.toml
+++ b/crates/simulacrum/Cargo.toml
@@ -34,6 +34,3 @@ move-binary-format.workspace = true
 move-bytecode-utils.workspace = true
 move-core-types.workspace = true
 shared-crypto.workspace = true
-
-[dev-dependencies]
-iota-types = { workspace = true, features = ["test-utils"] }

--- a/crates/test-cluster/Cargo.toml
+++ b/crates/test-cluster/Cargo.toml
@@ -18,7 +18,7 @@ futures.workspace = true
 jsonrpsee.workspace = true
 prometheus.workspace = true
 rand.workspace = true
-tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
+tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 
 # internal dependencies
@@ -37,7 +37,7 @@ iota-sdk.workspace = true
 iota-swarm.workspace = true
 iota-swarm-config.workspace = true
 iota-test-transaction-builder.workspace = true
-iota-types = { workspace = true, features = ["test-utils"] }
+iota-types.workspace = true
 move-binary-format.workspace = true
 
 [target.'cfg(msim)'.dependencies]

--- a/crates/transaction-fuzzer/Cargo.toml
+++ b/crates/transaction-fuzzer/Cargo.toml
@@ -25,6 +25,3 @@ iota-move-build.workspace = true
 iota-protocol-config.workspace = true
 iota-types = { workspace = true, features = ["fuzzing"] }
 move-core-types.workspace = true
-
-[dev-dependencies]
-iota-types = { workspace = true, features = ["test-utils"] }


### PR DESCRIPTION
## Description 

Removes the `test-utils` feature from `iota-types`.

Implements upstream changes from https://github.com/MystenLabs/sui/commit/36156977ce1660248b502a02b4ab8197716152c8

## Related Issues

Closes #4917