### PR TITLE
fix(iota-move): update move command to use module labels, generate-struct-layouts fix

### DIFF
--- a/crates/iota-move/src/build.rs
+++ b/crates/iota-move/src/build.rs
@@ -100,7 +100,6 @@ impl Build {
             let dir_name = rerooted_path
                 .join("build")
                 .join(pkg.package.compiled_package_info.package_name.as_str())
-                .join(LAYOUTS_DIR)
                 .join(LAYOUTS_DIR);
             let layout_filename = dir_name.join(STRUCT_LAYOUTS_FILENAME);
             fs::create_dir_all(dir_name)?;

--- a/crates/iota-move/src/build.rs
+++ b/crates/iota-move/src/build.rs
@@ -97,11 +97,13 @@ impl Build {
         if generate_struct_layouts {
             let layout_str = serde_yaml::to_string(&pkg.generate_struct_layouts()).unwrap();
             // store under <package_path>/build/<package_name>/layouts/struct_layouts.yaml
-            let layout_filename = rerooted_path
+            let dir_name = rerooted_path
                 .join("build")
                 .join(pkg.package.compiled_package_info.package_name.as_str())
                 .join(LAYOUTS_DIR)
-                .join(STRUCT_LAYOUTS_FILENAME);
+                .join(LAYOUTS_DIR);
+            let layout_filename = dir_name.join(STRUCT_LAYOUTS_FILENAME);
+            fs::create_dir_all(dir_name)?;
             fs::write(layout_filename, layout_str)?
         }
 

--- a/crates/iota-move/src/new.rs
+++ b/crates/iota-move/src/new.rs
@@ -37,9 +37,7 @@ impl New {
             w,
             r#"/*
 /// Module: {name}
-module {name}::{name} {{
-
-}}
+module {name}::{name};
 */"#,
             name = name
         )?;
@@ -53,21 +51,20 @@ module {name}::{name} {{
             w,
             r#"/*
 #[test_only]
-module {name}::{name}_tests {{
-    // uncomment this line to import the module
-    // use {name}::{name};
+module {name}::{name}_tests;
+// uncomment this line to import the module
+// use {name}::{name};
 
-    const ENotImplemented: u64 = 0;
+const ENotImplemented: u64 = 0;
 
-    #[test]
-    fun test_{name}() {{
-        // pass
-    }}
+#[test]
+fun test_{name}() {{
+    // pass
+}}
 
-    #[test, expected_failure(abort_code = ::{name}::{name}_tests::ENotImplemented)]
-    fun test_{name}_fail() {{
-        abort ENotImplemented
-    }}
+#[test, expected_failure(abort_code = ::{name}::{name}_tests::ENotImplemented)]
+fun test_{name}_fail() {{
+    abort ENotImplemented
 }}
 */"#,
             name = name


### PR DESCRIPTION
# Description of change

Update sui-move new to use module labels. According to [changes](https://github.com/MystenLabs/sui/commit/5efd2c4b32df36983220a8a3ce25bd148a610f47)
CLI generate-struct-layouts fix. According to [changes](https://github.com/MystenLabs/sui/commit/7e01df826d676519cba3c0be4e1c68652adf7df0)
[Changes](https://github.com/MystenLabs/sui/commit/1837a5e366553e51d1f87ff2d034720476ee1b39) were applied already.

## Links to any relevant issues

#5249 .

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)