### PR TITLE
fix: `basic_read_cmd_snapshot_tests` by ignoring it

### DIFF
--- a/crates/iota-e2e-tests/tests/snapshot_tests.rs
+++ b/crates/iota-e2e-tests/tests/snapshot_tests.rs
@@ -51,6 +51,7 @@ async fn run_one(
     Ok(test_output)
 }
 
+#[ignore = "This test is not stable, random MSIM_TEST_SEEDs will break this test, ignored on upstream"]
 #[sim_test]
 async fn basic_read_cmd_snapshot_tests() -> Result<(), anyhow::Error> {
     let mut test_cluster = TestClusterBuilder::new().build().await;
@@ -63,13 +64,8 @@ async fn basic_read_cmd_snapshot_tests() -> Result<(), anyhow::Error> {
         "iota client objects 0x0000000000000000000000000000000000000000000000000000000000000000", /* empty addr */
         "iota client object 0x5",       // valid object
         "iota client object 0x5 --bcs", // valid object BCS
-        // Simtest object IDs are not stable so these object IDs may or may not exist currently --
-        // commenting them out for now.
-        // WARNING: Do not uncomment this, because that will break simtests with random
-        // MSIM_TEST_SEED! "iota client object
-        // 0x3b5121a0603ef7ab4cb57827fceca17db3338ef2cd76126cc1523b681df27cee", // valid object
-        // "iota client object 0x3b5121a0603ef7ab4cb57827fceca17db3338ef2cd76126cc1523b681df27cee
-        // --bcs", // valid object BCS
+        "iota client object 0x4d03f39deb5e27a76a568adb591da553688e6df6fb053bc9ac069f2bd9495ae3", /* valid object */
+        "iota client object 0x4d03f39deb5e27a76a568adb591da553688e6df6fb053bc9ac069f2bd9495ae3 --bcs", /* valid object BCS */
         "iota client object 0x0000000000000000000000000000000000000000000000000000000000000000", /* non-existent object */
         "iota client tx-block 88FqW2hyUgShTyLcGzbh6scZB45XZYmXpXSxydkBVTPu", // valid tx digest
         "iota client tx-block 11111111111111111111111111111111",             /* non-existent tx

--- a/crates/iota-e2e-tests/tests/snapshots/snapshot_tests__body_fn.snap
+++ b/crates/iota-e2e-tests/tests/snapshots/snapshot_tests__body_fn.snap
@@ -176,6 +176,54 @@ snapshot_kind: text
       }
     }
   ],
+  "iota client object 0x4d03f39deb5e27a76a568adb591da553688e6df6fb053bc9ac069f2bd9495ae3",
+  [
+    {
+      "data": {
+        "objectId": "0x4d03f39deb5e27a76a568adb591da553688e6df6fb053bc9ac069f2bd9495ae3",
+        "version": "1",
+        "digest": "6cjAEhKn8mmgQC6TPSrFASBNUBcSkTscuYpVdBEBbbfz",
+        "type": "0x2::coin::Coin<0x2::iota::IOTA>",
+        "owner": {
+          "AddressOwner": "0x2868fed4dbeb23d2ace3ee3ad6e39061423c5692a2b289b39c643c0baf2d8d85"
+        },
+        "previousTransaction": "88FqW2hyUgShTyLcGzbh6scZB45XZYmXpXSxydkBVTPu",
+        "storageRebate": "0",
+        "content": {
+          "dataType": "moveObject",
+          "type": "0x2::coin::Coin<0x2::iota::IOTA>",
+          "fields": {
+            "balance": "30000000000000000",
+            "id": {
+              "id": "0x4d03f39deb5e27a76a568adb591da553688e6df6fb053bc9ac069f2bd9495ae3"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "iota client object 0x4d03f39deb5e27a76a568adb591da553688e6df6fb053bc9ac069f2bd9495ae3 --bcs",
+  [
+    {
+      "data": {
+        "objectId": "0x4d03f39deb5e27a76a568adb591da553688e6df6fb053bc9ac069f2bd9495ae3",
+        "version": "1",
+        "digest": "6cjAEhKn8mmgQC6TPSrFASBNUBcSkTscuYpVdBEBbbfz",
+        "type": "0x2::coin::Coin<0x2::iota::IOTA>",
+        "owner": {
+          "AddressOwner": "0x2868fed4dbeb23d2ace3ee3ad6e39061423c5692a2b289b39c643c0baf2d8d85"
+        },
+        "previousTransaction": "88FqW2hyUgShTyLcGzbh6scZB45XZYmXpXSxydkBVTPu",
+        "storageRebate": "0",
+        "bcs": {
+          "dataType": "moveObject",
+          "type": "0x2::coin::Coin<0x2::iota::IOTA>",
+          "version": 1,
+          "bcsBytes": "TQPzneteJ6dqVorbWR2lU2iObfb7BTvJrAafK9lJWuMAAENP15RqAA=="
+        }
+      }
+    }
+  ],
   "iota client object 0x0000000000000000000000000000000000000000000000000000000000000000",
   [
     {


### PR DESCRIPTION
# Description of change

The fix from yesterday was actually wrong. I reverted the changes in the expectations and in the test itself.
The whole test is actually not stable, and thats why it is also ignored on upstream as well. @miker83z agreed that we should just simply ignore it for now. Maybe in the future we could add a parameter to the `simtest` macro that overwrites the `SIM_TEST_SEED` with a fixed value?

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Failing test is disabled.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
