### PR TITLE
feat(consensus): linearizer to use commit up to gc round

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -491,6 +491,11 @@ mod tests {
         let (committee, keypairs) = local_committee_and_keys(0, [1; NUM_OF_AUTHORITIES].to_vec());
         let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
         protocol_config.set_consensus_gc_depth_for_testing(gc_depth);
+
+        if gc_depth == 0 {
+            protocol_config.set_consensus_linearize_subdag_v2_for_testing(false);
+        }
+
         let temp_dirs = (0..NUM_OF_AUTHORITIES)
             .map(|_| TempDir::new().unwrap())
             .collect::<Vec<_>>();
@@ -597,6 +602,10 @@ mod tests {
 
         let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
         protocol_config.set_consensus_gc_depth_for_testing(gc_depth);
+
+        if gc_depth == 0 {
+            protocol_config.set_consensus_linearize_subdag_v2_for_testing(false);
+        }
 
         for (index, _authority_info) in committee.authorities() {
             let dir = TempDir::new().unwrap();

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -57,8 +57,12 @@ impl CommitObserver {
         leader_schedule: Arc<LeaderSchedule>,
     ) -> Self {
         let mut observer = Self {
+            commit_interpreter: Linearizer::new(
+                context.clone(),
+                dag_state.clone(),
+                leader_schedule.clone(),
+            ),
             context,
-            commit_interpreter: Linearizer::new(dag_state.clone(), leader_schedule.clone()),
             sender: commit_consumer.sender,
             store,
             leader_schedule,

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -1693,275 +1693,274 @@ mod test {
         assert_eq!(result, expected);
     }
 
-
     #[tokio::test]
     async fn test_flush_and_recovery() {
-    telemetry_subscribers::init_for_testing();
-    let num_authorities: u32 = 4;
-    let (context, _) = Context::new_for_test(num_authorities as usize);
-    let context = Arc::new(context);
-    let store = Arc::new(MemStore::new());
-    let mut dag_state = DagState::new(context.clone(), store.clone());
+        telemetry_subscribers::init_for_testing();
+        let num_authorities: u32 = 4;
+        let (context, _) = Context::new_for_test(num_authorities as usize);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let mut dag_state = DagState::new(context.clone(), store.clone());
 
-    // Create test blocks and commits for round 1 ~ 10
-    let num_rounds: u32 = 10;
-    let mut dag_builder = DagBuilder::new(context.clone());
-    dag_builder.layers(1..=num_rounds).build();
-    let mut commits = vec![];
-    for (_subdag, commit) in dag_builder.get_sub_dag_and_commits(1..=num_rounds)
-    { commits.push(commit);
-    }
+        // Create test blocks and commits for round 1 ~ 10
+        let num_rounds: u32 = 10;
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=num_rounds).build();
+        let mut commits = vec![];
+        for (_subdag, commit) in dag_builder.get_sub_dag_and_commits(1..=num_rounds) {
+            commits.push(commit);
+        }
 
-    // Add the blocks from first 5 rounds and first 5 commits to the dag state
-    let temp_commits = commits.split_off(5);
-    dag_state.accept_blocks(dag_builder.blocks(1..=5));
-    for commit in commits.clone() {
-    dag_state.add_commit(commit);
-    }
+        // Add the blocks from first 5 rounds and first 5 commits to the dag state
+        let temp_commits = commits.split_off(5);
+        dag_state.accept_blocks(dag_builder.blocks(1..=5));
+        for commit in commits.clone() {
+            dag_state.add_commit(commit);
+        }
 
-    // Flush the dag state
-    dag_state.flush();
+        // Flush the dag state
+        dag_state.flush();
 
-    // Add the rest of the blocks and commits to the dag state
-    dag_state.accept_blocks(dag_builder.blocks(6..=num_rounds));
-    for commit in temp_commits.clone() {
-    dag_state.add_commit(commit);
-    }
+        // Add the rest of the blocks and commits to the dag state
+        dag_state.accept_blocks(dag_builder.blocks(6..=num_rounds));
+        for commit in temp_commits.clone() {
+            dag_state.add_commit(commit);
+        }
 
-    // All blocks should be found in DagState.
-    let all_blocks = dag_builder.blocks(6..=num_rounds);
-    let block_refs = all_blocks
-    .iter()
-    .map(|block| block.reference())
-    .collect::<Vec<_>>();
-    let result = dag_state
-    .get_blocks(&block_refs)
-    .into_iter()
-    .map(|b| b.unwrap())
-    .collect::<Vec<_>>();
-    assert_eq!(result, all_blocks);
+        // All blocks should be found in DagState.
+        let all_blocks = dag_builder.blocks(6..=num_rounds);
+        let block_refs = all_blocks
+            .iter()
+            .map(|block| block.reference())
+            .collect::<Vec<_>>();
+        let result = dag_state
+            .get_blocks(&block_refs)
+            .into_iter()
+            .map(|b| b.unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(result, all_blocks);
 
-    // Last commit index should be 10.
-    assert_eq!(dag_state.last_commit_index(), 10);
-    assert_eq!(
-    dag_state.last_committed_rounds(),
-    dag_builder.last_committed_rounds.clone()
-    );
+        // Last commit index should be 10.
+        assert_eq!(dag_state.last_commit_index(), 10);
+        assert_eq!(
+            dag_state.last_committed_rounds(),
+            dag_builder.last_committed_rounds.clone()
+        );
 
-    // Destroy the dag state.
-    drop(dag_state);
+        // Destroy the dag state.
+        drop(dag_state);
 
-    // Recover the state from the store
-    let dag_state = DagState::new(context.clone(), store.clone());
+        // Recover the state from the store
+        let dag_state = DagState::new(context.clone(), store.clone());
 
-    // Blocks of first 5 rounds should be found in DagState.
-    let blocks = dag_builder.blocks(1..=5);
-    let block_refs = blocks
-    .iter()
-    .map(|block| block.reference())
-    .collect::<Vec<_>>();
-    let result = dag_state
-    .get_blocks(&block_refs)
-    .into_iter()
-    .map(|b| b.unwrap())
-    .collect::<Vec<_>>();
-    assert_eq!(result, blocks);
+        // Blocks of first 5 rounds should be found in DagState.
+        let blocks = dag_builder.blocks(1..=5);
+        let block_refs = blocks
+            .iter()
+            .map(|block| block.reference())
+            .collect::<Vec<_>>();
+        let result = dag_state
+            .get_blocks(&block_refs)
+            .into_iter()
+            .map(|b| b.unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(result, blocks);
 
-    // Blocks above round 5 should not be in DagState, because they are not flushed.
-    let missing_blocks = dag_builder.blocks(6..=num_rounds);
-    let block_refs = missing_blocks
-    .iter()
-    .map(|block| block.reference())
-    .collect::<Vec<_>>();
-    let retrieved_blocks = dag_state
-    .get_blocks(&block_refs)
-    .into_iter()
-    .flatten()
-    .collect::<Vec<_>>();
-    assert!(retrieved_blocks.is_empty());
+        // Blocks above round 5 should not be in DagState, because they are not flushed.
+        let missing_blocks = dag_builder.blocks(6..=num_rounds);
+        let block_refs = missing_blocks
+            .iter()
+            .map(|block| block.reference())
+            .collect::<Vec<_>>();
+        let retrieved_blocks = dag_state
+            .get_blocks(&block_refs)
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        assert!(retrieved_blocks.is_empty());
 
-    // Last commit index should be 5.
-    assert_eq!(dag_state.last_commit_index(), 5);
+        // Last commit index should be 5.
+        assert_eq!(dag_state.last_commit_index(), 5);
 
-    // This is the last_commit_rounds of the first 5 commits that were flushed
-    let expected_last_committed_rounds = vec![4, 5, 4, 4];
-    assert_eq!(
-    dag_state.last_committed_rounds(),
-    expected_last_committed_rounds
-    );
-    // Unscored subdags will be recovered based on the flushed commits and no commit
-    // info
-    assert_eq!(dag_state.scoring_subdags_count(), 5);
+        // This is the last_commit_rounds of the first 5 commits that were flushed
+        let expected_last_committed_rounds = vec![4, 5, 4, 4];
+        assert_eq!(
+            dag_state.last_committed_rounds(),
+            expected_last_committed_rounds
+        );
+        // Unscored subdags will be recovered based on the flushed commits and no commit
+        // info
+        assert_eq!(dag_state.scoring_subdags_count(), 5);
     }
 
     #[tokio::test]
     async fn test_flush_and_recovery_gc_enabled() {
-    telemetry_subscribers::init_for_testing();
+        telemetry_subscribers::init_for_testing();
 
-    const GC_DEPTH: u32 = 3;
-    const CACHED_ROUNDS: u32 = 4;
+        const GC_DEPTH: u32 = 3;
+        const CACHED_ROUNDS: u32 = 4;
 
-    let num_authorities: u32 = 4;
-    let (mut context, _) = Context::new_for_test(num_authorities as usize);
-    context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
-    context
-    .protocol_config
-    .set_consensus_gc_depth_for_testing(GC_DEPTH);
-    context
-    .protocol_config
-    .set_consensus_linearize_subdag_v2_for_testing(true);
+        let num_authorities: u32 = 4;
+        let (mut context, _) = Context::new_for_test(num_authorities as usize);
+        context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
+        context
+            .protocol_config
+            .set_consensus_gc_depth_for_testing(GC_DEPTH);
+        context
+            .protocol_config
+            .set_consensus_linearize_subdag_v2_for_testing(true);
 
-    let context = Arc::new(context);
+        let context = Arc::new(context);
 
-    let store = Arc::new(MemStore::new());
-    let mut dag_state = DagState::new(context.clone(), store.clone());
+        let store = Arc::new(MemStore::new());
+        let mut dag_state = DagState::new(context.clone(), store.clone());
 
-    let num_rounds: u32 = 10;
-    let mut dag_builder = DagBuilder::new(context.clone());
-    dag_builder.layers(1..=5).build();
-    dag_builder
-    .layers(6..=8)
-    .authorities(vec![AuthorityIndex::new_for_test(0)])
-    .skip_block()
-    .build();
-    dag_builder.layers(9..=num_rounds).build();
+        let num_rounds: u32 = 10;
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=5).build();
+        dag_builder
+            .layers(6..=8)
+            .authorities(vec![AuthorityIndex::new_for_test(0)])
+            .skip_block()
+            .build();
+        dag_builder.layers(9..=num_rounds).build();
 
-    let mut commits = dag_builder
-                .get_sub_dag_and_commits(1..=num_rounds)
-                .into_iter()
-                .map(|(_subdag, commit)| commit)
-                .collect::<Vec<_>>();
+        let mut commits = dag_builder
+            .get_sub_dag_and_commits(1..=num_rounds)
+            .into_iter()
+            .map(|(_subdag, commit)| commit)
+            .collect::<Vec<_>>();
 
-    // Add the blocks from first 8 rounds and first 7 commits to the dag state
-    // It's 7 commits because we missing the commit of round 8 where authority 0 is
-    // the leader, but produced no block
-    let temp_commits = commits.split_off(7);
-    dag_state.accept_blocks(dag_builder.blocks(1..=8));
-    for commit in commits.clone() {
-    dag_state.add_commit(commit);
-    }
+        // Add the blocks from first 8 rounds and first 7 commits to the dag state
+        // It's 7 commits because we missing the commit of round 8 where authority 0 is
+        // the leader, but produced no block
+        let temp_commits = commits.split_off(7);
+        dag_state.accept_blocks(dag_builder.blocks(1..=8));
+        for commit in commits.clone() {
+            dag_state.add_commit(commit);
+        }
 
-    // Holds all the committed blocks from the commits that ended up being persisted
-    // (flushed). Any commits that not flushed will not be considered.
-    let mut all_committed_blocks = BTreeSet::<BlockRef>::new();
-    for commit in commits.iter() {
-    all_committed_blocks.extend(commit.blocks());
-    }
-    // Flush the dag state
-    dag_state.flush();
+        // Holds all the committed blocks from the commits that ended up being persisted
+        // (flushed). Any commits that not flushed will not be considered.
+        let mut all_committed_blocks = BTreeSet::<BlockRef>::new();
+        for commit in commits.iter() {
+            all_committed_blocks.extend(commit.blocks());
+        }
+        // Flush the dag state
+        dag_state.flush();
 
-    // Add the rest of the blocks and commits to the dag state
-    dag_state.accept_blocks(dag_builder.blocks(9..=num_rounds));
-    for commit in temp_commits.clone() {
-    dag_state.add_commit(commit);
-    }
+        // Add the rest of the blocks and commits to the dag state
+        dag_state.accept_blocks(dag_builder.blocks(9..=num_rounds));
+        for commit in temp_commits.clone() {
+            dag_state.add_commit(commit);
+        }
 
-    // All blocks should be found in DagState.
-    let all_blocks = dag_builder.blocks(1..=num_rounds);
-    let block_refs = all_blocks
-    .iter()
-    .map(|block| block.reference())
-    .collect::<Vec<_>>();
-    let result = dag_state
-    .get_blocks(&block_refs)
-    .into_iter()
-    .map(|b| b.unwrap())
-    .collect::<Vec<_>>();
-    assert_eq!(result, all_blocks);
+        // All blocks should be found in DagState.
+        let all_blocks = dag_builder.blocks(1..=num_rounds);
+        let block_refs = all_blocks
+            .iter()
+            .map(|block| block.reference())
+            .collect::<Vec<_>>();
+        let result = dag_state
+            .get_blocks(&block_refs)
+            .into_iter()
+            .map(|b| b.unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(result, all_blocks);
 
-    // Last commit index should be 9
-    assert_eq!(dag_state.last_commit_index(), 9);
-    assert_eq!(
-    dag_state.last_committed_rounds(),
-    dag_builder.last_committed_rounds.clone()
-    );
+        // Last commit index should be 9
+        assert_eq!(dag_state.last_commit_index(), 9);
+        assert_eq!(
+            dag_state.last_committed_rounds(),
+            dag_builder.last_committed_rounds.clone()
+        );
 
-    // Destroy the dag state.
-    drop(dag_state);
+        // Destroy the dag state.
+        drop(dag_state);
 
-    // Recover the state from the store
-    let dag_state = DagState::new(context.clone(), store.clone());
+        // Recover the state from the store
+        let dag_state = DagState::new(context.clone(), store.clone());
 
-    // Blocks of first 5 rounds should be found in DagState.
-    let blocks = dag_builder.blocks(1..=5);
-    let block_refs = blocks
-    .iter()
-    .map(|block| block.reference())
-    .collect::<Vec<_>>();
-    let result = dag_state
-    .get_blocks(&block_refs)
-    .into_iter()
-    .map(|b| b.unwrap())
-    .collect::<Vec<_>>();
-    assert_eq!(result, blocks);
+        // Blocks of first 5 rounds should be found in DagState.
+        let blocks = dag_builder.blocks(1..=5);
+        let block_refs = blocks
+            .iter()
+            .map(|block| block.reference())
+            .collect::<Vec<_>>();
+        let result = dag_state
+            .get_blocks(&block_refs)
+            .into_iter()
+            .map(|b| b.unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(result, blocks);
 
-    // Blocks above round 9 should not be in DagState, because they are not flushed.
-    let missing_blocks = dag_builder.blocks(9..=num_rounds);
-    let block_refs = missing_blocks
-    .iter()
-    .map(|block| block.reference())
-    .collect::<Vec<_>>();
-    let retrieved_blocks = dag_state
-    .get_blocks(&block_refs)
-    .into_iter()
-    .flatten()
-    .collect::<Vec<_>>();
-    assert!(retrieved_blocks.is_empty());
+        // Blocks above round 9 should not be in DagState, because they are not flushed.
+        let missing_blocks = dag_builder.blocks(9..=num_rounds);
+        let block_refs = missing_blocks
+            .iter()
+            .map(|block| block.reference())
+            .collect::<Vec<_>>();
+        let retrieved_blocks = dag_state
+            .get_blocks(&block_refs)
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        assert!(retrieved_blocks.is_empty());
 
-    // Last commit index should be 7.
-     assert_eq!(dag_state.last_commit_index(), 7);
+        // Last commit index should be 7.
+        assert_eq!(dag_state.last_commit_index(), 7);
 
-    // This is the last_commit_rounds of the first 7 commits that were flushed
-     let expected_last_committed_rounds = vec![5, 6, 6, 7];
-     assert_eq!(
-     dag_state.last_committed_rounds(),
-     expected_last_committed_rounds
-     );
-    // Unscored subdags will be recoverd based on the flushed commits and no commit
-    // info
-     assert_eq!(dag_state.scoring_subdags_count(), 7);
-    //
-    // Ensure that cached blocks exist only for specific rounds per authority
-     for (authority_index, _) in context.committee.authorities() {
-     let blocks = dag_state.get_cached_blocks(authority_index, 1);
+        // This is the last_commit_rounds of the first 7 commits that were flushed
+        let expected_last_committed_rounds = vec![5, 6, 6, 7];
+        assert_eq!(
+            dag_state.last_committed_rounds(),
+            expected_last_committed_rounds
+        );
+        // Unscored subdags will be recoverd based on the flushed commits and no commit
+        // info
+        assert_eq!(dag_state.scoring_subdags_count(), 7);
+        // Ensure that cached blocks exist only for specific rounds per authority
+        for (authority_index, _) in context.committee.authorities() {
+            let blocks = dag_state.get_cached_blocks(authority_index, 1);
 
-    // Ensure that eviction rounds have been properly recovered
-    // DagState should hold cached blocks for authority 0 for rounds [2..=5] as no
-    // higher blocks exist and due to CACHED_ROUNDS = 4 we want at max
-    // to hold blocks for 4 rounds in cache.
-     if authority_index == AuthorityIndex::new_for_test(0) {
-     assert_eq!(blocks.len(), 4);
-     assert_eq!(dag_state.evicted_rounds[authority_index.value()], 1);
-     assert!(
-     blocks
-     .into_iter()
-     .all(|block| block.round() >= 2 && block.round() <= 5)
-     );
-     } else {
-     assert_eq!(blocks.len(), 4);
-     assert_eq!(dag_state.evicted_rounds[authority_index.value()], 4);
-     assert!(
-     blocks
-     .into_iter()
-     .all(|block| block.round() >= 5 && block.round() <= 8)
-     );
-     }
-     }
-    // Ensure that committed blocks from > gc_round have been correctly marked as
-    // committed according to committed sub dags
-    let gc_round =
-     dag_state.gc_round(); assert_eq!(gc_round, 4);
-     dag_state
-    .recent_blocks
-    .iter()
-    .for_each(|(block_ref, block_info)| {
-     if block_ref.round > gc_round && all_committed_blocks.contains(block_ref) {
-     assert!(
-     block_info.committed,
-    "Block {:?} should be committed",
-     block_ref
-    );
-    });
+            // Ensure that eviction rounds have been properly recovered
+            // DagState should hold cached blocks for authority 0 for rounds [2..=5] as no
+            // higher blocks exist and due to CACHED_ROUNDS = 4 we want at max
+            // to hold blocks for 4 rounds in cache.
+            if authority_index == AuthorityIndex::new_for_test(0) {
+                assert_eq!(blocks.len(), 4);
+                assert_eq!(dag_state.evicted_rounds[authority_index.value()], 1);
+                assert!(
+                    blocks
+                        .into_iter()
+                        .all(|block| block.round() >= 2 && block.round() <= 5)
+                );
+            } else {
+                assert_eq!(blocks.len(), 4);
+                assert_eq!(dag_state.evicted_rounds[authority_index.value()], 4);
+                assert!(
+                    blocks
+                        .into_iter()
+                        .all(|block| block.round() >= 5 && block.round() <= 8)
+                );
+            }
+        }
+        // Ensure that committed blocks from > gc_round have been correctly marked as
+        // committed according to committed sub dags
+        let gc_round = dag_state.gc_round();
+        assert_eq!(gc_round, 4);
+        dag_state
+            .recent_blocks
+            .iter()
+            .for_each(|(block_ref, block_info)| {
+                if block_ref.round > gc_round && all_committed_blocks.contains(block_ref) {
+                    assert!(
+                        block_info.committed,
+                        "Block {:?} should be committed",
+                        block_ref
+                    );
+                };
+            });
     }
 
     #[tokio::test]

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -1693,6 +1693,121 @@ mod test {
         assert_eq!(result, expected);
     }
 
+    // TODO: Remove when DistributedVoteScoring is enabled.
+    #[rstest]
+    #[tokio::test]
+    async fn test_flush_and_recovery_with_unscored_subdag(#[values(0, 5)] gc_depth: u32) {
+        telemetry_subscribers::init_for_testing();
+        let num_authorities: u32 = 4;
+        let (mut context, _) = Context::new_for_test(num_authorities as usize);
+        context
+            .protocol_config
+            .set_consensus_distributed_vote_scoring_strategy_for_testing(false);
+
+        if gc_depth > 0 {
+            context
+                .protocol_config
+                .set_consensus_gc_depth_for_testing(gc_depth);
+        }
+
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let mut dag_state = DagState::new(context.clone(), store.clone());
+
+        // Create test blocks and commits for round 1 ~ 10
+        let num_rounds: u32 = 10;
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=num_rounds).build();
+        let mut commits = vec![];
+
+        for (_subdag, commit) in dag_builder.get_sub_dag_and_commits(1..=num_rounds) {
+            commits.push(commit);
+        }
+
+        // Add the blocks from first 5 rounds and first 5 commits to the dag state
+        let temp_commits = commits.split_off(5);
+        dag_state.accept_blocks(dag_builder.blocks(1..=5));
+        for commit in commits.clone() {
+            dag_state.add_commit(commit);
+        }
+
+        // Flush the dag state
+        dag_state.flush();
+
+        // Add the rest of the blocks and commits to the dag state
+        dag_state.accept_blocks(dag_builder.blocks(6..=num_rounds));
+        for commit in temp_commits.clone() {
+            dag_state.add_commit(commit);
+        }
+
+        // All blocks should be found in DagState.
+        let all_blocks = dag_builder.blocks(6..=num_rounds);
+        let block_refs = all_blocks
+            .iter()
+            .map(|block| block.reference())
+            .collect::<Vec<_>>();
+
+        let result = dag_state
+            .get_blocks(&block_refs)
+            .into_iter()
+            .map(|b| b.unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(result, all_blocks);
+
+        // Last commit index should be 10.
+        assert_eq!(dag_state.last_commit_index(), 10);
+        assert_eq!(
+            dag_state.last_committed_rounds(),
+            dag_builder.last_committed_rounds.clone()
+        );
+
+        // Destroy the dag state.
+        drop(dag_state);
+
+        // Recover the state from the store
+        let dag_state = DagState::new(context.clone(), store.clone());
+
+        // Blocks of first 5 rounds should be found in DagState.
+        let blocks = dag_builder.blocks(1..=5);
+        let block_refs = blocks
+            .iter()
+            .map(|block| block.reference())
+            .collect::<Vec<_>>();
+        let result = dag_state
+            .get_blocks(&block_refs)
+            .into_iter()
+            .map(|b| b.unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(result, blocks);
+
+        // Blocks above round 5 should not be in DagState, because they are not flushed.
+        let missing_blocks = dag_builder.blocks(6..=num_rounds);
+        let block_refs = missing_blocks
+            .iter()
+            .map(|block| block.reference())
+            .collect::<Vec<_>>();
+        let retrieved_blocks = dag_state
+            .get_blocks(&block_refs)
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        assert!(retrieved_blocks.is_empty());
+
+        // Last commit index should be 5.
+        assert_eq!(dag_state.last_commit_index(), 5);
+
+        // This is the last_commit_rounds of the first 5 commits that were flushed
+        let expected_last_committed_rounds = vec![4, 5, 4, 4];
+        assert_eq!(
+            dag_state.last_committed_rounds(),
+            expected_last_committed_rounds
+        );
+
+        // Unscored subdags will be recovered based on the flushed commits and no commit
+        // info
+        assert_eq!(dag_state.unscored_committed_subdags_count(), 5);
+    }
+
     #[tokio::test]
     async fn test_flush_and_recovery() {
         telemetry_subscribers::init_for_testing();

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -55,7 +55,7 @@ pub(crate) struct DagState {
     // than or equal to both `gc_round`, and `highest authority round - cached rounds`.
     // This ensures that the GC requirements are respected (we never clean up any block above
     // `gc_round`), and there are enough blocks cached.
-    recent_blocks: BTreeMap<BlockRef, VerifiedBlock>,
+    recent_blocks: BTreeMap<BlockRef, BlockInfo>,
 
     // Indexes recent block refs by their authorities.
     // Vec position corresponds to the authority index.
@@ -174,7 +174,7 @@ impl DagState {
             recent_blocks: BTreeMap::new(),
             recent_refs_by_authority: vec![BTreeSet::new(); num_authorities],
             highest_accepted_round: 0,
-            last_commit,
+            last_commit: last_commit.clone(),
             last_commit_round_advancement_time: None,
             last_committed_rounds: last_committed_rounds.clone(),
             pending_commit_votes: VecDeque::new(),
@@ -183,7 +183,7 @@ impl DagState {
             commit_info_to_write: vec![],
             scoring_subdag,
             unscored_committed_subdags,
-            store,
+            store: store.clone(),
             cached_rounds,
             evicted_rounds: vec![0; num_authorities],
         };
@@ -237,6 +237,55 @@ impl DagState {
                     .map(|b| b.reference())
                     .collect::<Vec<BlockRef>>()
             );
+        }
+
+        if state.gc_enabled() {
+            if let Some(last_commit) = last_commit {
+                let mut index = last_commit.index();
+                let gc_round = state.gc_round();
+                info!(
+                    "Recovering block commit statuses from commit index {} and backwards until leader of round <= gc_round {:?}",
+                    index, gc_round
+                );
+
+                loop {
+                    let commits = store
+                        .scan_commits((index..=index).into())
+                        .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e));
+                    let Some(commit) = commits.first() else {
+                        info!(
+                            "Recovering finished up to index {index}, no more commits to recover"
+                        );
+                        break;
+                    };
+
+                    // Check the commit leader round to see if it is within the gc_round. If it is
+                    // not then we can stop the recovery process.
+                    if gc_round > 0 && commit.leader().round <= gc_round {
+                        info!(
+                            "Recovering finished, reached commit leader round {} <= gc_round {}",
+                            commit.leader().round,
+                            gc_round
+                        );
+                        break;
+                    }
+
+                    commit.blocks().iter().filter(|b| b.round > gc_round).for_each(|block_ref|{
+                        debug!(
+                            "Setting block {:?} as committed based on commit {:?}",
+                            block_ref,
+                            commit.index()
+                        );
+                        assert!(state.set_committed(block_ref), "Attempted to set again a block {:?} as committed when recovering commit {:?}", block_ref, commit);
+                    });
+
+                    // All commits are indexed starting from 1, so one reach zero exit.
+                    index = index.saturating_sub(1);
+                    if index == 0 {
+                        break;
+                    }
+                }
+            }
         }
 
         state
@@ -293,7 +342,8 @@ impl DagState {
     /// Updates internal metadata for a block.
     fn update_block_metadata(&mut self, block: &VerifiedBlock) {
         let block_ref = block.reference();
-        self.recent_blocks.insert(block_ref, block.clone());
+        self.recent_blocks
+            .insert(block_ref, BlockInfo::new(block.clone()));
         self.recent_refs_by_authority[block_ref.author].insert(block_ref);
         self.highest_accepted_round = max(self.highest_accepted_round, block.round());
         self.context
@@ -349,8 +399,8 @@ impl DagState {
                 }
                 continue;
             }
-            if let Some(block) = self.recent_blocks.get(block_ref) {
-                blocks[index] = Some(block.clone());
+            if let Some(block_info) = self.recent_blocks.get(block_ref) {
+                blocks[index] = Some(block_info.block.clone());
                 continue;
             }
             missing.push((index, block_ref));
@@ -382,6 +432,31 @@ impl DagState {
         blocks
     }
 
+    // Sets the block as committed in the cache. If the block is set as committed
+    // for first time, then true is returned, otherwise false is returned instead.
+    // Method will panic if the block is not found in the cache.
+    pub(crate) fn set_committed(&mut self, block_ref: &BlockRef) -> bool {
+        if let Some(block_info) = self.recent_blocks.get_mut(block_ref) {
+            if !block_info.committed {
+                block_info.committed = true;
+                return true;
+            }
+            false
+        } else {
+            panic!(
+                "Block {:?} not found in cache to set as committed.",
+                block_ref
+            );
+        }
+    }
+
+    pub(crate) fn is_committed(&self, block_ref: &BlockRef) -> bool {
+        self.recent_blocks
+            .get(block_ref)
+            .unwrap_or_else(|| panic!("Attempted to query for commit status for a block not in cached data {block_ref}"))
+            .committed
+    }
+
     /// Gets all uncommitted blocks in a slot.
     /// Uncommitted blocks must exist in memory, so only in-memory blocks are
     /// checked.
@@ -391,11 +466,11 @@ impl DagState {
         // to edge cases.
 
         let mut blocks = vec![];
-        for (_block_ref, block) in self.recent_blocks.range((
+        for (_block_ref, block_info) in self.recent_blocks.range((
             Included(BlockRef::new(slot.round, slot.authority, BlockDigest::MIN)),
             Included(BlockRef::new(slot.round, slot.authority, BlockDigest::MAX)),
         )) {
-            blocks.push(block.clone())
+            blocks.push(block_info.block.clone())
         }
         blocks
     }
@@ -409,7 +484,7 @@ impl DagState {
         }
 
         let mut blocks = vec![];
-        for (_block_ref, block) in self.recent_blocks.range((
+        for (_block_ref, block_info) in self.recent_blocks.range((
             Included(BlockRef::new(round, AuthorityIndex::ZERO, BlockDigest::MIN)),
             Excluded(BlockRef::new(
                 round + 1,
@@ -417,7 +492,7 @@ impl DagState {
                 BlockDigest::MIN,
             )),
         )) {
-            blocks.push(block.clone())
+            blocks.push(block_info.block.clone())
         }
         blocks
     }
@@ -473,6 +548,7 @@ impl DagState {
                 .recent_blocks
                 .get(last)
                 .expect("Block should be found in recent blocks")
+                .block
                 .clone();
         }
 
@@ -500,11 +576,11 @@ impl DagState {
             Included(BlockRef::new(start, authority, BlockDigest::MIN)),
             Unbounded,
         )) {
-            let block = self
+            let block_info = self
                 .recent_blocks
                 .get(block_ref)
                 .expect("Block should exist in recent blocks");
-            blocks.push(block.clone());
+            blocks.push(block_info.block.clone());
         }
         blocks
     }
@@ -558,12 +634,12 @@ impl DagState {
                 ))
                 .next_back()
             {
-                let block = self
+                let block_info = self
                     .recent_blocks
                     .get(block_ref)
                     .expect("Block should exist in recent blocks");
 
-                blocks[authority_index] = block.clone();
+                blocks[authority_index] = block_info.block.clone();
             }
         }
 
@@ -1006,6 +1082,21 @@ impl DagState {
     #[cfg(test)]
     pub(crate) fn set_last_commit(&mut self, commit: TrustedCommit) {
         self.last_commit = Some(commit);
+    }
+}
+
+struct BlockInfo {
+    block: VerifiedBlock,
+    // Whether the block has been committed
+    committed: bool,
+}
+
+impl BlockInfo {
+    fn new(block: VerifiedBlock) -> Self {
+        Self {
+            block,
+            committed: false,
+        }
     }
 }
 
@@ -1602,364 +1693,313 @@ mod test {
         assert_eq!(result, expected);
     }
 
-    // TODO: Remove when DistributedVoteScoring is enabled.
-    #[rstest]
-    #[tokio::test]
-    async fn test_flush_and_recovery_with_unscored_subdag(#[values(0, 5)] gc_depth: u32) {
-        telemetry_subscribers::init_for_testing();
-        let num_authorities: u32 = 4;
-        let (mut context, _) = Context::new_for_test(num_authorities as usize);
-        context
-            .protocol_config
-            .set_consensus_distributed_vote_scoring_strategy_for_testing(false);
-
-        if gc_depth > 0 {
-            context
-                .protocol_config
-                .set_consensus_gc_depth_for_testing(gc_depth);
-        }
-
-        let context = Arc::new(context);
-        let store = Arc::new(MemStore::new());
-        let mut dag_state = DagState::new(context.clone(), store.clone());
-
-        // Create test blocks and commits for round 1 ~ 10
-        let num_rounds: u32 = 10;
-        let mut dag_builder = DagBuilder::new(context.clone());
-        dag_builder.layers(1..=num_rounds).build();
-        let mut commits = vec![];
-
-        for (_subdag, commit) in dag_builder.get_sub_dag_and_commits(1..=num_rounds) {
-            commits.push(commit);
-        }
-
-        // Add the blocks from first 5 rounds and first 5 commits to the dag state
-        let temp_commits = commits.split_off(5);
-        dag_state.accept_blocks(dag_builder.blocks(1..=5));
-        for commit in commits.clone() {
-            dag_state.add_commit(commit);
-        }
-
-        // Flush the dag state
-        dag_state.flush();
-
-        // Add the rest of the blocks and commits to the dag state
-        dag_state.accept_blocks(dag_builder.blocks(6..=num_rounds));
-        for commit in temp_commits.clone() {
-            dag_state.add_commit(commit);
-        }
-
-        // All blocks should be found in DagState.
-        let all_blocks = dag_builder.blocks(6..=num_rounds);
-        let block_refs = all_blocks
-            .iter()
-            .map(|block| block.reference())
-            .collect::<Vec<_>>();
-
-        let result = dag_state
-            .get_blocks(&block_refs)
-            .into_iter()
-            .map(|b| b.unwrap())
-            .collect::<Vec<_>>();
-        assert_eq!(result, all_blocks);
-
-        // Last commit index should be 10.
-        assert_eq!(dag_state.last_commit_index(), 10);
-        assert_eq!(
-            dag_state.last_committed_rounds(),
-            dag_builder.last_committed_rounds.clone()
-        );
-
-        // Destroy the dag state.
-        drop(dag_state);
-
-        // Recover the state from the store
-        let dag_state = DagState::new(context.clone(), store.clone());
-
-        // Blocks of first 5 rounds should be found in DagState.
-        let blocks = dag_builder.blocks(1..=5);
-        let block_refs = blocks
-            .iter()
-            .map(|block| block.reference())
-            .collect::<Vec<_>>();
-        let result = dag_state
-            .get_blocks(&block_refs)
-            .into_iter()
-            .map(|b| b.unwrap())
-            .collect::<Vec<_>>();
-        assert_eq!(result, blocks);
-
-        // Blocks above round 5 should not be in DagState, because they are not flushed.
-        let missing_blocks = dag_builder.blocks(6..=num_rounds);
-        let block_refs = missing_blocks
-            .iter()
-            .map(|block| block.reference())
-            .collect::<Vec<_>>();
-        let retrieved_blocks = dag_state
-            .get_blocks(&block_refs)
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>();
-        assert!(retrieved_blocks.is_empty());
-
-        // Last commit index should be 5.
-        assert_eq!(dag_state.last_commit_index(), 5);
-
-        // This is the last_commit_rounds of the first 5 commits that were flushed
-        let expected_last_committed_rounds = vec![4, 5, 4, 4];
-        assert_eq!(
-            dag_state.last_committed_rounds(),
-            expected_last_committed_rounds
-        );
-
-        // Unscored subdags will be recovered based on the flushed commits and no commit
-        // info
-        assert_eq!(dag_state.unscored_committed_subdags_count(), 5);
-    }
 
     #[tokio::test]
     async fn test_flush_and_recovery() {
-        telemetry_subscribers::init_for_testing();
-        let num_authorities: u32 = 4;
-        let (context, _) = Context::new_for_test(num_authorities as usize);
-        let context = Arc::new(context);
-        let store = Arc::new(MemStore::new());
-        let mut dag_state = DagState::new(context.clone(), store.clone());
+    telemetry_subscribers::init_for_testing();
+    let num_authorities: u32 = 4;
+    let (context, _) = Context::new_for_test(num_authorities as usize);
+    let context = Arc::new(context);
+    let store = Arc::new(MemStore::new());
+    let mut dag_state = DagState::new(context.clone(), store.clone());
 
-        // Create test blocks and commits for round 1 ~ 10
-        let num_rounds: u32 = 10;
-        let mut dag_builder = DagBuilder::new(context.clone());
-        dag_builder.layers(1..=num_rounds).build();
-        let mut commits = vec![];
-        for (_subdag, commit) in dag_builder.get_sub_dag_and_commits(1..=num_rounds) {
-            commits.push(commit);
-        }
+    // Create test blocks and commits for round 1 ~ 10
+    let num_rounds: u32 = 10;
+    let mut dag_builder = DagBuilder::new(context.clone());
+    dag_builder.layers(1..=num_rounds).build();
+    let mut commits = vec![];
+    for (_subdag, commit) in dag_builder.get_sub_dag_and_commits(1..=num_rounds)
+    { commits.push(commit);
+    }
 
-        // Add the blocks from first 5 rounds and first 5 commits to the dag state
-        let temp_commits = commits.split_off(5);
-        dag_state.accept_blocks(dag_builder.blocks(1..=5));
-        for commit in commits.clone() {
-            dag_state.add_commit(commit);
-        }
+    // Add the blocks from first 5 rounds and first 5 commits to the dag state
+    let temp_commits = commits.split_off(5);
+    dag_state.accept_blocks(dag_builder.blocks(1..=5));
+    for commit in commits.clone() {
+    dag_state.add_commit(commit);
+    }
 
-        // Flush the dag state
-        dag_state.flush();
+    // Flush the dag state
+    dag_state.flush();
 
-        // Add the rest of the blocks and commits to the dag state
-        dag_state.accept_blocks(dag_builder.blocks(6..=num_rounds));
-        for commit in temp_commits.clone() {
-            dag_state.add_commit(commit);
-        }
+    // Add the rest of the blocks and commits to the dag state
+    dag_state.accept_blocks(dag_builder.blocks(6..=num_rounds));
+    for commit in temp_commits.clone() {
+    dag_state.add_commit(commit);
+    }
 
-        // All blocks should be found in DagState.
-        let all_blocks = dag_builder.blocks(6..=num_rounds);
-        let block_refs = all_blocks
-            .iter()
-            .map(|block| block.reference())
-            .collect::<Vec<_>>();
-        let result = dag_state
-            .get_blocks(&block_refs)
-            .into_iter()
-            .map(|b| b.unwrap())
-            .collect::<Vec<_>>();
-        assert_eq!(result, all_blocks);
+    // All blocks should be found in DagState.
+    let all_blocks = dag_builder.blocks(6..=num_rounds);
+    let block_refs = all_blocks
+    .iter()
+    .map(|block| block.reference())
+    .collect::<Vec<_>>();
+    let result = dag_state
+    .get_blocks(&block_refs)
+    .into_iter()
+    .map(|b| b.unwrap())
+    .collect::<Vec<_>>();
+    assert_eq!(result, all_blocks);
 
-        // Last commit index should be 10.
-        assert_eq!(dag_state.last_commit_index(), 10);
-        assert_eq!(
-            dag_state.last_committed_rounds(),
-            dag_builder.last_committed_rounds.clone()
-        );
+    // Last commit index should be 10.
+    assert_eq!(dag_state.last_commit_index(), 10);
+    assert_eq!(
+    dag_state.last_committed_rounds(),
+    dag_builder.last_committed_rounds.clone()
+    );
 
-        // Destroy the dag state.
-        drop(dag_state);
+    // Destroy the dag state.
+    drop(dag_state);
 
-        // Recover the state from the store
-        let dag_state = DagState::new(context.clone(), store.clone());
+    // Recover the state from the store
+    let dag_state = DagState::new(context.clone(), store.clone());
 
-        // Blocks of first 5 rounds should be found in DagState.
-        let blocks = dag_builder.blocks(1..=5);
-        let block_refs = blocks
-            .iter()
-            .map(|block| block.reference())
-            .collect::<Vec<_>>();
-        let result = dag_state
-            .get_blocks(&block_refs)
-            .into_iter()
-            .map(|b| b.unwrap())
-            .collect::<Vec<_>>();
-        assert_eq!(result, blocks);
+    // Blocks of first 5 rounds should be found in DagState.
+    let blocks = dag_builder.blocks(1..=5);
+    let block_refs = blocks
+    .iter()
+    .map(|block| block.reference())
+    .collect::<Vec<_>>();
+    let result = dag_state
+    .get_blocks(&block_refs)
+    .into_iter()
+    .map(|b| b.unwrap())
+    .collect::<Vec<_>>();
+    assert_eq!(result, blocks);
 
-        // Blocks above round 5 should not be in DagState, because they are not flushed.
-        let missing_blocks = dag_builder.blocks(6..=num_rounds);
-        let block_refs = missing_blocks
-            .iter()
-            .map(|block| block.reference())
-            .collect::<Vec<_>>();
-        let retrieved_blocks = dag_state
-            .get_blocks(&block_refs)
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>();
-        assert!(retrieved_blocks.is_empty());
+    // Blocks above round 5 should not be in DagState, because they are not flushed.
+    let missing_blocks = dag_builder.blocks(6..=num_rounds);
+    let block_refs = missing_blocks
+    .iter()
+    .map(|block| block.reference())
+    .collect::<Vec<_>>();
+    let retrieved_blocks = dag_state
+    .get_blocks(&block_refs)
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>();
+    assert!(retrieved_blocks.is_empty());
 
-        // Last commit index should be 5.
-        assert_eq!(dag_state.last_commit_index(), 5);
+    // Last commit index should be 5.
+    assert_eq!(dag_state.last_commit_index(), 5);
 
-        // This is the last_commit_rounds of the first 5 commits that were flushed
-        let expected_last_committed_rounds = vec![4, 5, 4, 4];
-        assert_eq!(
-            dag_state.last_committed_rounds(),
-            expected_last_committed_rounds
-        );
-        // Unscored subdags will be recoverd based on the flushed commits and no commit
-        // info
-        assert_eq!(dag_state.scoring_subdags_count(), 5);
+    // This is the last_commit_rounds of the first 5 commits that were flushed
+    let expected_last_committed_rounds = vec![4, 5, 4, 4];
+    assert_eq!(
+    dag_state.last_committed_rounds(),
+    expected_last_committed_rounds
+    );
+    // Unscored subdags will be recovered based on the flushed commits and no commit
+    // info
+    assert_eq!(dag_state.scoring_subdags_count(), 5);
     }
 
     #[tokio::test]
     async fn test_flush_and_recovery_gc_enabled() {
-        telemetry_subscribers::init_for_testing();
+    telemetry_subscribers::init_for_testing();
 
-        const GC_DEPTH: u32 = 3;
-        const CACHED_ROUNDS: u32 = 4;
+    const GC_DEPTH: u32 = 3;
+    const CACHED_ROUNDS: u32 = 4;
 
+    let num_authorities: u32 = 4;
+    let (mut context, _) = Context::new_for_test(num_authorities as usize);
+    context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
+    context
+    .protocol_config
+    .set_consensus_gc_depth_for_testing(GC_DEPTH);
+    context
+    .protocol_config
+    .set_consensus_linearize_subdag_v2_for_testing(true);
+
+    let context = Arc::new(context);
+
+    let store = Arc::new(MemStore::new());
+    let mut dag_state = DagState::new(context.clone(), store.clone());
+
+    let num_rounds: u32 = 10;
+    let mut dag_builder = DagBuilder::new(context.clone());
+    dag_builder.layers(1..=5).build();
+    dag_builder
+    .layers(6..=8)
+    .authorities(vec![AuthorityIndex::new_for_test(0)])
+    .skip_block()
+    .build();
+    dag_builder.layers(9..=num_rounds).build();
+
+    let mut commits = dag_builder
+                .get_sub_dag_and_commits(1..=num_rounds)
+                .into_iter()
+                .map(|(_subdag, commit)| commit)
+                .collect::<Vec<_>>();
+
+    // Add the blocks from first 8 rounds and first 7 commits to the dag state
+    // It's 7 commits because we missing the commit of round 8 where authority 0 is
+    // the leader, but produced no block
+    let temp_commits = commits.split_off(7);
+    dag_state.accept_blocks(dag_builder.blocks(1..=8));
+    for commit in commits.clone() {
+    dag_state.add_commit(commit);
+    }
+
+    // Holds all the committed blocks from the commits that ended up being persisted
+    // (flushed). Any commits that not flushed will not be considered.
+    let mut all_committed_blocks = BTreeSet::<BlockRef>::new();
+    for commit in commits.iter() {
+    all_committed_blocks.extend(commit.blocks());
+    }
+    // Flush the dag state
+    dag_state.flush();
+
+    // Add the rest of the blocks and commits to the dag state
+    dag_state.accept_blocks(dag_builder.blocks(9..=num_rounds));
+    for commit in temp_commits.clone() {
+    dag_state.add_commit(commit);
+    }
+
+    // All blocks should be found in DagState.
+    let all_blocks = dag_builder.blocks(1..=num_rounds);
+    let block_refs = all_blocks
+    .iter()
+    .map(|block| block.reference())
+    .collect::<Vec<_>>();
+    let result = dag_state
+    .get_blocks(&block_refs)
+    .into_iter()
+    .map(|b| b.unwrap())
+    .collect::<Vec<_>>();
+    assert_eq!(result, all_blocks);
+
+    // Last commit index should be 9
+    assert_eq!(dag_state.last_commit_index(), 9);
+    assert_eq!(
+    dag_state.last_committed_rounds(),
+    dag_builder.last_committed_rounds.clone()
+    );
+
+    // Destroy the dag state.
+    drop(dag_state);
+
+    // Recover the state from the store
+    let dag_state = DagState::new(context.clone(), store.clone());
+
+    // Blocks of first 5 rounds should be found in DagState.
+    let blocks = dag_builder.blocks(1..=5);
+    let block_refs = blocks
+    .iter()
+    .map(|block| block.reference())
+    .collect::<Vec<_>>();
+    let result = dag_state
+    .get_blocks(&block_refs)
+    .into_iter()
+    .map(|b| b.unwrap())
+    .collect::<Vec<_>>();
+    assert_eq!(result, blocks);
+
+    // Blocks above round 9 should not be in DagState, because they are not flushed.
+    let missing_blocks = dag_builder.blocks(9..=num_rounds);
+    let block_refs = missing_blocks
+    .iter()
+    .map(|block| block.reference())
+    .collect::<Vec<_>>();
+    let retrieved_blocks = dag_state
+    .get_blocks(&block_refs)
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>();
+    assert!(retrieved_blocks.is_empty());
+
+    // Last commit index should be 7.
+     assert_eq!(dag_state.last_commit_index(), 7);
+
+    // This is the last_commit_rounds of the first 7 commits that were flushed
+     let expected_last_committed_rounds = vec![5, 6, 6, 7];
+     assert_eq!(
+     dag_state.last_committed_rounds(),
+     expected_last_committed_rounds
+     );
+    // Unscored subdags will be recoverd based on the flushed commits and no commit
+    // info
+     assert_eq!(dag_state.scoring_subdags_count(), 7);
+    //
+    // Ensure that cached blocks exist only for specific rounds per authority
+     for (authority_index, _) in context.committee.authorities() {
+     let blocks = dag_state.get_cached_blocks(authority_index, 1);
+
+    // Ensure that eviction rounds have been properly recovered
+    // DagState should hold cached blocks for authority 0 for rounds [2..=5] as no
+    // higher blocks exist and due to CACHED_ROUNDS = 4 we want at max
+    // to hold blocks for 4 rounds in cache.
+     if authority_index == AuthorityIndex::new_for_test(0) {
+     assert_eq!(blocks.len(), 4);
+     assert_eq!(dag_state.evicted_rounds[authority_index.value()], 1);
+     assert!(
+     blocks
+     .into_iter()
+     .all(|block| block.round() >= 2 && block.round() <= 5)
+     );
+     } else {
+     assert_eq!(blocks.len(), 4);
+     assert_eq!(dag_state.evicted_rounds[authority_index.value()], 4);
+     assert!(
+     blocks
+     .into_iter()
+     .all(|block| block.round() >= 5 && block.round() <= 8)
+     );
+     }
+     }
+    // Ensure that committed blocks from > gc_round have been correctly marked as
+    // committed according to committed sub dags
+    let gc_round =
+     dag_state.gc_round(); assert_eq!(gc_round, 4);
+     dag_state
+    .recent_blocks
+    .iter()
+    .for_each(|(block_ref, block_info)| {
+     if block_ref.round > gc_round && all_committed_blocks.contains(block_ref) {
+     assert!(
+     block_info.committed,
+    "Block {:?} should be committed",
+     block_ref
+    );
+    });
+    }
+
+    #[tokio::test]
+    async fn test_block_info_as_committed() {
         let num_authorities: u32 = 4;
-        let (mut context, _) = Context::new_for_test(num_authorities as usize);
-        context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
-        context
-            .protocol_config
-            .set_consensus_gc_depth_for_testing(GC_DEPTH);
-
+        let (context, _) = Context::new_for_test(num_authorities as usize);
         let context = Arc::new(context);
 
         let store = Arc::new(MemStore::new());
         let mut dag_state = DagState::new(context.clone(), store.clone());
 
-        let num_rounds: u32 = 10;
-        let mut dag_builder = DagBuilder::new(context.clone());
-        dag_builder.layers(1..=5).build();
-        dag_builder
-            .layers(6..=8)
-            .authorities(vec![AuthorityIndex::new_for_test(0)])
-            .skip_block()
-            .build();
-        dag_builder.layers(9..=num_rounds).build();
-
-        let mut commits = vec![];
-        for (_subdag, commit) in dag_builder.get_sub_dag_and_commits(1..=num_rounds) {
-            commits.push(commit);
-        }
-
-        // Add the blocks from first 8 rounds and first 7 commits to the dag state
-        // It's 7 commits because we missing the commit of round 8 where authority 0 is
-        // the leader, but produced no block
-        let temp_commits = commits.split_off(7);
-        dag_state.accept_blocks(dag_builder.blocks(1..=8));
-        for commit in commits.clone() {
-            dag_state.add_commit(commit);
-        }
-
-        // Flush the dag state
-        dag_state.flush();
-
-        // Add the rest of the blocks and commits to the dag state
-        dag_state.accept_blocks(dag_builder.blocks(9..=num_rounds));
-        for commit in temp_commits.clone() {
-            dag_state.add_commit(commit);
-        }
-
-        // All blocks should be found in DagState.
-        let all_blocks = dag_builder.blocks(1..=num_rounds);
-        let block_refs = all_blocks
-            .iter()
-            .map(|block| block.reference())
-            .collect::<Vec<_>>();
-        let result = dag_state
-            .get_blocks(&block_refs)
-            .into_iter()
-            .map(|b| b.unwrap())
-            .collect::<Vec<_>>();
-        assert_eq!(result, all_blocks);
-
-        // Last commit index should be 9
-        assert_eq!(dag_state.last_commit_index(), 9);
-        assert_eq!(
-            dag_state.last_committed_rounds(),
-            dag_builder.last_committed_rounds.clone()
+        // Accept a block
+        let block = VerifiedBlock::new_for_test(
+            TestBlock::new(1, 0)
+                .set_timestamp_ms(1000)
+                .set_ancestors(vec![])
+                .build(),
         );
 
-        // Destroy the dag state.
-        drop(dag_state);
+        dag_state.accept_block(block.clone());
 
-        // Recover the state from the store
-        let dag_state = DagState::new(context.clone(), store.clone());
+        // Query is committed
+        assert!(!dag_state.is_committed(&block.reference()));
 
-        // Blocks of first 5 rounds should be found in DagState.
-        let blocks = dag_builder.blocks(1..=5);
-        let block_refs = blocks
-            .iter()
-            .map(|block| block.reference())
-            .collect::<Vec<_>>();
-        let result = dag_state
-            .get_blocks(&block_refs)
-            .into_iter()
-            .map(|b| b.unwrap())
-            .collect::<Vec<_>>();
-        assert_eq!(result, blocks);
-
-        // Blocks above round 9 should not be in DagState, because they are not flushed.
-        let missing_blocks = dag_builder.blocks(9..=num_rounds);
-        let block_refs = missing_blocks
-            .iter()
-            .map(|block| block.reference())
-            .collect::<Vec<_>>();
-        let retrieved_blocks = dag_state
-            .get_blocks(&block_refs)
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>();
-        assert!(retrieved_blocks.is_empty());
-
-        // Last commit index should be 7.
-        assert_eq!(dag_state.last_commit_index(), 7);
-
-        // This is the last_commit_rounds of the first 7 commits that were flushed
-        let expected_last_committed_rounds = vec![5, 6, 6, 7];
-        assert_eq!(
-            dag_state.last_committed_rounds(),
-            expected_last_committed_rounds
+        // Set block as committed for first time should return true
+        assert!(
+            dag_state.set_committed(&block.reference()),
+            "Block should be successfully set as committed for first time"
         );
-        // Unscored subdags will be recoverd based on the flushed commits and no commit
-        // info
-        assert_eq!(dag_state.scoring_subdags_count(), 7);
 
-        // Ensure that cached blocks exist only for specific rounds per authority
-        for (authority_index, _) in context.committee.authorities() {
-            let blocks = dag_state.get_cached_blocks(authority_index, 1);
+        // Now it should appear as committed
+        assert!(dag_state.is_committed(&block.reference()));
 
-            // Ensure that eviction rounds have been properly recovered
-            // DagState should hold cached blocks for authority 0 for rounds [2..=5] as no
-            // higher blocks exist and due to CACHED_ROUNDS = 4 we want at max
-            // to hold blocks for 4 rounds in cache.
-            if authority_index == AuthorityIndex::new_for_test(0) {
-                assert_eq!(blocks.len(), 4);
-                assert_eq!(dag_state.evicted_rounds[authority_index.value()], 1);
-                assert!(
-                    blocks
-                        .into_iter()
-                        .all(|block| block.round() >= 2 && block.round() <= 5)
-                );
-            } else {
-                assert_eq!(blocks.len(), 4);
-                assert_eq!(dag_state.evicted_rounds[authority_index.value()], 4);
-                assert!(
-                    blocks
-                        .into_iter()
-                        .all(|block| block.round() >= 5 && block.round() <= 8)
-                );
-            }
-        }
+        // Trying to set the block as committed again, it should return false.
+        assert!(
+            !dag_state.set_committed(&block.reference()),
+            "Block should not be successfully set as committed"
+        );
     }
 
     #[tokio::test]

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -211,7 +211,7 @@ impl Linearizer {
                             .filter(|ancestor| {
                                 // We skip the block if we already committed it or we reached a
                                 // round that we already committed.
-                                // TODO: for Fast Path we need to ammend the recursion rule here and
+                                // TODO: for Fast Path we need to amend the recursion rule here and
                                 // allow us to commit blocks all the way up to the `gc_round`.
                                 // Some additional work will be needed to make sure that we keep the
                                 // uncommitted blocks up to the `gc_round` across commits.
@@ -772,7 +772,7 @@ mod tests {
         // it on round 2. Then on round 3 the authorities A, B & C will link to
         // block D1. Once the DAG gets committed we should see the block D1 getting
         // committed as well. Normally ,as block D2 would have been committed
-        // first block D1 should be ommitted. With the new logic this is no longer true.
+        // first block D1 should be omitted. With the new logic this is no longer true.
         let dag_str = "DAG {
                 Round 0 : { 4 },
                 Round 1 : { * },

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -456,7 +456,8 @@ mod tests {
             LeaderSchedule::new(context.clone(), LeaderSwapTable::default())
                 .with_num_commits_per_schedule(NUM_OF_COMMITS_PER_SCHEDULE),
         );
-        let mut linearizer = Linearizer::new(dag_state.clone(), leader_schedule.clone());
+        let mut linearizer =
+            Linearizer::new(context.clone(), dag_state.clone(), leader_schedule.clone());
 
         // Populate fully connected test blocks for round 0 ~ 20, authorities 0 ~ 3.
         let num_rounds: u32 = 20;

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -11,6 +11,7 @@ use crate::{
     Round,
     block::{BlockAPI, BlockRef, VerifiedBlock},
     commit::{Commit, CommittedSubDag, TrustedCommit, sort_sub_dag_blocks},
+    context::Context,
     dag_state::DagState,
     leader_schedule::LeaderSchedule,
 };
@@ -24,10 +25,14 @@ pub(crate) trait BlockStoreAPI {
     fn gc_round(&self) -> Round;
 
     fn gc_enabled(&self) -> bool;
+
+    fn set_committed(&mut self, block_ref: &BlockRef) -> bool;
+
+    fn is_committed(&self, block_ref: &BlockRef) -> bool;
 }
 
 impl BlockStoreAPI
-    for parking_lot::lock_api::RwLockReadGuard<'_, parking_lot::RawRwLock, DagState>
+    for parking_lot::lock_api::RwLockWriteGuard<'_, parking_lot::RawRwLock, DagState>
 {
     fn get_blocks(&self, refs: &[BlockRef]) -> Vec<Option<VerifiedBlock>> {
         DagState::get_blocks(self, refs)
@@ -40,24 +45,35 @@ impl BlockStoreAPI
     fn gc_enabled(&self) -> bool {
         DagState::gc_enabled(self)
     }
+
+    fn set_committed(&mut self, block_ref: &BlockRef) -> bool {
+        DagState::set_committed(self, block_ref)
+    }
+
+    fn is_committed(&self, block_ref: &BlockRef) -> bool {
+        DagState::is_committed(self, block_ref)
+    }
 }
 
 /// Expand a committed sequence of leader into a sequence of sub-dags.
 #[derive(Clone)]
 pub(crate) struct Linearizer {
     /// In memory block store representing the dag state
+    context: Arc<Context>,
     dag_state: Arc<RwLock<DagState>>,
     leader_schedule: Arc<LeaderSchedule>,
 }
 
 impl Linearizer {
     pub(crate) fn new(
+        context: Arc<Context>,
         dag_state: Arc<RwLock<DagState>>,
         leader_schedule: Arc<LeaderSchedule>,
     ) -> Self {
         Self {
             dag_state,
             leader_schedule,
+            context,
         }
     }
 
@@ -69,8 +85,15 @@ impl Linearizer {
         leader_block: VerifiedBlock,
         reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
     ) -> (CommittedSubDag, TrustedCommit) {
+        let _s = self
+            .context
+            .metrics
+            .node_metrics
+            .scope_processing_time
+            .with_label_values(&["Linearizer::collect_sub_dag_and_commit"])
+            .start_timer();
         // Grab latest commit state from dag state
-        let dag_state = self.dag_state.read();
+        let mut dag_state = self.dag_state.write();
         let last_commit_index = dag_state.last_commit_index();
         let last_commit_digest = dag_state.last_commit_digest();
         let last_commit_timestamp_ms = dag_state.last_commit_timestamp_ms();
@@ -78,8 +101,14 @@ impl Linearizer {
         let timestamp_ms = leader_block.timestamp_ms().max(last_commit_timestamp_ms);
 
         // Now linearize the sub-dag starting from the leader block
-        let to_commit =
-            Self::linearize_sub_dag(leader_block.clone(), last_committed_rounds, dag_state);
+        let to_commit = Self::linearize_sub_dag(
+            &self.context,
+            leader_block.clone(),
+            last_committed_rounds,
+            &mut dag_state,
+        );
+
+        drop(dag_state);
 
         // Create the Commit.
         let commit = Commit::new(
@@ -110,9 +139,10 @@ impl Linearizer {
     }
 
     pub(crate) fn linearize_sub_dag(
+        context: &Context,
         leader_block: VerifiedBlock,
         last_committed_rounds: Vec<u32>,
-        dag_state: impl BlockStoreAPI,
+        dag_state: &mut impl BlockStoreAPI,
     ) -> Vec<VerifiedBlock> {
         let gc_enabled = dag_state.gc_enabled();
         // The GC round here is calculated based on the last committed round of the
@@ -124,46 +154,89 @@ impl Linearizer {
         let gc_round: Round = dag_state.gc_round();
         let leader_block_ref = leader_block.reference();
         let mut buffer = vec![leader_block];
-        let mut committed = HashSet::new();
+
         let mut to_commit = Vec::new();
-        assert!(committed.insert(leader_block_ref));
 
-        while let Some(x) = buffer.pop() {
-            to_commit.push(x.clone());
+        // The new logic will perform the recursion without stopping at the highest
+        // round round that has been committed per authority. Instead it will
+        // allow to commit blocks that are lower than the highest committed round for an
+        // authority but higher than gc_round.
+        if context.protocol_config.consensus_linearize_subdag_v2() {
+            assert!(
+                dag_state.set_committed(&leader_block_ref),
+                "Leader block with reference {:?} attempted to be committed twice",
+                leader_block_ref
+            );
 
-            let ancestors: Vec<VerifiedBlock> = dag_state
-                .get_blocks(
-                    &x.ancestors()
-                        .iter()
-                        .copied()
-                        .filter(|ancestor| {
-                            // We skip the block if we already committed it or we reached a
-                            // round that we already committed.
-                            // TODO: for Fast Path we need to amend the recursion rule here and
-                            // allow us to commit blocks all the way up to the `gc_round`.
-                            // Some additional work will be needed to make sure that we keep the
-                            // uncommitted blocks up to the `gc_round` across commits.
-                            !committed.contains(ancestor)
-                                && last_committed_rounds[ancestor.author] < ancestor.round
-                        })
-                        .filter(|ancestor| {
-                            // Keep the block if GC is not enabled or it is enabled and the block is
-                            // above the gc_round. We do this
-                            // to stop the recursion early and avoid going to deep when it's
-                            // unnecessary.
-                            !gc_enabled || ancestor.round > gc_round
-                        })
-                        .collect::<Vec<_>>(),
-                )
-                .into_iter()
-                .map(|ancestor_opt| {
-                    ancestor_opt.expect("We should have all uncommitted blocks in dag state.")
-                })
-                .collect();
+            while let Some(x) = buffer.pop() {
+                to_commit.push(x.clone());
 
-            for ancestor in ancestors {
-                buffer.push(ancestor.clone());
-                assert!(committed.insert(ancestor.reference()));
+                let ancestors: Vec<VerifiedBlock> = dag_state
+                    .get_blocks(
+                        &x.ancestors()
+                            .iter()
+                            .copied()
+                            .filter(|ancestor| {
+                                ancestor.round > gc_round && !dag_state.is_committed(ancestor)
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                    .into_iter()
+                    .map(|ancestor_opt| {
+                        ancestor_opt.expect("We should have all uncommitted blocks in dag state.")
+                    })
+                    .collect();
+
+                for ancestor in ancestors {
+                    buffer.push(ancestor.clone());
+                    assert!(
+                        dag_state.set_committed(&ancestor.reference()),
+                        "Block with reference {:?} attempted to be committed twice",
+                        ancestor.reference()
+                    );
+                }
+            }
+        } else {
+            let mut committed = HashSet::new();
+            assert!(committed.insert(leader_block_ref));
+
+            while let Some(x) = buffer.pop() {
+                to_commit.push(x.clone());
+
+                let ancestors: Vec<VerifiedBlock> = dag_state
+                    .get_blocks(
+                        &x.ancestors()
+                            .iter()
+                            .copied()
+                            .filter(|ancestor| {
+                                // We skip the block if we already committed it or we reached a
+                                // round that we already committed.
+                                // TODO: for Fast Path we need to ammend the recursion rule here and
+                                // allow us to commit blocks all the way up to the `gc_round`.
+                                // Some additional work will be needed to make sure that we keep the
+                                // uncommitted blocks up to the `gc_round` across commits.
+                                !committed.contains(ancestor)
+                                    && last_committed_rounds[ancestor.author] < ancestor.round
+                            })
+                            .filter(|ancestor| {
+                                // Keep the block if GC is not enabled or it is enabled and the
+                                // block is above the gc_round. We do this
+                                // to stop the recursion early and avoid going to deep when it's
+                                // unnecessary.
+                                !gc_enabled || ancestor.round > gc_round
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                    .into_iter()
+                    .map(|ancestor_opt| {
+                        ancestor_opt.expect("We should have all uncommitted blocks in dag state.")
+                    })
+                    .collect();
+
+                for ancestor in ancestors {
+                    buffer.push(ancestor.clone());
+                    assert!(committed.insert(ancestor.reference()));
+                }
             }
         }
 
@@ -265,7 +338,7 @@ mod tests {
             context.clone(),
             LeaderSwapTable::default(),
         ));
-        let mut linearizer = Linearizer::new(dag_state.clone(), leader_schedule);
+        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
 
         // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
         let num_rounds: u32 = 10;
@@ -315,7 +388,8 @@ mod tests {
             LeaderSchedule::new(context.clone(), LeaderSwapTable::default())
                 .with_num_commits_per_schedule(NUM_OF_COMMITS_PER_SCHEDULE),
         );
-        let mut linearizer = Linearizer::new(dag_state.clone(), leader_schedule.clone());
+        let mut linearizer =
+            Linearizer::new(context.clone(), dag_state.clone(), leader_schedule.clone());
 
         // Populate fully connected test blocks for round 0 ~ 20, authorities 0 ~ 3.
         let num_rounds: u32 = 20;
@@ -450,7 +524,8 @@ mod tests {
             context.clone(),
             LeaderSwapTable::default(),
         ));
-        let mut linearizer = Linearizer::new(dag_state.clone(), leader_schedule.clone());
+        let mut linearizer =
+            Linearizer::new(context.clone(), dag_state.clone(), leader_schedule.clone());
         let wave_length = DEFAULT_WAVE_LENGTH;
 
         let leader_round_wave_1 = 3;
@@ -553,6 +628,13 @@ mod tests {
         let num_authorities = 4;
         let (mut context, _keys) = Context::new_for_test(num_authorities);
         context.protocol_config.set_gc_depth_for_testing(gc_depth);
+
+        if gc_depth > 0 {
+            context
+                .protocol_config
+                .set_consensus_linearize_subdag_v2_for_testing(true);
+        }
+
         let context = Arc::new(context);
         let dag_state = Arc::new(RwLock::new(DagState::new(
             context.clone(),
@@ -562,7 +644,7 @@ mod tests {
             context.clone(),
             LeaderSwapTable::default(),
         ));
-        let mut linearizer = Linearizer::new(dag_state.clone(), leader_schedule);
+        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
 
         // Authorities of index 0->2 will always creates blocks that see each other, but
         // until round 5 they won't see the blocks of authority 3. For authority
@@ -653,6 +735,111 @@ mod tests {
                     assert_eq!(dag_state.read().gc_round(), 0);
                 }
             }
+            for block in subdag.blocks.iter() {
+                assert!(block.round() <= leaders[idx].round());
+            }
+            assert_eq!(subdag.commit_ref.index, idx as CommitIndex + 1);
+        }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_handle_commit_below_highest_committed_round(#[values(3)] gc_depth: u32) {
+        telemetry_subscribers::init_for_testing();
+
+        let num_authorities = 4;
+        let (mut context, _keys) = Context::new_for_test(num_authorities);
+        context
+            .protocol_config
+            .set_consensus_gc_depth_for_testing(gc_depth);
+        context
+            .protocol_config
+            .set_consensus_linearize_subdag_v2_for_testing(true);
+
+        let context = Arc::new(context);
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new()),
+        )));
+        let leader_schedule = Arc::new(LeaderSchedule::new(
+            context.clone(),
+            LeaderSwapTable::default(),
+        ));
+        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
+
+        // Authority D will create an "orphaned" block on round 1 as it won't reference
+        // to it on the block of round 2. Similar, no other authority will reference to
+        // it on round 2. Then on round 3 the authorities A, B & C will link to
+        // block D1. Once the DAG gets committed we should see the block D1 getting
+        // committed as well. Normally ,as block D2 would have been committed
+        // first block D1 should be ommitted. With the new logic this is no longer true.
+        let dag_str = "DAG {
+                Round 0 : { 4 },
+                Round 1 : { * },
+                Round 2 : {
+                    A -> [-D1],
+                    B -> [-D1],
+                    C -> [-D1],
+                    D -> [-D1],
+                },
+                Round 3 : {
+                    A -> [A2, B2, C2, D1],
+                    B -> [A2, B2, C2, D1],
+                    C -> [A2, B2, C2, D1],
+                    D -> [A2, B2, C2, D2]
+                },
+                Round 4 : { * },
+            }";
+
+        let (_, dag_builder) = parse_dag(dag_str).expect("Invalid dag");
+        dag_builder.print();
+        dag_builder.persist_all_blocks(dag_state.clone());
+
+        let leaders = dag_builder
+            .leader_blocks(1..=4)
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+
+        let commits = linearizer.handle_commit(leaders.clone());
+        for (idx, subdag) in commits.into_iter().enumerate() {
+            tracing::info!("{subdag:?}");
+            assert_eq!(subdag.leader, leaders[idx].reference());
+            assert_eq!(subdag.timestamp_ms, leaders[idx].timestamp_ms());
+            if idx == 0 {
+                // First subdag includes the leader block only B1
+                assert_eq!(subdag.blocks.len(), 1);
+            } else if idx == 1 {
+                // We commit:
+                // * 1 block on round 2, the leader block C2
+                // * 2 blocks on round 1, A1, C1
+                assert_eq!(subdag.blocks.len(), 3);
+            } else if idx == 2 {
+                // We commit:
+                // * 1 block on round 3, the leader block D3
+                // * 3 blocks on round 2, A2, B2, D2
+                assert_eq!(subdag.blocks.len(), 4);
+
+                assert!(
+                    subdag.blocks.iter().any(|block| block.round() == 2
+                        && block.author() == AuthorityIndex::new_for_test(3)),
+                    "Block D2 should have been committed."
+                );
+            } else if idx == 3 {
+                // We commit:
+                // * 1 block on round 4, the leader block A4
+                // * 3 blocks on round 3, A3, B3, C3
+                // * 1 block of round 1, D1
+                assert_eq!(subdag.blocks.len(), 5);
+                assert!(
+                    subdag.blocks.iter().any(|block| block.round() == 1
+                        && block.author() == AuthorityIndex::new_for_test(3)),
+                    "Block D1 should have been committed."
+                );
+            } else {
+                panic!("Unexpected subdag with index {:?}", idx);
+            }
+
             for block in subdag.blocks.iter() {
                 assert!(block.round() <= leaders[idx].round());
             }

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -157,7 +157,8 @@ impl DagBuilder {
         struct BlockStorage {
             gc_round: Round,
             context: Arc<Context>,
-            blocks: BTreeMap<BlockRef, (VerifiedBlock, bool)>, // the tuple represends the block and whether it is committed
+            blocks: BTreeMap<BlockRef, (VerifiedBlock, bool)>, /* the tuple represends the block
+                                                                * and whether it is committed */
         }
         impl BlockStoreAPI for BlockStorage {
             fn get_blocks(&self, refs: &[BlockRef]) -> Vec<Option<VerifiedBlock>> {

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -154,49 +154,80 @@ impl DagBuilder {
                 (0, 0, 0)
             };
 
+        struct BlockStorage {
+            gc_round: Round,
+            context: Arc<Context>,
+            blocks: BTreeMap<BlockRef, (VerifiedBlock, bool)>, // the tuple represends the block and whether it is committed
+        }
+        impl BlockStoreAPI for BlockStorage {
+            fn get_blocks(&self, refs: &[BlockRef]) -> Vec<Option<VerifiedBlock>> {
+                refs.iter()
+                    .map(|block_ref| {
+                        self.blocks
+                            .get(block_ref)
+                            .map(|(block, _committed)| block.clone())
+                    })
+                    .collect()
+            }
+
+            fn gc_round(&self) -> Round {
+                self.gc_round
+            }
+
+            fn gc_enabled(&self) -> bool {
+                self.context.protocol_config.gc_depth() > 0
+            }
+
+            fn set_committed(&mut self, block_ref: &BlockRef) -> bool {
+                let Some((block, committed)) = self.blocks.get_mut(block_ref) else {
+                    panic!("Block {:?} should be found in store", block_ref);
+                };
+                if !*committed {
+                    *committed = true;
+                    return true;
+                }
+                false
+            }
+
+            fn is_committed(&self, block_ref: &BlockRef) -> bool {
+                self.blocks
+                    .get(block_ref)
+                    .map(|(_, committed)| *committed)
+                    .expect("Block should be found in store")
+            }
+        }
+        let mut storage = BlockStorage {
+            context: self.context.clone(),
+            blocks: self
+                .blocks
+                .clone()
+                .into_iter()
+                .map(|(k, v)| (k, (v, false)))
+                .collect(),
+            gc_round: 0,
+        };
+
         // Create any remaining committed sub dags
         for leader_block in self
             .leader_blocks(last_leader_round + 1..=*leader_rounds.end())
             .into_iter()
             .flatten()
         {
+            // set the gc round to the round of the leader block
+            storage.gc_round = leader_block
+                .round()
+                .saturating_sub(1)
+                .saturating_sub(self.context.protocol_config.gc_depth());
+
             let leader_block_ref = leader_block.reference();
             last_commit_index += 1;
             last_timestamp_ms = leader_block.timestamp_ms().max(last_timestamp_ms);
 
-            struct FooStorage {
-                gc_round: Round,
-                context: Arc<Context>,
-                blocks: BTreeMap<BlockRef, VerifiedBlock>,
-            }
-            impl BlockStoreAPI for FooStorage {
-                fn get_blocks(&self, refs: &[BlockRef]) -> Vec<Option<VerifiedBlock>> {
-                    refs.iter()
-                        .map(|block_ref| self.blocks.get(block_ref).cloned())
-                        .collect()
-                }
-
-                fn gc_round(&self) -> Round {
-                    self.gc_round
-                }
-
-                fn gc_enabled(&self) -> bool {
-                    self.context.protocol_config.gc_depth() > 0
-                }
-            }
-            let storage = FooStorage {
-                context: self.context.clone(),
-                blocks: self.blocks.clone(),
-                gc_round: leader_block
-                    .round()
-                    .saturating_sub(1)
-                    .saturating_sub(self.context.protocol_config.gc_depth()),
-            };
-
             let to_commit = Linearizer::linearize_sub_dag(
+                &self.context.clone(),
                 leader_block,
                 self.last_committed_rounds.clone(),
-                storage,
+                &mut storage,
             );
 
             // Update the last committed rounds

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -157,7 +157,7 @@ impl DagBuilder {
         struct BlockStorage {
             gc_round: Round,
             context: Arc<Context>,
-            blocks: BTreeMap<BlockRef, (VerifiedBlock, bool)>, /* the tuple represends the block
+            blocks: BTreeMap<BlockRef, (VerifiedBlock, bool)>, /* the tuple represents the block
                                                                 * and whether it is committed */
         }
         impl BlockStoreAPI for BlockStorage {
@@ -180,7 +180,7 @@ impl DagBuilder {
             }
 
             fn set_committed(&mut self, block_ref: &BlockRef) -> bool {
-                let Some((block, committed)) = self.blocks.get_mut(block_ref) else {
+                let Some((_block, committed)) = self.blocks.get_mut(block_ref) else {
                     panic!("Block {:?} should be found in store", block_ref);
                 };
                 if !*committed {

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1306,6 +1306,7 @@
                 "accept_zklogin_in_multisig": false,
                 "bridge": false,
                 "consensus_distributed_vote_scoring_strategy": true,
+                "consensus_linearize_subdag_v2": false,
                 "consensus_round_prober": true,
                 "disable_invariant_violation_check_in_swap_loc": true,
                 "enable_group_ops_native_function_msm": true,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -207,6 +207,12 @@ struct FeatureFlags {
     // Use distributed vote leader scoring strategy in consensus.
     #[serde(skip_serializing_if = "is_false")]
     consensus_distributed_vote_scoring_strategy: bool,
+
+    // Enables the new logic for collecting the subdag in the consensus linearizer. The new logic
+    // does not stop the recursion at the highest committed round for each authority, but
+    // allows to commit uncommitted blocks up to gc round (excluded) for that authority.
+    #[serde(skip_serializing_if = "is_false")]
+    consensus_linearize_subdag_v2: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1118,6 +1124,15 @@ impl ProtocolConfig {
     pub fn gc_depth(&self) -> u32 {
         self.consensus_gc_depth.unwrap_or(0)
     }
+
+    pub fn consensus_linearize_subdag_v2(&self) -> bool {
+        let res = self.feature_flags.consensus_linearize_subdag_v2;
+        assert!(
+            !res || self.gc_depth() > 0,
+            "The consensus linearize sub dag V2 requires GC to be enabled"
+        );
+        res
+    }
 }
 
 #[cfg(not(msim))]
@@ -1862,6 +1877,10 @@ impl ProtocolConfig {
 
     pub fn set_gc_depth_for_testing(&mut self, val: u32) {
         self.consensus_gc_depth = Some(val);
+    }
+
+    pub fn set_consensus_linearize_subdag_v2_for_testing(&mut self, val: bool) {
+        self.feature_flags.consensus_linearize_subdag_v2 = val;
     }
 }
 


### PR DESCRIPTION
Porting upstream change: https://github.com/MystenLabs/sui/commit/22aedf0fae942dc0fd8d232e1c0b6988357ee895

# Description of change
Copied from upstream:
Currently when committing/collecting the sub dag we always stop the
recursion when we come across the highest committed round for an
authority. This works well, but with the upcoming Fast Path changes it
can lead to uncommitted FP certificates in the presence of blocks that
don't form a proper hash chain.

This could be done if for example an authority `A` produces blocks
`A100, A101, A102` , but block `A102` uses as ancestor block `A100` and
never references `A101`. `A101` gets broadcasted and participate in the
form of an FP certificate and referenced by others. With the current
logic in Linearizer, if `A102` gets committed first, then `A101` will
never get committed as part of subsequent DAG sequencing as we always
stop our recursion to the highest committed round. With the new logic we
ensure that `A101` will get committed as well if it's `> gc_round`.
Having `Garbage Collection` allows us to limit the recursion depth
making the process efficient enough and knowing that we'll not attempt
to keep committing blocks too far in the past. Using a reasonable depth
(ex 50 - 60) for production shouldn't cause performance troubles.

To achieve the above `DagState` has been refactored to keep a global
commit state of blocks. When we linearise the DAG across commits we do
not re-commit previously committed blocks.

The new changes are guarded behind a feature flag and can only be
enabled if GC is enabled.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/5643

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
