### PR TITLE
chore(iota-names): domain cleanup

### DIFF
--- a/crates/iota-names/src/config.rs
+++ b/crates/iota-names/src/config.rs
@@ -14,8 +14,8 @@ use crate::Domain;
 
 pub const LEAF_EXPIRATION_TIMESTAMP: u64 = 0;
 pub const DEFAULT_TLD: &str = "iota";
-pub const ACCEPTED_SEPARATORS: [char; 2] = ['.', '*'];
-pub const IOTA_AT_FORMAT_SEPARATOR: char = '@';
+pub const IOTA_NAMES_SEPARATOR_DOT: char = '.';
+pub const IOTA_NAMES_SEPARATOR_AT: char = '@';
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]

--- a/crates/iota-names/src/config.rs
+++ b/crates/iota-names/src/config.rs
@@ -12,11 +12,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::Domain;
 
-pub const LEAF_EXPIRATION_TIMESTAMP: u64 = 0;
-pub const DEFAULT_TLD: &str = "iota";
-pub const IOTA_NAMES_SEPARATOR_DOT: char = '.';
-pub const IOTA_NAMES_SEPARATOR_AT: char = '@';
-
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub struct IotaNamesConfig {

--- a/crates/iota-names/src/constants.rs
+++ b/crates/iota-names/src/constants.rs
@@ -5,3 +5,6 @@ pub const LEAF_EXPIRATION_TIMESTAMP: u64 = 0;
 pub const DEFAULT_TLD: &str = "iota";
 pub const IOTA_NAMES_SEPARATOR_DOT: char = '.';
 pub const IOTA_NAMES_SEPARATOR_AT: char = '@';
+pub const MIN_LABEL_LENGTH: usize = 1;
+pub const MAX_LABEL_LENGTH: usize = 63;
+pub const MAX_DOMAIN_LENGTH: usize = 235;

--- a/crates/iota-names/src/constants.rs
+++ b/crates/iota-names/src/constants.rs
@@ -1,0 +1,7 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+pub const LEAF_EXPIRATION_TIMESTAMP: u64 = 0;
+pub const DEFAULT_TLD: &str = "iota";
+pub const IOTA_NAMES_SEPARATOR_DOT: char = '.';
+pub const IOTA_NAMES_SEPARATOR_AT: char = '@';

--- a/crates/iota-names/src/constants.rs
+++ b/crates/iota-names/src/constants.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub const LEAF_EXPIRATION_TIMESTAMP: u64 = 0;
-pub const DEFAULT_TLD: &str = "iota";
+pub const IOTA_NAMES_TLD: &str = "iota";
 pub const IOTA_NAMES_SEPARATOR_DOT: char = '.';
 pub const IOTA_NAMES_SEPARATOR_AT: char = '@';
 pub const MIN_LABEL_LENGTH: usize = 1;

--- a/crates/iota-names/src/constants.rs
+++ b/crates/iota-names/src/constants.rs
@@ -1,10 +1,10 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-pub const LEAF_EXPIRATION_TIMESTAMP: u64 = 0;
+pub const IOTA_NAMES_LEAF_EXPIRATION_TIMESTAMP: u64 = 0;
 pub const IOTA_NAMES_TLD: &str = "iota";
 pub const IOTA_NAMES_SEPARATOR_DOT: char = '.';
 pub const IOTA_NAMES_SEPARATOR_AT: char = '@';
-pub const MIN_LABEL_LENGTH: usize = 1;
-pub const MAX_LABEL_LENGTH: usize = 63;
-pub const MAX_DOMAIN_LENGTH: usize = 235;
+pub const IOTA_NAMES_MIN_LABEL_LENGTH: usize = 1;
+pub const IOTA_NAMES_MAX_LABEL_LENGTH: usize = 63;
+pub const IOTA_NAMES_MAX_DOMAIN_LENGTH: usize = 235;

--- a/crates/iota-names/src/domain.rs
+++ b/crates/iota-names/src/domain.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     constants::{
-        DEFAULT_TLD, IOTA_NAMES_SEPARATOR_AT, IOTA_NAMES_SEPARATOR_DOT, MAX_DOMAIN_LENGTH,
+        IOTA_NAMES_SEPARATOR_AT, IOTA_NAMES_SEPARATOR_DOT, IOTA_NAMES_TLD, MAX_DOMAIN_LENGTH,
         MAX_LABEL_LENGTH, MIN_LABEL_LENGTH,
     },
     error::IotaNamesError,
@@ -60,6 +60,10 @@ impl FromStr for Domain {
         // A valid domain in our system has at least a TLD and an SLD (len == 2).
         if labels.len() < 2 {
             return Err(IotaNamesError::LabelsEmpty);
+        }
+
+        if labels[0] != IOTA_NAMES_TLD {
+            return Err(IotaNamesError::InvalidTld(labels[0].to_string()));
         }
 
         let labels = labels.into_iter().map(ToOwned::to_owned).collect();
@@ -211,7 +215,7 @@ fn convert_from_at_format(s: &str, separator: &char) -> Result<String, IotaNames
     }
 
     parts.push(after);
-    parts.push(DEFAULT_TLD);
+    parts.push(IOTA_NAMES_TLD);
 
     Ok(parts.join(&separator.to_string()))
 }
@@ -304,6 +308,7 @@ mod tests {
         assert!("iota".parse::<Domain>().is_err());
         assert!("test.test@example.iota".parse::<Domain>().is_err());
         assert!("test@test@example".parse::<Domain>().is_err());
+        assert!("test.atoi".parse::<Domain>().is_err());
     }
 
     #[test]

--- a/crates/iota-names/src/domain.rs
+++ b/crates/iota-names/src/domain.rs
@@ -153,15 +153,18 @@ impl Domain {
         labels.reverse();
 
         if format == DomainFormat::Dot {
-            return labels.join(sep);
-        };
+            // DOT format, all labels joined together with dots, including the TLD.
+            labels.join(sep)
+        } else {
+            // SAFETY: This is a safe operation because we only allow a
+            // domain's label vector size to be >= 2 (see `Domain::from_str`)
+            let _tld = labels.pop();
+            let sld = labels.pop().unwrap();
 
-        // SAFETY: This is a safe operation because we only allow a
-        // domain's label vector size to be >= 2 (see `Domain::from_str`)
-        let _tld = labels.pop();
-        let sld = labels.pop().unwrap();
-
-        format!("{}{IOTA_NAMES_SEPARATOR_AT}{sld}", labels.join(sep))
+            // AT format, labels minus SLD joined together with dots, then joined to SLD
+            // with @, no TLD.
+            format!("{}{IOTA_NAMES_SEPARATOR_AT}{sld}", labels.join(sep))
+        }
     }
 }
 

--- a/crates/iota-names/src/domain.rs
+++ b/crates/iota-names/src/domain.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     constants::{
-        IOTA_NAMES_SEPARATOR_AT, IOTA_NAMES_SEPARATOR_DOT, IOTA_NAMES_TLD, MAX_DOMAIN_LENGTH,
-        MAX_LABEL_LENGTH, MIN_LABEL_LENGTH,
+        IOTA_NAMES_MAX_DOMAIN_LENGTH, IOTA_NAMES_MAX_LABEL_LENGTH, IOTA_NAMES_MIN_LABEL_LENGTH,
+        IOTA_NAMES_SEPARATOR_AT, IOTA_NAMES_SEPARATOR_DOT, IOTA_NAMES_TLD,
     },
     error::IotaNamesError,
 };
@@ -25,10 +25,10 @@ impl FromStr for Domain {
     type Err = IotaNamesError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.len() > MAX_DOMAIN_LENGTH {
+        if s.len() > IOTA_NAMES_MAX_DOMAIN_LENGTH {
             return Err(IotaNamesError::DomainLengthExceeded(
                 s.len(),
-                MAX_DOMAIN_LENGTH,
+                IOTA_NAMES_MAX_DOMAIN_LENGTH,
             ));
         }
 
@@ -204,18 +204,19 @@ fn convert_from_at_format(s: &str, separator: &char) -> Result<String, IotaNames
 }
 
 /// Checks the validity of a label according to these rules:
-/// - length must be in [MIN_LABEL_LENGTH..MAX_LABEL_LENGTH]
+/// - length must be in
+///   [IOTA_NAMES_MIN_LABEL_LENGTH..IOTA_NAMES_MAX_LABEL_LENGTH]
 /// - must contain only '0'..'9', 'a'..'z' and '-'
 /// - must not start or end with '-'
 pub fn validate_label(label: &str) -> Result<&str, IotaNamesError> {
     let bytes = label.as_bytes();
     let len = bytes.len();
 
-    if !(MIN_LABEL_LENGTH..=MAX_LABEL_LENGTH).contains(&len) {
+    if !(IOTA_NAMES_MIN_LABEL_LENGTH..=IOTA_NAMES_MAX_LABEL_LENGTH).contains(&len) {
         return Err(IotaNamesError::InvalidLabelLength(
             len,
-            MIN_LABEL_LENGTH,
-            MAX_LABEL_LENGTH,
+            IOTA_NAMES_MIN_LABEL_LENGTH,
+            IOTA_NAMES_MAX_LABEL_LENGTH,
         ));
     }
 

--- a/crates/iota-names/src/domain.rs
+++ b/crates/iota-names/src/domain.rs
@@ -8,7 +8,7 @@ use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructT
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    config::{ACCEPTED_SEPARATORS, DEFAULT_TLD, IOTA_AT_FORMAT_SEPARATOR},
+    config::{DEFAULT_TLD, IOTA_NAMES_SEPARATOR_AT, IOTA_NAMES_SEPARATOR_DOT},
     error::IotaNamesError,
 };
 
@@ -45,12 +45,11 @@ impl FromStr for Domain {
         if s.len() > MAX_DOMAIN_LENGTH {
             return Err(IotaNamesError::ExceedsMaxLength(s.len(), MAX_DOMAIN_LENGTH));
         }
-        let separator = separator(s)?;
 
-        let formatted_string = convert_from_at_format(s, &separator)?;
+        let formatted_string = convert_from_at_format(s, &IOTA_NAMES_SEPARATOR_DOT)?;
 
         let labels = formatted_string
-            .split(separator)
+            .split(IOTA_NAMES_SEPARATOR_DOT)
             .rev()
             .map(validate_label)
             .collect::<Result<Vec<_>, Self::Err>>()?;
@@ -61,6 +60,7 @@ impl FromStr for Domain {
         }
 
         let labels = labels.into_iter().map(ToOwned::to_owned).collect();
+
         Ok(Domain { labels })
     }
 }
@@ -160,7 +160,7 @@ impl Domain {
     /// The default separator is `.`
     pub fn format(&self, format: DomainFormat) -> String {
         let mut labels = self.labels.clone();
-        let sep = &ACCEPTED_SEPARATORS[0].to_string();
+        let sep = &IOTA_NAMES_SEPARATOR_DOT.to_string();
         labels.reverse();
 
         if format == DomainFormat::Dot {
@@ -172,7 +172,7 @@ impl Domain {
         let _tld = labels.pop();
         let sld = labels.pop().unwrap();
 
-        format!("{}{IOTA_AT_FORMAT_SEPARATOR}{sld}", labels.join(sep))
+        format!("{}{IOTA_NAMES_SEPARATOR_AT}{sld}", labels.join(sep))
     }
 }
 
@@ -184,32 +184,11 @@ pub enum DomainFormat {
     Dot,
 }
 
-/// Parses a separator from the domain string input.
-/// E.g.  `example.iota` -> `.` | example*iota -> `@` | `example*iota` -> `*`
-fn separator(s: &str) -> Result<char, IotaNamesError> {
-    let mut domain_separator: Option<char> = None;
-
-    for separator in ACCEPTED_SEPARATORS.iter() {
-        if s.contains(*separator) {
-            if domain_separator.is_some() {
-                return Err(IotaNamesError::InvalidSeparator);
-            }
-
-            domain_separator = Some(*separator);
-        }
-    }
-
-    match domain_separator {
-        Some(separator) => Ok(separator),
-        None => Ok(ACCEPTED_SEPARATORS[0]),
-    }
-}
-
 /// Converts @label ending to label{separator}iota ending.
 ///
 /// E.g. `@example` -> `example.iota` | `test@example` -> `test.example.iota`
 fn convert_from_at_format(s: &str, separator: &char) -> Result<String, IotaNamesError> {
-    let mut splits = s.split(IOTA_AT_FORMAT_SEPARATOR);
+    let mut splits = s.split(IOTA_NAMES_SEPARATOR_AT);
 
     let Some(before) = splits.next() else {
         return Err(IotaNamesError::InvalidSeparator);
@@ -304,13 +283,7 @@ mod tests {
             "iota@iota".parse::<Domain>().unwrap().to_string(),
             "iota.iota.iota"
         );
-
         assert_eq!("@iota".parse::<Domain>().unwrap().to_string(), "iota.iota");
-
-        assert_eq!(
-            "test*test@test".parse::<Domain>().unwrap().to_string(),
-            "test.test.test.iota"
-        );
         assert_eq!(
             "test.test.iota".parse::<Domain>().unwrap().to_string(),
             "test.test.iota"
@@ -322,19 +295,10 @@ mod tests {
     }
 
     #[test]
-    fn different_wildcard() {
-        assert_eq!("test.iota".parse::<Domain>(), "test*iota".parse::<Domain>(),);
-
-        assert_eq!("@test".parse::<Domain>(), "test*iota".parse::<Domain>(),);
-    }
-
-    #[test]
     fn invalid_inputs() {
-        assert!("*".parse::<Domain>().is_err());
         assert!(".".parse::<Domain>().is_err());
         assert!("@".parse::<Domain>().is_err());
         assert!("@inner.iota".parse::<Domain>().is_err());
-        assert!("@inner*iota".parse::<Domain>().is_err());
         assert!("test@".parse::<Domain>().is_err());
         assert!("iota".parse::<Domain>().is_err());
         assert!("test.test@example.iota".parse::<Domain>().is_err());

--- a/crates/iota-names/src/domain.rs
+++ b/crates/iota-names/src/domain.rs
@@ -42,7 +42,7 @@ impl FromStr for Domain {
 
         // A valid domain in our system has at least a TLD and an SLD (len == 2).
         if labels.len() < 2 {
-            return Err(IotaNamesError::LabelsEmpty);
+            return Err(IotaNamesError::NotEnoughLabels);
         }
 
         if labels[0] != IOTA_NAMES_TLD {

--- a/crates/iota-names/src/domain.rs
+++ b/crates/iota-names/src/domain.rs
@@ -133,9 +133,8 @@ impl Domain {
     /// Returns the number of labels including TLD.
     ///
     /// ```
-    /// use std::str::FromStr;
-    ///
-    /// use iota_names::domain::Domain;
+    /// # use std::str::FromStr;
+    /// # use iota_names::domain::Domain;
     /// assert_eq!(
     ///     Domain::from_str("test.example.iota").unwrap().num_labels(),
     ///     3

--- a/crates/iota-names/src/domain.rs
+++ b/crates/iota-names/src/domain.rs
@@ -8,7 +8,10 @@ use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructT
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    constants::{DEFAULT_TLD, IOTA_NAMES_SEPARATOR_AT, IOTA_NAMES_SEPARATOR_DOT},
+    constants::{
+        DEFAULT_TLD, IOTA_NAMES_SEPARATOR_AT, IOTA_NAMES_SEPARATOR_DOT, MAX_DOMAIN_LENGTH,
+        MAX_LABEL_LENGTH, MIN_LABEL_LENGTH,
+    },
     error::IotaNamesError,
 };
 
@@ -39,9 +42,6 @@ impl FromStr for Domain {
     type Err = IotaNamesError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        /// The maximum length of a full domain
-        const MAX_DOMAIN_LENGTH: usize = 235;
-
         if s.len() > MAX_DOMAIN_LENGTH {
             return Err(IotaNamesError::DomainLengthExceeded(
                 s.len(),
@@ -221,9 +221,6 @@ fn convert_from_at_format(s: &str, separator: &char) -> Result<String, IotaNames
 /// - must contain only '0'..'9', 'a'..'z' and '-'
 /// - must not start or end with '-'
 pub fn validate_label(label: &str) -> Result<&str, IotaNamesError> {
-    const MIN_LABEL_LENGTH: usize = 1;
-    const MAX_LABEL_LENGTH: usize = 63;
-
     let bytes = label.as_bytes();
     let len = bytes.len();
 

--- a/crates/iota-names/src/domain.rs
+++ b/crates/iota-names/src/domain.rs
@@ -8,7 +8,7 @@ use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructT
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    config::{DEFAULT_TLD, IOTA_NAMES_SEPARATOR_AT, IOTA_NAMES_SEPARATOR_DOT},
+    constants::{DEFAULT_TLD, IOTA_NAMES_SEPARATOR_AT, IOTA_NAMES_SEPARATOR_DOT},
     error::IotaNamesError,
 };
 

--- a/crates/iota-names/src/domain.rs
+++ b/crates/iota-names/src/domain.rs
@@ -43,7 +43,10 @@ impl FromStr for Domain {
         const MAX_DOMAIN_LENGTH: usize = 235;
 
         if s.len() > MAX_DOMAIN_LENGTH {
-            return Err(IotaNamesError::ExceedsMaxLength(s.len(), MAX_DOMAIN_LENGTH));
+            return Err(IotaNamesError::DomainLengthExceeded(
+                s.len(),
+                MAX_DOMAIN_LENGTH,
+            ));
         }
 
         let formatted_string = convert_from_at_format(s, &IOTA_NAMES_SEPARATOR_DOT)?;
@@ -225,7 +228,7 @@ pub fn validate_label(label: &str) -> Result<&str, IotaNamesError> {
     let len = bytes.len();
 
     if !(MIN_LABEL_LENGTH..=MAX_LABEL_LENGTH).contains(&len) {
-        return Err(IotaNamesError::InvalidLength(
+        return Err(IotaNamesError::InvalidLabelLength(
             len,
             MIN_LABEL_LENGTH,
             MAX_LABEL_LENGTH,
@@ -235,7 +238,9 @@ pub fn validate_label(label: &str) -> Result<&str, IotaNamesError> {
     for (i, character) in bytes.iter().enumerate() {
         match character {
             b'a'..=b'z' | b'0'..=b'9' => continue,
-            b'-' if i == 0 || i == len - 1 => return Err(IotaNamesError::HyphensAsFirstOrLastChar),
+            b'-' if i == 0 || i == len - 1 => {
+                return Err(IotaNamesError::HyphensAsFirstOrLastLabelChar);
+            }
             _ => return Err(IotaNamesError::InvalidLabelChar),
         };
     }

--- a/crates/iota-names/src/domain.rs
+++ b/crates/iota-names/src/domain.rs
@@ -21,23 +21,6 @@ pub struct Domain {
     labels: Vec<String>,
 }
 
-// impl FromStr for Domain {
-//     type Err = anyhow::Error;
-
-//     fn from_str(s: &str) -> Result<Self, Self::Err> {
-//         const VALID_TLDS: &[&str] = &["iota"];
-//         let mut segments = s.split('.').collect::<Vec<_>>();
-//         anyhow::ensure!(segments.len() >= 2, "domain has too few labels");
-//         let tld = segments.pop().unwrap();
-//         anyhow::ensure!(VALID_TLDS.contains(&tld), "invalid TLD: {tld}");
-//         let mut labels = vec![tld.to_owned()];
-//         for segment in segments.into_iter().rev() {
-//             labels.push(parse_domain_label(segment)?);
-//         }
-//         Ok(Self { labels })
-//     }
-// }
-
 impl FromStr for Domain {
     type Err = IotaNamesError;
 

--- a/crates/iota-names/src/error.rs
+++ b/crates/iota-names/src/error.rs
@@ -22,4 +22,6 @@ pub enum IotaNamesError {
     NameExpired,
     #[error("Malformed object for {0}")]
     MalformedObject(ObjectID),
+    #[error("Invalid TLD {0}")]
+    InvalidTld(String),
 }

--- a/crates/iota-names/src/error.rs
+++ b/crates/iota-names/src/error.rs
@@ -17,7 +17,7 @@ pub enum IotaNamesError {
     #[error("Domain must contain at least two labels, TLD and SLD")]
     NotEnoughLabels,
     #[error("Domain must include only one separator")]
-    InvalidSeparator, //
+    InvalidSeparator,
     #[error("Name has expired")]
     NameExpired,
     #[error("Malformed object for {0}")]

--- a/crates/iota-names/src/error.rs
+++ b/crates/iota-names/src/error.rs
@@ -14,8 +14,8 @@ pub enum IotaNamesError {
     HyphensAsFirstOrLastLabelChar,
     #[error("Only lowercase letters, numbers, and hyphens are allowed as label characters")]
     InvalidLabelChar,
-    #[error("Domain must contain at least one label")]
-    LabelsEmpty, //
+    #[error("Domain must contain at least two labels, TLD and SLD")]
+    NotEnoughLabels,
     #[error("Domain must include only one separator")]
     InvalidSeparator, //
     #[error("Name has expired")]

--- a/crates/iota-names/src/error.rs
+++ b/crates/iota-names/src/error.rs
@@ -6,18 +6,18 @@ use serde::{Deserialize, Serialize};
 
 #[derive(thiserror::Error, Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub enum IotaNamesError {
-    #[error("String length: {0} exceeds maximum allowed length: {1}")]
-    ExceedsMaxLength(usize, usize),
-    #[error("String length: {0} outside of valid range: [{1}, {2}]")]
-    InvalidLength(usize, usize, usize),
-    #[error("Hyphens are not allowed as the first or last character")]
-    HyphensAsFirstOrLastChar,
+    #[error("Domain length {0} exceeds maximum length {1}")]
+    DomainLengthExceeded(usize, usize),
+    #[error("Label length {0} outside of valid range [{1}, {2}]")]
+    InvalidLabelLength(usize, usize, usize),
+    #[error("Hyphens are not allowed as first or last character of a label")]
+    HyphensAsFirstOrLastLabelChar,
     #[error("Only lowercase letters, numbers, and hyphens are allowed as label characters")]
     InvalidLabelChar,
     #[error("Domain must contain at least one label")]
-    LabelsEmpty,
+    LabelsEmpty, //
     #[error("Domain must include only one separator")]
-    InvalidSeparator,
+    InvalidSeparator, //
     #[error("Name has expired")]
     NameExpired,
     #[error("Malformed object for {0}")]

--- a/crates/iota-names/src/lib.rs
+++ b/crates/iota-names/src/lib.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod config;
+pub mod constants;
 pub mod domain;
 pub mod error;
 pub mod registry;

--- a/crates/iota-names/src/registry.rs
+++ b/crates/iota-names/src/registry.rs
@@ -12,7 +12,7 @@ use iota_types::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{config::LEAF_EXPIRATION_TIMESTAMP, domain::Domain, error::IotaNamesError};
+use crate::{constants::LEAF_EXPIRATION_TIMESTAMP, domain::Domain, error::IotaNamesError};
 
 /// Rust version of the Move `iota::table::Table` type.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/crates/iota-names/src/registry.rs
+++ b/crates/iota-names/src/registry.rs
@@ -12,7 +12,9 @@ use iota_types::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{constants::LEAF_EXPIRATION_TIMESTAMP, domain::Domain, error::IotaNamesError};
+use crate::{
+    constants::IOTA_NAMES_LEAF_EXPIRATION_TIMESTAMP, domain::Domain, error::IotaNamesError,
+};
 
 /// Rust version of the Move `iota::table::Table` type.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -96,7 +98,7 @@ impl NameRecord {
     /// Leaf records expire when their parent expires.
     /// The `expiration_timestamp_ms` is set to `0` (on-chain) to indicate this.
     pub fn is_leaf_record(&self) -> bool {
-        self.expiration_timestamp_ms == LEAF_EXPIRATION_TIMESTAMP
+        self.expiration_timestamp_ms == IOTA_NAMES_LEAF_EXPIRATION_TIMESTAMP
     }
 
     /// Validates that a `NameRecord` is a valid parent of a child `NameRecord`.

--- a/crates/iota-types/src/digests.rs
+++ b/crates/iota-types/src/digests.rs
@@ -159,6 +159,7 @@ impl fmt::UpperHex for Digest {
 )]
 pub struct ChainIdentifier(pub(crate) CheckpointDigest);
 
+// TODO: https://github.com/iotaledger/iota/issues/5484
 pub const MAINNET_CHAIN_IDENTIFIER_BASE58: &str = "4btiuiMPvEENsttpZC7CZ53DruC3MAgfznDbASZ7DR6S";
 pub const TESTNET_CHAIN_IDENTIFIER_BASE58: &str = "3MhPzSaSTHGffwPSV2Ws2DaK8LR8DBGPozTd2CbiJRwe";
 

--- a/crates/iota-types/src/digests.rs
+++ b/crates/iota-types/src/digests.rs
@@ -159,7 +159,6 @@ impl fmt::UpperHex for Digest {
 )]
 pub struct ChainIdentifier(pub(crate) CheckpointDigest);
 
-// TODO: https://github.com/iotaledger/iota/issues/5484
 pub const MAINNET_CHAIN_IDENTIFIER_BASE58: &str = "4btiuiMPvEENsttpZC7CZ53DruC3MAgfznDbASZ7DR6S";
 pub const TESTNET_CHAIN_IDENTIFIER_BASE58: &str = "3MhPzSaSTHGffwPSV2Ws2DaK8LR8DBGPozTd2CbiJRwe";
 


### PR DESCRIPTION
Improves errors, removes outdated and commented code, removes unwanted `*` syntax, increases reusability.