### PR TITLE
feat(iota-sdk): add get_circulating_supply to client

### DIFF
--- a/crates/iota-sdk/examples/coin_read_api.rs
+++ b/crates/iota-sdk/examples/coin_read_api.rs
@@ -15,6 +15,7 @@
 mod utils;
 
 use futures::{future, stream::StreamExt};
+use iota_types::gas_coin::NANOS_PER_IOTA;
 use utils::setup_for_read;
 
 #[tokio::main]
@@ -104,5 +105,10 @@ async fn main() -> Result<(), anyhow::Error> {
     println!("{:?}", total_supply);
     println!(" *** Total Supply ***\n ");
 
+    // IOTA Circulating supply
+    let circulating_supply = client.coin_read_api().get_circulating_supply().await?;
+    println!(" *** IOTA Circulating Supply *** ");
+    println!("{:?}", circulating_supply.value / NANOS_PER_IOTA);
+    println!(" *** IOTA Circulating Supply *** ");
     Ok(())
 }

--- a/crates/iota-sdk/src/apis/coin_read.rs
+++ b/crates/iota-sdk/src/apis/coin_read.rs
@@ -7,7 +7,7 @@ use std::{future, sync::Arc};
 use futures::{StreamExt, stream};
 use futures_core::Stream;
 use iota_json_rpc_api::CoinReadApiClient;
-use iota_json_rpc_types::{Balance, Coin, CoinPage, IotaCoinMetadata};
+use iota_json_rpc_types::{Balance, Coin, CoinPage, IotaCirculatingSupply, IotaCoinMetadata};
 use iota_types::{
     balance::Supply,
     base_types::{IotaAddress, ObjectID},
@@ -312,5 +312,26 @@ impl CoinReadApi {
     /// ```
     pub async fn get_total_supply(&self, coin_type: impl Into<String>) -> IotaRpcResult<Supply> {
         Ok(self.api.http.get_total_supply(coin_type.into()).await?)
+    }
+
+    /// Get the circulating supply for IOTA.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use iota_sdk::IotaClientBuilder;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), anyhow::Error> {
+    ///     let iota = IotaClientBuilder::default().build_mainnet().await?;
+    ///     let circulating_supply = iota
+    ///         .coin_read_api()
+    ///         .get_circulating_supply()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn get_circulating_supply(&self) -> IotaRpcResult<IotaCirculatingSupply> {
+        Ok(self.api.http.get_circulating_supply().await?)
     }
 }


### PR DESCRIPTION
# Description of change

Make the new `getCirculatingSupply` rpc endpoint callable from the rust sdk client.

## Links to any relevant issues

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Run the provided example in `crates/iota-sdk`. Method is not found on testnet as `v0.11.x-rc` is not released yet.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
