### PR TITLE
feat(consensus): Remove conflicting tx retry logic

### DIFF
--- a/crates/iota-core/src/authority_aggregator.rs
+++ b/crates/iota-core/src/authority_aggregator.rs
@@ -239,18 +239,6 @@ pub enum AggregatorProcessTransactionError {
     },
 
     #[error(
-        "Validators returned conflicting transactions but it is potentially recoverable. Locked objects: {:?}. Validator errors: {:?}",
-        conflicting_tx_digests,
-        errors
-    )]
-    RetryableConflictingTransaction {
-        conflicting_tx_digest_to_retry: Option<TransactionDigest>,
-        errors: GroupedErrors,
-        conflicting_tx_digests:
-            BTreeMap<TransactionDigest, (Vec<(AuthorityName, ObjectRef)>, StakeUnit)>,
-    },
-
-    #[error(
         "{} of the validators by stake are overloaded with transactions pending execution. Validator errors: {:?}",
         overloaded_stake,
         errors
@@ -368,40 +356,18 @@ struct ProcessTransactionState {
     overloaded_stake: StakeUnit,
     // Validators that are overloaded and request client to retry.
     retryable_overload_info: RetryableOverloadInfo,
-    // If there are conflicting transactions, we note them down and may attempt to retry
+    // If there are conflicting transactions, we note them down to report to user.
     conflicting_tx_digests:
         BTreeMap<TransactionDigest, (Vec<(AuthorityName, ObjectRef)>, StakeUnit)>,
     // As long as none of the exit criteria are met we consider the state retryable
     // 1) >= 2f+1 signatures
     // 2) >= f+1 non-retryable errors
     // 3) >= 2f+1 object not found errors
-    // Note: For conflicting transactions we collect as many responses as possible
-    // before we know for sure no tx can reach quorum. Namely, stake of the most
-    // promising tx + retryable stake < 2f+1.
     retryable: bool,
     tx_finalized_with_different_user_sig: bool,
-
-    conflicting_tx_total_stake: StakeUnit,
-    most_staked_conflicting_tx_stake: StakeUnit,
 }
 
 impl ProcessTransactionState {
-    /// Returns the conflicting transaction digest and its validators with the
-    /// most stake.
-    #[expect(clippy::type_complexity)]
-    pub fn conflicting_tx_digest_with_most_stake(
-        &self,
-    ) -> Option<(
-        TransactionDigest,
-        &Vec<(AuthorityName, ObjectRef)>,
-        StakeUnit,
-    )> {
-        self.conflicting_tx_digests
-            .iter()
-            .max_by_key(|(_, (_, stake))| *stake)
-            .map(|(digest, (validators, stake))| (*digest, validators, *stake))
-    }
-
     /// Records the conflicting transaction, returns `true` if there is any, and
     /// returns `false` otherwise.
     pub fn record_conflicting_transaction_if_any(
@@ -409,7 +375,7 @@ impl ProcessTransactionState {
         validator_name: AuthorityName,
         weight: StakeUnit,
         err: &IotaError,
-    ) -> bool {
+    ) {
         if let IotaError::ObjectLockConflict {
             obj_ref,
             pending_transaction: transaction,
@@ -421,13 +387,7 @@ impl ProcessTransactionState {
                 .or_insert((Vec::new(), 0));
             lock_records.push((validator_name, *obj_ref));
             *total_stake += weight;
-            self.conflicting_tx_total_stake += weight;
-            if *total_stake > self.most_staked_conflicting_tx_stake {
-                self.most_staked_conflicting_tx_stake = *total_stake;
-            }
-            return true;
         }
-        false
     }
 
     /// Checks if the error indicates that the transaction is already finalized.
@@ -1091,9 +1051,7 @@ where
             retryable_overload_info: Default::default(),
             retryable: true,
             conflicting_tx_digests: Default::default(),
-            conflicting_tx_total_stake: 0,
             tx_finalized_with_different_user_sig: false,
-            most_staked_conflicting_tx_stake: 0,
         };
 
         let transaction_ref = &transaction;
@@ -1135,6 +1093,8 @@ where
                                     .with_label_values(&[display_name.as_str(), err.as_ref()])
                                     .inc();
                                 Self::record_rpc_error_maybe(self.metrics.clone(), &display_name, &err);
+                                // Record conflicting transactions if any to report to user.
+                                state.record_conflicting_transaction_if_any(name, weight, &err);
                                 let (retryable, categorized) = err.is_retryable();
                                 if !categorized {
                                     // TODO: Should minimize possible uncategorized errors here
@@ -1167,9 +1127,7 @@ where
                                     // code path to handle both overload scenarios.
                                     state.retryable_overload_info.add_stake_retryable_overload(weight, Duration::from_secs(err.retry_after_secs()));
                                 }
-                                else if !retryable && !state.record_conflicting_transaction_if_any(name, weight, &err) {
-                                    // We don't count conflicting transactions as non-retryable errors here
-                                    // because its handling is a bit different.
+                                else if !retryable {
                                     state.non_retryable_stake += weight;
                                 }
                                 state.errors.push((err, vec![name], weight));
@@ -1179,12 +1137,10 @@ where
 
                         let retryable_stake = self.get_retryable_stake(&state);
                         let good_stake = std::cmp::max(state.tx_signatures.total_votes(), state.effects_map.total_votes());
-                        let stake_of_most_promising_tx = std::cmp::max(good_stake, state.most_staked_conflicting_tx_stake);
-                        if stake_of_most_promising_tx + retryable_stake < quorum_threshold {
+                        if good_stake + retryable_stake < quorum_threshold {
                             debug!(
                                 tx_digest = ?tx_digest,
                                 good_stake,
-                                most_staked_conflicting_tx_stake =? state.most_staked_conflicting_tx_stake,
                                 retryable_stake,
                                 "No chance for any tx to get quorum, exiting. Conflicting_txes: {:?}",
                                 state.conflicting_tx_digests
@@ -1217,7 +1173,7 @@ where
             Err(state) => {
                 self.record_process_transaction_metrics(tx_digest, &state);
                 let state = self.record_non_quorum_effects_maybe(tx_digest, state);
-                Err(self.handle_process_transaction_error(tx_digest, state))
+                Err(self.handle_process_transaction_error(state))
             }
         }
     }
@@ -1235,7 +1191,6 @@ where
     /// Handles the transaction processing error.
     fn handle_process_transaction_error(
         &self,
-        original_tx_digest: &TransactionDigest,
         state: ProcessTransactionState,
     ) -> AggregatorProcessTransactionError {
         let quorum_threshold = self.committee.quorum_threshold();
@@ -1248,49 +1203,6 @@ where
             };
         }
 
-        // Handle possible conflicts first as `FatalConflictingTransaction` is
-        // more meaningful than `FatalTransaction`.
-        if let Some((most_staked_conflicting_tx, validators, most_staked_conflicting_tx_stake)) =
-            state.conflicting_tx_digest_with_most_stake()
-        {
-            let good_stake = state.tx_signatures.total_votes();
-            let retryable_stake = self.get_retryable_stake(&state);
-
-            if good_stake + retryable_stake >= quorum_threshold {
-                return AggregatorProcessTransactionError::RetryableConflictingTransaction {
-                    errors: group_errors(state.errors),
-                    conflicting_tx_digest_to_retry: None,
-                    conflicting_tx_digests: state.conflicting_tx_digests,
-                };
-            }
-
-            if most_staked_conflicting_tx_stake + retryable_stake >= quorum_threshold {
-                return AggregatorProcessTransactionError::RetryableConflictingTransaction {
-                    errors: group_errors(state.errors),
-                    conflicting_tx_digest_to_retry: Some(most_staked_conflicting_tx),
-                    conflicting_tx_digests: state.conflicting_tx_digests,
-                };
-            }
-
-            warn!(
-                ?state.conflicting_tx_digests,
-                ?most_staked_conflicting_tx,
-                ?original_tx_digest,
-                original_tx_stake = good_stake,
-                most_staked_conflicting_tx_stake = most_staked_conflicting_tx_stake,
-                "Client double spend attempt detected: {:?}",
-                validators
-            );
-            self.metrics
-                .total_client_double_spend_attempts_detected
-                .inc();
-
-            return AggregatorProcessTransactionError::FatalConflictingTransaction {
-                errors: group_errors(state.errors),
-                conflicting_tx_digests: state.conflicting_tx_digests,
-            };
-        }
-
         if !state.retryable {
             if state.tx_finalized_with_different_user_sig
                 || state.check_if_error_indicates_tx_finalized_with_different_user_sig(
@@ -1299,6 +1211,25 @@ where
             {
                 return AggregatorProcessTransactionError::TxAlreadyFinalizedWithDifferentUserSignatures;
             }
+
+            // Handle conflicts first as `FatalConflictingTransaction` which is
+            // more meaningful than `FatalTransaction`
+            if !state.conflicting_tx_digests.is_empty() {
+                let good_stake = state.tx_signatures.total_votes();
+                warn!(
+                    ?state.conflicting_tx_digests,
+                    original_tx_stake = good_stake,
+                    "Client double spend attempt detected!",
+                );
+                self.metrics
+                    .total_client_double_spend_attempts_detected
+                    .inc();
+                return AggregatorProcessTransactionError::FatalConflictingTransaction {
+                    errors: group_errors(state.errors),
+                    conflicting_tx_digests: state.conflicting_tx_digests,
+                };
+            }
+
             return AggregatorProcessTransactionError::FatalTransaction {
                 errors: group_errors(state.errors),
             };
@@ -1324,8 +1255,7 @@ where
             };
         }
 
-        // No conflicting transaction, the system is not overloaded and transaction
-        // state is still retryable.
+        // The system is not overloaded and transaction state is still retryable.
         AggregatorProcessTransactionError::RetryableTransaction {
             errors: group_errors(state.errors),
         }
@@ -1537,7 +1467,6 @@ where
     /// Gets the retryable stake for the transaction.
     fn get_retryable_stake(&self, state: &ProcessTransactionState) -> StakeUnit {
         self.committee.total_votes()
-            - state.conflicting_tx_total_stake
             - state.non_retryable_stake
             - state.effects_map.total_votes()
             - state.tx_signatures.total_votes()

--- a/crates/iota-core/src/quorum_driver/metrics.rs
+++ b/crates/iota-core/src/quorum_driver/metrics.rs
@@ -29,10 +29,6 @@ pub struct QuorumDriverMetrics {
     // TODO: add histogram of attempt that tx succeeds
     pub(crate) current_requests_in_flight: IntGauge,
 
-    pub(crate) total_err_process_tx_responses_with_nonzero_conflicting_transactions: IntCounter,
-    pub(crate) total_attempts_retrying_conflicting_transaction: IntCounter,
-    pub(crate) total_successful_attempts_retrying_conflicting_transaction: IntCounter,
-    pub(crate) total_times_conflicting_transaction_already_finalized_when_retrying: IntCounter,
     pub(crate) total_retryable_overload_errors: IntCounter,
     pub(crate) transaction_retry_count: Histogram,
     pub(crate) current_transactions_in_retry: IntGauge,
@@ -77,30 +73,6 @@ impl QuorumDriverMetrics {
             current_requests_in_flight: register_int_gauge_with_registry!(
                 "current_requests_in_flight",
                 "Current number of requests being processed in QuorumDriver",
-                registry,
-            )
-            .unwrap(),
-            total_err_process_tx_responses_with_nonzero_conflicting_transactions: register_int_counter_with_registry!(
-                "quorum_driver_total_err_process_tx_responses_with_nonzero_conflicting_transactions",
-                "Total number of err process_tx responses with non empty conflicting transactions",
-                registry,
-            )
-            .unwrap(),
-            total_attempts_retrying_conflicting_transaction: register_int_counter_with_registry!(
-                "quorum_driver_total_attempts_trying_conflicting_transaction",
-                "Total number of attempts to retry a conflicting transaction",
-                registry,
-            )
-            .unwrap(),
-            total_successful_attempts_retrying_conflicting_transaction: register_int_counter_with_registry!(
-                "quorum_driver_total_successful_attempts_trying_conflicting_transaction",
-                "Total number of successful attempts to retry a conflicting transaction",
-                registry,
-            )
-            .unwrap(),
-            total_times_conflicting_transaction_already_finalized_when_retrying: register_int_counter_with_registry!(
-                "quorum_driver_total_times_conflicting_transaction_already_finalized_when_retrying",
-                "Total number of times the conflicting transaction is already finalized when retrying",
                 registry,
             )
             .unwrap(),

--- a/crates/iota-core/src/quorum_driver/metrics.rs
+++ b/crates/iota-core/src/quorum_driver/metrics.rs
@@ -69,7 +69,8 @@ impl QuorumDriverMetrics {
                 "Total attempt times of ok response",
                 iota_metrics::COUNT_BUCKETS.to_vec(),
                 registry,
-            ).unwrap(),
+            )
+            .unwrap(),
             current_requests_in_flight: register_int_gauge_with_registry!(
                 "current_requests_in_flight",
                 "Current number of requests being processed in QuorumDriver",
@@ -87,7 +88,8 @@ impl QuorumDriverMetrics {
                 "Histogram of transaction retry count",
                 iota_metrics::COUNT_BUCKETS.to_vec(),
                 registry,
-            ).unwrap(),
+            )
+            .unwrap(),
             current_transactions_in_retry: register_int_gauge_with_registry!(
                 "current_transactions_in_retry",
                 "Current number of transactions in retry loop in QuorumDriver",

--- a/crates/iota-core/src/quorum_driver/mod.rs
+++ b/crates/iota-core/src/quorum_driver/mod.rs
@@ -8,7 +8,6 @@ pub use metrics::*;
 pub mod reconfig_observer;
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
     fmt::{Debug, Formatter, Write},
     net::SocketAddr,
     sync::Arc,
@@ -22,11 +21,10 @@ use iota_metrics::{
     GaugeGuard, TX_TYPE_SHARED_OBJ_TX, TX_TYPE_SINGLE_WRITER_TX, spawn_monitored_task,
 };
 use iota_types::{
-    base_types::{AuthorityName, ObjectRef, TransactionDigest},
-    committee::{Committee, EpochId, StakeUnit},
+    base_types::TransactionDigest,
+    committee::{Committee, EpochId},
     error::{IotaError, IotaResult},
     messages_grpc::HandleCertificateRequestV1,
-    messages_safe_client::PlainTransactionInfoResponse,
     quorum_driver_types::{
         ExecuteTransactionRequestV1, QuorumDriverEffectsQueueResult, QuorumDriverError,
         QuorumDriverResponse, QuorumDriverResult,
@@ -309,8 +307,7 @@ where
         let tx_digest = *transaction.digest();
         let result = auth_agg.process_transaction(transaction, client_addr).await;
 
-        self.process_transaction_result(result, tx_digest, client_addr)
-            .await
+        self.process_transaction_result(result, tx_digest).await
     }
 
     #[instrument(level = "trace", skip_all)]
@@ -318,44 +315,9 @@ where
         &self,
         result: Result<ProcessTransactionResult, AggregatorProcessTransactionError>,
         tx_digest: TransactionDigest,
-        client_addr: Option<SocketAddr>,
     ) -> Result<ProcessTransactionResult, Option<QuorumDriverError>> {
         match result {
             Ok(resp) => Ok(resp),
-            Err(AggregatorProcessTransactionError::RetryableConflictingTransaction {
-                conflicting_tx_digest_to_retry,
-                errors,
-                conflicting_tx_digests,
-            }) => {
-                self.metrics
-                    .total_err_process_tx_responses_with_nonzero_conflicting_transactions
-                    .inc();
-                debug!(
-                    ?tx_digest,
-                    "Observed {} conflicting transactions: {:?}",
-                    conflicting_tx_digests.len(),
-                    conflicting_tx_digests
-                );
-
-                if let Some(conflicting_tx_digest) = conflicting_tx_digest_to_retry {
-                    self.process_conflicting_tx(
-                        tx_digest,
-                        conflicting_tx_digest,
-                        conflicting_tx_digests,
-                        client_addr,
-                    )
-                    .await
-                } else {
-                    // If no retryable conflicting transaction was returned that means we have >=
-                    // 2f+1 good stake for the original transaction + retryable
-                    // stake. Will continue to retry the original transaction.
-                    debug!(
-                        ?errors,
-                        "Observed Tx {tx_digest:} is still in retryable state. Conflicting Txes: {conflicting_tx_digests:?}",
-                    );
-                    Err(None)
-                }
-            }
 
             Err(AggregatorProcessTransactionError::FatalConflictingTransaction {
                 errors,
@@ -367,7 +329,6 @@ where
                 );
                 Err(Some(QuorumDriverError::ObjectsDoubleUsed {
                     conflicting_txes: conflicting_tx_digests,
-                    retried_tx_status: None,
                 }))
             }
 
@@ -426,66 +387,6 @@ where
         }
     }
 
-    #[instrument(level = "trace", skip_all)]
-    async fn process_conflicting_tx(
-        &self,
-        tx_digest: TransactionDigest,
-        conflicting_tx_digest: TransactionDigest,
-        conflicting_tx_digests: BTreeMap<
-            TransactionDigest,
-            (Vec<(AuthorityName, ObjectRef)>, StakeUnit),
-        >,
-        client_addr: Option<SocketAddr>,
-    ) -> Result<ProcessTransactionResult, Option<QuorumDriverError>> {
-        // Safe to unwrap because tx_digest_to_retry is generated from
-        // conflicting_tx_digests
-        // in ProcessTransactionState::conflicting_tx_digest_with_most_stake()
-        let (validators, _) = conflicting_tx_digests.get(&conflicting_tx_digest).unwrap();
-        let attempt_result = self
-            .attempt_conflicting_transaction(
-                &conflicting_tx_digest,
-                &tx_digest,
-                validators.iter().map(|(pub_key, _)| *pub_key).collect(),
-                client_addr,
-            )
-            .await;
-        self.metrics
-            .total_attempts_retrying_conflicting_transaction
-            .inc();
-
-        match attempt_result {
-            Err(err) => {
-                debug!(
-                    ?tx_digest,
-                    ?conflicting_tx_digest,
-                    "Encountered error while attempting conflicting transaction: {:?}",
-                    err
-                );
-                Err(Some(QuorumDriverError::ObjectsDoubleUsed {
-                    conflicting_txes: conflicting_tx_digests,
-                    retried_tx_status: None,
-                }))
-            }
-            Ok(success) => {
-                debug!(
-                    ?tx_digest,
-                    ?conflicting_tx_digest,
-                    "Retried conflicting transaction. Success: {}",
-                    success
-                );
-                if success {
-                    self.metrics
-                        .total_successful_attempts_retrying_conflicting_transaction
-                        .inc();
-                }
-                Err(Some(QuorumDriverError::ObjectsDoubleUsed {
-                    conflicting_txes: conflicting_tx_digests,
-                    retried_tx_status: Some((conflicting_tx_digest, success)),
-                }))
-            }
-        }
-    }
-
     #[instrument(level = "trace", skip_all, fields(tx_digest = ?request.certificate.digest()))]
     pub(crate) async fn process_certificate(
         &self,
@@ -529,99 +430,6 @@ where
             new_validators.committee
         );
         self.validators.store(new_validators);
-    }
-
-    /// Returns Some(true) if the conflicting transaction is executed
-    /// successfully (or already executed), or Some(false) if it did not.
-    #[instrument(level = "trace", skip_all)]
-    async fn attempt_conflicting_transaction(
-        &self,
-        tx_digest: &TransactionDigest,
-        original_tx_digest: &TransactionDigest,
-        validators: BTreeSet<AuthorityName>,
-        client_addr: Option<SocketAddr>,
-    ) -> IotaResult<bool> {
-        let response = self
-            .validators
-            .load()
-            .handle_transaction_info_request_from_some_validators(
-                tx_digest,
-                &validators,
-                Some(Duration::from_secs(10)),
-            )
-            .await?;
-
-        // If we are able to get a certificate right away, we use it and execute the
-        // cert; otherwise, we have to re-form a cert and execute it.
-        let transaction = match response {
-            PlainTransactionInfoResponse::ExecutedWithCert(cert, _, _) => {
-                self.metrics
-                    .total_times_conflicting_transaction_already_finalized_when_retrying
-                    .inc();
-                // We still want to ask validators to execute this certificate in case this
-                // certificate is not known to the rest of them (e.g. when
-                // *this* validator is bad).
-                let result = self
-                    .validators
-                    .load()
-                    .process_certificate(
-                        HandleCertificateRequestV1 {
-                            certificate: cert,
-                            include_events: true,
-                            include_input_objects: false,
-                            include_output_objects: false,
-                            include_auxiliary_data: false,
-                        },
-                        client_addr,
-                    )
-                    .await
-                    .tap_ok(|_resp| {
-                        debug!(
-                            ?tx_digest,
-                            ?original_tx_digest,
-                            "Retry conflicting transaction certificate succeeded."
-                        );
-                    })
-                    .tap_err(|err| {
-                        debug!(
-                            ?tx_digest,
-                            ?original_tx_digest,
-                            "Retry conflicting transaction certificate got an error: {:?}",
-                            err
-                        );
-                    });
-                // We only try it once.
-                return Ok(result.is_ok());
-            }
-            PlainTransactionInfoResponse::Signed(signed) => {
-                signed.verify_committee_sigs_only(&self.clone_committee())?;
-                signed.into_unsigned()
-            }
-            PlainTransactionInfoResponse::ExecutedWithoutCert(transaction, _, _) => transaction,
-        };
-        // Now ask validators to execute this transaction.
-        let result = self
-            .validators
-            .load()
-            .execute_transaction_block(&transaction, client_addr)
-            .await
-            .tap_ok(|_resp| {
-                debug!(
-                    ?tx_digest,
-                    ?original_tx_digest,
-                    "Retry conflicting transaction succeeded."
-                );
-            })
-            .tap_err(|err| {
-                debug!(
-                    ?tx_digest,
-                    ?original_tx_digest,
-                    "Retry conflicting transaction got an error: {:?}",
-                    err
-                );
-            });
-        // We only try it once
-        Ok(result.is_ok())
     }
 }
 

--- a/crates/iota-core/src/quorum_driver/tests.rs
+++ b/crates/iota-core/src/quorum_driver/tests.rs
@@ -417,22 +417,47 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
 
     let tx3 = make_tx(&gas, sender, &keypair, rgp);
 
-    let res = quorum_driver
-        .submit_transaction(ExecuteTransactionRequestV1::new(tx3))
-        .await
-        .unwrap()
+    let mut res = quorum_driver
+        .submit_transaction(ExecuteTransactionRequestV1::new(tx3.clone()))
+        .await?
         .await;
 
+    // If the quorum driver got responses from client0 and client1, it will return
+    // early with only 1 conflicting transaction. Let's retry a couple of times to
+    // get responses from a validator that has signed tx2 as well.
+    // This way we only retry this part instead of failing and re-trying the whole
+    // test.
+    for _ in 0..8 {
+        if let Err(QuorumDriverError::ObjectsDoubleUsed { conflicting_txes }) = &res {
+            if conflicting_txes.len() == 2 {
+                break;
+            }
+        } else {
+            panic!(
+                "expect Err(QuorumDriverError::ObjectsDoubleUsed) but got {:?}",
+                res
+            );
+        }
+
+        res = quorum_driver
+            .submit_transaction(ExecuteTransactionRequestV1::new(tx3.clone()))
+            .await?
+            .await;
+    }
+
     if let Err(QuorumDriverError::ObjectsDoubleUsed { conflicting_txes }) = res {
-        assert_eq!(conflicting_txes.len(), 2);
         let tx_stake = conflicting_txes.get(tx.digest()).unwrap().1;
-        assert!(tx_stake == 2500 || tx_stake == 5000);
+        // The tx_stake returned by the QuorumDriver is 2500 despite tx1 being signed by
+        // two validators. It's because QuorumDriver only considers a response from one
+        // of the validators that signed tx1 and one validator that signed tx2
+        // to see that tx3 will never reach quorum and return early.
+        assert_eq!(tx_stake, 2500);
         assert_eq!(conflicting_txes.get(tx2.digest()).unwrap().1, 2500);
     } else {
         panic!(
             "expect Err(QuorumDriverError::ObjectsDoubleUsed) but got {:?}",
             res
-        )
+        );
     }
 
     println!(

--- a/crates/iota-core/src/quorum_driver/tests.rs
+++ b/crates/iota-core/src/quorum_driver/tests.rs
@@ -314,12 +314,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
     // there are not enough retryable errors to push the original tx or the most
     // staked conflicting tx >= 2f+1 stake. Neither transaction can be retried
     // due to client double spend and this is a fatal error.
-    if let Err(QuorumDriverError::ObjectsDoubleUsed {
-        conflicting_txes,
-        retried_tx_status,
-    }) = res
-    {
-        assert_eq!(retried_tx_status, None);
+    if let Err(QuorumDriverError::ObjectsDoubleUsed { conflicting_txes }) = res {
         assert_eq!(conflicting_txes.len(), 1);
         assert_eq!(conflicting_txes.iter().next().unwrap().0, tx.digest());
     } else {
@@ -360,12 +355,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
         .unwrap()
         .await;
     // Aggregator gets three bad responses, and tries tx, which should succeed.
-    if let Err(QuorumDriverError::ObjectsDoubleUsed {
-        conflicting_txes,
-        retried_tx_status,
-    }) = res
-    {
-        assert_eq!(retried_tx_status, Some((*tx.digest(), true)));
+    if let Err(QuorumDriverError::ObjectsDoubleUsed { conflicting_txes }) = res {
         assert_eq!(conflicting_txes.len(), 1);
         assert_eq!(conflicting_txes.iter().next().unwrap().0, tx.digest());
     } else {
@@ -433,12 +423,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
         .unwrap()
         .await;
 
-    if let Err(QuorumDriverError::ObjectsDoubleUsed {
-        conflicting_txes,
-        retried_tx_status,
-    }) = res
-    {
-        assert_eq!(retried_tx_status, None);
+    if let Err(QuorumDriverError::ObjectsDoubleUsed { conflicting_txes }) = res {
         assert_eq!(conflicting_txes.len(), 2);
         let tx_stake = conflicting_txes.get(tx.digest()).unwrap().1;
         assert!(tx_stake == 2500 || tx_stake == 5000);
@@ -480,12 +465,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
         .unwrap()
         .await;
 
-    if let Err(QuorumDriverError::ObjectsDoubleUsed {
-        conflicting_txes,
-        retried_tx_status,
-    }) = res
-    {
-        assert_eq!(retried_tx_status, None);
+    if let Err(QuorumDriverError::ObjectsDoubleUsed { conflicting_txes }) = res {
         assert_eq!(conflicting_txes.len(), 1);
         assert_eq!(conflicting_txes.get(tx.digest()).unwrap().1, 5000);
     } else {
@@ -563,12 +543,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
         .unwrap()
         .await;
 
-    if let Err(QuorumDriverError::ObjectsDoubleUsed {
-        conflicting_txes,
-        retried_tx_status,
-    }) = res
-    {
-        assert_eq!(retried_tx_status, None);
+    if let Err(QuorumDriverError::ObjectsDoubleUsed { conflicting_txes }) = res {
         assert!(conflicting_txes.len() == 3 || conflicting_txes.len() == 2);
         assert!(
             conflicting_txes

--- a/crates/iota-core/src/quorum_driver/tests.rs
+++ b/crates/iota-core/src/quorum_driver/tests.rs
@@ -417,47 +417,25 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
 
     let tx3 = make_tx(&gas, sender, &keypair, rgp);
 
-    let mut res = quorum_driver
+    let res = quorum_driver
         .submit_transaction(ExecuteTransactionRequestV1::new(tx3.clone()))
         .await?
         .await;
 
-    // If the quorum driver got responses from client0 and client1, it will return
-    // early with only 1 conflicting transaction. Let's retry a couple of times to
-    // get responses from a validator that has signed tx2 as well.
-    // This way we only retry this part instead of failing and re-trying the whole
-    // test.
-    for _ in 0..8 {
-        if let Err(QuorumDriverError::ObjectsDoubleUsed { conflicting_txes }) = &res {
-            if conflicting_txes.len() == 2 {
-                break;
-            }
-        } else {
-            panic!(
-                "expect Err(QuorumDriverError::ObjectsDoubleUsed) but got {:?}",
-                res
-            );
-        }
-
-        res = quorum_driver
-            .submit_transaction(ExecuteTransactionRequestV1::new(tx3.clone()))
-            .await?
-            .await;
-    }
-
     if let Err(QuorumDriverError::ObjectsDoubleUsed { conflicting_txes }) = res {
         let tx_stake = conflicting_txes.get(tx.digest()).unwrap().1;
-        // The tx_stake returned by the QuorumDriver is 2500 despite tx1 being signed by
-        // two validators. It's because QuorumDriver only considers a response from one
-        // of the validators that signed tx1 and one validator that signed tx2
-        // to see that tx3 will never reach quorum and return early.
-        assert_eq!(tx_stake, 2500);
-        assert_eq!(conflicting_txes.get(tx2.digest()).unwrap().1, 2500);
+        if tx_stake == 5000 {
+            assert_eq!(conflicting_txes.len(), 1);
+        } else {
+            assert_eq!(conflicting_txes.len(), 2);
+            assert_eq!(tx_stake, 2500);
+            assert_eq!(conflicting_txes.get(tx2.digest()).unwrap().1, 2500);
+        }
     } else {
         panic!(
             "expect Err(QuorumDriverError::ObjectsDoubleUsed) but got {:?}",
             res
-        );
+        )
     }
 
     println!(

--- a/crates/iota-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_aggregator_tests.rs
@@ -1548,10 +1548,7 @@ async fn test_handle_conflicting_transaction_response() {
         |e| {
             matches!(
                 e,
-                AggregatorProcessTransactionError::RetryableConflictingTransaction {
-                    conflicting_tx_digest_to_retry,
-                    ..
-                } if conflicting_tx_digest_to_retry.is_none()
+                AggregatorProcessTransactionError::RetryableTransaction { .. }
             )
         },
         |e| matches!(e, IotaError::ObjectLockConflict { .. } | IotaError::Rpc(..)),
@@ -1576,17 +1573,14 @@ async fn test_handle_conflicting_transaction_response() {
         |e| {
             matches!(
                 e,
-                AggregatorProcessTransactionError::RetryableConflictingTransaction {
-                    conflicting_tx_digest_to_retry,
-                    ..
-                } if conflicting_tx_digest_to_retry.is_none()
+                AggregatorProcessTransactionError::RetryableTransaction { .. }
             )
         },
         |e| matches!(e, IotaError::ObjectLockConflict { .. } | IotaError::Rpc(..)),
     )
     .await;
 
-    println!("Case 2 - Non-retryable Tx but Retryable Conflicting Transaction");
+    println!("Case 2 - Non-retryable Tx1 due to conflicting Tx2");
     // Validators return >= f+1 conflicting Tx2
     set_retryable_tx_info_response_error(&mut clients, &authority_keys);
     for (name, _) in authority_keys.iter().skip(1) {
@@ -1603,10 +1597,10 @@ async fn test_handle_conflicting_transaction_response() {
         |e| {
             matches!(
                 e,
-                AggregatorProcessTransactionError::RetryableConflictingTransaction {
-                    conflicting_tx_digest_to_retry,
+                AggregatorProcessTransactionError::FatalConflictingTransaction {
+                    conflicting_tx_digests,
                     ..
-                } if *conflicting_tx_digest_to_retry == Some(*conflicting_tx2.digest())
+                } if conflicting_tx_digests.contains_key(conflicting_tx2.digest())
             )
         },
         |e| matches!(e, IotaError::ObjectLockConflict { .. } | IotaError::Rpc(..)),
@@ -1630,14 +1624,17 @@ async fn test_handle_conflicting_transaction_response() {
         |e| {
             matches!(
                 e,
-                AggregatorProcessTransactionError::FatalConflictingTransaction { .. }
+                AggregatorProcessTransactionError::FatalConflictingTransaction {
+                    conflicting_tx_digests,
+                    ..
+                } if conflicting_tx_digests.contains_key(conflicting_tx2.digest())
             )
         },
         |e| matches!(e, IotaError::ObjectLockConflict { .. }),
     )
     .await;
 
-    println!("Case 3 - Non-retryable Tx (Mixed Response - 2 conflicts, 1 signed, 1 non-retryable)");
+    println!("Case 4 - Non-retryable Tx (Mixed Response - 2 conflicts, 1 signed, 1 non-retryable)");
     // Validator 1 returns a signed tx1
     set_tx_info_response_with_signed_tx(&mut clients, &authority_keys, &tx1, 0);
     // Validator 2 returns a conflicting tx2
@@ -1675,7 +1672,10 @@ async fn test_handle_conflicting_transaction_response() {
         |e| {
             matches!(
                 e,
-                AggregatorProcessTransactionError::FatalConflictingTransaction { .. }
+                AggregatorProcessTransactionError::FatalConflictingTransaction {
+                    conflicting_tx_digests,
+                    ..
+                } if !conflicting_tx_digests.is_empty()
             )
         },
         |e| {
@@ -1689,7 +1689,7 @@ async fn test_handle_conflicting_transaction_response() {
     .await;
 
     println!(
-        "Case 3.1 - Non-retryable Tx (Mixed Response - 1 conflict, 1 signed, 1 non-retryable, 1 retryable)"
+        "Case 4.1 - Non-retryable Tx (Mixed Response - 1 conflict, 1 signed, 1 non-retryable, 1 retryable)"
     );
     // Validator 1 returns a signed tx1
     set_tx_info_response_with_signed_tx(&mut clients, &authority_keys, &tx1, 0);
@@ -1728,7 +1728,12 @@ async fn test_handle_conflicting_transaction_response() {
         |e| {
             matches!(
                 e,
-                AggregatorProcessTransactionError::FatalConflictingTransaction { .. }
+                AggregatorProcessTransactionError::FatalConflictingTransaction {
+                    conflicting_tx_digests,
+                    ..
+                } if conflicting_tx_digests.contains_key(conflicting_tx2.digest()) &&
+                conflicting_tx_digests.contains_key(conflicting_tx3.digest())
+
             )
         },
         |e| {
@@ -1741,7 +1746,7 @@ async fn test_handle_conflicting_transaction_response() {
     .await;
 
     println!(
-        "Case 3.2 - Non-retryable Tx (Mixed Response - 1 conflict, 1 signed, 1 non-retryable, 1 ObjectNotFoundError)"
+        "Case 4.2 - Non-retryable Tx (Mixed Response - 1 conflict, 1 signed, 1 non-retryable, 1 ObjectNotFoundError)"
     );
     // Validator 1 returns a signed tx1
     set_tx_info_response_with_signed_tx(&mut clients, &authority_keys, &tx1, 0);
@@ -1768,7 +1773,10 @@ async fn test_handle_conflicting_transaction_response() {
         |e| {
             matches!(
                 e,
-                AggregatorProcessTransactionError::FatalConflictingTransaction { .. }
+                AggregatorProcessTransactionError::FatalConflictingTransaction {
+                    conflicting_tx_digests,
+                    ..
+                } if conflicting_tx_digests.contains_key(conflicting_tx2.digest())
             )
         },
         |e| {
@@ -1782,7 +1790,7 @@ async fn test_handle_conflicting_transaction_response() {
     )
     .await;
 
-    println!("Case 4 - Successful Conflicting Transaction with Cert");
+    println!("Case 5 - Successful Conflicting Transaction with Cert");
     // All Validators gives signed-tx
     set_tx_info_response_with_signed_tx(&mut clients, &authority_keys, &tx1, 0);
 
@@ -1821,7 +1829,7 @@ async fn test_handle_conflicting_transaction_response() {
         .await
         .unwrap();
 
-    println!("Case 5 - Retryable Transaction (MissingCommitteeAtEpoch Error)");
+    println!("Case 6 - Retryable Transaction (MissingCommitteeAtEpoch Error)");
     // Validators return signed-tx with epoch 1
     set_tx_info_response_with_signed_tx(&mut clients, &authority_keys, &tx1, 1);
 
@@ -1864,7 +1872,7 @@ async fn test_handle_conflicting_transaction_response() {
         |e| {
             matches!(
                 e,
-                AggregatorProcessTransactionError::RetryableConflictingTransaction { .. }
+                AggregatorProcessTransactionError::RetryableTransaction { .. }
             )
         },
         |e| {
@@ -1876,7 +1884,7 @@ async fn test_handle_conflicting_transaction_response() {
     )
     .await;
 
-    println!("Case 5.1 - Retryable Transaction (WrongEpoch Error)");
+    println!("Case 6.1 - Retryable Transaction (WrongEpoch Error)");
     // Update committee store to epoch 2, now SafeClient will pass
     let committee_2 =
         Committee::new_for_testing_with_normalized_voting_power(2, authorities.clone());
@@ -1889,7 +1897,7 @@ async fn test_handle_conflicting_transaction_response() {
         |e| {
             matches!(
                 e,
-                AggregatorProcessTransactionError::RetryableConflictingTransaction { .. }
+                AggregatorProcessTransactionError::RetryableTransaction { .. }
             )
         },
         |e| {
@@ -1901,7 +1909,7 @@ async fn test_handle_conflicting_transaction_response() {
     )
     .await;
 
-    println!("Case 5.2 - Successful Cert Transaction");
+    println!("Case 6.2 - Successful Cert Transaction");
     // Update aggregator committee to epoch 2, and transaction will succeed.
     agg.committee = Arc::new(committee_2);
     agg.process_transaction(tx1.clone().into(), Some(client_ip))
@@ -2465,14 +2473,6 @@ async fn assert_resp_err<E, F>(
 {
     match agg.process_transaction(tx, Some(make_socket_addr())).await {
         Err(received_agg_err) if agg_err_checker(&received_agg_err) => match received_agg_err {
-            AggregatorProcessTransactionError::RetryableConflictingTransaction {
-                errors,
-                conflicting_tx_digest_to_retry: _,
-                conflicting_tx_digests,
-            } => {
-                assert!(!conflicting_tx_digests.is_empty());
-                assert!(errors.iter().map(|e| &e.0).all(iota_err_checker));
-            }
             AggregatorProcessTransactionError::TxAlreadyFinalizedWithDifferentUserSignatures => (),
             AggregatorProcessTransactionError::FatalConflictingTransaction {
                 errors,

--- a/crates/iota-json-rpc/src/error.rs
+++ b/crates/iota-json-rpc/src/error.rs
@@ -170,10 +170,7 @@ impl From<Error> for RpcError {
                         );
                         RpcError::Call(error_object)
                     }
-                    QuorumDriverError::ObjectsDoubleUsed {
-                        conflicting_txes,
-                        retried_tx_status: _,
-                    } => {
+                    QuorumDriverError::ObjectsDoubleUsed { conflicting_txes } => {
                         let new_map = conflicting_txes
                             .into_iter()
                             .map(|(digest, (pairs, _))| {
@@ -371,18 +368,17 @@ mod tests {
             let authority_name = AuthorityPublicKeyBytes([1; AuthorityPublicKey::LENGTH]);
             conflicting_txes.insert(tx_digest, (vec![(authority_name, object_ref)], stake_unit));
 
-            let quorum_driver_error = QuorumDriverError::ObjectsDoubleUsed {
-                conflicting_txes,
-                retried_tx_status: Some((TransactionDigest::from([1; 32]), true)),
-            };
+            let quorum_driver_error = QuorumDriverError::ObjectsDoubleUsed { conflicting_txes };
 
             let error_object: ErrorObjectOwned = Error::QuorumDriver(quorum_driver_error).into();
 
             let expected_code = expect!["-32002"];
             expected_code.assert_eq(&error_object.code().to_string());
-            let expected_message = expect![
-                "Failed to sign transaction by a quorum of validators because one or more of its objects is reserved for another transaction. Retried transaction 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi (succeeded) because it was able to gather the necessary votes. Other transactions locking these objects:\n- 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi (stake 80.0)\n- 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR (stake 5.0)"
-            ];
+            println!("error_object.message() {}", error_object.message());
+            let expected_message = expect![[r#"
+                Failed to sign transaction by a quorum of validators because one or more of its objects is reserved for another transaction. Other transactions locking these objects:
+                - 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi (stake 80.0)
+                - 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR (stake 5.0)"#]];
             expected_message.assert_eq(error_object.message());
             let expected_data = expect![[
                 r#"{"4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]],"8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]]}"#
@@ -413,20 +409,17 @@ mod tests {
             let authority_name = AuthorityPublicKeyBytes([1; AuthorityPublicKey::LENGTH]);
             conflicting_txes.insert(tx_digest, (vec![(authority_name, object_ref)], stake_unit));
 
-            let quorum_driver_error = QuorumDriverError::ObjectsDoubleUsed {
-                conflicting_txes,
-                // below threshold
-                retried_tx_status: None,
-            };
+            let quorum_driver_error = QuorumDriverError::ObjectsDoubleUsed { conflicting_txes };
 
             let rpc_error: RpcError = Error::QuorumDriver(quorum_driver_error).into();
 
             let error_object = error_object_from_rpc(rpc_error);
             let expected_code = expect!["-32002"];
             expected_code.assert_eq(&error_object.code().to_string());
-            let expected_message = expect![
-                "Failed to sign transaction by a quorum of validators because one or more of its objects is equivocated until the next epoch.  Other transactions locking these objects:\n- 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR (stake 50.0)\n- 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi (stake 40.0)"
-            ];
+            let expected_message = expect![[r#"
+                Failed to sign transaction by a quorum of validators because one or more of its objects is equivocated until the next epoch. Other transactions locking these objects:
+                - 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR (stake 50.0)
+                - 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi (stake 40.0)"#]];
             expected_message.assert_eq(error_object.message());
             let expected_data = expect![[
                 r#"{"4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]],"8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]]}"#

--- a/crates/iota-rest-api/src/error.rs
+++ b/crates/iota-rest-api/src/error.rs
@@ -86,10 +86,7 @@ impl From<iota_types::quorum_driver_types::QuorumDriverError> for RestError {
             QuorumDriverInternal(err) => {
                 RestError::new(StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
             }
-            ObjectsDoubleUsed {
-                conflicting_txes,
-                retried_tx_status,
-            } => {
+            ObjectsDoubleUsed { conflicting_txes } => {
                 let new_map = conflicting_txes
                     .into_iter()
                     .map(|(digest, (pairs, _))| {
@@ -101,10 +98,7 @@ impl From<iota_types::quorum_driver_types::QuorumDriverError> for RestError {
                     .collect::<std::collections::BTreeMap<_, Vec<_>>>();
 
                 let message = format!(
-                    "Failed to sign transaction by a quorum of validators because of locked objects. Retried a conflicting transaction {:?}, success: {:?}. Conflicting Transactions:\n{:#?}",
-                    retried_tx_status.map(|(tx, _)| tx),
-                    retried_tx_status.map(|(_, success)| success),
-                    new_map,
+                    "Failed to sign transaction by a quorum of validators because of locked objects. Conflicting Transactions:\n{new_map:#?}",
                 );
 
                 RestError::new(StatusCode::CONFLICT, message)

--- a/crates/iota-types/src/quorum_driver_types.rs
+++ b/crates/iota-types/src/quorum_driver_types.rs
@@ -41,14 +41,10 @@ pub enum QuorumDriverError {
     #[error("Invalid user signature: {0}.")]
     InvalidUserSignature(IotaError),
     #[error(
-        "Failed to sign transaction by a quorum of validators because of locked objects: {:?}, retried a conflicting transaction {:?}, success: {:?}",
-        conflicting_txes,
-        .retried_tx_status.map(|(tx, success)| tx),
-        .retried_tx_status.map(|(tx, success)| success),
+        "Failed to sign transaction by a quorum of validators because of locked objects: {conflicting_txes:?}"
     )]
     ObjectsDoubleUsed {
         conflicting_txes: BTreeMap<TransactionDigest, (Vec<(AuthorityName, ObjectRef)>, StakeUnit)>,
-        retried_tx_status: Option<(TransactionDigest, bool)>,
     },
     #[error("Transaction timed out before reaching finality")]
     TimeoutBeforeFinality,
@@ -91,10 +87,7 @@ impl QuorumDriverError {
             | QuorumDriverError::FailedWithTransientErrorAfterMaximumAttempts { .. }
             | QuorumDriverError::SystemOverload { .. }
             | QuorumDriverError::SystemOverloadRetryAfter { .. } => self.to_string(),
-            QuorumDriverError::ObjectsDoubleUsed {
-                conflicting_txes,
-                retried_tx_status,
-            } => {
+            QuorumDriverError::ObjectsDoubleUsed { conflicting_txes } => {
                 let weights: Vec<u64> =
                     conflicting_txes.values().map(|(_, stake)| *stake).collect();
                 let remaining: u64 = TOTAL_VOTING_POWER - weights.iter().sum::<u64>();
@@ -106,21 +99,9 @@ impl QuorumDriverError {
                     "reserved for another transaction"
                 };
 
-                let retried_info = match retried_tx_status {
-                    Some((digest, success)) => {
-                        format!(
-                            "Retried transaction {} ({}) because it was able to gather the necessary votes.",
-                            digest,
-                            if *success { "succeeded" } else { "failed" }
-                        )
-                    }
-                    None => "".to_string(),
-                };
-
                 format!(
-                    "Failed to sign transaction by a quorum of validators because one or more of its objects is {}. {} Other transactions locking these objects:\n{}",
+                    "Failed to sign transaction by a quorum of validators because one or more of its objects is {}. Other transactions locking these objects:\n{}",
                     reason,
-                    retried_info,
                     conflicting_txes
                         .iter()
                         .sorted_by(|(_, (_, a)), (_, (_, b))| b.cmp(a))


### PR DESCRIPTION
# Description of change

Porting upstream change https://github.com/MystenLabs/sui/commit/9b460365f8556dd2668b597317534fe2020892d6


> The logic in quorum driver to retry conflicting transactions can end up
> in a situation where it is waiting for responses from all validators
> which can clog up QD and limit the throughput of our fullnodes.
> Additionally with `ValidatorTransactionFinalizer` component added
> recently we no longer need to rely on QD to do this retry of conflicting
> tx. We still track the conflicting tx digest so that we can return a
> more useful error to the user in the case that those conflicting tx
> digests exist.


## Links to any relevant issues

Closes #6572 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

CI

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] 
### Release Notes

- [x] Protocol: The logic in quorum driver to retry conflicting transactions can end up in a situation where it is waiting for responses from all validators which can clog up QD and limit the throughput of our fullnodes.
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
