### PR TITLE
fix(docs): `IotaClientBuilder` case

### DIFF
--- a/docs/content/developer/iota-101/using-events.mdx
+++ b/docs/content/developer/iota-101/using-events.mdx
@@ -169,12 +169,12 @@ See [Rust SDK](../../references/rust-sdk.mdx).
 ```rust
 use futures::StreamExt;
 use iota_sdk::rpc_types::EventFilter;
-use iota_sdk::IOTAClientBuilder;
+use iota_sdk::IotaClientBuilder;
 use anyhow::Result;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let iota = IOTAClientBuilder::default()
+    let iota = IotaClientBuilder::default()
         .ws_url("wss://api.testnet.iota.cafe:443")
         .build("https://api.testnet.iota.cafe:443")
         .await.unwrap();

--- a/docs/content/references/exchange-integration-guide.mdx
+++ b/docs/content/references/exchange-integration-guide.mdx
@@ -139,12 +139,12 @@ The following example demonstrates using iota_getBalance in Rust:
 ```rust
 use std::str::FromStr;
 use iota_sdk::types::base_types::IOTAAddress;
-use iota_sdk::{IOTAClient, IOTAClientBuilder};
+use iota_sdk::{IOTAClient, IotaClientBuilder};
 
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-   let iota = IOTAClientBuilder::default().build(
+   let iota = IotaClientBuilder::default().build(
       "https://api.devnet.iota.cafe:443",
    ).await.unwrap();
    let address = IOTAAddress::from_str("0x849d63687330447431a2e76fecca4f3c10f6884ebaa9909674123c6c662612a3")?;


### PR DESCRIPTION
Examples don't compile because of the wrong case