### PR TITLE
fix(indexer): run only pending migrations

### DIFF
--- a/crates/iota-indexer/src/db.rs
+++ b/crates/iota-indexer/src/db.rs
@@ -282,8 +282,8 @@ pub mod setup_postgres {
             })?;
             info!("Reset Postgres database complete.");
         } else {
-            conn.run_migrations(&MIGRATIONS.migrations().unwrap())
-                .map_err(|e| anyhow!("Failed to run migrations {e}"))?;
+            conn.run_pending_migrations(MIGRATIONS)
+                .map_err(|e| anyhow!("Failed to run pending migrations {e}"))?;
             info!("Database migrations are up to date.");
         }
         let indexer_metrics = IndexerMetrics::new(&registry);


### PR DESCRIPTION
# Description of change

This patch ensures that **only** pending migrations run on indexer restarts as opposed [to](https://docs.rs/diesel_migrations/2.2.0/src/diesel_migrations/migration_harness.rs.html#42-46) 
```rust
    /// Execute all migrations in the given list
    ///
    /// This method does not check if a certain migration was already applied or not
    #[doc(hidden)]
    fn run_migrations(
```
