### PR TITLE
scripts: add `ignore-folders` and renamed folder mapping to `compare` script

### DIFF
--- a/scripts/compare/run.sh
+++ b/scripts/compare/run.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
-# usage: compare.py [-h] 
+# usage: compare.py [-h]
 #                   --source-folder SOURCE_FOLDER
 #                   --target-folder TARGET_FOLDER
 #                   [--codeowners CODEOWNERS [CODEOWNERS ...]]
 #                   [--codeowners-file CODEOWNERS_FILE]
 #                   [--compare-tool-binary COMPARE_TOOL_BINARY]
 #                   [--compare-tool-arguments COMPARE_TOOL_ARGUMENTS]
+#                   [--ignore-folders IGNORE_FOLDERS [IGNORE_FOLDERS ...]]
 # 
 # Repository comparison tool with optional code ownership filter.
 # 
@@ -23,10 +24,13 @@
 #                         The binary to use for comparison.
 #   --compare-tool-arguments COMPARE_TOOL_ARGUMENTS
 #                         The arguments to use for comparison.
+#   --ignore-folders IGNORE_FOLDERS [IGNORE_FOLDERS ...]
+#                         Optionally ignore folders (e.g., "node_modules").
 source ../utils/python_venv_wrapper.sh
 
 $PYTHON_CMD compare.py \
-    --source-folder ../slipstream/results/mainnet-v1.32.2/main \
-    --target-folder ../slipstream/results/mainnet-v1.41.1/main \
-    --codeowners @iotaledger/node \
+    --source-folder ../../ \
+    --target-folder ../slipstream/results/mainnet-v1.44.3/main \
+    --codeowners @iotaledger/node @iotaledger/core-protocol \
+    --ignore-folders bridge crates/anemo-benchmark crates/x dashboards dev-tools doc docker nre scripts setups \
     "$@"

--- a/scripts/slipstream/run.sh
+++ b/scripts/slipstream/run.sh
@@ -42,7 +42,8 @@ source ../utils/python_venv_wrapper.sh
 #REPO_TAG=mainnet-v1.40.3
 #REPO_TAG=mainnet-v1.41.2
 #REPO_TAG=mainnet-v1.42.2
-REPO_TAG=mainnet-v1.43.1
+#REPO_TAG=mainnet-v1.43.1
+REPO_TAG=mainnet-v1.44.3
 
 $PYTHON_CMD slipstream.py \
     --config config_slipstream.json \


### PR DESCRIPTION
Enhance the compare script with the possibility to ignore folders and map renamed paths.