### PR TITLE
refactor(iota-tx-test-runner): add named variable for transaction digests

### DIFF
--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -135,6 +135,9 @@ pub struct IotaTestAdapter {
     default_account: TestAccount,
     default_syntax: SyntaxChoice,
     object_enumeration: BiBTreeMap<ObjectID, FakeID>,
+    /// Mapping from task ID to a transaction digest, for use in named variable
+    /// substitution.
+    digest_enumeration: BTreeMap<u64, TransactionDigest>,
     next_fake: (u64, u64),
     gas_price: u64,
     pub(crate) staged_modules: BTreeMap<Symbol, StagedPackage>,
@@ -360,6 +363,7 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
             default_account,
             default_syntax,
             object_enumeration: BiBTreeMap::new(),
+            digest_enumeration: BTreeMap::new(),
             next_fake: (0, 0),
             // TODO: make this configurable
             gas_price: default_gas_price.unwrap_or(DEFAULT_GAS_PRICE),
@@ -1209,6 +1213,10 @@ impl IotaTestAdapter {
             }
         }
 
+        for (tid, digest) in &self.digest_enumeration {
+            variables.insert(format!("digest_{tid}"), digest.to_string());
+        }
+
         for (idx, s) in cursors.iter().enumerate() {
             // an object cursor may be either @{obj_x_y} or @{obj_x_y,n}
             // if the former, then use highest_checkpoint
@@ -1485,6 +1493,19 @@ impl IotaTestAdapter {
             .contains_shared_object();
         let (effects, error_opt) = self.executor.execute_txn(transaction).await?;
         let digest = effects.transaction_digest();
+
+        // Try to assign `digest_$task` to this transaction's digest -- panic if a
+        // transaction has already been set. Currently each task executes at
+        // most one transaction, and everything is fine. This panic triggering
+        // will be an early warning that we need to do something
+        // more sophisticated.
+        let task = self.next_fake.0;
+        if let Some(prev) = self.digest_enumeration.insert(task, *digest) {
+            panic!(
+                "Task {task} executed two transactions (expected at most one): {prev}, {digest}"
+            );
+        }
+
         let mut created_ids: Vec<_> = effects
             .created()
             .iter()


### PR DESCRIPTION
# Description of change

According to [changes](https://github.com/MystenLabs/sui/commit/88a4c5b0da3ee8b8d3b181009f0b85a4101cead6)

For each transaction that is executed by the test adapter, record a
named variable, `digest_$task` where `$task` is the transactional
testing task number (the same number that appears in the first position
of fake object IDs).

This is to allow later tasks to refer to transaction digests as
variables in their bodies (in particular JSON RPC and GraphQL requests).

This is in preparation for adding tests for querying transaction blocks
by their digest.

## Links to any relevant issues

Fixes #6233 .

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

```
cargo nextest run            \
  -p iota-graphql-e2e-tests     \
  -p iota-adapter-transactional-tests

```