### PR TITLE
fix: expect format strings

### DIFF
--- a/crates/iota-archival/src/reader.rs
+++ b/crates/iota-archival/src/reader.rs
@@ -672,7 +672,7 @@ impl ArchiveReader {
                         std::cmp::Ordering::Equal
                     }
                 })
-                .expect("Archive does not contain checkpoint {checkpoint}");
+                .expect(&format!("Archive does not contain checkpoint {checkpoint}"));
             summaries_filtered.push(summary_files[index].clone());
         }
 

--- a/crates/iota-archival/src/reader.rs
+++ b/crates/iota-archival/src/reader.rs
@@ -672,7 +672,7 @@ impl ArchiveReader {
                         std::cmp::Ordering::Equal
                     }
                 })
-                .expect(&format!("Archive does not contain checkpoint {checkpoint}"));
+                .unwrap_or_else(|_| panic!("Archive does not contain checkpoint {checkpoint}"));
             summaries_filtered.push(summary_files[index].clone());
         }
 

--- a/crates/iota-cluster-test/src/test_case/shared_object_test.rs
+++ b/crates/iota-cluster-test/src/test_case/shared_object_test.rs
@@ -56,7 +56,7 @@ impl TestCaseImpl for SharedCounterTest {
             .shared_objects()
             .iter()
             .find(|o| o.object_id == counter_id)
-            .expect(&format!("Expect obj {counter_id} in shared_objects"));
+            .unwrap_or_else(|| panic!("Expect obj {counter_id} in shared_objects"));
 
         let counter_version = response
             .effects
@@ -80,7 +80,7 @@ impl TestCaseImpl for SharedCounterTest {
                     None
                 }
             })
-            .expect(&format!("Expect obj {counter_id} in mutated"));
+            .unwrap_or_else(|| panic!("Expect obj {counter_id} in mutated"));
 
         // Verify fullnode observes the txn
         ctx.let_fullnode_sync(vec![response.digest], 5).await;

--- a/crates/iota-cluster-test/src/test_case/shared_object_test.rs
+++ b/crates/iota-cluster-test/src/test_case/shared_object_test.rs
@@ -56,7 +56,7 @@ impl TestCaseImpl for SharedCounterTest {
             .shared_objects()
             .iter()
             .find(|o| o.object_id == counter_id)
-            .expect("Expect obj {counter_id} in shared_objects");
+            .expect(&format!("Expect obj {counter_id} in shared_objects"));
 
         let counter_version = response
             .effects
@@ -80,7 +80,7 @@ impl TestCaseImpl for SharedCounterTest {
                     None
                 }
             })
-            .expect("Expect obj {counter_id} in mutated");
+            .expect(&format!("Expect obj {counter_id} in mutated"));
 
         // Verify fullnode observes the txn
         ctx.let_fullnode_sync(vec![response.digest], 5).await;

--- a/crates/iota-faucet/src/faucet/write_ahead_log.rs
+++ b/crates/iota-faucet/src/faucet/write_ahead_log.rs
@@ -92,7 +92,7 @@ impl WriteAheadLog {
                 // the WAL.
                 self.log
                     .remove(&coin)
-                    .expect(&format!("Coin: {coin:?} unable to be removed from log."));
+                    .unwrap_or_else(|_| panic!("Coin: {coin:?} unable to be removed from log."));
                 Ok(None)
             }
             Err(err) => Err(err),

--- a/crates/iota-faucet/src/faucet/write_ahead_log.rs
+++ b/crates/iota-faucet/src/faucet/write_ahead_log.rs
@@ -92,7 +92,7 @@ impl WriteAheadLog {
                 // the WAL.
                 self.log
                     .remove(&coin)
-                    .expect("Coin: {coin:?} unable to be removed from log.");
+                    .expect(&format!("Coin: {coin:?} unable to be removed from log."));
                 Ok(None)
             }
             Err(err) => Err(err),

--- a/crates/iota-types/src/deny_list_v1.rs
+++ b/crates/iota-types/src/deny_list_v1.rs
@@ -261,9 +261,9 @@ pub fn get_deny_list_root_object(object_store: &dyn ObjectStore) -> IotaResult<O
         }
         Err(err) => {
             error!("Failed to get deny list object: {err}");
-            Err(IotaError::Storage(
-                "Failed to get deny list object: {err}".to_string(),
-            ))
+            Err(IotaError::Storage(format!(
+                "Failed to get deny list object: {err}"
+            )))
         }
     }
 }

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -2586,7 +2586,7 @@ async fn get_parsed_object_assert_existence(
 ) -> IotaObjectData {
     get_object(object_id, context)
         .await
-        .expect(&format!("Object {object_id} does not exist."))
+        .unwrap_or_else(|| panic!("Object {object_id} does not exist."))
 }
 
 #[sim_test]

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -2586,7 +2586,7 @@ async fn get_parsed_object_assert_existence(
 ) -> IotaObjectData {
     get_object(object_id, context)
         .await
-        .expect("Object {object_id} does not exist.")
+        .expect(&format!("Object {object_id} does not exist."))
 }
 
 #[sim_test]


### PR DESCRIPTION
Some `expect` are assuming the string is formatted but it's not so the panic message is incomplete, the parameter not actually being replaced with the variable's value.