### PR TITLE
feat(admin): Return error status code from admin console if tracing is disabled on startup.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14538,6 +14538,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prometheus",
  "prost",
+ "thiserror",
  "tokio",
  "tonic",
  "tracing",

--- a/crates/iota-node/src/admin.rs
+++ b/crates/iota-node/src/admin.rs
@@ -205,8 +205,8 @@ async fn enable_tracing(
             (StatusCode::OK, response.join("\n"))
         }
         Err(TelemetryError::TracingDisabled) => {
-            response.push("tracing is not supported as it was disabled in the node's TelemetryConfig\nignoring request".into());
-            (StatusCode::FORBIDDEN, response.join("\n"))
+            response.push("can't update filter: tracing is not enabled. to enable it, run the node with 'TRACE_FILTER' set.".into());
+            (StatusCode::NOT_IMPLEMENTED, response.join("\n"))
         }
         Err(err) => {
             response.push(format!("can't update filter: {:?}", err));
@@ -217,15 +217,13 @@ async fn enable_tracing(
 
 async fn reset_tracing(State(state): State<Arc<AppState>>) -> (StatusCode, String) {
     match state.tracing_handle.reset_trace() {
-        Ok(()) => {
-            (
-                StatusCode::OK,
-                "tracing filter reset to TRACE_FILTER env var".into(),
-            )
-        }
+        Ok(()) => (
+            StatusCode::OK,
+            "tracing filter reset to TRACE_FILTER env var".into(),
+        ),
         Err(TelemetryError::TracingDisabled) => (
-            StatusCode::FORBIDDEN,
-            "tracing was disabled in the node's TelemetryConfig. so it is not supported\nignoring request".into(),
+            StatusCode::NOT_IMPLEMENTED,
+            "tracing is not enabled. to enable it, run the node with 'TRACE_FILTER' set.".into(),
         ),
         Err(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
     }

--- a/crates/iota-node/src/admin.rs
+++ b/crates/iota-node/src/admin.rs
@@ -18,7 +18,7 @@ use iota_types::{
     error::IotaError,
 };
 use serde::Deserialize;
-use telemetry_subscribers::TracingHandle;
+use telemetry_subscribers::{TelemetryError, TracingHandle};
 use tokio::sync::oneshot;
 use tracing::info;
 
@@ -204,6 +204,10 @@ async fn enable_tracing(
             response.push(format!("filter will be reset after {:?}", duration));
             (StatusCode::OK, response.join("\n"))
         }
+        Err(TelemetryError::TracingDisabled) => {
+            response.push("tracing is not supported as it was disabled in the node's TelemetryConfig\nignoring request".into());
+            (StatusCode::FORBIDDEN, response.join("\n"))
+        }
         Err(err) => {
             response.push(format!("can't update filter: {:?}", err));
             (StatusCode::BAD_REQUEST, response.join("\n"))
@@ -212,11 +216,19 @@ async fn enable_tracing(
 }
 
 async fn reset_tracing(State(state): State<Arc<AppState>>) -> (StatusCode, String) {
-    state.tracing_handle.reset_trace();
-    (
-        StatusCode::OK,
-        "tracing filter reset to TRACE_FILTER env var".into(),
-    )
+    match state.tracing_handle.reset_trace() {
+        Ok(()) => {
+            (
+                StatusCode::OK,
+                "tracing filter reset to TRACE_FILTER env var".into(),
+            )
+        }
+        Err(TelemetryError::TracingDisabled) => (
+            StatusCode::FORBIDDEN,
+            "tracing was disabled in the node's TelemetryConfig. so it is not supported\nignoring request".into(),
+        ),
+        Err(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
+    }
 }
 
 async fn get_filter(State(state): State<Arc<AppState>>) -> (StatusCode, String) {

--- a/crates/telemetry-subscribers/Cargo.toml
+++ b/crates/telemetry-subscribers/Cargo.toml
@@ -22,6 +22,7 @@ opentelemetry-proto = "0.7"
 opentelemetry_sdk = { version = "0.24", features = ["rt-tokio"] }
 prometheus.workspace = true
 prost.workspace = true
+thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tonic.workspace = true
 tracing.workspace = true

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -24,6 +24,7 @@ use opentelemetry_sdk::{
     trace::{BatchSpanProcessor, Sampler, ShouldSample, TracerProvider},
 };
 use span_latency_prom::PrometheusSpanLatencyLayer;
+use thiserror::Error;
 use tracing::{Level, error, info, metadata::LevelFilter};
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 use tracing_subscriber::{EnvFilter, Layer, Registry, filter, fmt, layer::SubscriberExt, reload};
@@ -35,6 +36,15 @@ pub mod span_latency_prom;
 
 /// Alias for a type-erased error type.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+#[derive(Debug, Error)]
+pub enum TelemetryError {
+    #[error("OTLP protocol not enabled in the node's configuration")]
+    TracingDisabled,
+
+    #[error("{0}")]
+    Other(#[from] BoxError),
+}
 
 /// Configuration for different logging/tracing options
 /// ===
@@ -107,9 +117,8 @@ impl FilterHandle {
     }
 
     pub fn get(&self) -> Result<String, BoxError> {
-        self.0
-            .with_current(|filter| filter.to_string())
-            .map_err(Into::into)
+        let result = self.0.with_current(|filter| filter.to_string())?;
+        Ok(result)
     }
 }
 
@@ -143,9 +152,9 @@ impl TracingHandle {
         &self,
         directives: S,
         duration: Duration,
-    ) -> Result<(), BoxError> {
+    ) -> Result<(), TelemetryError> {
         if let Some(trace) = &self.trace {
-            let res = trace.update(directives);
+            trace.update(directives)?;
             // after duration is elapsed, reset to the env setting
             let trace = trace.clone();
             let trace_filter_env = env::var("TRACE_FILTER").unwrap_or_else(|_| "off".to_string());
@@ -155,10 +164,10 @@ impl TracingHandle {
                     error!("failed to reset trace filter: {}", e);
                 }
             });
-            res
+            Ok(())
         } else {
             info!("tracing not enabled, ignoring update");
-            Ok(())
+            Err(TelemetryError::TracingDisabled)
         }
     }
 
@@ -166,12 +175,13 @@ impl TracingHandle {
         self.file_output.clear_path();
     }
 
-    pub fn reset_trace(&self) {
+    pub fn reset_trace(&self) -> Result<(), TelemetryError> {
         if let Some(trace) = &self.trace {
             let trace_filter_env = env::var("TRACE_FILTER").unwrap_or_else(|_| "off".to_string());
-            if let Err(e) = trace.update(trace_filter_env) {
-                error!("failed to reset trace filter: {}", e);
-            }
+            trace.update(trace_filter_env).map_err(|e| e.into())
+        } else {
+            info!("tracing not enabled, ignoring reset");
+            Err(TelemetryError::TracingDisabled)
         }
     }
 }

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -25,7 +25,7 @@ use opentelemetry_sdk::{
 };
 use span_latency_prom::PrometheusSpanLatencyLayer;
 use thiserror::Error;
-use tracing::{Level, error, info, metadata::LevelFilter};
+use tracing::{Level, error, metadata::LevelFilter};
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 use tracing_subscriber::{EnvFilter, Layer, Registry, filter, fmt, layer::SubscriberExt, reload};
 

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -117,8 +117,9 @@ impl FilterHandle {
     }
 
     pub fn get(&self) -> Result<String, BoxError> {
-        let result = self.0.with_current(|filter| filter.to_string())?;
-        Ok(result)
+        self.0
+            .with_current(|filter| filter.to_string())
+            .map_err(Into::into)
     }
 }
 
@@ -166,7 +167,6 @@ impl TracingHandle {
             });
             Ok(())
         } else {
-            info!("tracing not enabled, ignoring update");
             Err(TelemetryError::TracingDisabled)
         }
     }
@@ -180,7 +180,6 @@ impl TracingHandle {
             let trace_filter_env = env::var("TRACE_FILTER").unwrap_or_else(|_| "off".to_string());
             trace.update(trace_filter_env).map_err(|e| e.into())
         } else {
-            info!("tracing not enabled, ignoring reset");
             Err(TelemetryError::TracingDisabled)
         }
     }


### PR DESCRIPTION
# Description of change
Because tracing might be expensive operation, tracing is not enabled by default and it can be enabled only if node operator provide TRACE_FILTER on the node startup.
The admin interface endpoints: `enable-tracing` and `reset_tracing` allow to start and reset level of tracing but they work only if tracing was enabled on the node startup. Currently admin endpoint always returned OK status and information about ignoring request was only printed in logs, what was misleading. Now we correctly inform that tracing cannot be enabled and why.

## Links to any relevant issues

Related to #4322

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)


## How the change has been tested

Tested by running a node and using admin api


## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
