### PR TITLE
feat(bin-version): add `-debug` suffix to VERSION

### DIFF
--- a/crates/bin-version/src/lib.rs
+++ b/crates/bin-version/src/lib.rs
@@ -25,10 +25,17 @@ macro_rules! bin_version {
     () => {
         $crate::git_revision!();
 
-        const VERSION: &str = if GIT_REVISION.is_empty() {
-            env!("CARGO_PKG_VERSION")
-        } else {
-            $crate::_hidden::concat!(env!("CARGO_PKG_VERSION"), "-", GIT_REVISION)
+        const VERSION: &str = {
+            const _VERSION_BASE: &str = if GIT_REVISION.is_empty() {
+                env!("CARGO_PKG_VERSION")
+            } else {
+                $crate::_hidden::concat!(env!("CARGO_PKG_VERSION"), "-", GIT_REVISION)
+            };
+            if cfg!(debug_assertions) {
+                $crate::_hidden::concat!(_VERSION_BASE, "-debug")
+            } else {
+                _VERSION_BASE
+            }
         };
     };
 }


### PR DESCRIPTION
Adds a `-debug` suffix to the binary version when it has been built in debug mode so it's easier to identify when investigating.

# Before

```
thibault@Thibaults-MacBook-Pro-2 ~/i/iota (develop)> ./target/debug/iota --version
iota 0.9.0-alpha-6c73bf02e376

thibault@Thibaults-MacBook-Pro-2 ~/i/iota (develop)> ./target/release/iota --version
iota 0.9.0-alpha-6c73bf02e376
```

# After

```
thibault@Thibaults-MacBook-Pro-2 ~/i/iota (feat/bin-version-debug-suffix)> ./target/debug/iota --version
iota 0.9.0-alpha-20dbb3664e5d-debug

thibault@Thibaults-MacBook-Pro-2 ~/i/iota (feat/bin-version-debug-suffix)> ./target/release/iota --version
iota 0.9.0-alpha-20dbb3664e5d
```