### PR TITLE
fix(iota, iota-move, iota-framework-tests): removes the feature flags for the `iota-move` crate

### DIFF
--- a/crates/iota-framework-tests/Cargo.toml
+++ b/crates/iota-framework-tests/Cargo.toml
@@ -22,7 +22,7 @@ prometheus.workspace = true
 # internal dependencies
 iota-adapter = { path = "../../iota-execution/latest/iota-adapter", package = "iota-adapter-latest" }
 iota-framework.workspace = true
-iota-move = { workspace = true, features = ["unit_test"] }
+iota-move.workspace = true
 iota-move-build.workspace = true
 iota-protocol-config.workspace = true
 iota-types.workspace = true

--- a/crates/iota-move/Cargo.toml
+++ b/crates/iota-move/Cargo.toml
@@ -14,7 +14,7 @@ clap.workspace = true
 colored.workspace = true
 const-str.workspace = true
 git-version.workspace = true
-once_cell = { workspace = true, optional = true }
+once_cell.workspace = true
 prometheus.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
@@ -24,7 +24,7 @@ tracing.workspace = true
 # internal dependencies
 bin-version.workspace = true
 iota-move-build.workspace = true
-iota-move-natives = { path = "../../iota-execution/latest/iota-move-natives", package = "iota-move-natives-latest", optional = true }
+iota-move-natives = { path = "../../iota-execution/latest/iota-move-natives", package = "iota-move-natives-latest" }
 iota-protocol-config.workspace = true
 iota-types.workspace = true
 move-binary-format.workspace = true
@@ -53,13 +53,3 @@ move-package.workspace = true
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["jemalloc-ctl"]
-
-[features]
-default = []
-build = []
-coverage = []
-disassemble = []
-prove = []
-unit_test = ["build", "dep:once_cell", "dep:iota-move-natives"]
-calibrate = []
-all = ["build", "coverage", "disassemble", "prove", "unit_test", "calibrate"]

--- a/crates/iota-move/src/lib.rs
+++ b/crates/iota-move/src/lib.rs
@@ -6,34 +6,25 @@ use std::path::Path;
 
 use clap::Parser;
 use iota_move_build::set_iota_flavor;
-#[cfg(feature = "unit_test")]
 use move_cli::base::test::UnitTestResult;
 use move_package::BuildConfig;
 
-#[cfg(feature = "build")]
 pub mod build;
-#[cfg(feature = "coverage")]
 pub mod coverage;
-#[cfg(feature = "disassemble")]
 pub mod disassemble;
 pub mod manage_package;
 pub mod migrate;
 pub mod new;
-#[cfg(feature = "unit_test")]
 pub mod unit_test;
 
 #[derive(Parser)]
 pub enum Command {
-    #[cfg(feature = "build")]
     Build(build::Build),
-    #[cfg(feature = "coverage")]
     Coverage(coverage::Coverage),
-    #[cfg(feature = "disassemble")]
     Disassemble(disassemble::Disassemble),
     ManagePackage(manage_package::ManagePackage),
     Migrate(migrate::Migrate),
     New(new::New),
-    #[cfg(feature = "unit_test")]
     Test(unit_test::Test),
 }
 #[derive(Parser)]
@@ -53,17 +44,13 @@ pub fn execute_move_command(
         anyhow::bail!(err_msg);
     }
     match command {
-        #[cfg(feature = "build")]
         Command::Build(c) => c.execute(package_path, build_config),
-        #[cfg(feature = "coverage")]
         Command::Coverage(c) => c.execute(package_path, build_config),
-        #[cfg(feature = "disassemble")]
         Command::Disassemble(c) => c.execute(package_path, build_config),
         Command::ManagePackage(c) => c.execute(package_path, build_config),
         Command::Migrate(c) => c.execute(package_path, build_config),
         Command::New(c) => c.execute(package_path),
 
-        #[cfg(feature = "unit_test")]
         Command::Test(c) => {
             let result = c.execute(package_path, build_config)?;
 

--- a/crates/iota-source-validation-service/Cargo.toml
+++ b/crates/iota-source-validation-service/Cargo.toml
@@ -54,5 +54,5 @@ reqwest.workspace = true
 # internal dependencies
 iota.workspace = true
 iota-json-rpc-types.workspace = true
-iota-move = { workspace = true, features = ["all"] }
+iota-move.workspace = true
 test-cluster.workspace = true

--- a/crates/iota/Cargo.toml
+++ b/crates/iota/Cargo.toml
@@ -72,7 +72,7 @@ iota-indexer = { workspace = true, optional = true }
 iota-json.workspace = true
 iota-json-rpc-types.workspace = true
 iota-keys.workspace = true
-iota-move = { workspace = true, features = ["all"] }
+iota-move.workspace = true
 iota-move-build.workspace = true
 iota-package-management.workspace = true
 iota-protocol-config.workspace = true


### PR DESCRIPTION
# Description of change

This removes the feature flags for the `iota`, `iota-move`, `iota-framework-tests` crates. 
According to [changes](https://github.com/MystenLabs/sui/commit/b14ee43a5b297471da3b7381b5c744afb78188f4#diff-315d632752743a07219143b25bb2becfee2c17314e7d9830488256c563250dbe)

## Links to any relevant issues

Fixes #5558 .

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Run tests for 
iota, 
iota-move, 
iota-framework-tests
