### PR TITLE
fix(graphql-e2e-tests): bump protocol version and update baselines

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/iota-graphql-e2e-tests/tests/call/simple.exp
@@ -7,37 +7,31 @@ task 1, lines 7-26:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5563200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, computation_cost_burned: 234000, storage_cost: 5563200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2, line 28:
 //# run Test::M1::create --args 0 @A --gas-price 1000
 created: object(2,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2287600,  storage_rebate: 980400, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, computation_cost_burned: 234000, storage_cost: 2287600,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
 task 3, line 30:
 //# run Test::M1::create --args 0 @validator_0
 created: object(3,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2287600,  storage_rebate: 980400, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, computation_cost_burned: 234000, storage_cost: 2287600,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
 task 4, line 32:
 //# view-object 0,0
 Owner: Account Address ( validator_0 )
 Version: 1
-Contents: iota_system::staking_pool::StakedIota {
+Contents: iota_system::validator_cap::UnverifiedValidatorOperationCap {
     id: iota::object::UID {
         id: iota::object::ID {
             bytes: fake(0,0),
         },
     },
-    pool_id: iota::object::ID {
-        bytes: _,
-    },
-    stake_activation_epoch: 0u64,
-    principal: iota::balance::Balance<iota::iota::IOTA> {
-        value: 1500000000000000u64,
-    },
+    authorizer_validator_address: validator_0,
 }
 
 task 5, line 34:
@@ -73,7 +67,7 @@ Checkpoint created: 4
 task 8, line 40:
 //# view-checkpoint
 CheckpointSummary { epoch: 0, seq: 4, content_digest: D3oWLCcqoa1D15gxzvMaDemNNY8YYVspAkYkcmtQKWRt,
-            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 3000000, computation_cost_burned: 3000000, storage_cost: 10138400, storage_rebate: 1960800, non_refundable_storage_fee: 0 }}
+            epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 3000000, computation_cost_burned: 702000, storage_cost: 10138400, storage_rebate: 1960800, non_refundable_storage_fee: 0 }}
 
 task 9, line 42:
 //# advance-epoch 6
@@ -81,7 +75,7 @@ Epoch advanced: 5
 
 task 10, line 44:
 //# view-checkpoint
-CheckpointSummary { epoch: 5, seq: 10, content_digest: CB9R4MWVWhxipXjFBF8mHyCXxW4EGGvuW4wJj5dNAnDT,
+CheckpointSummary { epoch: 5, seq: 10, content_digest: GkqKbSicHxvBTFevDCAHRgAV1QZTFnbTLXoJfoopqgiA,
             epoch_rolling_gas_cost_summary: GasCostSummary { computation_cost: 0, computation_cost_burned: 0, storage_cost: 0, storage_rebate: 0, non_refundable_storage_fee: 0 }}
 
 task 11, lines 46-51:
@@ -159,8 +153,8 @@ Response: {
         "edges": [
           {
             "node": {
-              "address": "0xc5547cb57ae1630fc7cf34a29f6ec145e58adabd0311ce2792266d8976e795be",
-              "digest": "8vkyLhyKuqv4Cb8QNafGWkL8s44B6RPSzSoVAMCLLaT2",
+              "address": "0x055a981a36510240d0126a08b665e5c45a0104f61147f822ce3f14578a9471e1",
+              "digest": "F2eGVLzNjbGJNpPoNDyXNWBbsHkNgk27TdwnWnvFYbV4",
               "owner": {
                 "__typename": "AddressOwner"
               }
@@ -186,8 +180,8 @@ Response: {
         "edges": [
           {
             "node": {
-              "address": "0xc5547cb57ae1630fc7cf34a29f6ec145e58adabd0311ce2792266d8976e795be",
-              "digest": "8vkyLhyKuqv4Cb8QNafGWkL8s44B6RPSzSoVAMCLLaT2",
+              "address": "0x055a981a36510240d0126a08b665e5c45a0104f61147f822ce3f14578a9471e1",
+              "digest": "F2eGVLzNjbGJNpPoNDyXNWBbsHkNgk27TdwnWnvFYbV4",
               "owner": {
                 "__typename": "AddressOwner"
               }
@@ -201,8 +195,8 @@ Response: {
         "edges": [
           {
             "node": {
-              "address": "0x0084a2538454a4bfeb925217fa95fffa045a38335d282ca5530d9840e876d0da",
-              "digest": "23zDGWdD79fCBpxNtWTcDnJhV38bXFiB3GAkunm1b56g",
+              "address": "0x122bee69d717e6e35f5da21ab6db6039527b90213fb370cf5d85baa98af57bfc",
+              "digest": "UKpyPsij9GcYM4PAMfTewHqt2aEEx6hR4fnmn8npmGY",
               "owner": {
                 "__typename": "AddressOwner"
               }
@@ -210,8 +204,8 @@ Response: {
           },
           {
             "node": {
-              "address": "0x0bbf08b0544c2bca37dd2df7a17be39750d42da6f85b8a51532c7cf80187081d",
-              "digest": "9XtvG1yWpC5XK3bapyZvh9VUhwDD3fHk4bxxQ3tgnaPU",
+              "address": "0x1acd8b2e6c4b9330de864460c5729a1e7e257be0276f6e3f274aaec491298394",
+              "digest": "FVUjrqubjyS7pLyr2fdamzw6Y6ahBkBmpVbpqtWaEv7A",
               "owner": {
                 "__typename": "AddressOwner"
               }
@@ -219,8 +213,8 @@ Response: {
           },
           {
             "node": {
-              "address": "0x4a76e29f2f24ecc99efb7b2f957e8c02f2da75607f165cc0fdf207c351d84525",
-              "digest": "Exui5TbuC6ULRSuWw61a2uPQ75iUHrrUtpkTHFgvynna",
+              "address": "0x1b17d55f62475ecc5340dc637c24a492a60c75da3d00b2c33b5d58b2ece0be9a",
+              "digest": "23VSZHcHKR2ShVkCMgE1q87Tahk37ypB3rpvyT8b93By",
               "owner": {
                 "__typename": "AddressOwner"
               }
@@ -228,8 +222,8 @@ Response: {
           },
           {
             "node": {
-              "address": "0x65671988f83d32f85536873463400433e8d96bfd1ec5290acbd0b045bbe13b5a",
-              "digest": "8HHvyHTSNd3wk6vcKeFYkvAQodGNRN2XGfmv47t9rNUP",
+              "address": "0x3ef26752db86a6c902f0bd74a5533147b2e0ade90fdc011b63c6857eb0185d03",
+              "digest": "4F4evHDp2rPitGibt51xdfACTsJ1aoWdTCRiCYbTEKCt",
               "owner": {
                 "__typename": "AddressOwner"
               }
@@ -237,8 +231,8 @@ Response: {
           },
           {
             "node": {
-              "address": "0x69b923df83a37826d09c5e792df93e74ec626012fe5ada7576f7338362ddc90a",
-              "digest": "ArdhQjom6J58yB2hyoZQkzVE4ocRKvDm8FKam7fcNM8f",
+              "address": "0x6188230917472c4bdf281f7eade822598836d75443dd15bd68e941d5f3fb76aa",
+              "digest": "EyRUfXdmN5pn93sdS39SfCEQJ5SGvguK6RaLEKCbhFfv",
               "owner": {
                 "__typename": "AddressOwner"
               }
@@ -246,8 +240,8 @@ Response: {
           },
           {
             "node": {
-              "address": "0x6eaef7d89547478bcfe78c9427d9c81ed9202f6cb2c1ab0ae5adb711d9891c11",
-              "digest": "CdaxhhWZ7YZx5fJfWH8d2RMgAn5bMjzSXtaYqg2C3wps",
+              "address": "0x704fb07df8f2f7fb1640d26c066b66a8f2192ab0ca05aa12ebc489eec6635096",
+              "digest": "GwEZAzKdudr6ZUmbQixiz3jFVYoQPrWyxRw5Rq3c5UDG",
               "owner": {
                 "__typename": "AddressOwner"
               }
@@ -255,8 +249,8 @@ Response: {
           },
           {
             "node": {
-              "address": "0x9e69c660d4dc8e176f2874922a24bb90184b372dc04f73a48fc87ce2b07c954b",
-              "digest": "Eg2kC6UNeGg9D8gGSSxzzvSXbZ1REW9VWqZx8E8myQFg",
+              "address": "0x80c5c249c4c846eff3a64a04289cc47c658e26a07ae9a2575ec5f5c66d25b90d",
+              "digest": "A7zsU3EoB4LguqDsoukPFZP2u2CHWpnbgUGxF6x1iPTu",
               "owner": {
                 "__typename": "AddressOwner"
               }
@@ -264,8 +258,8 @@ Response: {
           },
           {
             "node": {
-              "address": "0x9f121e5b846bfbcd6c8b2bcb29f0250c43e8cdbd05f54b8189e9e47c34e28ad7",
-              "digest": "9v8gB9WuXwdtL6r8Ktu9FW84A2yvkdu1QGFwzsDYySfg",
+              "address": "0xabcdade341c325caf94e3e22fdc06f190619c0cf58c83fc394621054838562d4",
+              "digest": "Bd2NTQJfCrRwvEGkT7xNrrTQv364orod6REz1yZ7pmAy",
               "owner": {
                 "__typename": "AddressOwner"
               }
@@ -273,8 +267,8 @@ Response: {
           },
           {
             "node": {
-              "address": "0xa4ba1aa7137d5c35b8ab987eaf40535462f10840208ccb3cb90820e7a26bc427",
-              "digest": "AgLAqPqjKbraBM8io7w3iqxZ2t9biS3D9aR42dQXLwXU",
+              "address": "0xaf6cc809f167cc6461248e7361755ade86f07e2551444ddba313729d51e175bd",
+              "digest": "9HJqiKA7SdXvaXM1vpRWd4dX7PM6k9w4cVpNuctZM7Hp",
               "owner": {
                 "__typename": "AddressOwner"
               }
@@ -282,8 +276,8 @@ Response: {
           },
           {
             "node": {
-              "address": "0xbd20e8340a2bf69e0884f7a6c35a7ff89b81be3ee90e0453573bd12121e1c0c5",
-              "digest": "41XUuFssKpqCmFC8TyCB21Dn3qmv8L44y3KuVNpgsdhY",
+              "address": "0xb79c6c572023583edc8ff218ff81ba170bde5a1d690a8fc748296c566345ee88",
+              "digest": "4e3waaXSCZRbj1qiFDNpYe39av2iphk3AcnT5pvrD17Z",
               "owner": {
                 "__typename": "AddressOwner"
               }
@@ -291,8 +285,8 @@ Response: {
           },
           {
             "node": {
-              "address": "0xbd83e4bcdb7b40f0ade263fa26531af46940740a2a4b4a615829060e9f6e0331",
-              "digest": "22kkXiTjUJX7gX26P92CBq7HySLsasC6pSGbK1TbkBe7",
+              "address": "0xc6524e8c3dd3f57f353b4ac001123cd9de1b8dcf2f9afdee91310268f0701265",
+              "digest": "7RqHedG1niAQrfeAiMmAXRBEbZzr2cbfmJKRuC4JeSoc",
               "owner": {
                 "__typename": "AddressOwner"
               }
@@ -300,8 +294,8 @@ Response: {
           },
           {
             "node": {
-              "address": "0xea204146efbdcb2d3245464e7d50130b72c51788e2323ebba7a03109fd94a48a",
-              "digest": "CfnwEHv4Z9uN9DWU9J6qdKqvT6i7kfTEMbKrEYX4aDzU",
+              "address": "0xd8873d2bcbf0e3a06f24f3a2e4c7ae69705e68eb74a33ed62c65bda2b32cfc97",
+              "digest": "sMJkEkK1BrDh4hds19Nu9jYGhidjPSvwNQUKqBLfxtf",
               "owner": {
                 "__typename": "AddressOwner"
               }
@@ -359,19 +353,19 @@ task 22, line 178:
 //# run Test::M1::create --args 0 @A --gas-price 999
 created: object(22,0)
 mutated: object(0,1)
-gas summary: computation_cost: 999000, computation_cost_burned: 999000, storage_cost: 2287600,  storage_rebate: 980400, non_refundable_storage_fee: 0
+gas summary: computation_cost: 999000, computation_cost_burned: 234000, storage_cost: 2287600,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
 task 23, line 180:
 //# run Test::M1::create --args 0 @A --gas-price 1000
 created: object(23,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2287600,  storage_rebate: 980400, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, computation_cost_burned: 234000, storage_cost: 2287600,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
 task 24, line 182:
 //# run Test::M1::create --args 0 @A --gas-price 235
 created: object(24,0)
 mutated: object(0,1)
-gas summary: computation_cost: 235000, computation_cost_burned: 235000, storage_cost: 2287600,  storage_rebate: 980400, non_refundable_storage_fee: 0
+gas summary: computation_cost: 235000, computation_cost_burned: 234000, storage_cost: 2287600,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
 task 25, lines 184-189:
 //# run-graphql

--- a/crates/iota-graphql-e2e-tests/tests/call/simple.move
+++ b/crates/iota-graphql-e2e-tests/tests/call/simple.move
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 4 --addresses Test=0x0 A=0x42 --simulator --custom-validator-account --reference-gas-price 234 --default-gas-price 1000
+//# init --protocol-version 5 --addresses Test=0x0 A=0x42 --simulator --custom-validator-account --reference-gas-price 234 --default-gas-price 1000
 
 //# publish
 module Test::M1 {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/epochs/checkpoints.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/epochs/checkpoints.move
@@ -9,7 +9,7 @@
 // 2     | 2
 // An additional checkpoint is created at the end.
 
-//# init --protocol-version 4 --addresses Test=0x0 --accounts A B --simulator
+//# init --protocol-version 5 --addresses Test=0x0 --accounts A B --simulator
 
 //# create-checkpoint
 

--- a/crates/iota-graphql-e2e-tests/tests/consistency/epochs/transaction_blocks.exp
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/epochs/transaction_blocks.exp
@@ -41,25 +41,25 @@ Response: {
           {
             "cursor": "eyJjIjozLCJ0IjowLCJpIjpmYWxzZX0",
             "node": {
-              "digest": "2joLmY9Sv1wqMwzSfA3DkKC4FsWcV3WfjA2mYFWeCHtF"
+              "digest": "5v3R2yrTxtE9Mid18BiPCy9vsgFXLmjksxxVyr14JtpA"
             }
           },
           {
             "cursor": "eyJjIjozLCJ0IjoxLCJpIjpmYWxzZX0",
             "node": {
-              "digest": "ARh44eM27MtgwomtNHSXeBeA1rMpGjndyRt6wH3yDgd7"
+              "digest": "6hsWDoqG3WSUJrJpWt3P2knFrfhtYh8gRhR4gTFdFLJP"
             }
           },
           {
             "cursor": "eyJjIjozLCJ0IjoyLCJpIjpmYWxzZX0",
             "node": {
-              "digest": "AqKeLka2psDxT5mKGaW3BtMtsZSaBAvePSgneTBhMaM3"
+              "digest": "GwNeHRyX66pvkMMG2zzzx5acvMKXtLBXniUVLzVYzRj9"
             }
           },
           {
             "cursor": "eyJjIjozLCJ0IjozLCJpIjpmYWxzZX0",
             "node": {
-              "digest": "3D2DfKxndHNjZDXQqjasU19gZE9NJyAFf8fwPajC7KDn"
+              "digest": "CCWGo3mktMapsV9DKmzXHysxzaJip3kujsWaSuvMEQNd"
             }
           }
         ]
@@ -154,25 +154,25 @@ Response: {
           {
             "cursor": "eyJjIjoxMiwidCI6MCwiaSI6ZmFsc2V9",
             "node": {
-              "digest": "2joLmY9Sv1wqMwzSfA3DkKC4FsWcV3WfjA2mYFWeCHtF"
+              "digest": "5v3R2yrTxtE9Mid18BiPCy9vsgFXLmjksxxVyr14JtpA"
             }
           },
           {
             "cursor": "eyJjIjoxMiwidCI6MSwiaSI6ZmFsc2V9",
             "node": {
-              "digest": "ARh44eM27MtgwomtNHSXeBeA1rMpGjndyRt6wH3yDgd7"
+              "digest": "6hsWDoqG3WSUJrJpWt3P2knFrfhtYh8gRhR4gTFdFLJP"
             }
           },
           {
             "cursor": "eyJjIjoxMiwidCI6MiwiaSI6ZmFsc2V9",
             "node": {
-              "digest": "AqKeLka2psDxT5mKGaW3BtMtsZSaBAvePSgneTBhMaM3"
+              "digest": "GwNeHRyX66pvkMMG2zzzx5acvMKXtLBXniUVLzVYzRj9"
             }
           },
           {
             "cursor": "eyJjIjoxMiwidCI6MywiaSI6ZmFsc2V9",
             "node": {
-              "digest": "3D2DfKxndHNjZDXQqjasU19gZE9NJyAFf8fwPajC7KDn"
+              "digest": "CCWGo3mktMapsV9DKmzXHysxzaJip3kujsWaSuvMEQNd"
             }
           }
         ]
@@ -183,19 +183,19 @@ Response: {
         {
           "cursor": "eyJjIjo0LCJ0IjowLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "2joLmY9Sv1wqMwzSfA3DkKC4FsWcV3WfjA2mYFWeCHtF"
+            "digest": "5v3R2yrTxtE9Mid18BiPCy9vsgFXLmjksxxVyr14JtpA"
           }
         },
         {
           "cursor": "eyJjIjo0LCJ0IjoxLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "ARh44eM27MtgwomtNHSXeBeA1rMpGjndyRt6wH3yDgd7"
+            "digest": "6hsWDoqG3WSUJrJpWt3P2knFrfhtYh8gRhR4gTFdFLJP"
           }
         },
         {
           "cursor": "eyJjIjo0LCJ0IjoyLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "AqKeLka2psDxT5mKGaW3BtMtsZSaBAvePSgneTBhMaM3"
+            "digest": "GwNeHRyX66pvkMMG2zzzx5acvMKXtLBXniUVLzVYzRj9"
           }
         }
       ]
@@ -207,25 +207,25 @@ Response: {
           {
             "cursor": "eyJjIjoxMiwidCI6NCwiaSI6ZmFsc2V9",
             "node": {
-              "digest": "2Xo3P52jeiqttVZUE5MyTdwbSjjcgGCuFgYtF74P5Cru"
+              "digest": "9PVUCS3ssrmYowK3epNi1AHkmTd3WFUVnzRiYoi8t9EU"
             }
           },
           {
             "cursor": "eyJjIjoxMiwidCI6NSwiaSI6ZmFsc2V9",
             "node": {
-              "digest": "5ZFxt4Vo5w6478FCiR2yGG16JyZC6HeWBZFL28JKU2of"
+              "digest": "2eDGSYYM273F6my8RRgnSyVGY6Aw3uf7NXtfWAER1J6T"
             }
           },
           {
             "cursor": "eyJjIjoxMiwidCI6NiwiaSI6ZmFsc2V9",
             "node": {
-              "digest": "5i9zqxCjr7rkhA2uYaHrrJZn8uFE8jvjwUQf3dA8kA6b"
+              "digest": "Cb8ByaR6o5nX2dnPuLNnTfLgyKbrKU3JXzhUXau7xh8c"
             }
           },
           {
             "cursor": "eyJjIjoxMiwidCI6NywiaSI6ZmFsc2V9",
             "node": {
-              "digest": "8Aqf9snm8NPAFhQqJUJmaoQSJ2U6avtgFHWAwQSWhW27"
+              "digest": "GFCx8HXzQg73TjHd54dFk6DVhPjU9pwMi4cXT27Mu7kr"
             }
           }
         ]
@@ -236,43 +236,43 @@ Response: {
         {
           "cursor": "eyJjIjo4LCJ0IjowLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "2joLmY9Sv1wqMwzSfA3DkKC4FsWcV3WfjA2mYFWeCHtF"
+            "digest": "5v3R2yrTxtE9Mid18BiPCy9vsgFXLmjksxxVyr14JtpA"
           }
         },
         {
           "cursor": "eyJjIjo4LCJ0IjoxLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "ARh44eM27MtgwomtNHSXeBeA1rMpGjndyRt6wH3yDgd7"
+            "digest": "6hsWDoqG3WSUJrJpWt3P2knFrfhtYh8gRhR4gTFdFLJP"
           }
         },
         {
           "cursor": "eyJjIjo4LCJ0IjoyLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "AqKeLka2psDxT5mKGaW3BtMtsZSaBAvePSgneTBhMaM3"
+            "digest": "GwNeHRyX66pvkMMG2zzzx5acvMKXtLBXniUVLzVYzRj9"
           }
         },
         {
           "cursor": "eyJjIjo4LCJ0IjozLCJpIjpmYWxzZX0",
           "node": {
-            "digest": "3D2DfKxndHNjZDXQqjasU19gZE9NJyAFf8fwPajC7KDn"
+            "digest": "CCWGo3mktMapsV9DKmzXHysxzaJip3kujsWaSuvMEQNd"
           }
         },
         {
           "cursor": "eyJjIjo4LCJ0Ijo0LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "2Xo3P52jeiqttVZUE5MyTdwbSjjcgGCuFgYtF74P5Cru"
+            "digest": "9PVUCS3ssrmYowK3epNi1AHkmTd3WFUVnzRiYoi8t9EU"
           }
         },
         {
           "cursor": "eyJjIjo4LCJ0Ijo1LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "5ZFxt4Vo5w6478FCiR2yGG16JyZC6HeWBZFL28JKU2of"
+            "digest": "2eDGSYYM273F6my8RRgnSyVGY6Aw3uf7NXtfWAER1J6T"
           }
         },
         {
           "cursor": "eyJjIjo4LCJ0Ijo2LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "5i9zqxCjr7rkhA2uYaHrrJZn8uFE8jvjwUQf3dA8kA6b"
+            "digest": "Cb8ByaR6o5nX2dnPuLNnTfLgyKbrKU3JXzhUXau7xh8c"
           }
         }
       ]
@@ -284,25 +284,25 @@ Response: {
           {
             "cursor": "eyJjIjoxMiwidCI6OCwiaSI6ZmFsc2V9",
             "node": {
-              "digest": "AoorSccqwZCGgiPQgNzSRGqNBhvR18iwF1UboCzAUCoj"
+              "digest": "7zekmw4yhEnKTFmtmJPaw7JLWK91yVdbpvUaD1MnKi3g"
             }
           },
           {
             "cursor": "eyJjIjoxMiwidCI6OSwiaSI6ZmFsc2V9",
             "node": {
-              "digest": "Ak8JCxSwJrVGeGyGShsRbF2koRxbYB7u3yhiKkzEhg5x"
+              "digest": "2ZAd9j8pY4uLmWf3rzcKqRpUZL3Z8wDy9RcX2hooLaxU"
             }
           },
           {
             "cursor": "eyJjIjoxMiwidCI6MTAsImkiOmZhbHNlfQ",
             "node": {
-              "digest": "rTtcpSJm2DJ1joEVd5JhoPBgmntTHcpNz1mDMLw99E8"
+              "digest": "7GatNA6rLyPi6QWTVQCoSdMk97sheiF3c2r84tJSAPV7"
             }
           },
           {
             "cursor": "eyJjIjoxMiwidCI6MTEsImkiOmZhbHNlfQ",
             "node": {
-              "digest": "2f8Pb4WM4S44FMgE41URwKRENdRmeEbPiZDnkM8VQiMR"
+              "digest": "kuZL4jSXz1ZRweGqK8qet9k2DTJV8DYZ7TmmB7fbzZS"
             }
           }
         ]
@@ -313,67 +313,67 @@ Response: {
         {
           "cursor": "eyJjIjoxMiwidCI6MCwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "2joLmY9Sv1wqMwzSfA3DkKC4FsWcV3WfjA2mYFWeCHtF"
+            "digest": "5v3R2yrTxtE9Mid18BiPCy9vsgFXLmjksxxVyr14JtpA"
           }
         },
         {
           "cursor": "eyJjIjoxMiwidCI6MSwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "ARh44eM27MtgwomtNHSXeBeA1rMpGjndyRt6wH3yDgd7"
+            "digest": "6hsWDoqG3WSUJrJpWt3P2knFrfhtYh8gRhR4gTFdFLJP"
           }
         },
         {
           "cursor": "eyJjIjoxMiwidCI6MiwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "AqKeLka2psDxT5mKGaW3BtMtsZSaBAvePSgneTBhMaM3"
+            "digest": "GwNeHRyX66pvkMMG2zzzx5acvMKXtLBXniUVLzVYzRj9"
           }
         },
         {
           "cursor": "eyJjIjoxMiwidCI6MywiaSI6ZmFsc2V9",
           "node": {
-            "digest": "3D2DfKxndHNjZDXQqjasU19gZE9NJyAFf8fwPajC7KDn"
+            "digest": "CCWGo3mktMapsV9DKmzXHysxzaJip3kujsWaSuvMEQNd"
           }
         },
         {
           "cursor": "eyJjIjoxMiwidCI6NCwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "2Xo3P52jeiqttVZUE5MyTdwbSjjcgGCuFgYtF74P5Cru"
+            "digest": "9PVUCS3ssrmYowK3epNi1AHkmTd3WFUVnzRiYoi8t9EU"
           }
         },
         {
           "cursor": "eyJjIjoxMiwidCI6NSwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "5ZFxt4Vo5w6478FCiR2yGG16JyZC6HeWBZFL28JKU2of"
+            "digest": "2eDGSYYM273F6my8RRgnSyVGY6Aw3uf7NXtfWAER1J6T"
           }
         },
         {
           "cursor": "eyJjIjoxMiwidCI6NiwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "5i9zqxCjr7rkhA2uYaHrrJZn8uFE8jvjwUQf3dA8kA6b"
+            "digest": "Cb8ByaR6o5nX2dnPuLNnTfLgyKbrKU3JXzhUXau7xh8c"
           }
         },
         {
           "cursor": "eyJjIjoxMiwidCI6NywiaSI6ZmFsc2V9",
           "node": {
-            "digest": "8Aqf9snm8NPAFhQqJUJmaoQSJ2U6avtgFHWAwQSWhW27"
+            "digest": "GFCx8HXzQg73TjHd54dFk6DVhPjU9pwMi4cXT27Mu7kr"
           }
         },
         {
           "cursor": "eyJjIjoxMiwidCI6OCwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "AoorSccqwZCGgiPQgNzSRGqNBhvR18iwF1UboCzAUCoj"
+            "digest": "7zekmw4yhEnKTFmtmJPaw7JLWK91yVdbpvUaD1MnKi3g"
           }
         },
         {
           "cursor": "eyJjIjoxMiwidCI6OSwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "Ak8JCxSwJrVGeGyGShsRbF2koRxbYB7u3yhiKkzEhg5x"
+            "digest": "2ZAd9j8pY4uLmWf3rzcKqRpUZL3Z8wDy9RcX2hooLaxU"
           }
         },
         {
           "cursor": "eyJjIjoxMiwidCI6MTAsImkiOmZhbHNlfQ",
           "node": {
-            "digest": "rTtcpSJm2DJ1joEVd5JhoPBgmntTHcpNz1mDMLw99E8"
+            "digest": "7GatNA6rLyPi6QWTVQCoSdMk97sheiF3c2r84tJSAPV7"
           }
         }
       ]
@@ -395,19 +395,19 @@ Response: {
           {
             "cursor": "eyJjIjo3LCJ0IjoxLCJpIjpmYWxzZX0",
             "node": {
-              "digest": "ARh44eM27MtgwomtNHSXeBeA1rMpGjndyRt6wH3yDgd7"
+              "digest": "6hsWDoqG3WSUJrJpWt3P2knFrfhtYh8gRhR4gTFdFLJP"
             }
           },
           {
             "cursor": "eyJjIjo3LCJ0IjoyLCJpIjpmYWxzZX0",
             "node": {
-              "digest": "AqKeLka2psDxT5mKGaW3BtMtsZSaBAvePSgneTBhMaM3"
+              "digest": "GwNeHRyX66pvkMMG2zzzx5acvMKXtLBXniUVLzVYzRj9"
             }
           },
           {
             "cursor": "eyJjIjo3LCJ0IjozLCJpIjpmYWxzZX0",
             "node": {
-              "digest": "3D2DfKxndHNjZDXQqjasU19gZE9NJyAFf8fwPajC7KDn"
+              "digest": "CCWGo3mktMapsV9DKmzXHysxzaJip3kujsWaSuvMEQNd"
             }
           }
         ]
@@ -420,19 +420,19 @@ Response: {
           {
             "cursor": "eyJjIjoxMSwidCI6NSwiaSI6ZmFsc2V9",
             "node": {
-              "digest": "5ZFxt4Vo5w6478FCiR2yGG16JyZC6HeWBZFL28JKU2of"
+              "digest": "2eDGSYYM273F6my8RRgnSyVGY6Aw3uf7NXtfWAER1J6T"
             }
           },
           {
             "cursor": "eyJjIjoxMSwidCI6NiwiaSI6ZmFsc2V9",
             "node": {
-              "digest": "5i9zqxCjr7rkhA2uYaHrrJZn8uFE8jvjwUQf3dA8kA6b"
+              "digest": "Cb8ByaR6o5nX2dnPuLNnTfLgyKbrKU3JXzhUXau7xh8c"
             }
           },
           {
             "cursor": "eyJjIjoxMSwidCI6NywiaSI6ZmFsc2V9",
             "node": {
-              "digest": "8Aqf9snm8NPAFhQqJUJmaoQSJ2U6avtgFHWAwQSWhW27"
+              "digest": "GFCx8HXzQg73TjHd54dFk6DVhPjU9pwMi4cXT27Mu7kr"
             }
           }
         ]
@@ -445,19 +445,19 @@ Response: {
           {
             "cursor": "eyJjIjoxMiwidCI6OSwiaSI6ZmFsc2V9",
             "node": {
-              "digest": "Ak8JCxSwJrVGeGyGShsRbF2koRxbYB7u3yhiKkzEhg5x"
+              "digest": "2ZAd9j8pY4uLmWf3rzcKqRpUZL3Z8wDy9RcX2hooLaxU"
             }
           },
           {
             "cursor": "eyJjIjoxMiwidCI6MTAsImkiOmZhbHNlfQ",
             "node": {
-              "digest": "rTtcpSJm2DJ1joEVd5JhoPBgmntTHcpNz1mDMLw99E8"
+              "digest": "7GatNA6rLyPi6QWTVQCoSdMk97sheiF3c2r84tJSAPV7"
             }
           },
           {
             "cursor": "eyJjIjoxMiwidCI6MTEsImkiOmZhbHNlfQ",
             "node": {
-              "digest": "2f8Pb4WM4S44FMgE41URwKRENdRmeEbPiZDnkM8VQiMR"
+              "digest": "kuZL4jSXz1ZRweGqK8qet9k2DTJV8DYZ7TmmB7fbzZS"
             }
           }
         ]
@@ -480,7 +480,7 @@ Response: {
           {
             "cursor": "eyJjIjoyLCJ0IjoyLCJpIjpmYWxzZX0",
             "node": {
-              "digest": "AqKeLka2psDxT5mKGaW3BtMtsZSaBAvePSgneTBhMaM3"
+              "digest": "GwNeHRyX66pvkMMG2zzzx5acvMKXtLBXniUVLzVYzRj9"
             }
           }
         ]
@@ -493,7 +493,7 @@ Response: {
           {
             "cursor": "eyJjIjo2LCJ0Ijo2LCJpIjpmYWxzZX0",
             "node": {
-              "digest": "5i9zqxCjr7rkhA2uYaHrrJZn8uFE8jvjwUQf3dA8kA6b"
+              "digest": "Cb8ByaR6o5nX2dnPuLNnTfLgyKbrKU3JXzhUXau7xh8c"
             }
           }
         ]
@@ -506,7 +506,7 @@ Response: {
           {
             "cursor": "eyJjIjoxMCwidCI6MTAsImkiOmZhbHNlfQ",
             "node": {
-              "digest": "rTtcpSJm2DJ1joEVd5JhoPBgmntTHcpNz1mDMLw99E8"
+              "digest": "7GatNA6rLyPi6QWTVQCoSdMk97sheiF3c2r84tJSAPV7"
             }
           }
         ]
@@ -527,24 +527,24 @@ Response: {
         {
           "cursor": "eyJjIjo2LCJ0Ijo2LCJpIjpmYWxzZX0",
           "node": {
-            "digest": "5i9zqxCjr7rkhA2uYaHrrJZn8uFE8jvjwUQf3dA8kA6b",
+            "digest": "Cb8ByaR6o5nX2dnPuLNnTfLgyKbrKU3JXzhUXau7xh8c",
             "sender": {
               "objects": {
                 "edges": [
                   {
-                    "cursor": "IBv06n5VZDWEEY0pppKG8zUs4HJhTTmskx1gM9yeW2GeBgAAAAAAAAA="
+                    "cursor": "IAw9ZwX1jmog4p+ZnBd1BS7wwxH7BCgWQp7uKBXqjMdgBgAAAAAAAAA="
                   },
                   {
-                    "cursor": "IFfgHaolGXK4Rvlw1WYOC3LKNF52OF5myww6k0UbdE9UBgAAAAAAAAA="
+                    "cursor": "IDQ5bsgxHjaVc6nABAPXGaOQeYM7o12z4kEy7rC6ROJ2BgAAAAAAAAA="
                   },
                   {
-                    "cursor": "IGChL2MaSNe7wDoDrtn7NK8AA4fZ/0o+6rY8Fo7qI1yJBgAAAAAAAAA="
+                    "cursor": "IEPg2mMiqyl+Exu7/wLLxqmiNvix3u9ZprZ4nlgoyUwEBgAAAAAAAAA="
                   },
                   {
-                    "cursor": "ILTukj/dHMrTShL1wP0lSoTybGv7OnFi3GSe4UgQjEmbBgAAAAAAAAA="
+                    "cursor": "IFwIeAOSR6HYB9NcDqJmhkRbSBd8cB3TlSBMN4DXJS82BgAAAAAAAAA="
                   },
                   {
-                    "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qBgAAAAAAAAA="
+                    "cursor": "IGtvZR/LSrXlyoBaXvshZXcztTjUpwF9LDdcOsPpzS1EBgAAAAAAAAA="
                   }
                 ]
               }
@@ -558,33 +558,33 @@ Response: {
         {
           "cursor": "eyJjIjoxMiwidCI6MiwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "AqKeLka2psDxT5mKGaW3BtMtsZSaBAvePSgneTBhMaM3",
+            "digest": "GwNeHRyX66pvkMMG2zzzx5acvMKXtLBXniUVLzVYzRj9",
             "sender": {
               "objects": {
                 "edges": [
                   {
-                    "cursor": "IBu3DStJFgt/VTUu87HHbyuslmgfAkAR++eiATcNMDwoDAAAAAAAAAA="
+                    "cursor": "IAw9ZwX1jmog4p+ZnBd1BS7wwxH7BCgWQp7uKBXqjMdgDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IBv06n5VZDWEEY0pppKG8zUs4HJhTTmskx1gM9yeW2GeDAAAAAAAAAA="
+                    "cursor": "IDQ5bsgxHjaVc6nABAPXGaOQeYM7o12z4kEy7rC6ROJ2DAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IFfgHaolGXK4Rvlw1WYOC3LKNF52OF5myww6k0UbdE9UDAAAAAAAAAA="
+                    "cursor": "IEPg2mMiqyl+Exu7/wLLxqmiNvix3u9ZprZ4nlgoyUwEDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IGChL2MaSNe7wDoDrtn7NK8AA4fZ/0o+6rY8Fo7qI1yJDAAAAAAAAAA="
+                    "cursor": "IFwIeAOSR6HYB9NcDqJmhkRbSBd8cB3TlSBMN4DXJS82DAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IKKZiUBQ+A6uSKG+mYXAFTN6Mjx0L4tIEmJRdxmjXqYjDAAAAAAAAAA="
+                    "cursor": "IGSbVfgUupPzSJrdB34w9bSCrE74yaeaYfLmlq9INVuWDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IKaDnU8Z0d9FXXModa1A7nQ9sZ+HDwil7XmY7B5K0xzMDAAAAAAAAAA="
+                    "cursor": "IGtvZR/LSrXlyoBaXvshZXcztTjUpwF9LDdcOsPpzS1EDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "ILTukj/dHMrTShL1wP0lSoTybGv7OnFi3GSe4UgQjEmbDAAAAAAAAAA="
+                    "cursor": "IHoHVHQZdmNV4qCCoCvQKFGuzA0tczDWNqPDzSyrLQPSDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qDAAAAAAAAAA="
+                    "cursor": "INwmqMNFmdYSw0QrvL2dT7cwarmBVhX6L+up47Ut+L2vDAAAAAAAAAA="
                   }
                 ]
               }
@@ -594,33 +594,33 @@ Response: {
         {
           "cursor": "eyJjIjoxMiwidCI6NCwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "2Xo3P52jeiqttVZUE5MyTdwbSjjcgGCuFgYtF74P5Cru",
+            "digest": "9PVUCS3ssrmYowK3epNi1AHkmTd3WFUVnzRiYoi8t9EU",
             "sender": {
               "objects": {
                 "edges": [
                   {
-                    "cursor": "IBu3DStJFgt/VTUu87HHbyuslmgfAkAR++eiATcNMDwoDAAAAAAAAAA="
+                    "cursor": "IAw9ZwX1jmog4p+ZnBd1BS7wwxH7BCgWQp7uKBXqjMdgDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IBv06n5VZDWEEY0pppKG8zUs4HJhTTmskx1gM9yeW2GeDAAAAAAAAAA="
+                    "cursor": "IDQ5bsgxHjaVc6nABAPXGaOQeYM7o12z4kEy7rC6ROJ2DAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IFfgHaolGXK4Rvlw1WYOC3LKNF52OF5myww6k0UbdE9UDAAAAAAAAAA="
+                    "cursor": "IEPg2mMiqyl+Exu7/wLLxqmiNvix3u9ZprZ4nlgoyUwEDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IGChL2MaSNe7wDoDrtn7NK8AA4fZ/0o+6rY8Fo7qI1yJDAAAAAAAAAA="
+                    "cursor": "IFwIeAOSR6HYB9NcDqJmhkRbSBd8cB3TlSBMN4DXJS82DAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IKKZiUBQ+A6uSKG+mYXAFTN6Mjx0L4tIEmJRdxmjXqYjDAAAAAAAAAA="
+                    "cursor": "IGSbVfgUupPzSJrdB34w9bSCrE74yaeaYfLmlq9INVuWDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IKaDnU8Z0d9FXXModa1A7nQ9sZ+HDwil7XmY7B5K0xzMDAAAAAAAAAA="
+                    "cursor": "IGtvZR/LSrXlyoBaXvshZXcztTjUpwF9LDdcOsPpzS1EDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "ILTukj/dHMrTShL1wP0lSoTybGv7OnFi3GSe4UgQjEmbDAAAAAAAAAA="
+                    "cursor": "IHoHVHQZdmNV4qCCoCvQKFGuzA0tczDWNqPDzSyrLQPSDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qDAAAAAAAAAA="
+                    "cursor": "INwmqMNFmdYSw0QrvL2dT7cwarmBVhX6L+up47Ut+L2vDAAAAAAAAAA="
                   }
                 ]
               }
@@ -630,33 +630,33 @@ Response: {
         {
           "cursor": "eyJjIjoxMiwidCI6NSwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "5ZFxt4Vo5w6478FCiR2yGG16JyZC6HeWBZFL28JKU2of",
+            "digest": "2eDGSYYM273F6my8RRgnSyVGY6Aw3uf7NXtfWAER1J6T",
             "sender": {
               "objects": {
                 "edges": [
                   {
-                    "cursor": "IBu3DStJFgt/VTUu87HHbyuslmgfAkAR++eiATcNMDwoDAAAAAAAAAA="
+                    "cursor": "IAw9ZwX1jmog4p+ZnBd1BS7wwxH7BCgWQp7uKBXqjMdgDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IBv06n5VZDWEEY0pppKG8zUs4HJhTTmskx1gM9yeW2GeDAAAAAAAAAA="
+                    "cursor": "IDQ5bsgxHjaVc6nABAPXGaOQeYM7o12z4kEy7rC6ROJ2DAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IFfgHaolGXK4Rvlw1WYOC3LKNF52OF5myww6k0UbdE9UDAAAAAAAAAA="
+                    "cursor": "IEPg2mMiqyl+Exu7/wLLxqmiNvix3u9ZprZ4nlgoyUwEDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IGChL2MaSNe7wDoDrtn7NK8AA4fZ/0o+6rY8Fo7qI1yJDAAAAAAAAAA="
+                    "cursor": "IFwIeAOSR6HYB9NcDqJmhkRbSBd8cB3TlSBMN4DXJS82DAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IKKZiUBQ+A6uSKG+mYXAFTN6Mjx0L4tIEmJRdxmjXqYjDAAAAAAAAAA="
+                    "cursor": "IGSbVfgUupPzSJrdB34w9bSCrE74yaeaYfLmlq9INVuWDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IKaDnU8Z0d9FXXModa1A7nQ9sZ+HDwil7XmY7B5K0xzMDAAAAAAAAAA="
+                    "cursor": "IGtvZR/LSrXlyoBaXvshZXcztTjUpwF9LDdcOsPpzS1EDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "ILTukj/dHMrTShL1wP0lSoTybGv7OnFi3GSe4UgQjEmbDAAAAAAAAAA="
+                    "cursor": "IHoHVHQZdmNV4qCCoCvQKFGuzA0tczDWNqPDzSyrLQPSDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qDAAAAAAAAAA="
+                    "cursor": "INwmqMNFmdYSw0QrvL2dT7cwarmBVhX6L+up47Ut+L2vDAAAAAAAAAA="
                   }
                 ]
               }
@@ -666,33 +666,33 @@ Response: {
         {
           "cursor": "eyJjIjoxMiwidCI6NiwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "5i9zqxCjr7rkhA2uYaHrrJZn8uFE8jvjwUQf3dA8kA6b",
+            "digest": "Cb8ByaR6o5nX2dnPuLNnTfLgyKbrKU3JXzhUXau7xh8c",
             "sender": {
               "objects": {
                 "edges": [
                   {
-                    "cursor": "IBu3DStJFgt/VTUu87HHbyuslmgfAkAR++eiATcNMDwoDAAAAAAAAAA="
+                    "cursor": "IAw9ZwX1jmog4p+ZnBd1BS7wwxH7BCgWQp7uKBXqjMdgDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IBv06n5VZDWEEY0pppKG8zUs4HJhTTmskx1gM9yeW2GeDAAAAAAAAAA="
+                    "cursor": "IDQ5bsgxHjaVc6nABAPXGaOQeYM7o12z4kEy7rC6ROJ2DAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IFfgHaolGXK4Rvlw1WYOC3LKNF52OF5myww6k0UbdE9UDAAAAAAAAAA="
+                    "cursor": "IEPg2mMiqyl+Exu7/wLLxqmiNvix3u9ZprZ4nlgoyUwEDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IGChL2MaSNe7wDoDrtn7NK8AA4fZ/0o+6rY8Fo7qI1yJDAAAAAAAAAA="
+                    "cursor": "IFwIeAOSR6HYB9NcDqJmhkRbSBd8cB3TlSBMN4DXJS82DAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IKKZiUBQ+A6uSKG+mYXAFTN6Mjx0L4tIEmJRdxmjXqYjDAAAAAAAAAA="
+                    "cursor": "IGSbVfgUupPzSJrdB34w9bSCrE74yaeaYfLmlq9INVuWDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IKaDnU8Z0d9FXXModa1A7nQ9sZ+HDwil7XmY7B5K0xzMDAAAAAAAAAA="
+                    "cursor": "IGtvZR/LSrXlyoBaXvshZXcztTjUpwF9LDdcOsPpzS1EDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "ILTukj/dHMrTShL1wP0lSoTybGv7OnFi3GSe4UgQjEmbDAAAAAAAAAA="
+                    "cursor": "IHoHVHQZdmNV4qCCoCvQKFGuzA0tczDWNqPDzSyrLQPSDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qDAAAAAAAAAA="
+                    "cursor": "INwmqMNFmdYSw0QrvL2dT7cwarmBVhX6L+up47Ut+L2vDAAAAAAAAAA="
                   }
                 ]
               }
@@ -702,33 +702,33 @@ Response: {
         {
           "cursor": "eyJjIjoxMiwidCI6OCwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "AoorSccqwZCGgiPQgNzSRGqNBhvR18iwF1UboCzAUCoj",
+            "digest": "7zekmw4yhEnKTFmtmJPaw7JLWK91yVdbpvUaD1MnKi3g",
             "sender": {
               "objects": {
                 "edges": [
                   {
-                    "cursor": "IBu3DStJFgt/VTUu87HHbyuslmgfAkAR++eiATcNMDwoDAAAAAAAAAA="
+                    "cursor": "IAw9ZwX1jmog4p+ZnBd1BS7wwxH7BCgWQp7uKBXqjMdgDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IBv06n5VZDWEEY0pppKG8zUs4HJhTTmskx1gM9yeW2GeDAAAAAAAAAA="
+                    "cursor": "IDQ5bsgxHjaVc6nABAPXGaOQeYM7o12z4kEy7rC6ROJ2DAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IFfgHaolGXK4Rvlw1WYOC3LKNF52OF5myww6k0UbdE9UDAAAAAAAAAA="
+                    "cursor": "IEPg2mMiqyl+Exu7/wLLxqmiNvix3u9ZprZ4nlgoyUwEDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IGChL2MaSNe7wDoDrtn7NK8AA4fZ/0o+6rY8Fo7qI1yJDAAAAAAAAAA="
+                    "cursor": "IFwIeAOSR6HYB9NcDqJmhkRbSBd8cB3TlSBMN4DXJS82DAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IKKZiUBQ+A6uSKG+mYXAFTN6Mjx0L4tIEmJRdxmjXqYjDAAAAAAAAAA="
+                    "cursor": "IGSbVfgUupPzSJrdB34w9bSCrE74yaeaYfLmlq9INVuWDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IKaDnU8Z0d9FXXModa1A7nQ9sZ+HDwil7XmY7B5K0xzMDAAAAAAAAAA="
+                    "cursor": "IGtvZR/LSrXlyoBaXvshZXcztTjUpwF9LDdcOsPpzS1EDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "ILTukj/dHMrTShL1wP0lSoTybGv7OnFi3GSe4UgQjEmbDAAAAAAAAAA="
+                    "cursor": "IHoHVHQZdmNV4qCCoCvQKFGuzA0tczDWNqPDzSyrLQPSDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qDAAAAAAAAAA="
+                    "cursor": "INwmqMNFmdYSw0QrvL2dT7cwarmBVhX6L+up47Ut+L2vDAAAAAAAAAA="
                   }
                 ]
               }
@@ -738,33 +738,33 @@ Response: {
         {
           "cursor": "eyJjIjoxMiwidCI6OSwiaSI6ZmFsc2V9",
           "node": {
-            "digest": "Ak8JCxSwJrVGeGyGShsRbF2koRxbYB7u3yhiKkzEhg5x",
+            "digest": "2ZAd9j8pY4uLmWf3rzcKqRpUZL3Z8wDy9RcX2hooLaxU",
             "sender": {
               "objects": {
                 "edges": [
                   {
-                    "cursor": "IBu3DStJFgt/VTUu87HHbyuslmgfAkAR++eiATcNMDwoDAAAAAAAAAA="
+                    "cursor": "IAw9ZwX1jmog4p+ZnBd1BS7wwxH7BCgWQp7uKBXqjMdgDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IBv06n5VZDWEEY0pppKG8zUs4HJhTTmskx1gM9yeW2GeDAAAAAAAAAA="
+                    "cursor": "IDQ5bsgxHjaVc6nABAPXGaOQeYM7o12z4kEy7rC6ROJ2DAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IFfgHaolGXK4Rvlw1WYOC3LKNF52OF5myww6k0UbdE9UDAAAAAAAAAA="
+                    "cursor": "IEPg2mMiqyl+Exu7/wLLxqmiNvix3u9ZprZ4nlgoyUwEDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IGChL2MaSNe7wDoDrtn7NK8AA4fZ/0o+6rY8Fo7qI1yJDAAAAAAAAAA="
+                    "cursor": "IFwIeAOSR6HYB9NcDqJmhkRbSBd8cB3TlSBMN4DXJS82DAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IKKZiUBQ+A6uSKG+mYXAFTN6Mjx0L4tIEmJRdxmjXqYjDAAAAAAAAAA="
+                    "cursor": "IGSbVfgUupPzSJrdB34w9bSCrE74yaeaYfLmlq9INVuWDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IKaDnU8Z0d9FXXModa1A7nQ9sZ+HDwil7XmY7B5K0xzMDAAAAAAAAAA="
+                    "cursor": "IGtvZR/LSrXlyoBaXvshZXcztTjUpwF9LDdcOsPpzS1EDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "ILTukj/dHMrTShL1wP0lSoTybGv7OnFi3GSe4UgQjEmbDAAAAAAAAAA="
+                    "cursor": "IHoHVHQZdmNV4qCCoCvQKFGuzA0tczDWNqPDzSyrLQPSDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qDAAAAAAAAAA="
+                    "cursor": "INwmqMNFmdYSw0QrvL2dT7cwarmBVhX6L+up47Ut+L2vDAAAAAAAAAA="
                   }
                 ]
               }
@@ -774,33 +774,33 @@ Response: {
         {
           "cursor": "eyJjIjoxMiwidCI6MTAsImkiOmZhbHNlfQ",
           "node": {
-            "digest": "rTtcpSJm2DJ1joEVd5JhoPBgmntTHcpNz1mDMLw99E8",
+            "digest": "7GatNA6rLyPi6QWTVQCoSdMk97sheiF3c2r84tJSAPV7",
             "sender": {
               "objects": {
                 "edges": [
                   {
-                    "cursor": "IBu3DStJFgt/VTUu87HHbyuslmgfAkAR++eiATcNMDwoDAAAAAAAAAA="
+                    "cursor": "IAw9ZwX1jmog4p+ZnBd1BS7wwxH7BCgWQp7uKBXqjMdgDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IBv06n5VZDWEEY0pppKG8zUs4HJhTTmskx1gM9yeW2GeDAAAAAAAAAA="
+                    "cursor": "IDQ5bsgxHjaVc6nABAPXGaOQeYM7o12z4kEy7rC6ROJ2DAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IFfgHaolGXK4Rvlw1WYOC3LKNF52OF5myww6k0UbdE9UDAAAAAAAAAA="
+                    "cursor": "IEPg2mMiqyl+Exu7/wLLxqmiNvix3u9ZprZ4nlgoyUwEDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IGChL2MaSNe7wDoDrtn7NK8AA4fZ/0o+6rY8Fo7qI1yJDAAAAAAAAAA="
+                    "cursor": "IFwIeAOSR6HYB9NcDqJmhkRbSBd8cB3TlSBMN4DXJS82DAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IKKZiUBQ+A6uSKG+mYXAFTN6Mjx0L4tIEmJRdxmjXqYjDAAAAAAAAAA="
+                    "cursor": "IGSbVfgUupPzSJrdB34w9bSCrE74yaeaYfLmlq9INVuWDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "IKaDnU8Z0d9FXXModa1A7nQ9sZ+HDwil7XmY7B5K0xzMDAAAAAAAAAA="
+                    "cursor": "IGtvZR/LSrXlyoBaXvshZXcztTjUpwF9LDdcOsPpzS1EDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "ILTukj/dHMrTShL1wP0lSoTybGv7OnFi3GSe4UgQjEmbDAAAAAAAAAA="
+                    "cursor": "IHoHVHQZdmNV4qCCoCvQKFGuzA0tczDWNqPDzSyrLQPSDAAAAAAAAAA="
                   },
                   {
-                    "cursor": "INZmzdmWPU/lOSO6+ZIJf5dFU6m78tdMLLQs96g3v73qDAAAAAAAAAA="
+                    "cursor": "INwmqMNFmdYSw0QrvL2dT7cwarmBVhX6L+up47Ut+L2vDAAAAAAAAAA="
                   }
                 ]
               }

--- a/crates/iota-graphql-e2e-tests/tests/consistency/epochs/transaction_blocks.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/epochs/transaction_blocks.move
@@ -18,7 +18,7 @@
 // 11 | epoch          |        11 |     2
 // 12 | epoch          |        12 |     3
 
-//# init --protocol-version 4 --addresses Test=0x0 --accounts A B --simulator
+//# init --protocol-version 5 --addresses Test=0x0 --accounts A B --simulator
 
 //# publish
 module Test::M1 {

--- a/crates/iota-graphql-e2e-tests/tests/consistency/staked_iota.exp
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/staked_iota.exp
@@ -25,11 +25,11 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 25:
 //# run 0x3::iota_system::request_add_stake --args object(0x5) object(2,0) @validator_0 --sender C
-events: Event { package_id: iota_system, transaction_module: Identifier("iota_system"), sender: C, type_: StructTag { address: iota_system, module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [243, 141, 225, 236, 161, 3, 21, 48, 245, 12, 169, 60, 4, 142, 157, 15, 79, 66, 170, 55, 43, 112, 117, 62, 99, 78, 32, 20, 130, 43, 88, 203, 175, 163, 158, 79, 0, 218, 226, 120, 249, 119, 199, 198, 147, 10, 94, 44, 118, 232, 93, 23, 165, 38, 215, 36, 187, 206, 15, 184, 31, 176, 125, 76, 140, 202, 78, 28, 224, 186, 89, 4, 206, 166, 29, 249, 36, 45, 162, 247, 210, 158, 62, 243, 40, 251, 126, 192, 124, 8, 107, 59, 244, 124, 166, 26, 0, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0] }
-created: object(3,0)
-mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000005, object(0,0)
-deleted: object(2,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 14500800,  storage_rebate: 1960800, non_refundable_storage_fee: 0
+events: Event { package_id: iota_system, transaction_module: Identifier("iota_system"), sender: C, type_: StructTag { address: iota_system, module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [52, 235, 172, 54, 254, 187, 232, 55, 222, 119, 24, 132, 11, 131, 107, 28, 195, 175, 227, 168, 229, 120, 48, 228, 44, 242, 219, 27, 175, 91, 153, 192, 175, 163, 158, 79, 0, 218, 226, 120, 249, 119, 199, 198, 147, 10, 94, 44, 118, 232, 93, 23, 165, 38, 215, 36, 187, 206, 15, 184, 31, 176, 125, 76, 140, 202, 78, 28, 224, 186, 89, 4, 206, 166, 29, 249, 36, 45, 162, 247, 210, 158, 62, 243, 40, 251, 126, 192, 124, 8, 107, 59, 244, 124, 166, 26, 0, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0] }
+created: object(3,0), object(3,1)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000005, object(0,0)
+deleted: object(_), object(2,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 14561600,  storage_rebate: 1960800, non_refundable_storage_fee: 0
 
 task 4, line 27:
 //# create-checkpoint
@@ -49,11 +49,11 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 7, line 35:
 //# run 0x3::iota_system::request_add_stake --args object(0x5) object(6,0) @validator_0 --sender C
-events: Event { package_id: iota_system, transaction_module: Identifier("iota_system"), sender: C, type_: StructTag { address: iota_system, module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [243, 141, 225, 236, 161, 3, 21, 48, 245, 12, 169, 60, 4, 142, 157, 15, 79, 66, 170, 55, 43, 112, 117, 62, 99, 78, 32, 20, 130, 43, 88, 203, 175, 163, 158, 79, 0, 218, 226, 120, 249, 119, 199, 198, 147, 10, 94, 44, 118, 232, 93, 23, 165, 38, 215, 36, 187, 206, 15, 184, 31, 176, 125, 76, 140, 202, 78, 28, 224, 186, 89, 4, 206, 166, 29, 249, 36, 45, 162, 247, 210, 158, 62, 243, 40, 251, 126, 192, 124, 8, 107, 59, 244, 124, 166, 26, 1, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0] }
+events: Event { package_id: iota_system, transaction_module: Identifier("iota_system"), sender: C, type_: StructTag { address: iota_system, module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [52, 235, 172, 54, 254, 187, 232, 55, 222, 119, 24, 132, 11, 131, 107, 28, 195, 175, 227, 168, 229, 120, 48, 228, 44, 242, 219, 27, 175, 91, 153, 192, 175, 163, 158, 79, 0, 218, 226, 120, 249, 119, 199, 198, 147, 10, 94, 44, 118, 232, 93, 23, 165, 38, 215, 36, 187, 206, 15, 184, 31, 176, 125, 76, 140, 202, 78, 28, 224, 186, 89, 4, 206, 166, 29, 249, 36, 45, 162, 247, 210, 158, 62, 243, 40, 251, 126, 192, 124, 8, 107, 59, 244, 124, 166, 26, 1, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0] }
 created: object(7,0)
-mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000005, object(0,0)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000005, object(0,0), object(3,0)
 deleted: object(6,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 14500800,  storage_rebate: 14196800, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 14561600,  storage_rebate: 14257600, non_refundable_storage_fee: 0
 
 task 8, line 37:
 //# create-checkpoint
@@ -65,20 +65,563 @@ Epoch advanced: 1
 
 task 10, line 41:
 //# view-object 3,0
-Owner: Account Address ( C )
-Version: 3
-Contents: iota_system::staking_pool::StakedIota {
+Owner: Object ID: ( 0x0000000000000000000000000000000000000000000000000000000000000005 )
+Version: 6
+Contents: iota::dynamic_field::Field<u64, iota_system::iota_system_state_inner::IotaSystemStateV2> {
     id: iota::object::UID {
         id: iota::object::ID {
             bytes: fake(3,0),
         },
     },
-    pool_id: iota::object::ID {
-        bytes: _,
-    },
-    stake_activation_epoch: 1u64,
-    principal: iota::balance::Balance<iota::iota::IOTA> {
-        value: 10000000000u64,
+    name: 2u64,
+    value: iota_system::iota_system_state_inner::IotaSystemStateV2 {
+        epoch: 2u64,
+        protocol_version: 5u64,
+        system_state_version: 2u64,
+        iota_treasury_cap: iota::iota::IotaTreasuryCap {
+            inner: iota::coin::TreasuryCap<iota::iota::IOTA> {
+                id: iota::object::UID {
+                    id: iota::object::ID {
+                        bytes: _,
+                    },
+                },
+                total_supply: iota::balance::Supply<iota::iota::IOTA> {
+                    value: 33633999996000000u64,
+                },
+            },
+        },
+        validators: iota_system::validator_set::ValidatorSetV1 {
+            total_stake: 3034020000000000u64,
+            active_validators: vector[
+                iota_system::validator::ValidatorV1 {
+                    metadata: iota_system::validator::ValidatorMetadataV1 {
+                        iota_address: validator_0,
+                        authority_pubkey_bytes: vector[
+                            170u8,
+                            168u8,
+                            27u8,
+                            180u8,
+                            67u8,
+                            249u8,
+                            237u8,
+                            32u8,
+                            176u8,
+                            26u8,
+                            179u8,
+                            187u8,
+                            182u8,
+                            103u8,
+                            10u8,
+                            195u8,
+                            47u8,
+                            221u8,
+                            105u8,
+                            234u8,
+                            14u8,
+                            23u8,
+                            0u8,
+                            13u8,
+                            154u8,
+                            179u8,
+                            19u8,
+                            155u8,
+                            84u8,
+                            46u8,
+                            226u8,
+                            53u8,
+                            9u8,
+                            70u8,
+                            24u8,
+                            182u8,
+                            85u8,
+                            227u8,
+                            243u8,
+                            253u8,
+                            186u8,
+                            197u8,
+                            245u8,
+                            128u8,
+                            28u8,
+                            142u8,
+                            98u8,
+                            123u8,
+                            4u8,
+                            179u8,
+                            169u8,
+                            55u8,
+                            199u8,
+                            57u8,
+                            33u8,
+                            174u8,
+                            243u8,
+                            99u8,
+                            52u8,
+                            205u8,
+                            152u8,
+                            107u8,
+                            70u8,
+                            161u8,
+                            165u8,
+                            39u8,
+                            142u8,
+                            134u8,
+                            43u8,
+                            110u8,
+                            240u8,
+                            198u8,
+                            244u8,
+                            77u8,
+                            57u8,
+                            179u8,
+                            214u8,
+                            167u8,
+                            183u8,
+                            4u8,
+                            166u8,
+                            144u8,
+                            112u8,
+                            8u8,
+                            26u8,
+                            195u8,
+                            60u8,
+                            154u8,
+                            73u8,
+                            158u8,
+                            6u8,
+                            68u8,
+                            163u8,
+                            72u8,
+                            26u8,
+                            237u8,
+                        ],
+                        network_pubkey_bytes: vector[
+                            101u8,
+                            225u8,
+                            19u8,
+                            186u8,
+                            91u8,
+                            171u8,
+                            27u8,
+                            145u8,
+                            41u8,
+                            68u8,
+                            26u8,
+                            30u8,
+                            194u8,
+                            145u8,
+                            118u8,
+                            234u8,
+                            156u8,
+                            139u8,
+                            66u8,
+                            218u8,
+                            84u8,
+                            171u8,
+                            1u8,
+                            245u8,
+                            79u8,
+                            162u8,
+                            234u8,
+                            130u8,
+                            232u8,
+                            7u8,
+                            4u8,
+                            133u8,
+                        ],
+                        protocol_pubkey_bytes: vector[
+                            222u8,
+                            193u8,
+                            56u8,
+                            253u8,
+                            223u8,
+                            140u8,
+                            108u8,
+                            228u8,
+                            161u8,
+                            246u8,
+                            151u8,
+                            172u8,
+                            42u8,
+                            190u8,
+                            219u8,
+                            243u8,
+                            212u8,
+                            210u8,
+                            59u8,
+                            152u8,
+                            5u8,
+                            6u8,
+                            236u8,
+                            134u8,
+                            82u8,
+                            53u8,
+                            90u8,
+                            224u8,
+                            105u8,
+                            93u8,
+                            152u8,
+                            85u8,
+                        ],
+                        proof_of_possession: vector[
+                            183u8,
+                            90u8,
+                            42u8,
+                            151u8,
+                            218u8,
+                            5u8,
+                            130u8,
+                            225u8,
+                            250u8,
+                            89u8,
+                            73u8,
+                            38u8,
+                            222u8,
+                            95u8,
+                            48u8,
+                            236u8,
+                            57u8,
+                            134u8,
+                            229u8,
+                            140u8,
+                            142u8,
+                            143u8,
+                            123u8,
+                            75u8,
+                            95u8,
+                            176u8,
+                            137u8,
+                            107u8,
+                            18u8,
+                            107u8,
+                            110u8,
+                            174u8,
+                            124u8,
+                            105u8,
+                            96u8,
+                            151u8,
+                            248u8,
+                            44u8,
+                            52u8,
+                            20u8,
+                            20u8,
+                            92u8,
+                            222u8,
+                            163u8,
+                            10u8,
+                            5u8,
+                            24u8,
+                            248u8,
+                        ],
+                        name: std::string::String {
+                            bytes: vector[
+                                118u8,
+                                97u8,
+                                108u8,
+                                105u8,
+                                100u8,
+                                97u8,
+                                116u8,
+                                111u8,
+                                114u8,
+                                45u8,
+                                48u8,
+                            ],
+                        },
+                        description: std::string::String {
+                            bytes: vector[],
+                        },
+                        image_url: iota::url::Url {
+                            url: std::ascii::String {
+                                bytes: vector[],
+                            },
+                        },
+                        project_url: iota::url::Url {
+                            url: std::ascii::String {
+                                bytes: vector[],
+                            },
+                        },
+                        net_address: std::string::String {
+                            bytes: vector[
+                                47u8,
+                                105u8,
+                                112u8,
+                                52u8,
+                                47u8,
+                                49u8,
+                                50u8,
+                                55u8,
+                                46u8,
+                                48u8,
+                                46u8,
+                                48u8,
+                                46u8,
+                                49u8,
+                                47u8,
+                                116u8,
+                                99u8,
+                                112u8,
+                                47u8,
+                                56u8,
+                                48u8,
+                                48u8,
+                                48u8,
+                                47u8,
+                                104u8,
+                                116u8,
+                                116u8,
+                                112u8,
+                            ],
+                        },
+                        p2p_address: std::string::String {
+                            bytes: vector[
+                                47u8,
+                                105u8,
+                                112u8,
+                                52u8,
+                                47u8,
+                                49u8,
+                                50u8,
+                                55u8,
+                                46u8,
+                                48u8,
+                                46u8,
+                                48u8,
+                                46u8,
+                                49u8,
+                                47u8,
+                                117u8,
+                                100u8,
+                                112u8,
+                                47u8,
+                                56u8,
+                                48u8,
+                                48u8,
+                                49u8,
+                                47u8,
+                                104u8,
+                                116u8,
+                                116u8,
+                                112u8,
+                            ],
+                        },
+                        primary_address: std::string::String {
+                            bytes: vector[
+                                47u8,
+                                105u8,
+                                112u8,
+                                52u8,
+                                47u8,
+                                49u8,
+                                50u8,
+                                55u8,
+                                46u8,
+                                48u8,
+                                46u8,
+                                48u8,
+                                46u8,
+                                49u8,
+                                47u8,
+                                117u8,
+                                100u8,
+                                112u8,
+                                47u8,
+                                56u8,
+                                48u8,
+                                48u8,
+                                51u8,
+                                47u8,
+                                104u8,
+                                116u8,
+                                116u8,
+                                112u8,
+                            ],
+                        },
+                        next_epoch_authority_pubkey_bytes: std::option::Option<vector<u8>> {
+                            vec: vector[],
+                        },
+                        next_epoch_proof_of_possession: std::option::Option<vector<u8>> {
+                            vec: vector[],
+                        },
+                        next_epoch_network_pubkey_bytes: std::option::Option<vector<u8>> {
+                            vec: vector[],
+                        },
+                        next_epoch_protocol_pubkey_bytes: std::option::Option<vector<u8>> {
+                            vec: vector[],
+                        },
+                        next_epoch_net_address: std::option::Option<std::string::String> {
+                            vec: vector[],
+                        },
+                        next_epoch_p2p_address: std::option::Option<std::string::String> {
+                            vec: vector[],
+                        },
+                        next_epoch_primary_address: std::option::Option<std::string::String> {
+                            vec: vector[],
+                        },
+                        extra_fields: iota::bag::Bag {
+                            id: iota::object::UID {
+                                id: iota::object::ID {
+                                    bytes: _,
+                                },
+                            },
+                            size: 0u64,
+                        },
+                    },
+                    voting_power: 10000u64,
+                    operation_cap_id: iota::object::ID {
+                        bytes: _,
+                    },
+                    gas_price: 1000u64,
+                    staking_pool: iota_system::staking_pool::StakingPoolV1 {
+                        id: iota::object::UID {
+                            id: iota::object::ID {
+                                bytes: _,
+                            },
+                        },
+                        activation_epoch: std::option::Option<u64> {
+                            vec: vector[
+                                0u64,
+                            ],
+                        },
+                        deactivation_epoch: std::option::Option<u64> {
+                            vec: vector[],
+                        },
+                        iota_balance: 3034020000000000u64,
+                        rewards_pool: iota::balance::Balance<iota::iota::IOTA> {
+                            value: 1503320000000000u64,
+                        },
+                        pool_token_balance: 1517905318654003u64,
+                        exchange_rates: iota::table::Table<u64, iota_system::staking_pool::PoolTokenExchangeRate> {
+                            id: iota::object::UID {
+                                id: iota::object::ID {
+                                    bytes: _,
+                                },
+                            },
+                            size: 3u64,
+                        },
+                        pending_stake: 0u64,
+                        pending_total_iota_withdraw: 0u64,
+                        pending_pool_token_withdraw: 0u64,
+                        extra_fields: iota::bag::Bag {
+                            id: iota::object::UID {
+                                id: iota::object::ID {
+                                    bytes: _,
+                                },
+                            },
+                            size: 0u64,
+                        },
+                    },
+                    commission_rate: 200u64,
+                    next_epoch_stake: 3034020000000000u64,
+                    next_epoch_gas_price: 1000u64,
+                    next_epoch_commission_rate: 200u64,
+                    extra_fields: iota::bag::Bag {
+                        id: iota::object::UID {
+                            id: iota::object::ID {
+                                bytes: _,
+                            },
+                        },
+                        size: 0u64,
+                    },
+                },
+            ],
+            pending_active_validators: iota::table_vec::TableVec<iota_system::validator::ValidatorV1> {
+                contents: iota::table::Table<u64, iota_system::validator::ValidatorV1> {
+                    id: iota::object::UID {
+                        id: iota::object::ID {
+                            bytes: _,
+                        },
+                    },
+                    size: 0u64,
+                },
+            },
+            pending_removals: vector[],
+            staking_pool_mappings: iota::table::Table<iota::object::ID, address> {
+                id: iota::object::UID {
+                    id: iota::object::ID {
+                        bytes: _,
+                    },
+                },
+                size: 1u64,
+            },
+            inactive_validators: iota::table::Table<iota::object::ID, iota_system::validator_wrapper::Validator> {
+                id: iota::object::UID {
+                    id: iota::object::ID {
+                        bytes: _,
+                    },
+                },
+                size: 0u64,
+            },
+            validator_candidates: iota::table::Table<address, iota_system::validator_wrapper::Validator> {
+                id: iota::object::UID {
+                    id: iota::object::ID {
+                        bytes: _,
+                    },
+                },
+                size: 0u64,
+            },
+            at_risk_validators: iota::vec_map::VecMap<address, u64> {
+                contents: vector[],
+            },
+            extra_fields: iota::bag::Bag {
+                id: iota::object::UID {
+                    id: iota::object::ID {
+                        bytes: _,
+                    },
+                },
+                size: 0u64,
+            },
+        },
+        storage_fund: iota_system::storage_fund::StorageFundV1 {
+            total_object_storage_rebates: iota::balance::Balance<iota::iota::IOTA> {
+                value: 15846000u64,
+            },
+            non_refundable_balance: iota::balance::Balance<iota::iota::IOTA> {
+                value: 0u64,
+            },
+        },
+        parameters: iota_system::iota_system_state_inner::SystemParametersV1 {
+            epoch_duration_ms: 86400000u64,
+            min_validator_count: 4u64,
+            max_validator_count: 150u64,
+            min_validator_joining_stake: 2000000000000000u64,
+            validator_low_stake_threshold: 1500000000000000u64,
+            validator_very_low_stake_threshold: 1000000000000000u64,
+            validator_low_stake_grace_period: 7u64,
+            extra_fields: iota::bag::Bag {
+                id: iota::object::UID {
+                    id: iota::object::ID {
+                        bytes: _,
+                    },
+                },
+                size: 0u64,
+            },
+        },
+        iota_system_admin_cap: iota::system_admin_cap::IotaSystemAdminCap {
+            dummy_field: false,
+        },
+        reference_gas_price: 1000u64,
+        validator_report_records: iota::vec_map::VecMap<address, iota::vec_set::VecSet<address>> {
+            contents: vector[],
+        },
+        safe_mode: false,
+        safe_mode_storage_charges: iota::balance::Balance<iota::iota::IOTA> {
+            value: 0u64,
+        },
+        safe_mode_computation_charges: iota::balance::Balance<iota::iota::IOTA> {
+            value: 0u64,
+        },
+        safe_mode_computation_charges_burned: 0u64,
+        safe_mode_storage_rebates: 0u64,
+        safe_mode_non_refundable_storage_fee: 0u64,
+        epoch_start_timestamp_ms: 0u64,
+        extra_fields: iota::bag::Bag {
+            id: iota::object::UID {
+                id: iota::object::ID {
+                    bytes: _,
+                },
+            },
+            size: 0u64,
+        },
     },
 }
 
@@ -109,13 +652,13 @@ Response: {
       "stakedIotas": {
         "edges": [
           {
-            "cursor": "IPFIRA69p/BgQGDAB+mh4XseGsZxF+c5dhnydruBm4qYBAAAAAAAAAA=",
+            "cursor": "IC9vpEQTKNOa3iJFzueG5E+lAN4mJeQO41lkKqNmIrHfBAAAAAAAAAA=",
             "node": {
               "principal": "10000000000"
             }
           },
           {
-            "cursor": "IPo8X8jPGMhQG4YzldRN9Bb3VVwoOWdqevkLYNK5A4z0BAAAAAAAAAA=",
+            "cursor": "IEkkfx928ZokrMBKh027DVz3DEeilQOvfJ//y0Q3KKywBAAAAAAAAAA=",
             "node": {
               "principal": "10000000000"
             }
@@ -137,7 +680,14 @@ Response: {
     },
     "no_coins_before_obj_3_0_chkpt_1": {
       "stakedIotas": {
-        "edges": []
+        "edges": [
+          {
+            "cursor": "IEkkfx928ZokrMBKh027DVz3DEeilQOvfJ//y0Q3KKywAQAAAAAAAAA=",
+            "node": {
+              "principal": "10000000000"
+            }
+          }
+        ]
       }
     },
     "no_coins_after_obj_7_0_chkpt_1": {
@@ -147,7 +697,14 @@ Response: {
     },
     "no_coins_before_obj_7_0_chkpt_1": {
       "stakedIotas": {
-        "edges": []
+        "edges": [
+          {
+            "cursor": "IEkkfx928ZokrMBKh027DVz3DEeilQOvfJ//y0Q3KKywAQAAAAAAAAA=",
+            "node": {
+              "principal": "10000000000"
+            }
+          }
+        ]
       }
     }
   }
@@ -161,7 +718,7 @@ Response: {
       "stakedIotas": {
         "edges": [
           {
-            "cursor": "IPo8X8jPGMhQG4YzldRN9Bb3VVwoOWdqevkLYNK5A4z0AwAAAAAAAAA=",
+            "cursor": "IEkkfx928ZokrMBKh027DVz3DEeilQOvfJ//y0Q3KKywAwAAAAAAAAA=",
             "node": {
               "principal": "10000000000"
             }
@@ -183,7 +740,13 @@ Response: {
       "stakedIotas": {
         "edges": [
           {
-            "cursor": "IPFIRA69p/BgQGDAB+mh4XseGsZxF+c5dhnydruBm4qYAwAAAAAAAAA=",
+            "cursor": "IC9vpEQTKNOa3iJFzueG5E+lAN4mJeQO41lkKqNmIrHfAwAAAAAAAAA=",
+            "node": {
+              "principal": "10000000000"
+            }
+          },
+          {
+            "cursor": "IEkkfx928ZokrMBKh027DVz3DEeilQOvfJ//y0Q3KKywAwAAAAAAAAA=",
             "node": {
               "principal": "10000000000"
             }

--- a/crates/iota-graphql-e2e-tests/tests/consistency/staked_iota.move
+++ b/crates/iota-graphql-e2e-tests/tests/consistency/staked_iota.move
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 4 --simulator --accounts C
+//# init --protocol-version 5 --simulator --accounts C
 
 //# run-graphql
 {

--- a/crates/iota-graphql-e2e-tests/tests/datetime/datetime.move
+++ b/crates/iota-graphql-e2e-tests/tests/datetime/datetime.move
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 4 --simulator
+//# init --protocol-version 5 --simulator
 
 //# create-checkpoint
 

--- a/crates/iota-graphql-e2e-tests/tests/epoch/epoch.exp
+++ b/crates/iota-graphql-e2e-tests/tests/epoch/epoch.exp
@@ -21,11 +21,11 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, lines 17-19:
 //# run 0x3::iota_system::request_add_stake --args object(0x5) object(3,0) @validator_0 --sender C
-events: Event { package_id: iota_system, transaction_module: Identifier("iota_system"), sender: C, type_: StructTag { address: iota_system, module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [243, 141, 225, 236, 161, 3, 21, 48, 245, 12, 169, 60, 4, 142, 157, 15, 79, 66, 170, 55, 43, 112, 117, 62, 99, 78, 32, 20, 130, 43, 88, 203, 175, 163, 158, 79, 0, 218, 226, 120, 249, 119, 199, 198, 147, 10, 94, 44, 118, 232, 93, 23, 165, 38, 215, 36, 187, 206, 15, 184, 31, 176, 125, 76, 140, 202, 78, 28, 224, 186, 89, 4, 206, 166, 29, 249, 36, 45, 162, 247, 210, 158, 62, 243, 40, 251, 126, 192, 124, 8, 107, 59, 244, 124, 166, 26, 1, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0] }
+events: Event { package_id: iota_system, transaction_module: Identifier("iota_system"), sender: C, type_: StructTag { address: iota_system, module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [52, 235, 172, 54, 254, 187, 232, 55, 222, 119, 24, 132, 11, 131, 107, 28, 195, 175, 227, 168, 229, 120, 48, 228, 44, 242, 219, 27, 175, 91, 153, 192, 175, 163, 158, 79, 0, 218, 226, 120, 249, 119, 199, 198, 147, 10, 94, 44, 118, 232, 93, 23, 165, 38, 215, 36, 187, 206, 15, 184, 31, 176, 125, 76, 140, 202, 78, 28, 224, 186, 89, 4, 206, 166, 29, 249, 36, 45, 162, 247, 210, 158, 62, 243, 40, 251, 126, 192, 124, 8, 107, 59, 244, 124, 166, 26, 1, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0] }
 created: object(4,0)
 mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000005, object(0,0)
 deleted: object(3,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 14500800,  storage_rebate: 1960800, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 14561600,  storage_rebate: 1960800, non_refundable_storage_fee: 0
 
 task 5, line 20:
 //# create-checkpoint
@@ -67,11 +67,11 @@ Response: {
           ]
         },
         "validatorCandidatesSize": 0,
-        "inactivePoolsId": "0xe7fa2d6d0fbfff7a79d23ace219bfddad6505e6c38bfa2b853a985f4d44bc26e"
+        "inactivePoolsId": "0x23e7c5199bcbff10b50ba9e8ee0d40c105d657cfaa416ec745119ecf1b02532e"
       },
       "totalGasFees": "1000000",
       "totalStakeRewards": "767000000000000",
-      "fundSize": "14500800",
+      "fundSize": "14561600",
       "fundInflow": "1960800",
       "fundOutflow": "980400",
       "netInflow": "980400",
@@ -81,13 +81,13 @@ Response: {
             "kind": {
               "__typename": "ProgrammableTransactionBlock"
             },
-            "digest": "4ZuijuJcJQuSnnNU56s37VcjcNsvfhBVszB558ej1pAo"
+            "digest": "3NXhZYScAfWxCitjBXXQdgSDqfcakKEu3ktqnu2udVLn"
           },
           {
             "kind": {
               "__typename": "EndOfEpochTransaction"
             },
-            "digest": "CriT4Yyp6qe4vrfiudWE7NFSXRZnjB9kL6nuWM7uR6rW"
+            "digest": "FdnPEGUzRm4MeHdXm9a5VQyzS1jSTEsAPsg3XMH7jb5N"
           }
         ]
       }

--- a/crates/iota-graphql-e2e-tests/tests/epoch/epoch.move
+++ b/crates/iota-graphql-e2e-tests/tests/epoch/epoch.move
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 4 --simulator --accounts C
+//# init --protocol-version 5 --simulator --accounts C
 
 
 // TODO: Short term hack to get around indexer epoch issue

--- a/crates/iota-graphql-e2e-tests/tests/epoch/system_state.exp
+++ b/crates/iota-graphql-e2e-tests/tests/epoch/system_state.exp
@@ -21,11 +21,11 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, line 19:
 //# run 0x3::iota_system::request_add_stake --args object(0x5) object(3,0) @validator_0 --sender C
-events: Event { package_id: iota_system, transaction_module: Identifier("iota_system"), sender: C, type_: StructTag { address: iota_system, module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [163, 90, 62, 2, 65, 234, 220, 11, 15, 199, 246, 224, 247, 79, 189, 101, 76, 54, 15, 79, 234, 22, 36, 210, 225, 64, 121, 144, 253, 194, 37, 93, 175, 163, 158, 79, 0, 218, 226, 120, 249, 119, 199, 198, 147, 10, 94, 44, 118, 232, 93, 23, 165, 38, 215, 36, 187, 206, 15, 184, 31, 176, 125, 76, 140, 202, 78, 28, 224, 186, 89, 4, 206, 166, 29, 249, 36, 45, 162, 247, 210, 158, 62, 243, 40, 251, 126, 192, 124, 8, 107, 59, 244, 124, 166, 26, 1, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0] }
+events: Event { package_id: iota_system, transaction_module: Identifier("iota_system"), sender: C, type_: StructTag { address: iota_system, module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [204, 176, 167, 95, 248, 46, 95, 48, 109, 183, 47, 223, 223, 8, 28, 29, 91, 19, 236, 91, 10, 118, 229, 7, 182, 166, 162, 111, 28, 231, 164, 237, 175, 163, 158, 79, 0, 218, 226, 120, 249, 119, 199, 198, 147, 10, 94, 44, 118, 232, 93, 23, 165, 38, 215, 36, 187, 206, 15, 184, 31, 176, 125, 76, 140, 202, 78, 28, 224, 186, 89, 4, 206, 166, 29, 249, 36, 45, 162, 247, 210, 158, 62, 243, 40, 251, 126, 192, 124, 8, 107, 59, 244, 124, 166, 26, 1, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0] }
 created: object(4,0)
 mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000005, object(0,0)
 deleted: object(3,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 14500800,  storage_rebate: 1960800, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 14561600,  storage_rebate: 1960800, non_refundable_storage_fee: 0
 
 task 5, line 21:
 //# create-checkpoint
@@ -61,11 +61,11 @@ Epoch advanced: 3
 
 task 12, line 37:
 //# run 0x3::iota_system::request_withdraw_stake --args object(0x5) object(4,0) --sender C
-events: Event { package_id: iota_system, transaction_module: Identifier("iota_system"), sender: C, type_: StructTag { address: iota_system, module: Identifier("validator"), name: Identifier("UnstakingRequestEvent"), type_params: [] }, contents: [163, 90, 62, 2, 65, 234, 220, 11, 15, 199, 246, 224, 247, 79, 189, 101, 76, 54, 15, 79, 234, 22, 36, 210, 225, 64, 121, 144, 253, 194, 37, 93, 175, 163, 158, 79, 0, 218, 226, 120, 249, 119, 199, 198, 147, 10, 94, 44, 118, 232, 93, 23, 165, 38, 215, 36, 187, 206, 15, 184, 31, 176, 125, 76, 140, 202, 78, 28, 224, 186, 89, 4, 206, 166, 29, 249, 36, 45, 162, 247, 210, 158, 62, 243, 40, 251, 126, 192, 124, 8, 107, 59, 244, 124, 166, 26, 2, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0, 12, 33, 189, 38, 1, 0, 0, 0] }
+events: Event { package_id: iota_system, transaction_module: Identifier("iota_system"), sender: C, type_: StructTag { address: iota_system, module: Identifier("validator"), name: Identifier("UnstakingRequestEvent"), type_params: [] }, contents: [204, 176, 167, 95, 248, 46, 95, 48, 109, 183, 47, 223, 223, 8, 28, 29, 91, 19, 236, 91, 10, 118, 229, 7, 182, 166, 162, 111, 28, 231, 164, 237, 175, 163, 158, 79, 0, 218, 226, 120, 249, 119, 199, 198, 147, 10, 94, 44, 118, 232, 93, 23, 165, 38, 215, 36, 187, 206, 15, 184, 31, 176, 125, 76, 140, 202, 78, 28, 224, 186, 89, 4, 206, 166, 29, 249, 36, 45, 162, 247, 210, 158, 62, 243, 40, 251, 126, 192, 124, 8, 107, 59, 244, 124, 166, 26, 2, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0, 12, 33, 189, 38, 1, 0, 0, 0] }
 created: object(12,0)
 mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000005, object(0,0)
 deleted: object(4,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 14196800,  storage_rebate: 14500800, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 14257600,  storage_rebate: 14561600, non_refundable_storage_fee: 0
 
 task 13, line 39:
 //# create-checkpoint
@@ -97,9 +97,9 @@ Response: {
   "data": {
     "epoch": {
       "epochId": 4,
-      "systemStateVersion": 1,
+      "systemStateVersion": 2,
       "storageFund": {
-        "totalObjectStorageRebates": "15177200",
+        "totalObjectStorageRebates": "15238000",
         "nonRefundableBalance": "0"
       }
     }
@@ -112,9 +112,9 @@ Response: {
   "data": {
     "epoch": {
       "epochId": 3,
-      "systemStateVersion": 1,
+      "systemStateVersion": 2,
       "storageFund": {
-        "totalObjectStorageRebates": "15481200",
+        "totalObjectStorageRebates": "15542000",
         "nonRefundableBalance": "0"
       }
     }
@@ -127,9 +127,9 @@ Response: {
   "data": {
     "epoch": {
       "epochId": 2,
-      "systemStateVersion": 1,
+      "systemStateVersion": 2,
       "storageFund": {
-        "totalObjectStorageRebates": "14500800",
+        "totalObjectStorageRebates": "14561600",
         "nonRefundableBalance": "0"
       }
     }
@@ -142,9 +142,9 @@ Response: {
   "data": {
     "epoch": {
       "epochId": 1,
-      "systemStateVersion": 1,
+      "systemStateVersion": 2,
       "storageFund": {
-        "totalObjectStorageRebates": "14500800",
+        "totalObjectStorageRebates": "14561600",
         "nonRefundableBalance": "0"
       }
     }
@@ -157,9 +157,9 @@ Response: {
   "data": {
     "epoch": {
       "epochId": 4,
-      "systemStateVersion": 1,
+      "systemStateVersion": 2,
       "storageFund": {
-        "totalObjectStorageRebates": "15177200",
+        "totalObjectStorageRebates": "15238000",
         "nonRefundableBalance": "0"
       }
     }

--- a/crates/iota-graphql-e2e-tests/tests/epoch/system_state.move
+++ b/crates/iota-graphql-e2e-tests/tests/epoch/system_state.move
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 4 --simulator --accounts C --custom-validator-account
+//# init --protocol-version 5 --simulator --accounts C --custom-validator-account
 
 // Run a few transactions and check that the system state storage fund is correctly reported
 // for historical epochs

--- a/crates/iota-graphql-e2e-tests/tests/objects/filter_by_type.exp
+++ b/crates/iota-graphql-e2e-tests/tests/objects/filter_by_type.exp
@@ -21,11 +21,11 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 4, lines 16-18:
 //# run 0x3::iota_system::request_add_stake --args object(0x5) object(3,0) @validator_0 --sender C
-events: Event { package_id: iota_system, transaction_module: Identifier("iota_system"), sender: C, type_: StructTag { address: iota_system, module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [243, 141, 225, 236, 161, 3, 21, 48, 245, 12, 169, 60, 4, 142, 157, 15, 79, 66, 170, 55, 43, 112, 117, 62, 99, 78, 32, 20, 130, 43, 88, 203, 175, 163, 158, 79, 0, 218, 226, 120, 249, 119, 199, 198, 147, 10, 94, 44, 118, 232, 93, 23, 165, 38, 215, 36, 187, 206, 15, 184, 31, 176, 125, 76, 140, 202, 78, 28, 224, 186, 89, 4, 206, 166, 29, 249, 36, 45, 162, 247, 210, 158, 62, 243, 40, 251, 126, 192, 124, 8, 107, 59, 244, 124, 166, 26, 1, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0] }
+events: Event { package_id: iota_system, transaction_module: Identifier("iota_system"), sender: C, type_: StructTag { address: iota_system, module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [52, 235, 172, 54, 254, 187, 232, 55, 222, 119, 24, 132, 11, 131, 107, 28, 195, 175, 227, 168, 229, 120, 48, 228, 44, 242, 219, 27, 175, 91, 153, 192, 175, 163, 158, 79, 0, 218, 226, 120, 249, 119, 199, 198, 147, 10, 94, 44, 118, 232, 93, 23, 165, 38, 215, 36, 187, 206, 15, 184, 31, 176, 125, 76, 140, 202, 78, 28, 224, 186, 89, 4, 206, 166, 29, 249, 36, 45, 162, 247, 210, 158, 62, 243, 40, 251, 126, 192, 124, 8, 107, 59, 244, 124, 166, 26, 1, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0] }
 created: object(4,0)
 mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000005, object(0,0)
 deleted: object(3,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 14500800,  storage_rebate: 1960800, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 14561600,  storage_rebate: 1960800, non_refundable_storage_fee: 0
 
 task 5, line 19:
 //# create-checkpoint
@@ -134,7 +134,18 @@ Response: {
             "asMoveObject": {
               "contents": {
                 "type": {
-                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<0x0000000000000000000000000000000000000000000000000000000000000002::object::ID,address>"
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<u64,0x0000000000000000000000000000000000000000000000000000000000000003::staking_pool::PoolTokenExchangeRate>"
+                }
+              }
+            }
+          }
+        },
+        {
+          "node": {
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::iota::IOTA>"
                 }
               }
             }
@@ -167,7 +178,7 @@ Response: {
             "asMoveObject": {
               "contents": {
                 "type": {
-                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<u64,0x0000000000000000000000000000000000000000000000000000000000000003::staking_pool::PoolTokenExchangeRate>"
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::CoinMetadata<0x0000000000000000000000000000000000000000000000000000000000000002::iota::IOTA>"
                 }
               }
             }
@@ -178,7 +189,7 @@ Response: {
             "asMoveObject": {
               "contents": {
                 "type": {
-                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<u64,0x0000000000000000000000000000000000000000000000000000000000000003::iota_system_state_inner::IotaSystemStateV1>"
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<u64,0x0000000000000000000000000000000000000000000000000000000000000003::iota_system_state_inner::IotaSystemStateV2>"
                 }
               }
             }
@@ -190,17 +201,6 @@ Response: {
               "contents": {
                 "type": {
                   "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::iota::IOTA>"
-                }
-              }
-            }
-          }
-        },
-        {
-          "node": {
-            "asMoveObject": {
-              "contents": {
-                "type": {
-                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::CoinMetadata<0x0000000000000000000000000000000000000000000000000000000000000002::iota::IOTA>"
                 }
               }
             }
@@ -222,7 +222,7 @@ Response: {
             "asMoveObject": {
               "contents": {
                 "type": {
-                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::iota::IOTA>"
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<0x0000000000000000000000000000000000000000000000000000000000000002::object::ID,address>"
                 }
               }
             }

--- a/crates/iota-graphql-e2e-tests/tests/objects/filter_by_type.move
+++ b/crates/iota-graphql-e2e-tests/tests/objects/filter_by_type.move
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 4 --simulator --accounts C
+//# init --protocol-version 5 --simulator --accounts C
 
 // TODO: Short term hack to get around indexer epoch issue
 //# create-checkpoint

--- a/crates/iota-graphql-e2e-tests/tests/objects/staked_iota.exp
+++ b/crates/iota-graphql-e2e-tests/tests/objects/staked_iota.exp
@@ -10,7 +10,7 @@ Response: {
     "objects": {
       "edges": [
         {
-          "cursor": "IPaqsJnP2iXcg3oJ09P+Ks1sTltZO1GwbHp3uqpyMzMUAAAAAAAAAAA=",
+          "cursor": "ICN4W/zyXMBs8Y/diVGb7V+tLDPX9rYxBkyswoM1x2hiAAAAAAAAAAA=",
           "node": {
             "asMoveObject": {
               "asStakedIota": {
@@ -39,11 +39,11 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 3, line 38:
 //# run 0x3::iota_system::request_add_stake --args object(0x5) object(2,0) @validator_0 --sender C
-events: Event { package_id: iota_system, transaction_module: Identifier("iota_system"), sender: C, type_: StructTag { address: iota_system, module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [243, 141, 225, 236, 161, 3, 21, 48, 245, 12, 169, 60, 4, 142, 157, 15, 79, 66, 170, 55, 43, 112, 117, 62, 99, 78, 32, 20, 130, 43, 88, 203, 175, 163, 158, 79, 0, 218, 226, 120, 249, 119, 199, 198, 147, 10, 94, 44, 118, 232, 93, 23, 165, 38, 215, 36, 187, 206, 15, 184, 31, 176, 125, 76, 140, 202, 78, 28, 224, 186, 89, 4, 206, 166, 29, 249, 36, 45, 162, 247, 210, 158, 62, 243, 40, 251, 126, 192, 124, 8, 107, 59, 244, 124, 166, 26, 0, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0] }
-created: object(3,0)
-mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000005, object(0,0)
-deleted: object(2,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 14500800,  storage_rebate: 1960800, non_refundable_storage_fee: 0
+events: Event { package_id: iota_system, transaction_module: Identifier("iota_system"), sender: C, type_: StructTag { address: iota_system, module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [52, 235, 172, 54, 254, 187, 232, 55, 222, 119, 24, 132, 11, 131, 107, 28, 195, 175, 227, 168, 229, 120, 48, 228, 44, 242, 219, 27, 175, 91, 153, 192, 175, 163, 158, 79, 0, 218, 226, 120, 249, 119, 199, 198, 147, 10, 94, 44, 118, 232, 93, 23, 165, 38, 215, 36, 187, 206, 15, 184, 31, 176, 125, 76, 140, 202, 78, 28, 224, 186, 89, 4, 206, 166, 29, 249, 36, 45, 162, 247, 210, 158, 62, 243, 40, 251, 126, 192, 124, 8, 107, 59, 244, 124, 166, 26, 0, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0] }
+created: object(3,0), object(3,1)
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000005, object(0,0)
+deleted: object(_), object(2,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 14561600,  storage_rebate: 1960800, non_refundable_storage_fee: 0
 
 task 4, line 40:
 //# create-checkpoint
@@ -60,34 +60,34 @@ Response: {
     "objects": {
       "edges": [
         {
-          "cursor": "IHlTQq7m2fMOnAyGcpY7WW/kAvLgQFIdXmuQOHom9m8FAgAAAAAAAAA=",
-          "node": {
-            "asMoveObject": {
-              "asStakedIota": {
-                "principal": "15340000000000",
-                "poolId": "0xf38de1eca1031530f50ca93c048e9d0f4f42aa372b70753e634e2014822b58cb"
-              }
-            }
-          }
-        },
-        {
-          "cursor": "IPaqsJnP2iXcg3oJ09P+Ks1sTltZO1GwbHp3uqpyMzMUAgAAAAAAAAA=",
+          "cursor": "ICN4W/zyXMBs8Y/diVGb7V+tLDPX9rYxBkyswoM1x2hiAgAAAAAAAAA=",
           "node": {
             "asMoveObject": {
               "asStakedIota": {
                 "principal": "1500000000000000",
-                "poolId": "0xf38de1eca1031530f50ca93c048e9d0f4f42aa372b70753e634e2014822b58cb"
+                "poolId": "0x34ebac36febbe837de7718840b836b1cc3afe3a8e57830e42cf2db1baf5b99c0"
               }
             }
           }
         },
         {
-          "cursor": "IPo8X8jPGMhQG4YzldRN9Bb3VVwoOWdqevkLYNK5A4z0AgAAAAAAAAA=",
+          "cursor": "IEkkfx928ZokrMBKh027DVz3DEeilQOvfJ//y0Q3KKywAgAAAAAAAAA=",
           "node": {
             "asMoveObject": {
               "asStakedIota": {
                 "principal": "10000000000",
-                "poolId": "0xf38de1eca1031530f50ca93c048e9d0f4f42aa372b70753e634e2014822b58cb"
+                "poolId": "0x34ebac36febbe837de7718840b836b1cc3afe3a8e57830e42cf2db1baf5b99c0"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "IPYi3RvwU/w/rb97YP5Cc9ykqR1SkqI2pRfPe6FDWzE1AgAAAAAAAAA=",
+          "node": {
+            "asMoveObject": {
+              "asStakedIota": {
+                "principal": "15340000000000",
+                "poolId": "0x34ebac36febbe837de7718840b836b1cc3afe3a8e57830e42cf2db1baf5b99c0"
               }
             }
           }
@@ -98,7 +98,7 @@ Response: {
       "stakedIotas": {
         "edges": [
           {
-            "cursor": "IPo8X8jPGMhQG4YzldRN9Bb3VVwoOWdqevkLYNK5A4z0AgAAAAAAAAA=",
+            "cursor": "IEkkfx928ZokrMBKh027DVz3DEeilQOvfJ//y0Q3KKywAgAAAAAAAAA=",
             "node": {
               "principal": "10000000000"
             }

--- a/crates/iota-graphql-e2e-tests/tests/objects/staked_iota.move
+++ b/crates/iota-graphql-e2e-tests/tests/objects/staked_iota.move
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 4 --simulator --accounts C
+//# init --protocol-version 5 --simulator --accounts C
 
 //# run-graphql
 { # Initial query yields only the validator's stake

--- a/crates/iota-graphql-e2e-tests/tests/transaction_block_effects/balance_changes.exp
+++ b/crates/iota-graphql-e2e-tests/tests/transaction_block_effects/balance_changes.exp
@@ -48,13 +48,13 @@ Response: {
                 "edges": [
                   {
                     "node": {
-                      "amount": "4000"
+                      "amount": "2000"
                     },
                     "cursor": "eyJpIjowLCJjIjoyfQ"
                   },
                   {
                     "node": {
-                      "amount": "2000"
+                      "amount": "3000"
                     },
                     "cursor": "eyJpIjoxLCJjIjoyfQ"
                   },
@@ -66,19 +66,19 @@ Response: {
                   },
                   {
                     "node": {
-                      "amount": "5000"
+                      "amount": "1000"
                     },
                     "cursor": "eyJpIjozLCJjIjoyfQ"
                   },
                   {
                     "node": {
-                      "amount": "3000"
+                      "amount": "4000"
                     },
                     "cursor": "eyJpIjo0LCJjIjoyfQ"
                   },
                   {
                     "node": {
-                      "amount": "1000"
+                      "amount": "5000"
                     },
                     "cursor": "eyJpIjo1LCJjIjoyfQ"
                   }
@@ -111,13 +111,13 @@ Response: {
                 "edges": [
                   {
                     "node": {
-                      "amount": "5000"
+                      "amount": "1000"
                     },
                     "cursor": "eyJpIjozLCJjIjoxfQ"
                   },
                   {
                     "node": {
-                      "amount": "3000"
+                      "amount": "4000"
                     },
                     "cursor": "eyJpIjo0LCJjIjoxfQ"
                   }
@@ -150,13 +150,13 @@ Response: {
                 "edges": [
                   {
                     "node": {
-                      "amount": "4000"
+                      "amount": "2000"
                     },
                     "cursor": "eyJpIjowLCJjIjoxfQ"
                   },
                   {
                     "node": {
-                      "amount": "2000"
+                      "amount": "3000"
                     },
                     "cursor": "eyJpIjoxLCJjIjoxfQ"
                   },

--- a/crates/iota-graphql-e2e-tests/tests/transaction_block_effects/balance_changes.move
+++ b/crates/iota-graphql-e2e-tests/tests/transaction_block_effects/balance_changes.move
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 4 --simulator --accounts C O P Q R S
+//# init --protocol-version 5 --simulator --accounts C O P Q R S
 
 //# programmable --sender C --inputs @C 1000 2000 3000 4000 5000
 //> SplitCoins(Gas, [Input(1), Input(2), Input(3), Input(4), Input(5)]);

--- a/crates/iota-graphql-e2e-tests/tests/transactions/system.exp
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/system.exp
@@ -7,7 +7,7 @@ Response: {
     "transactionBlocks": {
       "nodes": [
         {
-          "digest": "FsHAuWJAVkoEfTxphR92wR9LJUrZ7Ct3WgFx2sXJjAi8",
+          "digest": "4hFLX6VsVPJYw25qBHQ45zGT81jsLWcKhc42LXDkN2xN",
           "sender": null,
           "signatures": [
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
@@ -407,7 +407,7 @@ Response: {
                         "json": {
                           "id": "0x0000000000000000000000000000000000000000000000000000000000000008",
                           "inner": {
-                            "id": "0x641bd86e87be3f0ce633439e72d2e9281f536d2a14dc6d6a32b6eb477a0082ab",
+                            "id": "0xb1af3a0c530338393a5cb8ba6836d39fecaf1ae3f3adc5db8aafad282497c68c",
                             "version": "1"
                           }
                         }
@@ -489,7 +489,7 @@ Response: {
                         "json": {
                           "id": "0x0000000000000000000000000000000000000000000000000000000000000403",
                           "lists": {
-                            "id": "0x4840dac4497c3e9496557031c54c2dfd7dfafcaeeae2e5d71cc14d53bcc8a8ef",
+                            "id": "0x542cf6850379353a099e2429912a96f05aa076a67823032312685f63da7109de",
                             "size": "0"
                           }
                         }
@@ -586,32 +586,14 @@ Response: {
                 {
                   "cursor": "eyJpIjo5LCJjIjowfQ",
                   "node": {
-                    "address": "0x5901f846c182090a2d6ba4d89fc78554e7eb0f7280d38d206bd2d32a9464f8de",
-                    "asMoveObject": {
-                      "contents": {
-                        "type": {
-                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000003::validator_cap::UnverifiedValidatorOperationCap"
-                        },
-                        "json": {
-                          "id": "0x5901f846c182090a2d6ba4d89fc78554e7eb0f7280d38d206bd2d32a9464f8de",
-                          "authorizer_validator_address": "0x28f02a953f3553f51a9365593c7d4bd0643d2085f004b18c6ca9de51682b2c80"
-                        }
-                      }
-                    },
-                    "asMovePackage": null
-                  }
-                },
-                {
-                  "cursor": "eyJpIjoxMCwiYyI6MH0",
-                  "node": {
-                    "address": "0x64d58be1dcb5465aa5c48b80cba8e3b222f86c82a58c0ec2e035de8d767560c8",
+                    "address": "0x0de93f077b03d9a836993a45cf5451f761dde9874802f687233aeb500724fd61",
                     "asMoveObject": {
                       "contents": {
                         "type": {
                           "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::CoinMetadata<0x0000000000000000000000000000000000000000000000000000000000000002::iota::IOTA>"
                         },
                         "json": {
-                          "id": "0x64d58be1dcb5465aa5c48b80cba8e3b222f86c82a58c0ec2e035de8d767560c8",
+                          "id": "0x0de93f077b03d9a836993a45cf5451f761dde9874802f687233aeb500724fd61",
                           "decimals": 9,
                           "name": "IOTA",
                           "symbol": "IOTA",
@@ -626,7 +608,68 @@ Response: {
                   }
                 },
                 {
+                  "cursor": "eyJpIjoxMCwiYyI6MH0",
+                  "node": {
+                    "address": "0x0fdb5efc31ede8eb7cdf09f2abe37f2eab3505d33a791abb27f6c1faa5fff206",
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000003::staking_pool::StakedIota"
+                        },
+                        "json": {
+                          "id": "0x0fdb5efc31ede8eb7cdf09f2abe37f2eab3505d33a791abb27f6c1faa5fff206",
+                          "pool_id": "0x6845189babd695285767d81df802c8d94d8191486bb7fdd87779907a4610dac0",
+                          "stake_activation_epoch": "0",
+                          "principal": {
+                            "value": "1500000000000000"
+                          }
+                        }
+                      }
+                    },
+                    "asMovePackage": null
+                  }
+                },
+                {
                   "cursor": "eyJpIjoxMSwiYyI6MH0",
+                  "node": {
+                    "address": "0x336fcc05a9eb4b738cc3716c1218a0963c333bbada745315b756db9e8def20dc",
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::iota::IOTA>"
+                        },
+                        "json": {
+                          "id": "0x336fcc05a9eb4b738cc3716c1218a0963c333bbada745315b756db9e8def20dc",
+                          "balance": {
+                            "value": "30000000000000000"
+                          }
+                        }
+                      }
+                    },
+                    "asMovePackage": null
+                  }
+                },
+                {
+                  "cursor": "eyJpIjoxMiwiYyI6MH0",
+                  "node": {
+                    "address": "0x6811eec344c5bb6431a6c3a7be310de2440790d2ba06020afb63faef0e1be2ce",
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<0x0000000000000000000000000000000000000000000000000000000000000002::object::ID,address>"
+                        },
+                        "json": {
+                          "id": "0x6811eec344c5bb6431a6c3a7be310de2440790d2ba06020afb63faef0e1be2ce",
+                          "name": "0x6845189babd695285767d81df802c8d94d8191486bb7fdd87779907a4610dac0",
+                          "value": "0x28f02a953f3553f51a9365593c7d4bd0643d2085f004b18c6ca9de51682b2c80"
+                        }
+                      }
+                    },
+                    "asMovePackage": null
+                  }
+                },
+                {
+                  "cursor": "eyJpIjoxMywiYyI6MH0",
                   "node": {
                     "address": "0x6af2a2b7ca60bf76174adfd3e9c4957f8e937759603182f9b46c7f6c5f19c6d2",
                     "asMoveObject": {
@@ -639,11 +682,11 @@ Response: {
                           "name": "1",
                           "value": {
                             "epoch": "0",
-                            "protocol_version": "4",
+                            "protocol_version": "5",
                             "system_state_version": "1",
                             "iota_treasury_cap": {
                               "inner": {
-                                "id": "0x7b538646d553bac1ec9f3486e1ecd153d702c663f3181cfb76d5da2cea20281b",
+                                "id": "0x171360fb5b26498628a2c224d13853324cf3b2fcbb445a753790b9f1c046c608",
                                 "total_supply": {
                                   "value": "31800000000000000"
                                 }
@@ -890,15 +933,15 @@ Response: {
                                     "next_epoch_p2p_address": null,
                                     "next_epoch_primary_address": null,
                                     "extra_fields": {
-                                      "id": "0x78ab97e524798a68a38465c90074822c272044773267cab7bdd42a55282049bb",
+                                      "id": "0xacdad4d8b0f12781514171ce59ff6f7dd7e9e0ae591c8f440b31907af7ab54f1",
                                       "size": "0"
                                     }
                                   },
                                   "voting_power": "10000",
-                                  "operation_cap_id": "0x5901f846c182090a2d6ba4d89fc78554e7eb0f7280d38d206bd2d32a9464f8de",
+                                  "operation_cap_id": "0xdf26f1e7424babee37b9bfde840ffd5458aad8c73ac95faedff729c9f1c26e77",
                                   "gas_price": "1000",
                                   "staking_pool": {
-                                    "id": "0x4a0ccfcc91f27329009360896497b5644ef4a2d1b6943e6dd3d6b963831252b5",
+                                    "id": "0x6845189babd695285767d81df802c8d94d8191486bb7fdd87779907a4610dac0",
                                     "activation_epoch": "0",
                                     "deactivation_epoch": null,
                                     "iota_balance": "1500000000000000",
@@ -907,14 +950,14 @@ Response: {
                                     },
                                     "pool_token_balance": "1500000000000000",
                                     "exchange_rates": {
-                                      "id": "0x376aae2ed83e1ea14f79c73852c79266a51024be2047bd0d6bbd4e33ee740a6a",
+                                      "id": "0x6ae726e06f6c46b9c4db633527d1c0ddb637dd2daf6e124658095d353959f2e8",
                                       "size": "1"
                                     },
                                     "pending_stake": "0",
                                     "pending_total_iota_withdraw": "0",
                                     "pending_pool_token_withdraw": "0",
                                     "extra_fields": {
-                                      "id": "0x388a5d434c23818d6bd2044f8f03b80a07cb1b4306aeb82b7035907a59b28ec7",
+                                      "id": "0xe3f579d1270323974dd98b368ca9b80b7019f273f402640ab46e3a0433ebbd42",
                                       "size": "0"
                                     }
                                   },
@@ -923,35 +966,35 @@ Response: {
                                   "next_epoch_gas_price": "1000",
                                   "next_epoch_commission_rate": "200",
                                   "extra_fields": {
-                                    "id": "0xc95c2f8eecfac76b56eaa689836d2ca9962f8bc4daf4db8b12b956c86da0b915",
+                                    "id": "0x85ef93067213f0527fe77d558687f6c9f4477bdbfdb074266afaa05d866d363a",
                                     "size": "0"
                                   }
                                 }
                               ],
                               "pending_active_validators": {
                                 "contents": {
-                                  "id": "0xa9f518812bdd09f58e277cb28d25f80c1c4cfdcdcd5ed0f5a4e167a3b7f1f108",
+                                  "id": "0x60d1e5d02533dc04bc73a2491ae30edce932b541796656ca85b559ac3fe95db9",
                                   "size": "0"
                                 }
                               },
                               "pending_removals": [],
                               "staking_pool_mappings": {
-                                "id": "0x2e710efc9826eaa42d83db08f5c2ed34385743ad2f0dd6cdea38f46ce32393cb",
+                                "id": "0xeb06558c606868cb6256c56b9eee50454b019da4dfe982e02173ebe7e952dffc",
                                 "size": "1"
                               },
                               "inactive_validators": {
-                                "id": "0xc9bad32c3c0cc635d7f6eca2c9f5651ddb661239d57241f8cde2fd71b40d00ba",
+                                "id": "0xd5be548bbfd9e1c4e0fa75e59e638c6d2f4bd2d307dc3bbdd5c7bd4c11873971",
                                 "size": "0"
                               },
                               "validator_candidates": {
-                                "id": "0xe78bf1f7366512f1c1682489d0308eff37d3d306398f58a6354295b1e5517801",
+                                "id": "0xd15d71c9f47fefa9ebe1feefced2d852c7e352645461beb9d79ef803510037df",
                                 "size": "0"
                               },
                               "at_risk_validators": {
                                 "contents": []
                               },
                               "extra_fields": {
-                                "id": "0xadec4e8bfdb5dd22c8d4abe648555f7f12055900254fa14e2ff67c74c1ca1c08",
+                                "id": "0xaf9a0b8dd0eb038cfda6ec64a385e453b875b3fdb737d898301827c47bae2cca",
                                 "size": "0"
                               }
                             },
@@ -972,7 +1015,7 @@ Response: {
                               "validator_very_low_stake_threshold": "1000000000000000",
                               "validator_low_stake_grace_period": "7",
                               "extra_fields": {
-                                "id": "0xa8737bd4be2ba2a134117941a980d297bd2e1da7fd6b0b74b8c2c071312c907f",
+                                "id": "0xf643d7c845681353db8e6de41d2840e3fd0f81de23bc16f2644f2b7ce86944d9",
                                 "size": "0"
                               }
                             },
@@ -994,7 +1037,7 @@ Response: {
                             "safe_mode_non_refundable_storage_fee": "0",
                             "epoch_start_timestamp_ms": "0",
                             "extra_fields": {
-                              "id": "0x1c39044e04c4b6c8b0d757349bd63c4694b0b2be78e46592908a9fb139a6c31f",
+                              "id": "0x077142d5658bfe0cf3a2a29b16ad0a424587a57f6271e0d81a398cdf57a603bf",
                               "size": "0"
                             }
                           }
@@ -1005,36 +1048,16 @@ Response: {
                   }
                 },
                 {
-                  "cursor": "eyJpIjoxMiwiYyI6MH0",
+                  "cursor": "eyJpIjoxNCwiYyI6MH0",
                   "node": {
-                    "address": "0x6d72312db992499a342d70e04c177cfc9cb0dc264b0792c9d7bc10e0cc584940",
-                    "asMoveObject": {
-                      "contents": {
-                        "type": {
-                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::iota::IOTA>"
-                        },
-                        "json": {
-                          "id": "0x6d72312db992499a342d70e04c177cfc9cb0dc264b0792c9d7bc10e0cc584940",
-                          "balance": {
-                            "value": "300000000000000"
-                          }
-                        }
-                      }
-                    },
-                    "asMovePackage": null
-                  }
-                },
-                {
-                  "cursor": "eyJpIjoxMywiYyI6MH0",
-                  "node": {
-                    "address": "0x779469ee996b5284fc5e3dbcbc2952655a23630b5e7dd65043780721478199e4",
+                    "address": "0xa5b5d6f972581d7885b24f417787e9d5c2ccbcb1a32b52328dea9f64b662c8f2",
                     "asMoveObject": {
                       "contents": {
                         "type": {
                           "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::display::Display<0x000000000000000000000000000000000000000000000000000000000000107a::nft::Nft>"
                         },
                         "json": {
-                          "id": "0x779469ee996b5284fc5e3dbcbc2952655a23630b5e7dd65043780721478199e4",
+                          "id": "0xa5b5d6f972581d7885b24f417787e9d5c2ccbcb1a32b52328dea9f64b662c8f2",
                           "fields": {
                             "contents": [
                               {
@@ -1079,77 +1102,16 @@ Response: {
                   }
                 },
                 {
-                  "cursor": "eyJpIjoxNCwiYyI6MH0",
-                  "node": {
-                    "address": "0x8885ad350a4800966438b59ea74de375e42c6056861797b7975eec2ab40e84f6",
-                    "asMoveObject": {
-                      "contents": {
-                        "type": {
-                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000003::staking_pool::StakedIota"
-                        },
-                        "json": {
-                          "id": "0x8885ad350a4800966438b59ea74de375e42c6056861797b7975eec2ab40e84f6",
-                          "pool_id": "0x4a0ccfcc91f27329009360896497b5644ef4a2d1b6943e6dd3d6b963831252b5",
-                          "stake_activation_epoch": "0",
-                          "principal": {
-                            "value": "1500000000000000"
-                          }
-                        }
-                      }
-                    },
-                    "asMovePackage": null
-                  }
-                },
-                {
                   "cursor": "eyJpIjoxNSwiYyI6MH0",
                   "node": {
-                    "address": "0xbdc6da96832088412b517eb59c24640b459b871a402b94a4ae03a193135272ee",
-                    "asMoveObject": {
-                      "contents": {
-                        "type": {
-                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<0x0000000000000000000000000000000000000000000000000000000000000002::object::ID,address>"
-                        },
-                        "json": {
-                          "id": "0xbdc6da96832088412b517eb59c24640b459b871a402b94a4ae03a193135272ee",
-                          "name": "0x4a0ccfcc91f27329009360896497b5644ef4a2d1b6943e6dd3d6b963831252b5",
-                          "value": "0x28f02a953f3553f51a9365593c7d4bd0643d2085f004b18c6ca9de51682b2c80"
-                        }
-                      }
-                    },
-                    "asMovePackage": null
-                  }
-                },
-                {
-                  "cursor": "eyJpIjoxNiwiYyI6MH0",
-                  "node": {
-                    "address": "0xc2d4044c0f3875035b61c7987d6c06117587d2a6eb5ce4224bdc7dd42c86130b",
-                    "asMoveObject": {
-                      "contents": {
-                        "type": {
-                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::iota::IOTA>"
-                        },
-                        "json": {
-                          "id": "0xc2d4044c0f3875035b61c7987d6c06117587d2a6eb5ce4224bdc7dd42c86130b",
-                          "balance": {
-                            "value": "30000000000000000"
-                          }
-                        }
-                      }
-                    },
-                    "asMovePackage": null
-                  }
-                },
-                {
-                  "cursor": "eyJpIjoxNywiYyI6MH0",
-                  "node": {
-                    "address": "0xd69f167d17a18d52398cce7bfa433b6c0f64fceffe3e1227c246586ec05412e8",
+                    "address": "0xc80dbad756d3220af4af9b23ad6bf9a17a51ec54f3d3e5c4442de805c27c8e04",
                     "asMoveObject": {
                       "contents": {
                         "type": {
                           "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<u64,0x0000000000000000000000000000000000000000000000000000000000000002::random::RandomInner>"
                         },
                         "json": {
-                          "id": "0xd69f167d17a18d52398cce7bfa433b6c0f64fceffe3e1227c246586ec05412e8",
+                          "id": "0xc80dbad756d3220af4af9b23ad6bf9a17a51ec54f3d3e5c4442de805c27c8e04",
                           "name": "1",
                           "value": {
                             "version": "1",
@@ -1164,16 +1126,54 @@ Response: {
                   }
                 },
                 {
+                  "cursor": "eyJpIjoxNiwiYyI6MH0",
+                  "node": {
+                    "address": "0xdf26f1e7424babee37b9bfde840ffd5458aad8c73ac95faedff729c9f1c26e77",
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000003::validator_cap::UnverifiedValidatorOperationCap"
+                        },
+                        "json": {
+                          "id": "0xdf26f1e7424babee37b9bfde840ffd5458aad8c73ac95faedff729c9f1c26e77",
+                          "authorizer_validator_address": "0x28f02a953f3553f51a9365593c7d4bd0643d2085f004b18c6ca9de51682b2c80"
+                        }
+                      }
+                    },
+                    "asMovePackage": null
+                  }
+                },
+                {
+                  "cursor": "eyJpIjoxNywiYyI6MH0",
+                  "node": {
+                    "address": "0xefadeb019cdf34fcbfa4a56d067cc5e8eeddde2aa1df4c08dadbf6641bc23d29",
+                    "asMoveObject": {
+                      "contents": {
+                        "type": {
+                          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::iota::IOTA>"
+                        },
+                        "json": {
+                          "id": "0xefadeb019cdf34fcbfa4a56d067cc5e8eeddde2aa1df4c08dadbf6641bc23d29",
+                          "balance": {
+                            "value": "300000000000000"
+                          }
+                        }
+                      }
+                    },
+                    "asMovePackage": null
+                  }
+                },
+                {
                   "cursor": "eyJpIjoxOCwiYyI6MH0",
                   "node": {
-                    "address": "0xd9c379ae1aa92ed99fd9ce1b448f66717b1f5d89d912be3e93e4a05dcde56661",
+                    "address": "0xf643e1062c30850dc5071ec72ebba9bf375c89aef4a7c700678378c453518435",
                     "asMoveObject": {
                       "contents": {
                         "type": {
                           "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<u64,0x0000000000000000000000000000000000000000000000000000000000000003::staking_pool::PoolTokenExchangeRate>"
                         },
                         "json": {
-                          "id": "0xd9c379ae1aa92ed99fd9ce1b448f66717b1f5d89d912be3e93e4a05dcde56661",
+                          "id": "0xf643e1062c30850dc5071ec72ebba9bf375c89aef4a7c700678378c453518435",
                           "name": "0",
                           "value": {
                             "iota_amount": "0",
@@ -1225,7 +1225,7 @@ Response: {
                   "idDeleted": false,
                   "outputState": {
                     "address": "0x0000000000000000000000000000000000000000000000000000000000000001",
-                    "digest": "3EjMz83K2ofGgSUKFJNFwLByZzdX8DtAowswYUWf8yLP"
+                    "digest": "4G5cgvT2TvnTEsJ6Q9eSD8FvA8SgaheVzBGwYWJG3VGX"
                   }
                 },
                 {
@@ -1234,7 +1234,7 @@ Response: {
                   "idDeleted": false,
                   "outputState": {
                     "address": "0x0000000000000000000000000000000000000000000000000000000000000002",
-                    "digest": "J28KKQDSrFXbcdxrV6kufgHZdmakG8k2oSwPw1gntvSa"
+                    "digest": "AaGiZSUipqC62J4L2bBi9UPPAQ8R4YviT1pL1uqzjhdr"
                   }
                 },
                 {
@@ -1243,7 +1243,7 @@ Response: {
                   "idDeleted": false,
                   "outputState": {
                     "address": "0x0000000000000000000000000000000000000000000000000000000000000003",
-                    "digest": "HtamiUjzDWYW2J47uknidEndyPj98KZrZ6gajoxHBvRa"
+                    "digest": "HqKjohwxnua2mrzMxmRRe87dg4VGLxJy5n57ueuL7mAf"
                   }
                 },
                 {
@@ -1252,7 +1252,7 @@ Response: {
                   "idDeleted": false,
                   "outputState": {
                     "address": "0x0000000000000000000000000000000000000000000000000000000000000005",
-                    "digest": "34ghbPTc54zVsWBUFjGMMZK42vD9TjttpBT7kUZYCiwC"
+                    "digest": "EkAxEeJtwEiTWQFNfXAqJVQLTAFVXU8X7vFxVjX8t536"
                   }
                 },
                 {
@@ -1261,7 +1261,7 @@ Response: {
                   "idDeleted": false,
                   "outputState": {
                     "address": "0x0000000000000000000000000000000000000000000000000000000000000006",
-                    "digest": "GXzWwRLLH5bmrisRZDfuxAfpTQohQdeSVeAXiQ3Jufsh"
+                    "digest": "FF4x3i1xe7uWhUuDyYWfWnLRFRDk37hrwS6vHCfUYZSo"
                   }
                 },
                 {
@@ -1270,7 +1270,7 @@ Response: {
                   "idDeleted": false,
                   "outputState": {
                     "address": "0x0000000000000000000000000000000000000000000000000000000000000008",
-                    "digest": "78rfKLVpidBjU3qL2CvjT8QFRYRU1Qz9h4gY6mqWNTpH"
+                    "digest": "CEJqwzaeGapUHLGs2NRWvbKzENnx4NF8dRLDduDimeUi"
                   }
                 },
                 {
@@ -1279,7 +1279,7 @@ Response: {
                   "idDeleted": false,
                   "outputState": {
                     "address": "0x000000000000000000000000000000000000000000000000000000000000000b",
-                    "digest": "3x8RYpEXcWKDQBS32udeS5dGYM4S5Ptsevd11jtkPUyC"
+                    "digest": "8Qfsxmiya3SR3Gms4JE5BDiD83PpEZq8gZGwscgUGUDo"
                   }
                 },
                 {
@@ -1288,7 +1288,7 @@ Response: {
                   "idDeleted": false,
                   "outputState": {
                     "address": "0x0000000000000000000000000000000000000000000000000000000000000403",
-                    "digest": "CPG9spufFbupsuYwsKA7paDkVSg14BzojfoGCrRYLpoK"
+                    "digest": "GSRarpirQZy8fmq9U67HuJ27mpxKF3x65CnTj2chzznr"
                   }
                 },
                 {
@@ -1297,25 +1297,43 @@ Response: {
                   "idDeleted": false,
                   "outputState": {
                     "address": "0x000000000000000000000000000000000000000000000000000000000000107a",
-                    "digest": "4u2YVMV3PmC4t5hhuPGWqRHLYLntnDTkqsr4gSmPQt47"
+                    "digest": "4wc25xCv9B7ZmUTFt1EXQBRjmoYVr9LSbE31uKr9epkm"
                   }
                 },
                 {
-                  "address": "0x5901f846c182090a2d6ba4d89fc78554e7eb0f7280d38d206bd2d32a9464f8de",
+                  "address": "0x0de93f077b03d9a836993a45cf5451f761dde9874802f687233aeb500724fd61",
                   "idCreated": true,
                   "idDeleted": false,
                   "outputState": {
-                    "address": "0x5901f846c182090a2d6ba4d89fc78554e7eb0f7280d38d206bd2d32a9464f8de",
-                    "digest": "9z4WvQQ5mkF48hCirh4pAQQu4EopZdKEeKcT9wB3hQXt"
+                    "address": "0x0de93f077b03d9a836993a45cf5451f761dde9874802f687233aeb500724fd61",
+                    "digest": "G5LSWPaM8dirLdefzqHgecsQEYUh9Lq5dygPtBQoBr2f"
                   }
                 },
                 {
-                  "address": "0x64d58be1dcb5465aa5c48b80cba8e3b222f86c82a58c0ec2e035de8d767560c8",
+                  "address": "0x0fdb5efc31ede8eb7cdf09f2abe37f2eab3505d33a791abb27f6c1faa5fff206",
                   "idCreated": true,
                   "idDeleted": false,
                   "outputState": {
-                    "address": "0x64d58be1dcb5465aa5c48b80cba8e3b222f86c82a58c0ec2e035de8d767560c8",
-                    "digest": "E64PBE8JyamnidUw4XqkZHPHwVYj6N5UiuatcHWkYhhj"
+                    "address": "0x0fdb5efc31ede8eb7cdf09f2abe37f2eab3505d33a791abb27f6c1faa5fff206",
+                    "digest": "GAG1oKZdg2LqLEgUks2EvwceZN6bpMV9BsJeTK3gmAeR"
+                  }
+                },
+                {
+                  "address": "0x336fcc05a9eb4b738cc3716c1218a0963c333bbada745315b756db9e8def20dc",
+                  "idCreated": true,
+                  "idDeleted": false,
+                  "outputState": {
+                    "address": "0x336fcc05a9eb4b738cc3716c1218a0963c333bbada745315b756db9e8def20dc",
+                    "digest": "FdYKjt79zAAQbw1Djy2zY5QqnQe5X9rFJ5WKGoHYXfZg"
+                  }
+                },
+                {
+                  "address": "0x6811eec344c5bb6431a6c3a7be310de2440790d2ba06020afb63faef0e1be2ce",
+                  "idCreated": true,
+                  "idDeleted": false,
+                  "outputState": {
+                    "address": "0x6811eec344c5bb6431a6c3a7be310de2440790d2ba06020afb63faef0e1be2ce",
+                    "digest": "5Axpz9DtXexMXxm4XuC6sp4ZxeSRDq9u6aRuENCZoWG6"
                   }
                 },
                 {
@@ -1324,70 +1342,52 @@ Response: {
                   "idDeleted": false,
                   "outputState": {
                     "address": "0x6af2a2b7ca60bf76174adfd3e9c4957f8e937759603182f9b46c7f6c5f19c6d2",
-                    "digest": "5DMv5kSVRFDCMiAYe3qJNMDhSmgQnN1taCCrGwDJU3xE"
+                    "digest": "BKBE2Gt5aQQPgGGkeoZcyfo6HaHQqMZJ4irKKUR6nHFr"
                   }
                 },
                 {
-                  "address": "0x6d72312db992499a342d70e04c177cfc9cb0dc264b0792c9d7bc10e0cc584940",
+                  "address": "0xa5b5d6f972581d7885b24f417787e9d5c2ccbcb1a32b52328dea9f64b662c8f2",
                   "idCreated": true,
                   "idDeleted": false,
                   "outputState": {
-                    "address": "0x6d72312db992499a342d70e04c177cfc9cb0dc264b0792c9d7bc10e0cc584940",
-                    "digest": "Av3QqBerespFLD9dKyDrKxNgpBT2DGKw1Xi1rjgxqy9Q"
+                    "address": "0xa5b5d6f972581d7885b24f417787e9d5c2ccbcb1a32b52328dea9f64b662c8f2",
+                    "digest": "5j3PAqbbLmfm9FCah3dj1ATt26abaixrMqnpXmtjFPx5"
                   }
                 },
                 {
-                  "address": "0x779469ee996b5284fc5e3dbcbc2952655a23630b5e7dd65043780721478199e4",
+                  "address": "0xc80dbad756d3220af4af9b23ad6bf9a17a51ec54f3d3e5c4442de805c27c8e04",
                   "idCreated": true,
                   "idDeleted": false,
                   "outputState": {
-                    "address": "0x779469ee996b5284fc5e3dbcbc2952655a23630b5e7dd65043780721478199e4",
-                    "digest": "7N1FdeHFg3AGzwFMvwtmZjKxGbcD6BTmUJp2gFGCdrqz"
+                    "address": "0xc80dbad756d3220af4af9b23ad6bf9a17a51ec54f3d3e5c4442de805c27c8e04",
+                    "digest": "CV3UfXGRn9g2B6iWRef6tKsXxgxtSRA8aKiiZj4QA2Ca"
                   }
                 },
                 {
-                  "address": "0x8885ad350a4800966438b59ea74de375e42c6056861797b7975eec2ab40e84f6",
+                  "address": "0xdf26f1e7424babee37b9bfde840ffd5458aad8c73ac95faedff729c9f1c26e77",
                   "idCreated": true,
                   "idDeleted": false,
                   "outputState": {
-                    "address": "0x8885ad350a4800966438b59ea74de375e42c6056861797b7975eec2ab40e84f6",
-                    "digest": "9HK9RqGyDfXUhktJBaNFSiaxMLmQUen9AwqwzRBhRwqz"
+                    "address": "0xdf26f1e7424babee37b9bfde840ffd5458aad8c73ac95faedff729c9f1c26e77",
+                    "digest": "5cg2ppdqQZR3cYVjGsDfeewjBecGznZSDhvEQ2AKuZtj"
                   }
                 },
                 {
-                  "address": "0xbdc6da96832088412b517eb59c24640b459b871a402b94a4ae03a193135272ee",
+                  "address": "0xefadeb019cdf34fcbfa4a56d067cc5e8eeddde2aa1df4c08dadbf6641bc23d29",
                   "idCreated": true,
                   "idDeleted": false,
                   "outputState": {
-                    "address": "0xbdc6da96832088412b517eb59c24640b459b871a402b94a4ae03a193135272ee",
-                    "digest": "sHA8APPDREHZPkoNsUTRQS2o8zYoJvpAYRXxaTvxSx9"
+                    "address": "0xefadeb019cdf34fcbfa4a56d067cc5e8eeddde2aa1df4c08dadbf6641bc23d29",
+                    "digest": "8nMTeGAUrx69P1ame8ph7W1hRwTrkznf1vYiKmDfG2Cc"
                   }
                 },
                 {
-                  "address": "0xc2d4044c0f3875035b61c7987d6c06117587d2a6eb5ce4224bdc7dd42c86130b",
+                  "address": "0xf643e1062c30850dc5071ec72ebba9bf375c89aef4a7c700678378c453518435",
                   "idCreated": true,
                   "idDeleted": false,
                   "outputState": {
-                    "address": "0xc2d4044c0f3875035b61c7987d6c06117587d2a6eb5ce4224bdc7dd42c86130b",
-                    "digest": "3pwLzsk11J62Sy9S7CbBrLidoEuj4cgHDTwZMBsbPxCj"
-                  }
-                },
-                {
-                  "address": "0xd69f167d17a18d52398cce7bfa433b6c0f64fceffe3e1227c246586ec05412e8",
-                  "idCreated": true,
-                  "idDeleted": false,
-                  "outputState": {
-                    "address": "0xd69f167d17a18d52398cce7bfa433b6c0f64fceffe3e1227c246586ec05412e8",
-                    "digest": "AqwNaubB57X16PoHUA5wg7EGzFUQ9PWJmKmFbY1mjd2m"
-                  }
-                },
-                {
-                  "address": "0xd9c379ae1aa92ed99fd9ce1b448f66717b1f5d89d912be3e93e4a05dcde56661",
-                  "idCreated": true,
-                  "idDeleted": false,
-                  "outputState": {
-                    "address": "0xd9c379ae1aa92ed99fd9ce1b448f66717b1f5d89d912be3e93e4a05dcde56661",
-                    "digest": "3tGAtyNkds8gUQxzwQrJXmKSc6U7sM6KNinKdRe428xv"
+                    "address": "0xf643e1062c30850dc5071ec72ebba9bf375c89aef4a7c700678378c453518435",
+                    "digest": "HD3jrNPoRd1Kacw6DVAo6fA1ssYwgjmZcFKWe78UH3aw"
                   }
                 }
               ]
@@ -1409,7 +1409,7 @@ Response: {
               "sequenceNumber": 0
             },
             "transactionBlock": {
-              "digest": "FsHAuWJAVkoEfTxphR92wR9LJUrZ7Ct3WgFx2sXJjAi8"
+              "digest": "4hFLX6VsVPJYw25qBHQ45zGT81jsLWcKhc42LXDkN2xN"
             }
           },
           "expiration": null
@@ -1461,7 +1461,7 @@ Response: {
             "dependencies": {
               "nodes": [
                 {
-                  "digest": "FsHAuWJAVkoEfTxphR92wR9LJUrZ7Ct3WgFx2sXJjAi8"
+                  "digest": "4hFLX6VsVPJYw25qBHQ45zGT81jsLWcKhc42LXDkN2xN"
                 }
               ]
             },
@@ -1519,7 +1519,7 @@ Response: {
     "transactionBlocks": {
       "nodes": [
         {
-          "digest": "CtUeA5hUiZpkzrZj6u3CA1cqT5ojdzDjiUTS9WzRAkF4",
+          "digest": "Gx5HK2D56vGgZmAwxtKV44QRvigMwhVYhxiCsCtvczxq",
           "sender": null,
           "signatures": [
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
@@ -1541,14 +1541,7 @@ Response: {
                 {
                   "cursor": "eyJpIjowLCJjIjoyfQ",
                   "node": {
-                    "__typename": "ChangeEpochTransaction",
-                    "epoch": null,
-                    "protocolVersion": 4,
-                    "storageCharge": "0",
-                    "computationCharge": "0",
-                    "storageRebate": "0",
-                    "nonRefundableStorageFee": "0",
-                    "startTimestamp": "1970-01-01T00:01:25Z"
+                    "__typename": "ChangeEpochTransactionV2"
                   }
                 }
               ]
@@ -1561,7 +1554,7 @@ Response: {
             "dependencies": {
               "nodes": [
                 {
-                  "digest": "FsHAuWJAVkoEfTxphR92wR9LJUrZ7Ct3WgFx2sXJjAi8"
+                  "digest": "4hFLX6VsVPJYw25qBHQ45zGT81jsLWcKhc42LXDkN2xN"
                 }
               ]
             },
@@ -1576,35 +1569,41 @@ Response: {
                   "idDeleted": false,
                   "outputState": {
                     "address": "0x0000000000000000000000000000000000000000000000000000000000000005",
-                    "digest": "7tMZQkoMMPe274gCbbzPo8WE3R2fxy2eW5tUYPkhQhAW"
+                    "digest": "3Bfiz4yi6GmpKUWUi3UggttQMVbuxdNSW6A9R6s7NbaK"
+                  }
+                },
+                {
+                  "address": "0x1d207e42cefc8f4a8881380e8470f4e19699e8afe47aa7067e4c2ea0b84f104f",
+                  "idCreated": true,
+                  "idDeleted": false,
+                  "outputState": {
+                    "address": "0x1d207e42cefc8f4a8881380e8470f4e19699e8afe47aa7067e4c2ea0b84f104f",
+                    "digest": "AwMeLYRxEyRGmz9bo9EFdE4V5dyhCerL7ofMe1qdhAYb"
+                  }
+                },
+                {
+                  "address": "0x2d1f84cc8b187a56adc5ed50fb881fc16632781c21efa96e914abd3773305a23",
+                  "idCreated": true,
+                  "idDeleted": false,
+                  "outputState": {
+                    "address": "0x2d1f84cc8b187a56adc5ed50fb881fc16632781c21efa96e914abd3773305a23",
+                    "digest": "7q9NiyedzqiAQto5VR2zaCjmKtpX3ESwr8ZNWrsZkoxM"
+                  }
+                },
+                {
+                  "address": "0x5b890eaf2abcfa2ab90b77b8e6f3d5d8609586c3e583baf3dccd5af17edf48d1",
+                  "idCreated": true,
+                  "idDeleted": false,
+                  "outputState": {
+                    "address": "0x5b890eaf2abcfa2ab90b77b8e6f3d5d8609586c3e583baf3dccd5af17edf48d1",
+                    "digest": "3vL1b34dQV4fEat3kzWKZj5LXkQ22mQi7xopZycWSguG"
                   }
                 },
                 {
                   "address": "0x6af2a2b7ca60bf76174adfd3e9c4957f8e937759603182f9b46c7f6c5f19c6d2",
                   "idCreated": false,
-                  "idDeleted": false,
-                  "outputState": {
-                    "address": "0x6af2a2b7ca60bf76174adfd3e9c4957f8e937759603182f9b46c7f6c5f19c6d2",
-                    "digest": "FcTo9DTbUNDbf4N2phPuH4Kzkc5nzfhU3ocRMpH91gXw"
-                  }
-                },
-                {
-                  "address": "0xbf3dcd802652282cf9538fe8927691c56b57ea32e83d467fbeb36bac0c9a485e",
-                  "idCreated": true,
-                  "idDeleted": false,
-                  "outputState": {
-                    "address": "0xbf3dcd802652282cf9538fe8927691c56b57ea32e83d467fbeb36bac0c9a485e",
-                    "digest": "9wZsKPg5QXEVRtAeYTbNKQqSQQ9gAqJ99RxMKu5dNbPt"
-                  }
-                },
-                {
-                  "address": "0xda0b1cb59f28bf4f64b31fe4109d25295b798c8c8a81f58e3a956de13b4098cc",
-                  "idCreated": true,
-                  "idDeleted": false,
-                  "outputState": {
-                    "address": "0xda0b1cb59f28bf4f64b31fe4109d25295b798c8c8a81f58e3a956de13b4098cc",
-                    "digest": "2ZF7yAC3JWXwnMWqR1rcUDkEGkDD9hmJzTJmUgxish4q"
-                  }
+                  "idDeleted": true,
+                  "outputState": null
                 }
               ]
             },
@@ -1625,7 +1624,7 @@ Response: {
               "sequenceNumber": 2
             },
             "transactionBlock": {
-              "digest": "CtUeA5hUiZpkzrZj6u3CA1cqT5ojdzDjiUTS9WzRAkF4"
+              "digest": "Gx5HK2D56vGgZmAwxtKV44QRvigMwhVYhxiCsCtvczxq"
             }
           },
           "expiration": null

--- a/crates/iota-graphql-e2e-tests/tests/transactions/system.move
+++ b/crates/iota-graphql-e2e-tests/tests/transactions/system.move
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 4 --simulator
+//# init --protocol-version 5 --simulator
 
 // Tests for representations of all the various system transactions
 

--- a/crates/iota-graphql-e2e-tests/tests/validator/validator.move
+++ b/crates/iota-graphql-e2e-tests/tests/validator/validator.move
@@ -4,7 +4,7 @@
 
 // Test heavy transactions.
 
-//# init --protocol-version 4 --simulator --accounts A --addresses P0=0x0
+//# init --protocol-version 5 --simulator --accounts A --addresses P0=0x0
 
 //# advance-epoch
 


### PR DESCRIPTION
# Description of change

This patch bumps the protocol version in failing tests, and updates baselines.


## How the change has been tested

```sh
$ cargo nextest run --no-fail-fast --test-threads 8 --package iota-graphql-e2e-tests --features pg_integration
```
