### PR TITLE
fix(iota-genesis-builder): add additional checks to verify_basic_output()

### DIFF
--- a/crates/iota-genesis-builder/src/stardust/migration/verification/basic.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/verification/basic.rs
@@ -89,6 +89,26 @@ pub(super) fn verify_basic_output(
             expected_label
         );
 
+        ensure!(
+            created_objects.native_token_coin().is_err(),
+            "unexpected native token coin found"
+        );
+
+        ensure!(
+            created_objects.coin_manager().is_err(),
+            "unexpected coin manager found"
+        );
+
+        ensure!(
+            created_objects.coin_manager_treasury_cap().is_err(),
+            "unexpected coin manager cap found"
+        );
+
+        ensure!(
+            created_objects.package().is_err(),
+            "unexpected package found"
+        );
+
         return Ok(());
     }
 


### PR DESCRIPTION
# Description of change

According to audit [issue](https://github.com/orgs/iotaledger/projects/79/views/26?pane=issue&itemId=98223066&issue=iotaledger%7Ciota-private%7C59) - add additional checks to verify_basic_output() to ensure only a TimeLock<Balance> has been created during migrations.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota-private/issues/59 .

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
