### PR TITLE
refactor(iota-data-ingestion): use FileProgressStore

### DIFF
--- a/dev-tools/iota-data-ingestion/README.md
+++ b/dev-tools/iota-data-ingestion/README.md
@@ -26,14 +26,12 @@ path: "./test-checkpoints"
 # IOTA Node Rest API URL
 remote-store-url: "http://localhost:9000/api/v1"
 
-# DynamoDbProgressStore config
+# Path to the progress store JSON file.
 #
-progress-store:
-  aws-access-key-id: "test"
-  aws-secret-access-key: "test"
-  aws-region: "us-east-1"
-  # DynamoDB table name
-  table-name: "checkpoint-progress"
+# The ingestion pipeline uses this file to persist its progress,
+# ensuring state is preserved across restarts.
+#
+progress-store-path: "/iota/output/ingestion_progress.json"
 
 # Workers Configs
 #
@@ -124,36 +122,12 @@ Before starting the service, you need to set up the required AWS components. The
 aws --profile localstack s3 mb s3://checkpoints
 ```
 
-### 2. Set up DynamoDB
-
-Create the DynamoDB table:
-
-```bash
-aws --profile localstack dynamodb create-table \
-    --table-name checkpoint-progress \
-    --attribute-definitions AttributeName=task_name,AttributeType=S \
-    --key-schema AttributeName=task_name,KeyType=HASH \
-    --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5
-```
-
-Initialize the required record:
-
-```bash
-aws --profile localstack dynamodb put-item \
-    --table-name checkpoint-progress \
-    --item '{
-        "task_name": {"S": "local-blob-storage"},
-        "nstate": {"N": "0"}
-    }'
-```
-
-### 3. Verify Resources
+### 2. Verify Resources
 
 Verify that the resources were created correctly:
 
 ```bash
 aws --profile localstack s3 ls
-aws --profile localstack dynamodb list-tables
 ```
 
 ## Troubleshooting

--- a/dev-tools/iota-data-ingestion/config/config.yaml
+++ b/dev-tools/iota-data-ingestion/config/config.yaml
@@ -22,14 +22,12 @@ path: "./test-checkpoints"
 # 3. HTTP access is preferred over local filesystem
 remote-store-url: "http://localhost:9000/api/v1"
 
-# DynamoDbProgressStore config
+# Path to the progress store JSON file.
 #
-progress-store:
-  aws-access-key-id: "test"
-  aws-secret-access-key: "test"
-  aws-region: "us-east-1"
-  # DynamoDB table name
-  table-name: "checkpoint-progress"
+# The ingestion pipeline uses this file to persist its progress,
+# ensuring state is preserved across restarts.
+#
+progress-store-path: "/iota/output/ingestion_progress.json"
 
 # Workers Configs
 #

--- a/dev-tools/iota-data-ingestion/config/kv_store_config.yaml
+++ b/dev-tools/iota-data-ingestion/config/kv_store_config.yaml
@@ -22,14 +22,12 @@ path: "./test-checkpoints"
 # 3. HTTP access is preferred over local filesystem
 remote-store-url: "http://localhost:9000/api/v1"
 
-# DynamoDbProgressStore config
+# Path to the progress store JSON file.
 #
-progress-store:
-  aws-access-key-id: "test"
-  aws-secret-access-key: "test"
-  aws-region: "us-east-1"
-  # DynamoDB table name
-  table-name: "checkpoint-progress"
+# The ingestion pipeline uses this file to persist its progress,
+# ensuring state is preserved across restarts.
+#
+progress-store-path: "/iota/output/ingestion_progress.json"
 
 # Workers Configs
 #

--- a/dev-tools/iota-data-ingestion/config/multiple_workers.yaml
+++ b/dev-tools/iota-data-ingestion/config/multiple_workers.yaml
@@ -22,14 +22,12 @@ path: "./test-checkpoints"
 # 3. HTTP access is preferred over local filesystem
 remote-store-url: "http://localhost:9000/api/v1"
 
-# DynamoDbProgressStore config
+# Path to the progress store JSON file.
 #
-progress-store:
-  aws-access-key-id: "test"
-  aws-secret-access-key: "test"
-  aws-region: "us-east-1"
-  # DynamoDB table name
-  table-name: "checkpoint-progress"
+# The ingestion pipeline uses this file to persist its progress,
+# ensuring state is preserved across restarts.
+#
+progress-store-path: "/iota/output/ingestion_progress.json"
 
 # Workers Configs
 #

--- a/dev-tools/iota-data-ingestion/docker-compose.yaml
+++ b/dev-tools/iota-data-ingestion/docker-compose.yaml
@@ -1,10 +1,9 @@
 services:
   checkpoints-remote-store:
     image: iotaledger/iota-data-ingestion
-    env_file:
-      - .env
     volumes:
       - ./config/config.yaml:/iota/config.yaml:r
+      - ./output:/iota/output
     command: >
       iota-data-ingestion
       /iota/config.yaml

--- a/dev-tools/iota-rest-kv/config/config.yaml
+++ b/dev-tools/iota-rest-kv/config/config.yaml
@@ -3,7 +3,7 @@
 # The Rest Api address
 server-address: "0.0.0.0:3555"
 
-# remote Object Store config for more info:
+# Remote Object Store config for more info:
 # - https://docs.iota.org/operator/archives#set-up-archival-fallback
 #
 # The object store config should point to the same object store the


### PR DESCRIPTION
# Description of change

Use `FileProgressStore` for persisting pipeline progress across restarts instead of `DynamoDbProgressStore`.

## Links to any relevant issues

fixes #5946 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Start the `docker-compose` service and make sure that it sync checkpoints and update the file located in `./output` directory.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
