### PR TITLE
feat(iota-indexer, ts-sdk): Add participation metric

### DIFF
--- a/crates/iota-indexer/migrations/pg/2025-03-21-081552_participation_metrics/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-03-21-081552_participation_metrics/down.sql
@@ -1,0 +1,1 @@
+DROP MATERIALIZED VIEW IF EXISTS participation_metrics;

--- a/crates/iota-indexer/migrations/pg/2025-03-21-081552_participation_metrics/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-03-21-081552_participation_metrics/up.sql
@@ -1,0 +1,10 @@
+-- A materialized view that the total number of unique addresses that have delegated stake in the current epoch.
+-- Includes both staked and timelocked staked IOTA.
+CREATE MATERIALIZED VIEW participation_metrics AS
+SELECT
+    COUNT(DISTINCT owner_id) AS total_addresses
+FROM
+    objects
+WHERE
+        object_type IN ('0x0000000000000000000000000000000000000000000000000000000000000003::staking_pool::StakedIota', '0x0000000000000000000000000000000000000000000000000000000000000003::timelocked_staking::TimelockedStakedIota')
+  AND owner_id IS NOT NULL;

--- a/crates/iota-indexer/src/apis/extended_api.rs
+++ b/crates/iota-indexer/src/apis/extended_api.rs
@@ -8,7 +8,7 @@ use iota_json_rpc_api::{
 };
 use iota_json_rpc_types::{
     AddressMetrics, EpochInfo, EpochMetrics, EpochMetricsPage, EpochPage, MoveCallMetrics,
-    NetworkMetrics, Page,
+    NetworkMetrics, Page, ParticipationMetrics,
 };
 use iota_open_rpc::Module;
 use iota_types::iota_serde::BigInt;
@@ -154,6 +154,13 @@ impl ExtendedApiServer for ExtendedApi {
             .spawn_blocking(|this| this.get_latest_checkpoint())
             .await?;
         Ok(latest_checkpoint.network_total_transactions.into())
+    }
+
+    async fn get_participation_metrics(&self) -> RpcResult<ParticipationMetrics> {
+        self.inner
+            .spawn_blocking(|this| this.get_participation_metrics())
+            .await
+            .map_err(Into::into)
     }
 }
 

--- a/crates/iota-indexer/src/handlers/committer.rs
+++ b/crates/iota-indexer/src/handlers/committer.rs
@@ -175,6 +175,15 @@ async fn commit_checkpoints<S>(
             })
             .expect("Advancing epochs in DB should not fail.");
         metrics.total_epoch_committed.inc();
+
+        // Refresh participation metrics after advancing epoch
+        state
+            .refresh_participation_metrics()
+            .await
+            .tap_err(|e| {
+                error!("Failed to update participation metrics: {e}");
+            })
+            .expect("Updating participation metrics should not fail.");
     }
 
     state

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -22,7 +22,8 @@ use iota_json_rpc_types::{
     AddressMetrics, Balance, CheckpointId, Coin as IotaCoin, DisplayFieldsResponse, EpochInfo,
     EventFilter, IotaCoinMetadata, IotaEvent, IotaMoveValue, IotaObjectDataFilter,
     IotaTransactionBlockEffects, IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse,
-    IotaTransactionKind, MoveCallMetrics, MoveFunctionName, NetworkMetrics, TransactionFilter,
+    IotaTransactionKind, MoveCallMetrics, MoveFunctionName, NetworkMetrics, ParticipationMetrics,
+    TransactionFilter,
 };
 use iota_package_resolver::{Package, PackageStore, PackageStoreWithLruCache, Resolver};
 use iota_types::{
@@ -59,6 +60,7 @@ use crate::{
         network_metrics::StoredNetworkMetrics,
         obj_indices::StoredObjectVersion,
         objects::{CoinBalance, StoredHistoryObject, StoredObject},
+        participation_metrics::StoredParticipationMetrics,
         transactions::{
             StoredTransaction, StoredTransactionEvents, stored_events_to_events,
             tx_events_to_iota_tx_events,
@@ -1989,6 +1991,17 @@ impl IndexerReader {
         })
         .await
         .map_err(Into::into)
+    }
+
+    /// Get the participation metrics. Participation is defined as the total
+    /// number of unique addresses that have delegated stake in the current
+    /// epoch. Includes both staked and timelocked staked IOTA.
+    pub fn get_participation_metrics(&self) -> IndexerResult<ParticipationMetrics> {
+        run_query!(&self.pool, |conn| {
+            diesel::sql_query("SELECT * FROM participation_metrics")
+                .get_result::<StoredParticipationMetrics>(conn)
+        })
+        .map(Into::into)
     }
 }
 

--- a/crates/iota-indexer/src/models/mod.rs
+++ b/crates/iota-indexer/src/models/mod.rs
@@ -13,6 +13,7 @@ pub mod network_metrics;
 pub mod obj_indices;
 pub mod objects;
 pub mod packages;
+pub mod participation_metrics;
 pub mod transactions;
 pub mod tx_count_metrics;
 pub mod tx_indices;

--- a/crates/iota-indexer/src/models/participation_metrics.rs
+++ b/crates/iota-indexer/src/models/participation_metrics.rs
@@ -1,0 +1,19 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use diesel::{prelude::*, sql_types::BigInt};
+use iota_json_rpc_types::ParticipationMetrics;
+
+#[derive(Clone, Debug, Default, QueryableByName)]
+pub struct StoredParticipationMetrics {
+    #[diesel(sql_type = BigInt)]
+    pub total_addresses: i64,
+}
+
+impl From<StoredParticipationMetrics> for ParticipationMetrics {
+    fn from(metrics: StoredParticipationMetrics) -> Self {
+        Self {
+            total_addresses: metrics.total_addresses as u64,
+        }
+    }
+}

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -105,5 +105,7 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
         epoch: u64,
     ) -> Result<u64, IndexerError>;
 
+    async fn refresh_participation_metrics(&self) -> Result<(), IndexerError>;
+
     fn as_any(&self) -> &dyn Any;
 }

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -1509,6 +1509,24 @@ impl PgIndexerStore {
         .map(|v| v as u64)
     }
 
+    fn refresh_participation_metrics(&self) -> Result<(), IndexerError> {
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                diesel::sql_query("REFRESH MATERIALIZED VIEW participation_metrics")
+                    .execute(conn)?;
+                Ok::<(), IndexerError>(())
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+        .tap_ok(|_| {
+            info!("Successfully refreshed participation_metrics");
+        })
+        .tap_err(|e| {
+            tracing::error!("Failed to refresh participation_metrics: {e}");
+        })
+    }
+
     async fn execute_in_blocking_worker<F, R>(&self, f: F) -> Result<R, IndexerError>
     where
         F: FnOnce(Self) -> Result<R, IndexerError> + Send + 'static,
@@ -2090,6 +2108,11 @@ impl IndexerStore for PgIndexerStore {
             this.get_network_total_transactions_by_end_of_epoch(epoch)
         })
         .await
+    }
+
+    async fn refresh_participation_metrics(&self) -> Result<(), IndexerError> {
+        self.execute_in_blocking_worker(move |this| this.refresh_participation_metrics())
+            .await
     }
 
     fn as_any(&self) -> &dyn StdAny {

--- a/crates/iota-json-rpc-api/src/extended.rs
+++ b/crates/iota-json-rpc-api/src/extended.rs
@@ -4,6 +4,7 @@
 
 use iota_json_rpc_types::{
     AddressMetrics, EpochInfo, EpochMetricsPage, EpochPage, MoveCallMetrics, NetworkMetrics,
+    ParticipationMetrics,
 };
 use iota_open_rpc_macros::open_rpc;
 use iota_types::iota_serde::BigInt;
@@ -71,4 +72,11 @@ pub trait ExtendedApi {
     /// indexer.
     #[method(name = "getTotalTransactions")]
     async fn get_total_transactions(&self) -> RpcResult<BigInt<u64>>;
+
+    /// Returns the participation metrics. Participation is defined as the total
+    /// number of unique addresses that have delegated stake in the current
+    /// epoch. Includes both staked and timelocked staked IOTA.
+    /// Exclusively served by the indexer.
+    #[method(name = "getParticipationMetrics")]
+    async fn get_participation_metrics(&self) -> RpcResult<ParticipationMetrics>;
 }

--- a/crates/iota-json-rpc-types/src/iota_extended.rs
+++ b/crates/iota-json-rpc-types/src/iota_extended.rs
@@ -223,3 +223,12 @@ pub struct AddressMetrics {
     /// The count of daily unique sender addresses.
     pub daily_active_addresses: u64,
 }
+
+/// Provides metrics about the participation in the network.
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ParticipationMetrics {
+    /// The count of distinct addresses with delegated stake.
+    pub total_addresses: u64,
+}

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -4149,6 +4149,23 @@
       ]
     },
     {
+      "name": "iotax_getParticipationMetrics",
+      "tags": [
+        {
+          "name": "Extended API"
+        }
+      ],
+      "description": "Returns the participation metrics. Participation is defined as the total number of unique addresses that have delegated stake in the current epoch. Includes both staked and timelocked staked IOTA. Exclusively served by the indexer.",
+      "params": [],
+      "result": {
+        "name": "ParticipationMetrics",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/ParticipationMetrics"
+        }
+      }
+    },
+    {
       "name": "iotax_getReferenceGasPrice",
       "tags": [
         {
@@ -10902,6 +10919,21 @@
                 "type": "null"
               }
             ]
+          }
+        }
+      },
+      "ParticipationMetrics": {
+        "description": "Provides metrics about the participation in the network.",
+        "type": "object",
+        "required": [
+          "totalAddresses"
+        ],
+        "properties": {
+          "totalAddresses": {
+            "description": "The count of distinct addresses with delegated stake.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           }
         }
       },

--- a/sdk/graphql-transport/README.md
+++ b/sdk/graphql-transport/README.md
@@ -45,6 +45,7 @@ error, or fallback to the JSON RPC API if a `fallbackFullNodeUrl` is provided:
 - `dryRunTransactionBlock`
 - `devInspectTransactionBlock`
 - `executeTransactionBlock`
+- `getParticipationMetrics`
 
 ### Unsupported parameters
 

--- a/sdk/graphql-transport/test/compatibility.test.ts
+++ b/sdk/graphql-transport/test/compatibility.test.ts
@@ -679,6 +679,13 @@ describe('GraphQL IotaClient compatibility', () => {
         expect(graphql).toEqual(rpc);
     });
 
+    test.skip('getParticipationMetrics', async () => {
+        const rpc = await toolbox.client.getParticipationMetrics();
+        const graphql = await graphQLClient!.getParticipationMetrics();
+
+        expect(graphql).toEqual(rpc);
+    });
+
     test.skip('getMoveCallMetrics', async () => {
         const rpc = await toolbox.client.getMoveCallMetrics();
         const graphql = await graphQLClient!.getMoveCallMetrics();

--- a/sdk/typescript/src/client/client.ts
+++ b/sdk/typescript/src/client/client.ts
@@ -90,6 +90,7 @@ import type {
     DelegatedTimelockedStake,
     GetTimelockedStakesByIdsParams,
     IotaSystemStateSummaryV1,
+    ParticipationMetrics,
 } from './types/index.js';
 
 export interface PaginationArguments<Cursor> {
@@ -809,6 +810,16 @@ export class IotaClient {
         return await this.transport.request({
             method: 'iota_getProtocolConfig',
             params: [input?.version],
+        });
+    }
+
+    /**
+     * Returns the participation metrics (total unique addresses with delegated stake in the current epoch).
+     */
+    async getParticipationMetrics(): Promise<ParticipationMetrics> {
+        return await this.transport.request({
+            method: 'iotax_getParticipationMetrics',
+            params: [],
         });
     }
 

--- a/sdk/typescript/src/client/types/generated.ts
+++ b/sdk/typescript/src/client/types/generated.ts
@@ -1376,6 +1376,11 @@ export interface PaginatedTransactionResponse {
     hasNextPage: boolean;
     nextCursor?: string | null;
 }
+/** Provides metrics about the participation in the network. */
+export interface ParticipationMetrics {
+    /** The count of distinct addresses with delegated stake. */
+    totalAddresses: string;
+}
 /**
  * An passkey authenticator with parsed fields. See field definition below. Can be initialized from
  * [struct RawPasskeyAuthenticator].

--- a/sdk/typescript/src/client/types/params.ts
+++ b/sdk/typescript/src/client/types/params.ts
@@ -307,6 +307,12 @@ export type GetOwnedObjectsParams = {
     /** Max number of items returned per page, default to [QUERY_MAX_RESULT_LIMIT] if not specified. */
     limit?: number | null | undefined;
 } & RpcTypes.IotaObjectResponseQuery;
+/**
+ * Returns the participation metrics. Participation is defined as the total number of unique addresses
+ * that have delegated stake in the current epoch. Includes both staked and timelocked staked IOTA.
+ * Exclusively served by the indexer.
+ */
+export interface GetParticipationMetricsParams {}
 /** Return the reference gas price for the network */
 export interface GetReferenceGasPriceParams {}
 /** Return all [DelegatedStake]. */


### PR DESCRIPTION
# Description of change

Adds the participation metric feature.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/5608
Fixes https://github.com/iotaledger/iota/issues/6092

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested by the dedicated PRs.

To see if the OpenRPC spec is up-to-date when integrating with `develop`:
`cargo run --package iota-open-rpc --example generate-json-rpc-spec`

In addition, to test the feature branch for localnet:
`cargo run --features indexer --bin iota start --with-indexer --pg-port 5432 --pg-db-name iota_indexer --with-graphql=0.0.0.0:8000 --with-faucet --force-regenesis`

```sh
curl --location --request POST 'http://localhost:9124' \
--header 'Content-Type: application/json' \
--data-raw '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "iotax_getParticipationMetrics"
}
```

`{"jsonrpc":"2.0","id":1,"result":{"totalAddresses":4}}`

