### PR TITLE
feat(iota-json-rpc-api): Introduce `get_dynamic_field_object_v2` RPC APIs

### DIFF
--- a/crates/iota-indexer/src/apis/indexer_api.rs
+++ b/crates/iota-indexer/src/apis/indexer_api.rs
@@ -91,6 +91,65 @@ impl IndexerApi {
             has_next_page,
         })
     }
+
+    async fn get_dynamic_field_object(
+        &self,
+        parent_object_id: ObjectID,
+        name: DynamicFieldName,
+        options: Option<IotaObjectDataOptions>,
+    ) -> RpcResult<IotaObjectResponse> {
+        let name_bcs_value = self.inner.bcs_name_from_dynamic_field_name(&name).await?;
+
+        // Try as Dynamic Field
+        let id = iota_types::dynamic_field::derive_dynamic_field_id(
+            parent_object_id,
+            &name.type_,
+            &name_bcs_value,
+        )
+        .expect("deriving dynamic field id can't fail");
+
+        let options = options.unwrap_or_default();
+
+        match self.inner.get_object_read_in_blocking_task(id).await? {
+            iota_types::object::ObjectRead::NotExists(_)
+            | iota_types::object::ObjectRead::Deleted(_) => {}
+            iota_types::object::ObjectRead::Exists(object_ref, o, layout) => {
+                return Ok(IotaObjectResponse::new_with_data(
+                    IotaObjectData::new(object_ref, o, layout, options, None)
+                        .map_err(internal_error)?,
+                ));
+            }
+        }
+
+        // Try as Dynamic Field Object
+        let dynamic_object_field_struct =
+            iota_types::dynamic_field::DynamicFieldInfo::dynamic_object_field_wrapper(name.type_);
+        let dynamic_object_field_type = TypeTag::Struct(Box::new(dynamic_object_field_struct));
+        let dynamic_object_field_id = iota_types::dynamic_field::derive_dynamic_field_id(
+            parent_object_id,
+            &dynamic_object_field_type,
+            &name_bcs_value,
+        )
+        .expect("deriving dynamic field id can't fail");
+        match self
+            .inner
+            .get_object_read_in_blocking_task(dynamic_object_field_id)
+            .await?
+        {
+            iota_types::object::ObjectRead::NotExists(_)
+            | iota_types::object::ObjectRead::Deleted(_) => {}
+            iota_types::object::ObjectRead::Exists(object_ref, o, layout) => {
+                return Ok(IotaObjectResponse::new_with_data(
+                    IotaObjectData::new(object_ref, o, layout, options, None)
+                        .map_err(internal_error)?,
+                ));
+            }
+        }
+
+        Ok(IotaObjectResponse::new_with_error(
+            iota_types::error::IotaObjectResponseError::DynamicFieldNotFound { parent_object_id },
+        ))
+    }
 }
 
 async fn construct_object_response(
@@ -238,56 +297,22 @@ impl IndexerApiServer for IndexerApi {
         parent_object_id: ObjectID,
         name: DynamicFieldName,
     ) -> RpcResult<IotaObjectResponse> {
-        let name_bcs_value = self.inner.bcs_name_from_dynamic_field_name(&name).await?;
-
-        // Try as Dynamic Field
-        let id = iota_types::dynamic_field::derive_dynamic_field_id(
+        self.get_dynamic_field_object(
             parent_object_id,
-            &name.type_,
-            &name_bcs_value,
+            name,
+            Some(IotaObjectDataOptions::full_content()),
         )
-        .expect("deriving dynamic field id can't fail");
+        .await
+    }
 
-        let options = iota_json_rpc_types::IotaObjectDataOptions::full_content();
-        match self.inner.get_object_read_in_blocking_task(id).await? {
-            iota_types::object::ObjectRead::NotExists(_)
-            | iota_types::object::ObjectRead::Deleted(_) => {}
-            iota_types::object::ObjectRead::Exists(object_ref, o, layout) => {
-                return Ok(IotaObjectResponse::new_with_data(
-                    IotaObjectData::new(object_ref, o, layout, options, None)
-                        .map_err(internal_error)?,
-                ));
-            }
-        }
-
-        // Try as Dynamic Field Object
-        let dynamic_object_field_struct =
-            iota_types::dynamic_field::DynamicFieldInfo::dynamic_object_field_wrapper(name.type_);
-        let dynamic_object_field_type = TypeTag::Struct(Box::new(dynamic_object_field_struct));
-        let dynamic_object_field_id = iota_types::dynamic_field::derive_dynamic_field_id(
-            parent_object_id,
-            &dynamic_object_field_type,
-            &name_bcs_value,
-        )
-        .expect("deriving dynamic field id can't fail");
-        match self
-            .inner
-            .get_object_read_in_blocking_task(dynamic_object_field_id)
-            .await?
-        {
-            iota_types::object::ObjectRead::NotExists(_)
-            | iota_types::object::ObjectRead::Deleted(_) => {}
-            iota_types::object::ObjectRead::Exists(object_ref, o, layout) => {
-                return Ok(IotaObjectResponse::new_with_data(
-                    IotaObjectData::new(object_ref, o, layout, options, None)
-                        .map_err(internal_error)?,
-                ));
-            }
-        }
-
-        Ok(IotaObjectResponse::new_with_error(
-            iota_types::error::IotaObjectResponseError::DynamicFieldNotFound { parent_object_id },
-        ))
+    async fn get_dynamic_field_object_v2(
+        &self,
+        parent_object_id: ObjectID,
+        name: DynamicFieldName,
+        options: Option<IotaObjectDataOptions>,
+    ) -> RpcResult<IotaObjectResponse> {
+        self.get_dynamic_field_object(parent_object_id, name, options)
+            .await
     }
 
     fn subscribe_event(

--- a/crates/iota-json-rpc-api/src/indexer.rs
+++ b/crates/iota-json-rpc-api/src/indexer.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_json_rpc_types::{
-    DynamicFieldPage, EventFilter, EventPage, IotaEvent, IotaObjectResponse,
+    DynamicFieldPage, EventFilter, EventPage, IotaEvent, IotaObjectDataOptions, IotaObjectResponse,
     IotaObjectResponseQuery, IotaTransactionBlockEffects, IotaTransactionBlockResponseQuery,
     ObjectsPage, TransactionBlocksPage, TransactionFilter,
 };
@@ -108,5 +108,18 @@ pub trait IndexerApi {
         parent_object_id: ObjectID,
         /// The Name of the dynamic field
         name: DynamicFieldName,
+    ) -> RpcResult<IotaObjectResponse>;
+
+    /// Return the dynamic field object information for a specified object with content options.
+    #[rustfmt::skip]
+    #[method(name = "getDynamicFieldObjectV2")]
+    async fn get_dynamic_field_object_v2(
+        &self,
+        /// The ID of the queried parent object
+        parent_object_id: ObjectID,
+        /// The Name of the dynamic field
+        name: DynamicFieldName,
+        /// Options for specifying the content to be returned
+        options: Option<IotaObjectDataOptions>,
     ) -> RpcResult<IotaObjectResponse>;
 }

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -3741,6 +3741,47 @@
       ]
     },
     {
+      "name": "iotax_getDynamicFieldObjectV2",
+      "tags": [
+        {
+          "name": "Extended API"
+        }
+      ],
+      "description": "Return the dynamic field object information for a specified object with content options.",
+      "params": [
+        {
+          "name": "parent_object_id",
+          "description": "The ID of the queried parent object",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/ObjectID"
+          }
+        },
+        {
+          "name": "name",
+          "description": "The Name of the dynamic field",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/DynamicFieldName"
+          }
+        },
+        {
+          "name": "options",
+          "description": "Options for specifying the content to be returned",
+          "schema": {
+            "$ref": "#/components/schemas/ObjectDataOptions"
+          }
+        }
+      ],
+      "result": {
+        "name": "IotaObjectResponse",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/IotaObjectResponse"
+        }
+      }
+    },
+    {
       "name": "iotax_getDynamicFields",
       "tags": [
         {


### PR DESCRIPTION
# Description of change

Introduces `get_dynamic_field_object_v2` RPC APIs which allow to pass a content option parameter.

Previous PR https://github.com/iotaledger/iota/pull/6316 which added a simple parameter to the existing function signature was closed in favor of this patch to avoid any potential breaking changes.

## Links to any relevant issues

https://github.com/iotaledger/iota/issues/5807

## Type of change

- Feature (Non-breaking change)

## How the change has been tested

```
cargo build
cargo clippy
```
Node RPC tests:
```
cargo nextest run --cargo-profile simulator -p iota-json-rpc-tests
```
Indexer RPC tests:
```
cargo test --profile simulator --features shared_test_runtime
```

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
