### PR TITLE
test: Revive simtest test_apy

### DIFF
--- a/crates/iota-e2e-tests/tests/apy_test.rs
+++ b/crates/iota-e2e-tests/tests/apy_test.rs
@@ -44,7 +44,6 @@ use test_cluster::TestClusterBuilder;
 /// of the pool at the expected number (a quarter of 3.5B IOTAs) starting from
 /// epoch 1, this is totally fine.
 #[sim_test]
-#[ignore = "Very flaky. TODO in tracking issue https://github.com/iotaledger/iota/issues/5293: reactivate"]
 async fn test_apy() {
     // We need a large stake for low enough APY values such that they are not
     // filtered out by the APY calculation function.


### PR DESCRIPTION
# Description of change

The test now passes after a refactor in the CI script that sets `MSIM_WATCHDOG_TIMEOUT_MS` to `180000` milliseconds. Previously, it failed on the first run from a clean build due to the default value of `5000` milliseconds, but it passed on subsequent runs.

## Links to any relevant issues

Close #5293 

## Type of change

- Bug fix

## How the change has been tested

Run `scripts/simtest/cargo-simtest simtest --package iota-e2e-tests -- test_apy`

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have checked that new and existing unit tests pass locally with my changes
