### PR TITLE
fix(dashboard): Add build step for wallet-dashboard before e2e tests

### DIFF
--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -107,6 +107,10 @@ jobs:
           path: apps/explorer/playwright-report/
           retention-days: 30
 
+      - name: Build Dashboard
+        if: inputs.isWalletDashboard || inputs.isRpc || inputs.isTypescriptSDK || github.ref_name == 'develop'
+        run: pnpm --filter wallet-dashboard build
+
       - name: Run Dashboard e2e tests
         if: inputs.isWalletDashboard || inputs.isRpc || inputs.isTypescriptSDK || github.ref_name == 'develop'
         run: pnpm --filter wallet-dashboard playwright test

--- a/apps/wallet-dashboard/playwright.config.ts
+++ b/apps/wallet-dashboard/playwright.config.ts
@@ -51,9 +51,9 @@ export default defineConfig({
             timeout: 120 * 1000,
             reuseExistingServer: !process.env.CI,
         },
-        // Localnet-based dev server:
+        // Localnet-based server:
         {
-            command: 'pnpm dev',
+            command: 'pnpm start',
             port: 3000,
             timeout: 120 * 1000,
             reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
The dashboard e2e tests were failing due to missing built dependencies (https://github.com/iotaledger/iota/actions/runs/14443807252/job/40499738341?pr=6398#step:18:67), this was not caught in https://github.com/iotaledger/iota/pull/6258 because the deps were cached, in the other hand this failed in https://github.com/iotaledger/iota/pull/6398 because of the change to .eslintrc.js, as it is included in turbo.json it invalidates the cache.