### PR TITLE
Update version and mainnet chain id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,7 +1738,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "const-str",
  "git-version",
@@ -5732,7 +5732,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "iota"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5783,7 +5783,7 @@ dependencies = [
  "iota-package-management",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-simulator",
  "iota-source-validation",
  "iota-swarm",
@@ -5861,7 +5861,7 @@ dependencies = [
 
 [[package]]
 name = "iota-adapter-transactional-tests"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -5869,7 +5869,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "arrow",
@@ -5920,7 +5920,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer-derive"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5929,7 +5929,7 @@ dependencies = [
 
 [[package]]
 name = "iota-archival"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -5961,7 +5961,7 @@ dependencies = [
 
 [[package]]
 name = "iota-authority-aggregation"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "futures",
  "iota-metrics",
@@ -5972,7 +5972,7 @@ dependencies = [
 
 [[package]]
 name = "iota-aws-orchestrator"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "iota-benchmark"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6024,7 +6024,7 @@ dependencies = [
  "iota-metrics",
  "iota-network",
  "iota-protocol-config",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-simulator",
  "iota-storage",
  "iota-surfer",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "iota-bridge"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6074,7 +6074,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-keys",
  "iota-metrics",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-test-transaction-builder",
  "iota-types",
  "lru",
@@ -6101,7 +6101,7 @@ dependencies = [
 
 [[package]]
 name = "iota-bridge-cli"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -6112,7 +6112,7 @@ dependencies = [
  "iota-config",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-types",
  "move-core-types",
  "reqwest 0.12.7",
@@ -6127,7 +6127,7 @@ dependencies = [
 
 [[package]]
 name = "iota-bridge-indexer"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6143,7 +6143,7 @@ dependencies = [
  "iota-indexer-builder",
  "iota-json-rpc-types",
  "iota-metrics",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-test-transaction-builder",
  "iota-types",
  "prometheus",
@@ -6157,7 +6157,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cluster-test"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6175,7 +6175,7 @@ dependencies = [
  "iota-json",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-swarm",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -6197,7 +6197,7 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "futures",
  "parking_lot 0.12.3",
@@ -6207,7 +6207,7 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -6235,7 +6235,7 @@ dependencies = [
 
 [[package]]
 name = "iota-core"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -6337,7 +6337,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cost"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6392,7 +6392,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6429,7 +6429,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion-core"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "iota-e2e-tests"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6493,7 +6493,7 @@ dependencies = [
  "iota-node",
  "iota-protocol-config",
  "iota-rest-api",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-simulator",
  "iota-storage",
  "iota-swarm",
@@ -6524,7 +6524,7 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "serde_yaml",
 ]
@@ -6562,7 +6562,7 @@ dependencies = [
 
 [[package]]
 name = "iota-faucet"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6578,7 +6578,7 @@ dependencies = [
  "iota-keys",
  "iota-metrics",
  "iota-network-stack",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-types",
  "parking_lot 0.12.3",
  "prometheus",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6624,7 +6624,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6639,7 +6639,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-tests"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "datatest-stable",
  "iota-adapter-latest",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-builder"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6712,7 +6712,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -6722,7 +6722,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-config"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6730,7 +6730,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-e2e-tests"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "datatest-stable",
  "iota-graphql-rpc",
@@ -6741,7 +6741,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6781,7 +6781,7 @@ dependencies = [
  "iota-package-resolver",
  "iota-protocol-config",
  "iota-rest-api",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-swarm-config",
  "iota-test-transaction-builder",
  "iota-types",
@@ -6821,7 +6821,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-client"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6836,14 +6836,14 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-headers"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "axum",
 ]
 
 [[package]]
 name = "iota-http"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "axum",
  "bytes",
@@ -6864,7 +6864,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6895,7 +6895,7 @@ dependencies = [
  "iota-package-resolver",
  "iota-protocol-config",
  "iota-rest-api",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-swarm-config",
  "iota-test-transaction-builder",
  "iota-transaction-builder",
@@ -6926,7 +6926,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer-builder"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6961,7 +6961,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7019,7 +7019,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-tests"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7057,7 +7057,7 @@ dependencies = [
  "iota-open-rpc",
  "iota-open-rpc-macros",
  "iota-protocol-config",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-simulator",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -7076,7 +7076,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7108,7 +7108,7 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "bip32",
@@ -7127,7 +7127,7 @@ dependencies = [
 
 [[package]]
 name = "iota-light-client"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7138,7 +7138,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-package-resolver",
  "iota-rest-api",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-types",
  "log",
  "move-core-types",
@@ -7153,7 +7153,7 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -7163,7 +7163,7 @@ dependencies = [
 
 [[package]]
 name = "iota-mainnet-unlocks"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metric-checker"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "backoff",
@@ -7196,7 +7196,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "better_any",
@@ -7260,7 +7260,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -7283,7 +7283,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-lsp"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "bin-version",
  "clap",
@@ -7314,7 +7314,7 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "bcs",
  "iota-types",
@@ -7325,7 +7325,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -7363,7 +7363,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anemo",
  "bcs",
@@ -7387,7 +7387,7 @@ dependencies = [
 
 [[package]]
 name = "iota-node"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7438,7 +7438,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7462,7 +7462,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -7474,7 +7474,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-dump"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7491,11 +7491,11 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "iota-json-rpc-types",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-types",
  "move-core-types",
  "move-package",
@@ -7506,7 +7506,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7529,7 +7529,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -7539,7 +7539,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "clap",
  "insta",
@@ -7554,7 +7554,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7563,7 +7563,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proxy"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "axum",
@@ -7579,7 +7579,7 @@ dependencies = [
  "hex",
  "hyper 1.4.1",
  "iota-metrics",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-tls",
  "iota-types",
  "itertools 0.13.0",
@@ -7609,7 +7609,7 @@ dependencies = [
 
 [[package]]
 name = "iota-replay"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7625,7 +7625,7 @@ dependencies = [
  "iota-json-rpc-api",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-storage",
  "iota-transaction-checks",
  "iota-types",
@@ -7656,7 +7656,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7687,7 +7687,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-kv"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -7713,7 +7713,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rosetta"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7731,7 +7731,7 @@ dependencies = [
  "iota-metrics",
  "iota-move-build",
  "iota-node",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-swarm-config",
  "iota-types",
  "move-core-types",
@@ -7755,7 +7755,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rpc-loadgen"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7765,7 +7765,7 @@ dependencies = [
  "futures",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-types",
  "itertools 0.13.0",
  "serde",
@@ -7800,7 +7800,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7878,7 +7878,7 @@ dependencies = [
 
 [[package]]
 name = "iota-simulator"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7900,7 +7900,7 @@ dependencies = [
 
 [[package]]
 name = "iota-single-node-benchmark"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7934,7 +7934,7 @@ dependencies = [
 
 [[package]]
 name = "iota-snapshot"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7962,7 +7962,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "colored",
@@ -7972,7 +7972,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-test-transaction-builder",
  "iota-types",
  "move-binary-format",
@@ -7994,7 +7994,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation-service"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "axum",
@@ -8010,7 +8010,7 @@ dependencies = [
  "iota-metrics",
  "iota-move",
  "iota-move-build",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-source-validation",
  "jsonrpsee",
  "move-compiler",
@@ -8033,7 +8033,7 @@ dependencies = [
 
 [[package]]
 name = "iota-storage"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8088,7 +8088,7 @@ dependencies = [
 
 [[package]]
 name = "iota-surfer"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "async-trait",
  "bcs",
@@ -8117,7 +8117,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "futures",
@@ -8142,7 +8142,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm-config"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8169,12 +8169,12 @@ dependencies = [
 
 [[package]]
 name = "iota-test-transaction-builder"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "bcs",
  "iota-genesis-builder",
  "iota-move-build",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-types",
  "move-core-types",
  "shared-crypto",
@@ -8182,7 +8182,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8204,7 +8204,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tool"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -8226,7 +8226,7 @@ dependencies = [
  "iota-package-dump",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-snapshot",
  "iota-storage",
  "iota-types",
@@ -8249,7 +8249,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8265,7 +8265,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-checks"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "fastcrypto-zkp",
  "iota-config",
@@ -8279,7 +8279,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transactional-test-runner"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8329,7 +8329,7 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8411,7 +8411,7 @@ dependencies = [
 
 [[package]]
 name = "iota-upgrade-compatibility-transactional-tests"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "datatest-stable",
@@ -8425,7 +8425,7 @@ dependencies = [
 
 [[package]]
 name = "iota-util-mem"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "cfg-if",
  "ed25519-consensus",
@@ -8443,7 +8443,7 @@ dependencies = [
 
 [[package]]
 name = "iota-util-mem-derive"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "proc-macro2",
  "syn 1.0.109",
@@ -8467,7 +8467,7 @@ dependencies = [
 
 [[package]]
 name = "iota-verifier-transactional-tests"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -11860,7 +11860,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -13639,7 +13639,7 @@ dependencies = [
 
 [[package]]
 name = "shared-crypto"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "bcs",
  "eyre",
@@ -13758,7 +13758,7 @@ dependencies = [
 
 [[package]]
 name = "simulacrum"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14474,7 +14474,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry-subscribers"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -14561,7 +14561,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-cluster"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14581,7 +14581,7 @@ dependencies = [
  "iota-metrics",
  "iota-node",
  "iota-protocol-config",
- "iota-sdk 0.13.0-alpha",
+ "iota-sdk 1.1.0-alpha",
  "iota-simulator",
  "iota-swarm",
  "iota-swarm-config",
@@ -15363,7 +15363,7 @@ dependencies = [
 
 [[package]]
 name = "transaction-fuzzer"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "iota-core",
  "iota-move-build",
@@ -15456,7 +15456,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "async-trait",
  "bcs",
@@ -15487,7 +15487,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-derive"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -15497,7 +15497,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "serde",
  "thiserror 1.0.64",
@@ -15505,7 +15505,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-workspace-hack"
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 dependencies = [
  "libc",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by iota-core, iota-faucet, iota-node, iota-tools, iota-sdk, iota-move-build, and iota crates.
-version = "0.13.0-alpha"
+version = "1.1.0-alpha"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/crates/iota-graphql-e2e-tests/tests/call/simple.exp
+++ b/crates/iota-graphql-e2e-tests/tests/call/simple.exp
@@ -114,11 +114,11 @@ task 15, lines 64-69:
 Headers: {
     "content-type": "application/json",
     "content-length": "157",
-    "x-iota-rpc-version": "0.13.0-testing-no-sha",
+    "x-iota-rpc-version": "1.1.0-testing-no-sha",
     "vary": "origin, access-control-request-method, access-control-request-headers",
     "access-control-allow-origin": "*",
 }
-Service version: 0.13.0-testing-no-sha
+Service version: 1.1.0-testing-no-sha
 Response: {
   "data": {
     "checkpoint": {
@@ -375,7 +375,7 @@ Response: {
   "data": {
     "serviceConfig": {
       "availableVersions": [
-        "0.13"
+        "1.1"
       ]
     }
   }

--- a/crates/iota-move/src/manage_package.rs
+++ b/crates/iota-move/src/manage_package.rs
@@ -28,7 +28,7 @@ pub struct ManagePackage {
     /// using `iota client active-env`).
     pub environment: String,
     #[arg(long = "network-id")]
-    /// The network chain identifier. Use '35834a8a' for mainnet.
+    /// The network chain identifier. Use '6364aad5' for mainnet.
     pub chain_id: String,
     #[arg(long, value_parser = ObjectID::from_hex_literal)]
     /// The original address (Object ID) where this package is published.

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/iotaledger/iota/main/LICENSE"
     },
-    "version": "0.13.0-alpha"
+    "version": "1.1.0-alpha"
   },
   "methods": [
     {

--- a/crates/iota-types/src/digests.rs
+++ b/crates/iota-types/src/digests.rs
@@ -159,8 +159,7 @@ impl fmt::UpperHex for Digest {
 )]
 pub struct ChainIdentifier(pub(crate) CheckpointDigest);
 
-// TODO: https://github.com/iotaledger/iota/issues/5484
-pub const MAINNET_CHAIN_IDENTIFIER_BASE58: &str = "4btiuiMPvEENsttpZC7CZ53DruC3MAgfznDbASZ7DR6S";
+pub const MAINNET_CHAIN_IDENTIFIER_BASE58: &str = "7gzPnGnmjqvpmF7NXTCmtacXLqx1cMaJFV6GCmi1peqr";
 pub const TESTNET_CHAIN_IDENTIFIER_BASE58: &str = "3MhPzSaSTHGffwPSV2Ws2DaK8LR8DBGPozTd2CbiJRwe";
 
 pub static MAINNET_CHAIN_IDENTIFIER: OnceCell<ChainIdentifier> = OnceCell::new();
@@ -1052,7 +1051,7 @@ mod test {
 
     #[test]
     fn test_chain_id_mainnet() {
-        let chain_id = ChainIdentifier::from_chain_short_id("35834a8a");
+        let chain_id = ChainIdentifier::from_chain_short_id("6364aad5");
         assert_eq!(
             chain_id.unwrap().chain(),
             iota_protocol_config::Chain::Mainnet

--- a/docs/content/developer/iota-101/move-overview/package-upgrades/automated-address-management.mdx
+++ b/docs/content/developer/iota-101/move-overview/package-upgrades/automated-address-management.mdx
@@ -83,7 +83,7 @@ latest-published-id = "0xa6041ac57f9151d49d00dcdc4f79f8c5ba1e399e1005dcb0fdd1c86
 published-version = "1"
 
 [env.mainnet]
-chain-id = "35834a8a"
+chain-id = "6364aad5"
 original-published-id = "0xaee5759aedf6c533634cdd2de412f6e6dfc754a89b0ec554a73597348f334477"
 latest-published-id = "0xaee5759aedf6c533634cdd2de412f6e6dfc754a89b0ec554a73597348f334477"
 published-version = "1"

--- a/external-crates/move/crates/move-package/tests/test_lock_file.rs
+++ b/external-crates/move/crates/move-package/tests/test_lock_file.rs
@@ -232,7 +232,7 @@ fn test_update_managed_address() {
         "default",
         ManagedAddressUpdate::Published {
             original_id: "0x123".into(),
-            chain_id: "35834a8a".into(),
+            chain_id: "6364aad5".into(),
         },
     )
     .unwrap();
@@ -260,7 +260,7 @@ fn test_update_managed_address() {
             (
                 "default",
                 ManagedPackage {
-                    chain_id: "35834a8a",
+                    chain_id: "6364aad5",
                     original_published_id: "0x123",
                     latest_published_id: "0x456",
                     version: "2",


### PR DESCRIPTION
# Description of change

Changed version to `1.1.0-alpha` and updated mainnet chain id.

## Links to any relevant issues

fixes #5484

