### PR TITLE
feat(iota-move): add override=true to iota move new manifest template

### DIFF
--- a/crates/iota-move/src/new.rs
+++ b/crates/iota-move/src/new.rs
@@ -12,10 +12,10 @@ const IOTA_PKG_NAME: &str = "Iota";
 
 // Use testnet by default. Probably want to add options to make this
 // configurable later
-const IOTA_PKG_PATH: &str = "{ git = \"https://github.com/iotaledger/iota.git\", subdir = \"crates/iota-framework/packages/iota-framework\", rev = \"testnet\" }";
+const IOTA_PKG_PATH: &str = "{ git = \"https://github.com/iotaledger/iota.git\", subdir = \"crates/iota-framework/packages/iota-framework\", rev = \"testnet\", override = true }";
 
 #[derive(Parser)]
-#[group(id = "iota-move-new")]
+    #[group(id = "iota-move-new")]
 pub struct New {
     #[command(flatten)]
     pub new: new::New,

--- a/crates/iota-move/src/new.rs
+++ b/crates/iota-move/src/new.rs
@@ -15,7 +15,7 @@ const IOTA_PKG_NAME: &str = "Iota";
 const IOTA_PKG_PATH: &str = "{ git = \"https://github.com/iotaledger/iota.git\", subdir = \"crates/iota-framework/packages/iota-framework\", rev = \"testnet\", override = true }";
 
 #[derive(Parser)]
-    #[group(id = "iota-move-new")]
+#[group(id = "iota-move-new")]
 pub struct New {
     #[command(flatten)]
     pub new: new::New,

--- a/crates/iota-move/tests/snapshots/cli_tests__new_tests__manifest_template.sh.snap
+++ b/crates/iota-move/tests/snapshots/cli_tests__new_tests__manifest_template.sh.snap
@@ -12,7 +12,7 @@ edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
 # authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 
 [dependencies]
-Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "testnet" }
+Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "testnet", override = true }
 
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
 # Revision can be a branch, a tag, and a commit hash.

--- a/crates/iota/tests/snapshots/shell_tests__new_tests__manifest_template.sh.snap
+++ b/crates/iota/tests/snapshots/shell_tests__new_tests__manifest_template.sh.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/iota/tests/shell_tests.rs
+assertion_line: 78
 description: tests/shell_tests/new_tests/manifest_template.sh
 ---
 ----- script -----
@@ -21,7 +22,7 @@ edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
 # authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 
 [dependencies]
-Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "testnet" }
+Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "testnet", override = true }
 
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
 # Revision can be a branch, a tag, and a commit hash.


### PR DESCRIPTION
# Description of change

Adds `override = true` to Move.toml of a new iota move package.

## Links to any relevant issues

fixes #6231

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
