### PR TITLE
feat(ci): build images for iota-data-ingestion services on release

### DIFF
--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -26,6 +26,16 @@ on:
         description: "Release iota-graphql-rpc image"
         required: false
         default: false
+      iota_data_ingestion:
+        type: boolean
+        description: "Release iota-data-ingestion image"
+        required: false
+        default: false
+      iota_rest_kv:
+        type: boolean
+        description: "Release iota-rest-kv image"
+        required: false
+        default: false
 
 jobs:
   prepare:
@@ -60,6 +70,18 @@ jobs:
           # or if the event is a release (in which case the job should run regardless of the input).
           if [ "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.iota_graphql_rpc == 'true' || github.event_name == 'release' }}" == "true" ]; then
             images_array+=("iota-graphql-rpc")
+          fi
+
+          # Check iota_data_ingestion: true if the input is set to true and the event is workflow_dispatch,
+          # or if the event is a release (in which case the job should run regardless of the input).
+          if [ "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.iota_data_ingestion == 'true' || github.event_name == 'release' }}" == "true" ]; then
+            images_array+=("iota-data-ingestion")
+          fi
+
+          # Check iota_rest_kv: true if the input is set to true and the event is workflow_dispatch,
+          # or if the event is a release (in which case the job should run regardless of the input).
+          if [ "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.iota_rest_kv == 'true' || github.event_name == 'release' }}" == "true" ]; then
+            images_array+=("iota-rest-kv")
           fi
 
           # Check if the images_array is empty


### PR DESCRIPTION
# Description of change

Automatically build Docker images for `iota-data-ingestion` services when a release is triggered. To ensures all related images are consistently published and prevents the kv-store REST API from returning a ‘dirty’ version.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have performed a self-review of my own code

### Release Notes

<!--
Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.
-->

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
