### PR TITLE
feat(iota-genesis-builder) Add ability to have comments in genesis ceremony csv files

### DIFF
--- a/crates/iota-config/src/genesis.rs
+++ b/crates/iota-config/src/genesis.rs
@@ -518,7 +518,9 @@ impl TokenDistributionSchedule {
     /// The file is encoded such that the final entry in the CSV file is used to
     /// denote the allocation to the stake subsidy fund.
     pub fn from_csv<R: std::io::Read>(reader: R) -> Result<Self> {
-        let mut reader = csv::ReaderBuilder::new().comment(Some(b'#')).from_reader(reader);
+        let mut reader = csv::ReaderBuilder::new()
+            .comment(Some(b'#'))
+            .from_reader(reader);
         let mut allocations: Vec<TokenAllocation> =
             reader.deserialize().collect::<Result<_, _>>()?;
 
@@ -700,10 +702,12 @@ impl Delegations {
     /// <delegator1-address>,<validator-1-address>,2000000000000000,5000000000
     /// <delegator1-address>,<validator-2-address>,3000000000000000,5000000000
     /// <delegator2-address>,<validator-3-address>,4500000000000000,5000000000`
-    /// 
+    ///
     /// Comments are optional, and start with a `#` character.
     pub fn from_csv<R: std::io::Read>(reader: R) -> Result<Self> {
-        let mut reader = csv::ReaderBuilder::new().comment(Some(b'#')).from_reader(reader);
+        let mut reader = csv::ReaderBuilder::new()
+            .comment(Some(b'#'))
+            .from_reader(reader);
 
         let mut delegations = Self::default();
         for delegation in reader.deserialize::<Delegation>() {

--- a/crates/iota-config/src/genesis.rs
+++ b/crates/iota-config/src/genesis.rs
@@ -518,7 +518,7 @@ impl TokenDistributionSchedule {
     /// The file is encoded such that the final entry in the CSV file is used to
     /// denote the allocation to the stake subsidy fund.
     pub fn from_csv<R: std::io::Read>(reader: R) -> Result<Self> {
-        let mut reader = csv::Reader::from_reader(reader);
+        let mut reader = csv::ReaderBuilder::new().comment(Some(b'#')).from_reader(reader);
         let mut allocations: Vec<TokenAllocation> =
             reader.deserialize().collect::<Result<_, _>>()?;
 
@@ -701,7 +701,7 @@ impl Delegations {
     /// <delegator1-address>,<validator-2-address>,3000000000000000,5000000000
     /// <delegator2-address>,<validator-3-address>,4500000000000000,5000000000`
     pub fn from_csv<R: std::io::Read>(reader: R) -> Result<Self> {
-        let mut reader = csv::Reader::from_reader(reader);
+        let mut reader = csv::ReaderBuilder::new().comment(Some(b'#')).from_reader(reader);
 
         let mut delegations = Self::default();
         for delegation in reader.deserialize::<Delegation>() {

--- a/crates/iota-config/src/genesis.rs
+++ b/crates/iota-config/src/genesis.rs
@@ -700,6 +700,8 @@ impl Delegations {
     /// <delegator1-address>,<validator-1-address>,2000000000000000,5000000000
     /// <delegator1-address>,<validator-2-address>,3000000000000000,5000000000
     /// <delegator2-address>,<validator-3-address>,4500000000000000,5000000000`
+    /// 
+    /// Comments are optional, and start with a `#` character.
     pub fn from_csv<R: std::io::Read>(reader: R) -> Result<Self> {
         let mut reader = csv::ReaderBuilder::new().comment(Some(b'#')).from_reader(reader);
 

--- a/crates/iota-config/src/genesis.rs
+++ b/crates/iota-config/src/genesis.rs
@@ -521,7 +521,7 @@ impl TokenDistributionSchedule {
     /// Comments are optional, and start with a `#` character.
     /// Only entries that start with this character are treated as comments.
     pub fn from_csv<R: std::io::Read>(reader: R) -> Result<Self> {
-        let mut reader = custom_csv_reader(reader);
+        let mut reader = csv_reader_with_comments(reader);
         let mut allocations: Vec<TokenAllocation> =
             reader.deserialize().collect::<Result<_, _>>()?;
 
@@ -707,7 +707,7 @@ impl Delegations {
     /// Comments are optional, and start with a `#` character.
     /// Only entries that start with this character are treated as comments.
     pub fn from_csv<R: std::io::Read>(reader: R) -> Result<Self> {
-        let mut reader = custom_csv_reader(reader);
+        let mut reader = csv_reader_with_comments(reader);
 
         let mut delegations = Self::default();
         for delegation in reader.deserialize::<Delegation>() {
@@ -756,7 +756,7 @@ impl Delegations {
 
 /// Helper function to create a CSV reader with custom settings.
 /// In this case, it sets the comment character to `#`.
-pub fn custom_csv_reader<R: std::io::Read>(reader: R) -> csv::Reader<R> {
+pub fn csv_reader_with_comments<R: std::io::Read>(reader: R) -> csv::Reader<R> {
     csv::ReaderBuilder::new()
         .comment(Some(b'#'))
         .from_reader(reader)

--- a/crates/iota-config/src/genesis.rs
+++ b/crates/iota-config/src/genesis.rs
@@ -521,9 +521,7 @@ impl TokenDistributionSchedule {
     /// Comments are optional, and start with a `#` character.
     /// Only entries that start with this character are treated as comments.
     pub fn from_csv<R: std::io::Read>(reader: R) -> Result<Self> {
-        let mut reader = csv::ReaderBuilder::new()
-            .comment(Some(b'#'))
-            .from_reader(reader);
+        let mut reader = custom_csv_reader(reader);
         let mut allocations: Vec<TokenAllocation> =
             reader.deserialize().collect::<Result<_, _>>()?;
 
@@ -709,9 +707,7 @@ impl Delegations {
     /// Comments are optional, and start with a `#` character.
     /// Only entries that start with this character are treated as comments.
     pub fn from_csv<R: std::io::Read>(reader: R) -> Result<Self> {
-        let mut reader = csv::ReaderBuilder::new()
-            .comment(Some(b'#'))
-            .from_reader(reader);
+        let mut reader = custom_csv_reader(reader);
 
         let mut delegations = Self::default();
         for delegation in reader.deserialize::<Delegation>() {
@@ -756,4 +752,12 @@ impl Delegations {
 
         Ok(())
     }
+}
+
+/// Helper function to create a CSV reader with custom settings.
+/// In this case, it sets the comment character to `#`.
+pub fn custom_csv_reader<R: std::io::Read>(reader: R) -> csv::Reader<R> {
+    csv::ReaderBuilder::new()
+        .comment(Some(b'#'))
+        .from_reader(reader)
 }

--- a/crates/iota-config/src/genesis.rs
+++ b/crates/iota-config/src/genesis.rs
@@ -517,6 +517,9 @@ impl TokenDistributionSchedule {
     ///
     /// The file is encoded such that the final entry in the CSV file is used to
     /// denote the allocation to the stake subsidy fund.
+    ///
+    /// Comments are optional, and start with a `#` character.
+    /// Only entries that start with this character are treated as comments.
     pub fn from_csv<R: std::io::Read>(reader: R) -> Result<Self> {
         let mut reader = csv::ReaderBuilder::new()
             .comment(Some(b'#'))
@@ -704,6 +707,7 @@ impl Delegations {
     /// <delegator2-address>,<validator-3-address>,4500000000000000,5000000000`
     ///
     /// Comments are optional, and start with a `#` character.
+    /// Only entries that start with this character are treated as comments.
     pub fn from_csv<R: std::io::Read>(reader: R) -> Result<Self> {
         let mut reader = csv::ReaderBuilder::new()
             .comment(Some(b'#'))

--- a/crates/iota-e2e-tests/tests/migration/address_swap.csv
+++ b/crates/iota-e2e-tests/tests/migration/address_swap.csv
@@ -1,2 +1,3 @@
 Origin,Destination
+# Optional comments regarding identities of the addresses can be added.
 iota1qp8h9augeh6tk3uvlxqfapuwv93atv63eqkpru029p6sgvr49eufyz7katr,0x4f72f788cdf4bb478cf9809e878e6163d5b351c82c11f1ea28750430752e7892

--- a/crates/iota-e2e-tests/tests/migration/swap_split.csv
+++ b/crates/iota-e2e-tests/tests/migration/swap_split.csv
@@ -1,3 +1,5 @@
 Origin,Destination,Tokens,TokensTimelocked
+# Optional comments regarding identities of the addresses can be added.
 iota1qp8h9augeh6tk3uvlxqfapuwv93atv63eqkpru029p6sgvr49eufyz7katr,0x1336d143de5eb55bcb069f55da5fc9f0c84e368022fd2bbe0125b1093b446313,107667149000,107667149000
+# Optional comments regarding identities of the addresses can be added.
 iota1qp8h9augeh6tk3uvlxqfapuwv93atv63eqkpru029p6sgvr49eufyz7katr,0x83b5ed87bac715ecb09017a72d531ccc3c43bcb58edeb1ce383f1c46cfd79bec,388647312000,0

--- a/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
@@ -3,8 +3,10 @@
 
 use std::collections::HashMap;
 
+use iota_config::genesis::custom_csv_reader;
 use iota_sdk::types::block::address::Address as StardustAddress;
 use iota_types::{base_types::IotaAddress, object::Owner, stardust::stardust_to_iota_address};
+use std::fs::File;
 
 type OriginAddress = IotaAddress;
 
@@ -159,9 +161,7 @@ impl AddressSwapMap {
     pub fn from_csv(file_path: &str) -> Result<AddressSwapMap, anyhow::Error> {
         let current_dir = std::env::current_dir()?;
         let file_path = current_dir.join(file_path);
-        let mut reader = csv::ReaderBuilder::new()
-            .comment(Some(b'#'))
-            .from_path(file_path)?;
+        let mut reader = custom_csv_reader(File::open(file_path)?);
         let mut addresses = HashMap::new();
 
         verify_headers(reader.headers()?)?;

--- a/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
@@ -140,6 +140,8 @@ impl AddressSwapMap {
     /// iota1qp8h9augeh6tk3uvlxqfapuwv93atv63eqkpru029p6sgvr49eufyz7katr,0xa12b4d6ec3f9a28437d5c8f3e96ba72d3c4e8f5ac98d17b1a3b8e9f2c71d4a3c
     /// iota1qp7h2lkjhs6tk3uvlxqfjhlfw34atv63eqkpru356p6sgvr76eufyz1opkh,0x42d8c182eb1f3b2366d353eed4eb02a31d1d7982c0fd44683811d7036be3a85e
     /// ```
+    /// 
+    /// Comments are optional, and start with a `#` character.
     ///
     /// # Parameters
     /// - `file_path`: The relative path to the CSV file containing the address

--- a/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
@@ -140,7 +140,7 @@ impl AddressSwapMap {
     /// iota1qp8h9augeh6tk3uvlxqfapuwv93atv63eqkpru029p6sgvr49eufyz7katr,0xa12b4d6ec3f9a28437d5c8f3e96ba72d3c4e8f5ac98d17b1a3b8e9f2c71d4a3c
     /// iota1qp7h2lkjhs6tk3uvlxqfjhlfw34atv63eqkpru356p6sgvr76eufyz1opkh,0x42d8c182eb1f3b2366d353eed4eb02a31d1d7982c0fd44683811d7036be3a85e
     /// ```
-    /// 
+    ///
     /// Comments are optional, and start with a `#` character.
     ///
     /// # Parameters
@@ -158,7 +158,9 @@ impl AddressSwapMap {
     pub fn from_csv(file_path: &str) -> Result<AddressSwapMap, anyhow::Error> {
         let current_dir = std::env::current_dir()?;
         let file_path = current_dir.join(file_path);
-        let mut reader = csv::ReaderBuilder::new().comment(Some(b'#')).from_path(file_path)?;
+        let mut reader = csv::ReaderBuilder::new()
+            .comment(Some(b'#'))
+            .from_path(file_path)?;
         let mut addresses = HashMap::new();
 
         verify_headers(reader.headers()?)?;

--- a/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
@@ -156,7 +156,7 @@ impl AddressSwapMap {
     pub fn from_csv(file_path: &str) -> Result<AddressSwapMap, anyhow::Error> {
         let current_dir = std::env::current_dir()?;
         let file_path = current_dir.join(file_path);
-        let mut reader = csv::ReaderBuilder::new().from_path(file_path)?;
+        let mut reader = csv::ReaderBuilder::new().comment(Some(b'#')).from_path(file_path)?;
         let mut addresses = HashMap::new();
 
         verify_headers(reader.headers()?)?;

--- a/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
@@ -1,12 +1,11 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
+use std::{collections::HashMap, fs::File};
 
 use iota_config::genesis::custom_csv_reader;
 use iota_sdk::types::block::address::Address as StardustAddress;
 use iota_types::{base_types::IotaAddress, object::Owner, stardust::stardust_to_iota_address};
-use std::fs::File;
 
 type OriginAddress = IotaAddress;
 

--- a/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
@@ -142,6 +142,7 @@ impl AddressSwapMap {
     /// ```
     ///
     /// Comments are optional, and start with a `#` character.
+    /// Only entries that start with this character are treated as comments.
     ///
     /// # Parameters
     /// - `file_path`: The relative path to the CSV file containing the address

--- a/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/address_swap_map.rs
@@ -3,7 +3,7 @@
 
 use std::{collections::HashMap, fs::File};
 
-use iota_config::genesis::custom_csv_reader;
+use iota_config::genesis::csv_reader_with_comments;
 use iota_sdk::types::block::address::Address as StardustAddress;
 use iota_types::{base_types::IotaAddress, object::Owner, stardust::stardust_to_iota_address};
 
@@ -160,7 +160,7 @@ impl AddressSwapMap {
     pub fn from_csv(file_path: &str) -> Result<AddressSwapMap, anyhow::Error> {
         let current_dir = std::env::current_dir()?;
         let file_path = current_dir.join(file_path);
-        let mut reader = custom_csv_reader(File::open(file_path)?);
+        let mut reader = csv_reader_with_comments(File::open(file_path)?);
         let mut addresses = HashMap::new();
 
         verify_headers(reader.headers()?)?;

--- a/crates/iota-genesis-builder/src/stardust/types/address_swap_split_map.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/address_swap_split_map.rs
@@ -3,7 +3,7 @@
 
 use std::{collections::HashMap, fs::File};
 
-use iota_config::genesis::custom_csv_reader;
+use iota_config::genesis::csv_reader_with_comments;
 use iota_sdk::types::block::address::Address;
 use iota_types::base_types::IotaAddress;
 
@@ -142,7 +142,7 @@ impl AddressSwapSplitMap {
     pub fn from_csv(file_path: &str) -> Result<AddressSwapSplitMap, anyhow::Error> {
         let current_dir = std::env::current_dir()?;
         let file_path = current_dir.join(file_path);
-        let mut reader = custom_csv_reader(File::open(file_path)?);
+        let mut reader = csv_reader_with_comments(File::open(file_path)?);
         let mut address_swap_split_map: AddressSwapSplitMap = Default::default();
 
         let headers = reader.headers()?;

--- a/crates/iota-genesis-builder/src/stardust/types/address_swap_split_map.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/address_swap_split_map.rs
@@ -1,13 +1,11 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::fs::File;
-
-use iota_sdk::types::block::address::Address;
-use iota_types::base_types::IotaAddress;
+use std::{collections::HashMap, fs::File};
 
 use iota_config::genesis::custom_csv_reader;
+use iota_sdk::types::block::address::Address;
+use iota_types::base_types::IotaAddress;
 
 type OriginAddress = Address;
 type Destination = (IotaAddress, u64, u64);

--- a/crates/iota-genesis-builder/src/stardust/types/address_swap_split_map.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/address_swap_split_map.rs
@@ -124,6 +124,7 @@ impl AddressSwapSplitMap {
     /// ```
     ///
     /// Comments are optional, and start with a `#` character.
+    /// Only entries that start with this character are treated as comments.
     ///
     /// # Parameters
     /// - `file_path`: The relative path to the CSV file containing the address

--- a/crates/iota-genesis-builder/src/stardust/types/address_swap_split_map.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/address_swap_split_map.rs
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
+use std::fs::File;
 
 use iota_sdk::types::block::address::Address;
 use iota_types::base_types::IotaAddress;
+
+use iota_config::genesis::custom_csv_reader;
 
 type OriginAddress = Address;
 type Destination = (IotaAddress, u64, u64);
@@ -141,9 +144,7 @@ impl AddressSwapSplitMap {
     pub fn from_csv(file_path: &str) -> Result<AddressSwapSplitMap, anyhow::Error> {
         let current_dir = std::env::current_dir()?;
         let file_path = current_dir.join(file_path);
-        let mut reader = csv::ReaderBuilder::new()
-            .comment(Some(b'#'))
-            .from_path(file_path)?;
+        let mut reader = custom_csv_reader(File::open(file_path)?);
         let mut address_swap_split_map: AddressSwapSplitMap = Default::default();
 
         let headers = reader.headers()?;

--- a/crates/iota-genesis-builder/src/stardust/types/address_swap_split_map.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/address_swap_split_map.rs
@@ -122,7 +122,7 @@ impl AddressSwapSplitMap {
     /// iota1qrukjnd6jhgwc0ls6dgt574sxuulcsmq5lnzhtv4jmlwkydhe2zvy69t7jj,0x1336d143de5eb55bcb069f55da5fc9f0c84e368022fd2bbe0125b1093b446313,107667149000,107667149000
     /// iota1qr4chj9jwhauvegqy40sdhj93mzmvc3mg9cmzlv2y6j8vpyxpvug2y6h5jd,0x83b5ed87bac715ecb09017a72d531ccc3c43bcb58edeb1ce383f1c46cfd79bec,388647312000,0
     /// ```
-    /// 
+    ///
     /// Comments are optional, and start with a `#` character.
     ///
     /// # Parameters
@@ -140,7 +140,9 @@ impl AddressSwapSplitMap {
     pub fn from_csv(file_path: &str) -> Result<AddressSwapSplitMap, anyhow::Error> {
         let current_dir = std::env::current_dir()?;
         let file_path = current_dir.join(file_path);
-        let mut reader = csv::ReaderBuilder::new().comment(Some(b'#')).from_path(file_path)?;
+        let mut reader = csv::ReaderBuilder::new()
+            .comment(Some(b'#'))
+            .from_path(file_path)?;
         let mut address_swap_split_map: AddressSwapSplitMap = Default::default();
 
         let headers = reader.headers()?;

--- a/crates/iota-genesis-builder/src/stardust/types/address_swap_split_map.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/address_swap_split_map.rs
@@ -138,7 +138,7 @@ impl AddressSwapSplitMap {
     pub fn from_csv(file_path: &str) -> Result<AddressSwapSplitMap, anyhow::Error> {
         let current_dir = std::env::current_dir()?;
         let file_path = current_dir.join(file_path);
-        let mut reader = csv::ReaderBuilder::new().from_path(file_path)?;
+        let mut reader = csv::ReaderBuilder::new().comment(Some(b'#')).from_path(file_path)?;
         let mut address_swap_split_map: AddressSwapSplitMap = Default::default();
 
         let headers = reader.headers()?;

--- a/crates/iota-genesis-builder/src/stardust/types/address_swap_split_map.rs
+++ b/crates/iota-genesis-builder/src/stardust/types/address_swap_split_map.rs
@@ -122,6 +122,8 @@ impl AddressSwapSplitMap {
     /// iota1qrukjnd6jhgwc0ls6dgt574sxuulcsmq5lnzhtv4jmlwkydhe2zvy69t7jj,0x1336d143de5eb55bcb069f55da5fc9f0c84e368022fd2bbe0125b1093b446313,107667149000,107667149000
     /// iota1qr4chj9jwhauvegqy40sdhj93mzmvc3mg9cmzlv2y6j8vpyxpvug2y6h5jd,0x83b5ed87bac715ecb09017a72d531ccc3c43bcb58edeb1ce383f1c46cfd79bec,388647312000,0
     /// ```
+    /// 
+    /// Comments are optional, and start with a `#` character.
     ///
     /// # Parameters
     /// - `file_path`: The relative path to the CSV file containing the address


### PR DESCRIPTION
# Description of change

This PR adds the ability to have comments in the genesis ceremony csv input files: 

1. AddressSwapMap
2. AddressSwapSplitMap
3. Delegations

## Links to any relevant issues

fixes #6157 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Ran the genesis ceremony with comments and without comments.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
