### PR TITLE
fix(core-node): clear exchange rates cache

### DIFF
--- a/crates/iota-e2e-tests/tests/apy_test.rs
+++ b/crates/iota-e2e-tests/tests/apy_test.rs
@@ -46,7 +46,10 @@ use test_cluster::TestClusterBuilder;
 #[sim_test]
 async fn test_apy() {
     // clean up the `cached` cache before running the test.
-    iota_json_rpc::governance_api::clear_exchange_rates_cache_for_testing().await;
+    #[cfg(msim)]
+    {
+        iota_json_rpc::governance_api::clear_exchange_rates_cache_for_testing().await;
+    }
 
     // We need a large stake for low enough APY values such that they are not
     // filtered out by the APY calculation function.

--- a/crates/iota-e2e-tests/tests/apy_test.rs
+++ b/crates/iota-e2e-tests/tests/apy_test.rs
@@ -46,7 +46,7 @@ use test_cluster::TestClusterBuilder;
 #[sim_test]
 async fn test_apy() {
     // clean up the `cached` cache before running the test.
-    iota_json_rpc::governance_api::clear_exchange_rates_cache().await;
+    iota_json_rpc::governance_api::clear_exchange_rates_cache_for_testing().await;
 
     // We need a large stake for low enough APY values such that they are not
     // filtered out by the APY calculation function.

--- a/crates/iota-e2e-tests/tests/apy_test.rs
+++ b/crates/iota-e2e-tests/tests/apy_test.rs
@@ -45,6 +45,9 @@ use test_cluster::TestClusterBuilder;
 /// epoch 1, this is totally fine.
 #[sim_test]
 async fn test_apy() {
+    // clean up the `cached` cache before running the test.
+    iota_json_rpc::governance_api::clear_exchange_rates_cache().await;
+
     // We need a large stake for low enough APY values such that they are not
     // filtered out by the APY calculation function.
     let pool_stake = 3_500_000_000 * NANOS_PER_IOTA / 4;

--- a/crates/iota-json-rpc/Cargo.toml
+++ b/crates/iota-json-rpc/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 license = "Apache-2.0"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 # external dependencies
 anyhow.workspace = true

--- a/crates/iota-json-rpc/src/governance_api.rs
+++ b/crates/iota-json-rpc/src/governance_api.rs
@@ -564,7 +564,8 @@ async fn exchange_rates(
 // In tests that run several different networks the latter calls
 // will get incorrect/outdated cached results.
 // This function allows to clear `cached` cache for `exchange_rates`.
-pub async fn clear_exchange_rates_cache() {
+#[cfg(msim)]
+pub async fn clear_exchange_rates_cache_for_testing() {
     use cached::Cached;
     if let Some(mutex) = ::cached::once_cell::sync::Lazy::get(&EXCHANGE_RATES) {
         let mut cache = mutex.lock().await;

--- a/crates/iota-json-rpc/src/governance_api.rs
+++ b/crates/iota-json-rpc/src/governance_api.rs
@@ -557,6 +557,21 @@ async fn exchange_rates(
         .collect())
 }
 
+// `cached` keeps results by the input key -- `current_epoch`.
+// `exchange_rates` is not a pure function, has effects via `state`
+// which `cached` is not aware of.
+// In normal node operation this does not create issues.
+// In tests that run several different networks the latter calls
+// will get incorrect/outdated cached results.
+// This function allows to clear `cached` cache for `exchange_rates`.
+pub async fn clear_exchange_rates_cache() {
+    use cached::Cached;
+    if let Some(mutex) = ::cached::once_cell::sync::Lazy::get(&EXCHANGE_RATES) {
+        let mut cache = mutex.lock().await;
+        cache.cache_clear();
+    }
+}
+
 /// Get validator exchange rates
 fn validator_exchange_rates(
     state: &Arc<dyn StateRead>,


### PR DESCRIPTION
# Description of change

`test_apy` simtest failed with `MSIM_TEST_NUM=2` which runs the test two times. The APYs are calculated by `iota-json-rpc` crate that caches the results of `async fn exchange_rates` with `cached`. In the second run the cache is polluted thus returning the wrong exchange rates (for the committee from the previous test run). Clearing the cache before running the test fixes the issue.

It seems that `cached` doesn't provide a public API to clear the cache created with proc macro `#[cached]`. The current approach uses `cached-0.43` and the way it stores the cache. With future version of `cached` it might break.

## Links to any relevant issues

Fixes #5293.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

```
MSIM_TEST_SEED=1 \
MSIM_TEST_NUM=2 \
MSIM_WATCHDOG_TIMEOUT_MS=180000 \
RUST_LOG=warn \
scripts/simtest/cargo-simtest simtest \
  --color always \
  --package iota-e2e-tests \
  --test "apy_test" \
  --profile ci
```

The test should PASS.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
