### PR TITLE
fix(iota-genesis-builder): add missing is_empty assertion

### DIFF
--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -772,6 +772,7 @@ impl Builder {
         if !self.parameters.allow_insertion_of_extra_objects {
             assert!(gas_objects.is_empty());
             assert!(staked_iota_objects.is_empty());
+            assert!(timelock_staked_iota_objects.is_empty());
         }
 
         let committee = system_state.get_current_epoch_committee();


### PR DESCRIPTION
# Description of change

The following validation is added to check whether they have been allocated: 

`assert!(timelock_staked_iota_objects.is_empty());`

## Links to any relevant issues

fixes iotaledger/iota-private#62

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Ran the ceremony commands.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
