### PR TITLE
feat(iota-indexer): Add participation metric endpoint

### DIFF
--- a/crates/iota-indexer/migrations/pg/2025-03-21-081552_participation_metrics/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-03-21-081552_participation_metrics/down.sql
@@ -1,0 +1,1 @@
+DROP MATERIALIZED VIEW IF EXISTS participation_metrics;

--- a/crates/iota-indexer/migrations/pg/2025-03-21-081552_participation_metrics/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-03-21-081552_participation_metrics/up.sql
@@ -1,3 +1,5 @@
+-- A materialized view that the total number of unique addresses that have delegated stake in the current epoch.
+-- This view is refreshed on epoch change.
 CREATE MATERIALIZED VIEW participation_metrics AS
 SELECT
     COUNT(DISTINCT owner_id) AS total_addresses

--- a/crates/iota-indexer/migrations/pg/2025-03-21-081552_participation_metrics/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-03-21-081552_participation_metrics/up.sql
@@ -1,8 +1,8 @@
 CREATE MATERIALIZED VIEW participation_metrics AS
 SELECT
-    COUNT(DISTINCT owner_id) AS total_addresses,
+    COUNT(DISTINCT owner_id) AS total_addresses
 FROM
     objects
 WHERE
-        object_type IN ('StakedIota', 'TimelockedStakedIota')
+        object_type IN ('0x0000000000000000000000000000000000000000000000000000000000000003::staking_pool::StakedIota', '0x0000000000000000000000000000000000000000000000000000000000000003::timelocked_staking::TimelockedStakedIota')
   AND owner_id IS NOT NULL;

--- a/crates/iota-indexer/migrations/pg/2025-03-21-081552_participation_metrics/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-03-21-081552_participation_metrics/up.sql
@@ -1,5 +1,5 @@
 -- A materialized view that the total number of unique addresses that have delegated stake in the current epoch.
--- This view is refreshed on epoch change.
+-- Includes both staked and timelocked staked IOTA.
 CREATE MATERIALIZED VIEW participation_metrics AS
 SELECT
     COUNT(DISTINCT owner_id) AS total_addresses

--- a/crates/iota-indexer/migrations/pg/2025-03-21-081552_participation_metrics/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-03-21-081552_participation_metrics/up.sql
@@ -1,0 +1,8 @@
+CREATE MATERIALIZED VIEW participation_metrics AS
+SELECT
+    COUNT(DISTINCT owner_id) AS total_addresses,
+FROM
+    objects
+WHERE
+        object_type IN ('StakedIota', 'TimelockedStakedIota')
+  AND owner_id IS NOT NULL;

--- a/crates/iota-indexer/src/apis/extended_api.rs
+++ b/crates/iota-indexer/src/apis/extended_api.rs
@@ -157,11 +157,10 @@ impl ExtendedApiServer for ExtendedApi {
     }
 
     async fn get_participation_metrics(&self) -> RpcResult<ParticipationMetrics> {
-        let participation_metrics = self
-            .inner
+        self.inner
             .spawn_blocking(|this| this.get_participation_metrics())
-            .await?;
-        Ok(participation_metrics)
+            .await
+            .map_err(Into::into)
     }
 }
 

--- a/crates/iota-indexer/src/apis/extended_api.rs
+++ b/crates/iota-indexer/src/apis/extended_api.rs
@@ -8,7 +8,7 @@ use iota_json_rpc_api::{
 };
 use iota_json_rpc_types::{
     AddressMetrics, EpochInfo, EpochMetrics, EpochMetricsPage, EpochPage, MoveCallMetrics,
-    NetworkMetrics, Page,
+    NetworkMetrics, Page, ParticipationMetrics,
 };
 use iota_open_rpc::Module;
 use iota_types::iota_serde::BigInt;
@@ -154,6 +154,14 @@ impl ExtendedApiServer for ExtendedApi {
             .spawn_blocking(|this| this.get_latest_checkpoint())
             .await?;
         Ok(latest_checkpoint.network_total_transactions.into())
+    }
+
+    async fn get_participation_metrics(&self) -> RpcResult<ParticipationMetrics> {
+        let participation_metrics = self
+            .inner
+            .spawn_blocking(|this| this.get_participation_metrics())
+            .await?;
+        Ok(participation_metrics)
     }
 }
 

--- a/crates/iota-indexer/src/handlers/committer.rs
+++ b/crates/iota-indexer/src/handlers/committer.rs
@@ -149,7 +149,6 @@ async fn commit_checkpoints<S>(
         ];
         if let Some(epoch_data) = epoch.clone() {
             persist_tasks.push(state.persist_epoch(epoch_data));
-            persist_tasks.push(state.refresh_participation_metrics());
         }
         futures::future::join_all(persist_tasks)
             .await
@@ -176,6 +175,15 @@ async fn commit_checkpoints<S>(
             })
             .expect("Advancing epochs in DB should not fail.");
         metrics.total_epoch_committed.inc();
+
+        // Refresh participation metrics after advancing epoch
+        state
+            .refresh_participation_metrics()
+            .await
+            .tap_err(|e| {
+                error!("Failed to update participation metrics: {}", e.to_string());
+            })
+            .expect("Updating participation metrics should not fail.");
     }
 
     state

--- a/crates/iota-indexer/src/handlers/committer.rs
+++ b/crates/iota-indexer/src/handlers/committer.rs
@@ -149,6 +149,7 @@ async fn commit_checkpoints<S>(
         ];
         if let Some(epoch_data) = epoch.clone() {
             persist_tasks.push(state.persist_epoch(epoch_data));
+            persist_tasks.push(state.refresh_participation_metrics());
         }
         futures::future::join_all(persist_tasks)
             .await

--- a/crates/iota-indexer/src/handlers/committer.rs
+++ b/crates/iota-indexer/src/handlers/committer.rs
@@ -181,7 +181,7 @@ async fn commit_checkpoints<S>(
             .refresh_participation_metrics()
             .await
             .tap_err(|e| {
-                error!("Failed to update participation metrics: {}", e.to_string());
+                error!("Failed to update participation metrics: {e}");
             })
             .expect("Updating participation metrics should not fail.");
     }

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -1993,8 +1993,9 @@ impl IndexerReader {
         .map_err(Into::into)
     }
 
-    /// Get the participation metrics. Participation as the total number of
-    /// unique addresses that have delegated stake in the current epoch.
+    /// Get the participation metrics. Participation is defined as the total
+    /// number of unique addresses that have delegated stake in the current
+    /// epoch. Includes both staked and timelocked staked IOTA.
     pub fn get_participation_metrics(&self) -> IndexerResult<ParticipationMetrics> {
         let stored_participation_metrics = run_query!(&self.pool, |conn| {
             diesel::sql_query("SELECT * FROM participation_metrics")

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -1993,6 +1993,8 @@ impl IndexerReader {
         .map_err(Into::into)
     }
 
+    /// Get the participation metrics. Participation as the total number of
+    /// unique addresses that have delegated stake in the current epoch.
     pub fn get_participation_metrics(&self) -> IndexerResult<ParticipationMetrics> {
         let stored_participation_metrics = run_query!(&self.pool, |conn| {
             diesel::sql_query("SELECT * FROM participation_metrics")

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -22,7 +22,8 @@ use iota_json_rpc_types::{
     AddressMetrics, Balance, CheckpointId, Coin as IotaCoin, DisplayFieldsResponse, EpochInfo,
     EventFilter, IotaCoinMetadata, IotaEvent, IotaMoveValue, IotaObjectDataFilter,
     IotaTransactionBlockEffects, IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse,
-    IotaTransactionKind, MoveCallMetrics, MoveFunctionName, NetworkMetrics, TransactionFilter,
+    IotaTransactionKind, MoveCallMetrics, MoveFunctionName, NetworkMetrics, ParticipationMetrics,
+    TransactionFilter,
 };
 use iota_package_resolver::{Package, PackageStore, PackageStoreWithLruCache, Resolver};
 use iota_types::{
@@ -59,6 +60,7 @@ use crate::{
         network_metrics::StoredNetworkMetrics,
         obj_indices::StoredObjectVersion,
         objects::{CoinBalance, StoredHistoryObject, StoredObject},
+        participation_metrics::StoredParticipationMetrics,
         transactions::{
             StoredTransaction, StoredTransactionEvents, stored_events_to_events,
             tx_events_to_iota_tx_events,
@@ -1989,6 +1991,14 @@ impl IndexerReader {
         })
         .await
         .map_err(Into::into)
+    }
+
+    pub fn get_participation_metrics(&self) -> IndexerResult<ParticipationMetrics> {
+        let stored_participation_metrics = run_query!(&self.pool, |conn| {
+            diesel::sql_query("SELECT * FROM participation_metrics")
+                .get_result::<StoredParticipationMetrics>(conn)
+        })?;
+        Ok(stored_participation_metrics.into())
     }
 }
 

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -1997,11 +1997,11 @@ impl IndexerReader {
     /// number of unique addresses that have delegated stake in the current
     /// epoch. Includes both staked and timelocked staked IOTA.
     pub fn get_participation_metrics(&self) -> IndexerResult<ParticipationMetrics> {
-        let stored_participation_metrics = run_query!(&self.pool, |conn| {
+        run_query!(&self.pool, |conn| {
             diesel::sql_query("SELECT * FROM participation_metrics")
                 .get_result::<StoredParticipationMetrics>(conn)
-        })?;
-        Ok(stored_participation_metrics.into())
+        })
+        .map(Into::into)
     }
 }
 

--- a/crates/iota-indexer/src/models/mod.rs
+++ b/crates/iota-indexer/src/models/mod.rs
@@ -13,6 +13,7 @@ pub mod network_metrics;
 pub mod obj_indices;
 pub mod objects;
 pub mod packages;
+pub mod participation_metrics;
 pub mod transactions;
 pub mod tx_count_metrics;
 pub mod tx_indices;

--- a/crates/iota-indexer/src/models/participation_metrics.rs
+++ b/crates/iota-indexer/src/models/participation_metrics.rs
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use diesel::{prelude::*, sql_types::BigInt};
+use iota_json_rpc_types::ParticipationMetrics;
+
+#[derive(Clone, Debug, Default, QueryableByName)]
+pub struct StoredParticipationMetrics {
+    #[diesel(sql_type = BigInt)]
+    pub total_addresses: i64,
+}
+
+impl From<StoredParticipationMetrics> for ParticipationMetrics {
+    fn from(metrics: StoredParticipationMetrics) -> Self {
+        Self {
+            total_addresses: metrics.total_addresses as u64,
+        }
+    }
+}

--- a/crates/iota-indexer/src/models/participation_metrics.rs
+++ b/crates/iota-indexer/src/models/participation_metrics.rs
@@ -1,5 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2024 IOTA Stiftung
+// Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use diesel::{prelude::*, sql_types::BigInt};

--- a/crates/iota-indexer/src/models/participation_metrics.rs
+++ b/crates/iota-indexer/src/models/participation_metrics.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 IOTA Stiftung
+// Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use diesel::{prelude::*, sql_types::BigInt};

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -105,5 +105,7 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
         epoch: u64,
     ) -> Result<u64, IndexerError>;
 
+    async fn refresh_participation_metrics(&self) -> Result<(), IndexerError>;
+
     fn as_any(&self) -> &dyn Any;
 }

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -1509,6 +1509,24 @@ impl PgIndexerStore {
         .map(|v| v as u64)
     }
 
+    fn refresh_participation_metrics(&self) -> Result<(), IndexerError> {
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                diesel::sql_query("REFRESH MATERIALIZED VIEW participation_metrics")
+                    .execute(conn)?;
+                Ok::<(), IndexerError>(())
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+        .tap_ok(|_| {
+            info!("Successfully refreshed participation_metrics");
+        })
+        .tap_err(|e| {
+            tracing::error!("Failed to refresh participation_metrics: {}", e);
+        })
+    }
+
     async fn execute_in_blocking_worker<F, R>(&self, f: F) -> Result<R, IndexerError>
     where
         F: FnOnce(Self) -> Result<R, IndexerError> + Send + 'static,
@@ -2090,6 +2108,11 @@ impl IndexerStore for PgIndexerStore {
             this.get_network_total_transactions_by_end_of_epoch(epoch)
         })
         .await
+    }
+
+    async fn refresh_participation_metrics(&self) -> Result<(), IndexerError> {
+        self.execute_in_blocking_worker(move |this| this.refresh_participation_metrics())
+            .await
     }
 
     fn as_any(&self) -> &dyn StdAny {

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -1523,7 +1523,7 @@ impl PgIndexerStore {
             info!("Successfully refreshed participation_metrics");
         })
         .tap_err(|e| {
-            tracing::error!("Failed to refresh participation_metrics: {}", e);
+            tracing::error!("Failed to refresh participation_metrics: {e}");
         })
     }
 

--- a/crates/iota-json-rpc-api/src/extended.rs
+++ b/crates/iota-json-rpc-api/src/extended.rs
@@ -4,6 +4,7 @@
 
 use iota_json_rpc_types::{
     AddressMetrics, EpochInfo, EpochMetricsPage, EpochPage, MoveCallMetrics, NetworkMetrics,
+    ParticipationMetrics,
 };
 use iota_open_rpc_macros::open_rpc;
 use iota_types::iota_serde::BigInt;
@@ -71,4 +72,8 @@ pub trait ExtendedApi {
     /// indexer.
     #[method(name = "getTotalTransactions")]
     async fn get_total_transactions(&self) -> RpcResult<BigInt<u64>>;
+
+    /// Return the participation metrics. Exclusively served by the indexer.
+    #[method(name = "getParticipationMetrics")]
+    async fn get_participation_metrics(&self) -> RpcResult<ParticipationMetrics>;
 }

--- a/crates/iota-json-rpc-api/src/extended.rs
+++ b/crates/iota-json-rpc-api/src/extended.rs
@@ -73,7 +73,9 @@ pub trait ExtendedApi {
     #[method(name = "getTotalTransactions")]
     async fn get_total_transactions(&self) -> RpcResult<BigInt<u64>>;
 
-    /// Return the participation metrics. Exclusively served by the indexer.
+    /// Return the participation metrics. Participation as the total number of
+    /// unique addresses that have delegated stake in the current epoch.
+    /// Exclusively served by the indexer.
     #[method(name = "getParticipationMetrics")]
     async fn get_participation_metrics(&self) -> RpcResult<ParticipationMetrics>;
 }

--- a/crates/iota-json-rpc-api/src/extended.rs
+++ b/crates/iota-json-rpc-api/src/extended.rs
@@ -73,8 +73,9 @@ pub trait ExtendedApi {
     #[method(name = "getTotalTransactions")]
     async fn get_total_transactions(&self) -> RpcResult<BigInt<u64>>;
 
-    /// Return the participation metrics. Participation as the total number of
-    /// unique addresses that have delegated stake in the current epoch.
+    /// Returns the participation metrics. Participation is defined as the total
+    /// number of unique addresses that have delegated stake in the current
+    /// epoch. Includes both staked and timelocked staked IOTA.
     /// Exclusively served by the indexer.
     #[method(name = "getParticipationMetrics")]
     async fn get_participation_metrics(&self) -> RpcResult<ParticipationMetrics>;

--- a/crates/iota-json-rpc-types/src/iota_extended.rs
+++ b/crates/iota-json-rpc-types/src/iota_extended.rs
@@ -229,7 +229,6 @@ pub struct AddressMetrics {
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ParticipationMetrics {
-    /// The count of distinct addresses with delegated stake in the current
-    /// epoch.
+    /// The count of distinct addresses with delegated stake.
     pub total_addresses: u64,
 }

--- a/crates/iota-json-rpc-types/src/iota_extended.rs
+++ b/crates/iota-json-rpc-types/src/iota_extended.rs
@@ -223,3 +223,13 @@ pub struct AddressMetrics {
     /// The count of daily unique sender addresses.
     pub daily_active_addresses: u64,
 }
+
+/// Provides metrics about the participation in the network.
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ParticipationMetrics {
+    /// The count of distinct addresses with delegated stake in the current
+    /// epoch.
+    pub total_addresses: u64,
+}

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -4149,6 +4149,23 @@
       ]
     },
     {
+      "name": "iotax_getParticipationMetrics",
+      "tags": [
+        {
+          "name": "Extended API"
+        }
+      ],
+      "description": "Returns the participation metrics. Participation is defined as the total number of unique addresses that have delegated stake in the current epoch. Includes both staked and timelocked staked IOTA. Exclusively served by the indexer.",
+      "params": [],
+      "result": {
+        "name": "ParticipationMetrics",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/ParticipationMetrics"
+        }
+      }
+    },
+    {
       "name": "iotax_getReferenceGasPrice",
       "tags": [
         {
@@ -10902,6 +10919,21 @@
                 "type": "null"
               }
             ]
+          }
+        }
+      },
+      "ParticipationMetrics": {
+        "description": "Provides metrics about the participation in the network.",
+        "type": "object",
+        "required": [
+          "totalAddresses"
+        ],
+        "properties": {
+          "totalAddresses": {
+            "description": "The count of distinct addresses with delegated stake.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           }
         }
       },


### PR DESCRIPTION
# Description of change

Implements the participation metric which is defined as the total number of unique addresses that have delegated stake in the current epoch.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/5608

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Start the test cluster:

`cargo run --features indexer --bin iota start --with-indexer --pg-port 5432 --pg-db-name iota_indexer --with-graphql=0.0.0.0:8000 --with-faucet --force-regenesis`

You can fetch the participation metric using:

```sh
curl --location --request POST 'http://localhost:9124' \
--header 'Content-Type: application/json' \
--data-raw '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "iotax_getParticipationMetrics"
}'
```

`{"jsonrpc":"2.0","id":1,"result":{"totalAddresses":4}}`