### PR TITLE
feat: add `iota-rest-kv` docker configuration

### DIFF
--- a/dev-tools/iota-rest-kv/README.md
+++ b/dev-tools/iota-rest-kv/README.md
@@ -1,6 +1,6 @@
 # Kv Store Rest Api
 
-This Docker container enables reading historical data from the kv store (e.g., `KvStoreWorker` from the `iota-data-ingestion` crate writes historical data into remote storages and database). The service requires AWS credentials for proper execution.
+This docker-compose configuration allows running the `iota-rest-kv` service.  The service requires AWS credentials for proper execution.
 
 ## Configuration
 

--- a/dev-tools/iota-rest-kv/README.md
+++ b/dev-tools/iota-rest-kv/README.md
@@ -1,12 +1,10 @@
 # Kv Store Rest Api
 
-This docker-compose configuration allows running the `iota-rest-kv` service.  The service requires AWS credentials for proper execution.
+This docker-compose configuration allows running the `iota-rest-kv` service. The service requires AWS credentials for proper execution.
 
 ## Configuration
 
-The application to function does require a config file.
-
-### Configuration File
+The application requires a `yaml` file for its configuration.
 
 A default configuration file is provided at `config/config.yaml`. This configuration can be customized based on your needs and is mounted into the container via Docker Compose.
 

--- a/dev-tools/iota-rest-kv/README.md
+++ b/dev-tools/iota-rest-kv/README.md
@@ -1,0 +1,124 @@
+# Kv Store Rest Api
+
+This Docker container enables reading historical data from the kv store (e.g., `KvStoreWorker` from the `iota-data-ingestion` crate writes historical data into remote storages and database). The service requires AWS credentials for proper execution.
+
+## Configuration
+
+The application to function does require a config file.
+
+### Configuration File
+
+A default configuration file is provided at `config/config.yaml`. This configuration can be customized based on your needs and is mounted into the container via Docker Compose.
+
+```yaml
+# Remote KV Store REST API config
+#
+# The Rest Api address
+rest-api-address: "0.0.0.0:3555"
+
+# remote Object Store config for more info:
+# - https://docs.iota.org/operator/archives#set-up-archival-fallback
+#
+# The object store config should point to the same object store the
+# `KvStoreWorker` from the `iota-data-ingestion` crate uses to write data
+object-store-config:
+  object-store: "S3"
+  aws-endpoint: "http://0.0.0.0:4566"
+  bucket: "iota-storage-bucket"
+  aws-access-key-id: "test"
+  aws-secret-access-key: "test"
+  aws-allow-http: true
+  object-store-connection-limit: 20
+
+# DynamoDb config
+#
+# The DynamoDb config should point to the same tables the
+# `KvStoreWorker` from the `iota-data-ingestion` crate uses to write data
+dynamo-db-config:
+  aws-access-key-id: "test"
+  aws-secret-access-key: "test"
+  aws-region: "us-east-1"
+  aws-endpoint: "http://0.0.0.0:4566"
+  # DynamoDB table name
+  table-name: "iota-storage"
+```
+
+## Usage
+
+#### 1. Build the required image
+
+```shell
+pushd <iota project directory>/docker/iota-rest-kv && ./build.sh && popd
+```
+
+#### 2. CD into the iota-rest-kv directory
+
+```shell
+cd <iota project directory>/dev-tools/iota-rest-kv
+```
+
+### 3. Start the Service
+
+Run the container in detached mode:
+
+```shell
+docker compose up -d
+```
+
+> [!NOTE]
+> Double check the rest api server port in the `config.yaml` and the exposed port on the `docker-compose.yaml` file, they should match.
+
+### 4. Stop the Service
+
+Stop and remove the container and associated resources:
+
+```shell
+docker compose down
+```
+
+## Local development
+
+### Prerequisites
+
+Before starting the service, you need to set up the required AWS components. The following examples use [localstack](https://github.com/localstack/localstack), but can be adapted for production AWS environments.
+
+### 1. Create S3 Bucket
+
+```bash
+aws --profile localstack s3 mb s3://iota-storage-bucket
+```
+
+### 2. Set up DynamoDB
+
+Create the DynamoDB table:
+
+```bash
+aws --profile localstack \
+dynamodb create-table \
+--table-name iota-storage \
+--attribute-definitions \
+    AttributeName=digest,AttributeType=B \
+    AttributeName=type,AttributeType=S \
+--key-schema \
+    AttributeName=digest,KeyType=HASH \
+    AttributeName=type,KeyType=RANGE \
+--provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5
+```
+
+### 3. Verify Resources
+
+Verify that the resources were created correctly:
+
+```bash
+aws --profile localstack s3 ls
+aws --profile localstack dynamodb list-tables
+```
+
+## Troubleshooting
+
+- Ensure all AWS credentials are properly set in the `config.yaml` file
+- Verify that the S3 bucket and DynamoDB table exist before starting the service
+- Check container logs if the service fails to start:
+  ```bash
+  docker compose logs
+  ```

--- a/dev-tools/iota-rest-kv/config/config.yaml
+++ b/dev-tools/iota-rest-kv/config/config.yaml
@@ -1,0 +1,30 @@
+# Remote KV Store REST API config
+#
+# The Rest Api address
+rest-api-address: "0.0.0.0:3555"
+
+# remote Object Store config for more info:
+# - https://docs.iota.org/operator/archives#set-up-archival-fallback
+#
+# The object store config should point to the same object store the
+# `KvStoreWorker` from the `iota-data-ingestion` crate uses to write data
+object-store-config:
+  object-store: "S3"
+  aws-endpoint: "http://0.0.0.0:4566"
+  bucket: "iota-storage-bucket"
+  aws-access-key-id: "test"
+  aws-secret-access-key: "test"
+  aws-allow-http: true
+  object-store-connection-limit: 20
+
+# DynamoDb config
+#
+# The DynamoDb config should point to the same tables the
+# `KvStoreWorker` from the `iota-data-ingestion` crate uses to write data
+dynamo-db-config:
+  aws-access-key-id: "test"
+  aws-secret-access-key: "test"
+  aws-region: "us-east-1"
+  aws-endpoint: "http://0.0.0.0:4566"
+  # DynamoDB table name
+  table-name: "iota-storage"

--- a/dev-tools/iota-rest-kv/docker-compose.yaml
+++ b/dev-tools/iota-rest-kv/docker-compose.yaml
@@ -1,0 +1,11 @@
+services:
+  kv-store-rest-api:
+    image: iotaledger/iota-rest-kv
+    volumes:
+      - ./config/config.yaml:/iota/config.yaml:r
+    # The exposed port should match the one declared in the config.yaml
+    ports:
+      - "3555:3555"
+    command: >
+      iota-rest-kv
+      --config /iota/config.yaml

--- a/docker/iota-rest-kv/Dockerfile
+++ b/docker/iota-rest-kv/Dockerfile
@@ -1,0 +1,56 @@
+# Build image (the specific rust version can also be passed, e.g. "1.82-bookworm")
+ARG RUST_IMAGE_VERSION=bookworm
+FROM rust:${RUST_IMAGE_VERSION} AS builder
+
+ARG PROFILE=release
+ARG CARGO_BUILD_FEATURES
+# The GIT_REVISION environment variable is used during build time inside the rust crates
+ARG GIT_REVISION
+ENV GIT_REVISION=$GIT_REVISION
+
+WORKDIR "/iota"
+
+# Install build dependencies, including clang and lld for faster linking
+RUN apt update && apt install -y cmake clang lld
+
+# Configure Rust to use clang and lld as the linker
+RUN mkdir -p ~/.cargo && \
+    echo -e "[target.x86_64-unknown-linux-gnu]\nlinker = \"clang\"\nrustflags = [\"-C\", \"link-arg=-fuse-ld=lld\"]" > ~/.cargo/config.toml
+
+# Install additional dependencies
+RUN apt install -y ca-certificates
+
+# Copy in all crates, Cargo.toml, and Cargo.lock
+COPY consensus consensus
+COPY crates crates
+COPY docs docs
+COPY external-crates external-crates
+COPY iota-execution iota-execution
+COPY Cargo.toml Cargo.lock ./
+
+RUN cargo build --profile ${PROFILE} --bin iota-rest-kv --features ${CARGO_BUILD_FEATURES:=default}
+
+# Copy the built binary to the working directory depending on the output folder of the profile,
+# so we can copy it to the runtime image
+RUN if [ -d target/release ]; then \
+  TARGET_DIR="target/release"; \
+elif [ -d target/debug ]; then \
+  TARGET_DIR="target/debug"; \
+else \
+  echo "Error: No build directory found"; \
+  exit 1; \
+fi && \
+mv $TARGET_DIR/iota-rest-kv ./;
+
+# Production image
+FROM debian:bookworm-slim AS runtime
+
+# Install runtime dependencies and tools
+RUN apt update && apt install -y ca-certificates curl
+
+COPY --from=builder /iota/iota-rest-kv /usr/local/bin
+
+ARG BUILD_DATE
+ARG GIT_REVISION
+LABEL build-date=$BUILD_DATE
+LABEL git-revision=$GIT_REVISION

--- a/docker/iota-rest-kv/build.sh
+++ b/docker/iota-rest-kv/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+./../utils/build-script.sh --image-tag "iotaledger/iota-rest-kv"


### PR DESCRIPTION
# Description of change

This second part PR extends the first one https://github.com/iotaledger/iota/pull/5296 by providing docker configurations file in the following directories:
- `docker`: Add Dockerfile
-  `dev-tools`: Add `docker-compose` and `config` files needed for the application to run and a `README.md` file

## Links to any relevant issues

fixes #5149 

## Type of change

- Enhancement (a non-breaking change which adds functionality)


## How the change has been tested

- Following the `README.md` file instructions the docker image compilation and containers execution does succeed.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code

