### PR TITLE
[`iota-data-ingestion-core`]: add `Reducer` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6562,6 +6562,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-util 0.7.12",
  "tracing",
  "url",

--- a/crates/iota-analytics-indexer/src/analytics_processor.rs
+++ b/crates/iota-analytics-indexer/src/analytics_processor.rs
@@ -51,12 +51,13 @@ const CHECK_FILE_SIZE_ITERATION_CYCLE: u64 = 50;
 
 #[async_trait::async_trait]
 impl<S: Serialize + ParquetSchema + 'static> Worker for AnalyticsProcessor<S> {
+    type Message = ();
     type Error = anyhow::Error;
 
     async fn process_checkpoint(
         &self,
         checkpoint_data: &CheckpointData,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<Self::Message, Self::Error> {
         // get epoch id, checkpoint sequence number and timestamp, those are important
         // indexes when operating on data
         let epoch: u64 = checkpoint_data.checkpoint_summary.epoch();

--- a/crates/iota-analytics-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/checkpoint_handler.rs
@@ -25,12 +25,13 @@ struct State {
 
 #[async_trait::async_trait]
 impl Worker for CheckpointHandler {
+    type Message = ();
     type Error = anyhow::Error;
 
     async fn process_checkpoint(
         &self,
         checkpoint_data: &CheckpointData,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<Self::Message, Self::Error> {
         let CheckpointData {
             checkpoint_summary,
             transactions: checkpoint_transactions,

--- a/crates/iota-analytics-indexer/src/handlers/df_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/df_handler.rs
@@ -40,12 +40,13 @@ struct State {
 
 #[async_trait::async_trait]
 impl Worker for DynamicFieldHandler {
+    type Message = ();
     type Error = anyhow::Error;
 
     async fn process_checkpoint(
         &self,
         checkpoint_data: &CheckpointData,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<Self::Message, Self::Error> {
         let CheckpointData {
             checkpoint_summary,
             transactions: checkpoint_transactions,

--- a/crates/iota-analytics-indexer/src/handlers/event_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/event_handler.rs
@@ -35,12 +35,13 @@ struct State {
 
 #[async_trait::async_trait]
 impl Worker for EventHandler {
+    type Message = ();
     type Error = anyhow::Error;
 
     async fn process_checkpoint(
         &self,
         checkpoint_data: &CheckpointData,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<Self::Message, Self::Error> {
         let CheckpointData {
             checkpoint_summary,
             transactions: checkpoint_transactions,

--- a/crates/iota-analytics-indexer/src/handlers/mod.rs
+++ b/crates/iota-analytics-indexer/src/handlers/mod.rs
@@ -41,7 +41,7 @@ const WRAPPED_INDEXING_DISALLOW_LIST: [&str; 4] = [
 ];
 
 #[async_trait::async_trait]
-pub trait AnalyticsHandler<S>: Worker<Error = anyhow::Error> {
+pub trait AnalyticsHandler<S>: Worker<Message = (), Error = anyhow::Error> {
     /// Read back rows which are ready to be persisted. This function
     /// will be invoked by the analytics processor after every call to
     /// process_checkpoint

--- a/crates/iota-analytics-indexer/src/handlers/move_call_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/move_call_handler.rs
@@ -21,12 +21,13 @@ struct State {
 
 #[async_trait::async_trait]
 impl Worker for MoveCallHandler {
+    type Message = ();
     type Error = anyhow::Error;
 
     async fn process_checkpoint(
         &self,
         checkpoint_data: &CheckpointData,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<Self::Message, Self::Error> {
         let CheckpointData {
             checkpoint_summary,
             transactions: checkpoint_transactions,

--- a/crates/iota-analytics-indexer/src/handlers/object_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/object_handler.rs
@@ -35,12 +35,13 @@ struct State {
 
 #[async_trait::async_trait]
 impl Worker for ObjectHandler {
+    type Message = ();
     type Error = anyhow::Error;
 
     async fn process_checkpoint(
         &self,
         checkpoint_data: &CheckpointData,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<Self::Message, Self::Error> {
         let CheckpointData {
             checkpoint_summary,
             transactions: checkpoint_transactions,

--- a/crates/iota-analytics-indexer/src/handlers/package_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/package_handler.rs
@@ -21,12 +21,13 @@ struct State {
 
 #[async_trait::async_trait]
 impl Worker for PackageHandler {
+    type Message = ();
     type Error = anyhow::Error;
 
     async fn process_checkpoint(
         &self,
         checkpoint_data: &CheckpointData,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<Self::Message, Self::Error> {
         let CheckpointData {
             checkpoint_summary,
             transactions: checkpoint_transactions,

--- a/crates/iota-analytics-indexer/src/handlers/transaction_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/transaction_handler.rs
@@ -27,12 +27,13 @@ pub(crate) struct State {
 
 #[async_trait::async_trait]
 impl Worker for TransactionHandler {
+    type Message = ();
     type Error = anyhow::Error;
 
     async fn process_checkpoint(
         &self,
         checkpoint_data: &CheckpointData,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<Self::Message, Self::Error> {
         let CheckpointData {
             checkpoint_summary,
             transactions: checkpoint_transactions,

--- a/crates/iota-analytics-indexer/src/handlers/transaction_objects_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/transaction_objects_handler.rs
@@ -26,12 +26,13 @@ struct State {
 
 #[async_trait::async_trait]
 impl Worker for TransactionObjectsHandler {
+    type Message = ();
     type Error = anyhow::Error;
 
     async fn process_checkpoint(
         &self,
         checkpoint_data: &CheckpointData,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<Self::Message, Self::Error> {
         let CheckpointData {
             checkpoint_summary,
             transactions: checkpoint_transactions,

--- a/crates/iota-analytics-indexer/src/handlers/wrapped_object_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/wrapped_object_handler.rs
@@ -30,12 +30,13 @@ struct State {
 
 #[async_trait::async_trait]
 impl Worker for WrappedObjectHandler {
+    type Message = ();
     type Error = anyhow::Error;
 
     async fn process_checkpoint(
         &self,
         checkpoint_data: &CheckpointData,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<Self::Message, Self::Error> {
         let CheckpointData {
             checkpoint_summary,
             transactions: checkpoint_transactions,

--- a/crates/iota-analytics-indexer/src/lib.rs
+++ b/crates/iota-analytics-indexer/src/lib.rs
@@ -483,19 +483,20 @@ impl FileMetadata {
 }
 
 pub struct Processor {
-    pub processor: Box<dyn Worker<Error = anyhow::Error>>,
+    pub processor: Box<dyn Worker<Message = (), Error = anyhow::Error>>,
     pub starting_checkpoint_seq_num: CheckpointSequenceNumber,
 }
 
 #[async_trait::async_trait]
 impl Worker for Processor {
+    type Message = ();
     type Error = anyhow::Error;
 
     #[inline]
     async fn process_checkpoint(
         &self,
         checkpoint_data: &CheckpointData,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<Self::Message, Self::Error> {
         self.processor.process_checkpoint(checkpoint_data).await
     }
 }

--- a/crates/iota-data-ingestion-core/Cargo.toml
+++ b/crates/iota-data-ingestion-core/Cargo.toml
@@ -21,6 +21,7 @@ tap.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tokio-stream.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
 url.workspace = true

--- a/crates/iota-data-ingestion-core/src/errors.rs
+++ b/crates/iota-data-ingestion-core/src/errors.rs
@@ -42,6 +42,9 @@ pub enum IngestionError {
     #[error("Progress Store error: `{0}`")]
     ProgressStore(String),
 
+    #[error("Reducer error: `{0}`")]
+    Reducer(String),
+
     #[error("Deserialize checkpoint failed: `{0}`")]
     DeserializeCheckpoint(String),
 }

--- a/crates/iota-data-ingestion-core/src/executor.rs
+++ b/crates/iota-data-ingestion-core/src/executor.rs
@@ -71,6 +71,14 @@ impl<P: ProgressStore> IndexerExecutor<P> {
         Ok(())
     }
 
+    pub async fn update_watermark(
+        &mut self,
+        task_name: String,
+        watermark: CheckpointSequenceNumber,
+    ) -> IngestionResult<()> {
+        self.progress_store.save(task_name, watermark).await
+    }
+
     /// Main executor loop
     pub async fn run(
         mut self,

--- a/crates/iota-data-ingestion-core/src/executor.rs
+++ b/crates/iota-data-ingestion-core/src/executor.rs
@@ -110,8 +110,8 @@ impl<P: ProgressStore> IndexerExecutor<P> {
             tokio::select! {
                 Some(worker_pool_progress_msg) = self.pool_status_receiver.recv() => {
                     match worker_pool_progress_msg {
-                        WorkerPoolStatus::Running((task_name, sequence_number)) => {
-                            self.progress_store.save(task_name.clone(), sequence_number).await.map_err(|err| IngestionError::ProgressStore(err.to_string()))?;
+                        WorkerPoolStatus::Running((task_name, watermark)) => {
+                            self.progress_store.save(task_name.clone(), watermark).await.map_err(|err| IngestionError::ProgressStore(err.to_string()))?;
                             let seq_number = self.progress_store.min_watermark()?;
                             if seq_number > reader_checkpoint_number {
                                 gc_sender.send(seq_number).await.map_err(|_| {
@@ -122,7 +122,7 @@ impl<P: ProgressStore> IndexerExecutor<P> {
                                 })?;
                                 reader_checkpoint_number = seq_number;
                             }
-                            self.metrics.data_ingestion_checkpoint.with_label_values(&[&task_name]).set(sequence_number as i64);
+                            self.metrics.data_ingestion_checkpoint.with_label_values(&[&task_name]).set(watermark as i64);
                         }
                         WorkerPoolStatus::Shutdown(worker_pool_name) => {
                             // Track worker pools that have initiated shutdown

--- a/crates/iota-data-ingestion-core/src/lib.rs
+++ b/crates/iota-data-ingestion-core/src/lib.rs
@@ -29,6 +29,7 @@ mod executor;
 mod metrics;
 mod progress_store;
 mod reader;
+mod reducer;
 #[cfg(test)]
 mod tests;
 mod util;
@@ -39,9 +40,7 @@ use std::fmt::{Debug, Display};
 use async_trait::async_trait;
 pub use errors::{IngestionError, IngestionResult};
 pub use executor::{IndexerExecutor, MAX_CHECKPOINTS_IN_PROGRESS, setup_single_workflow};
-use iota_types::{
-    full_checkpoint_content::CheckpointData, messages_checkpoint::CheckpointSequenceNumber,
-};
+use iota_types::full_checkpoint_content::CheckpointData;
 pub use metrics::DataIngestionMetrics;
 pub use progress_store::{FileProgressStore, ProgressStore, ShimProgressStore};
 pub use reader::ReaderOptions;
@@ -51,21 +50,25 @@ pub use worker_pool::WorkerPool;
 #[async_trait]
 pub trait Worker: Send + Sync {
     type Error: Debug + Display;
+    type Message: Send + Sync;
 
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<(), Self::Error>;
-    /// Optional method. Allows controlling when workflow progress is updated in
-    /// the progress store. For instance, some pipelines may benefit from
-    /// aggregating checkpoints, thus skipping the saving of updates for
-    /// intermediate checkpoints. The default implementation is to update
-    /// the progress store for every processed checkpoint.
-    async fn save_progress(
+    async fn process_checkpoint(
         &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> Option<CheckpointSequenceNumber> {
-        Some(sequence_number)
-    }
+        checkpoint: &CheckpointData,
+    ) -> Result<Self::Message, Self::Error>;
 
     fn preprocess_hook(&self, _: &CheckpointData) -> Result<(), Self::Error> {
         Ok(())
+    }
+}
+
+#[async_trait]
+pub trait Reducer<R: Send + Sync>: Send + Sync {
+    type Error: Debug + Display;
+
+    async fn commit(&self, batch: Vec<R>) -> Result<(), Self::Error>;
+
+    fn should_close_batch(&self, _batch: &[R], next_item: Option<&R>) -> bool {
+        next_item.is_none()
     }
 }

--- a/crates/iota-data-ingestion-core/src/lib.rs
+++ b/crates/iota-data-ingestion-core/src/lib.rs
@@ -63,7 +63,7 @@ pub trait Worker: Send + Sync {
 }
 
 #[async_trait]
-pub trait Reducer<R: Send + Sync>: Send + Sync {
+pub trait Reducer<R>: Send + Sync {
     type Error: Debug + Display;
 
     async fn commit(&self, batch: Vec<R>) -> Result<(), Self::Error>;

--- a/crates/iota-data-ingestion-core/src/lib.rs
+++ b/crates/iota-data-ingestion-core/src/lib.rs
@@ -44,6 +44,7 @@ use iota_types::full_checkpoint_content::CheckpointData;
 pub use metrics::DataIngestionMetrics;
 pub use progress_store::{FileProgressStore, ProgressStore, ShimProgressStore};
 pub use reader::ReaderOptions;
+pub use reducer::Reducer;
 pub use util::{create_remote_store_client, create_remote_store_client_with_ops};
 pub use worker_pool::WorkerPool;
 
@@ -59,16 +60,5 @@ pub trait Worker: Send + Sync {
 
     fn preprocess_hook(&self, _: &CheckpointData) -> Result<(), Self::Error> {
         Ok(())
-    }
-}
-
-#[async_trait]
-pub trait Reducer<R>: Send + Sync {
-    type Error: Debug + Display;
-
-    async fn commit(&self, batch: Vec<R>) -> Result<(), Self::Error>;
-
-    fn should_close_batch(&self, _batch: &[R], next_item: Option<&R>) -> bool {
-        next_item.is_none()
     }
 }

--- a/crates/iota-data-ingestion-core/src/progress_store/file.rs
+++ b/crates/iota-data-ingestion-core/src/progress_store/file.rs
@@ -28,9 +28,10 @@ use crate::{IngestionError, IngestionResult, progress_store::ProgressStore};
 /// async fn main() {
 ///     let mut store = FileProgressStore::new("progress.json").await.unwrap();
 ///     store.save("task1".into(), 42).await.unwrap();
+///     # tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 ///     let checkpoint = store.load("task1".into()).await.unwrap();
-///     assert_eq!(checkpoint, 42);
 ///     # tokio::fs::remove_file("progress.json").await.unwrap();
+///     assert_eq!(checkpoint, 42);
 /// }
 /// ```
 pub struct FileProgressStore {

--- a/crates/iota-data-ingestion-core/src/reducer.rs
+++ b/crates/iota-data-ingestion-core/src/reducer.rs
@@ -2,58 +2,29 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::HashMap,
-    fmt::{Debug, Display},
-};
+use std::collections::HashMap;
 
 use async_trait::async_trait;
 use futures::StreamExt;
 use iota_types::messages_checkpoint::CheckpointSequenceNumber;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
 use crate::{
-    IngestionError, IngestionResult, MAX_CHECKPOINTS_IN_PROGRESS, Reducer, Worker,
+    IngestionError, IngestionResult, MAX_CHECKPOINTS_IN_PROGRESS, Worker,
     worker_pool::WorkerPoolStatus,
 };
 
-/// A wrapper type that adapts a [`Reducer`] implementation to use
-/// [`IngestionError`] as its error type.
-///
-/// This wrapper is used internally by the worker pool to standardize error
-/// handling across different reducer implementations. It converts the reducer's
-/// original error type into [`IngestionError`].
-pub(crate) struct ReducerWrapper<R>(R);
-
-impl<R> ReducerWrapper<R> {
-    /// Creates a new `ReducerWrapper` instance containing the provided reducer.
-    pub(crate) fn new(reducer: R) -> Self {
-        Self(reducer)
-    }
-}
-
 #[async_trait]
-impl<R, T> Reducer<T> for ReducerWrapper<R>
-where
-    R: Reducer<T>,
-    R::Error: Debug + Display,
-    T: Send + Sync + 'static,
-{
-    type Error = IngestionError;
+pub trait Reducer<Mapper: Worker>: Send + Sync {
+    async fn commit(&self, batch: Vec<Mapper::Message>) -> Result<(), Mapper::Error>;
 
-    /// Delegates the commit operation to the wrapped reducer and converts its
-    /// error type.
-    async fn commit(&self, batch: Vec<T>) -> Result<(), Self::Error> {
-        self.0
-            .commit(batch)
-            .await
-            .map_err(|err| IngestionError::Reducer(format!("failed to commit batch: {err}")))
-    }
-
-    /// Delegates the batch closing decision to the wrapped reducer.
-    fn should_close_batch(&self, batch: &[T], next_item: Option<&T>) -> bool {
-        self.0.should_close_batch(batch, next_item)
+    fn should_close_batch(
+        &self,
+        _batch: &[Mapper::Message],
+        next_item: Option<&Mapper::Message>,
+    ) -> bool {
+        next_item.is_none()
     }
 }
 
@@ -69,8 +40,8 @@ where
 /// 1. Receives messages in chunks up to [`MAX_CHECKPOINTS_IN_PROGRESS`]
 /// 2. Maintains message order using checkpoint sequence numbers
 /// 3. Batches messages according to reducer's [`Reducer::should_close_batch`]
-///    logic
-/// 4. Commits batches when appropriate
+///    policy and after that its committed
+/// 4. Progress is updated after each commit
 /// 5. Reports progress back to the executor
 ///
 /// # Shutdown Behavior
@@ -80,15 +51,14 @@ where
 pub(crate) async fn reduce<W: Worker>(
     task_name: String,
     mut current_checkpoint_number: CheckpointSequenceNumber,
-    progress_receiver: mpsc::Receiver<(CheckpointSequenceNumber, W::Message)>,
+    watermark_receiver: mpsc::Receiver<(CheckpointSequenceNumber, W::Message)>,
     executor_progress_sender: mpsc::Sender<WorkerPoolStatus>,
-    reducer: Option<Box<dyn Reducer<W::Message, Error = IngestionError>>>,
-    mut shutdown: oneshot::Receiver<()>,
+    reducer: Box<dyn Reducer<W>>,
 ) -> IngestionResult<()> {
     // convert to a stream of MAX_CHECKPOINTS_IN_PROGRESS size. This way, each
     // iteration of the loop will process all ready messages
     let mut stream =
-        ReceiverStream::new(progress_receiver).ready_chunks(MAX_CHECKPOINTS_IN_PROGRESS);
+        ReceiverStream::new(watermark_receiver).ready_chunks(MAX_CHECKPOINTS_IN_PROGRESS);
     // store unprocessed progress messages from workers.
     let mut unprocessed = HashMap::new();
     // buffer to accumulate results before passing them to the reducer.
@@ -99,55 +69,46 @@ pub(crate) async fn reduce<W: Worker>(
     // after each chunk of messages is received from the stream.
     let mut progress_update = None;
 
-    loop {
-        tokio::select! {
-            _ = &mut shutdown => break,
-            // get the available progress from workers as a chunks
-            Some(update_batch) = stream.next() => {
-                unprocessed.extend(update_batch.into_iter());
-                // Process messages sequentially based on checkpoint sequence number.
-                // This ensures in-order processing and maintains progress integrity.
-                while let Some(message) = unprocessed.remove(&current_checkpoint_number) {
-                    if let Some(ref reducer) = reducer {
-                        // reducer is configured, collect messages in batch based on
-                        // `reducer.should_close_batch` policy, once a batch is collected it gets
-                        // committed and a new batch is created with the current message.
-                        if reducer.should_close_batch(&batch, Some(&message)) {
-                            reducer
-                                .commit(std::mem::take(&mut batch))
-                                .await?;
-                            batch = vec![message];
-                            progress_update = Some(current_checkpoint_number);
-                        } else {
-                            // Add message to existing batch since no commit needed
-                            batch.push(message);
-                        }
-                    }
-                    current_checkpoint_number += 1;
-                }
-                // Handle final batch processing
-                match reducer {
-                    Some(ref reducer) => {
-                        // Check if the final batch should be committed.
-                        // None parameter indicates no more messages available
-                        if reducer.should_close_batch(&batch, None) {
-                            reducer
-                                .commit(std::mem::take(&mut batch))
-                                .await?;
-                            progress_update = Some(current_checkpoint_number);
-                        }
-                    }
-                    None => progress_update = Some(current_checkpoint_number),
-                }
-                // report progress update to executor
-                if let Some(watermark) = progress_update {
-                    executor_progress_sender
-                        .send(WorkerPoolStatus::Running((task_name.clone(), watermark)))
-                        .await
-                        .map_err(|_| IngestionError::Channel("unable to send worker pool progress updates to executor, receiver half closed".into()))?;
-                    progress_update = None;
-                }
+    while let Some(update_batch) = stream.next().await {
+        unprocessed.extend(update_batch.into_iter());
+        // Process messages sequentially based on checkpoint sequence number.
+        // This ensures in-order processing and maintains progress integrity.
+        while let Some(message) = unprocessed.remove(&current_checkpoint_number) {
+            // reducer is configured, collect messages in batch based on
+            // `reducer.should_close_batch` policy, once a batch is collected it gets
+            // committed and a new batch is created with the current message.
+            if reducer.should_close_batch(&batch, Some(&message)) {
+                reducer
+                    .commit(std::mem::take(&mut batch))
+                    .await
+                    .map_err(|err| {
+                        IngestionError::Reducer(format!("failed to commit batch: {err}"))
+                    })?;
+                batch = vec![message];
+                progress_update = Some(current_checkpoint_number);
+            } else {
+                // Add message to existing batch since no commit needed
+                batch.push(message);
             }
+            current_checkpoint_number += 1;
+        }
+        // Handle final batch processing
+        // Check if the final batch should be committed.
+        // None parameter indicates no more messages available
+        if reducer.should_close_batch(&batch, None) {
+            reducer
+                .commit(std::mem::take(&mut batch))
+                .await
+                .map_err(|err| IngestionError::Reducer(format!("failed to commit batch: {err}")))?;
+            progress_update = Some(current_checkpoint_number);
+        }
+        // report progress update to executor
+        if let Some(watermark) = progress_update {
+            executor_progress_sender
+                .send(WorkerPoolStatus::Running((task_name.clone(), watermark)))
+                .await
+                .map_err(|_| IngestionError::Channel("unable to send worker pool progress updates to executor, receiver half closed".into()))?;
+            progress_update = None;
         }
     }
     Ok(())

--- a/crates/iota-data-ingestion-core/src/reducer.rs
+++ b/crates/iota-data-ingestion-core/src/reducer.rs
@@ -65,7 +65,7 @@ pub(crate) async fn reduce<W: Worker>(
     // The size of this batch is dynamically determined by the reducer's
     // `should_close_batch` method.
     let mut batch = vec![];
-    // track the latest processed checkpoint number for reporting progress
+    // track the next unprocessed checkpoint number for reporting progress
     // after each chunk of messages is received from the stream.
     let mut progress_update = None;
 

--- a/crates/iota-data-ingestion-core/src/reducer.rs
+++ b/crates/iota-data-ingestion-core/src/reducer.rs
@@ -1,0 +1,154 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::HashMap,
+    fmt::{Debug, Display},
+};
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use iota_types::messages_checkpoint::CheckpointSequenceNumber;
+use tokio::sync::{mpsc, oneshot};
+use tokio_stream::wrappers::ReceiverStream;
+
+use crate::{
+    IngestionError, IngestionResult, MAX_CHECKPOINTS_IN_PROGRESS, Reducer, Worker,
+    worker_pool::WorkerPoolStatus,
+};
+
+/// A wrapper type that adapts a [`Reducer`] implementation to use
+/// [`IngestionError`] as its error type.
+///
+/// This wrapper is used internally by the worker pool to standardize error
+/// handling across different reducer implementations. It converts the reducer's
+/// original error type into [`IngestionError`].
+pub(crate) struct ReducerWrapper<R>(R);
+
+impl<R> ReducerWrapper<R> {
+    /// Creates a new `ReducerWrapper` instance containing the provided reducer.
+    pub(crate) fn new(reducer: R) -> Self {
+        Self(reducer)
+    }
+}
+
+#[async_trait]
+impl<R, T> Reducer<T> for ReducerWrapper<R>
+where
+    R: Reducer<T>,
+    R::Error: Debug + Display,
+    T: Send + Sync + 'static,
+{
+    type Error = IngestionError;
+
+    /// Delegates the commit operation to the wrapped reducer and converts its
+    /// error type.
+    async fn commit(&self, batch: Vec<T>) -> Result<(), Self::Error> {
+        self.0
+            .commit(batch)
+            .await
+            .map_err(|err| IngestionError::Reducer(format!("failed to commit batch: {err}")))
+    }
+
+    /// Delegates the batch closing decision to the wrapped reducer.
+    fn should_close_batch(&self, batch: &[T], next_item: Option<&T>) -> bool {
+        self.0.should_close_batch(batch, next_item)
+    }
+}
+
+/// Processes worker messages and manages batching through a reducer.
+///
+/// This function is the core of the reduction pipeline, handling message
+/// batching, watermark tracking, and progress reporting. It maintains message
+/// order by checkpoint sequence number and applies batching logic through the
+/// provided reducer.
+///
+/// # Message Processing Flow
+///
+/// 1. Receives messages in chunks up to [`MAX_CHECKPOINTS_IN_PROGRESS`]
+/// 2. Maintains message order using checkpoint sequence numbers
+/// 3. Batches messages according to reducer's [`Reducer::should_close_batch`]
+///    logic
+/// 4. Commits batches when appropriate
+/// 5. Reports progress back to the executor
+///
+/// # Shutdown Behavior
+///
+/// The function will gracefully exit when receiving a shutdown signal,
+/// ensuring no data loss for processed messages.
+pub(crate) async fn reduce<W: Worker>(
+    task_name: String,
+    mut current_checkpoint_number: CheckpointSequenceNumber,
+    progress_receiver: mpsc::Receiver<(CheckpointSequenceNumber, W::Message)>,
+    executor_progress_sender: mpsc::Sender<WorkerPoolStatus>,
+    reducer: Option<Box<dyn Reducer<W::Message, Error = IngestionError>>>,
+    mut shutdown: oneshot::Receiver<()>,
+) -> IngestionResult<()> {
+    // convert to a stream of MAX_CHECKPOINTS_IN_PROGRESS size. This way, each
+    // iteration of the loop will process all ready messages
+    let mut stream =
+        ReceiverStream::new(progress_receiver).ready_chunks(MAX_CHECKPOINTS_IN_PROGRESS);
+    // store unprocessed progress messages from workers.
+    let mut unprocessed = HashMap::new();
+    // buffer to accumulate results before passing them to the reducer.
+    // The size of this batch is dynamically determined by the reducer's
+    // `should_close_batch` method.
+    let mut batch = vec![];
+    // track the latest processed checkpoint number for reporting progress
+    // after each chunk of messages is received from the stream.
+    let mut progress_update = None;
+
+    loop {
+        tokio::select! {
+            _ = &mut shutdown => break,
+            // get the available progress from workers as a chunks
+            Some(update_batch) = stream.next() => {
+                unprocessed.extend(update_batch.into_iter());
+                // Process messages sequentially based on checkpoint sequence number.
+                // This ensures in-order processing and maintains progress integrity.
+                while let Some(message) = unprocessed.remove(&current_checkpoint_number) {
+                    if let Some(ref reducer) = reducer {
+                        // reducer is configured, collect messages in batch based on
+                        // `reducer.should_close_batch` policy, once a batch is collected it gets
+                        // committed and a new batch is created with the current message.
+                        if reducer.should_close_batch(&batch, Some(&message)) {
+                            reducer
+                                .commit(std::mem::take(&mut batch))
+                                .await?;
+                            batch = vec![message];
+                            progress_update = Some(current_checkpoint_number);
+                        } else {
+                            // Add message to existing batch since no commit needed
+                            batch.push(message);
+                        }
+                    }
+                    current_checkpoint_number += 1;
+                }
+                // Handle final batch processing
+                match reducer {
+                    Some(ref reducer) => {
+                        // Check if the final batch should be committed.
+                        // None parameter indicates no more messages available
+                        if reducer.should_close_batch(&batch, None) {
+                            reducer
+                                .commit(std::mem::take(&mut batch))
+                                .await?;
+                            progress_update = Some(current_checkpoint_number);
+                        }
+                    }
+                    None => progress_update = Some(current_checkpoint_number),
+                }
+                // report progress update to executor
+                if let Some(watermark) = progress_update {
+                    executor_progress_sender
+                        .send(WorkerPoolStatus::Running((task_name.clone(), watermark)))
+                        .await
+                        .map_err(|_| IngestionError::Channel("unable to send worker pool progress updates to executor, receiver half closed".into()))?;
+                    progress_update = None;
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/iota-data-ingestion-core/src/worker_pool.rs
+++ b/crates/iota-data-ingestion-core/src/worker_pool.rs
@@ -328,7 +328,7 @@ async fn simple_watermark_tracking<W: Worker>(
         ReceiverStream::new(watermark_receiver).ready_chunks(MAX_CHECKPOINTS_IN_PROGRESS);
     // store unprocessed progress messages from workers.
     let mut unprocessed = HashMap::new();
-    // track the latest processed checkpoint number for reporting progress
+    // track the next unprocessed checkpoint number for reporting progress
     // after each chunk of messages is received from the stream.
     let mut progress_update = None;
 

--- a/crates/iota-data-ingestion-core/src/worker_pool.rs
+++ b/crates/iota-data-ingestion-core/src/worker_pool.rs
@@ -92,7 +92,7 @@ impl<W: Worker + 'static> WorkerPool<W> {
         // This channel will be used to send progress data from Workers to WorkerPool
         // mian loop
         let (progress_sender, mut progress_receiver) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
-        // This channel will be used to send Wrokers progress data from WorkerPool to
+        // This channel will be used to send Workers progress data from WorkerPool to
         // watermark tracking task
         let (watermark_sender, watermark_receiver) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
         let mut idle: BTreeSet<_> = (0..self.concurrency).collect();
@@ -319,13 +319,13 @@ impl<W: Worker + 'static> WorkerPool<W> {
 async fn simple_watermark_tracking<W: Worker>(
     task_name: String,
     mut current_checkpoint_number: CheckpointSequenceNumber,
-    reducer_receiver: mpsc::Receiver<(CheckpointSequenceNumber, W::Message)>,
+    watermark_receiver: mpsc::Receiver<(CheckpointSequenceNumber, W::Message)>,
     executor_progress_sender: mpsc::Sender<WorkerPoolStatus>,
 ) -> IngestionResult<()> {
     // convert to a stream of MAX_CHECKPOINTS_IN_PROGRESS size. This way, each
     // iteration of the loop will process all ready messages
     let mut stream =
-        ReceiverStream::new(reducer_receiver).ready_chunks(MAX_CHECKPOINTS_IN_PROGRESS);
+        ReceiverStream::new(watermark_receiver).ready_chunks(MAX_CHECKPOINTS_IN_PROGRESS);
     // store unprocessed progress messages from workers.
     let mut unprocessed = HashMap::new();
     // track the latest processed checkpoint number for reporting progress

--- a/crates/iota-data-ingestion-core/src/worker_pool.rs
+++ b/crates/iota-data-ingestion-core/src/worker_pool.rs
@@ -4,29 +4,29 @@
 
 use std::{
     collections::{BTreeSet, HashMap, VecDeque},
+    fmt::Debug,
     sync::Arc,
     time::Instant,
 };
 
+use futures::StreamExt;
 use iota_metrics::spawn_monitored_task;
 use iota_rest_api::CheckpointData;
 use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 use tokio::{sync::mpsc, task::JoinHandle};
+use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
-use crate::{IngestionError, Worker, executor::MAX_CHECKPOINTS_IN_PROGRESS};
+use crate::{
+    IngestionError, IngestionResult, Reducer, Worker, executor::MAX_CHECKPOINTS_IN_PROGRESS,
+    reducer::reduce,
+};
 
 type TaskName = String;
 type WorkerID = usize;
 
-pub struct WorkerPool<W: Worker> {
-    pub task_name: String,
-    concurrency: usize,
-    worker: Arc<W>,
-}
-
-/// Represents the possible message types a WorkerPool can communicate with
+/// Represents the possible message types a [`WorkerPool`] can communicate with
 /// external components
 #[derive(Debug, Clone)]
 pub enum WorkerPoolStatus {
@@ -37,23 +37,23 @@ pub enum WorkerPoolStatus {
     Shutdown(String),
 }
 
-/// Represents the possible message types a Worker can communicate with external
-/// components
+/// Represents the possible message types a [`Worker`] can communicate with
+/// external components
 #[derive(Debug, Clone, Copy)]
-enum WorkerStatus {
-    /// Message with information (e.g. `(<worker-id>,
-    /// checkpoint_sequence_number,
-    /// <saved-progress-store-checkpoint-sequence-number>)`) about the ingestion
+enum WorkerStatus<M> {
+    /// Message with information (e.g. `(<worker-id>`,
+    /// `checkpoint_sequence_number`, [`Worker::Message`]) about the ingestion
     /// progress.
-    Running(
-        (
-            WorkerID,
-            CheckpointSequenceNumber,
-            Option<CheckpointSequenceNumber>,
-        ),
-    ),
+    Running((WorkerID, CheckpointSequenceNumber, M)),
     /// Message with information (e.g. `<worker-id>`) about shutdown status
     Shutdown(WorkerID),
+}
+
+pub struct WorkerPool<W: Worker> {
+    pub task_name: String,
+    concurrency: usize,
+    worker: Arc<W>,
+    reducer: Option<Box<dyn Reducer<W>>>,
 }
 
 impl<W: Worker + 'static> WorkerPool<W> {
@@ -62,53 +62,63 @@ impl<W: Worker + 'static> WorkerPool<W> {
             task_name,
             concurrency,
             worker: Arc::new(worker),
+            reducer: None,
         }
     }
+
+    pub fn new_with_reducer<R>(worker: W, task_name: String, concurrency: usize, reducer: R) -> Self
+    where
+        R: Reducer<W> + 'static,
+    {
+        Self {
+            task_name,
+            concurrency,
+            worker: Arc::new(worker),
+            reducer: Some(Box::new(reducer)),
+        }
+    }
+
     pub async fn run(
-        self,
-        mut current_checkpoint_number: CheckpointSequenceNumber,
+        mut self,
+        watermark: CheckpointSequenceNumber,
         mut checkpoint_receiver: mpsc::Receiver<Arc<CheckpointData>>,
         pool_status_sender: mpsc::Sender<WorkerPoolStatus>,
         token: CancellationToken,
     ) {
         info!(
-            "Starting indexing pipeline {} with concurrency {}. Current watermark is {}.",
-            self.task_name, self.concurrency, current_checkpoint_number
+            "Starting indexing pipeline {} with concurrency {}. Current watermark is {watermark}.",
+            self.task_name, self.concurrency
         );
-        let mut updates = HashMap::new();
-
+        // This channel will be used to send progress data from Workers to WorkerPool
+        // mian loop
         let (progress_sender, mut progress_receiver) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
+        // This channel will be used to send Wrokers progress data from WorkerPool to
+        // watermark tracking task
+        let (watermark_sender, watermark_receiver) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
         let mut idle: BTreeSet<_> = (0..self.concurrency).collect();
         let mut checkpoints = VecDeque::new();
         let mut workers_shutdown_signals = vec![];
-
         let (workers, workers_join_handles) = self.spawn_workers(progress_sender, token.clone());
-
+        // Spawn a task that tracks checkpoint processing progress. The task:
+        // - Receives (checkpoint_number, message) pairs from workers
+        // - Maintains checkpoint sequence order
+        // - Reports progress either:
+        //   * After processing each chunk (simple tracking)
+        //   * After committing batches (with reducer)
+        let watermark_handle = self.spawn_watermark_tracking(
+            watermark,
+            watermark_receiver,
+            pool_status_sender.clone(),
+        );
         // main worker pool loop
         loop {
             tokio::select! {
                 Some(worker_progress_msg) = progress_receiver.recv() => {
                     match worker_progress_msg {
-                        WorkerStatus::Running((worker_id, status_update, progress_watermark)) => {
+                        WorkerStatus::Running((worker_id, checkpoint_number, message)) => {
                             idle.insert(worker_id);
-                            updates.insert(status_update, progress_watermark);
-                            if status_update == current_checkpoint_number {
-                                let mut executor_status_update = None;
-                                while let Some(progress_watermark) = updates.remove(&current_checkpoint_number) {
-                                    if let Some(watermark) =  progress_watermark {
-                                        executor_status_update = Some(watermark + 1);
-                                    }
-                                    current_checkpoint_number += 1;
-                                }
-                                if let Some(update) = executor_status_update {
-                                    if pool_status_sender
-                                        .send(WorkerPoolStatus::Running((self.task_name.clone(), update)))
-                                        .await.is_err() {
-                                            // The executor progress channel closing is a sign we need to
-                                            // exit this loop.
-                                            break;
-                                        }
-                                }
+                            if watermark_sender.send((checkpoint_number, message)).await.is_err() {
+                                break;
                             }
                             // By checking if token was not cancelled we ensure that no
                             // further checkpoints will be sent to the workers
@@ -127,19 +137,17 @@ impl<W: Worker + 'static> WorkerPool<W> {
                         }
                     }
                 }
-
                 // Adding an if guard to this branch ensure that no checkpoints
                 // will be sent to workers once the token has been cancelled
                 Some(checkpoint) = checkpoint_receiver.recv(), if !token.is_cancelled() => {
                     let sequence_number = checkpoint.checkpoint_summary.sequence_number;
-                    if sequence_number < current_checkpoint_number {
+                    if sequence_number < watermark {
                         continue;
                     }
                     self.worker
                         .preprocess_hook(&checkpoint)
                         .map_err(|err| IngestionError::CheckpointHookProcessing(err.to_string()))
                         .expect("failed to preprocess task");
-
                     if idle.is_empty() {
                         checkpoints.push_back(checkpoint);
                     } else {
@@ -151,12 +159,16 @@ impl<W: Worker + 'static> WorkerPool<W> {
                     }
                 }
             }
-
             // Once all workers have signaled completion, start the graceful shutdown
             // process
             if workers_shutdown_signals.len() == self.concurrency {
                 break self
-                    .workers_graceful_shutdown(workers_join_handles, pool_status_sender)
+                    .workers_graceful_shutdown(
+                        workers_join_handles,
+                        watermark_handle,
+                        pool_status_sender,
+                        watermark_sender,
+                    )
                     .await;
             }
         }
@@ -166,7 +178,7 @@ impl<W: Worker + 'static> WorkerPool<W> {
     /// in parallel
     fn spawn_workers(
         &self,
-        progress_sender: mpsc::Sender<WorkerStatus>,
+        progress_sender: mpsc::Sender<WorkerStatus<W::Message>>,
         token: CancellationToken,
     ) -> (Vec<mpsc::Sender<Arc<CheckpointData>>>, Vec<JoinHandle<()>>) {
         let mut worker_senders = Vec::with_capacity(self.concurrency);
@@ -207,9 +219,8 @@ impl<W: Worker + 'static> WorkerPool<W> {
                                 if processed_checkpoint_result.is_err() && token.is_cancelled() {
                                     return Ok(WorkerStatus::Shutdown(worker_id))
                                 }
-                                let wroker_progress = worker.save_progress(sequence_number).await;
                                 processed_checkpoint_result
-                                    .map(|_| WorkerStatus::Running((worker_id, sequence_number, wroker_progress)))
+                                    .map(|message| WorkerStatus::Running((worker_id, sequence_number, message)))
                             })
                             .await
                             .expect("checkpoint processing failed for checkpoint");
@@ -232,24 +243,110 @@ impl<W: Worker + 'static> WorkerPool<W> {
         (worker_senders, workers_join_handles)
     }
 
+    /// Spawns a task that tracks the progress of checkpoint processing,
+    /// optionally with message reduction.
+    ///
+    /// This function spawns one of two types of tracking tasks:
+    ///
+    /// 1. Simple Watermark Tracking (when reducer = None):
+    ///    - Reports watermark after processing each chunk.
+    ///
+    /// 2. Batch Processing (when reducer = Some):
+    ///    - Reports progress only after successful batch commits.
+    ///    - A batch is committed based on
+    ///      [`should_close_batch`](Reducer::should_close_batch) policy.
+    fn spawn_watermark_tracking(
+        &mut self,
+        watermark: CheckpointSequenceNumber,
+        watermark_receiver: mpsc::Receiver<(CheckpointSequenceNumber, W::Message)>,
+        executor_progress_sender: mpsc::Sender<WorkerPoolStatus>,
+    ) -> JoinHandle<Result<(), IngestionError>> {
+        let task_name = self.task_name.clone();
+        if let Some(reducer) = self.reducer.take() {
+            return spawn_monitored_task!(reduce::<W>(
+                task_name,
+                watermark,
+                watermark_receiver,
+                executor_progress_sender,
+                reducer,
+            ));
+        };
+        spawn_monitored_task!(simple_watermark_tracking::<W>(
+            task_name,
+            watermark,
+            watermark_receiver,
+            executor_progress_sender
+        ))
+    }
+
     /// Start the workers graceful shutdown
     ///
     /// - Awaits all worker handles
+    /// - Awaits the reducer handle
     /// - Send `WorkerPoolStatus::Shutdown(<task-name>)` message notifying
     ///   external components that Worker Pool has been shutdown
     async fn workers_graceful_shutdown(
         &self,
         workers_join_handles: Vec<JoinHandle<()>>,
+        watermark_handle: JoinHandle<Result<(), IngestionError>>,
         executor_progress_sender: mpsc::Sender<WorkerPoolStatus>,
+        watermark_sender: mpsc::Sender<(u64, <W as Worker>::Message)>,
     ) {
         for worker in workers_join_handles {
-            if let Err(err) = worker.await {
-                tracing::error!("worker thread panicked: {err}");
-            }
+            _ = worker
+                .await
+                .inspect_err(|err| tracing::error!("worker task panicked: {err}"));
         }
+        // by dropping the sender we make sure that the stream will be closed and the
+        // watermark tracker task will exit its loop
+        drop(watermark_sender);
+        _ = watermark_handle
+            .await
+            .inspect_err(|err| tracing::error!("watermark task panicked: {err}"));
         _ = executor_progress_sender
             .send(WorkerPoolStatus::Shutdown(self.task_name.clone()))
             .await;
         tracing::info!("Worker pool `{}` terminated gracefully", self.task_name);
     }
+}
+
+/// Tracks checkpoint progress without reduction logic.
+///
+/// This function maintains a watermark of processed checkpoints by worker:
+/// 1. Receiving batches of progress status from workers
+/// 2. Processing them in sequence order
+/// 3. Reporting progress to the executor after each chunk from the stream
+async fn simple_watermark_tracking<W: Worker>(
+    task_name: String,
+    mut current_checkpoint_number: CheckpointSequenceNumber,
+    reducer_receiver: mpsc::Receiver<(CheckpointSequenceNumber, W::Message)>,
+    executor_progress_sender: mpsc::Sender<WorkerPoolStatus>,
+) -> IngestionResult<()> {
+    // convert to a stream of MAX_CHECKPOINTS_IN_PROGRESS size. This way, each
+    // iteration of the loop will process all ready messages
+    let mut stream =
+        ReceiverStream::new(reducer_receiver).ready_chunks(MAX_CHECKPOINTS_IN_PROGRESS);
+    // store unprocessed progress messages from workers.
+    let mut unprocessed = HashMap::new();
+    // track the latest processed checkpoint number for reporting progress
+    // after each chunk of messages is received from the stream.
+    let mut progress_update = None;
+
+    while let Some(update_batch) = stream.next().await {
+        unprocessed.extend(update_batch.into_iter());
+        // Process messages sequentially based on checkpoint sequence number.
+        // This ensures in-order processing and maintains progress integrity.
+        while unprocessed.remove(&current_checkpoint_number).is_some() {
+            current_checkpoint_number += 1;
+            progress_update = Some(current_checkpoint_number);
+        }
+        // report progress update to executor
+        if let Some(watermark) = progress_update.take() {
+            executor_progress_sender
+                .send(WorkerPoolStatus::Running((task_name.clone(), watermark)))
+                .await
+                .map_err(|_| IngestionError::Channel("unable to send worker pool progress updates to executor, receiver half closed".into()))?;
+        }
+    }
+    Ok(())
 }

--- a/crates/iota-data-ingestion/Cargo.toml
+++ b/crates/iota-data-ingestion/Cargo.toml
@@ -25,6 +25,7 @@ prometheus.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
+tempfile.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tokio-util.workspace = true
 tracing.workspace = true

--- a/crates/iota-data-ingestion/src/bin/archival_ingestion.rs
+++ b/crates/iota-data-ingestion/src/bin/archival_ingestion.rs
@@ -3,9 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use iota_data_ingestion::{ArchivalConfig, ArchivalWorker};
-use iota_data_ingestion_core::setup_single_workflow;
+use iota_data_ingestion::{ArchivalConfig, ArchivalReducer, ArchivalWorker};
+use iota_data_ingestion_core::{
+    DataIngestionMetrics, IndexerExecutor, ReaderOptions, ShimProgressStore, WorkerPool,
+};
+use prometheus::Registry;
 use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Config {
@@ -38,17 +42,25 @@ async fn main() -> Result<()> {
         commit_file_size: config.commit_file_size,
         commit_duration_seconds: config.commit_duration_seconds,
     };
-    let worker = ArchivalWorker::new(archival_config).await?;
-    let initial_checkpoint_number = worker.initial_checkpoint_number().await;
 
-    let (executor, _exit_sender) = setup_single_workflow(
-        worker,
-        config.remote_store_url,
-        initial_checkpoint_number,
+    let reducer = ArchivalReducer::new(archival_config).await?;
+    let progress_store = ShimProgressStore(reducer.get_watermark().await?);
+    let mut executor = IndexerExecutor::new(
+        progress_store,
         1,
-        None,
-    )
-    .await?;
-    executor.await?;
+        DataIngestionMetrics::new(&Registry::new()),
+        CancellationToken::new(),
+    );
+    let worker_pool =
+        WorkerPool::new_with_reducer(ArchivalWorker, "archival".to_string(), 1, reducer);
+    executor.register(worker_pool).await?;
+    executor
+        .run(
+            tempfile::tempdir()?.into_path(),
+            Some(config.remote_store_url),
+            vec![],
+            ReaderOptions::default(),
+        )
+        .await?;
     Ok(())
 }

--- a/crates/iota-data-ingestion/src/lib.rs
+++ b/crates/iota-data-ingestion/src/lib.rs
@@ -7,5 +7,6 @@ mod workers;
 
 pub use progress_store::DynamoDBProgressStore;
 pub use workers::{
-    ArchivalConfig, ArchivalWorker, BlobTaskConfig, BlobWorker, KVStoreTaskConfig, KVStoreWorker,
+    ArchivalConfig, ArchivalReducer, ArchivalWorker, BlobTaskConfig, BlobWorker, KVStoreTaskConfig,
+    KVStoreWorker,
 };

--- a/crates/iota-data-ingestion/src/workers/archival.rs
+++ b/crates/iota-data-ingestion/src/workers/archival.rs
@@ -2,9 +2,8 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{io::Cursor, ops::Range};
+use std::io::Cursor;
 
-use anyhow::Result;
 use async_trait::async_trait;
 use byteorder::{BigEndian, ByteOrder};
 use bytes::Bytes;
@@ -12,7 +11,7 @@ use iota_archival::{
     CHECKPOINT_FILE_MAGIC, FileType, Manifest, SUMMARY_FILE_MAGIC, create_file_metadata_from_bytes,
     finalize_manifest, read_manifest_from_bytes,
 };
-use iota_data_ingestion_core::{Worker, create_remote_store_client};
+use iota_data_ingestion_core::{Reducer, Worker, create_remote_store_client};
 use iota_storage::{
     FileCompression, StorageFormat,
     blob::{Blob, BlobEncoding},
@@ -25,7 +24,6 @@ use iota_types::{
 };
 use object_store::{ObjectStore, path::Path};
 use serde::{Deserialize, Serialize};
-use tokio::sync::Mutex;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "kebab-case")]
@@ -36,90 +34,75 @@ pub struct ArchivalConfig {
     pub commit_duration_seconds: u64,
 }
 
-struct AccumulatedState {
-    epoch: EpochId,
-    checkpoint_range: Range<u64>,
-    buffer: Vec<u8>,
-    summary_buffer: Vec<u8>,
-    last_commit_ms: u64,
-    should_update_progress: bool,
+pub struct ArchivalWorker;
+
+#[async_trait]
+impl Worker for ArchivalWorker {
+    type Message = CheckpointData;
+    type Error = anyhow::Error;
+
+    async fn process_checkpoint(
+        &self,
+        checkpoint: &CheckpointData,
+    ) -> Result<Self::Message, Self::Error> {
+        Ok(checkpoint.clone())
+    }
 }
 
-pub struct ArchivalWorker {
+pub struct ArchivalReducer {
     remote_store: Box<dyn ObjectStore>,
-    state: Mutex<AccumulatedState>,
-    commit_file_size: usize,
     commit_duration_ms: u64,
 }
 
-impl ArchivalWorker {
-    pub async fn new(config: ArchivalConfig) -> Result<Self> {
+impl ArchivalReducer {
+    pub async fn new(config: ArchivalConfig) -> anyhow::Result<Self> {
         let remote_store =
             create_remote_store_client(config.remote_url, config.remote_store_options, 10)?;
-        let manifest = Self::read_manifest(&remote_store).await?;
-        let state = AccumulatedState {
-            epoch: manifest.epoch_num(),
-            checkpoint_range: manifest.next_checkpoint_seq_num()
-                ..manifest.next_checkpoint_seq_num(),
-            buffer: vec![],
-            summary_buffer: vec![],
-            last_commit_ms: 0,
-            should_update_progress: false,
-        };
+
         Ok(Self {
             remote_store,
-            state: Mutex::new(state),
-            commit_file_size: config.commit_file_size,
             commit_duration_ms: config.commit_duration_seconds * 1000,
         })
     }
 
-    async fn read_manifest(remote_store: &dyn ObjectStore) -> Result<Manifest> {
-        Ok(match remote_store.get(&Path::from("MANIFEST")).await {
-            Ok(resp) => read_manifest_from_bytes(resp.bytes().await?.to_vec())?,
-            Err(err) if err.to_string().contains("404") => Manifest::new(0, 0),
-            Err(err) => Err(err)?,
-        })
-    }
-
-    async fn upload(&self, state: &AccumulatedState) -> Result<()> {
-        let checkpoint_file_path =
-            format!("epoch_{}/{}.chk", state.epoch, state.checkpoint_range.start);
+    async fn upload(
+        &self,
+        epoch: EpochId,
+        start: CheckpointSequenceNumber,
+        end: CheckpointSequenceNumber,
+        summary_buffer: Vec<u8>,
+        buffer: Vec<u8>,
+    ) -> anyhow::Result<()> {
+        let checkpoint_file_path = format!("epoch_{}/{}.chk", epoch, start);
         let chk_bytes = self
             .upload_file(
                 Path::from(checkpoint_file_path.clone()),
                 CHECKPOINT_FILE_MAGIC,
-                &state.buffer,
+                &buffer,
             )
             .await?;
-        let summary_file_path =
-            format!("epoch_{}/{}.sum", state.epoch, state.checkpoint_range.start);
+        let summary_file_path = format!("epoch_{}/{}.sum", epoch, start);
         let sum_bytes = self
             .upload_file(
                 Path::from(summary_file_path.clone()),
                 SUMMARY_FILE_MAGIC,
-                &state.summary_buffer,
+                &summary_buffer,
             )
             .await?;
         let mut manifest = Self::read_manifest(&self.remote_store).await?;
         let checkpoint_file_metadata = create_file_metadata_from_bytes(
             chk_bytes,
             FileType::CheckpointContent,
-            state.epoch,
-            state.checkpoint_range.clone(),
+            epoch,
+            start..end,
         )?;
         let summary_file_metadata = create_file_metadata_from_bytes(
             sum_bytes,
             FileType::CheckpointSummary,
-            state.epoch,
-            state.checkpoint_range.clone(),
+            epoch,
+            start..end,
         )?;
-        manifest.update(
-            state.epoch,
-            state.checkpoint_range.end,
-            checkpoint_file_metadata,
-            summary_file_metadata,
-        );
+        manifest.update(epoch, end, checkpoint_file_metadata, summary_file_metadata);
 
         let bytes = finalize_manifest(manifest)?;
         self.remote_store
@@ -128,7 +111,12 @@ impl ArchivalWorker {
         Ok(())
     }
 
-    async fn upload_file(&self, location: Path, magic: u32, content: &[u8]) -> Result<Bytes> {
+    async fn upload_file(
+        &self,
+        location: Path,
+        magic: u32,
+        content: &[u8],
+    ) -> anyhow::Result<Bytes> {
         let mut buffer = vec![0; 4];
         BigEndian::write_u32(&mut buffer, magic);
         buffer.push(StorageFormat::Blob.into());
@@ -143,69 +131,74 @@ impl ArchivalWorker {
         Ok(Bytes::from(compressed_buffer))
     }
 
-    pub async fn initial_checkpoint_number(&self) -> CheckpointSequenceNumber {
-        self.state.lock().await.checkpoint_range.start
+    pub async fn get_watermark(&self) -> anyhow::Result<CheckpointSequenceNumber> {
+        let manifest = Self::read_manifest(&self.remote_store).await?;
+        Ok(manifest.next_checkpoint_seq_num())
+    }
+
+    async fn read_manifest(remote_store: &dyn ObjectStore) -> anyhow::Result<Manifest> {
+        Ok(match remote_store.get(&Path::from("MANIFEST")).await {
+            Ok(resp) => read_manifest_from_bytes(resp.bytes().await?.to_vec())?,
+            Err(err) if err.to_string().contains("404") => Manifest::new(0, 0),
+            Err(err) => Err(err)?,
+        })
     }
 }
 
 #[async_trait]
-impl Worker for ArchivalWorker {
+impl Reducer<CheckpointData> for ArchivalReducer {
     type Error = anyhow::Error;
 
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<(), Self::Error> {
-        let mut state = self.state.lock().await;
-        let sequence_number = checkpoint.checkpoint_summary.sequence_number;
-        if sequence_number < state.checkpoint_range.start {
-            return Ok(());
+    async fn commit(&self, batch: Vec<CheckpointData>) -> Result<(), Self::Error> {
+        if batch.is_empty() {
+            return Err(anyhow::anyhow!("commit batch can't be empty"));
         }
-        let epoch = checkpoint.checkpoint_summary.epoch;
-        if state.buffer.is_empty() {
-            assert!(epoch == state.epoch || epoch == state.epoch + 1);
-            state.epoch = epoch;
-            state.last_commit_ms = checkpoint.checkpoint_summary.timestamp_ms;
+        let mut summary_buffer = vec![];
+        let mut buffer = vec![];
+        let first_checkpoint = &batch[0];
+        let epoch = first_checkpoint.checkpoint_summary.epoch;
+        let start_checkpoint = first_checkpoint.checkpoint_summary.sequence_number;
+        let mut last_checkpoint = start_checkpoint;
+        for checkpoint in batch {
+            let full_checkpoint_contents = FullCheckpointContents::from_contents_and_execution_data(
+                checkpoint.checkpoint_contents.clone(),
+                checkpoint
+                    .transactions
+                    .iter()
+                    .map(|t| ExecutionData::new(t.transaction.clone(), t.effects.clone())),
+            );
+            let contents_blob = Blob::encode(&full_checkpoint_contents, BlobEncoding::Bcs).unwrap();
+            let summary_blob =
+                Blob::encode(&checkpoint.checkpoint_summary, BlobEncoding::Bcs).unwrap();
+            contents_blob.write(&mut buffer).unwrap();
+            summary_blob.write(&mut summary_buffer).unwrap();
+            last_checkpoint += 1;
         }
-        let full_checkpoint_contents = FullCheckpointContents::from_contents_and_execution_data(
-            checkpoint.checkpoint_contents.clone(),
-            checkpoint
-                .transactions
-                .iter()
-                .map(|t| ExecutionData::new(t.transaction.clone(), t.effects.clone())),
-        );
-        let contents_blob = Blob::encode(&full_checkpoint_contents, BlobEncoding::Bcs)?;
-        let blob_size = contents_blob.size();
-        let summary_blob = Blob::encode(&checkpoint.checkpoint_summary, BlobEncoding::Bcs)?;
-
-        if !state.buffer.is_empty()
-            && (((state.buffer.len() + blob_size) > self.commit_file_size)
-                || state.epoch != epoch
-                || checkpoint.checkpoint_summary.timestamp_ms
-                    > (self.commit_duration_ms + state.last_commit_ms))
-        {
-            self.upload(&state).await?;
-            state.epoch = epoch;
-            state.checkpoint_range = sequence_number..sequence_number;
-            state.buffer = vec![];
-            state.summary_buffer = vec![];
-            state.last_commit_ms = checkpoint.checkpoint_summary.timestamp_ms;
-            state.should_update_progress = true;
-        }
-        contents_blob.write(&mut state.buffer)?;
-        summary_blob.write(&mut state.summary_buffer)?;
-        state.checkpoint_range.end += 1;
+        self.upload(
+            epoch,
+            start_checkpoint,
+            last_checkpoint,
+            summary_buffer,
+            buffer,
+        )
+        .await
+        .unwrap();
         Ok(())
     }
 
-    async fn save_progress(
+    fn should_close_batch(
         &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> Option<CheckpointSequenceNumber> {
-        let mut state = self.state.lock().await;
-        let should_update_progress = state.should_update_progress;
-        state.should_update_progress = false;
-        if should_update_progress && sequence_number > 0 {
-            Some(sequence_number - 1)
-        } else {
-            None
+        batch: &[CheckpointData],
+        next_item: Option<&CheckpointData>,
+    ) -> bool {
+        // never close a batch without a trigger condition
+        if batch.is_empty() || next_item.is_none() {
+            return false;
         }
+        let first_checkpoint = &batch[0].checkpoint_summary;
+        let next_checkpoint = next_item.expect("invariant's checked");
+        next_checkpoint.checkpoint_summary.epoch != first_checkpoint.epoch
+            || next_checkpoint.checkpoint_summary.timestamp_ms
+                > (self.commit_duration_ms + first_checkpoint.timestamp_ms)
     }
 }

--- a/crates/iota-data-ingestion/src/workers/archival.rs
+++ b/crates/iota-data-ingestion/src/workers/archival.rs
@@ -146,10 +146,8 @@ impl ArchivalReducer {
 }
 
 #[async_trait]
-impl Reducer<CheckpointData> for ArchivalReducer {
-    type Error = anyhow::Error;
-
-    async fn commit(&self, batch: Vec<CheckpointData>) -> Result<(), Self::Error> {
+impl Reducer<ArchivalWorker> for ArchivalReducer {
+    async fn commit(&self, batch: Vec<CheckpointData>) -> Result<(), anyhow::Error> {
         if batch.is_empty() {
             return Err(anyhow::anyhow!("commit batch can't be empty"));
         }

--- a/crates/iota-data-ingestion/src/workers/blob.rs
+++ b/crates/iota-data-ingestion/src/workers/blob.rs
@@ -128,9 +128,13 @@ impl BlobWorker {
 
 #[async_trait]
 impl Worker for BlobWorker {
+    type Message = ();
     type Error = anyhow::Error;
 
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<(), Self::Error> {
+    async fn process_checkpoint(
+        &self,
+        checkpoint: &CheckpointData,
+    ) -> Result<Self::Message, Self::Error> {
         let bytes = Blob::encode(checkpoint, BlobEncoding::Bcs)?.to_bytes();
         let location = Path::from(format!(
             "{}.chk",

--- a/crates/iota-data-ingestion/src/workers/kv_store.rs
+++ b/crates/iota-data-ingestion/src/workers/kv_store.rs
@@ -182,9 +182,13 @@ impl KVStoreWorker {
 
 #[async_trait]
 impl Worker for KVStoreWorker {
+    type Message = ();
     type Error = anyhow::Error;
 
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<(), Self::Error> {
+    async fn process_checkpoint(
+        &self,
+        checkpoint: &CheckpointData,
+    ) -> Result<Self::Message, Self::Error> {
         let mut transactions = vec![];
         let mut effects = vec![];
         let mut events = vec![];

--- a/crates/iota-data-ingestion/src/workers/mod.rs
+++ b/crates/iota-data-ingestion/src/workers/mod.rs
@@ -5,6 +5,6 @@
 mod archival;
 mod blob;
 mod kv_store;
-pub use archival::{ArchivalConfig, ArchivalWorker};
+pub use archival::{ArchivalConfig, ArchivalReducer, ArchivalWorker};
 pub use blob::{BlobTaskConfig, BlobWorker};
 pub use kv_store::{KVStoreTaskConfig, KVStoreWorker};

--- a/crates/iota-indexer-builder/src/iota_datasource.rs
+++ b/crates/iota-indexer-builder/src/iota_datasource.rs
@@ -126,9 +126,13 @@ pub type CheckpointTxnData = (CheckpointTransaction, u64, u64);
 
 #[async_trait]
 impl Worker for IndexerWorker<CheckpointTxnData> {
+    type Message = ();
     type Error = anyhow::Error;
 
-    async fn process_checkpoint(&self, checkpoint: &IotaCheckpointData) -> Result<(), Self::Error> {
+    async fn process_checkpoint(
+        &self,
+        checkpoint: &IotaCheckpointData,
+    ) -> Result<Self::Message, Self::Error> {
         info!(
             "Received checkpoint [{}] {}: {}",
             checkpoint.checkpoint_summary.epoch,

--- a/crates/iota-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/iota-indexer/src/handlers/checkpoint_handler.rs
@@ -111,9 +111,13 @@ pub struct CheckpointHandler {
 
 #[async_trait]
 impl Worker for CheckpointHandler {
+    type Message = ();
     type Error = IndexerError;
 
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<(), Self::Error> {
+    async fn process_checkpoint(
+        &self,
+        checkpoint: &CheckpointData,
+    ) -> Result<Self::Message, Self::Error> {
         self.metrics
             .latest_fullnode_checkpoint_sequence_number
             .set(checkpoint.checkpoint_summary.sequence_number as i64);

--- a/crates/iota-indexer/src/handlers/objects_snapshot_processor.rs
+++ b/crates/iota-indexer/src/handlers/objects_snapshot_processor.rs
@@ -96,9 +96,13 @@ impl Default for SnapshotLagConfig {
 
 #[async_trait]
 impl Worker for ObjectsSnapshotProcessor {
+    type Message = ();
     type Error = IndexerError;
 
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<(), Self::Error> {
+    async fn process_checkpoint(
+        &self,
+        checkpoint: &CheckpointData,
+    ) -> Result<Self::Message, Self::Error> {
         let checkpoint_sequence_number = checkpoint.checkpoint_summary.sequence_number;
         // Index the object changes and send them to the committer.
         let object_changes: TransactionObjectChangesToCommit = CheckpointHandler::index_objects(

--- a/examples/custom-indexer/rust/local_reader.rs
+++ b/examples/custom-indexer/rust/local_reader.rs
@@ -17,9 +17,10 @@ struct CustomWorker;
 
 #[async_trait]
 impl Worker for CustomWorker {
+    type Message = ();
     type Error = anyhow::Error;
 
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<()> {
+    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<Self::Message> {
         // custom processing logic
         println!(
             "Processing Local checkpoint: {}",

--- a/examples/custom-indexer/rust/local_reader.rs
+++ b/examples/custom-indexer/rust/local_reader.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
     let metrics = DataIngestionMetrics::new(&Registry::new());
     let backfill_progress_file_path =
         env::var("BACKFILL_PROGRESS_FILE_PATH").unwrap_or("/tmp/local_reader_progress".to_string());
-    let progress_store = FileProgressStore::new(PathBuf::from(backfill_progress_file_path));
+    let progress_store = FileProgressStore::new(backfill_progress_file_path).await?;
     let mut executor = IndexerExecutor::new(
         progress_store,
         1, // number of workflow types

--- a/examples/custom-indexer/rust/remote_reader.rs
+++ b/examples/custom-indexer/rust/remote_reader.rs
@@ -11,9 +11,10 @@ struct CustomWorker;
 
 #[async_trait]
 impl Worker for CustomWorker {
+    type Message = ();
     type Error = anyhow::Error;
 
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<()> {
+    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<Self::Message> {
         // custom processing logic
         // print out the checkpoint number
         println!(


### PR DESCRIPTION
# Description of change

This first part PR introduces the `Reducer` trait in the `data-ingestion-core`. 
Later the second part will introduce rust docs for traits and update to the `README.md` file explaining the `Reducer` logic.
- https://github.com/iotaledger/iota/issues/5551

The functionality is optional and will not impact existing workflows. When enabled, it allows for the accumulation of a batch of checkpoints (or any value the Worker's `process_checkpoint` method may return) for post-processing.

This change is inherited from the upstream commit: https://github.com/MystenLabs/sui/commit/2c421c3451a7dfbb553d7a91d7007816587b624b

## Links to any relevant issues

fixes #5337 
fixes #5644 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

- A new test case was introduced to test the behavior of the Reducer trait.
```shell
cargo test -p iota-data-ingestion-core
```
- Tested if the existing workflows were not altered, used iota bin to start a local network with indexer and checked internal Postgres records making sure all data were consistent and looked as expected
```shell
cargo r --bin iota --features indexer -- start --with-indexer --force-regenesis
```

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
