### PR TITLE
chore(docs): format rust code in sponsored tx code

### DIFF
--- a/docs/content/developer/iota-101/transactions/sponsored-transactions/about-sponsored-transactions.mdx
+++ b/docs/content/developer/iota-101/transactions/sponsored-transactions/about-sponsored-transactions.mdx
@@ -61,25 +61,25 @@ A transaction in IOTA has a specific data structure, which can be represented as
 
 ```rust
 pub struct SenderSignedTransaction {
-pub intent_message: IntentMessage<TransactionData>,
-/// A list of signatures signed by all transaction participants.
-/// 1. Non-participant signatures must not be present.
-/// 2. Signature order does not matter.
-pub tx_signatures: Vec<GenericSignature>,
+  pub intent_message: IntentMessage<TransactionData>,
+  /// A list of signatures signed by all transaction participants.
+  /// 1. Non-participant signatures must not be present.
+  /// 2. Signature order does not matter.
+  pub tx_signatures: Vec<GenericSignature>,
 }
 
 pub struct TransactionDataV1 {  // <-- A variant of `TransactionData`
-pub kind: TransactionKind,  // <-- This contains the transaction details
-pub sender: IOTAAddress,
-pub gas_data: GasData,
-pub expiration: TransactionExpiration,
+  pub kind: TransactionKind,  // <-- This contains the transaction details
+  pub sender: IOTAAddress,
+  pub gas_data: GasData,
+  pub expiration: TransactionExpiration,
 }
 
 pub struct GasData {
-pub payment: Vec<ObjectRef>,
-pub owner: IOTAAddress,
-pub price: u64,
-pub budget: u64,
+  pub payment: Vec<ObjectRef>,
+  pub owner: IOTAAddress,
+  pub price: u64,
+  pub budget: u64,
 }
 ```
 


### PR DESCRIPTION
# Description of change

Just a small fix. Let the indentation battle begin. 2 vs 4 spaces :trollface: 
