### PR TITLE
upstream(consensus): remove rolling hash from consensus handler

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -184,12 +184,6 @@ pub enum ConsensusCertificateResult {
     ),
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
-pub struct ExecutionIndicesWithHash {
-    pub index: ExecutionIndices,
-    pub hash: u64,
-}
-
 /// ConsensusStats is versioned because we may iterate on the struct, and it is
 /// stored on disk.
 #[enum_dispatch]
@@ -290,6 +284,7 @@ impl PartialOrd for ExecutionIndices {
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
 pub struct ExecutionIndicesWithStats {
     pub index: ExecutionIndices,
+    // Hash is always 0 and kept for compatibility only.
     pub hash: u64,
     pub stats: ConsensusStats,
 }
@@ -502,13 +497,9 @@ pub struct AuthorityEpochTables {
     #[default_options_override_fn = "pending_consensus_transactions_table_default_config"]
     pending_consensus_transactions: DBMap<ConsensusTransactionKey, ConsensusTransaction>,
 
-    /// The following table is used to store a single value (the corresponding
-    /// key is a constant). The value represents the index of the latest
-    /// consensus message this authority processed. This field is written by
-    /// a single process acting as consensus (light) client. It is used to
-    /// ensure the authority processes every message output by consensus
-    /// (and in the right order).
-    last_consensus_index: DBMap<u64, ExecutionIndicesWithHash>,
+    /// this table is not used
+    #[allow(dead_code)]
+    last_consensus_index: DBMap<(), ()>,
 
     /// The following table is used to store a single value (the corresponding
     /// key is a constant). The value represents the index of the latest
@@ -720,8 +711,11 @@ impl AuthorityEpochTables {
         Ok(())
     }
 
-    pub fn get_last_consensus_index(&self) -> IotaResult<Option<ExecutionIndicesWithHash>> {
-        Ok(self.last_consensus_index.get(&LAST_CONSENSUS_STATS_ADDR)?)
+    pub fn get_last_consensus_index(&self) -> IotaResult<Option<ExecutionIndices>> {
+        Ok(self
+            .last_consensus_stats
+            .get(&LAST_CONSENSUS_STATS_ADDR)?
+            .map(|s| s.index))
     }
 
     pub fn get_last_consensus_stats(&self) -> IotaResult<Option<ExecutionIndicesWithStats>> {
@@ -1339,24 +1333,17 @@ impl AuthorityPerEpochStore {
             .collect()
     }
 
-    pub fn get_last_consensus_index(&self) -> IotaResult<ExecutionIndicesWithHash> {
-        self.tables()?
-            .get_last_consensus_index()
-            .map(|x| x.unwrap_or_default())
-    }
-
     pub fn get_last_consensus_stats(&self) -> IotaResult<ExecutionIndicesWithStats> {
         match self.tables()?.get_last_consensus_stats()? {
             Some(stats) => Ok(stats),
-            // TODO: stop reading from last_consensus_index after rollout.
             None => {
                 let indices = self
                     .tables()?
                     .get_last_consensus_index()
                     .map(|x| x.unwrap_or_default())?;
                 Ok(ExecutionIndicesWithStats {
-                    index: indices.index,
-                    hash: indices.hash,
+                    index: indices,
+                    hash: 0, // unused
                     stats: ConsensusStats::default(),
                 })
             }
@@ -2524,7 +2511,7 @@ impl AuthorityPerEpochStore {
     }
 
     fn db_batch(&self) -> IotaResult<DBBatch> {
-        Ok(self.tables()?.last_consensus_index.batch())
+        Ok(self.tables()?.last_consensus_stats.batch())
     }
 
     #[cfg(test)]
@@ -4094,16 +4081,6 @@ impl ConsensusCommitOutput {
         }
 
         if let Some(consensus_commit_stats) = &self.consensus_commit_stats {
-            batch.insert_batch(
-                &tables.last_consensus_index,
-                [(
-                    LAST_CONSENSUS_STATS_ADDR,
-                    ExecutionIndicesWithHash {
-                        index: consensus_commit_stats.index,
-                        hash: consensus_commit_stats.hash,
-                    },
-                )],
-            )?;
             batch.insert_batch(
                 &tables.last_consensus_stats,
                 [(LAST_CONSENSUS_STATS_ADDR, consensus_commit_stats)],

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{HashMap, HashSet, hash_map::DefaultHasher},
-    hash::{Hash, Hasher},
+    collections::{HashMap, HashSet},
+    hash::Hash,
     num::NonZeroUsize,
     sync::Arc,
 };
@@ -160,38 +160,6 @@ impl<C> ConsensusHandler<C> {
     pub fn last_processed_subdag_index(&self) -> u64 {
         self.last_consensus_stats.index.sub_dag_index
     }
-
-    /// Updates the execution indexes based on the provided input.
-    fn update_index_and_hash(&mut self, index: ExecutionIndices, v: &[u8]) {
-        update_index_and_hash(&mut self.last_consensus_stats, index, v)
-    }
-}
-
-fn update_index_and_hash(
-    last_consensus_stats: &mut ExecutionIndicesWithStats,
-    index: ExecutionIndices,
-    v: &[u8],
-) {
-    // The entry point of handle_consensus_output_internal() has filtered out any
-    // already processed consensus output. So we can safely assume that the
-    // index is always increasing.
-    assert!(last_consensus_stats.index < index);
-
-    let previous_hash = last_consensus_stats.hash;
-    let mut hasher = DefaultHasher::new();
-    previous_hash.hash(&mut hasher);
-    v.hash(&mut hasher);
-    let hash = hasher.finish();
-    // Log hash every 1000th transaction of the subdag
-    if index.transaction_index % 1000 == 0 {
-        debug!(
-            "Integrity hash for consensus output at subdag {} transaction {} is {:016x}",
-            index.sub_dag_index, index.transaction_index, hash
-        );
-    }
-
-    last_consensus_stats.index = index;
-    last_consensus_stats.hash = hash;
 }
 
 impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
@@ -228,19 +196,20 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             "Received consensus output"
         );
 
-        // TODO: testing empty commit explicitly.
+        let execution_index = ExecutionIndices {
+            last_committed_round: round,
+            sub_dag_index: commit_sub_dag_index,
+            transaction_index: 0_u64,
+        };
+        // This function has filtered out any already processed consensus output.
+        // So we can safely assume that the index is always increasing.
+        assert!(self.last_consensus_stats.index < execution_index);
+
+        // TODO: test empty commit explicitly.
         // Note that consensus commit batch may contain no transactions, but we still
         // need to record the current round and subdag index in the
         // last_consensus_stats, so that it won't be re-executed in the future.
-        let empty_bytes = vec![];
-        self.update_index_and_hash(
-            ExecutionIndices {
-                last_committed_round: round,
-                sub_dag_index: commit_sub_dag_index,
-                transaction_index: 0_u64,
-            },
-            &empty_bytes,
-        );
+        self.last_consensus_stats.index = execution_index;
 
         // Load all jwks that became active in the previous round, and commit them in
         // this round. We want to delay one round because none of the
@@ -266,7 +235,6 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             );
 
             transactions.push((
-                empty_bytes.as_slice(),
                 SequencedConsensusTransactionKind::System(authenticator_state_update_transaction),
                 leader_author,
             ));
@@ -296,7 +264,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 self.last_consensus_stats
                     .stats
                     .inc_num_messages(authority_index as usize);
-                for (serialized_transaction, transaction) in authority_transactions {
+                for (transaction, serialized_len) in authority_transactions {
                     let kind = classify(&transaction);
                     self.metrics
                         .consensus_handler_processed
@@ -305,7 +273,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                     self.metrics
                         .consensus_handler_transaction_sizes
                         .with_label_values(&[kind])
-                        .observe(serialized_transaction.len() as f64);
+                        .observe(serialized_len as f64);
                     if matches!(
                         &transaction.kind,
                         ConsensusTransactionKind::UserTransaction(_)
@@ -316,7 +284,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                     }
 
                     let transaction = SequencedConsensusTransactionKind::External(transaction);
-                    transactions.push((serialized_transaction, transaction, authority_index));
+                    transactions.push((transaction, authority_index));
                 }
             }
         }
@@ -344,9 +312,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             // transactions.
             let mut processed_set = HashSet::new();
 
-            for (seq, (serialized, transaction, cert_origin)) in
-                transactions.into_iter().enumerate()
-            {
+            for (seq, (transaction, cert_origin)) in transactions.into_iter().enumerate() {
                 // In process_consensus_transactions_and_commit_boundary(), we will add a system
                 // consensus commit prologue transaction, which will be the
                 // first transaction in this consensus commit batch. Therefore,
@@ -357,7 +323,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                     transaction_index: (seq + 1) as u64,
                 };
 
-                self.update_index_and_hash(current_tx_index, serialized);
+                self.last_consensus_stats.index = current_tx_index;
 
                 let certificate_author = *self
                     .epoch_store
@@ -903,7 +869,7 @@ mod tests {
         );
         assert_eq!(last_consensus_stats_1.index.sub_dag_index, 10_u64);
         assert_eq!(last_consensus_stats_1.index.last_committed_round, 100_u64);
-        assert_ne!(last_consensus_stats_1.hash, 0);
+        assert_eq!(last_consensus_stats_1.hash, 0);
         assert_eq!(
             last_consensus_stats_1.stats.get_num_messages(0),
             num_blocks as u64
@@ -922,31 +888,6 @@ mod tests {
             let last_consensus_stats_2 = consensus_handler.last_consensus_stats.clone();
             assert_eq!(last_consensus_stats_1, last_consensus_stats_2);
         }
-    }
-
-    #[test]
-    pub fn test_update_index_and_hash() {
-        let index0 = ExecutionIndices {
-            sub_dag_index: 0,
-            transaction_index: 5,
-            last_committed_round: 0,
-        };
-        let index1 = ExecutionIndices {
-            sub_dag_index: 1,
-            transaction_index: 2,
-            last_committed_round: 3,
-        };
-
-        let mut last_seen = ExecutionIndicesWithStats {
-            index: index0,
-            hash: 1000,
-            stats: ConsensusStats::default(),
-        };
-
-        let tx = &[0];
-        update_index_and_hash(&mut last_seen, index1, tx);
-        assert_eq!(last_seen.index, index1);
-        assert_ne!(last_seen.hash, 1000);
     }
 
     #[test]

--- a/crates/iota-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/iota-core/src/consensus_types/consensus_output_api.rs
@@ -10,10 +10,10 @@ use iota_types::{digests::ConsensusCommitDigest, messages_consensus::ConsensusTr
 use crate::consensus_types::AuthorityIndex;
 
 /// A list of tuples of:
-/// (certificate origin authority index, all transactions corresponding to the
-/// certificate). For each transaction, returns the serialized transaction and
-/// the deserialized transaction.
-type ConsensusOutputTransactions<'a> = Vec<(AuthorityIndex, Vec<(&'a [u8], ConsensusTransaction)>)>;
+/// (block origin authority index, all transactions contained in the block).
+/// For each transaction, returns deserialized transaction and its serialized
+/// size.
+type ConsensusOutputTransactions = Vec<(AuthorityIndex, Vec<(ConsensusTransaction, usize)>)>;
 
 pub(crate) trait ConsensusOutputAPI: Display {
     fn reputation_score_sorted_desc(&self) -> Option<Vec<(AuthorityIndex, u64)>>;
@@ -27,7 +27,7 @@ pub(crate) trait ConsensusOutputAPI: Display {
     fn commit_sub_dag_index(&self) -> u64;
 
     /// Returns all transactions in the commit.
-    fn transactions(&self) -> ConsensusOutputTransactions<'_>;
+    fn transactions(&self) -> ConsensusOutputTransactions;
 
     /// Returns the digest of consensus output.
     fn consensus_digest(&self) -> ConsensusCommitDigest;
@@ -77,8 +77,8 @@ impl ConsensusOutputAPI for consensus_core::CommittedSubDag {
                         let transaction = bcs::from_bytes::<ConsensusTransaction>(tx.data());
                         match transaction {
                             Ok(transaction) => Some((
-                                tx.data(),
                                 transaction,
+                                tx.data().len(),
                             )),
                             Err(err) => {
                                 tracing::error!("Failed to deserialize sequenced consensus transaction(this should not happen) {} from {author} at {round}", err);


### PR DESCRIPTION
# Description of change

Port upstream change: [Cleanup] remove rolling hash from consensus handler https://github.com/MystenLabs/sui/commit/fe8982b16c3d62bfd9df7d8f805cd2cac8ffc1d3 (PR: https://github.com/MystenLabs/sui/pull/19628)

> - Each consensus commit includes its previous commit's digest. Commit
> digests are logged inside consensus. So I believe we have what is needed
> to debug forks without the rolling hash inside consensus handler now.
> - Deprecate the `last_consensus_index` table. It's replacement
> `last_consensus_stats` has been populated for awhile.

## Links to any relevant issues

Closes #6563.

## Type of change

Cleanup

## How the change has been tested

CI

- [x] Protocol: PR removes rolling hash from consensus handler
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
