### PR TITLE
fix(node): Wait for checkpoint service to stop during reconfig

### DIFF
--- a/crates/iota-core/src/unit_tests/mysticeti_manager_tests.rs
+++ b/crates/iota-core/src/unit_tests/mysticeti_manager_tests.rs
@@ -33,7 +33,7 @@ pub fn checkpoint_service_for_testing(state: Arc<AuthorityState>) -> Arc<Checkpo
     ));
     let (certified_output, _certified_result) = mpsc::channel::<CertifiedCheckpointSummary>(10);
 
-    let (checkpoint_service, _) = CheckpointService::spawn(
+    let (checkpoint_service, _, _) = CheckpointService::spawn(
         state.clone(),
         state.get_checkpoint_store().clone(),
         epoch_store.clone(),


### PR DESCRIPTION
# Description of change

Merge the fix from upstream: https://github.com/MystenLabs/sui/commit/8d2bb84a1cc1773077208e48182283fc20e58aba

Currently during reconfig, CheckpointService tasks, including CheckpointBuilder and CheckpointAggregator, are [notified to shut down](https://github.com/MystenLabs/sui/blob/b1540cdb2019f0501d2cd7f6dad208f65a66b6d2/crates/sui-node/src/lib.rs#L1551). But reconfig does not wait for them to finish shutting down. There can be a race between the reconfig loop proceeding to [drop the epoch db handle](https://github.com/MystenLabs/sui/blob/b1540cdb2019f0501d2cd7f6dad208f65a66b6d2/crates/sui-node/src/lib.rs#L1633), while CheckpointBuilder tries to [read from epoch db when creating a new checkpoint](https://github.com/MystenLabs/sui/blob/b1540cdb2019f0501d2cd7f6dad208f65a66b6d2/crates/sui-core/src/checkpoints/mod.rs#L1378). The race can result in panics.


## Links to any relevant issues

Close #4691 

## Type of change

- Bug fix


## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked that new and existing unit tests pass locally with my changes
