### PR TITLE
fix(CI): Use grep instead of cut to extract toolchain

### DIFF
--- a/.github/workflows/cargo_llvm_cov.yml
+++ b/.github/workflows/cargo_llvm_cov.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install llvm-tools
         run: |
-          TOOLCHAIN=$(rustup show active-toolchain | cut -d ' ' -f 1)
+          TOOLCHAIN=$(rustup show active-toolchain | grep -Eo '\S+' | head -n 1)
           rustup component add llvm-tools --toolchain "$TOOLCHAIN"
           LLVM_PROFDATA="$HOME/.rustup/toolchains/$TOOLCHAIN/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata"
 


### PR DESCRIPTION
## Description 

The current command to get the toolchain using `rustup show active-toolchain` seems to have been broken by the 1.28.1 rustup release. This PR modifies the command in `cargo_llvm_cov.yml` to address this.