### PR TITLE
docs(consensus): update iota architecture

### DIFF
--- a/docs/content/about-iota/iota-architecture/iota-architecture.mdx
+++ b/docs/content/about-iota/iota-architecture/iota-architecture.mdx
@@ -4,7 +4,7 @@ tags: [core-protocol]
 ---
 import ThemedImage from '@theme/ThemedImage';
 
-IOTA shares some similarities with other blockchains but is unique in many ways. Use the topics in this section to understand the features that define the IOTA network.
+IOTA shares some similarities with traditional blockchains but is unique in many ways. Use the topics in this section to understand the features that define the IOTA network.
 
 ## Understand IOTA Security
 

--- a/docs/content/about-iota/iota-architecture/iota-security.mdx
+++ b/docs/content/about-iota/iota-architecture/iota-security.mdx
@@ -18,7 +18,8 @@ The set of validators changes periodically and is [determined by the amount of l
 
 ### Delegated PoS Consensus Mechanism
 
-IOTA employs a delegated Proof-of-Stake (dPoS) mechanism to select validators (nodes that help secure and operate the network) for each epoch. Users can lock and delegate their IOTA tokens to vote for validators, granting them voting power. Validators are chosen based on the number of delegated tokens, and any node with sufficient support can become a validator.
+
+IOTA employs a delegated Proof-of-Stake (dPoS) mechanism to select validators (nodes that help secure and operate the network) for each epoch. Users can lock and delegate their IOTA tokens to validators, granting them voting power. Validators are chosen based on the number of delegated tokens, and any node with sufficient support can become a validator.
 
 ## Validators and Consensus Protocol
 
@@ -29,10 +30,6 @@ Additionally, all transactions in IOTA are publicly available and auditable to v
 ### Rewards for Validators and Stakers
 
 Validators receive incentives through a fixed inflation of 767,000 IOTA tokens per epoch. These tokens are distributed to validators and their delegators based on specific rules, such as the validator's commission rate and total stake. Transaction fees are burned and do not contribute to validator rewards. Staked tokens remain secure and cannot be seized by validators or other participants. For more details, refer to the [staking and rewards](./staking-rewards.mdx) documentation.
-
-### Accountability and Rotation of Validators
-
-Validators must operate reliably and follow protocol rules. If validators attempt to censor transactions or act maliciously, they can be replaced. However, it is not solely the users’ responsibility to detect malicious behavior—protocol mechanisms and cryptographic guarantees ensure that validators cannot arbitrarily alter or block transactions.
 
 ## Addresses and Keys
 

--- a/docs/content/about-iota/iota-architecture/transaction-lifecycle.mdx
+++ b/docs/content/about-iota/iota-architecture/transaction-lifecycle.mdx
@@ -83,7 +83,7 @@ Depending on whether the transaction uses shared input objects, the validators w
 * Execute it immediately if no shared objects are involved.
 * Submit it to IOTA's consensus layer to order the transaction with others if shared objects are involved, and then execute it.
 
-This ensures that transactions are processed in the correct order and prevent conflicts.
+This ensures that transactions involving shared objects are consistently ordered across validators, preventing conflicts.
 
 ### Effects Certificate
 
@@ -99,16 +99,11 @@ Once you or the full node sees an effects _certificate_, you can be sure that th
 
 ### Checkpoints
 
-The final stage in a transaction's life is its inclusion in a checkpoint. Validators send executed transactions to the consensus layer, which orders all transactions universally. This ordered list of transactions is used to create checkpoints. Checkpoints include:
-
-* Ordered transaction lists.
-* Transaction effects.
-
-Transactions are added to checkpoints once they are complete and causally ordered, meaning any related dependencies are included and ordered correctly. This ensures the transactions are processed in the right sequence. Forming checkpoints usually takes a few seconds. Once included in a checkpoint, the transaction is permanently recorded on the IOTA network.
+The final stage in a transaction's life is its inclusion in a checkpoint. The consensus layer produces a globally agreed-upon ordering of transactions. Validators take chunks of this ordered list and use them to form checkpoints. Each checkpoint contains a list of transaction digests and the digests of their effects. To ensure completeness, the network may wait until all required transaction data is available. This process typically takes a few seconds. Once a transaction is included in a checkpoint, it becomes part of the permanent record on the IOTA network.
 
 ### Transaction Finality
 
-Transaction finality means that once a transaction is executed, it can't be reversed or changed. From the time a transaction is sent to when it receives validator signatures, less than half a second passes. At this point, the sender knows the transaction will be processed and can't be undone. Honest validators will reject any subsequent transactions that try to use the same input objects within the same epoch.
+Transaction finality means that once a transaction is executed, it can't be reversed or changed. From the time a transaction is sent to when it receives validator signatures, less than half a second passes. At this point, the sender knows the transaction will be processed and can't be undone. Honest validators will reject any subsequent transactions that try to use the same owned objects within the same epoch.
 
 ### Settlement Finality
 

--- a/docs/content/about-iota/iota-architecture/validator-committee.mdx
+++ b/docs/content/about-iota/iota-architecture/validator-committee.mdx
@@ -5,7 +5,7 @@ description: IOTA has a committee of validators to verify on-chain transactions.
 import Quiz from '@site/src/components/Quiz';
 import questions from '/json/node-operators/validator-committee.json';
 
-A set of independent validators participate on the IOTA network, each running its own instance of the IOTA software on a separate machine (or a sharded cluster of machines the same entity operates). Each validator handles read and write requests sent by clients, verifying transactions and updating on-chain information.
+A set of independent validators participate on the IOTA network, each running its own instance of the IOTA software on a dedicated machine or virtual server. Each validator handles read and write requests sent by clients, verifying transactions and updating on-chain information.
 
 To learn how to set up and run an IOTA Validator node, including how staking and rewards work, see [IOTA Validator Node Configuration](../../operator/validator-config.mdx).
 
@@ -38,19 +38,6 @@ The process of collecting validator signatures on a transaction into a _certific
 
 After the client forms a _certificate_, it submits it to the validators, which perform _certificate_ validity checks. These checks ensure the signers are validators in the current epoch, and the signatures are cryptographically valid. If the checks pass, the validators execute the transaction inside the _certificate_. Execution of a transaction either succeeds and commits all of its effects or aborts and has no effect other than debiting the transaction's gas input. Some reasons a transaction might abort include an explicit abort instruction, a runtime error such as division by zero, or exceeding the maximum gas budget. Whether it succeeds or aborts, the validator durably stores the _certificate_ indexed by the hash of its inner transaction.
 
-If a client collects a quorum of signatures on the effects of the transaction, then the client has a promise of finality. This means that transaction effects persist on the shared database and are actually committed and visible to everyone by the end of the epoch. This does not mean that the latency is a full epoch, because you can use the effects _certificate_ to convince anyone of the transactions finality, as well as to access the effects and issue new transactions. As with transactions, you can parallelize the process of sharing a _certificate_ with validators and (if desired) outsource to a third-party service provider.
-
-## The role of Narwhal and Bullshark
-
-IOTA takes advantage of Narwhal and Bullshark as its mempool and consensus engines. Narwhal/Bullshark (N/B) is also implemented in IOTA so that when Byzantine agreement is required it uses a high-throughput DAG-based consensus to manage shared locks while execution on different shared objects is parallelized.
-
-Narwhal enables the parallel ordering of transactions into batches that are collected into concurrently proposed blocks, and Bullshark defines an algorithm for executing the DAG that these blocks form. N/B combined builds a DAG of blocks, concurrently proposed, and creates an order between those blocks as a byproduct of the building of the DAG. But that order is overlaid on top of the _causal order_ of IOTA transactions (the "payload" of Narwhal/Bullshark here), and does not substitute for it:
-
-- N/B operates in OX, rather than XO mode (O = order, X = execute); the execution occurs after the Narwhal/Bullshark ordering.
-- The output of N/B is therefore a sequence of transactions, with interdependencies stored in the transaction data itself.
-
-Consensus sequences _certificates_ of transactions. These represent transactions that have already been presented to 2/3 of validators that checked that all their owned objects are available to be operated on and signed the transaction. Upon a _certificate_ being sequenced, IOTA sets the lock of the shared objects at the next available version to map to the execution of that _certificate_. So for example if you have a shared object X at version 2, and you sequence _certificate_ T, IOTA stores T -> [(X, 2)]. That is all you do when IOTA reaches consensus, and as a result IOTA can ingest a lot of sequenced transactions.
-
-Now, after this is done IOTA can execute all _certificates_ that have their locks set, on one or multiple cores. Obviously, transactions for earlier versions of objects need to be processed first (causally), and that reduces the degree of concurrency. The read and write set of the transaction can be statically determined from its versioned object inputs--execution can only read/write an object that was an input to the transaction, or that was created by the transaction.
+If a client collects a quorum of signatures on the effects of a transaction, the transaction is final. This means the effects will persist on the shared database and be permanently recorded in a checkpoint within a few seconds. The epoch boundary serves as an upper bound, but in practice, the effects certificate can be used immediately to prove finality, access results, and trigger new transactions. Clients may share the certificate directly with others or use a third-party service to help propagate it.
 
 <Quiz questions={questions} />

--- a/docs/site/static/json/about-iota/iota-architecture/iota-security.json
+++ b/docs/site/static/json/about-iota/iota-architecture/iota-security.json
@@ -4,9 +4,9 @@
         "questionText": "Given that the Move compiler ensures assets can't be spent twice or lost due to logic errors, which of the following scenarios might still pose a risk to asset security despite the compiler's safeguards?",
         "answerOptions": [
           { "answerText": "Validators misbehaving during transaction processing.", "isCorrect": false },
-          { "answerText": "A flaw in the cryptographic methods securing private keys.", "isCorrect": false },
+          { "answerText": "A flaw in the cryptographic methods securing private keys.", "isCorrect": true },
           { "answerText": "Improper implementation of the asset logic in the smart contract by a third-party developer.", "isCorrect": true },
-          { "answerText": "Delegating asset access to an untrusted third-party service.", "isCorrect": false }
+          { "answerText": "Delegating asset access to an untrusted third-party service.", "isCorrect": true }
         ]
       },
       {
@@ -30,16 +30,16 @@
       {
         "questionText": "If a user mistakenly submits a transaction to the wrong address and it reaches finality, what technical aspect of the IOTA network prevents the transaction from being reversed or altered?",
         "answerOptions": [
-          { "answerText": "Validators are bound by the cryptographic proof of the private key associated with the recipient address.", "isCorrect": false },
+          { "answerText": "Validators are bound by the cryptographic proof of the private key associated with the recipient address.", "isCorrect": true },
           { "answerText": "The smart contract logic prevents asset redirection after finality is reached.", "isCorrect": false },
           { "answerText": "The Move compiler automatically enforces transaction irreversibility.", "isCorrect": false },
-          { "answerText": "The recipient's private key holds exclusive access rights, making any further modification impossible.", "isCorrect": true }
+          { "answerText": "The recipient's private key holds exclusive access rights, making any further modification impossible.", "isCorrect": false }
         ]
       },
       {
         "questionText": "Considering the public auditability of all transactions on IOTA, which of the following could be a potential vulnerability for users seeking privacy, even if they use pseudonymous addresses?",
         "answerOptions": [
-          { "answerText": "Validators can track the transaction history and link multiple addresses to a single user.", "isCorrect": false },
+          { "answerText": "Validators can track the transaction history and link multiple addresses to a single user.", "isCorrect": true },
           { "answerText": "Third-party services can provide enhanced privacy by masking user identity during asset transfers.", "isCorrect": false },
           { "answerText": "Pseudonymous addresses are still visible on the blockchain, which could lead to de-anonymization through pattern analysis.", "isCorrect": true },
           { "answerText": "The cryptographic proof provided by validators reveals the private key of the user involved in the transaction.", "isCorrect": false }

--- a/docs/site/static/json/about-iota/iota-architecture/iota-security.json
+++ b/docs/site/static/json/about-iota/iota-architecture/iota-security.json
@@ -39,7 +39,7 @@
       {
         "questionText": "Considering the public auditability of all transactions on IOTA, which of the following could be a potential vulnerability for users seeking privacy, even if they use pseudonymous addresses?",
         "answerOptions": [
-          { "answerText": "Validators can track the transaction history and link multiple addresses to a single user.", "isCorrect": true },
+          { "answerText": "Public auditability allows validators to modify past transactions.", "isCorrect": false },
           { "answerText": "Third-party services can provide enhanced privacy by masking user identity during asset transfers.", "isCorrect": false },
           { "answerText": "Pseudonymous addresses are still visible on the blockchain, which could lead to de-anonymization through pattern analysis.", "isCorrect": true },
           { "answerText": "The cryptographic proof provided by validators reveals the private key of the user involved in the transaction.", "isCorrect": false }

--- a/docs/site/static/json/node-operators/validator-committee.json
+++ b/docs/site/static/json/node-operators/validator-committee.json
@@ -9,15 +9,6 @@
         ]
     },
     {
-        "questionText": "Which consensus engines does IOTA utilize to handle transactions?",
-        "answerOptions": [
-            { "answerText": "PoW and PoS", "isCorrect": false },
-            { "answerText": "Narwhal and Bullshark", "isCorrect": true },
-            { "answerText": "DAG and Blockchain", "isCorrect": false },
-            { "answerText": "BFT and DPoS", "isCorrect": false }
-        ]
-    },
-    {
         "questionText": "What is the purpose of certificates in IOTA’s consensus process?",
         "answerOptions": [
             { "answerText": "To confirm that a transaction has been validated by a quorum of validators.", "isCorrect": true },


### PR DESCRIPTION
# Description of change

This PR refines various sections of the IOTA documentation to improve clarity and accuracy. Key updates include:

Changes
	•	Quiz Fixes: Updated quiz answers to reflect multiple correct responses where applicable and ensured factual accuracy.
	•	Validator Accountability: Removed unsupported claims regarding active detection mechanisms.
	•	Checkpoint Description: Clarified how transactions are ordered and finalized, avoiding misleading “causal ordering” terminology.
	•	Finality Explanation: Improved wording around transaction finality and clarified that epoch duration is an upper bound for latency.
	•	Intro Wording: Minor refinements to improve readability while maintaining structure.
	•	Bullshark-Narwhal Reference: Removed outdated mentions to align with the current protocol.

Why These Changes?

These modifications ensure the documentation is technically accurate and enhances readability without altering the intended meaning.

## Links to any relevant issues

Closes #5414

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Documentation Fix

## Testing Required

Note: The quiz now includes multiple correct answers for some questions. Please verify that the system correctly supports this behavior before merging.

