### PR TITLE
feat(iota-types, iota-json-rpc-types): Use base64 encoding

### DIFF
--- a/crates/iota-bridge-indexer/src/iota_transaction_handler.rs
+++ b/crates/iota-bridge-indexer/src/iota_transaction_handler.rs
@@ -94,7 +94,7 @@ pub fn into_token_transfers(
             "TokenDepositedEvent" => {
                 info!("Observed IOTA Deposit {:?}", ev);
                 metrics.total_iota_token_deposited.inc();
-                let move_event: MoveTokenDepositedEvent = bcs::from_bytes(&ev.bcs)?;
+                let move_event: MoveTokenDepositedEvent = bcs::from_bytes(ev.bcs.bytes())?;
                 transfers.push(ProcessedTxnData::TokenTransfer(TokenTransfer {
                     chain_id: move_event.source_chain,
                     nonce: move_event.seq_num,
@@ -117,7 +117,7 @@ pub fn into_token_transfers(
             "TokenTransferApproved" => {
                 info!("Observed IOTA Approval {:?}", ev);
                 metrics.total_iota_token_transfer_approved.inc();
-                let event: MoveTokenTransferApproved = bcs::from_bytes(&ev.bcs)?;
+                let event: MoveTokenTransferApproved = bcs::from_bytes(ev.bcs.bytes())?;
                 transfers.push(ProcessedTxnData::TokenTransfer(TokenTransfer {
                     chain_id: event.message_key.source_chain,
                     nonce: event.message_key.bridge_seq_num,
@@ -134,7 +134,7 @@ pub fn into_token_transfers(
             "TokenTransferClaimed" => {
                 info!("Observed IOTA Claim {:?}", ev);
                 metrics.total_iota_token_transfer_claimed.inc();
-                let event: MoveTokenTransferClaimed = bcs::from_bytes(&ev.bcs)?;
+                let event: MoveTokenTransferClaimed = bcs::from_bytes(ev.bcs.bytes())?;
                 transfers.push(ProcessedTxnData::TokenTransfer(TokenTransfer {
                     chain_id: event.message_key.source_chain,
                     nonce: event.message_key.bridge_seq_num,

--- a/crates/iota-bridge/src/events.rs
+++ b/crates/iota-bridge/src/events.rs
@@ -393,7 +393,7 @@ macro_rules! declare_events {
                 // Unwrap safe: we inited above
                 $(
                     if &event.type_ == $variant.get().unwrap() {
-                        let event_struct: $event_struct = bcs::from_bytes(&event.bcs).map_err(|e| BridgeError::Internal(format!("Failed to deserialize event to {}: {:?}", stringify!($event_struct), e)))?;
+                        let event_struct: $event_struct = bcs::from_bytes(&event.bcs.bytes()).map_err(|e| BridgeError::Internal(format!("Failed to deserialize event to {}: {:?}", stringify!($event_struct), e)))?;
                         return Ok(Some(IotaBridgeEvent::$variant(event_struct.try_into()?)));
                     }
                 )*
@@ -487,7 +487,7 @@ pub mod tests {
         });
         let event = IotaEvent {
             type_: IotaToEthTokenBridgeV1.get().unwrap().clone(),
-            bcs: bcs::to_bytes(&emitted_event).unwrap(),
+            bcs: BcsEvent::new(bcs::to_bytes(&emitted_event).unwrap()),
             id: EventID {
                 tx_digest,
                 event_seq: event_idx as u64,

--- a/crates/iota-bridge/src/events.rs
+++ b/crates/iota-bridge/src/events.rs
@@ -393,7 +393,7 @@ macro_rules! declare_events {
                 // Unwrap safe: we inited above
                 $(
                     if &event.type_ == $variant.get().unwrap() {
-                        let event_struct: $event_struct = bcs::from_bytes(&event.bcs.bytes()).map_err(|e| BridgeError::Internal(format!("Failed to deserialize event to {}: {:?}", stringify!($event_struct), e)))?;
+                        let event_struct: $event_struct = bcs::from_bytes(event.bcs.bytes()).map_err(|e| BridgeError::Internal(format!("Failed to deserialize event to {}: {:?}", stringify!($event_struct), e)))?;
                         return Ok(Some(IotaBridgeEvent::$variant(event_struct.try_into()?)));
                     }
                 )*

--- a/crates/iota-bridge/src/events.rs
+++ b/crates/iota-bridge/src/events.rs
@@ -439,7 +439,7 @@ pub mod tests {
     use std::collections::HashSet;
 
     use ethers::types::Address as EthAddress;
-    use iota_json_rpc_types::IotaEvent;
+    use iota_json_rpc_types::{BcsEvent, IotaEvent};
     use iota_types::{
         Identifier,
         base_types::{IotaAddress, ObjectID},

--- a/crates/iota-bridge/src/iota_client.rs
+++ b/crates/iota-bridge/src/iota_client.rs
@@ -621,6 +621,7 @@ mod tests {
     use std::str::FromStr;
 
     use ethers::types::Address as EthAddress;
+    use iota_json_rpc_types::BcsEvent;
     use iota_types::{
         bridge::{BridgeChainId, TOKEN_ID_IOTA, TOKEN_ID_USDC},
         crypto::get_key_pair,

--- a/crates/iota-bridge/src/iota_client.rs
+++ b/crates/iota-bridge/src/iota_client.rs
@@ -680,7 +680,7 @@ mod tests {
 
         let mut iota_event_1 = IotaEvent::random_for_testing();
         iota_event_1.type_ = IotaToEthTokenBridgeV1.get().unwrap().clone();
-        iota_event_1.bcs = bcs::to_bytes(&emitted_event_1).unwrap();
+        iota_event_1.bcs = BcsEvent::new(bcs::to_bytes(&emitted_event_1).unwrap());
 
         #[derive(Serialize, Deserialize)]
         struct RandomStruct {}
@@ -690,7 +690,7 @@ mod tests {
         let mut iota_event_2 = IotaEvent::random_for_testing();
         iota_event_2.type_ = IotaToEthTokenBridgeV1.get().unwrap().clone();
         iota_event_2.type_.module = Identifier::from_str("unrecognized_module").unwrap();
-        iota_event_2.bcs = bcs::to_bytes(&event_2).unwrap();
+        iota_event_2.bcs = BcsEvent::new(bcs::to_bytes(&event_2).unwrap());
 
         // Event 3 is defined in non-bridge package
         let mut iota_event_3 = iota_event_1.clone();

--- a/crates/iota-bridge/src/server/handler.rs
+++ b/crates/iota-bridge/src/server/handler.rs
@@ -352,7 +352,7 @@ mod tests {
     use std::collections::HashSet;
 
     use ethers::types::{Address as EthAddress, TransactionReceipt};
-    use iota_json_rpc_types::IotaEvent;
+    use iota_json_rpc_types::{BcsEvent, IotaEvent};
     use iota_types::{
         base_types::IotaAddress,
         bridge::{BridgeChainId, TOKEN_ID_USDC},

--- a/crates/iota-bridge/src/server/handler.rs
+++ b/crates/iota-bridge/src/server/handler.rs
@@ -468,12 +468,12 @@ mod tests {
 
         let mut iota_event_1 = IotaEvent::random_for_testing();
         iota_event_1.type_ = IotaToEthTokenBridgeV1.get().unwrap().clone();
-        iota_event_1.bcs = bcs::to_bytes(&emitted_event_1).unwrap();
+        iota_event_1.bcs = BcsEvent::new(bcs::to_bytes(&emitted_event_1).unwrap());
         let iota_tx_digest = iota_event_1.id.tx_digest;
 
         let mut iota_event_2 = IotaEvent::random_for_testing();
         iota_event_2.type_ = IotaToEthTokenBridgeV1.get().unwrap().clone();
-        iota_event_2.bcs = bcs::to_bytes(&emitted_event_1).unwrap();
+        iota_event_2.bcs = BcsEvent::new(bcs::to_bytes(&emitted_event_1).unwrap());
         let iota_event_idx_2 = 1;
         iota_client_mock.add_events_by_tx_digest(iota_tx_digest, vec![iota_event_2.clone()]);
 

--- a/crates/iota-graphql-rpc/src/mutation.rs
+++ b/crates/iota-graphql-rpc/src/mutation.rs
@@ -132,7 +132,7 @@ impl Mutation {
                 transaction_module: e.transaction_module,
                 sender: e.sender,
                 type_: e.type_,
-                contents: e.bcs,
+                contents: e.bcs.into_bytes(),
             })
             .collect();
 

--- a/crates/iota-indexer/src/apis/indexer_api.rs
+++ b/crates/iota-indexer/src/apis/indexer_api.rs
@@ -227,7 +227,7 @@ impl IndexerApiServer for IndexerApi {
         results.truncate(limit);
         let next_cursor = results.last().map(|o| o.object_id);
         Ok(Page {
-            data: results,
+            data: results.into_iter().map(Into::into).collect(),
             next_cursor,
             has_next_page,
         })

--- a/crates/iota-indexer/src/models/events.rs
+++ b/crates/iota-indexer/src/models/events.rs
@@ -5,7 +5,7 @@
 use std::{str::FromStr, sync::Arc};
 
 use diesel::prelude::*;
-use iota_json_rpc_types::{IotaEvent, type_and_fields_from_move_event_data};
+use iota_json_rpc_types::{BcsEvent, IotaEvent, type_and_fields_from_move_event_data};
 use iota_package_resolver::{PackageStore, Resolver};
 use iota_types::{
     base_types::{IotaAddress, ObjectID},
@@ -135,7 +135,7 @@ impl StoredEvent {
             transaction_module: Identifier::from_str(&self.module)?,
             sender,
             type_,
-            bcs: self.bcs,
+            bcs: BcsEvent::new(self.bcs),
             parsed_json,
             timestamp_ms: Some(self.timestamp_ms as u64),
         })

--- a/crates/iota-json-rpc-types/src/iota_event.rs
+++ b/crates/iota-json-rpc-types/src/iota_event.rs
@@ -438,5 +438,17 @@ mod test {
                 .unwrap()
                 .into_bytes()
         );
+
+        // Roundtrip base64
+        let event = serde_json::from_str::<BcsEvent>(tagged_base64).unwrap();
+        let json = serde_json::to_string(&event).unwrap();
+        let from_json = serde_json::from_str::<BcsEvent>(&json).unwrap();
+        assert_eq!(event, from_json);
+
+        // Roundtrip base58
+        let event = serde_json::from_str::<BcsEvent>(tagged_base58).unwrap();
+        let json = serde_json::to_string(&event).unwrap();
+        let from_json = serde_json::from_str::<BcsEvent>(&json).unwrap();
+        assert_eq!(event, from_json);
     }
 }

--- a/crates/iota-json-rpc-types/src/iota_event.rs
+++ b/crates/iota-json-rpc-types/src/iota_event.rs
@@ -50,7 +50,7 @@ pub struct IotaEvent {
     pub type_: StructTag,
     /// Parsed json value of the event
     pub parsed_json: Value,
-    #[serde_as(as = "Base64")]
+    #[serde_as(as = "iota_types::iota_serde::Base64orBase58")]
     #[schemars(with = "Base64")]
     /// Base64 encoded bcs bytes of the move event
     pub bcs: Vec<u8>,

--- a/crates/iota-json-rpc-types/src/iota_event.rs
+++ b/crates/iota-json-rpc-types/src/iota_event.rs
@@ -4,7 +4,7 @@
 
 use std::{fmt, fmt::Display, str::FromStr};
 
-use fastcrypto::encoding::{Base58, Base64};
+use fastcrypto::encoding::Base64;
 use iota_metrics::monitored_scope;
 use iota_types::{
     base_types::{IotaAddress, ObjectID, TransactionDigest},
@@ -50,9 +50,9 @@ pub struct IotaEvent {
     pub type_: StructTag,
     /// Parsed json value of the event
     pub parsed_json: Value,
-    #[serde_as(as = "Base58")]
-    #[schemars(with = "Base58")]
-    /// Base 58 encoded bcs bytes of the move event
+    #[serde_as(as = "Base64")]
+    #[schemars(with = "Base64")]
+    /// Base64 encoded bcs bytes of the move event
     pub bcs: Vec<u8>,
     /// UTC timestamp in milliseconds since epoch (1/1/1970)
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/iota-json-rpc-types/src/iota_event.rs
+++ b/crates/iota-json-rpc-types/src/iota_event.rs
@@ -4,7 +4,7 @@
 
 use std::{fmt, fmt::Display, str::FromStr};
 
-use fastcrypto::encoding::Base64;
+use fastcrypto::encoding::{Base58, Base64};
 use iota_metrics::monitored_scope;
 use iota_types::{
     base_types::{IotaAddress, ObjectID, TransactionDigest},
@@ -50,15 +50,92 @@ pub struct IotaEvent {
     pub type_: StructTag,
     /// Parsed json value of the event
     pub parsed_json: Value,
-    #[serde_as(as = "iota_types::iota_serde::Base64orBase58")]
     #[schemars(with = "Base64")]
     /// Base64 encoded bcs bytes of the move event
-    pub bcs: Vec<u8>,
+    #[serde(flatten)]
+    pub bcs: BcsEvent,
     /// UTC timestamp in milliseconds since epoch (1/1/1970)
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(with = "Option<BigInt<u64>>")]
     #[serde_as(as = "Option<BigInt<u64>>")]
     pub timestamp_ms: Option<u64>,
+}
+
+#[serde_as]
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", tag = "bcsEncoding")]
+#[serde(from = "MaybeTaggedBcsEvent")]
+pub enum BcsEvent {
+    Base64 {
+        #[serde_as(as = "Base64")]
+        #[schemars(with = "Base64")]
+        bcs: Vec<u8>,
+    },
+    Base58 {
+        #[serde_as(as = "Base58")]
+        #[schemars(with = "Base58")]
+        bcs: Vec<u8>,
+    },
+}
+
+impl BcsEvent {
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self::Base64 { bcs: bytes }
+    }
+
+    pub fn bytes(&self) -> &[u8] {
+        match self {
+            BcsEvent::Base64 { bcs } => bcs.as_ref(),
+            BcsEvent::Base58 { bcs } => bcs.as_ref(),
+        }
+    }
+
+    pub fn into_bytes(self) -> Vec<u8> {
+        match self {
+            BcsEvent::Base64 { bcs } => bcs,
+            BcsEvent::Base58 { bcs } => bcs,
+        }
+    }
+}
+
+#[allow(unused)]
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", untagged)]
+enum MaybeTaggedBcsEvent {
+    Tagged(TaggedBcsEvent),
+    Base58 {
+        #[serde_as(as = "Base58")]
+        bcs: Vec<u8>,
+    },
+}
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "bcsEncoding")]
+enum TaggedBcsEvent {
+    Base64 {
+        #[serde_as(as = "Base64")]
+        bcs: Vec<u8>,
+    },
+    Base58 {
+        #[serde_as(as = "Base58")]
+        bcs: Vec<u8>,
+    },
+}
+
+impl From<MaybeTaggedBcsEvent> for BcsEvent {
+    fn from(event: MaybeTaggedBcsEvent) -> BcsEvent {
+        let bcs = match event {
+            MaybeTaggedBcsEvent::Tagged(TaggedBcsEvent::Base58 { bcs })
+            | MaybeTaggedBcsEvent::Base58 { bcs } => bcs,
+            MaybeTaggedBcsEvent::Tagged(TaggedBcsEvent::Base64 { bcs }) => bcs,
+        };
+
+        // Bytes are already decoded, force into Base64 variant to avoid serializing to
+        // base58
+        Self::Base64 { bcs }
+    }
 }
 
 impl From<EventEnvelope> for IotaEvent {
@@ -73,7 +150,9 @@ impl From<EventEnvelope> for IotaEvent {
             sender: ev.event.sender,
             type_: ev.event.type_,
             parsed_json: ev.parsed_json,
-            bcs: ev.event.contents,
+            bcs: BcsEvent::Base64 {
+                bcs: ev.event.contents,
+            },
             timestamp_ms: Some(ev.timestamp),
         }
     }
@@ -86,7 +165,7 @@ impl From<IotaEvent> for Event {
             transaction_module: val.transaction_module,
             sender: val.sender,
             type_: val.type_,
-            contents: val.bcs,
+            contents: val.bcs.into_bytes(),
         }
     }
 }
@@ -107,7 +186,9 @@ impl IotaEvent {
             contents,
         } = event;
 
-        let bcs = contents.to_vec();
+        let bcs = BcsEvent::Base64 {
+            bcs: contents.to_vec(),
+        };
 
         let move_value = Event::move_event_to_move_value(&contents, layout)?;
         let (type_, fields) = type_and_fields_from_move_event_data(move_value)?;
@@ -171,7 +252,7 @@ impl IotaEvent {
             sender: IotaAddress::random_for_testing_only(),
             type_: StructTag::from_str("0x6666::random_for_testing::RandomForTesting").unwrap(),
             parsed_json: json!({}),
-            bcs: vec![],
+            bcs: BcsEvent::new(vec![]),
             timestamp_ms: None,
         }
     }
@@ -326,4 +407,36 @@ impl Filter<IotaEvent> for EventFilter {
 
 pub trait Filter<T> {
     fn matches(&self, item: &T) -> bool;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn bcs_event_test() {
+        let bytes = vec![0, 1, 2, 3, 4];
+        let untagged_base58 = r#"{"bcs":"12VfUX"}"#;
+        let tagged_base58 = r#"{"bcsEncoding":"base58","bcs":"12VfUX"}"#;
+        let tagged_base64 = r#"{"bcsEncoding":"base64","bcs":"AAECAwQ="}"#;
+
+        assert_eq!(
+            bytes,
+            serde_json::from_str::<BcsEvent>(untagged_base58)
+                .unwrap()
+                .into_bytes()
+        );
+        assert_eq!(
+            bytes,
+            serde_json::from_str::<BcsEvent>(tagged_base58)
+                .unwrap()
+                .into_bytes()
+        );
+        assert_eq!(
+            bytes,
+            serde_json::from_str::<BcsEvent>(tagged_base64)
+                .unwrap()
+                .into_bytes()
+        );
+    }
 }

--- a/crates/iota-json-rpc-types/src/iota_event.rs
+++ b/crates/iota-json-rpc-types/src/iota_event.rs
@@ -50,7 +50,6 @@ pub struct IotaEvent {
     pub type_: StructTag,
     /// Parsed json value of the event
     pub parsed_json: Value,
-    #[schemars(with = "Base64")]
     /// Base64 encoded bcs bytes of the move event
     #[serde(flatten)]
     pub bcs: BcsEvent,

--- a/crates/iota-json-rpc-types/src/lib.rs
+++ b/crates/iota-json-rpc-types/src/lib.rs
@@ -189,14 +189,6 @@ mod test {
         let tagged_base58 = r#"{"bcsEncoding":"base58","bcsName":"12VfUX"}"#;
         let tagged_base64 = r#"{"bcsEncoding":"base64","bcsName":"AAECAwQ="}"#;
 
-        println!(
-            "{}",
-            serde_json::to_string(&TaggedBcsName::Base64 {
-                bcs_name: bytes.clone()
-            })
-            .unwrap()
-        );
-
         assert_eq!(
             bytes,
             serde_json::from_str::<BcsName>(untagged_base58)

--- a/crates/iota-json-rpc-types/src/lib.rs
+++ b/crates/iota-json-rpc-types/src/lib.rs
@@ -104,11 +104,13 @@ pub enum BcsName {
     Base64 {
         #[serde_as(as = "Base64")]
         #[schemars(with = "Base64")]
+        #[serde(rename = "bcsName")]
         bcs_name: Vec<u8>,
     },
     Base58 {
         #[serde_as(as = "Base58")]
         #[schemars(with = "Base58")]
+        #[serde(rename = "bcsName")]
         bcs_name: Vec<u8>,
     },
 }
@@ -213,5 +215,17 @@ mod test {
                 .unwrap()
                 .into_bytes()
         );
+
+        // Roundtrip base64
+        let name = serde_json::from_str::<BcsName>(tagged_base64).unwrap();
+        let json = serde_json::to_string(&name).unwrap();
+        let from_json = serde_json::from_str::<BcsName>(&json).unwrap();
+        assert_eq!(name, from_json);
+
+        // Roundtrip base58
+        let name = serde_json::from_str::<BcsName>(tagged_base58).unwrap();
+        let json = serde_json::to_string(&name).unwrap();
+        let from_json = serde_json::from_str::<BcsName>(&json).unwrap();
+        assert_eq!(name, from_json);
     }
 }

--- a/crates/iota-json-rpc-types/src/lib.rs
+++ b/crates/iota-json-rpc-types/src/lib.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use balance_changes::*;
+use fastcrypto::encoding::{Base58, Base64};
 pub use iota_checkpoint::*;
 pub use iota_coin::*;
 pub use iota_event::*;
@@ -12,10 +13,11 @@ pub use iota_move::*;
 pub use iota_object::*;
 pub use iota_protocol::*;
 pub use iota_transaction::*;
-use iota_types::{base_types::ObjectID, dynamic_field::DynamicFieldInfo};
+use iota_types::base_types::ObjectID;
 pub use object_changes::*;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
 #[cfg(test)]
 #[path = "unit_tests/rpc_types_tests.rs"]
@@ -53,5 +55,163 @@ impl<T, C> Page<T, C> {
             next_cursor: None,
             has_next_page: false,
         }
+    }
+}
+
+#[serde_with::serde_as]
+#[derive(Clone, Serialize, Deserialize, JsonSchema, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DynamicFieldInfo {
+    pub name: iota_types::dynamic_field::DynamicFieldName,
+    #[serde(flatten)]
+    pub bcs_name: BcsName,
+    pub type_: iota_types::dynamic_field::DynamicFieldType,
+    pub object_type: String,
+    pub object_id: ObjectID,
+    pub version: iota_types::base_types::SequenceNumber,
+    pub digest: iota_types::digests::ObjectDigest,
+}
+
+impl From<iota_types::dynamic_field::DynamicFieldInfo> for DynamicFieldInfo {
+    fn from(
+        iota_types::dynamic_field::DynamicFieldInfo {
+            name,
+            bcs_name,
+            type_,
+            object_type,
+            object_id,
+            version,
+            digest,
+        }: iota_types::dynamic_field::DynamicFieldInfo,
+    ) -> Self {
+        Self {
+            name,
+            bcs_name: BcsName::new(bcs_name),
+            type_,
+            object_type,
+            object_id,
+            version,
+            digest,
+        }
+    }
+}
+
+#[serde_as]
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", tag = "bcsEncoding")]
+#[serde(from = "MaybeTaggedBcsName")]
+pub enum BcsName {
+    Base64 {
+        #[serde_as(as = "Base64")]
+        #[schemars(with = "Base64")]
+        bcs_name: Vec<u8>,
+    },
+    Base58 {
+        #[serde_as(as = "Base58")]
+        #[schemars(with = "Base58")]
+        bcs_name: Vec<u8>,
+    },
+}
+
+impl BcsName {
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self::Base64 { bcs_name: bytes }
+    }
+
+    pub fn bytes(&self) -> &[u8] {
+        match self {
+            BcsName::Base64 { bcs_name } => bcs_name.as_ref(),
+            BcsName::Base58 { bcs_name } => bcs_name.as_ref(),
+        }
+    }
+
+    pub fn into_bytes(self) -> Vec<u8> {
+        match self {
+            BcsName::Base64 { bcs_name } => bcs_name,
+            BcsName::Base58 { bcs_name } => bcs_name,
+        }
+    }
+}
+
+#[allow(unused)]
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", untagged)]
+enum MaybeTaggedBcsName {
+    Tagged(TaggedBcsName),
+    Base58 {
+        #[serde_as(as = "Base58")]
+        #[serde(rename = "bcsName")]
+        bcs_name: Vec<u8>,
+    },
+}
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "bcsEncoding")]
+enum TaggedBcsName {
+    Base64 {
+        #[serde_as(as = "Base64")]
+        #[serde(rename = "bcsName")]
+        bcs_name: Vec<u8>,
+    },
+    Base58 {
+        #[serde_as(as = "Base58")]
+        #[serde(rename = "bcsName")]
+        bcs_name: Vec<u8>,
+    },
+}
+
+impl From<MaybeTaggedBcsName> for BcsName {
+    fn from(name: MaybeTaggedBcsName) -> BcsName {
+        let bcs_name = match name {
+            MaybeTaggedBcsName::Tagged(TaggedBcsName::Base58 { bcs_name })
+            | MaybeTaggedBcsName::Base58 { bcs_name } => bcs_name,
+            MaybeTaggedBcsName::Tagged(TaggedBcsName::Base64 { bcs_name }) => bcs_name,
+        };
+
+        // Bytes are already decoded, force into Base64 variant to avoid serializing to
+        // base58
+        Self::Base64 { bcs_name }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn bcs_name_test() {
+        let bytes = vec![0, 1, 2, 3, 4];
+        let untagged_base58 = r#"{"bcsName":"12VfUX"}"#;
+        let tagged_base58 = r#"{"bcsEncoding":"base58","bcsName":"12VfUX"}"#;
+        let tagged_base64 = r#"{"bcsEncoding":"base64","bcsName":"AAECAwQ="}"#;
+
+        println!(
+            "{}",
+            serde_json::to_string(&TaggedBcsName::Base64 {
+                bcs_name: bytes.clone()
+            })
+            .unwrap()
+        );
+
+        assert_eq!(
+            bytes,
+            serde_json::from_str::<BcsName>(untagged_base58)
+                .unwrap()
+                .into_bytes()
+        );
+        assert_eq!(
+            bytes,
+            serde_json::from_str::<BcsName>(tagged_base58)
+                .unwrap()
+                .into_bytes()
+        );
+        assert_eq!(
+            bytes,
+            serde_json::from_str::<BcsName>(tagged_base64)
+                .unwrap()
+                .into_bytes()
+        );
     }
 }

--- a/crates/iota-json-rpc/src/indexer_api.rs
+++ b/crates/iota-json-rpc/src/indexer_api.rs
@@ -377,7 +377,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
                 .get_dynamic_fields_result_size_total
                 .inc_by(data.len() as u64);
             Ok(DynamicFieldPage {
-                data: data.into_iter().map(|(_, w)| w).collect(),
+                data: data.into_iter().map(|(_, w)| w.into()).collect(),
                 next_cursor,
                 has_next_page,
             })

--- a/crates/iota-json-rpc/src/read_api.rs
+++ b/crates/iota-json-rpc/src/read_api.rs
@@ -1157,7 +1157,7 @@ async fn get_display_object_by_type(
     // If there's any recent version of Display, give it to the client.
     // TODO: add support for version query.
     if let Some(event) = events.pop() {
-        let display: DisplayVersionUpdatedEvent = bcs::from_bytes(&event.bcs[..])?;
+        let display: DisplayVersionUpdatedEvent = bcs::from_bytes(&event.bcs.into_bytes())?;
         Ok(Some(display))
     } else {
         Ok(None)

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -800,6 +800,7 @@
                   "parsedJson": {
                     "test": "example value"
                   },
+                  "bcsEncoding": "base64",
                   "bcs": ""
                 }
               ],
@@ -3777,6 +3778,7 @@
                     "type": "0x0000000000000000000000000000000000000000000000000000000000000009::test::TestField",
                     "value": "some_value"
                   },
+                  "bcsEncoding": "base64",
                   "bcsName": "FDB4OTo6dGVzdDo6VGVzdEZpZWxk",
                   "type": "DynamicField",
                   "objectType": "test",
@@ -3789,6 +3791,7 @@
                     "type": "0x0000000000000000000000000000000000000000000000000000000000000009::test::TestField",
                     "value": "some_value"
                   },
+                  "bcsEncoding": "base64",
                   "bcsName": "FDB4OTo6dGVzdDo6VGVzdEZpZWxk",
                   "type": "DynamicField",
                   "objectType": "test",
@@ -3801,6 +3804,7 @@
                     "type": "0x0000000000000000000000000000000000000000000000000000000000000009::test::TestField",
                     "value": "some_value"
                   },
+                  "bcsEncoding": "base64",
                   "bcsName": "FDB4OTo6dGVzdDo6VGVzdEZpZWxk",
                   "type": "DynamicField",
                   "objectType": "test",
@@ -4546,6 +4550,7 @@
                   "sender": "0x84bd999f9ff7a1804872957fafa528628a24386298faa98850887f64da841b87",
                   "type": "0x3::test::Test<0x3::test::Test>",
                   "parsedJson": "some_value",
+                  "bcsEncoding": "base64",
                   "bcs": ""
                 },
                 {
@@ -4558,6 +4563,7 @@
                   "sender": "0x279efd098d59a66a3d9adc87cce81fe9ec69dc8105b2b60140589ec8be44c29f",
                   "type": "0x3::test::Test<0x3::test::Test>",
                   "parsedJson": "some_value",
+                  "bcsEncoding": "base64",
                   "bcs": ""
                 },
                 {
@@ -4570,6 +4576,7 @@
                   "sender": "0x289be027d2a94f744b4c59fda7b528f9c59f430eaba84b8bee9b43a30f9cc83f",
                   "type": "0x3::test::Test<0x3::test::Test>",
                   "parsedJson": "some_value",
+                  "bcsEncoding": "base64",
                   "bcs": ""
                 },
                 {
@@ -4582,6 +4589,7 @@
                   "sender": "0xa395759ca37c6e1ffc179184e98a6f9a2da5d78f6e34b0e5044ed52a6bc0a1bc",
                   "type": "0x3::test::Test<0x3::test::Test>",
                   "parsedJson": "some_value",
+                  "bcsEncoding": "base64",
                   "bcs": ""
                 }
               ],
@@ -6428,8 +6436,45 @@
       },
       "DynamicFieldInfo": {
         "type": "object",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "bcsEncoding",
+              "bcsName"
+            ],
+            "properties": {
+              "bcsEncoding": {
+                "type": "string",
+                "enum": [
+                  "base64"
+                ]
+              },
+              "bcsName": {
+                "$ref": "#/components/schemas/Base64"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "bcsEncoding",
+              "bcsName"
+            ],
+            "properties": {
+              "bcsEncoding": {
+                "type": "string",
+                "enum": [
+                  "base58"
+                ]
+              },
+              "bcsName": {
+                "$ref": "#/components/schemas/Base58"
+              }
+            }
+          }
+        ],
         "required": [
-          "bcsName",
           "digest",
           "name",
           "objectId",
@@ -6438,9 +6483,6 @@
           "version"
         ],
         "properties": {
-          "bcsName": {
-            "$ref": "#/components/schemas/Base64"
-          },
           "digest": {
             "$ref": "#/components/schemas/ObjectDigest"
           },
@@ -6738,9 +6780,12 @@
         }
       },
       "Event": {
-        "type": "object",
+        "description": "Base64 encoding",
+        "type": [
+          "object",
+          "string"
+        ],
         "required": [
-          "bcs",
           "id",
           "packageId",
           "parsedJson",
@@ -6749,14 +6794,6 @@
           "type"
         ],
         "properties": {
-          "bcs": {
-            "description": "Base64 encoded bcs bytes of the move event",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Base64"
-              }
-            ]
-          },
           "id": {
             "description": "Sequential event ID, ie (transaction seq number, event seq number). 1) Serves as a unique event ID for each fullnode 2) Also serves to sequence events for the purposes of pagination and querying. A higher id is an event seen later by that fullnode. This ID is the \"cursor\" for event querying.",
             "allOf": [

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -3777,7 +3777,7 @@
                     "type": "0x0000000000000000000000000000000000000000000000000000000000000009::test::TestField",
                     "value": "some_value"
                   },
-                  "bcsName": "2F1KQ3miNpBx1RzoRr1MVYMraK7RV",
+                  "bcsName": "FDB4OTo6dGVzdDo6VGVzdEZpZWxk",
                   "type": "DynamicField",
                   "objectType": "test",
                   "objectId": "0x82b2fd67344691abd0efc771941b948ad35360b08e449fbbc28b0641175bf60b",
@@ -3789,7 +3789,7 @@
                     "type": "0x0000000000000000000000000000000000000000000000000000000000000009::test::TestField",
                     "value": "some_value"
                   },
-                  "bcsName": "2F1KQ3miNpBx1RzoRr1MVYMraK7RV",
+                  "bcsName": "FDB4OTo6dGVzdDo6VGVzdEZpZWxk",
                   "type": "DynamicField",
                   "objectType": "test",
                   "objectId": "0x21564fc5a68ace997461b098c1d1f3ccbde241d8fdf562db36bc1423ee10cecb",
@@ -3801,7 +3801,7 @@
                     "type": "0x0000000000000000000000000000000000000000000000000000000000000009::test::TestField",
                     "value": "some_value"
                   },
-                  "bcsName": "2F1KQ3miNpBx1RzoRr1MVYMraK7RV",
+                  "bcsName": "FDB4OTo6dGVzdDo6VGVzdEZpZWxk",
                   "type": "DynamicField",
                   "objectType": "test",
                   "objectId": "0x7e00acf5386662fa062483ba507b1e9e3039750f0a270f2e12441ad7f611a5f7",
@@ -6439,7 +6439,7 @@
         ],
         "properties": {
           "bcsName": {
-            "$ref": "#/components/schemas/Base58"
+            "$ref": "#/components/schemas/Base64"
           },
           "digest": {
             "$ref": "#/components/schemas/ObjectDigest"
@@ -6750,10 +6750,10 @@
         ],
         "properties": {
           "bcs": {
-            "description": "Base 58 encoded bcs bytes of the move event",
+            "description": "Base64 encoded bcs bytes of the move event",
             "allOf": [
               {
-                "$ref": "#/components/schemas/Base58"
+                "$ref": "#/components/schemas/Base64"
               }
             ]
           },

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -6780,10 +6780,44 @@
         }
       },
       "Event": {
-        "description": "Base64 encoding",
-        "type": [
-          "object",
-          "string"
+        "type": "object",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "bcs",
+              "bcsEncoding"
+            ],
+            "properties": {
+              "bcs": {
+                "$ref": "#/components/schemas/Base64"
+              },
+              "bcsEncoding": {
+                "type": "string",
+                "enum": [
+                  "base64"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "bcs",
+              "bcsEncoding"
+            ],
+            "properties": {
+              "bcs": {
+                "$ref": "#/components/schemas/Base58"
+              },
+              "bcsEncoding": {
+                "type": "string",
+                "enum": [
+                  "base58"
+                ]
+              }
+            }
+          }
         ],
         "required": [
           "id",

--- a/crates/iota-open-rpc/src/examples.rs
+++ b/crates/iota-open-rpc/src/examples.rs
@@ -8,7 +8,7 @@ use fastcrypto::traits::EncodeDecodeBase64;
 use iota_json::IotaJsonValue;
 use iota_json_rpc::error::Error;
 use iota_json_rpc_types::{
-    Balance, Checkpoint, CheckpointId, CheckpointPage, Coin, CoinPage, DelegatedStake,
+    Balance, BcsEvent, Checkpoint, CheckpointId, CheckpointPage, Coin, CoinPage, DelegatedStake,
     DevInspectArgs, DevInspectResults, DynamicFieldPage, EventFilter, EventPage, IotaCoinMetadata,
     IotaCommittee, IotaData, IotaEvent, IotaExecutionStatus, IotaGetPastObjectRequest,
     IotaMoveAbility, IotaMoveAbilitySet, IotaMoveNormalizedFunction, IotaMoveNormalizedModule,
@@ -777,7 +777,7 @@ impl RpcExampleProvider {
             sender: IotaAddress::from(ObjectID::new(self.rng.gen())),
             type_: parse_iota_struct_tag("0x9::test::TestEvent").unwrap(),
             parsed_json: json!({"test": "example value"}),
-            bcs: vec![],
+            bcs: BcsEvent::new(vec![]),
             timestamp_ms: None,
         };
 
@@ -1154,6 +1154,7 @@ impl RpcExampleProvider {
                 version: SequenceNumber::from_u64(1),
                 digest: ObjectDigest::new(self.rng.gen()),
             })
+            .map(Into::into)
             .collect::<Vec<_>>();
 
         let next_cursor = ObjectID::new(self.rng.gen());
@@ -1312,7 +1313,7 @@ impl RpcExampleProvider {
                 sender: IotaAddress::from(ObjectID::new(self.rng.gen())),
                 type_: StructTag::from_str("0x3::test::Test<0x3::test::Test>").unwrap(),
                 parsed_json: serde_json::Value::String("some_value".to_string()),
-                bcs: vec![],
+                cs: BcsEvent::new(vec![]),
                 timestamp_ms: None,
             })
             .collect();

--- a/crates/iota-open-rpc/src/examples.rs
+++ b/crates/iota-open-rpc/src/examples.rs
@@ -1313,7 +1313,7 @@ impl RpcExampleProvider {
                 sender: IotaAddress::from(ObjectID::new(self.rng.gen())),
                 type_: StructTag::from_str("0x3::test::Test<0x3::test::Test>").unwrap(),
                 parsed_json: serde_json::Value::String("some_value".to_string()),
-                cs: BcsEvent::new(vec![]),
+                bcs: BcsEvent::new(vec![]),
                 timestamp_ms: None,
             })
             .collect();

--- a/crates/iota-types/src/dynamic_field.rs
+++ b/crates/iota-types/src/dynamic_field.rs
@@ -65,12 +65,11 @@ where
 }
 
 #[serde_as]
-#[derive(Clone, Serialize, Deserialize, JsonSchema, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct DynamicFieldInfo {
     pub name: DynamicFieldName,
-    #[schemars(with = "Base64")]
-    #[serde_as(as = "Readable<crate::iota_serde::Base64orBase58, _>")]
+    #[serde_as(as = "Readable<Base64, _>")]
     pub bcs_name: Vec<u8>,
     pub type_: DynamicFieldType,
     pub object_type: String,

--- a/crates/iota-types/src/dynamic_field.rs
+++ b/crates/iota-types/src/dynamic_field.rs
@@ -7,7 +7,7 @@ use std::{
     fmt::{Display, Formatter},
 };
 
-use fastcrypto::{encoding::Base58, hash::HashFunction};
+use fastcrypto::{encoding::Base64, hash::HashFunction};
 use move_core_types::{
     annotated_value::{MoveStruct, MoveValue},
     ident_str,
@@ -69,8 +69,8 @@ where
 #[serde(rename_all = "camelCase")]
 pub struct DynamicFieldInfo {
     pub name: DynamicFieldName,
-    #[schemars(with = "Base58")]
-    #[serde_as(as = "Readable<Base58, _>")]
+    #[schemars(with = "Base64")]
+    #[serde_as(as = "Readable<Base64, _>")]
     pub bcs_name: Vec<u8>,
     pub type_: DynamicFieldType,
     pub object_type: String,

--- a/crates/iota-types/src/dynamic_field.rs
+++ b/crates/iota-types/src/dynamic_field.rs
@@ -70,7 +70,7 @@ where
 pub struct DynamicFieldInfo {
     pub name: DynamicFieldName,
     #[schemars(with = "Base64")]
-    #[serde_as(as = "Readable<Base64, _>")]
+    #[serde_as(as = "Readable<crate::iota_serde::Base64orBase58, _>")]
     pub bcs_name: Vec<u8>,
     pub type_: DynamicFieldType,
     pub object_type: String,

--- a/crates/iota-types/src/iota_serde.rs
+++ b/crates/iota-types/src/iota_serde.rs
@@ -369,3 +369,31 @@ impl<'de> DeserializeAs<'de, ProtocolVersion> for AsProtocolVersion {
         Ok(ProtocolVersion::from(*b))
     }
 }
+
+/// Always serialize as base64, but deserialize from either Base64 or Base58
+pub struct Base64orBase58;
+impl<T> SerializeAs<T> for Base64orBase58
+where
+    T: AsRef<[u8]>,
+{
+    fn serialize_as<S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use fastcrypto::encoding::Encoding;
+        let encoded_string = fastcrypto::encoding::Base64::encode(value);
+        encoded_string.serialize(serializer)
+    }
+}
+impl<'de> DeserializeAs<'de, Vec<u8>> for Base64orBase58 {
+    fn deserialize_as<D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use fastcrypto::encoding::Encoding;
+        let s = String::deserialize(deserializer)?;
+        fastcrypto::encoding::Base64::decode(&s)
+            .or_else(|_| fastcrypto::encoding::Base58::decode(&s))
+            .map_err(|_| Error::custom("Deserialization failed"))
+    }
+}

--- a/crates/iota-types/src/iota_serde.rs
+++ b/crates/iota-types/src/iota_serde.rs
@@ -369,31 +369,3 @@ impl<'de> DeserializeAs<'de, ProtocolVersion> for AsProtocolVersion {
         Ok(ProtocolVersion::from(*b))
     }
 }
-
-/// Always serialize as base64, but deserialize from either Base64 or Base58
-pub struct Base64orBase58;
-impl<T> SerializeAs<T> for Base64orBase58
-where
-    T: AsRef<[u8]>,
-{
-    fn serialize_as<S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        use fastcrypto::encoding::Encoding;
-        let encoded_string = fastcrypto::encoding::Base64::encode(value);
-        encoded_string.serialize(serializer)
-    }
-}
-impl<'de> DeserializeAs<'de, Vec<u8>> for Base64orBase58 {
-    fn deserialize_as<D>(deserializer: D) -> Result<Vec<u8>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        use fastcrypto::encoding::Encoding;
-        let s = String::deserialize(deserializer)?;
-        fastcrypto::encoding::Base64::decode(&s)
-            .or_else(|_| fastcrypto::encoding::Base58::decode(&s))
-            .map_err(|_| Error::custom("Deserialization failed"))
-    }
-}

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -22,11 +22,12 @@ use fastcrypto::{
 };
 use iota_json::IotaJsonValue;
 use iota_json_rpc_types::{
-    Coin, DevInspectArgs, DevInspectResults, DryRunTransactionBlockResponse, DynamicFieldPage,
-    IotaCoinMetadata, IotaData, IotaExecutionStatus, IotaObjectData, IotaObjectDataOptions,
-    IotaObjectResponse, IotaObjectResponseQuery, IotaParsedData, IotaProtocolConfigValue,
-    IotaRawData, IotaTransactionBlockEffects, IotaTransactionBlockEffectsAPI,
-    IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions,
+    Coin, DevInspectArgs, DevInspectResults, DryRunTransactionBlockResponse, DynamicFieldInfo,
+    DynamicFieldPage, IotaCoinMetadata, IotaData, IotaExecutionStatus, IotaObjectData,
+    IotaObjectDataOptions, IotaObjectResponse, IotaObjectResponseQuery, IotaParsedData,
+    IotaProtocolConfigValue, IotaRawData, IotaTransactionBlockEffects,
+    IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse,
+    IotaTransactionBlockResponseOptions,
 };
 use iota_keys::keystore::AccountKeystore;
 use iota_move::manage_package::resolve_lock_file_path;
@@ -50,7 +51,6 @@ use iota_types::{
     base_types::{IotaAddress, ObjectID, SequenceNumber},
     crypto::{EmptySignInfo, SignatureScheme},
     digests::TransactionDigest,
-    dynamic_field::DynamicFieldInfo,
     error::IotaError,
     gas::GasCostSummary,
     gas_coin::GasCoin,


### PR DESCRIPTION
# Description of change

Allows deserialization from both base58 and base64 encodings and changes serialization only to base64.

Implements the following upstream patches:

- [X] [types: use base64 for display](https://github.com/MystenLabs/sui/commit/327afdfbd34a90e42e3da71c13c2ec6c76a1281c)
- [X] [types: support decoding from both base64 as well as base58](https://github.com/MystenLabs/sui/commit/b8b491671f833a5eaa90c05ec76ffc0acf011ec7)
- [X] [jsonrpc: introduce bcsEncoding tag to ease migration to base64](https://github.com/MystenLabs/sui/commit/8a992f0f7f02b48304cc052172a344d6de62d0f9)
- [X] [jsonrpc: correctly serialize bcsName field](https://github.com/MystenLabs/sui/commit/29f17da5e070113d9d624ec265aa5155829bac9a)

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/5413

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo test`

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
