### PR TITLE
fix(wallet, wallet-dashboard): Sort wallet transactions by timestamp

### DIFF
--- a/apps/core/src/hooks/useQueryTransactionsByAddress.ts
+++ b/apps/core/src/hooks/useQueryTransactionsByAddress.ts
@@ -78,7 +78,9 @@ export function useQueryTransactionsByAddress(address: string = '') {
             }, new Map())
             .values(),
     );
-    const allTransactions = allTransactionsUnsorted.sort((a, b) => Number(b.timestampMs || 0) - Number(a.timestampMs || 0))
+    const allTransactions = allTransactionsUnsorted.sort(
+        (a, b) => Number(b.timestampMs || 0) - Number(a.timestampMs || 0),
+    );
     const lastPage = query.data?.pages[query.data.pages.length - 1];
 
     return {

--- a/apps/core/src/hooks/useQueryTransactionsByAddress.ts
+++ b/apps/core/src/hooks/useQueryTransactionsByAddress.ts
@@ -68,7 +68,7 @@ export function useQueryTransactionsByAddress(address: string = '') {
                 : undefined,
     });
     const flattenTransactions = query.data?.pages.flatMap((page) => page.transactions) || [];
-    const allTransactions = Array.from(
+    const allTransactionsUnsorted = Array.from<IotaTransactionBlockResponse>(
         flattenTransactions
             .reduce((map, item) => {
                 if (!map.has(item.digest)) {
@@ -78,6 +78,7 @@ export function useQueryTransactionsByAddress(address: string = '') {
             }, new Map())
             .values(),
     );
+    const allTransactions = allTransactionsUnsorted.sort((a, b) => Number(b.timestampMs || 0) - Number(a.timestampMs || 0))
     const lastPage = query.data?.pages[query.data.pages.length - 1];
 
     return {


### PR DESCRIPTION
Wallets transactions were not sorted by timestamp leading to inconsistencies like:

![image](https://github.com/user-attachments/assets/2919b3f9-7339-476f-95ec-cf16d9b09f4f)
