### PR TITLE
chore: Use mysten crates for simtests

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -40,7 +40,6 @@ numer = "numer"
 extend-exclude = [
   "pnpm-lock.yaml",
   "external-crates/*",
-  "config-patch",
   "*.patch",
   "*.svg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ dependencies = [
  "rustls-webpki 0.102.8",
  "serde",
  "serde_json",
- "socket2",
+ "socket2 0.5.7",
  "tap",
  "thiserror",
  "tokio",
@@ -983,9 +983,8 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+version = "4.3.0"
+source = "git+https://github.com/mystenmark/async-task?rev=4e45b26e11126b191701b9b2ce5e2346b8d7682f#4e45b26e11126b191701b9b2ce5e2346b8d7682f"
 
 [[package]]
 name = "async-trait"
@@ -1544,7 +1543,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "hyper-util",
  "itoa",
  "matchit 0.7.3",
@@ -1622,7 +1621,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.23.18",
@@ -1876,7 +1875,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -2700,7 +2699,7 @@ dependencies = [
  "fastcrypto",
  "futures",
  "http 1.1.0",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "hyper-rustls 0.27.3",
  "hyper-util",
  "iota-common",
@@ -5370,7 +5369,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -5379,9 +5378,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -5422,7 +5421,7 @@ checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "hyper-util",
  "log",
  "rustls 0.23.18",
@@ -5440,7 +5439,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
 dependencies = [
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -5458,9 +5457,9 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -6863,7 +6862,7 @@ dependencies = [
  "hex",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "im",
  "insta",
  "iota-framework",
@@ -6923,7 +6922,7 @@ dependencies = [
  "anyhow",
  "async-graphql",
  "axum",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "iota-graphql-rpc-headers",
  "reqwest 0.12.7",
  "serde_json",
@@ -7048,7 +7047,7 @@ dependencies = [
  "fastcrypto",
  "futures",
  "http-body 1.0.1",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "indexmap 2.5.0",
  "iota-config",
  "iota-core",
@@ -7113,7 +7112,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bcs",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "iota-config",
  "iota-core",
  "iota-json",
@@ -7548,7 +7547,7 @@ dependencies = [
  "async-trait",
  "bcs",
  "eyre",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "insta",
  "iota-move-build",
  "iota-types",
@@ -7612,7 +7611,7 @@ dependencies = [
  "futures",
  "git-version",
  "hex",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "iota-metrics",
  "iota-tls",
  "iota-types",
@@ -7732,7 +7731,7 @@ dependencies = [
  "eyre",
  "fastcrypto",
  "futures",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "iota-config",
  "iota-json-rpc-types",
  "iota-keys",
@@ -8013,7 +8012,7 @@ dependencies = [
  "expect-test",
  "fs_extra",
  "git-version",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "iota",
  "iota-json-rpc-types",
  "iota-metrics",
@@ -8057,7 +8056,7 @@ dependencies = [
  "eyre",
  "fastcrypto",
  "futures",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "hyper-rustls 0.27.3",
  "indicatif",
  "integer-encoding",
@@ -8737,7 +8736,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "http-body 1.0.1",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "hyper-rustls 0.27.3",
  "hyper-util",
  "jsonrpsee-core",
@@ -8776,7 +8775,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -9019,9 +9018,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libflate"
@@ -9054,7 +9053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -10124,10 +10123,11 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota-sim.git?rev=f16ef50ba7d874fe1f0960f248f6c651a634d6a5#f16ef50ba7d874fe1f0960f248f6c651a634d6a5"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=d3784f9b32efa3f929bacacb527f3c468a63c01e#d3784f9b32efa3f929bacacb527f3c468a63c01e"
 dependencies = [
- "ahash 0.8.11",
+ "ahash 0.7.8",
  "async-task",
+ "bincode",
  "bytes",
  "cc",
  "downcast-rs",
@@ -10141,10 +10141,10 @@ dependencies = [
  "rand 0.8.5",
  "real_tokio",
  "serde",
- "socket2",
+ "socket2 0.4.10",
  "tap",
- "tokio-util 0.7.11",
- "toml 0.8.19",
+ "tokio-util 0.7.13",
+ "toml 0.5.11",
  "tracing",
  "tracing-subscriber",
 ]
@@ -10152,7 +10152,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota-sim.git?rev=f16ef50ba7d874fe1f0960f248f6c651a634d6a5#f16ef50ba7d874fe1f0960f248f6c651a634d6a5"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=d3784f9b32efa3f929bacacb527f3c468a63c01e#d3784f9b32efa3f929bacacb527f3c468a63c01e"
 dependencies = [
  "darling 0.14.4",
  "proc-macro2",
@@ -10598,7 +10598,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -10640,7 +10640,7 @@ dependencies = [
  "chrono",
  "futures",
  "humantime",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "itertools 0.13.0",
  "md-5",
  "parking_lot 0.12.3",
@@ -10671,7 +10671,7 @@ dependencies = [
  "chrono",
  "futures",
  "humantime",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "itertools 0.13.0",
  "md-5",
  "parking_lot 0.12.3",
@@ -11957,7 +11957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.13.0",
  "log",
  "multimap",
@@ -12061,7 +12061,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.0.0",
  "rustls 0.23.18",
- "socket2",
+ "socket2 0.5.7",
  "thiserror",
  "tokio",
  "tracing",
@@ -12092,7 +12092,7 @@ checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
 dependencies = [
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.7",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -12317,8 +12317,8 @@ dependencies = [
 
 [[package]]
 name = "real_tokio"
-version = "1.39.2"
-source = "git+https://github.com/iotaledger/tokio-madsim-fork.git?branch=main#e34a35287024b341db16139a402508aaea8ec955"
+version = "1.43.0"
+source = "git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=7329bff6ee996d8df6cf810a9c2e59631ad5a2fb#7329bff6ee996d8df6cf810a9c2e59631ad5a2fb"
 dependencies = [
  "backtrace",
  "bytes",
@@ -12327,8 +12327,8 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
- "tokio-macros 2.4.0 (git+https://github.com/iotaledger/tokio-madsim-fork.git?branch=main)",
+ "socket2 0.5.7",
+ "tokio-macros 2.5.0 (git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=7329bff6ee996d8df6cf810a9c2e59631ad5a2fb)",
  "windows-sys 0.52.0",
 ]
 
@@ -12488,7 +12488,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "hyper-rustls 0.27.3",
  "hyper-util",
  "ipnet",
@@ -12546,7 +12546,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.15",
  "http 1.1.0",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "parking_lot 0.11.2",
  "reqwest 0.12.7",
  "reqwest-middleware",
@@ -13917,7 +13917,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -13969,6 +13969,16 @@ dependencies = [
  "sha2 0.10.8",
  "thiserror",
  "time",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -14859,9 +14869,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -14870,17 +14880,17 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
- "tokio-macros 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "socket2 0.5.7",
+ "tokio-macros 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14889,8 +14899,8 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
-source = "git+https://github.com/iotaledger/tokio-madsim-fork.git?branch=main#e34a35287024b341db16139a402508aaea8ec955"
+version = "2.5.0"
+source = "git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=7329bff6ee996d8df6cf810a9c2e59631ad5a2fb#7329bff6ee996d8df6cf810a9c2e59631ad5a2fb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14959,22 +14969,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
-source = "git+https://github.com/iotaledger/tokio-madsim-fork.git?branch=main#e34a35287024b341db16139a402508aaea8ec955"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-util",
- "hashbrown 0.14.5",
- "pin-project-lite",
- "real_tokio",
- "slab",
-]
-
-[[package]]
-name = "tokio-util"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
@@ -14987,6 +14981,22 @@ dependencies = [
  "hashbrown 0.14.5",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.13"
+source = "git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=7329bff6ee996d8df6cf810a9c2e59631ad5a2fb#7329bff6ee996d8df6cf810a9c2e59631ad5a2fb"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-util",
+ "hashbrown 0.14.5",
+ "pin-project-lite",
+ "real_tokio",
+ "slab",
 ]
 
 [[package]]
@@ -15085,13 +15095,13 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.6.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -15460,7 +15470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -16020,7 +16030,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ arc-swap = { version = "1.5.1", features = ["serde"] }
 async-graphql = "=7.0.11"
 async-recursion = "1.0.4"
 async-trait = "0.1.61"
-aws-config = "0.56"
+aws-config = "1.5"
 axum = { version = "0.7", default-features = false, features = ["tokio", "http1", "http2", "json", "matched-path", "original-uri", "form", "query", "ws"] }
 axum-extra = { version = "0.9", features = ["typed-header"] }
 axum-server = { git = "https://github.com/bmwill/axum-server.git", rev = "f44323e271afdd1365fd0c8b0a4c0bbdf4956cb7", version = "0.6", default-features = false, features = ["tls-rustls"] }
@@ -264,7 +264,7 @@ hdrhistogram = "7.5.1"
 hex = "0.4.3"
 http = "1"
 humantime = "2.1.0"
-hyper = "1"
+hyper = "1.6"
 hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-roots", "http2", "ring", "tls12"] }
 im = "15"
 indexmap = { version = "2.1.0", features = ["serde"] }
@@ -278,7 +278,7 @@ leb128 = "0.2.5"
 lru = "0.12"
 mockall = "0.11.4"
 more-asserts = "0.3.1"
-msim = { git = "https://github.com/iotaledger/iota-sim.git", rev = "f16ef50ba7d874fe1f0960f248f6c651a634d6a5", package = "msim" }
+msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "d3784f9b32efa3f929bacacb527f3c468a63c01e", package = "msim" }
 nonempty = "0.9.0"
 notify = "6.1.1"
 num-bigint = "0.4.4"
@@ -331,8 +331,8 @@ tempfile = "3.3.0"
 test-fuzz = "3.0.4"
 thiserror = "1.0.40"
 # tokio is defined at a specific version to support patching with iota-sim
-# Do not upgrade without updating https://github.com/iotaledger/iota-sim first
-tokio = "=1.39.2"
+# Do not upgrade without updating https://github.com/MystenLabs/mysten-sim first
+tokio = "=1.43.0"
 tokio-rustls = { version = "0.26", default-features = false, features = ["tls12", "ring"] }
 tokio-stream = { version = "0.1.14", features = ["sync", "net"] }
 tokio-util = "0.7.10"

--- a/crates/iota-proc-macros/Cargo.toml
+++ b/crates/iota-proc-macros/Cargo.toml
@@ -18,4 +18,4 @@ quote.workspace = true
 syn = { version = "2.0", features = ["full", "fold", "extra-traits"] }
 
 [target.'cfg(msim)'.dependencies]
-msim-macros = { git = "https://github.com/iotaledger/iota-sim.git", rev = "f16ef50ba7d874fe1f0960f248f6c651a634d6a5", package = "msim-macros" }
+msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "d3784f9b32efa3f929bacacb527f3c468a63c01e", package = "msim-macros" }

--- a/deny.toml
+++ b/deny.toml
@@ -230,10 +230,11 @@ unknown-git = "warn"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
-  "https://github.com/iotaledger/iota-sim.git",
+  "https://github.com/MystenLabs/mysten-sim.git",
   "https://github.com/MystenLabs/fastcrypto.git",
   "https://github.com/mystenlabs/anemo.git",
-  "https://github.com/iotaledger/tokio-madsim-fork.git",
+  "https://github.com/mystenmark/async-task.git",
+  "https://github.com/MystenLabs/tokio-msim-fork.git",
   "https://github.com/nextest-rs/datatest-stable.git",
   "https://github.com/zhiburt/tabled.git",
   "https://github.com/iotaledger/iota-rust-sdk.git",

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -49,15 +49,15 @@ RUST_FLAGS=('"--cfg"' '"msim"')
 if [ -n "$LOCAL_MSIM_PATH" ]; then
   cargo_patch_args=(
     --config "patch.crates-io.tokio.path = \"$LOCAL_MSIM_PATH/msim-tokio\""
-    --config "patch.'https://github.com/iotaledger/iota-sim'.msim.path = \"$LOCAL_MSIM_PATH/msim\""
+    --config "patch.'https://github.com/MystenLabs/mysten-sim'.msim.path = \"$LOCAL_MSIM_PATH/msim\""
     --config "patch.crates-io.futures-timer.path = \"$LOCAL_MSIM_PATH/mocked-crates/futures-timer\""
   )
 else
   cargo_patch_args=(
-    --config 'patch.crates-io.tokio.git = "https://github.com/iotaledger/iota-sim.git"'
-    --config 'patch.crates-io.tokio.rev = "f16ef50ba7d874fe1f0960f248f6c651a634d6a5"'
-    --config 'patch.crates-io.futures-timer.git = "https://github.com/iotaledger/iota-sim.git"'
-    --config 'patch.crates-io.futures-timer.rev = "f16ef50ba7d874fe1f0960f248f6c651a634d6a5"'
+    --config 'patch.crates-io.tokio.git = "https://github.com/MystenLabs/mysten-sim.git"'
+    --config 'patch.crates-io.tokio.rev = "d3784f9b32efa3f929bacacb527f3c468a63c01e"'
+    --config 'patch.crates-io.futures-timer.git = "https://github.com/MystenLabs/mysten-sim.git"'
+    --config 'patch.crates-io.futures-timer.rev = "d3784f9b32efa3f929bacacb527f3c468a63c01e"'
   )
 fi
 

--- a/scripts/simtest/clippy.sh
+++ b/scripts/simtest/clippy.sh
@@ -10,7 +10,7 @@ if [[ -n $(git status -s) ]]; then
 fi
 
 # apply git patch
-git apply ./scripts/simtest/config-patch
+git apply ./scripts/simtest/config.patch
 
 root_dir=$(git rev-parse --show-toplevel)
 export SIMTEST_STATIC_INIT_MOVE=$root_dir"/examples/move/basics"

--- a/scripts/simtest/config.patch
+++ b/scripts/simtest/config.patch
@@ -21,5 +21,5 @@ index e91e9c7d48..d719828c54 100644
  typed-store-error = { path = "crates/typed-store-error" }
 +
 +[patch.crates-io]
-+tokio = { git = "https://github.com/iotaledger/iota-sim.git", rev = "f16ef50ba7d874fe1f0960f248f6c651a634d6a5" }
-+futures-timer = { git = "https://github.com/iotaledger/iota-sim.git", rev = "f16ef50ba7d874fe1f0960f248f6c651a634d6a5" }
++tokio = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "d3784f9b32efa3f929bacacb527f3c468a63c01e" }
++futures-timer = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "d3784f9b32efa3f929bacacb527f3c468a63c01e" }

--- a/scripts/simtest/simtest-cov.sh
+++ b/scripts/simtest/simtest-cov.sh
@@ -15,7 +15,7 @@ if [[ -n $(git status -s) ]]; then
 fi
 
 # apply git patch
-git apply ./scripts/simtest/config-patch
+git apply ./scripts/simtest/config.patch
 
 root_dir=$(git rev-parse --show-toplevel)
 export SIMTEST_STATIC_INIT_MOVE=$root_dir"/examples/move/basics"


### PR DESCRIPTION
## Description 

Reverts to using the mysten crates for simtests. Updates a few dependencies to match.