### PR TITLE
enhance(test): Add timeout and retry to test to make them more stable

### DIFF
--- a/.github/workflows/_rust_tests.yml
+++ b/.github/workflows/_rust_tests.yml
@@ -61,7 +61,7 @@ jobs:
     if: |
       !cancelled() && (inputs.isRust || inputs.isPgIntegration || inputs.isMoveExampleUsedByOthers)
     timeout-minutes: 90
-    runs-on: [self-hosted-x64]
+    runs-on: [self-hosted-arm64]
     env:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgrespw

--- a/.github/workflows/_rust_tests.yml
+++ b/.github/workflows/_rust_tests.yml
@@ -61,7 +61,7 @@ jobs:
     if: |
       !cancelled() && (inputs.isRust || inputs.isPgIntegration || inputs.isMoveExampleUsedByOthers)
     timeout-minutes: 90
-    runs-on: [self-hosted-arm64]
+    runs-on: [self-hosted-x64]
     env:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgrespw

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -56,7 +56,7 @@ pub async fn test_checkpoint_executor_crash_recovery() {
     let checkpoints = sync_new_checkpoints(
         &checkpoint_store,
         &checkpoint_sender,
-        2 * buffer_size,
+        buffer_size,
         None,
         &committee,
     );
@@ -74,7 +74,7 @@ pub async fn test_checkpoint_executor_crash_recovery() {
                 .unwrap()
                 .unwrap_or_default();
 
-            if highest_executed == 2 * (buffer_size as u64) - 1 {
+            if highest_executed == (buffer_size as u64) - 1 {
                 break;
             }
 
@@ -91,7 +91,7 @@ pub async fn test_checkpoint_executor_crash_recovery() {
     let _ = sync_new_checkpoints(
         &checkpoint_store,
         &checkpoint_sender,
-        2 * buffer_size,
+        buffer_size,
         Some(checkpoints.last().cloned().unwrap()),
         &committee,
     );
@@ -116,7 +116,7 @@ pub async fn test_checkpoint_executor_crash_recovery() {
                 .unwrap()
                 .unwrap_or_default();
 
-            if highest_executed == 4 * (buffer_size as u64) - 1 {
+            if highest_executed == 2 * (buffer_size as u64) - 1 {
                 break;
             }
 

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -64,19 +64,30 @@ pub async fn test_checkpoint_executor_crash_recovery() {
     let epoch_store = state.epoch_store_for_testing().clone();
     let executor_handle =
         spawn_monitored_task!(async move { executor.run_epoch(epoch_store, None).await });
-    tokio::time::sleep(Duration::from_secs(5)).await;
 
-    // ensure we executed all synced checkpoints
-    let highest_executed = checkpoint_store
-        .get_highest_executed_checkpoint_seq_number()
-        .unwrap()
-        .expect("Expected highest executed to not be None");
-    assert_eq!(highest_executed, 2 * (buffer_size as u64) - 1,);
+    // Use a timer to ensure all checkpoints are executed
+    let timeout_duration = Duration::from_secs(20);
+    tokio::time::timeout(timeout_duration, async {
+        loop {
+            let highest_executed = checkpoint_store
+                .get_highest_executed_checkpoint_seq_number()
+                .unwrap()
+                .unwrap_or_default();
+
+            if highest_executed == 2 * (buffer_size as u64) - 1 {
+                break;
+            }
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("Timeout waiting for checkpoints to be executed");
 
     // Simulate node restart
     executor_handle.abort();
 
-    // sync more checkpoints in the meantime
+    // Sync more checkpoints in the meantime
     let _ = sync_new_checkpoints(
         &checkpoint_store,
         &checkpoint_sender,
@@ -85,8 +96,7 @@ pub async fn test_checkpoint_executor_crash_recovery() {
         &committee,
     );
 
-    // restart checkpoint executor and ensure that it picks
-    // up where it left off
+    // Restart checkpoint executor and ensure that it picks up where it left off
     let mut executor = CheckpointExecutor::new_for_tests(
         checkpoint_sender.subscribe(),
         checkpoint_store.clone(),
@@ -97,13 +107,24 @@ pub async fn test_checkpoint_executor_crash_recovery() {
     let epoch_store = state.epoch_store_for_testing().clone();
     let executor_handle =
         spawn_monitored_task!(async move { executor.run_epoch(epoch_store, None).await });
-    tokio::time::sleep(Duration::from_secs(15)).await;
 
-    let highest_executed = checkpoint_store
-        .get_highest_executed_checkpoint_seq_number()
-        .unwrap()
-        .expect("Expected highest executed to not be None");
-    assert_eq!(highest_executed, 4 * (buffer_size as u64) - 1);
+    // Use a timer to ensure all checkpoints are executed
+    tokio::time::timeout(timeout_duration, async {
+        loop {
+            let highest_executed = checkpoint_store
+                .get_highest_executed_checkpoint_seq_number()
+                .unwrap()
+                .unwrap_or_default();
+
+            if highest_executed == 4 * (buffer_size as u64) - 1 {
+                break;
+            }
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("Timeout waiting for checkpoints to be executed after restart");
 
     executor_handle.abort();
 }

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -66,7 +66,7 @@ pub async fn test_checkpoint_executor_crash_recovery() {
         spawn_monitored_task!(async move { executor.run_epoch(epoch_store, None).await });
 
     // Use a timer to ensure all checkpoints are executed
-    let timeout_duration = Duration::from_secs(20);
+    let timeout_duration = Duration::from_secs(60);
     tokio::time::timeout(timeout_duration, async {
         loop {
             let highest_executed = checkpoint_store

--- a/crates/iota-network/src/randomness/mod.rs
+++ b/crates/iota-network/src/randomness/mod.rs
@@ -986,7 +986,7 @@ impl RandomnessEventLoop {
                 // longer to verify invalid signatures and thus needs larger
                 // timeouts.
                 #[cfg(test)]
-                const SEND_PARTIAL_SIGNATURES_TIMEOUT: Duration = Duration::from_secs(500);
+                const SEND_PARTIAL_SIGNATURES_TIMEOUT: Duration = Duration::from_secs(300);
                 // In release signature verification should take less, so
                 // smaller timeout should be enough.
                 #[cfg(not(test))]

--- a/crates/iota-network/src/randomness/mod.rs
+++ b/crates/iota-network/src/randomness/mod.rs
@@ -986,7 +986,7 @@ impl RandomnessEventLoop {
                 // longer to verify invalid signatures and thus needs larger
                 // timeouts.
                 #[cfg(test)]
-                const SEND_PARTIAL_SIGNATURES_TIMEOUT: Duration = Duration::from_secs(100);
+                const SEND_PARTIAL_SIGNATURES_TIMEOUT: Duration = Duration::from_secs(500);
                 // In release signature verification should take less, so
                 // smaller timeout should be enough.
                 #[cfg(not(test))]

--- a/crates/iota-network/src/randomness/mod.rs
+++ b/crates/iota-network/src/randomness/mod.rs
@@ -982,7 +982,15 @@ impl RandomnessEventLoop {
                     continue; // don't send partial sigs to self
                 }
                 let mut client = RandomnessClient::new(peer.clone());
-                const SEND_PARTIAL_SIGNATURES_TIMEOUT: Duration = Duration::from_secs(30);
+                // `test_byzantine_peer_handling` built in debug mode takes
+                // longer to verify invalid signatures and thus needs larger
+                // timeouts.
+                #[cfg(test)]
+                const SEND_PARTIAL_SIGNATURES_TIMEOUT: Duration = Duration::from_secs(100);
+                // In release signature verification should take less, so
+                // smaller timeout should be enough.
+                #[cfg(not(test))]
+                const SEND_PARTIAL_SIGNATURES_TIMEOUT: Duration = Duration::from_secs(10);
                 let full_sig = full_sig.get().cloned();
                 let request = anemo::Request::new(SendSignaturesRequest {
                     epoch,

--- a/crates/iota-network/src/randomness/mod.rs
+++ b/crates/iota-network/src/randomness/mod.rs
@@ -982,7 +982,7 @@ impl RandomnessEventLoop {
                     continue; // don't send partial sigs to self
                 }
                 let mut client = RandomnessClient::new(peer.clone());
-                const SEND_PARTIAL_SIGNATURES_TIMEOUT: Duration = Duration::from_secs(10);
+                const SEND_PARTIAL_SIGNATURES_TIMEOUT: Duration = Duration::from_secs(30);
                 let full_sig = full_sig.get().cloned();
                 let request = anemo::Request::new(SendSignaturesRequest {
                     epoch,

--- a/crates/iota-network/src/randomness/tests.rs
+++ b/crates/iota-network/src/randomness/tests.rs
@@ -447,18 +447,15 @@ async fn test_byzantine_peer_handling() {
     let (rx2_mut, rx3_mut) = randomness_rxs.split_at_mut(3);
     let rnd2_fut = rx2_mut[2].recv();
     let rnd3_fut = rx3_mut[0].recv();
-    tokio::select! {
-        // Validators (2, 3) can communicate normally.
-        rnds = futures::future::join_all([rnd2_fut, rnd3_fut]) => {
-            for rnd in rnds {
-                let (epoch, round, bytes) = rnd
-                    .expect("Validators (2, 3) should receive randomness in epoch 0, round 0");
-                assert_eq!(0, epoch);
-                assert_eq!(0, round.0);
-                assert_ne!(0, bytes.len());
-            }
-        },
-        _ = tokio::time::sleep(timeout) => panic!("Timeout expired to receive randomness"),
+    // Validators (2, 3) can communicate normally.
+    let rnds = tokio::time::timeout(timeout, futures::future::join_all([rnd2_fut, rnd3_fut]))
+        .await
+        .expect("Honest peers (2, 3) should produce randomness in time");
+    for rnd in rnds {
+        let (epoch, round, bytes) = rnd.expect("Channel is not closed and randomness is produced");
+        assert_eq!(0, epoch, "Honest peers produce randomness in epoch 0");
+        assert_eq!(0, round.0, "Honest peers produce randomness in round 0");
+        assert_ne!(0, bytes.len(), "Honest peers produce non-empty randomness");
     }
     for rx in &mut randomness_rxs[..2] {
         // Validators (0, 1) are byzantine.
@@ -490,18 +487,19 @@ async fn test_byzantine_peer_handling() {
     let (rx0_mut, rx1_mut) = randomness_rxs.split_at_mut(1);
     let rnd0_fut = rx0_mut[0].recv();
     let rnd1_fut = rx1_mut[0].recv();
-    tokio::select! {
-        // Validators (0, 1) can communicate normally in new epoch.
-        rnds = futures::future::join_all([rnd0_fut, rnd1_fut]) => {
-            for rnd in rnds {
-                let (epoch, round, bytes) = rnd
-                    .expect("Validators (0, 1) should receive randomness in epoch 1, round 0");
-                assert_eq!(1, epoch);
-                assert_eq!(0, round.0);
-                assert_ne!(0, bytes.len());
-            }
-        },
-        _ = tokio::time::sleep(timeout) => panic!("Timeout expired to receive randomness"),
+    // Validators (0, 1) can communicate normally in new epoch.
+    let rnds = tokio::time::timeout(timeout, futures::future::join_all([rnd0_fut, rnd1_fut]))
+        .await
+        .expect("Byzantine peers (0, 1) should produce randomness in time");
+    for rnd in rnds {
+        let (epoch, round, bytes) = rnd.expect("Channel is not closed and randomness is produced");
+        assert_eq!(1, epoch, "Byzantine peers produce randomness in epoch 1");
+        assert_eq!(0, round.0, "Byzantine peers produce randomness in round 0");
+        assert_ne!(
+            0,
+            bytes.len(),
+            "Byzantine peers produce non-empty randomness"
+        );
     }
     for rx in &mut randomness_rxs[2..] {
         // Validators (2, 3) are still on old epoch.

--- a/crates/iota-network/src/randomness/tests.rs
+++ b/crates/iota-network/src/randomness/tests.rs
@@ -439,7 +439,7 @@ async fn test_byzantine_peer_handling() {
         );
     }
 
-    // Use tokio timeout to ensure the test has sometime to meet expected results.
+    // Use tokio timeout to ensure the test has some time to meet expected results.
     async fn receive_with_timeout(
         rx: &mut mpsc::Receiver<(u64, RandomnessRound, Vec<u8>)>,
         expected_epoch: u64,
@@ -460,7 +460,9 @@ async fn test_byzantine_peer_handling() {
 
     for rx in &mut randomness_rxs[2..] {
         // Validators (2, 3) can communicate normally.
-        receive_with_timeout(rx, 0, 0).await.unwrap();
+        receive_with_timeout(rx, 0, 0)
+            .await
+            .expect("Validators (2, 3) should receive randomness in epoch 0, round 0");
     }
     for rx in &mut randomness_rxs[..2] {
         // Validators (0, 1) are byzantine.
@@ -490,7 +492,9 @@ async fn test_byzantine_peer_handling() {
     }
     for rx in &mut randomness_rxs[..2] {
         // Validators (0, 1) can communicate normally in new epoch.
-        receive_with_timeout(rx, 1, 0).await.unwrap();
+        receive_with_timeout(rx, 1, 0)
+            .await
+            .expect("Validators (0, 1) should receive randomness in epoch 1, round 0");
     }
     for rx in &mut randomness_rxs[2..] {
         // Validators (2, 3) are still on old epoch.

--- a/crates/iota-network/src/randomness/tests.rs
+++ b/crates/iota-network/src/randomness/tests.rs
@@ -439,9 +439,10 @@ async fn test_byzantine_peer_handling() {
         );
     }
 
-    // This test can just deadlock, ie. run indefinitely without making any progress.
-    // We can control it by waiting on expected randomness for `timeout` secs.
-    // For some reason it takes so much time for honest peers to produce randomness in presence of byzantine peers.
+    // This test can just deadlock, ie. run indefinitely without making any
+    // progress. We can control it by waiting on expected randomness for
+    // `timeout` secs. For some reason it takes so much time for honest peers to
+    // produce randomness in presence of byzantine peers.
     let timeout = std::time::Duration::from_secs(60);
     let (rx2_mut, rx3_mut) = randomness_rxs.split_at_mut(3);
     let rnd2_fut = rx2_mut[2].recv();

--- a/crates/iota-network/src/randomness/tests.rs
+++ b/crates/iota-network/src/randomness/tests.rs
@@ -445,17 +445,23 @@ async fn test_byzantine_peer_handling() {
         expected_epoch: u64,
         expected_round: u64,
     ) -> Result<(), ()> {
-        let timeout = std::time::Duration::from_secs(30);
-        let start = std::time::Instant::now();
-        while start.elapsed() < timeout {
-            if let Some((epoch, round, bytes)) = rx.recv().await {
-                if epoch == expected_epoch && round.0 == expected_round && !bytes.is_empty() {
-                    return Ok(());
+        loop {
+            tokio::select! {
+                received = rx.recv() => match received {
+                    Some((epoch, round, bytes)) => {
+                        assert_eq!(expected_epoch, epoch);
+                        assert_eq!(expected_round, round.0);
+                        assert_ne!(0, bytes.len());
+
+                        return Ok(());
+                    },
+                    None => tokio::time::sleep(std::time::Duration::from_millis(100)).await,
+                },
+                _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                    return Err(());
                 }
             }
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         }
-        Err(())
     }
 
     for rx in &mut randomness_rxs[2..] {

--- a/crates/iota-network/src/randomness/tests.rs
+++ b/crates/iota-network/src/randomness/tests.rs
@@ -439,36 +439,15 @@ async fn test_byzantine_peer_handling() {
         );
     }
 
-    // Use tokio timeout to ensure the test has some time to meet expected results.
-    async fn receive_with_timeout(
-        rx: &mut mpsc::Receiver<(u64, RandomnessRound, Vec<u8>)>,
-        expected_epoch: u64,
-        expected_round: u64,
-    ) -> Result<(), String> {
-        tokio::select! {
-            received = rx.recv() => match received {
-                Some((epoch, round, bytes)) => {
-                    assert_eq!(expected_epoch, epoch);
-                    assert_eq!(expected_round, round.0);
-                    assert_ne!(0, bytes.len());
-
-                    Ok(())
-                },
-                None => {
-                    Err("Randomness channels has been closed".to_string())
-                },
-            },
-            _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
-                Err("Timeout expired to receive randomness".to_string())
-            }
-        }
-    }
-
     for rx in &mut randomness_rxs[2..] {
         // Validators (2, 3) can communicate normally.
-        receive_with_timeout(rx, 0, 0)
+        let (epoch, round, bytes) = rx
+            .recv()
             .await
             .expect("Validators (2, 3) should receive randomness in epoch 0, round 0");
+        assert_eq!(0, epoch);
+        assert_eq!(0, round.0);
+        assert_ne!(0, bytes.len());
     }
     for rx in &mut randomness_rxs[..2] {
         // Validators (0, 1) are byzantine.
@@ -498,9 +477,13 @@ async fn test_byzantine_peer_handling() {
     }
     for rx in &mut randomness_rxs[..2] {
         // Validators (0, 1) can communicate normally in new epoch.
-        receive_with_timeout(rx, 1, 0)
+        let (epoch, round, bytes) = rx
+            .recv()
             .await
             .expect("Validators (0, 1) should receive randomness in epoch 1, round 0");
+        assert_eq!(1, epoch);
+        assert_eq!(0, round.0);
+        assert_ne!(0, bytes.len());
     }
     for rx in &mut randomness_rxs[2..] {
         // Validators (2, 3) are still on old epoch.

--- a/crates/iota-network/src/randomness/tests.rs
+++ b/crates/iota-network/src/randomness/tests.rs
@@ -439,23 +439,15 @@ async fn test_byzantine_peer_handling() {
         );
     }
 
-    // This test can just deadlock, ie. run indefinitely without making any
-    // progress. We can control it by waiting on expected randomness for
-    // `timeout` secs. For some reason it takes so much time for honest peers to
-    // produce randomness in presence of byzantine peers.
-    let timeout = std::time::Duration::from_secs(60);
-    let (rx2_mut, rx3_mut) = randomness_rxs.split_at_mut(3);
-    let rnd2_fut = rx2_mut[2].recv();
-    let rnd3_fut = rx3_mut[0].recv();
-    // Validators (2, 3) can communicate normally.
-    let rnds = tokio::time::timeout(timeout, futures::future::join_all([rnd2_fut, rnd3_fut]))
-        .await
-        .expect("Honest peers (2, 3) should produce randomness in time");
-    for rnd in rnds {
-        let (epoch, round, bytes) = rnd.expect("Channel is not closed and randomness is produced");
-        assert_eq!(0, epoch, "Honest peers produce randomness in epoch 0");
-        assert_eq!(0, round.0, "Honest peers produce randomness in round 0");
-        assert_ne!(0, bytes.len(), "Honest peers produce non-empty randomness");
+    for rx in &mut randomness_rxs[2..] {
+        // Validators (2, 3) can communicate normally.
+        let (epoch, round, bytes) = rx
+            .recv()
+            .await
+            .expect("Validators (2, 3) should receive randomness in epoch 0, round 0");
+        assert_eq!(0, epoch);
+        assert_eq!(0, round.0);
+        assert_ne!(0, bytes.len());
     }
     for rx in &mut randomness_rxs[..2] {
         // Validators (0, 1) are byzantine.
@@ -483,23 +475,15 @@ async fn test_byzantine_peer_handling() {
             None,
         );
     }
-
-    let (rx0_mut, rx1_mut) = randomness_rxs.split_at_mut(1);
-    let rnd0_fut = rx0_mut[0].recv();
-    let rnd1_fut = rx1_mut[0].recv();
-    // Validators (0, 1) can communicate normally in new epoch.
-    let rnds = tokio::time::timeout(timeout, futures::future::join_all([rnd0_fut, rnd1_fut]))
-        .await
-        .expect("Byzantine peers (0, 1) should produce randomness in time");
-    for rnd in rnds {
-        let (epoch, round, bytes) = rnd.expect("Channel is not closed and randomness is produced");
-        assert_eq!(1, epoch, "Byzantine peers produce randomness in epoch 1");
-        assert_eq!(0, round.0, "Byzantine peers produce randomness in round 0");
-        assert_ne!(
-            0,
-            bytes.len(),
-            "Byzantine peers produce non-empty randomness"
-        );
+    for rx in &mut randomness_rxs[..2] {
+        // Validators (0, 1) can communicate normally in new epoch.
+        let (epoch, round, bytes) = rx
+            .recv()
+            .await
+            .expect("Validators (0, 1) should receive randomness in epoch 1, round 0");
+        assert_eq!(1, epoch);
+        assert_eq!(0, round.0);
+        assert_ne!(0, bytes.len());
     }
     for rx in &mut randomness_rxs[2..] {
         // Validators (2, 3) are still on old epoch.

--- a/crates/iota-network/src/randomness/tests.rs
+++ b/crates/iota-network/src/randomness/tests.rs
@@ -459,7 +459,7 @@ async fn test_byzantine_peer_handling() {
                 },
             },
             _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
-                return Err("Timeout expired to receive randomness".to_string());
+                Err("Timeout expired to receive randomness".to_string())
             }
         }
     }

--- a/crates/iota-network/src/randomness/tests.rs
+++ b/crates/iota-network/src/randomness/tests.rs
@@ -438,12 +438,29 @@ async fn test_byzantine_peer_handling() {
             None,
         );
     }
+
+    // Use tokio timeout to ensure the test has sometime to meet expected results.
+    async fn receive_with_timeout(
+        rx: &mut mpsc::Receiver<(u64, RandomnessRound, Vec<u8>)>,
+        expected_epoch: u64,
+        expected_round: u64,
+    ) -> Result<(), ()> {
+        let timeout = std::time::Duration::from_secs(30);
+        let start = std::time::Instant::now();
+        while start.elapsed() < timeout {
+            if let Some((epoch, round, bytes)) = rx.recv().await {
+                if epoch == expected_epoch && round.0 == expected_round && !bytes.is_empty() {
+                    return Ok(());
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        Err(())
+    }
+
     for rx in &mut randomness_rxs[2..] {
         // Validators (2, 3) can communicate normally.
-        let (epoch, round, bytes) = rx.recv().await.unwrap();
-        assert_eq!(0, epoch);
-        assert_eq!(0, round.0);
-        assert_ne!(0, bytes.len());
+        receive_with_timeout(rx, 0, 0).await.unwrap();
     }
     for rx in &mut randomness_rxs[..2] {
         // Validators (0, 1) are byzantine.
@@ -473,10 +490,7 @@ async fn test_byzantine_peer_handling() {
     }
     for rx in &mut randomness_rxs[..2] {
         // Validators (0, 1) can communicate normally in new epoch.
-        let (epoch, round, bytes) = rx.recv().await.unwrap();
-        assert_eq!(1, epoch);
-        assert_eq!(0, round.0);
-        assert_ne!(0, bytes.len());
+        receive_with_timeout(rx, 1, 0).await.unwrap();
     }
     for rx in &mut randomness_rxs[2..] {
         // Validators (2, 3) are still on old epoch.

--- a/crates/iota-network/src/randomness/tests.rs
+++ b/crates/iota-network/src/randomness/tests.rs
@@ -371,7 +371,6 @@ async fn test_restart_recovery() {
 }
 
 #[tokio::test]
-#[ignore = "https://github.com/iotaledger/iota/issues/5620"]
 async fn test_byzantine_peer_handling() {
     telemetry_subscribers::init_for_testing();
     let committee_fixture = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);

--- a/crates/iota-network/src/randomness/tests.rs
+++ b/crates/iota-network/src/randomness/tests.rs
@@ -444,22 +444,22 @@ async fn test_byzantine_peer_handling() {
         rx: &mut mpsc::Receiver<(u64, RandomnessRound, Vec<u8>)>,
         expected_epoch: u64,
         expected_round: u64,
-    ) -> Result<(), ()> {
-        loop {
-            tokio::select! {
-                received = rx.recv() => match received {
-                    Some((epoch, round, bytes)) => {
-                        assert_eq!(expected_epoch, epoch);
-                        assert_eq!(expected_round, round.0);
-                        assert_ne!(0, bytes.len());
+    ) -> Result<(), String> {
+        tokio::select! {
+            received = rx.recv() => match received {
+                Some((epoch, round, bytes)) => {
+                    assert_eq!(expected_epoch, epoch);
+                    assert_eq!(expected_round, round.0);
+                    assert_ne!(0, bytes.len());
 
-                        return Ok(());
-                    },
-                    None => tokio::time::sleep(std::time::Duration::from_millis(100)).await,
+                    Ok(())
                 },
-                _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
-                    return Err(());
-                }
+                None => {
+                    Err("Randomness channels has been closed".to_string())
+                },
+            },
+            _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                return Err("Timeout expired to receive randomness".to_string());
             }
         }
     }

--- a/crates/iota-network/src/randomness/tests.rs
+++ b/crates/iota-network/src/randomness/tests.rs
@@ -439,15 +439,25 @@ async fn test_byzantine_peer_handling() {
         );
     }
 
-    for rx in &mut randomness_rxs[2..] {
+    // This test can just deadlock, ie. run indefinitely without making any progress.
+    // We can control it by waiting on expected randomness for `timeout` secs.
+    // For some reason it takes so much time for honest peers to produce randomness in presence of byzantine peers.
+    let timeout = std::time::Duration::from_secs(60);
+    let (rx2_mut, rx3_mut) = randomness_rxs.split_at_mut(3);
+    let rnd2_fut = rx2_mut[2].recv();
+    let rnd3_fut = rx3_mut[0].recv();
+    tokio::select! {
         // Validators (2, 3) can communicate normally.
-        let (epoch, round, bytes) = rx
-            .recv()
-            .await
-            .expect("Validators (2, 3) should receive randomness in epoch 0, round 0");
-        assert_eq!(0, epoch);
-        assert_eq!(0, round.0);
-        assert_ne!(0, bytes.len());
+        rnds = futures::future::join_all([rnd2_fut, rnd3_fut]) => {
+            for rnd in rnds {
+                let (epoch, round, bytes) = rnd
+                    .expect("Validators (2, 3) should receive randomness in epoch 0, round 0");
+                assert_eq!(0, epoch);
+                assert_eq!(0, round.0);
+                assert_ne!(0, bytes.len());
+            }
+        },
+        _ = tokio::time::sleep(timeout) => panic!("Timeout expired to receive randomness"),
     }
     for rx in &mut randomness_rxs[..2] {
         // Validators (0, 1) are byzantine.
@@ -475,15 +485,22 @@ async fn test_byzantine_peer_handling() {
             None,
         );
     }
-    for rx in &mut randomness_rxs[..2] {
+
+    let (rx0_mut, rx1_mut) = randomness_rxs.split_at_mut(1);
+    let rnd0_fut = rx0_mut[0].recv();
+    let rnd1_fut = rx1_mut[0].recv();
+    tokio::select! {
         // Validators (0, 1) can communicate normally in new epoch.
-        let (epoch, round, bytes) = rx
-            .recv()
-            .await
-            .expect("Validators (0, 1) should receive randomness in epoch 1, round 0");
-        assert_eq!(1, epoch);
-        assert_eq!(0, round.0);
-        assert_ne!(0, bytes.len());
+        rnds = futures::future::join_all([rnd0_fut, rnd1_fut]) => {
+            for rnd in rnds {
+                let (epoch, round, bytes) = rnd
+                    .expect("Validators (0, 1) should receive randomness in epoch 1, round 0");
+                assert_eq!(1, epoch);
+                assert_eq!(0, round.0);
+                assert_ne!(0, bytes.len());
+            }
+        },
+        _ = tokio::time::sleep(timeout) => panic!("Timeout expired to receive randomness"),
     }
     for rx in &mut randomness_rxs[2..] {
         // Validators (2, 3) are still on old epoch.

--- a/crates/iota-network/src/randomness/tests.rs
+++ b/crates/iota-network/src/randomness/tests.rs
@@ -371,6 +371,7 @@ async fn test_restart_recovery() {
 }
 
 #[tokio::test]
+#[ignore = "https://github.com/iotaledger/iota/issues/5620"]
 async fn test_byzantine_peer_handling() {
     telemetry_subscribers::init_for_testing();
     let committee_fixture = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);


### PR DESCRIPTION
# Description of change

Rust tests fail during nightly tests, because the tests get slower and thus fail to reach the expected values immediately, this PR adds timeout and retries to fix them.

## Links to any relevant issues

Close #5620 
Close #5584 

## Type of change

- Enhancement 


## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked that new and existing unit tests pass locally with my changes
