### PR TITLE
fix(tooling-ci): Update `actions/cache` to v4.2

### DIFF
--- a/.github/workflows/apps_explorer_prod_deploy.yml
+++ b/.github/workflows/apps_explorer_prod_deploy.yml
@@ -24,7 +24,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Turbo Cache
         id: turbo-cache
-        uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4.1.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: node_modules/.cache/turbo
           key: turbo-${{ runner.os }}-${{ github.sha }}

--- a/.github/workflows/apps_wallet_dashboard_prod_deploy.yml
+++ b/.github/workflows/apps_wallet_dashboard_prod_deploy.yml
@@ -24,7 +24,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Turbo Cache
         id: turbo-cache
-        uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4.1.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: node_modules/.cache/turbo
           key: turbo-${{ runner.os }}-${{ github.sha }}

--- a/.github/workflows/apps_wallet_nightly_build.yml
+++ b/.github/workflows/apps_wallet_nightly_build.yml
@@ -36,7 +36,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Turbo Cache
         id: turbo-cache
-        uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4.1.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: node_modules/.cache/turbo
           key: turbo-${{ runner.os }}-${{ github.sha }}

--- a/.github/workflows/turbo_hierarchy.yml
+++ b/.github/workflows/turbo_hierarchy.yml
@@ -74,7 +74,7 @@ jobs:
         run: pnpm manypkg check
       - name: Turbo Cache
         id: turbo-cache
-        uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4.1.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ github.sha }}


### PR DESCRIPTION
https://github.com/actions/cache?tab=readme-ov-file#%EF%B8%8F-important-changes

```
If you are using pinned SHAs, please use the SHAs of versions v4.2.0 or v3.4.0
```