### PR TITLE
fix(CI): longer timeout for nightly tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: Nightly checks
 
 on:
   schedule:
-    - cron: "0 0 * * *" # every day at midnight
+    - cron: "0 22 * * *" # daily at 10:00 PM
   workflow_dispatch:
     inputs:
       iota_ref:
@@ -99,7 +99,7 @@ jobs:
     uses: ./.github/workflows/_split_cluster.yml
 
   simtest:
-    timeout-minutes: 240
+    timeout-minutes: 600
     runs-on: [self-hosted]
 
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: Nightly checks
 
 on:
   schedule:
-    - cron: "0 22 * * *" # daily at 10:00 PM
+    - cron: "0 22 * * *" # daily at 10:00 PM (UTC)
   workflow_dispatch:
     inputs:
       iota_ref:


### PR DESCRIPTION
# Description of change

Nightly simtests are still failing, this time because they get cut off by the timeout we set on them.
We recently changed their configuration so they would run flaky tests without other tests running concurrently, but that makes test (expectedly) run for longer.

This gives nightly simtests a longer timeout, and makes them start earlier at night.

## Type of change

- Bug fix for CI (a non-breaking change which fixes an issue)

## How the change has been tested

No testing, this should only impact nightly CI.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
