### PR TITLE
refactor!(iota-data-ingestion-core): use `Arc<CheckpointData>` for `Worker` trait

### DIFF
--- a/crates/iota-analytics-indexer/src/analytics_processor.rs
+++ b/crates/iota-analytics-indexer/src/analytics_processor.rs
@@ -56,7 +56,7 @@ impl<S: Serialize + ParquetSchema + 'static> Worker for AnalyticsProcessor<S> {
 
     async fn process_checkpoint(
         &self,
-        checkpoint_data: &CheckpointData,
+        checkpoint_data: Arc<CheckpointData>,
     ) -> Result<Self::Message, Self::Error> {
         // get epoch id, checkpoint sequence number and timestamp, those are important
         // indexes when operating on data

--- a/crates/iota-analytics-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/checkpoint_handler.rs
@@ -2,6 +2,8 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use anyhow::Result;
 use fastcrypto::traits::EncodeDecodeBase64;
 use iota_data_ingestion_core::Worker;
@@ -30,13 +32,13 @@ impl Worker for CheckpointHandler {
 
     async fn process_checkpoint(
         &self,
-        checkpoint_data: &CheckpointData,
+        checkpoint_data: Arc<CheckpointData>,
     ) -> Result<Self::Message, Self::Error> {
         let CheckpointData {
             checkpoint_summary,
             transactions: checkpoint_transactions,
             ..
-        } = checkpoint_data;
+        } = checkpoint_data.as_ref();
         self.process_checkpoint_transactions(checkpoint_summary, checkpoint_transactions)
             .await;
         Ok(())

--- a/crates/iota-analytics-indexer/src/handlers/df_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/df_handler.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, path::Path};
+use std::{collections::HashMap, path::Path, sync::Arc};
 
 use anyhow::Result;
 use fastcrypto::encoding::{Base64, Encoding};
@@ -45,13 +45,13 @@ impl Worker for DynamicFieldHandler {
 
     async fn process_checkpoint(
         &self,
-        checkpoint_data: &CheckpointData,
+        checkpoint_data: Arc<CheckpointData>,
     ) -> Result<Self::Message, Self::Error> {
         let CheckpointData {
             checkpoint_summary,
             transactions: checkpoint_transactions,
             ..
-        } = checkpoint_data;
+        } = checkpoint_data.as_ref();
         let mut state = self.state.lock().await;
         for checkpoint_transaction in checkpoint_transactions {
             for object in checkpoint_transaction.output_objects.iter() {

--- a/crates/iota-analytics-indexer/src/handlers/event_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/event_handler.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::Path;
+use std::{path::Path, sync::Arc};
 
 use anyhow::Result;
 use fastcrypto::encoding::{Base64, Encoding};
@@ -40,13 +40,13 @@ impl Worker for EventHandler {
 
     async fn process_checkpoint(
         &self,
-        checkpoint_data: &CheckpointData,
+        checkpoint_data: Arc<CheckpointData>,
     ) -> Result<Self::Message, Self::Error> {
         let CheckpointData {
             checkpoint_summary,
             transactions: checkpoint_transactions,
             ..
-        } = checkpoint_data;
+        } = checkpoint_data.as_ref();
         let mut state = self.state.lock().await;
         for checkpoint_transaction in checkpoint_transactions {
             for object in checkpoint_transaction.output_objects.iter() {

--- a/crates/iota-analytics-indexer/src/handlers/move_call_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/move_call_handler.rs
@@ -2,6 +2,8 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use anyhow::Result;
 use iota_data_ingestion_core::Worker;
 use iota_rest_api::CheckpointData;
@@ -26,13 +28,13 @@ impl Worker for MoveCallHandler {
 
     async fn process_checkpoint(
         &self,
-        checkpoint_data: &CheckpointData,
+        checkpoint_data: Arc<CheckpointData>,
     ) -> Result<Self::Message, Self::Error> {
         let CheckpointData {
             checkpoint_summary,
             transactions: checkpoint_transactions,
             ..
-        } = checkpoint_data;
+        } = checkpoint_data.as_ref();
         let mut state = self.state.lock().await;
         for checkpoint_transaction in checkpoint_transactions {
             let move_calls = checkpoint_transaction

--- a/crates/iota-analytics-indexer/src/handlers/object_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/object_handler.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::Path;
+use std::{path::Path, sync::Arc};
 
 use anyhow::Result;
 use fastcrypto::encoding::{Base64, Encoding};
@@ -40,13 +40,13 @@ impl Worker for ObjectHandler {
 
     async fn process_checkpoint(
         &self,
-        checkpoint_data: &CheckpointData,
+        checkpoint_data: Arc<CheckpointData>,
     ) -> Result<Self::Message, Self::Error> {
         let CheckpointData {
             checkpoint_summary,
             transactions: checkpoint_transactions,
             ..
-        } = checkpoint_data;
+        } = checkpoint_data.as_ref();
         let mut state = self.state.lock().await;
         for checkpoint_transaction in checkpoint_transactions {
             for object in checkpoint_transaction.output_objects.iter() {

--- a/crates/iota-analytics-indexer/src/handlers/package_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/package_handler.rs
@@ -2,6 +2,8 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use anyhow::Result;
 use fastcrypto::encoding::{Base64, Encoding};
 use iota_data_ingestion_core::Worker;
@@ -26,13 +28,13 @@ impl Worker for PackageHandler {
 
     async fn process_checkpoint(
         &self,
-        checkpoint_data: &CheckpointData,
+        checkpoint_data: Arc<CheckpointData>,
     ) -> Result<Self::Message, Self::Error> {
         let CheckpointData {
             checkpoint_summary,
             transactions: checkpoint_transactions,
             ..
-        } = checkpoint_data;
+        } = checkpoint_data.as_ref();
         let mut state = self.state.lock().await;
         for checkpoint_transaction in checkpoint_transactions {
             self.process_transaction(

--- a/crates/iota-analytics-indexer/src/handlers/transaction_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/transaction_handler.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, sync::Arc};
 
 use anyhow::Result;
 use fastcrypto::encoding::{Base64, Encoding};
@@ -32,13 +32,13 @@ impl Worker for TransactionHandler {
 
     async fn process_checkpoint(
         &self,
-        checkpoint_data: &CheckpointData,
+        checkpoint_data: Arc<CheckpointData>,
     ) -> Result<Self::Message, Self::Error> {
         let CheckpointData {
             checkpoint_summary,
             transactions: checkpoint_transactions,
             ..
-        } = checkpoint_data;
+        } = checkpoint_data.as_ref();
         let mut state = self.state.lock().await;
         for checkpoint_transaction in checkpoint_transactions {
             self.process_transaction(
@@ -200,6 +200,8 @@ impl TransactionHandler {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use fastcrypto::encoding::{Base64, Encoding};
     use iota_data_ingestion_core::Worker;
     use iota_types::{base_types::IotaAddress, storage::ReadStore};
@@ -224,8 +226,11 @@ mod tests {
             sim.get_checkpoint_contents_by_digest(&checkpoint.content_digest)?
                 .unwrap(),
         )?;
+        let shared_checkpoint_data = Arc::new(checkpoint_data);
         let txn_handler = TransactionHandler::new();
-        txn_handler.process_checkpoint(&checkpoint_data).await?;
+        txn_handler
+            .process_checkpoint(shared_checkpoint_data)
+            .await?;
         let transaction_entries = txn_handler.state.lock().await.transactions.clone();
         assert_eq!(transaction_entries.len(), 1);
         let db_txn = transaction_entries.first().unwrap();

--- a/crates/iota-analytics-indexer/src/handlers/transaction_objects_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/transaction_objects_handler.rs
@@ -2,6 +2,8 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use anyhow::Result;
 use iota_data_ingestion_core::Worker;
 use iota_rest_api::{CheckpointData, CheckpointTransaction};
@@ -31,13 +33,13 @@ impl Worker for TransactionObjectsHandler {
 
     async fn process_checkpoint(
         &self,
-        checkpoint_data: &CheckpointData,
+        checkpoint_data: Arc<CheckpointData>,
     ) -> Result<Self::Message, Self::Error> {
         let CheckpointData {
             checkpoint_summary,
             transactions: checkpoint_transactions,
             ..
-        } = checkpoint_data;
+        } = checkpoint_data.as_ref();
         let mut state = self.state.lock().await;
         for checkpoint_transaction in checkpoint_transactions {
             self.process_transaction(

--- a/crates/iota-analytics-indexer/src/handlers/wrapped_object_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/wrapped_object_handler.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, path::Path};
+use std::{collections::BTreeMap, path::Path, sync::Arc};
 
 use anyhow::Result;
 use iota_data_ingestion_core::Worker;
@@ -35,13 +35,13 @@ impl Worker for WrappedObjectHandler {
 
     async fn process_checkpoint(
         &self,
-        checkpoint_data: &CheckpointData,
+        checkpoint_data: Arc<CheckpointData>,
     ) -> Result<Self::Message, Self::Error> {
         let CheckpointData {
             checkpoint_summary,
             transactions: checkpoint_transactions,
             ..
-        } = checkpoint_data;
+        } = checkpoint_data.as_ref();
         let mut state = self.state.lock().await;
         for checkpoint_transaction in checkpoint_transactions {
             for object in checkpoint_transaction.output_objects.iter() {

--- a/crates/iota-analytics-indexer/src/lib.rs
+++ b/crates/iota-analytics-indexer/src/lib.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{ops::Range, path::PathBuf};
+use std::{ops::Range, path::PathBuf, sync::Arc};
 
 use anyhow::{Result, anyhow};
 use arrow_array::Int32Array;
@@ -495,7 +495,7 @@ impl Worker for Processor {
     #[inline]
     async fn process_checkpoint(
         &self,
-        checkpoint_data: &CheckpointData,
+        checkpoint_data: Arc<CheckpointData>,
     ) -> Result<Self::Message, Self::Error> {
         self.processor.process_checkpoint(checkpoint_data).await
     }

--- a/crates/iota-data-ingestion-core/src/executor.rs
+++ b/crates/iota-data-ingestion-core/src/executor.rs
@@ -41,7 +41,7 @@ pub const MAX_CHECKPOINTS_IN_PROGRESS: usize = 10000;
 /// use iota_types::full_checkpoint_content::CheckpointData;
 /// use prometheus::Registry;
 /// use tokio_util::sync::CancellationToken;
-/// use std::path::PathBuf;
+/// use std::{path::PathBuf, sync::Arc};
 ///
 /// struct CustomWorker;
 ///
@@ -52,7 +52,7 @@ pub const MAX_CHECKPOINTS_IN_PROGRESS: usize = 10000;
 ///
 ///     async fn process_checkpoint(
 ///         &self,
-///         checkpoint: &CheckpointData,
+///         checkpoint: Arc<CheckpointData>,
 ///     ) -> Result<Self::Message, Self::Error> {
 ///         // custom processing logic.
 ///         println!(
@@ -268,6 +268,8 @@ async fn components_graceful_shutdown(
 ///
 /// # Example
 /// ```rust,no_run
+/// use std::sync::Arc;
+///
 /// use async_trait::async_trait;
 /// use iota_data_ingestion_core::{IngestionError, Worker, setup_single_workflow};
 /// use iota_types::full_checkpoint_content::CheckpointData;
@@ -281,7 +283,7 @@ async fn components_graceful_shutdown(
 ///
 ///     async fn process_checkpoint(
 ///         &self,
-///         checkpoint: &CheckpointData,
+///         checkpoint: Arc<CheckpointData>,
 ///     ) -> Result<Self::Message, Self::Error> {
 ///         // custom processing logic.
 ///         println!(

--- a/crates/iota-data-ingestion-core/src/lib.rs
+++ b/crates/iota-data-ingestion-core/src/lib.rs
@@ -35,7 +35,10 @@ mod tests;
 mod util;
 mod worker_pool;
 
-use std::fmt::{Debug, Display};
+use std::{
+    fmt::{Debug, Display},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 pub use errors::{IngestionError, IngestionResult};
@@ -95,7 +98,7 @@ pub trait Worker: Send + Sync {
     ///   checkpoint order.
     async fn process_checkpoint(
         &self,
-        checkpoint: &CheckpointData,
+        checkpoint: Arc<CheckpointData>,
     ) -> Result<Self::Message, Self::Error>;
 
     /// A hook that allows preprocessing a checkpoint before it's fully
@@ -108,7 +111,7 @@ pub trait Worker: Send + Sync {
     /// # Default implementation
     ///
     /// By default it returns `Ok(())`.
-    fn preprocess_hook(&self, _: &CheckpointData) -> Result<(), Self::Error> {
+    fn preprocess_hook(&self, _: Arc<CheckpointData>) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/crates/iota-data-ingestion-core/src/tests.rs
+++ b/crates/iota-data-ingestion-core/src/tests.rs
@@ -95,7 +95,7 @@ impl Worker for TestWorker {
 
     async fn process_checkpoint(
         &self,
-        _checkpoint: &CheckpointData,
+        _checkpoint: Arc<CheckpointData>,
     ) -> Result<Self::Message, Self::Error> {
         Ok(())
     }
@@ -115,7 +115,7 @@ impl Worker for FaultyWorker {
 
     async fn process_checkpoint(
         &self,
-        _checkpoint: &CheckpointData,
+        _checkpoint: Arc<CheckpointData>,
     ) -> Result<Self::Message, Self::Error> {
         Err(IngestionError::CheckpointProcessing(
             "unable to process checkpoint".into(),

--- a/crates/iota-data-ingestion-core/src/worker_pool.rs
+++ b/crates/iota-data-ingestion-core/src/worker_pool.rs
@@ -308,7 +308,7 @@ impl<W: Worker + 'static> WorkerPool<W> {
                         continue;
                     }
                     self.worker
-                        .preprocess_hook(&checkpoint)
+                        .preprocess_hook(checkpoint.clone())
                         .map_err(|err| IngestionError::CheckpointHookProcessing(err.to_string()))
                         .expect("failed to preprocess task");
                     if idle.is_empty() {
@@ -372,7 +372,7 @@ impl<W: Worker + 'static> WorkerPool<W> {
                             let backoff = backoff::ExponentialBackoff::default();
                             let status = backoff::future::retry(backoff, || async {
                                let processed_checkpoint_result = worker
-                                    .process_checkpoint(&checkpoint)
+                                    .process_checkpoint(checkpoint.clone())
                                     .await
                                     .map_err(|err| {
                                         let err = IngestionError::CheckpointProcessing(err.to_string());

--- a/crates/iota-data-ingestion-core/src/worker_pool.rs
+++ b/crates/iota-data-ingestion-core/src/worker_pool.rs
@@ -104,10 +104,10 @@ enum WorkerStatus<M> {
 ///
 ///     async fn process_checkpoint(
 ///         &self,
-///         checkpoint: &CheckpointData,
+///         checkpoint: Arc<CheckpointData>,
 ///     ) -> Result<Self::Message, Self::Error> {
 ///         // extract a particulat transaction we care about.
-///         let tx: CheckpointTransaction = extract_transaction(checkpoint);
+///         let tx: CheckpointTransaction = extract_transaction(checkpoint.as_ref());
 ///         // store the transaction in our database of choice.
 ///         self.client.store_transaction(&tx).await?;
 ///         Ok(())
@@ -161,7 +161,7 @@ enum WorkerStatus<M> {
 ///
 ///     async fn process_checkpoint(
 ///         &self,
-///         checkpoint: &CheckpointData,
+///         checkpoint: Arc<CheckpointData>,
 ///     ) -> Result<Self::Message, Self::Error> {
 ///         // collect all checkpoint transactions for batch processing.
 ///         Ok(checkpoint.transactions.clone())

--- a/crates/iota-data-ingestion/src/workers/blob.rs
+++ b/crates/iota-data-ingestion/src/workers/blob.rs
@@ -133,9 +133,9 @@ impl Worker for BlobWorker {
 
     async fn process_checkpoint(
         &self,
-        checkpoint: &CheckpointData,
+        checkpoint: Arc<CheckpointData>,
     ) -> Result<Self::Message, Self::Error> {
-        let bytes = Blob::encode(checkpoint, BlobEncoding::Bcs)?.to_bytes();
+        let bytes = Blob::encode(&checkpoint, BlobEncoding::Bcs)?.to_bytes();
         let location = Path::from(format!(
             "{}.chk",
             checkpoint.checkpoint_summary.sequence_number

--- a/crates/iota-data-ingestion/src/workers/kv_store.rs
+++ b/crates/iota-data-ingestion/src/workers/kv_store.rs
@@ -6,6 +6,7 @@ use std::{
     borrow::Borrow,
     collections::{HashMap, HashSet, VecDeque},
     iter::repeat,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -187,7 +188,7 @@ impl Worker for KVStoreWorker {
 
     async fn process_checkpoint(
         &self,
-        checkpoint: &CheckpointData,
+        checkpoint: Arc<CheckpointData>,
     ) -> Result<Self::Message, Self::Error> {
         let mut transactions = vec![];
         let mut effects = vec![];

--- a/crates/iota-indexer-builder/src/iota_datasource.rs
+++ b/crates/iota-indexer-builder/src/iota_datasource.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 use anyhow::Error;
 use async_trait::async_trait;
@@ -131,7 +131,7 @@ impl Worker for IndexerWorker<CheckpointTxnData> {
 
     async fn process_checkpoint(
         &self,
-        checkpoint: &IotaCheckpointData,
+        checkpoint: Arc<IotaCheckpointData>,
     ) -> Result<Self::Message, Self::Error> {
         info!(
             "Received checkpoint [{}] {}: {}",

--- a/crates/iota-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/iota-indexer/src/handlers/checkpoint_handler.rs
@@ -127,7 +127,7 @@ impl Worker for CheckpointHandler {
             self.state.clone().into(),
             &checkpoint,
             Arc::new(self.metrics.clone()),
-            Self::index_packages(slice::from_ref(checkpoint), &self.metrics),
+            Self::index_packages(slice::from_ref(&checkpoint), &self.metrics),
         )
         .await?;
         self.indexed_checkpoint_sender

--- a/crates/iota-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/iota-indexer/src/handlers/checkpoint_handler.rs
@@ -98,7 +98,7 @@ impl Worker for CheckpointHandler {
 
     async fn process_checkpoint(
         &self,
-        checkpoint: &CheckpointData,
+        checkpoint: Arc<CheckpointData>,
     ) -> Result<Self::Message, Self::Error> {
         self.metrics
             .latest_fullnode_checkpoint_sequence_number
@@ -125,7 +125,7 @@ impl Worker for CheckpointHandler {
 
         let checkpoint_data = Self::index_checkpoint(
             self.state.clone().into(),
-            checkpoint,
+            &checkpoint,
             Arc::new(self.metrics.clone()),
             Self::index_packages(slice::from_ref(checkpoint), &self.metrics),
         )

--- a/crates/iota-indexer/src/handlers/objects_snapshot_handler.rs
+++ b/crates/iota-indexer/src/handlers/objects_snapshot_handler.rs
@@ -2,6 +2,8 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use iota_data_ingestion_core::Worker;
 use iota_metrics::{get_metrics, metered_channel::Sender, spawn_monitored_task};
@@ -69,9 +71,9 @@ impl Worker for ObjectsSnapshotHandler {
 
     async fn process_checkpoint(
         &self,
-        checkpoint: &CheckpointData,
+        checkpoint: Arc<CheckpointData>,
     ) -> Result<Self::Message, Self::Error> {
-        let transformed_data = CheckpointHandler::index_objects(checkpoint, &self.metrics).await?;
+        let transformed_data = CheckpointHandler::index_objects(&checkpoint, &self.metrics).await?;
         self.sender
             .send((
                 checkpoint.checkpoint_summary.sequence_number,

--- a/examples/custom-indexer/rust/local_reader.rs
+++ b/examples/custom-indexer/rust/local_reader.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env, path::PathBuf};
+use std::{env, path::PathBuf, sync::Arc};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -20,7 +20,7 @@ impl Worker for CustomWorker {
     type Message = ();
     type Error = anyhow::Error;
 
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<Self::Message> {
+    async fn process_checkpoint(&self, checkpoint: Arc<CheckpointData>) -> Result<Self::Message> {
         // custom processing logic
         println!(
             "Processing Local checkpoint: {}",

--- a/examples/custom-indexer/rust/remote_reader.rs
+++ b/examples/custom-indexer/rust/remote_reader.rs
@@ -2,6 +2,8 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use anyhow::Result;
 use async_trait::async_trait;
 use iota_data_ingestion_core::{Worker, setup_single_workflow};
@@ -14,7 +16,7 @@ impl Worker for CustomWorker {
     type Message = ();
     type Error = anyhow::Error;
 
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<Self::Message> {
+    async fn process_checkpoint(&self, checkpoint: Arc<CheckpointData>) -> Result<Self::Message> {
         // custom processing logic
         // print out the checkpoint number
         println!(


### PR DESCRIPTION
# Description of change

This PR is the first part of the optimization effort to improve the `Worker::process_checkpoint` by passing `Arc<CheckpointData>` to avoid unnecessary cloning for `Reducer` functionality.

### Dependency Chain
This PR builds upon:
- Depends on: #5735

> **Note**: Currently based on `sc-platform/issue-5551-pt2`. Will automatically retarget to `develop` after #5735 merges.

## Links to any relevant issues

fixes #5676 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation Fix

## How the change has been tested

started the `indexer` and made sure that the data was synced as before the changes
```shell
cargo r --bin iota --features indexer -- start --with-indexer --force-regenesis
```

## Change checklist
- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
