### PR TITLE
Update link to Santoshi coin flip

### DIFF
--- a/dapps/README.md
+++ b/dapps/README.md
@@ -3,5 +3,5 @@
 This folder enlists full implementations of example IOTA dapps, including smart contracts, UIs and any related services
 (i.e. game server, ticketing engine etc).
 
-- [2-player Optimistic Satoshi Coin-Flip](https://github.com/iotaledger/satoshi-coin-flip)
+- [2-player Optimistic Satoshi Coin-Flip](https://github.com/MystenLabs/satoshi-coin-flip)
 - Add more...


### PR DESCRIPTION
Is this the right link? https://github.com/MystenLabs/satoshi-coin-flip

The previous [link](https://github.com/iotaledger/satoshi-coin-flip) is broken, and I couldn't find a repo called `satoshi...` under https://github.com/iotaledger
- search: https://github.com/search?q=org%3Aiotaledger+satoshi&type=repositories

---

# Description of change



## Type of change

- Documentation Fix

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
