### PR TITLE
chore: Remove unmaintained `derivative` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9569,7 +9569,6 @@ dependencies = [
  "clap",
  "codespan-reporting",
  "crossbeam",
- "derivative",
  "dunce",
  "im",
  "itertools 0.10.5",

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -711,17 +711,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,7 +1544,6 @@ dependencies = [
  "codespan-reporting",
  "crossbeam",
  "datatest-stable",
- "derivative",
  "dunce",
  "im",
  "itertools",

--- a/external-crates/move/crates/move-analyzer/Cargo.toml
+++ b/external-crates/move/crates/move-analyzer/Cargo.toml
@@ -12,7 +12,6 @@ anyhow.workspace = true
 clap.workspace = true
 codespan-reporting.workspace = true
 crossbeam.workspace = true
-derivative.workspace = true
 dunce.workspace = true
 im.workspace = true
 itertools.workspace = true

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -71,7 +71,6 @@ use std::{
 
 use anyhow::{Result, anyhow};
 use crossbeam::channel::Sender;
-use derivative::*;
 use im::ordmap::OrdMap;
 use lsp_server::{Request, RequestId};
 use lsp_types::{
@@ -412,16 +411,23 @@ pub struct MemberDef {
 }
 
 /// Definition of a local (or parameter)
-#[allow(clippy::non_canonical_partial_ord_impl)]
-#[derive(Derivative, Debug, Clone, Eq, PartialEq)]
-#[derivative(PartialOrd, Ord)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct LocalDef {
     /// Location of the definition
     pub def_loc: Loc,
     /// Type of definition
-    #[derivative(PartialOrd = "ignore")]
-    #[derivative(Ord = "ignore")]
     pub def_type: Type,
+}
+
+impl PartialOrd for LocalDef {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for LocalDef {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.def_loc.cmp(&other.def_loc)
+    }
 }
 
 /// Information about call sites relevant to the IDE

--- a/external-crates/move/deny.toml
+++ b/external-crates/move/deny.toml
@@ -58,8 +58,6 @@ ignore = [
 
   # allow unmaintained instant crate used in transitive dependencies (backoff, cached, fastrand, parking_lot_*)
   "RUSTSEC-2024-0384",
-  # allow unmaintained derivative crate used in transitive dependencies (ark-*)
-  "RUSTSEC-2024-0388",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
## Description 

This PR removes the unmaintained `derivative` dependency to resolve
[`RUSTSEC-2024-0388`](https://rustsec.org/advisories/RUSTSEC-2024-0388).

Upstream PR: https://github.com/MystenLabs/sui/pull/21288