### PR TITLE
feat(indexer): Add optimistic tables for events

### DIFF
--- a/crates/iota-indexer/migrations/pg/2025-03-13-113634_optimistic_events/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-03-13-113634_optimistic_events/down.sql
@@ -1,0 +1,8 @@
+DROP TABLE IF EXISTS optimistic_events;
+DROP TABLE IF EXISTS optimistic_event_emit_package;
+DROP TABLE IF EXISTS optimistic_event_emit_module;
+DROP TABLE IF EXISTS optimistic_event_struct_package;
+DROP TABLE IF EXISTS optimistic_event_struct_module;
+DROP TABLE IF EXISTS optimistic_event_struct_name;
+DROP TABLE IF EXISTS optimistic_event_struct_instantiation;
+DROP TABLE IF EXISTS optimistic_event_senders;

--- a/crates/iota-indexer/migrations/pg/2025-03-13-113634_optimistic_events/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-03-13-113634_optimistic_events/up.sql
@@ -1,3 +1,7 @@
+-- Main table storing data about optimistically indexed events
+-- (events produced by transactions that were executed by the indexer,
+-- and indexed without waiting for the transaction to be checkpointed).
+-- Equivalent of `events` table.
 CREATE TABLE optimistic_events
 (
     tx_insertion_order          BIGINT       REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
@@ -21,6 +25,8 @@ CREATE INDEX optimistic_events_package ON optimistic_events (package, tx_inserti
 CREATE INDEX optimistic_events_package_module ON optimistic_events (package, module, tx_insertion_order, event_sequence_number);
 CREATE INDEX optimistic_events_event_type ON optimistic_events (event_type text_pattern_ops, tx_insertion_order, event_sequence_number);
 
+-- Lookup table to search for optimistic events by emitting package address.
+-- Equivalent of `event_emit_package` table.
 CREATE TABLE optimistic_event_emit_package
 (
     package                     BYTEA   NOT NULL,
@@ -31,6 +37,8 @@ CREATE TABLE optimistic_event_emit_package
 );
 CREATE INDEX optimistic_event_emit_package_sender ON optimistic_event_emit_package (sender, package, tx_insertion_order, event_sequence_number);
 
+-- Lookup table to search for optimistic events by emitting module name.
+-- Equivalent of `event_emit_module` table.
 CREATE TABLE optimistic_event_emit_module
 (
     package                     BYTEA   NOT NULL,
@@ -42,6 +50,8 @@ CREATE TABLE optimistic_event_emit_module
 );
 CREATE INDEX optimistic_event_emit_module_sender ON optimistic_event_emit_module (sender, package, module, tx_insertion_order, event_sequence_number);
 
+-- Lookup table to search for optimistic events by package address of emitted type.
+-- Equivalent of `event_struct_package` table.
 CREATE TABLE optimistic_event_struct_package
 (
     package                     BYTEA   NOT NULL,
@@ -52,7 +62,8 @@ CREATE TABLE optimistic_event_struct_package
 );
 CREATE INDEX optimistic_event_struct_package_sender ON optimistic_event_struct_package (sender, package, tx_insertion_order, event_sequence_number);
 
-
+-- Lookup table to search for optimistic events by module name of emitted type.
+-- Equivalent of `event_struct_module` table.
 CREATE TABLE optimistic_event_struct_module
 (
     package                     BYTEA   NOT NULL,
@@ -64,6 +75,8 @@ CREATE TABLE optimistic_event_struct_module
 );
 CREATE INDEX optimistic_event_struct_module_sender ON optimistic_event_struct_module (sender, package, module, tx_insertion_order, event_sequence_number);
 
+-- Lookup table to search for optimistic events by emitted type name.
+-- Equivalent of `event_struct_name` table.
 CREATE TABLE optimistic_event_struct_name
 (
     package                     BYTEA   NOT NULL,
@@ -76,6 +89,8 @@ CREATE TABLE optimistic_event_struct_name
 );
 CREATE INDEX optimistic_event_struct_name_sender ON optimistic_event_struct_name (sender, package, module, type_name, tx_insertion_order, event_sequence_number);
 
+-- Lookup table to search for optimistic events by emitted type name with type parameters.
+-- Equivalent of `event_struct_instantiation` table.
 CREATE TABLE optimistic_event_struct_instantiation
 (
     package                     BYTEA   NOT NULL,
@@ -88,6 +103,8 @@ CREATE TABLE optimistic_event_struct_instantiation
 );
 CREATE INDEX optimistic_event_struct_instantiation_sender ON optimistic_event_struct_instantiation (sender, package, module, type_instantiation, tx_insertion_order, event_sequence_number);
 
+-- Lookup table to search for optimistic events by event sender address
+-- Equivalent of `event_senders` table.
 CREATE TABLE optimistic_event_senders
 (
     sender                      BYTEA   NOT NULL,

--- a/crates/iota-indexer/migrations/pg/2025-03-13-113634_optimistic_events/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-03-13-113634_optimistic_events/up.sql
@@ -1,0 +1,97 @@
+CREATE TABLE optimistic_events
+(
+    tx_insertion_order          BIGINT       REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    event_sequence_number       BIGINT       NOT NULL,
+    transaction_digest          bytea        NOT NULL,
+    -- array of IotaAddress in bytes. All signers of the transaction.
+    senders                     bytea[]      NOT NULL,
+    -- bytes of the entry package ID. Notice that the package and module here
+    -- are the package and module of the function that emitted the event, different
+    -- from the package and module of the event type.
+    package                     bytea        NOT NULL,
+    -- entry module name
+    module                      text         NOT NULL,
+    -- StructTag in Display format, fully qualified including type parameters
+    event_type                  text         NOT NULL,
+    -- bcs of the Event contents (Event.contents)
+    bcs                         BYTEA        NOT NULL,
+    PRIMARY KEY(tx_insertion_order, event_sequence_number)
+);
+CREATE INDEX optimistic_events_package ON optimistic_events (package, tx_insertion_order, event_sequence_number);
+CREATE INDEX optimistic_events_package_module ON optimistic_events (package, module, tx_insertion_order, event_sequence_number);
+CREATE INDEX optimistic_events_event_type ON optimistic_events (event_type text_pattern_ops, tx_insertion_order, event_sequence_number);
+
+CREATE TABLE optimistic_event_emit_package
+(
+    package                     BYTEA   NOT NULL,
+    tx_insertion_order          BIGINT  REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    event_sequence_number       BIGINT  NOT NULL,
+    sender                      BYTEA   NOT NULL,
+    PRIMARY KEY(package, tx_insertion_order, event_sequence_number)
+);
+CREATE INDEX optimistic_event_emit_package_sender ON optimistic_event_emit_package (sender, package, tx_insertion_order, event_sequence_number);
+
+CREATE TABLE optimistic_event_emit_module
+(
+    package                     BYTEA   NOT NULL,
+    module                      TEXT    NOT NULL,
+    tx_insertion_order          BIGINT  REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    event_sequence_number       BIGINT  NOT NULL,
+    sender                      BYTEA   NOT NULL,
+    PRIMARY KEY(package, module, tx_insertion_order, event_sequence_number)
+);
+CREATE INDEX optimistic_event_emit_module_sender ON optimistic_event_emit_module (sender, package, module, tx_insertion_order, event_sequence_number);
+
+CREATE TABLE optimistic_event_struct_package
+(
+    package                     BYTEA   NOT NULL,
+    tx_insertion_order          BIGINT  REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    event_sequence_number       BIGINT  NOT NULL,
+    sender                      BYTEA   NOT NULL,
+    PRIMARY KEY(package, tx_insertion_order, event_sequence_number)
+);
+CREATE INDEX optimistic_event_struct_package_sender ON optimistic_event_struct_package (sender, package, tx_insertion_order, event_sequence_number);
+
+
+CREATE TABLE optimistic_event_struct_module
+(
+    package                     BYTEA   NOT NULL,
+    module                      TEXT    NOT NULL,
+    tx_insertion_order          BIGINT  REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    event_sequence_number       BIGINT  NOT NULL,
+    sender                      BYTEA   NOT NULL,
+    PRIMARY KEY(package, module, tx_insertion_order, event_sequence_number)
+);
+CREATE INDEX optimistic_event_struct_module_sender ON optimistic_event_struct_module (sender, package, module, tx_insertion_order, event_sequence_number);
+
+CREATE TABLE optimistic_event_struct_name
+(
+    package                     BYTEA   NOT NULL,
+    module                      TEXT    NOT NULL,
+    type_name                   TEXT    NOT NULL,
+    tx_insertion_order          BIGINT  REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    event_sequence_number       BIGINT  NOT NULL,
+    sender                      BYTEA   NOT NULL,
+    PRIMARY KEY(package, module, type_name, tx_insertion_order, event_sequence_number)
+);
+CREATE INDEX optimistic_event_struct_name_sender ON optimistic_event_struct_name (sender, package, module, type_name, tx_insertion_order, event_sequence_number);
+
+CREATE TABLE optimistic_event_struct_instantiation
+(
+    package                     BYTEA   NOT NULL,
+    module                      TEXT    NOT NULL,
+    type_instantiation          TEXT    NOT NULL,
+    tx_insertion_order          BIGINT  REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    event_sequence_number       BIGINT  NOT NULL,
+    sender                      BYTEA   NOT NULL,
+    PRIMARY KEY(package, module, type_instantiation, tx_insertion_order, event_sequence_number)
+);
+CREATE INDEX optimistic_event_struct_instantiation_sender ON optimistic_event_struct_instantiation (sender, package, module, type_instantiation, tx_insertion_order, event_sequence_number);
+
+CREATE TABLE optimistic_event_senders
+(
+    sender                      BYTEA   NOT NULL,
+    tx_insertion_order          BIGINT  REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    event_sequence_number       BIGINT  NOT NULL,
+    PRIMARY KEY(sender, tx_insertion_order, event_sequence_number)
+);

--- a/crates/iota-indexer/src/models/event_indices.rs
+++ b/crates/iota-indexer/src/models/event_indices.rs
@@ -7,7 +7,10 @@ use diesel::prelude::*;
 use crate::{
     schema::{
         event_emit_module, event_emit_package, event_senders, event_struct_instantiation,
-        event_struct_module, event_struct_name, event_struct_package,
+        event_struct_module, event_struct_name, event_struct_package, optimistic_event_emit_module,
+        optimistic_event_emit_package, optimistic_event_senders,
+        optimistic_event_struct_instantiation, optimistic_event_struct_module,
+        optimistic_event_struct_name, optimistic_event_struct_package,
     },
     types::EventIndex,
 };
@@ -143,5 +146,237 @@ impl EventIndex {
                 sender: self.sender.to_vec(),
             },
         )
+    }
+}
+
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
+#[diesel(table_name = optimistic_event_emit_package)]
+pub struct OptimisticEventEmitPackage {
+    pub tx_insertion_order: i64,
+    pub event_sequence_number: i64,
+    pub package: Vec<u8>,
+    pub sender: Vec<u8>,
+}
+
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
+#[diesel(table_name = optimistic_event_emit_module)]
+pub struct OptimisticEventEmitModule {
+    pub tx_insertion_order: i64,
+    pub event_sequence_number: i64,
+    pub package: Vec<u8>,
+    pub module: String,
+    pub sender: Vec<u8>,
+}
+
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
+#[diesel(table_name = optimistic_event_senders)]
+pub struct OptimisticEventSenders {
+    pub tx_insertion_order: i64,
+    pub event_sequence_number: i64,
+    pub sender: Vec<u8>,
+}
+
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
+#[diesel(table_name = optimistic_event_struct_package)]
+pub struct OptimisticEventStructPackage {
+    pub tx_insertion_order: i64,
+    pub event_sequence_number: i64,
+    pub package: Vec<u8>,
+    pub sender: Vec<u8>,
+}
+
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
+#[diesel(table_name = optimistic_event_struct_module)]
+pub struct OptimisticEventStructModule {
+    pub tx_insertion_order: i64,
+    pub event_sequence_number: i64,
+    pub package: Vec<u8>,
+    pub module: String,
+    pub sender: Vec<u8>,
+}
+
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
+#[diesel(table_name = optimistic_event_struct_name)]
+pub struct OptimisticEventStructName {
+    pub tx_insertion_order: i64,
+    pub event_sequence_number: i64,
+    pub package: Vec<u8>,
+    pub module: String,
+    pub type_name: String,
+    pub sender: Vec<u8>,
+}
+
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
+#[diesel(table_name = optimistic_event_struct_instantiation)]
+pub struct OptimisticEventStructInstantiation {
+    pub tx_insertion_order: i64,
+    pub event_sequence_number: i64,
+    pub package: Vec<u8>,
+    pub module: String,
+    pub type_instantiation: String,
+    pub sender: Vec<u8>,
+}
+
+impl From<OptimisticEventEmitPackage> for StoredEventEmitPackage {
+    fn from(ev: OptimisticEventEmitPackage) -> Self {
+        StoredEventEmitPackage {
+            tx_sequence_number: ev.tx_insertion_order,
+            event_sequence_number: ev.event_sequence_number,
+            package: ev.package,
+            sender: ev.sender,
+        }
+    }
+}
+
+impl From<StoredEventEmitPackage> for OptimisticEventEmitPackage {
+    fn from(ev: StoredEventEmitPackage) -> Self {
+        OptimisticEventEmitPackage {
+            tx_insertion_order: ev.tx_sequence_number,
+            event_sequence_number: ev.event_sequence_number,
+            package: ev.package,
+            sender: ev.sender,
+        }
+    }
+}
+
+impl From<OptimisticEventEmitModule> for StoredEventEmitModule {
+    fn from(ev: OptimisticEventEmitModule) -> Self {
+        StoredEventEmitModule {
+            tx_sequence_number: ev.tx_insertion_order,
+            event_sequence_number: ev.event_sequence_number,
+            package: ev.package,
+            module: ev.module,
+            sender: ev.sender,
+        }
+    }
+}
+
+impl From<StoredEventEmitModule> for OptimisticEventEmitModule {
+    fn from(ev: StoredEventEmitModule) -> Self {
+        OptimisticEventEmitModule {
+            tx_insertion_order: ev.tx_sequence_number,
+            event_sequence_number: ev.event_sequence_number,
+            package: ev.package,
+            module: ev.module,
+            sender: ev.sender,
+        }
+    }
+}
+
+impl From<OptimisticEventSenders> for StoredEventSenders {
+    fn from(ev: OptimisticEventSenders) -> Self {
+        StoredEventSenders {
+            tx_sequence_number: ev.tx_insertion_order,
+            event_sequence_number: ev.event_sequence_number,
+            sender: ev.sender,
+        }
+    }
+}
+
+impl From<StoredEventSenders> for OptimisticEventSenders {
+    fn from(ev: StoredEventSenders) -> Self {
+        OptimisticEventSenders {
+            tx_insertion_order: ev.tx_sequence_number,
+            event_sequence_number: ev.event_sequence_number,
+            sender: ev.sender,
+        }
+    }
+}
+
+impl From<OptimisticEventStructPackage> for StoredEventStructPackage {
+    fn from(ev: OptimisticEventStructPackage) -> Self {
+        StoredEventStructPackage {
+            tx_sequence_number: ev.tx_insertion_order,
+            event_sequence_number: ev.event_sequence_number,
+            package: ev.package,
+            sender: ev.sender,
+        }
+    }
+}
+
+impl From<StoredEventStructPackage> for OptimisticEventStructPackage {
+    fn from(ev: StoredEventStructPackage) -> Self {
+        OptimisticEventStructPackage {
+            tx_insertion_order: ev.tx_sequence_number,
+            event_sequence_number: ev.event_sequence_number,
+            package: ev.package,
+            sender: ev.sender,
+        }
+    }
+}
+
+impl From<OptimisticEventStructModule> for StoredEventStructModule {
+    fn from(ev: OptimisticEventStructModule) -> Self {
+        StoredEventStructModule {
+            tx_sequence_number: ev.tx_insertion_order,
+            event_sequence_number: ev.event_sequence_number,
+            package: ev.package,
+            module: ev.module,
+            sender: ev.sender,
+        }
+    }
+}
+
+impl From<StoredEventStructModule> for OptimisticEventStructModule {
+    fn from(ev: StoredEventStructModule) -> Self {
+        OptimisticEventStructModule {
+            tx_insertion_order: ev.tx_sequence_number,
+            event_sequence_number: ev.event_sequence_number,
+            package: ev.package,
+            module: ev.module,
+            sender: ev.sender,
+        }
+    }
+}
+
+impl From<OptimisticEventStructName> for StoredEventStructName {
+    fn from(ev: OptimisticEventStructName) -> Self {
+        StoredEventStructName {
+            tx_sequence_number: ev.tx_insertion_order,
+            event_sequence_number: ev.event_sequence_number,
+            package: ev.package,
+            module: ev.module,
+            type_name: ev.type_name,
+            sender: ev.sender,
+        }
+    }
+}
+
+impl From<StoredEventStructName> for OptimisticEventStructName {
+    fn from(ev: StoredEventStructName) -> Self {
+        OptimisticEventStructName {
+            tx_insertion_order: ev.tx_sequence_number,
+            event_sequence_number: ev.event_sequence_number,
+            package: ev.package,
+            module: ev.module,
+            type_name: ev.type_name,
+            sender: ev.sender,
+        }
+    }
+}
+
+impl From<OptimisticEventStructInstantiation> for StoredEventStructInstantiation {
+    fn from(ev: OptimisticEventStructInstantiation) -> Self {
+        StoredEventStructInstantiation {
+            tx_sequence_number: ev.tx_insertion_order,
+            event_sequence_number: ev.event_sequence_number,
+            package: ev.package,
+            module: ev.module,
+            type_instantiation: ev.type_instantiation,
+            sender: ev.sender,
+        }
+    }
+}
+
+impl From<StoredEventStructInstantiation> for OptimisticEventStructInstantiation {
+    fn from(ev: StoredEventStructInstantiation) -> Self {
+        OptimisticEventStructInstantiation {
+            tx_insertion_order: ev.tx_sequence_number,
+            event_sequence_number: ev.event_sequence_number,
+            package: ev.package,
+            module: ev.module,
+            type_instantiation: ev.type_instantiation,
+            sender: ev.sender,
+        }
     }
 }

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -284,6 +284,87 @@ diesel::table! {
 }
 
 diesel::table! {
+    optimistic_event_emit_module (package, module, tx_insertion_order, event_sequence_number) {
+        package -> Bytea,
+        module -> Text,
+        tx_insertion_order -> Int8,
+        event_sequence_number -> Int8,
+        sender -> Bytea,
+    }
+}
+
+diesel::table! {
+    optimistic_event_emit_package (package, tx_insertion_order, event_sequence_number) {
+        package -> Bytea,
+        tx_insertion_order -> Int8,
+        event_sequence_number -> Int8,
+        sender -> Bytea,
+    }
+}
+
+diesel::table! {
+    optimistic_event_senders (sender, tx_insertion_order, event_sequence_number) {
+        sender -> Bytea,
+        tx_insertion_order -> Int8,
+        event_sequence_number -> Int8,
+    }
+}
+
+diesel::table! {
+    optimistic_event_struct_instantiation (package, module, type_instantiation, tx_insertion_order, event_sequence_number) {
+        package -> Bytea,
+        module -> Text,
+        type_instantiation -> Text,
+        tx_insertion_order -> Int8,
+        event_sequence_number -> Int8,
+        sender -> Bytea,
+    }
+}
+
+diesel::table! {
+    optimistic_event_struct_module (package, module, tx_insertion_order, event_sequence_number) {
+        package -> Bytea,
+        module -> Text,
+        tx_insertion_order -> Int8,
+        event_sequence_number -> Int8,
+        sender -> Bytea,
+    }
+}
+
+diesel::table! {
+    optimistic_event_struct_name (package, module, type_name, tx_insertion_order, event_sequence_number) {
+        package -> Bytea,
+        module -> Text,
+        type_name -> Text,
+        tx_insertion_order -> Int8,
+        event_sequence_number -> Int8,
+        sender -> Bytea,
+    }
+}
+
+diesel::table! {
+    optimistic_event_struct_package (package, tx_insertion_order, event_sequence_number) {
+        package -> Bytea,
+        tx_insertion_order -> Int8,
+        event_sequence_number -> Int8,
+        sender -> Bytea,
+    }
+}
+
+diesel::table! {
+    optimistic_events (tx_insertion_order, event_sequence_number) {
+        tx_insertion_order -> Int8,
+        event_sequence_number -> Int8,
+        transaction_digest -> Bytea,
+        senders -> Array<Nullable<Bytea>>,
+        package -> Bytea,
+        module -> Text,
+        event_type -> Text,
+        bcs -> Bytea,
+    }
+}
+
+diesel::table! {
     optimistic_transactions (insertion_order) {
         insertion_order -> Int8,
         transaction_digest -> Bytea,
@@ -494,6 +575,14 @@ diesel::table! {
     }
 }
 
+diesel::joinable!(optimistic_event_emit_module -> optimistic_transactions (tx_insertion_order));
+diesel::joinable!(optimistic_event_emit_package -> optimistic_transactions (tx_insertion_order));
+diesel::joinable!(optimistic_event_senders -> optimistic_transactions (tx_insertion_order));
+diesel::joinable!(optimistic_event_struct_instantiation -> optimistic_transactions (tx_insertion_order));
+diesel::joinable!(optimistic_event_struct_module -> optimistic_transactions (tx_insertion_order));
+diesel::joinable!(optimistic_event_struct_name -> optimistic_transactions (tx_insertion_order));
+diesel::joinable!(optimistic_event_struct_package -> optimistic_transactions (tx_insertion_order));
+diesel::joinable!(optimistic_events -> optimistic_transactions (tx_insertion_order));
 diesel::joinable!(optimistic_tx_calls_fun -> optimistic_transactions (tx_insertion_order));
 diesel::joinable!(optimistic_tx_calls_mod -> optimistic_transactions (tx_insertion_order));
 diesel::joinable!(optimistic_tx_calls_pkg -> optimistic_transactions (tx_insertion_order));
@@ -530,6 +619,14 @@ macro_rules! for_all_tables {
             objects_history,
             objects_snapshot,
             objects_version,
+            optimistic_event_emit_module,
+            optimistic_event_emit_package,
+            optimistic_event_senders,
+            optimistic_event_struct_instantiation,
+            optimistic_event_struct_module,
+            optimistic_event_struct_name,
+            optimistic_event_struct_package,
+            optimistic_events,
             optimistic_transactions,
             optimistic_tx_calls_fun,
             optimistic_tx_calls_mod,


### PR DESCRIPTION
# Description of change

Add optimistic tables for events.

This PR is currently rebased on top of https://github.com/iotaledger/iota/pull/5938.
Will be retargeted to develop once the base PR is merged.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/5869

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo ci-clippy`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
