### PR TITLE
fix(iota-framework): `iota::object::delete` documentation comment

### DIFF
--- a/crates/iota-framework/packages/iota-framework/sources/object.move
+++ b/crates/iota-framework/packages/iota-framework/sources/object.move
@@ -176,10 +176,10 @@ module iota::object {
     }
 
     /// Delete the object and it's `UID`. This is the only way to eliminate a `UID`.
-    // This exists to inform IOTA of object deletions. When an object
-    // gets unpacked, the programmer will have to do something with its
-    // `UID`. The implementation of this function emits a deleted
-    // system event so IOTA knows to process the object deletion
+    /// This exists to inform IOTA of object deletions. When an object
+    /// gets unpacked, the programmer will have to do something with its
+    /// `UID`. The implementation of this function emits a deleted
+    /// system event so IOTA knows to process the object deletion
     public fun delete(id: UID) {
         let UID { id: ID { bytes } } = id;
         delete_impl(bytes)


### PR DESCRIPTION
# Description of change

The comment must be fixed so the package can be built with the external crates of version `1.41.1`.
