### PR TITLE
refactor(storage,json-rpc)!: remove obsolete kv queries

### DIFF
--- a/crates/iota-json-rpc/src/authority_state.rs
+++ b/crates/iota-json-rpc/src/authority_state.rs
@@ -29,7 +29,7 @@ use iota_types::{
     base_types::{IotaAddress, MoveObjectType, ObjectID, ObjectInfo, ObjectRef, SequenceNumber},
     bridge::Bridge,
     committee::{Committee, EpochId},
-    digests::{ChainIdentifier, TransactionDigest, TransactionEventsDigest},
+    digests::{ChainIdentifier, TransactionDigest},
     dynamic_field::DynamicFieldInfo,
     effects::TransactionEffects,
     error::{IotaError, UserInputError},
@@ -64,7 +64,6 @@ pub trait StateRead: Send + Sync {
         &self,
         transactions: &[TransactionDigest],
         effects: &[TransactionDigest],
-        events: &[TransactionEventsDigest],
     ) -> StateReadResult<KVStoreTransactionData>;
 
     fn get_object_read(&self, object_id: &ObjectID) -> StateReadResult<ObjectRead>;
@@ -247,14 +246,12 @@ impl StateRead for AuthorityState {
         &self,
         transactions: &[TransactionDigest],
         effects: &[TransactionDigest],
-        events: &[TransactionEventsDigest],
     ) -> StateReadResult<KVStoreTransactionData> {
         Ok(
             <AuthorityState as TransactionKeyValueStoreTrait>::multi_get(
                 self,
                 transactions,
                 effects,
-                events,
             )
             .await?,
         )

--- a/crates/iota-json-rpc/src/authority_state.rs
+++ b/crates/iota-json-rpc/src/authority_state.rs
@@ -62,8 +62,8 @@ pub type StateReadResult<T = ()> = Result<T, StateReadError>;
 pub trait StateRead: Send + Sync {
     async fn multi_get(
         &self,
-        transactions: &[TransactionDigest],
-        effects: &[TransactionDigest],
+        transaction_keys: &[TransactionDigest],
+        effects_keys: &[TransactionDigest],
     ) -> StateReadResult<KVStoreTransactionData>;
 
     fn get_object_read(&self, object_id: &ObjectID) -> StateReadResult<ObjectRead>;
@@ -244,14 +244,14 @@ pub trait StateRead: Send + Sync {
 impl StateRead for AuthorityState {
     async fn multi_get(
         &self,
-        transactions: &[TransactionDigest],
-        effects: &[TransactionDigest],
+        transaction_keys: &[TransactionDigest],
+        effects_keys: &[TransactionDigest],
     ) -> StateReadResult<KVStoreTransactionData> {
         Ok(
             <AuthorityState as TransactionKeyValueStoreTrait>::multi_get(
                 self,
-                transactions,
-                effects,
+                transaction_keys,
+                effects_keys,
             )
             .await?,
         )

--- a/crates/iota-json-rpc/src/coin_api.rs
+++ b/crates/iota-json-rpc/src/coin_api.rs
@@ -423,7 +423,7 @@ mod tests {
         balance::Supply,
         base_types::{IotaAddress, ObjectID, SequenceNumber},
         coin::TreasuryCap,
-        digests::{ObjectDigest, TransactionDigest, TransactionEventsDigest},
+        digests::{ObjectDigest, TransactionDigest},
         effects::{TransactionEffects, TransactionEvents},
         error::{IotaError, IotaResult},
         gas_coin::GAS,
@@ -445,9 +445,8 @@ mod tests {
         impl TransactionKeyValueStoreTrait for KeyValueStore {
             async fn multi_get(
                 &self,
-                transactions: &[TransactionDigest],
-                effects: &[TransactionDigest],
-                events: &[TransactionEventsDigest],
+                transaction_keys: &[TransactionDigest],
+                effects_keys: &[TransactionDigest],
             ) -> IotaResult<KVStoreTransactionData>;
 
             async fn multi_get_checkpoints(

--- a/crates/iota-storage/src/bin/http_kv_tool.rs
+++ b/crates/iota-storage/src/bin/http_kv_tool.rs
@@ -11,7 +11,7 @@ use iota_storage::{
 };
 use iota_types::{
     base_types::ObjectID,
-    digests::{CheckpointDigest, TransactionDigest, TransactionEventsDigest},
+    digests::{CheckpointDigest, TransactionDigest},
     messages_checkpoint::CheckpointSequenceNumber,
 };
 
@@ -79,21 +79,6 @@ async fn main() {
                 for (digest, fx) in digests.iter().zip(fx.iter()) {
                     println!("fetched fx: {:?} {:?}", digest, fx);
                 }
-            }
-        }
-
-        "events" => {
-            let digests: Vec<_> = options
-                .digest
-                .into_iter()
-                .map(|digest| {
-                    TransactionEventsDigest::from_str(&digest).expect("invalid events digest")
-                })
-                .collect();
-
-            let tx = kv.multi_get_events(&digests).await.unwrap();
-            for (digest, ev) in digests.iter().zip(tx.iter()) {
-                println!("fetched events: {:?} {:?}", digest, ev);
             }
         }
 


### PR DESCRIPTION
# Description of change

With this patch we remove key-value queries that have been made obsolete by #5227. This follows the respective upstream patch:  https://www.github.com/MystenLabs/sui/pull/20720

On top some minor refactorings (renamed args) have been iimplemented that intend in improving readability.

## Links to any relevant issues

Fixes #5194

## Type of change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How the change has been tested

```
$ cargo {sim,}test -p iota-storage
$ cargo simtest -p iota-json-rpc-tests
```

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
