### PR TITLE
feat(iota-protocol, iota-execution, iota-framework): Update signing verifier constants setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6699,7 +6699,6 @@ dependencies = [
  "anyhow",
  "bcs",
  "capitalize",
- "iota-config",
  "iota-move-build",
  "iota-types",
  "move-binary-format",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6323,6 +6323,7 @@ dependencies = [
  "iota-keys",
  "iota-protocol-config",
  "iota-types",
+ "move-vm-config",
  "object_store 0.10.2",
  "once_cell",
  "prometheus",
@@ -6698,6 +6699,7 @@ dependencies = [
  "anyhow",
  "bcs",
  "capitalize",
+ "iota-config",
  "iota-move-build",
  "iota-types",
  "move-binary-format",
@@ -6733,6 +6735,7 @@ version = "0.10.0-alpha"
 dependencies = [
  "datatest-stable",
  "iota-adapter-latest",
+ "iota-config",
  "iota-framework",
  "iota-move",
  "iota-move-build",

--- a/crates/iota-config/Cargo.toml
+++ b/crates/iota-config/Cargo.toml
@@ -33,3 +33,4 @@ iota-genesis-common.workspace = true
 iota-keys.workspace = true
 iota-protocol-config.workspace = true
 iota-types.workspace = true
+move-vm-config.workspace = true

--- a/crates/iota-config/src/lib.rs
+++ b/crates/iota-config/src/lib.rs
@@ -21,6 +21,7 @@ pub mod node_config_metrics;
 pub mod object_storage_config;
 pub mod p2p;
 pub mod transaction_deny_config;
+pub mod verifier_signing_config;
 
 use iota_types::multiaddr::Multiaddr;
 pub use node::{ConsensusConfig, ExecutionCacheConfig, NodeConfig};

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -34,7 +34,7 @@ use tracing::info;
 use crate::{
     Config, certificate_deny_config::CertificateDenyConfig, genesis,
     migration_tx_data::MigrationTxData, object_storage_config::ObjectStoreConfig, p2p::P2pConfig,
-    transaction_deny_config::TransactionDenyConfig,
+    transaction_deny_config::TransactionDenyConfig, verifier_signing_config::VerifierSigningConfig,
 };
 
 // Default max number of concurrent requests served
@@ -245,6 +245,9 @@ pub struct NodeConfig {
 
     #[serde(default = "bool_true")]
     pub enable_validator_tx_finalizer: bool,
+
+    #[serde(default)]
+    pub verifier_signing_config: VerifierSigningConfig,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]

--- a/crates/iota-config/src/verifier_signing_config.rs
+++ b/crates/iota-config/src/verifier_signing_config.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use move_vm_config::verifier::MeterConfig;

--- a/crates/iota-config/src/verifier_signing_config.rs
+++ b/crates/iota-config/src/verifier_signing_config.rs
@@ -1,0 +1,78 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use move_vm_config::verifier::MeterConfig;
+use serde::{Deserialize, Serialize};
+
+// Default values for verifier signing config.
+pub const DEFAULT_MAX_PER_FUN_METER_UNITS: usize = 2_200_000;
+pub const DEFAULT_MAX_PER_MOD_METER_UNITS: usize = 2_200_000;
+pub const DEFAULT_MAX_PER_PKG_METER_UNITS: usize = 2_200_000;
+
+pub const DEFAULT_MAX_BACK_EDGES_PER_FUNCTION: usize = 10_000;
+pub const DEFAULT_MAX_BACK_EDGES_PER_MODULE: usize = 10_000;
+
+/// This holds limits that are only set and used by the verifier during signing
+/// _only_. There are additional limits in the `MeterConfig` and
+/// `VerifierConfig` that are used during both signing and execution, however
+/// those limits cannot be set here and must be protocol versioned.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct VerifierSigningConfig {
+    #[serde(default)]
+    max_per_fun_meter_units: Option<usize>,
+    #[serde(default)]
+    max_per_mod_meter_units: Option<usize>,
+    #[serde(default)]
+    max_per_pkg_meter_units: Option<usize>,
+
+    #[serde(default)]
+    max_back_edges_per_function: Option<usize>,
+    #[serde(default)]
+    max_back_edges_per_module: Option<usize>,
+}
+
+impl VerifierSigningConfig {
+    pub fn max_per_fun_meter_units(&self) -> usize {
+        self.max_per_fun_meter_units
+            .unwrap_or(DEFAULT_MAX_PER_FUN_METER_UNITS)
+    }
+
+    pub fn max_per_mod_meter_units(&self) -> usize {
+        self.max_per_mod_meter_units
+            .unwrap_or(DEFAULT_MAX_PER_MOD_METER_UNITS)
+    }
+
+    pub fn max_per_pkg_meter_units(&self) -> usize {
+        self.max_per_pkg_meter_units
+            .unwrap_or(DEFAULT_MAX_PER_PKG_METER_UNITS)
+    }
+
+    pub fn max_back_edges_per_function(&self) -> usize {
+        self.max_back_edges_per_function
+            .unwrap_or(DEFAULT_MAX_BACK_EDGES_PER_FUNCTION)
+    }
+
+    pub fn max_back_edges_per_module(&self) -> usize {
+        self.max_back_edges_per_module
+            .unwrap_or(DEFAULT_MAX_BACK_EDGES_PER_MODULE)
+    }
+
+    /// Return sign-time only limit for back edges for the verifier.
+    pub fn limits_for_signing(&self) -> (usize, usize) {
+        (
+            self.max_back_edges_per_function(),
+            self.max_back_edges_per_module(),
+        )
+    }
+
+    /// MeterConfig for metering packages during signing. It is NOT stable
+    /// between binaries and cannot used during execution.
+    pub fn meter_config_for_signing(&self) -> MeterConfig {
+        MeterConfig {
+            max_per_fun_meter_units: Some(self.max_per_fun_meter_units() as u128),
+            max_per_mod_meter_units: Some(self.max_per_mod_meter_units() as u128),
+            max_per_pkg_meter_units: Some(self.max_per_pkg_meter_units() as u128),
+        }
+    }
+}

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1765,6 +1765,7 @@ impl AuthorityState {
                     receiving_objects,
                     gas_object,
                     &self.metrics.bytecode_verifier_metrics,
+                    &self.config.verifier_signing_config,
                 )?,
                 Some(gas_object_id),
             )
@@ -2006,6 +2007,7 @@ impl AuthorityState {
                     receiving_objects,
                     dummy_gas_object,
                     &self.metrics.bytecode_verifier_metrics,
+                    &self.config.verifier_signing_config,
                 )?
             } else {
                 iota_transaction_checks::check_transaction_input(

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -898,6 +898,7 @@ impl AuthorityState {
                 input_objects,
                 &receiving_objects,
                 &self.metrics.bytecode_verifier_metrics,
+                &self.config.verifier_signing_config,
             )?;
 
         check_coin_deny_list_v1_during_signing(
@@ -1776,6 +1777,7 @@ impl AuthorityState {
                     input_objects,
                     &receiving_objects,
                     &self.metrics.bytecode_verifier_metrics,
+                    &self.config.verifier_signing_config,
                 )?,
                 None,
             )
@@ -2013,6 +2015,7 @@ impl AuthorityState {
                     input_objects,
                     &receiving_objects,
                     &self.metrics.bytecode_verifier_metrics,
+                    &self.config.verifier_signing_config,
                 )?
             }
         };

--- a/crates/iota-framework-tests/Cargo.toml
+++ b/crates/iota-framework-tests/Cargo.toml
@@ -21,6 +21,7 @@ prometheus.workspace = true
 
 # internal dependencies
 iota-adapter = { path = "../../iota-execution/latest/iota-adapter", package = "iota-adapter-latest" }
+iota-config.workspace = true
 iota-framework.workspace = true
 iota-move = { workspace = true, features = ["unit_test"] }
 iota-move-build.workspace = true
@@ -32,6 +33,5 @@ move-bytecode-verifier-meter.workspace = true
 move-cli.workspace = true
 move-package.workspace = true
 move-unit-test.workspace = true
-iota-config.workspace = true
 
 [dependencies]

--- a/crates/iota-framework-tests/Cargo.toml
+++ b/crates/iota-framework-tests/Cargo.toml
@@ -32,5 +32,6 @@ move-bytecode-verifier-meter.workspace = true
 move-cli.workspace = true
 move-package.workspace = true
 move-unit-test.workspace = true
+iota-config.workspace = true
 
 [dependencies]

--- a/crates/iota-framework-tests/src/metered_verifier.rs
+++ b/crates/iota-framework-tests/src/metered_verifier.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use iota_adapter::adapter::run_metered_move_bytecode_verifier;
+use iota_config::verifier_signing_config::VerifierSigningConfig;
 use iota_framework::BuiltInFramework;
 use iota_move_build::{CompiledPackage, IotaPackageHooks};
 use iota_protocol_config::ProtocolConfig;
@@ -36,8 +37,10 @@ fn test_metered_move_bytecode_verifier() {
     let compiled_modules: Vec<_> = compiled_package.get_modules().cloned().collect();
 
     let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-    let mut verifier_config = protocol_config.verifier_config(/* for_signing */ true);
-    let mut meter_config = protocol_config.meter_config_for_signing();
+    let signing_config = VerifierSigningConfig::default();
+    let mut verifier_config =
+        protocol_config.verifier_config(Some(signing_config.limits_for_signing()));
+    let mut meter_config = signing_config.meter_config_for_signing();
     let registry = &Registry::new();
     let bytecode_verifier_metrics = Arc::new(BytecodeVerifierMetrics::new(registry));
     let mut meter = IotaVerifierMeter::new(meter_config.clone());
@@ -202,9 +205,11 @@ fn test_metered_move_bytecode_verifier() {
     let package = build(&path).unwrap();
     packages.push(package.get_dependency_sorted_modules(with_unpublished_deps));
 
+    let signing_config = VerifierSigningConfig::default();
     let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-    let verifier_config = protocol_config.verifier_config(/* for_signing */ true);
-    let meter_config = protocol_config.meter_config_for_signing();
+    let verifier_config =
+        protocol_config.verifier_config(Some(signing_config.limits_for_signing()));
+    let meter_config = signing_config.meter_config_for_signing();
 
     // Check if the same meter is indeed used multiple invocations of the verifier
     let mut meter = IotaVerifierMeter::new(meter_config);
@@ -229,9 +234,11 @@ fn test_metered_move_bytecode_verifier() {
 fn test_meter_system_packages() {
     move_package::package_hooks::register_package_hooks(Box::new(IotaPackageHooks));
 
+    let signing_config = VerifierSigningConfig::default();
     let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-    let verifier_config = protocol_config.verifier_config(/* for_signing */ true);
-    let meter_config = protocol_config.meter_config_for_signing();
+    let verifier_config =
+        protocol_config.verifier_config(Some(signing_config.limits_for_signing()));
+    let meter_config = signing_config.meter_config_for_signing();
     let registry = &Registry::new();
     let bytecode_verifier_metrics = Arc::new(BytecodeVerifierMetrics::new(registry));
     let mut meter = IotaVerifierMeter::new(meter_config);
@@ -283,9 +290,13 @@ fn test_meter_system_packages() {
 fn test_build_and_verify_programmability_examples() {
     move_package::package_hooks::register_package_hooks(Box::new(IotaPackageHooks));
 
+    let signing_config = VerifierSigningConfig::default();
     let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
     let verifier_config = protocol_config.verifier_config(/* for_signing */ true);
     let meter_config = protocol_config.meter_config_for_signing();
+    let verifier_config =
+        protocol_config.verifier_config(Some(signing_config.limits_for_signing()));
+    let meter_config = signing_config.meter_config_for_signing();
     let registry = &Registry::new();
     let bytecode_verifier_metrics = Arc::new(BytecodeVerifierMetrics::new(registry));
     let examples = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../examples");

--- a/crates/iota-framework-tests/src/metered_verifier.rs
+++ b/crates/iota-framework-tests/src/metered_verifier.rs
@@ -292,8 +292,6 @@ fn test_build_and_verify_programmability_examples() {
 
     let signing_config = VerifierSigningConfig::default();
     let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-    let verifier_config = protocol_config.verifier_config(/* for_signing */ true);
-    let meter_config = protocol_config.meter_config_for_signing();
     let verifier_config =
         protocol_config.verifier_config(Some(signing_config.limits_for_signing()));
     let meter_config = signing_config.meter_config_for_signing();

--- a/crates/iota-framework/Cargo.toml
+++ b/crates/iota-framework/Cargo.toml
@@ -29,7 +29,6 @@ serde_json.workspace = true
 tempfile.workspace = true
 
 # internal dependencies
-iota-config.workspace = true
 iota-move-build.workspace = true
 move-binary-format.workspace = true
 move-compiler.workspace = true

--- a/crates/iota-framework/Cargo.toml
+++ b/crates/iota-framework/Cargo.toml
@@ -29,8 +29,8 @@ serde_json.workspace = true
 tempfile.workspace = true
 
 # internal dependencies
+iota-config.workspace = true
 iota-move-build.workspace = true
 move-binary-format.workspace = true
 move-compiler.workspace = true
 move-package.workspace = true
-iota-config.workspace = true

--- a/crates/iota-framework/Cargo.toml
+++ b/crates/iota-framework/Cargo.toml
@@ -33,3 +33,4 @@ iota-move-build.workspace = true
 move-binary-format.workspace = true
 move-compiler.workspace = true
 move-package.workspace = true
+iota-config.workspace = true

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -9,7 +9,7 @@ use std::{
 
 use clap::*;
 use iota_protocol_config_macros::{ProtocolConfigAccessors, ProtocolConfigFeatureFlagsGetters};
-use move_vm_config::verifier::{MeterConfig, VerifierConfig};
+use move_vm_config::verifier::VerifierConfig;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use tracing::{info, warn};
@@ -1706,11 +1706,15 @@ impl ProtocolConfig {
     // Extract the bytecode verifier config from this protocol config. `for_signing`
     // indicates whether this config is used for verification during signing or
     // execution.
-    pub fn verifier_config(&self, for_signing: bool) -> VerifierConfig {
-        let (max_back_edges_per_function, max_back_edges_per_module) = if for_signing {
+    pub fn verifier_config(&self, signing_limits: Option<(usize, usize)>) -> VerifierConfig {
+        let (max_back_edges_per_function, max_back_edges_per_module) = if let Some((
+            max_back_edges_per_function,
+            max_back_edges_per_module,
+        )) = signing_limits
+        {
             (
-                Some(self.max_back_edges_per_function() as usize),
-                Some(self.max_back_edges_per_module() as usize),
+                Some(max_back_edges_per_function),
+                Some(max_back_edges_per_module),
             )
         } else {
             (None, None)
@@ -1737,16 +1741,6 @@ impl ProtocolConfig {
                                                                            * no limit */
             bytecode_version: self.move_binary_format_version(),
             max_variants_in_enum: self.max_move_enum_variants_as_option(),
-        }
-    }
-
-    /// MeterConfig for metering packages during signing. It is NOT stable
-    /// between binaries and cannot used during execution.
-    pub fn meter_config_for_signing(&self) -> MeterConfig {
-        MeterConfig {
-            max_per_fun_meter_units: Some(2_200_000),
-            max_per_mod_meter_units: Some(2_200_000),
-            max_per_pkg_meter_units: Some(2_200_000),
         }
     }
 

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -19,6 +19,7 @@ use iota_config::{
         default_end_of_epoch_broadcast_channel_capacity, default_zklogin_oauth_providers,
     },
     p2p::{P2pConfig, SeedPeer, StateSyncConfig},
+    verifier_signing_config::VerifierSigningConfig,
 };
 use iota_types::{
     crypto::{AuthorityKeyPair, AuthorityPublicKeyBytes, IotaKeyPair, NetworkKeyPair},
@@ -223,6 +224,7 @@ impl ValidatorConfigBuilder {
             firewall_config: self.firewall_config,
             execution_cache: ExecutionCacheConfig::default(),
             enable_validator_tx_finalizer: true,
+            verifier_signing_config: VerifierSigningConfig::default(),
         }
     }
 
@@ -515,6 +517,7 @@ impl FullnodeConfigBuilder {
             execution_cache: ExecutionCacheConfig::default(),
             // This is a validator specific feature.
             enable_validator_tx_finalizer: false,
+            verifier_signing_config: VerifierSigningConfig::default(),
         }
     }
 

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -123,6 +123,12 @@ validator_configs:
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
     enable-validator-tx-finalizer: true
+    verifier-signing-config:
+      max-per-fun-meter-units: ~
+      max-per-mod-meter-units: ~
+      max-per-pkg-meter-units: ~
+      max-back-edges-per-function: ~
+      max-back-edges-per-module: ~
   - authority-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
     protocol-key-pair:
@@ -243,6 +249,12 @@ validator_configs:
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
     enable-validator-tx-finalizer: true
+    verifier-signing-config:
+      max-per-fun-meter-units: ~
+      max-per-mod-meter-units: ~
+      max-per-pkg-meter-units: ~
+      max-back-edges-per-function: ~
+      max-back-edges-per-module: ~
   - authority-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
     protocol-key-pair:
@@ -363,6 +375,12 @@ validator_configs:
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
     enable-validator-tx-finalizer: true
+    verifier-signing-config:
+      max-per-fun-meter-units: ~
+      max-per-mod-meter-units: ~
+      max-per-pkg-meter-units: ~
+      max-back-edges-per-function: ~
+      max-back-edges-per-module: ~
   - authority-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
     protocol-key-pair:
@@ -483,6 +501,12 @@ validator_configs:
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
     enable-validator-tx-finalizer: true
+    verifier-signing-config:
+      max-per-fun-meter-units: ~
+      max-per-mod-meter-units: ~
+      max-per-pkg-meter-units: ~
+      max-back-edges-per-function: ~
+      max-back-edges-per-module: ~
   - authority-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
     protocol-key-pair:
@@ -603,6 +627,12 @@ validator_configs:
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
     enable-validator-tx-finalizer: true
+    verifier-signing-config:
+      max-per-fun-meter-units: ~
+      max-per-mod-meter-units: ~
+      max-per-pkg-meter-units: ~
+      max-back-edges-per-function: ~
+      max-back-edges-per-module: ~
   - authority-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
     protocol-key-pair:
@@ -723,6 +753,12 @@ validator_configs:
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
     enable-validator-tx-finalizer: true
+    verifier-signing-config:
+      max-per-fun-meter-units: ~
+      max-per-mod-meter-units: ~
+      max-per-pkg-meter-units: ~
+      max-back-edges-per-function: ~
+      max-back-edges-per-module: ~
   - authority-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
     protocol-key-pair:
@@ -843,6 +879,12 @@ validator_configs:
       max-transaction-manager-per-object-queue-length: 100
     execution-cache: passthrough-cache
     enable-validator-tx-finalizer: true
+    verifier-signing-config:
+      max-per-fun-meter-units: ~
+      max-per-mod-meter-units: ~
+      max-per-pkg-meter-units: ~
+      max-back-edges-per-function: ~
+      max-back-edges-per-module: ~
 account_keys:
   - Hloy4pnf8pWEHGP+4OFsXz56bLdIJhkD2O+OdKMqCA4=
   - pvMScjoMR/DaN0M5IOxS2VpGC59N6kv6gDm63ufLQ5w=

--- a/crates/iota-transaction-checks/src/lib.rs
+++ b/crates/iota-transaction-checks/src/lib.rs
@@ -13,6 +13,7 @@ mod checked {
         sync::Arc,
     };
 
+    use iota_config::verifier_signing_config::VerifierSigningConfig;
     use iota_protocol_config::ProtocolConfig;
     use iota_types::{
         IOTA_AUTHENTICATOR_STATE_OBJECT_ID, IOTA_CLOCK_OBJECT_ID, IOTA_CLOCK_OBJECT_SHARED_VERSION,
@@ -72,6 +73,7 @@ mod checked {
         input_objects: InputObjects,
         receiving_objects: &ReceivingObjects,
         metrics: &Arc<BytecodeVerifierMetrics>,
+        verifier_signing_config: &VerifierSigningConfig,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
         let gas_status = check_transaction_input_inner(
             protocol_config,
@@ -82,7 +84,12 @@ mod checked {
         )?;
         check_receiving_objects(&input_objects, receiving_objects)?;
         // Runs verifier, which could be expensive.
-        check_non_system_packages_to_be_published(transaction, protocol_config, metrics)?;
+        check_non_system_packages_to_be_published(
+            transaction,
+            protocol_config,
+            metrics,
+            verifier_signing_config,
+        )?;
 
         Ok((gas_status, input_objects.into_checked()))
     }
@@ -95,6 +102,7 @@ mod checked {
         receiving_objects: ReceivingObjects,
         gas_object: Object,
         metrics: &Arc<BytecodeVerifierMetrics>,
+        verifier_signing_config: &VerifierSigningConfig,
     ) -> IotaResult<(IotaGasStatus, CheckedInputObjects)> {
         let gas_object_ref = gas_object.compute_object_reference();
         input_objects.push(ObjectReadResult::new_from_gas_object(&gas_object));
@@ -108,7 +116,12 @@ mod checked {
         )?;
         check_receiving_objects(&input_objects, &receiving_objects)?;
         // Runs verifier, which could be expensive.
-        check_non_system_packages_to_be_published(transaction, protocol_config, metrics)?;
+        check_non_system_packages_to_be_published(
+            transaction,
+            protocol_config,
+            metrics,
+            verifier_signing_config,
+        )?;
 
         Ok((gas_status, input_objects.into_checked()))
     }
@@ -565,6 +578,7 @@ mod checked {
         transaction: &TransactionData,
         protocol_config: &ProtocolConfig,
         metrics: &Arc<BytecodeVerifierMetrics>,
+        verifier_signing_config: &VerifierSigningConfig,
     ) -> UserInputResult<()> {
         // Only meter non-system programmable transaction blocks
         if transaction.is_system_tx() {
@@ -577,9 +591,9 @@ mod checked {
 
         // Use the same verifier and meter for all packages, custom configured for
         // signing.
-        let for_signing = true;
-        let mut verifier = iota_execution::verifier(protocol_config, for_signing, metrics);
-        let mut meter = verifier.meter(protocol_config.meter_config_for_signing());
+        let signing_limits = Some(verifier_signing_config.limits_for_signing());
+        let mut verifier = iota_execution::verifier(protocol_config, signing_limits, metrics);
+        let mut meter = verifier.meter(verifier_signing_config.meter_config_for_signing());
 
         // Measure time for verifying all packages in the PTB
         let shared_meter_verifier_timer = metrics

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -20,6 +20,7 @@ use fastcrypto::{
     encoding::{Base64, Encoding},
     traits::ToFromBytes,
 };
+use iota_config::verifier_signing_config::VerifierSigningConfig;
 use iota_json::IotaJsonValue;
 use iota_json_rpc_types::{
     Coin, DevInspectArgs, DevInspectResults, DryRunTransactionBlockResponse, DynamicFieldPage,
@@ -1117,10 +1118,10 @@ impl IotaClientCommands {
                     }
                 };
 
-                let for_signing = true;
+                let signing_limits = Some(VerifierSigningConfig::default().limits_for_signing());
                 let mut verifier = iota_execution::verifier(
                     &protocol_config,
-                    for_signing,
+                    signing_limits,
                     &bytecode_verifier_metrics,
                 );
 
@@ -1136,7 +1137,7 @@ impl IotaClientCommands {
                 let mut used_ticks = meter.accumulator(Scope::Package).clone();
                 used_ticks.name = pkg_name;
 
-                let meter_config = protocol_config.meter_config_for_signing();
+                let meter_config = VerifierSigningConfig::default().meter_config_for_signing();
 
                 let exceeded = matches!(
                     meter_config.max_per_pkg_meter_units,

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -5,7 +5,9 @@
 use std::{collections::HashSet, sync::Arc};
 
 use anyhow::Result;
-use iota_config::transaction_deny_config::TransactionDenyConfig;
+use iota_config::{
+    transaction_deny_config::TransactionDenyConfig, verifier_signing_config::VerifierSigningConfig,
+};
 use iota_execution::Executor;
 use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use iota_types::{
@@ -92,6 +94,7 @@ impl EpochState {
         &self,
         store: &dyn SimulatorStore,
         deny_config: &TransactionDenyConfig,
+        verifier_signing_config: &VerifierSigningConfig,
         transaction: &VerifiedTransaction,
     ) -> Result<(
         InnerTemporaryStore,
@@ -128,6 +131,7 @@ impl EpochState {
             input_objects,
             &receiving_objects,
             &self.bytecode_verifier_metrics,
+            verifier_signing_config,
         )?;
 
         let transaction_data = transaction.data().transaction_data();

--- a/iota-execution/latest/iota-adapter/src/adapter.rs
+++ b/iota-execution/latest/iota-adapter/src/adapter.rs
@@ -58,7 +58,7 @@ mod checked {
         MoveVM::new_with_config(
             natives,
             VMConfig {
-                verifier: protocol_config.verifier_config(/* for_signing */ false),
+                verifier: protocol_config.verifier_config(/* signing_limits */ None),
                 max_binary_format_version: protocol_config.move_binary_format_version(),
                 runtime_limits_config: VMRuntimeLimitsConfig {
                     vector_len_max: protocol_config.max_move_vector_len(),

--- a/iota-execution/src/lib.rs
+++ b/iota-execution/src/lib.rs
@@ -38,11 +38,11 @@ pub fn executor(
 
 pub fn verifier<'m>(
     protocol_config: &ProtocolConfig,
-    for_signing: bool,
+    signing_limits: Option<(usize, usize)>,
     metrics: &'m Arc<BytecodeVerifierMetrics>,
 ) -> Box<dyn Verifier + 'm> {
     let version = protocol_config.execution_version_as_option().unwrap_or(1);
-    let config = protocol_config.verifier_config(for_signing);
+    let config = protocol_config.verifier_config(signing_limits);
     match version {
         1 => Box::new(latest::Verifier::new(config, metrics)),
         v => panic!("Unsupported execution version {v}"),

--- a/iota-execution/src/lib.template.rs
+++ b/iota-execution/src/lib.template.rs
@@ -34,11 +34,11 @@ pub fn executor(
 
 pub fn verifier<'m>(
     protocol_config: &ProtocolConfig,
-    for_signing: bool,
+    signing_limits: Option<(usize, usize)>,
     metrics: &'m Arc<BytecodeVerifierMetrics>,
 ) -> Box<dyn Verifier + 'm> {
     let version = protocol_config.execution_version_as_option().unwrap_or(1);
-    let config = protocol_config.verifier_config(for_signing);
+    let config = protocol_config.verifier_config(signing_limits);
     match version {
         // $VERIFIER_CUTS
         v => panic!("Unsupported execution version {v}"),


### PR DESCRIPTION
# Description of change

Allowing verifier constants for limits and metering to be set by the node config instead of being hardcoded into the binary
According to [changes](https://github.com/MystenLabs/sui/commit/89f3a3a86719c5f7c64352072cc777f6e7e585b8#diff-419528073414539f10b5d7725e8385d9b7aaeb525004ed2a7b20261b3a4edfab).

## Links to any relevant issues

Fixes #5246 .

## Type of change

- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Run tests:
TODO