### PR TITLE
fix(iota-keys): check alias uniqueness in alias update

### DIFF
--- a/crates/iota-keys/src/keystore.rs
+++ b/crates/iota-keys/src/keystore.rs
@@ -92,16 +92,9 @@ pub trait AccountKeystore: Send + Sync {
         if !self.alias_exists(old_alias) {
             bail!("The provided alias {old_alias} does not exist");
         }
-        let new_alias_name = match new_alias {
-            Some(x) => validate_alias(x)?,
-            None => random_name(
-                &self
-                    .alias_names()
-                    .into_iter()
-                    .map(|x| x.to_string())
-                    .collect::<HashSet<_>>(),
-            ),
-        };
+
+        let new_alias_name = self.create_alias(new_alias.map(str::to_string))?;
+
         for a in self.aliases_mut() {
             if a.alias == old_alias {
                 let pk = &a.public_key_base64;

--- a/crates/iota-keys/tests/tests.rs
+++ b/crates/iota-keys/tests/tests.rs
@@ -163,6 +163,21 @@ fn update_alias_test() {
     let update = keystore.update_alias("o", None).unwrap();
     let aliases = keystore.alias_names();
     assert_eq!(vec![&update], aliases);
+
+    // check that updating alias does not allow duplicates
+    keystore
+        .generate_and_add_new_key(
+            SignatureScheme::ED25519,
+            Some("my_alias_test".to_string()),
+            None,
+            None,
+        )
+        .unwrap();
+    assert!(
+        keystore
+            .update_alias("my_alias_test", Some(&update))
+            .is_err()
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes https://github.com/iotaledger/iota/issues/4880

It is not supposed to be possible to create different addresses with the same alias, as shown here when using the `client new-address` CLI.
```
thibault@Mac ~/i/iota (develop)> ./target/debug/iota client new-address --alias tibo
Keys saved as Bech32.
╭───────────────────────────────────────────────────────────────────────────────────────────────╮
│ Created new keypair and saved it to keystore.                                                 │
├────────────────┬──────────────────────────────────────────────────────────────────────────────┤
│ alias          │ tibo                                                                         │
│ address        │ 0x77d2fc4949895e3f6c1b3e1cdcde1f873c9ad4436a5962029fc157ee215dfcc3           │
│ keyScheme      │ ed25519                                                                      │
│ recoveryPhrase │ off toss pass pepper nominee pelican clutch taste child tree tomorrow tenant │
╰────────────────┴──────────────────────────────────────────────────────────────────────────────╯

thibault@Mac ~/i/iota (develop)> ./target/debug/iota client new-address --alias tibo
Alias tibo already exists. Please choose another alias.
```

However, it is possible to update an alias in such a way to create duplicates.

# Before

```
thibault@Mac ~/i/iota (develop) [1]> ./target/debug/iota client new-address
Keys saved as Bech32.
╭─────────────────────────────────────────────────────────────────────────────────────────────╮
│ Created new keypair and saved it to keystore.                                               │
├────────────────┬────────────────────────────────────────────────────────────────────────────┤
│ alias          │ strange-jasper                                                             │
│ address        │ 0xd06b0069cf83e586eee980fb800a6f55d56450eaa8f2b4b0663bd7657fc415c5         │
│ keyScheme      │ ed25519                                                                    │
│ recoveryPhrase │ lab just slide over census wheat fantasy scorpion attack surround draw fox │
╰────────────────┴────────────────────────────────────────────────────────────────────────────╯

thibault@Mac ~/i/iota (develop)> ./target/debug/iota keytool update-alias strange-jasper tibo
Old alias strange-jasper was updated to tibo

thibault@Mac ~/i/iota (develop)> ./target/debug/iota keytool list
╭────────────────────────────────────────────────────────────────────────────────────────────╮
│ ╭─────────────────┬──────────────────────────────────────────────────────────────────────╮ │
│ │ alias           │  competent-plasma                                                    │ │
│ │ iotaAddress     │  0x1775ea9f3322548fe31e71aa01a41b496adaa29a5f6d94140cab2e91c8d8378d  │ │
│ │ publicBase64Key │  jbXCqXdAUHdgV7zi44SGwQ4MR2b9eufKZvIs1PJ943k=                        │ │
│ │ keyScheme       │  ed25519                                                             │ │
│ │ flag            │  0                                                                   │ │
│ │ peerId          │  8db5c2a9774050776057bce2e38486c10e0c4766fd7ae7ca66f22cd4f27de379    │ │
│ ╰─────────────────┴──────────────────────────────────────────────────────────────────────╯ │
│ ╭─────────────────┬──────────────────────────────────────────────────────────────────────╮ │
│ │ alias           │  tibo                                                                │ │
│ │ iotaAddress     │  0x77d2fc4949895e3f6c1b3e1cdcde1f873c9ad4436a5962029fc157ee215dfcc3  │ │
│ │ publicBase64Key │  JHkDOLTf2q0seprIYHQ8puv0tfzW3g0NuFkBhLPTUP0=                        │ │
│ │ keyScheme       │  ed25519                                                             │ │
│ │ flag            │  0                                                                   │ │
│ │ peerId          │  24790338b4dfdaad2c7a9ac860743ca6ebf4b5fcd6de0d0db8590184b3d350fd    │ │
│ ╰─────────────────┴──────────────────────────────────────────────────────────────────────╯ │
│ ╭─────────────────┬──────────────────────────────────────────────────────────────────────╮ │
│ │ alias           │  tibo                                                                │ │
│ │ iotaAddress     │  0xd06b0069cf83e586eee980fb800a6f55d56450eaa8f2b4b0663bd7657fc415c5  │ │
│ │ publicBase64Key │  NApvsk0asdz+WWu99dqhGj965tzBBh255E1O2FJF/CI=                        │ │
│ │ keyScheme       │  ed25519                                                             │ │
│ │ flag            │  0                                                                   │ │
│ │ peerId          │  340a6fb24d1ab1dcfe596bbdf5daa11a3f7ae6dcc1061db9e44d4ed85245fc22    │ │
│ ╰─────────────────┴──────────────────────────────────────────────────────────────────────╯ │
╰────────────────────────────────────────────────────────────────────────────────────────────╯
thibault@Mac ~/i/iota (develop)> 
```

# After

```
thibault@Mac ~/i/iota (develop)> ./target/debug/iota client new-address --alias tibo
Keys saved as Bech32.
╭──────────────────────────────────────────────────────────────────────────────────────────╮
│ Created new keypair and saved it to keystore.                                            │
├────────────────┬─────────────────────────────────────────────────────────────────────────┤
│ alias          │ tibo                                                                    │
│ address        │ 0xa609e45c4932c2d017acbe6b89ebb7cb9ff2003dd4f98bad5884072c5ec1a6bc      │
│ keyScheme      │ ed25519                                                                 │
│ recoveryPhrase │ west try scout shoe tornado steel width age favorite uniform near float │
╰────────────────┴─────────────────────────────────────────────────────────────────────────╯

thibault@Mac ~/i/iota (develop)> ./target/debug/iota client new-address
Keys saved as Bech32.
╭──────────────────────────────────────────────────────────────────────────────────────╮
│ Created new keypair and saved it to keystore.                                        │
├────────────────┬─────────────────────────────────────────────────────────────────────┤
│ alias          │ ecstatic-obsidian                                                   │
│ address        │ 0xb46a5ce8a44d9f93e8bf82b4cf06e4aed0ce7f8e696f1f812d8466f43d314ce7  │
│ keyScheme      │ ed25519                                                             │
│ recoveryPhrase │ hammer setup artwork trim top echo photo run render onion rural day │
╰────────────────┴─────────────────────────────────────────────────────────────────────╯

thibault@Mac ~/i/iota (develop)> ./target/debug/iota keytool update-alias ecstatic-obsidian tibo
Alias tibo already exists. Please choose another alias.
```