### PR TITLE
refactor(storage,json-rpc)!: remove support for querying checkpoint contents by digest

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -4965,12 +4965,10 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
         checkpoint_summaries: &[CheckpointSequenceNumber],
         checkpoint_contents: &[CheckpointSequenceNumber],
         checkpoint_summaries_by_digest: &[CheckpointDigest],
-        checkpoint_contents_by_digest: &[CheckpointContentsDigest],
     ) -> IotaResult<(
         Vec<Option<CertifiedCheckpointSummary>>,
         Vec<Option<CheckpointContents>>,
         Vec<Option<CertifiedCheckpointSummary>>,
-        Vec<Option<CheckpointContents>>,
     )> {
         // TODO: use multi-get methods if it ever becomes important (unlikely)
         let mut summaries = Vec::with_capacity(checkpoint_summaries.len());
@@ -5003,13 +5001,7 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
             summaries_by_digest.push(checkpoint);
         }
 
-        let mut contents_by_digest = Vec::with_capacity(checkpoint_contents_by_digest.len());
-        for digest in checkpoint_contents_by_digest {
-            let checkpoint = store.get_checkpoint_contents(digest)?;
-            contents_by_digest.push(checkpoint);
-        }
-
-        Ok((summaries, contents, summaries_by_digest, contents_by_digest))
+        Ok((summaries, contents, summaries_by_digest))
     }
 
     async fn get_transaction_perpetual_checkpoint(

--- a/crates/iota-json-rpc/src/authority_state.rs
+++ b/crates/iota-json-rpc/src/authority_state.rs
@@ -22,8 +22,7 @@ use iota_json_rpc_types::{
 use iota_storage::{
     indexes::TotalBalance,
     key_value_store::{
-        KVStoreCheckpointData, KVStoreTransactionData, TransactionKeyValueStore,
-        TransactionKeyValueStoreTrait,
+        KVStoreTransactionData, TransactionKeyValueStore, TransactionKeyValueStoreTrait,
     },
 };
 use iota_types::{
@@ -67,14 +66,6 @@ pub trait StateRead: Send + Sync {
         effects: &[TransactionDigest],
         events: &[TransactionEventsDigest],
     ) -> StateReadResult<KVStoreTransactionData>;
-
-    async fn multi_get_checkpoints(
-        &self,
-        checkpoint_summaries: &[CheckpointSequenceNumber],
-        checkpoint_contents: &[CheckpointSequenceNumber],
-        checkpoint_summaries_by_digest: &[CheckpointDigest],
-        checkpoint_contents_by_digest: &[CheckpointContentsDigest],
-    ) -> StateReadResult<KVStoreCheckpointData>;
 
     fn get_object_read(&self, object_id: &ObjectID) -> StateReadResult<ObjectRead>;
 
@@ -264,25 +255,6 @@ impl StateRead for AuthorityState {
                 transactions,
                 effects,
                 events,
-            )
-            .await?,
-        )
-    }
-
-    async fn multi_get_checkpoints(
-        &self,
-        checkpoint_summaries: &[CheckpointSequenceNumber],
-        checkpoint_contents: &[CheckpointSequenceNumber],
-        checkpoint_summaries_by_digest: &[CheckpointDigest],
-        checkpoint_contents_by_digest: &[CheckpointContentsDigest],
-    ) -> StateReadResult<KVStoreCheckpointData> {
-        Ok(
-            <AuthorityState as TransactionKeyValueStoreTrait>::multi_get_checkpoints(
-                self,
-                checkpoint_summaries,
-                checkpoint_contents,
-                checkpoint_summaries_by_digest,
-                checkpoint_contents_by_digest,
             )
             .await?,
         )

--- a/crates/iota-json-rpc/src/coin_api.rs
+++ b/crates/iota-json-rpc/src/coin_api.rs
@@ -428,9 +428,7 @@ mod tests {
         error::{IotaError, IotaResult},
         gas_coin::GAS,
         id::UID,
-        messages_checkpoint::{
-            CheckpointContentsDigest, CheckpointDigest, CheckpointSequenceNumber,
-        },
+        messages_checkpoint::{CheckpointDigest, CheckpointSequenceNumber},
         object::Object,
         parse_iota_struct_tag,
         utils::create_fake_transaction,
@@ -457,7 +455,6 @@ mod tests {
                 checkpoint_summaries: &[CheckpointSequenceNumber],
                 checkpoint_contents: &[CheckpointSequenceNumber],
                 checkpoint_summaries_by_digest: &[CheckpointDigest],
-                checkpoint_contents_by_digest: &[CheckpointContentsDigest],
             ) -> IotaResult<KVStoreCheckpointData>;
 
             async fn get_transaction_perpetual_checkpoint(

--- a/crates/iota-json-rpc/src/read_api.rs
+++ b/crates/iota-json-rpc/src/read_api.rs
@@ -34,8 +34,7 @@ use iota_types::{
     error::{IotaError, IotaObjectResponseError},
     iota_serde::BigInt,
     messages_checkpoint::{
-        CheckpointContents, CheckpointContentsDigest, CheckpointSequenceNumber, CheckpointSummary,
-        CheckpointTimestamp,
+        CheckpointContents, CheckpointSequenceNumber, CheckpointSummary, CheckpointTimestamp,
     },
     object::{Object, ObjectRead, PastObjectRead},
     transaction::{Transaction, TransactionDataAPI},
@@ -120,7 +119,7 @@ impl ReadApi {
                     .await?;
                 let content = self
                     .transaction_kv_store
-                    .get_checkpoint_contents_by_digest(verified_summary.content_digest)
+                    .get_checkpoint_contents(verified_summary.sequence_number)
                     .await?;
                 let signature = verified_summary.auth_sig().signature.clone();
                 (verified_summary.into_data(), content, signature).into()
@@ -132,7 +131,7 @@ impl ReadApi {
                     .await?;
                 let content = self
                     .transaction_kv_store
-                    .get_checkpoint_contents_by_digest(verified_summary.content_digest)
+                    .get_checkpoint_contents(verified_summary.sequence_number)
                     .await?;
                 let signature = verified_summary.auth_sig().signature.clone();
                 (verified_summary.into_data(), content, signature).into()
@@ -170,13 +169,8 @@ impl ReadApi {
             })
             .collect();
 
-        let checkpoint_contents_digest: Vec<CheckpointContentsDigest> =
-            checkpoint_summaries_and_signatures
-                .iter()
-                .map(|summary| summary.0.content_digest)
-                .collect();
         let checkpoint_contents = transaction_kv_store
-            .multi_get_checkpoints_contents_by_digest(checkpoint_contents_digest.as_slice())
+            .multi_get_checkpoints_contents(&checkpoint_numbers)
             .await?;
         let contents: Vec<CheckpointContents> = checkpoint_contents.into_iter().flatten().collect();
 

--- a/crates/iota-storage/src/bin/http_kv_tool.rs
+++ b/crates/iota-storage/src/bin/http_kv_tool.rs
@@ -11,9 +11,7 @@ use iota_storage::{
 };
 use iota_types::{
     base_types::ObjectID,
-    digests::{
-        CheckpointContentsDigest, CheckpointDigest, TransactionDigest, TransactionEventsDigest,
-    },
+    digests::{CheckpointDigest, TransactionDigest, TransactionEventsDigest},
     messages_checkpoint::CheckpointSequenceNumber,
 };
 
@@ -100,26 +98,12 @@ async fn main() {
         }
 
         "ckpt_contents" => {
-            let digests: Vec<_> = options
-                .digest
-                .into_iter()
-                .map(|s| CheckpointContentsDigest::from_str(&s).expect("invalid checkpoint digest"))
-                .collect();
-
-            let ckpts = kv
-                .multi_get_checkpoints(&[], &seqs, &[], &digests)
-                .await
-                .unwrap();
+            let ckpts = kv.multi_get_checkpoints(&[], &seqs, &[]).await.unwrap();
 
             for (seq, ckpt) in seqs.iter().zip(ckpts.1.iter()) {
                 // populate digest before printing
                 ckpt.as_ref().map(|c| c.digest());
                 println!("fetched ckpt contents: {:?} {:?}", seq, ckpt);
-            }
-            for (digest, ckpt) in digests.iter().zip(ckpts.3.iter()) {
-                // populate digest before printing
-                ckpt.as_ref().map(|c| c.digest());
-                println!("fetched ckpt contents: {:?} {:?}", digest, ckpt);
             }
         }
 
@@ -131,7 +115,7 @@ async fn main() {
                 .collect();
 
             let ckpts = kv
-                .multi_get_checkpoints(&seqs, &[], &digests, &[])
+                .multi_get_checkpoints(&seqs, &[], &digests)
                 .await
                 .unwrap();
 


### PR DESCRIPTION
# Description of change

This patch cherry picks the upstream changes from https://www.github.com/MystenLabs/sui/pull/20370.

On top we remove the `CheckpointContentsByDigest` key from `iota_storage::http_key_value_store`.

## Links to any relevant issues

Part of #5194 

## How the change has been tested

```
$ cargo simtest -p iota-json-rpc-tests
$ cargo test -p iota-storage
```

