### PR TITLE
feat(consensus): `try_find_blocks` to respect GC threshold

### DIFF
--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -155,10 +155,23 @@ impl BlockManager {
 
     /// Tries to find the provided block_refs in DagState and BlockManager,
     /// and returns missing block refs.
-    pub(crate) fn try_find_blocks(&mut self, mut block_refs: Vec<BlockRef>) -> BTreeSet<BlockRef> {
+    pub(crate) fn try_find_blocks(&mut self, block_refs: Vec<BlockRef>) -> BTreeSet<BlockRef> {
         let _s = monitored_scope("BlockManager::try_find_blocks");
+        let gc_round = self.dag_state.read().gc_round();
+
+        // No need to fetch blocks that are <= gc_round as they won't get processed
+        // anyways and they'll get skipped. So keep only the ones above.
+        let mut block_refs = block_refs
+            .into_iter()
+            .filter(|block_ref| block_ref.round > gc_round)
+            .collect::<Vec<_>>();
+
+        if block_refs.is_empty() {
+            return BTreeSet::new();
+        }
 
         block_refs.sort_by_key(|b| b.round);
+
         debug!(
             "Trying to find blocks: {}",
             block_refs.iter().map(|b| b.to_string()).join(",")


### PR DESCRIPTION
# Description of change

Porting upstream commit: https://github.com/MystenLabs/sui/commit/d2996dcbbba1a6da4962b191452f699dadf8790f


> There is no reason to try and synchronize blocks that are `<= gc_round`. Updating the `try_find_blocks` to respect gc round. This should lead to less unnecessary synchronization when nodes lag behind in network.


## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #(issue)`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
