### PR TITLE
fix(indexer): run migrations when restarting the application

### DIFF
--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -61,6 +61,7 @@ async fn get_objects_to_mutate(
     (object_ids, gas)
 }
 
+#[ignore = "https://github.com/iotaledger/iota/issues/6120"]
 #[test]
 fn dry_run_transaction_block() {
     let ApiTestSetup {


### PR DESCRIPTION
# Description of change

Hotfix to update the db with new migrations while restarting `iota-indexer`

## Links to any relevant issues

Fixes #6138

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Just checked compilation with 
```
$ cargo clippy --all-targets --all-features
```

The logic implemented ensures that migrations run while setting up the db.
