### PR TITLE
feat(consensus): add missing blocks per authority metric

### DIFF
--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -124,6 +124,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) fetch_blocks_scheduler_inflight: IntGauge,
     pub(crate) fetch_blocks_scheduler_skipped: IntCounterVec,
     pub(crate) synchronizer_fetched_blocks_by_peer: IntCounterVec,
+    pub(crate) synchronizer_missing_blocks_by_authority: IntCounterVec,
     pub(crate) synchronizer_fetched_blocks_by_authority: IntCounterVec,
     pub(crate) invalid_blocks: IntCounterVec,
     pub(crate) rejected_blocks: IntCounterVec,
@@ -329,6 +330,12 @@ impl NodeMetrics {
                 "synchronizer_fetched_blocks_by_authority",
                 "Number of fetched blocks per block author via the synchronizer",
                 &["authority", "type"],
+                registry,
+            ).unwrap(),
+            synchronizer_missing_blocks_by_authority: register_int_counter_vec_with_registry!(
+                "synchronizer_missing_blocks_by_authority",
+                "Number of missing blocks per block author, as observed by the synchronizer during periodic sync.",
+                &["authority"],
                 registry,
             ).unwrap(),
             last_known_own_block_round: register_int_gauge_with_registry!(

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -19,8 +19,7 @@ use iota_metrics::{
 };
 use itertools::Itertools as _;
 use parking_lot::{Mutex, RwLock};
-#[cfg(not(test))]
-use rand::{prelude::SliceRandom, rngs::ThreadRng};
+use rand::{prelude::SliceRandom as _, rngs::ThreadRng};
 use tap::TapFallible;
 use tokio::{
     sync::{mpsc::error::TrySendError, oneshot},
@@ -899,6 +898,11 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                     dag_state,
                 )
                 .await;
+                context
+                    .metrics
+                    .node_metrics
+                    .fetch_blocks_scheduler_inflight
+                    .dec();
                 if results.is_empty() {
                     warn!("No results returned while requesting missing blocks");
                     return;
@@ -928,11 +932,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                     }
                 }
 
-                context
-                    .metrics
-                    .node_metrics
-                    .fetch_blocks_scheduler_inflight
-                    .dec();
                 debug!(
                     "Total blocks requested to fetch: {}, total fetched: {}",
                     total_requested, total_fetched
@@ -974,6 +973,21 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             .into_iter()
             .take(MAX_PEERS * context.parameters.max_blocks_per_fetch)
             .collect::<Vec<_>>();
+        let mut missing_blocks_per_authority = vec![0; context.committee.size()];
+        for block in &missing_blocks {
+            missing_blocks_per_authority[block.author] += 1;
+        }
+        for (missing, (_, authority)) in missing_blocks_per_authority
+            .into_iter()
+            .zip(context.committee.authorities())
+        {
+            context
+                .metrics
+                .node_metrics
+                .synchronizer_missing_blocks_by_authority
+                .with_label_values(&[&authority.hostname])
+                .inc_by(missing as u64);
+        }
 
         #[cfg_attr(test, expect(unused_mut))]
         let mut peers = context

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -19,7 +19,7 @@ use iota_metrics::{
 };
 use itertools::Itertools as _;
 use parking_lot::{Mutex, RwLock};
-use rand::{prelude::SliceRandom, rngs::ThreadRng};
+#[allow(unused_imports)] use rand::{prelude::SliceRandom, rngs::ThreadRng};
 use tap::TapFallible;
 use tokio::{
     sync::{mpsc::error::TrySendError, oneshot},

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -19,7 +19,8 @@ use iota_metrics::{
 };
 use itertools::Itertools as _;
 use parking_lot::{Mutex, RwLock};
-#[allow(unused_imports)] use rand::{prelude::SliceRandom, rngs::ThreadRng};
+#[cfg(not(test))]
+use rand::{prelude::SliceRandom, rngs::ThreadRng};
 use tap::TapFallible;
 use tokio::{
     sync::{mpsc::error::TrySendError, oneshot},

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -19,8 +19,7 @@ use iota_metrics::{
 };
 use itertools::Itertools as _;
 use parking_lot::{Mutex, RwLock};
-use rand::prelude::SliceRandom;
-use rand::rngs::ThreadRng;
+use rand::{prelude::SliceRandom, rngs::ThreadRng};
 use tap::TapFallible;
 use tokio::{
     sync::{mpsc::error::TrySendError, oneshot},

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -19,7 +19,8 @@ use iota_metrics::{
 };
 use itertools::Itertools as _;
 use parking_lot::{Mutex, RwLock};
-use rand::{prelude::SliceRandom as _, rngs::ThreadRng};
+use rand::prelude::SliceRandom;
+use rand::rngs::ThreadRng;
 use tap::TapFallible;
 use tokio::{
     sync::{mpsc::error::TrySendError, oneshot},


### PR DESCRIPTION
Porting from upstream: [MystenLabs/sui@](https://github.com/MystenLabs/sui) [055c20c](https://github.com/MystenLabs/sui/commit/055c20ce5515f6f604c3a982d47c10fdf0044965)

# Description of change

The commit adds a new metric that counts the number of missing blocks per authority

This metric might provide us with a better idea on blocks from which
authorities are having propagation problems.

Also, decrement the synchronizer inflight metric properly.

## Type of change

Enhancement 

## Change checklist

- [+] I have followed the contribution guidelines for this project
- [+] I have performed a self-review of my own code
- [+] I have checked that new and existing unit tests pass locally with my changes
