### PR TITLE
feat(iota-indexer)!: enable analytical indexer in iota start

### DIFF
--- a/crates/iota-cluster-test/src/cluster.rs
+++ b/crates/iota-cluster-test/src/cluster.rs
@@ -13,7 +13,7 @@ use iota_genesis_builder::SnapshotSource;
 use iota_graphql_rpc::{
     config::ConnectionConfig, test_infra::cluster::start_graphql_server_with_fn_rpc,
 };
-use iota_indexer::test_utils::{ReaderWriterConfig, start_test_indexer};
+use iota_indexer::test_utils::{IndexerTypeConfig, start_test_indexer};
 use iota_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use iota_sdk::{
     iota_client_config::{IotaClientConfig, IotaEnv},
@@ -245,7 +245,7 @@ impl Cluster for LocalNewCluster {
             start_test_indexer(
                 Some(pg_address.clone()),
                 fullnode_url.clone(),
-                ReaderWriterConfig::writer_mode(None),
+                IndexerTypeConfig::writer_mode(None),
                 Some(data_ingestion_path.clone()),
                 None,
             )
@@ -255,7 +255,7 @@ impl Cluster for LocalNewCluster {
             start_test_indexer(
                 Some(pg_address),
                 fullnode_url.clone(),
-                ReaderWriterConfig::reader_mode(indexer_address.to_string()),
+                IndexerTypeConfig::reader_mode(indexer_address.to_string()),
                 Some(data_ingestion_path),
                 None,
             )

--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -9,7 +9,7 @@ pub use iota_indexer::handlers::objects_snapshot_processor::SnapshotLagConfig;
 use iota_indexer::{
     errors::IndexerError,
     store::{PgIndexerStore, indexer_store::IndexerStore},
-    test_utils::{ReaderWriterConfig, force_delete_database, start_test_indexer_impl},
+    test_utils::{IndexerTypeConfig, force_delete_database, start_test_indexer_impl},
 };
 use iota_swarm_config::genesis_config::{AccountConfig, DEFAULT_GAS_AMOUNT};
 use iota_types::storage::RestStateReader;
@@ -68,7 +68,7 @@ pub async fn start_cluster(
     let (pg_store, pg_handle) = start_test_indexer_impl(
         Some(db_url),
         val_fn.rpc_url().to_string(),
-        ReaderWriterConfig::writer_mode(None),
+        IndexerTypeConfig::writer_mode(None),
         // reset_database
         true,
         Some(data_ingestion_path),
@@ -133,7 +133,7 @@ pub async fn serve_executor(
     let (pg_store, pg_handle) = start_test_indexer_impl(
         Some(db_url),
         format!("http://{}", executor_server_url),
-        ReaderWriterConfig::writer_mode(snapshot_config.clone()),
+        IndexerTypeConfig::writer_mode(snapshot_config.clone()),
         // reset_database
         true,
         Some(data_ingestion_path),

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -96,7 +96,6 @@ pub async fn start_test_indexer_impl(
         fullnode_sync_worker: true,
         rpc_server_worker: false,
         data_ingestion_path,
-        analytical_worker: true,
         ..Default::default()
     };
 

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -18,15 +18,16 @@ use crate::{
     errors::IndexerError,
     handlers::objects_snapshot_processor::SnapshotLagConfig,
     indexer::Indexer,
-    store::PgIndexerStore,
+    store::{PgIndexerAnalyticalStore, PgIndexerStore},
 };
 
-pub enum ReaderWriterConfig {
+pub enum IndexerTypeConfig {
     Reader { reader_mode_rpc_url: String },
     Writer { snapshot_config: SnapshotLagConfig },
+    AnalyticalWorker,
 }
 
-impl ReaderWriterConfig {
+impl IndexerTypeConfig {
     pub fn reader_mode(reader_mode_rpc_url: String) -> Self {
         Self::Reader {
             reader_mode_rpc_url,
@@ -43,7 +44,7 @@ impl ReaderWriterConfig {
 pub async fn start_test_indexer(
     db_url: Option<String>,
     rpc_url: String,
-    reader_writer_config: ReaderWriterConfig,
+    reader_writer_config: IndexerTypeConfig,
     data_ingestion_path: Option<PathBuf>,
     new_database: Option<&str>,
 ) -> (PgIndexerStore, JoinHandle<Result<(), IndexerError>>) {
@@ -66,7 +67,7 @@ pub async fn start_test_indexer(
 pub async fn start_test_indexer_impl(
     db_url: Option<String>,
     rpc_url: String,
-    reader_writer_config: ReaderWriterConfig,
+    reader_writer_config: IndexerTypeConfig,
     mut reset_database: bool,
     data_ingestion_path: Option<PathBuf>,
     cancel: CancellationToken,
@@ -95,6 +96,7 @@ pub async fn start_test_indexer_impl(
         fullnode_sync_worker: true,
         rpc_server_worker: false,
         data_ingestion_path,
+        analytical_worker: true,
         ..Default::default()
     };
 
@@ -102,7 +104,7 @@ pub async fn start_test_indexer_impl(
 
     let registry = prometheus::Registry::default();
     let handle = match reader_writer_config {
-        ReaderWriterConfig::Reader {
+        IndexerTypeConfig::Reader {
             reader_mode_rpc_url,
         } => {
             let reader_mode_rpc_url = reader_mode_rpc_url
@@ -114,7 +116,7 @@ pub async fn start_test_indexer_impl(
             config.rpc_server_port = reader_mode_rpc_url.port();
             tokio::spawn(async move { Indexer::start_reader(&config, &registry, db_url).await })
         }
-        ReaderWriterConfig::Writer { snapshot_config } => {
+        IndexerTypeConfig::Writer { snapshot_config } => {
             if config.reset_db {
                 let blocking_pool =
                     new_connection_pool_with_config(&db_url, Some(5), Default::default()).unwrap();
@@ -136,6 +138,19 @@ pub async fn start_test_indexer_impl(
                 )
                 .await
             })
+        }
+        IndexerTypeConfig::AnalyticalWorker => {
+            let blocking_pool =
+                new_connection_pool_with_config(&db_url, Some(5), Default::default()).unwrap();
+
+            let store = PgIndexerAnalyticalStore::new(blocking_pool);
+
+            init_metrics(&registry);
+            let indexer_metrics = IndexerMetrics::new(&registry);
+
+            tokio::spawn(
+                async move { Indexer::start_analytical_worker(store, indexer_metrics).await },
+            )
         }
     };
 

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -141,6 +141,9 @@ pub async fn start_test_indexer_impl(
         IndexerTypeConfig::AnalyticalWorker => {
             let blocking_pool =
                 new_connection_pool_with_config(&db_url, Some(5), Default::default()).unwrap();
+            if config.reset_db {
+                crate::db::reset_database(&mut blocking_pool.get().unwrap()).unwrap();
+            }
 
             let store = PgIndexerAnalyticalStore::new(blocking_pool);
 

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -14,7 +14,7 @@ use iota_indexer::{
     errors::IndexerError,
     indexer::Indexer,
     store::{PgIndexerStore, indexer_store::IndexerStore},
-    test_utils::{ReaderWriterConfig, start_test_indexer},
+    test_utils::{IndexerTypeConfig, start_test_indexer},
 };
 use iota_json_rpc_api::ReadApiClient;
 use iota_json_rpc_types::{IotaTransactionBlockResponseOptions, TransactionBlockBytes};
@@ -127,7 +127,7 @@ pub async fn start_test_cluster_with_read_write_indexer(
     let (pg_store, _pg_store_handle) = start_test_indexer(
         Some(get_indexer_db_url(None)),
         cluster.rpc_url().to_string(),
-        ReaderWriterConfig::writer_mode(None),
+        IndexerTypeConfig::writer_mode(None),
         None,
         database_name,
     )
@@ -312,7 +312,7 @@ pub async fn start_simulacrum_rest_api_with_write_indexer(
     let (pg_store, pg_handle) = start_test_indexer(
         Some(get_indexer_db_url(None)),
         format!("http://{}", server_url),
-        ReaderWriterConfig::writer_mode(None),
+        IndexerTypeConfig::writer_mode(None),
         Some(data_ingestion_path),
         database_name,
     )

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -31,7 +31,7 @@ use iota_graphql_rpc::{
     config::ConnectionConfig, test_infra::cluster::start_graphql_server_with_fn_rpc,
 };
 #[cfg(feature = "indexer")]
-use iota_indexer::test_utils::{ReaderWriterConfig, start_test_indexer};
+use iota_indexer::test_utils::{IndexerTypeConfig, start_test_indexer};
 use iota_keys::{
     keypair_file::read_key,
     keystore::{AccountKeystore, FileBasedKeystore, Keystore},
@@ -807,7 +807,7 @@ async fn start(
         start_test_indexer(
             Some(pg_address.clone()),
             fullnode_url.clone(),
-            ReaderWriterConfig::writer_mode(None),
+            IndexerTypeConfig::writer_mode(None),
             data_ingestion_dir.clone(),
             None,
         )
@@ -818,12 +818,23 @@ async fn start(
         start_test_indexer(
             Some(pg_address.clone()),
             fullnode_url.clone(),
-            ReaderWriterConfig::reader_mode(indexer_address.to_string()),
-            data_ingestion_dir,
+            IndexerTypeConfig::reader_mode(indexer_address.to_string()),
+            data_ingestion_dir.clone(),
             None,
         )
         .await;
         info!("Indexer in reader mode started");
+
+        // Start in analytical worker mode
+        start_test_indexer(
+            Some(pg_address.clone()),
+            fullnode_url.clone(),
+            IndexerTypeConfig::AnalyticalWorker,
+            data_ingestion_dir,
+            None,
+        )
+        .await;
+        info!("Indexer in analytical worker mode started");
     }
 
     #[cfg(feature = "indexer")]


### PR DESCRIPTION
# Description of change

Make it possible to start the analytical_worker in start_test_indexer_impl and start it when `iota start --with-indexer` is used

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/5102

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Running `cargo run --features=indexer start --force-regenesis --with-faucet --with-indexer` and then after ~1 minute with faucet requests
```
curl http://localhost:9124 \
--header 'content-type: application/json' \
--data '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "iotax_getNetworkMetrics",
  "params": []
}'
```
```
{"jsonrpc":"2.0","id":1,"result":{"currentTps":17.621145374449338,"tps30Days":26.08695652173913,"totalPackages":"5","totalAddresses":"18446744073709551615","totalObjects":"133","currentEpoch":"1","currentCheckpoint":"261"}}
```