### PR TITLE
fix: default node p2p `listen_address` port

### DIFF
--- a/crates/iota-config/src/p2p.rs
+++ b/crates/iota-config/src/p2p.rs
@@ -42,7 +42,7 @@ pub struct P2pConfig {
 }
 
 fn default_listen_address() -> SocketAddr {
-    "0.0.0.0:8080".parse().unwrap()
+    "0.0.0.0:8084".parse().unwrap()
 }
 
 impl Default for P2pConfig {


### PR DESCRIPTION
# Description of change

The default port for p2p is 8084.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)