### PR TITLE
fix(move-stdlib): print string instead of bytes

### DIFF
--- a/crates/iota-framework/packages/move-stdlib/sources/unit_test.move
+++ b/crates/iota-framework/packages/move-stdlib/sources/unit_test.move
@@ -25,9 +25,9 @@ module std::unit_test {
         let t2 = $t2;
         let res = t1 == t2;
         if (!res) {
-            std::debug::print(&b"Assertion failed:");
+            std::debug::print(&b"Assertion failed:".to_string());
             std::debug::print(t1);
-            std::debug::print(&b"!=");
+            std::debug::print(&b"!=".to_string());
             std::debug::print(t2);
             assert!(false);
         }


### PR DESCRIPTION
# Description of change

Now prints the actual string representation of the bytes instead of only the byte representation.

## Links to any relevant issues

fixes #5135 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
