### PR TITLE
enhancement(types): Add tests module iota-types/object.rs

### DIFF
--- a/crates/iota-types/src/object.rs
+++ b/crates/iota-types/src/object.rs
@@ -1198,77 +1198,86 @@ impl Display for PastObjectRead {
     }
 }
 
-// Ensure that object digest computation and bcs serialized format are not
-// inadvertently changed.
-#[test]
-fn test_object_digest_and_serialized_format() {
-    let g = GasCoin::new_for_testing_with_id(ObjectID::ZERO, 123).to_object(OBJECT_START_VERSION);
-    let o = Object::new_move(
-        g,
-        Owner::AddressOwner(IotaAddress::ZERO),
-        TransactionDigest::ZERO,
-    );
-    let bytes = bcs::to_bytes(&o).unwrap();
+#[cfg(test)]
+mod tests {
+    use crate::{
+        base_types::{IotaAddress, ObjectID, TransactionDigest},
+        gas_coin::GasCoin,
+        object::{OBJECT_START_VERSION, Object, Owner},
+    };
 
-    assert_eq!(
-        bytes,
-        [
-            0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-        ]
-    );
+    // Ensure that object digest computation and bcs serialized format are not
+    // inadvertently changed.
+    #[test]
+    fn test_object_digest_and_serialized_format() {
+        let g =
+            GasCoin::new_for_testing_with_id(ObjectID::ZERO, 123).to_object(OBJECT_START_VERSION);
+        let o = Object::new_move(
+            g,
+            Owner::AddressOwner(IotaAddress::ZERO),
+            TransactionDigest::ZERO,
+        );
+        let bytes = bcs::to_bytes(&o).unwrap();
 
-    let objref = format!("{:?}", o.compute_object_reference());
-    assert_eq!(
-        objref,
-        "(0x0000000000000000000000000000000000000000000000000000000000000000, SequenceNumber(1), o#Ba4YyVBcpc9jgX4PMLRoyt9dKLftYVSDvuKbtMr9f4NM)"
-    );
-}
-
-#[test]
-fn test_get_coin_value_unsafe() {
-    fn test_for_value(v: u64) {
-        let g = GasCoin::new_for_testing(v).to_object(OBJECT_START_VERSION);
-        assert_eq!(g.get_coin_value_unsafe(), v);
-        assert_eq!(GasCoin::try_from(&g).unwrap().value(), v);
+        assert_eq!(
+            bytes,
+            [
+                0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+            ]
+        );
+        let objref = format!("{:?}", o.compute_object_reference());
+        assert_eq!(
+            objref,
+            "(0x0000000000000000000000000000000000000000000000000000000000000000, SequenceNumber(1), o#Ba4YyVBcpc9jgX4PMLRoyt9dKLftYVSDvuKbtMr9f4NM)"
+        );
     }
 
-    test_for_value(0);
-    test_for_value(1);
-    test_for_value(8);
-    test_for_value(9);
-    test_for_value(u8::MAX as u64);
-    test_for_value(u8::MAX as u64 + 1);
-    test_for_value(u16::MAX as u64);
-    test_for_value(u16::MAX as u64 + 1);
-    test_for_value(u32::MAX as u64);
-    test_for_value(u32::MAX as u64 + 1);
-    test_for_value(u64::MAX);
-}
+    #[test]
+    fn test_get_coin_value_unsafe() {
+        fn test_for_value(v: u64) {
+            let g = GasCoin::new_for_testing(v).to_object(OBJECT_START_VERSION);
+            assert_eq!(g.get_coin_value_unsafe(), v);
+            assert_eq!(GasCoin::try_from(&g).unwrap().value(), v);
+        }
 
-#[test]
-fn test_set_coin_value_unsafe() {
-    fn test_for_value(v: u64) {
-        let mut g = GasCoin::new_for_testing(u64::MAX).to_object(OBJECT_START_VERSION);
-        g.set_coin_value_unsafe(v);
-        assert_eq!(g.get_coin_value_unsafe(), v);
-        assert_eq!(GasCoin::try_from(&g).unwrap().value(), v);
-        assert_eq!(g.version(), OBJECT_START_VERSION);
-        assert_eq!(g.contents().len(), 40);
+        test_for_value(0);
+        test_for_value(1);
+        test_for_value(8);
+        test_for_value(9);
+        test_for_value(u8::MAX as u64);
+        test_for_value(u8::MAX as u64 + 1);
+        test_for_value(u16::MAX as u64);
+        test_for_value(u16::MAX as u64 + 1);
+        test_for_value(u32::MAX as u64);
+        test_for_value(u32::MAX as u64 + 1);
+        test_for_value(u64::MAX);
     }
 
-    test_for_value(0);
-    test_for_value(1);
-    test_for_value(8);
-    test_for_value(9);
-    test_for_value(u8::MAX as u64);
-    test_for_value(u8::MAX as u64 + 1);
-    test_for_value(u16::MAX as u64);
-    test_for_value(u16::MAX as u64 + 1);
-    test_for_value(u32::MAX as u64);
-    test_for_value(u32::MAX as u64 + 1);
-    test_for_value(u64::MAX);
+    #[test]
+    fn test_set_coin_value_unsafe() {
+        fn test_for_value(v: u64) {
+            let mut g = GasCoin::new_for_testing(u64::MAX).to_object(OBJECT_START_VERSION);
+            g.set_coin_value_unsafe(v);
+            assert_eq!(g.get_coin_value_unsafe(), v);
+            assert_eq!(GasCoin::try_from(&g).unwrap().value(), v);
+            assert_eq!(g.version(), OBJECT_START_VERSION);
+            assert_eq!(g.contents().len(), 40);
+        }
+
+        test_for_value(0);
+        test_for_value(1);
+        test_for_value(8);
+        test_for_value(9);
+        test_for_value(u8::MAX as u64);
+        test_for_value(u8::MAX as u64 + 1);
+        test_for_value(u16::MAX as u64);
+        test_for_value(u16::MAX as u64 + 1);
+        test_for_value(u32::MAX as u64);
+        test_for_value(u32::MAX as u64 + 1);
+        test_for_value(u64::MAX);
+    }
 }


### PR DESCRIPTION
# Description of change

Port https://github.com/MystenLabs/sui/commit/495def8285fc4a44a8bab7f17ae1cf07a91cebdb

From Sui's commit description:
Put tests in sui-types/object.rs in their own module
The tests are just floating around in the main module, which presumably
means they are also compiled into our production builds? They should go
into their own module, guarded by a #[cfg(test] annotation.

**Note that some files already include the changes in the Sui commit, thus only 1 file got changed.**

## Links to any relevant issues

Part of #3990 

## Type of change

- Enhancement 


## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
