### PR TITLE
refactor(json-rpc): support new system state summary

### DIFF
--- a/crates/iota-json-rpc-api/src/governance.rs
+++ b/crates/iota-json-rpc-api/src/governance.rs
@@ -7,7 +7,9 @@ use iota_open_rpc_macros::open_rpc;
 use iota_types::{
     base_types::{IotaAddress, ObjectID},
     iota_serde::BigInt,
-    iota_system_state::iota_system_state_summary::IotaSystemStateSummary,
+    iota_system_state::iota_system_state_summary::{
+        IotaSystemStateSummaryV1, IotaSystemStateSummaryV2,
+    },
 };
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
@@ -53,7 +55,13 @@ pub trait GovernanceReadApi {
 
     /// Return the latest IOTA system state object on-chain.
     #[method(name = "getLatestIotaSystemState")]
-    async fn get_latest_iota_system_state(&self) -> RpcResult<IotaSystemStateSummary>;
+    async fn get_latest_iota_system_state(&self) -> RpcResult<IotaSystemStateSummaryV2>;
+
+    /// Return the latest IOTA system state object on-chain (version 1).
+    /// Requires the `client-target-api-version` header to be set into
+    /// a value `<= 0.10` during requests.
+    #[method(name = "getLatestIotaSystemState", version <= "0.10")]
+    async fn get_latest_iota_system_state_v1(&self) -> RpcResult<IotaSystemStateSummaryV1>;
 
     /// Return the reference gas price for the network
     #[method(name = "getReferenceGasPrice")]

--- a/crates/iota-json-rpc-api/src/governance.rs
+++ b/crates/iota-json-rpc-api/src/governance.rs
@@ -59,8 +59,8 @@ pub trait GovernanceReadApi {
 
     /// Return the latest IOTA system state object on-chain (version 1).
     /// Requires the `client-target-api-version` header to be set into
-    /// a value `<= 0.10` during requests.
-    #[method(name = "getLatestIotaSystemState", version <= "0.10")]
+    /// a value `< 0.11` during requests.
+    #[method(name = "getLatestIotaSystemState", version <= "0.10.99")]
     async fn get_latest_iota_system_state_v1(&self) -> RpcResult<IotaSystemStateSummaryV1>;
 
     /// Return the reference gas price for the network

--- a/crates/iota-json-rpc/src/coin_api.rs
+++ b/crates/iota-json-rpc/src/coin_api.rs
@@ -18,7 +18,9 @@ use iota_types::{
     coin::{CoinMetadata, TreasuryCap},
     effects::TransactionEffectsAPI,
     gas_coin::GAS,
-    iota_system_state::IotaSystemStateTrait,
+    iota_system_state::{
+        IotaSystemStateTrait, iota_system_state_summary::IotaSystemStateSummaryV2,
+    },
     object::Object,
     parse_iota_struct_tag,
 };
@@ -224,11 +226,12 @@ impl CoinReadApiServer for CoinReadApi {
         async move {
             let coin_struct = parse_to_struct_tag(&coin_type)?;
             Ok(if GAS::is_gas(&coin_struct) {
-                let system_state_summary = self
-                    .internal
-                    .get_state()
-                    .get_system_state()?
-                    .into_iota_system_state_summary();
+                let system_state_summary = IotaSystemStateSummaryV2::try_from(
+                    self.internal
+                        .get_state()
+                        .get_system_state()?
+                        .into_iota_system_state_summary(),
+                )?;
                 Supply {
                     value: system_state_summary.iota_total_supply,
                 }

--- a/crates/iota-json-rpc/src/governance_api.rs
+++ b/crates/iota-json-rpc/src/governance_api.rs
@@ -27,7 +27,7 @@ use iota_types::{
     iota_serde::BigInt,
     iota_system_state::{
         IotaSystemState, IotaSystemStateTrait, PoolTokenExchangeRate, get_validator_from_table,
-        iota_system_state_summary::IotaSystemStateSummary,
+        iota_system_state_summary::{IotaSystemStateSummaryV1, IotaSystemStateSummaryV2},
     },
     object::{Object, ObjectRead},
     timelock::timelocked_staked_iota::TimelockedStakedIota,
@@ -198,7 +198,9 @@ impl GovernanceReadApi {
         );
 
         let system_state = self.get_system_state()?;
-        let system_state_summary = system_state.clone().into_iota_system_state_summary();
+        let system_state_summary = IotaSystemStateSummaryV2::try_from(
+            system_state.clone().into_iota_system_state_summary(),
+        )?;
 
         let rates = exchange_rates(&self.state, system_state_summary.epoch)
             .await?
@@ -264,8 +266,9 @@ impl GovernanceReadApi {
         );
 
         let system_state = self.get_system_state()?;
-        let system_state_summary: IotaSystemStateSummary =
-            system_state.clone().into_iota_system_state_summary();
+        let system_state_summary = IotaSystemStateSummaryV2::try_from(
+            system_state.clone().into_iota_system_state_summary(),
+        )?;
 
         let rates = exchange_rates(&self.state, system_state_summary.epoch)
             .await?
@@ -400,13 +403,26 @@ impl GovernanceReadApiServer for GovernanceReadApi {
     }
 
     #[instrument(skip(self))]
-    async fn get_latest_iota_system_state(&self) -> RpcResult<IotaSystemStateSummary> {
+    async fn get_latest_iota_system_state(&self) -> RpcResult<IotaSystemStateSummaryV2> {
         async move {
             Ok(self
                 .state
-                .get_system_state()
-                .map_err(Error::from)?
-                .into_iota_system_state_summary())
+                .get_system_state()?
+                .into_iota_system_state_summary()
+                .try_into()?)
+        }
+        .trace()
+        .await
+    }
+
+    #[instrument(skip(self))]
+    async fn get_latest_iota_system_state_v1(&self) -> RpcResult<IotaSystemStateSummaryV1> {
+        async move {
+            Ok(self
+                .state
+                .get_system_state()?
+                .into_iota_system_state_summary()
+                .try_into()?)
         }
         .trace()
         .await
@@ -425,8 +441,7 @@ impl GovernanceReadApiServer for GovernanceReadApi {
     #[instrument(skip(self))]
     async fn get_validators_apy(&self) -> RpcResult<ValidatorApys> {
         info!("get_validator_apy");
-        let system_state_summary: IotaSystemStateSummary =
-            self.get_latest_iota_system_state().await?;
+        let system_state_summary = self.get_latest_iota_system_state().await?;
 
         let exchange_rate_table = exchange_rates(&self.state, system_state_summary.epoch)
             .await
@@ -592,7 +607,9 @@ fn validator_exchange_rates(
 fn active_validators_exchange_rates(
     state: &Arc<dyn StateRead>,
 ) -> RpcInterimResult<Vec<ValidatorExchangeRates>> {
-    let system_state_summary = state.get_system_state()?.into_iota_system_state_summary();
+    let system_state_summary = IotaSystemStateSummaryV2::try_from(
+        state.get_system_state()?.into_iota_system_state_summary(),
+    )?;
 
     let tables = system_state_summary
         .active_validators
@@ -615,7 +632,9 @@ fn active_validators_exchange_rates(
 fn inactive_validators_exchange_rates(
     state: &Arc<dyn StateRead>,
 ) -> RpcInterimResult<Vec<ValidatorExchangeRates>> {
-    let system_state_summary = state.get_system_state()?.into_iota_system_state_summary();
+    let system_state_summary = IotaSystemStateSummaryV2::try_from(
+        state.get_system_state()?.into_iota_system_state_summary(),
+    )?;
 
     let tables = validator_summary_from_system_state(
         state,
@@ -664,7 +683,9 @@ fn pending_validators_exchange_rate(
 fn candidate_validators_exchange_rate(
     state: &Arc<dyn StateRead>,
 ) -> RpcInterimResult<Vec<ValidatorExchangeRates>> {
-    let system_state_summary = state.get_system_state()?.into_iota_system_state_summary();
+    let system_state_summary = IotaSystemStateSummaryV2::try_from(
+        state.get_system_state()?.into_iota_system_state_summary(),
+    )?;
 
     // From validator_candidates_id table get validator info using as key its
     // IotaAddress

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -3927,10 +3927,10 @@
       "description": "Return the latest IOTA system state object on-chain.",
       "params": [],
       "result": {
-        "name": "IotaSystemStateSummary",
+        "name": "IotaSystemStateSummaryV2",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/IotaSystemStateSummary"
+          "$ref": "#/components/schemas/IotaSystemStateSummaryV2"
         }
       },
       "examples": [
@@ -8340,8 +8340,8 @@
           }
         }
       },
-      "IotaSystemStateSummary": {
-        "description": "This is the JSON-RPC type for the IOTA system state object. It flattens all fields to make them top-level fields such that it as minimum dependencies to the internal data structures of the IOTA system state type.",
+      "IotaSystemStateSummaryV2": {
+        "description": "This is the JSON-RPC type for the [`IotaSystemStateV2`](super::iota_system_state_inner_v2::IotaSystemStateV2) object. It flattens all fields to make them top-level fields such that it as minimum dependencies to the internal data structures of the IOTA system state type.",
         "type": "object",
         "required": [
           "activeValidators",
@@ -8529,7 +8529,7 @@
             "type": "boolean"
           },
           "safeModeComputationCharges": {
-            "description": "Amount of computation rewards accumulated (and not yet distributed) during safe mode.",
+            "description": "Amount of computation charges accumulated (and not yet distributed) during safe mode.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/BigInt_for_uint64"
@@ -8537,7 +8537,7 @@
             ]
           },
           "safeModeComputationChargesBurned": {
-            "description": "Amount of burned computation rewards accumulated during safe mode.",
+            "description": "Amount of burned computation charges accumulated during safe mode.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/BigInt_for_uint64"


### PR DESCRIPTION
# Description of change

This patch refactors the json-rpc crates to accommodate the new iota system state summary.