### PR TITLE
fix(`iota-storage`): fix `test_multi_fetch` test case

### DIFF
--- a/crates/iota-storage/tests/key_value_tests.rs
+++ b/crates/iota-storage/tests/key_value_tests.rs
@@ -452,21 +452,21 @@ mod simtests {
         }
 
         data.insert(
-            format!("{}/tx", encode_digest(&tx_digest)),
+            format!("tx/{}", encode_digest(&tx_digest)),
             bcs::to_bytes(&tx).unwrap(),
         );
         data.insert(
-            format!("{}/evtx", encode_digest(&tx_digest)),
+            format!("evtx/{}", encode_digest(&tx_digest)),
             bcs::to_bytes(&ev).unwrap(),
         );
         data.insert(
-            format!("{}/fx", encode_digest(fx.transaction_digest())),
+            format!("fx/{}", encode_digest(fx.transaction_digest())),
             bcs::to_bytes(&fx).unwrap(),
         );
 
         // a bogus entry with the wrong digest
         data.insert(
-            format!("{}/tx", encode_digest(&random_digest)),
+            format!("tx/{}", encode_digest(&random_digest)),
             bcs::to_bytes(&tx).unwrap(),
         );
 


### PR DESCRIPTION
# Description of change

This PR fixes the `test_multi_fetch` test case in `iota-storage` crate

## Links to any relevant issues

fixes #5549 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Made sure that `test_multi_fetch` test passed

```shell
cargo simtest -p iota-storage
```

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
