### PR TITLE
chore: using `contains()` instead of `iter().any()` is more efficient

### DIFF
--- a/crates/iota-types/src/multisig.rs
+++ b/crates/iota-types/src/multisig.rs
@@ -413,7 +413,7 @@ impl MultiSigPublicKey {
             || threshold == 0
             || pks.len() != weights.len()
             || pks.len() > MAX_SIGNER_IN_MULTISIG
-            || weights.iter().any(|w| *w == 0)
+            || weights.contains(&0)
             || weights
                 .iter()
                 .map(|w| *w as ThresholdUnit)

--- a/iota-execution/latest/iota-verifier/src/id_leak_verifier.rs
+++ b/iota-execution/latest/iota-verifier/src/id_leak_verifier.rs
@@ -142,16 +142,13 @@ fn verify_id_leak(
         let initial_state = AbstractState::new(&func_view);
         let mut verifier = IDLeakAnalysis::new(module, &func_view);
         let function_to_verify = verifier.cur_function();
-        if FUNCTIONS_TO_SKIP
-            .iter()
-            .any(|to_skip| function_to_verify == *to_skip)
-        {
+        if FUNCTIONS_TO_SKIP.contains(&function_to_verify) {
             continue;
         }
         verifier
             .analyze_function(initial_state, &func_view, meter)
             .map_err(|err| {
-                // Handle verifificaiton timeout specially
+                // Handle verification timeout specially
                 if check_for_verifier_timeout(&err.major_status()) {
                     to_verification_timeout_error(err.to_string())
                 } else if let Some(message) = err.source().as_ref() {
@@ -314,10 +311,7 @@ fn call(
 
     let return_ = verifier.binary_view.signature_at(function_handle.return_);
     let function = verifier.resolve_function(function_handle);
-    if FRESH_ID_FUNCTIONS
-        .iter()
-        .any(|makes_fresh| function == *makes_fresh)
-    {
+    if FRESH_ID_FUNCTIONS.contains(&function) {
         if return_.0.len() != 1 {
             debug_assert!(false, "{:?} should have a single return value", function);
             return Err(PartialVMError::new(StatusCode::UNKNOWN_VERIFICATION_ERROR)


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#manual_contains