### PR TITLE
chore: remove helm folder from dprint config

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -20,8 +20,6 @@
     "crates/iota-light-client/example_config/20873329.yaml",
     "**/pnpm-lock.yaml",
     "external-crates/move/crates/move-stdlib/**/docs/**/*.md",
-    "nre/helm/graphql/templates/**/*.yaml",
-    "nre/helm/indexer/templates/**/*.yaml",
     "crates/iota/src/unit_tests/fixtures/*"
   ],
   "toml": {


### PR DESCRIPTION
They don't exist anymore