### PR TITLE
feat(iota-json-rpc-api, ts-sdk): Allow to pass `IotaObjectDataOptions` to the `get_dynamic_field_object` function

### DIFF
--- a/crates/iota-e2e-tests/tests/full_node_migration_tests.rs
+++ b/crates/iota-e2e-tests/tests/full_node_migration_tests.rs
@@ -230,7 +230,7 @@ async fn address_unlock_condition(
     };
     let alias_object = iota_client
         .read_api()
-        .get_dynamic_field_object(alias_output_object_id, df_name)
+        .get_dynamic_field_object(alias_output_object_id, df_name, None)
         .await?
         .data
         .ok_or(anyhow!("alias not found"))?;

--- a/crates/iota-indexer/src/apis/indexer_api.rs
+++ b/crates/iota-indexer/src/apis/indexer_api.rs
@@ -237,6 +237,7 @@ impl IndexerApiServer for IndexerApi {
         &self,
         parent_object_id: ObjectID,
         name: DynamicFieldName,
+        options: Option<IotaObjectDataOptions>,
     ) -> RpcResult<IotaObjectResponse> {
         let name_bcs_value = self.inner.bcs_name_from_dynamic_field_name(&name).await?;
 
@@ -248,7 +249,8 @@ impl IndexerApiServer for IndexerApi {
         )
         .expect("deriving dynamic field id can't fail");
 
-        let options = iota_json_rpc_types::IotaObjectDataOptions::full_content();
+        let options = options.unwrap_or_else(IotaObjectDataOptions::full_content);
+
         match self.inner.get_object_read_in_blocking_task(id).await? {
             iota_types::object::ObjectRead::NotExists(_)
             | iota_types::object::ObjectRead::Deleted(_) => {}

--- a/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
@@ -740,7 +740,7 @@ fn test_get_dynamic_field_objects() -> Result<(), anyhow::Error> {
 
         // Verify that the dynamic field was successfully added
         let dynamic_fields = client
-            .get_dynamic_field_object(bag_object_ref.0, name)
+            .get_dynamic_field_object(bag_object_ref.0, name, None)
             .await
             .expect("Failed to get dynamic field object");
 

--- a/crates/iota-json-rpc-api/src/indexer.rs
+++ b/crates/iota-json-rpc-api/src/indexer.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_json_rpc_types::{
-    DynamicFieldPage, EventFilter, EventPage, IotaEvent, IotaObjectResponse,
+    DynamicFieldPage, EventFilter, EventPage, IotaEvent, IotaObjectDataOptions, IotaObjectResponse,
     IotaObjectResponseQuery, IotaTransactionBlockEffects, IotaTransactionBlockResponseQuery,
     ObjectsPage, TransactionBlocksPage, TransactionFilter,
 };
@@ -108,5 +108,7 @@ pub trait IndexerApi {
         parent_object_id: ObjectID,
         /// The Name of the dynamic field
         name: DynamicFieldName,
+        /// Options for specifying the content to be returned
+        options: Option<IotaObjectDataOptions>,
     ) -> RpcResult<IotaObjectResponse>;
 }

--- a/crates/iota-json-rpc-tests/tests/indexer_api.rs
+++ b/crates/iota-json-rpc-tests/tests/indexer_api.rs
@@ -728,7 +728,7 @@ async fn test_get_dynamic_field_object() -> Result<(), anyhow::Error> {
 
     // Verify that the dynamic field was successfully added
     let dynamic_fields = rpc_client
-        .get_dynamic_field_object(bag_object_ref.0, name)
+        .get_dynamic_field_object(bag_object_ref.0, name, None)
         .await
         .expect("Failed to get dynamic field object");
 

--- a/crates/iota-json-rpc/src/indexer_api.rs
+++ b/crates/iota-json-rpc/src/indexer_api.rs
@@ -391,6 +391,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         &self,
         parent_object_id: ObjectID,
         name: DynamicFieldName,
+        options: Option<IotaObjectDataOptions>,
     ) -> RpcResult<IotaObjectResponse> {
         async move {
             let (name_type, name_bcs_value) = self.extract_values_from_dynamic_field_name(name)?;
@@ -399,10 +400,12 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
                 .state
                 .get_dynamic_field_object_id(parent_object_id, name_type, &name_bcs_value)
                 .map_err(Error::from)?;
-            // TODO(chris): add options to `get_dynamic_field_object` API as well
+
+            let options = options.or_else(|| Some(IotaObjectDataOptions::full_content()));
+
             if let Some(id) = id {
                 self.read_api
-                    .get_object(id, Some(IotaObjectDataOptions::full_content()))
+                    .get_object(id, options)
                     .await
                     .map_err(|e| Error::Internal(anyhow!(e)))
             } else {

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -3691,6 +3691,13 @@
           "schema": {
             "$ref": "#/components/schemas/DynamicFieldName"
           }
+        },
+        {
+          "name": "options",
+          "description": "Options for specifying the content to be returned",
+          "schema": {
+            "$ref": "#/components/schemas/ObjectDataOptions"
+          }
         }
       ],
       "result": {
@@ -3713,6 +3720,18 @@
               "value": {
                 "type": "0x0000000000000000000000000000000000000000000000000000000000000009::test::TestField",
                 "value": "some_value"
+              }
+            },
+            {
+              "name": "options",
+              "value": {
+                "showType": true,
+                "showOwner": true,
+                "showPreviousTransaction": true,
+                "showDisplay": false,
+                "showContent": true,
+                "showBcs": false,
+                "showStorageRebate": true
               }
             }
           ],

--- a/crates/iota-open-rpc/src/examples.rs
+++ b/crates/iota-open-rpc/src/examples.rs
@@ -1228,6 +1228,7 @@ impl RpcExampleProvider {
                 vec![
                     ("parent_object_id", json!(parent_object_id)),
                     ("name", json!(field_name)),
+                    ("options", json!(IotaObjectDataOptions::full_content())),
                 ],
                 json!(resp),
             )],

--- a/crates/iota-sdk/examples/read_api/read_api.rs
+++ b/crates/iota-sdk/examples/read_api/read_api.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), anyhow::Error> {
         println!(" *** First Dynamic Field ***");
         let dynamic_field = client
             .read_api()
-            .get_dynamic_field_object(parent_object_id, dynamic_field_info.name)
+            .get_dynamic_field_object(parent_object_id, dynamic_field_info.name, None)
             .await?;
         println!("{dynamic_field:?}");
         println!(" *** First Dynamic Field ***\n");

--- a/crates/iota-sdk/src/apis/read.rs
+++ b/crates/iota-sdk/src/apis/read.rs
@@ -145,11 +145,12 @@ impl ReadApi {
         &self,
         parent_object_id: ObjectID,
         name: DynamicFieldName,
+        options: Option<IotaObjectDataOptions>,
     ) -> IotaRpcResult<IotaObjectResponse> {
         Ok(self
             .api
             .http
-            .get_dynamic_field_object(parent_object_id, name)
+            .get_dynamic_field_object(parent_object_id, name, options)
             .await?)
     }
 

--- a/crates/iota/src/validator_commands.rs
+++ b/crates/iota/src/validator_commands.rs
@@ -1057,7 +1057,7 @@ pub async fn get_validator_summary(
     };
     let res = client
         .read_api()
-        .get_dynamic_field_object(validator_candidates_id, name)
+        .get_dynamic_field_object(validator_candidates_id, name, None)
         .await?;
     if res.error.is_none() {
         let object_id = res.data.expect("no data in result").object_id;

--- a/docs/examples/rust/stardust/address-unlock-condition.rs
+++ b/docs/examples/rust/stardust/address-unlock-condition.rs
@@ -100,7 +100,7 @@ async fn main() -> Result<(), anyhow::Error> {
     };
     let alias_object = iota_client
         .read_api()
-        .get_dynamic_field_object(alias_output_object_id, df_name)
+        .get_dynamic_field_object(alias_output_object_id, df_name, None)
         .await?
         .data
         .ok_or(anyhow!("alias not found"))?;

--- a/docs/examples/rust/stardust/foundry-output-claim.rs
+++ b/docs/examples/rust/stardust/foundry-output-claim.rs
@@ -82,7 +82,7 @@ async fn main() -> Result<(), anyhow::Error> {
     };
     let alias_object = iota_client
         .read_api()
-        .get_dynamic_field_object(alias_output_object_id, df_name)
+        .get_dynamic_field_object(alias_output_object_id, df_name, None)
         .await?
         .data
         .ok_or(anyhow!("alias not found"))?;

--- a/sdk/typescript/src/client/types/params.ts
+++ b/sdk/typescript/src/client/types/params.ts
@@ -244,6 +244,8 @@ export interface GetDynamicFieldObjectParams {
     parentId: string;
     /** The Name of the dynamic field */
     name: RpcTypes.DynamicFieldName;
+    /** Options for specifying the content to be returned */
+    options?: RpcTypes.IotaObjectDataOptions | null | undefined;
 }
 /** Return the list of dynamic field objects owned by an object. */
 export interface GetDynamicFieldsParams {


### PR DESCRIPTION
# Description of change

Allows to provide `IotaObjectDataOptions` to the `get_dynamic_field_object` endpoint.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/5807
Fixes https://github.com/iotaledger/iota/issues/6116

## Type of change

- Breaking change

## How the change has been tested

Tested in the dedicated PRs.
