### PR TITLE
Wait for checkpoint service to stop during reconfig

### DIFF
--- a/crates/iota-core/src/unit_tests/mysticeti_manager_tests.rs
+++ b/crates/iota-core/src/unit_tests/mysticeti_manager_tests.rs
@@ -33,7 +33,7 @@ pub fn checkpoint_service_for_testing(state: Arc<AuthorityState>) -> Arc<Checkpo
     ));
     let (certified_output, _certified_result) = mpsc::channel::<CertifiedCheckpointSummary>(10);
 
-    let (checkpoint_service, _) = CheckpointService::spawn(
+    let (checkpoint_service, _, _) = CheckpointService::spawn(
         state.clone(),
         state.get_checkpoint_store().clone(),
         epoch_store.clone(),

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -25,6 +25,7 @@ use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId, OIDCProvider};
 use futures::TryFutureExt;
 pub use handle::IotaNodeHandle;
 use iota_archival::{reader::ArchiveReaderBalancer, writer::ArchiveWriter};
+use iota_common::debug_fatal;
 use iota_config::{
     ConsensusConfig, NodeConfig,
     node::{DBCheckpointConfig, RunWithRange},
@@ -123,7 +124,8 @@ use tap::tap::TapFallible;
 use tokio::{
     runtime::Handle,
     sync::{Mutex, broadcast, mpsc, watch},
-    task::JoinHandle,
+    task::{JoinHandle, JoinSet},
+    time::timeout,
 };
 use tower::ServiceBuilder;
 use tracing::{Instrument, debug, error, error_span, info, warn};
@@ -141,10 +143,12 @@ pub struct ValidatorComponents {
     consensus_manager: ConsensusManager,
     consensus_store_pruner: ConsensusStorePruner,
     consensus_adapter: Arc<ConsensusAdapter>,
-    // dropping this will eventually stop checkpoint tasks. The receiver side of this channel
-    // is copied into each checkpoint service task, and they are listening to any change to this
-    // channel. When the sender is dropped, a change is triggered and those tasks will exit.
+    // Sending to the channel or dropping this will eventually stop checkpoint tasks. The receiver
+    // side of this channel is copied into each checkpoint service task, and they are listening to
+    // any change to this channel.
     checkpoint_service_exit: watch::Sender<()>,
+    // Keeping the handle to the checkpoint service tasks to shut them down during reconfiguration.
+    checkpoint_service_tasks: JoinSet<()>,
     checkpoint_metrics: Arc<CheckpointMetrics>,
     iota_tx_validator_metrics: Arc<IotaTxValidatorMetrics>,
 }
@@ -1273,16 +1277,17 @@ impl IotaNode {
         iota_node_metrics: Arc<IotaNodeMetrics>,
         iota_tx_validator_metrics: Arc<IotaTxValidatorMetrics>,
     ) -> Result<ValidatorComponents> {
-        let (checkpoint_service, checkpoint_service_exit) = Self::start_checkpoint_service(
-            config,
-            consensus_adapter.clone(),
-            checkpoint_store,
-            epoch_store.clone(),
-            state.clone(),
-            state_sync_handle,
-            accumulator,
-            checkpoint_metrics.clone(),
-        );
+        let (checkpoint_service, checkpoint_service_exit, checkpoint_service_tasks) =
+            Self::start_checkpoint_service(
+                config,
+                consensus_adapter.clone(),
+                checkpoint_store,
+                epoch_store.clone(),
+                state.clone(),
+                state_sync_handle,
+                accumulator,
+                checkpoint_metrics.clone(),
+            );
 
         // create a new map that gets injected into both the consensus handler and the
         // consensus adapter the consensus handler will write values forwarded
@@ -1343,6 +1348,7 @@ impl IotaNode {
             consensus_store_pruner,
             consensus_adapter,
             checkpoint_service_exit,
+            checkpoint_service_tasks,
             checkpoint_metrics,
             iota_tx_validator_metrics,
         })
@@ -1363,7 +1369,7 @@ impl IotaNode {
         state_sync_handle: state_sync::Handle,
         accumulator: Weak<StateAccumulator>,
         checkpoint_metrics: Arc<CheckpointMetrics>,
-    ) -> (Arc<CheckpointService>, watch::Sender<()>) {
+    ) -> (Arc<CheckpointService>, watch::Sender<()>, JoinSet<()>) {
         let epoch_start_timestamp_ms = epoch_store.epoch_start_state().epoch_start_timestamp_ms();
         let epoch_duration_ms = epoch_store.epoch_start_state().epoch_duration_ms();
 
@@ -1646,15 +1652,33 @@ impl IotaNode {
                 consensus_store_pruner,
                 consensus_adapter,
                 checkpoint_service_exit,
+                mut checkpoint_service_tasks,
                 checkpoint_metrics,
                 iota_tx_validator_metrics,
             }) = self.validator_components.lock().await.take()
             {
                 info!("Reconfiguring the validator.");
-                // Stop the old checkpoint service.
-                drop(checkpoint_service_exit);
+                // Stop the old checkpoint service and wait for them to finish.
+                let _ = checkpoint_service_exit.send(());
+                let wait_result = timeout(Duration::from_secs(5), async move {
+                    while let Some(result) = checkpoint_service_tasks.join_next().await {
+                        if let Err(err) = result {
+                            if err.is_panic() {
+                                std::panic::resume_unwind(err.into_panic());
+                            }
+                            warn!("Error in checkpoint service task: {:?}", err);
+                        }
+                    }
+                })
+                .await;
+                if wait_result.is_err() {
+                    debug_fatal!("Timed out waiting for checkpoint service tasks to finish.");
+                } else {
+                    info!("Checkpoint service has shut down.");
+                }
 
                 consensus_manager.shutdown().await;
+                info!("Consensus has shut down.");
 
                 let new_epoch_store = self
                     .reconfigure_state(
@@ -1665,6 +1689,7 @@ impl IotaNode {
                         accumulator.clone(),
                     )
                     .await?;
+                info!("Epoch store finished reconfiguration.");
 
                 // No other components should be holding a strong reference to state accumulator
                 // at this point. Confirm here before we swap in the new accumulator.


### PR DESCRIPTION
# Description of change

This is the pre-required PR for issue #4692 
Apply the bug fixing from [[Checkpoint] wait for checkpoint service to stop during reconfig #17556](https://github.com/MystenLabs/sui/pull/17556):

_Currently during reconfig, CheckpointService tasks, including CheckpointBuilder and CheckpointAggregator, are [notified to shut down](https://github.com/MystenLabs/sui/blob/b1540cdb2019f0501d2cd7f6dad208f65a66b6d2/crates/sui-node/src/lib.rs#L1551). But reconfig does not wait for them to finish shutting down. There can be a race between the reconfig loop proceeding to [drop the epoch db handle](https://github.com/MystenLabs/sui/blob/b1540cdb2019f0501d2cd7f6dad208f65a66b6d2/crates/sui-node/src/lib.rs#L1633), while CheckpointBuilder tries to [read from epoch db when creating a new checkpoint](https://github.com/MystenLabs/sui/blob/b1540cdb2019f0501d2cd7f6dad208f65a66b6d2/crates/sui-core/src/checkpoints/mod.rs#L1378). The race can result in panics._

## Links to any relevant issues

fixes #5411 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Ran the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`



## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
