### PR TITLE
node-upstream-change([v1.32.2, v1.33.3)): add network key + /metrics/network_key rest endpoint

### DIFF
--- a/crates/iota-bridge/src/config.rs
+++ b/crates/iota-bridge/src/config.rs
@@ -14,7 +14,7 @@ use iota_sdk::{IotaClient as IotaSdkClient, IotaClientBuilder, apis::CoinReadApi
 use iota_types::{
     base_types::{IotaAddress, ObjectID, ObjectRef},
     bridge::BridgeChainId,
-    crypto::{IotaKeyPair, KeypairTraits},
+    crypto::{IotaKeyPair, KeypairTraits, NetworkKeyPair, get_key_pair_from_rng},
     digests::{get_mainnet_chain_identifier, get_testnet_chain_identifier},
     event::EventID,
     object::Owner,
@@ -96,7 +96,7 @@ pub struct IotaConfig {
 }
 
 #[serde_as]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct BridgeNodeConfig {
     /// The port that the server listens on.
@@ -118,6 +118,13 @@ pub struct BridgeNodeConfig {
     pub iota: IotaConfig,
     /// Eth configuration
     pub eth: EthConfig,
+    /// Network key used for metrics pushing
+    #[serde(default = "default_ed25519_key_pair")]
+    pub metrics_key_pair: NetworkKeyPair,
+}
+
+pub fn default_ed25519_key_pair() -> NetworkKeyPair {
+    get_key_pair_from_rng(&mut rand::rngs::OsRng).1
 }
 
 impl Config for BridgeNodeConfig {}

--- a/crates/iota-bridge/src/e2e_tests/test_utils.rs
+++ b/crates/iota-bridge/src/e2e_tests/test_utils.rs
@@ -41,7 +41,7 @@ use tracing::{error, info};
 use crate::{
     BRIDGE_ENABLE_PROTOCOL_VERSION,
     abi::{EthBridgeCommittee, EthBridgeConfig},
-    config::{BridgeNodeConfig, EthConfig, IotaConfig},
+    config::{BridgeNodeConfig, EthConfig, IotaConfig, default_ed25519_key_pair},
     crypto::{BridgeAuthorityKeyPair, BridgeAuthorityPublicKeyBytes},
     events::*,
     iota_client::IotaBridgeClient,
@@ -764,12 +764,12 @@ pub(crate) async fn start_bridge_cluster(
                 bridge_client_gas_object: None,
                 iota_bridge_module_last_processed_event_id_override: None,
             },
+            metrics_key_pair: default_ed25519_key_pair(),
         };
         // Spawn bridge node in memory
-        let config_clone = config.clone();
         handles.push(
             run_bridge_node(
-                config_clone,
+                config,
                 BridgeNodePublicMetadata::empty_for_testing(),
                 Registry::new(),
             )

--- a/crates/iota-bridge/src/main.rs
+++ b/crates/iota-bridge/src/main.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use clap::Parser;
+use fastcrypto::traits::KeyPair;
 use iota_bridge::{
     config::BridgeNodeConfig, node::run_bridge_node, server::BridgeNodePublicMetadata,
 };
@@ -43,7 +44,10 @@ async fn main() -> anyhow::Result<()> {
         .with_env()
         .with_prom_registry(&prometheus_registry)
         .init();
-    let metadata = BridgeNodePublicMetadata::new(VERSION.into());
+
+    let metadata =
+        BridgeNodePublicMetadata::new(VERSION.into(), config.metrics_key_pair.public().clone());
+
     Ok(run_bridge_node(config, metadata, prometheus_registry)
         .await?
         .await?)

--- a/crates/iota-bridge/src/node.rs
+++ b/crates/iota-bridge/src/node.rs
@@ -256,7 +256,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        config::{BridgeNodeConfig, EthConfig, IotaConfig},
+        config::{BridgeNodeConfig, EthConfig, IotaConfig, default_ed25519_key_pair},
         e2e_tests::test_utils::{BridgeTestCluster, BridgeTestClusterBuilder},
         utils::wait_for_server_to_be_up,
     };
@@ -438,6 +438,7 @@ mod tests {
             approved_governance_actions: vec![],
             run_client: false,
             db_path: None,
+            metrics_key_pair: default_ed25519_key_pair(),
         };
         // Spawn bridge node in memory
         let _handle = run_bridge_node(
@@ -502,6 +503,7 @@ mod tests {
             approved_governance_actions: vec![],
             run_client: true,
             db_path: Some(db_path),
+            metrics_key_pair: default_ed25519_key_pair(),
         };
         // Spawn bridge node in memory
         let _handle = run_bridge_node(
@@ -577,6 +579,7 @@ mod tests {
             approved_governance_actions: vec![],
             run_client: true,
             db_path: Some(db_path),
+            metrics_key_pair: default_ed25519_key_pair(),
         };
         // Spawn bridge node in memory
         let _handle = run_bridge_node(

--- a/crates/iota-bridge/src/server/mod.rs
+++ b/crates/iota-bridge/src/server/mod.rs
@@ -13,6 +13,7 @@ use axum::{
 };
 use ethers::types::Address as EthAddress;
 use fastcrypto::{
+    ed25519::Ed25519PublicKey,
     encoding::{Encoding, Hex},
     traits::ToFromBytes,
 };
@@ -41,6 +42,7 @@ pub(crate) mod mock_handler;
 pub const APPLICATION_JSON: &str = "application/json";
 
 pub const PING_PATH: &str = "/ping";
+pub const METRICS_KEY_PATH: &str = "/metrics_pub_key";
 
 // Important: for BridgeActions, the paths need to match the ones in
 // bridge_client.rs
@@ -61,22 +63,27 @@ pub const ADD_TOKENS_ON_IOTA_PATH: &str =
     "/sign/add_tokens_on_iota/:chain_id/:nonce/:native/:token_ids/:token_type_names/:token_prices";
 pub const ADD_TOKENS_ON_EVM_PATH: &str = "/sign/add_tokens_on_evm/:chain_id/:nonce/:native/:token_ids/:token_addresses/:token_iota_decimals/:token_prices";
 
-/// BridgeNode's public metadata that is acceesible via the `/ping` endpoint.
+// BridgeNode's public metadata that is accessible via the `/ping` endpoint.
 // Be careful with what to put here, as it is public.
-#[derive(serde::Serialize, Clone)]
+#[derive(serde::Serialize)]
 pub struct BridgeNodePublicMetadata {
     pub version: Option<String>,
+    pub metrics_pubkey: Option<Arc<Ed25519PublicKey>>,
 }
 
 impl BridgeNodePublicMetadata {
-    pub fn new(version: String) -> Self {
+    pub fn new(version: String, metrics_pubkey: Ed25519PublicKey) -> Self {
         Self {
             version: Some(version),
+            metrics_pubkey: Some(metrics_pubkey.into()),
         }
     }
 
     pub fn empty_for_testing() -> Self {
-        Self { version: None }
+        Self {
+            version: None,
+            metrics_pubkey: None,
+        }
     }
 }
 
@@ -106,6 +113,7 @@ pub(crate) fn make_router(
     Router::new()
         .route("/", get(health_check))
         .route(PING_PATH, get(ping))
+        .route(METRICS_KEY_PATH, get(metrics_key_fetch))
         .route(ETH_TO_IOTA_TX_PATH, get(handle_eth_tx_hash))
         .route(IOTA_TO_ETH_TX_PATH, get(handle_iota_tx_digest))
         .route(
@@ -158,8 +166,18 @@ async fn ping(
         Arc<BridgeMetrics>,
         Arc<BridgeNodePublicMetadata>,
     )>,
-) -> Result<Json<BridgeNodePublicMetadata>, BridgeError> {
-    Ok(Json(metadata.as_ref().clone()))
+) -> Result<Json<Arc<BridgeNodePublicMetadata>>, BridgeError> {
+    Ok(Json(metadata))
+}
+
+async fn metrics_key_fetch(
+    State((_handler, _metrics, metadata)): State<(
+        Arc<impl BridgeRequestHandlerTrait + Sync + Send>,
+        Arc<BridgeMetrics>,
+        Arc<BridgeNodePublicMetadata>,
+    )>,
+) -> Result<Json<Option<Arc<Ed25519PublicKey>>>, BridgeError> {
+    Ok(Json(metadata.metrics_pubkey.clone()))
 }
 
 #[instrument(level = "error", skip_all, fields(tx_hash_hex=tx_hash_hex, event_idx=event_idx))]

--- a/crates/iota-bridge/src/utils.rs
+++ b/crates/iota-bridge/src/utils.rs
@@ -38,7 +38,7 @@ use iota_types::{
 
 use crate::{
     abi::{EthBridgeCommittee, EthBridgeConfig, EthBridgeLimiter, EthBridgeVault, EthIotaBridge},
-    config::{BridgeNodeConfig, EthConfig, IotaConfig},
+    config::{BridgeNodeConfig, EthConfig, IotaConfig, default_ed25519_key_pair},
     crypto::{BridgeAuthorityKeyPair, BridgeAuthorityPublicKeyBytes},
     server::APPLICATION_JSON,
     types::{AddTokensOnIotaAction, BridgeAction},
@@ -199,6 +199,7 @@ pub fn generate_bridge_node_config_and_write_to_file(
         approved_governance_actions: vec![],
         run_client,
         db_path: None,
+        metrics_key_pair: default_ed25519_key_pair(),
     };
     if run_client {
         config.iota.bridge_client_key_path = Some(PathBuf::from("/path/to/your/bridge_client_key"));


### PR DESCRIPTION
# Description of change

Port https://github.com/MystenLabs/sui/commit/d43e7cc5125aee3023c3adb104d54c6b38884841

From [Sui's commit description](https://github.com/MystenLabs/sui/commit/d43e7cc5125aee3023c3adb104d54c6b38884841):
adds a ed25519 network key to the `BridgeNodePublicMetadata`.

I'm also adding a new api endpoint, `/metrics/network_key` which returns
only the network key, this isn't necessary, as `/ping` already returns
this info, I'm open to removing it.

## Links to any relevant issues

Part of #3990 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Ran the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
