### PR TITLE
chore: workspace dependency consistency

### DIFF
--- a/crates/iota-aws-orchestrator/Cargo.toml
+++ b/crates/iota-aws-orchestrator/Cargo.toml
@@ -30,10 +30,10 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 
 # internal dependencies
-iota-config = { path = "../iota-config" }
+iota-config.workspace = true
 iota-metrics.workspace = true
-iota-swarm-config = { path = "../iota-swarm-config" }
-iota-types = { path = "../iota-types" }
+iota-swarm-config.workspace = true
+iota-types.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/iota-core/Cargo.toml
+++ b/crates/iota-core/Cargo.toml
@@ -68,7 +68,7 @@ iota-archival.workspace = true
 iota-authority-aggregation.workspace = true
 iota-common.workspace = true
 iota-config.workspace = true
-iota-execution = { path = "../../iota-execution" }
+iota-execution.workspace = true
 iota-framework.workspace = true
 iota-genesis-builder.workspace = true
 iota-json-rpc-types.workspace = true

--- a/crates/iota/Cargo.toml
+++ b/crates/iota/Cargo.toml
@@ -64,7 +64,7 @@ uuid.workspace = true
 bin-version.workspace = true
 iota-bridge.workspace = true
 iota-config.workspace = true
-iota-execution = { path = "../../iota-execution" }
+iota-execution.workspace = true
 iota-faucet.workspace = true
 iota-genesis-builder.workspace = true
 iota-graphql-rpc = { workspace = true, optional = true }


### PR DESCRIPTION
Just a bit of consistency, some dependency were still using a qualified path instead of using the workspace.