### PR TITLE
fix(iota-node): unregister and re-register consensus adapter metrics during reconfiguration

### DIFF
--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -402,10 +402,7 @@ impl ConsensusAdapter {
         }
     }
 
-    pub fn unregister_consensus_adapter_metrics(
-        &self,
-        registry: &Registry,
-    ) {
+    pub fn unregister_consensus_adapter_metrics(&self, registry: &Registry) {
         self.metrics.unregister(registry);
     }
 

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -373,6 +373,13 @@ impl ConsensusAdapter {
         }
     }
 
+    pub fn unregister_consensus_adapter_metrics(
+        &self,
+        registry: &Registry,
+    ) {
+        self.metrics.unregister(registry);
+    }
+
     fn await_submit_delay(
         &self,
         committee: &Committee,

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -251,18 +251,18 @@ fn unregister_histogram_vec(name: &str, desc: &str, labels: &[&str], registry: &
     let sum = IntCounterVec::new(opts!(sum_name, desc), labels).unwrap();
     registry
         .unregister(Box::new(sum))
-        .expect("{}_sum counter is in prometheus registry", name);
+        .expect(&format!("{}_sum counter is in prometheus registry", name));
 
     let count = IntCounterVec::new(opts!(count_name, desc), labels).unwrap();
     registry
         .unregister(Box::new(count))
-        .expect("{}_count counter is in prometheus registry", name);
+        .expect(&format!("{}_count counter is in prometheus registry", name));
 
     let labels: Vec<_> = labels.iter().cloned().chain(["pct"]).collect();
     let gauge = IntGaugeVec::new(opts!(name, desc), &labels).unwrap();
     registry
         .unregister(Box::new(gauge))
-        .expect("{} gauge is in prometheus registry", name);
+        .expect(&format!("{} gauge is in prometheus registry", name));
 }
 
 #[mockall::automock]

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -1231,6 +1231,7 @@ mod adapter_tests {
         committee::Committee,
         crypto::{AuthorityKeyPair, AuthorityPublicKeyBytes, get_key_pair_from_rng},
     };
+    use prometheus::Registry;
     use rand::{Rng, SeedableRng, rngs::StdRng};
 
     use super::position_submit_certificate;

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -33,7 +33,7 @@ use iota_types::{
 use itertools::Itertools;
 use parking_lot::RwLockReadGuard;
 use prometheus::{
-    Histogram, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, Registry, opts,
+    Histogram, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, Registry,
     register_histogram_vec_with_registry, register_histogram_with_registry,
     register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry,
     register_int_gauge_with_registry,
@@ -196,8 +196,7 @@ impl ConsensusAdapterMetrics {
         registry
             .unregister(Box::new(self.sequencing_certificate_inflight.clone()))
             .expect("Failed to unregister sequencing_certificate_inflight");
-        // Use custom method to unregister self.sequencing_acknowledge_latency
-        unregister_histogram_vec(
+            iota_metrics::histogram::HistogramVec::unregister(
             "sequencing_acknowledge_latency",
             "The latency for acknowledgement from sequencing engine. The overall sequencing latency is measured by the sequencing_certificate_latency metric",
             &["retry", "tx_type"],
@@ -237,32 +236,6 @@ impl ConsensusAdapterMetrics {
             .unregister(Box::new(self.sequencing_resubmission_interval_ms.clone()))
             .expect("Failed to unregister sequencing_resubmission_interval_ms");
     }
-}
-
-// HistogramVec from iota-metrics uses asynchronous model to report metrics
-// which makes it difficult to unregister counters in the usual manner. Here we
-// re-create counters so that their `desc()`s match the ones created by
-// HistogramVec and remove them from the registry. Counters can be safely
-// unregistered even if they are still in use.
-fn unregister_histogram_vec(name: &str, desc: &str, labels: &[&str], registry: &Registry) {
-    let sum_name = format!("{}_sum", name);
-    let count_name = format!("{}_count", name);
-
-    let sum = IntCounterVec::new(opts!(sum_name, desc), labels).unwrap();
-    registry
-        .unregister(Box::new(sum))
-        .expect(&format!("{}_sum counter is in prometheus registry", name));
-
-    let count = IntCounterVec::new(opts!(count_name, desc), labels).unwrap();
-    registry
-        .unregister(Box::new(count))
-        .expect(&format!("{}_count counter is in prometheus registry", name));
-
-    let labels: Vec<_> = labels.iter().cloned().chain(["pct"]).collect();
-    let gauge = IntGaugeVec::new(opts!(name, desc), &labels).unwrap();
-    registry
-        .unregister(Box::new(gauge))
-        .expect(&format!("{} gauge is in prometheus registry", name));
 }
 
 #[mockall::automock]
@@ -1340,6 +1313,17 @@ mod adapter_tests {
             }
             assert!(zero_found);
         }
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_reregister_consensus_adapter_metrics() {
+        let registry = Registry::new();
+        // create metric the first time
+        let _metrics = ConsensusAdapterMetrics::new(&registry);
+        // create a new metric in the same registry without unregistering
+        // should panic
+        let _metrics = ConsensusAdapterMetrics::new(&registry);
     }
 
     #[test]

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -33,7 +33,7 @@ use iota_types::{
 use itertools::Itertools;
 use parking_lot::RwLockReadGuard;
 use prometheus::{
-    Histogram, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, Registry,
+    Histogram, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, Registry, opts,
     register_histogram_vec_with_registry, register_histogram_with_registry,
     register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry,
     register_int_gauge_with_registry,
@@ -196,10 +196,13 @@ impl ConsensusAdapterMetrics {
         registry
             .unregister(Box::new(self.sequencing_certificate_inflight.clone()))
             .expect("Failed to unregister sequencing_certificate_inflight");
-        // This is from iota-metrics, not prometheus
-        // registry
-        //     .unregister(Box::new(self.sequencing_acknowledge_latency.clone()))
-        //     .expect("Failed to unregister sequencing_acknowledge_latency");
+        // Use custom method to unregister self.sequencing_acknowledge_latency
+        unregister_histogram_vec(
+            "sequencing_acknowledge_latency",
+            "The latency for acknowledgement from sequencing engine. The overall sequencing latency is measured by the sequencing_certificate_latency metric",
+            &["retry", "tx_type"],
+            registry,
+        );
         registry
             .unregister(Box::new(self.sequencing_certificate_latency.clone()))
             .expect("Failed to unregister sequencing_certificate_latency");
@@ -234,6 +237,32 @@ impl ConsensusAdapterMetrics {
             .unregister(Box::new(self.sequencing_resubmission_interval_ms.clone()))
             .expect("Failed to unregister sequencing_resubmission_interval_ms");
     }
+}
+
+// HistogramVec from iota-metrics uses asynchronous model to report metrics
+// which makes it difficult to unregister counters in the usual manner. Here we
+// re-create counters so that their `desc()`s match the ones created by
+// HistogramVec and remove them from the registry. Counters can be safely
+// unregistered even if they are still in use.
+fn unregister_histogram_vec(name: &str, desc: &str, labels: &[&str], registry: &Registry) {
+    let sum_name = format!("{}_sum", name);
+    let count_name = format!("{}_count", name);
+
+    let sum = IntCounterVec::new(opts!(sum_name, desc), labels).unwrap();
+    registry
+        .unregister(Box::new(sum))
+        .expect("{}_sum counter is in prometheus registry", name);
+
+    let count = IntCounterVec::new(opts!(count_name, desc), labels).unwrap();
+    registry
+        .unregister(Box::new(count))
+        .expect("{}_count counter is in prometheus registry", name);
+
+    let labels: Vec<_> = labels.iter().cloned().chain(["pct"]).collect();
+    let gauge = IntGaugeVec::new(opts!(name, desc), &labels).unwrap();
+    registry
+        .unregister(Box::new(gauge))
+        .expect("{} gauge is in prometheus registry", name);
 }
 
 #[mockall::automock]

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -186,17 +186,17 @@ impl ConsensusAdapterMetrics {
     pub fn unregister(&self, registry: &Registry) {
         registry
             .unregister(Box::new(self.sequencing_certificate_attempt.clone()))
-            .expect("Failed to unregister sequencing_certificate_attempt");
+            .expect("sequencing_certificate_attempt is in registry");
         registry
             .unregister(Box::new(self.sequencing_certificate_success.clone()))
-            .expect("Failed to unregister sequencing_certificate_success");
+            .expect("sequencing_certificate_success is in registry");
         registry
             .unregister(Box::new(self.sequencing_certificate_failures.clone()))
-            .expect("Failed to unregister sequencing_certificate_failures");
+            .expect("sequencing_certificate_failures is in registry");
         registry
             .unregister(Box::new(self.sequencing_certificate_inflight.clone()))
-            .expect("Failed to unregister sequencing_certificate_inflight");
-            iota_metrics::histogram::HistogramVec::unregister(
+            .expect("sequencing_certificate_inflight is in registry");
+        iota_metrics::histogram::HistogramVec::unregister(
             "sequencing_acknowledge_latency",
             "The latency for acknowledgement from sequencing engine. The overall sequencing latency is measured by the sequencing_certificate_latency metric",
             &["retry", "tx_type"],
@@ -204,37 +204,37 @@ impl ConsensusAdapterMetrics {
         );
         registry
             .unregister(Box::new(self.sequencing_certificate_latency.clone()))
-            .expect("Failed to unregister sequencing_certificate_latency");
+            .expect("sequencing_certificate_latency is in registry");
         registry
             .unregister(Box::new(
                 self.sequencing_certificate_authority_position.clone(),
             ))
-            .expect("Failed to unregister sequencing_certificate_authority_position");
+            .expect("sequencing_certificate_authority_position is in registry");
         registry
             .unregister(Box::new(
                 self.sequencing_certificate_positions_moved.clone(),
             ))
-            .expect("Failed to unregister sequencing_certificate_positions_moved");
+            .expect("sequencing_certificate_positions_moved is in registry");
         registry
             .unregister(Box::new(
                 self.sequencing_certificate_preceding_disconnected.clone(),
             ))
-            .expect("Failed to unregister sequencing_certificate_preceding_disconnected");
+            .expect("sequencing_certificate_preceding_disconnected is in registry");
         registry
             .unregister(Box::new(self.sequencing_certificate_processed.clone()))
-            .expect("Failed to unregister sequencing_certificate_processed");
+            .expect("sequencing_certificate_processed is in registry");
         registry
             .unregister(Box::new(self.sequencing_in_flight_semaphore_wait.clone()))
-            .expect("Failed to unregister sequencing_in_flight_semaphore_wait");
+            .expect("sequencing_in_flight_semaphore_wait is in registry");
         registry
             .unregister(Box::new(self.sequencing_in_flight_submissions.clone()))
-            .expect("Failed to unregister sequencing_in_flight_submissions");
+            .expect("sequencing_in_flight_submissions is in registry");
         registry
             .unregister(Box::new(self.sequencing_estimated_latency.clone()))
-            .expect("Failed to unregister sequencing_estimated_latency");
+            .expect("sequencing_estimated_latency is in registry");
         registry
             .unregister(Box::new(self.sequencing_resubmission_interval_ms.clone()))
-            .expect("Failed to unregister sequencing_resubmission_interval_ms");
+            .expect("sequencing_resubmission_interval_ms is in registry");
     }
 }
 

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -1315,9 +1315,9 @@ mod adapter_tests {
         }
     }
 
-    #[test]
+    #[tokio::test]
     #[should_panic]
-    fn test_reregister_consensus_adapter_metrics() {
+    async fn test_reregister_consensus_adapter_metrics() {
         let registry = Registry::new();
         // create metric the first time
         let _metrics = ConsensusAdapterMetrics::new(&registry);
@@ -1326,8 +1326,8 @@ mod adapter_tests {
         let _metrics = ConsensusAdapterMetrics::new(&registry);
     }
 
-    #[test]
-    fn test_unregister_consensus_adapter_metrics() {
+    #[tokio::test]
+    async fn test_unregister_consensus_adapter_metrics() {
         let registry = Registry::new();
 
         // create metric the first time

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -1343,4 +1343,44 @@ mod adapter_tests {
             assert!(zero_found);
         }
     }
+
+    #[test]
+    fn test_unregister_consensus_adapter_metrics() {
+        let registry = Registry::new();
+
+        // create metric the first time
+        let metrics = ConsensusAdapterMetrics::new(&registry);
+        // use metric
+        metrics
+            .sequencing_certificate_attempt
+            .with_label_values(&["tx"])
+            .inc_by(1);
+        assert_eq!(
+            1,
+            metrics
+                .sequencing_certificate_attempt
+                .with_label_values(&["tx"])
+                .get()
+        );
+        // should not panic
+        metrics.unregister(&registry);
+        // metric can safely be used unregistered
+        metrics
+            .sequencing_certificate_attempt
+            .with_label_values(&["tx"])
+            .inc_by(1);
+
+        // create a new metric in the same registry
+        let metrics = ConsensusAdapterMetrics::new(&registry);
+        // it's fresh
+        assert_eq!(
+            0,
+            metrics
+                .sequencing_certificate_attempt
+                .with_label_values(&["tx"])
+                .get()
+        );
+        // and can be unregistered
+        metrics.unregister(&registry);
+    }
 }

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -182,6 +182,58 @@ impl ConsensusAdapterMetrics {
     pub fn new_test() -> Self {
         Self::new(&Registry::default())
     }
+
+    pub fn unregister(&self, registry: &Registry) {
+        registry
+            .unregister(Box::new(self.sequencing_certificate_attempt.clone()))
+            .expect("Failed to unregister sequencing_certificate_attempt");
+        registry
+            .unregister(Box::new(self.sequencing_certificate_success.clone()))
+            .expect("Failed to unregister sequencing_certificate_success");
+        registry
+            .unregister(Box::new(self.sequencing_certificate_failures.clone()))
+            .expect("Failed to unregister sequencing_certificate_failures");
+        registry
+            .unregister(Box::new(self.sequencing_certificate_inflight.clone()))
+            .expect("Failed to unregister sequencing_certificate_inflight");
+        // This is from iota-metrics, not prometheus
+        // registry
+        //     .unregister(Box::new(self.sequencing_acknowledge_latency.clone()))
+        //     .expect("Failed to unregister sequencing_acknowledge_latency");
+        registry
+            .unregister(Box::new(self.sequencing_certificate_latency.clone()))
+            .expect("Failed to unregister sequencing_certificate_latency");
+        registry
+            .unregister(Box::new(
+                self.sequencing_certificate_authority_position.clone(),
+            ))
+            .expect("Failed to unregister sequencing_certificate_authority_position");
+        registry
+            .unregister(Box::new(
+                self.sequencing_certificate_positions_moved.clone(),
+            ))
+            .expect("Failed to unregister sequencing_certificate_positions_moved");
+        registry
+            .unregister(Box::new(
+                self.sequencing_certificate_preceding_disconnected.clone(),
+            ))
+            .expect("Failed to unregister sequencing_certificate_preceding_disconnected");
+        registry
+            .unregister(Box::new(self.sequencing_certificate_processed.clone()))
+            .expect("Failed to unregister sequencing_certificate_processed");
+        registry
+            .unregister(Box::new(self.sequencing_in_flight_semaphore_wait.clone()))
+            .expect("Failed to unregister sequencing_in_flight_semaphore_wait");
+        registry
+            .unregister(Box::new(self.sequencing_in_flight_submissions.clone()))
+            .expect("Failed to unregister sequencing_in_flight_submissions");
+        registry
+            .unregister(Box::new(self.sequencing_estimated_latency.clone()))
+            .expect("Failed to unregister sequencing_estimated_latency");
+        registry
+            .unregister(Box::new(self.sequencing_resubmission_interval_ms.clone()))
+            .expect("Failed to unregister sequencing_resubmission_interval_ms");
+    }
 }
 
 #[mockall::automock]

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1733,8 +1733,10 @@ impl IotaNode {
                     )
                 } else {
                     info!("This node is no longer a validator after reconfiguration");
-                    
-                    consensus_adapter.unregister_consensus_adapter_metrics(&self.registry_service.default_registry());
+
+                    consensus_adapter.unregister_consensus_adapter_metrics(
+                        &self.registry_service.default_registry(),
+                    );
                     info!("Unregistered consensus adapter metrics");
                     None
                 }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1733,8 +1733,10 @@ impl IotaNode {
                     )
                 } else {
                     info!("This node is no longer a validator after reconfiguration");
+                    
+                    consensus_adapter.unregister_consensus_adapter_metrics(&self.registry_service.default_registry());
+                    info!("Unregistered consensus adapter metrics");
                     None
-                    // Unregister the consensus adapter metrics
                 }
             } else {
                 let new_epoch_store = self

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1734,6 +1734,7 @@ impl IotaNode {
                 } else {
                     info!("This node is no longer a validator after reconfiguration");
                     None
+                    // Unregister the consensus adapter metrics
                 }
             } else {
                 let new_epoch_store = self

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1737,7 +1737,7 @@ impl IotaNode {
                     consensus_adapter.unregister_consensus_adapter_metrics(
                         &self.registry_service.default_registry(),
                     );
-                    info!("Unregistered consensus adapter metrics");
+                    debug!("Unregistered consensus adapter metrics");
                     None
                 }
             } else {


### PR DESCRIPTION
# Description of change

This PR fixes an issue with an unwrap panic during creation of ConsensusAdapterMetrics with error AlreadyReg. Metrics are created during reconfiguration when a node becomes a validator. It a node becomes a validator for the second time (after eg. "leaving validator set") the metrics will be created for the second time reusing the same "default" registry which would lead to a crash as metrics are never unregistered.

This PR adds ConsensusAdapterMetrics::unregister function to unregister previously created metrics (it can't be done in `drop` as we need the registry). It is called when a node is no longer a validator after reconfiguration. HistogramVec from iota-metrics counters are dropped separately.

## Links to any relevant issues

fix #6277

## Type of change

- Bug fix (a non-breaking change which fixes an issue)


## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
