### PR TITLE
upstream-changes(zklogin/passkey): Fix a few flaky tests

### DIFF
--- a/crates/iota-e2e-tests/tests/multisig_tests.rs
+++ b/crates/iota-e2e-tests/tests/multisig_tests.rs
@@ -174,7 +174,7 @@ async fn test_multisig_with_zklogin_scenarios() {
     test_cluster.wait_for_authenticator_state_update().await;
     // Manually trigger epoch change to be able to test zklogin with multiple
     // epochs.
-    test_cluster.trigger_reconfiguration().await;
+    test_cluster.force_new_epoch().await;
 
     let rgp = test_cluster.get_reference_gas_price().await;
     let context = &test_cluster.wallet;

--- a/crates/iota-e2e-tests/tests/multisig_tests.rs
+++ b/crates/iota-e2e-tests/tests/multisig_tests.rs
@@ -164,12 +164,17 @@ async fn test_multisig_e2e() {
 #[ignore = "https://github.com/iotaledger/iota/issues/1777"]
 async fn test_multisig_with_zklogin_scenarios() {
     let test_cluster = TestClusterBuilder::new()
-        .with_epoch_duration_ms(15000)
+        // Use a long epoch duration such that it won't change epoch on its own.
+        .with_epoch_duration_ms(10000000)
         .with_default_jwks()
         .build()
         .await;
 
-    test_cluster.wait_for_epoch(Some(1)).await;
+    // Wait a bit for JWKs to be propagated.
+    test_cluster.wait_for_authenticator_state_update().await;
+    // Manually trigger epoch change to be able to test zklogin with multiple
+    // epochs.
+    test_cluster.trigger_reconfiguration().await;
 
     let rgp = test_cluster.get_reference_gas_price().await;
     let context = &test_cluster.wallet;

--- a/crates/iota-rosetta/tests/end_to_end_tests.rs
+++ b/crates/iota-rosetta/tests/end_to_end_tests.rs
@@ -330,7 +330,7 @@ async fn test_withdraw_stake() {
     assert_eq!(1000000000, response.balances[0].value);
 
     // Trigger epoch change.
-    test_cluster.trigger_reconfiguration().await;
+    test_cluster.force_new_epoch().await;
 
     // withdraw all stake
     let ops = serde_json::from_value(json!(

--- a/crates/iota-rosetta/tests/end_to_end_tests.rs
+++ b/crates/iota-rosetta/tests/end_to_end_tests.rs
@@ -261,7 +261,7 @@ async fn test_withdraw_stake() {
     telemetry_subscribers::init_for_testing();
 
     let test_cluster = TestClusterBuilder::new()
-        .with_epoch_duration_ms(15000)
+        .with_epoch_duration_ms(60000)
         .build()
         .await;
     let sender = test_cluster.get_address_0();
@@ -329,8 +329,8 @@ async fn test_withdraw_stake() {
     assert_eq!(1, response.balances.len());
     assert_eq!(1000000000, response.balances[0].value);
 
-    // wait for epoch.
-    tokio::time::sleep(Duration::from_millis(15000)).await;
+    // Trigger epoch change.
+    test_cluster.trigger_reconfiguration().await;
 
     // withdraw all stake
     let ops = serde_json::from_value(json!(


### PR DESCRIPTION
# Description of change

Port of https://github.com/MystenLabs/sui/commit/0f6c1293b44c77989ee90dbf4d13de97c787ae5b

This fixes a few flaky tests:
1. The multisig tests. If epoch duration is too small, some times it triggered epoch changes in the middle of test and the max epoch becomes insufficient.
2. The original upstream commit fixed transaction e2e tesets with message: "The query includes system transactions too, which there can be a lot more than 2 pages if enough checkpoints have passed by." The test fixed was test_get_fullnode_transaction which we don't have.
3. In rosetta with_draw_stake test, similar issue to (1), we need to manually control epoch change otherwise accidental epoch change could lead to wrong stake results.

## Links to any relevant issues

## Type of change

- Upstream commit port

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
