### PR TITLE
fix!: Remove double indirection in `MoveFieldLayout`

### DIFF
--- a/crates/iota-core/src/unit_tests/subscription_handler_tests.rs
+++ b/crates/iota-core/src/unit_tests/subscription_handler_tests.rs
@@ -82,7 +82,7 @@ impl TestEvent {
     fn layout() -> MoveStructLayout {
         MoveStructLayout {
             type_: Self::type_(),
-            fields: Box::new(vec![
+            fields: vec![
                 MoveFieldLayout::new(ident_str!("creator").to_owned(), MoveTypeLayout::Address),
                 MoveFieldLayout::new(
                     ident_str!("name").to_owned(),
@@ -98,7 +98,7 @@ impl TestEvent {
                         GasCoin::layout(),
                     )))),
                 ),
-            ]),
+            ],
         }
     }
 }
@@ -130,10 +130,10 @@ impl UTF8String {
     fn layout() -> MoveStructLayout {
         MoveStructLayout {
             type_: Self::type_(),
-            fields: Box::new(vec![MoveFieldLayout::new(
+            fields: vec![MoveFieldLayout::new(
                 ident_str!("bytes").to_owned(),
                 MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
-            )]),
+            )],
         }
     }
 }

--- a/crates/iota-graphql-rpc/src/types/move_value.rs
+++ b/crates/iota-graphql-rpc/src/types/move_value.rs
@@ -489,10 +489,10 @@ mod tests {
         ($type:literal { $($name:literal : $layout:expr),* $(,)?}) => {
             A::MoveTypeLayout::Struct(Box::new(S {
                 type_: StructTag::from_str($type).expect("Failed to parse struct"),
-                fields: Box::new(vec![$(MoveFieldLayout {
+                fields: vec![$(MoveFieldLayout {
                     name: ident_str!($name).to_owned(),
                     layout: $layout,
-                }),*])
+                }),*]
             }))
         }
     }

--- a/crates/iota-json/src/tests.rs
+++ b/crates/iota-json/src/tests.rs
@@ -636,10 +636,10 @@ fn test_iota_call_arg_string_type() {
             name: STD_ASCII_STRUCT_NAME.into(),
             type_params: vec![],
         },
-        fields: Box::new(vec![MoveFieldLayout {
+        fields: vec![MoveFieldLayout {
             name: ident_str!("bytes").into(),
             layout: MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
-        }]),
+        }],
     })));
     let v = IotaJsonValue::from_bcs_bytes(string_layout.as_ref(), &arg1).unwrap();
 
@@ -657,10 +657,10 @@ fn test_iota_call_arg_option_type() {
             name: STD_ASCII_STRUCT_NAME.into(),
             type_params: vec![],
         },
-        fields: Box::new(vec![MoveFieldLayout {
+        fields: vec![MoveFieldLayout {
             name: ident_str!("bytes").into(),
             layout: MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
-        }]),
+        }],
     }));
 
     let option_layout = MoveTypeLayout::Struct(Box::new(MoveStructLayout {
@@ -670,10 +670,10 @@ fn test_iota_call_arg_option_type() {
             name: STD_OPTION_STRUCT_NAME.into(),
             type_params: vec![],
         },
-        fields: Box::new(vec![MoveFieldLayout {
+        fields: vec![MoveFieldLayout {
             name: ident_str!("vec").into(),
             layout: MoveTypeLayout::Vector(Box::new(string_layout.clone())),
-        }]),
+        }],
     }));
 
     let v = IotaJsonValue::from_bcs_bytes(Some(option_layout).as_ref(), &arg1).unwrap();
@@ -720,10 +720,10 @@ fn test_convert_string_vec() {
             name: STD_ASCII_STRUCT_NAME.into(),
             type_params: vec![],
         },
-        fields: Box::new(vec![MoveFieldLayout {
+        fields: vec![MoveFieldLayout {
             name: ident_str!("bytes").into(),
             layout: MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
-        }]),
+        }],
     }));
 
     let layout = MoveTypeLayout::Vector(Box::new(string_layout));
@@ -755,10 +755,10 @@ fn test_string_vec_df_name_child_id_eq() {
             name: STD_ASCII_STRUCT_NAME.into(),
             type_params: vec![],
         },
-        fields: Box::new(vec![MoveFieldLayout {
+        fields: vec![MoveFieldLayout {
             name: ident_str!("bytes").into(),
             layout: MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
-        }]),
+        }],
     }));
 
     let layout = MoveTypeLayout::Struct(Box::new(MoveStructLayout {
@@ -768,10 +768,10 @@ fn test_string_vec_df_name_child_id_eq() {
             name: STD_ASCII_STRUCT_NAME.into(),
             type_params: vec![],
         },
-        fields: Box::new(vec![MoveFieldLayout::new(
+        fields: vec![MoveFieldLayout::new(
             Identifier::from_str("labels").unwrap(),
             MoveTypeLayout::Vector(Box::new(string_layout)),
-        )]),
+        )],
     }));
 
     let iota_json = IotaJsonValue::new(name).unwrap();

--- a/crates/iota-open-rpc/src/examples.rs
+++ b/crates/iota-open-rpc/src/examples.rs
@@ -1201,7 +1201,7 @@ impl RpcExampleProvider {
                     },
                     MoveStructLayout {
                         type_: struct_tag,
-                        fields: Box::new(Vec::new()),
+                        fields: Vec::new(),
                     },
                 )
                 .unwrap(),

--- a/crates/iota-package-resolver/src/lib.rs
+++ b/crates/iota-package-resolver/src/lib.rs
@@ -1505,7 +1505,7 @@ impl<'l> ResolutionContext<'l> {
                 (
                     MoveTypeLayout::Struct(Box::new(MoveStructLayout {
                         type_,
-                        fields: Box::new(resolved_fields),
+                        fields: resolved_fields,
                     })),
                     field_depth + 1,
                 )

--- a/crates/iota-types/src/balance.rs
+++ b/crates/iota-types/src/balance.rs
@@ -86,10 +86,10 @@ impl Balance {
     pub fn layout(type_param: TypeTag) -> MoveStructLayout {
         MoveStructLayout {
             type_: Self::type_(type_param),
-            fields: Box::new(vec![MoveFieldLayout::new(
+            fields: vec![MoveFieldLayout::new(
                 ident_str!("value").to_owned(),
                 MoveTypeLayout::U64,
-            )]),
+            )],
         }
     }
 }

--- a/crates/iota-types/src/base_types.rs
+++ b/crates/iota-types/src/base_types.rs
@@ -973,10 +973,10 @@ pub fn move_ascii_str_layout() -> A::MoveStructLayout {
             name: STD_ASCII_STRUCT_NAME.to_owned(),
             type_params: vec![],
         },
-        fields: Box::new(vec![A::MoveFieldLayout::new(
+        fields: vec![A::MoveFieldLayout::new(
             ident_str!("bytes").into(),
             A::MoveTypeLayout::Vector(Box::new(A::MoveTypeLayout::U8)),
-        )]),
+        )],
     }
 }
 
@@ -988,10 +988,10 @@ pub fn move_utf8_str_layout() -> A::MoveStructLayout {
             name: STD_UTF8_STRUCT_NAME.to_owned(),
             type_params: vec![],
         },
-        fields: Box::new(vec![A::MoveFieldLayout::new(
+        fields: vec![A::MoveFieldLayout::new(
             ident_str!("bytes").into(),
             A::MoveTypeLayout::Vector(Box::new(A::MoveTypeLayout::U8)),
-        )]),
+        )],
     }
 }
 

--- a/crates/iota-types/src/coin.rs
+++ b/crates/iota-types/src/coin.rs
@@ -99,7 +99,7 @@ impl Coin {
     pub fn layout(type_param: TypeTag) -> MoveStructLayout {
         MoveStructLayout {
             type_: Self::type_(type_param.clone()),
-            fields: Box::new(vec![
+            fields: vec![
                 MoveFieldLayout::new(
                     ident_str!("id").to_owned(),
                     MoveTypeLayout::Struct(Box::new(UID::layout())),
@@ -108,7 +108,7 @@ impl Coin {
                     ident_str!("balance").to_owned(),
                     MoveTypeLayout::Struct(Box::new(Balance::layout(type_param))),
                 ),
-            ]),
+            ],
         }
     }
 

--- a/crates/iota-types/src/id.rs
+++ b/crates/iota-types/src/id.rs
@@ -61,10 +61,10 @@ impl UID {
     pub fn layout() -> MoveStructLayout {
         MoveStructLayout {
             type_: Self::type_(),
-            fields: Box::new(vec![MoveFieldLayout::new(
+            fields: vec![MoveFieldLayout::new(
                 ident_str!("id").to_owned(),
                 MoveTypeLayout::Struct(Box::new(ID::layout())),
-            )]),
+            )],
         }
     }
 }
@@ -86,10 +86,10 @@ impl ID {
     pub fn layout() -> MoveStructLayout {
         MoveStructLayout {
             type_: Self::type_(),
-            fields: Box::new(vec![MoveFieldLayout::new(
+            fields: vec![MoveFieldLayout::new(
                 ident_str!("bytes").to_owned(),
                 MoveTypeLayout::Address,
-            )]),
+            )],
         }
     }
 }

--- a/crates/iota-types/src/object/balance_traversal.rs
+++ b/crates/iota-types/src/object/balance_traversal.rs
@@ -290,10 +290,7 @@ mod tests {
             .map(|(name, layout)| A::MoveFieldLayout::new(Identifier::new(name).unwrap(), layout))
             .collect();
 
-        A::MoveTypeLayout::Struct(Box::new(A::MoveStructLayout {
-            type_,
-            fields: Box::new(fields),
-        }))
+        A::MoveTypeLayout::Struct(Box::new(A::MoveStructLayout { type_, fields }))
     }
 
     /// BCS encode Move value.

--- a/crates/iota-types/src/object/bounded_visitor.rs
+++ b/crates/iota-types/src/object/bounded_visitor.rs
@@ -514,10 +514,7 @@ pub(crate) mod tests {
             .map(|(name, layout)| A::MoveFieldLayout::new(ident_(name), layout))
             .collect();
 
-        A::MoveTypeLayout::Struct(Box::new(A::MoveStructLayout {
-            type_,
-            fields: Box::new(fields),
-        }))
+        A::MoveTypeLayout::Struct(Box::new(A::MoveStructLayout { type_, fields }))
     }
 
     /// Create a variant value for test purposes.

--- a/external-crates/move/crates/move-bytecode-utils/src/layout.rs
+++ b/external-crates/move/crates/move-bytecode-utils/src/layout.rs
@@ -588,10 +588,7 @@ impl DatatypeLayoutBuilder {
                     .zip(layouts)
                     .map(|(name, layout)| A::MoveFieldLayout::new(name, layout))
                     .collect();
-                Ok(A::MoveStructLayout {
-                    type_,
-                    fields: Box::new(fields),
-                })
+                Ok(A::MoveStructLayout { type_, fields })
             }
         }
     }

--- a/external-crates/move/crates/move-core-types/src/annotated_value.rs
+++ b/external-crates/move/crates/move-core-types/src/annotated_value.rs
@@ -98,7 +98,7 @@ pub struct MoveStructLayout {
     /// An decorated representation with both types and human-readable field
     /// names
     pub type_: StructTag,
-    pub fields: Box<Vec<MoveFieldLayout>>,
+    pub fields: Vec<MoveFieldLayout>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -356,10 +356,7 @@ impl MoveVariant {
 
 impl MoveStructLayout {
     pub fn new(type_: StructTag, fields: Vec<MoveFieldLayout>) -> Self {
-        Self {
-            type_,
-            fields: Box::new(fields),
-        }
+        Self { type_, fields }
     }
 
     pub fn into_fields(self) -> Vec<MoveTypeLayout> {

--- a/external-crates/move/crates/move-core-types/src/unit_tests/value_test.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/value_test.rs
@@ -45,14 +45,12 @@ fn struct_deserialization() {
 
     let struct_type_layout = A::MoveStructLayout {
         type_: struct_type.clone(),
-        fields: Box::new(
-            vec![
-                A::MoveFieldLayout::new(ident_str!("f").to_owned(), A::MoveTypeLayout::U64),
-                A::MoveFieldLayout::new(ident_str!("g").to_owned(), A::MoveTypeLayout::Bool),
-            ]
-            .into_iter()
-            .collect(),
-        ),
+        fields: vec![
+            A::MoveFieldLayout::new(ident_str!("f").to_owned(), A::MoveTypeLayout::U64),
+            A::MoveFieldLayout::new(ident_str!("g").to_owned(), A::MoveTypeLayout::Bool),
+        ]
+        .into_iter()
+        .collect(),
     };
 
     let deser_typed_value = A::MoveValue::simple_deserialize(

--- a/external-crates/move/crates/move-core-types/src/unit_tests/visitor_test.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/visitor_test.rs
@@ -1075,10 +1075,7 @@ pub(crate) fn struct_layout_(rep: &str, fields: Vec<(&str, MoveTypeLayout)>) -> 
         .map(|(name, layout)| MoveFieldLayout::new(Identifier::new(name).unwrap(), layout))
         .collect();
 
-    MoveTypeLayout::Struct(Box::new(MoveStructLayout {
-        type_,
-        fields: Box::new(fields),
-    }))
+    MoveTypeLayout::Struct(Box::new(MoveStructLayout { type_, fields }))
 }
 
 /// Create a variant value for test purposes.


### PR DESCRIPTION
## Description 

The `MoveFieldLayout` struct `fields` was wrapped in a box as part of https://github.com/MystenLabs/sui/pull/19310, which states in its reasoning:

> Boxes fields in the MoveTypeLayout to make the enum size smaller for type layouts.

However, this field being boxed does not affect the enums which this was referring to as it is also boxed in the variants. This means that the variant size of those enums is always the size of a pointer. Thus, this
additional box around the vec serves only to create an additional indirection.

Upstream PR: https://github.com/MystenLabs/sui/pull/21249
