### PR TITLE
scripts: fix cargo sort grouping only in deps sections

### DIFF
--- a/scripts/cargo_sort/cargo_sort.py
+++ b/scripts/cargo_sort/cargo_sort.py
@@ -66,7 +66,10 @@ def process_cargo_toml(file_path, internal_crates_dict, debug):
             self.unknown_lines_end = []
         
         def add_node(self, node):
-            if not node.name in internal_crates_dict:
+            # we only want to add "internal crates" if we are in a "dependencies" section,
+            # otherwise we treat everything as external crates, so we don't have different
+            # groups for external and internal crates, but we still sort them.
+            if ('dependencies' not in self.line) or (not node.name in internal_crates_dict):
                 self.external_crates[node.alias] = node
             else:
                 self.internal_crates[node.alias] = node


### PR DESCRIPTION
# Description of change

the cargo sort script added internal and external groups also in sections that contained entries that match the internal crate names. this was the case in the "features" section and was now fixed.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

I cherry picked the commit on top of the `iota-names` branch and executing cargo sort yielded the correct result. 

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes