### PR TITLE
fix: fix secrets name for upload docs action

### DIFF
--- a/.github/workflows/upload-docs-to-aws.yml
+++ b/.github/workflows/upload-docs-to-aws.yml
@@ -48,8 +48,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_IOTA_WIKI }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_IOTA_WIKI }}
           aws-region: eu-central-1 # Change if needed
 
       # ----------- Upload Docs to S3 -----------


### PR DESCRIPTION
# Description of change

We didn't have those secrets enabled for this repo and we also didn't use the correct name it seems 😅.

## Links to any relevant issues

Fixes #6501 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

- 

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code

