### PR TITLE
refactor(iota-indexer): Refactor error handling in Indexer `get_dynamic_field_object_v2`

### DIFF
--- a/crates/iota-indexer/src/apis/indexer_api.rs
+++ b/crates/iota-indexer/src/apis/indexer_api.rs
@@ -106,14 +106,13 @@ impl IndexerApi {
             &name.type_,
             &name_bcs_value,
         )
-        .expect("deriving dynamic field id can't fail");
+        .map_err(internal_error)?;
 
         let options = options.unwrap_or_default();
 
         match self.inner.get_object_read_in_blocking_task(id).await? {
-            iota_types::object::ObjectRead::NotExists(_)
-            | iota_types::object::ObjectRead::Deleted(_) => {}
-            iota_types::object::ObjectRead::Exists(object_ref, o, layout) => {
+            ObjectRead::NotExists(_) | ObjectRead::Deleted(_) => {}
+            ObjectRead::Exists(object_ref, o, layout) => {
                 return Ok(IotaObjectResponse::new_with_data(
                     IotaObjectData::new(object_ref, o, layout, options, None)
                         .map_err(internal_error)?,
@@ -130,15 +129,15 @@ impl IndexerApi {
             &dynamic_object_field_type,
             &name_bcs_value,
         )
-        .expect("deriving dynamic field id can't fail");
+        .map_err(internal_error)?;
+
         match self
             .inner
             .get_object_read_in_blocking_task(dynamic_object_field_id)
             .await?
         {
-            iota_types::object::ObjectRead::NotExists(_)
-            | iota_types::object::ObjectRead::Deleted(_) => {}
-            iota_types::object::ObjectRead::Exists(object_ref, o, layout) => {
+            ObjectRead::NotExists(_) | ObjectRead::Deleted(_) => {}
+            ObjectRead::Exists(object_ref, o, layout) => {
                 return Ok(IotaObjectResponse::new_with_data(
                     IotaObjectData::new(object_ref, o, layout, options, None)
                         .map_err(internal_error)?,
@@ -147,7 +146,7 @@ impl IndexerApi {
         }
 
         Ok(IotaObjectResponse::new_with_error(
-            iota_types::error::IotaObjectResponseError::DynamicFieldNotFound { parent_object_id },
+            IotaObjectResponseError::DynamicFieldNotFound { parent_object_id },
         ))
     }
 }


### PR DESCRIPTION
# Description of change

Refactors the error handling in the Indexer `get_dynamic_field_object_v2` function to return an internal error instead. Furthermore, it shortens some type usages, relevant imports are already included.

## Links to any relevant issues

https://github.com/iotaledger/iota/pull/6337#discussion_r2039859668

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Indexer RPC tests:
`cargo test --profile simulator --features shared_test_runtime`

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes
