### PR TITLE
fix(workflows): fix ledger nano CI

### DIFF
--- a/.github/workflows/_ledgernano.yml
+++ b/.github/workflows/_ledgernano.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           sudo apt-get install -y qemu-user-static
           sudo apt-get install -y libxcb-xinerama0
-          sudo pip install speculos --break-system-packages
+          sudo python3 -m pip install speculos
 
       - name: Download ledgernano bin
         run: |

--- a/sdk/ledgerjs-hw-app-iota/src/Iota.ts
+++ b/sdk/ledgerjs-hw-app-iota/src/Iota.ts
@@ -112,9 +112,7 @@ export default class Iota {
         this.#log('Payload Txn', payload_txn);
         // TODO batch this since the payload length can be uint32le.max long
         const signature = await this.#sendChunks(cla, ins, p1, p2, [payload_txn, bip32KeyPayload]);
-        return {
-            signature,
-        };
+        return { signature };
     }
 
     /**


### PR DESCRIPTION
# Description of change

Fix ledger nano CI check
`--break-system-packages` doesn't work anymore and made the command fail in https://github.com/iotaledger/iota/actions/runs/14636379648/job/41068412292?pr=6521, but it's also not required for it to work

I changed the return statement so the CI runs and it's better anyways

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running it in the CI