### PR TITLE
fix(replay-tool/profiler): Update transaction hash in unit test

### DIFF
--- a/crates/iota/src/unit_tests/profiler_tests.rs
+++ b/crates/iota/src/unit_tests/profiler_tests.rs
@@ -47,7 +47,7 @@ async fn test_profiler() {
     let profile_output = output_dir.path().join("profile.json");
 
     let testnet_url = "https://api.testnet.iota.cafe".to_string();
-    let tx_digest = "7qq4W43TqHg9tQPMvdAFW4Tz6J88KnPppBPR1hNKmQAd".to_string();
+    let tx_digest = "21wPu7V3jwDtPAcMciqQTo8wFxGNu71Fnew7nwSmJJ61".to_string();
 
     let cmd = ReplayToolCommand::ProfileTransaction {
         tx_digest,


### PR DESCRIPTION
# Description of change

Until we have a fallback mechanism, we need to update the transaction hash once the transaction gets pruned. 

## Type of change

- Test fix 

## How the change has been tested

- `cargo test --features gas-profiler -- client_commands::profiler_tests::test_profiler --test-threads 8`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
