### PR TITLE
fix: adding missing dependencies for iota-genesis-builder docker image

### DIFF
--- a/docker/iota-tools/Dockerfile
+++ b/docker/iota-tools/Dockerfile
@@ -72,7 +72,7 @@ ARG WORKDIR="/iota"
 WORKDIR "$WORKDIR"
 
 # Install runtime dependencies and tools
-RUN apt update && apt install -y libpq5 ca-certificates curl
+RUN apt update && apt install -y libpq5 ca-certificates curl git
 
 COPY --from=builder /iota/iota-node /usr/local/bin
 COPY --from=builder /iota/stress /usr/local/bin


### PR DESCRIPTION
# Description of change

To fix:
```
2025-02-21T00:26:00.059974Z  INFO iota_genesis_builder::stardust::migration::migration: Starting the migration...
2025-02-21T00:26:00.074234Z DEBUG iota_genesis_builder::stardust::process_outputs: Found a vesting output with output index different than 0: 0xb191c4bc825ac6983789e50545d5ef07a1d293a98ad974fc9498cb18ffd7ffff2b00
2025-02-21T00:26:00.074251Z DEBUG iota_genesis_builder::stardust::process_outputs: Number of basic outputs used for a SwapSplit (no timelock): 1
2025-02-21T00:26:00.074255Z DEBUG iota_genesis_builder::stardust::process_outputs: Number of timelocked basic outputs used for a SwapSplit: 1
2025-02-21T00:26:00.074258Z DEBUG iota_genesis_builder::stardust::process_outputs: Number of outputs created with splits: 3
2025-02-21T00:26:00.074261Z DEBUG iota_genesis_builder::stardust::process_outputs: Number of participation outputs: 0
2025-02-21T00:26:00.074264Z DEBUG iota_genesis_builder::stardust::process_outputs: Participation outputs: []
2025-02-21T00:26:00.074268Z DEBUG iota_genesis_builder::stardust::process_outputs: Number of vesting outputs before merge: 3300
2025-02-21T00:26:00.074271Z DEBUG iota_genesis_builder::stardust::process_outputs: Number of vesting outputs after merging: 165
2025-02-21T00:26:00.074274Z DEBUG iota_genesis_builder::stardust::process_outputs: Number of scaled outputs: 11812
2025-02-21T00:26:00.077178Z  INFO iota_genesis_builder::stardust::migration::migration: Migrating foundries...
Error: Failed to build Move modules: Failed to resolve dependencies for package 'mnt'

Caused by:
    0: Fetching 'Iota'
    1: Git is not installed or not in the PATH..
```

## How the change has been tested

Build a docker image locally and test it.