### PR TITLE
[iota-rest-api]: Add tx exec endpoint for optimistic indexing

### DIFF
--- a/crates/iota-rest-api/openapi/openapi.json
+++ b/crates/iota-rest-api/openapi/openapi.json
@@ -725,6 +725,32 @@
         }
       }
     },
+    "/transactions/execute_for_optimistic_indexing": {
+      "post": {
+        "tags": [
+          "Transactions"
+        ],
+        "operationId": "ExecuteTransactionForOptimisticIndexing",
+        "requestBody": {
+          "content": {
+            "application/bcs": {}
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CheckpointTransaction"
+                }
+              },
+              "application/bcs": {}
+            }
+          }
+        }
+      }
+    },
     "/coins/{coin_type}": {
       "get": {
         "tags": [
@@ -1126,6 +1152,55 @@
             "description": "CheckpointSummary is not an evolvable structure - it must be readable by any version of the code. Therefore, in order to allow extensions to be added to CheckpointSummary, we allow opaque data to be added to checkpoints which can be deserialized based on the current protocol version.",
             "type": "string",
             "format": "base64"
+          }
+        }
+      },
+      "CheckpointTransaction": {
+        "type": "object",
+        "required": [
+          "effects",
+          "input_objects",
+          "output_objects",
+          "transaction"
+        ],
+        "properties": {
+          "effects": {
+            "description": "The effects produced by executing this transaction",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TransactionEffects"
+              }
+            ]
+          },
+          "events": {
+            "description": "The events, if any, emitted by this transaciton during execution",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TransactionEvents"
+              }
+            ]
+          },
+          "input_objects": {
+            "description": "The state of all inputs to this transaction as they were prior to execution.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Object"
+            }
+          },
+          "output_objects": {
+            "description": "The state of all output objects created or mutated by this transaction.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Object"
+            }
+          },
+          "transaction": {
+            "description": "The input Transaction",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SignedTransaction"
+              }
+            ]
           }
         }
       },

--- a/crates/iota-rest-api/src/client/mod.rs
+++ b/crates/iota-rest-api/src/client/mod.rs
@@ -5,14 +5,14 @@
 pub mod sdk;
 
 use iota_types::{
-    TypeTag,
     base_types::{IotaAddress, ObjectID, SequenceNumber},
     crypto::AuthorityStrongQuorumSignInfo,
     effects::{TransactionEffects, TransactionEvents},
-    full_checkpoint_content::CheckpointData,
+    full_checkpoint_content::{CheckpointData, CheckpointTransaction},
     messages_checkpoint::{CertifiedCheckpointSummary, CheckpointSequenceNumber},
     object::Object,
     transaction::Transaction,
+    TypeTag,
 };
 pub use reqwest;
 use sdk::Result;
@@ -113,6 +113,38 @@ impl Client {
             .client()
             .post(url)
             .query(parameters)
+            .header(reqwest::header::ACCEPT, crate::APPLICATION_BCS)
+            .header(reqwest::header::CONTENT_TYPE, crate::APPLICATION_BCS)
+            .body(body)
+            .send()
+            .await?;
+
+        self.inner.bcs(response).await.map(Response::into_inner)
+    }
+
+    pub async fn execute_transaction_for_optimistic_indexing(
+        &self,
+        transaction: &Transaction,
+    ) -> Result<CheckpointTransaction> {
+        #[derive(serde::Serialize)]
+        struct SignedTransaction<'a> {
+            transaction: &'a iota_types::transaction::TransactionData,
+            signatures: &'a [iota_types::signature::GenericSignature],
+        }
+
+        let url = self
+            .inner
+            .url()
+            .join("transactions/execute_for_optimistic_indexing")?;
+        let body = bcs::to_bytes(&SignedTransaction {
+            transaction: &transaction.inner().intent_message.value,
+            signatures: &transaction.inner().tx_signatures,
+        })?;
+
+        let response = self
+            .inner
+            .client()
+            .post(url)
             .header(reqwest::header::ACCEPT, crate::APPLICATION_BCS)
             .header(reqwest::header::CONTENT_TYPE, crate::APPLICATION_BCS)
             .body(body)

--- a/crates/iota-rest-api/src/lib.rs
+++ b/crates/iota-rest-api/src/lib.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 
-use axum::{Router, response::Redirect, routing::get};
+use axum::{response::Redirect, routing::get, Router};
 use iota_network_stack::callback::CallbackLayer;
 use iota_types::{storage::RestStateReader, transaction_executor::TransactionExecutor};
 use openapi::ApiEndpoint;
@@ -85,6 +85,7 @@ const ENDPOINTS: &[&dyn ApiEndpoint<RestService>] = &[
     &system::GetProtocolConfig,
     &system::GetGasInfo,
     &transactions::ExecuteTransaction,
+    &transactions::ExecuteTransactionForOptimisticIndexing,
     &coins::GetCoinInfo,
 ];
 
@@ -195,8 +196,8 @@ fn info() -> openapiv3::v3_1::Info {
 
 mod _schemars {
     use schemars::{
-        JsonSchema,
         schema::{InstanceType, Metadata, SchemaObject},
+        JsonSchema,
     };
 
     pub(crate) struct U64;

--- a/crates/iota-rest-api/src/transactions/execution.rs
+++ b/crates/iota-rest-api/src/transactions/execution.rs
@@ -4,23 +4,27 @@
 
 use std::{net::SocketAddr, sync::Arc};
 
-use axum::extract::{Query, State};
+use axum::extract::{ConnectInfo, Query, State};
 use iota_sdk2::types::{
-    Address, BalanceChange, CheckpointSequenceNumber, Object, Owner, SignedTransaction,
-    TransactionEffects, TransactionEvents, ValidatorAggregatedSignature, framework::Coin,
+    framework::Coin, Address, BalanceChange, CheckpointSequenceNumber, Object, Owner,
+    SignedTransaction, TransactionEffects, TransactionEvents, ValidatorAggregatedSignature,
 };
-use iota_types::transaction_executor::TransactionExecutor;
+use iota_types::{
+    full_checkpoint_content::CheckpointTransaction, transaction::Transaction,
+    transaction_executor::TransactionExecutor,
+};
 use schemars::JsonSchema;
 use tap::Pipe;
 
 use crate::{
-    RestService, Result,
-    accept::AcceptFormat,
-    openapi::{ApiEndpoint, OperationBuilder, RequestBodyBuilder, ResponseBuilder, RouteHandler},
+    accept::AcceptFormat, openapi::{ApiEndpoint, OperationBuilder, RequestBodyBuilder, ResponseBuilder, RouteHandler},
     response::{Bcs, ResponseContent},
+    RestService,
+    Result,
 };
 
 pub struct ExecuteTransaction;
+pub struct ExecuteTransactionForOptimisticIndexing;
 
 impl ApiEndpoint<RestService> for ExecuteTransaction {
     fn method(&self) -> axum::http::Method {
@@ -355,4 +359,82 @@ fn derive_balance_changes(
             })
         })
         .collect()
+}
+
+impl ApiEndpoint<RestService> for ExecuteTransactionForOptimisticIndexing {
+    fn method(&self) -> axum::http::Method {
+        axum::http::Method::POST
+    }
+
+    fn path(&self) -> &'static str {
+        "/transactions/execute_for_optimistic_indexing"
+    }
+
+    fn operation(
+        &self,
+        generator: &mut schemars::gen::SchemaGenerator,
+    ) -> openapiv3::v3_1::Operation {
+        generator.subschema_for::<SignedTransaction>();
+
+        OperationBuilder::new()
+            .tag("Transactions")
+            .operation_id("ExecuteTransactionForOptimisticIndexing")
+            .request_body(RequestBodyBuilder::new().bcs_content().build())
+            .response(
+                200,
+                ResponseBuilder::new()
+                    .json_content::<iota_sdk2::types::CheckpointTransaction>(generator)
+                    .bcs_content()
+                    .build(),
+            )
+            .build()
+    }
+
+    fn handler(&self) -> RouteHandler<RestService> {
+        RouteHandler::new(
+            self.method(),
+            execute_transaction_block_for_optimistic_indexing,
+        )
+    }
+}
+
+async fn execute_transaction_block_for_optimistic_indexing(
+    State(state): State<Option<Arc<dyn TransactionExecutor>>>,
+    client_address: Option<axum::extract::ConnectInfo<SocketAddr>>,
+    accept: AcceptFormat,
+    Bcs(transaction): Bcs<SignedTransaction>,
+) -> Result<ResponseContent<CheckpointTransaction>> {
+    let executor = state.ok_or_else(|| anyhow::anyhow!("No Transaction Executor"))?;
+    let transaction: Transaction = transaction.try_into()?;
+    let request = iota_types::quorum_driver_types::ExecuteTransactionRequestV1 {
+        transaction: transaction.clone(),
+        include_events: true,
+        include_input_objects: true,
+        include_output_objects: true,
+        include_auxiliary_data: false,
+    };
+
+    let iota_types::quorum_driver_types::ExecuteTransactionResponseV1 {
+        effects,
+        events,
+        input_objects,
+        output_objects,
+        auxiliary_data: _,
+    } = executor
+        .execute_transaction(request, client_address.map(|ConnectInfo(addr)| addr))
+        .await?;
+
+    let full_tx_contents_response = CheckpointTransaction {
+        transaction,
+        effects: effects.effects,
+        events,
+        input_objects: input_objects.expect("Input objects should be present in the response"),
+        output_objects: output_objects.expect("Output objects should be present in the response"),
+    };
+
+    match accept {
+        AcceptFormat::Json => ResponseContent::Json(full_tx_contents_response),
+        AcceptFormat::Bcs => ResponseContent::Bcs(full_tx_contents_response),
+    }
+    .pipe(Ok)
 }

--- a/crates/iota-rest-api/src/transactions/mod.rs
+++ b/crates/iota-rest-api/src/transactions/mod.rs
@@ -9,8 +9,8 @@ use axum::{
     http::StatusCode,
 };
 pub use execution::{
-    EffectsFinality, ExecuteTransaction, ExecuteTransactionQueryParameters,
-    TransactionExecutionResponse,
+    EffectsFinality, ExecuteTransaction, ExecuteTransactionForOptimisticIndexing,
+    ExecuteTransactionQueryParameters, TransactionExecutionResponse,
 };
 use iota_sdk2::types::{
     CheckpointSequenceNumber, Transaction, TransactionDigest, TransactionEffects,
@@ -19,11 +19,11 @@ use iota_sdk2::types::{
 use tap::Pipe;
 
 use crate::{
-    Direction, Page, RestError, RestService, Result,
-    accept::AcceptFormat,
-    openapi::{ApiEndpoint, OperationBuilder, ResponseBuilder, RouteHandler},
-    reader::StateReader,
-    response::ResponseContent,
+    accept::AcceptFormat, openapi::{ApiEndpoint, OperationBuilder, ResponseBuilder, RouteHandler}, reader::StateReader, response::ResponseContent, Direction,
+    Page,
+    RestError,
+    RestService,
+    Result,
 };
 
 pub struct GetTransaction;


### PR DESCRIPTION
# Description of change

Add `/transactions/execute_for_optimistic_indexing` which will be used by `iota-indexer` to execute tx and optimistically index it's effects, without waiting for tx to be included in checkpoint.

The response of `/transactions/execute_for_optimistic_indexing` should contain all informations needed to index a tx.

## Links to any relevant issues

fixes #5669

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo test --package=iota-rest-api`

Prepared scratchpad usage of the new endpoint in `iota-indexer` : 8150578aa1de637b42122da3aaaa02cca34fc12a
and tested if indexer can query the new  endpoint: 
`cargo test --package=iota-indexer --profile=simulator --features=shared_test_runtime --test rpc-tests write_api::execute_transaction_block`
The test fails because optimistic indexing is not implemented there yet, but the communication with new endpoint looks fine.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
