### PR TITLE
fix(node): Fix overload protection

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -877,7 +877,7 @@ pub struct AuthorityOverloadConfig {
 }
 
 fn default_max_txn_age_in_queue() -> Duration {
-    Duration::from_secs(1)
+    Duration::from_millis(500)
 }
 
 fn default_overload_monitor_interval() -> Duration {

--- a/crates/iota-core/src/transaction_manager.rs
+++ b/crates/iota-core/src/transaction_manager.rs
@@ -870,9 +870,9 @@ impl TransactionManager {
         for (object_id, queue_len, txn_age) in self.objects_queue_len_and_age(
             tx_data
                 .transaction_data()
-                .input_objects()?
+                .shared_input_objects()
                 .into_iter()
-                .map(|r| r.object_id())
+                .filter_map(|r| r.mutable.then_some(r.id))
                 .collect(),
         ) {
             // When this occurs, most likely transactions piled up on a shared object.
@@ -892,9 +892,9 @@ impl TransactionManager {
                 // queue.
                 if age >= overload_config.max_txn_age_in_queue {
                     info!(
-                        "Overload detected on object {:?} with oldest transaction pending for {} secs",
+                        "Overload detected on object {:?} with oldest transaction pending for {}ms",
                         object_id,
-                        age.as_secs()
+                        age.as_millis()
                     );
                     fp_bail!(IotaError::TooOldTransactionPendingOnObject {
                         object_id,

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -104,8 +104,8 @@ validator_configs:
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
-        secs: 1
-        nanos: 0
+        secs: 0
+        nanos: 500000000
       overload-monitor-interval:
         secs: 10
         nanos: 0
@@ -224,8 +224,8 @@ validator_configs:
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
-        secs: 1
-        nanos: 0
+        secs: 0
+        nanos: 500000000
       overload-monitor-interval:
         secs: 10
         nanos: 0
@@ -344,8 +344,8 @@ validator_configs:
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
-        secs: 1
-        nanos: 0
+        secs: 0
+        nanos: 500000000
       overload-monitor-interval:
         secs: 10
         nanos: 0
@@ -464,8 +464,8 @@ validator_configs:
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
-        secs: 1
-        nanos: 0
+        secs: 0
+        nanos: 500000000
       overload-monitor-interval:
         secs: 10
         nanos: 0
@@ -584,8 +584,8 @@ validator_configs:
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
-        secs: 1
-        nanos: 0
+        secs: 0
+        nanos: 500000000
       overload-monitor-interval:
         secs: 10
         nanos: 0
@@ -704,8 +704,8 @@ validator_configs:
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
-        secs: 1
-        nanos: 0
+        secs: 0
+        nanos: 500000000
       overload-monitor-interval:
         secs: 10
         nanos: 0
@@ -824,8 +824,8 @@ validator_configs:
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
-        secs: 1
-        nanos: 0
+        secs: 0
+        nanos: 500000000
       overload-monitor-interval:
         secs: 10
         nanos: 0


### PR DESCRIPTION
# Description of change

- Only check overload queues for mutable shared inputs
- Update the max tx queue age to `500ms` (Note that we are now using 1s, but it's a old configuration from the upstream [PR #16050](https://github.com/MystenLabs/sui/pull/16050)).

## Links to any relevant issues

fixes #5181  

## Type of change

- Bug fix

## How the change has been tested

Ran the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
