### PR TITLE
fix(iota): fix PTB upgrade command

### DIFF
--- a/crates/iota/src/client_ptb/builder.rs
+++ b/crates/iota/src/client_ptb/builder.rs
@@ -1055,7 +1055,8 @@ impl<'a> PTBBuilder<'a> {
                     .map_err(|e| err!(cmd_span, "{e}"))?;
                 let digest_arg = self
                     .ptb
-                    .pure(package_digest)
+                    // .to_vec() is necessary to get the length prefix
+                    .pure(package_digest.to_vec())
                     .map_err(|e| err!(cmd_span, "{e}"))?;
                 let upgrade_ticket =
                     self.ptb


### PR DESCRIPTION
# Description of change

Fix the PTB upgrade command by converting the package_digest to a vector instead of an array, because the .pure() function otherwise doesn't add the required length prefix byte.

## Links to any relevant issues

Fixes #4870 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Upgrading a package with a PTB command:
`iota client ptb --assign upgrade_cap @0x7ccc6c2fe6a509e6266b17e57a109f393f435a30da748c5168448958eb47d826 --upgrade "../../examples/move/nft" upgrade_cap`
https://explorer.rebased.iota.org/txblock/58pRmAPgB2o7aebpmjWQYW3wcXnsEuVq5EYvjtK67XVG
