### PR TITLE
refactor: use ObjectStoreConfig as remote store client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6502,6 +6502,7 @@ dependencies = [
  "bytes",
  "futures",
  "iota-archival",
+ "iota-config",
  "iota-data-ingestion-core",
  "iota-metrics",
  "iota-storage",

--- a/crates/iota-data-ingestion/Cargo.toml
+++ b/crates/iota-data-ingestion/Cargo.toml
@@ -32,6 +32,7 @@ url.workspace = true
 
 # internal dependencies
 iota-archival.workspace = true
+iota-config.workspace = true
 iota-data-ingestion-core.workspace = true
 iota-metrics.workspace = true
 iota-storage.workspace = true

--- a/crates/iota-data-ingestion/src/main.rs
+++ b/crates/iota-data-ingestion/src/main.rs
@@ -81,7 +81,7 @@ fn setup_env(token: CancellationToken) {
 
     tokio::spawn(async move {
         let mut signal_stream = tokio::signal::unix::signal(SignalKind::terminate())
-            .expect("Cannot listen to  SIGTERM signal");
+            .expect("Cannot listen to SIGTERM signal");
 
         tokio::select! {
             _ = tokio::signal::ctrl_c() => tracing::info!("CTRL+C signal received, shutting down"),

--- a/crates/iota-data-ingestion/src/main.rs
+++ b/crates/iota-data-ingestion/src/main.rs
@@ -134,7 +134,7 @@ async fn main() -> Result<()> {
             }
             Task::Blob(blob_config) => {
                 let worker_pool = WorkerPool::new(
-                    BlobWorker::try_new(blob_config)?,
+                    BlobWorker::new(blob_config)?,
                     task_config.name,
                     task_config.concurrency,
                 );

--- a/crates/iota-data-ingestion/src/main.rs
+++ b/crates/iota-data-ingestion/src/main.rs
@@ -12,11 +12,11 @@ use iota_data_ingestion::{
 use iota_data_ingestion_core::{DataIngestionMetrics, IndexerExecutor, ReaderOptions, WorkerPool};
 use prometheus::Registry;
 use serde::{Deserialize, Serialize};
-use tokio::signal;
+use tokio::signal::unix::SignalKind;
 use tokio_util::sync::CancellationToken;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "kebab-case")]
 enum Task {
     Archival(ArchivalConfig),
     Blob(BlobTaskConfig),
@@ -24,6 +24,7 @@ enum Task {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "kebab-case")]
 struct TaskConfig {
     #[serde(flatten)]
     task: Task,
@@ -32,7 +33,7 @@ struct TaskConfig {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "kebab-case")]
 struct ProgressStoreConfig {
     pub aws_access_key_id: String,
     pub aws_secret_access_key: String,
@@ -41,6 +42,7 @@ struct ProgressStoreConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 struct IndexerConfig {
     path: PathBuf,
     tasks: Vec<TaskConfig>,
@@ -78,9 +80,14 @@ fn setup_env(token: CancellationToken) {
     }));
 
     tokio::spawn(async move {
-        signal::ctrl_c()
-            .await
-            .expect("Failed to install Ctrl+C handler");
+        let mut signal_stream = tokio::signal::unix::signal(SignalKind::terminate())
+            .expect("Cannot listen to  SIGTERM signal");
+
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => tracing::info!("CTRL+C signal received, shutting down"),
+            _ = signal_stream.recv() => tracing::info!("SIGTERM signal received, shutting down")
+        };
+
         token.cancel();
     });
 }
@@ -127,7 +134,7 @@ async fn main() -> Result<()> {
             }
             Task::Blob(blob_config) => {
                 let worker_pool = WorkerPool::new(
-                    BlobWorker::new(blob_config),
+                    BlobWorker::try_new(blob_config)?,
                     task_config.name,
                     task_config.concurrency,
                 );
@@ -147,6 +154,7 @@ async fn main() -> Result<()> {
         batch_size: config.remote_read_batch_size,
         ..Default::default()
     };
+
     executor
         .run(
             config.path,

--- a/crates/iota-data-ingestion/src/workers/archival.rs
+++ b/crates/iota-data-ingestion/src/workers/archival.rs
@@ -28,6 +28,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "kebab-case")]
 pub struct ArchivalConfig {
     pub remote_url: String,
     pub remote_store_options: Vec<(String, String)>,

--- a/crates/iota-data-ingestion/src/workers/blob.rs
+++ b/crates/iota-data-ingestion/src/workers/blob.rs
@@ -2,16 +2,17 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Duration;
+use std::sync::Arc;
 
 use anyhow::{Result, bail};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::{StreamExt, stream};
-use iota_data_ingestion_core::{Worker, create_remote_store_client_with_ops};
+use iota_config::object_storage_config::ObjectStoreConfig;
+use iota_data_ingestion_core::Worker;
 use iota_storage::blob::{Blob, BlobEncoding};
 use iota_types::full_checkpoint_content::CheckpointData;
-use object_store::{BackoffConfig, MultipartUpload, ObjectStore, RetryConfig, path::Path};
+use object_store::{DynObjectStore, MultipartUpload, ObjectStore, path::Path};
 use serde::{Deserialize, Deserializer, Serialize};
 
 /// Minimum allowed chunk size to be uploaded to remote store
@@ -21,10 +22,9 @@ const MIN_CHUNK_SIZE_MB: u64 = 5 * 1024 * 1024; // 5 MB
 const MAX_CONCURRENT_PARTS_UPLOAD: usize = 50;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "kebab-case")]
 pub struct BlobTaskConfig {
-    pub url: String,
-    pub remote_store_options: Vec<(String, String)>,
-    pub request_timeout_secs: u64,
+    pub object_store_config: ObjectStoreConfig,
     #[serde(deserialize_with = "deserialize_chunk")]
     pub checkpoint_chunk_size_mb: u64,
 }
@@ -41,29 +41,17 @@ where
 }
 
 pub struct BlobWorker {
-    remote_store: Box<dyn ObjectStore>,
+    remote_store: Arc<DynObjectStore>,
     checkpoint_chunk_size_mb: u64,
 }
 
 impl BlobWorker {
-    pub fn new(config: BlobTaskConfig) -> Self {
-        Self {
+    pub fn try_new(config: BlobTaskConfig) -> anyhow::Result<Self> {
+        let remote_store = config.object_store_config.make()?;
+        Ok(Self {
             checkpoint_chunk_size_mb: config.checkpoint_chunk_size_mb,
-            remote_store: create_remote_store_client_with_ops(
-                config.url,
-                config.remote_store_options,
-                config.request_timeout_secs,
-                RetryConfig {
-                    max_retries: 10,
-                    retry_timeout: Duration::from_secs(config.request_timeout_secs + 1),
-                    backoff: BackoffConfig {
-                        init_backoff: Duration::from_secs(1),
-                        ..Default::default()
-                    },
-                },
-            )
-            .expect("failed to create remote store client"),
-        }
+            remote_store,
+        })
     }
 
     /// Uploads a Checkpoint blob to the Remote Store.

--- a/crates/iota-data-ingestion/src/workers/blob.rs
+++ b/crates/iota-data-ingestion/src/workers/blob.rs
@@ -46,7 +46,7 @@ pub struct BlobWorker {
 }
 
 impl BlobWorker {
-    pub fn try_new(config: BlobTaskConfig) -> anyhow::Result<Self> {
+    pub fn new(config: BlobTaskConfig) -> anyhow::Result<Self> {
         let remote_store = config.object_store_config.make()?;
         Ok(Self {
             checkpoint_chunk_size_mb: config.checkpoint_chunk_size_mb,

--- a/crates/iota-data-ingestion/src/workers/kv_store.rs
+++ b/crates/iota-data-ingestion/src/workers/kv_store.rs
@@ -28,6 +28,7 @@ use serde::{Deserialize, Serialize};
 const TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "kebab-case")]
 pub struct KVStoreTaskConfig {
     pub aws_access_key_id: String,
     pub aws_secret_access_key: String,

--- a/dev-tools/iota-data-ingestion/README.md
+++ b/dev-tools/iota-data-ingestion/README.md
@@ -24,18 +24,18 @@ A default configuration file is provided at `config/config.yaml`. This configura
 #
 path: "./test-checkpoints"
 # IOTA Node Rest API URL
-remote_store_url: "http://localhost:9000/api/v1"
+remote-store-url: "http://localhost:9000/api/v1"
 
 # DynamoDbProgressStore config
 #
-progress_store:
-  aws_access_key_id: "test"
-  aws_secret_access_key: "test"
-  aws_region: "us-east-1"
+progress-store:
+  aws-access-key-id: "test"
+  aws-secret-access-key: "test"
+  aws-region: "us-east-1"
   # DynamoDB table name
-  table_name: "checkpoint-progress"
+  table-name: "checkpoint-progress"
 
-# Wrokers Configs
+# Workers Configs
 #
 tasks:
   # Task unique name
@@ -44,15 +44,41 @@ tasks:
     concurrency: 1
     # Task type
     blob:
-      # S3 bucket where checkpoints will be stored
-      url: "s3://checkpoints"
-      # AWS S3 client config options
-      remote_store_options:
-        - ["access_key_id", "test"]
-        - ["secret_access_key", "test"]
-        - ["region", "us-east-1"]
-        # Only needed if using Localstack for local development purposes, it's preferred to be removed
-        - ["endpoint_url", "http://localhost:4566"]
+      # remote Object Store config for more info:
+      # - https://docs.iota.org/operator/archives#set-up-archival-fallback
+      #
+      object-store-config:
+        object-store: "S3"
+        aws-endpoint: "http://localhost:4566"
+        bucket: "checkpoints"
+        aws-access-key-id: "test"
+        aws-secret-access-key: "test"
+        aws-allow-http: true
+        object-store-connection-limit: 20
+      # Checkpoint upload chunk size (in MB) that determines the upload strategy:
+      #
+      # If checkpoint size < checkpoint_chunk_size_mb:
+      #   - Uploads checkpoint using single PUT operation
+      #   - Optimal for smaller checkpoints
+      #
+      # If checkpoint size >= checkpoint_chunk_size_mb:
+      #   - Divides checkpoint into chunks of this size
+      #   - Uploads chunks as multipart
+      #   - Storage service concatenates parts on completion
+      #
+      # Example with 50MB chunk size:
+      #   200MB checkpoint:
+      #   - Splits into 4 parts (50MB each)
+      #   - Multipart upload of each part
+      #   - Parts merged on remote storage
+      #
+      #   40MB checkpoint:
+      #   - Single PUT upload
+      #   - No chunking needed
+      #
+      # Minimum allowed chunk size is 5MB
+      #
+      checkpoint-chunk-size-mb: 100
 ```
 
 ## Usage

--- a/dev-tools/iota-data-ingestion/config/config.yaml
+++ b/dev-tools/iota-data-ingestion/config/config.yaml
@@ -2,16 +2,16 @@
 #
 path: "./test-checkpoints"
 # IOTA Node Rest API URL
-remote_store_url: "http://localhost:9000/api/v1"
+remote-store-url: "http://localhost:9000/api/v1"
 
 # DynamoDbProgressStore config
 #
-progress_store:
-  aws_access_key_id: "test"
-  aws_secret_access_key: "test"
-  aws_region: "us-east-1"
+progress-store:
+  aws-access-key-id: "test"
+  aws-secret-access-key: "test"
+  aws-region: "us-east-1"
   # DynamoDB table name
-  table_name: "checkpoint-progress"
+  table-name: "checkpoint-progress"
 
 # Workers Configs
 #
@@ -22,11 +22,17 @@ tasks:
     concurrency: 1
     # Task type
     blob:
-      # S3 bucket where checkpoints will be stored
-      url: "s3://checkpoints"
-      # S3 client timeout, a large timeout is needed to accommodate the checkpoints which could have the size of several GBs
+      # remote Object Store config for more info:
+      # - https://docs.iota.org/operator/archives#set-up-archival-fallback
       #
-      request_timeout_secs: 180
+      object-store-config:
+        object-store: "S3"
+        aws-endpoint: "http://localhost:4566"
+        bucket: "checkpoints"
+        aws-access-key-id: "test"
+        aws-secret-access-key: "test"
+        aws-allow-http: true
+        object-store-connection-limit: 20
       # Checkpoint upload chunk size (in MB) that determines the upload strategy:
       #
       # If checkpoint size < checkpoint_chunk_size_mb:
@@ -50,11 +56,4 @@ tasks:
       #
       # Minimum allowed chunk size is 5MB
       #
-      checkpoint_chunk_size_mb: 100
-      # AWS S3 client config options
-      remote_store_options:
-        - ["access_key_id", "test"]
-        - ["secret_access_key", "test"]
-        - ["region", "us-east-1"]
-        # Only needed if using Localstack for local development purposes, it's preferred to be removed
-        - ["endpoint_url", "http://localhost:4566"]
+      checkpoint-chunk-size-mb: 100


### PR DESCRIPTION
# Description of change

- accept `ObjectStoreConfig` and instantiate a Remote Store client from it
- listen for `SIGTERM` signal for graceful shutdown, useful in docker environments
- use `kebab-case` formatting for config file to comply with `ObjectStoreConfig`

## Links to any relevant issues

fixes #5145 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

- Followed the `dev-tools/iota-data-ingestion/README.md` instructions of setting up localstack and all the necessary components to test locally
- updated the `BlobWorker` to accommodate as checkpoint 0 with size around 13GB
```rust

#[async_trait]
impl Worker for BlobWorker {
    async fn process_checkpoint(&self, checkpoint: CheckpointData) -> Result<()> {
        let bytes = Blob::encode(&checkpoint, BlobEncoding::Bcs)?.to_bytes();
        let location = Path::from(format!(
            "{}.chk",
            checkpoint.checkpoint_summary.sequence_number
        ));

        let bytes = if checkpoint.checkpoint_summary.sequence_number == 0 {
            vec![0; 13000 * 1024 * 1024] // Around 13GB worth of zeros
        } else {
            bytes
        };

        self.upload_blob(
            bytes,
            checkpoint.checkpoint_summary.sequence_number,
            location,
        )
        .await?;

        Ok(())
    }
}
```
- Ran the local node and the data-ingestion-core bin
- Checked if any timeouts were encountered

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
