### PR TITLE
feat(workflows): add ubuntu arm64 target for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,7 @@ jobs:
       matrix:
         os: [
           self-hosted, # ubuntu-x86_64
-          # TODO: uncomment when runners are public available https://github.com/iotaledger/iota/issues/4421
-          # ubuntu-arm64, # ubuntu-arm64
+          ubuntu-24.04-arm,
           macos-latest, # macos-arm64
           windows-latest, # windows-x86_64
         ]
@@ -126,13 +125,12 @@ jobs:
         run: |
           brew install postgresql
 
-      # TODO: uncomment when runners are public available https://github.com/iotaledger/iota/issues/4421
       #  NOTE: Self-hosted runners should already have postgres installed
-      #      - name: Install postgres (Ubuntu arm64)
-      #        if: ${{ matrix.os == 'ubuntu-arm64' }}
-      #        shell: bash
-      #        run: |
-      #          sudo apt install libpq-dev
+      - name: Install postgres (Ubuntu arm64)
+        if: ${{ matrix.os == 'ubuntu-24.04-arm' }}
+        shell: bash
+        run: |
+          sudo apt install libpq-dev
 
       - name: Remove unused apps (MacOS arm64)
         if: ${{ matrix.os == 'macos-latest' }}


### PR DESCRIPTION
# Description of change

Add ubuntu arm target for releases so the binaries are available for this platform as well
`-latest` is currently not available: https://github.com/orgs/community/discussions/149392 that's why I just selected the latest available version from https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/#how-to-use-the-runners

## Links to any relevant issues

Fixes #4421 

## Type of change

- Enhancement (a non-breaking change which adds functionality)
