### PR TITLE
feat(iota-keys): improve error message if a path doesn't exist

### DIFF
--- a/crates/iota-keys/src/keystore.rs
+++ b/crates/iota-keys/src/keystore.rs
@@ -454,7 +454,6 @@ impl FileBasedKeystore {
         .with_context(|| format!("Cannot serialize keystore to file: {}", self.path.display()))?;
         fs::write(&self.path, store)
             .map_err(|e| anyhow!("Couldn't save keystore to {}: {e:?}", self.path.display()))?;
-        println!("Keys saved as Bech32.");
         Ok(())
     }
 

--- a/crates/iota-keys/src/keystore.rs
+++ b/crates/iota-keys/src/keystore.rs
@@ -433,7 +433,8 @@ impl FileBasedKeystore {
 
         let mut aliases_path = self.path.clone();
         aliases_path.set_extension("aliases");
-        fs::write(aliases_path, aliases_store)?;
+        fs::write(&aliases_path, aliases_store)
+            .map_err(|e| anyhow!("Couldn't save aliases to {}: {e:?}", aliases_path.display()))?;
         Ok(())
     }
 
@@ -451,7 +452,8 @@ impl FileBasedKeystore {
                 .map_err(|e| anyhow!(e))?,
         )
         .with_context(|| format!("Cannot serialize keystore to file: {}", self.path.display()))?;
-        fs::write(&self.path, store)?;
+        fs::write(&self.path, store)
+            .map_err(|e| anyhow!("Couldn't save keystore to {}: {e:?}", self.path.display()))?;
         println!("Keys saved as Bech32.");
         Ok(())
     }


### PR DESCRIPTION
# Description of change

Improve error message if a path doesn't exist or if there is another reason why one couldn't write the aliases or the keystore to a file.
I think this is better to throw this error than to create the non existing path, because if someone copies a client.yaml from someone else it could end up in a really confusing place

## Links to any relevant issues

Fixes #5273 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running `cargo run client new-address` in crates/iota and with a non existing path in the client.yaml
```
keystore:
  File: /home/t/.iota/iota_config/non-existing-path/iota.keystore
```
results now in this error message
`Couldn't save aliases to /home/t/.iota/iota_config/non-existing-path/iota.aliases: Os { code: 2, kind: NotFound, message: "No such file or directory" }`
