### PR TITLE
upstream(consensus): rest -- discard failed dynamic field indices

### DIFF
--- a/crates/iota-core/src/rest_index.rs
+++ b/crates/iota-core/src/rest_index.rs
@@ -456,7 +456,9 @@ impl IndexStoreTables {
                         }
                         Owner::ObjectOwner(parent) => {
                             if let Some(field_info) =
-                                try_create_dynamic_field_info(object, resolver)?
+                                try_create_dynamic_field_info(object, resolver)
+                                    .ok()
+                                    .flatten()
                             {
                                 let field_key = DynamicFieldKey::new(*parent, object.id());
 


### PR DESCRIPTION
# Description of change

Port upstream change: rest: discard failed dynamic field indices https://github.com/MystenLabs/sui/commit/f28674511c84e4f314d71f630a0e9e04ebe2981e (PR: https://github.com/MystenLabs/sui/pull/19377)

> Allow dynamic field indexing to fail when building up fullnode REST
> indices to bring it in line with behaviour in `sui-indexer`,
> `sui-analytics-indexer`, and the existing fullnode indices.

## Links to any relevant issues

Closes #6562 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

CI

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
