### PR TITLE
feat(iota): `KeyToolCommand::UpdateAlias` accepts a key identity instead of an alias

### DIFF
--- a/crates/iota/src/key_identity.rs
+++ b/crates/iota/src/key_identity.rs
@@ -62,3 +62,13 @@ pub fn get_identity_address_from_keystore(
         KeyIdentity::Alias(x) => Ok(*keystore.get_address_by_alias(x)?),
     }
 }
+
+pub fn get_identity_alias_from_keystore(
+    input: KeyIdentity,
+    keystore: &Keystore,
+) -> Result<String, Error> {
+    match input {
+        KeyIdentity::Address(x) => Ok(keystore.get_alias_by_address(&x)?),
+        KeyIdentity::Alias(x) => Ok(x),
+    }
+}

--- a/crates/iota/src/keytool.rs
+++ b/crates/iota/src/keytool.rs
@@ -58,7 +58,9 @@ use tabled::{
 };
 use tracing::info;
 
-use crate::key_identity::{KeyIdentity, get_identity_address_from_keystore};
+use crate::key_identity::{
+    KeyIdentity, get_identity_address_from_keystore, get_identity_alias_from_keystore,
+};
 
 #[derive(Subcommand)]
 #[command(rename_all = "kebab-case")]
@@ -208,7 +210,8 @@ pub enum KeyToolCommand {
     /// Update an old alias to a new one.
     /// If a new alias is not provided, a random one will be generated.
     UpdateAlias {
-        old_alias: String,
+        /// An IOTA address or its alias.
+        key_identity: KeyIdentity,
         /// The alias must start with a letter and can contain only letters,
         /// digits, dots, hyphens (-), or underscores (_).
         new_alias: Option<String>,
@@ -800,9 +803,10 @@ impl KeyToolCommand {
                 })
             }
             KeyToolCommand::UpdateAlias {
-                old_alias,
+                key_identity,
                 new_alias,
             } => {
+                let old_alias = get_identity_alias_from_keystore(key_identity, keystore)?;
                 let new_alias = keystore.update_alias(&old_alias, new_alias.as_deref())?;
                 CommandOutput::UpdateAlias(AliasUpdate {
                     old_alias,


### PR DESCRIPTION
So that it can update the alias by its alias or address.

Fixes https://github.com/iotaledger/iota/issues/4889

# Before 

```sh
thibault@Mac ~/i/iota (develop)> ./target/debug/iota client new-address
Keys saved as Bech32.
╭──────────────────────────────────────────────────────────────────────────────────────────────╮
│ Created new keypair and saved it to keystore.                                                │
├────────────────┬─────────────────────────────────────────────────────────────────────────────┤
│ alias          │ intelligent-moonstone                                                       │
│ address        │ 0x015a926a39f445392acf1843660648145148425e05f4cbc28d1275dda4b45b0f          │
│ keyScheme      │ ed25519                                                                     │
│ recoveryPhrase │ logic venue ridge throw addict gift tomorrow object ozone minor reform same │
╰────────────────┴─────────────────────────────────────────────────────────────────────────────╯

thibault@Mac ~/i/iota (develop)> ./target/debug/iota keytool update-alias intelligent-moonstone tibo
Old alias intelligent-moonstone was updated to tibo

thibault@Mac ~/i/iota (develop)> ./target/debug/iota keytool list
╭────────────────────────────────────────────────────────────────────────────────────────────╮
│ ╭─────────────────┬──────────────────────────────────────────────────────────────────────╮ │
│ │ alias           │  tibo                                                                │ │
│ │ iotaAddress     │  0x015a926a39f445392acf1843660648145148425e05f4cbc28d1275dda4b45b0f  │ │
│ │ publicBase64Key │  ahdwqh+MIa9nbSf+ikHyieCa2GjQzBzQXDG/DuBwVOw=                        │ │
│ │ keyScheme       │  ed25519                                                             │ │
│ │ flag            │  0                                                                   │ │
│ │ peerId          │  6a1770aa1f8c21af676d27fe8a41f289e09ad868d0cc1cd05c31bf0ee07054ec    │ │
│ ╰─────────────────┴──────────────────────────────────────────────────────────────────────╯ │
╰────────────────────────────────────────────────────────────────────────────────────────────╯

thibault@Mac ~/i/iota (develop)> ./target/debug/iota keytool update-alias 0x015a926a39f445392acf1843660648145148425e05f4cbc28d1275dda4b45b0f intelligent-moonstone
The provided alias 0x015a926a39f445392acf1843660648145148425e05f4cbc28d1275dda4b45b0f does not exist
```

# After

```sh
thibault@Mac ~/i/iota (flexible-update-alias)> ./target/debug/iota client new-address
Keys saved as Bech32.
╭───────────────────────────────────────────────────────────────────────────────────────────╮
│ Created new keypair and saved it to keystore.                                             │
├────────────────┬──────────────────────────────────────────────────────────────────────────┤
│ alias          │ vibrant-coral                                                            │
│ address        │ 0xe0f262552d792372137092c7c2d1acf952456400f784160a318c4242e4c3801f       │
│ keyScheme      │ ed25519                                                                  │
│ recoveryPhrase │ city august oppose change neither actor real act blanket casino cat hunt │
╰────────────────┴──────────────────────────────────────────────────────────────────────────╯

thibault@Mac ~/i/iota (flexible-update-alias)> ./target/debug/iota keytool update-alias vibrant-coral tibo
Old alias vibrant-coral was updated to tibo

thibault@Mac ~/i/iota (flexible-update-alias)> ./target/debug/iota keytool list
╭────────────────────────────────────────────────────────────────────────────────────────────╮
│ ╭─────────────────┬──────────────────────────────────────────────────────────────────────╮ │
│ │ alias           │  tibo                                                                │ │
│ │ iotaAddress     │  0xe0f262552d792372137092c7c2d1acf952456400f784160a318c4242e4c3801f  │ │
│ │ publicBase64Key │  lIvz0m1oiETfKXkh6NYlQlaqtTZeidt6ZuJs2UaZQhA=                        │ │
│ │ keyScheme       │  ed25519                                                             │ │
│ │ flag            │  0                                                                   │ │
│ │ peerId          │  948bf3d26d688844df297921e8d6254256aab5365e89db7a66e26cd946994210    │ │
│ ╰─────────────────┴──────────────────────────────────────────────────────────────────────╯ │
╰────────────────────────────────────────────────────────────────────────────────────────────╯

thibault@Mac ~/i/iota (flexible-update-alias)> ./target/debug/iota keytool update-alias 0xe0f262552d792372137092c7c2d1acf952456400f784160a318c4242e4c3801f vibrant-coral
Old alias tibo was updated to vibrant-coral

thibault@Mac ~/i/iota (flexible-update-alias)> ./target/debug/iota keytool list
╭────────────────────────────────────────────────────────────────────────────────────────────╮
│ ╭─────────────────┬──────────────────────────────────────────────────────────────────────╮ │
│ │ alias           │  vibrant-coral                                                       │ │
│ │ iotaAddress     │  0xe0f262552d792372137092c7c2d1acf952456400f784160a318c4242e4c3801f  │ │
│ │ publicBase64Key │  lIvz0m1oiETfKXkh6NYlQlaqtTZeidt6ZuJs2UaZQhA=                        │ │
│ │ keyScheme       │  ed25519                                                             │ │
│ │ flag            │  0                                                                   │ │
│ │ peerId          │  948bf3d26d688844df297921e8d6254256aab5365e89db7a66e26cd946994210    │ │
│ ╰─────────────────┴──────────────────────────────────────────────────────────────────────╯ │
╰────────────────────────────────────────────────────────────────────────────────────────────╯
```