### PR TITLE
refactor(indexer): Derive dynamic field info

### DIFF
--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -1413,7 +1413,11 @@ impl IndexerReader {
 
                 let version = object.version();
                 let digest = object.digest();
-                let object_type = object.data.type_().unwrap().clone();
+                let object_type = object
+                    .data
+                    .type_()
+                    .expect("Data represents a Move object and therefore should have type")
+                    .clone();
                 DynamicFieldInfo {
                     name,
                     bcs_name,

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -2,10 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
 use anyhow::{Result, anyhow};
 use cached::{Cached, SizedCache};
@@ -15,20 +12,22 @@ use diesel::{
     r2d2::ConnectionManager, sql_types::Bool,
 };
 use fastcrypto::encoding::{Encoding, Hex};
+use iota_json::MoveTypeLayout;
 use iota_json_rpc_types::{
     AddressMetrics, Balance, CheckpointId, Coin as IotaCoin, DisplayFieldsResponse, EpochInfo,
-    EventFilter, IotaCoinMetadata, IotaEvent, IotaObjectDataFilter, IotaTransactionBlockEffects,
-    IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse, MoveCallMetrics,
-    MoveFunctionName, NetworkMetrics, TransactionFilter,
+    EventFilter, IotaCoinMetadata, IotaEvent, IotaMoveValue, IotaObjectDataFilter,
+    IotaTransactionBlockEffects, IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse,
+    MoveCallMetrics, MoveFunctionName, NetworkMetrics, TransactionFilter,
 };
 use iota_package_resolver::{Package, PackageStore, PackageStoreWithLruCache, Resolver};
 use iota_types::{
+    TypeTag,
     balance::Supply,
-    base_types::{IotaAddress, ObjectID, ObjectRef, SequenceNumber, VersionNumber},
+    base_types::{IotaAddress, ObjectID, VersionNumber},
     coin::{CoinMetadata, TreasuryCap},
     committee::EpochId,
-    digests::{ObjectDigest, TransactionDigest},
-    dynamic_field::{DynamicFieldInfo, DynamicFieldName},
+    digests::TransactionDigest,
+    dynamic_field::{DynamicFieldInfo, DynamicFieldName, DynamicFieldType},
     effects::TransactionEvents,
     event::EventID,
     iota_system_state::{
@@ -38,7 +37,7 @@ use iota_types::{
     is_system_package,
     object::{Object, ObjectRead},
 };
-use itertools::{Itertools, any};
+use itertools::Itertools;
 use move_core_types::{annotated_value::MoveStructLayout, language_storage::StructTag};
 use tap::TapFallible;
 
@@ -53,7 +52,7 @@ use crate::{
         events::StoredEvent,
         move_call_metrics::QueriedMoveCallMetrics,
         network_metrics::StoredNetworkMetrics,
-        objects::{CoinBalance, ObjectRefColumn, StoredObject},
+        objects::{CoinBalance, StoredObject},
         transactions::{
             StoredTransaction, StoredTransactionEvents, stored_events_to_events,
             tx_events_to_iota_tx_events,
@@ -1290,61 +1289,39 @@ impl IndexerReader {
         cursor: Option<ObjectID>,
         limit: usize,
     ) -> Result<Vec<DynamicFieldInfo>, IndexerError> {
-        let objects = self
+        let stored_objects = self
             .spawn_blocking(move |this| {
                 this.get_dynamic_fields_raw(parent_object_id, cursor, limit)
             })
             .await?;
 
-        if any(objects.iter(), |o| o.df_object_id.is_none()) {
-            return Err(IndexerError::PersistentStorageDataCorruption(format!(
-                "Dynamic field has empty df_object_id column for parent object {}",
-                parent_object_id
-            )));
-        }
-
-        // for Dynamic field objects, df_object_id != object_id, we need another look up
-        // to get the version and digests.
-        // TODO: simply store df_object_version and df_object_digest as well?
-        let dfo_ids = objects
-            .iter()
-            .filter_map(|o| {
-                // Unwrap safe: checked nullity above
-                if o.df_object_id.as_ref().unwrap() == &o.object_id {
-                    None
-                } else {
-                    Some(o.df_object_id.clone().unwrap())
-                }
-            })
-            .collect::<Vec<_>>();
-
-        let object_refs = self
-            .spawn_blocking(move |this| this.get_object_refs(dfo_ids))
-            .await?;
         let mut df_futures = vec![];
-        for object in objects {
-            let package_resolver_clone = self.package_resolver.clone();
-            df_futures.push(tokio::task::spawn(
-                object.try_into_expectant_dynamic_field_info(package_resolver_clone),
-            ));
+        let indexer_reader_arc = Arc::new(self.clone());
+        for stored_object in stored_objects {
+            let indexer_reader_arc_clone = Arc::clone(&indexer_reader_arc);
+            df_futures.push(tokio::task::spawn(async move {
+                indexer_reader_arc_clone
+                    .try_create_dynamic_field_info(stored_object)
+                    .await
+            }));
         }
-        let mut dynamic_fields = futures::future::join_all(df_futures)
+        let df_infos = futures::future::join_all(df_futures)
             .await
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
             .tap_err(|e| tracing::error!("Error joining DF futures: {:?}", e))?
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
-            .tap_err(|e| tracing::error!("Error calling DF try_into function: {:?}", e))?;
-
-        for df in dynamic_fields.iter_mut() {
-            if let Some(obj_ref) = object_refs.get(&df.object_id) {
-                df.version = obj_ref.1;
-                df.digest = obj_ref.2;
-            }
-        }
-
-        Ok(dynamic_fields)
+            .tap_err(|e| {
+                tracing::error!(
+                    "Error calling DF try_create_dynamic_field_info function: {:?}",
+                    e
+                )
+            })?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        Ok(df_infos)
     }
 
     pub async fn get_dynamic_fields_raw_in_blocking_task(
@@ -1381,6 +1358,90 @@ impl IndexerReader {
         Ok(objects)
     }
 
+    async fn try_create_dynamic_field_info(
+        &self,
+        stored_object: StoredObject,
+    ) -> Result<Option<DynamicFieldInfo>, IndexerError> {
+        if stored_object.df_kind.is_none() {
+            return Ok(None);
+        }
+
+        let object: Object = stored_object.try_into()?;
+        let move_object = match object.data.try_as_move().cloned() {
+            Some(move_object) => move_object,
+            None => {
+                return Err(IndexerError::ResolveMoveStruct(
+                    "Object is not a MoveObject".to_string(),
+                ));
+            }
+        };
+        let struct_tag: StructTag = move_object.type_().clone().into();
+        let move_type_layout = self
+            .package_resolver
+            .type_layout(TypeTag::Struct(Box::new(struct_tag.clone())))
+            .await
+            .map_err(|e| {
+                IndexerError::ResolveMoveStruct(format!(
+                    "Failed to get type layout for type {}: {}",
+                    struct_tag, e
+                ))
+            })?;
+        let MoveTypeLayout::Struct(move_struct_layout) = move_type_layout else {
+            return Err(IndexerError::ResolveMoveStruct(
+                "MoveTypeLayout is not Struct".to_string(),
+            ));
+        };
+
+        let move_struct = move_object.to_move_struct(&move_struct_layout)?;
+        let (move_value, type_, object_id) =
+            DynamicFieldInfo::parse_move_object(&move_struct).tap_err(|e| tracing::warn!("{e}"))?;
+        let name_type = move_object.type_().try_extract_field_name(&type_)?;
+        let bcs_name = bcs::to_bytes(&move_value.clone().undecorate()).map_err(|e| {
+            IndexerError::Serde(format!(
+                "Failed to serialize dynamic field name {:?}: {e}",
+                move_value
+            ))
+        })?;
+        let name = DynamicFieldName {
+            type_: name_type,
+            value: IotaMoveValue::from(move_value).to_json_value(),
+        };
+
+        Ok(Some(match type_ {
+            DynamicFieldType::DynamicObject => {
+                let object = self.get_object_in_blocking_task(object_id).await?.ok_or(
+                    IndexerError::Uncategorized(anyhow::anyhow!(
+                        "Failed to find object_id {:?} when trying to create dynamic field info",
+                        object_id
+                    )),
+                )?;
+
+                let version = object.version();
+                let digest = object.digest();
+                let object_type = object.data.type_().unwrap().clone();
+                DynamicFieldInfo {
+                    name,
+                    bcs_name,
+                    type_,
+                    object_type: object_type.to_canonical_string(/* with_prefix */ true),
+                    object_id,
+                    version,
+                    digest,
+                }
+            }
+            DynamicFieldType::DynamicField => DynamicFieldInfo {
+                name,
+                bcs_name,
+                type_,
+                object_type: move_object.into_type().into_type_params()[1]
+                    .to_canonical_string(/* with_prefix */ true),
+                object_id: object.id(),
+                version: object.version(),
+                digest: object.digest(),
+            },
+        }))
+    }
+
     pub async fn bcs_name_from_dynamic_field_name(
         &self,
         name: &DynamicFieldName,
@@ -1398,42 +1459,6 @@ impl IndexerReader {
         let iota_json_value = iota_json::IotaJsonValue::new(name.value.clone())?;
         let name_bcs_value = iota_json_value.to_bcs_bytes(&move_type_layout)?;
         Ok(name_bcs_value)
-    }
-
-    fn get_object_refs(
-        &self,
-        object_ids: Vec<Vec<u8>>,
-    ) -> IndexerResult<HashMap<ObjectID, ObjectRef>> {
-        run_query!(&self.pool, |conn| {
-            let query = objects::dsl::objects
-                .select((
-                    objects::dsl::object_id,
-                    objects::dsl::object_version,
-                    objects::dsl::object_digest,
-                ))
-                .filter(objects::dsl::object_id.eq_any(object_ids))
-                .into_boxed();
-            query.load::<ObjectRefColumn>(conn)
-        })?
-        .into_iter()
-        .map(|object_ref: ObjectRefColumn| {
-            let object_id = ObjectID::from_bytes(object_ref.object_id.clone()).map_err(|_e| {
-                IndexerError::PersistentStorageDataCorruption(format!(
-                    "Can't convert {:?} to ObjectID",
-                    object_ref.object_id
-                ))
-            })?;
-            let seq = SequenceNumber::from_u64(object_ref.object_version as u64);
-            let object_digest = ObjectDigest::try_from(object_ref.object_digest.as_slice())
-                .map_err(|e| {
-                    IndexerError::PersistentStorageDataCorruption(format!(
-                        "object {:?} has incompatible object digest. Error: {e}",
-                        object_ref.object_digest
-                    ))
-                })?;
-            Ok((object_id, (object_id, seq, object_digest)))
-        })
-        .collect::<IndexerResult<HashMap<_, _>>>()
     }
 
     pub async fn get_display_object_by_type(

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -1305,10 +1305,8 @@ impl IndexerReader {
                     .await
             }));
         }
-        let df_infos = futures::future::join_all(df_futures)
+        let df_infos = futures::future::try_join_all(df_futures)
             .await
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()
             .tap_err(|e| tracing::error!("Error joining DF futures: {:?}", e))?
             .into_iter()
             .collect::<Result<Vec<_>, _>>()

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -1365,13 +1365,10 @@ impl IndexerReader {
         }
 
         let object: Object = stored_object.try_into()?;
-        let move_object = match object.data.try_as_move().cloned() {
-            Some(move_object) => move_object,
-            None => {
-                return Err(IndexerError::ResolveMoveStruct(
-                    "Object is not a MoveObject".to_string(),
-                ));
-            }
+        let Some(move_object) = object.data.try_as_move().cloned() else {
+            return Err(IndexerError::ResolveMoveStruct(
+                "Object is not a MoveObject".to_string(),
+            ));
         };
         let struct_tag: StructTag = move_object.type_().clone().into();
         let move_type_layout = self

--- a/crates/iota-indexer/src/models/objects.rs
+++ b/crates/iota-indexer/src/models/objects.rs
@@ -11,7 +11,7 @@ use iota_package_resolver::{PackageStore, Resolver};
 use iota_types::{
     base_types::{ObjectID, ObjectRef},
     digests::ObjectDigest,
-    dynamic_field::{DynamicFieldInfo, DynamicFieldName, DynamicFieldType, Field},
+    dynamic_field::{DynamicFieldType, Field},
     object::{Object, ObjectRead},
 };
 use move_core_types::annotated_value::MoveTypeLayout;
@@ -317,129 +317,6 @@ impl StoredObject {
         }?;
 
         Ok(ObjectRead::Exists(oref, object, Some(move_struct_layout)))
-    }
-
-    pub async fn try_into_expectant_dynamic_field_info(
-        self,
-        package_resolver: Arc<Resolver<impl PackageStore>>,
-    ) -> Result<DynamicFieldInfo, IndexerError> {
-        match self
-            .try_into_dynamic_field_info(package_resolver)
-            .await
-            .transpose()
-        {
-            Some(Ok(info)) => Ok(info),
-            Some(Err(e)) => Err(e),
-            None => Err(IndexerError::PersistentStorageDataCorruption(
-                "Dynamic field object has incompatible dynamic field type: empty df_kind".into(),
-            )),
-        }
-    }
-
-    pub async fn try_into_dynamic_field_info(
-        self,
-        package_resolver: Arc<Resolver<impl PackageStore>>,
-    ) -> Result<Option<DynamicFieldInfo>, IndexerError> {
-        if self.df_kind.is_none() {
-            return Ok(None);
-        }
-
-        // Past this point, if there is any unexpected field, it's a data corruption
-        // error
-        let object_id = ObjectID::from_bytes(&self.object_id).map_err(|_| {
-            IndexerError::PersistentStorageDataCorruption(format!(
-                "Can't convert {:?} to object_id",
-                self.object_id
-            ))
-        })?;
-        let object_digest = ObjectDigest::try_from(self.object_digest.as_slice()).map_err(|e| {
-            IndexerError::PersistentStorageDataCorruption(format!(
-                "object {} has incompatible object digest. Error: {e}",
-                object_id
-            ))
-        })?;
-        let df_object_id = if let Some(df_object_id) = self.df_object_id.clone() {
-            ObjectID::from_bytes(df_object_id).map_err(|e| {
-                IndexerError::PersistentStorageDataCorruption(format!(
-                    "object {} has incompatible dynamic field type: df_object_id. Error: {e}",
-                    object_id
-                ))
-            })
-        } else {
-            return Err(IndexerError::PersistentStorageDataCorruption(format!(
-                "object {} has incompatible dynamic field type: empty df_object_id",
-                object_id
-            )));
-        }?;
-        let type_ = match self.df_kind {
-            Some(0) => DynamicFieldType::DynamicField,
-            Some(1) => DynamicFieldType::DynamicObject,
-            _ => {
-                return Err(IndexerError::PersistentStorageDataCorruption(format!(
-                    "object {} has incompatible dynamic field type: empty df_kind",
-                    object_id
-                )));
-            }
-        };
-        let name = if let Some(field_name) = self.df_name.clone() {
-            let name: DynamicFieldName = bcs::from_bytes(&field_name).map_err(|e| {
-                IndexerError::PersistentStorageDataCorruption(format!(
-                    "object {} has incompatible dynamic field type: df_name. Error: {e}",
-                    object_id
-                ))
-            })?;
-            name
-        } else {
-            return Err(IndexerError::PersistentStorageDataCorruption(format!(
-                "object {} has incompatible dynamic field type: empty df_name",
-                object_id
-            )));
-        };
-
-        let oref = self.get_object_ref()?;
-        let object: iota_types::object::Object = self.clone().try_into()?;
-        let Some(move_object) = object.data.try_as_move().cloned() else {
-            return Err(IndexerError::PostgresRead(format!(
-                "Object {:?} is not a Move object",
-                oref,
-            )));
-        };
-        if !move_object.type_().is_dynamic_field() {
-            return Err(IndexerError::PostgresRead(format!(
-                "Object {:?} is not a dynamic field",
-                oref,
-            )));
-        }
-
-        let layout = package_resolver
-            .type_layout(name.type_.clone())
-            .await
-            .map_err(|e| {
-                IndexerError::ResolveMoveStruct(format!(
-                    "Failed to create dynamic field info for obj {}:{}, type: {}. Error: {e}",
-                    object.id(),
-                    object.version(),
-                    move_object.type_(),
-                ))
-            })?;
-        let iota_json_value = iota_json::IotaJsonValue::new(name.value.clone())?;
-        let bcs_name = iota_json_value.to_bcs_bytes(&layout)?;
-        let object_type =
-            self.df_object_type
-                .clone()
-                .ok_or(IndexerError::PersistentStorageDataCorruption(format!(
-                    "object {} has incompatible dynamic field type: empty df_object_type",
-                    object_id
-                )))?;
-        Ok(Some(DynamicFieldInfo {
-            version: oref.1,
-            digest: object_digest,
-            type_,
-            name,
-            bcs_name,
-            object_type,
-            object_id: df_object_id,
-        }))
     }
 
     pub fn get_object_ref(&self) -> Result<ObjectRef, IndexerError> {


### PR DESCRIPTION
# Description of change

Pull from upstream: https://github.com/MystenLabs/sui/pull/19099

Refactors way that dynamic fields are obtained in indexer api, to not use `df_object_id`, `df_name`, `df_object_type` columns in preparation for their removal.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/5049

## Type of change

- Refactoring

## How the change has been tested

`cargo test --package=iota-indexer --profile=simulator --features=shared_test_runtime`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
