### PR TITLE
feat(iota-indexer, iota-json-rpc-types): Support transaction kind filters in `query_transaction_blocks_impl`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7175,6 +7175,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "strum 0.26.3",
  "tabled",
  "tracing",
 ]

--- a/crates/iota-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/iota-indexer/src/handlers/checkpoint_handler.rs
@@ -426,7 +426,7 @@ impl CheckpointHandler {
                 .map(|events| events.data.clone())
                 .unwrap_or_default();
 
-            let transaction_kind = IotaTransactionKind::from(tx);
+            let transaction_kind = IotaTransactionKind::from(tx.kind());
 
             db_events.extend(events.iter().enumerate().map(|(idx, event)| {
                 IndexedEvent::from_event(

--- a/crates/iota-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/iota-indexer/src/handlers/checkpoint_handler.rs
@@ -9,7 +9,7 @@ use std::{
 
 use async_trait::async_trait;
 use iota_data_ingestion_core::Worker;
-use iota_json_rpc_types::{IotaMoveValue, TransactionKindMatch};
+use iota_json_rpc_types::{IotaMoveValue, IotaTransactionKind};
 use iota_metrics::{get_metrics, spawn_monitored_task};
 use iota_package_resolver::{PackageStore, PackageStoreWithLruCache, Resolver};
 use iota_rest_api::{CheckpointData, CheckpointTransaction};
@@ -426,7 +426,7 @@ impl CheckpointHandler {
                 .map(|events| events.data.clone())
                 .unwrap_or_default();
 
-            let transaction_kind = TransactionKindMatch::from(tx);
+            let transaction_kind = IotaTransactionKind::from(tx);
 
             db_events.extend(events.iter().enumerate().map(|(idx, event)| {
                 IndexedEvent::from_event(

--- a/crates/iota-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/iota-indexer/src/handlers/checkpoint_handler.rs
@@ -9,7 +9,7 @@ use std::{
 
 use async_trait::async_trait;
 use iota_data_ingestion_core::Worker;
-use iota_json_rpc_types::IotaMoveValue;
+use iota_json_rpc_types::{IotaMoveValue, TransactionKindMatch};
 use iota_metrics::{get_metrics, spawn_monitored_task};
 use iota_package_resolver::{PackageStore, PackageStoreWithLruCache, Resolver};
 use iota_rest_api::{CheckpointData, CheckpointTransaction};
@@ -54,7 +54,7 @@ use crate::{
     },
     types::{
         EventIndex, IndexedCheckpoint, IndexedDeletedObject, IndexedEpochInfo, IndexedEvent,
-        IndexedObject, IndexedPackage, IndexedTransaction, IndexerResult, TransactionKind, TxIndex,
+        IndexedObject, IndexedPackage, IndexedTransaction, IndexerResult, TxIndex,
     },
 };
 
@@ -426,11 +426,7 @@ impl CheckpointHandler {
                 .map(|events| events.data.clone())
                 .unwrap_or_default();
 
-            let transaction_kind = if tx.is_system_tx() {
-                TransactionKind::SystemTransaction
-            } else {
-                TransactionKind::ProgrammableTransaction
-            };
+            let transaction_kind = TransactionKindMatch::from(tx);
 
             db_events.extend(events.iter().enumerate().map(|(idx, event)| {
                 IndexedEvent::from_event(

--- a/crates/iota-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/iota-indexer/src/handlers/checkpoint_handler.rs
@@ -472,7 +472,7 @@ impl CheckpointHandler {
                 object_changes,
                 balance_change,
                 events,
-                transaction_kind: transaction_kind.clone(),
+                transaction_kind,
                 successful_tx_num: if fx.status().is_ok() {
                     tx.kind().tx_count() as u64
                 } else {

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -954,9 +954,7 @@ impl IndexerReader {
                 for kind in kind_vec.iter() {
                     let kind: IotaTransactionKind = (*kind).into();
                     match kind {
-                        IotaTransactionKind::SystemTransaction => {
-                            has_system_transaction = true
-                        }
+                        IotaTransactionKind::SystemTransaction => has_system_transaction = true,
                         IotaTransactionKind::ProgrammableTransaction => {
                             has_programmable_transaction = true
                         }

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -947,7 +947,7 @@ impl IndexerReader {
                     ));
                 }
 
-                let mut has_system_transaction_kind = false;
+                let mut has_system_transaction = false;
                 let mut has_programmable_transaction = false;
                 let mut other_kinds = Vec::new();
 
@@ -955,7 +955,7 @@ impl IndexerReader {
                     let kind: IotaTransactionKind = (*kind).into();
                     match kind {
                         IotaTransactionKind::SystemTransaction => {
-                            has_system_transaction_kind = true
+                            has_system_transaction = true
                         }
                         IotaTransactionKind::ProgrammableTransaction => {
                             has_programmable_transaction = true
@@ -964,7 +964,7 @@ impl IndexerReader {
                     }
                 }
 
-                let query = if has_system_transaction_kind {
+                let query = if has_system_transaction {
                     if has_programmable_transaction {
                         // Case: Both `0` (SystemTransaction) and `1` (ProgrammableTransaction) are
                         // included: Allow everything

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -2,7 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::{Arc, Mutex};
+use std::{
+    str::FromStr,
+    sync::{Arc, Mutex},
+};
 
 use anyhow::{Result, anyhow};
 use cached::{Cached, SizedCache};
@@ -17,7 +20,7 @@ use iota_json_rpc_types::{
     AddressMetrics, Balance, CheckpointId, Coin as IotaCoin, DisplayFieldsResponse, EpochInfo,
     EventFilter, IotaCoinMetadata, IotaEvent, IotaMoveValue, IotaObjectDataFilter,
     IotaTransactionBlockEffects, IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse,
-    MoveCallMetrics, MoveFunctionName, NetworkMetrics, TransactionFilter,
+    IotaTransactionKind, MoveCallMetrics, MoveFunctionName, NetworkMetrics, TransactionFilter,
 };
 use iota_package_resolver::{Package, PackageStore, PackageStoreWithLruCache, Resolver};
 use iota_types::{
@@ -931,7 +934,11 @@ impl IndexerReader {
                 (inner_query, "1 = 1".into())
             }
             Some(TransactionFilter::TransactionKind(kind)) => {
-                ("tx_kinds".into(), format!("tx_kind = {kind}"))
+                let valid_kind = IotaTransactionKind::from_str(&kind).map_err(|_| {
+                    IndexerError::InvalidArgument(format!("invalid transaction kind: {kind}"))
+                })?;
+
+                ("tx_kinds".into(), format!("tx_kind = '{valid_kind}'"))
             }
             Some(TransactionFilter::TransactionKindIn(kind_vec)) => {
                 if kind_vec.is_empty() {
@@ -939,12 +946,25 @@ impl IndexerReader {
                         "TransactionKindIn filter is empty".into(),
                     ));
                 }
-                let kinds_str = kind_vec
+
+                let valid_kinds_str = kind_vec
                     .iter()
-                    .map(|k| (*k as i16).to_string())
-                    .collect::<Vec<_>>()
+                    .map(|kind| {
+                        IotaTransactionKind::from_str(kind)
+                            .map(|k| format!("'{}'", k))
+                            .map_err(|_| {
+                                IndexerError::InvalidArgument(format!(
+                                    "invalid transaction kind: {kind}"
+                                ))
+                            })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?
                     .join(", ");
-                ("tx_kinds".into(), format!("tx_kind IN ({kinds_str})"))
+
+                (
+                    "tx_kinds".into(),
+                    format!("tx_kind IN ({})", valid_kinds_str),
+                )
             }
             None => {
                 // apply no filter

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -931,7 +931,7 @@ impl IndexerReader {
                 (inner_query, "1 = 1".into())
             }
             Some(TransactionFilter::TransactionKind(kind)) => {
-                ("tx_kinds".into(), format!("tx_kind = {}", kind as i16))
+                ("tx_kinds".into(), format!("tx_kind = {kind}"))
             }
             None => {
                 // apply no filter

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -933,6 +933,19 @@ impl IndexerReader {
             Some(TransactionFilter::TransactionKind(kind)) => {
                 ("tx_kinds".into(), format!("tx_kind = {kind}"))
             }
+            Some(TransactionFilter::TransactionKindIn(kind_vec)) => {
+                if kind_vec.is_empty() {
+                    return Err(IndexerError::InvalidArgument(
+                        "TransactionKindIn filter is empty".into(),
+                    ));
+                }
+                let kinds_str = kind_vec
+                    .iter()
+                    .map(|k| (*k as i16).to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                ("tx_kinds".into(), format!("tx_kind IN ({})", kinds_str))
+            }
             None => {
                 // apply no filter
                 ("transactions".into(), "1 = 1".into())

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -952,13 +952,12 @@ impl IndexerReader {
                 let mut other_kinds = Vec::new();
 
                 for kind in kind_vec.iter() {
-                    let kind: IotaTransactionKind = (*kind).into();
                     match kind {
                         IotaTransactionKind::SystemTransaction => has_system_transaction = true,
                         IotaTransactionKind::ProgrammableTransaction => {
                             has_programmable_transaction = true
                         }
-                        _ => other_kinds.push(kind as u8),
+                        _ => other_kinds.push(*kind as u8),
                     }
                 }
 
@@ -970,7 +969,7 @@ impl IndexerReader {
                     } else {
                         // Case: Only `0` and system transactions (`>1`): Allow all system
                         // transactions
-                        "tx_kind = 0 OR tx_kind > 1".to_string()
+                        "tx_kind != 1".to_string()
                     }
                 } else {
                     // Case: Only `1` (ProgrammableTransaction) and other fine-grained system

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -930,12 +930,21 @@ impl IndexerReader {
                 );
                 (inner_query, "1 = 1".into())
             }
-            Some(
-                TransactionFilter::TransactionKind(_) | TransactionFilter::TransactionKindIn(_),
-            ) => {
-                return Err(IndexerError::NotSupported(
-                    "TransactionKind filter is not supported.".into(),
-                ));
+            Some(TransactionFilter::TransactionKind(kind)) => {
+                ("tx_kinds".into(), format!("tx_kind = {}", kind as i16))
+            }
+            Some(TransactionFilter::TransactionKindIn(kind_vec)) => {
+                if kind_vec.is_empty() {
+                    return Err(IndexerError::InvalidArgument(
+                        "TransactionKindIn filter is empty".into(),
+                    ));
+                }
+                let kinds_str = kind_vec
+                    .iter()
+                    .map(|k| (*k as i16).to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                ("tx_kinds".into(), format!("tx_kind IN ({})", kinds_str))
             }
             None => {
                 // apply no filter

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -933,19 +933,6 @@ impl IndexerReader {
             Some(TransactionFilter::TransactionKind(kind)) => {
                 ("tx_kinds".into(), format!("tx_kind = {}", kind as i16))
             }
-            Some(TransactionFilter::TransactionKindIn(kind_vec)) => {
-                if kind_vec.is_empty() {
-                    return Err(IndexerError::InvalidArgument(
-                        "TransactionKindIn filter is empty".into(),
-                    ));
-                }
-                let kinds_str = kind_vec
-                    .iter()
-                    .map(|k| (*k as i16).to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                ("tx_kinds".into(), format!("tx_kind IN ({})", kinds_str))
-            }
             None => {
                 // apply no filter
                 ("transactions".into(), "1 = 1".into())

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -943,7 +943,7 @@ impl IndexerReader {
             Some(TransactionFilter::TransactionKindIn(kind_vec)) => {
                 if kind_vec.is_empty() {
                     return Err(IndexerError::InvalidArgument(
-                        "TransactionKindIn filter is empty".into(),
+                        "no transaction kind provided".into(),
                     ));
                 }
 

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    str::FromStr,
+    fmt::Write,
     sync::{Arc, Mutex},
 };
 
@@ -934,11 +934,11 @@ impl IndexerReader {
                 (inner_query, "1 = 1".into())
             }
             Some(TransactionFilter::TransactionKind(kind)) => {
-                let valid_kind = IotaTransactionKind::from_str(&kind).map_err(|_| {
-                    IndexerError::InvalidArgument(format!("invalid transaction kind: {kind}"))
-                })?;
-
-                ("tx_kinds".into(), format!("tx_kind = '{valid_kind}'"))
+                if kind == IotaTransactionKind::SystemTransaction {
+                    ("tx_kinds".into(), "tx_kind = 0 OR tx_kind > 1".to_string())
+                } else {
+                    ("tx_kinds".into(), format!("tx_kind = {}", kind as u8))
+                }
             }
             Some(TransactionFilter::TransactionKindIn(kind_vec)) => {
                 if kind_vec.is_empty() {
@@ -947,24 +947,48 @@ impl IndexerReader {
                     ));
                 }
 
-                let valid_kinds_str = kind_vec
-                    .iter()
-                    .map(|kind| {
-                        IotaTransactionKind::from_str(kind)
-                            .map(|k| format!("'{}'", k))
-                            .map_err(|_| {
-                                IndexerError::InvalidArgument(format!(
-                                    "invalid transaction kind: {kind}"
-                                ))
-                            })
-                    })
-                    .collect::<Result<Vec<_>, _>>()?
-                    .join(", ");
+                let mut has_system_transaction_kind = false;
+                let mut has_programmable_transaction = false;
+                let mut other_kinds = Vec::new();
 
-                (
-                    "tx_kinds".into(),
-                    format!("tx_kind IN ({})", valid_kinds_str),
-                )
+                for kind in kind_vec.iter() {
+                    let kind: IotaTransactionKind = (*kind).into();
+                    match kind {
+                        IotaTransactionKind::SystemTransaction => {
+                            has_system_transaction_kind = true
+                        }
+                        IotaTransactionKind::ProgrammableTransaction => {
+                            has_programmable_transaction = true
+                        }
+                        _ => other_kinds.push(kind as u8),
+                    }
+                }
+
+                let query = if has_system_transaction_kind {
+                    if has_programmable_transaction {
+                        // Case: Both `0` (SystemTransaction) and `1` (ProgrammableTransaction) are
+                        // included: Allow everything
+                        "tx_kind >= 0".to_string()
+                    } else {
+                        // Case: Only `0` and system transactions (`>1`): Allow all system
+                        // transactions
+                        "tx_kind = 0 OR tx_kind > 1".to_string()
+                    }
+                } else {
+                    // Case: Only `1` (ProgrammableTransaction) and other fine-grained system
+                    // transactions (>1): Normal `IN` filter
+                    let mut query = String::from("tx_kind IN (");
+                    for (i, kind) in other_kinds.iter().enumerate() {
+                        if i > 0 {
+                            query.push_str(", ");
+                        }
+                        write!(&mut query, "{}", kind).unwrap();
+                    }
+                    query.push(')');
+                    query
+                };
+
+                ("tx_kinds".into(), query)
             }
             None => {
                 // apply no filter

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -944,7 +944,7 @@ impl IndexerReader {
                     .map(|k| (*k as i16).to_string())
                     .collect::<Vec<_>>()
                     .join(", ");
-                ("tx_kinds".into(), format!("tx_kind IN ({})", kinds_str))
+                ("tx_kinds".into(), format!("tx_kind IN ({kinds_str})"))
             }
             None => {
                 // apply no filter

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -103,7 +103,7 @@ impl From<&IndexedTransaction> for StoredTransaction {
                 .map(|e| Some(bcs::to_bytes(&e).unwrap()))
                 .collect(),
             timestamp_ms: tx.timestamp_ms as i64,
-            transaction_kind: tx.transaction_kind.clone() as i16,
+            transaction_kind: tx.transaction_kind as i16,
             success_command_count: tx.successful_tx_num as i16,
         }
     }

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -4,6 +4,7 @@
 
 use iota_json_rpc_types::{
     IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions, ObjectChange,
+    TransactionKindMatch as TransactionKind,
 };
 use iota_types::{
     base_types::{IotaAddress, ObjectDigest, ObjectID, SequenceNumber},
@@ -363,12 +364,6 @@ pub struct IndexedPackage {
     pub package_id: ObjectID,
     pub move_package: MovePackage,
     pub checkpoint_sequence_number: u64,
-}
-
-#[derive(Debug, Clone)]
-pub enum TransactionKind {
-    SystemTransaction = 0,
-    ProgrammableTransaction = 1,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_json_rpc_types::{
-    IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions, ObjectChange,
-    TransactionKindMatch as TransactionKind,
+    IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions, IotaTransactionKind,
+    ObjectChange,
 };
 use iota_types::{
     base_types::{IotaAddress, ObjectDigest, ObjectID, SequenceNumber},
@@ -377,14 +377,14 @@ pub struct IndexedTransaction {
     pub object_changes: Vec<IndexedObjectChange>,
     pub balance_change: Vec<iota_json_rpc_types::BalanceChange>,
     pub events: Vec<iota_types::event::Event>,
-    pub transaction_kind: TransactionKind,
+    pub transaction_kind: IotaTransactionKind,
     pub successful_tx_num: u64,
 }
 
 #[derive(Debug, Clone)]
 pub struct TxIndex {
     pub tx_sequence_number: u64,
-    pub tx_kind: TransactionKind,
+    pub tx_kind: IotaTransactionKind,
     pub transaction_digest: TransactionDigest,
     pub checkpoint_sequence_number: u64,
     pub input_objects: Vec<ObjectID>,

--- a/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
@@ -7,12 +7,13 @@ use iota_json::{call_args, type_args};
 use iota_json_rpc_api::{IndexerApiClient, WriteApiClient};
 use iota_json_rpc_types::{
     EventFilter, EventPage, IotaMoveValue, IotaObjectDataFilter, IotaObjectDataOptions,
-    IotaObjectResponseQuery, IotaTransactionBlockResponseOptions,
-    IotaTransactionBlockResponseQuery, ObjectsPage, TransactionFilter,
+    IotaObjectResponseQuery, IotaTransactionBlockData, IotaTransactionBlockKind,
+    IotaTransactionBlockResponseOptions, IotaTransactionBlockResponseQuery, IotaTransactionKind,
+    ObjectsPage, TransactionFilter,
 };
 use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
-    IOTA_FRAMEWORK_ADDRESS,
+    IOTA_FRAMEWORK_ADDRESS, MOVE_STDLIB_PACKAGE_ID,
     base_types::{IotaAddress, ObjectID},
     crypto::{AccountKeyPair, get_key_pair},
     digests::TransactionDigest,
@@ -747,6 +748,198 @@ fn test_get_dynamic_field_objects() -> Result<(), anyhow::Error> {
             dynamic_fields.data.is_some(),
             "Dynamic field object was not added"
         );
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_query_transaction_blocks_tx_kind_filter() -> Result<(), anyhow::Error> {
+    let ApiTestSetup {
+        runtime,
+        store,
+        cluster,
+        client,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        let (address, keypair): (_, AccountKeyPair) = get_key_pair();
+
+        let gas = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(500_000_000),
+                address,
+            )
+            .await;
+        let iota_client = cluster.wallet.get_client().await.unwrap();
+
+        indexer_wait_for_object(client, gas.0, gas.1).await;
+
+        let objects = client
+            .get_owned_objects(
+                address,
+                Some(IotaObjectResponseQuery::new_with_options(
+                    IotaObjectDataOptions::new()
+                        .with_type()
+                        .with_owner()
+                        .with_previous_transaction(),
+                )),
+                None,
+                None,
+            )
+            .await?
+            .data;
+
+        assert_eq!(objects.len(), 1);
+
+        let signer = address;
+
+        let package_id = MOVE_STDLIB_PACKAGE_ID;
+        let module = Identifier::from_str("address")?;
+        let function = Identifier::from_str("length")?;
+
+        let mut pt_builder = ProgrammableTransactionBuilder::new();
+        pt_builder.move_call(package_id, module, function, vec![], vec![])?;
+        let pt = pt_builder.finish();
+
+        let tx_data = TransactionData::new_programmable(signer, vec![gas], pt, 10_000_000, 1_000);
+        let signed_transaction = to_sender_signed_transaction(tx_data, &keypair);
+
+        let response = iota_client
+            .quorum_driver_api()
+            .execute_transaction_block(
+                signed_transaction,
+                IotaTransactionBlockResponseOptions::new(),
+                Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+            )
+            .await
+            .unwrap();
+
+        indexer_wait_for_transaction(response.digest, store, client).await;
+
+        let options = IotaTransactionBlockResponseOptions::new().with_input();
+
+        // Test `ProgrammableTransaction` transaction kind filter
+        let filter =
+            TransactionFilter::TransactionKind(IotaTransactionKind::ProgrammableTransaction);
+        let query = IotaTransactionBlockResponseQuery::new(Some(filter), Some(options.clone()));
+        let res = client
+            .query_transaction_blocks(query, None, Some(1), Some(true))
+            .await
+            .unwrap();
+        assert_eq!(1, res.data.len());
+        //
+        let IotaTransactionBlockData::V1(tx_data_v1) = &res
+            .data
+            .first()
+            .as_ref()
+            .unwrap()
+            .transaction
+            .as_ref()
+            .unwrap()
+            .data;
+        assert!(matches!(
+            tx_data_v1.transaction,
+            IotaTransactionBlockKind::ProgrammableTransaction(_)
+        ));
+
+        // Test `Genesis` transaction kind filter
+        let filter = TransactionFilter::TransactionKind(IotaTransactionKind::Genesis);
+        let query = IotaTransactionBlockResponseQuery::new(Some(filter), Some(options.clone()));
+        let res = client
+            .query_transaction_blocks(query, None, Some(2), Some(false))
+            .await
+            .unwrap();
+        //
+        assert_eq!(1, res.data.len());
+        assert!(!res.has_next_page);
+        //
+        let IotaTransactionBlockData::V1(tx_data_v1) = &res
+            .data
+            .first()
+            .as_ref()
+            .unwrap()
+            .transaction
+            .as_ref()
+            .unwrap()
+            .data;
+        assert!(matches!(
+            tx_data_v1.transaction,
+            IotaTransactionBlockKind::Genesis(_)
+        ));
+
+        // Test `SystemTransaction` transaction kind filter
+        let filter = TransactionFilter::TransactionKind(IotaTransactionKind::SystemTransaction);
+        let query = IotaTransactionBlockResponseQuery::new(Some(filter), Some(options.clone()));
+        let res = client
+            .query_transaction_blocks(query, None, Some(1), Some(true))
+            .await
+            .unwrap();
+        //
+        assert_eq!(1, res.data.len());
+        assert!(res.has_next_page);
+        //
+        let IotaTransactionBlockData::V1(tx_data_v1) = &res
+            .data
+            .first()
+            .as_ref()
+            .unwrap()
+            .transaction
+            .as_ref()
+            .unwrap()
+            .data;
+        assert_eq!(tx_data_v1.sender, IotaAddress::ZERO);
+
+        // Test `ConsensusCommitPrologueV1` transaction kind filter
+        let filter =
+            TransactionFilter::TransactionKind(IotaTransactionKind::ConsensusCommitPrologueV1);
+        let query = IotaTransactionBlockResponseQuery::new(Some(filter), Some(options.clone()));
+        let res = client
+            .query_transaction_blocks(query, None, Some(1), Some(true))
+            .await
+            .unwrap();
+        //
+        assert_eq!(1, res.data.len());
+        assert!(res.has_next_page);
+        //
+        let IotaTransactionBlockData::V1(tx_data_v1) = &res
+            .data
+            .first()
+            .as_ref()
+            .unwrap()
+            .transaction
+            .as_ref()
+            .unwrap()
+            .data;
+        assert!(matches!(
+            tx_data_v1.transaction,
+            IotaTransactionBlockKind::ConsensusCommitPrologueV1(_)
+        ));
+
+        // Test `TransactionKindIn` filter
+        let filter = TransactionFilter::TransactionKindIn(vec![
+            IotaTransactionKind::ConsensusCommitPrologueV1,
+            IotaTransactionKind::ProgrammableTransaction,
+        ]);
+        let query = IotaTransactionBlockResponseQuery::new(Some(filter), Some(options));
+        let res = client
+            .query_transaction_blocks(query, None, Some(2), Some(true))
+            .await
+            .unwrap();
+        //
+        assert_eq!(2, res.data.len());
+        assert!(res.has_next_page);
+        //
+        for tb_res in res.data.iter() {
+            let IotaTransactionBlockData::V1(tx_data_v1) =
+                &tb_res.transaction.as_ref().unwrap().data;
+            assert!(matches!(
+                tx_data_v1.transaction,
+                IotaTransactionBlockKind::ConsensusCommitPrologueV1(_)
+                    | IotaTransactionBlockKind::ProgrammableTransaction(_)
+            ));
+        }
 
         Ok(())
     })

--- a/crates/iota-json-rpc-types/Cargo.toml
+++ b/crates/iota-json-rpc-types/Cargo.toml
@@ -19,6 +19,7 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
+strum.workspace = true
 tabled.workspace = true
 tracing.workspace = true
 

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -2315,8 +2315,6 @@ pub enum TransactionFilter {
     FromOrToAddress { addr: IotaAddress },
     /// Query by transaction kind
     TransactionKind(u8),
-    /// Query transactions of any given kind in the input.
-    TransactionKindIn(Vec<u8>),
 }
 
 impl Filter<EffectsWithInput> for TransactionFilter {
@@ -2358,9 +2356,6 @@ impl Filter<EffectsWithInput> for TransactionFilter {
             }),
             TransactionFilter::TransactionKind(kind) => {
                 TransactionKindMatch::from(&item.input) as u8 == *kind
-            }
-            TransactionFilter::TransactionKindIn(kinds) => {
-                kinds.contains(&(TransactionKindMatch::from(&item.input) as u8))
             }
             // this filter is not supported, RPC will reject it on subscription
             TransactionFilter::Checkpoint(_) => false,

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -2357,10 +2357,10 @@ impl Filter<EffectsWithInput> for TransactionFilter {
                     && (function.is_none() || matches!(function, Some(f2) if f2 == &f.to_string()))
             }),
             TransactionFilter::TransactionKind(kind) => {
-                IotaTransactionKind::from(&item.input) as u8 == *kind
+                IotaTransactionKind::from(item.input.kind()) as u8 == *kind
             }
             TransactionFilter::TransactionKindIn(kinds) => {
-                kinds.contains(&(IotaTransactionKind::from(&item.input) as u8))
+                kinds.contains(&(IotaTransactionKind::from(item.input.kind()) as u8))
             }
             // this filter is not supported, RPC will reject it on subscription
             TransactionFilter::Checkpoint(_) => false,
@@ -2379,9 +2379,9 @@ pub enum IotaTransactionKind {
     ProgrammableTransaction = 5,
 }
 
-impl From<&TransactionData> for IotaTransactionKind {
-    fn from(transaction_data: &TransactionData) -> Self {
-        match transaction_data.kind() {
+impl From<&TransactionKind> for IotaTransactionKind {
+    fn from(kind: &TransactionKind) -> Self {
+        match kind {
             TransactionKind::Genesis(_) => Self::Genesis,
             TransactionKind::ConsensusCommitPrologueV1(_) => Self::ConsensusCommitPrologueV1,
             TransactionKind::AuthenticatorStateUpdateV1(_) => Self::AuthenticatorStateUpdateV1,

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -2369,12 +2369,15 @@ impl Filter<EffectsWithInput> for TransactionFilter {
     }
 }
 
-/// Represents the type of a transaction.
+/// Represents the type of a transaction. All transactions except
+/// `ProgrammableTransaction` are considered system transactions.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, EnumString, Display, Serialize, Deserialize, JsonSchema,
 )]
 #[non_exhaustive]
 pub enum IotaTransactionKind {
+    /// The `SystemTransaction` variant can be used to filter for all types of
+    /// system transactions.
     SystemTransaction = 0,
     ProgrammableTransaction = 1,
     Genesis = 2,
@@ -2382,6 +2385,13 @@ pub enum IotaTransactionKind {
     AuthenticatorStateUpdateV1 = 4,
     RandomnessStateUpdate = 5,
     EndOfEpochTransaction = 6,
+}
+
+impl IotaTransactionKind {
+    /// Returns true if the transaction is a system transaction.
+    pub fn is_system_transaction(&self) -> bool {
+        !matches!(self, Self::ProgrammableTransaction)
+    }
 }
 
 impl From<&TransactionKind> for IotaTransactionKind {

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -4,7 +4,6 @@
 
 use std::{
     fmt::{self, Display, Formatter, Write},
-    str::FromStr,
     sync::Arc,
 };
 
@@ -2316,9 +2315,9 @@ pub enum TransactionFilter {
     /// Query txs that have a given address as sender or recipient.
     FromOrToAddress { addr: IotaAddress },
     /// Query by transaction kind
-    TransactionKind(String),
+    TransactionKind(IotaTransactionKind),
     /// Query transactions of any given kind in the input.
-    TransactionKindIn(Vec<String>),
+    TransactionKindIn(Vec<IotaTransactionKind>),
 }
 
 impl Filter<EffectsWithInput> for TransactionFilter {
@@ -2358,14 +2357,12 @@ impl Filter<EffectsWithInput> for TransactionFilter {
                     && (module.is_none() || matches!(module,  Some(m2) if m2 == &m.to_string()))
                     && (function.is_none() || matches!(function, Some(f2) if f2 == &f.to_string()))
             }),
-            TransactionFilter::TransactionKind(kind) => IotaTransactionKind::from_str(kind)
-                .map(|kind| IotaTransactionKind::from(item.input.kind()) == kind)
-                .unwrap_or(false),
-            TransactionFilter::TransactionKindIn(kinds) => kinds.iter().any(|kind| {
-                IotaTransactionKind::from_str(kind)
-                    .map(|kind| IotaTransactionKind::from(item.input.kind()) == kind)
-                    .unwrap_or(false)
-            }),
+            TransactionFilter::TransactionKind(kind) => {
+                kind == &IotaTransactionKind::from(item.input.kind())
+            }
+            TransactionFilter::TransactionKindIn(kinds) => kinds
+                .iter()
+                .any(|kind| kind == &IotaTransactionKind::from(item.input.kind())),
             // this filter is not supported, RPC will reject it on subscription
             TransactionFilter::Checkpoint(_) => false,
         }
@@ -2373,7 +2370,9 @@ impl Filter<EffectsWithInput> for TransactionFilter {
 }
 
 /// Represents the type of a transaction.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString, Display)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, EnumString, Display, Serialize, Deserialize, JsonSchema,
+)]
 #[non_exhaustive]
 pub enum IotaTransactionKind {
     SystemTransaction = 0,
@@ -2383,7 +2382,6 @@ pub enum IotaTransactionKind {
     AuthenticatorStateUpdateV1 = 4,
     RandomnessStateUpdate = 5,
     EndOfEpochTransaction = 6,
-
 }
 
 impl From<&TransactionKind> for IotaTransactionKind {

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -2356,15 +2356,20 @@ impl Filter<EffectsWithInput> for TransactionFilter {
                     && (module.is_none() || matches!(module,  Some(m2) if m2 == &m.to_string()))
                     && (function.is_none() || matches!(function, Some(f2) if f2 == &f.to_string()))
             }),
-            TransactionFilter::TransactionKind(kind) => TransactionKindMatch::from(&item.input) as u8 == *kind,
-            TransactionFilter::TransactionKindIn(kinds) => kinds.contains(&(TransactionKindMatch::from(&item.input) as u8)),
+            TransactionFilter::TransactionKind(kind) => {
+                TransactionKindMatch::from(&item.input) as u8 == *kind
+            }
+            TransactionFilter::TransactionKindIn(kinds) => {
+                kinds.contains(&(TransactionKindMatch::from(&item.input) as u8))
+            }
             // this filter is not supported, RPC will reject it on subscription
             TransactionFilter::Checkpoint(_) => false,
         }
     }
 }
 
-/// Represents the type of a transaction, either a system transaction or a programmable transaction.
+/// Represents the type of a transaction, either a system transaction or a
+/// programmable transaction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TransactionKindMatch {
     SystemTransaction = 0,

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -2376,12 +2376,14 @@ impl Filter<EffectsWithInput> for TransactionFilter {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString, Display)]
 #[non_exhaustive]
 pub enum IotaTransactionKind {
-    Genesis = 0,
-    ConsensusCommitPrologueV1 = 1,
-    AuthenticatorStateUpdateV1 = 2,
-    RandomnessStateUpdate = 3,
-    EndOfEpochTransaction = 4,
-    ProgrammableTransaction = 5,
+    SystemTransaction = 0,
+    ProgrammableTransaction = 1,
+    Genesis = 2,
+    ConsensusCommitPrologueV1 = 3,
+    AuthenticatorStateUpdateV1 = 4,
+    RandomnessStateUpdate = 5,
+    EndOfEpochTransaction = 6,
+
 }
 
 impl From<&TransactionKind> for IotaTransactionKind {

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -2385,7 +2385,7 @@ pub enum IotaTransactionKind {
 }
 
 impl IotaTransactionKind {
-    const STRING_MAPPING: &'static [(&'static str, IotaTransactionKind)] = &[
+    const STRINGS: &'static [(&'static str, IotaTransactionKind)] = &[
         ("Genesis", IotaTransactionKind::Genesis),
         (
             "ConsensusCommitPrologueV1",
@@ -2411,7 +2411,7 @@ impl IotaTransactionKind {
 
     /// Returns the string representation of the transaction kind.
     pub fn as_str(self) -> &'static str {
-        Self::STRING_MAPPING
+        Self::STRINGS
             .iter()
             .find(|&&(_, kind)| kind == self)
             .unwrap()
@@ -2429,7 +2429,7 @@ impl FromStr for IotaTransactionKind {
     type Err = anyhow::Error;
 
     fn from_str(kind: &str) -> Result<Self, Self::Err> {
-        Self::STRING_MAPPING
+        Self::STRINGS
             .iter()
             .find(|&&(s, _)| s == kind)
             .map(|&(_, kind)| kind)

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -8,7 +8,6 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::anyhow;
 use enum_dispatch::enum_dispatch;
 use fastcrypto::encoding::Base64;
 use iota_json::{IotaJsonValue, primitive_type};
@@ -52,6 +51,7 @@ use move_core_types::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+use strum::{Display, EnumString};
 use tabled::{
     builder::Builder as TableBuilder,
     settings::{Panel as TablePanel, Style as TableStyle, style::HorizontalLine},
@@ -2373,7 +2373,7 @@ impl Filter<EffectsWithInput> for TransactionFilter {
 }
 
 /// Represents the type of a transaction.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString, Display)]
 #[non_exhaustive]
 pub enum IotaTransactionKind {
     Genesis = 0,
@@ -2382,59 +2382,6 @@ pub enum IotaTransactionKind {
     RandomnessStateUpdate = 3,
     EndOfEpochTransaction = 4,
     ProgrammableTransaction = 5,
-}
-
-impl IotaTransactionKind {
-    const STRINGS: &'static [(&'static str, IotaTransactionKind)] = &[
-        ("Genesis", IotaTransactionKind::Genesis),
-        (
-            "ConsensusCommitPrologueV1",
-            IotaTransactionKind::ConsensusCommitPrologueV1,
-        ),
-        (
-            "AuthenticatorStateUpdateV1",
-            IotaTransactionKind::AuthenticatorStateUpdateV1,
-        ),
-        (
-            "RandomnessStateUpdate",
-            IotaTransactionKind::RandomnessStateUpdate,
-        ),
-        (
-            "EndOfEpochTransaction",
-            IotaTransactionKind::EndOfEpochTransaction,
-        ),
-        (
-            "ProgrammableTransaction",
-            IotaTransactionKind::ProgrammableTransaction,
-        ),
-    ];
-
-    /// Returns the string representation of the transaction kind.
-    pub fn as_str(self) -> &'static str {
-        Self::STRINGS
-            .iter()
-            .find(|&&(_, kind)| kind == self)
-            .unwrap()
-            .0
-    }
-}
-
-impl Display for IotaTransactionKind {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_str())
-    }
-}
-
-impl FromStr for IotaTransactionKind {
-    type Err = anyhow::Error;
-
-    fn from_str(kind: &str) -> Result<Self, Self::Err> {
-        Self::STRINGS
-            .iter()
-            .find(|&&(s, _)| s == kind)
-            .map(|&(_, kind)| kind)
-            .ok_or_else(|| anyhow!("invalid transaction kind: {}", kind))
-    }
 }
 
 impl From<&TransactionKind> for IotaTransactionKind {

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -2314,9 +2314,9 @@ pub enum TransactionFilter {
     /// Query txs that have a given address as sender or recipient.
     FromOrToAddress { addr: IotaAddress },
     /// Query by transaction kind
-    TransactionKind(String),
+    TransactionKind(u8),
     /// Query transactions of any given kind in the input.
-    TransactionKindIn(Vec<String>),
+    TransactionKindIn(Vec<u8>),
 }
 
 impl Filter<EffectsWithInput> for TransactionFilter {
@@ -2356,12 +2356,27 @@ impl Filter<EffectsWithInput> for TransactionFilter {
                     && (module.is_none() || matches!(module,  Some(m2) if m2 == &m.to_string()))
                     && (function.is_none() || matches!(function, Some(f2) if f2 == &f.to_string()))
             }),
-            TransactionFilter::TransactionKind(kind) => item.input.kind().to_string() == *kind,
-            TransactionFilter::TransactionKindIn(kinds) => {
-                kinds.contains(&item.input.kind().to_string())
-            }
+            TransactionFilter::TransactionKind(kind) => TransactionKindMatch::from(&item.input) as u8 == *kind,
+            TransactionFilter::TransactionKindIn(kinds) => kinds.contains(&(TransactionKindMatch::from(&item.input) as u8)),
             // this filter is not supported, RPC will reject it on subscription
             TransactionFilter::Checkpoint(_) => false,
+        }
+    }
+}
+
+/// Represents the type of a transaction, either a system transaction or a programmable transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransactionKindMatch {
+    SystemTransaction = 0,
+    ProgrammableTransaction = 1,
+}
+
+impl From<&TransactionData> for TransactionKindMatch {
+    fn from(transaction_data: &TransactionData) -> Self {
+        if transaction_data.is_system_tx() {
+            Self::SystemTransaction
+        } else {
+            Self::ProgrammableTransaction
         }
     }
 }

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -2315,6 +2315,8 @@ pub enum TransactionFilter {
     FromOrToAddress { addr: IotaAddress },
     /// Query by transaction kind
     TransactionKind(u8),
+    /// Query transactions of any given kind in the input.
+    TransactionKindIn(Vec<u8>),
 }
 
 impl Filter<EffectsWithInput> for TransactionFilter {
@@ -2356,6 +2358,9 @@ impl Filter<EffectsWithInput> for TransactionFilter {
             }),
             TransactionFilter::TransactionKind(kind) => {
                 TransactionKindMatch::from(&item.input) as u8 == *kind
+            }
+            TransactionFilter::TransactionKindIn(kinds) => {
+                kinds.contains(&(TransactionKindMatch::from(&item.input) as u8))
             }
             // this filter is not supported, RPC will reject it on subscription
             TransactionFilter::Checkpoint(_) => false,

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -2357,10 +2357,10 @@ impl Filter<EffectsWithInput> for TransactionFilter {
                     && (function.is_none() || matches!(function, Some(f2) if f2 == &f.to_string()))
             }),
             TransactionFilter::TransactionKind(kind) => {
-                TransactionKindMatch::from(&item.input) as u8 == *kind
+                IotaTransactionKind::from(&item.input) as u8 == *kind
             }
             TransactionFilter::TransactionKindIn(kinds) => {
-                kinds.contains(&(TransactionKindMatch::from(&item.input) as u8))
+                kinds.contains(&(IotaTransactionKind::from(&item.input) as u8))
             }
             // this filter is not supported, RPC will reject it on subscription
             TransactionFilter::Checkpoint(_) => false,
@@ -2368,20 +2368,26 @@ impl Filter<EffectsWithInput> for TransactionFilter {
     }
 }
 
-/// Represents the type of a transaction, either a system transaction or a
-/// programmable transaction.
+/// Represents the type of a transaction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TransactionKindMatch {
-    SystemTransaction = 0,
-    ProgrammableTransaction = 1,
+pub enum IotaTransactionKind {
+    Genesis = 0,
+    ConsensusCommitPrologueV1 = 1,
+    AuthenticatorStateUpdateV1 = 2,
+    RandomnessStateUpdate = 3,
+    EndOfEpochTransaction = 4,
+    ProgrammableTransaction = 5,
 }
 
-impl From<&TransactionData> for TransactionKindMatch {
+impl From<&TransactionData> for IotaTransactionKind {
     fn from(transaction_data: &TransactionData) -> Self {
-        if transaction_data.is_system_tx() {
-            Self::SystemTransaction
-        } else {
-            Self::ProgrammableTransaction
+        match transaction_data.kind() {
+            TransactionKind::Genesis(_) => Self::Genesis,
+            TransactionKind::ConsensusCommitPrologueV1(_) => Self::ConsensusCommitPrologueV1,
+            TransactionKind::AuthenticatorStateUpdateV1(_) => Self::AuthenticatorStateUpdateV1,
+            TransactionKind::RandomnessStateUpdate(_) => Self::RandomnessStateUpdate,
+            TransactionKind::EndOfEpochTransaction(_) => Self::EndOfEpochTransaction,
+            TransactionKind::ProgrammableTransaction(_) => Self::ProgrammableTransaction,
         }
     }
 }

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -4,9 +4,11 @@
 
 use std::{
     fmt::{self, Display, Formatter, Write},
+    str::FromStr,
     sync::Arc,
 };
 
+use anyhow::anyhow;
 use enum_dispatch::enum_dispatch;
 use fastcrypto::encoding::Base64;
 use iota_json::{IotaJsonValue, primitive_type};
@@ -2314,9 +2316,9 @@ pub enum TransactionFilter {
     /// Query txs that have a given address as sender or recipient.
     FromOrToAddress { addr: IotaAddress },
     /// Query by transaction kind
-    TransactionKind(u8),
+    TransactionKind(String),
     /// Query transactions of any given kind in the input.
-    TransactionKindIn(Vec<u8>),
+    TransactionKindIn(Vec<String>),
 }
 
 impl Filter<EffectsWithInput> for TransactionFilter {
@@ -2356,12 +2358,14 @@ impl Filter<EffectsWithInput> for TransactionFilter {
                     && (module.is_none() || matches!(module,  Some(m2) if m2 == &m.to_string()))
                     && (function.is_none() || matches!(function, Some(f2) if f2 == &f.to_string()))
             }),
-            TransactionFilter::TransactionKind(kind) => {
-                IotaTransactionKind::from(item.input.kind()) as u8 == *kind
-            }
-            TransactionFilter::TransactionKindIn(kinds) => {
-                kinds.contains(&(IotaTransactionKind::from(item.input.kind()) as u8))
-            }
+            TransactionFilter::TransactionKind(kind) => IotaTransactionKind::from_str(kind)
+                .map(|kind| IotaTransactionKind::from(item.input.kind()) == kind)
+                .unwrap_or(false),
+            TransactionFilter::TransactionKindIn(kinds) => kinds.iter().any(|kind| {
+                IotaTransactionKind::from_str(kind)
+                    .map(|kind| IotaTransactionKind::from(item.input.kind()) == kind)
+                    .unwrap_or(false)
+            }),
             // this filter is not supported, RPC will reject it on subscription
             TransactionFilter::Checkpoint(_) => false,
         }
@@ -2370,6 +2374,7 @@ impl Filter<EffectsWithInput> for TransactionFilter {
 
 /// Represents the type of a transaction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum IotaTransactionKind {
     Genesis = 0,
     ConsensusCommitPrologueV1 = 1,
@@ -2377,6 +2382,59 @@ pub enum IotaTransactionKind {
     RandomnessStateUpdate = 3,
     EndOfEpochTransaction = 4,
     ProgrammableTransaction = 5,
+}
+
+impl IotaTransactionKind {
+    const STRING_MAPPING: &'static [(&'static str, IotaTransactionKind)] = &[
+        ("Genesis", IotaTransactionKind::Genesis),
+        (
+            "ConsensusCommitPrologueV1",
+            IotaTransactionKind::ConsensusCommitPrologueV1,
+        ),
+        (
+            "AuthenticatorStateUpdateV1",
+            IotaTransactionKind::AuthenticatorStateUpdateV1,
+        ),
+        (
+            "RandomnessStateUpdate",
+            IotaTransactionKind::RandomnessStateUpdate,
+        ),
+        (
+            "EndOfEpochTransaction",
+            IotaTransactionKind::EndOfEpochTransaction,
+        ),
+        (
+            "ProgrammableTransaction",
+            IotaTransactionKind::ProgrammableTransaction,
+        ),
+    ];
+
+    /// Returns the string representation of the transaction kind.
+    pub fn as_str(self) -> &'static str {
+        Self::STRING_MAPPING
+            .iter()
+            .find(|&&(_, kind)| kind == self)
+            .unwrap()
+            .0
+    }
+}
+
+impl Display for IotaTransactionKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl FromStr for IotaTransactionKind {
+    type Err = anyhow::Error;
+
+    fn from_str(kind: &str) -> Result<Self, Self::Err> {
+        Self::STRING_MAPPING
+            .iter()
+            .find(|&&(s, _)| s == kind)
+            .map(|&(_, kind)| kind)
+            .ok_or_else(|| anyhow!("invalid transaction kind: {}", kind))
+    }
 }
 
 impl From<&TransactionKind> for IotaTransactionKind {

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -11709,9 +11709,7 @@
             ],
             "properties": {
               "TransactionKind": {
-                "type": "integer",
-                "format": "uint8",
-                "minimum": 0.0
+                "type": "string"
               }
             },
             "additionalProperties": false
@@ -11726,9 +11724,7 @@
               "TransactionKindIn": {
                 "type": "array",
                 "items": {
-                  "type": "integer",
-                  "format": "uint8",
-                  "minimum": 0.0
+                  "type": "string"
                 }
               }
             },

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -8827,7 +8827,7 @@
             ]
           },
           {
-            "description": "`SystemTransaction` is only used for backward compatibility reasons, as earlier versions of the indexer did not distinguish between different system transactions.",
+            "description": "The `SystemTransaction` variant can be used to filter for all types of system transactions.",
             "type": "string",
             "enum": [
               "SystemTransaction"

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -11715,6 +11715,24 @@
               }
             },
             "additionalProperties": false
+          },
+          {
+            "description": "Query transactions of any given kind in the input.",
+            "type": "object",
+            "required": [
+              "TransactionKindIn"
+            ],
+            "properties": {
+              "TransactionKindIn": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0.0
+                }
+              }
+            },
+            "additionalProperties": false
           }
         ]
       },

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -8812,6 +8812,19 @@
           }
         ]
       },
+      "IotaTransactionKind": {
+        "description": "Represents the type of a transaction.",
+        "type": "string",
+        "enum": [
+          "SystemTransaction",
+          "ProgrammableTransaction",
+          "Genesis",
+          "ConsensusCommitPrologueV1",
+          "AuthenticatorStateUpdateV1",
+          "RandomnessStateUpdate",
+          "EndOfEpochTransaction"
+        ]
+      },
       "IotaValidatorSummary": {
         "description": "This is the JSON-RPC type for the IOTA validator. It flattens all inner structures to top-level fields so that they are decoupled from the internal definitions.",
         "type": "object",
@@ -11709,7 +11722,7 @@
             ],
             "properties": {
               "TransactionKind": {
-                "type": "string"
+                "$ref": "#/components/schemas/IotaTransactionKind"
               }
             },
             "additionalProperties": false
@@ -11724,7 +11737,7 @@
               "TransactionKindIn": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/IotaTransactionKind"
                 }
               }
             },

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -11715,24 +11715,6 @@
               }
             },
             "additionalProperties": false
-          },
-          {
-            "description": "Query transactions of any given kind in the input.",
-            "type": "object",
-            "required": [
-              "TransactionKindIn"
-            ],
-            "properties": {
-              "TransactionKindIn": {
-                "type": "array",
-                "items": {
-                  "type": "integer",
-                  "format": "uint8",
-                  "minimum": 0.0
-                }
-              }
-            },
-            "additionalProperties": false
           }
         ]
       },

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -11709,7 +11709,9 @@
             ],
             "properties": {
               "TransactionKind": {
-                "type": "string"
+                "type": "integer",
+                "format": "uint8",
+                "minimum": 0.0
               }
             },
             "additionalProperties": false
@@ -11724,7 +11726,9 @@
               "TransactionKindIn": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0.0
                 }
               }
             },

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -8813,16 +8813,26 @@
         ]
       },
       "IotaTransactionKind": {
-        "description": "Represents the type of a transaction.",
-        "type": "string",
-        "enum": [
-          "SystemTransaction",
-          "ProgrammableTransaction",
-          "Genesis",
-          "ConsensusCommitPrologueV1",
-          "AuthenticatorStateUpdateV1",
-          "RandomnessStateUpdate",
-          "EndOfEpochTransaction"
+        "description": "Represents the type of a transaction. All transactions except `ProgrammableTransaction` are considered system transactions.",
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "ProgrammableTransaction",
+              "Genesis",
+              "ConsensusCommitPrologueV1",
+              "AuthenticatorStateUpdateV1",
+              "RandomnessStateUpdate",
+              "EndOfEpochTransaction"
+            ]
+          },
+          {
+            "description": "`SystemTransaction` is only used for backward compatibility reasons, as earlier versions of the indexer did not distinguish between different system transactions.",
+            "type": "string",
+            "enum": [
+              "SystemTransaction"
+            ]
+          }
         ]
       },
       "IotaValidatorSummary": {


### PR DESCRIPTION
# Description of change

Implements the `TransactionFilter::TransactionKind{s}` filters so that they can be used in the `query_transaction_blocks_impl`.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/4717

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Manual SQL tests on the indexer database and `curl` requests.

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
