### PR TITLE
feat(iota): display publicBase64Key -WithFlag in iota client new-address

### DIFF
--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -95,6 +95,7 @@ use crate::{
     client_ptb::ptb::PTB,
     displays::Pretty,
     key_identity::{KeyIdentity, get_identity_address},
+    keytool::Key,
     verifier_meter::{AccumulatingMeter, Accumulator},
 };
 
@@ -1409,10 +1410,26 @@ impl IotaClientCommands {
                     context.config_mut().set_active_address(address);
                     context.config().save()?;
                 }
+                let key = context
+                    .config()
+                    .keystore()
+                    .keys()
+                    .into_iter()
+                    .find_map(|pk| {
+                        let key = Key::from(pk);
+                        if key.iota_address == address {
+                            Some(key)
+                        } else {
+                            None
+                        }
+                    })
+                    .expect("missing generated key");
 
                 IotaClientCommandResult::NewAddress(NewAddressOutput {
                     alias,
                     address,
+                    public_base64_key: key.public_base64_key,
+                    public_base64_key_with_flag: key.public_base64_key_with_flag,
                     key_scheme: scheme,
                     recovery_phrase: phrase,
                 })
@@ -2039,6 +2056,14 @@ impl Display for IotaClientCommandResult {
                 builder.push_record(vec!["alias", new_address.alias.as_str()]);
                 builder.push_record(vec!["address", new_address.address.to_string().as_str()]);
                 builder.push_record(vec![
+                    "publicBase64Key",
+                    new_address.public_base64_key.as_str(),
+                ]);
+                builder.push_record(vec![
+                    "publicBase64KeyWithFlag",
+                    new_address.public_base64_key_with_flag.as_str(),
+                ]);
+                builder.push_record(vec![
                     "keyScheme",
                     new_address.key_scheme.to_string().as_str(),
                 ]);
@@ -2062,7 +2087,7 @@ impl Display for IotaClientCommandResult {
                         .with(TableBorder::default().corner_top_right('─')),
                 );
 
-                write!(f, "{}", table)?
+                write!(f, "{table}")?
             }
             IotaClientCommandResult::Object(object_read) => match object_read.object() {
                 Ok(obj) => {
@@ -2406,6 +2431,8 @@ pub struct DynamicFieldOutput {
 pub struct NewAddressOutput {
     pub alias: String,
     pub address: IotaAddress,
+    pub public_base64_key: String,
+    pub public_base64_key_with_flag: String,
     pub key_scheme: SignatureScheme,
     pub recovery_phrase: String,
 }

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -1413,16 +1413,8 @@ impl IotaClientCommands {
                 let key = context
                     .config()
                     .keystore()
-                    .keys()
-                    .into_iter()
-                    .find_map(|pk| {
-                        let key = Key::from(pk);
-                        if key.iota_address == address {
-                            Some(key)
-                        } else {
-                            None
-                        }
-                    })
+                    .get_key(&address)
+                    .map(Key::from)
                     .expect("missing generated key");
 
                 IotaClientCommandResult::NewAddress(NewAddressOutput {

--- a/crates/iota/src/keytool.rs
+++ b/crates/iota/src/keytool.rs
@@ -330,9 +330,9 @@ pub struct DecodeOrVerifyTxOutput {
 #[serde(rename_all = "camelCase")]
 pub struct Key {
     alias: Option<String>,
-    iota_address: IotaAddress,
-    public_base64_key: String,
-    public_base64_key_with_flag: String,
+    pub(crate) iota_address: IotaAddress,
+    pub(crate) public_base64_key: String,
+    pub(crate) public_base64_key_with_flag: String,
     key_scheme: String,
     flag: u8,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/docs/content/_snippets/operator/validator-generate-info.mdx
+++ b/docs/content/_snippets/operator/validator-generate-info.mdx
@@ -39,6 +39,8 @@ Executing the above command provides the key pair info as output, e.g.:
 
 - `alias`: A human-readable identifier to use within the CLI scope to refer to a key pair.
 - `address`: The public address representing the key pair.
+- `publicBase64Key`: The public key base64 encoded.
+- `publicBase64KeyWithFlag`: The public prefixed with the scheme flag byte base64 encoded.
 - `keyScheme`: The cryptographic scheme used to derive the keypair; the `ed25519` is the standard scheme, used most of the time, while the `BLS12381` scheme is used for the `authority_key`.
 - `recoveryPhrase`: A list of 12 words used by the cryptographic scheme used to derive the key pair.
 

--- a/docs/content/_snippets/operator/validator-generate-info.mdx
+++ b/docs/content/_snippets/operator/validator-generate-info.mdx
@@ -25,14 +25,16 @@ You can skip this step if you already have an account configured. If you would l
 Executing the above command provides the key pair info as output, e.g.:
 
 ```bash
-╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ Created new keypair and saved it to keystore.                                                    │
-├────────────────┬─────────────────────────────────────────────────────────────────────────────────┤
-│ alias          │ crazy-pearl                                                                     │
-│ address        │ 0x1ce209a128ab5185db4cab896bc88b255bce3fbdb1a2b3fa8ef1edf911628e3e              │
-│ keyScheme      │ ed25519                                                                         │
-│ recoveryPhrase │ limit chest cloth this possible sister kingdom thunder brother lame know orphan │
-╰────────────────┴─────────────────────────────────────────────────────────────────────────────────╯
+╭────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ Created new keypair and saved it to keystore.                                                          │
+├─────────────────────────┬──────────────────────────────────────────────────────────────────────────────┤
+│ alias                   │ intelligent-chalcedony                                                       │
+│ address                 │ 0x3607bc87821a13d861e1e09cd5a2525b272f8dbc3e00556a8baf940a39120f32           │
+│ publicBase64Key         │ m6mBnT0tq9CA1zgdwy9y6ag2e8sWyzHVAoca+zLKJq8=                                 │
+│ publicBase64KeyWithFlag │ AJupgZ09LavQgNc4HcMvcumoNnvLFssx1QKHGvsyyiav                                 │
+│ keyScheme               │ ed25519                                                                      │
+│ recoveryPhrase          │ glimpse hard relax method kid deliver nominee wait brief surprise speed pond │
+╰─────────────────────────┴──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 - `alias`: A human-readable identifier to use within the CLI scope to refer to a key pair.

--- a/docs/content/_snippets/operator/validator-generate-info.mdx
+++ b/docs/content/_snippets/operator/validator-generate-info.mdx
@@ -39,8 +39,8 @@ Executing the above command provides the key pair info as output, e.g.:
 
 - `alias`: A human-readable identifier to use within the CLI scope to refer to a key pair.
 - `address`: The public address representing the key pair.
-- `publicBase64Key`: The public key base64 encoded.
-- `publicBase64KeyWithFlag`: The public prefixed with the scheme flag byte base64 encoded.
+- `publicBase64Key`: The public key, base64 encoded.
+- `publicBase64KeyWithFlag`: The public key prefixed with the scheme flag byte, base64 encoded.
 - `keyScheme`: The cryptographic scheme used to derive the keypair; the `ed25519` is the standard scheme, used most of the time, while the `BLS12381` scheme is used for the `authority_key`.
 - `recoveryPhrase`: A list of 12 words used by the cryptographic scheme used to derive the key pair.
 


### PR DESCRIPTION
# Description of change

Display publicBase64Key -WithFlag in iota client new-address so one can see them directly and doesn't need to run a second command

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/6275

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

```
cargo run client new-address
╭────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Created new keypair and saved it to keystore.                                                          │
├─────────────────────────┬──────────────────────────────────────────────────────────────────────────────┤
│ alias                   │ intelligent-chalcedony                                                       │
│ address                 │ 0x3607bc87821a13d861e1e09cd5a2525b272f8dbc3e00556a8baf940a39120f32           │
│ publicBase64Key         │ m6mBnT0tq9CA1zgdwy9y6ag2e8sWyzHVAoca+zLKJq8=                                 │
│ publicBase64KeyWithFlag │ AJupgZ09LavQgNc4HcMvcumoNnvLFssx1QKHGvsyyiav                                 │
│ keyScheme               │ ed25519                                                                      │
│ recoveryPhrase          │ glimpse hard relax method kid deliver nominee wait brief surprise speed pond │
╰─────────────────────────┴──────────────────────────────────────────────────────────────────────────────╯
```
