### PR TITLE
[cherry-pick] fix(iota-node): unregister and re-register consensus adapter metrics during reconfiguration (#6283)

### DIFF
--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -182,6 +182,60 @@ impl ConsensusAdapterMetrics {
     pub fn new_test() -> Self {
         Self::new(&Registry::default())
     }
+
+    pub fn unregister(&self, registry: &Registry) {
+        registry
+            .unregister(Box::new(self.sequencing_certificate_attempt.clone()))
+            .expect("sequencing_certificate_attempt is in registry");
+        registry
+            .unregister(Box::new(self.sequencing_certificate_success.clone()))
+            .expect("sequencing_certificate_success is in registry");
+        registry
+            .unregister(Box::new(self.sequencing_certificate_failures.clone()))
+            .expect("sequencing_certificate_failures is in registry");
+        registry
+            .unregister(Box::new(self.sequencing_certificate_inflight.clone()))
+            .expect("sequencing_certificate_inflight is in registry");
+        iota_metrics::histogram::HistogramVec::unregister(
+            "sequencing_acknowledge_latency",
+            "The latency for acknowledgement from sequencing engine. The overall sequencing latency is measured by the sequencing_certificate_latency metric",
+            &["retry", "tx_type"],
+            registry,
+        );
+        registry
+            .unregister(Box::new(self.sequencing_certificate_latency.clone()))
+            .expect("sequencing_certificate_latency is in registry");
+        registry
+            .unregister(Box::new(
+                self.sequencing_certificate_authority_position.clone(),
+            ))
+            .expect("sequencing_certificate_authority_position is in registry");
+        registry
+            .unregister(Box::new(
+                self.sequencing_certificate_positions_moved.clone(),
+            ))
+            .expect("sequencing_certificate_positions_moved is in registry");
+        registry
+            .unregister(Box::new(
+                self.sequencing_certificate_preceding_disconnected.clone(),
+            ))
+            .expect("sequencing_certificate_preceding_disconnected is in registry");
+        registry
+            .unregister(Box::new(self.sequencing_certificate_processed.clone()))
+            .expect("sequencing_certificate_processed is in registry");
+        registry
+            .unregister(Box::new(self.sequencing_in_flight_semaphore_wait.clone()))
+            .expect("sequencing_in_flight_semaphore_wait is in registry");
+        registry
+            .unregister(Box::new(self.sequencing_in_flight_submissions.clone()))
+            .expect("sequencing_in_flight_submissions is in registry");
+        registry
+            .unregister(Box::new(self.sequencing_estimated_latency.clone()))
+            .expect("sequencing_estimated_latency is in registry");
+        registry
+            .unregister(Box::new(self.sequencing_resubmission_interval_ms.clone()))
+            .expect("sequencing_resubmission_interval_ms is in registry");
+    }
 }
 
 #[mockall::automock]
@@ -319,6 +373,10 @@ impl ConsensusAdapter {
             }
             self.submit_unchecked(&[transaction], epoch_store);
         }
+    }
+
+    pub fn unregister_consensus_adapter_metrics(&self, registry: &Registry) {
+        self.metrics.unregister(registry);
     }
 
     fn await_submit_delay(
@@ -1146,6 +1204,7 @@ mod adapter_tests {
         committee::Committee,
         crypto::{AuthorityKeyPair, AuthorityPublicKeyBytes, get_key_pair_from_rng},
     };
+    use prometheus::Registry;
     use rand::{Rng, SeedableRng, rngs::StdRng};
 
     use super::position_submit_certificate;
@@ -1254,5 +1313,56 @@ mod adapter_tests {
             }
             assert!(zero_found);
         }
+    }
+
+    #[tokio::test]
+    #[should_panic]
+    async fn test_reregister_consensus_adapter_metrics() {
+        let registry = Registry::new();
+        // create metric the first time
+        let _metrics = ConsensusAdapterMetrics::new(&registry);
+        // create a new metric in the same registry without unregistering
+        // should panic
+        let _metrics = ConsensusAdapterMetrics::new(&registry);
+    }
+
+    #[tokio::test]
+    async fn test_unregister_consensus_adapter_metrics() {
+        let registry = Registry::new();
+
+        // create metric the first time
+        let metrics = ConsensusAdapterMetrics::new(&registry);
+        // use metric
+        metrics
+            .sequencing_certificate_attempt
+            .with_label_values(&["tx"])
+            .inc_by(1);
+        assert_eq!(
+            1,
+            metrics
+                .sequencing_certificate_attempt
+                .with_label_values(&["tx"])
+                .get()
+        );
+        // should not panic
+        metrics.unregister(&registry);
+        // metric can safely be used unregistered
+        metrics
+            .sequencing_certificate_attempt
+            .with_label_values(&["tx"])
+            .inc_by(1);
+
+        // create a new metric in the same registry
+        let metrics = ConsensusAdapterMetrics::new(&registry);
+        // it's fresh
+        assert_eq!(
+            0,
+            metrics
+                .sequencing_certificate_attempt
+                .with_label_values(&["tx"])
+                .get()
+        );
+        // and can be unregistered
+        metrics.unregister(&registry);
     }
 }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1733,6 +1733,11 @@ impl IotaNode {
                     )
                 } else {
                     info!("This node is no longer a validator after reconfiguration");
+
+                    consensus_adapter.unregister_consensus_adapter_metrics(
+                        &self.registry_service.default_registry(),
+                    );
+                    debug!("Unregistered consensus adapter metrics");
                     None
                 }
             } else {


### PR DESCRIPTION
# Description of change

This PR fixes an issue with an unwrap panic during creation of ConsensusAdapterMetrics with error AlreadyReg. Metrics are created during reconfiguration when a node becomes a validator. It a node becomes a validator for the second time (after eg. "leaving validator set") the metrics will be created for the second time reusing the same "default" registry which would lead to a crash as metrics are never unregistered.

This PR adds ConsensusAdapterMetrics::unregister function to unregister previously created metrics (it can't be done in `drop` as we need the registry). It is called when a node is no longer a validator after reconfiguration. HistogramVec from iota-metrics counters are dropped separately.

## Links to any relevant issues

fix #6277

## Type of change

- Bug fix (a non-breaking change which fixes an issue)


## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

---------

# Description of change

Please write a summary of your changes and why you made them.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #(issue)`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation Fix

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
