### PR TITLE
fix(metrics): Reset some AuthorityMetrics on epoch change

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -742,6 +742,15 @@ impl AuthorityMetrics {
             execution_rate_tracker: Arc::new(Mutex::new(RateTracker::new(Duration::from_secs(10)))),
         }
     }
+
+    /// Reset metrics that contain `hostname` as one of the labels. This is
+    /// needed to avoid retaining metrics for long-gone committee members and
+    /// only exposing metrics for the committee in the current epoch.
+    pub fn reset_on_reconfigure(&self) {
+        self.consensus_committed_messages.reset();
+        self.consensus_handler_scores.reset();
+        self.consensus_committed_user_transactions.reset();
+    }
 }
 
 /// a Trait object for `Signer` that is:
@@ -2885,7 +2894,7 @@ impl AuthorityState {
                 .epoch_start_state()
                 .protocol_version(),
         );
-
+        self.metrics.reset_on_reconfigure();
         self.committee_store.insert_new_committee(&new_committee)?;
         let mut execution_lock = self.execution_lock_for_reconfiguration().await;
         // TODO: revert_uncommitted_epoch_transactions will soon be unnecessary -


### PR DESCRIPTION
# Description of change

Reset some authority metrics on epoch change to stop exposing metrics for old committee members and only expose metrics that belong to the current committee members. 

## Links to any relevant issues

Fixes #4903 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Ran a local Docker network with mulitple validators and checked that the metrics are correctly reset during reconfiguration. 

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
