### PR TITLE
fix(docs): Use two $ signs for latex syntax

### DIFF
--- a/docs/content/about-iota/tokenomics/proof-of-stake.mdx
+++ b/docs/content/about-iota/tokenomics/proof-of-stake.mdx
@@ -42,13 +42,13 @@ This occurs through three main steps:
 Finally, let $$\beta_v$$ represent the share of stake managed by a validator $$v$$ that is owned by itself, while $$(1-\beta_v)$$ represents the share owned by third-party stakers.
 The rewards for users of validator's $$v$$ staking pool and for the validator $$v$$ itself equal:
 
-$$$$
+$$
 UserStakeRewards_v \ = (1-\delta_v) \times (1-\beta_v) \times \mu_v \times \sigma_v \times TotalStakeRewards,
-$$$$
+$$
 
-$$$$
+$$
 ValidatorRewards_v \ = \ \Big(\beta_v + \delta_v \times (1-\beta_v)\Big) \times \mu_v \times \sigma_v \times TotalStakeRewards.
-$$$$
+$$
 
 The $$\mu_v$$ variable captures the output of the [tallying rule](./gas-pricing.mdx#computation-gas-prices) computed as part of the [gas price mechanism](./gas-pricing.mdx) and corresponds to $$\mu_v=1$$ for performant validators and $$\mu_v<1$$ for non-performant validators.
 This variable ensures that validators have incurred monetary risk and therefore are incentivized to operate the IOTA network efficiently.

--- a/docs/content/about-iota/tokenomics/proof-of-stake.mdx
+++ b/docs/content/about-iota/tokenomics/proof-of-stake.mdx
@@ -37,24 +37,24 @@ This occurs through three main steps:
 
 - The total amount of stake rewards is calculated. The stake rewards are composed of a validator subsidy, which is currently set as 767,000 IOTA tokens per epoch, plus any tips from user transactions.
 - The total amount of stake rewards is distributed across various pools, proportionally to their stake and accordingly to the [tallying rule](./gas-pricing.mdx#computation-gas-prices).
-- Each pool's amount of rewards is distributed between the validator and the other parties. Validators first keep a commission $\delta_v$ (maximum 20%) of the total pool rewards as a fee to cover their costs. The rest of the rewards (i.e., after discounting the validator's commission) is distributed among all users (including the validator) proportionally to their stake.
+- Each pool's amount of rewards is distributed between the validator and the other parties. Validators first keep a commission $$\delta_v$$ (maximum 20%) of the total pool rewards as a fee to cover their costs. The rest of the rewards (i.e., after discounting the validator's commission) is distributed among all users (including the validator) proportionally to their stake.
 
-Finally, let $\beta_v$ represent the share of stake managed by a validator $v$ that is owned by itself, while $(1-\beta_v)$ represents the share owned by third-party stakers.
-The rewards for users of validator's $v$ staking pool and for the validator $v$ itself equal:
+Finally, let $$\beta_v$$ represent the share of stake managed by a validator $$v$$ that is owned by itself, while $$(1-\beta_v)$$ represents the share owned by third-party stakers.
+The rewards for users of validator's $$v$$ staking pool and for the validator $$v$$ itself equal:
 
-$$
+$$$$
 UserStakeRewards_v \ = (1-\delta_v) \times (1-\beta_v) \times \mu_v \times \sigma_v \times TotalStakeRewards,
-$$
+$$$$
 
-$$
+$$$$
 ValidatorRewards_v \ = \ \Big(\beta_v + \delta_v \times (1-\beta_v)\Big) \times \mu_v \times \sigma_v \times TotalStakeRewards.
-$$
+$$$$
 
-The $\mu_v$ variable captures the output of the [tallying rule](./gas-pricing.mdx#computation-gas-prices) computed as part of the [gas price mechanism](./gas-pricing.mdx) and corresponds to $\mu_v=1$ for performant validators and $\mu_v<1$ for non-performant validators.
+The $$\mu_v$$ variable captures the output of the [tallying rule](./gas-pricing.mdx#computation-gas-prices) computed as part of the [gas price mechanism](./gas-pricing.mdx) and corresponds to $$\mu_v=1$$ for performant validators and $$\mu_v<1$$ for non-performant validators.
 This variable ensures that validators have incurred monetary risk and therefore are incentivized to operate the IOTA network efficiently.
-The $\sigma_v$ parameter captures each pool's share of total stake.
+The $$\sigma_v$$ parameter captures each pool's share of total stake.
 
-Consequently, validators with more stake earn more stake rewards and the joint $\mu_v\sigma_v$ term incentivizes validators to increase their share of the stake while also operating the network performantly.
+Consequently, validators with more stake earn more stake rewards and the joint $$\mu_v\sigma_v$$ term incentivizes validators to increase their share of the stake while also operating the network performantly.
 In the long-run, this incentive encourages users to shift the stake distribution towards the network's most efficient validators, delivering a cost-efficient and decentralized network.
 
 ## IOTA Incentives

--- a/docs/content/about-iota/tokenomics/validators-staking.mdx
+++ b/docs/content/about-iota/tokenomics/validators-staking.mdx
@@ -18,13 +18,13 @@ The staking pool is implemented in a system-level smart contract ([staking_pool.
 
 ## Validator Pool Rewards
 
-At each epoch boundary, the system computes the staking rewards for each validator pool proportionally to the staked tokens in each pool. The staking rewards $rewards(i, E)$ for validator pool $i$ at epoch $E$ are computed as follows:
+At each epoch boundary, the system computes the staking rewards for each validator pool proportionally to the staked tokens in each pool. The staking rewards $$rewards(i, E)$$ for validator pool $$i$$ at epoch $$E$$ are computed as follows:
 
 $$
 rewards(i, E) = \frac{ stakedTokens(i, E)}{\sum_i (stakedTokens(i, E)) }\times totalRewards(E).
 $$
 
-$rewards(i, E)$ is then adjusted to consider potential slashed validators who have not met minimum quality requirements. Additionally, validators earn commissions on the staking pool's tokens. IOTA keeps track of the rewards accrued by both validators and delegators using a single global exchange rate table.
+$$rewards(i, E)$$ is then adjusted to consider potential slashed validators who have not met minimum quality requirements. Additionally, validators earn commissions on the staking pool's tokens. IOTA keeps track of the rewards accrued by both validators and delegators using a single global exchange rate table.
 
 <StakingPoolReqs />
 

--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -181,13 +181,7 @@ const config = {
             [codeImport, { rootDir: path.resolve(__dirname, `../../`) }],
           ],
           rehypePlugins: [
-            //katex,
-            function attacher(options) {
-              return function transformer(tree, file) {
-                if (file.path.includes('references/')) return; // Skip KaTeX for "reference/" docs
-                return katex(options)(tree, file);
-              };
-            },
+            katex,
             [require('rehype-jargon'), { jargon: jargonConfig}]
           ],
         },

--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -4,8 +4,8 @@
 
 import { themes } from "prism-react-renderer";
 import path from "path";
-import math from "remark-math";
 import katex from "rehype-katex";
+import math from "remark-math";
 import codeImport from "remark-code-import";
 
 require("dotenv").config();
@@ -172,14 +172,8 @@ const config = {
             "current",
             "1.0.0",
           ],*/
-          remarkPlugins: [
-            //math,
-            function attacher(options) {
-              return function transformer(tree, file) {
-                if (file.path.includes('references/')) return; // Skip KaTeX for "reference/" docs
-                return math(options)(tree, file);
-              };
-            },
+          remarkPlugins: [            
+            [math,{singleDollarTextMath:false}],
             [
               require("@docusaurus/remark-plugin-npm2yarn"),
               { sync: true, converters: ["yarn", "pnpm"] },

--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -4,8 +4,8 @@
 
 import { themes } from "prism-react-renderer";
 import path from "path";
-import katex from "rehype-katex";
 import math from "remark-math";
+import katex from "rehype-katex";
 import codeImport from "remark-code-import";
 
 require("dotenv").config();

--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -172,7 +172,7 @@ const config = {
             "current",
             "1.0.0",
           ],*/
-          remarkPlugins: [            
+          remarkPlugins: [
             [math,{singleDollarTextMath:false}],
             [
               require("@docusaurus/remark-plugin-npm2yarn"),

--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -173,7 +173,13 @@ const config = {
             "1.0.0",
           ],*/
           remarkPlugins: [
-            math,
+            //math,
+            function attacher(options) {
+              return function transformer(tree, file) {
+                if (file.path.includes('references/')) return; // Skip KaTeX for "reference/" docs
+                return math(options)(tree, file);
+              };
+            },
             [
               require("@docusaurus/remark-plugin-npm2yarn"),
               { sync: true, converters: ["yarn", "pnpm"] },
@@ -181,7 +187,13 @@ const config = {
             [codeImport, { rootDir: path.resolve(__dirname, `../../`) }],
           ],
           rehypePlugins: [
-            katex,
+            //katex,
+            function attacher(options) {
+              return function transformer(tree, file) {
+                if (file.path.includes('references/')) return; // Skip KaTeX for "reference/" docs
+                return katex(options)(tree, file);
+              };
+            },
             [require('rehype-jargon'), { jargon: jargonConfig}]
           ],
         },


### PR DESCRIPTION
# Description of change

Latex breaks the reference docs ~~but isn't actually needed in there. So this PR disabled the plugin for the reference docs~~, but we can just configure math to use two $ signs as the trigger instead of one

## Links to any relevant issues

Fixes #5832 

## Type of change

- Documentation Fix

## How the change has been tested

-

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
