### PR TITLE
chore: Remove unmaintained `difference` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3548,12 +3548,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
-name = "difference"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9677,11 +9671,9 @@ name = "move-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bcs",
  "clap",
  "codespan-reporting",
  "colored",
- "difference",
  "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier",
@@ -9712,7 +9704,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
- "difference",
+ "colored",
  "dirs-next",
  "hex",
  "move-binary-format",
@@ -9721,6 +9713,7 @@ dependencies = [
  "once_cell",
  "serde",
  "sha2 0.9.9",
+ "similar",
  "vfs",
  "walkdir",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -49,8 +49,6 @@ ignore = [
   "RUSTSEC-2024-0320",
   # tui is unmaintained
   "RUSTSEC-2023-0049",
-  # difference is unmaintained
-  "RUSTSEC-2020-0095",
   # derivative is unmaintained
   "RUSTSEC-2024-0388",
   # instant is unmaintained

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -733,12 +733,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "difference"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,12 +1662,10 @@ name = "move-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bcs",
  "clap 4.5.23",
  "codespan-reporting",
  "colored",
  "datatest-stable",
- "difference",
  "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier",
@@ -1704,7 +1696,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
- "difference",
+ "colored",
  "dirs-next",
  "hex",
  "move-binary-format",
@@ -1714,6 +1706,7 @@ dependencies = [
  "proptest",
  "serde",
  "sha2",
+ "similar",
  "vfs",
  "walkdir",
 ]

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -34,7 +34,6 @@ crossterm = "0.25.0"
 curve25519-dalek = { version = "0.1.0", package = "curve25519-dalek-fiat", default-features = false, features = ["std", "u64_backend"] }
 datatest-stable = "0.1.1"
 derivative = "2.2.0"
-difference = "2.0.0"
 digest = "0.9.0"
 dir-diff = "0.3.2"
 dirs-next = "2.0.0"

--- a/external-crates/move/crates/move-cli/Cargo.toml
+++ b/external-crates/move/crates/move-cli/Cargo.toml
@@ -12,13 +12,10 @@ anyhow.workspace = true
 clap.workspace = true
 codespan-reporting.workspace = true
 colored.workspace = true
-difference.workspace = true
 serde_yaml.workspace = true
 tempfile.workspace = true
 toml_edit.workspace = true
 walkdir.workspace = true
-
-bcs.workspace = true
 
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true

--- a/external-crates/move/crates/move-command-line-common/Cargo.toml
+++ b/external-crates/move/crates/move-command-line-common/Cargo.toml
@@ -10,13 +10,14 @@ description = "Move shared command line and file tools"
 [dependencies]
 anyhow.workspace = true
 bcs.workspace = true
-difference.workspace = true
+colored.workspace = true
 dirs-next.workspace = true
 hex.workspace = true
 num-bigint = "0.4"
 once_cell.workspace = true
 serde.workspace = true
 sha2.workspace = true
+similar.workspace = true
 vfs.workspace = true
 walkdir.workspace = true
 

--- a/external-crates/move/crates/move-command-line-common/src/testing.rs
+++ b/external-crates/move/crates/move-command-line-common/src/testing.rs
@@ -36,31 +36,16 @@ pub fn add_update_baseline_fix(s: impl AsRef<str>) -> String {
 }
 
 pub fn format_diff(expected: impl AsRef<str>, actual: impl AsRef<str>) -> String {
-    use difference::*;
+    use colored::Colorize;
+    use similar::ChangeTag;
+    let diff = similar::TextDiff::from_lines(expected.as_ref(), actual.as_ref());
 
-    let changeset = Changeset::new(expected.as_ref(), actual.as_ref(), "\n");
-
-    let mut ret = String::new();
-
-    for seq in changeset.diffs {
-        match &seq {
-            Difference::Same(x) => {
-                ret.push_str(x);
-                ret.push('\n');
-            }
-            Difference::Add(x) => {
-                ret.push_str("\x1B[92m");
-                ret.push_str(x);
-                ret.push_str("\x1B[0m");
-                ret.push('\n');
-            }
-            Difference::Rem(x) => {
-                ret.push_str("\x1B[91m");
-                ret.push_str(x);
-                ret.push_str("\x1B[0m");
-                ret.push('\n');
-            }
-        }
-    }
-    ret
+    diff.iter_all_changes()
+        .map(|change| match change.tag() {
+            ChangeTag::Delete => format!("{}{}", "-".bold(), change.value()).red(),
+            ChangeTag::Insert => format!("{}{}", "+".bold(), change.value()).green(),
+            ChangeTag::Equal => change.value().dimmed(),
+        })
+        .map(|s| s.to_string())
+        .collect()
 }

--- a/external-crates/move/deny.toml
+++ b/external-crates/move/deny.toml
@@ -41,8 +41,6 @@ yanked = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-  # difference 2.0.0 is unmaintained
-  "RUSTSEC-2020-0095",
   # `tui` is unmaintained; use `ratatui` instead
   "RUSTSEC-2023-0049",
   # `yaml-rust` is unmaintained


### PR DESCRIPTION
## Description 

This PR removes the `difference` dependency and replaces it in one
instance with `similar`, to resolve
[`RUSTSEC-2020-0095`](https://rustsec.org/advisories/RUSTSEC-2020-0095).

Upstream PR: https://github.com/MystenLabs/sui/pull/21287