### PR TITLE
feat(iota-genesis-builder): add check for distinct protocol and network pubkeys

### DIFF
--- a/crates/iota-genesis-builder/src/validator_info.rs
+++ b/crates/iota-genesis-builder/src/validator_info.rs
@@ -152,6 +152,10 @@ impl GenesisValidatorInfo {
             bail!("proof of possession is incorrect: {e}");
         }
 
+        if self.info.protocol_key() == self.info.network_key() {
+            bail!("protocol pubkey must be different from the network pubkey");
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
# Description of change

Added a check for distinct protocol and network pubkeys in the genesis ceremony validation used in `iota genesis-ceremony validate-state`
Without this check it would fail later in `iota genesis-ceremony build-unsigned-checkpoint`

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/1279

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running these commands, once with a valid validator info
```bash
mkdir genesistest && cd genesistest
iota genesis-ceremony init
iota keytool generate bls12381
BLS_KEY=$(ls -t *.key | head -n 1)
echo $BLS_KEY
iota keytool generate ed25519
FIRST_ED25519_KEY=$(ls -t *.key | head -n 1)
echo $FIRST_ED25519_KEY
iota keytool generate ed25519
SECOND_ED25519_KEY=$(ls -t *.key | head -n 1)
echo $SECOND_ED25519_KEY
iota genesis-ceremony add-validator \
    --name validator0 \
    --authority-key-file $BLS_KEY \
    --protocol-key-file $FIRST_ED25519_KEY \
    --account-key-file $SECOND_ED25519_KEY \
    --network-key-file $SECOND_ED25519_KEY \
    --network-address /ip4/127.0.0.1/tcp/38189/http \
    --p2p-address /ip4/127.0.0.1/udp/34523 \
    --primary-address /ip4/127.0.0.1/udp/38603 \
    --description validator0 \
    --image-url https://www.iota.org/favicon.png \
    --project-url https://www.iota.org
iota genesis-ceremony validate-state
iota genesis-ceremony build-unsigned-checkpoint
```
```
Successfully validated ceremony builder at /home/t/Desktop/iota/genesistest/genesistest/genesistest/parameters
Successfully built unsigned checkpoint: 6X93hFjMs1g4QSKThDHd5M9hgiWk831iL4otLifGtQ1i
```

and once with an invalid validator info (protocol key == network key)
```bash
mkdir genesistest && cd genesistest
iota genesis-ceremony init
iota keytool generate bls12381
BLS_KEY=$(ls -t *.key | head -n 1)
echo $BLS_KEY
iota keytool generate ed25519
FIRST_ED25519_KEY=$(ls -t *.key | head -n 1)
echo $FIRST_ED25519_KEY
iota keytool generate ed25519
SECOND_ED25519_KEY=$(ls -t *.key | head -n 1)
echo $SECOND_ED25519_KEY
iota genesis-ceremony add-validator \
    --name validator0 \
    --authority-key-file $BLS_KEY \
    --protocol-key-file $FIRST_ED25519_KEY \
    --account-key-file $FIRST_ED25519_KEY \
    --network-key-file $FIRST_ED25519_KEY \
    --network-address /ip4/127.0.0.1/tcp/38189/http \
    --p2p-address /ip4/127.0.0.1/udp/34523 \
    --primary-address /ip4/127.0.0.1/udp/38603 \
    --description validator0 \
    --image-url https://www.iota.org/favicon.png \
    --project-url https://www.iota.org
iota genesis-ceremony validate-state
iota genesis-ceremony build-unsigned-checkpoint
```
which errors now as expected with
```
metadata for validator validator0 is invalid

Caused by:
    protocol pubkey must be different from the network pubkey
```