### PR TITLE
chore: Fix new deny audits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2941,9 +2941,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -55,8 +55,6 @@ ignore = [
   "RUSTSEC-2024-0436",
   # backoff is unmaintained
   "RUSTSEC-2025-0012",
-  # humantime is unmaintained
-  "RUSTSEC-2025-0014",
   # ring 0.16 is unmaintained
   "RUSTSEC-2025-0010",
   # ethers uses ring 0.16

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -611,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
# Description of change

- The `humantime` crate is no longer marked unmaintained (https://rustsec.org/advisories/RUSTSEC-2025-0014) so it has been removed from the ignored audits.
- The `crossbeam-channel` crate has been updated `v0.5.13 -> v0.5.15` to fix https://rustsec.org/advisories/RUSTSEC-2025-0024
