### PR TITLE
feat(iota-sdk): add pretty print formatting for balance in example

### DIFF
--- a/crates/iota-sdk/README.md
+++ b/crates/iota-sdk/README.md
@@ -130,7 +130,7 @@ async fn main() -> Result<(), anyhow::Error> {
       .coin_read_api()
       .get_all_balances(active_address)
       .await?;
-   println!("The balances for all coins owned by address: {active_address} are {total_balance:?}");
+   println!("The balances for all coins owned by address: {active_address} are {total_balance:#?}");
    Ok(())
 }
 ```


### PR DESCRIPTION
# Description of change

Add pretty print formatting for balance in example so the output looks nicer:
```
The balances for all coins owned by address: 0x111111111504e9350e635d65cd38ccd2c029434c6a3a480d8947a9ba6a15b215 are [
    Balance {
        coin_type: "0x1ec8ca48b9b39f721510dc717d7f077c9bc84eca28e784ba8dc0b913e23ed5ca::deposit_test_coin::DEPOSIT_TEST_COIN",
        coin_object_count: 1,
        total_balance: 1000000000,
    },
    Balance {
        coin_type: "0x2::iota::IOTA",
        coin_object_count: 346,
        total_balance: 1441298431036,
    },
]
```
instead of 
```
The balances for all coins owned by address: 0x111111111504e9350e635d65cd38ccd2c029434c6a3a480d8947a9ba6a15b215 are [Balance { coin_type: "0x1ec8ca48b9b39f721510dc717d7f077c9bc84eca28e784ba8dc0b913e23ed5ca::deposit_test_coin::DEPOSIT_TEST_COIN", coin_object_count: 1, total_balance: 1000000000 }, Balance { coin_type: "0x2::iota::IOTA", coin_object_count: 346, total_balance: 1441298431036 }]
```

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/5990

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running the example
