### PR TITLE
fix(iota-indexer, iota-graphql-rpc, iota-transactional-test-runner): Pruner should prune only epoch-partitioned tables

### DIFF
--- a/crates/iota-cluster-test/src/cluster.rs
+++ b/crates/iota-cluster-test/src/cluster.rs
@@ -248,7 +248,7 @@ impl Cluster for LocalNewCluster {
                 true,
                 None,
                 fullnode_url.clone(),
-                IndexerTypeConfig::writer_mode(None),
+                IndexerTypeConfig::writer_mode(None, None),
                 Some(data_ingestion_path.clone()),
             )
             .await;

--- a/crates/iota-graphql-e2e-tests/tests/prune/prune.exp
+++ b/crates/iota-graphql-e2e-tests/tests/prune/prune.exp
@@ -1,0 +1,125 @@
+processed 13 tasks
+
+task 1, lines 6-25:
+//# publish
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5570800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 27:
+//# run Test::M1::create --args 0 @A
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, line 29:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, line 31:
+//# advance-epoch
+Epoch advanced: 0
+
+task 5, line 33:
+//# run Test::M1::create --args 1 @A
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, line 35:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 7, line 37:
+//# advance-epoch
+Epoch advanced: 1
+
+task 8, line 39:
+//# run Test::M1::create --args 2 @A
+created: object(8,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 9, line 41:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 10, line 43:
+//# advance-epoch
+Epoch advanced: 2
+
+task 11, lines 45-55:
+//# run-graphql
+Response: {
+  "data": {
+    "checkpoints": {
+      "nodes": [
+        {
+          "epoch": {
+            "epochId": 0
+          },
+          "sequenceNumber": 0
+        },
+        {
+          "epoch": {
+            "epochId": 0
+          },
+          "sequenceNumber": 1
+        },
+        {
+          "epoch": {
+            "epochId": 0
+          },
+          "sequenceNumber": 2
+        },
+        {
+          "epoch": {
+            "epochId": 1
+          },
+          "sequenceNumber": 3
+        },
+        {
+          "epoch": {
+            "epochId": 1
+          },
+          "sequenceNumber": 4
+        },
+        {
+          "epoch": {
+            "epochId": 2
+          },
+          "sequenceNumber": 5
+        },
+        {
+          "epoch": {
+            "epochId": 2
+          },
+          "sequenceNumber": 6
+        }
+      ]
+    }
+  }
+}
+
+task 12, lines 58-68:
+//# run-graphql --wait-for-checkpoint-pruned 0
+Response: {
+  "data": {
+    "checkpoints": {
+      "nodes": [
+        {
+          "epoch": {
+            "epochId": 2
+          },
+          "sequenceNumber": 5
+        },
+        {
+          "epoch": {
+            "epochId": 2
+          },
+          "sequenceNumber": 6
+        }
+      ]
+    }
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/prune/prune.exp
+++ b/crates/iota-graphql-e2e-tests/tests/prune/prune.exp
@@ -1,54 +1,54 @@
 processed 13 tasks
 
-task 1, lines 6-25:
+task 1, lines 7-26:
 //# publish
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5570800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5563200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, line 27:
+task 2, line 28:
 //# run Test::M1::create --args 0 @A
 created: object(2,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2287600,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 3, line 29:
+task 3, line 30:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 4, line 31:
+task 4, line 32:
 //# advance-epoch
 Epoch advanced: 0
 
-task 5, line 33:
+task 5, line 34:
 //# run Test::M1::create --args 1 @A
 created: object(5,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2287600,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 6, line 35:
+task 6, line 36:
 //# create-checkpoint
 Checkpoint created: 3
 
-task 7, line 37:
+task 7, line 38:
 //# advance-epoch
 Epoch advanced: 1
 
-task 8, line 39:
+task 8, line 40:
 //# run Test::M1::create --args 2 @A
 created: object(8,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2287600,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 9, line 41:
+task 9, line 42:
 //# create-checkpoint
 Checkpoint created: 5
 
-task 10, line 43:
+task 10, line 44:
 //# advance-epoch
 Epoch advanced: 2
 
-task 11, lines 45-55:
+task 11, lines 46-56:
 //# run-graphql
 Response: {
   "data": {
@@ -101,7 +101,7 @@ Response: {
   }
 }
 
-task 12, lines 58-68:
+task 12, lines 59-69:
 //# run-graphql --wait-for-checkpoint-pruned 0
 Response: {
   "data": {

--- a/crates/iota-graphql-e2e-tests/tests/prune/prune.move
+++ b/crates/iota-graphql-e2e-tests/tests/prune/prune.move
@@ -1,0 +1,69 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 5 --addresses Test=0x0 A=0x42 --simulator --epochs-to-keep 2
+
+//# publish
+module Test::M1 {
+    use iota::coin::Coin;
+
+    public struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    fun foo<T: key, T2: drop>(_p1: u64, value1: T, _value2: &Coin<T2>, _p2: u64): T {
+        value1
+    }
+
+    public entry fun create(value: u64, recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Object { id: object::new(ctx), value },
+            recipient
+        )
+    }
+}
+
+//# run Test::M1::create --args 0 @A
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run Test::M1::create --args 1 @A
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run Test::M1::create --args 2 @A
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run-graphql
+{
+  checkpoints {
+    nodes {
+      epoch {
+        epochId
+      }
+      sequenceNumber
+    }
+  }
+}
+
+
+//# run-graphql --wait-for-checkpoint-pruned 0
+{
+  checkpoints {
+    nodes {
+      epoch {
+        epochId
+      }
+      sequenceNumber
+    }
+  }
+}

--- a/crates/iota-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/iota-graphql-rpc/tests/e2e_tests.rs
@@ -41,6 +41,7 @@ mod tests {
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
             None,
+            None,
             data_ingestion_path,
         )
         .await;
@@ -120,6 +121,7 @@ mod tests {
             ConnectionConfig::default(),
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
+            None,
             None,
             data_ingestion_path,
         )

--- a/crates/iota-graphql-rpc/tests/examples_validation_tests.rs
+++ b/crates/iota-graphql-rpc/tests/examples_validation_tests.rs
@@ -155,6 +155,7 @@ mod tests {
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
             None,
+            None,
             data_ingestion_path,
         )
         .await;
@@ -220,6 +221,7 @@ mod tests {
             ConnectionConfig::default(),
             DEFAULT_INTERNAL_DATA_SOURCE_PORT,
             Arc::new(sim),
+            None,
             None,
             data_ingestion_path,
         )

--- a/crates/iota-indexer/src/handlers/pruner.rs
+++ b/crates/iota-indexer/src/handlers/pruner.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
@@ -55,10 +55,21 @@ impl Pruner {
                 (min_epoch, max_epoch) = self.store.get_available_epoch_range().await?;
             }
 
-            let table_partitions = self.partition_manager.get_table_partitions()?;
-            let table_names = table_partitions.keys().cloned().collect::<Vec<_>>();
-            for (table_name, (min_partition, max_partition)) in table_partitions {
-                if max_epoch != max_partition {
+            // Not all partitioned tables are epoch-partitioned, so we need to filter them
+            // out.
+            let table_partitions: HashMap<_, _> = self
+                .partition_manager
+                .get_table_partitions()?
+                .into_iter()
+                .filter(|(table_name, _)| {
+                    self.partition_manager
+                        .get_strategy(table_name)
+                        .is_epoch_partitioned()
+                })
+                .collect();
+
+            for (table_name, (min_partition, max_partition)) in &table_partitions {
+                if max_epoch != *max_partition {
                     error!(
                         "Epochs are out of sync for table {}: max_epoch={}, max_partition={}",
                         table_name, max_epoch, max_partition
@@ -67,7 +78,7 @@ impl Pruner {
                 // drop partitions if pruning is enabled afterwards, where all epochs before
                 // min_epoch would have been pruned already if the pruner was
                 // running.
-                for epoch in min_partition..min_epoch {
+                for epoch in *min_partition..min_epoch {
                     self.partition_manager
                         .drop_table_partition(table_name.clone(), epoch)?;
                     info!(
@@ -83,7 +94,7 @@ impl Pruner {
                     return Ok(());
                 }
                 info!("Pruning epoch {}", epoch);
-                for table_name in table_names.clone() {
+                for table_name in table_partitions.keys() {
                     self.partition_manager
                         .drop_table_partition(table_name.clone(), epoch)?;
                     info!("Dropped table partition {} epoch {}", table_name, epoch);

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -50,6 +50,7 @@ impl Indexer {
             store,
             metrics,
             snapshot_config,
+            None,
             CancellationToken::new(),
         )
         .await
@@ -60,6 +61,7 @@ impl Indexer {
         store: PgIndexerStore,
         metrics: IndexerMetrics,
         snapshot_config: SnapshotLagConfig,
+        epochs_to_keep: Option<u64>,
         cancel: CancellationToken,
     ) -> Result<(), IndexerError> {
         info!(
@@ -102,9 +104,11 @@ impl Indexer {
         )
         .await?;
 
-        let epochs_to_keep = std::env::var("EPOCHS_TO_KEEP")
-            .map(|s| s.parse::<u64>().ok())
-            .unwrap_or_else(|_e| None);
+        let epochs_to_keep = epochs_to_keep.or_else(|| {
+            std::env::var("EPOCHS_TO_KEEP")
+                .ok()
+                .and_then(|s| s.parse::<u64>().ok())
+        });
         if let Some(epochs_to_keep) = epochs_to_keep {
             info!(
                 "Starting indexer pruner with epochs to keep: {}",

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -60,8 +60,13 @@ use crate::{
 pub type DBInitHook = Box<dyn FnOnce(&PgIndexerStore) + Send>;
 
 pub enum IndexerTypeConfig {
-    Reader { reader_mode_rpc_url: String },
-    Writer { snapshot_config: SnapshotLagConfig },
+    Reader {
+        reader_mode_rpc_url: String,
+    },
+    Writer {
+        snapshot_config: SnapshotLagConfig,
+        epochs_to_keep: Option<u64>,
+    },
     AnalyticalWorker,
 }
 
@@ -72,9 +77,13 @@ impl IndexerTypeConfig {
         }
     }
 
-    pub fn writer_mode(snapshot_config: Option<SnapshotLagConfig>) -> Self {
+    pub fn writer_mode(
+        snapshot_config: Option<SnapshotLagConfig>,
+        epochs_to_keep: Option<u64>,
+    ) -> Self {
         Self::Writer {
             snapshot_config: snapshot_config.unwrap_or_default(),
+            epochs_to_keep,
         }
     }
 }
@@ -146,7 +155,10 @@ pub async fn start_test_indexer_impl(
             config.rpc_server_port = reader_mode_rpc_url.port();
             tokio::spawn(async move { Indexer::start_reader(&config, &registry, db_url).await })
         }
-        IndexerTypeConfig::Writer { snapshot_config } => {
+        IndexerTypeConfig::Writer {
+            snapshot_config,
+            epochs_to_keep,
+        } => {
             let store_clone = store.clone();
 
             init_metrics(&registry);
@@ -158,6 +170,7 @@ pub async fn start_test_indexer_impl(
                     store_clone,
                     indexer_metrics,
                     snapshot_config,
+                    epochs_to_keep,
                     cancel,
                 )
                 .await

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -318,10 +318,13 @@ pub async fn start_simulacrum_rest_api_with_write_indexer(
         true,
         db_init_hook,
         format!("http://{}", server_url),
-        IndexerTypeConfig::writer_mode(Some(SnapshotLagConfig {
-            snapshot_min_lag: 5,
-            sleep_duration: 0,
-        })),
+        IndexerTypeConfig::writer_mode(
+            Some(SnapshotLagConfig {
+                snapshot_min_lag: 5,
+                sleep_duration: 0,
+            }),
+            None,
+        ),
         Some(data_ingestion_path),
     )
     .await;

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -131,7 +131,7 @@ pub async fn start_test_cluster_with_read_write_indexer(
         true,
         None,
         cluster.rpc_url().to_string(),
-        IndexerTypeConfig::writer_mode(None),
+        IndexerTypeConfig::writer_mode(None, None),
         None,
     )
     .await;

--- a/crates/iota-transactional-test-runner/src/args.rs
+++ b/crates/iota-transactional-test-runner/src/args.rs
@@ -71,6 +71,10 @@ pub struct IotaInitArgs {
     pub object_snapshot_min_checkpoint_lag: Option<usize>,
     #[arg(long)]
     pub flavor: Option<Flavor>,
+    /// The number of epochs to keep in the database. Epochs outside of this
+    /// range will be pruned by the indexer.
+    #[arg(long)]
+    pub epochs_to_keep: Option<u64>,
 }
 
 #[derive(Debug, clap::Parser)]
@@ -173,6 +177,8 @@ pub struct RunGraphqlCommand {
     pub show_service_version: bool,
     #[arg(long, num_args(1..))]
     pub cursors: Vec<String>,
+    #[arg(long)]
+    pub wait_for_checkpoint_pruned: Option<u64>,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -808,7 +808,7 @@ async fn start(
             true,
             None,
             fullnode_url.clone(),
-            IndexerTypeConfig::writer_mode(None),
+            IndexerTypeConfig::writer_mode(None, None),
             data_ingestion_dir.clone(),
         )
         .await;


### PR DESCRIPTION
# Description of change

Currently, the pruner assumes that all partitioned tables are partitioned on epoch, which is an issue since `objects_version` is not partitioned by epoch. Modifies the pruner so that it will filter out non-epoch-partitioned tables.

## Links to any relevant issues

https://github.com/iotaledger/iota/issues/6200

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

See the provided test in `iota-graphql-e2e-tests`

To verify run: `cargo nextest run --features pg_integration`

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
