### PR TITLE
Fix failed deserialization of `TransactionEvents` in `HttpKVStore`

### DIFF
--- a/crates/iota-storage/src/http_key_value_store.rs
+++ b/crates/iota-storage/src/http_key_value_store.rs
@@ -428,8 +428,7 @@ impl TransactionKeyValueStoreTrait for HttpKVStore {
             .zip(digests.iter())
             .map(map_fetch)
             .map(|maybe_bytes| {
-                maybe_bytes
-                    .and_then(|(bytes, key)| deser::<_, TransactionEvents>(&key, &bytes.slice(1..)))
+                maybe_bytes.and_then(|(bytes, key)| deser::<_, TransactionEvents>(&key, bytes))
             })
             .collect::<Vec<_>>())
     }


### PR DESCRIPTION
# Description of change

Fix failed deserialization of `TransactionEvents` in `HttpKVStore`

## Links to any relevant issues

Fixes #5307 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)


## How the change has been tested

```shell
cargo simtest -p iota-storage
```

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code

