### PR TITLE
feat(iota): add `--dev-inspect` flag to CLI

### DIFF
--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -22,11 +22,11 @@ use fastcrypto::{
 };
 use iota_json::IotaJsonValue;
 use iota_json_rpc_types::{
-    Coin, DryRunTransactionBlockResponse, DynamicFieldPage, IotaCoinMetadata, IotaData,
-    IotaExecutionStatus, IotaObjectData, IotaObjectDataOptions, IotaObjectResponse,
-    IotaObjectResponseQuery, IotaParsedData, IotaProtocolConfigValue, IotaRawData,
-    IotaTransactionBlockEffects, IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse,
-    IotaTransactionBlockResponseOptions,
+    Coin, DevInspectArgs, DevInspectResults, DryRunTransactionBlockResponse, DynamicFieldPage,
+    IotaCoinMetadata, IotaData, IotaExecutionStatus, IotaObjectData, IotaObjectDataOptions,
+    IotaObjectResponse, IotaObjectResponseQuery, IotaParsedData, IotaProtocolConfigValue,
+    IotaRawData, IotaTransactionBlockEffects, IotaTransactionBlockEffectsAPI,
+    IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions,
 };
 use iota_keys::keystore::AccountKeystore;
 use iota_move::manage_package::resolve_lock_file_path;
@@ -54,6 +54,7 @@ use iota_types::{
     error::IotaError,
     gas::GasCostSummary,
     gas_coin::GasCoin,
+    iota_serde,
     message_envelope::Envelope,
     metrics::BytecodeVerifierMetrics,
     move_package::UpgradeCap,
@@ -561,6 +562,9 @@ pub struct Opts {
     /// Perform a dry run of the transaction, without executing it.
     #[arg(long)]
     pub dry_run: bool,
+    /// Perform a dev inspect of the transaction, without executing it.
+    #[arg(long)]
+    pub dev_inspect: bool,
     /// Instead of executing the transaction, serialize the bcs bytes of the
     /// unsigned transaction data (TransactionData) using base64 encoding,
     /// and print out the string <TX_BYTES>. The string can be used to
@@ -604,6 +608,7 @@ impl Opts {
         Self {
             gas_budget: Some(gas_budget),
             dry_run: false,
+            dev_inspect: false,
             serialize_unsigned_transaction: false,
             serialize_signed_transaction: false,
             emit: HashSet::new(),
@@ -616,6 +621,7 @@ impl Opts {
         Self {
             gas_budget: Some(gas_budget),
             dry_run: true,
+            dev_inspect: false,
             serialize_unsigned_transaction: false,
             serialize_signed_transaction: false,
             emit: HashSet::new(),
@@ -629,6 +635,7 @@ impl Opts {
         Self {
             gas_budget: Some(gas_budget),
             dry_run: false,
+            dev_inspect: false,
             serialize_unsigned_transaction: false,
             serialize_signed_transaction: false,
             emit,
@@ -2223,6 +2230,9 @@ impl Display for IotaClientCommandResult {
             IotaClientCommandResult::DryRun(response) => {
                 writeln!(f, "{}", Pretty(response))?;
             }
+            IotaClientCommandResult::DevInspect(response) => {
+                writeln!(f, "{}", Pretty(response))?;
+            }
         }
         write!(f, "{}", writer.trim_end_matches('\n'))
     }
@@ -2325,6 +2335,7 @@ impl IotaClientCommandResult {
             | IotaClientCommandResult::Balance(_, _)
             | IotaClientCommandResult::ChainIdentifier(_)
             | IotaClientCommandResult::DynamicFieldQuery(_)
+            | IotaClientCommandResult::DevInspect(_)
             | IotaClientCommandResult::Envs(_, _)
             | IotaClientCommandResult::Gas(_)
             | IotaClientCommandResult::NewAddress(_)
@@ -2474,6 +2485,7 @@ pub enum IotaClientCommandResult {
     ChainIdentifier(String),
     DynamicFieldQuery(DynamicFieldPage),
     DryRun(DryRunTransactionBlockResponse),
+    DevInspect(DevInspectResults),
     Envs(Vec<IotaEnv>, Option<String>),
     Gas(Vec<GasCoin>),
     NewAddress(NewAddressOutput),
@@ -2804,8 +2816,15 @@ pub(crate) async fn dry_run_or_execute_or_serialize(
     gas: Option<ObjectID>,
     opts: Opts,
 ) -> Result<IotaClientCommandResult, anyhow::Error> {
-    let (dry_run, gas_budget, serialize_unsigned_transaction, serialize_signed_transaction) = (
+    let (
+        dry_run,
+        dev_inspect,
+        gas_budget,
+        serialize_unsigned_transaction,
+        serialize_signed_transaction,
+    ) = (
         opts.dry_run,
+        opts.dev_inspect,
         opts.gas_budget,
         opts.serialize_unsigned_transaction,
         opts.serialize_signed_transaction,
@@ -2820,12 +2839,27 @@ pub(crate) async fn dry_run_or_execute_or_serialize(
         context.get_reference_gas_price().await?
     };
 
+    let client = context.get_client().await?;
+
+    if dev_inspect {
+        return execute_dev_inspect(
+            context,
+            signer,
+            tx_kind,
+            gas_budget,
+            gas_price,
+            gas_payment,
+            None,
+            None,
+        )
+        .await;
+    }
+
     let gas = match gas_payment {
         Some(obj_ids) => Some(obj_ids),
         None => gas.map(|x| vec![x]),
     };
 
-    let client = context.get_client().await?;
     if dry_run {
         return execute_dry_run(
             context,
@@ -2914,6 +2948,49 @@ pub(crate) async fn dry_run_or_execute_or_serialize(
             Ok(IotaClientCommandResult::TransactionBlock(response))
         }
     }
+}
+
+async fn execute_dev_inspect(
+    context: &mut WalletContext,
+    signer: IotaAddress,
+    tx_kind: TransactionKind,
+    gas_budget: Option<u64>,
+    gas_price: u64,
+    gas_payment: Option<Vec<ObjectID>>,
+    gas_sponsor: Option<IotaAddress>,
+    skip_checks: Option<bool>,
+) -> Result<IotaClientCommandResult, anyhow::Error> {
+    let client = context.get_client().await?;
+    let gas_budget = gas_budget.map(iota_serde::BigInt::from);
+    let mut gas_objs = vec![];
+    let gas_objects = if let Some(gas_payment) = gas_payment {
+        for o in gas_payment.iter() {
+            let obj_ref = context.get_object_ref(*o).await?;
+            gas_objs.push(obj_ref);
+        }
+        Some(gas_objs)
+    } else {
+        None
+    };
+
+    let dev_inspect_args = DevInspectArgs {
+        gas_sponsor,
+        gas_budget,
+        gas_objects,
+        skip_checks,
+        show_raw_txn_data_and_effects: None,
+    };
+    let dev_inspect_result = client
+        .read_api()
+        .dev_inspect_transaction_block(
+            signer,
+            tx_kind,
+            Some(iota_serde::BigInt::from(gas_price)),
+            None,
+            Some(dev_inspect_args),
+        )
+        .await?;
+    Ok(IotaClientCommandResult::DevInspect(dev_inspect_result))
 }
 
 pub(crate) async fn prerender_clever_errors(

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -2964,11 +2964,15 @@ async fn execute_dev_inspect(
     let gas_budget = gas_budget.map(iota_serde::BigInt::from);
     let mut gas_objs = vec![];
     let gas_objects = if let Some(gas_payment) = gas_payment {
-        for o in gas_payment.iter() {
-            let obj_ref = context.get_object_ref(*o).await?;
-            gas_objs.push(obj_ref);
+        if gas_payment.is_empty() {
+            None
+        } else {
+            for o in gas_payment.iter() {
+                let obj_ref = context.get_object_ref(*o).await?;
+                gas_objs.push(obj_ref);
+            }
+            Some(gas_objs)
         }
-        Some(gas_objs)
     } else {
         None
     };

--- a/crates/iota/src/client_ptb/ast.rs
+++ b/crates/iota/src/client_ptb/ast.rs
@@ -35,6 +35,7 @@ pub const SUMMARY: &str = "summary";
 pub const GAS_COIN: &str = "gas-coin";
 pub const JSON: &str = "json";
 pub const DRY_RUN: &str = "dry-run";
+pub const DEV_INSPECT: &str = "dev-inspect";
 pub const SERIALIZE_UNSIGNED: &str = "serialize-unsigned-transaction";
 pub const SERIALIZE_SIGNED: &str = "serialize-signed-transaction";
 
@@ -74,6 +75,7 @@ pub const COMMANDS: &[&str] = &[
     GAS_COIN,
     JSON,
     DRY_RUN,
+    DEV_INSPECT,
     SERIALIZE_UNSIGNED,
     SERIALIZE_SIGNED,
 ];
@@ -111,6 +113,7 @@ pub struct ProgramMetadata {
     pub gas_object_id: Option<Spanned<ObjectID>>,
     pub json_set: bool,
     pub dry_run_set: bool,
+    pub dev_inspect_set: bool,
     pub gas_budget: Option<Spanned<u64>>,
 }
 

--- a/crates/iota/src/client_ptb/parser.rs
+++ b/crates/iota/src/client_ptb/parser.rs
@@ -41,6 +41,7 @@ struct ProgramParsingState {
     serialize_signed_set: bool,
     json_set: bool,
     dry_run_set: bool,
+    dev_inspect_set: bool,
     gas_object_id: Option<Spanned<ObjectID>>,
     gas_budget: Option<Spanned<u64>>,
 }
@@ -63,6 +64,7 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
                 serialize_signed_set: false,
                 json_set: false,
                 dry_run_set: false,
+                dev_inspect_set: false,
                 gas_object_id: None,
                 gas_budget: None,
             },
@@ -111,6 +113,7 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
                 L(T::Command, A::SUMMARY) => flag!(summary_set),
                 L(T::Command, A::JSON) => flag!(json_set),
                 L(T::Command, A::DRY_RUN) => flag!(dry_run_set),
+                L(T::Command, A::DEV_INSPECT) => flag!(dev_inspect_set),
                 L(T::Command, A::PREVIEW) => flag!(preview_set),
                 L(T::Command, A::WARN_SHADOWS) => flag!(warn_shadows_set),
                 L(T::Command, A::GAS_COIN) => {
@@ -208,6 +211,7 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
                     gas_object_id: self.state.gas_object_id,
                     json_set: self.state.json_set,
                     dry_run_set: self.state.dry_run_set,
+                    dev_inspect_set: self.state.dev_inspect_set,
                     gas_budget: self.state.gas_budget,
                 },
             ))

--- a/crates/iota/src/client_ptb/ptb.rs
+++ b/crates/iota/src/client_ptb/ptb.rs
@@ -177,6 +177,10 @@ impl PTB {
                 return Ok(());
             }
             IotaClientCommandResult::TransactionBlock(response) => response,
+            IotaClientCommandResult::DevInspect(response) => {
+                println!("{}", Pretty(&response));
+                return Ok(());
+            }
             _ => anyhow::bail!("Internal error, unexpected response from PTB execution."),
         };
 

--- a/crates/iota/src/client_ptb/ptb.rs
+++ b/crates/iota/src/client_ptb/ptb.rs
@@ -153,6 +153,7 @@ impl PTB {
             gas: program_metadata.gas_object_id.map(|x| x.value),
             rest: Opts {
                 dry_run: program_metadata.dry_run_set,
+                dev_inspect: program_metadata.dev_inspect_set,
                 gas_budget: program_metadata.gas_budget.map(|x| x.value),
                 serialize_unsigned_transaction: program_metadata.serialize_unsigned_set,
                 serialize_signed_transaction: program_metadata.serialize_signed_set,
@@ -298,6 +299,10 @@ pub fn ptb_description() -> clap::Command {
         .arg(arg!(
             --"dry-run"
             "Perform a dry run of the PTB instead of executing it."
+        ))
+        .arg(arg!(
+            --"dev-inspect"
+            "Perform a dev-inspect of the PTB instead of executing it."
         ))
         .arg(arg!(
             --"gas-coin" <ID> ...

--- a/crates/iota/src/client_ptb/snapshots/iota__client_ptb__parser__tests__parse_commands.snap
+++ b/crates/iota/src/client_ptb/snapshots/iota__client_ptb__parser__tests__parse_commands.snap
@@ -32,6 +32,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -72,6 +73,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -121,6 +123,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -189,6 +192,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -248,6 +252,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -322,6 +327,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -390,6 +396,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -449,6 +456,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -517,6 +525,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -576,6 +585,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -623,6 +633,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -689,6 +700,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -802,6 +814,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -892,6 +905,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -982,6 +996,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1023,6 +1038,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1089,6 +1105,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1140,6 +1157,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1191,6 +1209,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1276,6 +1295,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1333,6 +1353,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1396,6 +1417,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1428,6 +1450,7 @@ expression: parsed
             ),
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1452,6 +1475,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1476,6 +1500,7 @@ expression: parsed
             gas_object_id: None,
             json_set: true,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1500,6 +1525,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -1524,6 +1550,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {

--- a/crates/iota/src/client_ptb/snapshots/iota__client_ptb__parser__tests__parse_publish.snap
+++ b/crates/iota/src/client_ptb/snapshots/iota__client_ptb__parser__tests__parse_publish.snap
@@ -32,6 +32,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {
@@ -72,6 +73,7 @@ expression: parsed
             gas_object_id: None,
             json_set: false,
             dry_run_set: false,
+            dev_inspect_set: false,
             gas_budget: Some(
                 Spanned {
                     span: Span {

--- a/crates/iota/src/displays/dev_inspect.rs
+++ b/crates/iota/src/displays/dev_inspect.rs
@@ -27,19 +27,29 @@ impl<'a> Display for Pretty<'a, DevInspectResults> {
         write!(f, "{}", response.events)?;
 
         if let Some(results) = &response.results {
+            if results.is_empty() {
+                writeln!(f, "No execution results")?;
+                return Ok(());
+            }
+
+            writeln!(f, "Execution Result")?;
             for result in results {
-                writeln!(f, "Execution Result")?;
-                writeln!(f, "  Mutable Reference Outputs")?;
-                for m in result.mutable_reference_outputs.iter() {
-                    writeln!(f, "    IOTA Argument: {}", m.0)?;
-                    writeln!(f, "    IOTA TypeTag: {:?}", m.2)?;
-                    writeln!(f, "    Bytes: {:?}", m.1)?;
+                if !result.mutable_reference_outputs.is_empty() {
+                    writeln!(f, "  Mutable Reference Outputs")?;
+                    for m in result.mutable_reference_outputs.iter() {
+                        writeln!(f, "    IOTA Argument: {}", m.0)?;
+                        writeln!(f, "    IOTA TypeTag: {:?}", m.2)?;
+                        writeln!(f, "    Bytes: {:?}", m.1)?;
+                    }
                 }
 
-                writeln!(f, "  Return values")?;
-                for val in result.return_values.iter() {
-                    writeln!(f, "    IOTA TypeTag: {:?}", val.1)?;
-                    writeln!(f, "    Bytes: {:?}", val.0)?;
+                if !result.return_values.is_empty() {
+                    writeln!(f, "  Return values")?;
+
+                    for val in result.return_values.iter() {
+                        writeln!(f, "    IOTA TypeTag: {:?}", val.1)?;
+                        writeln!(f, "    Bytes: {:?}", val.0)?;
+                    }
                 }
             }
         }

--- a/crates/iota/src/displays/dev_inspect.rs
+++ b/crates/iota/src/displays/dev_inspect.rs
@@ -8,7 +8,7 @@ use iota_json_rpc_types::{DevInspectResults, IotaTransactionBlockEffectsAPI};
 
 use crate::displays::Pretty;
 
-impl<'a> Display for Pretty<'a, DevInspectResults> {
+impl Display for Pretty<'_, DevInspectResults> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let Pretty(response) = self;
 

--- a/crates/iota/src/displays/dev_inspect.rs
+++ b/crates/iota/src/displays/dev_inspect.rs
@@ -1,0 +1,49 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt::{Display, Formatter};
+
+use iota_json_rpc_types::{DevInspectResults, IotaTransactionBlockEffectsAPI};
+
+use crate::displays::Pretty;
+
+impl<'a> Display for Pretty<'a, DevInspectResults> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let Pretty(response) = self;
+
+        if let Some(error) = &response.error {
+            writeln!(f, "Dev inspect failed: {}", error)?;
+            return Ok(());
+        }
+
+        writeln!(
+            f,
+            "Dev inspect completed, execution status: {}",
+            response.effects.status()
+        )?;
+
+        writeln!(f, "{}", response.effects)?;
+        write!(f, "{}", response.events)?;
+
+        if let Some(results) = &response.results {
+            for result in results {
+                writeln!(f, "Execution Result")?;
+                writeln!(f, "  Mutable Reference Outputs")?;
+                for m in result.mutable_reference_outputs.iter() {
+                    writeln!(f, "    IOTA Argument: {}", m.0)?;
+                    writeln!(f, "    IOTA TypeTag: {:?}", m.2)?;
+                    writeln!(f, "    Bytes: {:?}", m.1)?;
+                }
+
+                writeln!(f, "  Return values")?;
+                for val in result.return_values.iter() {
+                    writeln!(f, "    IOTA TypeTag: {:?}", val.1)?;
+                    writeln!(f, "    Bytes: {:?}", val.0)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/iota/src/displays/mod.rs
+++ b/crates/iota/src/displays/mod.rs
@@ -2,6 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+mod dev_inspect;
 mod dry_run_tx_block;
 mod gas_cost_summary;
 mod ptb_preview;

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -2985,6 +2985,7 @@ async fn test_serialize_tx() -> Result<(), anyhow::Error> {
         opts: Opts {
             gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER),
             dry_run: false,
+            dev_inspect: false,
             serialize_unsigned_transaction: true,
             serialize_signed_transaction: false,
             emit: HashSet::new(),
@@ -3000,6 +3001,7 @@ async fn test_serialize_tx() -> Result<(), anyhow::Error> {
         opts: Opts {
             gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER),
             dry_run: false,
+            dev_inspect: false,
             serialize_unsigned_transaction: false,
             serialize_signed_transaction: true,
             emit: HashSet::new(),
@@ -3016,6 +3018,7 @@ async fn test_serialize_tx() -> Result<(), anyhow::Error> {
         opts: Opts {
             gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER),
             dry_run: false,
+            dev_inspect: false,
             serialize_unsigned_transaction: false,
             serialize_signed_transaction: true,
             emit: HashSet::new(),
@@ -3763,6 +3766,7 @@ async fn test_gas_estimation() -> Result<(), anyhow::Error> {
         opts: Opts {
             gas_budget: None,
             dry_run: false,
+            dev_inspect: false,
             serialize_unsigned_transaction: false,
             serialize_signed_transaction: false,
             emit: HashSet::new(),


### PR DESCRIPTION
# Description of change

Add a `dev-inspect` flag to all executing-related commands.

Porting over https://github.com/MystenLabs/sui/pull/19972 and https://github.com/MystenLabs/sui/pull/20599

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/4925
Fixes https://github.com/iotaledger/iota/issues/4915

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running these commands
```
iota client ptb \
--move-call iota::tx_context::sender \
--assign sender \
--split-coins gas "[1000000000]" \
--assign coin \
--transfer-objects "[coin]" sender \
--dev-inspect

activeAddress=$(iota client active-address)
coinObjectId=$(iota client gas --json | jq -r '.[0].gasCoinId')
iota client pay --recipients $activeAddress --amounts 0 --input-coins $coinObjectId --gas-budget 10000000 --dev-inspect

coinObjectId=$(iota client gas --json | jq -r '.[0].gasCoinId')
iota client split-coin --coin-id $coinObjectId --count 2 --dev-inspect
```

Output for the ptb command:
```
Dev inspect completed, execution status: success
╭───────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Transaction Effects                                                                               │
├───────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Digest: DkkfwFB3qqojaKaijocXhWYwHhDysEQEceZpwDBaoBgv                                              │
│ Status: Success                                                                                   │
│ Executed Epoch: 67                                                                                │
│                                                                                                   │
│ Created Objects:                                                                                  │
│  ┌──                                                                                              │
│  │ ID: 0x66cb2f98a4cbb9da278e197ec7fe675f9e47b12c13aac731c94f46d29153d425                         │
│  │ Owner: Account Address ( 0xa5657935a0698bf654ce4ceb66b5a6d6a371a934a6afcfd1e191aa2ee460c8cc )  │
│  │ Version: 2                                                                                     │
│  │ Digest: Zy4jEt7kaFEjeaFRnbw9BRSo8CJibJXD2JtLeVe3duc                                            │
│  └──                                                                                              │
│ Mutated Objects:                                                                                  │
│  ┌──                                                                                              │
│  │ ID: 0x78da119695689ab7f556845cd66cd93b99653f656fb3d96b6439ab8964a4a8c7                         │
│  │ Owner: Account Address ( 0xa5657935a0698bf654ce4ceb66b5a6d6a371a934a6afcfd1e191aa2ee460c8cc )  │
│  │ Version: 2                                                                                     │
│  │ Digest: BdeAd31qSXaynYe27T8PMabdFWypAAc3hHo5EgaMGq6a                                           │
│  └──                                                                                              │
│ Gas Object:                                                                                       │
│  ┌──                                                                                              │
│  │ ID: 0x78da119695689ab7f556845cd66cd93b99653f656fb3d96b6439ab8964a4a8c7                         │
│  │ Owner: Account Address ( 0xa5657935a0698bf654ce4ceb66b5a6d6a371a934a6afcfd1e191aa2ee460c8cc )  │
│  │ Version: 2                                                                                     │
│  │ Digest: BdeAd31qSXaynYe27T8PMabdFWypAAc3hHo5EgaMGq6a                                           │
│  └──                                                                                              │
│ Gas Cost Summary:                                                                                 │
│    Storage Cost: 1960800 NANOS                                                                    │
│    Computation Cost: 1000000 NANOS                                                                │
│    Storage Rebate: 0 NANOS                                                                        │
│    Non-refundable Storage Fee: 0 NANOS                                                            │
│                                                                                                   │
│ Transaction Dependencies:                                                                         │
│    AS3GZusoMp8xxPvPBvwbUYnPPH7GxVNxnjkgLXzQAPPk                                                   │
╰───────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─────────────────────────────╮
│ No transaction block events │
╰─────────────────────────────╯
Execution Result
  Return values
    IOTA TypeTag: IotaTypeTag("address")
    Bytes: [165, 101, 121, 53, 160, 105, 139, 246, 84, 206, 76, 235, 102, 181, 166, 214, 163, 113, 169, 52, 166, 175, 207, 209, 225, 145, 170, 46, 228, 96, 200, 204]
  Mutable Reference Outputs
    IOTA Argument: GasCoin
    IOTA TypeTag: IotaTypeTag("0x2::coin::Coin<0x2::iota::IOTA>")
    Bytes: [120, 218, 17, 150, 149, 104, 154, 183, 245, 86, 132, 92, 214, 108, 217, 59, 153, 101, 63, 101, 111, 179, 217, 107, 100, 57, 171, 137, 100, 164, 168, 199, 0, 210, 206, 244, 220, 0, 0, 0]
  Return values
    IOTA TypeTag: IotaTypeTag("0x2::coin::Coin<0x2::iota::IOTA>")
    Bytes: [102, 203, 47, 152, 164, 203, 185, 218, 39, 142, 25, 126, 199, 254, 103, 95, 158, 71, 177, 44, 19, 170, 199, 49, 201, 79, 70, 210, 145, 83, 212, 37, 0, 202, 154, 59, 0, 0, 0, 0]
```
