### PR TITLE
fix(iota): Fix `IotaTransactionBlockResponseOptions` param for `get_dynamic_field_object` in `validator_commands.rs`.

### DIFF
--- a/crates/iota/src/validator_commands.rs
+++ b/crates/iota/src/validator_commands.rs
@@ -1057,7 +1057,7 @@ pub async fn get_validator_summary(
     };
     let res = client
         .read_api()
-        .get_dynamic_field_object(validator_candidates_id, name)
+        .get_dynamic_field_object(validator_candidates_id, name, None)
         .await?;
     if res.error.is_none() {
         let object_id = res.data.expect("no data in result").object_id;


### PR DESCRIPTION
# Description of change

With latest changes on develop, the `IotaTransactionBlockResponseOptions` param for `get_dynamic_field_object` in `validator_commands.rs` needs to be fixed in https://github.com/iotaledger/iota/pull/6316.

## Relevant Links

https://github.com/iotaledger/iota/pull/6316#issuecomment-2787410827

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`cargo build`
`cargo clippy`

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
