### PR TITLE
ci: check `rosetta` workflow only during `nightly`

### DIFF
--- a/.github/workflows/hierarchy.yml
+++ b/.github/workflows/hierarchy.yml
@@ -91,7 +91,7 @@ jobs:
       - typos
     if: |
       !cancelled() && !failure() &&
-      (needs.diff.outputs.isRosetta == 'true' || needs.diff.outputs.isRust == 'true')
+      (needs.diff.outputs.isRosetta == 'true')
     uses: ./.github/workflows/_rosetta.yml
 
   move-ide:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -70,6 +70,9 @@ jobs:
   split-cluster:
     uses: ./.github/workflows/_split_cluster.yml
 
+  rosetta:
+    uses: ./.github/workflows/_rosetta.yml
+
   simtest:
     timeout-minutes: 600
     runs-on: [self-hosted-x64]


### PR DESCRIPTION
Rosetta workflow is triggered for every single rust file change right now, which clogs the CI with rosetta jobs.

IMO it is enough to run these tests in nightly, or if the rosetta code actually changed.