### PR TITLE
fix nightly simtests

### DIFF
--- a/crates/iota-e2e-tests/tests/snapshot_tests.rs
+++ b/crates/iota-e2e-tests/tests/snapshot_tests.rs
@@ -63,8 +63,11 @@ async fn basic_read_cmd_snapshot_tests() -> Result<(), anyhow::Error> {
         "iota client objects 0x0000000000000000000000000000000000000000000000000000000000000000", /* empty addr */
         "iota client object 0x5",       // valid object
         "iota client object 0x5 --bcs", // valid object BCS
-        "iota client object 0x4d03f39deb5e27a76a568adb591da553688e6df6fb053bc9ac069f2bd9495ae3", /* valid object */
-        "iota client object 0x4d03f39deb5e27a76a568adb591da553688e6df6fb053bc9ac069f2bd9495ae3 --bcs", /* valid object BCS */
+        // Simtest object IDs are not stable so these object IDs may or may not exist currently --
+        // commenting them out for now.
+        // WARNING: Do not uncomment this, because that will break simtests with random MSIM_TEST_SEED!
+        // "iota client object 0x3b5121a0603ef7ab4cb57827fceca17db3338ef2cd76126cc1523b681df27cee", // valid object
+        // "iota client object 0x3b5121a0603ef7ab4cb57827fceca17db3338ef2cd76126cc1523b681df27cee --bcs", // valid object BCS
         "iota client object 0x0000000000000000000000000000000000000000000000000000000000000000", /* non-existent object */
         "iota client tx-block 88FqW2hyUgShTyLcGzbh6scZB45XZYmXpXSxydkBVTPu", // valid tx digest
         "iota client tx-block 11111111111111111111111111111111",             /* non-existent tx

--- a/crates/iota-e2e-tests/tests/snapshot_tests.rs
+++ b/crates/iota-e2e-tests/tests/snapshot_tests.rs
@@ -65,9 +65,11 @@ async fn basic_read_cmd_snapshot_tests() -> Result<(), anyhow::Error> {
         "iota client object 0x5 --bcs", // valid object BCS
         // Simtest object IDs are not stable so these object IDs may or may not exist currently --
         // commenting them out for now.
-        // WARNING: Do not uncomment this, because that will break simtests with random MSIM_TEST_SEED!
-        // "iota client object 0x3b5121a0603ef7ab4cb57827fceca17db3338ef2cd76126cc1523b681df27cee", // valid object
-        // "iota client object 0x3b5121a0603ef7ab4cb57827fceca17db3338ef2cd76126cc1523b681df27cee --bcs", // valid object BCS
+        // WARNING: Do not uncomment this, because that will break simtests with random
+        // MSIM_TEST_SEED! "iota client object
+        // 0x3b5121a0603ef7ab4cb57827fceca17db3338ef2cd76126cc1523b681df27cee", // valid object
+        // "iota client object 0x3b5121a0603ef7ab4cb57827fceca17db3338ef2cd76126cc1523b681df27cee
+        // --bcs", // valid object BCS
         "iota client object 0x0000000000000000000000000000000000000000000000000000000000000000", /* non-existent object */
         "iota client tx-block 88FqW2hyUgShTyLcGzbh6scZB45XZYmXpXSxydkBVTPu", // valid tx digest
         "iota client tx-block 11111111111111111111111111111111",             /* non-existent tx

--- a/crates/iota-e2e-tests/tests/snapshots/snapshot_tests__body_fn.snap
+++ b/crates/iota-e2e-tests/tests/snapshots/snapshot_tests__body_fn.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/iota-e2e-tests/tests/snapshot_tests.rs
 expression: "run_one(cmds, context).await?"
+snapshot_kind: text
 ---
 [
   "iota client objects {ME}",
@@ -171,54 +172,6 @@ expression: "run_one(cmds, context).await?"
           "type": "0x3::iota_system::IotaSystemState",
           "version": 1,
           "bcsBytes": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUBAAAAAAAAAA=="
-        }
-      }
-    }
-  ],
-  "iota client object 0x4d03f39deb5e27a76a568adb591da553688e6df6fb053bc9ac069f2bd9495ae3",
-  [
-    {
-      "data": {
-        "objectId": "0x4d03f39deb5e27a76a568adb591da553688e6df6fb053bc9ac069f2bd9495ae3",
-        "version": "1",
-        "digest": "6cjAEhKn8mmgQC6TPSrFASBNUBcSkTscuYpVdBEBbbfz",
-        "type": "0x2::coin::Coin<0x2::iota::IOTA>",
-        "owner": {
-          "AddressOwner": "0x2868fed4dbeb23d2ace3ee3ad6e39061423c5692a2b289b39c643c0baf2d8d85"
-        },
-        "previousTransaction": "88FqW2hyUgShTyLcGzbh6scZB45XZYmXpXSxydkBVTPu",
-        "storageRebate": "0",
-        "content": {
-          "dataType": "moveObject",
-          "type": "0x2::coin::Coin<0x2::iota::IOTA>",
-          "fields": {
-            "balance": "30000000000000000",
-            "id": {
-              "id": "0x4d03f39deb5e27a76a568adb591da553688e6df6fb053bc9ac069f2bd9495ae3"
-            }
-          }
-        }
-      }
-    }
-  ],
-  "iota client object 0x4d03f39deb5e27a76a568adb591da553688e6df6fb053bc9ac069f2bd9495ae3 --bcs",
-  [
-    {
-      "data": {
-        "objectId": "0x4d03f39deb5e27a76a568adb591da553688e6df6fb053bc9ac069f2bd9495ae3",
-        "version": "1",
-        "digest": "6cjAEhKn8mmgQC6TPSrFASBNUBcSkTscuYpVdBEBbbfz",
-        "type": "0x2::coin::Coin<0x2::iota::IOTA>",
-        "owner": {
-          "AddressOwner": "0x2868fed4dbeb23d2ace3ee3ad6e39061423c5692a2b289b39c643c0baf2d8d85"
-        },
-        "previousTransaction": "88FqW2hyUgShTyLcGzbh6scZB45XZYmXpXSxydkBVTPu",
-        "storageRebate": "0",
-        "bcs": {
-          "dataType": "moveObject",
-          "type": "0x2::coin::Coin<0x2::iota::IOTA>",
-          "version": 1,
-          "bcsBytes": "TQPzneteJ6dqVorbWR2lU2iObfb7BTvJrAafK9lJWuMAAENP15RqAA=="
         }
       }
     }

--- a/scripts/simtest/simtest-run.sh
+++ b/scripts/simtest/simtest-run.sh
@@ -3,7 +3,17 @@
 # Modifications Copyright (c) 2024 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 
+# INPUTS
+# We want reproducible nightly tests in CI, so we always use the same simtest seed (default 1).
+# To override and get a semi-random seed when running tests locally, set the USE_DATE_AS_SEED env var to 1
+USE_DATE_AS_SEED=${USE_DATE_AS_SEED:-0}
+# If tests timeout on your machine, override the per test timeout:
+PER_TEST_TIMEOUT_MS=${PER_TEST_TIMEOUT_MS:-60000}
+# Override the default dir for logs output:
+SIMTEST_LOGS_DIR="${SIMTEST_LOGS_DIR:-"~/simtest_logs"}"
+
 echo "Running simulator tests at commit $(git rev-parse HEAD)"
+echo "Using PER_TEST_TIMEOUT_MS=${PER_TEST_TIMEOUT_MS} from env var"
 
 # Function to handle SIGINT signal (Ctrl+C)
 cleanup() {
@@ -12,26 +22,23 @@ cleanup() {
     kill -- "-$$"
     exit 1
 }
-
 # Set up the signal handler
 trap cleanup SIGINT
 
 if [ -z "$NUM_CPUS" ]; then
-  NUM_CPUS=$(cat /proc/cpuinfo | grep processor | wc -l) # ubuntu
+  if [ "$(uname -s)" == "Darwin" ]; 
+    then NUM_CPUS="$(sysctl -n hw.ncpu)"; # mac
+    else NUM_CPUS=$(cat /proc/cpuinfo | grep processor | wc -l) # ubuntu
+  fi
 fi
 
 # filter out some tests that give spurious failures.
 TEST_FILTER="(not (test(~batch_verification_tests)))"
 
 DATE=$(date +%s)
-SEED="$DATE"
+SEED=1; if [ "$USE_DATE_AS_SEED" == "1" ]; then SEED="$DATE"; fi
 
-# create logs directory
-SIMTEST_LOGS_DIR=~/simtest_logs
-[ ! -d ${SIMTEST_LOGS_DIR} ] && mkdir -p ${SIMTEST_LOGS_DIR}
-[ ! -d ${SIMTEST_LOGS_DIR}/${DATE} ] && mkdir -p ${SIMTEST_LOGS_DIR}/${DATE}
-
-LOG_DIR="${SIMTEST_LOGS_DIR}/${DATE}"
+LOG_DIR="${SIMTEST_LOGS_DIR}/${DATE}"; mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/log"
 
 # By default run 1 iteration for each test, if not specified.
@@ -48,7 +55,7 @@ date
 # TODO: this logs directly to stdout since it is not being run in parallel. is that ok?
 MSIM_TEST_SEED="$SEED" \
 MSIM_TEST_NUM=${TEST_NUM} \
-MSIM_WATCHDOG_TIMEOUT_MS=60000 \
+MSIM_WATCHDOG_TIMEOUT_MS=${PER_TEST_TIMEOUT_MS} \
 scripts/simtest/cargo-simtest simtest \
   --color always \
   --test-threads "$NUM_CPUS" \
@@ -72,7 +79,7 @@ for SUB_SEED in `seq 1 $NUM_CPUS`; do
   # --test-threads 1 is important: parallelism is achieved via the for loop
   MSIM_TEST_SEED="$SEED" \
   MSIM_TEST_NUM=1 \
-  MSIM_WATCHDOG_TIMEOUT_MS=60000 \
+  MSIM_WATCHDOG_TIMEOUT_MS=${PER_TEST_TIMEOUT_MS} \
   SIM_STRESS_TEST_DURATION_SECS=300 \
   scripts/simtest/cargo-simtest simtest \
     --color always \
@@ -98,7 +105,7 @@ echo "Using MSIM_TEST_SEED=$SEED, logging to $LOG_FILE"
 
 MSIM_TEST_SEED="$SEED" \
 MSIM_TEST_NUM=1 \
-MSIM_WATCHDOG_TIMEOUT_MS=60000 \
+MSIM_WATCHDOG_TIMEOUT_MS=${PER_TEST_TIMEOUT_MS} \
 MSIM_TEST_CHECK_DETERMINISM=1
 scripts/simtest/cargo-simtest simtest \
   --color always \

--- a/scripts/simtest/simtest-run.sh
+++ b/scripts/simtest/simtest-run.sh
@@ -4,16 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # INPUTS
-# We want reproducible nightly tests in CI, so we always use the same simtest seed (default 1).
-# To override and get a semi-random seed when running tests locally, set the SIMTEST_USE_DATE_AS_SEED env var to 1
-SIMTEST_USE_DATE_AS_SEED=${SIMTEST_USE_DATE_AS_SEED:-0}
 # If tests timeout on your machine, override the per test timeout:
-PER_SIMTEST_TIMEOUT_MS=${PER_SIMTEST_TIMEOUT_MS:-60000}
+SIMTEST_PER_TEST_TIMEOUT_MS=${SIMTEST_PER_TEST_TIMEOUT_MS:-60000}
 # Override the default dir for logs output:
-SIMTEST_LOGS_DIR="${SIMTEST_LOGS_DIR:-"~/simtest_logs"}"
+SIMTEST_LOGS_DIR="${SIMTEST_LOGS_DIR:-"$HOME/simtest_logs"}"
 
 echo "Running simulator tests at commit $(git rev-parse HEAD)"
-echo "Using PER_SIMTEST_TIMEOUT_MS=${PER_SIMTEST_TIMEOUT_MS} from env var"
+echo "Using SIMTEST_PER_TEST_TIMEOUT_MS=${SIMTEST_PER_TEST_TIMEOUT_MS} from env var"
 
 # Function to handle SIGINT signal (Ctrl+C)
 cleanup() {
@@ -35,11 +32,15 @@ fi
 # filter out some tests that give spurious failures.
 TEST_FILTER="(not (test(~batch_verification_tests)))"
 
+# we seed the rng with the current date
 DATE=$(date +%s)
-SEED=1; if [ "$SIMTEST_USE_DATE_AS_SEED" == "1" ]; then SEED="$DATE"; fi
+SEED="$DATE"
 
-LOG_DIR="${SIMTEST_LOGS_DIR}/${DATE}"; mkdir -p "$LOG_DIR"
+LOG_DIR="${SIMTEST_LOGS_DIR}/${DATE}"
 LOG_FILE="$LOG_DIR/log"
+
+# create the log directory if it doesn't exist
+mkdir -p "$LOG_DIR"
 
 # By default run 1 iteration for each test, if not specified.
 : ${TEST_NUM:=1}
@@ -55,7 +56,7 @@ date
 # TODO: this logs directly to stdout since it is not being run in parallel. is that ok?
 MSIM_TEST_SEED="$SEED" \
 MSIM_TEST_NUM=${TEST_NUM} \
-MSIM_WATCHDOG_TIMEOUT_MS=${PER_SIMTEST_TIMEOUT_MS} \
+MSIM_WATCHDOG_TIMEOUT_MS=${SIMTEST_PER_TEST_TIMEOUT_MS} \
 scripts/simtest/cargo-simtest simtest \
   --color always \
   --test-threads "$NUM_CPUS" \
@@ -79,7 +80,7 @@ for SUB_SEED in `seq 1 $NUM_CPUS`; do
   # --test-threads 1 is important: parallelism is achieved via the for loop
   MSIM_TEST_SEED="$SEED" \
   MSIM_TEST_NUM=1 \
-  MSIM_WATCHDOG_TIMEOUT_MS=${PER_SIMTEST_TIMEOUT_MS} \
+  MSIM_WATCHDOG_TIMEOUT_MS=${SIMTEST_PER_TEST_TIMEOUT_MS} \
   SIM_STRESS_TEST_DURATION_SECS=300 \
   scripts/simtest/cargo-simtest simtest \
     --color always \
@@ -105,7 +106,7 @@ echo "Using MSIM_TEST_SEED=$SEED, logging to $LOG_FILE"
 
 MSIM_TEST_SEED="$SEED" \
 MSIM_TEST_NUM=1 \
-MSIM_WATCHDOG_TIMEOUT_MS=${PER_SIMTEST_TIMEOUT_MS} \
+MSIM_WATCHDOG_TIMEOUT_MS=${SIMTEST_PER_TEST_TIMEOUT_MS} \
 MSIM_TEST_CHECK_DETERMINISM=1 \
 scripts/simtest/cargo-simtest simtest \
   --color always \

--- a/scripts/simtest/simtest-run.sh
+++ b/scripts/simtest/simtest-run.sh
@@ -5,15 +5,15 @@
 
 # INPUTS
 # We want reproducible nightly tests in CI, so we always use the same simtest seed (default 1).
-# To override and get a semi-random seed when running tests locally, set the USE_DATE_AS_SEED env var to 1
-USE_DATE_AS_SEED=${USE_DATE_AS_SEED:-0}
+# To override and get a semi-random seed when running tests locally, set the SIMTEST_USE_DATE_AS_SEED env var to 1
+SIMTEST_USE_DATE_AS_SEED=${SIMTEST_USE_DATE_AS_SEED:-0}
 # If tests timeout on your machine, override the per test timeout:
-PER_TEST_TIMEOUT_MS=${PER_TEST_TIMEOUT_MS:-60000}
+PER_SIMTEST_TIMEOUT_MS=${PER_SIMTEST_TIMEOUT_MS:-60000}
 # Override the default dir for logs output:
 SIMTEST_LOGS_DIR="${SIMTEST_LOGS_DIR:-"~/simtest_logs"}"
 
 echo "Running simulator tests at commit $(git rev-parse HEAD)"
-echo "Using PER_TEST_TIMEOUT_MS=${PER_TEST_TIMEOUT_MS} from env var"
+echo "Using PER_SIMTEST_TIMEOUT_MS=${PER_SIMTEST_TIMEOUT_MS} from env var"
 
 # Function to handle SIGINT signal (Ctrl+C)
 cleanup() {
@@ -36,7 +36,7 @@ fi
 TEST_FILTER="(not (test(~batch_verification_tests)))"
 
 DATE=$(date +%s)
-SEED=1; if [ "$USE_DATE_AS_SEED" == "1" ]; then SEED="$DATE"; fi
+SEED=1; if [ "$SIMTEST_USE_DATE_AS_SEED" == "1" ]; then SEED="$DATE"; fi
 
 LOG_DIR="${SIMTEST_LOGS_DIR}/${DATE}"; mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/log"
@@ -55,7 +55,7 @@ date
 # TODO: this logs directly to stdout since it is not being run in parallel. is that ok?
 MSIM_TEST_SEED="$SEED" \
 MSIM_TEST_NUM=${TEST_NUM} \
-MSIM_WATCHDOG_TIMEOUT_MS=${PER_TEST_TIMEOUT_MS} \
+MSIM_WATCHDOG_TIMEOUT_MS=${PER_SIMTEST_TIMEOUT_MS} \
 scripts/simtest/cargo-simtest simtest \
   --color always \
   --test-threads "$NUM_CPUS" \
@@ -79,7 +79,7 @@ for SUB_SEED in `seq 1 $NUM_CPUS`; do
   # --test-threads 1 is important: parallelism is achieved via the for loop
   MSIM_TEST_SEED="$SEED" \
   MSIM_TEST_NUM=1 \
-  MSIM_WATCHDOG_TIMEOUT_MS=${PER_TEST_TIMEOUT_MS} \
+  MSIM_WATCHDOG_TIMEOUT_MS=${PER_SIMTEST_TIMEOUT_MS} \
   SIM_STRESS_TEST_DURATION_SECS=300 \
   scripts/simtest/cargo-simtest simtest \
     --color always \
@@ -105,7 +105,7 @@ echo "Using MSIM_TEST_SEED=$SEED, logging to $LOG_FILE"
 
 MSIM_TEST_SEED="$SEED" \
 MSIM_TEST_NUM=1 \
-MSIM_WATCHDOG_TIMEOUT_MS=${PER_TEST_TIMEOUT_MS} \
+MSIM_WATCHDOG_TIMEOUT_MS=${PER_SIMTEST_TIMEOUT_MS} \
 MSIM_TEST_CHECK_DETERMINISM=1 \
 scripts/simtest/cargo-simtest simtest \
   --color always \

--- a/scripts/simtest/simtest-run.sh
+++ b/scripts/simtest/simtest-run.sh
@@ -106,7 +106,7 @@ echo "Using MSIM_TEST_SEED=$SEED, logging to $LOG_FILE"
 MSIM_TEST_SEED="$SEED" \
 MSIM_TEST_NUM=1 \
 MSIM_WATCHDOG_TIMEOUT_MS=${PER_TEST_TIMEOUT_MS} \
-MSIM_TEST_CHECK_DETERMINISM=1
+MSIM_TEST_CHECK_DETERMINISM=1 \
 scripts/simtest/cargo-simtest simtest \
   --color always \
   --test-threads "$NUM_CPUS" \


### PR DESCRIPTION
# Description of change

Previously, we were using the current date as a simtest seed in nightly CI, which means nightly tests would often fail.

Fix nightly tests: previously, the current date was used as a seed for simtest pseudo-randomness
- this made one test fail, which was relying on static objects, but actual objects were generated pseudo-randomly each time

Other additions:
- make it possible to override the timeout for simtests locally (previous hardcoded value becomes default in CI)
- make it possible to override the SIMTEST_LOGS_DIR

## Links to any relevant issues

Fixes #4909 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Relevant configurations: when running `./scripts/simtest/simtest-run.sh`, you can now pass env vars to override:
- PER_TEST_TIMEOUT_MS: if tests timeout on your machine, override the per test timeout
Docs are as comments at the top of the script.
- SIMTEST_LOGS_DIR: override the default logs directory

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that existing unit tests pass locally with my changes 

## Follow-up issues to create

- [x] fixing env vars (actually passing them) on the last call to `cargo simtest` made some tests fail more often because of non-determinism.
- [ ] Sould we also use non-determinism in CI tests run on each PR ? This doesn't seem to be the case yet, but double-check
