### PR TITLE
fix(iota-genesis-builder): add treasury filtration in order to avoid failing of migration process

### DIFF
--- a/crates/iota-genesis-builder/src/stardust/migration/verification/mod.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/mod.rs
@@ -35,33 +35,34 @@ pub(crate) fn verify_outputs<'a>(
     address_swap_map: &AddressSwapMap,
 ) -> anyhow::Result<()> {
     let mut tokens_counter = TokensAmountCounter::new(total_supply);
-    for (header, output) in outputs {
-        if !output.is_treasury() {
-            let created_objects = output_objects_map.get(&header.output_id()).ok_or_else(|| {
-                anyhow!("missing created objects for output {}", header.output_id())
-            })?;
-            verify_output(
-                header,
-                output,
-                created_objects,
-                foundry_data,
-                target_milestone_timestamp,
-                storage,
-                &mut tokens_counter,
-                address_swap_map,
-            )?;
-        }
-        for (key, (total_value, expected_value)) in tokens_counter.into_inner() {
-            if key == BASE_TOKEN_KEY {
-                ensure!(
-                    total_value == expected_value,
-                    "base token total supply: found {total_value}, expected {expected_value}"
-                )
-            } else if expected_value != total_value {
-                warn!(
-                    "total supply mismatch for {key}: found {total_value}, expected {expected_value}"
-                );
-            }
+    for (header, output) in outputs
+        .into_iter()
+        .filter(|(_, output)| !output.is_treasury())
+    {
+        let created_objects = output_objects_map
+            .get(&header.output_id())
+            .ok_or_else(|| anyhow!("missing created objects for output {}", header.output_id()))?;
+        verify_output(
+            header,
+            output,
+            created_objects,
+            foundry_data,
+            target_milestone_timestamp,
+            storage,
+            &mut tokens_counter,
+            address_swap_map,
+        )?;
+    }
+    for (key, (total_value, expected_value)) in tokens_counter.into_inner() {
+        if key == BASE_TOKEN_KEY {
+            ensure!(
+                total_value == expected_value,
+                "base token total supply: found {total_value}, expected {expected_value}"
+            )
+        } else if expected_value != total_value {
+            warn!(
+                "total supply mismatch for {key}: found {total_value}, expected {expected_value}"
+            );
         }
     }
     Ok(())

--- a/crates/iota-genesis-builder/src/stardust/migration/verification/mod.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/mod.rs
@@ -36,30 +36,32 @@ pub(crate) fn verify_outputs<'a>(
 ) -> anyhow::Result<()> {
     let mut tokens_counter = TokensAmountCounter::new(total_supply);
     for (header, output) in outputs {
-        let created_objects = output_objects_map
-            .get(&header.output_id())
-            .ok_or_else(|| anyhow!("missing created objects for output {}", header.output_id()))?;
-        verify_output(
-            header,
-            output,
-            created_objects,
-            foundry_data,
-            target_milestone_timestamp,
-            storage,
-            &mut tokens_counter,
-            address_swap_map,
-        )?;
-    }
-    for (key, (total_value, expected_value)) in tokens_counter.into_inner() {
-        if key == BASE_TOKEN_KEY {
-            ensure!(
-                total_value == expected_value,
-                "base token total supply: found {total_value}, expected {expected_value}"
-            )
-        } else if expected_value != total_value {
-            warn!(
-                "total supply mismatch for {key}: found {total_value}, expected {expected_value}"
-            );
+        if !output.is_treasury() {
+            let created_objects = output_objects_map.get(&header.output_id()).ok_or_else(|| {
+                anyhow!("missing created objects for output {}", header.output_id())
+            })?;
+            verify_output(
+                header,
+                output,
+                created_objects,
+                foundry_data,
+                target_milestone_timestamp,
+                storage,
+                &mut tokens_counter,
+                address_swap_map,
+            )?;
+        }
+        for (key, (total_value, expected_value)) in tokens_counter.into_inner() {
+            if key == BASE_TOKEN_KEY {
+                ensure!(
+                    total_value == expected_value,
+                    "base token total supply: found {total_value}, expected {expected_value}"
+                )
+            } else if expected_value != total_value {
+                warn!(
+                    "total supply mismatch for {key}: found {total_value}, expected {expected_value}"
+                );
+            }
         }
     }
     Ok(())


### PR DESCRIPTION
# Description of change

According to audit [issue](https://github.com/orgs/iotaledger/projects/79/views/26?pane=issue&itemId=96304369&issue=iotaledger%7Ciota-private%7C52), TreasuryOutput has been filtered during verification step.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota-private/issues/52 .

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

