### PR TITLE
refactor(iota-node): Use `IotaNamesConfig::default()` if not populated in `NodeConfig`

### DIFF
--- a/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
+++ b/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
@@ -637,7 +637,7 @@ impl IotaNamesRegistration {
         Ok(Self {
             super_: move_object.clone(),
             native: bcs::from_bytes(move_object.native.contents())
-                .map_err(|e| IotaNamesRegistrationDowncastError::Bcs(e))?,
+                .map_err(IotaNamesRegistrationDowncastError::Bcs)?,
         })
     }
 }

--- a/crates/iota-graphql-rpc/src/types/move_type.rs
+++ b/crates/iota-graphql-rpc/src/types/move_type.rs
@@ -209,13 +209,13 @@ impl MoveType {
 impl From<MoveObjectType> for MoveType {
     fn from(obj: MoveObjectType) -> Self {
         let tag: TypeTag = obj.into();
-        Self { native: tag.into() }
+        Self { native: tag }
     }
 }
 
 impl From<TypeTag> for MoveType {
     fn from(tag: TypeTag) -> Self {
-        Self { native: tag.into() }
+        Self { native: tag }
     }
 }
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -86,7 +86,6 @@ use iota_metrics::{
     metrics_network::{MetricsMakeCallbackHandler, NetworkConnectionMetrics, NetworkMetrics},
     server_timing_middleware, spawn_monitored_task,
 };
-use iota_names::config::IotaNamesConfig;
 use iota_network::{
     api::ValidatorServer, discovery, discovery::TrustedPeerChangeEvent, randomness, state_sync,
 };
@@ -2067,16 +2066,9 @@ pub async fn build_http_server(
             ))?;
         }
 
-        let iota_names_config = match &config.iota_names_config {
-            Some(config) => config.clone(),
-            None => {
-                let chain = state
-                    .get_chain_identifier()
-                    .ok_or(IotaError::Storage("chain identifier not found".to_string()))?
-                    .chain();
-                IotaNamesConfig::from_chain(&chain)
-            }
-        };
+        // TODO: Init from chain if config is not set when `IotaNamesConfig::from_chain`
+        // once implemented
+        let iota_names_config = config.iota_names_config.clone().unwrap_or_default();
 
         server.register_module(IndexerApi::new(
             state.clone(),

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -2066,8 +2066,8 @@ pub async fn build_http_server(
             ))?;
         }
 
-        // TODO: Init from chain if config is not set when `IotaNamesConfig::from_chain`
-        // once implemented
+        // TODO: Init from chain if config is not set once `IotaNamesConfig::from_chain`
+        // is implemented
         let iota_names_config = config.iota_names_config.clone().unwrap_or_default();
 
         server.register_module(IndexerApi::new(


### PR DESCRIPTION
# Description of change

In case the optional `IotaNamesConfig` isn't populated in the `NodeConfig` the node needs to instantiate the correct `IotaNamesConfig` itself. As done currently `IotaNamesConfig::from_chain` is used for that which however isn't fully implemented yet and would run into panic, as the `testnet/mainnet` branches are not implemented. 

Therefore this PR replaces that logic for now to use `IotaNamesConfig::default()` if no config is provided. This aligns with the default configuration for the Indexer and GraphQL services.

In future, this change should be reverted so that the node will be able to derive the `IotaNamesConfig` directly from the chain, similarly as done in upstream (https://github.com/MystenLabs/sui/blob/main/crates/sui-node/src/lib.rs#L2247-L2251). This would bring out-of-the-box support for `Chain::{Unknown,Testnet, Mainnet}` without the need of providing a configuration to the node.

## Type of change

- Feature (Non-breaking change)

## How the change has been tested

- [X] Basic tests (linting, compilation, formatting, unit/integration tests)
- [X] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [X] Deployment of services using Docker.
- [X] Verification of API backward compatibility.

## Change checklist

- [X] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

<!--
Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.
-->

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
