### PR TITLE
feat(iota): cleanup iota config directory usage

### DIFF
--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -706,6 +706,14 @@ async fn start(
         let network_config_path = config_path.join(IOTA_NETWORK_CONFIG);
         // Auto genesis if no configuration exists in the configuration directory.
         if !network_config_path.exists() {
+            if !config_path.exists() {
+                fs::create_dir(&config_path).map_err(|err| {
+                    anyhow!(err).context(format!(
+                        "Cannot create network config dir {}",
+                        config_path.display()
+                    ))
+                })?;
+            }
             genesis(
                 None,
                 None,
@@ -756,7 +764,7 @@ async fn start(
         };
 
         swarm_builder = swarm_builder
-            .dir(config_path)
+            .dir(config_path.clone())
             .with_network_config(network_config);
     }
 
@@ -865,13 +873,11 @@ async fn start(
         let faucet_address = parse_host_port(input, DEFAULT_FAUCET_PORT)
             .map_err(|_| anyhow!("Invalid faucet host and port"))?;
         tracing::info!("Starting the faucet service at {faucet_address}");
-        let config_dir = if force_regenesis {
+        let faucet_config_dir = if force_regenesis {
+            // tempdir is used so the faucet file is cleaned up afterwards
             tempdir()?.into_path()
         } else {
-            match config_dir {
-                Some(config) => config,
-                None => iota_config_dir()?,
-            }
+            config_path
         };
 
         let host_ip = match faucet_address {
@@ -890,7 +896,7 @@ async fn start(
         let prometheus_registry = prometheus::Registry::new();
         if force_regenesis {
             let kp = swarm.config_mut().account_keys.swap_remove(0);
-            let keystore_path = config_dir.join(IOTA_KEYSTORE_FILENAME);
+            let keystore_path = faucet_config_dir.join(IOTA_KEYSTORE_FILENAME);
             let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path).unwrap());
             let address: IotaAddress = kp.public().into();
             keystore.add_key(None, IotaKeyPair::Ed25519(kp)).unwrap();
@@ -898,13 +904,13 @@ async fn start(
                 .with_envs([IotaEnv::new("localnet", fullnode_url)])
                 .with_active_address(address)
                 .with_active_env("localnet".to_string())
-                .persisted(config_dir.join(IOTA_CLIENT_CONFIG).as_path())
+                .persisted(faucet_config_dir.join(IOTA_CLIENT_CONFIG).as_path())
                 .save()
                 .unwrap();
         }
-        let faucet_wal = config_dir.join("faucet.wal");
+        let faucet_wal = faucet_config_dir.join("faucet.wal");
         let simple_faucet = SimpleFaucet::new(
-            create_wallet_context(config.wallet_client_timeout_secs, config_dir)?,
+            create_wallet_context(config.wallet_client_timeout_secs, faucet_config_dir)?,
             &prometheus_registry,
             faucet_wal.as_path(),
             config.clone(),

--- a/docs/content/developer/getting-started/local-network.mdx
+++ b/docs/content/developer/getting-started/local-network.mdx
@@ -54,7 +54,11 @@ components except `iota-node`. If you want to see more detailed logs, you can re
 Data on the local network does not persist when the `--force-regenesis` flag is
 used.
 
-To persist data use the `--config-dir` flag instead.
+To persist data use the `--network.config` flag instead.
+
+``bash
+iota start --network.config persisted-localnet --with-faucet --committee-size 2 --epoch-duration-ms 60000
+```
 
 :::
 

--- a/docs/site/static/json/developer/getting-started/local-network.json
+++ b/docs/site/static/json/developer/getting-started/local-network.json
@@ -24,7 +24,7 @@
         "questionText": "Which flag should be used to persist data on the local network instead of using --force-regenesis?",
         "answerOptions": [
             {
-                "answerText": "--config-dir",
+                "answerText": "--network.config",
                 "isCorrect": true
             },
             {


### PR DESCRIPTION
# Description of change

Cleanup iota config directory usage

## Links to any relevant issues

Fixes #6441 

## Type of change

- Enhancement (a non-breaking change which adds functionality)
- Documentation Fix

## How the change has been tested

`iota start --network.config persisted-localnet --with-faucet --committee-size 2 --epoch-duration-ms 60000`
and then after stopping running
`iota start --network.config persisted-localnet`
works and continues with the state

`iota start --force-regenesis` still works fine and doesn't leave faucet files in the iota_config

`iota start --force-regenesis --network.config persisted-localnet` still fails as expected

[run-ci]
