### PR TITLE
Refactor ConsensusTransactionKind

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -815,7 +815,9 @@ impl AuthorityPerEpochStore {
         let pending_consensus_certificates: HashSet<_> = pending_consensus_transactions
             .iter()
             .filter_map(|transaction| {
-                if let ConsensusTransactionKind::UserTransaction(certificate) = &transaction.kind {
+                if let ConsensusTransactionKind::CertifiedTransaction(certificate) =
+                    &transaction.kind
+                {
                     Some(*certificate.digest())
                 } else {
                     None
@@ -1842,7 +1844,7 @@ impl AuthorityPerEpochStore {
 
         // TODO: lock once for all insert() calls.
         for transaction in transactions {
-            if let ConsensusTransactionKind::UserTransaction(cert) = &transaction.kind {
+            if let ConsensusTransactionKind::CertifiedTransaction(cert) = &transaction.kind {
                 let state = lock.expect("Must pass reconfiguration lock when storing certificate");
                 // Caller is responsible for performing graceful check
                 assert!(
@@ -2431,7 +2433,7 @@ impl AuthorityPerEpochStore {
         // IotaTxValidator
         match &transaction.transaction {
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::UserTransaction(_certificate),
+                kind: ConsensusTransactionKind::CertifiedTransaction(_certificate),
                 ..
             }) => {}
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
@@ -3354,7 +3356,7 @@ impl AuthorityPerEpochStore {
 
         match &transaction {
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::UserTransaction(certificate),
+                kind: ConsensusTransactionKind::CertifiedTransaction(certificate),
                 ..
             }) => {
                 if certificate.epoch() != self.epoch() {

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -330,7 +330,7 @@ impl ConsensusAdapter {
         let min_digest = transactions
             .iter()
             .filter_map(|tx| match &tx.kind {
-                ConsensusTransactionKind::UserTransaction(certificate) => {
+                ConsensusTransactionKind::CertifiedTransaction(certificate) => {
                     Some(certificate.digest())
                 }
                 _ => None,
@@ -527,7 +527,7 @@ impl ConsensusAdapter {
                 fp_ensure!(
                     matches!(
                         transaction.kind,
-                        ConsensusTransactionKind::UserTransaction(_)
+                        ConsensusTransactionKind::CertifiedTransaction(_)
                     ),
                     IotaError::InvalidTxKindInSoftBundle
                 );
@@ -778,7 +778,7 @@ impl ConsensusAdapter {
         let is_user_tx = is_soft_bundle
             || matches!(
                 transactions[0].kind,
-                ConsensusTransactionKind::UserTransaction(_)
+                ConsensusTransactionKind::CertifiedTransaction(_)
             );
         let send_end_of_publish = if is_user_tx {
             // If we are in RejectUserCerts state and we just drained the list we need to

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -308,13 +308,12 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                         .observe(serialized_transaction.len() as f64);
                     if matches!(
                         &transaction.kind,
-                        ConsensusTransactionKind::UserTransaction(_)
+                        ConsensusTransactionKind::CertifiedTransaction(_)
                     ) {
                         self.last_consensus_stats
                             .stats
                             .inc_num_user_transactions(authority_index as usize);
                     }
-
                     let transaction = SequencedConsensusTransactionKind::External(transaction);
                     transactions.push((serialized_transaction, transaction, authority_index));
                 }
@@ -521,7 +520,7 @@ impl<C> ConsensusHandler<C> {
 
 pub(crate) fn classify(transaction: &ConsensusTransaction) -> &'static str {
     match &transaction.kind {
-        ConsensusTransactionKind::UserTransaction(certificate) => {
+        ConsensusTransactionKind::CertifiedTransaction(certificate) => {
             if certificate.contains_shared_object() {
                 "shared_certificate"
             } else {
@@ -636,7 +635,7 @@ impl SequencedConsensusTransactionKind {
     pub fn executable_transaction_digest(&self) -> Option<TransactionDigest> {
         match self {
             SequencedConsensusTransactionKind::External(ext) => {
-                if let ConsensusTransactionKind::UserTransaction(txn) = &ext.kind {
+                if let ConsensusTransactionKind::CertifiedTransaction(txn) = &ext.kind {
                     Some(*txn.digest())
                 } else {
                     None
@@ -682,7 +681,7 @@ impl SequencedConsensusTransaction {
 
     pub fn is_user_tx_with_randomness(&self) -> bool {
         let SequencedConsensusTransactionKind::External(ConsensusTransaction {
-            kind: ConsensusTransactionKind::UserTransaction(certificate),
+            kind: ConsensusTransactionKind::CertifiedTransaction(certificate),
             ..
         }) = &self.transaction
         else {
@@ -694,7 +693,7 @@ impl SequencedConsensusTransaction {
     pub fn as_shared_object_txn(&self) -> Option<&SenderSignedData> {
         match &self.transaction {
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                kind: ConsensusTransactionKind::UserTransaction(certificate),
+                kind: ConsensusTransactionKind::CertifiedTransaction(certificate),
                 ..
             }) if certificate.contains_shared_object() => Some(certificate.data()),
             SequencedConsensusTransactionKind::System(txn) if txn.contains_shared_object() => {
@@ -1028,7 +1027,7 @@ mod tests {
                 ConsensusTransactionKind::CapabilityNotificationV1(cap) => {
                     format!("cap({})", cap.generation)
                 }
-                ConsensusTransactionKind::UserTransaction(txn) => {
+                ConsensusTransactionKind::CertifiedTransaction(txn) => {
                     format!("user({})", txn.transaction_data().gas_price())
                 }
                 _ => unreachable!(),
@@ -1072,7 +1071,7 @@ mod tests {
             ),
             vec![],
         );
-        txn(ConsensusTransactionKind::UserTransaction(Box::new(
+        txn(ConsensusTransactionKind::CertifiedTransaction(Box::new(
             CertifiedTransaction::new_from_keypairs_for_testing(data, &keypairs, &committee),
         )))
     }

--- a/crates/iota-core/src/consensus_validator.rs
+++ b/crates/iota-core/src/consensus_validator.rs
@@ -58,7 +58,7 @@ impl IotaTxValidator {
         let mut ckpt_batch = Vec::new();
         for tx in txs.into_iter() {
             match tx {
-                ConsensusTransactionKind::UserTransaction(certificate) => {
+                ConsensusTransactionKind::CertifiedTransaction(certificate) => {
                     cert_batch.push(*certificate);
 
                     // if !certificate.contains_shared_object() {

--- a/crates/iota-core/src/mock_consensus.rs
+++ b/crates/iota-core/src/mock_consensus.rs
@@ -80,7 +80,7 @@ impl MockConsensusClient {
                         .unwrap();
                 }
             }
-            if let ConsensusTransactionKind::UserTransaction(tx) = tx.kind {
+            if let ConsensusTransactionKind::CertifiedTransaction(tx) = tx.kind {
                 if tx.contains_shared_object() {
                     validator.enqueue_certificates_for_execution(
                         vec![VerifiedCertificate::new_unchecked(*tx)],

--- a/crates/iota-core/src/post_consensus_tx_reorder.rs
+++ b/crates/iota-core/src/post_consensus_tx_reorder.rs
@@ -36,7 +36,7 @@ impl PostConsensusTxReorder {
                 match &txn.0.transaction {
                     SequencedConsensusTransactionKind::External(ConsensusTransaction {
                         tracking_id: _,
-                        kind: ConsensusTransactionKind::UserTransaction(cert),
+                        kind: ConsensusTransactionKind::CertifiedTransaction(cert),
                     }) => cert.gas_price(),
                     // Non-user transactions are considered to have gas price of MAX u64 and are
                     // put to the beginning.

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -80,7 +80,7 @@ pub enum ConsensusTransactionKey {
     Certificate(TransactionDigest),
     CheckpointSignature(AuthorityName, CheckpointSequenceNumber),
     EndOfPublish(AuthorityName),
-    CapabilityNotification(AuthorityName, u64 /* generation */),
+    CapabilityNotificationV1(AuthorityName, u64 /* generation */),
     // Key must include both id and jwk, because honest validators could be given multiple jwks
     // for the same id by malfunctioning providers.
     NewJWKFetched(Box<(AuthorityName, JwkId, JWK)>),
@@ -96,9 +96,9 @@ impl Debug for ConsensusTransactionKey {
                 write!(f, "CheckpointSignature({:?}, {:?})", name.concise(), seq)
             }
             Self::EndOfPublish(name) => write!(f, "EndOfPublish({:?})", name.concise()),
-            Self::CapabilityNotification(name, generation) => write!(
+            Self::CapabilityNotificationV1(name, generation) => write!(
                 f,
-                "CapabilityNotification({:?}, {:?})",
+                "CapabilityNotificationV1({:?}, {:?})",
                 name.concise(),
                 generation
             ),
@@ -187,23 +187,25 @@ impl AuthorityCapabilitiesV1 {
     }
 }
 
+#[repr(u8)]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum ConsensusTransactionKind {
-    UserTransaction(Box<CertifiedTransaction>),
-    CheckpointSignature(Box<CheckpointSignatureMessage>),
-    EndOfPublish(AuthorityName),
+    CertifiedTransaction(Box<CertifiedTransaction>) = 0,
+    CheckpointSignature(Box<CheckpointSignatureMessage>) = 1,
+    EndOfPublish(AuthorityName) = 2,
 
-    CapabilityNotificationV1(AuthorityCapabilitiesV1),
+    CapabilityNotificationV1(AuthorityCapabilitiesV1) = 3,
 
-    NewJWKFetched(AuthorityName, JwkId, JWK),
+    NewJWKFetched(AuthorityName, JwkId, JWK) = 4,
+
     // DKG is used to generate keys for use in the random beacon protocol.
     // `RandomnessDkgMessage` is sent out at start-of-epoch to initiate the process.
     // Contents are a serialized `fastcrypto_tbls::dkg::Message`.
-    RandomnessDkgMessage(AuthorityName, Vec<u8>),
+    RandomnessDkgMessage(AuthorityName, Vec<u8>) = 6,
     // `RandomnessDkgConfirmation` is the second DKG message, sent as soon as a threshold amount
     // of `RandomnessDkgMessages` have been received locally, to complete the key generation
     // process. Contents are a serialized `fastcrypto_tbls::dkg::Confirmation`.
-    RandomnessDkgConfirmation(AuthorityName, Vec<u8>),
+    RandomnessDkgConfirmation(AuthorityName, Vec<u8>) = 7,
 }
 
 impl ConsensusTransactionKind {
@@ -303,7 +305,7 @@ impl ConsensusTransaction {
         let tracking_id = hasher.finish().to_le_bytes();
         Self {
             tracking_id,
-            kind: ConsensusTransactionKind::UserTransaction(Box::new(certificate)),
+            kind: ConsensusTransactionKind::CertifiedTransaction(Box::new(certificate)),
         }
     }
 
@@ -350,7 +352,7 @@ impl ConsensusTransaction {
         let tracking_id = hasher.finish().to_le_bytes();
         Self {
             tracking_id,
-            kind: ConsensusTransactionKind::UserTransaction(Box::new(certificate)),
+            kind: ConsensusTransactionKind::CertifiedTransaction(Box::new(certificate)),
         }
     }
 
@@ -401,7 +403,7 @@ impl ConsensusTransaction {
 
     pub fn key(&self) -> ConsensusTransactionKey {
         match &self.kind {
-            ConsensusTransactionKind::UserTransaction(cert) => {
+            ConsensusTransactionKind::CertifiedTransaction(cert) => {
                 ConsensusTransactionKey::Certificate(*cert.digest())
             }
             ConsensusTransactionKind::CheckpointSignature(data) => {
@@ -414,7 +416,7 @@ impl ConsensusTransaction {
                 ConsensusTransactionKey::EndOfPublish(*authority)
             }
             ConsensusTransactionKind::CapabilityNotificationV1(cap) => {
-                ConsensusTransactionKey::CapabilityNotification(cap.authority, cap.generation)
+                ConsensusTransactionKey::CapabilityNotificationV1(cap.authority, cap.generation)
             }
             ConsensusTransactionKind::NewJWKFetched(authority, id, key) => {
                 ConsensusTransactionKey::NewJWKFetched(Box::new((
@@ -433,7 +435,7 @@ impl ConsensusTransaction {
     }
 
     pub fn is_user_certificate(&self) -> bool {
-        matches!(self.kind, ConsensusTransactionKind::UserTransaction(_))
+        matches!(self.kind, ConsensusTransactionKind::CertifiedTransaction(_))
     }
 
     pub fn is_end_of_publish(&self) -> bool {

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -80,7 +80,7 @@ pub enum ConsensusTransactionKey {
     Certificate(TransactionDigest),
     CheckpointSignature(AuthorityName, CheckpointSequenceNumber),
     EndOfPublish(AuthorityName),
-    CapabilityNotificationV1(AuthorityName, u64 /* generation */),
+    CapabilityNotification(AuthorityName, u64 /* generation */),
     // Key must include both id and jwk, because honest validators could be given multiple jwks
     // for the same id by malfunctioning providers.
     NewJWKFetched(Box<(AuthorityName, JwkId, JWK)>),
@@ -96,9 +96,9 @@ impl Debug for ConsensusTransactionKey {
                 write!(f, "CheckpointSignature({:?}, {:?})", name.concise(), seq)
             }
             Self::EndOfPublish(name) => write!(f, "EndOfPublish({:?})", name.concise()),
-            Self::CapabilityNotificationV1(name, generation) => write!(
+            Self::CapabilityNotification(name, generation) => write!(
                 f,
-                "CapabilityNotificationV1({:?}, {:?})",
+                "CapabilityNotification({:?}, {:?})",
                 name.concise(),
                 generation
             ),
@@ -415,7 +415,7 @@ impl ConsensusTransaction {
                 ConsensusTransactionKey::EndOfPublish(*authority)
             }
             ConsensusTransactionKind::CapabilityNotificationV1(cap) => {
-                ConsensusTransactionKey::CapabilityNotificationV1(cap.authority, cap.generation)
+                ConsensusTransactionKey::CapabilityNotification(cap.authority, cap.generation)
             }
             ConsensusTransactionKind::NewJWKFetched(authority, id, key) => {
                 ConsensusTransactionKey::NewJWKFetched(Box::new((

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -187,25 +187,24 @@ impl AuthorityCapabilitiesV1 {
     }
 }
 
-#[repr(u8)]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum ConsensusTransactionKind {
-    CertifiedTransaction(Box<CertifiedTransaction>) = 0,
-    CheckpointSignature(Box<CheckpointSignatureMessage>) = 1,
-    EndOfPublish(AuthorityName) = 2,
+    CertifiedTransaction(Box<CertifiedTransaction>),
+    CheckpointSignature(Box<CheckpointSignatureMessage>),
+    EndOfPublish(AuthorityName),
 
-    CapabilityNotificationV1(AuthorityCapabilitiesV1) = 3,
+    CapabilityNotificationV1(AuthorityCapabilitiesV1),
 
-    NewJWKFetched(AuthorityName, JwkId, JWK) = 4,
+    NewJWKFetched(AuthorityName, JwkId, JWK),
 
     // DKG is used to generate keys for use in the random beacon protocol.
     // `RandomnessDkgMessage` is sent out at start-of-epoch to initiate the process.
     // Contents are a serialized `fastcrypto_tbls::dkg::Message`.
-    RandomnessDkgMessage(AuthorityName, Vec<u8>) = 6,
+    RandomnessDkgMessage(AuthorityName, Vec<u8>),
     // `RandomnessDkgConfirmation` is the second DKG message, sent as soon as a threshold amount
     // of `RandomnessDkgMessages` have been received locally, to complete the key generation
     // process. Contents are a serialized `fastcrypto_tbls::dkg::Confirmation`.
-    RandomnessDkgConfirmation(AuthorityName, Vec<u8>) = 7,
+    RandomnessDkgConfirmation(AuthorityName, Vec<u8>),
 }
 
 impl ConsensusTransactionKind {


### PR DESCRIPTION
# Description of change

Port of https://github.com/MystenLabs/sui/commit/fa7419bfcfeffaa816e3232c5d6af5db67dc7ca8

PR contains some changes that are partially reverted in subsequent upstream commits, notably:
- RandomnessStateUpdate was removed in this PR and later reverted back, not it's in the upstream HEAD.
- AuthorityCapabilitiesV2 are used in the upstream which were not ported.
- renames UserTransaction to CertifiedTransaction, but UserTransaction is reintroduced later again.

Should be merged before PR for https://github.com/MystenLabs/sui/commit/c1384f97e67b805f5a915742892206a65f120b54.

## Links to any relevant issues

Part of #3990 

## Type of change

- Upstream commit port