### PR TITLE
ci: fix rosetta-cli install after repo got moved

### DIFF
--- a/.github/scripts/rosetta/setup.sh
+++ b/.github/scripts/rosetta/setup.sh
@@ -13,5 +13,5 @@ iota genesis --force
 echo "generate rosetta configuration"
 iota-rosetta generate-rosetta-cli-config --online-url http://127.0.0.1:9002 --offline-url http://127.0.0.1:9003
 
-echo "install rosetta-cli"
-curl -sSfL https://raw.githubusercontent.com/coinbase/rosetta-cli/master/scripts/install.sh | sh -s
+echo "install rosetta-cli"     # workaround because the install script is broken after rename
+curl -sSfL https://raw.githubusercontent.com/coinbase/mesh-cli/master/scripts/install.sh | sed -e 's/^REPO=.*/REPO=mesh-cli/' | sh -s

--- a/crates/iota-rosetta/README.md
+++ b/crates/iota-rosetta/README.md
@@ -38,7 +38,7 @@ default.
 #### 5. Generate configuration with prefunded accounts for rosetta-cli
 
 `./iota-rosetta generate-rosetta-cli-config`
-This will generate the `rosetta-cli.json` and `iota.ros` file to be used by the [Rosetta-CLI](https://github.com/coinbase/rosetta-cli)
+This will generate the `rosetta-cli.json` and `iota.ros` file to be used by the [Rosetta-CLI](https://github.com/coinbase/mesh-cli)
 
 ### Build local test network using Docker Compose
 
@@ -221,7 +221,7 @@ the `/construction/parse` endpoint is used for checking transaction correctness 
 
 The sender, recipients and transfer amounts are specified in the intent operations,
 these data are being used to create TransactionData for signature.
-After the tx is executed, the rosetta-cli compare the intent operations with the confirmed operations ,
+After the tx is executed, the rosetta-cli compares the intent operations with the confirmed operations ,
 the confirmed operations must contain the intent operations (the confirmed operations can have more operations than the intent).
 Since the intent operations of TransferIota contains all the balance change information(amount field) already,
 we don't need to use the event to create the operations, also operation created by `get_coin_operation_from_event` will contain recipient's coin id, which will cause a mismatch.

--- a/docker/iota-rosetta/Dockerfile
+++ b/docker/iota-rosetta/Dockerfile
@@ -53,9 +53,8 @@ WORKDIR "$WORKDIR"
 # Install runtime dependencies and tools
 RUN apt update && apt install -y libpq5 ca-certificates curl
 
-# Install rosetta-cli
-RUN curl -sSfL https://raw.githubusercontent.com/coinbase/rosetta-cli/master/scripts/install.sh | sh -s
-
+# Install rosetta-cli (workaround because the install script is broken after rename)
+RUN curl -sSfL https://raw.githubusercontent.com/coinbase/mesh-cli/master/scripts/install.sh | sed -e 's/^REPO=.*/REPO=mesh-cli/' | sh -s
 COPY --from=builder /iota/iota-rosetta /usr/local/bin
 
 ARG BUILD_DATE


### PR DESCRIPTION
# Description of change

Nightly rosetta tests fail because the install script fails. The project got moved (but not renamed :picard:).

## Type of change

- Bug fix (a non-breaking change which fixes an issue)