### PR TITLE
chore: update criterion and use standard timing

### DIFF
--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -48,6 +48,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,14 +387,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "2.34.0"
+name = "ciborium"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
- "bitflags 1.3.2",
- "textwrap 0.11.0",
- "unicode-width",
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -405,7 +427,7 @@ dependencies = [
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.16.1",
+ "textwrap",
 ]
 
 [[package]]
@@ -534,24 +556,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.6"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
 dependencies = [
- "atty",
+ "anes",
  "cast",
- "clap 2.34.0",
+ "ciborium",
+ "clap 4.5.23",
  "criterion-plot",
- "csv",
+ "is-terminal",
  "itertools",
- "lazy_static",
  "num-traits",
+ "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -559,20 +581,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "criterion-cpu-time"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63aaaf47e457badbcb376c65a49d0f182c317ebd97dc6d1ced94c8e1d09c0f3a"
-dependencies = [
- "criterion",
- "libc",
-]
-
-[[package]]
 name = "criterion-plot"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",
@@ -679,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
 dependencies = [
  "memchr",
 ]
@@ -965,9 +977,13 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "half"
-version = "1.8.3"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1340,7 +1356,6 @@ name = "language-benchmarks"
 version = "0.1.0"
 dependencies = [
  "criterion",
- "criterion-cpu-time",
  "move-binary-format",
  "move-compiler",
  "move-core-types",
@@ -3052,16 +3067,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3380,15 +3385,6 @@ dependencies = [
  "rand 0.8.5",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -26,8 +26,7 @@ clap = { version = "4", features = ["derive"] }
 codespan = "0.11.1"
 codespan-reporting = "0.11.1"
 colored = "2.0.0"
-criterion = { version = "0.3.4", features = ["html_reports"] }
-criterion-cpu-time = "0.1.0"
+criterion = { version = "0.5.1", features = ["html_reports"] }
 crossbeam = "0.8"
 crossbeam-channel = "0.5.0"
 crossterm = "0.25.0"

--- a/external-crates/move/crates/language-benchmarks/Cargo.toml
+++ b/external-crates/move/crates/language-benchmarks/Cargo.toml
@@ -9,7 +9,6 @@ description = "Move language benchmarks"
 
 [dependencies]
 criterion.workspace = true
-criterion-cpu-time.workspace = true
 once_cell.workspace = true
 
 move-binary-format.workspace = true

--- a/external-crates/move/crates/language-benchmarks/benches/criterion.rs
+++ b/external-crates/move/crates/language-benchmarks/benches/criterion.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{criterion_group, criterion_main, measurement::Measurement, Criterion};
-use language_benchmarks::{measurement::cpu_time_measurement, move_vm::bench};
+use language_benchmarks::{measurement::wall_time_measurement, move_vm::bench};
 
 //
 // MoveVM benchmarks
@@ -44,7 +44,7 @@ fn vector<M: Measurement + 'static>(c: &mut Criterion<M>) {
 
 criterion_group!(
     name = vm_benches;
-    config = cpu_time_measurement();
+    config = wall_time_measurement();
     targets =
         arith,
         arith_2,

--- a/external-crates/move/crates/language-benchmarks/src/measurement.rs
+++ b/external-crates/move/crates/language-benchmarks/src/measurement.rs
@@ -4,19 +4,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::Criterion;
-use criterion_cpu_time::PosixTime;
 use std::time::Duration;
 
-pub fn cpu_time_measurement() -> Criterion<PosixTime> {
+pub fn wall_time_measurement() -> Criterion {
     Criterion::default()
-        .with_measurement(PosixTime::UserAndSystemTime)
         .without_plots()
         .noise_threshold(0.20)
         .confidence_level(0.9)
         .warm_up_time(Duration::from_secs(10)) // Warm-up time before measurements start
         .measurement_time(Duration::from_secs(30)) // Measurement time of 30 seconds
-}
-
-pub fn wall_time_measurement() -> Criterion {
-    Criterion::default()
 }

--- a/external-crates/move/deny.toml
+++ b/external-crates/move/deny.toml
@@ -49,8 +49,6 @@ ignore = [
   "RUSTSEC-2024-0320",
   # `proc-macro-error` is unmaintained, needed by `tabled`
   "RUSTSEC-2024-0370",
-  # `serde_cbor` is unmaintained
-  "RUSTSEC-2021-0127",
   # `atty` is unmaintained
   "RUSTSEC-2024-0375",
   # Potential unaligned read in `atty`


### PR DESCRIPTION
## Description 

This PR updates criterion and migrates to using its standard timing
framework instead of using
[`criterion-cpu-time`](https://github.com/YangKeao/criterion-cpu-time)
in order to resolve
[`RUSTSEC-2021-0127`](https://rustsec.org/advisories/RUSTSEC-2021-0127).

Upstream PR: https://github.com/MystenLabs/sui/pull/21286