### PR TITLE
fix(iota-genesis-builder): use getter for protocol parameters to get outputs

### DIFF
--- a/crates/iota-genesis-builder/src/stardust/parse.rs
+++ b/crates/iota-genesis-builder/src/stardust/parse.rs
@@ -6,7 +6,9 @@ use std::io::{BufReader, Read};
 
 use anyhow::Result;
 use iota_sdk::types::block::{
-    output::Output, payload::milestone::MilestoneOption, protocol::{self, ProtocolParameters},
+    output::Output,
+    payload::milestone::MilestoneOption,
+    protocol::ProtocolParameters,
 };
 use iota_types::stardust::error::StardustError;
 use packable::{
@@ -77,10 +79,12 @@ impl<R: Read> HornetSnapshotParser<R> {
     /// Get the protocol parameters.
     pub fn protocol_parameters(&self) -> Result<ProtocolParameters> {
         if let MilestoneOption::Parameters(params) = self.header.parameters_milestone_option() {
-            Ok(<ProtocolParameters as packable::PackableExt>::unpack_unverified(
-                params.binary_parameters(),
+            Ok(
+                <ProtocolParameters as packable::PackableExt>::unpack_unverified(
+                    params.binary_parameters(),
+                )
+                .expect("invalid protocol params"),
             )
-            .expect("invalid protocol params"))
         } else {
             Err(StardustError::HornetSnapshotParametersNotFound.into())
         }

--- a/crates/iota-genesis-builder/src/stardust/parse.rs
+++ b/crates/iota-genesis-builder/src/stardust/parse.rs
@@ -6,9 +6,7 @@ use std::io::{BufReader, Read};
 
 use anyhow::Result;
 use iota_sdk::types::block::{
-    output::Output,
-    payload::milestone::MilestoneOption,
-    protocol::ProtocolParameters,
+    output::Output, payload::milestone::MilestoneOption, protocol::ProtocolParameters,
 };
 use iota_types::stardust::error::StardustError;
 use packable::{

--- a/crates/iota-genesis-builder/src/stardust/parse.rs
+++ b/crates/iota-genesis-builder/src/stardust/parse.rs
@@ -6,7 +6,7 @@ use std::io::{BufReader, Read};
 
 use anyhow::Result;
 use iota_sdk::types::block::{
-    output::Output, payload::milestone::MilestoneOption, protocol::ProtocolParameters,
+    output::Output, payload::milestone::MilestoneOption, protocol::{self, ProtocolParameters},
 };
 use iota_types::stardust::error::StardustError;
 use packable::{
@@ -35,10 +35,12 @@ impl<R: Read> HornetSnapshotParser<R> {
 
     /// Provide an iterator over the Stardust UTXOs recorded in the snapshot.
     pub fn outputs(&mut self) -> impl Iterator<Item = anyhow::Result<(OutputHeader, Output)>> + '_ {
+        let protocol_params = self.protocol_parameters().unwrap_or_default();
+
         (0..self.header.output_count()).map(move |_| {
             Ok((
                 OutputHeader::unpack::<_, true>(&mut self.reader, &())?,
-                Output::unpack::<_, true>(&mut self.reader, &ProtocolParameters::default())?,
+                Output::unpack::<_, true>(&mut self.reader, &protocol_params)?,
             ))
         })
     }
@@ -69,12 +71,16 @@ impl<R: Read> HornetSnapshotParser<R> {
     /// Provide the network main token total supply through the snapshot
     /// protocol parameters.
     pub fn total_supply(&self) -> Result<u64> {
+        Ok(self.protocol_parameters()?.token_supply())
+    }
+
+    /// Get the protocol parameters.
+    pub fn protocol_parameters(&self) -> Result<ProtocolParameters> {
         if let MilestoneOption::Parameters(params) = self.header.parameters_milestone_option() {
-            let protocol_params = <ProtocolParameters as packable::PackableExt>::unpack_unverified(
+            Ok(<ProtocolParameters as packable::PackableExt>::unpack_unverified(
                 params.binary_parameters(),
             )
-            .expect("invalid protocol params");
-            Ok(protocol_params.token_supply())
+            .expect("invalid protocol params"))
         } else {
             Err(StardustError::HornetSnapshotParametersNotFound.into())
         }


### PR DESCRIPTION
# Description of change

Instead of using the default protocol parameters to unpack each `Output` in the `outputs()` function, we now get and use the actual protocol parameters instead of using the default one. This PR creates a new helper function to get the protocol parameters and additionally modifies `total_supply()` function to use this new function.

## Links to any relevant issues

fixes iotaledger/iota-private#51

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Ran the ceremony script successfully.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
