### PR TITLE
feat(indexer): Read transactions from optimistic tables

### DIFF
--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -63,15 +63,15 @@ use crate::{
         objects::{CoinBalance, StoredHistoryObject, StoredObject},
         participation_metrics::StoredParticipationMetrics,
         transactions::{
-            StoredTransaction, StoredTransactionEvents, stored_events_to_events,
-            tx_events_to_iota_tx_events,
+            OptimisticTransaction, StoredTransaction, StoredTransactionEvents,
+            stored_events_to_events, tx_events_to_iota_tx_events,
         },
         tx_indices::TxSequenceNumber,
     },
     schema::{
         address_metrics, addresses, chain_identifier, checkpoints, display, epochs, events,
-        objects, objects_history, objects_snapshot, objects_version, packages, pruner_cp_watermark,
-        transactions, tx_digests,
+        objects, objects_history, objects_snapshot, objects_version, optimistic_transactions,
+        packages, pruner_cp_watermark, transactions, tx_digests, tx_insertion_order,
     },
     store::{diesel_macro::*, package_resolver::IndexerStorePackageResolver},
     types::{IndexerResult, OwnerType},
@@ -634,7 +634,7 @@ impl IndexerReader {
             .iter()
             .map(|digest| digest.inner().to_vec())
             .collect::<Vec<_>>();
-        run_query!(&self.pool, |conn| {
+        let checkpointed_txs = run_query!(&self.pool, |conn| {
             transactions::table
                 .inner_join(
                     tx_digests::table
@@ -642,10 +642,36 @@ impl IndexerReader {
                 )
                 // we filter the tx_digests table because it is indexed by digest,
                 // transactions table is not
-                .filter(tx_digests::tx_digest.eq_any(digests))
+                .filter(tx_digests::tx_digest.eq_any(&digests))
                 .select(StoredTransaction::as_select())
                 .load::<StoredTransaction>(conn)
-        })
+        })?;
+        let missing_digests: Vec<Vec<u8>> = {
+            let loaded_digests: HashSet<_> = checkpointed_txs
+                .iter()
+                .map(|tx| tx.transaction_digest.clone())
+                .collect();
+            digests
+                .into_iter()
+                .filter(|d| !loaded_digests.contains(d))
+                .collect()
+        };
+        let optimistic_txs = run_query!(&self.pool, |conn| {
+            optimistic_transactions::table
+                .inner_join(
+                    tx_insertion_order::table.on(optimistic_transactions::insertion_order
+                        .eq(tx_insertion_order::insertion_order)),
+                )
+                // we filter the tx_insertion_order table because it is indexed by digest,
+                // optimistic_transactions table is not
+                .filter(tx_insertion_order::tx_digest.eq_any(missing_digests))
+                .select(OptimisticTransaction::as_select())
+                .load::<OptimisticTransaction>(conn)
+        })?;
+        Ok(checkpointed_txs
+            .into_iter()
+            .chain(optimistic_txs.into_iter().map(Into::into))
+            .collect())
     }
 
     async fn multi_get_transactions_in_blocking_task(

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -633,7 +633,7 @@ impl IndexerReader {
         let digests = digests
             .iter()
             .map(|digest| digest.inner().to_vec())
-            .collect::<Vec<_>>();
+            .collect::<HashSet<_>>();
         let checkpointed_txs = run_query!(&self.pool, |conn| {
             transactions::table
                 .inner_join(
@@ -646,16 +646,14 @@ impl IndexerReader {
                 .select(StoredTransaction::as_select())
                 .load::<StoredTransaction>(conn)
         })?;
-        let missing_digests: Vec<Vec<u8>> = {
-            let loaded_digests: HashSet<_> = checkpointed_txs
-                .iter()
-                .map(|tx| tx.transaction_digest.clone())
-                .collect();
-            digests
-                .into_iter()
-                .filter(|d| !loaded_digests.contains(d))
-                .collect()
-        };
+        if checkpointed_txs.len() == digests.len() {
+            return Ok(checkpointed_txs);
+        }
+        let loaded_digests = checkpointed_txs
+            .iter()
+            .map(|tx| tx.transaction_digest.clone())
+            .collect();
+        let missing_digests = digests.difference(&loaded_digests);
         let optimistic_txs = run_query!(&self.pool, |conn| {
             optimistic_transactions::table
                 .inner_join(

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -649,11 +649,13 @@ impl IndexerReader {
         if checkpointed_txs.len() == digests.len() {
             return Ok(checkpointed_txs);
         }
-        let loaded_digests = checkpointed_txs
-            .iter()
-            .map(|tx| tx.transaction_digest.clone())
-            .collect();
-        let missing_digests = digests.difference(&loaded_digests);
+        let missing_digests = {
+            let mut missing_digests = digests;
+            for tx in &checkpointed_txs {
+                missing_digests.remove(&tx.transaction_digest);
+            }
+            missing_digests
+        };
         let optimistic_txs = run_query!(&self.pool, |conn| {
             optimistic_transactions::table
                 .inner_join(

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -649,13 +649,10 @@ impl IndexerReader {
         if checkpointed_txs.len() == digests.len() {
             return Ok(checkpointed_txs);
         }
-        let missing_digests = {
-            let mut missing_digests = digests;
-            for tx in &checkpointed_txs {
-                missing_digests.remove(&tx.transaction_digest);
-            }
-            missing_digests
-        };
+        let mut missing_digests = digests;
+        for tx in &checkpointed_txs {
+            missing_digests.remove(&tx.transaction_digest);
+        }
         let optimistic_txs = run_query!(&self.pool, |conn| {
             optimistic_transactions::table
                 .inner_join(

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -196,6 +196,12 @@ impl StoredTransaction {
         self.events.get(idx).cloned().flatten()
     }
 
+    /// True for checkpointed transactions, False for optimistically indexed
+    /// transactions
+    pub fn is_checkpointed_transaction(&self) -> bool {
+        self.checkpoint_sequence_number >= 0
+    }
+
     pub async fn try_into_iota_transaction_block_response(
         self,
         options: IotaTransactionBlockResponseOptions,
@@ -209,6 +215,16 @@ impl StoredTransaction {
                     self.transaction_digest
                 ))
             })?;
+        let (checkpoint, timestamp_ms) = {
+            if self.is_checkpointed_transaction() {
+                (
+                    Some(self.checkpoint_sequence_number as u64),
+                    Some(self.timestamp_ms as u64),
+                )
+            } else {
+                (None, None)
+            }
+        };
 
         let transaction = if options.show_input {
             let sender_signed_data = self.try_into_sender_signed_data()?;
@@ -316,8 +332,8 @@ impl StoredTransaction {
             events,
             object_changes,
             balance_changes,
-            timestamp_ms: Some(self.timestamp_ms as u64),
-            checkpoint: Some(self.checkpoint_sequence_number as u64),
+            timestamp_ms,
+            checkpoint,
             confirmed_local_execution: None,
             errors: vec![],
             raw_effects,

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -215,16 +215,13 @@ impl StoredTransaction {
                     self.transaction_digest
                 ))
             })?;
-        let (checkpoint, timestamp_ms) = {
-            if self.is_checkpointed_transaction() {
-                (
-                    Some(self.checkpoint_sequence_number as u64),
-                    Some(self.timestamp_ms as u64),
-                )
-            } else {
-                (None, None)
-            }
-        };
+
+        let timestamp_ms = self
+            .is_checkpointed_transaction()
+            .then_some(self.timestamp_ms as u64);
+        let checkpoint = self
+            .is_checkpointed_transaction()
+            .then_some(self.checkpoint_sequence_number as u64);
 
         let transaction = if options.show_input {
             let sender_signed_data = self.try_into_sender_signed_data()?;


### PR DESCRIPTION
# Description of change

Read transactions from optimistic tables.
To be able to return transaction results to the user once optimistic indexing is introduced.

## Links to any relevant issues

fixes #6346

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo ci-clippy`
`cargo test --profile simulator --package iota-indexer --test rpc-tests --all-features`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
