### PR TITLE
fix(script): Fix `track_upstream_commits` script and README error

### DIFF
--- a/scripts/track_upstream_commits/README.md
+++ b/scripts/track_upstream_commits/README.md
@@ -39,8 +39,7 @@ Either codeowner or folders must be provided. If both are provided, the script w
 input:
 
 ```bash
-./run.sh --since bb778828e36d53a7d91a27e55109f2f45621badc --until 3ada97c109cc7ae1b451cb384a1f2cfae49c8d3e --crates crates/iota-bridge --co
-codeowners @iotaledger/node
+./run.sh --since bb778828e36d53a7d91a27e55109f2f45621badc --until 3ada97c109cc7ae1b451cb384a1f2cfae49c8d3e --folders crates/iota-bridge --codeowners @iotaledger/node
 ```
 
 output:

--- a/scripts/track_upstream_commits/track_upstream_commits.py
+++ b/scripts/track_upstream_commits/track_upstream_commits.py
@@ -46,6 +46,15 @@ def analyze_folder_commits(start_ref, end_ref, folders):
     print(f"UNTIL: {end_ref}")
     print(f"FOLDERS: {', '.join(folders)}")
 
+    # This is necessary because there might be some missing tags/commits when 
+    # checking out to a specific version.
+    # E.g., when checking out to "mainnet-v1.41.1", the following commits will
+    # fail: 
+    # ./run.sh --since bb778828e36d53a7d91a27e55109f2f45621badc --until 
+    # 3ada97c109cc7ae1b451cb384a1f2cfae49c8d3e --codeowners @iotaledger/node
+    # This can be fixed by fetching all branches and tags from origin.
+    subprocess.run(["git", "fetch", "--all", "--tags", "--prune"], check=True)
+
     # Only insert non-empty lists into crates_commits
     folders_commits = {}
     for folder in folders:

--- a/scripts/track_upstream_commits/track_upstream_commits.py
+++ b/scripts/track_upstream_commits/track_upstream_commits.py
@@ -124,7 +124,7 @@ if __name__ == '__main__':
 
     folders = set()
     if args.folders:
-        folders.update(args.folders)        
+        folders.update(iota_to_sui_mapping_func(folder) for folder in args.folders)   
 
     if args.clone_source:
         # Check if the target folder already exists


### PR DESCRIPTION
# Description of change

Fix the folder parsing path, README error, and enhance the script to handle the situation where commits/tags are not fetched completely.

## Links to any relevant issues

N/A.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Verified by using the following command
```bash
./run.sh --since bb778828e36d53a7d91a27e55109f2f45621badc --until 3ada97c109cc7ae1b451cb384a1f2cfae49c8d3e --codeowners @iotaledger/node
```

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
