### PR TITLE
update(docs): checkpoint remote store

### DIFF
--- a/crates/iota-data-ingestion-core/src/executor.rs
+++ b/crates/iota-data-ingestion-core/src/executor.rs
@@ -304,10 +304,10 @@ async fn components_graceful_shutdown(
 /// async fn main() {
 ///     let (executor, _) = setup_single_workflow(
 ///         CustomWorker,
-///         "https://api.testnet.iota.cafe/api/v1".to_string(),
-///         0,    // initial checkpoint number.
-///         5,    // concurrency.
-///         None, // extra reader options.
+///         "http://127.0.0.1:9000/api/v1".to_string(), // fullnode REST API
+///         0,                                          // initial checkpoint number.
+///         5,                                          // concurrency.
+///         None,                                       // extra reader options.
 ///     )
 ///     .await
 ///     .unwrap();

--- a/crates/iota-indexer/src/lib.rs
+++ b/crates/iota-indexer/src/lib.rs
@@ -65,7 +65,7 @@ pub struct IndexerConfig {
     pub db_name: Option<String>,
     #[arg(long, default_value = "http://0.0.0.0:9000", global = true)]
     pub rpc_client_url: String,
-    #[arg(long, default_value = Some("https://api.testnet.iota.cafe/api/v1"), global = true)]
+    #[arg(long, default_value = Some("http://0.0.0.0:9000/api/v1"), global = true)]
     pub remote_store_url: Option<String>,
     #[arg(long, default_value = "0.0.0.0", global = true)]
     pub client_metric_host: String,
@@ -147,7 +147,7 @@ impl Default for IndexerConfig {
             db_port: None,
             db_name: None,
             rpc_client_url: "http://127.0.0.1:9000".to_string(),
-            remote_store_url: Some("https://api.testnet.iota.cafe/api/v1".to_string()),
+            remote_store_url: Some("http://127.0.0.1:9000/api/v1".to_string()),
             client_metric_host: "0.0.0.0".to_string(),
             client_metric_port: 9184,
             rpc_server_url: "0.0.0.0".to_string(),

--- a/docs/content/developer/advanced/custom-indexer.mdx
+++ b/docs/content/developer/advanced/custom-indexer.mdx
@@ -39,13 +39,13 @@ The most straightforward stream source is to subscribe to a remote store of chec
 
 :::info Unavailable
 
-The IOTA Foundation does not provide this service at the moment.
+The IOTA Foundation does not provide this service at the moment. It's possible to start a fullnode locally and use the REST API to sync.
 
 :::
 
 The checkpoints are stored in the following format:
 
-<code>{Networks.iota_move_testnet.jsonRpcUrl+`/api/v1/checkpoints/<checkpoint_id>/full`}</code>. You can download the checkpoint by
+`http://127.0.0.1:9000/api/v1/checkpoints/<checkpoint_id>/full`. You can download the checkpoint by
 sending an HTTP GET request to the relevant URL.
 
 ```mermaid
@@ -122,7 +122,7 @@ Specify both a local and remote store as a fallback to ensure constant data flow
 ```rust
 executor.run(
     PathBuf::from("./chk".to_string()), // path to a local directory
-    Some("https://api.testnet.iota.cafe/api/v1".to_string()), // Remote Checkpoint Store
+    Some("http://127.0.0.1:9000/api/v1".to_string()), // fullnode REST API
     vec![], // optional remote store access options
     ReaderOptions::default(),
     exit_receiver,

--- a/docs/content/developer/advanced/custom-indexer.mdx
+++ b/docs/content/developer/advanced/custom-indexer.mdx
@@ -43,9 +43,9 @@ The IOTA Foundation does not provide this service at the moment.
 
 :::
 
-The checkpoint files are stored in the following format:
+The checkpoints are stored in the following format:
 
-<code>{Networks.iota_move_testnet.indexerRpc+`/<checkpoint_id>.chk`}</code>. You can download the checkpoint file by
+<code>{Networks.iota_move_testnet.jsonRpcUrl+`/api/v1/checkpoints/<checkpoint_id>/full`}</code>. You can download the checkpoint by
 sending an HTTP GET request to the relevant URL.
 
 ```mermaid

--- a/docs/content/developer/advanced/custom-indexer.mdx
+++ b/docs/content/developer/advanced/custom-indexer.mdx
@@ -45,7 +45,11 @@ The IOTA Foundation does not provide this service at the moment. It's possible t
 
 If you are running a local fullnode, checkpoints are available for download via HTTP GET requests to a URL similar to the following:
 
-`http://127.0.0.1:9000/api/v1/checkpoints/<checkpoint_id>/full`. You can download the checkpoint by
+```
+http://127.0.0.1:9000/api/v1/checkpoints/<checkpoint_id>/full
+```
+
+You can download the checkpoint by
 sending an HTTP GET request to the relevant URL.
 
 ```mermaid

--- a/docs/content/developer/advanced/custom-indexer.mdx
+++ b/docs/content/developer/advanced/custom-indexer.mdx
@@ -43,7 +43,7 @@ The IOTA Foundation does not provide this service at the moment. It's possible t
 
 :::
 
-The checkpoints are stored in the following format:
+If you are running a local fullnode, checkpoints are available for download via HTTP GET requests to a URL similar to the following:
 
 `http://127.0.0.1:9000/api/v1/checkpoints/<checkpoint_id>/full`. You can download the checkpoint by
 sending an HTTP GET request to the relevant URL.

--- a/docs/content/developer/advanced/custom-indexer.mdx
+++ b/docs/content/developer/advanced/custom-indexer.mdx
@@ -49,9 +49,6 @@ If you are running a local fullnode, checkpoints are available for download via 
 http://127.0.0.1:9000/api/v1/checkpoints/<checkpoint_id>/full
 ```
 
-You can download the checkpoint by
-sending an HTTP GET request to the relevant URL.
-
 ```mermaid
 flowchart LR
   A("fa:fa-cloud Cloud storage(S3, GCP)");

--- a/examples/custom-indexer/rust/remote_reader.rs
+++ b/examples/custom-indexer/rust/remote_reader.rs
@@ -31,10 +31,10 @@ impl Worker for CustomWorker {
 async fn main() -> Result<()> {
     let (executor, _) = setup_single_workflow(
         CustomWorker,
-        "https://api.testnet.iota.cafe/api/v1".to_string(),
-        0,    // initial checkpoint number
-        5,    // concurrency
-        None, // extra reader options
+        "http://127.0.0.1:9000/api/v1".to_string(), // fullnode REST API
+        0,                                          // initial checkpoint number
+        5,                                          // concurrency
+        None,                                       // extra reader options
     )
     .await?;
     executor.await?;


### PR DESCRIPTION
# Description of change

Remove any references to urls for the inherited checkpoint remote store (e.g. https://indexer.testnet.iota.cafe/1.chk) in anticipation of the new uploading scheme.

## Links to any relevant issues

fixes #6016.

## Type of change

- Documentation Fix

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
