### PR TITLE
feat(consensus): Gargabe Collection - 2

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -482,12 +482,15 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn test_authority_committee(
         #[values(ConsensusNetwork::Tonic)] network_type: ConsensusNetwork,
+        #[values(0, 5, 10)] gc_depth: u32,
     ) {
         let db_registry = Registry::new();
         DBMetrics::init(&db_registry);
 
         const NUM_OF_AUTHORITIES: usize = 4;
         let (committee, keypairs) = local_committee_and_keys(0, [1; NUM_OF_AUTHORITIES].to_vec());
+        let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+        protocol_config.set_consensus_gc_depth_for_testing(gc_depth);
         let temp_dirs = (0..NUM_OF_AUTHORITIES)
             .map(|_| TempDir::new().unwrap())
             .collect::<Vec<_>>();
@@ -504,6 +507,7 @@ mod tests {
                 keypairs.clone(),
                 network_type,
                 boot_counters[index],
+                protocol_config.clone(),
             )
             .await;
             boot_counters[index] += 1;
@@ -560,6 +564,7 @@ mod tests {
             keypairs.clone(),
             network_type,
             boot_counters[index],
+            protocol_config.clone(),
         )
         .await;
         boot_counters[index] += 1;
@@ -577,6 +582,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn test_amnesia_recovery_success(
         #[values(ConsensusNetwork::Tonic)] network_type: ConsensusNetwork,
+        #[values(0, 5, 10)] gc_depth: u32,
     ) {
         telemetry_subscribers::init_for_testing();
         let db_registry = Registry::new();
@@ -589,6 +595,9 @@ mod tests {
         let mut temp_dirs = BTreeMap::new();
         let mut boot_counters = [0; NUM_OF_AUTHORITIES];
 
+        let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+        protocol_config.set_consensus_gc_depth_for_testing(gc_depth);
+
         for (index, _authority_info) in committee.authorities() {
             let dir = TempDir::new().unwrap();
             let (authority, receiver) = make_authority(
@@ -598,6 +607,7 @@ mod tests {
                 keypairs.clone(),
                 network_type,
                 boot_counters[index],
+                protocol_config.clone(),
             )
             .await;
             assert!(
@@ -655,6 +665,7 @@ mod tests {
             keypairs.clone(),
             network_type,
             boot_counters[index_1],
+            protocol_config.clone(),
         )
         .await;
         assert!(
@@ -676,6 +687,7 @@ mod tests {
             keypairs,
             network_type,
             boot_counters[index_2],
+            protocol_config.clone(),
         )
         .await;
         assert!(
@@ -710,6 +722,7 @@ mod tests {
         keypairs: Vec<(NetworkKeyPair, ProtocolKeyPair)>,
         network_type: ConsensusNetwork,
         boot_counter: u64,
+        protocol_config: ProtocolConfig,
     ) -> (ConsensusAuthority, UnboundedReceiver<CommittedSubDag>) {
         let registry = Registry::new();
 
@@ -735,7 +748,7 @@ mod tests {
             index,
             committee,
             parameters,
-            ProtocolConfig::get_for_max_version_UNSAFE(),
+            protocol_config,
             protocol_keypair,
             network_keypair,
             Arc::new(txn_verifier),
@@ -743,7 +756,7 @@ mod tests {
             registry,
             boot_counter,
         )
-        .await;
+            .await;
 
         (authority, receiver)
     }

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -12,11 +12,11 @@ use std::{
 use iota_metrics::monitored_scope;
 use itertools::Itertools as _;
 use parking_lot::RwLock;
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 
 use crate::{
     Round,
-    block::{BlockAPI, BlockRef, VerifiedBlock},
+    block::{BlockAPI, BlockRef, GENESIS_ROUND, VerifiedBlock},
     block_verifier::BlockVerifier,
     context::Context,
     dag_state::DagState,
@@ -123,79 +123,15 @@ impl BlockManager {
                     missing_blocks.extend(ancestors_to_fetch);
                     continue;
                 }
-                TryAcceptResult::Processed => continue,
+                TryAcceptResult::Processed | TryAcceptResult::Skipped => continue,
             };
 
             // If the block is accepted, try to unsuspend its children blocks if any.
-            let unsuspended_blocks = self.try_unsuspend_children_blocks(&block);
+            let unsuspended_blocks = self.try_unsuspend_children_blocks(block.reference());
 
-            // Try to verify the block and its children for timestamp, with ancestor blocks.
-            let mut blocks_to_accept: BTreeMap<BlockRef, VerifiedBlock> = BTreeMap::new();
-            let mut blocks_to_reject: BTreeMap<BlockRef, VerifiedBlock> = BTreeMap::new();
-            {
-                'block: for b in iter::once(block).chain(unsuspended_blocks) {
-                    let ancestors = self.dag_state.read().get_blocks(b.ancestors());
-                    assert_eq!(b.ancestors().len(), ancestors.len());
-                    let mut ancestor_blocks = vec![];
-                    'ancestor: for (ancestor_ref, found) in
-                        b.ancestors().iter().zip(ancestors.into_iter())
-                    {
-                        if let Some(found_block) = found {
-                            // This invariant should be guaranteed by DagState.
-                            assert_eq!(ancestor_ref, &found_block.reference());
-                            ancestor_blocks.push(found_block);
-                            continue 'ancestor;
-                        }
-                        // blocks_to_accept have not been added to DagState yet, but they
-                        // can appear in ancestors.
-                        if blocks_to_accept.contains_key(ancestor_ref) {
-                            ancestor_blocks.push(blocks_to_accept[ancestor_ref].clone());
-                            continue 'ancestor;
-                        }
-                        // If an ancestor is already rejected, reject this block as well.
-                        if blocks_to_reject.contains_key(ancestor_ref) {
-                            blocks_to_reject.insert(b.reference(), b);
-                            continue 'block;
-                        }
-                        panic!(
-                            "Unsuspended block {:?} has a missing ancestor! Ancestor not found in DagState: {:?}",
-                            b, ancestor_ref
-                        );
-                    }
-                    if let Err(e) = self.block_verifier.check_ancestors(&b, &ancestor_blocks) {
-                        warn!("Block {:?} failed to verify ancestors: {}", b, e);
-                        blocks_to_reject.insert(b.reference(), b);
-                    } else {
-                        blocks_to_accept.insert(b.reference(), b);
-                    }
-                }
-            }
-            for (block_ref, block) in blocks_to_reject {
-                let hostname = self
-                    .context
-                    .committee
-                    .authority(block_ref.author)
-                    .hostname
-                    .clone();
-
-                self.context
-                    .metrics
-                    .node_metrics
-                    .invalid_blocks
-                    .with_label_values(&[&hostname, "accept_block", "InvalidAncestors"])
-                    .inc();
-                warn!("Invalid block {:?} is rejected", block);
-            }
-
-            // TODO: report blocks_to_reject to peers.
-
-            // Insert the accepted blocks into DAG state so future blocks including them as
-            // ancestors do not get suspended.
-            let blocks_to_accept: Vec<_> = blocks_to_accept.into_values().collect();
-            self.dag_state
-                .write()
-                .accept_blocks(blocks_to_accept.clone());
-
+            // Verify block timestamps
+            let blocks_to_accept = self
+                .verify_block_timestamps_and_accept(iter::once(block).chain(unsuspended_blocks));
             accepted_blocks.extend(blocks_to_accept);
         }
 
@@ -217,6 +153,110 @@ impl BlockManager {
         (accepted_blocks, missing_blocks)
     }
 
+    // TODO: remove once timestamping is refactored to the new approach.
+    // Verifies each block's timestamp based on its ancestors, and persists in store
+    // all the valid blocks that should be accepted. Method returns the accepted
+    // and persisted blocks.
+    fn verify_block_timestamps_and_accept(
+        &mut self,
+        unsuspended_blocks: impl IntoIterator<Item = VerifiedBlock>,
+    ) -> Vec<VerifiedBlock> {
+        let (gc_enabled, gc_round) = {
+            let dag_state = self.dag_state.read();
+            (dag_state.gc_enabled(), dag_state.gc_round())
+        };
+        // Try to verify the block and its children for timestamp, with ancestor blocks.
+        let mut blocks_to_accept: BTreeMap<BlockRef, VerifiedBlock> = BTreeMap::new();
+        let mut blocks_to_reject: BTreeMap<BlockRef, VerifiedBlock> = BTreeMap::new();
+        {
+            'block: for b in unsuspended_blocks {
+                let ancestors = self.dag_state.read().get_blocks(b.ancestors());
+                assert_eq!(b.ancestors().len(), ancestors.len());
+                let mut ancestor_blocks = vec![];
+                'ancestor: for (ancestor_ref, found) in
+                    b.ancestors().iter().zip(ancestors.into_iter())
+                {
+                    if let Some(found_block) = found {
+                        // This invariant should be guaranteed by DagState.
+                        assert_eq!(ancestor_ref, &found_block.reference());
+                        ancestor_blocks.push(Some(found_block));
+                        continue 'ancestor;
+                    }
+                    // blocks_to_accept have not been added to DagState yet, but they
+                    // can appear in ancestors.
+                    if blocks_to_accept.contains_key(ancestor_ref) {
+                        ancestor_blocks.push(Some(blocks_to_accept[ancestor_ref].clone()));
+                        continue 'ancestor;
+                    }
+                    // If an ancestor is already rejected, reject this block as well.
+                    if blocks_to_reject.contains_key(ancestor_ref) {
+                        blocks_to_reject.insert(b.reference(), b);
+                        continue 'block;
+                    }
+
+                    // When gc is enabled it's possible that we indeed won't find any ancestors that
+                    // are passed gc_round. That's ok. We don't need to panic here.
+                    // We do want to panic if gc_enabled we and have an ancestor that is > gc_round,
+                    // or gc is disabled.
+                    if gc_enabled
+                        && ancestor_ref.round > GENESIS_ROUND
+                        && ancestor_ref.round <= gc_round
+                    {
+                        debug!(
+                            "Block {:?} has a missing ancestor: {:?} passed GC round {}",
+                            b.reference(),
+                            ancestor_ref,
+                            gc_round
+                        );
+                        ancestor_blocks.push(None);
+                    } else {
+                        panic!(
+                            "Unsuspended block {:?} has a missing ancestor! Ancestor not found in DagState: {:?}",
+                            b, ancestor_ref
+                        );
+                    }
+                }
+                if let Err(e) =
+                    self.block_verifier
+                        .check_ancestors(&b, &ancestor_blocks, gc_enabled, gc_round)
+                {
+                    warn!("Block {:?} failed to verify ancestors: {}", b, e);
+                    blocks_to_reject.insert(b.reference(), b);
+                } else {
+                    blocks_to_accept.insert(b.reference(), b);
+                }
+            }
+        }
+
+        // TODO: report blocks_to_reject to peers.
+        for (block_ref, block) in blocks_to_reject {
+            let hostname = self
+                .context
+                .committee
+                .authority(block_ref.author)
+                .hostname
+                .clone();
+
+            self.context
+                .metrics
+                .node_metrics
+                .invalid_blocks
+                .with_label_values(&[&hostname, "accept_block", "InvalidAncestors"])
+                .inc();
+            warn!("Invalid block {:?} is rejected", block);
+        }
+
+        let blocks_to_accept = blocks_to_accept.values().cloned().collect::<Vec<_>>();
+
+        // Insert the accepted blocks into DAG state so future blocks including them as
+        // ancestors do not get suspended.
+        self.dag_state
+            .write()
+            .accept_blocks(blocks_to_accept.clone());
+
+        blocks_to_accept
+    }
+
     /// Tries to accept the provided block. To accept a block its ancestors must
     /// have been already successfully accepted. If block is accepted then
     /// Some result is returned. None is returned when either the block is
@@ -226,6 +266,8 @@ impl BlockManager {
         let mut missing_ancestors = BTreeSet::new();
         let mut ancestors_to_fetch = BTreeSet::new();
         let dag_state = self.dag_state.read();
+        let gc_round = dag_state.gc_round();
+        let gc_enabled = dag_state.gc_enabled();
 
         // If block has been already received and suspended, or already processed and
         // stored, or is a genesis block, then skip it.
@@ -233,11 +275,41 @@ impl BlockManager {
             return TryAcceptResult::Processed;
         }
 
-        let ancestors = block.ancestors();
+        // If the block is <= gc_round, then we simply skip its processing as there is
+        // no meaning do any action on it or even store it.
+        if gc_enabled && block.round() <= gc_round {
+            let hostname = self
+                .context
+                .committee
+                .authority(block.author())
+                .hostname
+                .as_str();
+            self.context
+                .metrics
+                .node_metrics
+                .block_manager_skipped_blocks
+                .with_label_values(&[hostname])
+                .inc();
+            return TryAcceptResult::Skipped;
+        }
+
+        // Keep only the ancestors that are greater than the GC round to check for their
+        // existence. Keep in mind that if GC is disabled then gc_round will be
+        // 0 and all ancestors will be considered.
+        let ancestors = if gc_enabled {
+            block
+                .ancestors()
+                .iter()
+                .filter(|ancestor| ancestor.round == GENESIS_ROUND || ancestor.round > gc_round)
+                .cloned()
+                .collect::<Vec<_>>()
+        } else {
+            block.ancestors().to_vec()
+        };
 
         // make sure that we have all the required ancestors in store
         for (found, ancestor) in dag_state
-            .contains_blocks(ancestors.to_vec())
+            .contains_blocks(ancestors.clone())
             .into_iter()
             .zip(ancestors.iter())
         {
@@ -304,24 +376,19 @@ impl BlockManager {
     /// Given an accepted block `accepted_block` it attempts to accept all the
     /// suspended children blocks assuming such exist. All the unsuspended /
     /// accepted blocks are returned as a vector in causal order.
-    fn try_unsuspend_children_blocks(
-        &mut self,
-        accepted_block: &VerifiedBlock,
-    ) -> Vec<VerifiedBlock> {
+    fn try_unsuspend_children_blocks(&mut self, accepted_block: BlockRef) -> Vec<VerifiedBlock> {
         let mut unsuspended_blocks = vec![];
-        let mut to_process_blocks = vec![accepted_block.clone()];
+        let mut to_process_blocks = vec![accepted_block];
 
-        while let Some(block) = to_process_blocks.pop() {
+        while let Some(block_ref) = to_process_blocks.pop() {
             // And try to check if its direct children can be unsuspended
-            if let Some(block_refs_with_missing_deps) =
-                self.missing_ancestors.remove(&block.reference())
-            {
+            if let Some(block_refs_with_missing_deps) = self.missing_ancestors.remove(&block_ref) {
                 for r in block_refs_with_missing_deps {
                     // For each dependency try to unsuspend it. If that's successful then we add it
                     // to the queue so we can recursively try to unsuspend its
                     // children.
-                    if let Some(block) = self.try_unsuspend_block(&r, &block.reference()) {
-                        to_process_blocks.push(block.block.clone());
+                    if let Some(block) = self.try_unsuspend_block(&r, &block_ref) {
+                        to_process_blocks.push(block.block.reference());
                         unsuspended_blocks.push(block);
                     }
                 }
@@ -386,6 +453,76 @@ impl BlockManager {
         None
     }
 
+    /// Tries to unsuspend any blocks for the latest gc round. If gc round
+    /// hasn't changed then no blocks will be unsuspended due to
+    /// this action.
+    pub(crate) fn try_unsuspend_blocks_for_latest_gc_round(&mut self) {
+        let _s = monitored_scope("BlockManager::try_unsuspend_blocks_for_latest_gc_round");
+        let (gc_enabled, gc_round) = {
+            let dag_state = self.dag_state.read();
+            (dag_state.gc_enabled(), dag_state.gc_round())
+        };
+        let mut blocks_unsuspended_below_gc_round = 0;
+        let mut blocks_gc_ed = 0;
+
+        if !gc_enabled {
+            trace!("GC is disabled, no blocks will attempt to get unsuspended.");
+            return;
+        }
+
+        while let Some((block_ref, _children_refs)) = self.missing_ancestors.first_key_value() {
+            // If the first block in the missing ancestors is higher than the gc_round, then
+            // we can't unsuspend it yet. So we just put it back
+            // and we terminate the iteration as any next entry will be of equal or higher
+            // round anyways.
+            if block_ref.round > gc_round {
+                return;
+            }
+
+            blocks_gc_ed += 1;
+
+            assert!(
+                !self.suspended_blocks.contains_key(block_ref),
+                "Block should not be suspended, as we are causally GC'ing and no suspended block should exist for a missing ancestor."
+            );
+
+            // Also remove it from the missing list - we don't want to keep looking for it.
+            self.missing_blocks.remove(block_ref);
+
+            // Find all the children blocks that have a dependency on this one and try to
+            // unsuspend them
+            let unsuspended_blocks = self.try_unsuspend_children_blocks(*block_ref);
+
+            unsuspended_blocks.iter().for_each(|block| {
+                if block.round() <= gc_round {
+                    blocks_unsuspended_below_gc_round += 1;
+                }
+            });
+
+            // Now validate their timestamps and accept them
+            let accepted_blocks = self.verify_block_timestamps_and_accept(unsuspended_blocks);
+            for block in accepted_blocks {
+                let hostname = self
+                    .context
+                    .committee
+                    .authority(block.author())
+                    .hostname
+                    .as_str();
+                self.context
+                    .metrics
+                    .node_metrics
+                    .block_manager_gc_unsuspended_blocks
+                    .with_label_values(&[hostname])
+                    .inc();
+            }
+        }
+
+        debug!(
+            "Total {} blocks unsuspended and total blocks {} gc'ed <= gc_round {}",
+            blocks_unsuspended_below_gc_round, blocks_gc_ed, gc_round
+        );
+    }
+
     /// Returns all the blocks that are currently missing and needed in order to
     /// accept suspended blocks.
     pub(crate) fn missing_blocks(&self) -> BTreeSet<BlockRef> {
@@ -442,6 +579,9 @@ enum TryAcceptResult {
     // or in DagState (so has been already accepted). No further processing has been done at
     // this point.
     Processed,
+    // When a received block is <= gc_round, then we simply skip its processing as there is no
+    // meaning do any action on it or even store it.
+    Skipped,
 }
 
 #[cfg(test)]
@@ -451,16 +591,20 @@ mod tests {
     use consensus_config::AuthorityIndex;
     use parking_lot::RwLock;
     use rand::{SeedableRng, prelude::StdRng, seq::SliceRandom};
+    use rstest::rstest;
 
     use crate::{
-        block::{BlockAPI, BlockRef, SignedBlock, VerifiedBlock},
+        CommitDigest, Round,
+        block::{BlockAPI, BlockDigest, BlockRef, SignedBlock, VerifiedBlock},
         block_manager::BlockManager,
         block_verifier::{BlockVerifier, NoopBlockVerifier},
+        commit::TrustedCommit,
         context::Context,
         dag_state::DagState,
         error::{ConsensusError, ConsensusResult},
         storage::mem_store::MemStore,
         test_dag_builder::DagBuilder,
+        test_dag_parser::parse_dag,
     };
 
     #[tokio::test]
@@ -580,7 +724,7 @@ mod tests {
         let (accepted_blocks, missing) = block_manager.try_accept_blocks(all_blocks.clone());
 
         // THEN
-        assert!(accepted_blocks.len() == 8);
+        assert_eq!(accepted_blocks.len(), 8);
         assert_eq!(
             accepted_blocks,
             all_blocks
@@ -598,10 +742,166 @@ mod tests {
         assert!(accepted_blocks.is_empty());
     }
 
+    /// Tests that the block manager accepts blocks when some or all of their
+    /// causal history is below or equal to the GC round.
     #[tokio::test]
-    async fn accept_blocks_unsuspend_children_blocks() {
+    async fn accept_blocks_with_causal_history_below_gc_round() {
         // GIVEN
-        let (context, _key_pairs) = Context::new_for_test(4);
+        let (mut context, _key_pairs) = Context::new_for_test(4);
+
+        // We set the gc depth to 4
+        context
+            .protocol_config
+            .set_consensus_gc_depth_for_testing(4);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+
+        // We "fake" the commit for round 10, so we can test the GC round 6
+        // (commit_round - gc_depth = 10 - 4 = 6)
+        let last_commit = TrustedCommit::new_for_test(
+            10,
+            CommitDigest::MIN,
+            context.clock.timestamp_utc_ms(),
+            BlockRef::new(10, AuthorityIndex::new_for_test(0), BlockDigest::MIN),
+            vec![],
+        );
+        dag_state.write().set_last_commit(last_commit);
+        assert_eq!(
+            dag_state.read().gc_round(),
+            6,
+            "GC round should have moved to round 6"
+        );
+
+        let mut block_manager =
+            BlockManager::new(context.clone(), dag_state, Arc::new(NoopBlockVerifier));
+
+        // create a DAG of 10 rounds with some weak links for the blocks of round 9
+        let dag_str = "DAG {
+            Round 0 : { 4 },
+            Round 1 : { * },
+            Round 2 : { * },
+            Round 3 : { * },
+            Round 4 : { * },
+            Round 5 : { * },
+            Round 6 : { * },
+            Round 7 : {
+                A -> [*],
+                B -> [*],
+                C -> [*],
+            }
+            Round 8 : {
+                A -> [*],
+                B -> [*],
+                C -> [*],
+            },
+            Round 9 : {
+                A -> [A8, B8, C8, D6],
+                B -> [A8, B8, C8, D6],
+                C -> [A8, B8, C8, D6],
+                D -> [A8, B8, C8, D6],
+            },
+            Round 10 : { * },
+        }";
+
+        let (_, dag_builder) = parse_dag(dag_str).expect("Invalid dag");
+
+        // Now take all the blocks for round 7 & 8 , which are above the gc_round = 6.
+        // All those blocks should eventually be returned as accepted. Pay attention
+        // that without GC none of those blocks should get accepted.
+        let blocks_ranges = vec![7..=8 as Round, 9..=10 as Round];
+
+        for rounds_range in blocks_ranges {
+            let all_blocks = dag_builder
+                .blocks
+                .values()
+                .filter(|block| rounds_range.contains(&block.round()))
+                .cloned()
+                .collect::<Vec<_>>();
+
+            // WHEN
+            let mut reversed_blocks = all_blocks.clone();
+            reversed_blocks.sort_by_key(|b| std::cmp::Reverse(b.reference()));
+            let (mut accepted_blocks, missing) = block_manager.try_accept_blocks(reversed_blocks);
+            accepted_blocks.sort_by_key(|a| a.reference());
+
+            // THEN
+            assert_eq!(accepted_blocks, all_blocks.to_vec());
+            assert!(missing.is_empty());
+            assert!(block_manager.is_empty());
+
+            let (accepted_blocks, _) = block_manager.try_accept_blocks(all_blocks);
+            assert!(accepted_blocks.is_empty());
+        }
+    }
+
+    /// Blocks that are attempted to be accepted but are <= gc_round they will
+    /// be skipped for processing. Nothing should be stored or trigger any
+    /// unsuspension etc.
+    #[tokio::test]
+    async fn skip_accepting_blocks_below_gc_round() {
+        // GIVEN
+        let (mut context, _key_pairs) = Context::new_for_test(4);
+        // We set the gc depth to 4
+        context
+            .protocol_config
+            .set_consensus_gc_depth_for_testing(4);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+
+        // We "fake" the commit for round 10, so we can test the GC round 6
+        // (commit_round - gc_depth = 10 - 4 = 6)
+        let last_commit = TrustedCommit::new_for_test(
+            10,
+            CommitDigest::MIN,
+            context.clock.timestamp_utc_ms(),
+            BlockRef::new(10, AuthorityIndex::new_for_test(0), BlockDigest::MIN),
+            vec![],
+        );
+        dag_state.write().set_last_commit(last_commit);
+        assert_eq!(
+            dag_state.read().gc_round(),
+            6,
+            "GC round should have moved to round 6"
+        );
+
+        let mut block_manager =
+            BlockManager::new(context.clone(), dag_state, Arc::new(NoopBlockVerifier));
+
+        // create a DAG of 6 rounds
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=6).build();
+
+        let all_blocks = dag_builder.blocks.values().cloned().collect::<Vec<_>>();
+
+        // WHEN
+        let (accepted_blocks, missing) = block_manager.try_accept_blocks(all_blocks.clone());
+
+        // THEN
+        assert!(accepted_blocks.is_empty());
+        assert!(missing.is_empty());
+        assert!(block_manager.is_empty());
+    }
+
+    /// The test generate blocks for a well connected DAG and feed them to block
+    /// manager in random order. In the end all the blocks should be
+    /// uniquely suspended and no missing blocks should exist. The test will run
+    /// for both gc_enabled/disabled. When gc is enabeld we set a high
+    /// gc_depth value so in practice gc_round will be 0, but we'll be able to
+    /// test in the common case that this work exactly the same way as when
+    /// gc is disabled.
+    #[rstest]
+    #[tokio::test]
+    async fn accept_blocks_unsuspend_children_blocks(#[values(false, true)] gc_enabled: bool) {
+        // GIVEN
+        let (mut context, _key_pairs) = Context::new_for_test(4);
+
+        if gc_enabled {
+            context
+                .protocol_config
+                .set_consensus_gc_depth_for_testing(10);
+        }
         let context = Arc::new(context);
 
         // create a DAG of rounds 1 ~ 3
@@ -643,6 +943,84 @@ mod tests {
         }
     }
 
+    #[rstest]
+    #[tokio::test]
+    async fn unsuspend_blocks_for_latest_gc_round(#[values(5, 10, 14)] gc_depth: u32) {
+        telemetry_subscribers::init_for_testing();
+        // GIVEN
+        let (mut context, _key_pairs) = Context::new_for_test(4);
+
+        if gc_depth > 0 {
+            context
+                .protocol_config
+                .set_consensus_gc_depth_for_testing(gc_depth);
+        }
+        let context = Arc::new(context);
+
+        // create a DAG of rounds 1 ~ gc_depth * 2
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=gc_depth * 2).build();
+
+        // Pay attention that we start from round 2. Round 1 will always be missing so
+        // no matter what we do we can't unsuspend it unless gc_round has
+        // advanced to round >= 1.
+        let mut all_blocks = dag_builder
+            .blocks
+            .values()
+            .filter(|block| block.round() > 1)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        // Now randomize the sequence of sending the blocks to block manager. In the end
+        // all the blocks should be uniquely suspended and no missing blocks
+        // should exist.
+        for seed in 0..100u8 {
+            all_blocks.shuffle(&mut StdRng::from_seed([seed; 32]));
+
+            let store = Arc::new(MemStore::new());
+            let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+
+            let mut block_manager = BlockManager::new(
+                context.clone(),
+                dag_state.clone(),
+                Arc::new(NoopBlockVerifier),
+            );
+
+            // WHEN
+            for block in &all_blocks {
+                let (accepted_blocks, _) = block_manager.try_accept_blocks(vec![block.clone()]);
+                assert!(accepted_blocks.is_empty());
+            }
+            assert!(!block_manager.is_empty());
+
+            // AND
+            // Trigger a commit which will advance GC round
+            let last_commit = TrustedCommit::new_for_test(
+                gc_depth * 2,
+                CommitDigest::MIN,
+                context.clock.timestamp_utc_ms(),
+                BlockRef::new(
+                    gc_depth * 2,
+                    AuthorityIndex::new_for_test(0),
+                    BlockDigest::MIN,
+                ),
+                vec![],
+            );
+            dag_state.write().set_last_commit(last_commit);
+
+            // AND
+            block_manager.try_unsuspend_blocks_for_latest_gc_round();
+
+            // THEN
+            assert!(block_manager.is_empty());
+
+            // AND ensure that all have been accepted to the DAG
+            for block in &all_blocks {
+                assert!(dag_state.read().contains_block(&block.reference()));
+            }
+        }
+    }
+
     struct TestBlockVerifier {
         fail: BTreeSet<BlockRef>,
     }
@@ -661,7 +1039,9 @@ mod tests {
         fn check_ancestors(
             &self,
             block: &VerifiedBlock,
-            _ancestors: &[VerifiedBlock],
+            _ancestors: &[Option<VerifiedBlock>],
+            _gc_enabled: bool,
+            _gc_round: Round,
         ) -> ConsensusResult<()> {
             if self.fail.contains(&block.reference()) {
                 Err(ConsensusError::InvalidBlockTimestamp {

--- a/consensus/core/src/block_verifier.rs
+++ b/consensus/core/src/block_verifier.rs
@@ -5,6 +5,7 @@
 use std::{collections::BTreeSet, sync::Arc};
 
 use crate::{
+    Round,
     block::{
         BlockAPI, BlockRef, BlockTimestampMs, GENESIS_ROUND, SignedBlock, VerifiedBlock,
         genesis_blocks,
@@ -28,7 +29,9 @@ pub(crate) trait BlockVerifier: Send + Sync + 'static {
     fn check_ancestors(
         &self,
         block: &VerifiedBlock,
-        ancestors: &[VerifiedBlock],
+        ancestors: &[Option<VerifiedBlock>],
+        gc_enabled: bool,
+        gc_round: Round,
     ) -> ConsensusResult<()>;
 }
 
@@ -187,20 +190,45 @@ impl BlockVerifier for SignedBlockVerifier {
     fn check_ancestors(
         &self,
         block: &VerifiedBlock,
-        ancestors: &[VerifiedBlock],
+        ancestors: &[Option<VerifiedBlock>],
+        gc_enabled: bool,
+        gc_round: Round,
     ) -> ConsensusResult<()> {
-        assert_eq!(block.ancestors().len(), ancestors.len());
-        // This checks the invariant that block timestamp >= max ancestor timestamp.
-        let mut max_timestamp_ms = BlockTimestampMs::MIN;
-        for (ancestor_ref, ancestor_block) in block.ancestors().iter().zip(ancestors.iter()) {
-            assert_eq!(ancestor_ref, &ancestor_block.reference());
-            max_timestamp_ms = max_timestamp_ms.max(ancestor_block.timestamp_ms());
-        }
-        if max_timestamp_ms > block.timestamp_ms() {
-            return Err(ConsensusError::InvalidBlockTimestamp {
-                max_timestamp_ms,
-                block_timestamp_ms: block.timestamp_ms(),
-            });
+        if gc_enabled {
+            // TODO: will be removed with new timestamp calculation is in place as all these
+            // will be irrelevant. When gc is enabled we don't have gaurantees
+            // that all ancestors will be available. We'll take into account only the passed
+            // gc_round ones for the timestamp check.
+            let mut max_timestamp_ms = BlockTimestampMs::MIN;
+            for ancestor in ancestors.iter().flatten() {
+                if ancestor.round() <= gc_round {
+                    continue;
+                }
+                max_timestamp_ms = max_timestamp_ms.max(ancestor.timestamp_ms());
+                if max_timestamp_ms > block.timestamp_ms() {
+                    return Err(ConsensusError::InvalidBlockTimestamp {
+                        max_timestamp_ms,
+                        block_timestamp_ms: block.timestamp_ms(),
+                    });
+                }
+            }
+        } else {
+            assert_eq!(block.ancestors().len(), ancestors.len());
+            // This checks the invariant that block timestamp >= max ancestor timestamp.
+            let mut max_timestamp_ms = BlockTimestampMs::MIN;
+            for (ancestor_ref, ancestor_block) in block.ancestors().iter().zip(ancestors.iter()) {
+                let ancestor_block = ancestor_block
+                    .as_ref()
+                    .expect("There should never be an empty slot");
+                assert_eq!(ancestor_ref, &ancestor_block.reference());
+                max_timestamp_ms = max_timestamp_ms.max(ancestor_block.timestamp_ms());
+            }
+            if max_timestamp_ms > block.timestamp_ms() {
+                return Err(ConsensusError::InvalidBlockTimestamp {
+                    max_timestamp_ms,
+                    block_timestamp_ms: block.timestamp_ms(),
+                });
+            }
         }
         Ok(())
     }
@@ -218,7 +246,9 @@ impl BlockVerifier for NoopBlockVerifier {
     fn check_ancestors(
         &self,
         _block: &VerifiedBlock,
-        _ancestors: &[VerifiedBlock],
+        _ancestors: &[Option<VerifiedBlock>],
+        _gc_enabled: bool,
+        _gc_round: Round,
     ) -> ConsensusResult<()> {
         Ok(())
     }
@@ -227,6 +257,7 @@ impl BlockVerifier for NoopBlockVerifier {
 #[cfg(test)]
 mod test {
     use consensus_config::AuthorityIndex;
+    use rstest::rstest;
 
     use super::*;
     use crate::{
@@ -523,22 +554,28 @@ mod test {
         }
     }
 
+    /// Tests the block's ancestors for timestamp monotonicity. Test will run
+    /// for both when gc is enabled and disabled, but with none of the
+    /// ancestors being below the gc_round.
+    #[rstest]
     #[tokio::test]
-    async fn test_check_ancestors() {
+    async fn test_check_ancestors(#[values(false, true)] gc_enabled: bool) {
         let num_authorities = 4;
         let (context, _keypairs) = Context::new_for_test(num_authorities);
         let context = Arc::new(context);
         let verifier = SignedBlockVerifier::new(context.clone(), Arc::new(TxnSizeVerifier {}));
+        let gc_round = 0;
 
         let mut ancestor_blocks = vec![];
         for i in 0..num_authorities {
             let test_block = TestBlock::new(10, i as u32)
                 .set_timestamp_ms(1000 + 100 * i as BlockTimestampMs)
                 .build();
-            ancestor_blocks.push(VerifiedBlock::new_for_test(test_block));
+            ancestor_blocks.push(Some(VerifiedBlock::new_for_test(test_block)));
         }
         let ancestor_refs = ancestor_blocks
             .iter()
+            .flatten()
             .map(|block| block.reference())
             .collect::<Vec<_>>();
 
@@ -551,7 +588,7 @@ mod test {
             let verified_block = VerifiedBlock::new_for_test(block);
             assert!(
                 verifier
-                    .check_ancestors(&verified_block, &ancestor_blocks)
+                    .check_ancestors(&verified_block, &ancestor_blocks, gc_enabled, gc_round)
                     .is_ok()
             );
         }
@@ -564,7 +601,86 @@ mod test {
                 .build();
             let verified_block = VerifiedBlock::new_for_test(block);
             assert!(matches!(
-                verifier.check_ancestors(&verified_block, &ancestor_blocks),
+                verifier.check_ancestors(&verified_block, &ancestor_blocks, gc_enabled, gc_round),
+                Err(ConsensusError::InvalidBlockTimestamp {
+                    max_timestamp_ms: _,
+                    block_timestamp_ms: _
+                })
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_check_ancestors_passed_gc_round() {
+        let num_authorities = 4;
+        let (context, _keypairs) = Context::new_for_test(num_authorities);
+        let context = Arc::new(context);
+        let verifier = SignedBlockVerifier::new(context.clone(), Arc::new(TxnSizeVerifier {}));
+        let gc_enabled = true;
+        let gc_round = 3;
+
+        let mut ancestor_blocks = vec![];
+
+        // Create one block just on the `gc_round` (so it should be considered garbage
+        // collected). This has higher timestamp that the block we are testing.
+        let test_block = TestBlock::new(gc_round, 0_u32)
+            .set_timestamp_ms(1500 as BlockTimestampMs)
+            .build();
+        ancestor_blocks.push(Some(VerifiedBlock::new_for_test(test_block)));
+
+        // Rest of the blocks
+        for i in 1..=3 {
+            let test_block = TestBlock::new(gc_round + 1, i as u32)
+                .set_timestamp_ms(1000 + 100 * i as BlockTimestampMs)
+                .build();
+            ancestor_blocks.push(Some(VerifiedBlock::new_for_test(test_block)));
+        }
+
+        let ancestor_refs = ancestor_blocks
+            .iter()
+            .flatten()
+            .map(|block| block.reference())
+            .collect::<Vec<_>>();
+
+        // Block respecting timestamp invariant.
+        {
+            let block = TestBlock::new(gc_round + 2, 0)
+                .set_ancestors(ancestor_refs.clone())
+                .set_timestamp_ms(1600)
+                .build();
+            let verified_block = VerifiedBlock::new_for_test(block);
+            assert!(
+                verifier
+                    .check_ancestors(&verified_block, &ancestor_blocks, gc_enabled, gc_round)
+                    .is_ok()
+            );
+        }
+
+        // Block not respecting timestamp invariant for the block that is garbage
+        // collected Validation should pass.
+        {
+            let block = TestBlock::new(11, 0)
+                .set_ancestors(ancestor_refs.clone())
+                .set_timestamp_ms(1400)
+                .build();
+            let verified_block = VerifiedBlock::new_for_test(block);
+            assert!(
+                verifier
+                    .check_ancestors(&verified_block, &ancestor_blocks, gc_enabled, gc_round)
+                    .is_ok()
+            );
+        }
+
+        // Block not respecting timestamp invariant for the blocks that are not garbage
+        // collected
+        {
+            let block = TestBlock::new(11, 0)
+                .set_ancestors(ancestor_refs.clone())
+                .set_timestamp_ms(1100)
+                .build();
+            let verified_block = VerifiedBlock::new_for_test(block);
+            assert!(matches!(
+                verifier.check_ancestors(&verified_block, &ancestor_blocks, gc_enabled, gc_round),
                 Err(ConsensusError::InvalidBlockTimestamp {
                     max_timestamp_ms: _,
                     block_timestamp_ms: _

--- a/consensus/core/src/block_verifier.rs
+++ b/consensus/core/src/block_verifier.rs
@@ -196,7 +196,7 @@ impl BlockVerifier for SignedBlockVerifier {
     ) -> ConsensusResult<()> {
         if gc_enabled {
             // TODO: will be removed with new timestamp calculation is in place as all these
-            // will be irrelevant. When gc is enabled we don't have gaurantees
+            // will be irrelevant. When gc is enabled we don't have guarantees
             // that all ancestors will be available. We'll take into account only the passed
             // gc_round ones for the timestamp check.
             let mut max_timestamp_ms = BlockTimestampMs::MIN;

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -158,6 +158,8 @@ pub(crate) struct NodeMetrics {
     pub(crate) block_manager_missing_blocks: IntGauge,
     pub(crate) block_manager_missing_blocks_by_authority: IntCounterVec,
     pub(crate) block_manager_missing_ancestors_by_authority: IntCounterVec,
+    pub(crate) block_manager_gc_unsuspended_blocks: IntCounterVec,
+    pub(crate) block_manager_skipped_blocks: IntCounterVec,
     pub(crate) threshold_clock_round: IntGauge,
     pub(crate) subscriber_connection_attempts: IntCounterVec,
     pub(crate) subscriber_to: IntGaugeVec,
@@ -527,6 +529,18 @@ impl NodeMetrics {
             block_manager_missing_ancestors_by_authority: register_int_counter_vec_with_registry!(
                 "block_manager_missing_ancestors_by_authority",
                 "The number of missing ancestors by ancestor authority across received blocks",
+                &["authority"],
+                registry,
+            ).unwrap(),
+            block_manager_gc_unsuspended_blocks: register_int_counter_vec_with_registry!(
+                "block_manager_gc_unsuspended_blocks",
+                "The number of blocks unsuspended because their missing ancestors are garbage collected by the block manager, counted by block's source authority",
+                &["authority"],
+                registry,
+            ).unwrap(),
+            block_manager_skipped_blocks: register_int_counter_vec_with_registry!(
+                "block_manager_skipped_blocks",
+                "The number of blocks skipped by the block manager due to block round being <= gc_round",
                 &["authority"],
                 registry,
             ).unwrap(),

--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -60,11 +60,25 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
         let context = self.context.clone();
         let network_client = self.network_client.clone();
         let authority_service = self.authority_service.clone();
-        let last_received = self
-            .dag_state
-            .read()
-            .get_last_block_for_authority(peer)
-            .round();
+        let (mut last_received, gc_round, gc_enabled) = {
+            let dag_state = self.dag_state.read();
+            (
+                dag_state.get_last_block_for_authority(peer).round(),
+                dag_state.gc_round(),
+                dag_state.gc_enabled(),
+            )
+        };
+
+        // If the latest block we have accepted by an authority is older than the
+        // current gc round, then do not attempt to fetch any blocks from that
+        // point as they will simply be skipped. Instead do attempt to fetch
+        // from the gc round.
+        if gc_enabled && last_received < gc_round {
+            info!(
+                "Last received block for peer {peer} is older than GC round, {last_received} < {gc_round}, fetching from GC round"
+            );
+            last_received = gc_round;
+        }
 
         let mut subscriptions = self.subscriptions.lock();
         self.unsubscribe_locked(peer, &mut subscriptions[peer.value()]);


### PR DESCRIPTION
# Description of change

Porting upstream change: https://github.com/MystenLabs/sui/commit/6d9b1f98f595ff9cfa5a45ab2ec13b3a46cb1236

This is the second part of Garbage Collection which implements the
following ticked next steps as outlined on the previous PR

- [x] BlockManager to respect the gc_round when accepting blocks and
trigger clean ups for new gc rounds
- [x] Skip blocks that are received which are <= gc_round
- [x] Not propose ancestors that are <= gc_round
- [x] Subscriber to ask for blocks from `gc_round` when
`last_fetched_round < gc_round` for a peer to prevent us from fetching
unnecessary blocks

Next steps:

- [ ] Re-propose GC'ed transactions (probably not all of them)
- [ ] Implement new timestamp approach so ancestor verification is not
needed
- [ ] Harden testing for GC & edge cases


## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #(issue)`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
