### PR TITLE
chore: Update ring 0.17 and ignore some RUSTSEC audits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
  "quinn-proto",
  "rand 0.8.5",
  "rcgen",
- "ring 0.17.8",
+ "ring 0.17.13",
  "rustls 0.23.18",
  "rustls-webpki 0.102.8",
  "serde",
@@ -1081,7 +1081,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 0.2.12",
- "ring 0.17.8",
+ "ring 0.17.13",
  "time",
  "tokio",
  "tracing",
@@ -1346,7 +1346,7 @@ dependencies = [
  "once_cell",
  "p256 0.11.1",
  "percent-encoding",
- "ring 0.17.8",
+ "ring 0.17.13",
  "sha2 0.10.8",
  "subtle",
  "time",
@@ -2344,9 +2344,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.21"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -8937,7 +8937,7 @@ dependencies = [
  "base64 0.21.7",
  "js-sys",
  "pem 3.0.4",
- "ring 0.17.8",
+ "ring 0.17.13",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -9139,7 +9139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -10754,7 +10754,7 @@ dependencies = [
  "quick-xml",
  "rand 0.8.5",
  "reqwest 0.12.7",
- "ring 0.17.8",
+ "ring 0.17.13",
  "rustls-pemfile 2.1.3",
  "serde",
  "serde_json",
@@ -10785,7 +10785,7 @@ dependencies = [
  "quick-xml",
  "rand 0.8.5",
  "reqwest 0.12.7",
- "ring 0.17.8",
+ "ring 0.17.13",
  "serde",
  "serde_json",
  "snafu 0.8.5",
@@ -12181,7 +12181,7 @@ checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
  "rand 0.8.5",
- "ring 0.17.8",
+ "ring 0.17.13",
  "rustc-hash 2.0.0",
  "rustls 0.23.18",
  "slab",
@@ -12425,7 +12425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54077e1872c46788540de1ea3d7f4ccb1983d12f9aa909b234468676c1a36779"
 dependencies = [
  "pem 3.0.4",
- "ring 0.17.8",
+ "ring 0.17.13",
  "rustls-pki-types",
  "time",
  "yasna",
@@ -12730,15 +12730,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin 0.9.8",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
@@ -13073,7 +13072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.8",
+ "ring 0.17.13",
  "rustls-webpki 0.101.7",
  "sct",
 ]
@@ -13085,7 +13084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
- "ring 0.17.8",
+ "ring 0.17.13",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle",
@@ -13101,7 +13100,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring 0.17.8",
+ "ring 0.17.13",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle",
@@ -13204,7 +13203,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.13",
  "untrusted 0.9.0",
 ]
 
@@ -13215,7 +13214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "aws-lc-rs",
- "ring 0.17.8",
+ "ring 0.17.13",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
@@ -13406,7 +13405,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.13",
  "untrusted 0.9.0",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -51,6 +51,16 @@ ignore = [
   "RUSTSEC-2024-0388",
   # instant is unmaintained
   "RUSTSEC-2024-0384",
+  # paste is unmaintained
+  "RUSTSEC-2024-0436",
+  # backoff is unmaintained
+  "RUSTSEC-2025-0012",
+  # humantime is unmaintained
+  "RUSTSEC-2025-0014",
+  # ring 0.16 is unmaintained
+  "RUSTSEC-2025-0010",
+  # ethers uses ring 0.16
+  "RUSTSEC-2025-0009",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/deny.toml
+++ b/deny.toml
@@ -61,6 +61,8 @@ ignore = [
   "RUSTSEC-2025-0010",
   # ethers uses ring 0.16
   "RUSTSEC-2025-0009",
+  # protobuf uncontrolled recursion https://github.com/iotaledger/iota/issues/5861
+  "RUSTSEC-2024-0437",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/external-crates/move/deny.toml
+++ b/external-crates/move/deny.toml
@@ -49,6 +49,8 @@ ignore = [
   "RUSTSEC-2024-0375",
   # Potential unaligned read in `atty`
   "RUSTSEC-2021-0145",
+  # paste is unmaintained
+  "RUSTSEC-2024-0436",
 
   # allow unmaintained instant crate used in transitive dependencies (backoff, cached, fastrand, parking_lot_*)
   "RUSTSEC-2024-0384",


### PR DESCRIPTION
## Description 

Several RUSTSEC audits have appeared recently. Three are due to the `ring` dependency, which is used by `ethers`. Unfortunately the 0.16 versions of `ring` are unmaintained and thus there is no solution without waiting for `ethers` to update, and it is also in the process of becoming unmaintained.

- [`RUSTSEC-2024-0436`](https://rustsec.org/advisories/RUSTSEC-2024-0436)
`paste` is unmaintained and there is currently no alternative.
- [`RUSTSEC-2025-0012`](https://rustsec.org/advisories/RUSTSEC-2025-0012)
`backoff` is unmaintained. `backon` is the suggested alternative, however after investigating the changes needed, I believe it will take quite a lot of work to switch and some desired functionality will be lost.
- [`RUSTSEC-2025-0014`](https://rustsec.org/advisories/RUSTSEC-2025-0014)
`humantime` is unmaintained. There are currently no alternatives.
- [`RUSTSEC-2025-0010`](https://rustsec.org/advisories/RUSTSEC-2025-0010)
`ring 0.16` is unmaintained.
- [`RUSTSEC-2025-0009`](https://rustsec.org/advisories/RUSTSEC-2025-0009)
`ring 0.16` vulnerability.

I am leaving one additional audit: [`RUSTSEC-2024-0437`](https://rustsec.org/advisories/RUSTSEC-2024-0437) because it is potentially serious and there is a fix in progress of being released.