### PR TITLE
feat(iota-sdk): add get_dynamic_field_object_v2()

### DIFF
--- a/crates/iota-sdk/examples/read_api/read_api.rs
+++ b/crates/iota-sdk/examples/read_api/read_api.rs
@@ -45,10 +45,22 @@ async fn main() -> Result<(), anyhow::Error> {
         println!(" *** First Dynamic Field ***");
         let dynamic_field = client
             .read_api()
-            .get_dynamic_field_object(parent_object_id, dynamic_field_info.name)
+            .get_dynamic_field_object(parent_object_id, dynamic_field_info.name.clone())
             .await?;
         println!("{dynamic_field:?}");
         println!(" *** First Dynamic Field ***\n");
+
+        println!(" *** First Dynamic Field BCS***");
+        let dynamic_field = client
+            .read_api()
+            .get_dynamic_field_object_v2(
+                parent_object_id,
+                dynamic_field_info.name,
+                IotaObjectDataOptions::new().with_bcs(),
+            )
+            .await?;
+        println!("{:?}", dynamic_field.data.expect("missing data").bcs);
+        println!(" *** First Dynamic Field BCS***\n");
     }
 
     let object = owned_objects

--- a/crates/iota-sdk/src/apis/read.rs
+++ b/crates/iota-sdk/src/apis/read.rs
@@ -153,6 +153,21 @@ impl ReadApi {
             .await?)
     }
 
+    /// Get information for a specified dynamic field object by its parent
+    /// object ID and field name with options.
+    pub async fn get_dynamic_field_object_v2(
+        &self,
+        parent_object_id: ObjectID,
+        name: DynamicFieldName,
+        options: impl Into<Option<IotaObjectDataOptions>>,
+    ) -> IotaRpcResult<IotaObjectResponse> {
+        Ok(self
+            .api
+            .http
+            .get_dynamic_field_object_v2(parent_object_id, name, options.into())
+            .await?)
+    }
+
     /// Get a parsed past object and version for the provided object ID.
     ///
     /// An object's version increases when the object is mutated, though it is


### PR DESCRIPTION
# Description of change

Add get_dynamic_field_object_v2() to the iota-sdk that was introduced to the RPC API in https://github.com/iotaledger/iota/pull/6331

## Links to any relevant issues

https://github.com/iotaledger/iota/issues/5807

## Type of change

- Feature (Non-breaking change)

## How the change has been tested

```
cargo clippy
```

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [x] Rust SDK: added `get_dynamic_field_object_v2()`
- [ ] REST API: