### PR TITLE
fix: renamed `subscriber_to` metric to `subscribed_to` due to typo

### DIFF
--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -158,7 +158,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) block_manager_missing_ancestors_by_authority: IntCounterVec,
     pub(crate) threshold_clock_round: IntGauge,
     pub(crate) subscriber_connection_attempts: IntCounterVec,
-    pub(crate) subscriber_to: IntGaugeVec,
+    pub(crate) subscribed_to: IntGaugeVec,
     pub(crate) subscribed_by: IntGaugeVec,
     pub(crate) commit_sync_inflight_fetches: IntGauge,
     pub(crate) commit_sync_pending_fetches: IntGauge,
@@ -521,8 +521,8 @@ impl NodeMetrics {
                 &["authority", "status"],
                 registry,
             ).unwrap(),
-            subscriber_to: register_int_gauge_vec_with_registry!(
-                "subscriber_to",
+            subscribed_to: register_int_gauge_vec_with_registry!(
+                "subscribed_to",
                 "Peers that this authority subscribed to for block streams.",
                 &["authority"],
                 registry,

--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -95,7 +95,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
         self.context
             .metrics
             .node_metrics
-            .subscriber_to
+            .subscribed_to
             .with_label_values(&[peer_hostname])
             .set(0);
     }
@@ -119,7 +119,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
             context
                 .metrics
                 .node_metrics
-                .subscriber_to
+                .subscribed_to
                 .with_label_values(&[peer_hostname])
                 .set(0);
 
@@ -180,7 +180,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
             context
                 .metrics
                 .node_metrics
-                .subscriber_to
+                .subscribed_to
                 .with_label_values(&[peer_hostname])
                 .set(1);
 


### PR DESCRIPTION
# Description of change

We introduced a typo when we renamed the metrics `consensus_subcriber_to` should be called `consensus_subscribed_to`