### PR TITLE
upstream(consensus): remove high cardinality address label from safe client latency

### DIFF
--- a/crates/iota-core/src/safe_client.rs
+++ b/crates/iota-core/src/safe_client.rs
@@ -66,10 +66,11 @@ impl SafeClientMetricsBase {
                 registry,
             )
             .unwrap(),
+            // Address label is removed to reduce high cardinality, can be added back if needed
             latency: HistogramVec::new_in_registry(
                 "safe_client_latency",
-                "RPC latency observed by safe client aggregator, group by address and method",
-                &["address", "method"],
+                "RPC latency observed by safe client aggregator, group by method",
+                &["method"],
                 registry,
             ),
         }
@@ -115,17 +116,16 @@ impl SafeClientMetrics {
 
         let handle_transaction_latency = metrics_base
             .latency
-            .with_label_values(&[validator_address.as_str(), "handle_transaction"]);
+            .with_label_values(&["handle_transaction"]);
         let handle_certificate_latency = metrics_base
             .latency
-            .with_label_values(&[validator_address.as_str(), "handle_certificate"]);
+            .with_label_values(&["handle_certificate"]);
         let handle_obj_info_latency = metrics_base
             .latency
-            .with_label_values(&[validator_address.as_str(), "handle_object_info_request"]);
-        let handle_tx_info_latency = metrics_base.latency.with_label_values(&[
-            validator_address.as_str(),
-            "handle_transaction_info_request",
-        ]);
+            .with_label_values(&["handle_object_info_request"]);
+        let handle_tx_info_latency = metrics_base
+            .latency
+            .with_label_values(&["handle_transaction_info_request"]);
 
         Self {
             total_requests_handle_transaction_info_request,


### PR DESCRIPTION
# Description of change

Port upstream change: fix: remove high cardinality address label from safe_client_latency https://github.com/MystenLabs/sui/commit/d4b19659f30f6953df576709dd76d51ae765d614 (PR: https://github.com/MystenLabs/sui/pull/20165)

> safe_client_latency is the highest cardinality metric across our
> observability system due to the `address` label

## Links to any relevant issues

Closes #6565 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

CI

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
