### PR TITLE
chore: Update tokio to 1.44.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10260,7 +10260,7 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.43#d3ae9de63b7ebfbeea8fa5f9d111b9570be703f2"
+source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.44.2#56d9b6bec24b99e0d38329f244d418299ab04d71"
 dependencies = [
  "ahash 0.8.11",
  "async-task",
@@ -10288,7 +10288,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.43#d3ae9de63b7ebfbeea8fa5f9d111b9570be703f2"
+source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.44.2#56d9b6bec24b99e0d38329f244d418299ab04d71"
 dependencies = [
  "darling 0.14.4",
  "proc-macro2",
@@ -15049,9 +15049,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -284,7 +284,7 @@ leb128 = "0.2.5"
 lru = "0.12"
 mockall = "0.11.4"
 more-asserts = "0.3.1"
-msim = { git = "https://github.com/iotaledger/iota-sim.git", branch = "tokio-1.43", package = "msim" }
+msim = { git = "https://github.com/iotaledger/iota-sim.git", branch = "tokio-1.44.2", package = "msim" }
 nonempty = "0.9.0"
 notify = "6.1.1"
 num-bigint = "0.4.4"
@@ -339,7 +339,7 @@ test-fuzz = "3.0.4"
 thiserror = "1.0.40"
 # tokio is defined at a specific version to support patching with iota-sim
 # Do not upgrade without updating https://github.com/iotaledger/iota-sim first
-tokio = "=1.43.0"
+tokio = "=1.44.2"
 tokio-rustls = { version = "0.26", default-features = false, features = ["tls12", "ring"] }
 tokio-stream = { version = "0.1.14", features = ["sync", "net"] }
 tokio-util = "0.7.10"

--- a/crates/iota-proc-macros/Cargo.toml
+++ b/crates/iota-proc-macros/Cargo.toml
@@ -18,4 +18,4 @@ quote.workspace = true
 syn = { version = "2.0", features = ["full", "fold", "extra-traits"] }
 
 [target.'cfg(msim)'.dependencies]
-msim-macros = { git = "https://github.com/iotaledger/iota-sim.git", branch = "tokio-1.43", package = "msim-macros" }
+msim-macros = { git = "https://github.com/iotaledger/iota-sim.git", branch = "tokio-1.44.2", package = "msim-macros" }

--- a/docs/examples/rust/Cargo.toml
+++ b/docs/examples/rust/Cargo.toml
@@ -22,7 +22,7 @@ shared-crypto = { path = "../../../crates/shared-crypto" }
 bcs = "0.1"
 bip32 = "0.5"
 serde_json = "1.0"
-tokio = "1.43"
+tokio = "1.44"
 
 # internal dependencies
 move-core-types = { path = "../../../external-crates/move/crates/move-core-types" }

--- a/examples/custom-indexer/rust/Cargo.toml
+++ b/examples/custom-indexer/rust/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 anyhow = "1.0"
 async-trait = "0.1"
 prometheus = "0.13"
-tokio = "1.43"
+tokio = "1.44"
 tokio-util = "0.7"
 
 # internal dependencies

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -12,7 +12,7 @@ clap = { version = "4.5", features = ["derive", "env", "wrap_help"] }
 dirs = "6.0"
 fastcrypto = "0.1"
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.43", features = ["time"] }
+tokio = { version = "1.44", features = ["time"] }
 
 # internal dependencies
 iota-keys = { path = "../../../crates/iota-keys" }

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -3620,9 +3620,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3638,9 +3638,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -102,7 +102,7 @@ tempfile = "3.2.0"
 tera = "1.16.0"
 thiserror = "1.0.24"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
-tokio = { version = "1.18.2", features = ["full"] }
+tokio = { version = "1.44.2", features = ["full"] }
 toml = "0.5.8"
 toml_edit = { version = "0.14.3", features = ["easy"] }
 tracing = "0.1.26"

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -28,12 +28,12 @@ done
 #   echo "Please commit or revert your changes to Cargo.lock before running cargo simtest"
 #   exit 1
 # fi
-cd "$STARTING_DIR"
+cd "$STARTING_DIR" || exit
 
 cleanup () {
-  cd "$MANIFEST_DIR"
+  cd "$MANIFEST_DIR" || return
   git checkout Cargo.lock > /dev/null
-  cd "$STARTING_DIR"
+  cd "$STARTING_DIR" || return
 }
 
 trap cleanup SIGINT
@@ -55,9 +55,9 @@ if [ -n "$LOCAL_MSIM_PATH" ]; then
 else
   cargo_patch_args=(
     --config 'patch.crates-io.tokio.git = "https://github.com/iotaledger/iota-sim.git"'
-    --config 'patch.crates-io.tokio.branch = "tokio-1.43"'
+    --config 'patch.crates-io.tokio.branch = "tokio-1.44.2"'
     --config 'patch.crates-io.futures-timer.git = "https://github.com/iotaledger/iota-sim.git"'
-    --config 'patch.crates-io.futures-timer.branch = "tokio-1.43"'
+    --config 'patch.crates-io.futures-timer.branch = "tokio-1.44.2"'
   )
 fi
 
@@ -76,7 +76,7 @@ if [ -n "$USE_MOCK_CRYPTO" ]; then
   )
 fi
 
-RUST_FLAGS=$(IFS=, ; echo "${RUST_FLAGS[*]}")
+rust_flags_str=$(IFS=, ; echo "${RUST_FLAGS[*]}")
 
 if ! cargo nextest --help > /dev/null 2>&1; then
   echo "nextest (https://nexte.st) does not appear to be installed. Please install before proceeding."
@@ -95,7 +95,8 @@ if [ "$1" = "build" ]; then
 fi
 
 # Must supply a new temp dir - the test is deterministic and can't choose one randomly itself.
-export TMPDIR=$(mktemp -d)
+TMPDIR=$(mktemp -d)
+export TMPDIR
 
 # Set the example move package for the simtest static initializer
 # https://github.com/iotaledger/iota/blob/16a7b41c0d272b09969782147958bcf484a25a85/crates/iota-proc-macros/src/lib.rs#L53
@@ -103,8 +104,8 @@ root_dir=$(git rev-parse --show-toplevel)
 export SIMTEST_STATIC_INIT_MOVE=$root_dir"/examples/move/basics"
 
 # we need to use "target.'cfg(all())'.rustflags" instead of "build.rustflags" because the latter are ignored if any "target" flags are set
-cargo ${CARGO_COMMAND[@]} \
-  --config "target.'cfg(all())'.rustflags = [$RUST_FLAGS]" \
+cargo "${CARGO_COMMAND[@]}" \
+  --config "target.'cfg(all())'.rustflags = [$rust_flags_str]" \
   "${cargo_patch_args[@]}" \
   "$@"
 

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -28,7 +28,7 @@ done
 #   echo "Please commit or revert your changes to Cargo.lock before running cargo simtest"
 #   exit 1
 # fi
-cd "$STARTING_DIR" || exit
+cd "$STARTING_DIR" || exit 1
 
 cleanup () {
   cd "$MANIFEST_DIR" || return

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -31,9 +31,9 @@ done
 cd "$STARTING_DIR" || exit 1
 
 cleanup () {
-  cd "$MANIFEST_DIR" || return
+  cd "$MANIFEST_DIR" || exit 1
   git checkout Cargo.lock > /dev/null
-  cd "$STARTING_DIR" || return
+  cd "$STARTING_DIR" || exit 1
 }
 
 trap cleanup SIGINT

--- a/scripts/simtest/config-patch
+++ b/scripts/simtest/config-patch
@@ -12,14 +12,14 @@ index cc5620ecfe..d2ad8f1dac 100644
  # 64 bit MSVC, override default 1M stack with 8M stack
  [target.x86_64-pc-windows-msvc]
 diff --git a/Cargo.toml b/Cargo.toml
-index e91e9c7d48..d719828c54 100644
+index 8c3e44600d..c44174d67a 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -466,3 +466,7 @@ transaction-fuzzer = { path = "crates/transaction-fuzzer" }
+@@ -473,3 +473,7 @@ transaction-fuzzer = { path = "crates/transaction-fuzzer" }
  typed-store = { path = "crates/typed-store" }
  typed-store-derive = { path = "crates/typed-store-derive" }
  typed-store-error = { path = "crates/typed-store-error" }
 +
 +[patch.crates-io]
-+tokio = { git = "https://github.com/iotaledger/iota-sim.git", branch = "tokio-1.43" }
-+futures-timer = { git = "https://github.com/iotaledger/iota-sim.git", branch = "tokio-1.43" }
++tokio = { git = "https://github.com/iotaledger/iota-sim.git", branch = "tokio-1.44.2" }
++futures-timer = { git = "https://github.com/iotaledger/iota-sim.git", branch = "tokio-1.44.2" }


### PR DESCRIPTION
## Description 

Updates `tokio` to 1.44.2 to fix [`RUSTSEC-2025-0014`](https://rustsec.org/advisories/RUSTSEC-2025-0023)

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
