### PR TITLE
refactor(indexer, graphql-rpc): Remove df_object_id and related fields

### DIFF
--- a/crates/iota-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/iota-graphql-rpc/src/types/dynamic_field.rs
@@ -7,7 +7,12 @@ use async_graphql::{
     *,
 };
 use iota_indexer::{models::objects::StoredHistoryObject, types::OwnerType};
-use iota_types::dynamic_field::{DynamicFieldInfo, DynamicFieldType, derive_dynamic_field_id};
+use iota_types::{
+    TypeTag,
+    dynamic_field::{
+        DynamicFieldInfo, DynamicFieldType, derive_dynamic_field_id, extract_id_value,
+    },
+};
 use move_core_types::annotated_value::{self as A, MoveStruct};
 
 use crate::{
@@ -30,7 +35,6 @@ use crate::{
 
 pub(crate) struct DynamicField {
     pub super_: MoveObject,
-    pub df_object_id: IotaAddress,
     pub df_kind: DynamicFieldType,
 }
 
@@ -108,37 +112,44 @@ impl DynamicField {
     /// address. Its contents will be from the latest version that is at
     /// most equal to its parent object's version.
     async fn value(&self, ctx: &Context<'_>) -> Result<Option<DynamicFieldValue>> {
+        let resolver: &PackageResolver = ctx.data_unchecked();
+
+        // TODO(annotated-visitor): Use custom visitors to extract just the value.
+        let (struct_tag, move_struct) = deserialize_move_struct(&self.super_.native, resolver)
+            .await
+            .extend()?;
+
+        let value_move_value = extract_field_from_move_struct(move_struct, "value").extend()?;
+
         if self.df_kind == DynamicFieldType::DynamicObject {
             // If `df_kind` is a DynamicObject, the object we are currently on is the field
             // object, and we must resolve one more level down to the value
-            // object. Because we only have checkpoint-level granularity, we may
-            // end up reading a later version of the value object. Thus, we use
-            // the version of the field object to bound the value object at the
-            // correct version.
+            // object.
+            let df_object_id = extract_id_value(&value_move_value)
+                .ok_or_else(|| {
+                    Error::Internal(format!(
+                        "Couldn't find ID of dynamic object field value: {value_move_value:#?}"
+                    ))
+                })
+                .extend()?;
+
+            // Because we only have checkpoint-level granularity, we may end up reading a
+            // later version of the value object. Thus, we use the version of
+            // the field object to bound the value object at the correct
+            // version.
             let obj = MoveObject::query(
                 ctx,
-                self.df_object_id,
+                df_object_id.into(),
                 Object::under_parent(self.root_version(), self.super_.super_.checkpoint_viewed_at),
             )
             .await
             .extend()?;
             Ok(obj.map(DynamicFieldValue::MoveObject))
         } else {
-            let resolver: &PackageResolver = ctx
-                .data()
-                .map_err(|_| Error::Internal("Unable to fetch Package Cache.".to_string()))
-                .extend()?;
-
-            let (struct_tag, move_struct) = deserialize_move_struct(&self.super_.native, resolver)
-                .await
-                .extend()?;
-
             // Get TypeTag of the DynamicField value from StructTag of the MoveStruct
             let type_tag = DynamicFieldInfo::try_extract_field_value(&struct_tag)
                 .map_err(|e| Error::Internal(e.to_string()))
                 .extend()?;
-
-            let value_move_value = extract_field_from_move_struct(move_struct, "value").extend()?;
 
             let undecorated = value_move_value.undecorate();
             let bcs = bcs::to_bytes(&undecorated)
@@ -270,38 +281,43 @@ impl TryFrom<MoveObject> for DynamicField {
     fn try_from(stored: MoveObject) -> Result<Self, Error> {
         let super_ = &stored.super_;
 
-        let (df_object_id, df_kind) = match &super_.kind {
-            ObjectKind::Indexed(_, stored) => stored
-                .df_object_id
-                .as_ref()
-                .map(|id| (id, stored.df_kind))
-                .ok_or_else(|| Error::Internal("Object is not a dynamic field.".to_string()))?,
-            _ => {
+        let native = match &super_.kind {
+            ObjectKind::NotIndexed(native) | ObjectKind::Indexed(native, _) => native,
+
+            ObjectKind::WrappedOrDeleted(_) => {
                 return Err(Error::Internal(
-                    "A WrappedOrDeleted object cannot be converted into a DynamicField."
-                        .to_string(),
+                    "DynamicField is wrapped or deleted.".to_string(),
                 ));
             }
         };
 
-        let df_object_id = IotaAddress::from_bytes(df_object_id).map_err(|e| {
-            Error::Internal(format!("Failed to deserialize dynamic field ID: {e}."))
-        })?;
+        let Some(object) = native.data.try_as_move() else {
+            return Err(Error::Internal("DynamicField is not an object".to_string()));
+        };
 
-        let df_kind = match df_kind {
-            Some(0) => DynamicFieldType::DynamicField,
-            Some(1) => DynamicFieldType::DynamicObject,
-            Some(k) => {
-                return Err(Error::Internal(format!(
-                    "Unrecognized dynamic field kind: {k}."
-                )));
-            }
-            None => return Err(Error::Internal("No dynamic field kind.".to_string())),
+        let Some(tag) = object.type_().other() else {
+            return Err(Error::Internal("DynamicField is not a struct".to_string()));
+        };
+
+        if !DynamicFieldInfo::is_dynamic_field(tag) {
+            return Err(Error::Internal("Wrong type for DynamicField".to_string()));
+        }
+
+        let Some(name) = tag.type_params.first() else {
+            return Err(Error::Internal("No type for DynamicField name".to_string()));
+        };
+
+        let df_kind = if matches!(
+            name,
+            TypeTag::Struct(s) if DynamicFieldInfo::is_dynamic_object_field_wrapper(s)
+        ) {
+            DynamicFieldType::DynamicObject
+        } else {
+            DynamicFieldType::DynamicField
         };
 
         Ok(DynamicField {
             super_: stored,
-            df_object_id,
             df_kind,
         })
     }

--- a/crates/iota-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/iota-graphql-rpc/src/types/dynamic_field.rs
@@ -115,6 +115,7 @@ impl DynamicField {
         let resolver: &PackageResolver = ctx.data_unchecked();
 
         // TODO(annotated-visitor): Use custom visitors to extract just the value.
+        // https://github.com/iotaledger/iota/issues/4775
         let (struct_tag, move_struct) = deserialize_move_struct(&self.super_.native, resolver)
             .await
             .extend()?;

--- a/crates/iota-indexer/migrations/pg/2025-02-07-081500_drop_df_columns/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-02-07-081500_drop_df_columns/down.sql
@@ -1,0 +1,15 @@
+ALTER TABLE objects
+ADD COLUMN df_name bytea,
+ADD COLUMN df_object_type text,
+ADD COLUMN df_object_id bytea,
+ADD COLUMN checkpoint_sequence_number bigint;
+
+ALTER TABLE objects_snapshot
+ADD COLUMN df_name bytea,
+ADD COLUMN df_object_type text,
+ADD COLUMN df_object_id bytea;
+
+ALTER TABLE objects_history
+ADD COLUMN df_name bytea,
+ADD COLUMN df_object_type text,
+ADD COLUMN df_object_id bytea;

--- a/crates/iota-indexer/migrations/pg/2025-02-07-081500_drop_df_columns/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-02-07-081500_drop_df_columns/up.sql
@@ -1,0 +1,15 @@
+ALTER TABLE objects
+DROP COLUMN df_name,
+DROP COLUMN df_object_type,
+DROP COLUMN df_object_id,
+DROP COLUMN checkpoint_sequence_number;
+
+ALTER TABLE objects_snapshot
+DROP COLUMN df_name,
+DROP COLUMN df_object_type,
+DROP COLUMN df_object_id;
+
+ALTER TABLE objects_history
+DROP COLUMN df_name,
+DROP COLUMN df_object_type,
+DROP COLUMN df_object_id;

--- a/crates/iota-indexer/src/models/objects.rs
+++ b/crates/iota-indexer/src/models/objects.rs
@@ -24,17 +24,6 @@ use crate::{
 };
 
 #[derive(Queryable)]
-pub struct DynamicFieldColumn {
-    pub object_id: Vec<u8>,
-    pub object_version: i64,
-    pub object_digest: Vec<u8>,
-    pub df_kind: Option<i16>,
-    pub df_name: Option<Vec<u8>>,
-    pub df_object_type: Option<String>,
-    pub df_object_id: Option<Vec<u8>>,
-}
-
-#[derive(Queryable)]
 pub struct ObjectRefColumn {
     pub object_id: Vec<u8>,
     pub object_version: i64,
@@ -50,7 +39,6 @@ pub struct StoredObject {
     pub object_id: Vec<u8>,
     pub object_version: i64,
     pub object_digest: Vec<u8>,
-    pub checkpoint_sequence_number: i64,
     pub owner_type: i16,
     pub owner_id: Option<Vec<u8>>,
     /// The full type of this object, including package id, module, name and
@@ -66,9 +54,6 @@ pub struct StoredObject {
     // TODO deal with overflow
     pub coin_balance: Option<i64>,
     pub df_kind: Option<i16>,
-    pub df_name: Option<Vec<u8>>,
-    pub df_object_type: Option<String>,
-    pub df_object_id: Option<Vec<u8>>,
 }
 
 #[derive(Queryable, Insertable, Selectable, Debug, Identifiable, Clone, QueryableByName)]
@@ -89,44 +74,58 @@ pub struct StoredObjectSnapshot {
     pub coin_type: Option<String>,
     pub coin_balance: Option<i64>,
     pub df_kind: Option<i16>,
-    pub df_name: Option<Vec<u8>>,
-    pub df_object_type: Option<String>,
-    pub df_object_id: Option<Vec<u8>>,
 }
 
-impl From<StoredObject> for StoredObjectSnapshot {
-    fn from(o: StoredObject) -> Self {
+impl From<IndexedObject> for StoredObjectSnapshot {
+    fn from(o: IndexedObject) -> Self {
+        let IndexedObject {
+            checkpoint_sequence_number,
+            object,
+            df_info,
+        } = o;
+        let (owner_type, owner_id) = owner_to_owner_info(&object.owner);
+        let coin_type = object
+            .coin_type_maybe()
+            .map(|t| t.to_canonical_string(/* with_prefix */ true));
+        let coin_balance = if coin_type.is_some() {
+            Some(object.get_coin_value_unsafe())
+        } else {
+            None
+        };
+
         Self {
-            object_id: o.object_id,
-            object_version: o.object_version,
+            object_id: object.id().to_vec(),
+            object_version: object.version().value() as i64,
             object_status: ObjectStatus::Active as i16,
-            object_digest: Some(o.object_digest),
-            checkpoint_sequence_number: o.checkpoint_sequence_number,
-            owner_type: Some(o.owner_type),
-            object_type_package: o.object_type_package,
-            object_type_module: o.object_type_module,
-            object_type_name: o.object_type_name,
-            owner_id: o.owner_id,
-            object_type: o.object_type,
-            serialized_object: Some(o.serialized_object),
-            coin_type: o.coin_type,
-            coin_balance: o.coin_balance,
-            df_kind: o.df_kind,
-            df_name: o.df_name,
-            df_object_type: o.df_object_type,
-            df_object_id: o.df_object_id,
+            object_digest: Some(object.digest().into_inner().to_vec()),
+            checkpoint_sequence_number: checkpoint_sequence_number as i64,
+            owner_type: Some(owner_type as i16),
+            owner_id: owner_id.map(|id| id.to_vec()),
+            object_type: object
+                .type_()
+                .map(|t| t.to_canonical_string(/* with_prefix */ true)),
+            object_type_package: object.type_().map(|t| t.address().to_vec()),
+            object_type_module: object.type_().map(|t| t.module().to_string()),
+            object_type_name: object.type_().map(|t| t.name().to_string()),
+            serialized_object: Some(bcs::to_bytes(&object).unwrap()),
+            coin_type,
+            coin_balance: coin_balance.map(|b| b as i64),
+            df_kind: df_info.as_ref().map(|k| match k.type_ {
+                DynamicFieldType::DynamicField => 0,
+                DynamicFieldType::DynamicObject => 1,
+            }),
         }
     }
 }
 
-impl From<StoredDeletedObject> for StoredObjectSnapshot {
-    fn from(o: StoredDeletedObject) -> Self {
+impl From<IndexedDeletedObject> for StoredObjectSnapshot {
+    fn from(o: IndexedDeletedObject) -> Self {
         Self {
-            object_id: o.object_id,
-            object_version: o.object_version,
+            object_id: o.object_id.to_vec(),
+            object_version: o.object_version as i64,
             object_status: ObjectStatus::WrappedOrDeleted as i16,
             object_digest: None,
-            checkpoint_sequence_number: o.checkpoint_sequence_number,
+            checkpoint_sequence_number: o.checkpoint_sequence_number as i64,
             owner_type: None,
             owner_id: None,
             object_type: None,
@@ -137,9 +136,6 @@ impl From<StoredDeletedObject> for StoredObjectSnapshot {
             coin_type: None,
             coin_balance: None,
             df_kind: None,
-            df_name: None,
-            df_object_type: None,
-            df_object_id: None,
         }
     }
 }
@@ -162,32 +158,68 @@ pub struct StoredHistoryObject {
     pub coin_type: Option<String>,
     pub coin_balance: Option<i64>,
     pub df_kind: Option<i16>,
-    pub df_name: Option<Vec<u8>>,
-    pub df_object_type: Option<String>,
-    pub df_object_id: Option<Vec<u8>>,
 }
 
-impl From<StoredObject> for StoredHistoryObject {
-    fn from(o: StoredObject) -> Self {
+impl From<IndexedObject> for StoredHistoryObject {
+    fn from(o: IndexedObject) -> Self {
+        let IndexedObject {
+            checkpoint_sequence_number,
+            object,
+            df_info,
+        } = o;
+        let (owner_type, owner_id) = owner_to_owner_info(&object.owner);
+        let coin_type = object
+            .coin_type_maybe()
+            .map(|t| t.to_canonical_string(/* with_prefix */ true));
+        let coin_balance = if coin_type.is_some() {
+            Some(object.get_coin_value_unsafe())
+        } else {
+            None
+        };
+
         Self {
-            object_id: o.object_id,
-            object_version: o.object_version,
+            object_id: object.id().to_vec(),
+            object_version: object.version().value() as i64,
             object_status: ObjectStatus::Active as i16,
-            object_digest: Some(o.object_digest),
-            checkpoint_sequence_number: o.checkpoint_sequence_number,
-            owner_type: Some(o.owner_type),
-            object_type_package: o.object_type_package,
-            object_type_module: o.object_type_module,
-            object_type_name: o.object_type_name,
-            owner_id: o.owner_id,
-            object_type: o.object_type,
-            serialized_object: Some(o.serialized_object),
-            coin_type: o.coin_type,
-            coin_balance: o.coin_balance,
-            df_kind: o.df_kind,
-            df_name: o.df_name,
-            df_object_type: o.df_object_type,
-            df_object_id: o.df_object_id,
+            object_digest: Some(object.digest().into_inner().to_vec()),
+            checkpoint_sequence_number: checkpoint_sequence_number as i64,
+            owner_type: Some(owner_type as i16),
+            owner_id: owner_id.map(|id| id.to_vec()),
+            object_type: object
+                .type_()
+                .map(|t| t.to_canonical_string(/* with_prefix */ true)),
+            object_type_package: object.type_().map(|t| t.address().to_vec()),
+            object_type_module: object.type_().map(|t| t.module().to_string()),
+            object_type_name: object.type_().map(|t| t.name().to_string()),
+            serialized_object: Some(bcs::to_bytes(&object).unwrap()),
+            coin_type,
+            coin_balance: coin_balance.map(|b| b as i64),
+            df_kind: df_info.as_ref().map(|k| match k.type_ {
+                DynamicFieldType::DynamicField => 0,
+                DynamicFieldType::DynamicObject => 1,
+            }),
+        }
+    }
+}
+
+impl From<IndexedDeletedObject> for StoredHistoryObject {
+    fn from(o: IndexedDeletedObject) -> Self {
+        Self {
+            object_id: o.object_id.to_vec(),
+            object_version: o.object_version as i64,
+            object_status: ObjectStatus::WrappedOrDeleted as i16,
+            object_digest: None,
+            checkpoint_sequence_number: o.checkpoint_sequence_number as i64,
+            owner_type: None,
+            owner_id: None,
+            object_type: None,
+            object_type_package: None,
+            object_type_module: None,
+            object_type_name: None,
+            serialized_object: None,
+            coin_type: None,
+            coin_balance: None,
+            df_kind: None,
         }
     }
 }
@@ -197,7 +229,6 @@ impl From<StoredObject> for StoredHistoryObject {
 pub struct StoredDeletedObject {
     pub object_id: Vec<u8>,
     pub object_version: i64,
-    pub checkpoint_sequence_number: i64,
 }
 
 impl From<IndexedDeletedObject> for StoredDeletedObject {
@@ -205,7 +236,6 @@ impl From<IndexedDeletedObject> for StoredDeletedObject {
         Self {
             object_id: o.object_id.to_vec(),
             object_version: o.object_version as i64,
-            checkpoint_sequence_number: o.checkpoint_sequence_number as i64,
         }
     }
 }
@@ -219,21 +249,10 @@ pub(crate) struct StoredDeletedHistoryObject {
     pub checkpoint_sequence_number: i64,
 }
 
-impl From<StoredDeletedObject> for StoredDeletedHistoryObject {
-    fn from(o: StoredDeletedObject) -> Self {
-        Self {
-            object_id: o.object_id,
-            object_version: o.object_version,
-            object_status: ObjectStatus::WrappedOrDeleted as i16,
-            checkpoint_sequence_number: o.checkpoint_sequence_number,
-        }
-    }
-}
-
 impl From<IndexedObject> for StoredObject {
     fn from(o: IndexedObject) -> Self {
         let IndexedObject {
-            checkpoint_sequence_number,
+            checkpoint_sequence_number: _,
             object,
             df_info,
         } = o;
@@ -250,7 +269,6 @@ impl From<IndexedObject> for StoredObject {
             object_id: object.id().to_vec(),
             object_version: object.version().value() as i64,
             object_digest: object.digest().into_inner().to_vec(),
-            checkpoint_sequence_number: checkpoint_sequence_number as i64,
             owner_type: owner_type as i16,
             owner_id: owner_id.map(|id| id.to_vec()),
             object_type: object
@@ -266,9 +284,6 @@ impl From<IndexedObject> for StoredObject {
                 DynamicFieldType::DynamicField => 0,
                 DynamicFieldType::DynamicObject => 1,
             }),
-            df_name: df_info.as_ref().map(|n| bcs::to_bytes(&n.name).unwrap()),
-            df_object_type: df_info.as_ref().map(|v| v.object_type.clone()),
-            df_object_id: df_info.as_ref().map(|v| v.object_id.to_vec()),
         }
     }
 }

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -221,7 +221,6 @@ diesel::table! {
         object_id -> Bytea,
         object_version -> Int8,
         object_digest -> Bytea,
-        checkpoint_sequence_number -> Int8,
         owner_type -> Int2,
         owner_id -> Nullable<Bytea>,
         object_type -> Nullable<Text>,
@@ -232,9 +231,6 @@ diesel::table! {
         coin_type -> Nullable<Text>,
         coin_balance -> Nullable<Int8>,
         df_kind -> Nullable<Int2>,
-        df_name -> Nullable<Bytea>,
-        df_object_type -> Nullable<Text>,
-        df_object_id -> Nullable<Bytea>,
     }
 }
 
@@ -255,9 +251,6 @@ diesel::table! {
         coin_type -> Nullable<Text>,
         coin_balance -> Nullable<Int8>,
         df_kind -> Nullable<Int2>,
-        df_name -> Nullable<Bytea>,
-        df_object_type -> Nullable<Text>,
-        df_object_id -> Nullable<Bytea>,
     }
 }
 
@@ -278,9 +271,6 @@ diesel::table! {
         coin_type -> Nullable<Text>,
         coin_balance -> Nullable<Int8>,
         df_kind -> Nullable<Int2>,
-        df_name -> Nullable<Bytea>,
-        df_object_type -> Nullable<Text>,
-        df_object_id -> Nullable<Bytea>,
     }
 }
 

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 #[expect(clippy::large_enum_variant)]
-pub enum ObjectChangeToCommit {
+pub enum ObjectsToCommit {
     MutatedObject(StoredObject),
     DeletedObject(StoredDeletedObject),
 }

--- a/crates/iota-types/src/dynamic_field.rs
+++ b/crates/iota-types/src/dynamic_field.rs
@@ -247,7 +247,7 @@ fn extract_object_id(value: &MoveStruct) -> Option<ObjectID> {
     extract_id_value(id_value)
 }
 
-fn extract_id_value(id_value: &MoveValue) -> Option<ObjectID> {
+pub fn extract_id_value(id_value: &MoveValue) -> Option<ObjectID> {
     // the id struct has a single bytes field
     let id_bytes_value = match id_value {
         MoveValue::Struct(MoveStruct { fields, .. }) => &fields.first()?.1,


### PR DESCRIPTION
# Description of change

Clear up df_object_id and related fields from the codebase and from the db, following the changes from upstream.

## Links to any relevant issues

fixes #5146
fixes #5265

## Type of change

Refactor

## How the change has been tested

`cargo ci-clippy`
`cargo test -j2 --package=iota-indexer --profile=simulator --features=shared_test_runtime`
`cargo nextest run -p iota-graphql-rpc --features pg_integration --no-fail-fast --test-threads 1`
`cargo nextest run -p iota-graphql-e2e-tests --features pg_integration`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
