### PR TITLE
node-upstream-change([v1.32.2, v1.33.3)): e2e tests optimizations

### DIFF
--- a/crates/iota-bridge/src/e2e_tests/basic.rs
+++ b/crates/iota-bridge/src/e2e_tests/basic.rs
@@ -49,13 +49,18 @@ async fn test_bridge_from_eth_to_iota_to_eth() {
 
     let eth_chain_id = BridgeChainId::EthCustom as u8;
     let iota_chain_id = BridgeChainId::IotaCustom as u8;
-
+    let timer = std::time::Instant::now();
     let mut bridge_test_cluster = BridgeTestClusterBuilder::new()
         .with_eth_env(true)
         .with_bridge_cluster(true)
+        .with_num_validators(3)
         .build()
         .await;
-
+    info!(
+        "[Timer] Bridge test cluster started in {:?}",
+        timer.elapsed()
+    );
+    let timer = std::time::Instant::now();
     let (eth_signer, _) = bridge_test_cluster
         .get_eth_signer_and_address()
         .await
@@ -92,7 +97,11 @@ async fn test_bridge_from_eth_to_iota_to_eth() {
         .expect("Recipient should have received ETH coin now")
         .clone();
     assert_eq!(eth_coin.balance, iota_amount);
-    info!("Eth to iota bridge transfer finished");
+    info!(
+        "[Timer] Eth to IOTA bridge transfer finished in {:?}",
+        timer.elapsed()
+    );
+    let timer = std::time::Instant::now();
 
     // Now let the recipient send the coin back to ETH
     let eth_address_1 = EthAddress::random();
@@ -119,6 +128,11 @@ async fn test_bridge_from_eth_to_iota_to_eth() {
         .await;
     // There are exactly 1 deposit and 1 approved event
     assert_eq!(events.len(), 2);
+    info!(
+        "[Timer] IOTA to Eth bridge transfer approved in {:?}",
+        timer.elapsed()
+    );
+    let timer = std::time::Instant::now();
 
     // Test `get_parsed_token_transfer_message`
     let parsed_msg = bridge_test_cluster
@@ -152,7 +166,10 @@ async fn test_bridge_from_eth_to_iota_to_eth() {
     let call = eth_iota_bridge.transfer_bridged_tokens_with_signatures(signatures, message);
     let eth_claim_tx_receipt = send_eth_tx_and_get_tx_receipt(call).await;
     assert_eq!(eth_claim_tx_receipt.status.unwrap().as_u64(), 1);
-    info!("IOTA to Eth bridge transfer claimed");
+    info!(
+        "[Timer] IOTA to Eth bridge transfer claimed in {:?}",
+        timer.elapsed()
+    );
     // Assert eth_address_1 has received ETH
     assert_eq!(
         eth_signer.get_balance(eth_address_1, None).await.unwrap(),
@@ -510,7 +527,10 @@ pub async fn initiate_bridge_eth_to_iota(
     assert_eq!(eth_bridge_event.iota_adjusted_amount, iota_amount);
     assert_eq!(eth_bridge_event.sender_address, eth_address);
     assert_eq!(eth_bridge_event.recipient_address, iota_address.to_vec());
-    info!("Deposited Eth to Solidity contract");
+    info!(
+        "Deposited Eth to Solidity contract, block: {:?}",
+        tx_receipt.block_number
+    );
 
     wait_for_transfer_action_status(
         bridge_test_cluster.bridge_client(),

--- a/crates/iota-bridge/src/e2e_tests/test_utils.rs
+++ b/crates/iota-bridge/src/e2e_tests/test_utils.rs
@@ -170,6 +170,14 @@ impl BridgeTestClusterBuilder {
         let bridge_client = IotaBridgeClient::new(&test_cluster.fullnode_handle.rpc_url)
             .await
             .unwrap();
+        info!(
+            "Bridge committee: {:?}",
+            bridge_client
+                .get_bridge_committee()
+                .await
+                .unwrap()
+                .to_string()
+        );
         BridgeTestCluster {
             num_validators: self.num_validators,
             test_cluster,
@@ -197,7 +205,6 @@ impl BridgeTestClusterBuilder {
         test_cluster
             .trigger_reconfiguration_if_not_yet_and_assert_bridge_committee_initialized()
             .await;
-        info!("Bridge committee is finalized");
         test_cluster
     }
 
@@ -514,7 +521,7 @@ pub(crate) async fn deploy_sol_contract(
     };
 
     let serialized_config = serde_json::to_string_pretty(&deploy_config).unwrap();
-    tracing::debug!(
+    tracing::info!(
         "Serialized config written to {:?}: {:?}",
         deploy_config_path,
         serialized_config
@@ -653,7 +660,7 @@ impl EthBridgeEnvironment {
             .arg("--block-time")
             .arg("1") // 1 second block time
             .arg("--slots-in-an-epoch")
-            .arg("3") // 3 slots in an epoch
+            .arg("1") // 1 slots in an epoch
             .spawn()
             .expect("Failed to start anvil");
 
@@ -748,7 +755,7 @@ pub(crate) async fn start_bridge_cluster(
             metrics_port: get_available_port("127.0.0.1"),
             bridge_authority_key_path: authority_key_path,
             approved_governance_actions,
-            run_client: true,
+            run_client: i == 0,
             db_path: Some(db_path),
             eth: EthConfig {
                 eth_rpc_url: eth_environment.rpc_url.clone(),

--- a/crates/iota-bridge/src/iota_transaction_builder.rs
+++ b/crates/iota-bridge/src/iota_transaction_builder.rs
@@ -722,13 +722,15 @@ mod tests {
     #[ignore = "https://github.com/iotaledger/iota/issues/3224"]
     async fn test_build_iota_transaction_for_emergency_op() {
         telemetry_subscribers::init_for_testing();
+        let num_valdiator = 2;
         let mut bridge_keys = vec![];
-        for _ in 0..=3 {
+        for _ in 0..num_valdiator {
             let (_, kp): (_, BridgeAuthorityKeyPair) = get_key_pair();
             bridge_keys.push(kp);
         }
         let mut test_cluster: test_cluster::TestCluster = TestClusterBuilder::new()
             .with_protocol_version((BRIDGE_ENABLE_PROTOCOL_VERSION).into())
+            .with_num_validators(num_valdiator)
             .build_with_bridge(bridge_keys, true)
             .await;
         let iota_client = IotaClient::new(&test_cluster.fullnode_handle.rpc_url)

--- a/crates/iota-bridge/src/types.rs
+++ b/crates/iota-bridge/src/types.rs
@@ -10,7 +10,10 @@ use std::{
 use enum_dispatch::enum_dispatch;
 pub use ethers::types::H256 as EthTransactionHash;
 use ethers::types::{Address as EthAddress, H256, Log};
-use fastcrypto::hash::{HashFunction, Keccak256};
+use fastcrypto::{
+    encoding::{Encoding, Hex},
+    hash::{HashFunction, Keccak256},
+};
 use iota_types::{
     TypeTag,
     bridge::{
@@ -23,6 +26,7 @@ use iota_types::{
         MoveTypeTokenTransferPayload,
     },
     committee::{CommitteeTrait, StakeUnit},
+    crypto::ToFromBytes,
     digests::{Digest, TransactionDigest},
     message_envelope::{Envelope, Message, VerifiedEnvelope},
 };
@@ -119,6 +123,23 @@ impl BridgeCommittee {
 
     pub fn total_blocklisted_stake(&self) -> StakeUnit {
         self.total_blocklisted_stake
+    }
+}
+
+impl core::fmt::Display for BridgeCommittee {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> std::fmt::Result {
+        for m in self.members.values() {
+            writeln!(
+                f,
+                "pubkey: {:?}, url: {:?}, stake: {:?}, blocklisted: {}, eth address: {:x}",
+                Hex::encode(m.pubkey_bytes().as_bytes()),
+                m.base_url,
+                m.voting_power,
+                m.is_blocklisted,
+                m.pubkey_bytes().to_eth_address(),
+            )?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
# Description of change

Port https://github.com/MystenLabs/sui/commit/292031e819838ba66a173e51160e7cbda78af132

From [Sui's commit description](https://github.com/MystenLabs/sui/commit/292031e819838ba66a173e51160e7cbda78af132):
This PR does a few things to make e2e tests run faster:
1. instead of having every node running the client, only having one of
them do so.
2. allow custom number of bridge nodes, and reduce the amount of nodes
for some tests
3. reduce the epoch length to 1 slot from 3 slots

These jointly reduce the duration of the basic e2e transfer test from
100+s to 70s.

## Links to any relevant issues

Part of #3990 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Ran the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
