### PR TITLE
feat(iota-names): dynamically fetch subdomain proxy package

### DIFF
--- a/crates/iota-indexer/src/lib.rs
+++ b/crates/iota-indexer/src/lib.rs
@@ -183,9 +183,6 @@ pub struct IotaNamesOptions {
     #[arg(default_value_t = IotaNamesConfig::default().reverse_registry_id)]
     #[arg(long = "iota-names-reverse-registry-id")]
     pub reverse_registry_id: ObjectID,
-    #[arg(default_value_t = IotaNamesConfig::default().subdomain_proxy_package_id)]
-    #[arg(long = "iota-names-subdomain-proxy-package-id")]
-    pub subdomain_proxy_package_id: ObjectID,
 }
 
 impl From<IotaNamesOptions> for IotaNamesConfig {
@@ -196,7 +193,6 @@ impl From<IotaNamesOptions> for IotaNamesConfig {
             payments_package_address,
             registry_id,
             reverse_registry_id,
-            subdomain_proxy_package_id,
         } = options;
         Self {
             package_address,
@@ -204,7 +200,6 @@ impl From<IotaNamesOptions> for IotaNamesConfig {
             payments_package_address,
             registry_id,
             reverse_registry_id,
-            subdomain_proxy_package_id,
         }
     }
 }
@@ -217,7 +212,6 @@ impl From<IotaNamesConfig> for IotaNamesOptions {
             payments_package_address,
             registry_id,
             reverse_registry_id,
-            subdomain_proxy_package_id,
         } = config;
         Self {
             package_address,
@@ -225,7 +219,6 @@ impl From<IotaNamesConfig> for IotaNamesOptions {
             payments_package_address,
             registry_id,
             reverse_registry_id,
-            subdomain_proxy_package_id,
         }
     }
 }

--- a/crates/iota-names/src/config.rs
+++ b/crates/iota-names/src/config.rs
@@ -25,8 +25,6 @@ pub struct IotaNamesConfig {
     pub registry_id: ObjectID,
     /// ID of the reverse registry table.
     pub reverse_registry_id: ObjectID,
-    /// Address of the `subdomain_proxy` package.
-    pub subdomain_proxy_package_id: ObjectID,
 }
 
 impl Default for IotaNamesConfig {
@@ -44,7 +42,6 @@ impl IotaNamesConfig {
         payments_package_address: IotaAddress,
         registry_id: ObjectID,
         reverse_registry_id: ObjectID,
-        subdomain_proxy_package_id: ObjectID,
     ) -> Self {
         Self {
             package_address,
@@ -52,7 +49,6 @@ impl IotaNamesConfig {
             payments_package_address,
             registry_id,
             reverse_registry_id,
-            subdomain_proxy_package_id,
         }
     }
 
@@ -101,15 +97,12 @@ impl IotaNamesConfig {
             "0xff608b2b0d500b4d0cb25ff165bc3e01fce9bf3ef7fb002840b814d304a08b2a";
         const REVERSE_REGISTRY_ID: &str =
             "0x1c2eddd6c4f7510b35a9de575d9ccb1ad640de6aa3a5626937c21c9c62beaeed";
-        const SUBDOMAIN_PROXY_PACKAGE_ID: &str =
-            "0xf43e05a098dd8a339d478907418f42b30eddf661b029a48f313edee1420e22fe";
 
         let package_address = IotaAddress::from_str(PACKAGE_ADDRESS).unwrap();
         let object_id = ObjectID::from_str(OBJECT_ID).unwrap();
         let payments_package_address = IotaAddress::from_str(PAYMENTS_PACKAGE_ADDRESS).unwrap();
         let registry_id = ObjectID::from_str(REGISTRY_ID).unwrap();
         let reverse_registry_id = ObjectID::from_str(REVERSE_REGISTRY_ID).unwrap();
-        let subdomain_proxy_package_id = ObjectID::from_str(SUBDOMAIN_PROXY_PACKAGE_ID).unwrap();
 
         Self::new(
             package_address,
@@ -117,7 +110,6 @@ impl IotaNamesConfig {
             payments_package_address,
             registry_id,
             reverse_registry_id,
-            subdomain_proxy_package_id,
         )
     }
 }

--- a/crates/iota/src/name_commands.rs
+++ b/crates/iota/src/name_commands.rs
@@ -710,7 +710,7 @@ impl SubdomainCommand {
 
                 let parent = get_proxy_nft_by_name(&parent, context).await?;
                 anyhow::ensure!(!parent.has_expired(), "parent NFT has expired");
-                let package_id = parent.package_id(&client, &iota_names_config).await?;
+                let package_id = parent.package_id(&client).await?;
                 let module_name = parent.module_name();
 
                 let target_address = if let Some(target_address) = target_address {
@@ -757,7 +757,7 @@ impl SubdomainCommand {
 
                 let parent = get_proxy_nft_by_name(&parent, context).await?;
                 anyhow::ensure!(!parent.has_expired(), "parent NFT has expired");
-                let package_id = parent.package_id(&client, &iota_names_config).await?;
+                let package_id = parent.package_id(&client).await?;
                 let module_name = parent.module_name();
 
                 let expiration_timestamp =
@@ -808,7 +808,7 @@ impl SubdomainCommand {
                 let iota_names_config = get_iota_names_config(&client).await?;
 
                 let parent = get_proxy_nft_by_name(&parent, context).await?;
-                let package_id = parent.package_id(&client, &iota_names_config).await?;
+                let package_id = parent.package_id(&client).await?;
                 let module_name = parent.module_name();
 
                 NameCommandResult::Client(
@@ -1214,11 +1214,7 @@ impl IotaNamesNftProxy {
         fn id(&self) -> ObjectID;
     }
 
-    async fn package_id(
-        &self,
-        client: &IotaClient,
-        config: &IotaNamesConfig,
-    ) -> anyhow::Result<ObjectID> {
+    async fn package_id(&self, client: &IotaClient) -> anyhow::Result<ObjectID> {
         Ok(match self {
             IotaNamesNftProxy::Domain(_) => {
                 fetch_package_id_by_module_and_name(
@@ -1228,7 +1224,14 @@ impl IotaNamesNftProxy {
                 )
                 .await?
             }
-            IotaNamesNftProxy::Subdomain(_) => config.subdomain_proxy_package_id,
+            IotaNamesNftProxy::Subdomain(_) => {
+                fetch_package_id_by_module_and_name(
+                    client,
+                    &Identifier::from_str("subdomain_proxy")?,
+                    &Identifier::from_str("SubdomainProxyAuth")?,
+                )
+                .await?
+            }
         })
     }
 


### PR DESCRIPTION
# Description of change

Dynamically fetch subdomain proxy package instead of having it hardcoded in the config

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota-names/issues/135

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

In a localnet with the IOTA-Names version deployed that has the subdomain proxy authorized, by running
`cargo run --features=iota-names name register thoralf.iota`
`cargo run --features=iota-names name subdomain register-node sub.thoralf.iota`
`cargo run --features=iota-names name list`
