### PR TITLE
ci: do not run workflows in draft, except keyword is available in PR description

### DIFF
--- a/.github/workflows/_docs_lint.yml
+++ b/.github/workflows/_docs_lint.yml
@@ -10,7 +10,6 @@ jobs:
   spelling:
     name: Lint documentation
     runs-on: [self-hosted-x64]
-
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Spell Check Docs

--- a/.github/workflows/_rust.yml
+++ b/.github/workflows/_rust.yml
@@ -39,6 +39,7 @@ env:
 jobs:
   rust-lints:
     uses: ./.github/workflows/_rust_lints.yml
+    if: (!cancelled() && !failure())
     with:
       isRust: ${{ inputs.isRust }}
       isRustExample: ${{ inputs.isRustExample }}
@@ -59,6 +60,7 @@ jobs:
   external-changes:
     needs: rust-lints
     runs-on: [self-hosted-x64]
+    if: (!cancelled() && !failure())
     outputs:
       components: ${{ steps.filter.outputs.changes }}
     steps:
@@ -70,8 +72,7 @@ jobs:
           filters: .github/external-crates-filters.yml
 
   rust-tests:
-    if: |
-      !cancelled() && !failure() && github.event.pull_request.draft == false && (inputs.isRust || inputs.isPgIntegration || inputs.isMoveExampleUsedByOthers)
+    if: (!cancelled() && !failure() && (inputs.isRust || inputs.isPgIntegration || inputs.isMoveExampleUsedByOthers))
     needs:
       - crates-changes
       - external-changes
@@ -86,8 +87,7 @@ jobs:
       changedExternalCrates: ${{ join(fromJson(needs.external-changes.outputs.components), ' ') }}
 
   execution-cut:
-    if: |
-      !cancelled() && !failure() && inputs.isRust && github.event.pull_request.draft == false
+    if: (!cancelled() && !failure() && inputs.isRust)
     needs:
       - rust-lints
     uses: ./.github/workflows/_execution_cut.yml

--- a/.github/workflows/_rust_tests.yml
+++ b/.github/workflows/_rust_tests.yml
@@ -58,8 +58,7 @@ env:
 jobs:
   rust-tests:
     name: Run rust tests
-    if: |
-      !cancelled() && (inputs.isRust || inputs.isPgIntegration || inputs.isMoveExampleUsedByOthers)
+    if: (!cancelled() && (inputs.isRust || inputs.isPgIntegration || inputs.isMoveExampleUsedByOthers))
     timeout-minutes: 90
     runs-on: [self-hosted-x64]
     env:
@@ -117,8 +116,7 @@ jobs:
 
   rust-simtests:
     name: Run rust simtests
-    if: |
-      inputs.runSimtest && !cancelled() && (inputs.isRust || inputs.isPgIntegration || inputs.isMoveExampleUsedByOthers)
+    if: (!cancelled() && inputs.runSimtest && (inputs.isRust || inputs.isPgIntegration || inputs.isMoveExampleUsedByOthers))
     timeout-minutes: 90
     runs-on: [self-hosted-x64]
     env:
@@ -180,8 +178,7 @@ jobs:
 
   check-unused-deps:
     name: Check Unused Dependencies (${{ matrix.flags }})
-    if: |
-      !cancelled() && !failure() && inputs.isRust && github.event.pull_request.draft == false
+    if: (!cancelled() && !failure())
     strategy:
       matrix:
         flags: ["--all-features", "--no-default-features"]
@@ -201,6 +198,7 @@ jobs:
       # non-deterministic `test` job.
       IOTA_SKIP_SIMTESTS: 1
     runs-on: ${{ matrix.os }}
+    if: (!cancelled() && !failure())
     strategy:
       matrix:
         os:

--- a/.github/workflows/_split_cluster.yml
+++ b/.github/workflows/_split_cluster.yml
@@ -16,7 +16,6 @@ env:
 jobs:
   # TODO: re-enable https://github.com/iotaledger/iota/issues/3862
   # validate-mainnet:
-  #   if: github.event.pull_request.draft == false
   #   runs-on: self-hosted-x64
   #   steps:
   #     - name: Checkout code repository
@@ -29,8 +28,8 @@ jobs:
   #         IOTA_PROTOCOL_CONFIG_CHAIN_OVERRIDE=mainnet \
   #         scripts/compatibility/split-cluster-check.sh origin/mainnet ${{ github.sha }}
   validate-testnet:
-    if: github.event.pull_request.draft == false
     runs-on: self-hosted-x64
+    if: (!cancelled() && !failure())
     steps:
       - name: Checkout code repository
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1

--- a/.github/workflows/_typos.yml
+++ b/.github/workflows/_typos.yml
@@ -10,6 +10,7 @@ jobs:
   run:
     name: Spell Check with Typos
     runs-on: ubuntu-latest
+    if: (!cancelled() && !failure())
     steps:
       - name: Checkout Actions Repository
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1

--- a/.github/workflows/changesets_ci.yml
+++ b/.github/workflows/changesets_ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   validate:
-    if: github.event.pull_request.draft == false
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]'))
     runs-on: self-hosted-x64
     steps:
       - name: checkout code repository

--- a/.github/workflows/crate_docs.yml
+++ b/.github/workflows/crate_docs.yml
@@ -14,6 +14,7 @@ jobs:
   docs:
     name: Generate crate documentation
     runs-on: self-hosted-x64
+    if: (!cancelled() && !failure())
     steps:
       - name: Checkout sources
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1

--- a/.github/workflows/hierarchy.yml
+++ b/.github/workflows/hierarchy.yml
@@ -17,6 +17,7 @@ jobs:
     concurrency:
       group: diff-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
+    if: (!cancelled() && !failure() && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     outputs:
       isRust: ${{ steps.diff.outputs.isRust }}
       isRustExample: ${{ steps.diff.outputs.isRustExample }}
@@ -38,12 +39,14 @@ jobs:
     concurrency:
       group: dprint-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
+    if: (!cancelled() && !failure() && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Check dprint formatting
         run: dprint check
 
   typos:
+    if: (!cancelled() && !failure() && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_typos.yml
 
   license-check:
@@ -52,7 +55,7 @@ jobs:
       group: license-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
     needs: diff
-    if: (!cancelled() && needs.diff.outputs.isRust == 'true')
+    if: (!cancelled() && !failure() && needs.diff.outputs.isRust == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     runs-on: [self-hosted-x64]
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -61,12 +64,12 @@ jobs:
 
   docusaurus:
     needs: diff
-    if: (!cancelled() && needs.diff.outputs.isDoc == 'true' && !github.event.pull_request.draft)
+    if: (!cancelled() && !failure() && needs.diff.outputs.isDoc == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_docusaurus.yml
 
   docs-lint:
     needs: diff
-    if: (!cancelled() && needs.diff.outputs.isDoc == 'true')
+    if: (!cancelled() && !failure() && needs.diff.outputs.isDoc == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_docs_lint.yml
 
   rust:
@@ -75,7 +78,7 @@ jobs:
       - dprint-format
       - license-check
       - typos
-    if: (!cancelled() && !failure())
+    if: (!cancelled() && !failure() && needs.diff.outputs.isDoc == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_rust.yml
     secrets: inherit
     with:
@@ -89,9 +92,7 @@ jobs:
       - diff
       - dprint-format
       - typos
-    if: |
-      !cancelled() && !failure() &&
-      (needs.diff.outputs.isRosetta == 'true')
+    if: (!cancelled() && !failure() && needs.diff.outputs.isRosetta == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_rosetta.yml
 
   move-ide:
@@ -100,12 +101,12 @@ jobs:
       - dprint-format
       - license-check
       - typos
-    if: (!cancelled() && !failure()) && needs.diff.outputs.isExternalCrates == 'true' && github.event.pull_request.draft == false
+    if: (!cancelled() && !failure() && needs.diff.outputs.isExternalCrates == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_move_ide.yml
 
   split-cluster:
     needs:
       - diff
       - rust
-    if: (!cancelled() && !failure()) && needs.diff.outputs.isRust == 'true' && github.event.pull_request.draft == false
+    if: (!cancelled() && !failure() && needs.diff.outputs.isRust == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     uses: ./.github/workflows/_split_cluster.yml

--- a/.github/workflows/preview_wiki.yml
+++ b/.github/workflows/preview_wiki.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   wiki-preview:
     runs-on: self-hosted-x64
-    if: github.event.pull_request.draft == false
+    if: (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]'))
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 

--- a/.github/workflows/turbo_hierarchy.yml
+++ b/.github/workflows/turbo_hierarchy.yml
@@ -40,6 +40,7 @@ jobs:
     concurrency:
       group: turbo-audit-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
+    if: (!cancelled() && !failure() && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -57,6 +58,7 @@ jobs:
     concurrency:
       group: turbo-build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}
+    if: (!cancelled() && !failure() && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -108,7 +110,7 @@ jobs:
           retention-days: 7
 
   e2e:
-    if: (!cancelled() && !failure() && !github.event.pull_request.draft && github.ref_name != 'develop')
+    if: (!cancelled() && !failure() && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')) && github.ref_name != 'develop')
     needs: diff
     uses: ./.github/workflows/_e2e.yml
     with:
@@ -120,7 +122,7 @@ jobs:
       isGraphQlTransport: ${{ needs.diff.outputs.isGraphQlTransport == 'true' }}
 
   ledgernano:
-    if: (!cancelled() && !failure()) && needs.diff.outputs.isLedgerjs == 'true' && github.event.pull_request.draft == false
+    if: (!cancelled() && !failure() && needs.diff.outputs.isLedgerjs == 'true' && (github.event.pull_request.draft == false || contains(github.event.pull_request.body, '[run-ci]')))
     needs: diff
     uses: ./.github/workflows/_ledgernano.yml
     secrets: inherit


### PR DESCRIPTION
# Description of change

This PR should stop running workflows if the PR is a draft. This should reduce the load on the CI.
Sometimes the developer wants to run the CI anyway, but keep the PR as a draft.
For this the magic keyword `[run-ci]` should be added in the PR description.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

The changes seem to work fine.
First the keyword was not present in the PR description, and the tests were skipped.
Then I changed the PR description to add the keyword and pushed another commit (force-push). After that the tests were executed.
