### PR TITLE
refactor(rest-api): use v2 of system state summary

### DIFF
--- a/crates/iota-rest-api/openapi/openapi.json
+++ b/crates/iota-rest-api/openapi/openapi.json
@@ -4126,12 +4126,12 @@
             "type": "boolean"
           },
           "safe_mode_computation_charges": {
-            "description": "Amount of computation rewards accumulated (and not yet distributed) during safe mode.",
+            "description": "Amount of computation charges accumulated (and not yet distributed) during safe mode.",
             "type": "string",
             "format": "u64"
           },
           "safe_mode_computation_charges_burned": {
-            "description": "Amount of burned computation rewards accumulated during safe mode.",
+            "description": "Amount of burned computation charges accumulated during safe mode.",
             "type": "string",
             "format": "u64"
           },

--- a/crates/iota-rest-api/src/reader.rs
+++ b/crates/iota-rest-api/src/reader.rs
@@ -55,13 +55,17 @@ impl StateReader {
     }
 
     pub fn get_system_state_summary(&self) -> Result<super::system::SystemStateSummary> {
-        use iota_types::iota_system_state::IotaSystemStateTrait;
+        use iota_types::iota_system_state::{
+            IotaSystemStateTrait, iota_system_state_summary::IotaSystemStateSummaryV2,
+        };
 
         let system_state = iota_types::iota_system_state::get_iota_system_state(self.inner())
             .map_err(StorageError::custom)?;
-        let summary = system_state.into_iota_system_state_summary().into();
+        let summary =
+            IotaSystemStateSummaryV2::try_from(system_state.into_iota_system_state_summary())
+                .map_err(StorageError::custom)?;
 
-        Ok(summary)
+        Ok(summary.into())
     }
 
     pub fn get_transaction(

--- a/crates/iota-rest-api/src/system.rs
+++ b/crates/iota-rest-api/src/system.rs
@@ -117,12 +117,12 @@ pub struct SystemStateSummary {
     #[serde_as(as = "iota_types::iota_serde::BigInt<u64>")]
     #[schemars(with = "crate::_schemars::U64")]
     pub safe_mode_storage_charges: u64,
-    /// Amount of computation rewards accumulated (and not yet distributed)
+    /// Amount of computation charges accumulated (and not yet distributed)
     /// during safe mode.
     #[serde_as(as = "iota_types::iota_serde::BigInt<u64>")]
     #[schemars(with = "crate::_schemars::U64")]
     pub safe_mode_computation_charges: u64,
-    /// Amount of burned computation rewards accumulated during safe mode.
+    /// Amount of burned computation charges accumulated during safe mode.
     #[serde_as(as = "iota_types::iota_serde::BigInt<u64>")]
     #[schemars(with = "crate::_schemars::U64")]
     pub safe_mode_computation_charges_burned: u64,
@@ -430,13 +430,13 @@ impl From<iota_types::iota_system_state::iota_system_state_summary::IotaValidato
     }
 }
 
-impl From<iota_types::iota_system_state::iota_system_state_summary::IotaSystemStateSummary>
+impl From<iota_types::iota_system_state::iota_system_state_summary::IotaSystemStateSummaryV2>
     for SystemStateSummary
 {
     fn from(
-        value: iota_types::iota_system_state::iota_system_state_summary::IotaSystemStateSummary,
+        value: iota_types::iota_system_state::iota_system_state_summary::IotaSystemStateSummaryV2,
     ) -> Self {
-        let iota_types::iota_system_state::iota_system_state_summary::IotaSystemStateSummary {
+        let iota_types::iota_system_state::iota_system_state_summary::IotaSystemStateSummaryV2 {
             epoch,
             protocol_version,
             system_state_version,


### PR DESCRIPTION
# Description of change

Small patch to accommodate the new version of `IotaSystemStateSummary`.

The Rest API is not public so we can break the returning type.