### PR TITLE
feat(rest-api)!: Ensure input and output objects are always returned by rest api tx execution endpoint if requested

### DIFF
--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -518,12 +518,20 @@ impl ValidatorService {
                     None
                 };
 
+                let input_objects = include_input_objects
+                    .then(|| self.state.get_transaction_input_objects(&signed_effects))
+                    .and_then(Result::ok);
+
+                let output_objects = include_output_objects
+                    .then(|| self.state.get_transaction_output_objects(&signed_effects))
+                    .and_then(Result::ok);
+
                 return Ok((
                     Some(vec![HandleCertificateResponseV1 {
                         signed_effects: signed_effects.into_inner(),
                         events,
-                        input_objects: None,
-                        output_objects: None,
+                        input_objects,
+                        output_objects,
                         auxiliary_data: None,
                     }]),
                     Weight::one(),

--- a/crates/iota-e2e-tests/tests/rest.rs
+++ b/crates/iota-e2e-tests/tests/rest.rs
@@ -52,3 +52,35 @@ async fn execute_transaction_transfer() {
 
     assert_eq!(actual, expected);
 }
+
+#[sim_test]
+async fn reexecute_same_transaction() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+
+    let client = Client::new(test_cluster.rpc_url());
+    let address = IotaAddress::random_for_testing_only();
+    let amount = 9;
+    let txn =
+        make_transfer_iota_transaction(&test_cluster.wallet, Some(address), Some(amount)).await;
+
+    let request = ExecuteTransactionQueryParameters {
+        events: false,
+        balance_changes: false,
+        input_objects: true,
+        output_objects: true,
+    };
+
+    let initial_response = client.execute_transaction(&request, &txn).await.unwrap();
+    let reexecution_response = client.execute_transaction(&request, &txn).await.unwrap();
+
+    assert!(reexecution_response.input_objects.is_some());
+    assert!(reexecution_response.output_objects.is_some());
+    assert_eq!(
+        initial_response.input_objects,
+        reexecution_response.input_objects
+    );
+    assert_eq!(
+        initial_response.output_objects,
+        reexecution_response.output_objects
+    );
+}


### PR DESCRIPTION
# Description of change

The input and output objects are currently returned as None by validator in case the transaction is already executed.
This PR ensures that input and output objects are always returned by validator if requested.

We need input and output objects to be consistently present in the response to be able to optimistically index the transactions without waiting for them to be checkpointed.
Users attempting to execute transactions that are already executed should be a rare case, but nevertheless we should handle that and not error out in the indexer.

 

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/5669

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo test --package iota-e2e-tests --test rest`
`cargo ci-clippy`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
