### PR TITLE
feat(iota): make source verification opt-in instead of opt-out

### DIFF
--- a/crates/iota-source-validation-service/tests/tests.rs
+++ b/crates/iota-source-validation-service/tests/tests.rs
@@ -186,6 +186,7 @@ async fn run_publish(
         package_path: package_path.clone(),
         build_config,
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
     }
@@ -213,6 +214,7 @@ async fn run_upgrade(
         upgrade_capability: cap.reference.object_id,
         build_config,
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
     }

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -1691,21 +1691,28 @@ fn check_dep_verification_flags(
 ) -> anyhow::Result<bool> {
     match (skip_dependency_verification, verify_dependencies) {
         (true, true) => bail!(
-            "[error]: --skip_dependency_verification and --verify_dependencies are mutually exclusive"
+            "[error]: --skip-dependency-verification and --verify-deps are mutually exclusive"
         ),
 
         (false, false) => {
             eprintln!(
-                "{}: In a future release, dependency source code will no longer be verified by default during publication and upgrade. \
-                You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. \
-                You can also manually verify dependencies using `iota client verify-source`.",
-                "[warning]".bold().yellow()
+                "{}: Dependency sources are no longer verified automatically during publication and upgrade. \
+                You can pass the `--verify-deps` option if you would like to verify them as part of publication or upgrade.",
+                "[Note]".bold().yellow()
             );
-            Ok(true)
         }
 
-        _ => Ok(verify_dependencies),
+        (true, false) => {
+            eprintln!(
+                "{}: Dependency sources are no longer verified automatically during publication and upgrade, \
+                so the `--skip-dependency-verification` flag is no longer necessary.",
+                "[Warning]".bold().yellow()
+            );
+        }
+
+        (false, true) => {}
     }
+    Ok(verify_dependencies)
 }
 
 fn compile_package_simple(

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -355,11 +355,15 @@ pub enum IotaClientCommands {
         build_config: MoveBuildConfig,
         #[command(flatten)]
         opts: OptsWithGas,
-        /// Publish the package without checking whether compiling dependencies
-        /// from source results in bytecode matching the dependencies
-        /// found on-chain.
+        /// Publish the package without checking whether dependency source code
+        /// compiles to the on-chain bytecode.
         #[arg(long)]
         skip_dependency_verification: bool,
+        /// Check that the dependency source code compiles to the on-chain
+        /// bytecode before publishing the package (currently the
+        /// default behavior)
+        #[clap(long, conflicts_with = "skip_dependency_verification")]
+        verify_deps: bool,
         /// Also publish transitive dependencies that have not already been
         /// published.
         #[arg(long)]
@@ -426,11 +430,15 @@ pub enum IotaClientCommands {
         build_config: MoveBuildConfig,
         #[command(flatten)]
         opts: OptsWithGas,
-        /// Publish the package without checking whether compiling dependencies
-        /// from source results in bytecode matching the dependencies
-        /// found on-chain.
+        /// Upgrade the package without checking whether dependency source code
+        /// compiles to the on-chain bytecode
         #[arg(long)]
         skip_dependency_verification: bool,
+        /// Check that the dependency source code compiles to the on-chain
+        /// bytecode before upgrading the package (currently the default
+        /// behavior)
+        #[clap(long, conflicts_with = "skip_dependency_verification")]
+        verify_deps: bool,
         /// Also publish transitive dependencies that have not already been
         /// published.
         #[arg(long)]
@@ -885,6 +893,7 @@ impl IotaClientCommands {
                 upgrade_capability,
                 build_config,
                 skip_dependency_verification,
+                verify_deps,
                 with_unpublished_dependencies,
                 opts,
             } => {
@@ -913,13 +922,15 @@ impl IotaClientCommands {
                     None
                 };
                 let env_alias = context.active_env().map(|e| e.alias().clone()).ok();
+                let verify =
+                    check_dep_verification_flags(skip_dependency_verification, verify_deps)?;
                 let upgrade_result = upgrade_package(
                     client.read_api(),
                     build_config.clone(),
                     &package_path,
                     upgrade_capability,
                     with_unpublished_dependencies,
-                    skip_dependency_verification,
+                    !verify,
                     env_alias,
                 )
                 .await;
@@ -976,6 +987,7 @@ impl IotaClientCommands {
                 package_path,
                 build_config,
                 skip_dependency_verification,
+                verify_deps,
                 with_unpublished_dependencies,
                 opts,
             } => {
@@ -1018,12 +1030,14 @@ impl IotaClientCommands {
                 } else {
                     None
                 };
+                let verify =
+                    check_dep_verification_flags(skip_dependency_verification, verify_deps)?;
                 let compile_result = compile_package(
                     client.read_api(),
                     build_config.clone(),
                     &package_path,
                     with_unpublished_dependencies,
-                    skip_dependency_verification,
+                    !verify,
                 )
                 .await;
                 // Restore original ID, then check result.
@@ -1665,6 +1679,32 @@ impl IotaClientCommands {
         );
         config.set_active_env(env.to_owned());
         Ok(())
+    }
+}
+
+/// Process the `--skip-dependency-verification` and `--verify-dependencies`
+/// flags for a publish or upgrade command. Prints deprecation warnings as
+/// appropriate and returns true if the dependencies should be verified
+fn check_dep_verification_flags(
+    skip_dependency_verification: bool,
+    verify_dependencies: bool,
+) -> anyhow::Result<bool> {
+    match (skip_dependency_verification, verify_dependencies) {
+        (true, true) => bail!(
+            "[error]: --skip_dependency_verification and --verify_dependencies are mutually exclusive"
+        ),
+
+        (false, false) => {
+            eprintln!(
+                "{}: In a future release, dependency source code will no longer be verified by default during publication and upgrade. \
+                You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. \
+                You can also manually verify dependencies using `iota client verify-source`.",
+                "[warning]".bold().yellow()
+            );
+            Ok(true)
+        }
+
+        _ => Ok(verify_dependencies),
     }
 }
 

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -309,6 +309,7 @@ async fn test_ptb_publish_and_complex_arg_resolution() -> Result<(), anyhow::Err
         package_path: package_path.clone(),
         build_config,
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
     }
@@ -588,6 +589,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -854,6 +856,7 @@ async fn test_package_publish_command() -> Result<(), anyhow::Error> {
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -924,6 +927,7 @@ async fn test_package_management_on_publish_command() -> Result<(), anyhow::Erro
         build_config: build_config.clone(),
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -994,6 +998,7 @@ async fn test_delete_shared_object() -> Result<(), anyhow::Error> {
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -1098,6 +1103,7 @@ async fn test_receive_argument() -> Result<(), anyhow::Error> {
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -1222,6 +1228,7 @@ async fn test_receive_argument_by_immut_ref() -> Result<(), anyhow::Error> {
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -1346,6 +1353,7 @@ async fn test_receive_argument_by_mut_ref() -> Result<(), anyhow::Error> {
         build_config,
         skip_dependency_verification: false,
         with_unpublished_dependencies: false,
+        verify_deps: true,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
     }
     .execute(context)
@@ -1472,6 +1480,7 @@ async fn test_package_publish_command_with_unpublished_dependency_succeeds()
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies,
     }
     .execute(context)
@@ -1541,6 +1550,7 @@ async fn test_package_publish_command_with_unpublished_dependency_fails()
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies,
     }
     .execute(context)
@@ -1585,6 +1595,7 @@ async fn test_package_publish_command_non_zero_unpublished_dep_fails() -> Result
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies,
     }
     .execute(context)
@@ -1638,6 +1649,7 @@ async fn test_package_publish_command_failure_invalid() -> Result<(), anyhow::Er
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies,
     }
     .execute(context)
@@ -1677,6 +1689,7 @@ async fn test_package_publish_nonexistent_dependency() -> Result<(), anyhow::Err
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -1717,6 +1730,7 @@ async fn test_package_publish_test_flag() -> Result<(), anyhow::Error> {
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -1769,6 +1783,7 @@ async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -1843,6 +1858,7 @@ async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -1908,6 +1924,7 @@ async fn test_package_management_on_upgrade_command() -> Result<(), anyhow::Erro
         build_config: build_config.clone(),
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -1962,6 +1979,7 @@ async fn test_package_management_on_upgrade_command() -> Result<(), anyhow::Erro
         build_config: build_config.clone(),
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -2042,6 +2060,7 @@ async fn test_package_management_on_upgrade_command_conflict() -> Result<(), any
         build_config: build_config_publish.clone(),
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -2114,6 +2133,7 @@ async fn test_package_management_on_upgrade_command_conflict() -> Result<(), any
         build_config: build_config_upgrade.clone(),
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -3805,6 +3825,7 @@ async fn test_clever_errors() -> Result<(), anyhow::Error> {
         package_path: package_path.clone(),
         build_config,
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
     }

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -4409,6 +4409,7 @@ async fn test_call_command_emit_args() -> Result<(), anyhow::Error> {
         package_path: package_path.clone(),
         build_config,
         skip_dependency_verification: false,
+        verify_deps: false,
         with_unpublished_dependencies: false,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
     }

--- a/crates/iota/tests/shell_tests.rs
+++ b/crates/iota/tests/shell_tests.rs
@@ -50,6 +50,7 @@ async fn test_shell_snapshot(path: &Path) -> Result<(), Box<dyn std::error::Erro
             "PATH",
             format!("{}:{}", get_iota_bin_path(), std::env::var("PATH")?),
         )
+        .env("RUST_BACKTRACE", "0")
         .current_dir(sandbox)
         .arg(path.file_name().unwrap());
 

--- a/crates/iota/tests/shell_tests/with_network/move_build_bytecode_with_address_resolution/move_build_bytecode_with_address_resolution.sh
+++ b/crates/iota/tests/shell_tests/with_network/move_build_bytecode_with_address_resolution/move_build_bytecode_with_address_resolution.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 iota client --client.config $CONFIG \
-  publish simple \
+  publish simple --verify-deps \
   --json | jq '.effects.status'
 
 iota move --client.config $CONFIG \

--- a/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/README.md
+++ b/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/README.md
@@ -1,0 +1,2 @@
+This test suite checks that the deprecation warnings for dependency verification during publication and the
+associated flags `--skip-dependency-verification` and `--verify-deps` are working correctly.

--- a/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/both_flags.sh
+++ b/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/both_flags.sh
@@ -4,8 +4,8 @@
 
 # test that we get an error if we supply both `--skip-dependency-verification` and `--verify-deps`
 
-echo "=== publish ===" | tee /dev/stderr
+echo "=== publish (should fail) ===" | tee /dev/stderr
 iota client --client.config $CONFIG publish example --skip-dependency-verification --verify-deps
 
-echo "=== upgrade ===" | tee /dev/stderr
+echo "=== upgrade (should fail) ===" | tee /dev/stderr
 iota client --client.config $CONFIG upgrade example --upgrade-capability 0x1234 --skip-dependency-verification --verify-deps

--- a/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/both_flags.sh
+++ b/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/both_flags.sh
@@ -1,0 +1,11 @@
+# Copyright (c) Mysten Labs, Inc.
+# Modifications Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+# test that we get an error if we supply both `--skip-dependency-verification` and `--verify-deps`
+
+echo "=== publish ===" | tee /dev/stderr
+iota client --client.config $CONFIG publish example --skip-dependency-verification --verify-deps
+
+echo "=== upgrade ===" | tee /dev/stderr
+iota client --client.config $CONFIG upgrade example --upgrade-capability 0x1234 --skip-dependency-verification --verify-deps

--- a/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/dependency/Move.toml
+++ b/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/dependency/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "dependency"
+edition = "2024.beta"
+
+[dependencies]
+# Iota = { local = "FRAMEWORK_DIR", override = true }
+
+[addresses]
+dependency = "0x0"

--- a/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/dependency/sources/dependency.move
+++ b/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/dependency/sources/dependency.move
@@ -1,0 +1,7 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+module dependency::dependency;
+
+public fun f(): u64 { 0 }

--- a/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/example/Move.toml
+++ b/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/example/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "example"
+edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+
+[dependencies]
+# Iota = { local = "FRAMEWORK_DIR" }
+dependency = { local = "../dependency" }
+
+[addresses]
+example = "0x0"

--- a/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/example/sources/example.move
+++ b/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/example/sources/example.move
@@ -1,0 +1,10 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+/// Module: example
+module example::example;
+
+use dependency::dependency::f;
+
+public fun g(): u64 { f() }

--- a/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/no_flags.sh
+++ b/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/no_flags.sh
@@ -1,0 +1,37 @@
+# Copyright (c) Mysten Labs, Inc.
+# Modifications Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+# check that we get a deprecation warning when upgrading without any dependency verification flags
+
+echo "=== munge Move.toml files ===" | tee /dev/stderr
+FRAMEWORK_DIR=$(echo $CARGO_MANIFEST_DIR | sed 's#/crates/iota#/crates/iota-framework/packages/iota-framework#g')
+for i in dependency/Move.toml example/Move.toml
+do
+  cat $i | sed "s#FRAMEWORK_DIR#$FRAMEWORK_DIR#g" > Move.toml \
+    && mv Move.toml $i
+done
+
+echo "=== publish dependency ===" | tee /dev/stderr
+iota client --client.config $CONFIG publish "dependency" \
+  --json | jq '.effects.status'
+
+echo "=== publish package v0 (should warn) ===" | tee /dev/stderr
+UPGRADE_CAP=$(iota client --client.config $CONFIG publish "example" \
+  --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
+
+echo "=== upgrade package (should warn) ===" | tee /dev/stderr
+iota client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example \
+  --json | jq '.effects.status'
+
+echo "=== modify dependency ===" | tee /dev/stderr
+cat dependency/sources/dependency.move | sed 's#0#1#g' > dependency.move
+mv dependency.move dependency/sources/dependency.move
+
+echo "=== try to publish with modified dep (should fail) ===" | tee /dev/stderr
+iota client --client.config $CONFIG publish "example" \
+  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'
+
+echo "=== try to upgrade with modified dep (should fail) ===" | tee /dev/stderr
+iota client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example \
+  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'

--- a/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/no_flags.sh
+++ b/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/no_flags.sh
@@ -16,11 +16,11 @@ echo "=== publish dependency ===" | tee /dev/stderr
 iota client --client.config $CONFIG publish "dependency" \
   --json | jq '.effects.status'
 
-echo "=== publish package v0 (should warn) ===" | tee /dev/stderr
+echo "=== publish package v0 (should note deprecation) ===" | tee /dev/stderr
 UPGRADE_CAP=$(iota client --client.config $CONFIG publish "example" \
   --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
 
-echo "=== upgrade package (should warn) ===" | tee /dev/stderr
+echo "=== upgrade package (should note deprecation) ===" | tee /dev/stderr
 iota client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example \
   --json | jq '.effects.status'
 
@@ -28,10 +28,10 @@ echo "=== modify dependency ===" | tee /dev/stderr
 cat dependency/sources/dependency.move | sed 's#0#1#g' > dependency.move
 mv dependency.move dependency/sources/dependency.move
 
-echo "=== try to publish with modified dep (should fail) ===" | tee /dev/stderr
-iota client --client.config $CONFIG publish "example" \
-  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'
+echo "=== try to publish with modified dep (should succeed) ===" | tee /dev/stderr
+UPGRADE_CAP=$(iota client --client.config $CONFIG publish "example" \
+  --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
 
-echo "=== try to upgrade with modified dep (should fail) ===" | tee /dev/stderr
+echo "=== try to upgrade with modified dep (should succeed) ===" | tee /dev/stderr
 iota client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example \
-  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'
+  --json | jq '.effects.status'

--- a/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/skip_dep_verif.sh
+++ b/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/skip_dep_verif.sh
@@ -12,15 +12,15 @@ do
     && mv Move.toml $i
 done
 
-echo "=== publish dependency ===" | tee /dev/stderr
+echo "=== publish dependency (should warn about deprecation) ===" | tee /dev/stderr
 iota client --client.config $CONFIG publish "dependency" --skip-dependency-verification \
   --json | jq '.effects.status'
 
-echo "=== publish package v0 (should NOT warn) ===" | tee /dev/stderr
+echo "=== publish package v0 (should warn about deprecation) ===" | tee /dev/stderr
 UPGRADE_CAP=$(iota client --client.config $CONFIG publish "example" --skip-dependency-verification \
   --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
 
-echo "=== upgrade package (should NOT warn) ===" | tee /dev/stderr
+echo "=== upgrade package (should warn about deprecation) ===" | tee /dev/stderr
 iota client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example --skip-dependency-verification \
   --json | jq '.effects.status'
 

--- a/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/skip_dep_verif.sh
+++ b/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/skip_dep_verif.sh
@@ -1,0 +1,37 @@
+# Copyright (c) Mysten Labs, Inc.
+# Modifications Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+# check that --skip-dependency-verification has the right behavior on publish and upgrade
+
+echo "=== munge Move.toml files ===" | tee /dev/stderr
+FRAMEWORK_DIR=$(echo $CARGO_MANIFEST_DIR | sed 's#/crates/iota#/crates/iota-framework/packages/iota-framework#g')
+for i in dependency/Move.toml example/Move.toml
+do
+  cat $i | sed "s#FRAMEWORK_DIR#$FRAMEWORK_DIR#g" > Move.toml \
+    && mv Move.toml $i
+done
+
+echo "=== publish dependency ===" | tee /dev/stderr
+iota client --client.config $CONFIG publish "dependency" --skip-dependency-verification \
+  --json | jq '.effects.status'
+
+echo "=== publish package v0 (should NOT warn) ===" | tee /dev/stderr
+UPGRADE_CAP=$(iota client --client.config $CONFIG publish "example" --skip-dependency-verification \
+  --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
+
+echo "=== upgrade package (should NOT warn) ===" | tee /dev/stderr
+iota client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example --skip-dependency-verification \
+  --json | jq '.effects.status'
+
+echo "=== modify dependency ===" | tee /dev/stderr
+cat dependency/sources/dependency.move | sed 's#0#1#g' > dependency.move
+mv dependency.move dependency/sources/dependency.move
+
+echo "=== try to publish with modified dep (should succeed) ===" | tee /dev/stderr
+UPGRADE_CAP=$(iota client --client.config $CONFIG publish "example" --skip-dependency-verification \
+  --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
+
+echo "=== try to upgrade with modified dep (should succeed) ===" | tee /dev/stderr
+iota client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example --skip-dependency-verification \
+  --json | jq '.effects.status'

--- a/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/with_dep_verif.sh
+++ b/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/with_dep_verif.sh
@@ -1,0 +1,37 @@
+# Copyright (c) Mysten Labs, Inc.
+# Modifications Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+# check that --verify-deps has the right behavior on publish and upgrade
+
+echo "=== munge Move.toml files ===" | tee /dev/stderr
+FRAMEWORK_DIR=$(echo $CARGO_MANIFEST_DIR | sed 's#/crates/iota#/crates/iota-framework/packages/iota-framework#g')
+for i in dependency/Move.toml example/Move.toml
+do
+  cat $i | sed "s#FRAMEWORK_DIR#$FRAMEWORK_DIR#g" > Move.toml \
+    && mv Move.toml $i
+done
+
+echo "=== publish dependency ===" | tee /dev/stderr
+iota client --client.config $CONFIG publish "dependency" --verify-deps \
+  --json | jq '.effects.status'
+
+echo "=== publish package v0 (should NOT warn) ===" | tee /dev/stderr
+UPGRADE_CAP=$(iota client --client.config $CONFIG publish "example" --verify-deps \
+  --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
+
+echo "=== upgrade package (should NOT warn) ===" | tee /dev/stderr
+iota client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example --verify-deps \
+  --json | jq '.effects.status'
+
+echo "=== modify dependency ===" | tee /dev/stderr
+cat dependency/sources/dependency.move | sed 's#0#1#g' > dependency.move
+mv dependency.move dependency/sources/dependency.move
+
+echo "=== try to publish with modified dep (should fail) ===" | tee /dev/stderr
+iota client --client.config $CONFIG publish "example" --verify-deps \
+  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'
+
+echo "=== try to upgrade with modified dep (should fail) ===" | tee /dev/stderr
+iota client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example --verify-deps \
+  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'

--- a/crates/iota/tests/snapshots/shell_tests__with_network__move_build_bytecode_with_address_resolution__move_build_bytecode_with_address_resolution.sh.snap
+++ b/crates/iota/tests/snapshots/shell_tests__with_network__move_build_bytecode_with_address_resolution__move_build_bytecode_with_address_resolution.sh.snap
@@ -8,7 +8,7 @@ description: tests/shell_tests/with_network/move_build_bytecode_with_address_res
 # SPDX-License-Identifier: Apache-2.0
 
 iota client --client.config $CONFIG \
-  publish simple \
+  publish simple --verify-deps \
   --json | jq '.effects.status'
 
 iota move --client.config $CONFIG \

--- a/crates/iota/tests/snapshots/shell_tests__with_network__source_verification_deprecation__both_flags.sh.snap
+++ b/crates/iota/tests/snapshots/shell_tests__with_network__source_verification_deprecation__both_flags.sh.snap
@@ -9,27 +9,27 @@ description: tests/shell_tests/with_network/source_verification_deprecation/both
 
 # test that we get an error if we supply both `--skip-dependency-verification` and `--verify-deps`
 
-echo "=== publish ===" | tee /dev/stderr
+echo "=== publish (should fail) ===" | tee /dev/stderr
 iota client --client.config $CONFIG publish example --skip-dependency-verification --verify-deps
 
-echo "=== upgrade ===" | tee /dev/stderr
+echo "=== upgrade (should fail) ===" | tee /dev/stderr
 iota client --client.config $CONFIG upgrade example --upgrade-capability 0x1234 --skip-dependency-verification --verify-deps
 
 ----- results -----
 success: false
 exit_code: 2
 ----- stdout -----
-=== publish ===
-=== upgrade ===
+=== publish (should fail) ===
+=== upgrade (should fail) ===
 
 ----- stderr -----
-=== publish ===
+=== publish (should fail) ===
 error: the argument '--skip-dependency-verification' cannot be used with '--verify-deps'
 
 Usage: iota client publish --skip-dependency-verification <package_path>
 
 For more information, try '--help'.
-=== upgrade ===
+=== upgrade (should fail) ===
 error: the argument '--skip-dependency-verification' cannot be used with '--verify-deps'
 
 Usage: iota client upgrade --upgrade-capability <UPGRADE_CAPABILITY> --skip-dependency-verification <package_path>

--- a/crates/iota/tests/snapshots/shell_tests__with_network__source_verification_deprecation__both_flags.sh.snap
+++ b/crates/iota/tests/snapshots/shell_tests__with_network__source_verification_deprecation__both_flags.sh.snap
@@ -1,0 +1,37 @@
+---
+source: crates/iota/tests/shell_tests.rs
+description: tests/shell_tests/with_network/source_verification_deprecation/both_flags.sh
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# Modifications Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+# test that we get an error if we supply both `--skip-dependency-verification` and `--verify-deps`
+
+echo "=== publish ===" | tee /dev/stderr
+iota client --client.config $CONFIG publish example --skip-dependency-verification --verify-deps
+
+echo "=== upgrade ===" | tee /dev/stderr
+iota client --client.config $CONFIG upgrade example --upgrade-capability 0x1234 --skip-dependency-verification --verify-deps
+
+----- results -----
+success: false
+exit_code: 2
+----- stdout -----
+=== publish ===
+=== upgrade ===
+
+----- stderr -----
+=== publish ===
+error: the argument '--skip-dependency-verification' cannot be used with '--verify-deps'
+
+Usage: iota client publish --skip-dependency-verification <package_path>
+
+For more information, try '--help'.
+=== upgrade ===
+error: the argument '--skip-dependency-verification' cannot be used with '--verify-deps'
+
+Usage: iota client upgrade --upgrade-capability <UPGRADE_CAPABILITY> --skip-dependency-verification <package_path>
+
+For more information, try '--help'.

--- a/crates/iota/tests/snapshots/shell_tests__with_network__source_verification_deprecation__no_flags.sh.snap
+++ b/crates/iota/tests/snapshots/shell_tests__with_network__source_verification_deprecation__no_flags.sh.snap
@@ -1,0 +1,96 @@
+---
+source: crates/iota/tests/shell_tests.rs
+description: tests/shell_tests/with_network/source_verification_deprecation/no_flags.sh
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# Modifications Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+# check that we get a deprecation warning when upgrading without any dependency verification flags
+
+echo "=== munge Move.toml files ===" | tee /dev/stderr
+FRAMEWORK_DIR=$(echo $CARGO_MANIFEST_DIR | sed 's#/crates/iota#/crates/iota-framework/packages/iota-framework#g')
+for i in dependency/Move.toml example/Move.toml
+do
+  cat $i | sed "s#FRAMEWORK_DIR#$FRAMEWORK_DIR#g" > Move.toml \
+    && mv Move.toml $i
+done
+
+echo "=== publish dependency ===" | tee /dev/stderr
+iota client --client.config $CONFIG publish "dependency" \
+  --json | jq '.effects.status'
+
+echo "=== publish package v0 (should warn) ===" | tee /dev/stderr
+UPGRADE_CAP=$(iota client --client.config $CONFIG publish "example" \
+  --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
+
+echo "=== upgrade package (should warn) ===" | tee /dev/stderr
+iota client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example \
+  --json | jq '.effects.status'
+
+echo "=== modify dependency ===" | tee /dev/stderr
+cat dependency/sources/dependency.move | sed 's#0#1#g' > dependency.move
+mv dependency.move dependency/sources/dependency.move
+
+echo "=== try to publish with modified dep (should fail) ===" | tee /dev/stderr
+iota client --client.config $CONFIG publish "example" \
+  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'
+
+echo "=== try to upgrade with modified dep (should fail) ===" | tee /dev/stderr
+iota client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example \
+  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'
+
+----- results -----
+success: true
+exit_code: 0
+----- stdout -----
+=== munge Move.toml files ===
+=== publish dependency ===
+{
+  "status": "success"
+}
+=== publish package v0 (should warn) ===
+=== upgrade package (should warn) ===
+{
+  "status": "success"
+}
+=== modify dependency ===
+=== try to publish with modified dep (should fail) ===
+Failed to publish the Move module(s), reason: [warning] Local dependency did not match its on-chain version at [[package address]]::dependency::dependency
+
+This may indicate that the on-chain version(s) of your package's dependencies may behave differently than the source version(s) your package was built against.
+
+Fix this by rebuilding your packages with source versions matching on-chain versions of dependencies, or ignore this warning by re-running with the --skip-dependency-verification flag.
+=== try to upgrade with modified dep (should fail) ===
+Failed to publish the Move module(s), reason: [warning] Local dependency did not match its on-chain version at [[package address]]::dependency::dependency
+
+This may indicate that the on-chain version(s) of your package's dependencies may behave differently than the source version(s) your package was built against.
+
+Fix this by rebuilding your packages with source versions matching on-chain versions of dependencies, or ignore this warning by re-running with the --skip-dependency-verification flag.
+
+----- stderr -----
+=== munge Move.toml files ===
+=== publish dependency ===
+[warning]: In a future release, dependency source code will no longer be verified by default during publication and upgrade. You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. You can also manually verify dependencies using `iota client verify-source`.
+BUILDING dependency
+Successfully verified dependencies on-chain against source.
+=== publish package v0 (should warn) ===
+[warning]: In a future release, dependency source code will no longer be verified by default during publication and upgrade. You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. You can also manually verify dependencies using `iota client verify-source`.
+INCLUDING DEPENDENCY dependency
+BUILDING example
+Successfully verified dependencies on-chain against source.
+=== upgrade package (should warn) ===
+[warning]: In a future release, dependency source code will no longer be verified by default during publication and upgrade. You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. You can also manually verify dependencies using `iota client verify-source`.
+INCLUDING DEPENDENCY dependency
+BUILDING example
+Successfully verified dependencies on-chain against source.
+=== modify dependency ===
+=== try to publish with modified dep (should fail) ===
+[warning]: In a future release, dependency source code will no longer be verified by default during publication and upgrade. You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. You can also manually verify dependencies using `iota client verify-source`.
+INCLUDING DEPENDENCY dependency
+BUILDING example
+=== try to upgrade with modified dep (should fail) ===
+[warning]: In a future release, dependency source code will no longer be verified by default during publication and upgrade. You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. You can also manually verify dependencies using `iota client verify-source`.
+INCLUDING DEPENDENCY dependency
+BUILDING example

--- a/crates/iota/tests/snapshots/shell_tests__with_network__source_verification_deprecation__no_flags.sh.snap
+++ b/crates/iota/tests/snapshots/shell_tests__with_network__source_verification_deprecation__no_flags.sh.snap
@@ -21,11 +21,11 @@ echo "=== publish dependency ===" | tee /dev/stderr
 iota client --client.config $CONFIG publish "dependency" \
   --json | jq '.effects.status'
 
-echo "=== publish package v0 (should warn) ===" | tee /dev/stderr
+echo "=== publish package v0 (should note deprecation) ===" | tee /dev/stderr
 UPGRADE_CAP=$(iota client --client.config $CONFIG publish "example" \
   --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
 
-echo "=== upgrade package (should warn) ===" | tee /dev/stderr
+echo "=== upgrade package (should note deprecation) ===" | tee /dev/stderr
 iota client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example \
   --json | jq '.effects.status'
 
@@ -33,13 +33,13 @@ echo "=== modify dependency ===" | tee /dev/stderr
 cat dependency/sources/dependency.move | sed 's#0#1#g' > dependency.move
 mv dependency.move dependency/sources/dependency.move
 
-echo "=== try to publish with modified dep (should fail) ===" | tee /dev/stderr
-iota client --client.config $CONFIG publish "example" \
-  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'
+echo "=== try to publish with modified dep (should succeed) ===" | tee /dev/stderr
+UPGRADE_CAP=$(iota client --client.config $CONFIG publish "example" \
+  --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
 
-echo "=== try to upgrade with modified dep (should fail) ===" | tee /dev/stderr
+echo "=== try to upgrade with modified dep (should succeed) ===" | tee /dev/stderr
 iota client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example \
-  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'
+  --json | jq '.effects.status'
 
 ----- results -----
 success: true
@@ -50,47 +50,42 @@ exit_code: 0
 {
   "status": "success"
 }
-=== publish package v0 (should warn) ===
-=== upgrade package (should warn) ===
+=== publish package v0 (should note deprecation) ===
+=== upgrade package (should note deprecation) ===
 {
   "status": "success"
 }
 === modify dependency ===
-=== try to publish with modified dep (should fail) ===
-Failed to publish the Move module(s), reason: [warning] Local dependency did not match its on-chain version at [[package address]]::dependency::dependency
-
-This may indicate that the on-chain version(s) of your package's dependencies may behave differently than the source version(s) your package was built against.
-
-Fix this by rebuilding your packages with source versions matching on-chain versions of dependencies, or ignore this warning by re-running with the --skip-dependency-verification flag.
-=== try to upgrade with modified dep (should fail) ===
-Failed to publish the Move module(s), reason: [warning] Local dependency did not match its on-chain version at [[package address]]::dependency::dependency
-
-This may indicate that the on-chain version(s) of your package's dependencies may behave differently than the source version(s) your package was built against.
-
-Fix this by rebuilding your packages with source versions matching on-chain versions of dependencies, or ignore this warning by re-running with the --skip-dependency-verification flag.
+=== try to publish with modified dep (should succeed) ===
+=== try to upgrade with modified dep (should succeed) ===
+{
+  "status": "success"
+}
 
 ----- stderr -----
 === munge Move.toml files ===
 === publish dependency ===
-[warning]: In a future release, dependency source code will no longer be verified by default during publication and upgrade. You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. You can also manually verify dependencies using `iota client verify-source`.
+[Note]: Dependency sources are no longer verified automatically during publication and upgrade. You can pass the `--verify-deps` option if you would like to verify them as part of publication or upgrade.
 BUILDING dependency
-Successfully verified dependencies on-chain against source.
-=== publish package v0 (should warn) ===
-[warning]: In a future release, dependency source code will no longer be verified by default during publication and upgrade. You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. You can also manually verify dependencies using `iota client verify-source`.
+Skipping dependency verification
+=== publish package v0 (should note deprecation) ===
+[Note]: Dependency sources are no longer verified automatically during publication and upgrade. You can pass the `--verify-deps` option if you would like to verify them as part of publication or upgrade.
 INCLUDING DEPENDENCY dependency
 BUILDING example
-Successfully verified dependencies on-chain against source.
-=== upgrade package (should warn) ===
-[warning]: In a future release, dependency source code will no longer be verified by default during publication and upgrade. You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. You can also manually verify dependencies using `iota client verify-source`.
+Skipping dependency verification
+=== upgrade package (should note deprecation) ===
+[Note]: Dependency sources are no longer verified automatically during publication and upgrade. You can pass the `--verify-deps` option if you would like to verify them as part of publication or upgrade.
 INCLUDING DEPENDENCY dependency
 BUILDING example
-Successfully verified dependencies on-chain against source.
+Skipping dependency verification
 === modify dependency ===
-=== try to publish with modified dep (should fail) ===
-[warning]: In a future release, dependency source code will no longer be verified by default during publication and upgrade. You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. You can also manually verify dependencies using `iota client verify-source`.
+=== try to publish with modified dep (should succeed) ===
+[Note]: Dependency sources are no longer verified automatically during publication and upgrade. You can pass the `--verify-deps` option if you would like to verify them as part of publication or upgrade.
 INCLUDING DEPENDENCY dependency
 BUILDING example
-=== try to upgrade with modified dep (should fail) ===
-[warning]: In a future release, dependency source code will no longer be verified by default during publication and upgrade. You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. You can also manually verify dependencies using `iota client verify-source`.
+Skipping dependency verification
+=== try to upgrade with modified dep (should succeed) ===
+[Note]: Dependency sources are no longer verified automatically during publication and upgrade. You can pass the `--verify-deps` option if you would like to verify them as part of publication or upgrade.
 INCLUDING DEPENDENCY dependency
 BUILDING example
+Skipping dependency verification

--- a/crates/iota/tests/snapshots/shell_tests__with_network__source_verification_deprecation__skip_dep_verif.sh.snap
+++ b/crates/iota/tests/snapshots/shell_tests__with_network__source_verification_deprecation__skip_dep_verif.sh.snap
@@ -17,15 +17,15 @@ do
     && mv Move.toml $i
 done
 
-echo "=== publish dependency ===" | tee /dev/stderr
+echo "=== publish dependency (should warn about deprecation) ===" | tee /dev/stderr
 iota client --client.config $CONFIG publish "dependency" --skip-dependency-verification \
   --json | jq '.effects.status'
 
-echo "=== publish package v0 (should NOT warn) ===" | tee /dev/stderr
+echo "=== publish package v0 (should warn about deprecation) ===" | tee /dev/stderr
 UPGRADE_CAP=$(iota client --client.config $CONFIG publish "example" --skip-dependency-verification \
   --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
 
-echo "=== upgrade package (should NOT warn) ===" | tee /dev/stderr
+echo "=== upgrade package (should warn about deprecation) ===" | tee /dev/stderr
 iota client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example --skip-dependency-verification \
   --json | jq '.effects.status'
 
@@ -46,12 +46,12 @@ success: true
 exit_code: 0
 ----- stdout -----
 === munge Move.toml files ===
-=== publish dependency ===
+=== publish dependency (should warn about deprecation) ===
 {
   "status": "success"
 }
-=== publish package v0 (should NOT warn) ===
-=== upgrade package (should NOT warn) ===
+=== publish package v0 (should warn about deprecation) ===
+=== upgrade package (should warn about deprecation) ===
 {
   "status": "success"
 }
@@ -64,23 +64,28 @@ exit_code: 0
 
 ----- stderr -----
 === munge Move.toml files ===
-=== publish dependency ===
+=== publish dependency (should warn about deprecation) ===
+[Warning]: Dependency sources are no longer verified automatically during publication and upgrade, so the `--skip-dependency-verification` flag is no longer necessary.
 BUILDING dependency
 Skipping dependency verification
-=== publish package v0 (should NOT warn) ===
+=== publish package v0 (should warn about deprecation) ===
+[Warning]: Dependency sources are no longer verified automatically during publication and upgrade, so the `--skip-dependency-verification` flag is no longer necessary.
 INCLUDING DEPENDENCY dependency
 BUILDING example
 Skipping dependency verification
-=== upgrade package (should NOT warn) ===
+=== upgrade package (should warn about deprecation) ===
+[Warning]: Dependency sources are no longer verified automatically during publication and upgrade, so the `--skip-dependency-verification` flag is no longer necessary.
 INCLUDING DEPENDENCY dependency
 BUILDING example
 Skipping dependency verification
 === modify dependency ===
 === try to publish with modified dep (should succeed) ===
+[Warning]: Dependency sources are no longer verified automatically during publication and upgrade, so the `--skip-dependency-verification` flag is no longer necessary.
 INCLUDING DEPENDENCY dependency
 BUILDING example
 Skipping dependency verification
 === try to upgrade with modified dep (should succeed) ===
+[Warning]: Dependency sources are no longer verified automatically during publication and upgrade, so the `--skip-dependency-verification` flag is no longer necessary.
 INCLUDING DEPENDENCY dependency
 BUILDING example
 Skipping dependency verification

--- a/crates/iota/tests/snapshots/shell_tests__with_network__source_verification_deprecation__skip_dep_verif.sh.snap
+++ b/crates/iota/tests/snapshots/shell_tests__with_network__source_verification_deprecation__skip_dep_verif.sh.snap
@@ -1,0 +1,86 @@
+---
+source: crates/iota/tests/shell_tests.rs
+description: tests/shell_tests/with_network/source_verification_deprecation/skip_dep_verif.sh
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# Modifications Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+# check that --skip-dependency-verification has the right behavior on publish and upgrade
+
+echo "=== munge Move.toml files ===" | tee /dev/stderr
+FRAMEWORK_DIR=$(echo $CARGO_MANIFEST_DIR | sed 's#/crates/iota#/crates/iota-framework/packages/iota-framework#g')
+for i in dependency/Move.toml example/Move.toml
+do
+  cat $i | sed "s#FRAMEWORK_DIR#$FRAMEWORK_DIR#g" > Move.toml \
+    && mv Move.toml $i
+done
+
+echo "=== publish dependency ===" | tee /dev/stderr
+iota client --client.config $CONFIG publish "dependency" --skip-dependency-verification \
+  --json | jq '.effects.status'
+
+echo "=== publish package v0 (should NOT warn) ===" | tee /dev/stderr
+UPGRADE_CAP=$(iota client --client.config $CONFIG publish "example" --skip-dependency-verification \
+  --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
+
+echo "=== upgrade package (should NOT warn) ===" | tee /dev/stderr
+iota client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example --skip-dependency-verification \
+  --json | jq '.effects.status'
+
+echo "=== modify dependency ===" | tee /dev/stderr
+cat dependency/sources/dependency.move | sed 's#0#1#g' > dependency.move
+mv dependency.move dependency/sources/dependency.move
+
+echo "=== try to publish with modified dep (should succeed) ===" | tee /dev/stderr
+UPGRADE_CAP=$(iota client --client.config $CONFIG publish "example" --skip-dependency-verification \
+  --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
+
+echo "=== try to upgrade with modified dep (should succeed) ===" | tee /dev/stderr
+iota client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example --skip-dependency-verification \
+  --json | jq '.effects.status'
+
+----- results -----
+success: true
+exit_code: 0
+----- stdout -----
+=== munge Move.toml files ===
+=== publish dependency ===
+{
+  "status": "success"
+}
+=== publish package v0 (should NOT warn) ===
+=== upgrade package (should NOT warn) ===
+{
+  "status": "success"
+}
+=== modify dependency ===
+=== try to publish with modified dep (should succeed) ===
+=== try to upgrade with modified dep (should succeed) ===
+{
+  "status": "success"
+}
+
+----- stderr -----
+=== munge Move.toml files ===
+=== publish dependency ===
+BUILDING dependency
+Skipping dependency verification
+=== publish package v0 (should NOT warn) ===
+INCLUDING DEPENDENCY dependency
+BUILDING example
+Skipping dependency verification
+=== upgrade package (should NOT warn) ===
+INCLUDING DEPENDENCY dependency
+BUILDING example
+Skipping dependency verification
+=== modify dependency ===
+=== try to publish with modified dep (should succeed) ===
+INCLUDING DEPENDENCY dependency
+BUILDING example
+Skipping dependency verification
+=== try to upgrade with modified dep (should succeed) ===
+INCLUDING DEPENDENCY dependency
+BUILDING example
+Skipping dependency verification

--- a/crates/iota/tests/snapshots/shell_tests__with_network__source_verification_deprecation__with_dep_verif.sh.snap
+++ b/crates/iota/tests/snapshots/shell_tests__with_network__source_verification_deprecation__with_dep_verif.sh.snap
@@ -1,0 +1,91 @@
+---
+source: crates/iota/tests/shell_tests.rs
+description: tests/shell_tests/with_network/source_verification_deprecation/with_dep_verif.sh
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# Modifications Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+# check that --verify-deps has the right behavior on publish and upgrade
+
+echo "=== munge Move.toml files ===" | tee /dev/stderr
+FRAMEWORK_DIR=$(echo $CARGO_MANIFEST_DIR | sed 's#/crates/iota#/crates/iota-framework/packages/iota-framework#g')
+for i in dependency/Move.toml example/Move.toml
+do
+  cat $i | sed "s#FRAMEWORK_DIR#$FRAMEWORK_DIR#g" > Move.toml \
+    && mv Move.toml $i
+done
+
+echo "=== publish dependency ===" | tee /dev/stderr
+iota client --client.config $CONFIG publish "dependency" --verify-deps \
+  --json | jq '.effects.status'
+
+echo "=== publish package v0 (should NOT warn) ===" | tee /dev/stderr
+UPGRADE_CAP=$(iota client --client.config $CONFIG publish "example" --verify-deps \
+  --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
+
+echo "=== upgrade package (should NOT warn) ===" | tee /dev/stderr
+iota client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example --verify-deps \
+  --json | jq '.effects.status'
+
+echo "=== modify dependency ===" | tee /dev/stderr
+cat dependency/sources/dependency.move | sed 's#0#1#g' > dependency.move
+mv dependency.move dependency/sources/dependency.move
+
+echo "=== try to publish with modified dep (should fail) ===" | tee /dev/stderr
+iota client --client.config $CONFIG publish "example" --verify-deps \
+  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'
+
+echo "=== try to upgrade with modified dep (should fail) ===" | tee /dev/stderr
+iota client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example --verify-deps \
+  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'
+
+----- results -----
+success: true
+exit_code: 0
+----- stdout -----
+=== munge Move.toml files ===
+=== publish dependency ===
+{
+  "status": "success"
+}
+=== publish package v0 (should NOT warn) ===
+=== upgrade package (should NOT warn) ===
+{
+  "status": "success"
+}
+=== modify dependency ===
+=== try to publish with modified dep (should fail) ===
+Failed to publish the Move module(s), reason: [warning] Local dependency did not match its on-chain version at [[package address]]::dependency::dependency
+
+This may indicate that the on-chain version(s) of your package's dependencies may behave differently than the source version(s) your package was built against.
+
+Fix this by rebuilding your packages with source versions matching on-chain versions of dependencies, or ignore this warning by re-running with the --skip-dependency-verification flag.
+=== try to upgrade with modified dep (should fail) ===
+Failed to publish the Move module(s), reason: [warning] Local dependency did not match its on-chain version at [[package address]]::dependency::dependency
+
+This may indicate that the on-chain version(s) of your package's dependencies may behave differently than the source version(s) your package was built against.
+
+Fix this by rebuilding your packages with source versions matching on-chain versions of dependencies, or ignore this warning by re-running with the --skip-dependency-verification flag.
+
+----- stderr -----
+=== munge Move.toml files ===
+=== publish dependency ===
+BUILDING dependency
+Successfully verified dependencies on-chain against source.
+=== publish package v0 (should NOT warn) ===
+INCLUDING DEPENDENCY dependency
+BUILDING example
+Successfully verified dependencies on-chain against source.
+=== upgrade package (should NOT warn) ===
+INCLUDING DEPENDENCY dependency
+BUILDING example
+Successfully verified dependencies on-chain against source.
+=== modify dependency ===
+=== try to publish with modified dep (should fail) ===
+INCLUDING DEPENDENCY dependency
+BUILDING example
+=== try to upgrade with modified dep (should fail) ===
+INCLUDING DEPENDENCY dependency
+BUILDING example


### PR DESCRIPTION
# Description of change

Make source verification opt-in instead of opt-out (with `--verify-deps`), and deprecate `--skip-dependency-verification`
Porting https://github.com/MystenLabs/sui/pull/20977 and https://github.com/MystenLabs/sui/pull/21159

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/5991

## Type of change

- Enhancement (a non-breaking change which adds functionality)


### Release Notes

<!--
Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.
-->

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: publication and upgrade now have source verification opt-in instead of opt-out; --skip-dependency-verification is deprecated and a new --verify-deps flag can be used to verify the dependencies
- [ ] Rust SDK:
