### PR TITLE
node-upstream-change([v1.32.2, v1.33.3)): Delete sst files in key range in rocksdb

### DIFF
--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -343,6 +343,15 @@ impl RocksDB {
         delegate_call!(self.drop_cf(name))
     }
 
+    pub fn delete_file_in_range<K: AsRef<[u8]>>(
+        &self,
+        cf: &impl AsColumnFamilyRef,
+        from: K,
+        to: K,
+    ) -> Result<(), rocksdb::Error> {
+        delegate_call!(self.delete_file_in_range_cf(cf, from, to))
+    }
+
     pub fn delete_cf<K: AsRef<[u8]>>(
         &self,
         cf: &impl AsColumnFamilyRef,
@@ -2031,6 +2040,25 @@ where
                 .write_perf_ctx_metrics
                 .report_metrics(&self.cf);
         }
+        Ok(())
+    }
+
+    /// Deletes a range of keys between `from` (inclusive) and `to`
+    /// (non-inclusive) by immediately deleting any sst files whose key
+    /// range overlaps with the range. Files whose range only partially
+    /// overlaps with the range are not deleted. This can be useful for
+    /// quickly removing a large amount of data without having
+    /// to delete individual keys. Only files at level 1 or higher are
+    /// considered ( Level 0 files are skipped). It doesn't guarantee that
+    /// all keys in the range are deleted, as there might be keys in files
+    /// that weren't entirely within the range.
+    #[instrument(level = "trace", skip_all, err)]
+    fn delete_file_in_range(&self, from: &K, to: &K) -> Result<(), TypedStoreError> {
+        let from_buf = be_fix_int_ser(from.borrow())?;
+        let to_buf = be_fix_int_ser(to.borrow())?;
+        self.rocksdb
+            .delete_file_in_range(&self.cf(), from_buf, to_buf)
+            .map_err(typed_store_err_from_rocks_err)?;
         Ok(())
     }
 

--- a/crates/typed-store/src/test_db.rs
+++ b/crates/typed-store/src/test_db.rs
@@ -267,6 +267,13 @@ where
         Ok(())
     }
 
+    fn delete_file_in_range(&self, from: &K, to: &K) -> Result<(), TypedStoreError> {
+        let mut locked = self.rows.write().unwrap();
+        locked
+            .retain(|k, _| k < &be_fix_int_ser(from).unwrap() || k >= &be_fix_int_ser(to).unwrap());
+        Ok(())
+    }
+
     fn schedule_delete_all(&self) -> Result<(), TypedStoreError> {
         let mut locked = self.rows.write().unwrap();
         locked.clear();

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -52,6 +52,10 @@ where
     /// Removes every key-value pair from the map.
     fn unsafe_clear(&self) -> Result<(), Self::Error>;
 
+    /// Removes every key-value pair from the map by deleting the underlying
+    /// file.
+    fn delete_file_in_range(&self, from: &K, to: &K) -> Result<(), TypedStoreError>;
+
     /// Uses delete range on the entire key range
     fn schedule_delete_all(&self) -> Result<(), TypedStoreError>;
 


### PR DESCRIPTION
# Description of change

Port https://github.com/MystenLabs/sui/commit/6a0adb5de7f3fb87d3aa23364f200b542e3e8b87

From [Sui's commit description](https://github.com/MystenLabs/sui/commit/6a0adb5de7f3fb87d3aa23364f200b542e3e8b87):
This PR adds a rocksdb endpoint to delete .sst files in key range in rocksdb which is useful to prune data (in certain scenarios) without compaction.

## Links to any relevant issues

Part of #3990 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Ran the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
