### PR TITLE
fix(node): Fix estimated rewards during safe mode

### DIFF
--- a/crates/iota-indexer/src/apis/governance_api.rs
+++ b/crates/iota-indexer/src/apis/governance_api.rs
@@ -740,4 +740,37 @@ mod tests {
         ];
         assert_eq!(backfill_rates(rates), expected);
     }
+
+    #[test]
+    fn test_backfill_rates_missing_middle_epoch() {
+        let rate1 = PoolTokenExchangeRate::new_for_testing(100, 100);
+        let rate3 = PoolTokenExchangeRate::new_for_testing(300, 330);
+        let rates = vec![(1, rate1.clone()), (3, rate3.clone())];
+        let expected = vec![(3, rate3), (2, rate1.clone()), (1, rate1)];
+        assert_eq!(backfill_rates(rates), expected);
+    }
+
+    #[test]
+    fn test_backfill_rates_missing_middle_epochs() {
+        let rate1 = PoolTokenExchangeRate::new_for_testing(100, 100);
+        let rate4 = PoolTokenExchangeRate::new_for_testing(400, 440);
+        let rates = vec![(1, rate1.clone()), (4, rate4.clone())];
+        let expected = vec![
+            (4, rate4),
+            (3, rate1.clone()),
+            (2, rate1.clone()),
+            (1, rate1),
+        ];
+        assert_eq!(backfill_rates(rates), expected);
+    }
+
+    #[test]
+    fn test_backfill_rates_unordered_input() {
+        let rate1 = PoolTokenExchangeRate::new_for_testing(100, 100);
+        let rate3 = PoolTokenExchangeRate::new_for_testing(300, 330);
+        let rate4 = PoolTokenExchangeRate::new_for_testing(400, 440);
+        let rates = vec![(3, rate3.clone()), (1, rate1.clone()), (4, rate4.clone())];
+        let expected = vec![(4, rate4), (3, rate3), (2, rate1.clone()), (1, rate1)];
+        assert_eq!(backfill_rates(rates), expected);
+    }
 }

--- a/crates/iota-indexer/src/apis/governance_api.rs
+++ b/crates/iota-indexer/src/apis/governance_api.rs
@@ -579,15 +579,16 @@ fn backfill_rates(
     let (min_epoch, _) = rates.first().expect("rates should not be empty");
     let (max_epoch, _) = rates.last().expect("rates should not be empty");
     let expected_len = (max_epoch - min_epoch + 1) as usize;
+    let current_len = rates.len() as usize;
 
     // Only perform backfilling if there are gaps
-    if rates.len() == expected_len {
+    if current_len == expected_len {
         rates.reverse();
         return rates;
     }
 
     let mut filled_rates: Vec<(EpochId, PoolTokenExchangeRate)> = Vec::with_capacity(expected_len);
-    let mut missing_rates = Vec::new();
+    let mut missing_rates = Vec::with_capacity(expected_len - current_len);
     for (epoch_id, rate) in rates {
         // fill gaps between the last processed epoch and the current one
         if let Some((prev_epoch_id, prev_rate)) = filled_rates.last() {

--- a/crates/iota-indexer/src/apis/governance_api.rs
+++ b/crates/iota-indexer/src/apis/governance_api.rs
@@ -567,7 +567,7 @@ impl GovernanceReadApi {
 /// missing for epoch e, we will use the rate for epoch e-1 to fill it. Rates
 /// returned are in descending order by epoch.
 fn backfill_rates(
-    rates: Vec<(EpochId, PoolTokenExchangeRate)>,
+    mut rates: Vec<(EpochId, PoolTokenExchangeRate)>,
 ) -> Vec<(EpochId, PoolTokenExchangeRate)> {
     if rates.is_empty() {
         return rates;
@@ -707,9 +707,9 @@ mod tests {
     }
     #[test]
     fn test_backfill_rates_no_gaps() {
-        let rate1 = PoolTokenExchangeRate::new(100, 100);
-        let rate2 = PoolTokenExchangeRate::new(200, 220);
-        let rate3 = PoolTokenExchangeRate::new(300, 330);
+        let rate1 = PoolTokenExchangeRate::new_for_testing(100, 100);
+        let rate2 = PoolTokenExchangeRate::new_for_testing(200, 220);
+        let rate3 = PoolTokenExchangeRate::new_for_testing(300, 330);
         let rates = vec![(2, rate2.clone()), (3, rate3.clone()), (1, rate1.clone())];
         let expected: Vec<(u64, PoolTokenExchangeRate)> =
             vec![(3, rate3.clone()), (2, rate2), (1, rate1)];
@@ -717,9 +717,9 @@ mod tests {
     }
     #[test]
     fn test_backfill_rates_with_gaps() {
-        let rate1 = PoolTokenExchangeRate::new(100, 100);
-        let rate3 = PoolTokenExchangeRate::new(300, 330);
-        let rate5 = PoolTokenExchangeRate::new(500, 550);
+        let rate1 = PoolTokenExchangeRate::new_for_testing(100, 100);
+        let rate3 = PoolTokenExchangeRate::new_for_testing(300, 330);
+        let rate5 = PoolTokenExchangeRate::new_for_testing(500, 550);
         let rates = vec![(3, rate3.clone()), (1, rate1.clone()), (5, rate5.clone())];
         let expected = vec![
             (5, rate5.clone()),

--- a/crates/iota-indexer/src/apis/governance_api.rs
+++ b/crates/iota-indexer/src/apis/governance_api.rs
@@ -575,6 +575,17 @@ fn backfill_rates(
     // ensure epochs are processed in increasing order
     rates.sort_unstable_by_key(|(epoch_id, _)| *epoch_id);
 
+    // Check if there are any gaps in the epochs
+    let min_epoch = rates.first().unwrap().0;
+    let max_epoch = rates.last().unwrap().0;
+    let expected_len = (max_epoch - min_epoch + 1) as usize;
+
+    // Only perform backfilling if there are gaps
+    if rates.len() == expected_len {
+        rates.reverse();
+        return rates;
+    }
+
     let mut filled_rates: Vec<(EpochId, PoolTokenExchangeRate)> = Vec::with_capacity(rates.len());
     let mut missing_rates = Vec::new();
     for (epoch_id, rate) in rates {
@@ -712,6 +723,14 @@ mod tests {
     fn test_backfill_rates_empty() {
         let rates = vec![];
         assert_eq!(backfill_rates(rates), vec![]);
+    }
+
+    #[test]
+    fn test_backfill_single_rate() {
+        let rate1 = PoolTokenExchangeRate::new_for_testing(100, 100);
+        let rates = vec![(1, rate1.clone())];
+        let expected = vec![(1, rate1)];
+        assert_eq!(backfill_rates(rates), expected);
     }
 
     #[test]

--- a/crates/iota-indexer/src/apis/governance_api.rs
+++ b/crates/iota-indexer/src/apis/governance_api.rs
@@ -572,15 +572,22 @@ fn backfill_rates(
     if rates.is_empty() {
         return rates;
     }
+    // ensure epochs are processed in increasing order
     rates.sort_unstable_by_key(|(epoch_id, _)| *epoch_id);
+    
     let mut filled_rates: Vec<(EpochId, PoolTokenExchangeRate)> = Vec::with_capacity(rates.len());
     let mut missing_rates = Vec::new();
     for (epoch_id, rate) in rates {
+        // fill gaps between the last processed epoch and the current one
         if let Some((prev_epoch_id, prev_rate)) = filled_rates.last() {
             for missing_epoch_id in prev_epoch_id + 1..epoch_id {
                 missing_rates.push((missing_epoch_id, prev_rate.clone()));
             }
         };
+        
+        // append any missing_rates before adding the current epoch.
+        // if empty, nothing gets appended.
+        // if not empty, it will be empty afterwards because it was moved into filled_rates
         filled_rates.append(&mut missing_rates);
         filled_rates.push((epoch_id, rate));
     }

--- a/crates/iota-indexer/src/apis/governance_api.rs
+++ b/crates/iota-indexer/src/apis/governance_api.rs
@@ -586,7 +586,7 @@ fn backfill_rates(
         return rates;
     }
 
-    let mut filled_rates: Vec<(EpochId, PoolTokenExchangeRate)> = Vec::with_capacity(rates.len());
+    let mut filled_rates: Vec<(EpochId, PoolTokenExchangeRate)> = Vec::with_capacity(expected_len);
     let mut missing_rates = Vec::new();
     for (epoch_id, rate) in rates {
         // fill gaps between the last processed epoch and the current one

--- a/crates/iota-indexer/src/apis/governance_api.rs
+++ b/crates/iota-indexer/src/apis/governance_api.rs
@@ -338,7 +338,9 @@ impl GovernanceReadApi {
                 rates.push((dynamic_field.name, dynamic_field.value));
             }
 
-            rates.sort_by(|(a, _), (b, _)| a.cmp(b).reverse());
+            // Rates for some epochs might be missing due to safe mode, we need to backfill
+            // them.
+            rates = backfill_rates(rates);
 
             exchange_rates.push(ValidatorExchangeRates {
                 address,
@@ -561,6 +563,36 @@ impl GovernanceReadApi {
     }
 }
 
+/// Backfill missing rates for some epochs due to safe mode. If a rate is
+/// missing for epoch e, we will use the rate for epoch e-1 to fill it. Rates
+/// returned are in descending order by epoch.
+fn backfill_rates(
+    rates: Vec<(EpochId, PoolTokenExchangeRate)>,
+) -> Vec<(EpochId, PoolTokenExchangeRate)> {
+    if rates.is_empty() {
+        return rates;
+    }
+    let min_epoch = *rates.iter().map(|(e, _)| e).min().unwrap();
+    let max_epoch = *rates.iter().map(|(e, _)| e).max().unwrap();
+    let mut filled_rates = Vec::new();
+    let mut prev_rate = None;
+    for epoch in min_epoch..=max_epoch {
+        match rates.iter().find(|(e, _)| *e == epoch) {
+            Some((e, rate)) => {
+                prev_rate = Some(rate.clone());
+                filled_rates.push((*e, rate.clone()));
+            }
+            None => {
+                if let Some(rate) = prev_rate.clone() {
+                    filled_rates.push((epoch, rate));
+                }
+            }
+        }
+    }
+    filled_rates.reverse();
+    filled_rates
+}
+
 fn stake_status(
     epoch: u64,
     activation_epoch: u64,
@@ -665,5 +697,42 @@ impl IotaRpcModule for GovernanceReadApi {
 
     fn rpc_doc_module() -> Module {
         iota_json_rpc_api::GovernanceReadApiOpenRpc::module_doc()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use iota_types::iota_system_state::PoolTokenExchangeRate;
+
+    use super::*;
+    #[test]
+    fn test_backfill_rates_empty() {
+        let rates = vec![];
+        assert_eq!(backfill_rates(rates), vec![]);
+    }
+    #[test]
+    fn test_backfill_rates_no_gaps() {
+        let rate1 = PoolTokenExchangeRate::new(100, 100);
+        let rate2 = PoolTokenExchangeRate::new(200, 220);
+        let rate3 = PoolTokenExchangeRate::new(300, 330);
+        let rates = vec![(2, rate2.clone()), (3, rate3.clone()), (1, rate1.clone())];
+        let expected: Vec<(u64, PoolTokenExchangeRate)> =
+            vec![(3, rate3.clone()), (2, rate2), (1, rate1)];
+        assert_eq!(backfill_rates(rates), expected);
+    }
+    #[test]
+    fn test_backfill_rates_with_gaps() {
+        let rate1 = PoolTokenExchangeRate::new(100, 100);
+        let rate3 = PoolTokenExchangeRate::new(300, 330);
+        let rate5 = PoolTokenExchangeRate::new(500, 550);
+        let rates = vec![(3, rate3.clone()), (1, rate1.clone()), (5, rate5.clone())];
+        let expected = vec![
+            (5, rate5.clone()),
+            (4, rate3.clone()),
+            (3, rate3.clone()),
+            (2, rate1.clone()),
+            (1, rate1),
+        ];
+        assert_eq!(backfill_rates(rates), expected);
     }
 }

--- a/crates/iota-indexer/src/apis/governance_api.rs
+++ b/crates/iota-indexer/src/apis/governance_api.rs
@@ -713,6 +713,7 @@ mod tests {
         let rates = vec![];
         assert_eq!(backfill_rates(rates), vec![]);
     }
+
     #[test]
     fn test_backfill_rates_no_gaps() {
         let rate1 = PoolTokenExchangeRate::new_for_testing(100, 100);
@@ -723,6 +724,7 @@ mod tests {
             vec![(3, rate3.clone()), (2, rate2), (1, rate1)];
         assert_eq!(backfill_rates(rates), expected);
     }
+
     #[test]
     fn test_backfill_rates_with_gaps() {
         let rate1 = PoolTokenExchangeRate::new_for_testing(100, 100);

--- a/crates/iota-indexer/src/apis/governance_api.rs
+++ b/crates/iota-indexer/src/apis/governance_api.rs
@@ -576,8 +576,8 @@ fn backfill_rates(
     rates.sort_unstable_by_key(|(epoch_id, _)| *epoch_id);
 
     // Check if there are any gaps in the epochs
-    let min_epoch = rates.first().unwrap().0;
-    let max_epoch = rates.last().unwrap().0;
+    let (min_epoch, _) = rates.first().expect("rates should not be empty");
+    let (max_epoch, _) = rates.last().expect("rates should not be empty");
     let expected_len = (max_epoch - min_epoch + 1) as usize;
 
     // Only perform backfilling if there are gaps

--- a/crates/iota-indexer/src/apis/governance_api.rs
+++ b/crates/iota-indexer/src/apis/governance_api.rs
@@ -579,7 +579,7 @@ fn backfill_rates(
     let (min_epoch, _) = rates.first().expect("rates should not be empty");
     let (max_epoch, _) = rates.last().expect("rates should not be empty");
     let expected_len = (max_epoch - min_epoch + 1) as usize;
-    let current_len = rates.len() as usize;
+    let current_len = rates.len();
 
     // Only perform backfilling if there are gaps
     if current_len == expected_len {

--- a/crates/iota-indexer/src/apis/governance_api.rs
+++ b/crates/iota-indexer/src/apis/governance_api.rs
@@ -572,22 +572,17 @@ fn backfill_rates(
     if rates.is_empty() {
         return rates;
     }
-    let min_epoch = *rates.iter().map(|(e, _)| e).min().unwrap();
-    let max_epoch = *rates.iter().map(|(e, _)| e).max().unwrap();
-    let mut filled_rates = Vec::new();
-    let mut prev_rate = None;
-    for epoch in min_epoch..=max_epoch {
-        match rates.iter().find(|(e, _)| *e == epoch) {
-            Some((e, rate)) => {
-                prev_rate = Some(rate.clone());
-                filled_rates.push((*e, rate.clone()));
+    rates.sort_unstable_by_key(|(epoch_id, _)| *epoch_id);
+    let mut filled_rates: Vec<(EpochId, PoolTokenExchangeRate)> = Vec::with_capacity(rates.len());
+    let mut missing_rates = Vec::new();
+    for (epoch_id, rate) in rates {
+        if let Some((prev_epoch_id, prev_rate)) = filled_rates.last() {
+            for missing_epoch_id in prev_epoch_id + 1..epoch_id {
+                missing_rates.push((missing_epoch_id, prev_rate.clone()));
             }
-            None => {
-                if let Some(rate) = prev_rate.clone() {
-                    filled_rates.push((epoch, rate));
-                }
-            }
-        }
+        };
+        filled_rates.append(&mut missing_rates);
+        filled_rates.push((epoch_id, rate));
     }
     filled_rates.reverse();
     filled_rates

--- a/crates/iota-indexer/src/apis/governance_api.rs
+++ b/crates/iota-indexer/src/apis/governance_api.rs
@@ -574,7 +574,7 @@ fn backfill_rates(
     }
     // ensure epochs are processed in increasing order
     rates.sort_unstable_by_key(|(epoch_id, _)| *epoch_id);
-    
+
     let mut filled_rates: Vec<(EpochId, PoolTokenExchangeRate)> = Vec::with_capacity(rates.len());
     let mut missing_rates = Vec::new();
     for (epoch_id, rate) in rates {
@@ -584,10 +584,11 @@ fn backfill_rates(
                 missing_rates.push((missing_epoch_id, prev_rate.clone()));
             }
         };
-        
+
         // append any missing_rates before adding the current epoch.
         // if empty, nothing gets appended.
-        // if not empty, it will be empty afterwards because it was moved into filled_rates
+        // if not empty, it will be empty afterwards because it was moved into
+        // filled_rates
         filled_rates.append(&mut missing_rates);
         filled_rates.push((epoch_id, rate));
     }

--- a/crates/iota-json-rpc/src/governance_api.rs
+++ b/crates/iota-json-rpc/src/governance_api.rs
@@ -770,15 +770,23 @@ fn backfill_rates(
     if rates.is_empty() {
         return rates;
     }
+    // ensure epochs are processed in increasing order
     rates.sort_unstable_by_key(|(epoch_id, _)| *epoch_id);
+
     let mut filled_rates: Vec<(EpochId, PoolTokenExchangeRate)> = Vec::with_capacity(rates.len());
     let mut missing_rates = Vec::new();
     for (epoch_id, rate) in rates {
+        // fill gaps between the last processed epoch and the current one
         if let Some((prev_epoch_id, prev_rate)) = filled_rates.last() {
             for missing_epoch_id in prev_epoch_id + 1..epoch_id {
                 missing_rates.push((missing_epoch_id, prev_rate.clone()));
             }
         };
+
+        // append any missing_rates before adding the current epoch.
+        // if empty, nothing gets appended.
+        // if not empty, it will be empty afterwards because it was moved into
+        // filled_rates
         filled_rates.append(&mut missing_rates);
         filled_rates.push((epoch_id, rate));
     }

--- a/crates/iota-json-rpc/src/governance_api.rs
+++ b/crates/iota-json-rpc/src/governance_api.rs
@@ -773,7 +773,18 @@ fn backfill_rates(
     // ensure epochs are processed in increasing order
     rates.sort_unstable_by_key(|(epoch_id, _)| *epoch_id);
 
-    let mut filled_rates: Vec<(EpochId, PoolTokenExchangeRate)> = Vec::with_capacity(rates.len());
+    // Check if there are any gaps in the epochs
+    let min_epoch = rates.first().unwrap().0;
+    let max_epoch = rates.last().unwrap().0;
+    let expected_len = (max_epoch - min_epoch + 1) as usize;
+
+    // Only perform backfilling if there are gaps
+    if rates.len() == expected_len {
+        rates.reverse();
+        return rates;
+    }
+
+    let mut filled_rates: Vec<(EpochId, PoolTokenExchangeRate)> = Vec::with_capacity(expected_len);
     let mut missing_rates = Vec::new();
     for (epoch_id, rate) in rates {
         // fill gaps between the last processed epoch and the current one
@@ -856,6 +867,14 @@ mod tests {
 
         let expected: Vec<(u64, PoolTokenExchangeRate)> =
             vec![(3, rate3.clone()), (2, rate2), (1, rate1)];
+        assert_eq!(backfill_rates(rates), expected);
+    }
+
+    #[test]
+    fn test_backfill_single_rate() {
+        let rate1 = PoolTokenExchangeRate::new_for_testing(100, 100);
+        let rates = vec![(1, rate1.clone())];
+        let expected = vec![(1, rate1)];
         assert_eq!(backfill_rates(rates), expected);
     }
 

--- a/crates/iota-json-rpc/src/governance_api.rs
+++ b/crates/iota-json-rpc/src/governance_api.rs
@@ -503,6 +503,7 @@ fn stake_status(
     if !exists {
         StakeStatus::Unstaked
     } else if epoch >= activation_epoch {
+        // TODO: use dev_inspect to call a move function to get the estimated reward
         let estimated_reward = if let Some(current_rate) = current_rate {
             let stake_rate = rate_table
                 .rates
@@ -572,7 +573,9 @@ fn validator_exchange_rates(
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        rates.sort_by(|(a, _), (b, _)| a.cmp(b).reverse());
+        // Rates for some epochs might be missing due to safe mode, we need to backfill
+        // them.
+        rates = backfill_rates(rates);
 
         exchange_rates.push(ValidatorExchangeRates {
             address,
@@ -758,6 +761,36 @@ pub struct ValidatorExchangeRates {
     pub rates: Vec<(EpochId, PoolTokenExchangeRate)>,
 }
 
+/// Backfill missing rates for some epochs due to safe mode. If a rate is
+/// missing for epoch e, we will use the rate for epoch e-1 to fill it. Rates
+/// returned are in descending order by epoch.
+fn backfill_rates(
+    rates: Vec<(EpochId, PoolTokenExchangeRate)>,
+) -> Vec<(EpochId, PoolTokenExchangeRate)> {
+    if rates.is_empty() {
+        return rates;
+    }
+    let min_epoch = *rates.iter().map(|(e, _)| e).min().unwrap();
+    let max_epoch = *rates.iter().map(|(e, _)| e).max().unwrap();
+    let mut filled_rates = Vec::new();
+    let mut prev_rate = None;
+    for epoch in min_epoch..=max_epoch {
+        match rates.iter().find(|(e, _)| *e == epoch) {
+            Some((e, rate)) => {
+                prev_rate = Some(rate.clone());
+                filled_rates.push((*e, rate.clone()));
+            }
+            None => {
+                if let Some(rate) = prev_rate.clone() {
+                    filled_rates.push((epoch, rate));
+                }
+            }
+        }
+    }
+    filled_rates.reverse();
+    filled_rates
+}
+
 impl IotaRpcModule for GovernanceReadApi {
     fn rpc(self) -> RpcModule<Self> {
         self.into_rpc()
@@ -770,6 +803,8 @@ impl IotaRpcModule for GovernanceReadApi {
 
 #[cfg(test)]
 mod tests {
+    use iota_types::iota_system_state::PoolTokenExchangeRate;
+
     use super::*;
 
     #[test]
@@ -801,5 +836,40 @@ mod tests {
             println!("{}: {}", address_map[&apy.address], apy.apy);
             assert!(apy.apy < 0.25)
         }
+    }
+
+    #[test]
+    fn test_backfill_rates_empty() {
+        let rates = vec![];
+        assert_eq!(backfill_rates(rates), vec![]);
+    }
+
+    #[test]
+    fn test_backfill_rates_no_gaps() {
+        let rate1 = PoolTokenExchangeRate::new(100, 100);
+        let rate2 = PoolTokenExchangeRate::new(200, 220);
+        let rate3 = PoolTokenExchangeRate::new(300, 330);
+        let rates = vec![(2, rate2.clone()), (3, rate3.clone()), (1, rate1.clone())];
+
+        let expected: Vec<(u64, PoolTokenExchangeRate)> =
+            vec![(3, rate3.clone()), (2, rate2), (1, rate1)];
+        assert_eq!(backfill_rates(rates), expected);
+    }
+
+    #[test]
+    fn test_backfill_rates_with_gaps() {
+        let rate1 = PoolTokenExchangeRate::new(100, 100);
+        let rate3 = PoolTokenExchangeRate::new(300, 330);
+        let rate5 = PoolTokenExchangeRate::new(500, 550);
+        let rates = vec![(3, rate3.clone()), (1, rate1.clone()), (5, rate5.clone())];
+
+        let expected = vec![
+            (5, rate5.clone()),
+            (4, rate3.clone()),
+            (3, rate3.clone()),
+            (2, rate1.clone()),
+            (1, rate1),
+        ];
+        assert_eq!(backfill_rates(rates), expected);
     }
 }

--- a/crates/iota-json-rpc/src/governance_api.rs
+++ b/crates/iota-json-rpc/src/governance_api.rs
@@ -777,15 +777,16 @@ fn backfill_rates(
     let (min_epoch, _) = rates.first().expect("rates should not be empty");
     let (max_epoch, _) = rates.last().expect("rates should not be empty");
     let expected_len = (max_epoch - min_epoch + 1) as usize;
+    let current_len = rates.len() as usize;
 
     // Only perform backfilling if there are gaps
-    if rates.len() == expected_len {
+    if current_len == expected_len {
         rates.reverse();
         return rates;
     }
 
     let mut filled_rates: Vec<(EpochId, PoolTokenExchangeRate)> = Vec::with_capacity(expected_len);
-    let mut missing_rates = Vec::new();
+    let mut missing_rates = Vec::with_capacity(expected_len - current_len);
     for (epoch_id, rate) in rates {
         // fill gaps between the last processed epoch and the current one
         if let Some((prev_epoch_id, prev_rate)) = filled_rates.last() {

--- a/crates/iota-json-rpc/src/governance_api.rs
+++ b/crates/iota-json-rpc/src/governance_api.rs
@@ -774,8 +774,8 @@ fn backfill_rates(
     rates.sort_unstable_by_key(|(epoch_id, _)| *epoch_id);
 
     // Check if there are any gaps in the epochs
-    let min_epoch = rates.first().unwrap().0;
-    let max_epoch = rates.last().unwrap().0;
+    let (min_epoch, _) = rates.first().expect("rates should not be empty");
+    let (max_epoch, _) = rates.last().expect("rates should not be empty");
     let expected_len = (max_epoch - min_epoch + 1) as usize;
 
     // Only perform backfilling if there are gaps

--- a/crates/iota-json-rpc/src/governance_api.rs
+++ b/crates/iota-json-rpc/src/governance_api.rs
@@ -765,7 +765,7 @@ pub struct ValidatorExchangeRates {
 /// missing for epoch e, we will use the rate for epoch e-1 to fill it. Rates
 /// returned are in descending order by epoch.
 fn backfill_rates(
-    rates: Vec<(EpochId, PoolTokenExchangeRate)>,
+    mut rates: Vec<(EpochId, PoolTokenExchangeRate)>,
 ) -> Vec<(EpochId, PoolTokenExchangeRate)> {
     if rates.is_empty() {
         return rates;
@@ -841,9 +841,9 @@ mod tests {
 
     #[test]
     fn test_backfill_rates_no_gaps() {
-        let rate1 = PoolTokenExchangeRate::new(100, 100);
-        let rate2 = PoolTokenExchangeRate::new(200, 220);
-        let rate3 = PoolTokenExchangeRate::new(300, 330);
+        let rate1 = PoolTokenExchangeRate::new_for_testing(100, 100);
+        let rate2 = PoolTokenExchangeRate::new_for_testing(200, 220);
+        let rate3 = PoolTokenExchangeRate::new_for_testing(300, 330);
         let rates = vec![(2, rate2.clone()), (3, rate3.clone()), (1, rate1.clone())];
 
         let expected: Vec<(u64, PoolTokenExchangeRate)> =
@@ -853,9 +853,9 @@ mod tests {
 
     #[test]
     fn test_backfill_rates_with_gaps() {
-        let rate1 = PoolTokenExchangeRate::new(100, 100);
-        let rate3 = PoolTokenExchangeRate::new(300, 330);
-        let rate5 = PoolTokenExchangeRate::new(500, 550);
+        let rate1 = PoolTokenExchangeRate::new_for_testing(100, 100);
+        let rate3 = PoolTokenExchangeRate::new_for_testing(300, 330);
+        let rate5 = PoolTokenExchangeRate::new_for_testing(500, 550);
         let rates = vec![(3, rate3.clone()), (1, rate1.clone()), (5, rate5.clone())];
 
         let expected = vec![

--- a/crates/iota-json-rpc/src/governance_api.rs
+++ b/crates/iota-json-rpc/src/governance_api.rs
@@ -875,4 +875,37 @@ mod tests {
         ];
         assert_eq!(backfill_rates(rates), expected);
     }
+
+    #[test]
+    fn test_backfill_rates_missing_middle_epoch() {
+        let rate1 = PoolTokenExchangeRate::new_for_testing(100, 100);
+        let rate3 = PoolTokenExchangeRate::new_for_testing(300, 330);
+        let rates = vec![(1, rate1.clone()), (3, rate3.clone())];
+        let expected = vec![(3, rate3), (2, rate1.clone()), (1, rate1)];
+        assert_eq!(backfill_rates(rates), expected);
+    }
+
+    #[test]
+    fn test_backfill_rates_missing_middle_epochs() {
+        let rate1 = PoolTokenExchangeRate::new_for_testing(100, 100);
+        let rate4 = PoolTokenExchangeRate::new_for_testing(400, 440);
+        let rates = vec![(1, rate1.clone()), (4, rate4.clone())];
+        let expected = vec![
+            (4, rate4),
+            (3, rate1.clone()),
+            (2, rate1.clone()),
+            (1, rate1),
+        ];
+        assert_eq!(backfill_rates(rates), expected);
+    }
+
+    #[test]
+    fn test_backfill_rates_unordered_input() {
+        let rate1 = PoolTokenExchangeRate::new_for_testing(100, 100);
+        let rate3 = PoolTokenExchangeRate::new_for_testing(300, 330);
+        let rate4 = PoolTokenExchangeRate::new_for_testing(400, 440);
+        let rates = vec![(3, rate3.clone()), (1, rate1.clone()), (4, rate4.clone())];
+        let expected = vec![(4, rate4), (3, rate3), (2, rate1.clone()), (1, rate1)];
+        assert_eq!(backfill_rates(rates), expected);
+    }
 }

--- a/crates/iota-json-rpc/src/governance_api.rs
+++ b/crates/iota-json-rpc/src/governance_api.rs
@@ -770,22 +770,17 @@ fn backfill_rates(
     if rates.is_empty() {
         return rates;
     }
-    let min_epoch = *rates.iter().map(|(e, _)| e).min().unwrap();
-    let max_epoch = *rates.iter().map(|(e, _)| e).max().unwrap();
-    let mut filled_rates = Vec::new();
-    let mut prev_rate = None;
-    for epoch in min_epoch..=max_epoch {
-        match rates.iter().find(|(e, _)| *e == epoch) {
-            Some((e, rate)) => {
-                prev_rate = Some(rate.clone());
-                filled_rates.push((*e, rate.clone()));
+    rates.sort_unstable_by_key(|(epoch_id, _)| *epoch_id);
+    let mut filled_rates: Vec<(EpochId, PoolTokenExchangeRate)> = Vec::with_capacity(rates.len());
+    let mut missing_rates = Vec::new();
+    for (epoch_id, rate) in rates {
+        if let Some((prev_epoch_id, prev_rate)) = filled_rates.last() {
+            for missing_epoch_id in prev_epoch_id + 1..epoch_id {
+                missing_rates.push((missing_epoch_id, prev_rate.clone()));
             }
-            None => {
-                if let Some(rate) = prev_rate.clone() {
-                    filled_rates.push((epoch, rate));
-                }
-            }
-        }
+        };
+        filled_rates.append(&mut missing_rates);
+        filled_rates.push((epoch_id, rate));
     }
     filled_rates.reverse();
     filled_rates

--- a/crates/iota-json-rpc/src/governance_api.rs
+++ b/crates/iota-json-rpc/src/governance_api.rs
@@ -777,7 +777,7 @@ fn backfill_rates(
     let (min_epoch, _) = rates.first().expect("rates should not be empty");
     let (max_epoch, _) = rates.last().expect("rates should not be empty");
     let expected_len = (max_epoch - min_epoch + 1) as usize;
-    let current_len = rates.len() as usize;
+    let current_len = rates.len();
 
     // Only perform backfilling if there are gaps
     if current_len == expected_len {

--- a/crates/iota-types/src/iota_system_state/mod.rs
+++ b/crates/iota-types/src/iota_system_state/mod.rs
@@ -407,7 +407,7 @@ impl PoolTokenExchangeRate {
             self.pool_token_amount as f64 / self.iota_amount as f64
         }
     }
-#[cfg(test)]
+    #[cfg(test)]
     pub fn new(iota_amount: u64, pool_token_amount: u64) -> Self {
         Self {
             iota_amount,

--- a/crates/iota-types/src/iota_system_state/mod.rs
+++ b/crates/iota-types/src/iota_system_state/mod.rs
@@ -407,6 +407,13 @@ impl PoolTokenExchangeRate {
             self.pool_token_amount as f64 / self.iota_amount as f64
         }
     }
+
+    pub fn new(iota_amount: u64, pool_token_amount: u64) -> Self {
+        Self {
+            iota_amount,
+            pool_token_amount,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]

--- a/crates/iota-types/src/iota_system_state/mod.rs
+++ b/crates/iota-types/src/iota_system_state/mod.rs
@@ -407,7 +407,7 @@ impl PoolTokenExchangeRate {
             self.pool_token_amount as f64 / self.iota_amount as f64
         }
     }
-
+#[cfg(test)]
     pub fn new(iota_amount: u64, pool_token_amount: u64) -> Self {
         Self {
             iota_amount,

--- a/crates/iota-types/src/iota_system_state/mod.rs
+++ b/crates/iota-types/src/iota_system_state/mod.rs
@@ -408,7 +408,7 @@ impl PoolTokenExchangeRate {
         }
     }
 
-    pub fn new(iota_amount: u64, pool_token_amount: u64) -> Self {
+    pub fn new_for_testing(iota_amount: u64, pool_token_amount: u64) -> Self {
         Self {
             iota_amount,
             pool_token_amount,

--- a/crates/iota-types/src/iota_system_state/mod.rs
+++ b/crates/iota-types/src/iota_system_state/mod.rs
@@ -407,7 +407,7 @@ impl PoolTokenExchangeRate {
             self.pool_token_amount as f64 / self.iota_amount as f64
         }
     }
-    #[cfg(test)]
+
     pub fn new(iota_amount: u64, pool_token_amount: u64) -> Self {
         Self {
             iota_amount,


### PR DESCRIPTION
# Description of change

Uses the exchange rate from the previous existing epoch instead of the default one value.

## Links to any relevant issues

fixes #5180 

## Type of change

- Bug fix

## How the change has been tested

Ran the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
