### PR TITLE
[cherry-pick] fix: re-add rpc-indexes to support `InputObject` and `ChangedObject` filters (partly revert #3142) (#5074)

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2097,6 +2097,12 @@ impl AuthorityState {
         indexes
             .index_tx(
                 cert.data().intent_message().value.sender(),
+                cert.data()
+                    .intent_message()
+                    .value
+                    .input_objects()?
+                    .iter()
+                    .map(|o| o.object_id()),
                 effects
                     .all_changed_objects()
                     .into_iter()

--- a/crates/iota-tool/src/db_tool/index_search.rs
+++ b/crates/iota-tool/src/db_tool/index_search.rs
@@ -67,6 +67,22 @@ pub fn search_index(
                 termination
             )
         }
+        "transactions_by_input_object_id" => {
+            get_db_entries!(
+                db_read_only_handle.transactions_by_input_object_id,
+                from_id_seq,
+                start,
+                termination
+            )
+        }
+        "transactions_by_mutated_object_id" => {
+            get_db_entries!(
+                db_read_only_handle.transactions_by_mutated_object_id,
+                from_id_seq,
+                start,
+                termination
+            )
+        }
         "transactions_by_move_function" => {
             get_db_entries!(
                 db_read_only_handle.transactions_by_move_function,
@@ -239,6 +255,19 @@ fn from_addr_seq(s: &str) -> Result<(IotaAddress, TxSequenceNumber), anyhow::Err
     let sequence_number = TxSequenceNumber::from_str(tokens[1].trim())?;
 
     Ok((address, sequence_number))
+}
+
+fn from_id_seq(s: &str) -> Result<(ObjectID, TxSequenceNumber), anyhow::Error> {
+    // Remove whitespaces
+    let s = s.trim();
+    let tokens = s.split(',').collect::<Vec<&str>>();
+    if tokens.len() != 2 {
+        return Err(anyhow!("Invalid object id, sequence number pair"));
+    }
+    let oid = ObjectID::from_str(tokens[0].trim())?;
+    let sequence_number = TxSequenceNumber::from_str(tokens[1].trim())?;
+
+    Ok((oid, sequence_number))
 }
 
 fn from_id_module_function_txseq(


### PR DESCRIPTION
Cherry-picking #5074
# Description of change

This PR re-adds the needed tables in the `IndexStoreTables` to be able to filter by `InputObject` or `ChangedObject`.
The reason to remove them in the first place was that they are marked as deprecated and guarded by the `remove_deprecated_tables` flag. They will be removed eventually on upstream anyway.

⚠️ WARNING ⚠️
What do we do with existing databases that didn't index these object IDs before? 
Do we resync a node in testnet from genesis and instruct all fullnode operators to use our database snapshot?

## Links to any relevant issues

#5052 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
