### PR TITLE
refactor(iota-analytics-indexer): Use dynamic field visitors in analytics indexer

### DIFF
--- a/crates/iota-analytics-indexer/src/handlers/df_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/df_handler.rs
@@ -12,20 +12,20 @@ use iota_json_rpc_types::IotaMoveValue;
 use iota_package_resolver::Resolver;
 use iota_rest_api::{CheckpointData, CheckpointTransaction};
 use iota_types::{
-    base_types::ObjectID, dynamic_field::{visitor as DFV, DynamicFieldName, DynamicFieldType},
-    object::{bounded_visitor::BoundedVisitor, Object},
-    TypeTag,
-    SYSTEM_PACKAGE_ADDRESSES,
+    SYSTEM_PACKAGE_ADDRESSES, TypeTag,
+    base_types::ObjectID,
+    dynamic_field::{DynamicFieldName, DynamicFieldType, visitor as DFV},
+    object::{Object, bounded_visitor::BoundedVisitor},
 };
 use tap::tap::TapFallible;
 use tokio::sync::Mutex;
 use tracing::error;
 
 use crate::{
+    FileType,
     handlers::AnalyticsHandler,
     package_store::{LocalDBPackageStore, PackageCache},
     tables::DynamicFieldEntry,
-    FileType,
 };
 
 pub struct DynamicFieldHandler {

--- a/crates/iota-analytics-indexer/src/handlers/df_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/df_handler.rs
@@ -12,20 +12,20 @@ use iota_json_rpc_types::IotaMoveValue;
 use iota_package_resolver::Resolver;
 use iota_rest_api::{CheckpointData, CheckpointTransaction};
 use iota_types::{
-    SYSTEM_PACKAGE_ADDRESSES, TypeTag,
-    base_types::ObjectID,
-    dynamic_field::{DynamicFieldName, DynamicFieldType, visitor as DFV},
-    object::{Object, bounded_visitor::BoundedVisitor},
+    base_types::ObjectID, dynamic_field::{visitor as DFV, DynamicFieldName, DynamicFieldType},
+    object::{bounded_visitor::BoundedVisitor, Object},
+    TypeTag,
+    SYSTEM_PACKAGE_ADDRESSES,
 };
 use tap::tap::TapFallible;
 use tokio::sync::Mutex;
-use tracing::warn;
+use tracing::error;
 
 use crate::{
-    FileType,
     handlers::AnalyticsHandler,
     package_store::{LocalDBPackageStore, PackageCache},
     tables::DynamicFieldEntry,
+    FileType,
 };
 
 pub struct DynamicFieldHandler {
@@ -137,7 +137,7 @@ impl DynamicFieldHandler {
 
         let name_value = BoundedVisitor::deserialize_value(field.name_bytes, field.name_layout)
             .tap_err(|e| {
-                warn!("{e}");
+                error!("{e}");
             })?;
         let name = DynamicFieldName {
             type_: name_type,

--- a/crates/iota-analytics-indexer/src/handlers/df_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/df_handler.rs
@@ -12,10 +12,10 @@ use iota_json_rpc_types::IotaMoveValue;
 use iota_package_resolver::Resolver;
 use iota_rest_api::{CheckpointData, CheckpointTransaction};
 use iota_types::{
-    SYSTEM_PACKAGE_ADDRESSES,
+    SYSTEM_PACKAGE_ADDRESSES, TypeTag,
     base_types::ObjectID,
-    dynamic_field::{DynamicFieldInfo, DynamicFieldName, DynamicFieldType},
-    object::Object,
+    dynamic_field::{DynamicFieldName, DynamicFieldType, visitor as DFV},
+    object::{Object, bounded_visitor::BoundedVisitor},
 };
 use tap::tap::TapFallible;
 use tokio::sync::Mutex;
@@ -23,7 +23,7 @@ use tracing::warn;
 
 use crate::{
     FileType,
-    handlers::{AnalyticsHandler, get_move_struct},
+    handlers::AnalyticsHandler,
     package_store::{LocalDBPackageStore, PackageCache},
     tables::DynamicFieldEntry,
 };
@@ -123,28 +123,22 @@ impl DynamicFieldHandler {
         if !move_object.type_().is_dynamic_field() {
             return Ok(());
         }
-        let move_struct = if let Some((tag, contents)) = object
-            .struct_tag()
-            .and_then(|tag| object.data.try_as_move().map(|mo| (tag, mo.contents())))
-        {
-            let move_struct = get_move_struct(&tag, contents, &state.resolver).await?;
-            Some(move_struct)
-        } else {
-            None
-        };
-        let Some(move_struct) = move_struct else {
-            return Ok(());
-        };
-        let (name_value, type_, object_id) =
-            DynamicFieldInfo::parse_move_object(&move_struct).tap_err(|e| warn!("{e}"))?;
-        let name_type = move_object.type_().try_extract_field_name(&type_)?;
+        let layout = state
+            .resolver
+            .type_layout(move_object.type_().clone().into())
+            .await?;
+        let object_id = object.id();
 
-        let bcs_name = bcs::to_bytes(&name_value.clone().undecorate()).map_err(|e| {
-            IndexerError::Serde(format!(
-                "Failed to serialize dynamic field name {:?}: {e}",
-                name_value
-            ))
-        })?;
+        let field = DFV::FieldVisitor::deserialize(move_object.contents(), &layout)?;
+
+        let type_ = field.kind;
+        let name_type: TypeTag = field.name_layout.into();
+        let bcs_name = field.name_bytes.to_owned();
+
+        let name_value = BoundedVisitor::deserialize_value(field.name_bytes, field.name_layout)
+            .tap_err(|e| {
+                warn!("{e}");
+            })?;
         let name = DynamicFieldName {
             type_: name_type,
             value: IotaMoveValue::from(name_value).to_json_value(),


### PR DESCRIPTION
# Description of change

Use dynamic field visitors in analytics indexer

## Links to any relevant issues

fixes #5689

## Type of change

Refactoring

## How the change has been tested

`cargo ci-clippy`
`cargo nextest run -p iota-analytics-indexer`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
