### PR TITLE
[doc]: Remove references to checkpoint data remote store urls

### DIFF
--- a/crates/iota-data-ingestion-core/src/executor.rs
+++ b/crates/iota-data-ingestion-core/src/executor.rs
@@ -304,7 +304,7 @@ async fn components_graceful_shutdown(
 /// async fn main() {
 ///     let (executor, _) = setup_single_workflow(
 ///         CustomWorker,
-///         "https://checkpoints.testnet.iota.cafe".to_string(),
+///         "https://api.testnet.iota.cafe/api/v1".to_string(),
 ///         0,    // initial checkpoint number.
 ///         5,    // concurrency.
 ///         None, // extra reader options.

--- a/crates/iota-indexer/src/lib.rs
+++ b/crates/iota-indexer/src/lib.rs
@@ -65,7 +65,7 @@ pub struct IndexerConfig {
     pub db_name: Option<String>,
     #[arg(long, default_value = "http://0.0.0.0:9000", global = true)]
     pub rpc_client_url: String,
-    #[arg(long, default_value = Some("https://checkpoints.mainnet.iota.cafe"), global = true)]
+    #[arg(long, default_value = Some("https://api.testnet.iota.cafe/api/v1"), global = true)]
     pub remote_store_url: Option<String>,
     #[arg(long, default_value = "0.0.0.0", global = true)]
     pub client_metric_host: String,
@@ -147,7 +147,7 @@ impl Default for IndexerConfig {
             db_port: None,
             db_name: None,
             rpc_client_url: "http://127.0.0.1:9000".to_string(),
-            remote_store_url: Some("https://checkpoints.mainnet.iota.cafe".to_string()),
+            remote_store_url: Some("https://api.testnet.iota.cafe/api/v1".to_string()),
             client_metric_host: "0.0.0.0".to_string(),
             client_metric_port: 9184,
             rpc_server_url: "0.0.0.0".to_string(),

--- a/docs/content/developer/advanced/custom-indexer.mdx
+++ b/docs/content/developer/advanced/custom-indexer.mdx
@@ -1,7 +1,7 @@
 ---
 title: Custom Indexer
 description: You can build custom indexers using the IOTA micro-data ingestion framework. To create an indexer, you subscribe to a checkpoint stream with full checkpoint content. Establishing a custom indexer helps improve latency, allows pruning the data of your IOTA full node, and provides efficient assemblage of checkpoint data.
-tags: 
+tags:
   - infrastructure
 teams:
   - iotaledger/infrastructure
@@ -122,7 +122,7 @@ Specify both a local and remote store as a fallback to ensure constant data flow
 ```rust
 executor.run(
     PathBuf::from("./chk".to_string()), // path to a local directory
-    Some("https://indexer.testnet.iota.cafe".to_string()), // Remote Checkpoint Store
+    Some("https://api.testnet.iota.cafe/api/v1".to_string()), // Remote Checkpoint Store
     vec![], // optional remote store access options
     ReaderOptions::default(),
     exit_receiver,
@@ -137,7 +137,7 @@ Code for the cargo.toml manifest file for the custom indexer.
 ```toml file=<rootDir>/examples/custom-indexer/rust/Cargo.toml
 ```
 
-## Source Code 
+## Source Code
 
 Find the following source code in the [IOTA repo](https://github.com/iotaledger/iota/tree/main/examples/custom-indexer/rust).
 

--- a/examples/custom-indexer/rust/remote_reader.rs
+++ b/examples/custom-indexer/rust/remote_reader.rs
@@ -31,7 +31,7 @@ impl Worker for CustomWorker {
 async fn main() -> Result<()> {
     let (executor, _) = setup_single_workflow(
         CustomWorker,
-        "https://checkpoints.testnet.iota.cafe".to_string(),
+        "https://api.testnet.iota.cafe/api/v1".to_string(),
         0,    // initial checkpoint number
         5,    // concurrency
         None, // extra reader options


### PR DESCRIPTION
# Description of change

Remove any references to urls for the inherited checkpoint remote store (e.g. `https://checkpoints.testnet.iota.io/1.chk`) in anticipation of the new uploading scheme.

## Links to any relevant issues

fixes #6016 

## Type of change

- Documentation Fix

## How the change has been tested

- made sure doc tests passed in `iota-data-ingestion-core`
```shell
cargo test -p iota-data-ingestion-core
```

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked that new and existing unit tests pass locally with my changes
