### PR TITLE
fix(node): Remove kv store hardcoded URL templates / pass URL from config

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -209,7 +209,7 @@ pub struct NodeConfig {
     #[serde(default)]
     pub indexer_max_subscriptions: Option<usize>,
 
-    #[serde(default = "default_transaction_kv_store_config")]
+    #[serde(default)]
     pub transaction_kv_store_read_config: TransactionKeyValueStoreReadConfig,
 
     // TODO: write config seem to be unused.
@@ -308,12 +308,6 @@ pub fn default_zklogin_oauth_providers() -> BTreeMap<Chain, BTreeSet<String>> {
     map.insert(Chain::Testnet, providers);
     map.insert(Chain::Unknown, experimental_providers);
     map
-}
-
-fn default_transaction_kv_store_config() -> TransactionKeyValueStoreReadConfig {
-    TransactionKeyValueStoreReadConfig {
-        base_url: "https://transactions.iota.cafe/".to_string(),
-    }
 }
 
 fn default_authority_store_pruning_config() -> AuthorityStorePruningConfig {

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1969,23 +1969,13 @@ fn build_kv_store(
         return Ok(Arc::new(db_store));
     }
 
-    let base_url: url::Url = base_url.parse().tap_err(|e| {
+    base_url.parse::<url::Url>().tap_err(|e| {
         error!(
             "failed to parse config.transaction_kv_store_config.base_url ({:?}) as url: {}",
             base_url, e
         )
     })?;
 
-    let network_str = match state.get_chain_identifier().map(|c| c.chain()) {
-        Some(Chain::Mainnet) => "/mainnet",
-        Some(Chain::Testnet) => "/testnet",
-        _ => {
-            info!("using local db only for kv store for unknown chain");
-            return Ok(Arc::new(db_store));
-        }
-    };
-
-    let base_url = base_url.join(network_str)?.to_string();
     let http_store = HttpKVStore::new_kv(&base_url, metrics.clone())?;
     info!("using local key-value store with fallback to http key-value store");
     Ok(Arc::new(FallbackTransactionKVStore::new_kv(

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -90,7 +90,7 @@ use iota_network::{
     api::ValidatorServer, discovery, discovery::TrustedPeerChangeEvent, randomness, state_sync,
 };
 use iota_network_stack::server::ServerBuilder;
-use iota_protocol_config::{Chain, ProtocolConfig};
+use iota_protocol_config::ProtocolConfig;
 use iota_rest_api::RestMetrics;
 use iota_snapshot::uploader::StateSnapshotUploader;
 use iota_storage::{
@@ -1976,7 +1976,7 @@ fn build_kv_store(
         )
     })?;
 
-    let http_store = HttpKVStore::new_kv(&base_url, metrics.clone())?;
+    let http_store = HttpKVStore::new_kv(base_url, metrics.clone())?;
     info!("using local key-value store with fallback to http key-value store");
     Ok(Arc::new(FallbackTransactionKVStore::new_kv(
         db_store,

--- a/crates/iota-storage/src/bin/http_kv_tool.rs
+++ b/crates/iota-storage/src/bin/http_kv_tool.rs
@@ -21,8 +21,7 @@ use iota_types::{
 // --type <fx|tx|ev> - the type of key being fetched
 #[derive(Parser)]
 struct Options {
-    // default value of 'https://transactions.iota.cafe/'
-    #[arg(short, long, default_value = "https://transactions.iota.cafe/mainnet")]
+    #[arg(short, long)]
     base_url: String,
 
     #[arg(short, long)]


### PR DESCRIPTION
# Description of change

- Removed the default value `TransactionKeyValueStoreReadConfig :: base_url: "https://transactions.iota.cafe/`. 
- Removed all modifications to this URL done by code (e.g. adding mainnet/testnet)
- So, in short, now we take whatever there is for `transaction-kv-store-read-config: base-url` in config. (This is not a change in this PR but an info how code works: when this URL is not specified in config, the logic is local db for kv store is used with the log `info!("no http kv store url provided, using local db only"); } `)
- Removed default base URL value from iota-storage CLI (in `crates/iota-storage/src/bin/http_kv_tool.rs`)

## Links to any relevant issues

fixes #6466 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Run `cargo r --bin iota-node -- --config-path fullnode.yaml` for each scenario below:

**(a) No `transaction-kv-store-read-config: base-url:` in config:**
Node continues to run with this log:
``` 
INFO iota_node: no http kv store url provided, using local db only
```
test JSON-RPC works:
```
curl --json '{"jsonrpc":"2.0","id":1,"method":"iota_getLatestCheckpointSequenceNumber","params":[]}' localhost:9000 -s | jq .result
``` 
```
"2160601"
```

**(b) Invalid URL for `transaction-kv-store-read-config: base-url: "invalid url"` in config:**
Node panics.

**(c) Valid URL for `transaction-kv-store-read-config: base-url: "https://transactions.iota.cafe/mainnet"` in config:**
Node continues to run with the logs:

```
INFO iota_storage::http_key_value_store: creating HttpKVStore with base_url: https://transactions.iota.cafe/mainnet
INFO iota_node: using local key-value store with fallback to http key-value store
```

test JSON-RPC works:
```
curl --json '{"jsonrpc":"2.0","id":1,"method":"iota_getLatestCheckpointSequenceNumber","params":[]}' localhost:9000 -s | jq .result
``` 
```
"2160601"
```

