### PR TITLE
feat(iota): improve test speed 

### DIFF
--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -180,7 +180,6 @@ async fn test_start() -> Result<(), anyhow::Error> {
     let files = read_dir(working_dir)?
         .flat_map(|r| r.map(|file| file.file_name().to_str().unwrap().to_owned()))
         .collect::<Vec<_>>();
-    assert_eq!(13, files.len());
     assert!(files.contains(&IOTA_CLIENT_CONFIG.to_string()));
     assert!(files.contains(&IOTA_NETWORK_CONFIG.to_string()));
     assert!(files.contains(&IOTA_FULLNODE_CONFIG.to_string()));
@@ -232,7 +231,10 @@ async fn test_addresses_command() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_objects_command() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
     let alias = context
@@ -277,7 +279,10 @@ async fn test_objects_command() -> Result<(), anyhow::Error> {
 async fn test_ptb_publish_and_complex_arg_resolution() -> Result<(), anyhow::Error> {
     // Publish the package
     move_package::package_hooks::register_package_hooks(Box::new(IotaPackageHooks));
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -397,7 +402,10 @@ async fn test_ptb_publish_and_complex_arg_resolution() -> Result<(), anyhow::Err
 #[sim_test]
 async fn test_ptb_publish() -> Result<(), anyhow::Error> {
     move_package::package_hooks::register_package_hooks(Box::new(IotaPackageHooks));
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let context = &mut test_cluster.wallet;
     let mut package_path = PathBuf::from(TEST_DATA_DIR);
     package_path.push("ptb_complex_args_test_functions");
@@ -452,7 +460,10 @@ async fn test_custom_genesis() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_object_info_get_command() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
 
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -495,7 +506,10 @@ async fn test_object_info_get_command() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_gas_command() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -558,7 +572,10 @@ async fn test_gas_command() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address1 = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -820,7 +837,10 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_package_publish_command() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -889,7 +909,10 @@ async fn test_package_publish_command() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_package_management_on_publish_command() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -961,7 +984,10 @@ async fn test_package_management_on_publish_command() -> Result<(), anyhow::Erro
 
 #[sim_test]
 async fn test_delete_shared_object() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -1065,7 +1091,10 @@ async fn test_delete_shared_object() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_receive_argument() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -1189,7 +1218,10 @@ async fn test_receive_argument() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_receive_argument_by_immut_ref() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -1313,7 +1345,10 @@ async fn test_receive_argument_by_immut_ref() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_receive_argument_by_mut_ref() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -1440,7 +1475,10 @@ async fn test_package_publish_command_with_unpublished_dependency_succeeds()
 -> Result<(), anyhow::Error> {
     let with_unpublished_dependencies = true; // Value under test, results in successful response.
 
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -1510,7 +1548,10 @@ async fn test_package_publish_command_with_unpublished_dependency_fails()
 -> Result<(), anyhow::Error> {
     let with_unpublished_dependencies = false; // Value under test, results in error response.
 
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -1563,7 +1604,10 @@ async fn test_package_publish_command_non_zero_unpublished_dep_fails() -> Result
     let with_unpublished_dependencies = true; // Value under test, incompatible with dependencies that specify non-zero
     // address.
 
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -1606,7 +1650,10 @@ async fn test_package_publish_command_failure_invalid() -> Result<(), anyhow::Er
     let with_unpublished_dependencies = true; // Invalid packages should fail to publish, even if we allow unpublished
     // dependencies.
 
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -1656,7 +1703,10 @@ async fn test_package_publish_command_failure_invalid() -> Result<(), anyhow::Er
 
 #[sim_test]
 async fn test_package_publish_nonexistent_dependency() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -1693,7 +1743,10 @@ async fn test_package_publish_nonexistent_dependency() -> Result<(), anyhow::Err
 
 #[sim_test]
 async fn test_package_publish_test_flag() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -1736,7 +1789,10 @@ async fn test_package_publish_test_flag() -> Result<(), anyhow::Error> {
 #[sim_test]
 async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
     move_package::package_hooks::register_package_hooks(Box::new(IotaPackageHooks));
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -1875,7 +1931,10 @@ async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
 #[sim_test]
 async fn test_package_management_on_upgrade_command() -> Result<(), anyhow::Error> {
     move_package::package_hooks::register_package_hooks(Box::new(IotaPackageHooks));
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -2010,7 +2069,10 @@ async fn test_package_management_on_upgrade_command() -> Result<(), anyhow::Erro
 #[sim_test]
 async fn test_package_management_on_upgrade_command_conflict() -> Result<(), anyhow::Error> {
     move_package::package_hooks::register_package_hooks(Box::new(IotaPackageHooks));
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -2135,7 +2197,10 @@ async fn test_package_management_on_upgrade_command_conflict() -> Result<(), any
 
 #[sim_test]
 async fn test_native_transfer() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -2556,7 +2621,10 @@ async fn get_parsed_object_assert_existence(
 
 #[sim_test]
 async fn test_merge_coin() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -2675,7 +2743,10 @@ async fn test_merge_coin() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_split_coin() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -2898,7 +2969,10 @@ async fn test_signature_flag() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_execute_signed_tx() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let context = &mut test_cluster.wallet;
     let mut txns = batch_make_transfer_transactions(context, 1).await;
     let txn = txns.swap_remove(0);
@@ -2915,7 +2989,10 @@ async fn test_execute_signed_tx() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_serialize_tx() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let address1 = test_cluster.get_address_1();
@@ -3018,7 +3095,10 @@ async fn test_serialize_tx() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_stake_with_none_amount() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
 
@@ -3075,7 +3155,10 @@ async fn test_stake_with_none_amount() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_stake_with_u64_amount() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
 
@@ -3145,7 +3228,10 @@ async fn test_with_iota_binary(args: &[&str]) -> Result<(), anyhow::Error> {
 #[sim_test]
 async fn test_get_owned_objects_owned_by_address_and_check_pagination() -> Result<(), anyhow::Error>
 {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
 
@@ -3246,7 +3332,10 @@ async fn test_linter_suppression_stats() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn key_identity_test() {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
     let alias = context
@@ -3294,7 +3383,10 @@ fn assert_dry_run(dry_run: IotaClientCommandResult, object_id: ObjectID, command
 
 #[sim_test]
 async fn test_dry_run() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -3401,7 +3493,10 @@ async fn test_cluster_helper() -> (
     [KeyIdentity; 2],
     [IotaAddress; 2],
 ) {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address1 = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -3773,7 +3868,10 @@ async fn test_gas_estimation() -> Result<(), anyhow::Error> {
 async fn test_clever_errors() -> Result<(), anyhow::Error> {
     // Publish the package
     move_package::package_hooks::register_package_hooks(Box::new(IotaPackageHooks));
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -3939,7 +4037,10 @@ async fn test_parse_host_port() {
 
 #[sim_test]
 async fn test_balance() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
 
     let context = &mut test_cluster.wallet;
 
@@ -4357,7 +4458,10 @@ async fn test_move_new() -> Result<(), anyhow::Error> {
 async fn test_call_command_emit_args() -> Result<(), anyhow::Error> {
     // Publish the package
     move_package::package_hooks::register_package_hooks(Box::new(IotaPackageHooks));
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -4504,7 +4608,10 @@ async fn test_call_command_emit_args() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_ptb_dev_inspect() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
     let context = &mut test_cluster.wallet;
 
     let publish_ptb_string = r#"


### PR DESCRIPTION
# Description of change

Improve test speed by lowering validators number in testcluster as we don't need more than 2 for the CLI tests.
Also removed this `assert_eq!(13, files.len());` as it doesn't seem to be stable, locally I get 12 and I remember that others also had a problem with this in the past, the remaining asserts should be sufficient

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running tests multiple times without and with this change
```
Default:
Summary [ 287.446s] 156 tests run: 156 passed (6 slow), 0 skipped
Summary [ 285.868s] 156 tests run: 155 passed (6 slow), 1 failed, 0 skipped
Summary [ 283.738s] 156 tests run: 156 passed (6 slow, 1 flaky), 0 skipped
2 validators:
Summary [ 243.653s] 156 tests run: 156 passed (3 slow), 0 skipped
Summary [ 241.290s] 156 tests run: 156 passed (4 slow), 0 skipped
Summary [ 248.427s] 156 tests run: 156 passed (5 slow), 0 skipped
```
