### PR TITLE
refactor(data-ingestion): add RelayWorker

### DIFF
--- a/crates/iota-data-ingestion/src/bin/archival_ingestion.rs
+++ b/crates/iota-data-ingestion/src/bin/archival_ingestion.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use iota_data_ingestion::{ArchivalConfig, ArchivalReducer, ArchivalWorker};
+use iota_data_ingestion::{ArchivalConfig, ArchivalReducer, RelayWorker};
 use iota_data_ingestion_core::{
     DataIngestionMetrics, IndexerExecutor, ReaderOptions, ShimProgressStore, WorkerPool,
 };
@@ -51,8 +51,7 @@ async fn main() -> Result<()> {
         DataIngestionMetrics::new(&Registry::new()),
         CancellationToken::new(),
     );
-    let worker_pool =
-        WorkerPool::new_with_reducer(ArchivalWorker, "archival".to_string(), 1, reducer);
+    let worker_pool = WorkerPool::new_with_reducer(RelayWorker, "archival".to_string(), 1, reducer);
     executor.register(worker_pool).await?;
     executor
         .run(

--- a/crates/iota-data-ingestion/src/lib.rs
+++ b/crates/iota-data-ingestion/src/lib.rs
@@ -7,6 +7,6 @@ mod workers;
 
 pub use progress_store::DynamoDBProgressStore;
 pub use workers::{
-    ArchivalConfig, ArchivalReducer, ArchivalWorker, BlobTaskConfig, BlobWorker, KVStoreTaskConfig,
-    KVStoreWorker,
+    ArchivalConfig, ArchivalReducer, BlobTaskConfig, BlobWorker, KVStoreTaskConfig, KVStoreWorker,
+    RelayWorker,
 };

--- a/crates/iota-data-ingestion/src/main.rs
+++ b/crates/iota-data-ingestion/src/main.rs
@@ -6,8 +6,8 @@ use std::{env, path::PathBuf};
 
 use anyhow::Result;
 use iota_data_ingestion::{
-    ArchivalConfig, ArchivalReducer, ArchivalWorker, BlobTaskConfig, BlobWorker,
-    DynamoDBProgressStore, KVStoreTaskConfig, KVStoreWorker,
+    ArchivalConfig, ArchivalReducer, BlobTaskConfig, BlobWorker, DynamoDBProgressStore,
+    KVStoreTaskConfig, KVStoreWorker, RelayWorker,
 };
 use iota_data_ingestion_core::{DataIngestionMetrics, IndexerExecutor, ReaderOptions, WorkerPool};
 use prometheus::Registry;
@@ -137,7 +137,7 @@ async fn main() -> Result<()> {
                     .update_watermark(task_config.name.clone(), reducer.get_watermark().await?)
                     .await?;
                 let worker_pool = WorkerPool::new_with_reducer(
-                    ArchivalWorker,
+                    RelayWorker,
                     task_config.name,
                     task_config.concurrency,
                     reducer,

--- a/crates/iota-data-ingestion/src/workers/mod.rs
+++ b/crates/iota-data-ingestion/src/workers/mod.rs
@@ -5,6 +5,8 @@
 mod archival;
 mod blob;
 mod kv_store;
-pub use archival::{ArchivalConfig, ArchivalReducer, ArchivalWorker};
+mod relay;
+pub use archival::{ArchivalConfig, ArchivalReducer};
 pub use blob::{BlobTaskConfig, BlobWorker};
 pub use kv_store::{KVStoreTaskConfig, KVStoreWorker};
+pub use relay::RelayWorker;

--- a/crates/iota-data-ingestion/src/workers/mod.rs
+++ b/crates/iota-data-ingestion/src/workers/mod.rs
@@ -6,6 +6,7 @@ mod archival;
 mod blob;
 mod kv_store;
 mod relay;
+
 pub use archival::{ArchivalConfig, ArchivalReducer};
 pub use blob::{BlobTaskConfig, BlobWorker};
 pub use kv_store::{KVStoreTaskConfig, KVStoreWorker};

--- a/crates/iota-data-ingestion/src/workers/relay.rs
+++ b/crates/iota-data-ingestion/src/workers/relay.rs
@@ -9,9 +9,8 @@ use async_trait::async_trait;
 use iota_data_ingestion_core::Worker;
 use iota_types::full_checkpoint_content::CheckpointData;
 
-pub struct RelayWorker;
-
 /// Simple worker that relays checkpoint data without any side effects.
+pub struct RelayWorker;
 #[async_trait]
 impl Worker for RelayWorker {
     type Message = Arc<CheckpointData>;

--- a/crates/iota-data-ingestion/src/workers/relay.rs
+++ b/crates/iota-data-ingestion/src/workers/relay.rs
@@ -1,0 +1,26 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+//! Simple logic for relaying checkpoint data without any side effects.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use iota_data_ingestion_core::Worker;
+use iota_types::full_checkpoint_content::CheckpointData;
+
+pub struct RelayWorker;
+
+/// Simple worker that relays checkpoint data without any side effects.
+#[async_trait]
+impl Worker for RelayWorker {
+    type Message = Arc<CheckpointData>;
+    type Error = anyhow::Error;
+
+    async fn process_checkpoint(
+        &self,
+        checkpoint: Arc<CheckpointData>,
+    ) -> Result<Self::Message, Self::Error> {
+        Ok(checkpoint)
+    }
+}


### PR DESCRIPTION
# Description of change

Adds `RelayWorker` in place of the `ArchivalWorker` so that to reuse as a general worker that does not introduce side effects.

## Links to any relevant issues

Part of #5808

## How the change has been tested

`cargo clippy --all-targets --all-features`