### PR TITLE
node-upstream-change([v1.32.2, v1.33.3)): add monitored scopes to CheckpointExecutor

### DIFF
--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -255,6 +255,8 @@ impl CheckpointExecutor {
         let scheduling_timeout_config = get_scheduling_timeout();
 
         loop {
+            let schedule_scope = iota_metrics::monitored_scope("ScheduleCheckpointExecution");
+
             // If we have executed the last checkpoint of the current epoch, stop.
             // Note: when we arrive here with highest_executed == the final checkpoint of
             // the epoch, we are in an edge case where highest_executed does not
@@ -296,12 +298,15 @@ impl CheckpointExecutor {
             let panic_timeout = scheduling_timeout_config.panic_timeout;
             let warning_timeout = scheduling_timeout_config.warning_timeout;
 
+            drop(schedule_scope);
             tokio::select! {
                 // Check for completed workers and ratchet the highest_checkpoint_executed
                 // watermark accordingly. Note that given that checkpoints are guaranteed to
                 // be processed (added to FuturesOrdered) in seq_number order, using FuturesOrdered
                 // guarantees that we will also ratchet the watermarks in order.
                 Some(Ok((checkpoint, checkpoint_acc, tx_digests))) = pending.next() => {
+                    let _process_scope = iota_metrics::monitored_scope("ProcessExecutedCheckpoint");
+
                     self.process_executed_checkpoint(&epoch_store, &checkpoint, checkpoint_acc, &tx_digests).await;
                     highest_executed = Some(checkpoint.clone());
 


### PR DESCRIPTION
# Description of change

Port https://github.com/MystenLabs/sui/commit/a22b71b70d6330f33c165198c194e4b716bc953b

From [Sui's commit description](https://github.com/MystenLabs/sui/commit/a22b71b70d6330f33c165198c194e4b716bc953b):
add monitored scopes to CheckpointExecutor

## Links to any relevant issues

Part of #3990 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Ran the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
