### PR TITLE
upstream(consensus): checkpoint builder can be aborted

### DIFF
--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -991,6 +991,9 @@ impl CheckpointBuilder {
                 self.metrics.checkpoint_errors.inc();
                 return;
             }
+            // Ensure that the task can be cancelled at end of epoch, even if no other await
+            // yields execution.
+            tokio::task::yield_now().await;
         }
         debug!(
             "Waiting for more checkpoints from consensus after processing {last_height:?}; {} pending checkpoints left unprocessed until next interval",


### PR DESCRIPTION
# Description of change

Port upstream change: Ensure CheckpointBuilder can be aborted at end of epoch https://github.com/MystenLabs/sui/commit/53cccd8a54d37b9fb4b8a8833cb47cb779a307c6 (PR: https://github.com/MystenLabs/sui/pull/20442)

## Links to any relevant issues

Closes #6566 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

CI

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

<!--
Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.
-->

- [x] Protocol: PR allows CheckpointBuilder to be aborted at end of epoch 
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
