### PR TITLE
fix(iota-genesis-builder): Add check for filtering out outputs with native tokens in SwapSplitIterator

### DIFF
--- a/crates/iota-genesis-builder/src/stardust/process_outputs.rs
+++ b/crates/iota-genesis-builder/src/stardust/process_outputs.rs
@@ -202,9 +202,12 @@ where
             if let Ok((header, inner)) = &mut output {
                 if let Output::Basic(ref basic_output) = inner {
                     let uc = basic_output.unlock_conditions();
-                    // Only for outputs with timelock and/or address unlock conditions the SwapSplit
-                    // operation can be performed
-                    if uc.storage_deposit_return().is_none() && uc.expiration().is_none() {
+                    // Only for outputs with timelock and/or address unlock conditions (and not
+                    // holding native tokens) the SwapSplit operation can be performed
+                    if uc.storage_deposit_return().is_none()
+                        && uc.expiration().is_none()
+                        && basic_output.native_tokens().len() == 0
+                    {
                         // Now check if the addressUC's address is to swap
                         if let Some(destinations) = self
                             .swap_split_map

--- a/crates/iota-genesis-builder/src/stardust/process_outputs.rs
+++ b/crates/iota-genesis-builder/src/stardust/process_outputs.rs
@@ -206,7 +206,7 @@ where
                     // holding native tokens) the SwapSplit operation can be performed
                     if uc.storage_deposit_return().is_none()
                         && uc.expiration().is_none()
-                        && basic_output.native_tokens().len() == 0
+                        && basic_output.native_tokens().is_empty()
                     {
                         // Now check if the addressUC's address is to swap
                         if let Some(destinations) = self


### PR DESCRIPTION
# Description of change

This PR implements a safety check by filtering out the outputs that hold native tokens in the SwapSplitIterator: 
- the purpose of this iterator is to pick vested basic outputs and split those; 
- without any additional logic this split could duplicate the native tokens amounts in several outputs;
- so filtering out outputs holding native tokens at the inception of operations avoids the unwanted duplication.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota-private/issues/64

## Type of change

- Bug fix

## How the change has been tested

- `cargo run --release --bin iota-genesis-builder -- --disable-global-snapshot-verification iota  --snapshot-path ../latest-full_snapshot.bin --address-swap-split-map-path crates/iota-e2e-tests/tests/migration/swap_split.csv  --target-network alphanet-test`

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
