### PR TITLE
refactor(iota-data-ingestion-core): wrap `CheckpointData` in `Arc` to reduce memory footprint

### DIFF
--- a/crates/iota-data-ingestion-core/src/executor.rs
+++ b/crates/iota-data-ingestion-core/src/executor.rs
@@ -2,10 +2,11 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{path::PathBuf, pin::Pin};
+use std::{path::PathBuf, pin::Pin, sync::Arc};
 
 use futures::Future;
 use iota_metrics::spawn_monitored_task;
+use iota_rest_api::CheckpointData;
 use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 use prometheus::Registry;
 use tokio::{
@@ -17,7 +18,7 @@ use tokio_util::sync::CancellationToken;
 use crate::{
     DataIngestionMetrics, IngestionError, IngestionResult, ReaderOptions, Worker,
     progress_store::{ExecutorProgress, ProgressStore, ProgressStoreWrapper, ShimProgressStore},
-    reader::{CheckpointReader, SharedCheckpointData},
+    reader::CheckpointReader,
     worker_pool::{WorkerPool, WorkerPoolStatus},
 };
 
@@ -25,7 +26,7 @@ pub const MAX_CHECKPOINTS_IN_PROGRESS: usize = 10000;
 
 pub struct IndexerExecutor<P> {
     pools: Vec<Pin<Box<dyn Future<Output = ()> + Send>>>,
-    pool_senders: Vec<mpsc::Sender<SharedCheckpointData>>,
+    pool_senders: Vec<mpsc::Sender<Arc<CheckpointData>>>,
     progress_store: ProgressStoreWrapper<P>,
     pool_status_sender: mpsc::Sender<WorkerPoolStatus>,
     pool_status_receiver: mpsc::Receiver<WorkerPoolStatus>,
@@ -131,6 +132,8 @@ impl<P: ProgressStore> IndexerExecutor<P> {
                                     .to_owned(),
                             )
                         })?;
+
+                        println!("Executor ARC count: {}", Arc::strong_count(&checkpoint));
                     }
                 }
             }

--- a/crates/iota-data-ingestion-core/src/executor.rs
+++ b/crates/iota-data-ingestion-core/src/executor.rs
@@ -6,9 +6,7 @@ use std::{path::PathBuf, pin::Pin};
 
 use futures::Future;
 use iota_metrics::spawn_monitored_task;
-use iota_types::{
-    full_checkpoint_content::CheckpointData, messages_checkpoint::CheckpointSequenceNumber,
-};
+use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 use prometheus::Registry;
 use tokio::{
     sync::{mpsc, oneshot},
@@ -19,7 +17,7 @@ use tokio_util::sync::CancellationToken;
 use crate::{
     DataIngestionMetrics, IngestionError, IngestionResult, ReaderOptions, Worker,
     progress_store::{ExecutorProgress, ProgressStore, ProgressStoreWrapper, ShimProgressStore},
-    reader::CheckpointReader,
+    reader::{CheckpointReader, SharedCheckpointData},
     worker_pool::{WorkerPool, WorkerPoolStatus},
 };
 
@@ -27,7 +25,7 @@ pub const MAX_CHECKPOINTS_IN_PROGRESS: usize = 10000;
 
 pub struct IndexerExecutor<P> {
     pools: Vec<Pin<Box<dyn Future<Output = ()> + Send>>>,
-    pool_senders: Vec<mpsc::Sender<CheckpointData>>,
+    pool_senders: Vec<mpsc::Sender<SharedCheckpointData>>,
     progress_store: ProgressStoreWrapper<P>,
     pool_status_sender: mpsc::Sender<WorkerPoolStatus>,
     pool_status_receiver: mpsc::Receiver<WorkerPoolStatus>,

--- a/crates/iota-data-ingestion-core/src/reader.rs
+++ b/crates/iota-data-ingestion-core/src/reader.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, ffi::OsString, fs, path::PathBuf, time::Duration};
+use std::{collections::BTreeMap, ffi::OsString, fs, path::PathBuf, sync::Arc, time::Duration};
 
 use backoff::backoff::Backoff;
 use futures::StreamExt;
@@ -29,7 +29,13 @@ use crate::{
     executor::MAX_CHECKPOINTS_IN_PROGRESS,
 };
 
-type CheckpointResult = IngestionResult<(CheckpointData, usize)>;
+// A thread-safe reference-counted wrapper around [`CheckpointData`].
+/// This type alias provides a convenient way to share [`CheckpointData`] across
+/// multiple threads using [`Arc`]. Multiple threads can hold references to the
+/// same [`CheckpointData`] instance, and it will be automatically cleaned up
+/// when the last reference is dropped.
+pub type SharedCheckpointData = Arc<CheckpointData>;
+type CheckpointResult = IngestionResult<(SharedCheckpointData, usize)>;
 
 /// Implements a checkpoint reader that monitors a local directory.
 /// Designed for setups where the indexer daemon is colocated with FN.
@@ -40,7 +46,7 @@ pub struct CheckpointReader {
     remote_store_options: Vec<(String, String)>,
     current_checkpoint_number: CheckpointSequenceNumber,
     last_pruned_watermark: CheckpointSequenceNumber,
-    checkpoint_sender: mpsc::Sender<CheckpointData>,
+    checkpoint_sender: mpsc::Sender<SharedCheckpointData>,
     processed_receiver: mpsc::Receiver<CheckpointSequenceNumber>,
     remote_fetcher_receiver: Option<mpsc::Receiver<CheckpointResult>>,
     exit_receiver: oneshot::Receiver<()>,
@@ -79,7 +85,7 @@ impl CheckpointReader {
     /// Represents a single iteration of the reader.
     /// Reads files in a local directory, validates them, and forwards
     /// `CheckpointData` to the executor.
-    async fn read_local_files(&self) -> IngestionResult<Vec<CheckpointData>> {
+    async fn read_local_files(&self) -> IngestionResult<Vec<SharedCheckpointData>> {
         let mut files = vec![];
         for entry in fs::read_dir(self.path.clone())? {
             let entry = entry?;
@@ -94,7 +100,7 @@ impl CheckpointReader {
         debug!("unprocessed local files {:?}", files);
         let mut checkpoints = vec![];
         for (_, filename) in files.iter().take(MAX_CHECKPOINTS_IN_PROGRESS) {
-            let checkpoint = Blob::from_bytes::<CheckpointData>(&fs::read(filename)?)
+            let checkpoint = Blob::from_bytes::<SharedCheckpointData>(&fs::read(filename)?)
                 .map_err(|err| IngestionError::DeserializeCheckpoint(err.to_string()))?;
             if self.exceeds_capacity(checkpoint.checkpoint_summary.sequence_number) {
                 break;
@@ -112,12 +118,12 @@ impl CheckpointReader {
     async fn fetch_from_object_store(
         store: &dyn ObjectStore,
         checkpoint_number: CheckpointSequenceNumber,
-    ) -> IngestionResult<(CheckpointData, usize)> {
+    ) -> IngestionResult<(SharedCheckpointData, usize)> {
         let path = Path::from(format!("{}.chk", checkpoint_number));
         let response = store.get(&path).await?;
         let bytes = response.bytes().await?;
         Ok((
-            Blob::from_bytes::<CheckpointData>(&bytes)
+            Blob::from_bytes::<SharedCheckpointData>(&bytes)
                 .map_err(|err| IngestionError::DeserializeCheckpoint(err.to_string()))?,
             bytes.len(),
         ))
@@ -126,16 +132,16 @@ impl CheckpointReader {
     async fn fetch_from_full_node(
         client: &Client,
         checkpoint_number: CheckpointSequenceNumber,
-    ) -> IngestionResult<(CheckpointData, usize)> {
+    ) -> IngestionResult<(SharedCheckpointData, usize)> {
         let checkpoint = client.get_full_checkpoint(checkpoint_number).await?;
         let size = bcs::serialized_size(&checkpoint)?;
-        Ok((checkpoint, size))
+        Ok((Arc::new(checkpoint), size))
     }
 
     async fn remote_fetch_checkpoint_internal(
         store: &RemoteStore,
         checkpoint_number: CheckpointSequenceNumber,
-    ) -> IngestionResult<(CheckpointData, usize)> {
+    ) -> IngestionResult<(SharedCheckpointData, usize)> {
         match store {
             RemoteStore::ObjectStore(store) => {
                 Self::fetch_from_object_store(store, checkpoint_number).await
@@ -155,7 +161,7 @@ impl CheckpointReader {
     async fn remote_fetch_checkpoint(
         store: &RemoteStore,
         checkpoint_number: CheckpointSequenceNumber,
-    ) -> IngestionResult<(CheckpointData, usize)> {
+    ) -> IngestionResult<(SharedCheckpointData, usize)> {
         let mut backoff = backoff::ExponentialBackoff::default();
         backoff.max_elapsed_time = Some(Duration::from_secs(60));
         backoff.initial_interval = Duration::from_millis(100);
@@ -181,7 +187,9 @@ impl CheckpointReader {
         }
     }
 
-    fn start_remote_fetcher(&mut self) -> mpsc::Receiver<IngestionResult<(CheckpointData, usize)>> {
+    fn start_remote_fetcher(
+        &mut self,
+    ) -> mpsc::Receiver<IngestionResult<(SharedCheckpointData, usize)>> {
         let batch_size = self.options.batch_size;
         let start_checkpoint = self.current_checkpoint_number;
         let (sender, receiver) = mpsc::channel(batch_size);
@@ -225,7 +233,7 @@ impl CheckpointReader {
         receiver
     }
 
-    fn remote_fetch(&mut self) -> Vec<CheckpointData> {
+    fn remote_fetch(&mut self) -> Vec<SharedCheckpointData> {
         let mut checkpoints = vec![];
         if self.remote_fetcher_receiver.is_none() {
             self.remote_fetcher_receiver = Some(self.start_remote_fetcher());
@@ -334,7 +342,7 @@ impl CheckpointReader {
         options: ReaderOptions,
     ) -> (
         Self,
-        mpsc::Receiver<CheckpointData>,
+        mpsc::Receiver<SharedCheckpointData>,
         mpsc::Sender<CheckpointSequenceNumber>,
         oneshot::Sender<()>,
     ) {

--- a/crates/iota-data-ingestion-core/src/reader.rs
+++ b/crates/iota-data-ingestion-core/src/reader.rs
@@ -29,13 +29,7 @@ use crate::{
     executor::MAX_CHECKPOINTS_IN_PROGRESS,
 };
 
-// A thread-safe reference-counted wrapper around [`CheckpointData`].
-/// This type alias provides a convenient way to share [`CheckpointData`] across
-/// multiple threads using [`Arc`]. Multiple threads can hold references to the
-/// same [`CheckpointData`] instance, and it will be automatically cleaned up
-/// when the last reference is dropped.
-pub type SharedCheckpointData = Arc<CheckpointData>;
-type CheckpointResult = IngestionResult<(SharedCheckpointData, usize)>;
+type CheckpointResult = IngestionResult<(Arc<CheckpointData>, usize)>;
 
 /// Implements a checkpoint reader that monitors a local directory.
 /// Designed for setups where the indexer daemon is colocated with FN.
@@ -46,7 +40,7 @@ pub struct CheckpointReader {
     remote_store_options: Vec<(String, String)>,
     current_checkpoint_number: CheckpointSequenceNumber,
     last_pruned_watermark: CheckpointSequenceNumber,
-    checkpoint_sender: mpsc::Sender<SharedCheckpointData>,
+    checkpoint_sender: mpsc::Sender<Arc<CheckpointData>>,
     processed_receiver: mpsc::Receiver<CheckpointSequenceNumber>,
     remote_fetcher_receiver: Option<mpsc::Receiver<CheckpointResult>>,
     exit_receiver: oneshot::Receiver<()>,
@@ -85,7 +79,7 @@ impl CheckpointReader {
     /// Represents a single iteration of the reader.
     /// Reads files in a local directory, validates them, and forwards
     /// `CheckpointData` to the executor.
-    async fn read_local_files(&self) -> IngestionResult<Vec<SharedCheckpointData>> {
+    async fn read_local_files(&self) -> IngestionResult<Vec<Arc<CheckpointData>>> {
         let mut files = vec![];
         for entry in fs::read_dir(self.path.clone())? {
             let entry = entry?;
@@ -100,7 +94,7 @@ impl CheckpointReader {
         debug!("unprocessed local files {:?}", files);
         let mut checkpoints = vec![];
         for (_, filename) in files.iter().take(MAX_CHECKPOINTS_IN_PROGRESS) {
-            let checkpoint = Blob::from_bytes::<SharedCheckpointData>(&fs::read(filename)?)
+            let checkpoint = Blob::from_bytes::<Arc<CheckpointData>>(&fs::read(filename)?)
                 .map_err(|err| IngestionError::DeserializeCheckpoint(err.to_string()))?;
             if self.exceeds_capacity(checkpoint.checkpoint_summary.sequence_number) {
                 break;
@@ -118,12 +112,12 @@ impl CheckpointReader {
     async fn fetch_from_object_store(
         store: &dyn ObjectStore,
         checkpoint_number: CheckpointSequenceNumber,
-    ) -> IngestionResult<(SharedCheckpointData, usize)> {
+    ) -> IngestionResult<(Arc<CheckpointData>, usize)> {
         let path = Path::from(format!("{}.chk", checkpoint_number));
         let response = store.get(&path).await?;
         let bytes = response.bytes().await?;
         Ok((
-            Blob::from_bytes::<SharedCheckpointData>(&bytes)
+            Blob::from_bytes::<Arc<CheckpointData>>(&bytes)
                 .map_err(|err| IngestionError::DeserializeCheckpoint(err.to_string()))?,
             bytes.len(),
         ))
@@ -132,7 +126,7 @@ impl CheckpointReader {
     async fn fetch_from_full_node(
         client: &Client,
         checkpoint_number: CheckpointSequenceNumber,
-    ) -> IngestionResult<(SharedCheckpointData, usize)> {
+    ) -> IngestionResult<(Arc<CheckpointData>, usize)> {
         let checkpoint = client.get_full_checkpoint(checkpoint_number).await?;
         let size = bcs::serialized_size(&checkpoint)?;
         Ok((Arc::new(checkpoint), size))
@@ -141,7 +135,7 @@ impl CheckpointReader {
     async fn remote_fetch_checkpoint_internal(
         store: &RemoteStore,
         checkpoint_number: CheckpointSequenceNumber,
-    ) -> IngestionResult<(SharedCheckpointData, usize)> {
+    ) -> IngestionResult<(Arc<CheckpointData>, usize)> {
         match store {
             RemoteStore::ObjectStore(store) => {
                 Self::fetch_from_object_store(store, checkpoint_number).await
@@ -161,7 +155,7 @@ impl CheckpointReader {
     async fn remote_fetch_checkpoint(
         store: &RemoteStore,
         checkpoint_number: CheckpointSequenceNumber,
-    ) -> IngestionResult<(SharedCheckpointData, usize)> {
+    ) -> IngestionResult<(Arc<CheckpointData>, usize)> {
         let mut backoff = backoff::ExponentialBackoff::default();
         backoff.max_elapsed_time = Some(Duration::from_secs(60));
         backoff.initial_interval = Duration::from_millis(100);
@@ -189,7 +183,7 @@ impl CheckpointReader {
 
     fn start_remote_fetcher(
         &mut self,
-    ) -> mpsc::Receiver<IngestionResult<(SharedCheckpointData, usize)>> {
+    ) -> mpsc::Receiver<IngestionResult<(Arc<CheckpointData>, usize)>> {
         let batch_size = self.options.batch_size;
         let start_checkpoint = self.current_checkpoint_number;
         let (sender, receiver) = mpsc::channel(batch_size);
@@ -233,7 +227,7 @@ impl CheckpointReader {
         receiver
     }
 
-    fn remote_fetch(&mut self) -> Vec<SharedCheckpointData> {
+    fn remote_fetch(&mut self) -> Vec<Arc<CheckpointData>> {
         let mut checkpoints = vec![];
         if self.remote_fetcher_receiver.is_none() {
             self.remote_fetcher_receiver = Some(self.start_remote_fetcher());
@@ -342,7 +336,7 @@ impl CheckpointReader {
         options: ReaderOptions,
     ) -> (
         Self,
-        mpsc::Receiver<SharedCheckpointData>,
+        mpsc::Receiver<Arc<CheckpointData>>,
         mpsc::Sender<CheckpointSequenceNumber>,
         oneshot::Sender<()>,
     ) {

--- a/crates/iota-data-ingestion-core/src/worker_pool.rs
+++ b/crates/iota-data-ingestion-core/src/worker_pool.rs
@@ -9,14 +9,13 @@ use std::{
 };
 
 use iota_metrics::spawn_monitored_task;
+use iota_rest_api::CheckpointData;
 use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
-use crate::{
-    IngestionError, Worker, executor::MAX_CHECKPOINTS_IN_PROGRESS, reader::SharedCheckpointData,
-};
+use crate::{IngestionError, Worker, executor::MAX_CHECKPOINTS_IN_PROGRESS};
 
 type TaskName = String;
 type WorkerID = usize;
@@ -68,7 +67,7 @@ impl<W: Worker + 'static> WorkerPool<W> {
     pub async fn run(
         self,
         mut current_checkpoint_number: CheckpointSequenceNumber,
-        mut checkpoint_receiver: mpsc::Receiver<SharedCheckpointData>,
+        mut checkpoint_receiver: mpsc::Receiver<Arc<CheckpointData>>,
         pool_status_sender: mpsc::Sender<WorkerPoolStatus>,
         token: CancellationToken,
     ) {
@@ -169,13 +168,13 @@ impl<W: Worker + 'static> WorkerPool<W> {
         &self,
         progress_sender: mpsc::Sender<WorkerStatus>,
         token: CancellationToken,
-    ) -> (Vec<mpsc::Sender<SharedCheckpointData>>, Vec<JoinHandle<()>>) {
+    ) -> (Vec<mpsc::Sender<Arc<CheckpointData>>>, Vec<JoinHandle<()>>) {
         let mut worker_senders = vec![];
         let mut workers_join_handles = vec![];
 
         for worker_id in 0..self.concurrency {
             let (worker_sender, mut worker_recv) =
-                mpsc::channel::<SharedCheckpointData>(MAX_CHECKPOINTS_IN_PROGRESS);
+                mpsc::channel::<Arc<CheckpointData>>(MAX_CHECKPOINTS_IN_PROGRESS);
             let cloned_progress_sender = progress_sender.clone();
             let task_name = self.task_name.clone();
             worker_senders.push(worker_sender);

--- a/crates/iota-data-ingestion-core/src/worker_pool.rs
+++ b/crates/iota-data-ingestion-core/src/worker_pool.rs
@@ -9,14 +9,14 @@ use std::{
 };
 
 use iota_metrics::spawn_monitored_task;
-use iota_types::{
-    full_checkpoint_content::CheckpointData, messages_checkpoint::CheckpointSequenceNumber,
-};
+use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
-use crate::{IngestionError, Worker, executor::MAX_CHECKPOINTS_IN_PROGRESS};
+use crate::{
+    IngestionError, Worker, executor::MAX_CHECKPOINTS_IN_PROGRESS, reader::SharedCheckpointData,
+};
 
 type TaskName = String;
 type WorkerID = usize;
@@ -68,7 +68,7 @@ impl<W: Worker + 'static> WorkerPool<W> {
     pub async fn run(
         self,
         mut current_checkpoint_number: CheckpointSequenceNumber,
-        mut checkpoint_receiver: mpsc::Receiver<CheckpointData>,
+        mut checkpoint_receiver: mpsc::Receiver<SharedCheckpointData>,
         pool_status_sender: mpsc::Sender<WorkerPoolStatus>,
         token: CancellationToken,
     ) {
@@ -169,13 +169,13 @@ impl<W: Worker + 'static> WorkerPool<W> {
         &self,
         progress_sender: mpsc::Sender<WorkerStatus>,
         token: CancellationToken,
-    ) -> (Vec<mpsc::Sender<CheckpointData>>, Vec<JoinHandle<()>>) {
+    ) -> (Vec<mpsc::Sender<SharedCheckpointData>>, Vec<JoinHandle<()>>) {
         let mut worker_senders = vec![];
         let mut workers_join_handles = vec![];
 
         for worker_id in 0..self.concurrency {
             let (worker_sender, mut worker_recv) =
-                mpsc::channel::<CheckpointData>(MAX_CHECKPOINTS_IN_PROGRESS);
+                mpsc::channel::<SharedCheckpointData>(MAX_CHECKPOINTS_IN_PROGRESS);
             let cloned_progress_sender = progress_sender.clone();
             let task_name = self.task_name.clone();
             worker_senders.push(worker_sender);


### PR DESCRIPTION
# Description of change

This PR is the extension of: 
- #5329

It provides the second part of the optimization effort to reduce memory footprint for the `iota-data-ingestion-core` checkpoint processing pipeline.

This change is inherited from the upstream commit: https://github.com/MystenLabs/sui/commit/cf1cc2fe303a9f8a03b0b69a2765f5f2c2c81796
## Links to any relevant issues

fixes #5326 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Ran the `iota-data-ingestion-core` tests

```shell
cargo test -p iota-data-ingestion-core
```
Executed also the Indexer and checked synced data into Database using the iota cli

```shell
cargo r -p iota --features indexer -- start --force-regenesis --with-indexer
```

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
