### PR TITLE
refactor(wallet/dashboard/explorer): Use `SentryHttpTransport` when using Mainnet

### DIFF
--- a/apps/explorer/src/lib/utils/api/defaultRpcClient.ts
+++ b/apps/explorer/src/lib/utils/api/defaultRpcClient.ts
@@ -29,7 +29,7 @@ export const createIotaClient = (network: NetworkId): IotaClient => {
 
     const client = new IotaClient({
         transport:
-            supportedNetwork && network === Network.Testnet // Sentry dev hint: change this to eg [Network.Localnet]
+            supportedNetwork && network === Network.Mainnet // Sentry dev hint: change this to eg [Network.Localnet]
                 ? new SentryHttpTransport(networkUrl)
                 : new IotaHTTPTransport({ url: networkUrl }),
     });

--- a/apps/wallet-dashboard/lib/utils/defaultRpcClient.ts
+++ b/apps/wallet-dashboard/lib/utils/defaultRpcClient.ts
@@ -27,7 +27,7 @@ export const createIotaClient = (network: NetworkId): IotaClient => {
 
     const client = new IotaClient({
         transport:
-            supportedNetwork && network === Network.Testnet // Sentry dev hint: change this to eg [Network.Localnet]
+            supportedNetwork && network === Network.Mainnet // Sentry dev hint: change this to eg [Network.Localnet]
                 ? new SentryHttpTransport(networkUrl)
                 : new IotaHTTPTransport({ url: networkUrl }),
     });

--- a/apps/wallet/src/shared/iotaClient.ts
+++ b/apps/wallet/src/shared/iotaClient.ts
@@ -6,7 +6,7 @@ import { type NetworkEnvType, SentryHttpTransport } from '@iota/core';
 import { getNetwork, Network, IotaClient, IotaHTTPTransport } from '@iota/iota-sdk/client';
 
 const iotaClientPerNetwork = new Map<string, IotaClient>();
-const SENTRY_MONITORED_ENVS = [Network.Testnet]; // Sentry dev hint: change this to eg [Network.Localnet]
+const SENTRY_MONITORED_ENVS = [Network.Mainnet]; // Sentry dev hint: change this to eg [Network.Localnet]
 
 export function getIotaClient({ network, customRpcUrl }: NetworkEnvType): IotaClient {
     const key = `${network}_${customRpcUrl}`;


### PR DESCRIPTION
Closes https://github.com/iotaledger/iota/issues/4998

Use `SentryHttpTransport` when using Mainnet