### PR TITLE
hotfix(apps-core): Bring back fallback coin symbol to `useFormatCoin` hook

### DIFF
--- a/apps/core/src/hooks/useFormatCoin.ts
+++ b/apps/core/src/hooks/useFormatCoin.ts
@@ -116,6 +116,10 @@ export function useFormatCoin({
     format = CoinFormat.ROUNDED,
     showSign = false,
 }: FormatCoinOptions): FormattedCoin {
+    const fallbackSymbol = useMemo(
+        () => (coinType ? (getCoinSymbol(coinType) ?? '') : ''),
+        [coinType],
+    );
     const queryResult = useCoinMetadata(coinType);
     const { isFetched, data } = queryResult;
 
@@ -127,7 +131,7 @@ export function useFormatCoin({
         return formatBalance(balance, data?.decimals ?? 0, format, showSign);
     }, [data?.decimals, isFetched, balance, format]);
 
-    return [formatted, (isFetched && data?.symbol) || '', queryResult];
+    return [formatted, isFetched ? data?.symbol || fallbackSymbol : '', queryResult];
 }
 
 /** @deprecated use coin metadata instead */


### PR DESCRIPTION
Closes https://github.com/iotaledger/iota/issues/5805
Closes https://github.com/iotaledger/iota/issues/5806
Partial revert of https://github.com/iotaledger/iota/pull/5298/files#diff-0be905f28ef74f9f545922c69615cd9d70fcff794d5a53b18819d9d22d71e507L113-L115