### PR TITLE
fix(types): avoid deserialization when fetching ID of non-upgraded packages

### DIFF
--- a/crates/iota-types/src/move_package.rs
+++ b/crates/iota-types/src/move_package.rs
@@ -485,6 +485,11 @@ impl MovePackage {
     /// runtime (can differ from `MovePackage::id()` in the case of package
     /// upgrades).
     pub fn original_package_id(&self) -> ObjectID {
+        if self.version == OBJECT_START_VERSION {
+            // for a non-upgraded package, original ID is just the package ID
+            return self.id;
+        }
+
         let bytes = self.module_map.values().next().expect("Empty module map");
         let module = CompiledModule::deserialize_with_defaults(bytes)
             .expect("A Move package contains a module that cannot be deserialized");


### PR DESCRIPTION
# Description of change

Merge an enhancement from upstream: https://github.com/MystenLabs/sui/commit/11ddc9e6f58d2d6140ad27cc41413ab55e3fec13

The `original_package_id` function is showing up in some slow traces, so make it less expensive in the (common) case of grabbing the ID of a non-upgraded package

## Links to any relevant issues

Close #4688 

## Type of change

- Enhancement


## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have checked that new and existing unit tests pass locally with my changes
