### PR TITLE
feat(consensus): fix transaction size checks and metrics

### DIFF
--- a/consensus/core/src/block_verifier.rs
+++ b/consensus/core/src/block_verifier.rs
@@ -61,6 +61,42 @@ impl SignedBlockVerifier {
             transaction_verifier,
         }
     }
+
+    pub(crate) fn check_transactions(&self, batch: &[&[u8]]) -> ConsensusResult<()> {
+        let max_transaction_size_limit =
+            self.context.protocol_config.max_transaction_size_bytes() as usize;
+        for t in batch {
+            if t.len() > max_transaction_size_limit && max_transaction_size_limit > 0 {
+                return Err(ConsensusError::TransactionTooLarge {
+                    size: t.len(),
+                    limit: max_transaction_size_limit,
+                });
+            }
+        }
+
+        let max_num_transactions_limit =
+            self.context.protocol_config.max_num_transactions_in_block() as usize;
+        if batch.len() > max_num_transactions_limit && max_num_transactions_limit > 0 {
+            return Err(ConsensusError::TooManyTransactions {
+                count: batch.len(),
+                limit: max_num_transactions_limit,
+            });
+        }
+
+        let total_transactions_size_limit = self
+            .context
+            .protocol_config
+            .max_transactions_in_block_bytes() as usize;
+        if batch.iter().map(|t| t.len()).sum::<usize>() > total_transactions_size_limit
+            && total_transactions_size_limit > 0
+        {
+            return Err(ConsensusError::TooManyTransactionBytes {
+                size: batch.len(),
+                limit: total_transactions_size_limit,
+            });
+        }
+        Ok(())
+    }
 }
 
 // All block verification logic are implemented below.
@@ -149,38 +185,7 @@ impl BlockVerifier for SignedBlockVerifier {
 
         let batch: Vec<_> = block.transactions().iter().map(|t| t.data()).collect();
 
-        let max_transaction_size_limit =
-            self.context.protocol_config.max_transaction_size_bytes() as usize;
-        for t in &batch {
-            if t.len() > max_transaction_size_limit && max_transaction_size_limit > 0 {
-                return Err(ConsensusError::TransactionTooLarge {
-                    size: t.len(),
-                    limit: max_transaction_size_limit,
-                });
-            }
-        }
-
-        let max_num_transactions_limit =
-            self.context.protocol_config.max_num_transactions_in_block() as usize;
-        if batch.len() > max_num_transactions_limit && max_num_transactions_limit > 0 {
-            return Err(ConsensusError::TooManyTransactions {
-                count: batch.len(),
-                limit: max_num_transactions_limit,
-            });
-        }
-
-        let total_transactions_size_limit = self
-            .context
-            .protocol_config
-            .max_transactions_in_block_bytes() as usize;
-        if batch.iter().map(|t| t.len()).sum::<usize>() > total_transactions_size_limit
-            && total_transactions_size_limit > 0
-        {
-            return Err(ConsensusError::TooManyTransactionBytes {
-                size: batch.len(),
-                limit: total_transactions_size_limit,
-            });
-        }
+        self.check_transactions(&batch)?;
 
         self.transaction_verifier
             .verify_batch(&batch)

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -452,7 +452,7 @@ impl Core {
         // Consume the next transactions to be included. Do not drop the guards yet as
         // this would acknowledge the inclusion of transactions. Just let this
         // be done in the end of the method.
-        let (transactions, ack_transactions) = self.transaction_consumer.next();
+        let (transactions, ack_transactions, _limit_reached) = self.transaction_consumer.next();
         self.context
             .metrics
             .node_metrics

--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -4,6 +4,7 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
+use iota_common::debug_fatal;
 use iota_metrics::monitored_mpsc::{Receiver, Sender, channel};
 use parking_lot::Mutex;
 use tap::tap::TapFallible;
@@ -42,8 +43,8 @@ pub(crate) struct TransactionsGuard {
 pub(crate) struct TransactionConsumer {
     context: Arc<Context>,
     tx_receiver: Receiver<TransactionsGuard>,
-    max_consumed_bytes_per_request: u64,
-    max_consumed_transactions_per_request: u64,
+    max_transactions_in_block_bytes: u64,
+    max_num_transactions_in_block: u64,
     pending_transactions: Option<TransactionsGuard>,
     block_status_subscribers: Arc<Mutex<BTreeMap<BlockRef, Vec<oneshot::Sender<BlockStatus>>>>>,
 }
@@ -62,16 +63,24 @@ pub enum BlockStatus {
     GarbageCollected(BlockRef),
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum LimitReached {
+    // The maximum number of transactions have been included
+    MaxNumOfTransactions,
+    // The maximum number of bytes have been included
+    MaxBytes,
+    // All available transactions have been included
+    AllTransactionsIncluded,
+}
+
 impl TransactionConsumer {
     pub(crate) fn new(tx_receiver: Receiver<TransactionsGuard>, context: Arc<Context>) -> Self {
         Self {
             tx_receiver,
-            max_consumed_bytes_per_request: context
+            max_transactions_in_block_bytes: context
                 .protocol_config
                 .max_transactions_in_block_bytes(),
-            max_consumed_transactions_per_request: context
-                .protocol_config
-                .max_num_transactions_in_block(),
+            max_num_transactions_in_block: context.protocol_config.max_num_transactions_in_block(),
             context,
             pending_transactions: None,
             block_status_subscribers: Arc::new(Mutex::new(BTreeMap::new())),
@@ -79,33 +88,36 @@ impl TransactionConsumer {
     }
 
     // Attempts to fetch the next transactions that have been submitted for
-    // sequence. Also a `max_consumed_bytes_per_request` parameter is given in
-    // order to ensure up to `max_consumed_bytes_per_request` bytes of transactions
-    // are retrieved. This returns one or more transactions to be included in
-    // the block and a callback to acknowledge the inclusion of those transactions.
-    // Note that a TransactionsGuard may be partially consumed and the rest saved
-    // for the next pull, in which case its `included_in_block_ack` will not be
-    // signalled in the callback.
-    pub(crate) fn next(&mut self) -> (Vec<Transaction>, Box<dyn FnOnce(BlockRef)>) {
+    // sequence. Respects the `max_transactions_in_block_bytes`
+    // and `max_num_transactions_in_block` parameters specified via protocol config.
+    // This returns one or more transactions to be included in the block and a
+    // callback to acknowledge the inclusion of those transactions. Also returns
+    // a `LimitReached` enum to indicate which limit type has been reached.
+    pub(crate) fn next(&mut self) -> (Vec<Transaction>, Box<dyn FnOnce(BlockRef)>, LimitReached) {
         let mut transactions = Vec::new();
         let mut acks = Vec::new();
-        let mut total_size = 0;
+        let mut total_bytes = 0;
+        let mut limit_reached = LimitReached::AllTransactionsIncluded;
 
         // Handle one batch of incoming transactions from TransactionGuard.
         // The method will return `None` if all the transactions can be included in the
         // block. Otherwise none of the transactions will be included in the
         // block and the method will return the TransactionGuard.
         let mut handle_txs = |t: TransactionsGuard| -> Option<TransactionsGuard> {
-            let transactions_size =
+            let transactions_bytes =
                 t.transactions.iter().map(|t| t.data().len()).sum::<usize>() as u64;
+            let transactions_num = t.transactions.len() as u64;
 
-            if total_size + transactions_size > self.max_consumed_bytes_per_request
-                || transactions.len() as u64 > self.max_consumed_transactions_per_request
-            {
+            if total_bytes + transactions_bytes > self.max_transactions_in_block_bytes {
+                limit_reached = LimitReached::MaxBytes;
+                return Some(t);
+            }
+            if transactions.len() as u64 + transactions_num > self.max_num_transactions_in_block {
+                limit_reached = LimitReached::MaxNumOfTransactions;
                 return Some(t);
             }
 
-            total_size += transactions_size;
+            total_bytes += transactions_bytes;
 
             // The transactions can be consumed, register its ack.
             acks.push(t.included_in_block_ack);
@@ -114,7 +126,12 @@ impl TransactionConsumer {
         };
 
         if let Some(t) = self.pending_transactions.take() {
-            self.pending_transactions = handle_txs(t);
+            if let Some(pending_transactions) = handle_txs(t) {
+                debug_fatal!(
+                    "Previously pending transaction(s) should fit into an empty block! Dropping: {:?}",
+                    pending_transactions.transactions
+                );
+            }
         }
 
         // Until we have reached the limit for the pull.
@@ -155,6 +172,7 @@ impl TransactionConsumer {
                     let _ = ack.send((block_ref, status_rx));
                 }
             }),
+            limit_reached,
         )
     }
 
@@ -373,8 +391,12 @@ mod tests {
     use crate::{
         block::{BlockDigest, BlockRef},
         context::Context,
-        transaction::{BlockStatus, TransactionClient, TransactionConsumer},
+        transaction::{
+            BlockStatus, NoopTransactionVerifier, TransactionClient, TransactionConsumer,
+        },
     };
+    use crate::block_verifier::SignedBlockVerifier;
+    use crate::transaction::LimitReached;
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn basic_submit_and_consume() {
@@ -401,7 +423,7 @@ mod tests {
         }
 
         // now pull the transactions from the consumer
-        let (transactions, ack_transactions) = consumer.next();
+        let (transactions, ack_transactions, _limit_reached) = consumer.next();
         assert_eq!(transactions.len(), 3);
 
         for (i, t) in transactions.iter().enumerate() {
@@ -455,7 +477,7 @@ mod tests {
             // Every 2 transactions simulate the creation of a new block and acknowledge the
             // inclusion of the transactions
             if i % 2 == 0 {
-                let (transactions, ack_transactions) = consumer.next();
+                let (transactions, ack_transactions, _limit_reached) = consumer.next();
                 assert_eq!(transactions.len(), 2);
                 ack_transactions(BlockRef::new(
                     i,
@@ -527,7 +549,7 @@ mod tests {
             // Every 2 transactions simulate the creation of a new block and acknowledge the
             // inclusion of the transactions
             if i % 2 == 0 {
-                let (transactions, ack_transactions) = consumer.next();
+                let (transactions, ack_transactions, _limit_reached) = consumer.next();
                 assert_eq!(transactions.len(), 2);
                 ack_transactions(BlockRef::new(
                     i,
@@ -580,7 +602,7 @@ mod tests {
 
         // now pull the transactions from the consumer
         let mut all_transactions = Vec::new();
-        let (transactions, _ack_transactions) = consumer.next();
+        let (transactions, _ack_transactions, _limit_reached) = consumer.next();
         assert_eq!(transactions.len(), 7);
 
         // ensure their total size is less than `max_bytes_to_fetch`
@@ -593,7 +615,7 @@ mod tests {
         all_transactions.extend(transactions);
 
         // try to pull again transactions, next should be provided
-        let (transactions, _ack_transactions) = consumer.next();
+        let (transactions, _ack_transactions, _limit_reached) = consumer.next();
         assert_eq!(transactions.len(), 3);
 
         // ensure their total size is less than `max_bytes_to_fetch`
@@ -685,7 +707,7 @@ mod tests {
         let mut all_acks: Vec<Box<dyn FnOnce(BlockRef)>> = Vec::new();
         let mut batch_index = 0;
         while !consumer.is_empty() {
-            let (transactions, ack_transactions) = consumer.next();
+            let (transactions, ack_transactions, _limit_reached) = consumer.next();
 
             assert!(
                 transactions.len() as u64
@@ -735,6 +757,112 @@ mod tests {
         for w in all_receivers {
             let r = w.await;
             assert!(r.is_ok());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_submit_over_max_block_size_and_validate_block_size() {
+        // submit transactions individually so we make sure that we have reached the
+        // block size limit of 10
+        {
+            let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+                config.set_consensus_max_transaction_size_bytes_for_testing(100);
+                config.set_consensus_max_num_transactions_in_block_for_testing(10);
+                config.set_consensus_max_transactions_in_block_bytes_for_testing(300);
+                config
+            });
+
+            let context = Arc::new(Context::new_for_test(4).0);
+            let (client, tx_receiver) = TransactionClient::new(context.clone());
+            let mut consumer = TransactionConsumer::new(tx_receiver, context.clone());
+            let mut all_receivers = Vec::new();
+
+            // create enough transactions
+            let max_num_transactions_in_block =
+                context.protocol_config.max_num_transactions_in_block();
+            for i in 0..2 * max_num_transactions_in_block {
+                let transaction = bcs::to_bytes(&format!("transaction {i}"))
+                    .expect("Serialization should not fail.");
+                let w = client
+                    .submit_no_wait(vec![transaction])
+                    .await
+                    .expect("Should submit successfully transaction");
+                all_receivers.push(w);
+            }
+
+            // Fetch the next transactions to be included in a block
+            let (transactions, _ack_transactions, limit) = consumer.next();
+            assert_eq!(limit, LimitReached::MaxNumOfTransactions);
+            assert_eq!(transactions.len() as u64, max_num_transactions_in_block);
+
+            // Now create a block and verify that transactions are within the size limits
+            let block_verifier =
+                SignedBlockVerifier::new(context.clone(), Arc::new(NoopTransactionVerifier {}));
+
+            let batch: Vec<_> = transactions.iter().map(|t| t.data()).collect();
+            assert!(
+                block_verifier.check_transactions(&batch).is_ok(),
+                "Number of transactions limit verification failed"
+            );
+        }
+
+        // submit transactions individually so we make sure that we have reached the
+        // block size bytes 300
+        {
+            let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+                config.set_consensus_max_transaction_size_bytes_for_testing(100);
+                config.set_consensus_max_num_transactions_in_block_for_testing(1_000);
+                config.set_consensus_max_transactions_in_block_bytes_for_testing(300);
+                config
+            });
+
+            let context = Arc::new(Context::new_for_test(4).0);
+            let (client, tx_receiver) = TransactionClient::new(context.clone());
+            let mut consumer = TransactionConsumer::new(tx_receiver, context.clone());
+            let mut all_receivers = Vec::new();
+
+            let max_transactions_in_block_bytes =
+                context.protocol_config.max_transactions_in_block_bytes();
+            let mut total_size = 0;
+            loop {
+                let transaction = bcs::to_bytes(&"transaction".to_string())
+                    .expect("Serialization should not fail.");
+                total_size += transaction.len() as u64;
+                let w = client
+                    .submit_no_wait(vec![transaction])
+                    .await
+                    .expect("Should submit successfully transaction");
+                all_receivers.push(w);
+
+                // create enough transactions to reach the block size limit
+                if total_size >= 2 * max_transactions_in_block_bytes {
+                    break;
+                }
+            }
+
+            // Fetch the next transactions to be included in a block
+            let (transactions, _ack_transactions, limit) = consumer.next();
+            let batch: Vec<_> = transactions.iter().map(|t| t.data()).collect();
+            let size = batch.iter().map(|t| t.len() as u64).sum::<u64>();
+
+            assert_eq!(limit, LimitReached::MaxBytes);
+            assert!(
+                batch.len()
+                    < context
+                        .protocol_config
+                        .consensus_max_num_transactions_in_block() as usize,
+                "Should have submitted less than the max number of transactions in a block"
+            );
+            assert!(size <= max_transactions_in_block_bytes);
+
+            // Now create a block and verify that transactions are within the size limits
+            let block_verifier =
+                SignedBlockVerifier::new(context.clone(), Arc::new(NoopTransactionVerifier {}));
+
+            assert!(
+                block_verifier.check_transactions(&batch).is_ok(),
+                "Total size of transactions limit verification failed"
+            );
         }
     }
 }

--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -390,13 +390,13 @@ mod tests {
 
     use crate::{
         block::{BlockDigest, BlockRef},
+        block_verifier::SignedBlockVerifier,
         context::Context,
         transaction::{
-            BlockStatus, NoopTransactionVerifier, TransactionClient, TransactionConsumer,
+            BlockStatus, LimitReached, NoopTransactionVerifier, TransactionClient,
+            TransactionConsumer,
         },
     };
-    use crate::block_verifier::SignedBlockVerifier;
-    use crate::transaction::LimitReached;
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn basic_submit_and_consume() {

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -2281,7 +2281,12 @@ impl SenderSignedData {
 
     /// Validate untrusted user transaction, including its size, input count,
     /// command count, etc.
-    pub fn validity_check(&self, config: &ProtocolConfig, epoch: EpochId) -> IotaResult {
+    /// Returns the certificate serialised bytes size.
+    pub fn validity_check(
+        &self,
+        config: &ProtocolConfig,
+        epoch: EpochId,
+    ) -> Result<usize, IotaError> {
         // Check that the features used by the user signatures are enabled on the
         // network.
         self.check_user_signature_protocol_compatibility(config)?;
@@ -2325,7 +2330,7 @@ impl SenderSignedData {
             .validity_check(config)
             .map_err(Into::<IotaError>::into)?;
 
-        Ok(())
+        Ok(tx_size)
     }
 }
 


### PR DESCRIPTION
# Description of change

Porting from upstream https://github.com/MystenLabs/sui/pull/20325

> Fixes a bug when checking the total number of transactions included in a block via the transactions consumer in consensus. It would be possible to go over the max limit and effectively produce invalid blocks when it would verify on the block verifier side.
> 
> Also took this as opportunity to have an integration test that checks both the construction of block sizes and the block verifier so makes sure we are always aligned.
> 
> Added a couple of more soft bundle related metrics

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #(issue)`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
