### PR TITLE
chore(iota-framework/stardust): update outdated attach_nft() comment

### DIFF
--- a/crates/iota-framework/packages/stardust/sources/nft/nft_output.move
+++ b/crates/iota-framework/packages/stardust/sources/nft/nft_output.move
@@ -84,7 +84,7 @@ module stardust::nft_output {
 
     // === Public-Package Functions ===
 
-    /// Utility function to attach an `Alias` to an `AliasOutput`.
+    /// Utility function to attach an `Nft` to an `NftOutput`.
     public fun attach_nft<T>(output: &mut NftOutput<T>, nft: Nft) {
         dynamic_object_field::add(&mut output.id, NFT_NAME, nft)
     }


### PR DESCRIPTION
# Description of change
Updates an outdated function comment for attach_nft() incorrectly mentioning Alias and AliasOutput in the context of an NFT output.

## Links to any relevant issues

fixes iotaledger/iota-private#60

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Documentation Fix

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
