### PR TITLE
update: set `infrastructure` team as codeowners for `iota-rest-kv` crate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,6 +56,7 @@
 /crates/iota-proxy/ @iotaledger/node
 /crates/iota-replay/ @iotaledger/node
 /crates/iota-rest-api/ @iotaledger/node @iotaledger/infrastructure
+/crates/iota-rest-kv/ @iotaledger/infrastructure
 /crates/iota-rpc-loadgen/ @iotaledger/infrastructure
 /crates/iota-sdk/ @iotaledger/dev-tools
 /crates/iota-simulator/ @iotaledger/core-protocol
@@ -146,7 +147,7 @@ vercel.json @iotaledger/tooling
 /pnpm-lock.yaml
 
 # TODO
-# /crates/iota-bridge/ 
+# /crates/iota-bridge/
 # /crates/iota-bridge-cli/
 # /crates/iota-bridge-indexer/
 # /crates/iota-rosetta/


### PR DESCRIPTION
# Description of change
The PR: https://github.com/iotaledger/iota/pull/5296 introduces a new `iota-rest-kv` crate

This PR updates the `CODEOWNERS` file which adds the infra team as code owners to this crate.

## Type of change

- Enhancement (a non-breaking change which adds functionality)


Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code

