### PR TITLE
fix(node): Abort checkpoint service tasks on epoch change

### DIFF
--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -919,11 +919,9 @@ impl CheckpointBuilder {
     async fn run(mut self) {
         info!("Starting CheckpointBuilder");
         loop {
-            loop {
-                self.maybe_build_checkpoints().await;
+            self.maybe_build_checkpoints().await;
 
-                self.notify.notified().await;
-            }
+            self.notify.notified().await;
         }
     }
 

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -18,10 +18,6 @@ use std::{
 
 use chrono::Utc;
 use diffy::create_patch;
-use futures::{
-    FutureExt,
-    future::{Either, select},
-};
 use iota_macros::fail_point;
 use iota_metrics::{MonitoredFutureExt, monitored_future, monitored_scope};
 use iota_network::default_iota_network_config;
@@ -56,11 +52,7 @@ use itertools::Itertools;
 use parking_lot::Mutex;
 use rand::{rngs::OsRng, seq::SliceRandom};
 use serde::{Deserialize, Serialize};
-use tokio::{
-    sync::{Notify, watch},
-    task::JoinSet,
-    time::timeout,
-};
+use tokio::{sync::Notify, task::JoinSet, time::timeout};
 use tracing::{debug, error, info, instrument, warn};
 use typed_store::{
     DBMapUtils, Map, TypedStoreError,
@@ -866,7 +858,6 @@ pub struct CheckpointBuilder {
     effects_store: Arc<dyn TransactionCacheRead>,
     accumulator: Weak<StateAccumulator>,
     output: Box<dyn CheckpointOutput>,
-    exit: watch::Receiver<()>,
     metrics: Arc<CheckpointMetrics>,
     max_transactions_per_checkpoint: usize,
     max_checkpoint_size_bytes: usize,
@@ -876,7 +867,6 @@ pub struct CheckpointAggregator {
     tables: Arc<CheckpointStore>,
     epoch_store: Arc<AuthorityPerEpochStore>,
     notify: Arc<Notify>,
-    exit: watch::Receiver<()>,
     current: Option<CheckpointSignatureAggregator>,
     output: Box<dyn CertifiedCheckpointOutput>,
     state: Arc<AuthorityState>,
@@ -904,7 +894,6 @@ impl CheckpointBuilder {
         effects_store: Arc<dyn TransactionCacheRead>,
         accumulator: Weak<StateAccumulator>,
         output: Box<dyn CheckpointOutput>,
-        exit: watch::Receiver<()>,
         notify_aggregator: Arc<Notify>,
         metrics: Arc<CheckpointMetrics>,
         max_transactions_per_checkpoint: usize,
@@ -918,7 +907,6 @@ impl CheckpointBuilder {
             effects_store,
             accumulator,
             output,
-            exit,
             notify_aggregator,
             metrics,
             max_transactions_per_checkpoint,
@@ -930,41 +918,43 @@ impl CheckpointBuilder {
     /// creation of checkpoints.
     async fn run(mut self) {
         info!("Starting CheckpointBuilder");
-        'main: loop {
-            // Check whether an exit signal has been received, if so we break the loop.
-            // This gives us a chance to exit, in case checkpoint making keeps failing.
-            match self.exit.has_changed() {
-                Ok(true) | Err(_) => {
-                    break;
-                }
-                Ok(false) => (),
-            };
+        loop {
+            loop {
+                self.maybe_build_checkpoints().await;
 
-            // Collect info about the most recently built checkpoint.
-            let summary = self
-                .epoch_store
-                .last_built_checkpoint_builder_summary()
-                .expect("epoch should not have ended");
-            let mut last_height = summary.clone().and_then(|s| s.checkpoint_height);
-            let mut last_timestamp = summary.map(|s| s.summary.timestamp_ms);
+                self.notify.notified().await;
+            }
+        }
+    }
 
-            let min_checkpoint_interval_ms = self
-                .epoch_store
-                .protocol_config()
-                .min_checkpoint_interval_ms_as_option()
-                .unwrap_or_default();
-            let mut grouped_pending_checkpoints = Vec::new();
-            let mut checkpoints_iter = self
-                .epoch_store
-                .get_pending_checkpoints(last_height)
-                .expect("unexpected epoch store error")
-                .into_iter()
-                .peekable();
-            while let Some((height, pending)) = checkpoints_iter.next() {
-                // Group PendingCheckpoints until:
-                // - minimum interval has elapsed ...
-                let current_timestamp = pending.details().timestamp_ms;
-                let can_build = match last_timestamp {
+    async fn maybe_build_checkpoints(&mut self) {
+        let _scope = monitored_scope("BuildCheckpoints");
+
+        // Collect info about the most recently built checkpoint.
+        let summary = self
+            .epoch_store
+            .last_built_checkpoint_builder_summary()
+            .expect("epoch should not have ended");
+        let mut last_height = summary.clone().and_then(|s| s.checkpoint_height);
+        let mut last_timestamp = summary.map(|s| s.summary.timestamp_ms);
+
+        let min_checkpoint_interval_ms = self
+            .epoch_store
+            .protocol_config()
+            .min_checkpoint_interval_ms_as_option()
+            .unwrap_or_default();
+        let mut grouped_pending_checkpoints = Vec::new();
+        let mut checkpoints_iter = self
+            .epoch_store
+            .get_pending_checkpoints(last_height)
+            .expect("unexpected epoch store error")
+            .into_iter()
+            .peekable();
+        while let Some((height, pending)) = checkpoints_iter.next() {
+            // Group PendingCheckpoints until:
+            // - minimum interval has elapsed ...
+            let current_timestamp = pending.details().timestamp_ms;
+            let can_build = match last_timestamp {
                     Some(last_timestamp) => {
                         current_timestamp >= last_timestamp + min_checkpoint_interval_ms
                     }
@@ -976,47 +966,38 @@ impl CheckpointBuilder {
                     .is_some_and(|(_, next_pending)| next_pending.details().last_of_epoch)
                 // - or, we have reached end of epoch.
                     || pending.details().last_of_epoch;
-                grouped_pending_checkpoints.push(pending);
-                if !can_build {
-                    debug!(
-                        checkpoint_commit_height = height,
-                        ?last_timestamp,
-                        ?current_timestamp,
-                        "waiting for more PendingCheckpoints: minimum interval not yet elapsed"
-                    );
-                    continue;
-                }
-
-                // Min interval has elapsed, we can now coalesce and build a checkpoint.
-                last_height = Some(height);
-                last_timestamp = Some(current_timestamp);
+            grouped_pending_checkpoints.push(pending);
+            if !can_build {
                 debug!(
                     checkpoint_commit_height = height,
-                    "Making checkpoint at commit height"
+                    ?last_timestamp,
+                    ?current_timestamp,
+                    "waiting for more PendingCheckpoints: minimum interval not yet elapsed"
                 );
-                if let Err(e) = self
-                    .make_checkpoint(std::mem::take(&mut grouped_pending_checkpoints))
-                    .await
-                {
-                    error!("Error while making checkpoint, will retry in 1s: {:?}", e);
-                    tokio::time::sleep(Duration::from_secs(1)).await;
-                    self.metrics.checkpoint_errors.inc();
-                    continue 'main;
-                }
+                continue;
             }
+
+            // Min interval has elapsed, we can now coalesce and build a checkpoint.
+            last_height = Some(height);
+            last_timestamp = Some(current_timestamp);
             debug!(
-                "Waiting for more checkpoints from consensus after processing {last_height:?}; {} pending checkpoints left unprocessed until next interval",
-                grouped_pending_checkpoints.len(),
+                checkpoint_commit_height = height,
+                "Making checkpoint at commit height"
             );
-            match select(self.exit.changed().boxed(), self.notify.notified().boxed()).await {
-                Either::Left(_) => {
-                    // break loop on exit signal
-                    break;
-                }
-                Either::Right(_) => {}
+            if let Err(e) = self
+                .make_checkpoint(std::mem::take(&mut grouped_pending_checkpoints))
+                .await
+            {
+                error!("Error while making checkpoint, will retry in 1s: {:?}", e);
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                self.metrics.checkpoint_errors.inc();
+                return;
             }
         }
-        info!("Shutting down CheckpointBuilder");
+        debug!(
+            "Waiting for more checkpoints from consensus after processing {last_height:?}; {} pending checkpoints left unprocessed until next interval",
+            grouped_pending_checkpoints.len(),
+        );
     }
 
     #[instrument(level = "debug", skip_all, fields(last_height = pendings.last().unwrap().details().checkpoint_height))]
@@ -1759,7 +1740,6 @@ impl CheckpointAggregator {
         tables: Arc<CheckpointStore>,
         epoch_store: Arc<AuthorityPerEpochStore>,
         notify: Arc<Notify>,
-        exit: watch::Receiver<()>,
         output: Box<dyn CertifiedCheckpointOutput>,
         state: Arc<AuthorityState>,
         metrics: Arc<CheckpointMetrics>,
@@ -1769,7 +1749,6 @@ impl CheckpointAggregator {
             tables,
             epoch_store,
             notify,
-            exit,
             current,
             output,
             state,
@@ -1795,19 +1774,7 @@ impl CheckpointAggregator {
                 continue;
             }
 
-            match select(
-                self.exit.changed().boxed(),
-                timeout(Duration::from_secs(1), self.notify.notified()).boxed(),
-            )
-            .await
-            {
-                Either::Left(_) => {
-                    // return on exit signal
-                    info!("Shutting down CheckpointAggregator");
-                    return;
-                }
-                Either::Right(_) => {}
-            }
+            let _ = timeout(Duration::from_secs(1), self.notify.notified()).await;
         }
     }
 
@@ -2240,18 +2207,12 @@ impl CheckpointService {
         metrics: Arc<CheckpointMetrics>,
         max_transactions_per_checkpoint: usize,
         max_checkpoint_size_bytes: usize,
-    ) -> (
-        Arc<Self>,
-        watch::Sender<()>, // The exit sender
-        JoinSet<()>,       // Handle to tasks
-    ) {
+    ) -> (Arc<Self>, JoinSet<()> /* Handle to tasks */) {
         info!(
             "Starting checkpoint service with {max_transactions_per_checkpoint} max_transactions_per_checkpoint and {max_checkpoint_size_bytes} max_checkpoint_size_bytes"
         );
         let notify_builder = Arc::new(Notify::new());
         let notify_aggregator = Arc::new(Notify::new());
-
-        let (exit_snd, exit_rcv) = watch::channel(());
 
         let mut tasks = JoinSet::new();
 
@@ -2263,22 +2224,17 @@ impl CheckpointService {
             effects_store,
             accumulator,
             checkpoint_output,
-            exit_rcv.clone(),
             notify_aggregator.clone(),
             metrics.clone(),
             max_transactions_per_checkpoint,
             max_checkpoint_size_bytes,
         );
-        let epoch_store_clone = epoch_store.clone();
-        tasks.spawn(monitored_future!(async move {
-            let _ = epoch_store_clone.within_alive_epoch(builder.run()).await;
-        }));
+        tasks.spawn(monitored_future!(builder.run()));
 
         let aggregator = CheckpointAggregator::new(
             checkpoint_store.clone(),
             epoch_store.clone(),
             notify_aggregator.clone(),
-            exit_rcv,
             certified_checkpoint_output,
             state.clone(),
             metrics.clone(),
@@ -2298,7 +2254,7 @@ impl CheckpointService {
             metrics,
         });
 
-        (service, exit_snd, tasks)
+        (service, tasks)
     }
 
     #[cfg(test)]
@@ -2393,7 +2349,7 @@ mod tests {
         ops::Deref,
     };
 
-    use futures::future::BoxFuture;
+    use futures::{FutureExt as _, future::BoxFuture};
     use iota_macros::sim_test;
     use iota_protocol_config::{Chain, ProtocolConfig};
     use iota_types::{
@@ -2530,7 +2486,7 @@ mod tests {
             state.get_accumulator_store().clone(),
         ));
 
-        let (checkpoint_service, _exit_sender, _tasks) = CheckpointService::spawn(
+        let (checkpoint_service, _tasks) = CheckpointService::spawn(
             state.clone(),
             checkpoint_store,
             epoch_store.clone(),

--- a/crates/iota-core/src/unit_tests/mysticeti_manager_tests.rs
+++ b/crates/iota-core/src/unit_tests/mysticeti_manager_tests.rs
@@ -33,7 +33,7 @@ pub fn checkpoint_service_for_testing(state: Arc<AuthorityState>) -> Arc<Checkpo
     ));
     let (certified_output, _certified_result) = mpsc::channel::<CertifiedCheckpointSummary>(10);
 
-    let (checkpoint_service, _, _) = CheckpointService::spawn(
+    let (checkpoint_service, _) = CheckpointService::spawn(
         state.clone(),
         state.get_checkpoint_store().clone(),
         epoch_store.clone(),

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1663,6 +1663,7 @@ impl IotaNode {
                     }
                 }
                 info!("Checkpoint service has shut down.");
+
                 consensus_manager.shutdown().await;
                 info!("Consensus has shut down.");
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -25,7 +25,6 @@ use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId, OIDCProvider};
 use futures::TryFutureExt;
 pub use handle::IotaNodeHandle;
 use iota_archival::{reader::ArchiveReaderBalancer, writer::ArchiveWriter};
-use iota_common::debug_fatal;
 use iota_config::{
     ConsensusConfig, NodeConfig,
     node::{DBCheckpointConfig, RunWithRange},
@@ -125,7 +124,6 @@ use tokio::{
     runtime::Handle,
     sync::{Mutex, broadcast, mpsc, watch},
     task::{JoinHandle, JoinSet},
-    time::timeout,
 };
 use tower::ServiceBuilder;
 use tracing::{Instrument, debug, error, error_span, info, warn};
@@ -143,10 +141,6 @@ pub struct ValidatorComponents {
     consensus_manager: ConsensusManager,
     consensus_store_pruner: ConsensusStorePruner,
     consensus_adapter: Arc<ConsensusAdapter>,
-    // Sending to the channel or dropping this will eventually stop checkpoint tasks.
-    // The receiver side of this channel is copied into each checkpoint service task,
-    // and they are listening to any change to this channel.
-    checkpoint_service_exit: watch::Sender<()>,
     // Keeping the handle to the checkpoint service tasks to shut them down during reconfiguration.
     checkpoint_service_tasks: JoinSet<()>,
     checkpoint_metrics: Arc<CheckpointMetrics>,
@@ -1277,17 +1271,16 @@ impl IotaNode {
         iota_node_metrics: Arc<IotaNodeMetrics>,
         iota_tx_validator_metrics: Arc<IotaTxValidatorMetrics>,
     ) -> Result<ValidatorComponents> {
-        let (checkpoint_service, checkpoint_service_exit, checkpoint_service_tasks) =
-            Self::start_checkpoint_service(
-                config,
-                consensus_adapter.clone(),
-                checkpoint_store,
-                epoch_store.clone(),
-                state.clone(),
-                state_sync_handle,
-                accumulator,
-                checkpoint_metrics.clone(),
-            );
+        let (checkpoint_service, checkpoint_service_tasks) = Self::start_checkpoint_service(
+            config,
+            consensus_adapter.clone(),
+            checkpoint_store,
+            epoch_store.clone(),
+            state.clone(),
+            state_sync_handle,
+            accumulator,
+            checkpoint_metrics.clone(),
+        );
 
         // create a new map that gets injected into both the consensus handler and the
         // consensus adapter the consensus handler will write values forwarded
@@ -1347,7 +1340,6 @@ impl IotaNode {
             consensus_manager,
             consensus_store_pruner,
             consensus_adapter,
-            checkpoint_service_exit,
             checkpoint_service_tasks,
             checkpoint_metrics,
             iota_tx_validator_metrics,
@@ -1369,7 +1361,7 @@ impl IotaNode {
         state_sync_handle: state_sync::Handle,
         accumulator: Weak<StateAccumulator>,
         checkpoint_metrics: Arc<CheckpointMetrics>,
-    ) -> (Arc<CheckpointService>, watch::Sender<()>, JoinSet<()>) {
+    ) -> (Arc<CheckpointService>, JoinSet<()>) {
         let epoch_start_timestamp_ms = epoch_store.epoch_start_state().epoch_start_timestamp_ms();
         let epoch_duration_ms = epoch_store.epoch_start_state().epoch_duration_ms();
 
@@ -1651,32 +1643,26 @@ impl IotaNode {
                 consensus_manager,
                 consensus_store_pruner,
                 consensus_adapter,
-                checkpoint_service_exit,
                 mut checkpoint_service_tasks,
                 checkpoint_metrics,
                 iota_tx_validator_metrics,
             }) = self.validator_components.lock().await.take()
             {
                 info!("Reconfiguring the validator.");
-                // Stop the old checkpoint service and wait for them to finish.
-                let _ = checkpoint_service_exit.send(());
-                let wait_result = timeout(Duration::from_secs(5), async move {
-                    while let Some(result) = checkpoint_service_tasks.join_next().await {
-                        if let Err(err) = result {
-                            if err.is_panic() {
-                                std::panic::resume_unwind(err.into_panic());
-                            }
-                            warn!("Error in checkpoint service task: {:?}", err);
+                // Cancel the old checkpoint service tasks.
+                // Waiting for checkpoint builder to finish gracefully is not possible, because
+                // it may wait on transactions while consensus on peers have
+                // already shut down.
+                checkpoint_service_tasks.abort_all();
+                while let Some(result) = checkpoint_service_tasks.join_next().await {
+                    if let Err(err) = result {
+                        if err.is_panic() {
+                            std::panic::resume_unwind(err.into_panic());
                         }
+                        warn!("Error in checkpoint service task: {:?}", err);
                     }
-                })
-                .await;
-                if wait_result.is_err() {
-                    debug_fatal!("Timed out waiting for checkpoint service tasks to finish.");
-                } else {
-                    info!("Checkpoint service has shut down.");
                 }
-
+                info!("Checkpoint service has shut down.");
                 consensus_manager.shutdown().await;
                 info!("Consensus has shut down.");
 


### PR DESCRIPTION
# Description of change

Abort checkpoint service tasks on epoch change, from [Abort checkpoint service tasks on epoch change (#19915) · MystenLabs/sui@5102c1b](https://github.com/MystenLabs/sui/commit/5102c1bc461f619746b8a216f8d9549f7a4bb840).

**NOTE**: there is an additional pre-required change for `crates/iota-core/src/checkpoints/mod.rs` in [Add monitored scope for single threaded checkpoint builder #19197](https://github.com/MystenLabs/sui/pull/19197), also included in this PR. Because the [#19197](https://github.com/MystenLabs/sui/pull/19197) is a PR that only modifies the `crates/iota-core/src/checkpoints/mod.rs`, and then is overwritten by [#19915](https://github.com/MystenLabs/sui/commit/5102c1bc461f619746b8a216f8d9549f7a4bb840), I simply included both of them.)

## Links to any relevant issues

fixes #4692 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Ran the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
