### PR TITLE
feat(iota): add --emit flag to iota client ptb

### DIFF
--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -3061,7 +3061,7 @@ fn opts_from_cli(opts: HashSet<EmitOption>) -> IotaTransactionBlockResponseOptio
     }
 }
 
-fn parse_emit_option(s: &str) -> Result<HashSet<EmitOption>, String> {
+pub(crate) fn parse_emit_option(s: &str) -> Result<HashSet<EmitOption>, String> {
     let mut options = HashSet::new();
 
     // Split the input string by commas and try to parse each part

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -3043,20 +3043,20 @@ pub(crate) async fn prerender_clever_errors(
 fn opts_from_cli(opts: HashSet<EmitOption>) -> IotaTransactionBlockResponseOptions {
     if opts.is_empty() {
         IotaTransactionBlockResponseOptions::new()
-            .with_effects()
             .with_input()
+            .with_effects()
             .with_events()
             .with_object_changes()
             .with_balance_changes()
     } else {
         IotaTransactionBlockResponseOptions {
             show_input: opts.contains(&EmitOption::Input),
+            show_raw_input: false,
+            show_effects: true,
+            show_raw_effects: false,
             show_events: opts.contains(&EmitOption::Events),
             show_object_changes: opts.contains(&EmitOption::ObjectChanges),
             show_balance_changes: opts.contains(&EmitOption::BalanceChanges),
-            show_effects: true,
-            show_raw_effects: false,
-            show_raw_input: false,
         }
     }
 }

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -570,7 +570,7 @@ pub struct Opts {
 
     /// Select which fields of the response to display.
     /// If not provided, all fields are displayed.
-    /// The fields are: effects, input, events, object_changes,
+    /// The fields are: input, effects, events, object_changes,
     /// balance_changes.
     #[arg(long, required = false, num_args = 0.., value_parser = parse_emit_option, default_value = "effects,input,events,object_changes,balance_changes")]
     pub emit: HashSet<EmitOption>,

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -572,7 +572,7 @@ pub struct Opts {
     /// If not provided, all fields are displayed.
     /// The fields are: input, effects, events, object_changes,
     /// balance_changes.
-    #[arg(long, required = false, num_args = 0.., value_parser = parse_emit_option, default_value = "effects,input,events,object_changes,balance_changes")]
+    #[arg(long, required = false, num_args = 0.., value_parser = parse_emit_option, default_value = "input,effects,events,object_changes,balance_changes")]
     pub emit: HashSet<EmitOption>,
 }
 

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -667,8 +667,8 @@ impl OptsWithGas {
 #[derive(Clone, Debug, EnumString, Hash, Eq, PartialEq)]
 #[strum(serialize_all = "snake_case")]
 pub enum EmitOption {
-    Effects,
     Input,
+    Effects,
     Events,
     ObjectChanges,
     BalanceChanges,

--- a/crates/iota/src/client_ptb/ptb.rs
+++ b/crates/iota/src/client_ptb/ptb.rs
@@ -20,7 +20,8 @@ use serde::Serialize;
 use super::{ast::ProgramMetadata, lexer::Lexer, parser::ProgramParser};
 use crate::{
     client_commands::{
-        IotaClientCommandResult, Opts, OptsWithGas, dry_run_or_execute_or_serialize,
+        EmitOption, IotaClientCommandResult, Opts, OptsWithGas, dry_run_or_execute_or_serialize,
+        parse_emit_option,
     },
     client_ptb::{
         ast::{ParsedProgram, Program},
@@ -37,6 +38,12 @@ use crate::{
 pub struct PTB {
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub args: Vec<String>,
+    /// Select which fields of the response to display.
+    /// If not provided, all fields are displayed.
+    /// The fields are: effects, input, events, object_changes,
+    /// balance_changes.
+    #[arg(long, required = false, num_args = 0.., value_parser = parse_emit_option, default_value = "effects,input,events,object_changes,balance_changes")]
+    pub emit: HashSet<EmitOption>,
 }
 
 pub struct PTBPreview<'a> {
@@ -169,7 +176,7 @@ impl PTB {
                 gas_budget: program_metadata.gas_budget.map(|x| x.value),
                 serialize_unsigned_transaction: program_metadata.serialize_unsigned_set,
                 serialize_signed_transaction: program_metadata.serialize_signed_set,
-                emit: HashSet::new(),
+                emit: self.emit,
             },
         };
 
@@ -430,5 +437,13 @@ pub fn ptb_description() -> clap::Command {
         .arg(arg!(
             --"json"
             "Return command outputs in json format."
+        ))
+        .arg(arg!(
+            --"emit"
+            "Select which fields of the response to display. If not provided, all fields are displayed. \
+            The fields are: effects, input, events, object_changes, balance_changes. \
+            This command only works if it's passed as first argument to the command: \
+            `iota client ptb --emit=effects --split-coins gas [1000]`
+            "
         ))
 }

--- a/crates/iota/src/client_ptb/ptb.rs
+++ b/crates/iota/src/client_ptb/ptb.rs
@@ -42,7 +42,7 @@ pub struct PTB {
     /// If not provided, all fields are displayed.
     /// The fields are: input, effects, events, object_changes,
     /// balance_changes.
-    #[arg(long, required = false, num_args = 0.., value_parser = parse_emit_option, default_value = "effects,input,events,object_changes,balance_changes")]
+    #[arg(long, required = false, num_args = 0.., value_parser = parse_emit_option, default_value = "input,effects,events,object_changes,balance_changes")]
     pub emit: HashSet<EmitOption>,
 }
 

--- a/crates/iota/src/client_ptb/ptb.rs
+++ b/crates/iota/src/client_ptb/ptb.rs
@@ -442,7 +442,7 @@ pub fn ptb_description() -> clap::Command {
             --"emit"
             "Select which fields of the response to display. If not provided, all fields are displayed. \
             The fields are: effects, input, events, object_changes, balance_changes. \
-            This command only works if it's passed as first argument to the command: \
+            This option only works if it's passed as first argument to the command: \
             `iota client ptb --emit=effects --split-coins gas [1000]`
             "
         ))

--- a/crates/iota/src/client_ptb/ptb.rs
+++ b/crates/iota/src/client_ptb/ptb.rs
@@ -40,7 +40,7 @@ pub struct PTB {
     pub args: Vec<String>,
     /// Select which fields of the response to display.
     /// If not provided, all fields are displayed.
-    /// The fields are: effects, input, events, object_changes,
+    /// The fields are: input, effects, events, object_changes,
     /// balance_changes.
     #[arg(long, required = false, num_args = 0.., value_parser = parse_emit_option, default_value = "effects,input,events,object_changes,balance_changes")]
     pub emit: HashSet<EmitOption>,
@@ -441,7 +441,7 @@ pub fn ptb_description() -> clap::Command {
         .arg(arg!(
             --"emit"
             "Select which fields of the response to display. If not provided, all fields are displayed. \
-            The fields are: effects, input, events, object_changes, balance_changes. \
+            The fields are: input, effects, events, object_changes, balance_changes. \
             This option only works if it's passed as first argument to the command: \
             `iota client ptb --emit=effects --split-coins gas [1000]`
             "

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -376,9 +376,12 @@ async fn test_ptb_publish_and_complex_arg_resolution() -> Result<(), anyhow::Err
     );
 
     let args = shlex::split(&complex_ptb_string).unwrap();
-    iota::client_ptb::ptb::PTB { args: args.clone() }
-        .execute(context)
-        .await?;
+    iota::client_ptb::ptb::PTB {
+        args: args.clone(),
+        emit: HashSet::new(),
+    }
+    .execute(context)
+    .await?;
 
     let delete_object_ptb_string = format!(
         r#"
@@ -392,9 +395,12 @@ async fn test_ptb_publish_and_complex_arg_resolution() -> Result<(), anyhow::Err
     );
 
     let args = shlex::split(&delete_object_ptb_string).unwrap();
-    iota::client_ptb::ptb::PTB { args: args.clone() }
-        .execute(context)
-        .await?;
+    iota::client_ptb::ptb::PTB {
+        args: args.clone(),
+        emit: HashSet::new(),
+    }
+    .execute(context)
+    .await?;
 
     Ok(())
 }
@@ -421,9 +427,12 @@ async fn test_ptb_publish() -> Result<(), anyhow::Error> {
         package_path.display()
     );
     let args = shlex::split(&publish_ptb_string).unwrap();
-    iota::client_ptb::ptb::PTB { args: args.clone() }
-        .execute(context)
-        .await?;
+    iota::client_ptb::ptb::PTB {
+        args: args.clone(),
+        emit: HashSet::new(),
+    }
+    .execute(context)
+    .await?;
     Ok(())
 }
 
@@ -3102,11 +3111,17 @@ async fn test_serialize_tx() -> Result<(), anyhow::Error> {
     ];
     let mut args = ptb_args.clone();
     args.push("--serialize-signed-transaction".to_string());
-    let ptb = PTB { args };
+    let ptb = PTB {
+        args,
+        emit: HashSet::new(),
+    };
     IotaClientCommands::PTB(ptb).execute(context).await.unwrap();
     let mut args = ptb_args.clone();
     args.push("--serialize-unsigned-transaction".to_string());
-    let ptb = PTB { args };
+    let ptb = PTB {
+        args,
+        emit: HashSet::new(),
+    };
     IotaClientCommands::PTB(ptb).execute(context).await.unwrap();
 
     Ok(())
@@ -4639,7 +4654,12 @@ async fn test_ptb_dev_inspect() -> Result<(), anyhow::Error> {
         --dev-inspect
         "#;
     let args = shlex::split(publish_ptb_string).unwrap();
-    let res = iota::client_ptb::ptb::PTB { args }.execute(context).await?;
+    let res = iota::client_ptb::ptb::PTB {
+        args,
+        emit: HashSet::new(),
+    }
+    .execute(context)
+    .await?;
     assert!(res.contains("Execution Result\n  Return values\n    IOTA TypeTag: IotaTypeTag(\"0x1::string::String\")\n    Bytes: [5, 72, 101, 108, 108, 111]"));
     Ok(())
 }

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -4664,6 +4664,45 @@ async fn test_ptb_dev_inspect() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+#[sim_test]
+async fn test_ptb_emit_args() -> Result<(), anyhow::Error> {
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(2)
+        .build()
+        .await;
+    let context = &mut test_cluster.wallet;
+
+    let ptb_string = r#"
+    --make-move-vec <u8> "[1]"
+    "#;
+    let args = shlex::split(ptb_string).unwrap();
+    let res = iota::client_ptb::ptb::PTB {
+        args,
+        emit: HashSet::from([EmitOption::Input]),
+    }
+    .execute(context)
+    .await?;
+
+    assert!(res.contains("Transaction Data"));
+    assert!(res.contains("Transaction Effects"));
+
+    let ptb_string = r#"
+        --make-move-vec <u8> "[1]"
+        "#;
+    let args = shlex::split(ptb_string).unwrap();
+    let res = iota::client_ptb::ptb::PTB {
+        args,
+        emit: HashSet::from([EmitOption::Events]),
+    }
+    .execute(context)
+    .await?;
+    // `EmitOption::Input` wasn't provided, so there is no `Transaction Data`
+    assert!(!res.contains("Transaction Data"));
+    assert!(res.contains("Transaction Effects"));
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_new_env() -> Result<(), anyhow::Error> {
     let mut test_cluster = TestClusterBuilder::new()

--- a/docs/content/references/cli/ptb.mdx
+++ b/docs/content/references/cli/ptb.mdx
@@ -49,6 +49,7 @@ Options:
       --summary                                                       Show only a short summary (digest, execution status, gas cost). Do not use this flag when you need all the transaction data and the execution effects.
       --warn-shadows                                                  Enable shadow warning when the same variable name is declared multiple times. Off by default.
       --json                                                          Return command outputs in json format.
+      --emit                                                          Select which fields of the response to display. If not provided, all fields are displayed. The fields are: effects, input, events, object_changes, balance_changes. This command only works if it's passed as first argument to the command: `iota client ptb --emit=effects --split-coins gas [1000]`
   -h, --help                                                          Print help (see more with '--help')
 ```
 

--- a/docs/content/references/cli/ptb.mdx
+++ b/docs/content/references/cli/ptb.mdx
@@ -49,7 +49,7 @@ Options:
       --summary                                                       Show only a short summary (digest, execution status, gas cost). Do not use this flag when you need all the transaction data and the execution effects.
       --warn-shadows                                                  Enable shadow warning when the same variable name is declared multiple times. Off by default.
       --json                                                          Return command outputs in json format.
-      --emit                                                          Select which fields of the response to display. If not provided, all fields are displayed. The fields are: effects, input, events, object_changes, balance_changes. This command only works if it's passed as first argument to the command: `iota client ptb --emit=effects --split-coins gas [1000]`
+      --emit                                                          Select which fields of the response to display. If not provided, all fields are displayed. The fields are: effects, input, events, object_changes, balance_changes. This option only works if it's passed as first argument to the command: `iota client ptb --emit=effects --split-coins gas [1000]`
   -h, --help                                                          Print help (see more with '--help')
 ```
 

--- a/docs/content/references/cli/ptb.mdx
+++ b/docs/content/references/cli/ptb.mdx
@@ -49,7 +49,7 @@ Options:
       --summary                                                       Show only a short summary (digest, execution status, gas cost). Do not use this flag when you need all the transaction data and the execution effects.
       --warn-shadows                                                  Enable shadow warning when the same variable name is declared multiple times. Off by default.
       --json                                                          Return command outputs in json format.
-      --emit                                                          Select which fields of the response to display. If not provided, all fields are displayed. The fields are: effects, input, events, object_changes, balance_changes. This option only works if it's passed as first argument to the command: `iota client ptb --emit=effects --split-coins gas [1000]`
+      --emit                                                          Select which fields of the response to display. If not provided, all fields are displayed. The fields are: input, effects, events, object_changes, balance_changes. This option only works if it's passed as first argument to the command: `iota client ptb --emit=effects --split-coins gas [1000]`
   -h, --help                                                          Print help (see more with '--help')
 ```
 


### PR DESCRIPTION
# Description of change

Add --emit flag to iota client ptb
This PR only allows the flag to be at the first position, otherwise we can't use clap to parse it and would need to implement custom parsing in `ProgramParsingState` which would make it much more complex

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/5722

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`cargo run client ptb --emit=effects --gas-budget 10000000`