### PR TITLE
feat(storage): query events by transaction digest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4807,11 +4807,11 @@ checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 [[package]]
 name = "futures-timer"
 version = "3.0.3"
-source = "git+https://github.com/iotaledger/iota-sim.git?rev=f16ef50ba7d874fe1f0960f248f6c651a634d6a5#f16ef50ba7d874fe1f0960f248f6c651a634d6a5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 dependencies = [
  "gloo-timers 0.2.6",
  "send_wrapper 0.4.0",
- "tokio",
 ]
 
 [[package]]
@@ -9441,7 +9441,6 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
- "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
@@ -12317,8 +12316,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
- "tokio-macros",
- "tracing",
+ "tokio-macros 2.4.0 (git+https://github.com/iotaledger/tokio-madsim-fork.git?branch=main)",
  "windows-sys 0.52.0",
 ]
 
@@ -14850,15 +14848,31 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "tokio"
 version = "1.39.2"
-source = "git+https://github.com/iotaledger/iota-sim.git?rev=f16ef50ba7d874fe1f0960f248f6c651a634d6a5#f16ef50ba7d874fe1f0960f248f6c651a634d6a5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
+ "backtrace",
  "bytes",
- "futures",
  "libc",
  "mio 1.0.2",
- "msim",
- "real_tokio",
+ "parking_lot 0.12.3",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4807,11 +4807,11 @@ checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 [[package]]
 name = "futures-timer"
 version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+source = "git+https://github.com/iotaledger/iota-sim.git?rev=f16ef50ba7d874fe1f0960f248f6c651a634d6a5#f16ef50ba7d874fe1f0960f248f6c651a634d6a5"
 dependencies = [
  "gloo-timers 0.2.6",
  "send_wrapper 0.4.0",
+ "tokio",
 ]
 
 [[package]]
@@ -7028,6 +7028,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "axum",
+ "backoff",
  "bcs",
  "cached",
  "expect-test",
@@ -9440,6 +9441,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
@@ -12315,7 +12317,8 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
- "tokio-macros 2.4.0 (git+https://github.com/iotaledger/tokio-madsim-fork.git?branch=main)",
+ "tokio-macros",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -14847,31 +14850,15 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "tokio"
 version = "1.39.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+source = "git+https://github.com/iotaledger/iota-sim.git?rev=f16ef50ba7d874fe1f0960f248f6c651a634d6a5#f16ef50ba7d874fe1f0960f248f6c651a634d6a5"
 dependencies = [
- "backtrace",
  "bytes",
+ "futures",
  "libc",
  "mio 1.0.2",
- "parking_lot 0.12.3",
- "pin-project-lite",
- "signal-hook-registry",
- "socket2",
- "tokio-macros 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "msim",
+ "real_tokio",
  "tracing",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
 ]
 
 [[package]]

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -5035,6 +5035,30 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
             .map(|maybe| maybe.map(|(_epoch, checkpoint)| checkpoint))
             .collect())
     }
+
+    async fn multi_get_events_by_tx_digests(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> IotaResult<Vec<Option<TransactionEvents>>> {
+        if digests.is_empty() {
+            return Ok(vec![]);
+        }
+        let events_digests: Vec<_> = self
+            .get_transaction_cache_reader()
+            .multi_get_executed_effects(digests)?
+            .into_iter()
+            .map(|t| t.and_then(|t| t.events_digest().cloned()))
+            .collect();
+        let non_empty_events: Vec<_> = events_digests.iter().filter_map(|e| *e).collect();
+        let mut events = self
+            .get_transaction_cache_reader()
+            .multi_get_events(&non_empty_events)?
+            .into_iter();
+        Ok(events_digests
+            .into_iter()
+            .map(|ev| ev.and_then(|_| events.next()?))
+            .collect())
+    }
 }
 
 #[cfg(msim)]

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -5036,6 +5036,7 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
             .collect())
     }
 
+    #[instrument(skip(self))]
     async fn multi_get_events_by_tx_digests(
         &self,
         digests: &[TransactionDigest],

--- a/crates/iota-json-rpc-tests/tests/read_api.rs
+++ b/crates/iota-json-rpc-tests/tests/read_api.rs
@@ -1169,9 +1169,12 @@ async fn get_events_not_found() {
     let cluster = TestClusterBuilder::new().build().await;
     let http_client = cluster.rpc_client();
 
-    let result = http_client.get_events(TransactionDigest::ZERO).await;
+    let events = http_client
+        .get_events(TransactionDigest::ZERO)
+        .await
+        .unwrap();
 
-    assert!(result.is_err())
+    assert!(events.is_empty())
 }
 
 #[sim_test]

--- a/crates/iota-json-rpc/Cargo.toml
+++ b/crates/iota-json-rpc/Cargo.toml
@@ -12,6 +12,7 @@ anyhow.workspace = true
 arc-swap.workspace = true
 async-trait.workspace = true
 axum.workspace = true
+backoff.workspace = true
 bcs.workspace = true
 cached.workspace = true
 eyre.workspace = true

--- a/crates/iota-json-rpc/src/coin_api.rs
+++ b/crates/iota-json-rpc/src/coin_api.rs
@@ -424,7 +424,7 @@ mod tests {
         base_types::{IotaAddress, ObjectID, SequenceNumber},
         coin::TreasuryCap,
         digests::{ObjectDigest, TransactionDigest, TransactionEventsDigest},
-        effects::TransactionEffects,
+        effects::{TransactionEffects, TransactionEvents},
         error::{IotaError, IotaResult},
         gas_coin::GAS,
         id::UID,
@@ -468,6 +468,11 @@ mod tests {
                 &self,
                 digests: &[TransactionDigest],
             ) -> IotaResult<Vec<Option<CheckpointSequenceNumber>>>;
+
+            async fn multi_get_events_by_tx_digests(
+                &self,
+                digests: &[TransactionDigest]
+            ) -> IotaResult<Vec<Option<TransactionEvents>>>;
         }
     }
 

--- a/crates/iota-storage/tests/key_value_tests.rs
+++ b/crates/iota-storage/tests/key_value_tests.rs
@@ -235,7 +235,7 @@ impl TransactionKeyValueStoreTrait for MockTxStore {
 
     async fn multi_get_events_by_tx_digests(
         &self,
-        digests: &[TransactionDigest],
+        _digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Option<TransactionEvents>>> {
         Ok(vec![])
     }

--- a/crates/iota-storage/tests/key_value_tests.rs
+++ b/crates/iota-storage/tests/key_value_tests.rs
@@ -232,6 +232,13 @@ impl TransactionKeyValueStoreTrait for MockTxStore {
             .map(|digest| self.tx_to_checkpoint.get(digest).cloned())
             .collect())
     }
+
+    async fn multi_get_events_by_tx_digests(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> IotaResult<Vec<Option<TransactionEvents>>> {
+        Ok(vec![])
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Description of change

This patch enables querying events by transaction digests picking the respective upstream change: https://www.github.com/MystenLabs/sui/pull/20422

A failing `json-rpc` test is updated to comply with these changes.

## Links to any relevant issues

Part of #5194 

## Type of change

```
$ cargo test -p iota-storage
$ cargo simtest -p iota-json-rpc-tests
```