### PR TITLE
fix(iota-move/docs): Add Conventions as comments to a new package when `iota move new`

### DIFF
--- a/crates/iota-move/src/new.rs
+++ b/crates/iota-move/src/new.rs
@@ -38,7 +38,12 @@ impl New {
             r#"/*
 /// Module: {name}
 module {name}::{name};
-*/"#,
+*/
+
+// For Move coding conventions, see
+// https://docs.iota.org/developer/iota-101/move-overview/conventions
+
+"#,
             name = name
         )?;
 

--- a/docs/examples/move/move-overview/conventions/read.move
+++ b/docs/examples/move/move-overview/conventions/read.move
@@ -5,7 +5,7 @@ module conventions::profile {
     }
 
     // ✅ Correct
-    public fun age(self: &Profile):  u64 {
+    public fun age(self: &Profile): u64 {
         self.age
     }
 


### PR DESCRIPTION
# Description of change

Add Conventions link to a new package when ‘iota move new`

## Links to any relevant issues

Fixes #5254 .

## Type of change

- Enhancement (a non-breaking change which adds functionality)