### PR TITLE
fix(CI): if no tests in changed crates, make tests pass

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -60,7 +60,6 @@ or test(test_stake_all)
 or test(test_fullnode_traffic_control_spam_delegated)
 or test(ensure_no_tombstone_fragmentation_in_stack_frame_after_flush)
 or test(ip6)
-or test(test_profiler)
 '''
 
 [profile.simtestnightly]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -60,6 +60,7 @@ or test(test_stake_all)
 or test(test_fullnode_traffic_control_spam_delegated)
 or test(ensure_no_tombstone_fragmentation_in_stack_frame_after_flush)
 or test(ip6)
+or test(test_profiler)
 '''
 
 [profile.simtestnightly]

--- a/scripts/ci_tests/rust_tests.sh
+++ b/scripts/ci_tests/rust_tests.sh
@@ -143,7 +143,7 @@ function rust_crates() {
         FILTERSET="-E '($FILTERSET) & ($EXCLUDE_SET)'"
     fi
 
-    command="cargo nextest run --config-file .config/nextest.toml --profile ci --all-features $FILTERSET"
+    command="cargo nextest run --config-file .config/nextest.toml --profile ci --all-features $FILTERSET --no-tests=warn"
     echo "Running: $command"
     eval ${command}
 }
@@ -151,9 +151,9 @@ function rust_crates() {
 function external_crates() {
     # WARNING: this has  a side effect of updating the Cargo.lock file
     FILTERSET="$(mk_test_filterset) -E '!test(prove) and !test(run_all::simple_build_with_docs/args.txt) and !test(run_test::nested_deps_bad_parent/Move.toml)"
-    command="cargo nextest run --config-file .config/nextest.toml --profile ci --manifest-path external-crates/move/Cargo.toml $FILTERSET"
+    command="cargo nextest run --config-file .config/nextest.toml --profile ci --manifest-path external-crates/move/Cargo.toml $FILTERSET --no-tests=warn"
     echo "Running: $command"
-    cargo nextest run --config-file .config/nextest.toml --profile ci --manifest-path external-crates/move/Cargo.toml $FILTERSET
+    eval ${command}
 }
 
 function unused_deps() {


### PR DESCRIPTION
# Description of change

Recently a `cargo nextest` warning became an error: when no tests are found in changed crates in CI tests.
This fixes it

Fixes #5196:
- pass flag --no-tests=warn to cargo nextest
- tests will now pass if changed_crates contain no tests, with a warning still (all crates should likely be tested)

# Checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] Wait for #5035 to be merged (there were conflicts)
