### PR TITLE
chore: Add cargo deny check for external crates

### DIFF
--- a/.github/workflows/_cargo_deny.yml
+++ b/.github/workflows/_cargo_deny.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: [self-hosted-x64]
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - run: cargo deny --manifest-path ${{ inputs.manifest-path || './Cargo.toml' }} check bans licenses sources
+      - run: cargo deny --manifest-path ${{ inputs.manifest-path || './Cargo.toml' }} check bans licenses sources --hide-inclusion-graph
 
   advisories:
     name: cargo deny (advisories)
     runs-on: [self-hosted-x64]
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - run: cargo deny --manifest-path ${{ inputs.manifest-path || './Cargo.toml' }} check advisories
+      - run: cargo deny --manifest-path ${{ inputs.manifest-path || './Cargo.toml' }} check advisories --hide-inclusion-graph

--- a/external-crates/move/deny.toml
+++ b/external-crates/move/deny.toml
@@ -19,7 +19,6 @@
 # list here is effectively saying which targets you are building for.
 targets = [
 
-
   # The triple can be any string, but only the target triples built in to
   # rustc (as of 1.40) can be checked against actual config expressions
   # { triple = "x86_64-unknown-linux-musl" },
@@ -43,24 +42,24 @@ yanked = "warn"
 # output a note when they are encountered.
 ignore = [
   # difference 2.0.0 is unmaintained
-    "RUSTSEC-2020-0095",
-    # `tui` is unmaintained; use `ratatui` instead
-    "RUSTSEC-2023-0049",
-    # `yaml-rust` is unmaintained
-    "RUSTSEC-2024-0320",
-    # `proc-macro-error` is unmaintained, needed by `tabled`
-    "RUSTSEC-2024-0370",
-    # `serde_cbor` is unmaintained
-    "RUSTSEC-2021-0127",
-    # `atty` is unmaintained
-    "RUSTSEC-2024-0375",
-    # Potential unaligned read in `atty`
-    "RUSTSEC-2021-0145",
+  "RUSTSEC-2020-0095",
+  # `tui` is unmaintained; use `ratatui` instead
+  "RUSTSEC-2023-0049",
+  # `yaml-rust` is unmaintained
+  "RUSTSEC-2024-0320",
+  # `proc-macro-error` is unmaintained, needed by `tabled`
+  "RUSTSEC-2024-0370",
+  # `serde_cbor` is unmaintained
+  "RUSTSEC-2021-0127",
+  # `atty` is unmaintained
+  "RUSTSEC-2024-0375",
+  # Potential unaligned read in `atty`
+  "RUSTSEC-2021-0145",
 
-    # allow unmaintained instant crate used in transitive dependencies (backoff, cached, fastrand, parking_lot_*)
-    "RUSTSEC-2024-0384",
-    # allow unmaintained derivative crate used in transitive dependencies (ark-*)
-    "RUSTSEC-2024-0388",
+  # allow unmaintained instant crate used in transitive dependencies (backoff, cached, fastrand, parking_lot_*)
+  "RUSTSEC-2024-0384",
+  # allow unmaintained derivative crate used in transitive dependencies (ark-*)
+  "RUSTSEC-2024-0388",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories
@@ -91,7 +90,7 @@ allow = [
   "BSL-1.0",
   "Unicode-3.0",
   "Zlib",
-  "NCSA"
+  "NCSA",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
@@ -101,7 +100,6 @@ confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-
 
   # Each entry is the crate and version constraint, and its specific allow
   # list
@@ -137,7 +135,6 @@ ignore = false
 # not have its license(s) checked
 registries = [
 
-
   # "https://sekretz.com/registry
 ]
 
@@ -158,12 +155,10 @@ highlight = "all"
 # List of crates that are allowed. Use with care!
 allow = [
 
-
   # { name = "ansi_term", version = "=0.11.0" },
 ]
 # List of crates to deny
 deny = [
-
 
   # Each entry the name of a crate and a version range. If version is
   # not specified, all versions will be matched.

--- a/external-crates/move/deny.toml
+++ b/external-crates/move/deny.toml
@@ -19,6 +19,7 @@
 # list here is effectively saying which targets you are building for.
 targets = [
 
+
   # The triple can be any string, but only the target triples built in to
   # rustc (as of 1.40) can be checked against actual config expressions
   # { triple = "x86_64-unknown-linux-musl" },
@@ -41,20 +42,25 @@ yanked = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-  # we don't do RSA signing on IOTA (only verifying for zklogin)
-  "RUSTSEC-2023-0071",
-  # Cannot remove `proc-macro-error` until we can update `tabled`
-  "RUSTSEC-2024-0370",
-  # yaml-rust is unmaintained
-  "RUSTSEC-2024-0320",
-  # tui is unmaintained
-  "RUSTSEC-2023-0049",
-  # difference is unmaintained
-  "RUSTSEC-2020-0095",
-  # derivative is unmaintained
-  "RUSTSEC-2024-0388",
-  # instant is unmaintained
-  "RUSTSEC-2024-0384",
+  # difference 2.0.0 is unmaintained
+    "RUSTSEC-2020-0095",
+    # `tui` is unmaintained; use `ratatui` instead
+    "RUSTSEC-2023-0049",
+    # `yaml-rust` is unmaintained
+    "RUSTSEC-2024-0320",
+    # `proc-macro-error` is unmaintained, needed by `tabled`
+    "RUSTSEC-2024-0370",
+    # `serde_cbor` is unmaintained
+    "RUSTSEC-2021-0127",
+    # `atty` is unmaintained
+    "RUSTSEC-2024-0375",
+    # Potential unaligned read in `atty`
+    "RUSTSEC-2021-0145",
+
+    # allow unmaintained instant crate used in transitive dependencies (backoff, cached, fastrand, parking_lot_*)
+    "RUSTSEC-2024-0384",
+    # allow unmaintained derivative crate used in transitive dependencies (ark-*)
+    "RUSTSEC-2024-0388",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories
@@ -79,16 +85,13 @@ allow = [
   "BSD-3-Clause",
   "Apache-2.0",
   "MPL-2.0",
-  "ISC",
   "CC0-1.0",
   "0BSD",
-  "LicenseRef-ring",
   "Unlicense",
   "BSL-1.0",
-  "Unicode-DFS-2016",
-  "OpenSSL",
   "Unicode-3.0",
-  # "Apache-2.0 WITH LLVM-exception",
+  "Zlib",
+  "NCSA"
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
@@ -98,6 +101,7 @@ confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
+
 
   # Each entry is the crate and version constraint, and its specific allow
   # list
@@ -123,17 +127,6 @@ exceptions = [
 # Each entry is a crate relative path, and the (opaque) hash of its contents
 # { path = "LICENSE", hash = 0xbd0eed23 }
 # ]
-[[licenses.clarify]]
-name = "ring"
-expression = "LicenseRef-ring"
-license-files = [
-  { path = "LICENSE", hash = 0xbd0eed23 },
-]
-[[licenses.clarify]]
-name = "target-lexicon"
-version = "*"
-expression = "Apache-2.0"
-license-files = []
 
 [licenses.private]
 # If true, ignores workspace crates that aren't published, or are only
@@ -143,6 +136,7 @@ ignore = false
 # is only published to private registries, and ignore is true, the crate will
 # not have its license(s) checked
 registries = [
+
 
   # "https://sekretz.com/registry
 ]
@@ -164,10 +158,12 @@ highlight = "all"
 # List of crates that are allowed. Use with care!
 allow = [
 
+
   # { name = "ansi_term", version = "=0.11.0" },
 ]
 # List of crates to deny
 deny = [
+
 
   # Each entry the name of a crate and a version range. If version is
   # not specified, all versions will be matched.
@@ -179,7 +175,7 @@ deny = [
 ]
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-
+  "hermit-abi",
   # { name = "ansi_term", version = "=0.11.0" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
@@ -187,9 +183,14 @@ skip = [
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite
 skip-tree = [
-  { name = "anemo", version = "=0.0" },
-  { name = "iota-sdk" },
-  { name = "owo-colors", version = "=3.5" },
+  "codespan",
+  "colored",
+  "itertools",
+  "lsp-types",
+  "ouroboros",
+  "tracing-subscriber",
+  "serde_yaml",
+  "getrandom",
   # { name = "ansi_term", version = "=0.11.0", depth = 20 },
 ]
 
@@ -207,16 +208,6 @@ unknown-git = "warn"
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
-allow-git = [
-  "https://github.com/iotaledger/iota-sim.git",
-  "https://github.com/MystenLabs/fastcrypto.git",
-  "https://github.com/mystenlabs/anemo.git",
-  "https://github.com/iotaledger/tokio-madsim-fork.git",
-  "https://github.com/nextest-rs/datatest-stable.git",
-  "https://github.com/zhiburt/tabled.git",
-  "https://github.com/iotaledger/iota-rust-sdk.git",
-  "https://github.com/bmwill/openapiv3.git",
-  "https://github.com/bmwill/axum-server.git",
-]
+allow-git = []
 
 [sources.allow-org]


### PR DESCRIPTION
## Description

Currently the external crates cargo deny job runs at the top level and thus does not check the external crates manifest/lock file. This PR adds an additional `deny.toml` specific to the external crates and updates
the CI job so that it uses the correct manifest. Also adds the `--hide-inclusion-graph` flag as this helps to reduce the spam in the CI
logs.

NOTE: If only the top level `deny.toml` is used for both, then warnings are emitted for ignored RUSTSEC, licenses, etc. that do not apply to the manifest which cannot be silenced.

Upstream PR: https://github.com/MystenLabs/sui/pull/21268