### PR TITLE
refactor(iota-execution)!: Remove TxContext from executor API

### DIFF
--- a/crates/iota-genesis-builder/src/lib.rs
+++ b/crates/iota-genesis-builder/src/lib.rs
@@ -34,7 +34,6 @@ use iota_types::{
     balance::{BALANCE_MODULE_NAME, Balance},
     base_types::{
         ExecutionDigests, IotaAddress, ObjectID, ObjectRef, SequenceNumber, TransactionDigest,
-        TxContext,
     },
     bridge::{BRIDGE_CREATE_FUNCTION_NAME, BRIDGE_MODULE_NAME, BridgeChainId},
     committee::Committee,
@@ -1020,16 +1019,15 @@ impl Builder {
     }
 }
 
-// Create a Genesis Txn Context to be used when generating genesis objects by
-// hashing all of the inputs into genesis ans using that as our "Txn Digest".
+// Create a Genesis Txn Digest to be used when generating genesis objects by
+// hashing all of the inputs into genesis and using that as our "Txn Digest".
 // This is done to ensure that coin objects created between chains are unique
-fn create_genesis_context(
-    epoch_data: &EpochData,
+fn create_genesis_digest(
     genesis_chain_parameters: &GenesisChainParameters,
     genesis_validators: &[GenesisValidatorMetadata],
     token_distribution_schedule: &TokenDistributionSchedule,
     system_packages: &[SystemPackage],
-) -> TxContext {
+) -> TransactionDigest {
     let mut hasher = DefaultHash::default();
     hasher.update(b"iota-genesis");
     hasher.update(bcs::to_bytes(genesis_chain_parameters).unwrap());
@@ -1040,13 +1038,7 @@ fn create_genesis_context(
     }
 
     let hash = hasher.finalize();
-    let genesis_transaction_digest = TransactionDigest::new(hash.into());
-
-    TxContext::new(
-        &IotaAddress::default(),
-        &genesis_transaction_digest,
-        epoch_data,
-    )
+    TransactionDigest::new(hash.into())
 }
 
 fn build_unsigned_genesis_data<'info>(
@@ -1083,8 +1075,7 @@ fn build_unsigned_genesis_data<'info>(
     // certain tests.
     update_system_packages_from_objects(&mut system_packages, &objects);
 
-    let mut genesis_ctx = create_genesis_context(
-        &epoch_data,
+    let genesis_digest = create_genesis_digest(
         &genesis_chain_parameters,
         &genesis_validators,
         token_distribution_schedule,
@@ -1100,7 +1091,8 @@ fn build_unsigned_genesis_data<'info>(
     // In here the main genesis objects are created. This means the main system
     // objects and the ones that are created at genesis like the network coin.
     let (genesis_objects, events) = create_genesis_objects(
-        &mut genesis_ctx,
+        &epoch_data,
+        &genesis_digest,
         objects,
         &genesis_validators,
         &genesis_chain_parameters,
@@ -1121,7 +1113,8 @@ fn build_unsigned_genesis_data<'info>(
         // objects. Here then we need to destroy those assets from the original set of
         // migration objects.
         let migration_objects = destroy_staked_migration_objects(
-            &mut genesis_ctx,
+            &epoch_data,
+            &genesis_digest,
             migration_objects.take_objects(),
             &genesis_objects,
             &genesis_chain_parameters,
@@ -1346,7 +1339,8 @@ fn create_genesis_transaction(
 }
 
 fn create_genesis_objects(
-    genesis_ctx: &mut TxContext,
+    epoch_data: &EpochData,
+    genesis_digest: &TransactionDigest,
     input_objects: Vec<Object>,
     validators: &[GenesisValidatorMetadata],
     parameters: &GenesisChainParameters,
@@ -1372,7 +1366,8 @@ fn create_genesis_objects(
         let tx_events = process_package(
             &mut store,
             executor.as_ref(),
-            genesis_ctx,
+            epoch_data,
+            genesis_digest,
             &system_package.modules(),
             system_package.dependencies().to_vec(),
             &protocol_config,
@@ -1391,7 +1386,8 @@ fn create_genesis_objects(
         &mut store,
         executor.as_ref(),
         validators,
-        genesis_ctx,
+        epoch_data,
+        genesis_digest,
         parameters,
         token_distribution_schedule,
         metrics,
@@ -1404,7 +1400,8 @@ fn create_genesis_objects(
 pub(crate) fn process_package(
     store: &mut InMemoryStorage,
     executor: &dyn Executor,
-    ctx: &mut TxContext,
+    epoch_data: &EpochData,
+    genesis_digest: &TransactionDigest,
     modules: &[CompiledModule],
     dependencies: Vec<ObjectID>,
     protocol_config: &ProtocolConfig,
@@ -1466,7 +1463,9 @@ pub(crate) fn process_package(
         &*store,
         protocol_config,
         metrics,
-        ctx,
+        epoch_data.epoch_id(),
+        epoch_data.epoch_start_timestamp(),
+        genesis_digest,
         CheckedInputObjects::new_for_genesis(loaded_dependencies),
         pt,
     )?;
@@ -1480,7 +1479,8 @@ pub fn generate_genesis_system_object(
     store: &mut InMemoryStorage,
     executor: &dyn Executor,
     genesis_validators: &[GenesisValidatorMetadata],
-    genesis_ctx: &mut TxContext,
+    epoch_data: &EpochData,
+    genesis_digest: &TransactionDigest,
     genesis_chain_parameters: &GenesisChainParameters,
     token_distribution_schedule: &TokenDistributionSchedule,
     metrics: Arc<LimitsMetrics>,
@@ -1625,7 +1625,9 @@ pub fn generate_genesis_system_object(
         &*store,
         &protocol_config,
         metrics,
-        genesis_ctx,
+        epoch_data.epoch_id(),
+        epoch_data.epoch_start_timestamp(),
+        genesis_digest,
         CheckedInputObjects::new_for_genesis(vec![]),
         pt,
     )?;
@@ -1650,7 +1652,8 @@ pub fn generate_genesis_system_object(
 // the genesis. In this function the objects needed for the stake are destroyed
 // (and, if needed, split) to provide a new set of migration object as output.
 fn destroy_staked_migration_objects(
-    genesis_ctx: &mut TxContext,
+    epoch_data: &EpochData,
+    genesis_digest: &TransactionDigest,
     migration_objects: Vec<Object>,
     genesis_objects: &[Object],
     parameters: &GenesisChainParameters,
@@ -1676,7 +1679,8 @@ fn destroy_staked_migration_objects(
     split_timelocks(
         &mut store,
         executor.as_ref(),
-        genesis_ctx,
+        epoch_data,
+        genesis_digest,
         parameters,
         &genesis_stake.take_timelocks_to_split(),
         metrics.clone(),
@@ -1710,7 +1714,8 @@ fn destroy_staked_migration_objects(
 pub fn split_timelocks(
     store: &mut InMemoryStorage,
     executor: &dyn Executor,
-    genesis_ctx: &mut TxContext,
+    epoch_data: &EpochData,
+    genesis_digest: &TransactionDigest,
     genesis_chain_parameters: &GenesisChainParameters,
     timelocks_to_split: &[(ObjectRef, u64, IotaAddress)],
     metrics: Arc<LimitsMetrics>,
@@ -1762,7 +1767,9 @@ pub fn split_timelocks(
         &*store,
         &protocol_config,
         metrics,
-        genesis_ctx,
+        epoch_data.epoch_id(),
+        epoch_data.epoch_start_timestamp(),
+        genesis_digest,
         CheckedInputObjects::new_for_genesis(timelock_split_input_objects),
         pt,
     )?;

--- a/crates/iota-genesis-builder/src/stardust/migration/executor.rs
+++ b/crates/iota-genesis-builder/src/stardust/migration/executor.rs
@@ -25,6 +25,7 @@ use iota_types::{
     coin_manager::{CoinManager, CoinManagerTreasuryCap},
     collection_types::Bag,
     dynamic_field::Field,
+    epoch_data::EpochData,
     id::UID,
     in_memory_storage::InMemoryStorage,
     inner_temporary_store::InnerTemporaryStore,
@@ -88,7 +89,7 @@ impl Executor {
         target_network: MigrationTargetNetwork,
         coin_type: CoinType,
     ) -> Result<Self> {
-        let mut tx_context = create_migration_context(&coin_type, target_network);
+        let tx_context = create_migration_context(&coin_type, target_network);
         // Use a throwaway metrics registry for transaction execution.
         let metrics = Arc::new(LimitsMetrics::new(&prometheus::Registry::new()));
         let mut store = InMemoryStorage::new(Vec::new());
@@ -103,6 +104,8 @@ impl Executor {
             iota_framework_snapshot::load_bytecode_snapshot(protocol_version.as_u64())
                 .unwrap_or_else(|_| BuiltInFramework::iter_system_packages().cloned().collect());
 
+        let epoch_data = EpochData::new_genesis(tx_context.epoch());
+
         let silent = true;
         let executor = iota_execution::executor(&protocol_config, silent, None)
             .expect("Creating an executor should not fail here");
@@ -110,7 +113,8 @@ impl Executor {
             process_package(
                 &mut store,
                 executor.as_ref(),
-                &mut tx_context,
+                &epoch_data,
+                &tx_context.digest(),
                 &system_package.modules(),
                 system_package.dependencies().to_vec(),
                 &protocol_config,

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -319,6 +319,7 @@ mod checked {
             || transaction_kind.is_end_of_epoch_tx();
 
         let advance_epoch_gas_summary = transaction_kind.get_advance_epoch_tx_gas_summary();
+        let digest = tx_ctx.digest();
 
         // We must charge object read here during transaction execution, because if this
         // fails we must still ensure an effect is committed and all objects
@@ -400,7 +401,7 @@ mod checked {
         if let Err(e) = run_conservation_checks::<Mode>(
             temporary_store,
             gas_charger,
-            tx_ctx,
+            digest,
             move_vm,
             enable_expensive_checks,
             &cost_summary,
@@ -426,7 +427,7 @@ mod checked {
     fn run_conservation_checks<Mode: ExecutionMode>(
         temporary_store: &mut TemporaryStore<'_>,
         gas_charger: &mut GasCharger,
-        tx_ctx: &mut TxContext,
+        tx_digest: TransactionDigest,
         move_vm: &Arc<MoveVM>,
         enable_expensive_checks: bool,
         cost_summary: &GasCostSummary,
@@ -488,7 +489,7 @@ mod checked {
                     // we will create or destroy IOTA otherwise
                     panic!(
                         "IOTA conservation fail in tx block {}: {}\nGas status is {}\nTx was ",
-                        tx_ctx.digest(),
+                        tx_digest,
                         recovery_err,
                         gas_charger.summary()
                     )
@@ -1037,6 +1038,7 @@ mod checked {
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
     ) {
+        let digest = tx_ctx.digest();
         let binary_config = to_binary_config(protocol_config);
         for (version, modules, dependencies) in system_packages.into_iter() {
             let deserialized_modules: Vec<_> = modules
@@ -1069,7 +1071,7 @@ mod checked {
                     &deserialized_modules,
                     version,
                     dependencies,
-                    tx_ctx.digest(),
+                    digest,
                 );
 
                 info!(

--- a/iota-execution/src/executor.rs
+++ b/iota-execution/src/executor.rs
@@ -6,7 +6,7 @@ use std::{collections::HashSet, sync::Arc};
 
 use iota_protocol_config::ProtocolConfig;
 use iota_types::{
-    base_types::{IotaAddress, ObjectRef, TxContext},
+    base_types::{IotaAddress, ObjectRef},
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
@@ -83,8 +83,11 @@ pub trait Executor {
         // Configuration
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
-        // Genesis State
-        tx_context: &mut TxContext,
+        // Epoch
+        epoch_id: EpochId,
+        epoch_timestamp_ms: u64,
+        // Genesis Digest
+        transaction_digest: &TransactionDigest,
         // Transaction
         input_objects: CheckedInputObjects,
         pt: ProgrammableTransaction,

--- a/iota-execution/src/latest.rs
+++ b/iota-execution/src/latest.rs
@@ -165,16 +165,24 @@ impl executor::Executor for Executor {
         store: &dyn BackingStore,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
-        tx_context: &mut TxContext,
+        epoch_id: EpochId,
+        epoch_timestamp_ms: u64,
+        transaction_digest: &TransactionDigest,
         input_objects: CheckedInputObjects,
         pt: ProgrammableTransaction,
     ) -> Result<InnerTemporaryStore, ExecutionError> {
+        let mut tx_context = TxContext::new_from_components(
+            &IotaAddress::default(),
+            transaction_digest,
+            &epoch_id,
+            epoch_timestamp_ms,
+        );
         execute_genesis_state_update(
             store,
             protocol_config,
             metrics,
             &self.0,
-            tx_context,
+            &mut tx_context,
             input_objects,
             pt,
         )


### PR DESCRIPTION
(cherry picked from commit 90d5c60d5a674e120ad81e4ef1a6b2dad352e20a)

# Description of change

Remove TxContext from executor API.

## Links to any relevant issues

fixes #6229 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

```
cargo check --all-targets --all-features
cargo build —all

cargo nextest run -p iota-adapter-transactional-tests
cargo nextest run -p iota-genesis-builder
```

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
