### PR TITLE
fix(tests): if no crates changed, test all crates (#5202)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -30,6 +30,7 @@ or test(test_good_snapshot)
 or test(test_insufficient_balance_will_retry_success)
 or test(test_byzantine_peer_handling)
 or test(test_json_rpc_spec)
+or test(cluster_test)
 '''
 
 [[profile.ci.overrides]]
@@ -57,6 +58,8 @@ or test(test_pay_iota_multiple_times)
 or test(test_stake)
 or test(test_stake_all)
 or test(test_fullnode_traffic_control_spam_delegated)
+or test(ensure_no_tombstone_fragmentation_in_stack_frame_after_flush)
+or test(ip6)
 '''
 
 [profile.simtestnightly]

--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -51,11 +51,11 @@ runs:
             - ".github/workflows/_external_rust_tests.yml"
             - ".github/workflows/_cargo_deny.yml"
             - "scripts/cargo_sort/cargo_sort.py"
+            - "scripts/ci_tests/rust_tests.sh"
             - "Cargo.toml"
             - "Cargo.lock"
             - ".config/nextest.toml"
             - "rust-toolchain.toml"
-            - "scripts/ci_tests/rust_tests.sh"
           isRustExample:
             - "examples/custom-indexer/rust/**"
             - "examples/tic-tac-toe/cli/**"

--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -55,6 +55,7 @@ runs:
             - "Cargo.lock"
             - ".config/nextest.toml"
             - "rust-toolchain.toml"
+            - "scripts/ci_tests/rust_tests.sh"
           isRustExample:
             - "examples/custom-indexer/rust/**"
             - "examples/tic-tac-toe/cli/**"

--- a/scripts/ci_tests/rust_tests.sh
+++ b/scripts/ci_tests/rust_tests.sh
@@ -81,11 +81,11 @@ function mk_test_filterset() {
             FILTERSET="$FILTERSET $add_filter"
         fi
     done
-    # if filterset is sill empty here, it means no changed crates were detected, there are no crates to test
-    if [ -z "$FILTERSET" ]; then
-        echo "test_none"
-        return
-    fi
+
+    # if no crates were changed, we want to run all tests.
+    # because changes that trigger the workflow but which aren't explicitly in a crate can potentially affect the entire workspace
+    # returning an empty filterset does that
+
     echo "${FILTERSET}"
 }
 
@@ -105,11 +105,10 @@ function rust_crates() {
     # non-deterministic `test` job.
     export IOTA_SKIP_SIMTESTS=1
 
+    # if no crates were changed, we want to run all tests.
+    # because changes that trigger the workflow but which aren't explicitly in a crate can potentially affect the entire workspace
+    # mk_test_filterset returns an empty filterset in this case
     FILTERSET="$(mk_test_filterset)"
-    if [ "$FILTERSET" == "test_none" ]; then
-        echo "No changed crates detected. Skipping"
-        return
-    fi
 
     command="cargo nextest run --config-file .config/nextest.toml --profile ci $FILTERSET"
     echo "Running: $command"


### PR DESCRIPTION
## Bug description

Regression introduced in #4818: when no crates have changed, we now test no crates.

Instead, we want to test all the crates, as changes that trigger the workflow but which aren't explicitly in a crate can potentially affect the entire workspace

# Description of change

After this PR, if no crates were changed, all tests will be run.

Fixes #5202 


## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Ran tests in CI only.
This PR contains no crate changes, should test all crates.


## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked that new and existing unit tests pass locally with my changes
