### PR TITLE
node-upstream-change([v1.33.3, v1.34.2)): Count tx as success only if effects are ok

### DIFF
--- a/crates/iota-benchmark/src/drivers/bench_driver.rs
+++ b/crates/iota-benchmark/src/drivers/bench_driver.rs
@@ -752,11 +752,6 @@ async fn run_bench_worker(
                     .latency_squared_s
                     .with_label_values(&[&payload.to_string()])
                     .inc_by(square_latency_ms);
-
-                metrics_cloned
-                    .num_success
-                    .with_label_values(&[&payload.to_string()])
-                    .inc();
                 metrics_cloned
                     .num_in_flight
                     .with_label_values(&[&payload.to_string()])
@@ -764,10 +759,22 @@ async fn run_bench_worker(
 
                 let num_commands =
                     transaction.data().transaction_data().kind().num_commands() as u16;
-                metrics_cloned
-                    .num_success_cmds
-                    .with_label_values(&[&payload.to_string()])
-                    .inc_by(num_commands as u64);
+
+                if effects.is_ok() {
+                    metrics_cloned
+                        .num_success
+                        .with_label_values(&[&payload.to_string()])
+                        .inc();
+                    metrics_cloned
+                        .num_success_cmds
+                        .with_label_values(&[&payload.to_string()])
+                        .inc_by(num_commands as u64);
+                } else {
+                    metrics_cloned
+                        .num_error
+                        .with_label_values(&[&payload.to_string()])
+                        .inc();
+                }
 
                 if let Some(sig_info) = effects.quorum_sig() {
                     sig_info.authorities(&committee).for_each(|name| {


### PR DESCRIPTION
# Description of change

Port https://github.com/MystenLabs/sui/commit/5fb5da2a125644891de948e8a11d80ef572a7cc3

From [Sui's commit description](https://github.com/MystenLabs/sui/commit/5fb5da2a125644891de948e8a11d80ef572a7cc3):

This is more of an issue now that we have congestion control mechanisms
in place where transactions can get cancelled after consensus. We also
have not run our benchmark suite routinely to push these more congested
scenarios so we have not run into this issue before.

## Links to any relevant issues

Part of #3990 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Ran the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
