### PR TITLE
fix(consensus): fix gc_depth parameter for msim

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -4,6 +4,7 @@
 
 use std::{
     cell::RefCell,
+    cmp::min,
     sync::atomic::{AtomicBool, Ordering},
 };
 
@@ -1196,7 +1197,7 @@ impl ProtocolConfig {
     pub fn gc_depth(&self) -> u32 {
         if cfg!(msim) {
             // exercise a very low gc_depth
-            5
+            min(5, self.consensus_gc_depth.unwrap_or(0))
         } else {
             self.consensus_gc_depth.unwrap_or(0)
         }


### PR DESCRIPTION
# Description of change

The gc_depth (gc=garbage collection) parameter was set to 5 for msim, even when gc is disabled.
Now it is set to the minimum of 5 and the actual value (0 means gc is disabled).

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #(issue)`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

<!--
Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.
-->

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
