### PR TITLE
feat(data-ingestion-core): add history module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6595,10 +6595,15 @@ dependencies = [
 name = "iota-data-ingestion-core"
 version = "0.11.0-alpha"
 dependencies = [
+ "anyhow",
  "async-trait",
  "backoff",
  "bcs",
+ "byteorder",
+ "bytes",
+ "fastcrypto",
  "futures",
+ "iota-config",
  "iota-metrics",
  "iota-protocol-config",
  "iota-rest-api",

--- a/crates/iota-data-ingestion-core/Cargo.toml
+++ b/crates/iota-data-ingestion-core/Cargo.toml
@@ -8,9 +8,13 @@ publish = false
 
 [dependencies]
 # external dependencies
+anyhow.workspace = true
 async-trait.workspace = true
 backoff.workspace = true
 bcs.workspace = true
+byteorder.workspace = true
+bytes.workspace = true
+fastcrypto = { workspace = true, features = ["copy_key"] }
 futures.workspace = true
 notify.workspace = true
 object_store.workspace = true
@@ -27,6 +31,7 @@ tracing.workspace = true
 url.workspace = true
 
 # internal dependencies
+iota-config.workspace = true
 iota-metrics.workspace = true
 iota-protocol-config.workspace = true
 iota-rest-api.workspace = true

--- a/crates/iota-data-ingestion-core/src/errors.rs
+++ b/crates/iota-data-ingestion-core/src/errors.rs
@@ -3,6 +3,7 @@
 
 pub type IngestionResult<T, E = IngestionError> = core::result::Result<T, E>;
 
+// TODO: make first letter lower-case to all messages
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum IngestionError {
@@ -47,4 +48,10 @@ pub enum IngestionError {
 
     #[error("Deserialize checkpoint failed: `{0}`")]
     DeserializeCheckpoint(String),
+
+    #[error(transparent)]
+    Upstream(#[from] anyhow::Error),
+
+    #[error("reading historical data failed: `{0}`")]
+    HistoryRead(String),
 }

--- a/crates/iota-data-ingestion-core/src/history/manifest.rs
+++ b/crates/iota-data-ingestion-core/src/history/manifest.rs
@@ -153,10 +153,10 @@ pub fn create_file_metadata(
 }
 
 pub fn create_file_metadata_from_bytes(
-    bytes: Bytes,
+    contents: Bytes,
     checkpoint_seq_range: Range<u64>,
 ) -> Result<FileMetadata> {
-    let sha3_digest = compute_sha3_checksum_for_bytes(bytes)?;
+    let sha3_digest = compute_sha3_checksum_for_bytes(contents)?;
     let file_metadata = FileMetadata {
         checkpoint_seq_range,
         sha3_digest,

--- a/crates/iota-data-ingestion-core/src/history/manifest.rs
+++ b/crates/iota-data-ingestion-core/src/history/manifest.rs
@@ -1,0 +1,264 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+#![allow(dead_code)]
+
+//! Handle the manifest for historical checkpoint data.
+//!
+//! MANIFEST File Disk Format
+//! ┌──────────────────────────────┐
+//! │        magic<4 byte>         │
+//! ├──────────────────────────────┤
+//! │   serialized manifest        │
+//! ├──────────────────────────────┤
+//! │      sha3 <32 bytes>         │
+//! └──────────────────────────────┘
+
+use std::{
+    io::{BufWriter, Cursor, Read, Seek, SeekFrom, Write},
+    num::NonZeroUsize,
+    ops::Range,
+};
+
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use bytes::Bytes;
+use fastcrypto::hash::{HashFunction, Sha3_256};
+use iota_config::{
+    node::ArchiveReaderConfig as HistoricalReaderConfig, object_storage_config::ObjectStoreConfig,
+};
+use iota_storage::{
+    SHA3_BYTES,
+    blob::{Blob, BlobEncoding},
+    compute_sha3_checksum, compute_sha3_checksum_for_bytes,
+    object_store::{
+        ObjectStoreGetExt, ObjectStorePutExt,
+        util::{get, put},
+    },
+};
+use object_store::path::Path;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+use crate::{
+    IngestionError,
+    errors::IngestionResult as Result,
+    history::{
+        CHECKPOINT_FILE_SUFFIX, HISTORICAL_DIR_NAME, INGESTION_DIR_NAME, MAGIC_BYTES,
+        MANIFEST_FILE_MAGIC, MANIFEST_FILENAME, reader::HistoricalReader,
+    },
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct FileMetadata {
+    pub checkpoint_seq_range: Range<u64>,
+    pub sha3_digest: [u8; 32],
+}
+
+impl FileMetadata {
+    pub fn file_path(&self) -> Path {
+        Path::from(INGESTION_DIR_NAME)
+            .child(HISTORICAL_DIR_NAME)
+            .child(format!(
+                "{}.{CHECKPOINT_FILE_SUFFIX}",
+                self.checkpoint_seq_range.start
+            ))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct ManifestV1 {
+    pub archive_version: u8,
+    pub next_checkpoint_seq_num: u64,
+    pub file_metadata: Vec<FileMetadata>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum Manifest {
+    V1(ManifestV1),
+}
+
+impl Manifest {
+    pub fn new(next_checkpoint_seq_num: u64) -> Self {
+        Manifest::V1(ManifestV1 {
+            archive_version: 1,
+            next_checkpoint_seq_num,
+            file_metadata: vec![],
+        })
+    }
+
+    pub fn to_files(&self) -> Vec<FileMetadata> {
+        match self {
+            Manifest::V1(manifest) => manifest.file_metadata.clone(),
+        }
+    }
+
+    pub fn next_checkpoint_seq_num(&self) -> u64 {
+        match self {
+            Manifest::V1(manifest) => manifest.next_checkpoint_seq_num,
+        }
+    }
+
+    pub fn update(&mut self, checkpoint_sequence_number: u64, file_metadata: FileMetadata) {
+        match self {
+            Manifest::V1(manifest) => {
+                manifest.file_metadata.push(file_metadata);
+                manifest.next_checkpoint_seq_num = checkpoint_sequence_number;
+            }
+        }
+    }
+
+    pub fn file_path() -> Path {
+        Path::from(INGESTION_DIR_NAME)
+            .child(HISTORICAL_DIR_NAME)
+            .child(MANIFEST_FILENAME)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct CheckpointUpdates {
+    file_metadata: FileMetadata,
+    manifest: Manifest,
+}
+
+impl CheckpointUpdates {
+    pub fn new(
+        checkpoint_sequence_number: u64,
+        file_metadata: FileMetadata,
+        manifest: &mut Manifest,
+    ) -> Self {
+        manifest.update(checkpoint_sequence_number, file_metadata.clone());
+        CheckpointUpdates {
+            file_metadata,
+            manifest: manifest.clone(),
+        }
+    }
+
+    pub fn file_path(&self) -> Path {
+        self.file_metadata.file_path()
+    }
+
+    pub fn manifest_file_path(&self) -> Path {
+        Path::from(MANIFEST_FILENAME)
+    }
+}
+
+pub fn create_file_metadata(
+    file_path: &std::path::Path,
+    checkpoint_seq_range: Range<u64>,
+) -> Result<FileMetadata> {
+    let sha3_digest = compute_sha3_checksum(file_path)?;
+    let file_metadata = FileMetadata {
+        checkpoint_seq_range,
+        sha3_digest,
+    };
+    Ok(file_metadata)
+}
+
+pub fn create_file_metadata_from_bytes(
+    bytes: Bytes,
+    checkpoint_seq_range: Range<u64>,
+) -> Result<FileMetadata> {
+    let sha3_digest = compute_sha3_checksum_for_bytes(bytes)?;
+    let file_metadata = FileMetadata {
+        checkpoint_seq_range,
+        sha3_digest,
+    };
+    Ok(file_metadata)
+}
+
+/// Reads the manifest file from the store.
+pub async fn read_manifest<S: ObjectStoreGetExt>(remote_store: S) -> Result<Manifest> {
+    let vec = get(&remote_store, &Manifest::file_path()).await?.to_vec();
+    read_manifest_from_bytes(vec)
+}
+
+/// Reads the manifest file from the given byte vector and verifies the
+/// integrity of the file.
+pub fn read_manifest_from_bytes(vec: Vec<u8>) -> Result<Manifest> {
+    let manifest_file_size = vec.len();
+    let mut manifest_reader = Cursor::new(vec);
+
+    // Reads from the beginning of the file and verifies the magic byte
+    // is MANIFEST_FILE_MAGIC
+    manifest_reader.rewind()?;
+    let magic = manifest_reader.read_u32::<BigEndian>()?;
+    if magic != MANIFEST_FILE_MAGIC {
+        return Err(IngestionError::HistoryRead(format!(
+            "unexpected magic byte in manifest: {magic}",
+        )));
+    }
+
+    // Reads from the end of the file and gets the SHA3 checksum
+    // of the content.
+    manifest_reader.seek(SeekFrom::End(-(SHA3_BYTES as i64)))?;
+    let mut sha3_digest = [0u8; SHA3_BYTES];
+    manifest_reader.read_exact(&mut sha3_digest)?;
+
+    // Reads the content of the file and verifies the SHA3 checksum
+    // of the content matches the stored checksum.
+    manifest_reader.rewind()?;
+    let mut content_buf = vec![0u8; manifest_file_size - SHA3_BYTES];
+    manifest_reader.read_exact(&mut content_buf)?;
+    let mut hasher = Sha3_256::default();
+    hasher.update(&content_buf);
+    let computed_digest = hasher.finalize().digest;
+    if computed_digest != sha3_digest {
+        return Err(IngestionError::HistoryRead(format!(
+            "manifest corrupted, computed checksum: {computed_digest:?}, stored checksum: {sha3_digest:?}"
+        )));
+    }
+    manifest_reader.rewind()?;
+    manifest_reader.seek(SeekFrom::Start(MAGIC_BYTES as u64))?;
+    Ok(Blob::read(&mut manifest_reader)?.decode()?)
+}
+
+/// Computes the SHA3 checksum of the Manifest and writes it to a byte vector.
+pub fn finalize_manifest(manifest: Manifest) -> Result<Bytes> {
+    let mut buf = BufWriter::new(vec![]);
+    buf.write_u32::<BigEndian>(MANIFEST_FILE_MAGIC)?;
+    let blob = Blob::encode(&manifest, BlobEncoding::Bcs)?;
+    blob.write(&mut buf)?;
+    buf.flush()?;
+    let mut hasher = Sha3_256::default();
+    hasher.update(buf.get_ref());
+    let computed_digest = hasher.finalize().digest;
+    buf.write_all(&computed_digest)?;
+    Ok(Bytes::from(buf.into_inner().map_err(|e| e.into_error())?))
+}
+
+/// Writes the Manifest to the remote store.
+pub async fn write_manifest<S: ObjectStorePutExt>(
+    manifest: Manifest,
+    remote_store: S,
+) -> Result<()> {
+    let bytes = finalize_manifest(manifest)?;
+    put(&remote_store, &Manifest::file_path(), bytes).await?;
+    Ok(())
+}
+
+pub async fn verify_historical_checkpoints_with_checksums(
+    remote_store_config: ObjectStoreConfig,
+    concurrency: usize,
+) -> Result<()> {
+    let config = HistoricalReaderConfig {
+        remote_store_config,
+        download_concurrency: NonZeroUsize::new(concurrency).unwrap(),
+        use_for_pruning_watermark: false,
+    };
+    // Gets the Manifest from the remote store.
+    let reader = HistoricalReader::new(config)?;
+    reader.sync_manifest_once().await?;
+    let manifest = reader.get_manifest().await;
+    info!(
+        "next checkpoint in archive store: {}",
+        manifest.next_checkpoint_seq_num()
+    );
+
+    let file_metadata = reader.verify_manifest(manifest)?;
+    // Account for both summary and content files
+    let num_files = file_metadata.len() * 2;
+    reader.verify_file_consistency(file_metadata).await?;
+    info!("all {num_files} files are valid");
+    Ok(())
+}

--- a/crates/iota-data-ingestion-core/src/history/manifest.rs
+++ b/crates/iota-data-ingestion-core/src/history/manifest.rs
@@ -252,7 +252,7 @@ pub async fn verify_historical_checkpoints_with_checksums(
         manifest.next_checkpoint_seq_num()
     );
 
-    let file_metadata = reader.verify_manifest(manifest)?;
+    let file_metadata = reader.verify_and_get_manifest_files(manifest)?;
     // Account for both summary and content files
     let num_files = file_metadata.len() * 2;
     reader.verify_file_consistency(file_metadata).await?;

--- a/crates/iota-data-ingestion-core/src/history/manifest.rs
+++ b/crates/iota-data-ingestion-core/src/history/manifest.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
-#![allow(dead_code)]
-
 //! Handle the manifest for historical checkpoint data.
 //!
 //! MANIFEST File Disk Format
@@ -13,7 +11,6 @@
 //! ├──────────────────────────────┤
 //! │      sha3 <32 bytes>         │
 //! └──────────────────────────────┘
-
 use std::{
     io::{BufWriter, Cursor, Read, Seek, SeekFrom, Write},
     num::NonZeroUsize,

--- a/crates/iota-data-ingestion-core/src/history/mod.rs
+++ b/crates/iota-data-ingestion-core/src/history/mod.rs
@@ -1,0 +1,64 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+//! Handle historical checkpoint data.
+//!
+//! Full checkpoint data for epochs starting from genesis are persisted in
+//! batches as blob files in a remote store.
+//!
+//! Files are optionally compressed with the zstd
+//! compression format. Filenames follow the format <checkpoint_seq_num>.chk
+//! where `checkpoint_seq_num` is the first checkpoint present in that
+//! file. MANIFEST is the index and source of truth for all files present in the
+//! ingestion source history.
+//!
+//! Ingestion Source History Directory Layout
+//!  - ingestion/
+//!     - historical/
+//!          - MANIFEST
+//!          - 0.chk
+//!          - 1000.chk
+//!          - 3000.chk
+//!          - ...
+//!          - 100000.chk
+//!
+//! Blob File Disk Format
+//! ┌──────────────────────────────┐
+//! │       magic <4 byte>         │
+//! ├──────────────────────────────┤
+//! │  storage format <1 byte>     │
+//! ├──────────────────────────────┤
+//! │    file compression <1 byte> │
+//! ├──────────────────────────────┤
+//! │ ┌──────────────────────────┐ │
+//! │ │         Blob 1           │ │
+//! │ ├──────────────────────────┤ │
+//! │ │          ...             │ │
+//! │ ├──────────────────────────┤ │
+//! │ │        Blob N            │ │
+//! │ └──────────────────────────┘ │
+//! └──────────────────────────────┘
+//! Blob
+//! ┌───────────────┬───────────────────┬──────────────┐
+//! │ len <uvarint> │ encoding <1 byte> │ data <bytes> │
+//! └───────────────┴───────────────────┴──────────────┘
+//!
+//! MANIFEST File Disk Format
+//! ┌──────────────────────────────┐
+//! │        magic<4 byte>         │
+//! ├──────────────────────────────┤
+//! │   serialized manifest        │
+//! ├──────────────────────────────┤
+//! │      sha3 <32 bytes>         │
+//! └──────────────────────────────┘
+
+pub mod manifest;
+pub mod reader;
+
+pub const CHECKPOINT_FILE_MAGIC: u32 = 0x0000BEEF;
+pub const CHECKPOINT_FILE_SUFFIX: &str = "chk";
+const HISTORICAL_DIR_NAME: &str = "historical";
+const INGESTION_DIR_NAME: &str = "ingestion";
+pub const MAGIC_BYTES: usize = 4;
+pub const MANIFEST_FILE_MAGIC: u32 = 0x0000FACE;
+pub const MANIFEST_FILENAME: &str = "MANIFEST";

--- a/crates/iota-data-ingestion-core/src/history/mod.rs
+++ b/crates/iota-data-ingestion-core/src/history/mod.rs
@@ -13,6 +13,7 @@
 //! ingestion source history.
 //!
 //! Ingestion Source History Directory Layout
+//! ```text
 //!  - ingestion/
 //!     - historical/
 //!          - MANIFEST
@@ -51,6 +52,7 @@
 //! ├──────────────────────────────┤
 //! │      sha3 <32 bytes>         │
 //! └──────────────────────────────┘
+//! ```
 
 pub mod manifest;
 pub mod reader;

--- a/crates/iota-data-ingestion-core/src/history/reader.rs
+++ b/crates/iota-data-ingestion-core/src/history/reader.rs
@@ -141,7 +141,7 @@ impl HistoricalReader {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```ignore
     /// let range = 100..200;
     /// let stream = historical_reader.stream_for_range(range).await?;
     /// while let Some(result) = stream.next().await {

--- a/crates/iota-data-ingestion-core/src/history/reader.rs
+++ b/crates/iota-data-ingestion-core/src/history/reader.rs
@@ -137,7 +137,7 @@ impl HistoricalReader {
     /// In this case the stream will yield an `Err` containing the name of the
     /// remote [`Path`] to the file that gave rise to the error. This would
     /// allow retry attempts in the callers using
-    /// [`iter_for_range`][Self::iter_for_range].
+    /// [`iter_for_file`][Self::iter_for_file].
     ///
     /// # Examples
     ///

--- a/crates/iota-data-ingestion-core/src/history/reader.rs
+++ b/crates/iota-data-ingestion-core/src/history/reader.rs
@@ -33,7 +33,7 @@ use crate::{
 #[derive(Clone)]
 pub struct HistoricalReader {
     concurrency: usize,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     /// We store this to get dropped along with the
     /// reader and hence terminate the manifest sync
     /// process.

--- a/crates/iota-data-ingestion-core/src/history/reader.rs
+++ b/crates/iota-data-ingestion-core/src/history/reader.rs
@@ -61,12 +61,13 @@ impl HistoricalReader {
         })
     }
 
-    /// This function verifies the files included in the manifest.
+    /// This function verifies the manifest and returns the file metadata
+    /// sorted by the starting sequence number.
     ///
     /// More specifically it verifies that the files in the remote store
     /// cover the entire range of checkpoints from sequence number 0
     /// until the latest available checkpoint with no missing checkpoint.
-    pub fn verify_manifest(&self, manifest: Manifest) -> Result<Vec<FileMetadata>> {
+    pub fn verify_and_get_manifest_files(&self, manifest: Manifest) -> Result<Vec<FileMetadata>> {
         let mut files = manifest.to_files();
         if files.is_empty() {
             return Err(IngestionError::HistoryRead(
@@ -265,7 +266,7 @@ impl HistoricalReader {
             )));
         }
 
-        let files = self.verify_manifest(manifest)?;
+        let files = self.verify_and_get_manifest_files(manifest)?;
 
         let start_index = match files
             .binary_search_by_key(&checkpoint_range.start, |s| s.checkpoint_seq_range.start)

--- a/crates/iota-data-ingestion-core/src/history/reader.rs
+++ b/crates/iota-data-ingestion-core/src/history/reader.rs
@@ -1,0 +1,313 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{ops::Range, sync::Arc, time::Duration};
+
+use bytes::{Buf, Bytes, buf::Reader};
+use futures::{Stream, StreamExt, TryStreamExt};
+use iota_config::node::ArchiveReaderConfig as HistoricalReaderConfig;
+use iota_storage::{
+    compute_sha3_checksum_for_bytes, make_iterator,
+    object_store::{ObjectStoreGetExt, http::HttpDownloaderBuilder, util::get},
+};
+use iota_types::{
+    full_checkpoint_content::CheckpointData, messages_checkpoint::CheckpointSequenceNumber,
+};
+use object_store::path::Path;
+use tokio::sync::{
+    Mutex,
+    oneshot::{self, Sender},
+};
+use tracing::info;
+
+use crate::{
+    IngestionError,
+    errors::IngestionResult as Result,
+    history::{
+        CHECKPOINT_FILE_MAGIC,
+        manifest::{FileMetadata, Manifest, read_manifest},
+    },
+};
+
+#[derive(Clone)]
+pub struct HistoricalReader {
+    concurrency: usize,
+    #[allow(dead_code)]
+    /// We store this to get dropped along with the
+    /// reader and hence terminate the manifest sync
+    /// process.
+    sender: Arc<Sender<()>>,
+    manifest: Arc<Mutex<Manifest>>,
+    remote_object_store: Arc<dyn ObjectStoreGetExt>,
+}
+
+impl HistoricalReader {
+    pub fn new(config: HistoricalReaderConfig) -> Result<Self> {
+        let remote_object_store = if config.remote_store_config.no_sign_request {
+            config.remote_store_config.make_http()?
+        } else {
+            config.remote_store_config.make().map(Arc::new)?
+        };
+        let (sender, recv) = oneshot::channel();
+        let manifest = Arc::new(Mutex::new(Manifest::new(0)));
+        // Start a background tokio task to keep local manifest in sync with remote
+        Self::spawn_manifest_sync_task(remote_object_store.clone(), manifest.clone(), recv);
+        Ok(Self {
+            manifest,
+            sender: Arc::new(sender),
+            remote_object_store,
+            concurrency: config.download_concurrency.get(),
+        })
+    }
+
+    /// This function verifies the files included in the manifest.
+    ///
+    /// More specifically it verifies that the files in the remote store
+    /// cover the entire range of checkpoints from sequence number 0
+    /// until the latest available checkpoint with no missing checkpoint.
+    pub fn verify_manifest(&self, manifest: Manifest) -> Result<Vec<FileMetadata>> {
+        let mut files = manifest.to_files();
+        if files.is_empty() {
+            return Err(IngestionError::HistoryRead(
+                "unexpected empty remote store of historical data".to_string(),
+            ));
+        }
+
+        files.sort_by_key(|f| f.checkpoint_seq_range.start);
+
+        assert!(
+            files
+                .windows(2)
+                .all(|w| w[1].checkpoint_seq_range.start == w[0].checkpoint_seq_range.end)
+        );
+
+        assert_eq!(files.first().map(|f| f.checkpoint_seq_range.start), Some(0));
+
+        Ok(files)
+    }
+
+    /// This function downloads checkpoint data files and ensures their
+    /// computed checksum matches the one in manifest.
+    pub async fn verify_file_consistency(&self, files: Vec<FileMetadata>) -> Result<()> {
+        let remote_object_store = self.remote_object_store.clone();
+        futures::stream::iter(files.iter())
+            .map(|metadata| {
+                let remote_object_store = remote_object_store.clone();
+                async move {
+                    let checkpoint_data = get(&remote_object_store, &metadata.file_path()).await?;
+                    Ok::<(Bytes, &FileMetadata), IngestionError>((checkpoint_data, metadata))
+                }
+            })
+            .boxed()
+            .buffer_unordered(self.concurrency)
+            .try_for_each(|(checkpoint_data, metadata)| {
+                let checksum = compute_sha3_checksum_for_bytes(checkpoint_data).map_err(Into::into);
+                let result = checksum.and_then(|checksum| {
+                    if checksum == metadata.sha3_digest {
+                        return Ok(());
+                    };
+                    Err(IngestionError::HistoryRead(format!(
+                        "checksum doesn't match for file: {:?}",
+                        metadata.file_path()
+                    )))
+                });
+                futures::future::ready(result)
+            })
+            .await
+    }
+
+    /// Stream [`CheckpointData`] for the specified range.
+    ///
+    /// This method retrieves files with batches of serialized checkpoint
+    /// data from the remote store, decodes the raw data, and streams
+    /// the deserialized values.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if resolving the files that need to be fetched from the
+    /// remote store fails.
+    ///
+    /// Additionally the stream may contain errors in the following case:
+    ///
+    /// * If fetching the file from the remote store fails.
+    /// * If the file is corrupted and fails to decode.
+    ///
+    /// In this case the stream will yield an `Err` containing the name of the
+    /// remote [`Path`] to the file that gave rise to the error. This would
+    /// allow retry attempts in the callers using
+    /// [`iter_for_range`][Self::iter_for_range].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// let range = 100..200;
+    /// let stream = historical_reader.stream_for_range(range).await?;
+    /// while let Some(result) = stream.next().await {
+    ///     match result {
+    ///         Ok(data) => println!("Received checkpoint data: {data:?}"),
+    ///         Err(path) => eprintln!("Failed to load checkpoint from file: {path}"),
+    ///     }
+    /// }
+    /// ```
+    pub async fn stream_for_range(
+        &self,
+        checkpoint_range: Range<CheckpointSequenceNumber>,
+    ) -> Result<impl Stream<Item = std::result::Result<CheckpointData, Path>> + use<'_>> {
+        let files = self.get_files_for_range(checkpoint_range.clone()).await?;
+
+        Ok(futures::stream::iter(files)
+            .map(move |metadata| {
+                let checkpoint_range = checkpoint_range.clone();
+                async move {
+                    let data_batch = self
+                        .iter_for_file(metadata.file_path())
+                        .await
+                        .map_err(|_| metadata.file_path())?
+                        .filter(move |checkpoint_data| {
+                            checkpoint_range
+                                .contains(checkpoint_data.checkpoint_summary.sequence_number())
+                        });
+                    Ok::<_, Path>(futures::stream::iter(data_batch).map(Ok))
+                }
+            })
+            .buffered(self.concurrency)
+            .try_flatten())
+    }
+
+    /// Iterate [`CheckpointData`] from the given remote file.
+    ///
+    /// This method retrieves the file with batches of serialized checkpoint
+    /// data from the remote store, decodes the raw data, and streams the
+    /// deserialized values.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error in the following cases:
+    ///
+    /// * If fetching the file from the remote store fails.
+    /// * If the file is corrupted and fails to decode.
+    pub async fn iter_for_file(
+        &self,
+        file_path: Path,
+    ) -> Result<impl Iterator<Item = CheckpointData>> {
+        let raw_data_batch = get(&self.remote_object_store, &file_path).await?;
+        let data_batch = make_iterator::<CheckpointData, Reader<Bytes>>(
+            CHECKPOINT_FILE_MAGIC,
+            raw_data_batch.reader(),
+        )?;
+        Ok(data_batch)
+    }
+
+    /// Return latest available checkpoint in archive.
+    pub async fn latest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber> {
+        self.manifest
+            .lock()
+            .await
+            .next_checkpoint_seq_num()
+            .checked_sub(1)
+            .ok_or_else(|| {
+                IngestionError::HistoryRead("no checkpoint data in the remote store".into())
+            })
+    }
+
+    pub fn remote_store_identifier(&self) -> String {
+        self.remote_object_store.to_string()
+    }
+
+    /// Syncs the Manifest from remote store.
+    pub async fn sync_manifest_once(&self) -> Result<()> {
+        Self::sync_manifest(self.remote_object_store.clone(), self.manifest.clone()).await?;
+        Ok(())
+    }
+
+    pub async fn get_manifest(&self) -> Manifest {
+        self.manifest.lock().await.clone()
+    }
+
+    /// Copies Manifest from remote store to the given Manifest.
+    async fn sync_manifest(
+        remote_store: Arc<dyn ObjectStoreGetExt>,
+        manifest: Arc<Mutex<Manifest>>,
+    ) -> Result<()> {
+        let new_manifest = read_manifest(remote_store.clone()).await?;
+        let mut locked = manifest.lock().await;
+        *locked = new_manifest;
+        Ok(())
+    }
+
+    /// Resolve the files to fetch for the specified range.
+    ///
+    /// The method retrieves the manifest from the remote store and
+    /// searches for the files that cover the given range of checkpoint
+    /// data.
+    ///
+    /// # Errors
+    ///
+    /// The method fails if the remote store has no data, or if the
+    /// manifest fails to verify.
+    async fn get_files_for_range(
+        &self,
+        checkpoint_range: Range<CheckpointSequenceNumber>,
+    ) -> Result<impl Iterator<Item = FileMetadata>> {
+        let manifest = self.get_manifest().await;
+
+        let latest_available_checkpoint = manifest
+            .next_checkpoint_seq_num()
+            .checked_sub(1)
+            .ok_or_else(|| {
+                IngestionError::HistoryRead("no checkpoint data in the remote store".into())
+            })?;
+
+        if checkpoint_range.start > latest_available_checkpoint {
+            return Err(IngestionError::HistoryRead(format!(
+                "latest available checkpoint is: {latest_available_checkpoint}",
+            )));
+        }
+
+        let files = self.verify_manifest(manifest)?;
+
+        let start_index = match files
+            .binary_search_by_key(&checkpoint_range.start, |s| s.checkpoint_seq_range.start)
+        {
+            Ok(index) => index,
+            Err(index) => index - 1,
+        };
+
+        let end_index = match files
+            .binary_search_by_key(&checkpoint_range.end, |s| s.checkpoint_seq_range.start)
+        {
+            Ok(index) => index,
+            Err(index) => index,
+        };
+
+        Ok(files
+            .into_iter()
+            .enumerate()
+            .filter_map(move |(index, metadata)| {
+                (index >= start_index && index < end_index).then_some(metadata)
+            }))
+    }
+
+    fn spawn_manifest_sync_task<S: ObjectStoreGetExt + Clone>(
+        remote_store: S,
+        manifest: Arc<Mutex<Manifest>>,
+        mut recv: oneshot::Receiver<()>,
+    ) {
+        tokio::task::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(60));
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        let new_manifest = read_manifest(remote_store.clone()).await?;
+                        let mut locked = manifest.lock().await;
+                        *locked = new_manifest;
+                    }
+                    _ = &mut recv => break,
+                }
+            }
+            info!("terminating the manifest sync loop");
+            Ok::<(), IngestionError>(())
+        });
+    }
+}

--- a/crates/iota-data-ingestion-core/src/history/reader.rs
+++ b/crates/iota-data-ingestion-core/src/history/reader.rs
@@ -289,8 +289,8 @@ impl HistoricalReader {
             }))
     }
 
-    fn spawn_manifest_sync_task<S: ObjectStoreGetExt + Clone>(
-        remote_store: S,
+    fn spawn_manifest_sync_task(
+        remote_store: Arc<dyn ObjectStoreGetExt>,
         manifest: Arc<Mutex<Manifest>>,
         mut recv: oneshot::Receiver<()>,
     ) {
@@ -299,9 +299,7 @@ impl HistoricalReader {
             loop {
                 tokio::select! {
                     _ = interval.tick() => {
-                        let new_manifest = read_manifest(remote_store.clone()).await?;
-                        let mut locked = manifest.lock().await;
-                        *locked = new_manifest;
+                        Self::sync_manifest(remote_store.clone(), manifest.clone()).await?;
                     }
                     _ = &mut recv => break,
                 }

--- a/crates/iota-data-ingestion-core/src/lib.rs
+++ b/crates/iota-data-ingestion-core/src/lib.rs
@@ -26,6 +26,7 @@
 
 mod errors;
 mod executor;
+pub mod history;
 mod metrics;
 mod progress_store;
 mod reader;


### PR DESCRIPTION
# Description of change

This patch adds the `iota_data_ingestion_core::history` module that handles uploading of batches of full checkpoint data to S3. It follows the design of `iota-archival`.

## Links to any relevant issues

Part of #5808 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

```
$ cargo clippy --all-targets
```

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
