### PR TITLE
fix(examples): Update first package example dependency rev to `framework/testnet`

### DIFF
--- a/crates/iota/tests/snapshots/shell_tests__new_tests__manifest_template.sh.snap
+++ b/crates/iota/tests/snapshots/shell_tests__new_tests__manifest_template.sh.snap
@@ -21,7 +21,7 @@ edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
 # authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 
 [dependencies]
-Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "framework/testnet" }
+Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "testnet" }
 
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
 # Revision can be a branch, a tag, and a commit hash.

--- a/crates/iota/tests/snapshots/shell_tests__new_tests__manifest_template.sh.snap
+++ b/crates/iota/tests/snapshots/shell_tests__new_tests__manifest_template.sh.snap
@@ -21,7 +21,7 @@ edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
 # authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 
 [dependencies]
-Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "testnet" }
+Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "framework/testnet" }
 
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
 # Revision can be a branch, a tag, and a commit hash.

--- a/docs/content/developer/getting-started/create-a-package.mdx
+++ b/docs/content/developer/getting-started/create-a-package.mdx
@@ -106,7 +106,7 @@ for the dependencies.
 
 ```toml
 [dependencies]
-iota = { override = true, git = "", subdir = "crates/iota-framework/packages/iota-framework", rev = "testnet" }
+iota = { override = true, git = "", subdir = "crates/iota-framework/packages/iota-framework", rev = "framework/testnet" }
 MyPackage = { local = "../my-package" }
 ```
 
@@ -117,7 +117,7 @@ MyPackage = { local = "../my-package" }
 override = true
 git = "https://github.com/iotaledger/iota.git"
 subdir = "crates/iota-framework/packages/iota-framework"
-rev = "testnet"
+rev = "framework/testnet"
 
 [dependencies.MyPackage]
 local = "../my-package"

--- a/docs/content/references/cli/move.mdx
+++ b/docs/content/references/cli/move.mdx
@@ -73,7 +73,7 @@ name = "smart_contract_test"
 edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
 
 [dependencies]
-Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "testnet" }
+Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "framework/testnet" }
 
 [addresses]
 smart_contract_test = "0x0"

--- a/docs/examples/move/ctf/challenge_0/Move.toml
+++ b/docs/examples/move/ctf/challenge_0/Move.toml
@@ -5,7 +5,7 @@ edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
 # authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 
 [dependencies]
-Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "testnet" }
+Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "framework/testnet" }
 
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
 # Revision can be a branch, a tag, and a commit hash.

--- a/examples/move/first_package/Move.toml
+++ b/examples/move/first_package/Move.toml
@@ -5,7 +5,7 @@ edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
 # authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 
 [dependencies]
-Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "testnet" }
+Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "framework/testnet" }
 
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
 # Revision can be a branch, a tag, and a commit hash.


### PR DESCRIPTION
# Description of change

Make the examples of Move.toml files use the `framework/testnet` revision instead of `testnet`.

## Links to any relevant issues

Fixes #5405 

## Type of change

- Documentation Fix

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
