### PR TITLE
[iota-graphql-rpc]: Use dynamic field visitors in graphql rpc

### DIFF
--- a/crates/iota-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/iota-graphql-rpc/src/types/dynamic_field.rs
@@ -10,10 +10,10 @@ use iota_indexer::{models::objects::StoredHistoryObject, types::OwnerType};
 use iota_types::{
     TypeTag,
     dynamic_field::{
-        DynamicFieldInfo, DynamicFieldType, derive_dynamic_field_id, extract_id_value,
+        DynamicFieldInfo, DynamicFieldType, derive_dynamic_field_id,
+        visitor::{Field, FieldVisitor},
     },
 };
-use move_core_types::annotated_value::{self as A, MoveStruct};
 
 use crate::{
     consistency::{View, build_objects_query},
@@ -28,14 +28,13 @@ use crate::{
         iota_address::IotaAddress,
         move_object::MoveObject,
         move_value::MoveValue,
-        object::{self, Object, ObjectKind, deserialize_move_struct},
+        object::{self, Object, ObjectKind},
         type_filter::ExactTypeFilter,
     },
 };
 
 pub(crate) struct DynamicField {
     pub super_: MoveObject,
-    pub df_kind: DynamicFieldType,
 }
 
 #[derive(Union)]
@@ -71,40 +70,28 @@ impl DynamicField {
     /// field. This field is used to uniquely identify a child of the parent
     /// object.
     async fn name(&self, ctx: &Context<'_>) -> Result<Option<MoveValue>> {
-        let resolver: &PackageResolver = ctx
-            .data()
-            .map_err(|_| Error::Internal("Unable to fetch Package Cache.".to_string()))
-            .extend()?;
+        let resolver: &PackageResolver = ctx.data_unchecked();
 
-        let (struct_tag, move_struct) = deserialize_move_struct(&self.super_.native, resolver)
-            .await
-            .extend()?;
+        let type_ = TypeTag::from(self.super_.native.type_().clone());
+        let layout = resolver.type_layout(type_.clone()).await.map_err(|e| {
+            Error::Internal(format!(
+                "Error fetching layout for type {}: {e}",
+                type_.to_canonical_display(/* with_prefix */ true)
+            ))
+        })?;
 
-        // Get TypeTag of the DynamicField name from StructTag of the MoveStruct
-        let type_tag = DynamicFieldInfo::try_extract_field_name(&struct_tag, &self.df_kind)
+        let Field {
+            name_layout,
+            name_bytes,
+            ..
+        } = FieldVisitor::deserialize(self.super_.native.contents(), &layout)
             .map_err(|e| Error::Internal(e.to_string()))
             .extend()?;
 
-        let name_move_value = extract_field_from_move_struct(move_struct, "name").extend()?;
-
-        let undecorated = if self.df_kind == DynamicFieldType::DynamicObject {
-            let inner_name_move_value = match name_move_value {
-                A::MoveValue::Struct(inner_struct) => {
-                    extract_field_from_move_struct(inner_struct, "name")
-                }
-                _ => Err(Error::Internal("Expected a wrapper struct".to_string())),
-            }
-            .extend()?;
-            inner_name_move_value.undecorate()
-        } else {
-            name_move_value.undecorate()
-        };
-
-        let bcs = bcs::to_bytes(&undecorated)
-            .map_err(|e| Error::Internal(format!("Failed to serialize object: {e}")))
-            .extend()?;
-
-        Ok(Some(MoveValue::new(type_tag, Base64::from(bcs))))
+        Ok(Some(MoveValue::new(
+            name_layout.into(),
+            Base64::from(name_bytes.to_owned()),
+        )))
     }
 
     /// The returned dynamic field is an object if its return type is
@@ -114,52 +101,41 @@ impl DynamicField {
     async fn value(&self, ctx: &Context<'_>) -> Result<Option<DynamicFieldValue>> {
         let resolver: &PackageResolver = ctx.data_unchecked();
 
-        // TODO(annotated-visitor): Use custom visitors to extract just the value.
-        // https://github.com/iotaledger/iota/issues/4775
-        let (struct_tag, move_struct) = deserialize_move_struct(&self.super_.native, resolver)
-            .await
+        let type_ = TypeTag::from(self.super_.native.type_().clone());
+        let layout = resolver.type_layout(type_.clone()).await.map_err(|e| {
+            Error::Internal(format!(
+                "Error fetching layout for type {}: {e}",
+                type_.to_canonical_display(/* with_prefix */ true)
+            ))
+        })?;
+
+        let Field {
+            kind,
+            value_layout,
+            value_bytes,
+            ..
+        } = FieldVisitor::deserialize(self.super_.native.contents(), &layout)
+            .map_err(|e| Error::Internal(e.to_string()))
             .extend()?;
 
-        let value_move_value = extract_field_from_move_struct(move_struct, "value").extend()?;
-
-        if self.df_kind == DynamicFieldType::DynamicObject {
-            // If `df_kind` is a DynamicObject, the object we are currently on is the field
-            // object, and we must resolve one more level down to the value
-            // object.
-            let df_object_id = extract_id_value(&value_move_value)
-                .ok_or_else(|| {
-                    Error::Internal(format!(
-                        "Couldn't find ID of dynamic object field value: {value_move_value:#?}"
-                    ))
-                })
+        if kind == DynamicFieldType::DynamicObject {
+            let df_object_id: IotaAddress = bcs::from_bytes(value_bytes)
+                .map_err(|e| Error::Internal(format!("Failed to deserialize object ID: {e}")))
                 .extend()?;
 
-            // Because we only have checkpoint-level granularity, we may end up reading a
-            // later version of the value object. Thus, we use the version of
-            // the field object to bound the value object at the correct
-            // version.
             let obj = MoveObject::query(
                 ctx,
-                df_object_id.into(),
+                df_object_id,
                 Object::under_parent(self.root_version(), self.super_.super_.checkpoint_viewed_at),
             )
             .await
             .extend()?;
+
             Ok(obj.map(DynamicFieldValue::MoveObject))
         } else {
-            // Get TypeTag of the DynamicField value from StructTag of the MoveStruct
-            let type_tag = DynamicFieldInfo::try_extract_field_value(&struct_tag)
-                .map_err(|e| Error::Internal(e.to_string()))
-                .extend()?;
-
-            let undecorated = value_move_value.undecorate();
-            let bcs = bcs::to_bytes(&undecorated)
-                .map_err(|e| Error::Internal(format!("Failed to serialize object: {e}")))
-                .extend()?;
-
             Ok(Some(DynamicFieldValue::MoveValue(MoveValue::new(
-                type_tag,
-                Base64::from(bcs),
+                value_layout.into(),
+                Base64::from(value_bytes.to_owned()),
             ))))
         }
     }
@@ -304,41 +280,8 @@ impl TryFrom<MoveObject> for DynamicField {
             return Err(Error::Internal("Wrong type for DynamicField".to_string()));
         }
 
-        let Some(name) = tag.type_params.first() else {
-            return Err(Error::Internal("No type for DynamicField name".to_string()));
-        };
-
-        let df_kind = if matches!(
-            name,
-            TypeTag::Struct(s) if DynamicFieldInfo::is_dynamic_object_field_wrapper(s)
-        ) {
-            DynamicFieldType::DynamicObject
-        } else {
-            DynamicFieldType::DynamicField
-        };
-
-        Ok(DynamicField {
-            super_: stored,
-            df_kind,
-        })
+        Ok(DynamicField { super_: stored })
     }
-}
-
-pub fn extract_field_from_move_struct(
-    move_struct: MoveStruct,
-    field_name: &str,
-) -> Result<A::MoveValue, Error> {
-    move_struct
-        .fields
-        .into_iter()
-        .find_map(|(id, value)| {
-            if id.to_string() == field_name {
-                Some(value)
-            } else {
-                None
-            }
-        })
-        .ok_or_else(|| Error::Internal(format!("Field '{}' not found", field_name)))
 }
 
 /// Builds the `RawQuery` for fetching dynamic fields attached to a parent


### PR DESCRIPTION
# Description of change

Use dynamic field visitors in graphql rpc

## Links to any relevant issues

fixes #5691 

## Type of change

Refactoring

## How the change has been tested

`cargo ci-clippy`
`cargo nextest run -p iota-graphql-rpc --features pg_integration --no-fail-fast --test-threads 1`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
