### PR TITLE
chore(ts-sdk): Sync TS SDK with changes on get_dynamic_field_object

### DIFF
--- a/sdk/typescript/src/client/types/params.ts
+++ b/sdk/typescript/src/client/types/params.ts
@@ -244,6 +244,8 @@ export interface GetDynamicFieldObjectParams {
     parentId: string;
     /** The Name of the dynamic field */
     name: RpcTypes.DynamicFieldName;
+    /** Options for specifying the content to be returned */
+    options?: RpcTypes.IotaObjectDataOptions | null | undefined;
 }
 /** Return the list of dynamic field objects owned by an object. */
 export interface GetDynamicFieldsParams {


### PR DESCRIPTION
# Description of change

* Regenerated ts-sdk types from openrpc.json
* Since its an optional field in an existing params definition for an existing method, no additional changes to client needed

## Links to any relevant issues

Closes https://github.com/iotaledger/iota/issues/6116


