### PR TITLE
fix(iota-genesis-builder): fix csv headers validation for address_swap_map

### DIFF
--- a/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
@@ -182,9 +182,12 @@ fn verify_headers(headers: &csv::StringRecord) -> Result<(), anyhow::Error> {
     const LEFT_HEADER: &str = "Origin";
     const RIGHT_HEADER: &str = "Destination";
 
-    if &headers[0] != LEFT_HEADER || &headers[1] != RIGHT_HEADER {
-        anyhow::bail!("Invalid CSV headers");
-    }
+    anyhow::ensure!(
+        headers.len() == 2
+            && &headers[0] == "Origin"
+            && &headers[1] == "Destination",
+        "Invalid CSV headers"
+    );
     Ok(())
 }
 

--- a/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
@@ -179,13 +179,8 @@ impl AddressSwapMap {
 }
 
 fn verify_headers(headers: &csv::StringRecord) -> Result<(), anyhow::Error> {
-    const LEFT_HEADER: &str = "Origin";
-    const RIGHT_HEADER: &str = "Destination";
-
     anyhow::ensure!(
-        headers.len() == 2
-            && &headers[0] == "Origin"
-            && &headers[1] == "Destination",
+        headers.len() == 2 && &headers[0] == "Origin" && &headers[1] == "Destination",
         "Invalid CSV headers"
     );
     Ok(())

--- a/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
@@ -182,7 +182,7 @@ fn verify_headers(headers: &csv::StringRecord) -> Result<(), anyhow::Error> {
     const LEFT_HEADER: &str = "Origin";
     const RIGHT_HEADER: &str = "Destination";
 
-    if &headers[0] != LEFT_HEADER && &headers[1] != RIGHT_HEADER {
+    if &headers[0] != LEFT_HEADER || &headers[1] != RIGHT_HEADER {
         anyhow::bail!("Invalid CSV headers");
     }
     Ok(())


### PR DESCRIPTION
# Description of change

The current implementation only fails if both headers do not match, instead of failing when any one header is incorrect.
&& has been replaced with || to ensure that the check fails if any one of the headers is incorrect

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota-private/issues/69 .

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
