### PR TITLE
node-upstream-change([v1.32.2, v1.33.3)): Put back HandleConsensusOutput scope

### DIFF
--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -197,6 +197,8 @@ fn update_index_and_hash(
 impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
     #[instrument(level = "debug", skip_all)]
     async fn handle_consensus_output(&mut self, consensus_output: impl ConsensusOutputAPI) {
+        let _scope = monitored_scope("HandleConsensusOutput");
+
         let last_committed_round = self.last_consensus_stats.index.last_committed_round;
 
         let round = consensus_output.leader_round();


### PR DESCRIPTION
# Description of change

Port https://github.com/MystenLabs/sui/commit/346775946303e0e432685a7aebbe4ae108ed5e88

From [Sui's commit description](https://github.com/MystenLabs/sui/commit/346775946303e0e432685a7aebbe4ae108ed5e88):
Put back HandleConsensusOutput scope

Note that in the file `crates/sui-core/src/consensus_handler.rs`, you won't see the following code snippet in our codebase. The following is from a pretty old PR: [Use a single db batch per narwhal commit in consensus task. #10360](https://github.com/MystenLabs/sui/pull/10360/files), and we do need it.

```rust
        // This code no longer supports old protocol versions.
         assert!(self
             .epoch_store
          ...
 ```

## Links to any relevant issues

Part of #3990 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Ran the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
