### PR TITLE
fix(iota-data-ingestion): Move tokio signal unix import behind unix os check

### DIFF
--- a/crates/iota-data-ingestion/src/main.rs
+++ b/crates/iota-data-ingestion/src/main.rs
@@ -12,7 +12,6 @@ use iota_data_ingestion::{
 use iota_data_ingestion_core::{DataIngestionMetrics, IndexerExecutor, ReaderOptions, WorkerPool};
 use prometheus::Registry;
 use serde::{Deserialize, Serialize};
-use tokio::signal::unix::SignalKind;
 use tokio_util::sync::CancellationToken;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -82,7 +81,7 @@ fn setup_env(token: CancellationToken) {
     tokio::spawn(async move {
         #[cfg(unix)]
         let terminate = async {
-            tokio::signal::unix::signal(SignalKind::terminate())
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
                 .expect("Cannot listen to SIGTERM signal")
                 .recv()
                 .await;


### PR DESCRIPTION
Sequel to https://github.com/iotaledger/iota/pull/5471
Fixes https://github.com/iotaledger/iota/actions/runs/13581059570/job/37967065795#step:10:2172
Closes https://github.com/iotaledger/iota/issues/5685