### PR TITLE
fix(consensus): make verifier run in blocking pool

### DIFF
--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -43,6 +43,7 @@ use itertools::Itertools as _;
 use parking_lot::{Mutex, RwLock};
 use rand::prelude::SliceRandom as _;
 use tokio::{
+    runtime::Handle,
     sync::oneshot,
     task::{JoinHandle, JoinSet},
     time::{Instant, MissedTickBehavior, sleep},
@@ -494,12 +495,20 @@ impl<C: NetworkClient> CommitSyncer<C> {
         //    commit,
         // and the returned commits are chained by digest, so earlier commits are
         // certified as well.
-        let commits = inner.verify_commits(
-            target_authority,
-            commit_range,
-            serialized_commits,
-            serialized_blocks,
-        )?;
+        let commits = Handle::current()
+            .spawn_blocking({
+                let inner = inner.clone();
+                move || {
+                    inner.verify_commits(
+                        target_authority,
+                        commit_range,
+                        serialized_commits,
+                        serialized_blocks,
+                    )
+                }
+            })
+            .await
+            .expect("Spawn blocking should not fail")?;
 
         // 4. Fetch blocks referenced by the commits, from the same authority.
         let block_refs: Vec<_> = commits.iter().flat_map(|c| c.blocks()).cloned().collect();

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -23,6 +23,7 @@ use parking_lot::{Mutex, RwLock};
 use rand::{prelude::SliceRandom, rngs::ThreadRng};
 use tap::TapFallible;
 use tokio::{
+    runtime::Handle,
     sync::{mpsc::error::TrySendError, oneshot},
     task::{JoinError, JoinSet},
     time::{Instant, sleep, sleep_until, timeout},
@@ -520,12 +521,14 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         }
 
         // Verify all the fetched blocks
-        let blocks = Self::verify_blocks(
-            serialized_blocks,
-            block_verifier.clone(),
-            &context,
-            peer_index,
-        )?;
+        let blocks = Handle::current()
+            .spawn_blocking({
+                let block_verifier = block_verifier.clone();
+                let context = context.clone();
+                move || Self::verify_blocks(serialized_blocks, block_verifier, &context, peer_index)
+            })
+            .await
+            .expect("Spawn blocking should not fail")?;
 
         // Get all the ancestors of the requested blocks only
         let ancestors = blocks


### PR DESCRIPTION
Porting from upstream: [MystenLabs/sui@](https://github.com/MystenLabs/sui) [139a2b9](https://github.com/MystenLabs/sui/commit/139a2b9218733e0b299cca188bd8ff6168dc7e0e)

# Description of change

The verifier was running in the async thread pool, which may have caused thread stalls.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
