### PR TITLE
feat(consensus): small enhancement to the invalid blocks metric

### DIFF
--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -103,7 +103,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .metrics
                 .node_metrics
                 .invalid_blocks
-                .with_label_values(&[peer_hostname, "handle_send_block"])
+                .with_label_values(&[peer_hostname, "handle_send_block", "UnexpectedAuthority"])
                 .inc();
             let e = ConsensusError::UnexpectedAuthority(signed_block.author(), peer);
             info!("Block with wrong authority from {}: {}", peer, e);
@@ -117,7 +117,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .metrics
                 .node_metrics
                 .invalid_blocks
-                .with_label_values(&[peer_hostname, "handle_send_block"])
+                .with_label_values(&[peer_hostname, "handle_send_block", e.clone().name()])
                 .inc();
             info!("Invalid block from {}: {}", peer, e);
             return Err(e);

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -171,11 +171,18 @@ impl BlockManager {
                 }
             }
             for (block_ref, block) in blocks_to_reject {
+                let hostname = self
+                    .context
+                    .committee
+                    .authority(block_ref.author)
+                    .hostname
+                    .clone();
+
                 self.context
                     .metrics
                     .node_metrics
                     .invalid_blocks
-                    .with_label_values(&[&block_ref.author.to_string(), "accept_block"])
+                    .with_label_values(&[&hostname, "accept_block", "InvalidAncestors"])
                     .inc();
                 warn!("Invalid block {:?} is rejected", block);
             }

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -194,6 +194,13 @@ pub(crate) enum ConsensusError {
     Shutdown,
 }
 
+impl ConsensusError {
+    /// Returns the error name - only the enun name without any parameters - as a static string.
+    pub fn name(&self) -> &'static str {
+        self.into()
+    }
+}
+
 pub type ConsensusResult<T> = Result<T, ConsensusError>;
 
 #[macro_export]
@@ -210,4 +217,36 @@ macro_rules! ensure {
             bail!($e);
         }
     };
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    /// This test ensures that consensus errors when converted to a static string are the same as the enum name without
+    /// any parameterers included to the result string.
+    #[test]
+    fn test_error_name() {
+        {
+            let error = ConsensusError::InvalidAncestorRound {
+                ancestor: 10,
+                block: 11,
+            };
+            let error: &'static str = error.into();
+            assert_eq!(error, "InvalidAncestorRound");
+        }
+        {
+            let error = ConsensusError::InvalidAuthorityIndex {
+                index: AuthorityIndex::new_for_test(3),
+                max: 10,
+            };
+            assert_eq!(error.name(), "InvalidAuthorityIndex");
+        }
+        {
+            let error = ConsensusError::InsufficientParentStakes {
+                parent_stakes: 5,
+                quorum: 20,
+            };
+            assert_eq!(error.name(), "InsufficientParentStakes");
+        }
+    }
 }

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -195,7 +195,8 @@ pub(crate) enum ConsensusError {
 }
 
 impl ConsensusError {
-    /// Returns the error name - only the enun name without any parameters - as a static string.
+    /// Returns the error name - only the enun name without any parameters - as
+    /// a static string.
     pub fn name(&self) -> &'static str {
         self.into()
     }
@@ -222,8 +223,9 @@ macro_rules! ensure {
 #[cfg(test)]
 mod test {
     use super::*;
-    /// This test ensures that consensus errors when converted to a static string are the same as the enum name without
-    /// any parameterers included to the result string.
+    /// This test ensures that consensus errors when converted to a static
+    /// string are the same as the enum name without any parameterers
+    /// included to the result string.
     #[test]
     fn test_error_name() {
         {

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -345,7 +345,7 @@ impl NodeMetrics {
             invalid_blocks: register_int_counter_vec_with_registry!(
                 "invalid_blocks",
                 "Number of invalid blocks per peer authority",
-                &["authority", "source"],
+                &["authority", "source", "error"],
                 registry,
             ).unwrap(),
             rejected_blocks: register_int_counter_vec_with_registry!(

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -633,11 +633,13 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             if let Err(e) = block_verifier.verify(&signed_block) {
                 // TODO: we might want to use a different metric to track the invalid "served"
                 // blocks from the invalid "proposed" ones.
+                let hostname = context.committee.authority(peer_index).hostname.clone();
+
                 context
                     .metrics
                     .node_metrics
                     .invalid_blocks
-                    .with_label_values(&[&signed_block.author().to_string(), "synchronizer"])
+                    .with_label_values(&[&hostname, "synchronizer", e.clone().name()])
                     .inc();
                 warn!("Invalid block received from {}: {}", peer_index, e);
                 return Err(e);
@@ -743,11 +745,16 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                                     for serialized_block in blocks {
                                         let signed_block = bcs::from_bytes(&serialized_block).map_err(ConsensusError::MalformedBlock)?;
                                         block_verifier.verify(&signed_block).tap_err(|err|{
+                                            let hostname = if context.committee.is_valid_index(signed_block.author()) {
+                                                context.committee.authority(signed_block.author()).hostname.clone()
+                                            } else {
+                                                signed_block.author().to_string()
+                                            };
                                             context
                                                 .metrics
                                                 .node_metrics
                                                 .invalid_blocks
-                                                .with_label_values(&[&signed_block.author().to_string(), "synchronizer_own_block"])
+                                                .with_label_values(&[&hostname, "synchronizer_own_block", err.clone().name()])
                                                 .inc();
                                             warn!("Invalid block received from {}: {}", authority_index, err);
                                         })?;


### PR DESCRIPTION
Porting from upstream: [MystenLabs/sui@](https://github.com/MystenLabs/sui) [15de3f2](https://github.com/MystenLabs/sui/commit/15de3f24ac3bf9b32b93ef2e2c41c0bf040f1c92)

# Description of change

The commit makes a small enhancement to the invalid blocks metric.
A hostname is used as a label. Error type is added.

## Type of change

Enhancement (a non-breaking change which adds functionality)
## Change checklist

- [+] I have followed the contribution guidelines for this project
- [+] I have performed a self-review of my own code
- [+] I have checked that new and existing unit tests pass locally with my changes
