### PR TITLE
chore(ci): use pinned rust nightly version

### DIFF
--- a/.github/workflows/_rust_examples.yml
+++ b/.github/workflows/_rust_examples.yml
@@ -40,11 +40,11 @@ jobs:
           shopt -s globstar
           for manifest in ./**/examples/**/Cargo.toml; do
               echo "Checking format for $manifest"
-              cargo +nightly ci-fmt --manifest-path $manifest
+              cargo +nightly-2025-04-01 ci-fmt --manifest-path $manifest
 
               echo "Clippy linting for $manifest"
               cargo clippy --manifest-path $manifest --all-features
 
               echo "Checking unused dependencies of $manifest"
-              cargo +nightly ci-udeps --manifest-path $manifest
+              cargo +nightly-2025-04-01 ci-udeps --manifest-path $manifest
           done

--- a/.github/workflows/_rust_lints.yml
+++ b/.github/workflows/_rust_lints.yml
@@ -41,10 +41,8 @@ jobs:
     runs-on: [self-hosted-x64]
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - name: Install latest nightly
-        run: rustup toolchain install nightly --component rustfmt --allow-downgrade
       - name: Check Rust formatting
-        run: cargo +nightly ci-fmt
+        run: cargo +nightly-2025-04-01 ci-fmt
 
   cargo-sort:
     if: (!cancelled() && inputs.isRust)

--- a/.github/workflows/_rust_tests.yml
+++ b/.github/workflows/_rust_tests.yml
@@ -190,9 +190,9 @@ jobs:
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Run Cargo Udeps
-        run: cargo +nightly ci-udeps ${{ matrix.flags }}
+        run: cargo +nightly-2025-04-01 ci-udeps ${{ matrix.flags }}
       - name: Run Cargo Udeps (external crates)
-        run: cargo +nightly ci-udeps-external ${{ matrix.flags }}
+        run: cargo +nightly-2025-04-01 ci-udeps-external ${{ matrix.flags }}
 
   test-extra:
     env:

--- a/scripts/ci_tests/rust_tests.sh
+++ b/scripts/ci_tests/rust_tests.sh
@@ -384,8 +384,8 @@ function run_cargo_simtest() {
 
 # run cargo-udeps to check for unused dependencies
 function unused_deps() {
-    print_and_run_command "cargo +nightly ci-udeps --all-features"
-    print_and_run_command "cargo +nightly ci-udeps --no-default-features"
+    print_and_run_command "cargo +nightly-2025-04-01 ci-udeps --all-features"
+    print_and_run_command "cargo +nightly-2025-04-01 ci-udeps --no-default-features"
 }
 
 # run extra tests like stresstest, doc tests, doc generation, changed files, etc.

--- a/scripts/indexer-schema/generate.sh
+++ b/scripts/indexer-schema/generate.sh
@@ -76,4 +76,4 @@ docker exec ${CONTAINER_NAME} diesel print-schema \
 $PYTHON_CMD ${REPO}/scripts/indexer-schema/generate_for_all_tables_macro.py "${REPO}/crates/iota-indexer/src/schema.rs"
 
 # Applying the patch may destroy the formatting, fix it
-rustfmt +nightly "${REPO}/crates/iota-indexer/src/schema.rs"
+rustfmt +nightly-2025-04-01 "${REPO}/crates/iota-indexer/src/schema.rs"


### PR DESCRIPTION
To avoid components like fmt or udeps to be affected by breaking changes.