### PR TITLE
upstream(consensus): remove execution driver retries everywhere except mainnet

### DIFF
--- a/crates/iota-core/src/execution_driver.rs
+++ b/crates/iota-core/src/execution_driver.rs
@@ -9,6 +9,7 @@ use std::{
 
 use iota_macros::fail_point_async;
 use iota_metrics::{monitored_scope, spawn_monitored_task};
+use iota_protocol_config::Chain;
 use rand::{
     Rng, SeedableRng,
     rngs::{OsRng, StdRng},
@@ -43,6 +44,18 @@ pub async fn execution_process(
     // Rate limit concurrent executions to # of cpus.
     let limit = Arc::new(Semaphore::new(num_cpus::get()));
     let mut rng = StdRng::from_rng(&mut OsRng).unwrap();
+
+    let is_mainnet = {
+        let Some(state) = authority_state.upgrade() else {
+            info!("Authority state has shutdown. Exiting ...");
+            return;
+        };
+
+        state
+            .get_chain_identifier()
+            .map(|chain_id| chain_id.chain())
+            == Some(Chain::Mainnet)
+    };
 
     // Loop whenever there is a signal that a new transactions is ready to process.
     loop {
@@ -134,7 +147,9 @@ pub async fn execution_process(
                     .try_execute_immediately(&certificate, expected_effects_digest, &epoch_store_clone)
                     .await;
                 if let Err(e) = res {
-                    if attempts == EXECUTION_MAX_ATTEMPTS {
+                    // Tighten this check everywhere except mainnet - if we don't see an increase in
+                    // these crashes we will remove the retries.
+                    if !is_mainnet || attempts == EXECUTION_MAX_ATTEMPTS {
                         panic!("Failed to execute certified transaction {digest:?} after {attempts} attempts! error={e} certificate={certificate:?}");
                     }
                     // Assume only transient failure can happen. Permanent failure is probably


### PR DESCRIPTION
# Description of change

Port upstream change: Remove execution driver retries everywhere except mainnet https://github.com/MystenLabs/sui/commit/9bafc95e3d3f3c604b3d4170b32b267691477f8c (PR: https://github.com/MystenLabs/sui/pull/19952)

## Links to any relevant issues

Closes #6564 

## Type of change

Choose a type of change, and delete any options that are not relevant.

cleanup

## How the change has been tested

CI

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: PR removes execution driver retries everywhere except mainnet
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
