### PR TITLE
feat(consensus): resubmit gc-transaction

### DIFF
--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -1048,11 +1048,11 @@ mod test {
     use std::{collections::BTreeSet, time::Duration};
 
     use consensus_config::{AuthorityIndex, Parameters};
+    use futures::{StreamExt, stream::FuturesUnordered};
     use iota_metrics::monitored_mpsc::unbounded_channel;
     use iota_protocol_config::ProtocolConfig;
-    use tokio::time::sleep;
-    use futures::{stream::FuturesUnordered, StreamExt};
     use rstest::rstest;
+    use tokio::time::sleep;
 
     use super::*;
     use crate::{
@@ -1092,7 +1092,8 @@ mod test {
                         .build(),
                 );
 
-                // If it's round 1, that one will be committed later on, and it's our "own" block, then subscribe to listen for the block status.
+                // If it's round 1, that one will be committed later on, and it's our "own"
+                // block, then subscribe to listen for the block status.
                 if round == 1 && index == context.own_index {
                     let subscription =
                         transaction_consumer.subscribe_for_block_status_testing(block.reference());
@@ -1183,7 +1184,8 @@ mod test {
         let all_stored_commits = store.scan_commits((0..=CommitIndex::MAX).into()).unwrap();
         assert_eq!(all_stored_commits.len(), 2);
 
-        // And ensure that our "own" block 1 sent to TransactionConsumer as notification alongside with gc_round
+        // And ensure that our "own" block 1 sent to TransactionConsumer as notification
+        // alongside with gc_round
         while let Some(result) = block_status_subscriptions.next().await {
             let status = result.unwrap();
             assert!(matches!(status, BlockStatus::Sequenced(_)));
@@ -1563,7 +1565,8 @@ mod test {
         let (_, dag_builder) = parse_dag(dag_str).expect("Invalid dag");
         dag_builder.print();
 
-        // Subscribe to all created "own" blocks. We know that for our node (A) we'll be able to commit up to round 5.
+        // Subscribe to all created "own" blocks. We know that for our node (A) we'll be
+        // able to commit up to round 5.
         for block in dag_builder.blocks(1..=5) {
             if block.author() == context.own_index {
                 let subscription =

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -553,7 +553,7 @@ impl Core {
             .with_label_values(&["Core::try_commit"])
             .start_timer();
 
-        let mut committed_subdags = Vec::new();
+        let mut committed_sub_dags = Vec::new();
         // TODO: Add optimization to abort early without quorum for a round.
         loop {
             // LeaderSchedule has a limit to how many sequenced leaders can be committed
@@ -652,10 +652,21 @@ impl Core {
             // Try to unsuspend blocks if gc_round has advanced.
             self.block_manager
                 .try_unsuspend_blocks_for_latest_gc_round();
-            committed_subdags.extend(subdags);
+            committed_sub_dags.extend(subdags);
         }
 
-        Ok(committed_subdags)
+        // Notify about our own committed blocks
+        let committed_block_refs = committed_sub_dags
+            .iter()
+            .flat_map(|sub_dag| sub_dag.blocks.iter())
+            .filter_map(|block| {
+                (block.author() == self.context.own_index).then_some(block.reference())
+            })
+            .collect::<Vec<_>>();
+        self.transaction_consumer
+            .notify_own_blocks_status(committed_block_refs, self.dag_state.read().gc_round());
+
+        Ok(committed_sub_dags)
     }
 
     pub(crate) fn get_missing_blocks(&self) -> BTreeSet<BlockRef> {
@@ -1040,6 +1051,8 @@ mod test {
     use iota_metrics::monitored_mpsc::unbounded_channel;
     use iota_protocol_config::ProtocolConfig;
     use tokio::time::sleep;
+    use futures::{stream::FuturesUnordered, StreamExt};
+    use rstest::rstest;
 
     use super::*;
     use crate::{
@@ -1050,7 +1063,8 @@ mod test {
         leader_scoring::ReputationScores,
         storage::{Store, WriteBatch, mem_store::MemStore},
         test_dag_builder::DagBuilder,
-        transaction::TransactionClient,
+        test_dag_parser::parse_dag,
+        transaction::{BlockStatus, TransactionClient},
     };
 
     /// Recover Core and continue proposing from the last round which forms a
@@ -1063,6 +1077,7 @@ mod test {
         let store = Arc::new(MemStore::new());
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
         let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let mut block_status_subscriptions = FuturesUnordered::new();
 
         // Create test blocks for all the authorities for 4 rounds and populate them in
         // store
@@ -1076,6 +1091,13 @@ mod test {
                         .set_ancestors(last_round_blocks.iter().map(|b| b.reference()).collect())
                         .build(),
                 );
+
+                // If it's round 1, that one will be committed later on, and it's our "own" block, then subscribe to listen for the block status.
+                if round == 1 && index == context.own_index {
+                    let subscription =
+                        transaction_consumer.subscribe_for_block_status_testing(block.reference());
+                    block_status_subscriptions.push(subscription);
+                }
 
                 this_round_blocks.push(block);
             }
@@ -1117,7 +1139,7 @@ mod test {
         let (signals, signal_receivers) = CoreSignals::new(context.clone());
         // Need at least one subscriber to the block broadcast channel.
         let mut block_receiver = signal_receivers.block_broadcast_receiver();
-        let mut core = Core::new(
+        let _core = Core::new(
             context.clone(),
             leader_schedule,
             transaction_consumer,
@@ -1148,8 +1170,6 @@ mod test {
             assert_eq!(ancestor.round, 4);
         }
 
-        // Run commit rule.
-        core.try_commit().ok();
         let last_commit = store
             .read_last_commit()
             .unwrap()
@@ -1162,6 +1182,12 @@ mod test {
         assert_eq!(dag_state.read().last_commit_index(), 2);
         let all_stored_commits = store.scan_commits((0..=CommitIndex::MAX).into()).unwrap();
         assert_eq!(all_stored_commits.len(), 2);
+
+        // And ensure that our "own" block 1 sent to TransactionConsumer as notification alongside with gc_round
+        while let Some(result) = block_status_subscriptions.next().await {
+            let status = result.unwrap();
+            assert!(matches!(status, BlockStatus::Sequenced(_)));
+        }
     }
 
     /// Recover Core and continue proposing when having a partial last round
@@ -1487,6 +1513,139 @@ mod test {
         let last_commit = store.read_last_commit().unwrap();
         assert!(last_commit.is_none());
         assert_eq!(dag_state.read().last_commit_index(), 0);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_commit_and_notify_for_block_status(#[values(0, 2)] gc_depth: u32) {
+        telemetry_subscribers::init_for_testing();
+        let (mut context, mut key_pairs) = Context::new_for_test(4);
+
+        if gc_depth > 0 {
+            context
+                .protocol_config
+                .set_consensus_gc_depth_for_testing(gc_depth);
+        }
+
+        let context = Arc::new(context);
+
+        let store = Arc::new(MemStore::new());
+        let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
+        let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let mut block_status_subscriptions = FuturesUnordered::new();
+
+        let dag_str = "DAG {
+            Round 0 : { 4 },
+            Round 1 : { * },
+            Round 2 : { * },
+            Round 3 : {
+                A -> [*],
+                B -> [-A2],
+                C -> [-A2],
+                D -> [-A2],
+            },
+            Round 4 : {
+                B -> [-A3],
+                C -> [-A3],
+                D -> [-A3],
+            },
+            Round 5 : {
+                A -> [A3, B4, C4, D4]
+                B -> [*],
+                C -> [*],
+                D -> [*],
+            },
+            Round 6 : { * },
+            Round 7 : { * },
+            Round 8 : { * },
+        }";
+
+        let (_, dag_builder) = parse_dag(dag_str).expect("Invalid dag");
+        dag_builder.print();
+
+        // Subscribe to all created "own" blocks. We know that for our node (A) we'll be able to commit up to round 5.
+        for block in dag_builder.blocks(1..=5) {
+            if block.author() == context.own_index {
+                let subscription =
+                    transaction_consumer.subscribe_for_block_status_testing(block.reference());
+                block_status_subscriptions.push(subscription);
+            }
+        }
+
+        // write them in store
+        store
+            .write(WriteBatch::default().blocks(dag_builder.blocks(1..=8)))
+            .expect("Storage error");
+
+        // create dag state after all blocks have been written to store
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let block_manager = BlockManager::new(
+            context.clone(),
+            dag_state.clone(),
+            Arc::new(NoopBlockVerifier),
+        );
+        let leader_schedule = Arc::new(LeaderSchedule::from_store(
+            context.clone(),
+            dag_state.clone(),
+        ));
+
+        let (sender, _receiver) = unbounded_channel("consensus_output");
+        let commit_consumer = CommitConsumer::new(sender, 0);
+        let commit_observer = CommitObserver::new(
+            context.clone(),
+            commit_consumer,
+            dag_state.clone(),
+            store.clone(),
+            leader_schedule.clone(),
+        );
+
+        // Check no commits have been persisted to dag_state or store.
+        let last_commit = store.read_last_commit().unwrap();
+        assert!(last_commit.is_none());
+        assert_eq!(dag_state.read().last_commit_index(), 0);
+
+        // Now spin up core
+        let (signals, signal_receivers) = CoreSignals::new(context.clone());
+        // Need at least one subscriber to the block broadcast channel.
+        let _block_receiver = signal_receivers.block_broadcast_receiver();
+        let _core = Core::new(
+            context.clone(),
+            leader_schedule,
+            transaction_consumer,
+            block_manager,
+            true,
+            commit_observer,
+            signals,
+            key_pairs.remove(context.own_index.value()).1,
+            dag_state.clone(),
+            false,
+        );
+
+        let last_commit = store
+            .read_last_commit()
+            .unwrap()
+            .expect("last commit should be set");
+
+        assert_eq!(last_commit.index(), 5);
+
+        while let Some(result) = block_status_subscriptions.next().await {
+            let status = result.unwrap();
+
+            // If gc is enabled, then we expect some blocks to be garbage collected.
+            if gc_depth > 0 {
+                match status {
+                    BlockStatus::Sequenced(block_ref) => {
+                        assert!(block_ref.round == 1 || block_ref.round == 5);
+                    }
+                    BlockStatus::GarbageCollected(block_ref) => {
+                        assert!(block_ref.round == 2 || block_ref.round == 3);
+                    }
+                }
+            } else {
+                // otherwise all of them should be committed
+                assert!(matches!(status, BlockStatus::Sequenced(_)));
+            }
+        }
     }
 
     #[tokio::test]

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -46,9 +46,11 @@ mod test_dag_parser;
 
 /// Exported consensus API.
 pub use authority_node::ConsensusAuthority;
-pub use block::{BlockAPI, Round};
+pub use block::{BlockAPI, BlockRef, Round};
 /// Exported API for testing.
 pub use block::{TestBlock, Transaction, VerifiedBlock};
 pub use commit::{CommitDigest, CommitIndex, CommitRef, CommittedSubDag};
 pub use commit_consumer::{CommitConsumer, CommitConsumerMonitor};
-pub use transaction::{ClientError, TransactionClient, TransactionVerifier, ValidationError};
+pub use transaction::{
+    BlockStatus, ClientError, TransactionClient, TransactionVerifier, ValidationError,
+};

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -346,26 +346,6 @@ impl DagBuilder {
         blocks
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn get_blocks(&self, block_refs: &[BlockRef]) -> Vec<VerifiedBlock> {
-        let mut blocks = vec![None; block_refs.len()];
-
-        for (index, block_ref) in block_refs.iter().enumerate() {
-            if block_ref.round == 0 {
-                if let Some(block) = self.genesis.get(block_ref) {
-                    blocks[index] = Some(block.clone());
-                }
-                continue;
-            }
-            if let Some(block) = self.blocks.get(block_ref) {
-                blocks[index] = Some(block.clone());
-                continue;
-            }
-        }
-
-        blocks.into_iter().map(|x| x.unwrap()).collect()
-    }
-
     pub(crate) fn genesis_block_refs(&self) -> Vec<BlockRef> {
         self.genesis.keys().cloned().collect()
     }

--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -2,9 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use iota_metrics::monitored_mpsc::{Receiver, Sender, channel};
+use parking_lot::Mutex;
 use tap::tap::TapFallible;
 use thiserror::Error;
 use tokio::sync::oneshot;
@@ -13,6 +14,7 @@ use tracing::{error, warn};
 use crate::{
     block::{BlockRef, Transaction},
     context::Context,
+    Round,
 };
 
 /// The maximum number of transactions pending to the queue to be pulled for
@@ -30,7 +32,7 @@ pub(crate) struct TransactionsGuard {
     // holds the remaining transactions.
     transactions: Vec<Transaction>,
 
-    included_in_block_ack: oneshot::Sender<BlockRef>,
+    included_in_block_ack: oneshot::Sender<(BlockRef, oneshot::Receiver<BlockStatus>)>,
 }
 
 /// The TransactionConsumer is responsible for fetching the next transactions to
@@ -38,10 +40,23 @@ pub(crate) struct TransactionsGuard {
 /// channel which is shared between the TransactionConsumer and the
 /// TransactionClient and are pulled every time the `next` method is called.
 pub(crate) struct TransactionConsumer {
+    context: Arc<Context>,
     tx_receiver: Receiver<TransactionsGuard>,
     max_consumed_bytes_per_request: u64,
     max_consumed_transactions_per_request: u64,
     pending_transactions: Option<TransactionsGuard>,
+    block_status_subscribers: Arc<Mutex<BTreeMap<BlockRef, Vec<oneshot::Sender<BlockStatus>>>>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[allow(unused)]
+pub enum BlockStatus {
+    /// The block has been sequenced as part of a committed sub dag. That means that any transaction that has been included in the block
+    /// has been committed as well.
+    Sequenced(BlockRef),
+    /// The block has been garbage collected and will never be committed. Any transactions that have been included in the block should also
+    /// be considered as impossible to be committed as part of this block and might need to be retried
+    GarbageCollected(BlockRef),
 }
 
 impl TransactionConsumer {
@@ -54,7 +69,9 @@ impl TransactionConsumer {
             max_consumed_transactions_per_request: context
                 .protocol_config
                 .max_num_transactions_in_block(),
+            context,
             pending_transactions: None,
+            block_status_subscribers: Arc::new(Mutex::new(BTreeMap::new())),
         }
     }
 
@@ -125,14 +142,77 @@ impl TransactionConsumer {
             }
         }
 
+        let block_status_subscribers = self.block_status_subscribers.clone();
+        let gc_enabled = self.context.protocol_config.gc_depth() > 0;
+
         (
             transactions,
             Box::new(move |block_ref: BlockRef| {
+                let mut block_status_subscribers = block_status_subscribers.lock();
+
                 for ack in acks {
-                    let _ = ack.send(block_ref);
+                    let (status_tx, status_rx) = oneshot::channel();
+
+                    if gc_enabled {
+                        block_status_subscribers
+                            .entry(block_ref)
+                            .or_default()
+                            .push(status_tx);
+                    } else {
+                        // When gc is not enabled, then report directly the block as sequenced while tx is acknowledged for inclusion.
+                        // As blocks can never get garbage collected it is there is actually no meaning to do otherwise and also is safer for edge cases.
+                        status_tx.send(BlockStatus::Sequenced(block_ref)).ok();
+                    }
+
+                    let _ = ack.send((block_ref, status_rx));
                 }
             }),
         )
+    }
+
+    /// Notifies all the transaction submitters who are waiting to receive an update on the status of the block.
+    /// The `committed_blocks` are the blocks that have been committed and the `gc_round` is the round up to which the blocks have been garbage collected.
+    /// First we'll notify for all the committed blocks, and then for all the blocks that have been garbage collected.
+    pub(crate) fn notify_own_blocks_status(
+        &self,
+        committed_blocks: Vec<BlockRef>,
+        gc_round: Round,
+    ) {
+        // Notify for all the committed blocks first
+        let mut block_status_subscribers = self.block_status_subscribers.lock();
+        for block_ref in committed_blocks {
+            if let Some(subscribers) = block_status_subscribers.remove(&block_ref) {
+                subscribers.into_iter().for_each(|s| {
+                    let _ = s.send(BlockStatus::Sequenced(block_ref));
+                });
+            }
+        }
+
+        // Now notify everyone <= gc_round that their block has been garbage collected and clean up the entries
+        while let Some((block_ref, subscribers)) = block_status_subscribers.pop_first() {
+            if block_ref.round <= gc_round {
+                subscribers.into_iter().for_each(|s| {
+                    let _ = s.send(BlockStatus::GarbageCollected(block_ref));
+                });
+            } else {
+                block_status_subscribers.insert(block_ref, subscribers);
+                break;
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn subscribe_for_block_status_testing(
+        &self,
+        block_ref: BlockRef,
+    ) -> oneshot::Receiver<BlockStatus> {
+        let (tx, rx) = oneshot::channel();
+        let mut block_status_subscribers = self.block_status_subscribers.lock();
+        block_status_subscribers
+            .entry(block_ref)
+            .or_default()
+            .push(tx);
+        rx
     }
 
     #[cfg(test)]
@@ -179,7 +259,10 @@ impl TransactionClient {
     /// Submits a list of transactions to be sequenced. The method returns when
     /// all the transactions have been successfully included
     /// to next proposed blocks.
-    pub async fn submit(&self, transactions: Vec<Vec<u8>>) -> Result<BlockRef, ClientError> {
+    pub async fn submit(
+        &self,
+        transactions: Vec<Vec<u8>>,
+    ) -> Result<(BlockRef, oneshot::Receiver<BlockStatus>), ClientError> {
         // TODO: Support returning the block refs for transactions that span multiple
         // blocks
         let included_in_block = self.submit_no_wait(transactions).await?;
@@ -202,7 +285,7 @@ impl TransactionClient {
     pub(crate) async fn submit_no_wait(
         &self,
         transactions: Vec<Vec<u8>>,
-    ) -> Result<oneshot::Receiver<BlockRef>, ClientError> {
+    ) -> Result<oneshot::Receiver<(BlockRef, oneshot::Receiver<BlockStatus>)>, ClientError> {
         let (included_in_block_ack_send, included_in_block_ack_receive) = oneshot::channel();
         for transaction in &transactions {
             if transaction.len() as u64 > self.max_transaction_size {
@@ -254,14 +337,15 @@ impl TransactionVerifier for NoopTransactionVerifier {
 mod tests {
     use std::{sync::Arc, time::Duration};
 
+    use consensus_config::AuthorityIndex;
     use futures::{StreamExt, stream::FuturesUnordered};
     use iota_protocol_config::ProtocolConfig;
     use tokio::time::timeout;
 
     use crate::{
-        block::BlockRef,
+        block::{BlockDigest, BlockRef},
         context::Context,
-        transaction::{TransactionClient, TransactionConsumer},
+        transaction::{BlockStatus, TransactionClient, TransactionConsumer},
     };
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
@@ -314,6 +398,129 @@ mod tests {
 
         // try to pull again transactions, result should be empty
         assert!(consumer.is_empty());
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn block_status_update_gc_enabled() {
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+            config.set_consensus_max_transaction_size_bytes_for_testing(2_000); // 2KB
+            config.set_consensus_max_transactions_in_block_bytes_for_testing(2_000);
+            config.set_consensus_gc_depth_for_testing(10);
+            config
+        });
+
+        let context = Arc::new(Context::new_for_test(4).0);
+        let (client, tx_receiver) = TransactionClient::new(context.clone());
+        let mut consumer = TransactionConsumer::new(tx_receiver, context.clone());
+
+        // submit the transactions and include 2 of each on a new block
+        let mut included_in_block_waiters = FuturesUnordered::new();
+        for i in 1..=10 {
+            let transaction =
+                bcs::to_bytes(&format!("transaction {i}")).expect("Serialization should not fail.");
+            let w = client
+                .submit_no_wait(vec![transaction])
+                .await
+                .expect("Shouldn't submit successfully transaction");
+            included_in_block_waiters.push(w);
+
+            // Every 2 transactions simulate the creation of a new block and acknowledge the inclusion of the transactions
+            if i % 2 == 0 {
+                let (transactions, ack_transactions) = consumer.next();
+                assert_eq!(transactions.len(), 2);
+                ack_transactions(BlockRef::new(
+                    i,
+                    AuthorityIndex::new_for_test(0),
+                    BlockDigest::MIN,
+                ));
+            }
+        }
+
+        // Now iterate over all the waiters. Everyone should have been acknowledged.
+        let mut block_status_waiters = Vec::new();
+        while let Some(result) = included_in_block_waiters.next().await {
+            let (block_ref, block_status_waiter) =
+                result.expect("Block inclusion waiter shouldn't fail");
+            block_status_waiters.push((block_ref, block_status_waiter));
+        }
+
+        // Now acknowledge the commit of the blocks 6, 8, 10 and set gc_round = 5, which should trigger the garbage collection of blocks 1..=5
+        let gc_round = 5;
+        consumer.notify_own_blocks_status(
+            vec![
+                BlockRef::new(6, AuthorityIndex::new_for_test(0), BlockDigest::MIN),
+                BlockRef::new(8, AuthorityIndex::new_for_test(0), BlockDigest::MIN),
+                BlockRef::new(10, AuthorityIndex::new_for_test(0), BlockDigest::MIN),
+            ],
+            gc_round,
+        );
+
+        // Now iterate over all the block status waiters. Everyone should have been notified.
+        for (block_ref, waiter) in block_status_waiters {
+            let block_status = waiter.await.expect("Block status waiter shouldn't fail");
+
+            if block_ref.round <= gc_round {
+                assert!(matches!(block_status, BlockStatus::GarbageCollected(_)))
+            } else {
+                assert!(matches!(block_status, BlockStatus::Sequenced(_)));
+            }
+        }
+
+        // Ensure internal structure is clear
+        assert!(consumer.block_status_subscribers.lock().is_empty());
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn block_status_update_gc_disabled() {
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+            config.set_consensus_max_transaction_size_bytes_for_testing(2_000); // 2KB
+            config.set_consensus_max_transactions_in_block_bytes_for_testing(2_000);
+            config
+        });
+
+        let context = Arc::new(Context::new_for_test(4).0);
+        let (client, tx_receiver) = TransactionClient::new(context.clone());
+        let mut consumer = TransactionConsumer::new(tx_receiver, context.clone());
+
+        // submit the transactions and include 2 of each on a new block
+        let mut included_in_block_waiters = FuturesUnordered::new();
+        for i in 1..=10 {
+            let transaction =
+                bcs::to_bytes(&format!("transaction {i}")).expect("Serialization should not fail.");
+            let w = client
+                .submit_no_wait(vec![transaction])
+                .await
+                .expect("Shouldn't submit successfully transaction");
+            included_in_block_waiters.push(w);
+
+            // Every 2 transactions simulate the creation of a new block and acknowledge the inclusion of the transactions
+            if i % 2 == 0 {
+                let (transactions, ack_transactions) = consumer.next();
+                assert_eq!(transactions.len(), 2);
+                ack_transactions(BlockRef::new(
+                    i,
+                    AuthorityIndex::new_for_test(0),
+                    BlockDigest::MIN,
+                ));
+            }
+        }
+
+        // Now iterate over all the waiters. Everyone should have been acknowledged.
+        let mut block_status_waiters = Vec::new();
+        while let Some(result) = included_in_block_waiters.next().await {
+            let (block_ref, block_status_waiter) =
+                result.expect("Block inclusion waiter shouldn't fail");
+            block_status_waiters.push((block_ref, block_status_waiter));
+        }
+
+        // Now iterate over all the block status waiters. Everyone should have been notified and everyone should be considered sequenced.
+        for (_block_ref, waiter) in block_status_waiters {
+            let block_status = waiter.await.expect("Block status waiter shouldn't fail");
+            assert!(matches!(block_status, BlockStatus::Sequenced(_)));
+        }
+
+        // Ensure internal structure is clear
+        assert!(consumer.block_status_subscribers.lock().is_empty());
     }
 
     #[tokio::test]
@@ -458,7 +665,8 @@ mod tests {
 
         // expect all receivers to be resolved.
         for w in all_receivers {
-            assert!(w.await.is_ok());
+            let r = w.await;
+            assert!(r.is_ok());
         }
     }
 }

--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -12,9 +12,9 @@ use tokio::sync::oneshot;
 use tracing::{error, warn};
 
 use crate::{
+    Round,
     block::{BlockRef, Transaction},
     context::Context,
-    Round,
 };
 
 /// The maximum number of transactions pending to the queue to be pulled for
@@ -51,11 +51,14 @@ pub(crate) struct TransactionConsumer {
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[allow(unused)]
 pub enum BlockStatus {
-    /// The block has been sequenced as part of a committed sub dag. That means that any transaction that has been included in the block
+    /// The block has been sequenced as part of a committed sub dag. That means
+    /// that any transaction that has been included in the block
     /// has been committed as well.
     Sequenced(BlockRef),
-    /// The block has been garbage collected and will never be committed. Any transactions that have been included in the block should also
-    /// be considered as impossible to be committed as part of this block and might need to be retried
+    /// The block has been garbage collected and will never be committed. Any
+    /// transactions that have been included in the block should also
+    /// be considered as impossible to be committed as part of this block and
+    /// might need to be retried
     GarbageCollected(BlockRef),
 }
 
@@ -159,8 +162,10 @@ impl TransactionConsumer {
                             .or_default()
                             .push(status_tx);
                     } else {
-                        // When gc is not enabled, then report directly the block as sequenced while tx is acknowledged for inclusion.
-                        // As blocks can never get garbage collected it is there is actually no meaning to do otherwise and also is safer for edge cases.
+                        // When gc is not enabled, then report directly the block as sequenced while
+                        // tx is acknowledged for inclusion. As blocks can
+                        // never get garbage collected it is there is actually no meaning to do
+                        // otherwise and also is safer for edge cases.
                         status_tx.send(BlockStatus::Sequenced(block_ref)).ok();
                     }
 
@@ -170,9 +175,12 @@ impl TransactionConsumer {
         )
     }
 
-    /// Notifies all the transaction submitters who are waiting to receive an update on the status of the block.
-    /// The `committed_blocks` are the blocks that have been committed and the `gc_round` is the round up to which the blocks have been garbage collected.
-    /// First we'll notify for all the committed blocks, and then for all the blocks that have been garbage collected.
+    /// Notifies all the transaction submitters who are waiting to receive an
+    /// update on the status of the block. The `committed_blocks` are the
+    /// blocks that have been committed and the `gc_round` is the round up to
+    /// which the blocks have been garbage collected. First we'll notify for
+    /// all the committed blocks, and then for all the blocks that have been
+    /// garbage collected.
     pub(crate) fn notify_own_blocks_status(
         &self,
         committed_blocks: Vec<BlockRef>,
@@ -188,7 +196,8 @@ impl TransactionConsumer {
             }
         }
 
-        // Now notify everyone <= gc_round that their block has been garbage collected and clean up the entries
+        // Now notify everyone <= gc_round that their block has been garbage collected
+        // and clean up the entries
         while let Some((block_ref, subscribers)) = block_status_subscribers.pop_first() {
             if block_ref.round <= gc_round {
                 subscribers.into_iter().for_each(|s| {
@@ -424,7 +433,8 @@ mod tests {
                 .expect("Shouldn't submit successfully transaction");
             included_in_block_waiters.push(w);
 
-            // Every 2 transactions simulate the creation of a new block and acknowledge the inclusion of the transactions
+            // Every 2 transactions simulate the creation of a new block and acknowledge the
+            // inclusion of the transactions
             if i % 2 == 0 {
                 let (transactions, ack_transactions) = consumer.next();
                 assert_eq!(transactions.len(), 2);
@@ -444,7 +454,8 @@ mod tests {
             block_status_waiters.push((block_ref, block_status_waiter));
         }
 
-        // Now acknowledge the commit of the blocks 6, 8, 10 and set gc_round = 5, which should trigger the garbage collection of blocks 1..=5
+        // Now acknowledge the commit of the blocks 6, 8, 10 and set gc_round = 5, which
+        // should trigger the garbage collection of blocks 1..=5
         let gc_round = 5;
         consumer.notify_own_blocks_status(
             vec![
@@ -455,7 +466,8 @@ mod tests {
             gc_round,
         );
 
-        // Now iterate over all the block status waiters. Everyone should have been notified.
+        // Now iterate over all the block status waiters. Everyone should have been
+        // notified.
         for (block_ref, waiter) in block_status_waiters {
             let block_status = waiter.await.expect("Block status waiter shouldn't fail");
 
@@ -493,7 +505,8 @@ mod tests {
                 .expect("Shouldn't submit successfully transaction");
             included_in_block_waiters.push(w);
 
-            // Every 2 transactions simulate the creation of a new block and acknowledge the inclusion of the transactions
+            // Every 2 transactions simulate the creation of a new block and acknowledge the
+            // inclusion of the transactions
             if i % 2 == 0 {
                 let (transactions, ack_transactions) = consumer.next();
                 assert_eq!(transactions.len(), 2);
@@ -513,7 +526,8 @@ mod tests {
             block_status_waiters.push((block_ref, block_status_waiter));
         }
 
-        // Now iterate over all the block status waiters. Everyone should have been notified and everyone should be considered sequenced.
+        // Now iterate over all the block status waiters. Everyone should have been
+        // notified and everyone should be considered sequenced.
         for (_block_ref, waiter) in block_status_waiters {
             let block_status = waiter.await.expect("Block status waiter shouldn't fail");
             assert!(matches!(block_status, BlockStatus::Sequenced(_)));

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -73,7 +73,7 @@ pub struct ConsensusAdapterMetrics {
     pub sequencing_certificate_failures: IntCounterVec,
     pub sequencing_certificate_status: IntCounterVec,
     pub sequencing_certificate_inflight: IntGaugeVec,
-    pub sequencing_acknowledge_latency: iota_metrics::histogram::HistogramVec,
+    pub sequencing_acknowledge_latency: HistogramVec,
     pub sequencing_certificate_latency: HistogramVec,
     pub sequencing_certificate_authority_position: Histogram,
     pub sequencing_certificate_positions_moved: Histogram,
@@ -122,12 +122,14 @@ impl ConsensusAdapterMetrics {
                 registry,
             )
                 .unwrap(),
-            sequencing_acknowledge_latency: iota_metrics::histogram::HistogramVec::new_in_registry(
+            sequencing_acknowledge_latency: register_histogram_vec_with_registry!(
                 "sequencing_acknowledge_latency",
                 "The latency for acknowledgement from sequencing engine. The overall sequencing latency is measured by the sequencing_certificate_latency metric",
                 &["retry", "tx_type"],
+                SEQUENCING_CERTIFICATE_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
-            ),
+            )
+                .unwrap(),
             sequencing_certificate_latency: register_histogram_vec_with_registry!(
                 "sequencing_certificate_latency",
                 "The latency for sequencing a certificate.",
@@ -898,10 +900,10 @@ impl ConsensusAdapter {
             _ => "over_100".to_string(),
         };
 
-        // self.metrics
-        // .sequencing_acknowledge_latency
-        // .with_label_values(&[&bucket, tx_type])
-        // .observe(ack_start.elapsed().as_secs_f64());
+        self.metrics
+         .sequencing_acknowledge_latency
+         .with_label_values(&[&bucket, tx_type])
+         .observe(ack_start.elapsed().as_secs_f64());
 
         status_waiter
     }

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -14,6 +14,7 @@ use std::{
 };
 
 use arc_swap::ArcSwap;
+use consensus_core::BlockStatus;
 use dashmap::{DashMap, try_result::TryResult};
 use futures::{
     FutureExt,
@@ -38,11 +39,11 @@ use prometheus::{
     register_int_gauge_with_registry,
 };
 use tokio::{
-    sync::{Semaphore, SemaphorePermit},
+    sync::{Semaphore, SemaphorePermit, oneshot},
     task::JoinHandle,
     time::{self, Duration},
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, info, trace, warn};
 
 use crate::{
     authority::authority_per_epoch_store::AuthorityPerEpochStore,
@@ -70,6 +71,7 @@ pub struct ConsensusAdapterMetrics {
     pub sequencing_certificate_attempt: IntCounterVec,
     pub sequencing_certificate_success: IntCounterVec,
     pub sequencing_certificate_failures: IntCounterVec,
+    pub sequencing_certificate_status: IntCounterVec,
     pub sequencing_certificate_inflight: IntGaugeVec,
     pub sequencing_acknowledge_latency: iota_metrics::histogram::HistogramVec,
     pub sequencing_certificate_latency: HistogramVec,
@@ -103,6 +105,13 @@ impl ConsensusAdapterMetrics {
                 "sequencing_certificate_failures",
                 "Counts the number of sequenced certificates that failed other than by timeout.",
                 &["tx_type"],
+                registry,
+            )
+                .unwrap(),
+            sequencing_certificate_status: register_int_counter_vec_with_registry!(
+                "sequencing_certificate_status",
+                "The status of the certificate sequencing as reported by consensus. The status can be either sequenced or garbage collected.",
+                &["tx_type", "status"],
                 registry,
             )
                 .unwrap(),
@@ -176,6 +185,8 @@ impl ConsensusAdapterMetrics {
     }
 }
 
+pub type BlockStatusReceiver = oneshot::Receiver<BlockStatus>;
+
 #[mockall::automock]
 #[async_trait::async_trait]
 pub trait SubmitToConsensus: Sync + Send + 'static {
@@ -186,10 +197,20 @@ pub trait SubmitToConsensus: Sync + Send + 'static {
     ) -> IotaResult;
 }
 
+#[mockall::automock]
+#[async_trait::async_trait]
+pub trait ConsensusClient: Sync + Send + 'static {
+    async fn submit(
+        &self,
+        transactions: &[ConsensusTransaction],
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> IotaResult<BlockStatusReceiver>;
+}
+
 /// Submit IOTA certificates to the consensus.
 pub struct ConsensusAdapter {
     /// The network client connecting to the consensus node of this authority.
-    consensus_client: Arc<dyn SubmitToConsensus>,
+    consensus_client: Arc<dyn ConsensusClient>,
     /// Authority pubkey.
     authority: AuthorityName,
     /// The limit to number of inflight transactions at this node.
@@ -236,7 +257,7 @@ pub struct ConnectionMonitorStatusForTests {}
 impl ConsensusAdapter {
     /// Make a new Consensus adapter instance.
     pub fn new(
-        consensus_client: Arc<dyn SubmitToConsensus>,
+        consensus_client: Arc<dyn ConsensusClient>,
         authority: AuthorityName,
         connection_monitor_status: Arc<dyn CheckConnection>,
         max_pending_transactions: usize,
@@ -701,53 +722,62 @@ impl ConsensusAdapter {
             // processed_waiter is pending This means it is time for us to
             // submit transaction to consensus
             let submit_inner = async {
-                let ack_start = Instant::now();
-                let mut retries: u32 = 0;
-                while let Err(e) = self
-                    .consensus_client
-                    .submit_to_consensus(&transactions[..], epoch_store)
-                    .await
-                {
-                    // This can happen during reconfig, or when consensus has full internal buffers
-                    // and needs to back pressure, so retry a few times before logging warnings.
-                    if retries > 30
-                        || (retries > 3 && (is_soft_bundle || !transactions[0].kind.is_dkg()))
-                    {
-                        warn!(
-                            "Failed to submit transactions {transaction_keys:?} to consensus: {e:?}. Retry #{retries}"
-                        );
+                const RETRY_DELAY_STEP: Duration = Duration::from_secs(1);
+
+                loop {
+                    // Submit the transaction to consensus and return the submit result with a
+                    // status waiter
+                    let status_waiter = self
+                        .submit_inner(
+                            &transactions,
+                            epoch_store,
+                            &transaction_keys,
+                            tx_type,
+                            is_soft_bundle,
+                        )
+                        .await;
+
+                    match status_waiter.await {
+                        Ok(BlockStatus::Sequenced(_)) => {
+                            self.metrics
+                                .sequencing_certificate_status
+                                .with_label_values(&[tx_type, "sequenced"])
+                                .inc();
+                            // Block has been sequenced. Nothing more to do, we do have guarantees
+                            // that the transaction will appear in consensus output.
+                            trace!(
+                                "Transaction {transaction_keys:?} has been sequenced by consensus."
+                            );
+                            break;
+                        }
+                        Ok(BlockStatus::GarbageCollected(_)) => {
+                            self.metrics
+                                .sequencing_certificate_status
+                                .with_label_values(&[tx_type, "garbage_collected"])
+                                .inc();
+                            // Block has been garbage collected and we have no guarantees that the
+                            // transaction will appear in consensus output. We'll
+                            // resubmit the transaction to consensus. If the transaction has been
+                            // already "processed", then probably someone else has submitted
+                            // the transaction and managed to get sequenced. Then this future will
+                            // have been cancelled anyways so no need to check here on the processed
+                            // output.
+                            debug!(
+                                "Transaction {transaction_keys:?} was garbage collected before being sequenced. Will be retried."
+                            );
+                            time::sleep(RETRY_DELAY_STEP).await;
+                            continue;
+                        }
+                        Err(err) => {
+                            warn!(
+                                "Error while waiting for status from consensus for transactions {transaction_keys:?}, with error {:?}. Will be retried.",
+                                err
+                            );
+                            time::sleep(RETRY_DELAY_STEP).await;
+                            continue;
+                        }
                     }
-                    self.metrics
-                        .sequencing_certificate_failures
-                        .with_label_values(&[tx_type])
-                        .inc();
-                    retries += 1;
-
-                    if !is_soft_bundle && transactions[0].kind.is_dkg() {
-                        // Shorter delay for DKG messages, which are time-sensitive and happen at
-                        // start-of-epoch when submit errors due to active reconfig are likely.
-                        time::sleep(Duration::from_millis(100)).await;
-                    } else {
-                        time::sleep(Duration::from_secs(10)).await;
-                    };
                 }
-
-                // we want to record the num of retries when reporting latency but to avoid
-                // label cardinality we do some simple bucketing to give us a
-                // good enough idea of how many retries happened associated with
-                // the latency.
-                let bucket = match retries {
-                    0..=10 => retries.to_string(), // just report the retry count as is
-                    11..=20 => "between_10_and_20".to_string(),
-                    21..=50 => "between_20_and_50".to_string(),
-                    51..=100 => "between_50_and_100".to_string(),
-                    _ => "over_100".to_string(),
-                };
-
-                self.metrics
-                    .sequencing_acknowledge_latency
-                    .with_label_values(&[&bucket, tx_type])
-                    .report(ack_start.elapsed().as_millis() as u64);
             };
             match select(processed_waiter, submit_inner.boxed()).await {
                 Either::Left((processed, _submit_inner)) => processed,
@@ -808,6 +838,72 @@ impl ConsensusAdapter {
             .sequencing_certificate_success
             .with_label_values(&[tx_type])
             .inc();
+    }
+
+    async fn submit_inner(
+        self: &Arc<Self>,
+        transactions: &[ConsensusTransaction],
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+        transaction_keys: &[SequencedConsensusTransactionKey],
+        tx_type: &str,
+        is_soft_bundle: bool,
+    ) -> BlockStatusReceiver {
+        let ack_start = Instant::now();
+        let mut retries: u32 = 0;
+
+        let status_waiter = loop {
+            match self
+                .consensus_client
+                .submit(transactions, epoch_store)
+                .await
+            {
+                Err(err) => {
+                    // This can happen during reconfig, or when consensus has full internal buffers
+                    // and needs to back pressure, so retry a few times before logging warnings.
+                    if retries > 30
+                        || (retries > 3 && (is_soft_bundle || !transactions[0].kind.is_dkg()))
+                    {
+                        warn!(
+                            "Failed to submit transactions {transaction_keys:?} to consensus: {err:?}. Retry #{retries}"
+                        );
+                    }
+                    self.metrics
+                        .sequencing_certificate_failures
+                        .with_label_values(&[tx_type])
+                        .inc();
+                    retries += 1;
+
+                    if !is_soft_bundle && transactions[0].kind.is_dkg() {
+                        // Shorter delay for DKG messages, which are time-sensitive and happen at
+                        // start-of-epoch when submit errors due to active reconfig are likely.
+                        time::sleep(Duration::from_millis(100)).await;
+                    } else {
+                        time::sleep(Duration::from_secs(10)).await;
+                    };
+                }
+                Ok(status_waiter) => {
+                    break status_waiter;
+                }
+            }
+        };
+
+        // we want to record the num of retries when reporting latency but to avoid
+        // label cardinality we do some simple bucketing to give us a good
+        // enough idea of how many retries happened associated with the latency.
+        let bucket = match retries {
+            0..=10 => retries.to_string(), // just report the retry count as is
+            11..=20 => "between_10_and_20".to_string(),
+            21..=50 => "between_20_and_50".to_string(),
+            51..=100 => "between_50_and_100".to_string(),
+            _ => "over_100".to_string(),
+        };
+
+        // self.metrics
+        // .sequencing_acknowledge_latency
+        // .with_label_values(&[&bucket, tx_type])
+        // .observe(ack_start.elapsed().as_secs_f64());
+
+        status_waiter
     }
 }
 

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -901,9 +901,9 @@ impl ConsensusAdapter {
         };
 
         self.metrics
-         .sequencing_acknowledge_latency
-         .with_label_values(&[&bucket, tx_type])
-         .observe(ack_start.elapsed().as_secs_f64());
+            .sequencing_acknowledge_latency
+            .with_label_values(&[&bucket, tx_type])
+            .observe(ack_start.elapsed().as_secs_f64());
 
         status_waiter
     }

--- a/crates/iota-core/src/consensus_manager/mod.rs
+++ b/crates/iota-core/src/consensus_manager/mod.rs
@@ -25,8 +25,10 @@ use tracing::info;
 
 use crate::{
     authority::authority_per_epoch_store::AuthorityPerEpochStore,
-    consensus_adapter::SubmitToConsensus, consensus_handler::ConsensusHandlerInitializer,
-    consensus_manager::mysticeti_manager::MysticetiManager, consensus_validator::IotaTxValidator,
+    consensus_adapter::{BlockStatusReceiver, ConsensusClient},
+    consensus_handler::ConsensusHandlerInitializer,
+    consensus_manager::mysticeti_manager::MysticetiManager,
+    consensus_validator::IotaTxValidator,
     mysticeti_adapter::LazyMysticetiClient,
 };
 
@@ -87,7 +89,7 @@ pub struct ConsensusManager {
     mysticeti_manager: ProtocolManager,
     mysticeti_client: Arc<LazyMysticetiClient>,
     active: parking_lot::Mutex<bool>,
-    consensus_client: Arc<ConsensusClient>,
+    consensus_client: Arc<UpdatableConsensusClient>,
 }
 
 impl ConsensusManager {
@@ -95,7 +97,7 @@ impl ConsensusManager {
         node_config: &NodeConfig,
         consensus_config: &ConsensusConfig,
         registry_service: &RegistryService,
-        consensus_client: Arc<ConsensusClient>,
+        consensus_client: Arc<UpdatableConsensusClient>,
     ) -> Self {
         let metrics = Arc::new(ConsensusManagerMetrics::new(
             &registry_service.default_registry(),
@@ -168,20 +170,23 @@ impl ConsensusManagerTrait for ConsensusManager {
     }
 }
 
+/// A ConsensusClient that can be updated internally at any time. This usually
+/// happening during epoch change where a client is set after the new consensus
+/// is started for the new epoch.
 #[derive(Default)]
-pub struct ConsensusClient {
+pub struct UpdatableConsensusClient {
     // An extra layer of Arc<> is needed as required by ArcSwapAny.
-    client: ArcSwapOption<Arc<dyn SubmitToConsensus>>,
+    client: ArcSwapOption<Arc<dyn ConsensusClient>>,
 }
 
-impl ConsensusClient {
+impl UpdatableConsensusClient {
     pub fn new() -> Self {
         Self {
             client: ArcSwapOption::empty(),
         }
     }
 
-    async fn get(&self) -> Arc<Arc<dyn SubmitToConsensus>> {
+    async fn get(&self) -> Arc<Arc<dyn ConsensusClient>> {
         const START_TIMEOUT: Duration = Duration::from_secs(30);
         const RETRY_INTERVAL: Duration = Duration::from_millis(100);
         if let Ok(client) = timeout(START_TIMEOUT, async {
@@ -204,7 +209,7 @@ impl ConsensusClient {
         );
     }
 
-    pub fn set(&self, client: Arc<dyn SubmitToConsensus>) {
+    pub fn set(&self, client: Arc<dyn ConsensusClient>) {
         self.client.store(Some(Arc::new(client)));
     }
 
@@ -214,14 +219,14 @@ impl ConsensusClient {
 }
 
 #[async_trait]
-impl SubmitToConsensus for ConsensusClient {
-    async fn submit_to_consensus(
+impl ConsensusClient for UpdatableConsensusClient {
+    async fn submit(
         &self,
         transactions: &[ConsensusTransaction],
         epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> IotaResult {
+    ) -> IotaResult<BlockStatusReceiver> {
         let client = self.get().await;
-        client.submit_to_consensus(transactions, epoch_store).await
+        client.submit(transactions, epoch_store).await
     }
 }
 

--- a/crates/iota-core/src/epoch/randomness.rs
+++ b/crates/iota-core/src/epoch/randomness.rs
@@ -833,6 +833,7 @@ pub enum DkgStatus {
 mod tests {
     use std::num::NonZeroUsize;
 
+    use consensus_core::{BlockRef, BlockStatus};
     use iota_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
     use iota_types::messages_consensus::ConsensusTransactionKind;
     use tokio::sync::mpsc;
@@ -841,9 +842,10 @@ mod tests {
         authority::test_authority_builder::TestAuthorityBuilder,
         consensus_adapter::{
             ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
-            MockSubmitToConsensus,
+            MockConsensusClient,
         },
         epoch::randomness::*,
+        mock_consensus::with_block_status,
     };
 
     #[tokio::test]
@@ -870,15 +872,15 @@ mod tests {
 
         for validator in network_config.validator_configs.iter() {
             // Send consensus messages to channel.
-            let mut mock_consensus_client = MockSubmitToConsensus::new();
+            let mut mock_consensus_client = MockConsensusClient::new();
             let tx_consensus = tx_consensus.clone();
             mock_consensus_client
-                .expect_submit_to_consensus()
+                .expect_submit()
                 .withf(move |transactions: &[ConsensusTransaction], _epoch_store| {
                     tx_consensus.try_send(transactions.to_vec()).unwrap();
                     true
                 })
-                .returning(|_, _| Ok(()));
+                .returning(|_, _| Ok(with_block_status(BlockStatus::Sequenced(BlockRef::MIN))));
 
             let state = TestAuthorityBuilder::new()
                 .with_protocol_config(protocol_config.clone())
@@ -1001,15 +1003,19 @@ mod tests {
 
         for validator in network_config.validator_configs.iter() {
             // Send consensus messages to channel.
-            let mut mock_consensus_client = MockSubmitToConsensus::new();
+            let mut mock_consensus_client = MockConsensusClient::new();
             let tx_consensus = tx_consensus.clone();
             mock_consensus_client
-                .expect_submit_to_consensus()
+                .expect_submit()
                 .withf(move |transactions: &[ConsensusTransaction], _epoch_store| {
                     tx_consensus.try_send(transactions.to_vec()).unwrap();
                     true
                 })
-                .returning(|_, _| Ok(()));
+                .returning(|_, _| {
+                    Ok(with_block_status(consensus_core::BlockStatus::Sequenced(
+                        BlockRef::MIN,
+                    )))
+                });
 
             let state = TestAuthorityBuilder::new()
                 .with_protocol_config(protocol_config.clone())

--- a/crates/iota-core/src/mysticeti_adapter.rs
+++ b/crates/iota-core/src/mysticeti_adapter.rs
@@ -16,7 +16,8 @@ use tracing::{error, info, warn};
 
 use crate::{
     authority::authority_per_epoch_store::AuthorityPerEpochStore,
-    consensus_adapter::SubmitToConsensus, consensus_handler::SequencedConsensusTransactionKey,
+    consensus_adapter::{BlockStatusReceiver, ConsensusClient},
+    consensus_handler::SequencedConsensusTransactionKey,
 };
 
 /// Gets a client to submit transactions to Mysticeti, or waits for one to be
@@ -74,12 +75,12 @@ impl LazyMysticetiClient {
 }
 
 #[async_trait::async_trait]
-impl SubmitToConsensus for LazyMysticetiClient {
-    async fn submit_to_consensus(
+impl ConsensusClient for LazyMysticetiClient {
+    async fn submit(
         &self,
         transactions: &[ConsensusTransaction],
         _epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> IotaResult {
+    ) -> IotaResult<BlockStatusReceiver> {
         // TODO(mysticeti): confirm comment is still true
         // The retrieved TransactionClient can be from the past epoch. Submit would fail
         // after Mysticeti shuts down, so there should be no correctness issue.
@@ -88,7 +89,7 @@ impl SubmitToConsensus for LazyMysticetiClient {
             .iter()
             .map(|t| bcs::to_bytes(t).expect("Serializing consensus transaction cannot fail"))
             .collect::<Vec<_>>();
-        let (block_ref, _) = client
+        let (block_ref, status_waiter) = client
             .as_ref()
             .expect("Client should always be returned")
             .submit(transactions_bytes)
@@ -125,6 +126,6 @@ impl SubmitToConsensus for LazyMysticetiClient {
             let transaction_key = SequencedConsensusTransactionKey::External(transactions[0].key());
             tracing::info!("Transaction {transaction_key:?} was included in {block_ref}",)
         };
-        Ok(())
+        Ok(status_waiter)
     }
 }

--- a/crates/iota-core/src/mysticeti_adapter.rs
+++ b/crates/iota-core/src/mysticeti_adapter.rs
@@ -88,7 +88,7 @@ impl SubmitToConsensus for LazyMysticetiClient {
             .iter()
             .map(|t| bcs::to_bytes(t).expect("Serializing consensus transaction cannot fail"))
             .collect::<Vec<_>>();
-        let block_ref = client
+        let (block_ref, _) = client
             .as_ref()
             .expect("Client should always be returned")
             .submit(transactions_bytes)

--- a/crates/iota-core/src/unit_tests/consensus_tests.rs
+++ b/crates/iota-core/src/unit_tests/consensus_tests.rs
@@ -2,27 +2,27 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use consensus_core::{BlockRef, BlockStatus};
 use iota_types::{
     IOTA_FRAMEWORK_PACKAGE_ID,
     base_types::ObjectID,
     crypto::deterministic_random_account_key,
     object::Object,
     transaction::{
-        CallArg, CertifiedTransaction, ObjectArg, TransactionData,
-        TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS,
+        CallArg, CertifiedTransaction, ObjectArg, TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS,
+        TransactionData,
     },
     utils::to_sender_signed_transaction,
 };
-use crate::mock_consensus::with_block_status;
-use consensus_core::{BlockRef, BlockStatus};
-use parking_lot::Mutex;
 use move_core_types::{account_address::AccountAddress, ident_str};
+use parking_lot::Mutex;
 
 use super::*;
 use crate::{
     authority::{AuthorityState, authority_tests::init_state_with_objects},
     checkpoints::CheckpointServiceNoop,
     consensus_handler::SequencedConsensusTransaction,
+    mock_consensus::with_block_status,
 };
 
 /// Fixture: a few test gas objects.
@@ -193,11 +193,7 @@ async fn submit_transaction_to_consensus_adapter() {
         with_block_status(BlockStatus::GarbageCollected(BlockRef::MIN)),
         with_block_status(BlockStatus::Sequenced(BlockRef::MIN)),
     ];
-    let adapter = make_consensus_adapter_for_test(
-        state.clone(),
-        false,
-        block_status_receivers,
-    );
+    let adapter = make_consensus_adapter_for_test(state.clone(), false, block_status_receivers);
 
     // Submit the transaction and ensure the adapter reports success to the caller.
     // Note that consensus may drop some transactions (so we may need to

--- a/crates/iota-core/src/unit_tests/consensus_tests.rs
+++ b/crates/iota-core/src/unit_tests/consensus_tests.rs
@@ -8,11 +8,14 @@ use iota_types::{
     crypto::deterministic_random_account_key,
     object::Object,
     transaction::{
-        CallArg, CertifiedTransaction, ObjectArg, TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS,
-        TransactionData,
+        CallArg, CertifiedTransaction, ObjectArg, TransactionData,
+        TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS,
     },
     utils::to_sender_signed_transaction,
 };
+use crate::mock_consensus::with_block_status;
+use consensus_core::{BlockRef, BlockStatus};
+use parking_lot::Mutex;
 use move_core_types::{account_address::AccountAddress, ident_str};
 
 use super::*;
@@ -106,19 +109,24 @@ pub async fn test_certificates(
 pub fn make_consensus_adapter_for_test(
     state: Arc<AuthorityState>,
     execute: bool,
+    mock_block_status_receivers: Vec<BlockStatusReceiver>,
 ) -> Arc<ConsensusAdapter> {
     let metrics = ConsensusAdapterMetrics::new_test();
 
     #[derive(Clone)]
-    struct SubmitDirectly(Arc<AuthorityState>, bool);
+    struct SubmitDirectly {
+        state: Arc<AuthorityState>,
+        execute: bool,
+        mock_block_status_receivers: Arc<Mutex<Vec<BlockStatusReceiver>>>,
+    }
 
     #[async_trait::async_trait]
-    impl SubmitToConsensus for SubmitDirectly {
-        async fn submit_to_consensus(
+    impl ConsensusClient for SubmitDirectly {
+        async fn submit(
             &self,
             transactions: &[ConsensusTransaction],
             epoch_store: &Arc<AuthorityPerEpochStore>,
-        ) -> IotaResult {
+        ) -> IotaResult<BlockStatusReceiver> {
             let sequenced_transactions = transactions
                 .iter()
                 .map(|txn| SequencedConsensusTransaction::new_test(txn.clone()))
@@ -127,22 +135,31 @@ pub fn make_consensus_adapter_for_test(
                 .process_consensus_transactions_for_tests(
                     sequenced_transactions,
                     &Arc::new(CheckpointServiceNoop {}),
-                    self.0.get_object_cache_reader().as_ref(),
-                    &self.0.metrics,
+                    self.state.get_object_cache_reader().as_ref(),
+                    &self.state.metrics,
                     true,
                 )
                 .await?;
-            if self.1 {
-                self.0
+            if self.execute {
+                self.state
                     .transaction_manager()
                     .enqueue(transactions, epoch_store);
             }
-            Ok(())
+
+            assert!(
+                !self.mock_block_status_receivers.lock().is_empty(),
+                "No mock submit responses left"
+            );
+            Ok(self.mock_block_status_receivers.lock().remove(0))
         }
     }
     // Make a new consensus adapter instance.
     Arc::new(ConsensusAdapter::new(
-        Arc::new(SubmitDirectly(state.clone(), execute)),
+        Arc::new(SubmitDirectly {
+            state: state.clone(),
+            execute,
+            mock_block_status_receivers: Arc::new(Mutex::new(mock_block_status_receivers)),
+        }),
         state.name,
         Arc::new(ConnectionMonitorStatusForTests {}),
         100_000,
@@ -170,7 +187,17 @@ async fn submit_transaction_to_consensus_adapter() {
     let epoch_store = state.epoch_store_for_testing();
 
     // Make a new consensus adapter instance.
-    let adapter = make_consensus_adapter_for_test(state.clone(), false);
+    let block_status_receivers = vec![
+        with_block_status(BlockStatus::GarbageCollected(BlockRef::MIN)),
+        with_block_status(BlockStatus::GarbageCollected(BlockRef::MIN)),
+        with_block_status(BlockStatus::GarbageCollected(BlockRef::MIN)),
+        with_block_status(BlockStatus::Sequenced(BlockRef::MIN)),
+    ];
+    let adapter = make_consensus_adapter_for_test(
+        state.clone(),
+        false,
+        block_status_receivers,
+    );
 
     // Submit the transaction and ensure the adapter reports success to the caller.
     // Note that consensus may drop some transactions (so we may need to

--- a/crates/iota-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/iota-core/src/unit_tests/execution_driver_tests.rs
@@ -23,7 +23,6 @@ use iota_types::{
         VerifiedCertificate,
     },
 };
-use crate::consensus_adapter::{MockConsensusClient};
 use itertools::Itertools;
 use tokio::{
     sync::mpsc::UnboundedReceiver,
@@ -42,6 +41,7 @@ use crate::{
     authority_server::{ValidatorService, ValidatorServiceMetrics},
     consensus_adapter::{
         ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
+        MockConsensusClient,
     },
     safe_client::SafeClient,
     test_authority_clients::LocalAuthorityClient,

--- a/crates/iota-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/iota-core/src/unit_tests/execution_driver_tests.rs
@@ -23,6 +23,7 @@ use iota_types::{
         VerifiedCertificate,
     },
 };
+use crate::consensus_adapter::{MockConsensusClient};
 use itertools::Itertools;
 use tokio::{
     sync::mpsc::UnboundedReceiver,
@@ -41,7 +42,6 @@ use crate::{
     authority_server::{ValidatorService, ValidatorServiceMetrics},
     consensus_adapter::{
         ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
-        MockSubmitToConsensus,
     },
     safe_client::SafeClient,
     test_authority_clients::LocalAuthorityClient,
@@ -762,7 +762,7 @@ async fn test_authority_txn_signing_pushback() {
     // Create a validator service around the `authority_state`.
     let epoch_store = authority_state.epoch_store_for_testing();
     let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockSubmitToConsensus::new()),
+        Arc::new(MockConsensusClient::new()),
         authority_state.name,
         Arc::new(ConnectionMonitorStatusForTests {}),
         100_000,
@@ -892,7 +892,7 @@ async fn test_authority_txn_execution_pushback() {
 
     // Create a validator service around the `authority_state`.
     let consensus_adapter = Arc::new(ConsensusAdapter::new(
-        Arc::new(MockSubmitToConsensus::new()),
+        Arc::new(MockConsensusClient::new()),
         authority_state.name,
         Arc::new(ConnectionMonitorStatusForTests {}),
         100_000,

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -7,7 +7,6 @@ use std::{
     ops::Deref,
 };
 
-use crate::mock_consensus::with_block_status;
 use consensus_core::{BlockRef, BlockStatus};
 use fastcrypto::{ed25519::Ed25519KeyPair, traits::KeyPair};
 use fastcrypto_zkp::bn254::zk_login::{OIDCProvider, ZkLoginInputs, parse_jwks};
@@ -45,6 +44,7 @@ use crate::{
         test_authority_builder::TestAuthorityBuilder,
     },
     consensus_adapter::consensus_tests::make_consensus_adapter_for_test,
+    mock_consensus::with_block_status,
 };
 macro_rules! assert_matches {
     ($expression:expr, $pattern:pat $(if $guard: expr)?) => {

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -7,6 +7,8 @@ use std::{
     ops::Deref,
 };
 
+use crate::mock_consensus::with_block_status;
+use consensus_core::{BlockRef, BlockStatus};
 use fastcrypto::{ed25519::Ed25519KeyPair, traits::KeyPair};
 use fastcrypto_zkp::bn254::zk_login::{OIDCProvider, ZkLoginInputs, parse_jwks};
 use iota_macros::sim_test;
@@ -1700,7 +1702,11 @@ async fn test_handle_soft_bundle_certificates() {
 
     // Create a server with mocked consensus.
     // This ensures transactions submitted to consensus will get processed.
-    let adapter = make_consensus_adapter_for_test(authority.clone(), true);
+    let adapter = make_consensus_adapter_for_test(
+        authority.clone(),
+        true,
+        vec![with_block_status(BlockStatus::Sequenced(BlockRef::MIN))],
+    );
     let server = AuthorityServer::new_for_test_with_consensus_adapter(authority.clone(), adapter);
     let _metrics = server.metrics.clone();
     let server_handle = server.spawn_for_test().await.unwrap();

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -49,10 +49,10 @@ use iota_core::{
     connection_monitor::ConnectionMonitor,
     consensus_adapter::{
         CheckConnection, ConnectionMonitorStatus, ConsensusAdapter, ConsensusAdapterMetrics,
-        SubmitToConsensus,
+        ConsensusClient,
     },
     consensus_handler::ConsensusHandlerInitializer,
-    consensus_manager::{ConsensusClient, ConsensusManager, ConsensusManagerTrait},
+    consensus_manager::{ConsensusManager, ConsensusManagerTrait, UpdatableConsensusClient},
     consensus_validator::{IotaTxValidator, IotaTxValidatorMetrics},
     db_checkpoint_handler::DBCheckpointHandler,
     epoch::{
@@ -1181,7 +1181,7 @@ impl IotaNode {
             .as_mut()
             .ok_or_else(|| anyhow!("Validator is missing consensus config"))?;
 
-        let client = Arc::new(ConsensusClient::new());
+        let client = Arc::new(UpdatableConsensusClient::new());
         let consensus_adapter = Arc::new(Self::construct_consensus_adapter(
             &committee,
             consensus_config,
@@ -1406,7 +1406,7 @@ impl IotaNode {
         authority: AuthorityName,
         connection_monitor_status: Arc<ConnectionMonitorStatus>,
         prometheus_registry: &Registry,
-        consensus_client: Arc<dyn SubmitToConsensus>,
+        consensus_client: Arc<dyn ConsensusClient>,
     ) -> ConsensusAdapter {
         let ca_metrics = ConsensusAdapterMetrics::new(prometheus_registry);
         // The consensus adapter allows the authority to send user certificates through


### PR DESCRIPTION
Porting upstream change: https://github.com/MystenLabs/sui/commit/ae6275f6957ac936caffe04e82b7762ba192c4f8

# Description of change
Copied from upstream:
'Transactions of GC'ed blocks should be retried to remain compliant with
the so far system assumptions. Refactored the consensus side to signal
back the submitter about the status of the block that the submitted
transaction has been included to. Practically two possible outcomes:
1. Sequenced (when the block has been committed and consequently the tx
as well)
2. GarbageCollected (when the tx's block has not been committed and
passed gc_round)
also took the opportunity for a small refactoring around the
`SubmitToConsensus` trait and the `ConsensusClient` as intentions
started diverging.'



There is a difference from upstream changes in consensus_tests.rs, since some changes in upstream depend on previous commit f6dd9a8 that we haven't ported yet. So these changes will be ported later.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/5643

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
