### PR TITLE
Reject unsupported transaction filters in iotax_subscribeTransaction

### DIFF
--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -2357,7 +2357,8 @@ impl Filter<EffectsWithInput> for TransactionFilter {
             }
             // these filters are not supported, rpc will reject these filters on subscription
             TransactionFilter::Checkpoint(_) => false, // TODO: eventually support in future
-            TransactionFilter::FromOrToAddress { addr: _ } => false, // TODO: eventually support in future
+            TransactionFilter::FromOrToAddress { addr: _ } => false, /* TODO: eventually support
+                                                                      * in future */
         }
     }
 }

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -2342,6 +2342,9 @@ impl Filter<EffectsWithInput> for TransactionFilter {
             TransactionFilter::FromAndToAddress { from, to } => {
                 Self::FromAddress(*from).matches(item) && Self::ToAddress(*to).matches(item)
             }
+            TransactionFilter::FromOrToAddress { addr } => {
+                Self::FromAddress(*addr).matches(item) || Self::ToAddress(*addr).matches(item)
+            }
             TransactionFilter::MoveFunction {
                 package,
                 module,
@@ -2355,10 +2358,8 @@ impl Filter<EffectsWithInput> for TransactionFilter {
             TransactionFilter::TransactionKindIn(kinds) => {
                 kinds.contains(&item.input.kind().to_string())
             }
-            // these filters are not supported, rpc will reject these filters on subscription
-            TransactionFilter::Checkpoint(_) => false, // TODO: eventually support in future
-            TransactionFilter::FromOrToAddress { addr: _ } => false, /* TODO: eventually support
-                                                                      * in future */
+            // this filter is not supported, RPC will reject it on subscription
+            TransactionFilter::Checkpoint(_) => false,
         }
     }
 }

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -2356,8 +2356,8 @@ impl Filter<EffectsWithInput> for TransactionFilter {
                 kinds.contains(&item.input.kind().to_string())
             }
             // these filters are not supported, rpc will reject these filters on subscription
-            TransactionFilter::Checkpoint(_) => false,
-            TransactionFilter::FromOrToAddress { addr: _ } => false,
+            TransactionFilter::Checkpoint(_) => false, // TODO: eventually support in future
+            TransactionFilter::FromOrToAddress { addr: _ } => false, // TODO: eventually support in future
         }
     }
 }

--- a/crates/iota-json-rpc/src/indexer_api.rs
+++ b/crates/iota-json-rpc/src/indexer_api.rs
@@ -337,11 +337,8 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         filter: TransactionFilter,
     ) -> SubscriptionResult {
         // Validate unsupported filters
-        if matches!(
-            filter,
-            TransactionFilter::Checkpoint(_) | TransactionFilter::FromOrToAddress { .. }
-        ) {
-            return Err("unsupported transaction filter".into());
+        if matches!(filter, TransactionFilter::Checkpoint(_)) {
+            return Err("checkpoint filter is not supported".into());
         }
 
         let permit = self.acquire_subscribe_permit()?;

--- a/crates/iota-json-rpc/src/indexer_api.rs
+++ b/crates/iota-json-rpc/src/indexer_api.rs
@@ -336,6 +336,14 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         sink: PendingSubscriptionSink,
         filter: TransactionFilter,
     ) -> SubscriptionResult {
+        // Validate unsupported filters
+        if matches!(
+            filter,
+            TransactionFilter::Checkpoint(_) | TransactionFilter::FromOrToAddress { .. }
+        ) {
+            return Err("unsupported transaction filter".into());
+        }
+
         let permit = self.acquire_subscribe_permit()?;
         spawn_subscription(
             sink,


### PR DESCRIPTION
# Description of change

Currently, `iotax_subscribeTransaction` allows to pass a `TransactionFilter` with unsupported variants `Checkpoint` and `FromOrToAddress` even though these filters don’t emit events as they are not implemented. This can confuse users when they subscribe with these filters and nothing happens. If a non existent filter is passed, the input gets rejected directly in the RPC as expected. This can be explained by a failed deserialization of the TransactionFilter. The unsupported filters, on the other hand, are deserialized correctly, but should also be rejected.

This PR adds a validation check directly in the `subscribe_transaction` RPC method to reject unsupported filters with an explicit error message. This ensures that only valid filters are accepted and prevents unsupported ones from entering the subscription system.

The other options considered:

1. Validating the filter in the `Streamer` or `SubscriptionHandler` implementation:
Rejected because allowing unsupported filters to enter the subscription system and handling them there requires multiple changes in the layers and adds complexity.

2. Creating a separate filter type without the unsupported filters (only for this endpoint):
Rejected, as this would lead to a duplicate type 'TransactionFilter' without the two unsupported variants and there seems to be no significant benefit in retaining this duplicate type.

--

I have left a 'todo' for the unimplemented filters so that it is easier to keep track of them. A separate issue should be created to better keep track off (if desired).

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/2622

## Type of change

- Bug fix (a non-breaking change which fixes an issue)