### PR TITLE
fix(replay): Ignore `verify_latest_tx_replay_testnet_mainnet` test

### DIFF
--- a/crates/iota-replay/src/tests.rs
+++ b/crates/iota-replay/src/tests.rs
@@ -21,9 +21,11 @@ const NUM_CHECKPOINTS_TO_ATTEMPT: usize = 10_000;
 /// Checks that replaying the latest tx on each testnet and mainnet does not
 /// fail
 #[tokio::test]
+#[ignore = "https://github.com/iotaledger/iota/issues/5031"]
 async fn verify_latest_tx_replay_testnet_mainnet() {
     let _ = verify_latest_tx_replay_impl().await;
 }
+
 async fn verify_latest_tx_replay_impl() {
     let default_cfg = ReplayableNetworkConfigSet::default();
     let urls: Vec<_> = default_cfg
@@ -46,7 +48,7 @@ async fn verify_latest_tx_replay_impl() {
                     .await
                     .unwrap();
 
-                    let chain_id = rpc_client.read_api().get_chain_identifier().await.unwrap();
+                let chain_id = rpc_client.read_api().get_chain_identifier().await.unwrap();
 
                 let mut subject_checkpoint = rpc_client
                     .read_api()


### PR DESCRIPTION
# Description of change

~~Stabilize the `verify_latest_tx_replay_testnet_mainnet` test by adding a fallback checkpoint to replay a non-system transaction.~~

The issue is that non-system transactions are rare in the network, causing the test to spend a significant amount of time querying checkpoints (with records of querying over 2200 checkpoints). ~~To address this, a fallback checkpoint containing a known non-system transaction is added. If a non-system transaction cannot be found during iteration, the test will use this fallback checkpoint and replay the transaction.~~

Edit: The changes were reverted and the test is set to ignore for now, until a proper solution is implemented.

## Links to any relevant issues

Closes #4976

## Type of change

- Enhancement

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked that new and existing unit tests pass locally with my changes
