### PR TITLE
feat(consensus): get highest accepted rounds from round prober and use in ancestor selection

### DIFF
--- a/consensus/config/src/committee.rs
+++ b/consensus/config/src/committee.rs
@@ -69,11 +69,6 @@ impl Committee {
         self.total_stake
     }
 
-    pub fn n_percent_stake_threshold(&self, n: u64) -> Stake {
-        assert!(n <= 100, "n must be between 0 and 100");
-        self.total_stake * n / 100
-    }
-
     pub fn quorum_threshold(&self) -> Stake {
         self.quorum_threshold
     }

--- a/consensus/core/src/ancestor.rs
+++ b/consensus/core/src/ancestor.rs
@@ -283,7 +283,7 @@ impl AncestorStateManager {
     /// The authority high quorum round is the lowest round higher or equal to
     /// rounds from a quorum of authorities. The network high quorum round
     /// is using the high quorum round of each authority as reported by the
-    /// [`RoundProber`] and then finding the high quroum round of those high
+    /// [`RoundProber`] and then finding the high quorum round of those high
     /// quorum rounds.
     fn calculate_network_high_quorum_round_internal(
         &self,
@@ -463,7 +463,7 @@ mod test {
             .set_quorum_rounds_per_authority(received_quorum_rounds, accepted_quorum_rounds);
         ancestor_state_manager.update_all_ancestors_state();
 
-        // Ancestor 1 can transtion to the INCLUDE state. Ancestor 0 is still locked
+        // Ancestor 1 can transition to the INCLUDE state. Ancestor 0 is still locked
         // in the INCLUDE state until a score update is performed which is why
         // even though the scores are still low it has not moved to the EXCLUDE
         // state.

--- a/consensus/core/src/ancestor.rs
+++ b/consensus/core/src/ancestor.rs
@@ -237,10 +237,10 @@ impl AncestorStateManager {
         self.state_map[authority_id] = ancestor_info;
     }
 
-    /// Calculate the network's quorum round based on what information is available
-    /// via RoundProber.
-    /// When consensus_round_prober_probe_accepted_rounds is true, uses accepted rounds.
-    /// Otherwise falls back to received rounds.
+    /// Calculate the network's quorum round based on what information is
+    /// available via RoundProber.
+    /// When consensus_round_prober_probe_accepted_rounds is true, uses accepted
+    /// rounds. Otherwise falls back to received rounds.
     fn calculate_network_high_quorum_round(&self) -> u32 {
         if self
             .context
@@ -280,10 +280,11 @@ impl AncestorStateManager {
     }
 
     /// Calculate the network's high quorum round.
-    /// The authority high quorum round is the lowest round higher or equal to rounds  
-    /// from a quorum of authorities. The network high quorum round is using the high
-    /// quorum round of each authority as reported by the [`RoundProber`] and then
-    /// finding the high quroum round of those high quorum rounds.
+    /// The authority high quorum round is the lowest round higher or equal to
+    /// rounds from a quorum of authorities. The network high quorum round
+    /// is using the high quorum round of each authority as reported by the
+    /// [`RoundProber`] and then finding the high quroum round of those high
+    /// quorum rounds.
     fn calculate_network_high_quorum_round_internal(
         &self,
         mut high_quorum_rounds_with_stake: Vec<(u32, u64)>,

--- a/consensus/core/src/ancestor.rs
+++ b/consensus/core/src/ancestor.rs
@@ -53,7 +53,8 @@ pub(crate) struct AncestorStateManager {
     state_map: Vec<AncestorInfo>,
     propagation_score_update_count: u32,
     quorum_round_update_count: u32,
-    pub(crate) quorum_round_per_authority: Vec<QuorumRound>,
+    pub(crate) received_quorum_round_per_authority: Vec<QuorumRound>,
+    pub(crate) accepted_quorum_round_per_authority: Vec<QuorumRound>,
     // This is the reputation scores that we use for leader election but we are
     // using it here as a signal for high quality block propagation as well.
     pub(crate) propagation_scores: ReputationScores,
@@ -80,25 +81,29 @@ impl AncestorStateManager {
     // Exclusion threshold is based on propagation (reputation) scores
     const EXCLUSION_THRESHOLD_PERCENTAGE: u64 = 10;
 
-    // Inclusion threshold is based on network quorum round
-    const INCLUSION_THRESHOLD_PERCENTAGE: u64 = 90;
-
     pub(crate) fn new(context: Arc<Context>) -> Self {
         let state_map = vec![AncestorInfo::new(); context.committee.size()];
 
-        let quorum_round_per_authority = vec![(0, 0); context.committee.size()];
+        let received_quorum_round_per_authority = vec![(0, 0); context.committee.size()];
+        let accepted_quorum_round_per_authority = vec![(0, 0); context.committee.size()];
         Self {
             context,
             state_map,
             propagation_score_update_count: 0,
             quorum_round_update_count: 0,
             propagation_scores: ReputationScores::default(),
-            quorum_round_per_authority,
+            received_quorum_round_per_authority,
+            accepted_quorum_round_per_authority,
         }
     }
 
-    pub(crate) fn set_quorum_round_per_authority(&mut self, quorum_rounds: Vec<QuorumRound>) {
-        self.quorum_round_per_authority = quorum_rounds;
+    pub(crate) fn set_quorum_rounds_per_authority(
+        &mut self,
+        received_quorum_rounds: Vec<QuorumRound>,
+        accepted_quorum_rounds: Vec<QuorumRound>,
+    ) {
+        self.received_quorum_round_per_authority = received_quorum_rounds;
+        self.accepted_quorum_round_per_authority = accepted_quorum_rounds;
         self.quorum_round_update_count += 1;
     }
 
@@ -132,21 +137,29 @@ impl AncestorStateManager {
             .collect::<Vec<_>>();
 
         // If round prober has not run yet and we don't have network quorum round,
-        // it is okay because network_low_quorum_round will be zero and we will
+        // it is okay because network_high_quorum_round will be zero and we will
         // include all ancestors until we get more information.
-        let network_low_quorum_round = self.calculate_network_low_quorum_round();
+        let network_high_quorum_round = self.calculate_network_high_quorum_round();
 
         // If propagation scores are not ready because the first 300 commits have not
         // happened, this is okay as we will only start excluding ancestors after that
         // point in time.
         for (authority_id, score) in propagation_scores_by_authority {
-            let (authority_low_quorum_round, _high) = self.quorum_round_per_authority[authority_id];
+            let (_low, authority_high_quorum_round) = if self
+                .context
+                .protocol_config
+                .consensus_round_prober_probe_accepted_rounds()
+            {
+                self.accepted_quorum_round_per_authority[authority_id]
+            } else {
+                self.received_quorum_round_per_authority[authority_id]
+            };
 
             self.update_state(
                 authority_id,
                 score,
-                authority_low_quorum_round,
-                network_low_quorum_round,
+                authority_high_quorum_round,
+                network_high_quorum_round,
             );
         }
     }
@@ -157,8 +170,8 @@ impl AncestorStateManager {
         &mut self,
         authority_id: AuthorityIndex,
         propagation_score: u64,
-        authority_low_quorum_round: u32,
-        network_low_quorum_round: u32,
+        authority_high_quorum_round: u32,
+        network_high_quorum_round: u32,
     ) {
         let block_hostname = &self.context.committee.authority(authority_id).hostname;
         let mut ancestor_info = self.state_map[authority_id].clone();
@@ -176,6 +189,7 @@ impl AncestorStateManager {
 
         match ancestor_info.state {
             // Check conditions to switch to EXCLUDE state
+            // TODO: Consider using received round gaps for exclusion.
             AncestorState::Include => {
                 if propagation_score <= low_score_threshold {
                     ancestor_info.state = AncestorState::Exclude(propagation_score);
@@ -199,14 +213,14 @@ impl AncestorStateManager {
                 // It should not be possible for the scores to get over the threshold
                 // until the node is back in the INCLUDE state, but adding just in case.
                 if propagation_score > low_score_threshold
-                    || authority_low_quorum_round >= network_low_quorum_round
+                    || authority_high_quorum_round >= network_high_quorum_round
                 {
                     ancestor_info.state = AncestorState::Include;
                     ancestor_info.set_lock(
                         self.propagation_score_update_count + Self::STATE_LOCK_SCORE_UPDATES,
                     );
                     info!(
-                        "Authority {authority_id} moved to INCLUDE state with {propagation_score} > threshold of {low_score_threshold} or {authority_low_quorum_round} >= {network_low_quorum_round} and locked for {:?} score updates.",
+                        "Authority {authority_id} moved to INCLUDE state with {propagation_score} > threshold of {low_score_threshold} or {authority_high_quorum_round} >= {network_high_quorum_round} and locked for {:?} score updates.",
                         Self::STATE_LOCK_SCORE_UPDATES
                     );
                     self.context
@@ -223,39 +237,71 @@ impl AncestorStateManager {
         self.state_map[authority_id] = ancestor_info;
     }
 
-    /// Calculate the network's quorum round from authorities by inclusion stake
-    /// threshold, where quorum round is the highest round a block has been seen
-    /// by a percentage (inclusion threshold) of authorities.
-    /// TODO: experiment with using high quorum round
-    fn calculate_network_low_quorum_round(&self) -> u32 {
+    /// Calculate the network's quorum round based on what information is available
+    /// via RoundProber.
+    /// When consensus_round_prober_probe_accepted_rounds is true, uses accepted rounds.
+    /// Otherwise falls back to received rounds.
+    fn calculate_network_high_quorum_round(&self) -> u32 {
+        if self
+            .context
+            .protocol_config
+            .consensus_round_prober_probe_accepted_rounds()
+        {
+            self.calculate_network_high_accepted_quorum_round()
+        } else {
+            self.calculate_network_high_received_quorum_round()
+        }
+    }
+
+    fn calculate_network_high_accepted_quorum_round(&self) -> u32 {
         let committee = &self.context.committee;
-        let inclusion_stake_threshold = self.get_inclusion_stake_threshold();
-        let mut low_quorum_rounds_with_stake = self
-            .quorum_round_per_authority
+
+        let high_quorum_rounds_with_stake = self
+            .accepted_quorum_round_per_authority
             .iter()
             .zip(committee.authorities())
-            .map(|((low, _high), (_, authority))| (*low, authority.stake))
+            .map(|((_low, high), (_, authority))| (*high, authority.stake))
             .collect::<Vec<_>>();
-        low_quorum_rounds_with_stake.sort();
+
+        self.calculate_network_high_quorum_round_internal(high_quorum_rounds_with_stake)
+    }
+
+    fn calculate_network_high_received_quorum_round(&self) -> u32 {
+        let committee = &self.context.committee;
+
+        let high_quorum_rounds_with_stake = self
+            .received_quorum_round_per_authority
+            .iter()
+            .zip(committee.authorities())
+            .map(|((_low, high), (_, authority))| (*high, authority.stake))
+            .collect::<Vec<_>>();
+
+        self.calculate_network_high_quorum_round_internal(high_quorum_rounds_with_stake)
+    }
+
+    /// Calculate the network's high quorum round.
+    /// The authority high quorum round is the lowest round higher or equal to rounds  
+    /// from a quorum of authorities. The network high quorum round is using the high
+    /// quorum round of each authority as reported by the [`RoundProber`] and then
+    /// finding the high quroum round of those high quorum rounds.
+    fn calculate_network_high_quorum_round_internal(
+        &self,
+        mut high_quorum_rounds_with_stake: Vec<(u32, u64)>,
+    ) -> u32 {
+        high_quorum_rounds_with_stake.sort();
 
         let mut total_stake = 0;
-        let mut network_low_quorum_round = 0;
+        let mut network_high_quorum_round = 0;
 
-        for (round, stake) in low_quorum_rounds_with_stake.iter().rev() {
+        for (round, stake) in high_quorum_rounds_with_stake.iter() {
             total_stake += stake;
-            if total_stake >= inclusion_stake_threshold {
-                network_low_quorum_round = *round;
+            if total_stake >= self.context.committee.quorum_threshold() {
+                network_high_quorum_round = *round;
                 break;
             }
         }
 
-        network_low_quorum_round
-    }
-
-    fn get_inclusion_stake_threshold(&self) -> u64 {
-        self.context
-            .committee
-            .n_percent_stake_threshold(Self::INCLUSION_THRESHOLD_PERCENTAGE)
+        network_high_quorum_round
     }
 }
 
@@ -265,43 +311,94 @@ mod test {
     use crate::leader_scoring::ReputationScores;
 
     #[tokio::test]
-    async fn test_calculate_network_low_quorum_round() {
+    async fn test_calculate_network_high_received_quorum_round() {
         telemetry_subscribers::init_for_testing();
-        let context = Arc::new(Context::new_for_test(4).0);
+
+        let (mut context, _key_pairs) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_round_prober_probe_accepted_rounds(false);
+        let context = Arc::new(context);
 
         let scores = ReputationScores::new((1..=300).into(), vec![1, 2, 4, 3]);
-        let mut ancestor_state_manager = AncestorStateManager::new(context);
+        let mut ancestor_state_manager = AncestorStateManager::new(context.clone());
         ancestor_state_manager.set_propagation_scores(scores);
 
-        // Quorum rounds are not set yet, so we should calculate a network quorum
-        // round of 0 to start.
-        let network_low_quorum_round = ancestor_state_manager.calculate_network_low_quorum_round();
-        assert_eq!(network_low_quorum_round, 0);
+        // Quorum rounds are not set yet, so we should calculate a network
+        // quorum round of 0 to start.
+        let network_high_quorum_round =
+            ancestor_state_manager.calculate_network_high_quorum_round();
+        assert_eq!(network_high_quorum_round, 0);
 
-        let quorum_rounds = vec![(100, 229), (225, 300), (229, 300), (229, 300)];
-        ancestor_state_manager.set_quorum_round_per_authority(quorum_rounds);
+        let received_quorum_rounds = vec![(100, 229), (225, 229), (229, 300), (229, 300)];
+        let accepted_quorum_rounds = vec![(50, 229), (175, 229), (179, 229), (179, 300)];
+        ancestor_state_manager.set_quorum_rounds_per_authority(
+            received_quorum_rounds.clone(),
+            accepted_quorum_rounds.clone(),
+        );
 
-        let network_low_quorum_round = ancestor_state_manager.calculate_network_low_quorum_round();
-        assert_eq!(network_low_quorum_round, 225);
+        // When probe_accepted_rounds is false, should use received rounds
+        let network_high_quorum_round =
+            ancestor_state_manager.calculate_network_high_quorum_round();
+        assert_eq!(network_high_quorum_round, 300);
     }
 
-    // Test all state transitions
+    #[tokio::test]
+    async fn test_calculate_network_high_accepted_quorum_round() {
+        telemetry_subscribers::init_for_testing();
+
+        let (mut context, _key_pairs) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_round_prober_probe_accepted_rounds(true);
+        let context = Arc::new(context);
+
+        let scores = ReputationScores::new((1..=300).into(), vec![1, 2, 4, 3]);
+        let mut ancestor_state_manager = AncestorStateManager::new(context.clone());
+        ancestor_state_manager.set_propagation_scores(scores);
+
+        // Quorum rounds are not set yet, so we should calculate a network
+        // quorum round of 0 to start.
+        let network_high_quorum_round =
+            ancestor_state_manager.calculate_network_high_quorum_round();
+        assert_eq!(network_high_quorum_round, 0);
+
+        let received_quorum_rounds = vec![(100, 229), (225, 300), (229, 300), (229, 300)];
+        let accepted_quorum_rounds = vec![(50, 229), (175, 229), (179, 229), (179, 300)];
+        ancestor_state_manager.set_quorum_rounds_per_authority(
+            received_quorum_rounds.clone(),
+            accepted_quorum_rounds.clone(),
+        );
+
+        // When probe_accepted_rounds is true, should use accepted rounds
+        let network_high_quorum_round =
+            ancestor_state_manager.calculate_network_high_quorum_round();
+        assert_eq!(network_high_quorum_round, 229);
+    }
+
+    // Test all state transitions with probe_accepted_rounds = true
     // Default all INCLUDE -> EXCLUDE
     // EXCLUDE -> INCLUDE (Blocked due to lock)
     // EXCLUDE -> INCLUDE (Pass due to lock expired)
     // INCLUDE -> EXCLUDE (Blocked due to lock)
     // INCLUDE -> EXCLUDE (Pass due to lock expired)
     #[tokio::test]
-    async fn test_update_all_ancestor_state() {
+    async fn test_update_all_ancestor_state_using_accepted_rounds() {
         telemetry_subscribers::init_for_testing();
-        let context = Arc::new(Context::new_for_test(4).0);
+        let (mut context, _key_pairs) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_round_prober_probe_accepted_rounds(true);
+        let context = Arc::new(context);
 
         let scores = ReputationScores::new((1..=300).into(), vec![1, 2, 4, 3]);
         let mut ancestor_state_manager = AncestorStateManager::new(context);
         ancestor_state_manager.set_propagation_scores(scores);
 
-        let quorum_rounds = vec![(225, 229), (225, 300), (229, 300), (229, 300)];
-        ancestor_state_manager.set_quorum_round_per_authority(quorum_rounds);
+        let received_quorum_rounds = vec![(300, 400), (300, 400), (300, 400), (300, 400)];
+        let accepted_quorum_rounds = vec![(225, 229), (225, 229), (229, 300), (229, 300)];
+        ancestor_state_manager
+            .set_quorum_rounds_per_authority(received_quorum_rounds, accepted_quorum_rounds);
         ancestor_state_manager.update_all_ancestors_state();
 
         // Score threshold for exclude is (4 * 10) / 100 = 0
@@ -341,12 +438,14 @@ mod test {
 
         // Updating the quorum rounds will expire the lock as we only need 1
         // quorum round update for tests.
-        let quorum_rounds = vec![(229, 300), (225, 300), (229, 300), (229, 300)];
-        ancestor_state_manager.set_quorum_round_per_authority(quorum_rounds);
+        let received_quorum_rounds = vec![(400, 500), (400, 500), (400, 500), (400, 500)];
+        let accepted_quorum_rounds = vec![(229, 300), (225, 229), (229, 300), (229, 300)];
+        ancestor_state_manager
+            .set_quorum_rounds_per_authority(received_quorum_rounds, accepted_quorum_rounds);
         ancestor_state_manager.update_all_ancestors_state();
 
-        // Authority 0 should now be included again because low quorum round is
-        // at the network low quorum round of 229. Authority 1's quorum round is
+        // Authority 0 should now be included again because high quorum round is
+        // at the network high quorum round of 300. Authority 1's quorum round is
         // too low and will remain excluded.
         let state_map = ancestor_state_manager.get_ancestor_states();
         for (authority, state) in state_map.iter().enumerate() {
@@ -357,8 +456,122 @@ mod test {
             }
         }
 
-        let quorum_rounds = vec![(229, 300), (229, 300), (229, 300), (229, 300)];
-        ancestor_state_manager.set_quorum_round_per_authority(quorum_rounds);
+        let received_quorum_rounds = vec![(500, 600), (500, 600), (500, 600), (500, 600)];
+        let accepted_quorum_rounds = vec![(229, 300), (229, 300), (229, 300), (229, 300)];
+        ancestor_state_manager
+            .set_quorum_rounds_per_authority(received_quorum_rounds, accepted_quorum_rounds);
+        ancestor_state_manager.update_all_ancestors_state();
+
+        // Ancestor 1 can transtion to the INCLUDE state. Ancestor 0 is still locked
+        // in the INCLUDE state until a score update is performed which is why
+        // even though the scores are still low it has not moved to the EXCLUDE
+        // state.
+        let state_map = ancestor_state_manager.get_ancestor_states();
+        for state in state_map.iter() {
+            assert_eq!(*state, AncestorState::Include);
+        }
+
+        // Updating the scores will expire the lock as we only need 1 update for tests.
+        let scores = ReputationScores::new((1..=300).into(), vec![100, 10, 100, 100]);
+        ancestor_state_manager.set_propagation_scores(scores);
+        ancestor_state_manager.update_all_ancestors_state();
+
+        // Ancestor 1 can transition to EXCLUDE state now that the lock expired
+        // and its scores are below the threshold.
+        let state_map = ancestor_state_manager.get_ancestor_states();
+        for (authority, state) in state_map.iter().enumerate() {
+            if authority == 1 {
+                assert_eq!(*state, AncestorState::Exclude(10));
+            } else {
+                assert_eq!(*state, AncestorState::Include);
+            }
+        }
+    }
+
+    // Test all state transitions with probe_accepted_rounds = false
+    // Default all INCLUDE -> EXCLUDE
+    // EXCLUDE -> INCLUDE (Blocked due to lock)
+    // EXCLUDE -> INCLUDE (Pass due to lock expired)
+    // INCLUDE -> EXCLUDE (Blocked due to lock)
+    // INCLUDE -> EXCLUDE (Pass due to lock expired)
+    #[tokio::test]
+    async fn test_update_all_ancestor_state_using_received_rounds() {
+        telemetry_subscribers::init_for_testing();
+        let (mut context, _key_pairs) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_round_prober_probe_accepted_rounds(false);
+        let context = Arc::new(context);
+
+        let scores = ReputationScores::new((1..=300).into(), vec![1, 2, 4, 3]);
+        let mut ancestor_state_manager = AncestorStateManager::new(context);
+        ancestor_state_manager.set_propagation_scores(scores);
+
+        let received_quorum_rounds = vec![(225, 229), (225, 300), (229, 300), (229, 300)];
+        let accepted_quorum_rounds = vec![(100, 150), (100, 150), (100, 150), (100, 150)];
+        ancestor_state_manager
+            .set_quorum_rounds_per_authority(received_quorum_rounds, accepted_quorum_rounds);
+        ancestor_state_manager.update_all_ancestors_state();
+
+        // Score threshold for exclude is (4 * 10) / 100 = 0
+        // No ancestors should be excluded in with this threshold
+        let state_map = ancestor_state_manager.get_ancestor_states();
+        for state in state_map.iter() {
+            assert_eq!(*state, AncestorState::Include);
+        }
+
+        let scores = ReputationScores::new((1..=300).into(), vec![10, 10, 100, 100]);
+        ancestor_state_manager.set_propagation_scores(scores);
+        ancestor_state_manager.update_all_ancestors_state();
+
+        // Score threshold for exclude is (100 * 10) / 100 = 10
+        // 2 authorities should be excluded in with this threshold
+        let state_map = ancestor_state_manager.get_ancestor_states();
+        for (authority, state) in state_map.iter().enumerate() {
+            if (0..=1).contains(&authority) {
+                assert_eq!(*state, AncestorState::Exclude(10));
+            } else {
+                assert_eq!(*state, AncestorState::Include);
+            }
+        }
+
+        ancestor_state_manager.update_all_ancestors_state();
+
+        // 2 authorities should still be excluded with these scores and no new
+        // quorum round updates have been set to expire the locks.
+        let state_map = ancestor_state_manager.get_ancestor_states();
+        for (authority, state) in state_map.iter().enumerate() {
+            if (0..=1).contains(&authority) {
+                assert_eq!(*state, AncestorState::Exclude(10));
+            } else {
+                assert_eq!(*state, AncestorState::Include);
+            }
+        }
+
+        // Updating the quorum rounds will expire the lock as we only need 1
+        // quorum round update for tests.
+        let received_quorum_rounds = vec![(229, 300), (225, 229), (229, 300), (229, 300)];
+        let accepted_quorum_rounds = vec![(100, 150), (100, 150), (100, 150), (100, 150)];
+        ancestor_state_manager
+            .set_quorum_rounds_per_authority(received_quorum_rounds, accepted_quorum_rounds);
+        ancestor_state_manager.update_all_ancestors_state();
+
+        // Authority 0 should now be included again because high quorum round is
+        // at the network high quorum round of 300. Authority 1's quorum round is
+        // too low and will remain excluded.
+        let state_map = ancestor_state_manager.get_ancestor_states();
+        for (authority, state) in state_map.iter().enumerate() {
+            if authority == 1 {
+                assert_eq!(*state, AncestorState::Exclude(10));
+            } else {
+                assert_eq!(*state, AncestorState::Include);
+            }
+        }
+
+        let received_quorum_rounds = vec![(229, 300), (229, 300), (229, 300), (229, 300)];
+        let accepted_quorum_rounds = vec![(100, 150), (100, 150), (100, 150), (100, 150)];
+        ancestor_state_manager
+            .set_quorum_rounds_per_authority(received_quorum_rounds, accepted_quorum_rounds);
         ancestor_state_manager.update_all_ancestors_state();
 
         // Ancestor 1 can transition to the INCLUDE state. Ancestor 0 is still locked

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -415,19 +415,28 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         Ok(result)
     }
 
-    async fn handle_get_latest_rounds(&self, _peer: AuthorityIndex) -> ConsensusResult<Vec<Round>> {
+    async fn handle_get_latest_rounds(
+        &self,
+        _peer: AuthorityIndex,
+    ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
         fail_point_async!("consensus-rpc-response");
 
         let mut highest_received_rounds = self.core_dispatcher.highest_received_rounds();
-        // Own blocks do not go through the core dispatcher, so they need to be set
-        // separately.
-        highest_received_rounds[self.context.own_index] = self
+
+        let blocks = self
             .dag_state
             .read()
-            .get_last_block_for_authority(self.context.own_index)
-            .round();
+            .get_last_cached_block_per_authority(Round::MAX);
+        let highest_accepted_rounds = blocks
+            .into_iter()
+            .map(|block| block.round())
+            .collect::<Vec<_>>();
 
-        Ok(highest_received_rounds)
+        // Own blocks do not go through the core dispatcher, so they need to be set separately.
+        highest_received_rounds[self.context.own_index] =
+            highest_accepted_rounds[self.context.own_index];
+
+        Ok((highest_received_rounds, highest_accepted_rounds))
     }
 }
 
@@ -674,7 +683,8 @@ mod tests {
         fn set_propagation_delay_and_quorum_rounds(
             &self,
             _delay: Round,
-            _quorum_rounds: Vec<QuorumRound>,
+            _received_quorum_rounds: Vec<QuorumRound>,
+            _accepted_quorum_rounds: Vec<QuorumRound>,
         ) -> Result<(), CoreError> {
             todo!()
         }
@@ -745,7 +755,7 @@ mod tests {
             &self,
             _peer: AuthorityIndex,
             _timeout: Duration,
-        ) -> ConsensusResult<Vec<Round>> {
+        ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
             unimplemented!("Unimplemented")
         }
     }

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -432,7 +432,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .map(|block| block.round())
             .collect::<Vec<_>>();
 
-        // Own blocks do not go through the core dispatcher, so they need to be set separately.
+        // Own blocks do not go through the core dispatcher, so they need to be set
+        // separately.
         highest_received_rounds[self.context.own_index] =
             highest_accepted_rounds[self.context.own_index];
 

--- a/consensus/core/src/broadcaster.rs
+++ b/consensus/core/src/broadcaster.rs
@@ -284,7 +284,7 @@ mod test {
             &self,
             _peer: AuthorityIndex,
             _timeout: Duration,
-        ) -> ConsensusResult<Vec<Round>> {
+        ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
             unimplemented!("Unimplemented")
         }
     }

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -841,7 +841,7 @@ mod tests {
             &self,
             _peer: AuthorityIndex,
             _timeout: Duration,
-        ) -> ConsensusResult<Vec<Round>> {
+        ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
             unimplemented!("Unimplemented")
         }
     }

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -253,9 +253,10 @@ impl Core {
         self
     }
 
-    /// Processes the provided blocks and accepts them if possible when their
-    /// causal history exists. The method returns the references of parents
-    /// that are unknown and need to be fetched.
+    /// Processes the provided blocks and accepts them if possible when their causal history exists.
+    /// The method returns:
+    /// - The references of accepted blocks
+    /// - The references of ancestors missing their block
     pub(crate) fn add_blocks(
         &mut self,
         blocks: Vec<VerifiedBlock>,
@@ -293,13 +294,10 @@ impl Core {
 
             // Try to propose now since there are new blocks accepted.
             self.try_propose(false)?;
-        }
+        };
 
         if !missing_block_refs.is_empty() {
-            trace!(
-                "Missing block refs: {}",
-                missing_block_refs.iter().map(|b| b.to_string()).join(", ")
-            );
+            debug!("Missing block refs: {:?}", missing_block_refs);
         }
 
         Ok(missing_block_refs)
@@ -718,16 +716,18 @@ impl Core {
         self.subscriber_exists = exists;
     }
 
-    /// Sets the delay by round for propagating blocks to a quorum and the
-    /// quorum round per authority for ancestor state manager.
+    /// Sets the delay by round for propagating blocks to a quorum and the received
+    /// & accepted quorum rounds per authority for ancestor state manager.
     pub(crate) fn set_propagation_delay_and_quorum_rounds(
         &mut self,
         delay: Round,
-        quorum_rounds: Vec<QuorumRound>,
+        received_quorum_rounds: Vec<QuorumRound>,
+        accepted_quorum_rounds: Vec<QuorumRound>,
     ) {
-        info!("Quorum round per authority in ancestor state manager set to: {quorum_rounds:?}");
+        info!("Received quorum round per authority in ancestor state manager set to: {received_quorum_rounds:?}");
+        info!("Accepted quorum round per authority in ancestor state manager set to: {accepted_quorum_rounds:?}");
         self.ancestor_state_manager
-            .set_quorum_round_per_authority(quorum_rounds);
+            .set_quorum_rounds_per_authority(received_quorum_rounds, accepted_quorum_rounds);
         info!("Propagation round delay set to: {delay}");
         self.propagation_delay = delay;
     }
@@ -2415,7 +2415,7 @@ mod test {
         );
 
         // Use a large propagation delay to disable proposing.
-        core.set_propagation_delay_and_quorum_rounds(1000, vec![]);
+        core.set_propagation_delay_and_quorum_rounds(1000, vec![], vec![]);
 
         // Make propagation delay the only reason for not proposing.
         core.set_subscriber_exists(true);
@@ -2424,7 +2424,7 @@ mod test {
         assert!(core.try_propose(true).unwrap().is_none());
 
         // Let Core know there is no propagation delay.
-        core.set_propagation_delay_and_quorum_rounds(0, vec![]);
+        core.set_propagation_delay_and_quorum_rounds(0, vec![], vec![]);
 
         // Proposing now would succeed.
         assert!(core.try_propose(true).unwrap().is_some());

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -253,8 +253,8 @@ impl Core {
         self
     }
 
-    /// Processes the provided blocks and accepts them if possible when their causal history exists.
-    /// The method returns:
+    /// Processes the provided blocks and accepts them if possible when their
+    /// causal history exists. The method returns:
     /// - The references of accepted blocks
     /// - The references of ancestors missing their block
     pub(crate) fn add_blocks(
@@ -716,16 +716,21 @@ impl Core {
         self.subscriber_exists = exists;
     }
 
-    /// Sets the delay by round for propagating blocks to a quorum and the received
-    /// & accepted quorum rounds per authority for ancestor state manager.
+    /// Sets the delay by round for propagating blocks to a quorum and the
+    /// received & accepted quorum rounds per authority for ancestor state
+    /// manager.
     pub(crate) fn set_propagation_delay_and_quorum_rounds(
         &mut self,
         delay: Round,
         received_quorum_rounds: Vec<QuorumRound>,
         accepted_quorum_rounds: Vec<QuorumRound>,
     ) {
-        info!("Received quorum round per authority in ancestor state manager set to: {received_quorum_rounds:?}");
-        info!("Accepted quorum round per authority in ancestor state manager set to: {accepted_quorum_rounds:?}");
+        info!(
+            "Received quorum round per authority in ancestor state manager set to: {received_quorum_rounds:?}"
+        );
+        info!(
+            "Accepted quorum round per authority in ancestor state manager set to: {accepted_quorum_rounds:?}"
+        );
         self.ancestor_state_manager
             .set_quorum_rounds_per_authority(received_quorum_rounds, accepted_quorum_rounds);
         info!("Propagation round delay set to: {delay}");

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -70,11 +70,13 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
     fn set_subscriber_exists(&self, exists: bool) -> Result<(), CoreError>;
 
     /// Sets the estimated delay to propagate a block to a quorum of peers, in
-    /// number of rounds, and the quorum rounds for all authorities.
+    /// number of rounds, and the received & accepted quorum rounds for all
+    /// authorities.
     fn set_propagation_delay_and_quorum_rounds(
         &self,
         delay: Round,
-        quorum_rounds: Vec<QuorumRound>,
+        received_quorum_rounds: Vec<QuorumRound>,
+        accepted_quorum_rounds: Vec<QuorumRound>,
     ) -> Result<(), CoreError>;
 
     fn set_last_known_proposed_round(&self, round: Round) -> Result<(), CoreError>;
@@ -101,7 +103,7 @@ struct CoreThread {
     core: Core,
     receiver: Receiver<CoreThreadCommand>,
     rx_subscriber_exists: watch::Receiver<bool>,
-    rx_propagation_delay_and_quorum_rounds: watch::Receiver<(Round, Vec<QuorumRound>)>,
+    rx_propagation_delay_and_quorum_rounds: watch::Receiver<PropagationDelayAndQuorumRounds>,
     rx_last_known_proposed_round: watch::Receiver<Round>,
     context: Arc<Context>,
 }
@@ -120,8 +122,8 @@ impl CoreThread {
                     match command {
                         CoreThreadCommand::AddBlocks(blocks, sender) => {
                             let _scope = monitored_scope("CoreThread::loop::add_blocks");
-                            let missing_blocks = self.core.add_blocks(blocks)?;
-                            sender.send(missing_blocks).ok();
+                            let missing_block_refs = self.core.add_blocks(blocks)?;
+                            sender.send(missing_block_refs).ok();
                         }
                         CoreThreadCommand::NewBlock(round, sender, force) => {
                             let _scope = monitored_scope("CoreThread::loop::new_block");
@@ -154,8 +156,12 @@ impl CoreThread {
                 _ = self.rx_propagation_delay_and_quorum_rounds.changed() => {
                     let _scope = monitored_scope("CoreThread::loop::set_propagation_delay_and_quorum_rounds");
                     let should_propose_before = self.core.should_propose();
-                    let (delay, quorum_rounds) = self.rx_propagation_delay_and_quorum_rounds.borrow().clone();
-                    self.core.set_propagation_delay_and_quorum_rounds(delay, quorum_rounds);
+                    let state = self.rx_propagation_delay_and_quorum_rounds.borrow().clone();
+                    self.core.set_propagation_delay_and_quorum_rounds(
+                        state.delay,
+                        state.received_quorum_rounds,
+                        state.accepted_quorum_rounds
+                    );
                     if !should_propose_before && self.core.should_propose() {
                         // If core cannot propose before but can propose now, try to produce a new block to ensure liveness,
                         // because block proposal could have been skipped.
@@ -174,7 +180,7 @@ pub(crate) struct ChannelCoreThreadDispatcher {
     context: Arc<Context>,
     sender: WeakSender<CoreThreadCommand>,
     tx_subscriber_exists: Arc<watch::Sender<bool>>,
-    tx_propagation_delay_and_quorum_rounds: Arc<watch::Sender<(Round, Vec<QuorumRound>)>>,
+    tx_propagation_delay_and_quorum_rounds: Arc<watch::Sender<PropagationDelayAndQuorumRounds>>,
     tx_last_known_proposed_round: Arc<watch::Sender<Round>>,
     highest_received_rounds: Arc<Vec<AtomicU32>>,
 }
@@ -187,22 +193,28 @@ impl ChannelCoreThreadDispatcher {
         dag_state: &RwLock<DagState>,
         core: Core,
     ) -> (Self, CoreThreadHandle) {
-        // Initialize highest received rounds to last accepted rounds.
+        // Initialize highest received rounds.
         let highest_received_rounds = {
             let dag_state = dag_state.read();
-            context
+            let highest_received_rounds = context
                 .committee
                 .authorities()
                 .map(|(index, _)| {
                     AtomicU32::new(dag_state.get_last_block_for_authority(index).round())
                 })
-                .collect()
+                .collect();
+
+            highest_received_rounds
         };
         let (sender, receiver) =
             channel("consensus_core_commands", CORE_THREAD_COMMANDS_CHANNEL_SIZE);
         let (tx_subscriber_exists, mut rx_subscriber_exists) = watch::channel(false);
         let (tx_propagation_delay_and_quorum_rounds, mut rx_propagation_delay_and_quorum_rounds) =
-            watch::channel((0, vec![(0, 0); context.committee.size()]));
+            watch::channel(PropagationDelayAndQuorumRounds {
+                delay: 0,
+                received_quorum_rounds: vec![(0, 0); context.committee.size()],
+                accepted_quorum_rounds: vec![(0, 0); context.committee.size()],
+            });
         let (tx_last_known_proposed_round, mut rx_last_known_proposed_round) = watch::channel(0);
         rx_subscriber_exists.mark_unchanged();
         rx_propagation_delay_and_quorum_rounds.mark_unchanged();
@@ -270,9 +282,11 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
             self.highest_received_rounds[block.author()].fetch_max(block.round(), Ordering::AcqRel);
         }
         let (sender, receiver) = oneshot::channel();
-        self.send(CoreThreadCommand::AddBlocks(blocks, sender))
+        self.send(CoreThreadCommand::AddBlocks(blocks.clone(), sender))
             .await;
-        receiver.await.map_err(|e| Shutdown(e.to_string()))
+        let missing_block_refs = receiver.await.map_err(|e| Shutdown(e.to_string()))?;
+
+        Ok(missing_block_refs)
     }
 
     async fn new_block(&self, round: Round, force: bool) -> Result<(), CoreError> {
@@ -297,10 +311,15 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
     fn set_propagation_delay_and_quorum_rounds(
         &self,
         delay: Round,
-        quorum_rounds: Vec<QuorumRound>,
+        received_quorum_rounds: Vec<QuorumRound>,
+        accepted_quorum_rounds: Vec<QuorumRound>,
     ) -> Result<(), CoreError> {
         self.tx_propagation_delay_and_quorum_rounds
-            .send((delay, quorum_rounds))
+            .send(PropagationDelayAndQuorumRounds {
+                delay,
+                received_quorum_rounds,
+                accepted_quorum_rounds,
+            })
             .map_err(|e| Shutdown(e.to_string()))
     }
 
@@ -316,6 +335,13 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
             .map(|round| round.load(Ordering::Relaxed))
             .collect()
     }
+}
+
+#[derive(Clone)]
+struct PropagationDelayAndQuorumRounds {
+    delay: Round,
+    received_quorum_rounds: Vec<QuorumRound>,
+    accepted_quorum_rounds: Vec<QuorumRound>,
 }
 
 #[cfg(test)]
@@ -340,9 +366,9 @@ pub(crate) mod tests {
     // TODO: complete the Mock for thread dispatcher to be used from several tests
     #[derive(Default)]
     pub(crate) struct MockCoreThreadDispatcher {
-        add_blocks: Mutex<Vec<VerifiedBlock>>,
-        missing_blocks: Mutex<BTreeSet<BlockRef>>,
-        last_known_proposed_round: Mutex<Vec<Round>>,
+        add_blocks: parking_lot::Mutex<Vec<VerifiedBlock>>,
+        missing_blocks: parking_lot::Mutex<BTreeSet<BlockRef>>,
+        last_known_proposed_round: parking_lot::Mutex<Vec<Round>>,
     }
 
     impl MockCoreThreadDispatcher {
@@ -391,7 +417,8 @@ pub(crate) mod tests {
         fn set_propagation_delay_and_quorum_rounds(
             &self,
             _delay: Round,
-            _quorum_rounds: Vec<QuorumRound>,
+            _received_quorum_rounds: Vec<QuorumRound>,
+            _accepted_quorum_rounds: Vec<QuorumRound>,
         ) -> Result<(), CoreError> {
             todo!()
         }

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -347,7 +347,7 @@ struct PropagationDelayAndQuorumRounds {
 #[cfg(test)]
 pub(crate) mod tests {
     use iota_metrics::monitored_mpsc::unbounded_channel;
-    use parking_lot::{Mutex, RwLock};
+    use parking_lot::RwLock;
 
     use super::*;
     use crate::{

--- a/consensus/core/src/leader_timeout.rs
+++ b/consensus/core/src/leader_timeout.rs
@@ -189,7 +189,8 @@ mod tests {
         fn set_propagation_delay_and_quorum_rounds(
             &self,
             _delay: Round,
-            _quorum_rounds: Vec<QuorumRound>,
+            _received_quorum_rounds: Vec<QuorumRound>,
+            _accepted_quorum_rounds: Vec<QuorumRound>,
         ) -> Result<(), CoreError> {
             todo!()
         }

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -181,12 +181,15 @@ pub(crate) struct NodeMetrics {
     pub(crate) commit_sync_fetch_loop_latency: Histogram,
     pub(crate) commit_sync_fetch_once_latency: Histogram,
     pub(crate) commit_sync_fetch_once_errors: IntCounterVec,
-    pub(crate) round_prober_quorum_round_gaps: IntGaugeVec,
-    pub(crate) round_prober_low_quorum_round: IntGaugeVec,
-    pub(crate) round_prober_current_round_gaps: IntGaugeVec,
+    pub(crate) round_prober_received_quorum_round_gaps: IntGaugeVec,
+    pub(crate) round_prober_accepted_quorum_round_gaps: IntGaugeVec,
+    pub(crate) round_prober_low_received_quorum_round: IntGaugeVec,
+    pub(crate) round_prober_low_accepted_quorum_round: IntGaugeVec,
+    pub(crate) round_prober_current_received_round_gaps: IntGaugeVec,
+    pub(crate) round_prober_current_accepted_round_gaps: IntGaugeVec,
     pub(crate) round_prober_propagation_delays: Histogram,
     pub(crate) round_prober_last_propagation_delay: IntGauge,
-    pub(crate) round_prober_request_errors: IntCounter,
+    pub(crate) round_prober_request_errors: IntCounterVec,
     pub(crate) uptime: Histogram,
 }
 
@@ -662,21 +665,39 @@ impl NodeMetrics {
                 &["authority", "error"],
                 registry
             ).unwrap(),
-            round_prober_quorum_round_gaps: register_int_gauge_vec_with_registry!(
-                "round_prober_quorum_round_gaps",
-                "Round gaps among peers for blocks proposed from each authority",
+            round_prober_received_quorum_round_gaps: register_int_gauge_vec_with_registry!(
+                "round_prober_received_quorum_round_gaps",
+                "Received round gaps among peers for blocks proposed from each authority",
                 &["authority"],
                 registry
             ).unwrap(),
-            round_prober_low_quorum_round: register_int_gauge_vec_with_registry!(
-                "round_prober_low_quorum_round",
+            round_prober_accepted_quorum_round_gaps: register_int_gauge_vec_with_registry!(
+                "round_prober_accepted_quorum_round_gaps",
+                "Accepted round gaps among peers for blocks proposed & accepted from each authority",
+                &["authority"],
+                registry
+            ).unwrap(),
+            round_prober_low_received_quorum_round: register_int_gauge_vec_with_registry!(
+                "round_prober_low_received_quorum_round",
                 "Low quorum round among peers for blocks proposed from each authority",
                 &["authority"],
                 registry
             ).unwrap(),
-            round_prober_current_round_gaps: register_int_gauge_vec_with_registry!(
-                "round_prober_current_round_gaps",
-                "Round gaps from local last proposed round to the low quorum round of each peer. Can be negative.",
+            round_prober_low_accepted_quorum_round: register_int_gauge_vec_with_registry!(
+                "round_prober_low_accepted_quorum_round",
+                "Low quorum round among peers for blocks proposed & accepted from each authority",
+                &["authority"],
+                registry
+            ).unwrap(),
+            round_prober_current_received_round_gaps: register_int_gauge_vec_with_registry!(
+                "round_prober_current_received_round_gaps",
+                "Received round gaps from local last proposed round to the low received quorum round of each peer. Can be negative.",
+                &["authority"],
+                registry
+            ).unwrap(),
+            round_prober_current_accepted_round_gaps: register_int_gauge_vec_with_registry!(
+                "round_prober_current_accepted_round_gaps",
+                "Accepted round gaps from local last proposed & accepted round to the low accepted quorum round of each peer. Can be negative.",
                 &["authority"],
                 registry
             ).unwrap(),
@@ -691,9 +712,10 @@ impl NodeMetrics {
                 "Most recent propagation delay observed by RoundProber",
                 registry
             ).unwrap(),
-            round_prober_request_errors: register_int_counter_with_registry!(
+            round_prober_request_errors: register_int_counter_vec_with_registry!(
                 "round_prober_request_errors",
-                "Number of timeouts when probing against peers",
+                "Number of errors when probing against peers per error type",
+                &["error_type"],
                 registry
             ).unwrap(),
             uptime: register_histogram_with_registry!(

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -116,7 +116,8 @@ pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
         timeout: Duration,
     ) -> ConsensusResult<Vec<Bytes>>;
 
-    /// Gets the latest received & accepted rounds of all authorities from the peer.
+    /// Gets the latest received & accepted rounds of all authorities from the
+    /// peer.
     async fn get_latest_rounds(
         &self,
         peer: AuthorityIndex,
@@ -166,7 +167,8 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
         authorities: Vec<AuthorityIndex>,
     ) -> ConsensusResult<Vec<Bytes>>;
 
-    /// Handles the request to get the latest received & accepted rounds of all authorities.
+    /// Handles the request to get the latest received & accepted rounds of all
+    /// authorities.
     async fn handle_get_latest_rounds(
         &self,
         peer: AuthorityIndex,

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -116,12 +116,12 @@ pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
         timeout: Duration,
     ) -> ConsensusResult<Vec<Bytes>>;
 
-    /// Gets the latest received rounds of all authorities from the peer.
+    /// Gets the latest received & accepted rounds of all authorities from the peer.
     async fn get_latest_rounds(
         &self,
         peer: AuthorityIndex,
         timeout: Duration,
-    ) -> ConsensusResult<Vec<Round>>;
+    ) -> ConsensusResult<(Vec<Round>, Vec<Round>)>;
 }
 
 /// Network service for handling requests from peers.
@@ -166,9 +166,11 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
         authorities: Vec<AuthorityIndex>,
     ) -> ConsensusResult<Vec<Bytes>>;
 
-    /// Handles the request to get the latest received rounds of all
-    /// authorities.
-    async fn handle_get_latest_rounds(&self, peer: AuthorityIndex) -> ConsensusResult<Vec<Round>>;
+    /// Handles the request to get the latest received & accepted rounds of all authorities.
+    async fn handle_get_latest_rounds(
+        &self,
+        peer: AuthorityIndex,
+    ) -> ConsensusResult<(Vec<Round>, Vec<Round>)>;
 }
 
 /// An `AuthorityNode` holds a `NetworkManager` until shutdown.

--- a/consensus/core/src/network/test_network.rs
+++ b/consensus/core/src/network/test_network.rs
@@ -93,7 +93,10 @@ impl NetworkService for Mutex<TestService> {
         unimplemented!("Unimplemented")
     }
 
-    async fn handle_get_latest_rounds(&self, _peer: AuthorityIndex) -> ConsensusResult<Vec<Round>> {
+    async fn handle_get_latest_rounds(
+        &self,
+        _peer: AuthorityIndex,
+    ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
         unimplemented!("Unimplemented")
     }
 }

--- a/consensus/core/src/network/tonic_network.rs
+++ b/consensus/core/src/network/tonic_network.rs
@@ -307,14 +307,15 @@ impl NetworkClient for TonicClient {
         &self,
         peer: AuthorityIndex,
         timeout: Duration,
-    ) -> ConsensusResult<Vec<Round>> {
+    ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
         let mut client = self.get_client(peer, timeout).await?;
         let mut request = Request::new(GetLatestRoundsRequest {});
         request.set_timeout(timeout);
         let response = client.get_latest_rounds(request).await.map_err(|e| {
             ConsensusError::NetworkRequest(format!("get_latest_rounds failed: {e:?}"))
         })?;
-        Ok(response.into_inner().highest_received)
+        let response = response.into_inner();
+        Ok((response.highest_received, response.highest_accepted))
     }
 }
 
@@ -617,12 +618,15 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
         else {
             return Err(tonic::Status::internal("PeerInfo not found"));
         };
-        let highest_received = self
+        let (highest_received, highest_accepted) = self
             .service
             .handle_get_latest_rounds(peer_index)
             .await
             .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;
-        Ok(Response::new(GetLatestRoundsResponse { highest_received }))
+        Ok(Response::new(GetLatestRoundsResponse {
+            highest_received,
+            highest_accepted,
+        }))
     }
 }
 
@@ -1075,6 +1079,9 @@ pub(crate) struct GetLatestRoundsResponse {
     // Highest received round per authority.
     #[prost(uint32, repeated, tag = "1")]
     highest_received: Vec<u32>,
+    // Highest accepted round per authority.
+    #[prost(uint32, repeated, tag = "2")]
+    highest_accepted: Vec<u32>,
 }
 
 fn chunk_blocks(blocks: Vec<Bytes>, chunk_limit: usize) -> Vec<Vec<Bytes>> {

--- a/consensus/core/src/round_prober.rs
+++ b/consensus/core/src/round_prober.rs
@@ -2,21 +2,24 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! RoundProber periodically checks each peer for the latest rounds they received and accepted
-//! from others. This provides insight into how effectively each authority's blocks are propagated
-//! and accepted across the network.
+//! RoundProber periodically checks each peer for the latest rounds they
+//! received and accepted from others. This provides insight into how
+//! effectively each authority's blocks are propagated and accepted across the
+//! network.
 //!
 //! Unlike inferring accepted rounds from the DAG of each block, RoundProber has
 //! the benefit that it remains active even when peers are not proposing. This
 //! makes it essential for determining when to disable optimizations that
 //! improve DAG quality but may compromise liveness.
 //!
-//! RoundProber's data sources include the `highest_received_rounds` & `highest_accepted_rounds` tracked
-//! by the CoreThreadDispatcher and DagState. The received rounds are updated after blocks are verified
-//! but before checking for dependencies. This should make the values more indicative of how well authorities
-//! propagate blocks, and less influenced by the quality of ancestors in the proposed blocks. The
-//! accepted rounds are updated after checking for dependencies which should indicate the quality
-//! of the proposed blocks including its ancestors.
+//! RoundProber's data sources include the `highest_received_rounds` &
+//! `highest_accepted_rounds` tracked by the CoreThreadDispatcher and DagState.
+//! The received rounds are updated after blocks are verified but before
+//! checking for dependencies. This should make the values more indicative of
+//! how well authorities propagate blocks, and less influenced by the quality of
+//! ancestors in the proposed blocks. The accepted rounds are updated after
+//! checking for dependencies which should indicate the quality of the proposed
+//! blocks including its ancestors.
 
 use std::{sync::Arc, time::Duration};
 
@@ -280,8 +283,9 @@ impl<C: NetworkClient> RoundProber<C> {
         // get_latest_rounds requests arrive.
         // Using the lower bound to increase sensitivity about block propagation issues
         // that can reduce round rate.
-        // Because of the nature of TCP and block streaming, propagation delay is expected to be
-        // 0 in most cases, even when the actual latency of broadcasting blocks is high.
+        // Because of the nature of TCP and block streaming, propagation delay is
+        // expected to be 0 in most cases, even when the actual latency of
+        // broadcasting blocks is high.
         let propagation_delay =
             last_proposed_round.saturating_sub(received_quorum_rounds[own_index].0);
         node_metrics
@@ -571,7 +575,8 @@ mod test {
             network_client.clone(),
         );
 
-        // Create test blocks for each authority with incrementing rounds starting at 110
+        // Create test blocks for each authority with incrementing rounds starting at
+        // 110
         let blocks = (0..NUM_AUTHORITIES)
             .map(|authority| {
                 let round = 110 + (authority as u32 * 10);

--- a/consensus/core/src/round_prober.rs
+++ b/consensus/core/src/round_prober.rs
@@ -165,7 +165,7 @@ impl<C: NetworkClient> RoundProber<C> {
             .collect::<Vec<_>>();
         let last_proposed_round = local_highest_accepted_rounds[own_index];
 
-        // For our own index, the highest recieved & accepted round is our last
+        // For our own index, the highest received & accepted round is our last
         // accepted round or our last proposed round.
         highest_received_rounds[own_index] = self.core_thread_dispatcher.highest_received_rounds();
         highest_accepted_rounds[own_index] = local_highest_accepted_rounds;

--- a/consensus/core/src/round_prober.rs
+++ b/consensus/core/src/round_prober.rs
@@ -2,20 +2,21 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! RoundProber periodically checks each peer for the latest rounds they
-//! received from others. This provides insight into how effectively each
-//! authority's blocks are propagated across the network.
+//! RoundProber periodically checks each peer for the latest rounds they received and accepted
+//! from others. This provides insight into how effectively each authority's blocks are propagated
+//! and accepted across the network.
 //!
 //! Unlike inferring accepted rounds from the DAG of each block, RoundProber has
 //! the benefit that it remains active even when peers are not proposing. This
 //! makes it essential for determining when to disable optimizations that
 //! improve DAG quality but may compromise liveness.
 //!
-//! RoundProber's data source is the `highest_received_rounds` tracked by the
-//! CoreThreadDispatcher. These rounds are updated after blocks are verified but
-//! before checking for dependencies. This should make the values more
-//! indicative of how well authorities propagate blocks, and less influenced by
-//! the quality of ancestors in the proposed blocks.
+//! RoundProber's data sources include the `highest_received_rounds` & `highest_accepted_rounds` tracked
+//! by the CoreThreadDispatcher and DagState. The received rounds are updated after blocks are verified
+//! but before checking for dependencies. This should make the values more indicative of how well authorities
+//! propagate blocks, and less influenced by the quality of ancestors in the proposed blocks. The
+//! accepted rounds are updated after checking for dependencies which should indicate the quality
+//! of the proposed blocks including its ancestors.
 
 use std::{sync::Arc, time::Duration};
 
@@ -32,7 +33,8 @@ use crate::{
 };
 
 /// A [`QuorumRound`] is a round range [low, high]. It is computed from
-/// highest received rounds of an authority reported by all authorities.
+/// highest received or accepted rounds of an authority reported by all
+/// authorities.
 /// The bounds represent:
 /// - the highest round lower or equal to rounds from a quorum (low)
 /// - the lowest round higher or equal to rounds from a quorum (high)
@@ -121,20 +123,15 @@ impl<C: NetworkClient> RoundProber<C> {
     // Probes each peer for the latest rounds they received from others.
     // Returns the quorum round for each authority, and the propagation delay
     // of own blocks.
-    pub(crate) async fn probe(&self) -> (Vec<QuorumRound>, Round) {
+    pub(crate) async fn probe(&self) -> (Vec<QuorumRound>, Vec<QuorumRound>, Round) {
         let _scope = monitored_scope("RoundProber");
 
         let node_metrics = &self.context.metrics.node_metrics;
         let request_timeout =
             Duration::from_millis(self.context.parameters.round_prober_request_timeout_ms);
         let own_index = self.context.own_index;
-        let last_proposed_round = self
-            .dag_state
-            .read()
-            .get_last_block_for_authority(own_index)
-            .round();
-
         let mut requests = FuturesUnordered::new();
+
         for (peer, _) in self.context.committee.authorities() {
             if peer == own_index {
                 continue;
@@ -152,23 +149,52 @@ impl<C: NetworkClient> RoundProber<C> {
 
         let mut highest_received_rounds =
             vec![vec![0; self.context.committee.size()]; self.context.committee.size()];
+        let mut highest_accepted_rounds =
+            vec![vec![0; self.context.committee.size()]; self.context.committee.size()];
+
+        let blocks = self
+            .dag_state
+            .read()
+            .get_last_cached_block_per_authority(Round::MAX);
+        let local_highest_accepted_rounds = blocks
+            .into_iter()
+            .map(|block| block.round())
+            .collect::<Vec<_>>();
+        let last_proposed_round = local_highest_accepted_rounds[own_index];
+
+        // For our own index, the highest recieved & accepted round is our last
+        // accepted round or our last proposed round.
         highest_received_rounds[own_index] = self.core_thread_dispatcher.highest_received_rounds();
+        highest_accepted_rounds[own_index] = local_highest_accepted_rounds;
         highest_received_rounds[own_index][own_index] = last_proposed_round;
+        highest_accepted_rounds[own_index][own_index] = last_proposed_round;
+
         loop {
             tokio::select! {
                 result = requests.next() => {
-                    let Some((peer, result)) = result else {
-                        break;
-                    };
-                    let peer_name = &self.context.committee.authority(peer).hostname;
+                    let Some((peer, result)) = result else { break };
                     match result {
-                        Ok(Ok(rounds)) => {
-                            if rounds.len() == self.context.committee.size() {
-                                highest_received_rounds[peer] = rounds;
+                        Ok(Ok((received, accepted))) => {
+                            if received.len() == self.context.committee.size()
+                            {
+                                highest_received_rounds[peer] = received;
                             } else {
-                                node_metrics.round_prober_request_errors.inc();
-                                tracing::warn!("Received invalid number of accepted rounds from peer {}", peer_name);
+                                node_metrics.round_prober_request_errors.with_label_values(&["invalid_received_rounds"]).inc();
+                                tracing::warn!("Received invalid number of received rounds from peer {}", peer);
                             }
+
+                            if self
+                                .context
+                                .protocol_config
+                                .consensus_round_prober_probe_accepted_rounds() {
+                                    if accepted.len() == self.context.committee.size() {
+                                        highest_accepted_rounds[peer] = accepted;
+                                    } else {
+                                        node_metrics.round_prober_request_errors.with_label_values(&["invalid_accepted_rounds"]).inc();
+                                        tracing::warn!("Received invalid number of accepted rounds from peer {}", peer);
+                                    }
+                                }
+
                         },
                         // When a request fails, the highest received rounds from that authority will be 0
                         // for the subsequent computations.
@@ -181,22 +207,20 @@ impl<C: NetworkClient> RoundProber<C> {
                         // (peer A cannot propagate its blocks well). It can be difficult to distinguish between
                         // own probing failures and actual propagation issues.
                         Ok(Err(err)) => {
-                            node_metrics.round_prober_request_errors.inc();
-                            tracing::warn!("Failed to get latest rounds from peer {}: {:?}", peer_name, err);
+                            node_metrics.round_prober_request_errors.with_label_values(&["failed_fetch"]).inc();
+                            tracing::warn!("Failed to get latest rounds from peer {}: {:?}", peer, err);
                         },
                         Err(_) => {
-                            node_metrics.round_prober_request_errors.inc();
-                            tracing::warn!("Timeout while getting latest rounds from peer {}", peer_name);
+                            node_metrics.round_prober_request_errors.with_label_values(&["timeout"]).inc();
+                            tracing::warn!("Timeout while getting latest rounds from peer {}", peer);
                         },
                     }
                 }
-                _ = self.shutdown_notify.wait() => {
-                    break;
-                }
+                _ = self.shutdown_notify.wait() => break,
             }
         }
 
-        let quorum_rounds: Vec<_> = self
+        let received_quorum_rounds: Vec<_> = self
             .context
             .committee
             .authorities()
@@ -204,21 +228,48 @@ impl<C: NetworkClient> RoundProber<C> {
                 compute_quorum_round(&self.context.committee, peer, &highest_received_rounds)
             })
             .collect();
-        for ((low, high), (_, authority)) in quorum_rounds
+        for ((low, high), (_, authority)) in received_quorum_rounds
             .iter()
             .zip(self.context.committee.authorities())
         {
             node_metrics
-                .round_prober_quorum_round_gaps
+                .round_prober_received_quorum_round_gaps
                 .with_label_values(&[&authority.hostname])
                 .set((high - low) as i64);
             node_metrics
-                .round_prober_low_quorum_round
+                .round_prober_low_received_quorum_round
                 .with_label_values(&[&authority.hostname])
                 .set(*low as i64);
             // The gap can be negative if this validator is lagging behind the network.
             node_metrics
-                .round_prober_current_round_gaps
+                .round_prober_current_received_round_gaps
+                .with_label_values(&[&authority.hostname])
+                .set(last_proposed_round as i64 - *low as i64);
+        }
+
+        let accepted_quorum_rounds: Vec<_> = self
+            .context
+            .committee
+            .authorities()
+            .map(|(peer, _)| {
+                compute_quorum_round(&self.context.committee, peer, &highest_accepted_rounds)
+            })
+            .collect();
+        for ((low, high), (_, authority)) in accepted_quorum_rounds
+            .iter()
+            .zip(self.context.committee.authorities())
+        {
+            node_metrics
+                .round_prober_accepted_quorum_round_gaps
+                .with_label_values(&[&authority.hostname])
+                .set((high - low) as i64);
+            node_metrics
+                .round_prober_low_accepted_quorum_round
+                .with_label_values(&[&authority.hostname])
+                .set(*low as i64);
+            // The gap can be negative if this validator is lagging behind the network.
+            node_metrics
+                .round_prober_current_accepted_round_gaps
                 .with_label_values(&[&authority.hostname])
                 .set(last_proposed_round as i64 - *low as i64);
         }
@@ -229,10 +280,10 @@ impl<C: NetworkClient> RoundProber<C> {
         // get_latest_rounds requests arrive.
         // Using the lower bound to increase sensitivity about block propagation issues
         // that can reduce round rate.
-        // Because of the nature of TCP and block streaming, propagation delay is
-        // expected to be 0 in most cases, even when the actual latency of
-        // broadcasting blocks is high.
-        let propagation_delay = last_proposed_round.saturating_sub(quorum_rounds[own_index].0);
+        // Because of the nature of TCP and block streaming, propagation delay is expected to be
+        // 0 in most cases, even when the actual latency of broadcasting blocks is high.
+        let propagation_delay =
+            last_proposed_round.saturating_sub(received_quorum_rounds[own_index].0);
         node_metrics
             .round_prober_propagation_delays
             .observe(propagation_delay as f64);
@@ -241,15 +292,23 @@ impl<C: NetworkClient> RoundProber<C> {
             .set(propagation_delay as i64);
         if let Err(e) = self
             .core_thread_dispatcher
-            .set_propagation_delay_and_quorum_rounds(propagation_delay, quorum_rounds.clone())
+            .set_propagation_delay_and_quorum_rounds(
+                propagation_delay,
+                received_quorum_rounds.clone(),
+                accepted_quorum_rounds.clone(),
+            )
         {
             tracing::warn!(
-                "Failed to set propagation delay and quorum rounds {quorum_rounds:?} on Core: {:?}",
+                "Failed to set propagation delay and quorum rounds {received_quorum_rounds:?} on Core: {:?}",
                 e
             );
         }
 
-        (quorum_rounds, propagation_delay)
+        (
+            received_quorum_rounds,
+            accepted_quorum_rounds,
+            propagation_delay,
+        )
     }
 }
 
@@ -274,9 +333,8 @@ fn compute_quorum_round(
     let mut total_stake = 0;
     let mut low = 0;
     for (round, stake) in rounds_with_stake.iter().rev() {
-        let reached_quorum_before = total_stake >= committee.quorum_threshold();
         total_stake += stake;
-        if !reached_quorum_before && total_stake >= committee.quorum_threshold() {
+        if total_stake >= committee.quorum_threshold() {
             low = *round;
             break;
         }
@@ -285,9 +343,8 @@ fn compute_quorum_round(
     let mut total_stake = 0;
     let mut high = 0;
     for (round, stake) in rounds_with_stake.iter() {
-        let reached_quorum_before = total_stake >= committee.quorum_threshold();
         total_stake += stake;
-        if !reached_quorum_before && total_stake >= committee.quorum_threshold() {
+        if total_stake >= committee.quorum_threshold() {
             high = *round;
             break;
         }
@@ -322,7 +379,8 @@ mod test {
     struct FakeThreadDispatcher {
         highest_received_rounds: Vec<Round>,
         propagation_delay: Mutex<Round>,
-        quorum_rounds: Mutex<Vec<QuorumRound>>,
+        received_quorum_rounds: Mutex<Vec<QuorumRound>>,
+        accepted_quorum_rounds: Mutex<Vec<QuorumRound>>,
     }
 
     impl FakeThreadDispatcher {
@@ -330,7 +388,8 @@ mod test {
             Self {
                 highest_received_rounds,
                 propagation_delay: Mutex::new(0),
-                quorum_rounds: Mutex::new(Vec::new()),
+                received_quorum_rounds: Mutex::new(Vec::new()),
+                accepted_quorum_rounds: Mutex::new(Vec::new()),
             }
         }
 
@@ -338,8 +397,12 @@ mod test {
             *self.propagation_delay.lock()
         }
 
-        fn quorum_rounds(&self) -> Vec<QuorumRound> {
-            self.quorum_rounds.lock().clone()
+        fn received_quorum_rounds(&self) -> Vec<QuorumRound> {
+            self.received_quorum_rounds.lock().clone()
+        }
+
+        fn accepted_quorum_rounds(&self) -> Vec<QuorumRound> {
+            self.accepted_quorum_rounds.lock().clone()
         }
     }
 
@@ -367,10 +430,13 @@ mod test {
         fn set_propagation_delay_and_quorum_rounds(
             &self,
             delay: Round,
-            quorum_rounds: Vec<QuorumRound>,
+            received_quorum_rounds: Vec<QuorumRound>,
+            accepted_quorum_rounds: Vec<QuorumRound>,
         ) -> Result<(), CoreError> {
-            let mut quorum_round_per_authority = self.quorum_rounds.lock();
-            *quorum_round_per_authority = quorum_rounds;
+            let mut received_quorum_round_per_authority = self.received_quorum_rounds.lock();
+            *received_quorum_round_per_authority = received_quorum_rounds;
+            let mut accepted_quorum_round_per_authority = self.accepted_quorum_rounds.lock();
+            *accepted_quorum_round_per_authority = accepted_quorum_rounds;
             let mut propagation_delay = self.propagation_delay.lock();
             *propagation_delay = delay;
             Ok(())
@@ -387,12 +453,17 @@ mod test {
 
     struct FakeNetworkClient {
         highest_received_rounds: Vec<Vec<Round>>,
+        highest_accepted_rounds: Vec<Vec<Round>>,
     }
 
     impl FakeNetworkClient {
-        fn new(highest_received_rounds: Vec<Vec<Round>>) -> Self {
+        fn new(
+            highest_received_rounds: Vec<Vec<Round>>,
+            highest_accepted_rounds: Vec<Vec<Round>>,
+        ) -> Self {
             Self {
                 highest_received_rounds,
+                highest_accepted_rounds,
             }
         }
     }
@@ -452,12 +523,13 @@ mod test {
             &self,
             peer: AuthorityIndex,
             _timeout: Duration,
-        ) -> ConsensusResult<Vec<Round>> {
-            let rounds = self.highest_received_rounds[peer].clone();
-            if rounds.is_empty() {
+        ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
+            let received_rounds = self.highest_received_rounds[peer].clone();
+            let accepted_rounds = self.highest_accepted_rounds[peer].clone();
+            if received_rounds.is_empty() && accepted_rounds.is_empty() {
                 Err(ConsensusError::NetworkRequestTimeout("test".to_string()))
             } else {
-                Ok(rounds)
+                Ok((received_rounds, accepted_rounds))
             }
         }
     }
@@ -472,15 +544,26 @@ mod test {
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         // Have some peers return error or incorrect number of rounds.
-        let network_client = Arc::new(FakeNetworkClient::new(vec![
-            vec![],
-            vec![109, 121, 131, 0, 151, 161, 171],
-            vec![101, 0, 103, 104, 105, 166, 107],
-            vec![],
-            vec![100, 102, 133, 0, 155, 106, 177],
-            vec![105, 115, 103, 0, 125, 126, 127],
-            vec![10, 20, 30, 40, 50, 60],
-        ]));
+        let network_client = Arc::new(FakeNetworkClient::new(
+            vec![
+                vec![],
+                vec![109, 121, 131, 0, 151, 161, 171],
+                vec![101, 0, 103, 104, 105, 166, 107],
+                vec![],
+                vec![100, 102, 133, 0, 155, 106, 177],
+                vec![105, 115, 103, 0, 125, 126, 127],
+                vec![10, 20, 30, 40, 50, 60],
+            ], // highest_received_rounds
+            vec![
+                vec![],
+                vec![0, 121, 131, 0, 151, 161, 171],
+                vec![1, 0, 103, 104, 105, 166, 107],
+                vec![],
+                vec![0, 102, 133, 0, 155, 106, 177],
+                vec![1, 115, 103, 0, 125, 126, 127],
+                vec![1, 20, 30, 40, 50, 60],
+            ], // highest_accepted_rounds
+        ));
         let prober = RoundProber::new(
             context.clone(),
             core_thread_dispatcher.clone(),
@@ -488,9 +571,15 @@ mod test {
             network_client.clone(),
         );
 
-        // Fake last proposed round to be 110.
-        let block = VerifiedBlock::new_for_test(TestBlock::new(110, 0).build());
-        dag_state.write().accept_block(block);
+        // Create test blocks for each authority with incrementing rounds starting at 110
+        let blocks = (0..NUM_AUTHORITIES)
+            .map(|authority| {
+                let round = 110 + (authority as u32 * 10);
+                VerifiedBlock::new_for_test(TestBlock::new(round, authority as u32).build())
+            })
+            .collect::<Vec<_>>();
+
+        dag_state.write().accept_blocks(blocks);
 
         // Compute quorum rounds and propagation delay based on last proposed round =
         // 110, and highest received rounds:
@@ -502,10 +591,11 @@ mod test {
         // 105, 115, 103, 0,   125, 126, 127,
         // 0,   0,   0,   0,   0,   0,   0,
 
-        let (quorum_rounds, propagation_delay) = prober.probe().await;
+        let (received_quorum_rounds, accepted_quorum_rounds, propagation_delay) =
+            prober.probe().await;
 
         assert_eq!(
-            quorum_rounds,
+            received_quorum_rounds,
             vec![
                 (100, 105),
                 (0, 115),
@@ -518,7 +608,7 @@ mod test {
         );
 
         assert_eq!(
-            core_thread_dispatcher.quorum_rounds(),
+            core_thread_dispatcher.received_quorum_rounds(),
             vec![
                 (100, 105),
                 (0, 115),
@@ -532,6 +622,32 @@ mod test {
         // 110 - 100 = 10
         assert_eq!(propagation_delay, 10);
         assert_eq!(core_thread_dispatcher.propagation_delay(), 10);
+
+        assert_eq!(
+            accepted_quorum_rounds,
+            vec![
+                (0, 1),
+                (0, 115),
+                (103, 130),
+                (0, 0),
+                (105, 150),
+                (106, 160),
+                (107, 170)
+            ]
+        );
+
+        assert_eq!(
+            core_thread_dispatcher.accepted_quorum_rounds(),
+            vec![
+                (0, 1),
+                (0, 115),
+                (103, 130),
+                (0, 0),
+                (105, 150),
+                (106, 160),
+                (107, 170)
+            ]
+        );
     }
 
     #[tokio::test]

--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -325,7 +325,7 @@ mod test {
             &self,
             _peer: AuthorityIndex,
             _timeout: Duration,
-        ) -> ConsensusResult<Vec<Round>> {
+        ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
             unimplemented!("Unimplemented")
         }
     }

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -1324,7 +1324,7 @@ mod tests {
             &self,
             _peer: AuthorityIndex,
             _timeout: Duration,
-        ) -> ConsensusResult<Vec<Round>> {
+        ) -> ConsensusResult<(Vec<Round>, Vec<Round>)> {
             unimplemented!("Unimplemented")
         }
     }

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1308,6 +1308,7 @@
                 "consensus_distributed_vote_scoring_strategy": true,
                 "consensus_linearize_subdag_v2": false,
                 "consensus_round_prober": true,
+                "consensus_round_prober_probe_accepted_rounds": true,
                 "consensus_smart_ancestor_selection": true,
                 "disable_invariant_violation_check_in_swap_loc": true,
                 "enable_group_ops_native_function_msm": true,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1776,8 +1776,6 @@ impl ProtocolConfig {
                     if !matches!(chain, Chain::Mainnet | Chain::Testnet) {
                         // Enable smart ancestor selection for devnet
                         cfg.feature_flags.consensus_smart_ancestor_selection = true;
-                    }
-                    if chain != Chain::Mainnet && chain != Chain::Testnet {
                         // Enable probing for accepted rounds in round prober.
                         cfg.feature_flags
                             .consensus_round_prober_probe_accepted_rounds = true;

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -222,6 +222,10 @@ struct FeatureFlags {
     // Use smart ancestor selection in consensus.
     #[serde(skip_serializing_if = "is_false")]
     consensus_smart_ancestor_selection: bool,
+
+    // Probe accepted rounds in round prober.
+    #[serde(skip_serializing_if = "is_false")]
+    consensus_round_prober_probe_accepted_rounds: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1150,6 +1154,11 @@ impl ProtocolConfig {
     pub fn consensus_smart_ancestor_selection(&self) -> bool {
         self.feature_flags.consensus_smart_ancestor_selection
     }
+
+    pub fn consensus_round_prober_probe_accepted_rounds(&self) -> bool {
+        self.feature_flags
+            .consensus_round_prober_probe_accepted_rounds
+    }
 }
 
 #[cfg(not(msim))]
@@ -1768,6 +1777,11 @@ impl ProtocolConfig {
                         // Enable smart ancestor selection for devnet
                         cfg.feature_flags.consensus_smart_ancestor_selection = true;
                     }
+                    if chain != Chain::Mainnet && chain != Chain::Testnet {
+                        // Enable probing for accepted rounds in round prober.
+                        cfg.feature_flags
+                            .consensus_round_prober_probe_accepted_rounds = true;
+                    }
                 }
                 // Use this template when making changes:
                 //
@@ -1905,6 +1919,11 @@ impl ProtocolConfig {
 
     pub fn set_consensus_linearize_subdag_v2_for_testing(&mut self, val: bool) {
         self.feature_flags.consensus_linearize_subdag_v2 = val;
+    }
+
+    pub fn set_consensus_round_prober_probe_accepted_rounds(&mut self, val: bool) {
+        self.feature_flags
+            .consensus_round_prober_probe_accepted_rounds = val;
     }
 }
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -31,7 +31,7 @@ pub const MAX_PROTOCOL_VERSION: u64 = 6;
 // Version 5: Introduce fixed protocol-defined base fee, IotaSystemStateV2 and
 // SystemEpochInfoEventV2
 // Version 6: Variants as type nodes. Enable smart ancestor selection for
-// devnet.
+// devnet. Enable probing for accepted rounds in round prober for devnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_6.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_6.snap
@@ -17,6 +17,7 @@ feature_flags:
   consensus_distributed_vote_scoring_strategy: true
   variant_nodes: true
   consensus_smart_ancestor_selection: true
+  consensus_round_prober_probe_accepted_rounds: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000


### PR DESCRIPTION
# Description of change

Porting from upstream b4d6dc1

> For ancestor selection we want to ensure the highest quality ancestors
> are included in the proposal, therefore if an authority is excluded we
> should start including them once they have caught up to the network with
> their accepted blocks not just received as its possible for blocks to be
> received but suspended on many hosts which can cause performance
> degradation
> 
> Additionally switched to using high quorum round of the high quorum
> round of accepted rounds for inclusion metric.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #(issue)`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
