### PR TITLE
fix(iota-indexer, iota-cluster-test, iota-graphql-rpc): Reset indexer database for `iota start` only once + refactor interfaces

### DIFF
--- a/crates/iota-cluster-test/src/cluster.rs
+++ b/crates/iota-cluster-test/src/cluster.rs
@@ -244,9 +244,7 @@ impl Cluster for LocalNewCluster {
             // Start in writer mode
             start_test_indexer(
                 pg_address.clone(),
-                // don't drop and create db
-                false,
-                // reset existing db
+                // reset the existing db
                 true,
                 fullnode_url.clone(),
                 IndexerTypeConfig::writer_mode(None),
@@ -257,7 +255,6 @@ impl Cluster for LocalNewCluster {
             // Start in reader mode
             start_test_indexer(
                 pg_address,
-                false,
                 false,
                 fullnode_url.clone(),
                 IndexerTypeConfig::reader_mode(indexer_address.to_string()),

--- a/crates/iota-cluster-test/src/cluster.rs
+++ b/crates/iota-cluster-test/src/cluster.rs
@@ -243,21 +243,25 @@ impl Cluster for LocalNewCluster {
         {
             // Start in writer mode
             start_test_indexer(
-                Some(pg_address.clone()),
+                pg_address.clone(),
+                // don't drop and create db
+                false,
+                // reset existing db
+                true,
                 fullnode_url.clone(),
                 IndexerTypeConfig::writer_mode(None),
                 Some(data_ingestion_path.clone()),
-                None,
             )
             .await;
 
             // Start in reader mode
             start_test_indexer(
-                Some(pg_address),
+                pg_address,
+                false,
+                false,
                 fullnode_url.clone(),
                 IndexerTypeConfig::reader_mode(indexer_address.to_string()),
                 Some(data_ingestion_path),
-                None,
             )
             .await;
         }

--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -66,14 +66,15 @@ pub async fn start_cluster(
 
     // Starts indexer
     let (pg_store, pg_handle) = start_test_indexer_impl(
-        Some(db_url),
+        db_url,
+        // don't drop and create db
+        false,
+        // reset existing db
+        true,
         val_fn.rpc_url().to_string(),
         IndexerTypeConfig::writer_mode(None),
-        // reset_database
-        true,
         Some(data_ingestion_path),
         cancellation_token.clone(),
-        None,
     )
     .await;
 
@@ -131,14 +132,13 @@ pub async fn serve_executor(
     });
 
     let (pg_store, pg_handle) = start_test_indexer_impl(
-        Some(db_url),
+        db_url,
+        false,
+        true,
         format!("http://{}", executor_server_url),
         IndexerTypeConfig::writer_mode(snapshot_config.clone()),
-        // reset_database
-        true,
         Some(data_ingestion_path),
         cancellation_token.clone(),
-        Some(&graphql_connection_config.db_name()),
     )
     .await;
 

--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -67,9 +67,7 @@ pub async fn start_cluster(
     // Starts indexer
     let (pg_store, pg_handle) = start_test_indexer_impl(
         db_url,
-        // don't drop and create db
-        false,
-        // reset existing db
+        // reset the existing db
         true,
         val_fn.rpc_url().to_string(),
         IndexerTypeConfig::writer_mode(None),
@@ -133,7 +131,6 @@ pub async fn serve_executor(
 
     let (pg_store, pg_handle) = start_test_indexer_impl(
         db_url,
-        false,
         true,
         format!("http://{}", executor_server_url),
         IndexerTypeConfig::writer_mode(snapshot_config.clone()),

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env, net::SocketAddr, path::PathBuf};
+use std::{net::SocketAddr, path::PathBuf};
 
 use diesel::connection::SimpleConnection;
 use iota_json_rpc_types::IotaTransactionBlockResponse;
@@ -42,49 +42,36 @@ impl IndexerTypeConfig {
 }
 
 pub async fn start_test_indexer(
-    db_url: Option<String>,
+    db_url: String,
+    drop_and_create_db: bool,
+    reset_db: bool,
     rpc_url: String,
     reader_writer_config: IndexerTypeConfig,
     data_ingestion_path: Option<PathBuf>,
-    new_database: Option<&str>,
 ) -> (PgIndexerStore, JoinHandle<Result<(), IndexerError>>) {
     start_test_indexer_impl(
         db_url,
+        drop_and_create_db,
+        reset_db,
         rpc_url,
         reader_writer_config,
-        // reset_database
-        false,
         data_ingestion_path,
         CancellationToken::new(),
-        new_database,
     )
     .await
 }
 
 /// Starts an indexer reader or writer for testing depending on the
-/// `reader_writer_config`. If `reset_database` is true, the database instance
-/// named in `db_url` will be dropped and reinstantiated.
+/// `reader_writer_config`.
 pub async fn start_test_indexer_impl(
-    db_url: Option<String>,
+    db_url: String,
+    drop_and_create_db: bool,
+    reset_db: bool,
     rpc_url: String,
     reader_writer_config: IndexerTypeConfig,
-    mut reset_database: bool,
     data_ingestion_path: Option<PathBuf>,
     cancel: CancellationToken,
-    new_database: Option<&str>,
 ) -> (PgIndexerStore, JoinHandle<Result<(), IndexerError>>) {
-    let mut db_url = db_url.unwrap_or_else(|| {
-        let pg_host = env::var("POSTGRES_HOST").unwrap_or_else(|_| "localhost".into());
-        let pg_port = env::var("POSTGRES_PORT").unwrap_or_else(|_| "32770".into());
-        let pw = env::var("POSTGRES_PASSWORD").unwrap_or_else(|_| "postgrespw".into());
-        format!("postgres://postgres:{pw}@{pg_host}:{pg_port}")
-    });
-
-    if let Some(new_database) = new_database {
-        db_url = replace_db_name(&db_url, new_database).0;
-        reset_database = true;
-    };
-
     let mut config = IndexerConfig {
         db_url: Some(db_url.clone().into()),
         // As fallback sync mechanism enable Rest Api if `data_ingestion_path` was not provided
@@ -92,14 +79,14 @@ pub async fn start_test_indexer_impl(
             .is_none()
             .then_some(format!("{rpc_url}/api/v1")),
         rpc_client_url: rpc_url,
-        reset_db: true,
+        reset_db,
         fullnode_sync_worker: true,
         rpc_server_worker: false,
         data_ingestion_path,
         ..Default::default()
     };
 
-    let store = create_pg_store(config.get_db_url().unwrap(), reset_database);
+    let store = create_pg_store(config.get_db_url().unwrap(), drop_and_create_db);
 
     let registry = prometheus::Registry::default();
     let handle = match reader_writer_config {

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -43,7 +43,6 @@ impl IndexerTypeConfig {
 
 pub async fn start_test_indexer(
     db_url: String,
-    drop_and_create_db: bool,
     reset_db: bool,
     rpc_url: String,
     reader_writer_config: IndexerTypeConfig,
@@ -51,7 +50,6 @@ pub async fn start_test_indexer(
 ) -> (PgIndexerStore, JoinHandle<Result<(), IndexerError>>) {
     start_test_indexer_impl(
         db_url,
-        drop_and_create_db,
         reset_db,
         rpc_url,
         reader_writer_config,
@@ -65,7 +63,6 @@ pub async fn start_test_indexer(
 /// `reader_writer_config`.
 pub async fn start_test_indexer_impl(
     db_url: String,
-    drop_and_create_db: bool,
     reset_db: bool,
     rpc_url: String,
     reader_writer_config: IndexerTypeConfig,
@@ -86,7 +83,7 @@ pub async fn start_test_indexer_impl(
         ..Default::default()
     };
 
-    let store = create_pg_store(config.get_db_url().unwrap(), drop_and_create_db);
+    let store = create_pg_store(config.get_db_url().unwrap(), reset_db);
 
     let registry = prometheus::Registry::default();
     let handle = match reader_writer_config {

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -126,8 +126,8 @@ pub async fn start_test_cluster_with_read_write_indexer(
     // start indexer in write mode
     let (pg_store, _pg_store_handle) = start_test_indexer(
         get_indexer_db_url(database_name),
+        // reset the existing db
         true,
-        false,
         cluster.rpc_url().to_string(),
         IndexerTypeConfig::writer_mode(None),
         None,
@@ -313,7 +313,6 @@ pub async fn start_simulacrum_rest_api_with_write_indexer(
     let (pg_store, pg_handle) = start_test_indexer(
         get_indexer_db_url(database_name),
         true,
-        false,
         format!("http://{}", server_url),
         IndexerTypeConfig::writer_mode(None),
         Some(data_ingestion_path),

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -125,11 +125,12 @@ pub async fn start_test_cluster_with_read_write_indexer(
 
     // start indexer in write mode
     let (pg_store, _pg_store_handle) = start_test_indexer(
-        Some(get_indexer_db_url(None)),
+        get_indexer_db_url(database_name),
+        true,
+        false,
         cluster.rpc_url().to_string(),
         IndexerTypeConfig::writer_mode(None),
         None,
-        database_name,
     )
     .await;
 
@@ -310,11 +311,12 @@ pub async fn start_simulacrum_rest_api_with_write_indexer(
     });
     // Starts indexer
     let (pg_store, pg_handle) = start_test_indexer(
-        Some(get_indexer_db_url(None)),
+        get_indexer_db_url(database_name),
+        true,
+        false,
         format!("http://{}", server_url),
         IndexerTypeConfig::writer_mode(None),
         Some(data_ingestion_path),
-        database_name,
     )
     .await;
     (server_handle, pg_store, pg_handle)

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -810,33 +810,38 @@ async fn start(
         tracing::info!("Starting the indexer service at {indexer_address}");
         // Start in writer mode
         start_test_indexer(
-            Some(pg_address.clone()),
+            pg_address.clone(),
+            // don't drop and create db
+            false,
+            // reset existing db
+            true,
             fullnode_url.clone(),
             IndexerTypeConfig::writer_mode(None),
             data_ingestion_dir.clone(),
-            None,
         )
         .await;
         info!("Indexer in writer mode started");
 
         // Start in reader mode
         start_test_indexer(
-            Some(pg_address.clone()),
+            pg_address.clone(),
+            false,
+            false,
             fullnode_url.clone(),
             IndexerTypeConfig::reader_mode(indexer_address.to_string()),
             data_ingestion_dir.clone(),
-            None,
         )
         .await;
         info!("Indexer in reader mode started");
 
         // Start in analytical worker mode
         start_test_indexer(
-            Some(pg_address.clone()),
+            pg_address.clone(),
+            false,
+            false,
             fullnode_url.clone(),
             IndexerTypeConfig::AnalyticalWorker,
             data_ingestion_dir,
-            None,
         )
         .await;
         info!("Indexer in analytical worker mode started");

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -811,9 +811,7 @@ async fn start(
         // Start in writer mode
         start_test_indexer(
             pg_address.clone(),
-            // don't drop and create db
-            false,
-            // reset existing db
+            // reset the existing db
             true,
             fullnode_url.clone(),
             IndexerTypeConfig::writer_mode(None),
@@ -826,7 +824,6 @@ async fn start(
         start_test_indexer(
             pg_address.clone(),
             false,
-            false,
             fullnode_url.clone(),
             IndexerTypeConfig::reader_mode(indexer_address.to_string()),
             data_ingestion_dir.clone(),
@@ -837,7 +834,6 @@ async fn start(
         // Start in analytical worker mode
         start_test_indexer(
             pg_address.clone(),
-            false,
             false,
             fullnode_url.clone(),
             IndexerTypeConfig::AnalyticalWorker,


### PR DESCRIPTION
# Description of change

The hardcoding of `reset_db: true` in https://github.com/iotaledger/iota/blob/c00d430f3abb61d9ad9b35554db30837bb08d1ed/crates/iota-indexer/src/test_utils.rs#L95 resulted in multiple database resets when multiple indexer worker instances (writer mode, analytical writer) were created as in the `iota start` subcommand https://github.com/iotaledger/iota/blob/1b832e0126ad15cf53b58999770ced49b07cc3f1/crates/iota/src/iota_commands.rs#L811-L840

The second reset had side effects for the primary Writer, as tables might not exist and writing to them failed.

Furthermore, the mutable variable `reset_database` defined in 

https://github.com/iotaledger/iota/blob/c00d430f3abb61d9ad9b35554db30837bb08d1ed/crates/iota-indexer/src/test_utils.rs#L71

 and hardcoded by default to `false` in https://github.com/iotaledger/iota/blob/c00d430f3abb61d9ad9b35554db30837bb08d1ed/crates/iota-indexer/src/test_utils.rs#L55-L56

was used to indicate if the database should be dropped and created. This is not to be confused with database resets managed by the `reset_db` variable. It's about creating a new database if the test indexer should not run with the default db and therefore had a misleading naming. Also, `reset_database` was only enabled/mutated if https://github.com/iotaledger/iota/blob/c00d430f3abb61d9ad9b35554db30837bb08d1ed/crates/iota-indexer/src/test_utils.rs#L74 was `Some`. 

For this reason, the PR also refactors and simplifies the interfaces.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/5490
Fixes https://github.com/iotaledger/iota/issues/5365

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

To check if the database resets happen only once anymore, the output of following commands was checked:
`cargo run --features indexer --bin iota start --with-indexer --pg-port 5432 --pg-db-name iota_indexer --with-graphql=0.0.0.0:8000 --force-regenesis`

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
