### PR TITLE
fix(network-metrics-processor): Avoid expensive transaction table scans for `tx_count_metrics` table

### DIFF
--- a/crates/iota-indexer/src/processors/network_metrics_processor.rs
+++ b/crates/iota-indexer/src/processors/network_metrics_processor.rs
@@ -10,7 +10,7 @@ use crate::{
     types::IndexerResult,
 };
 
-const NETWORK_METRICS_PROCESSOR_BATCH_SIZE: usize = 10;
+const NETWORK_METRICS_PROCESSOR_BATCH_SIZE: usize = 1000;
 const PARALLELISM: usize = 1;
 
 pub struct NetworkMetricsProcessor<S> {

--- a/crates/iota-indexer/src/processors/network_metrics_processor.rs
+++ b/crates/iota-indexer/src/processors/network_metrics_processor.rs
@@ -10,7 +10,7 @@ use crate::{
     types::IndexerResult,
 };
 
-const NETWORK_METRICS_PROCESSOR_BATCH_SIZE: usize = 1000;
+const NETWORK_METRICS_PROCESSOR_BATCH_SIZE: usize = 10;
 const PARALLELISM: usize = 1;
 
 pub struct NetworkMetricsProcessor<S> {

--- a/crates/iota-indexer/src/store/pg_indexer_analytical_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_analytical_store.rs
@@ -513,7 +513,6 @@ fn construct_checkpoint_tx_count_query(start_checkpoint: i64, end_checkpoint: i6
     )
 }
 
-
 fn construct_peak_tps_query(epoch: i64, offset: i64) -> String {
     format!(
         "WITH filtered_checkpoints AS (

--- a/crates/iota-indexer/src/store/pg_indexer_analytical_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_analytical_store.rs
@@ -480,23 +480,27 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
 
 fn construct_checkpoint_tx_count_query(start_checkpoint: i64, end_checkpoint: i64) -> String {
     format!(
-        "WITH checkpoint_range AS (
+        "WITH expanded_checkpoint_range AS (
             SELECT
                 sequence_number AS checkpoint_sequence_number,
-                min_tx_sequence_number AS min_tx_seq,
-                max_tx_sequence_number AS max_tx_seq,
-                epoch
+                epoch,
+                generate_series(min_tx_sequence_number, max_tx_sequence_number) AS tx_sequence_number
             FROM checkpoints
             WHERE sequence_number >= {start_checkpoint} AND sequence_number < {end_checkpoint}
         ), filtered_txns AS (
             SELECT
-                cr.checkpoint_sequence_number,
-                cr.epoch,
+                t.checkpoint_sequence_number,
+                (SELECT ecr.epoch FROM expanded_checkpoint_range ecr
+                 WHERE ecr.tx_sequence_number = t.tx_sequence_number
+                 LIMIT 1) AS epoch,
                 t.timestamp_ms,
                 t.success_command_count
             FROM transactions t
-            JOIN checkpoint_range cr
-            ON t.tx_sequence_number BETWEEN cr.min_tx_seq AND cr.max_tx_seq
+            WHERE EXISTS (
+                SELECT 1
+                FROM expanded_checkpoint_range ecr
+                WHERE t.tx_sequence_number = ecr.tx_sequence_number
+            )
         )
         INSERT INTO tx_count_metrics
         SELECT

--- a/crates/iota-indexer/src/store/pg_indexer_analytical_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_analytical_store.rs
@@ -487,32 +487,21 @@ fn construct_checkpoint_tx_count_query(start_checkpoint: i64, end_checkpoint: i6
                 generate_series(min_tx_sequence_number, max_tx_sequence_number) AS tx_sequence_number
             FROM checkpoints
             WHERE sequence_number >= {start_checkpoint} AND sequence_number < {end_checkpoint}
-        ), filtered_txns AS (
-            SELECT
-                t.checkpoint_sequence_number,
-                (SELECT ecr.epoch FROM expanded_checkpoint_range ecr
-                 WHERE ecr.tx_sequence_number = t.tx_sequence_number
-                 LIMIT 1) AS epoch,
-                t.timestamp_ms,
-                t.success_command_count
-            FROM transactions t
-            WHERE EXISTS (
-                SELECT 1
-                FROM expanded_checkpoint_range ecr
-                WHERE t.tx_sequence_number = ecr.tx_sequence_number
-            )
         )
+
         INSERT INTO tx_count_metrics
         SELECT
-            checkpoint_sequence_number,
-            epoch,
-            MAX(timestamp_ms) AS timestamp_ms,
+            ecr.checkpoint_sequence_number,
+            ecr.epoch,
+            MAX(t.timestamp_ms) AS timestamp_ms,
             COUNT(*) AS total_transaction_blocks,
-            SUM(CASE WHEN success_command_count > 0 THEN 1 ELSE 0 END) AS total_successful_transaction_blocks,
-            SUM(success_command_count) AS total_successful_transactions
-        FROM filtered_txns
-        GROUP BY checkpoint_sequence_number, epoch
-        ORDER BY checkpoint_sequence_number
+            SUM(CASE WHEN t.success_command_count > 0 THEN 1 ELSE 0 END) AS total_successful_transaction_blocks,
+            SUM(t.success_command_count) AS total_successful_transactions
+        FROM expanded_checkpoint_range ecr
+        JOIN transactions t
+            ON t.tx_sequence_number = ecr.tx_sequence_number
+        GROUP BY ecr.checkpoint_sequence_number, ecr.epoch
+        ORDER BY ecr.checkpoint_sequence_number
         ON CONFLICT (checkpoint_sequence_number) DO NOTHING;"
     )
 }

--- a/crates/iota-indexer/src/store/pg_indexer_analytical_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_analytical_store.rs
@@ -480,31 +480,39 @@ impl IndexerAnalyticalStore for PgIndexerAnalyticalStore {
 
 fn construct_checkpoint_tx_count_query(start_checkpoint: i64, end_checkpoint: i64) -> String {
     format!(
-        "With filtered_txns AS (
+        "WITH checkpoint_range AS (
+            SELECT
+                sequence_number AS checkpoint_sequence_number,
+                min_tx_sequence_number AS min_tx_seq,
+                max_tx_sequence_number AS max_tx_seq,
+                epoch
+            FROM checkpoints
+            WHERE sequence_number >= {start_checkpoint} AND sequence_number < {end_checkpoint}
+        ), filtered_txns AS (
             SELECT
                 t.checkpoint_sequence_number,
-                c.epoch,
+                cr.epoch,
                 t.timestamp_ms,
                 t.success_command_count
             FROM transactions t
-            LEFT JOIN checkpoints c
-            ON t.checkpoint_sequence_number = c.sequence_number
-            WHERE t.checkpoint_sequence_number >= {} AND t.checkpoint_sequence_number < {}
-          )
-          INSERT INTO tx_count_metrics
-          SELECT
+            JOIN checkpoint_range cr
+            ON t.tx_sequence_number BETWEEN cr.min_tx_seq AND cr.max_tx_seq
+        )
+        INSERT INTO tx_count_metrics
+        SELECT
             checkpoint_sequence_number,
             epoch,
             MAX(timestamp_ms) AS timestamp_ms,
             COUNT(*) AS total_transaction_blocks,
             SUM(CASE WHEN success_command_count > 0 THEN 1 ELSE 0 END) AS total_successful_transaction_blocks,
             SUM(success_command_count) AS total_successful_transactions
-          FROM filtered_txns
-          GROUP BY checkpoint_sequence_number, epoch ORDER BY checkpoint_sequence_number
-          ON CONFLICT (checkpoint_sequence_number) DO NOTHING;
-        ", start_checkpoint, end_checkpoint
+        FROM filtered_txns
+        GROUP BY checkpoint_sequence_number, epoch
+        ORDER BY checkpoint_sequence_number
+        ON CONFLICT (checkpoint_sequence_number) DO NOTHING;"
     )
 }
+
 
 fn construct_peak_tps_query(epoch: i64, offset: i64) -> String {
     format!(

--- a/crates/iota-indexer/src/store/pg_indexer_analytical_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_analytical_store.rs
@@ -490,7 +490,7 @@ fn construct_checkpoint_tx_count_query(start_checkpoint: i64, end_checkpoint: i6
             WHERE sequence_number >= {start_checkpoint} AND sequence_number < {end_checkpoint}
         ), filtered_txns AS (
             SELECT
-                t.checkpoint_sequence_number,
+                cr.checkpoint_sequence_number,
                 cr.epoch,
                 t.timestamp_ms,
                 t.success_command_count


### PR DESCRIPTION
# Description of change

Refactors the existing query for inserting transaction count metrics into the `tx_count_metrics` table by:

- It efficiently filters transactions from the `transactions` table using `tx_sequence_number`, leveraging the indexed primary key, reducing unnecessary full table scans.
- The needed transaction sequence range is fetched from checkpoints via a `checkpoint_range` CTE.

These changes _**significantly**_ optimize the query performance and are critical in order to be able to maintain the `tx_count_metrics` table.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/5334

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Verified that the updated query correctly filters transaction data.

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
