### PR TITLE
feat(core,rpc): Improve clarity of errors for QuorumDriverError type and it's usage in RPCs

### DIFF
--- a/crates/iota-core/src/quorum_driver/mod.rs
+++ b/crates/iota-core/src/quorum_driver/mod.rs
@@ -367,8 +367,7 @@ where
                 );
                 Err(Some(QuorumDriverError::ObjectsDoubleUsed {
                     conflicting_txes: conflicting_tx_digests,
-                    retried_tx: None,
-                    retried_tx_success: None,
+                    retried_tx_status: None,
                 }))
             }
 
@@ -464,8 +463,7 @@ where
                 );
                 Err(Some(QuorumDriverError::ObjectsDoubleUsed {
                     conflicting_txes: conflicting_tx_digests,
-                    retried_tx: None,
-                    retried_tx_success: None,
+                    retried_tx_status: None,
                 }))
             }
             Ok(success) => {
@@ -482,8 +480,7 @@ where
                 }
                 Err(Some(QuorumDriverError::ObjectsDoubleUsed {
                     conflicting_txes: conflicting_tx_digests,
-                    retried_tx: Some(conflicting_tx_digest),
-                    retried_tx_success: Some(success),
+                    retried_tx_status: Some((conflicting_tx_digest, success)),
                 }))
             }
         }

--- a/crates/iota-core/src/quorum_driver/tests.rs
+++ b/crates/iota-core/src/quorum_driver/tests.rs
@@ -316,12 +316,10 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
     // due to client double spend and this is a fatal error.
     if let Err(QuorumDriverError::ObjectsDoubleUsed {
         conflicting_txes,
-        retried_tx,
-        retried_tx_success,
+        retried_tx_status,
     }) = res
     {
-        assert_eq!(retried_tx, None);
-        assert_eq!(retried_tx_success, None);
+        assert_eq!(retried_tx_status, None);
         assert_eq!(conflicting_txes.len(), 1);
         assert_eq!(conflicting_txes.iter().next().unwrap().0, tx.digest());
     } else {
@@ -364,12 +362,10 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
     // Aggregator gets three bad responses, and tries tx, which should succeed.
     if let Err(QuorumDriverError::ObjectsDoubleUsed {
         conflicting_txes,
-        retried_tx,
-        retried_tx_success,
+        retried_tx_status,
     }) = res
     {
-        assert_eq!(retried_tx, Some(*tx.digest()));
-        assert_eq!(retried_tx_success, Some(true));
+        assert_eq!(retried_tx_status, Some((*tx.digest(), true)));
         assert_eq!(conflicting_txes.len(), 1);
         assert_eq!(conflicting_txes.iter().next().unwrap().0, tx.digest());
     } else {
@@ -439,12 +435,10 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
 
     if let Err(QuorumDriverError::ObjectsDoubleUsed {
         conflicting_txes,
-        retried_tx,
-        retried_tx_success,
+        retried_tx_status,
     }) = res
     {
-        assert_eq!(retried_tx, None);
-        assert_eq!(retried_tx_success, None);
+        assert_eq!(retried_tx_status, None);
         assert_eq!(conflicting_txes.len(), 2);
         let tx_stake = conflicting_txes.get(tx.digest()).unwrap().1;
         assert!(tx_stake == 2500 || tx_stake == 5000);
@@ -488,12 +482,10 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
 
     if let Err(QuorumDriverError::ObjectsDoubleUsed {
         conflicting_txes,
-        retried_tx,
-        retried_tx_success,
+        retried_tx_status,
     }) = res
     {
-        assert_eq!(retried_tx, None);
-        assert_eq!(retried_tx_success, None);
+        assert_eq!(retried_tx_status, None);
         assert_eq!(conflicting_txes.len(), 1);
         assert_eq!(conflicting_txes.get(tx.digest()).unwrap().1, 5000);
     } else {
@@ -573,12 +565,10 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
 
     if let Err(QuorumDriverError::ObjectsDoubleUsed {
         conflicting_txes,
-        retried_tx,
-        retried_tx_success,
+        retried_tx_status,
     }) = res
     {
-        assert_eq!(retried_tx, None);
-        assert_eq!(retried_tx_success, None);
+        assert_eq!(retried_tx_status, None);
         assert!(conflicting_txes.len() == 3 || conflicting_txes.len() == 2);
         assert!(
             conflicting_txes

--- a/crates/iota-json-rpc/src/error.rs
+++ b/crates/iota-json-rpc/src/error.rs
@@ -11,6 +11,7 @@ use iota_json_rpc_api::{
 };
 use iota_names::error::IotaNamesError;
 use iota_types::{
+    committee::{QUORUM_THRESHOLD, TOTAL_VOTING_POWER},
     error::{IotaError, IotaObjectResponseError, UserInputError},
     quorum_driver_types::QuorumDriverError,
 };
@@ -160,18 +161,9 @@ impl From<Error> for RpcError {
             Error::QuorumDriver(err) => {
                 match err {
                     QuorumDriverError::InvalidUserSignature(err) => {
-                        let inner_error_str = match err {
-                            // TODO(wlmyng): update IotaError display trait to render UserInputError
-                            // with display
-                            IotaError::UserInput { error } => error.to_string(),
-                            _ => err.to_string(),
-                        };
-
-                        let error_message = format!("Invalid user signature: {inner_error_str}");
-
                         let error_object = ErrorObject::owned::<()>(
                             TRANSACTION_EXECUTION_CLIENT_ERROR_CODE,
-                            error_message,
+                            format!("Invalid user signature: {err}"),
                             None,
                         );
                         RpcError::Call(error_object)
@@ -192,12 +184,44 @@ impl From<Error> for RpcError {
                     }
                     QuorumDriverError::ObjectsDoubleUsed {
                         conflicting_txes,
-                        retried_tx,
-                        retried_tx_success,
+                        retried_tx_status,
                     } => {
+                        let weights: Vec<u64> =
+                            conflicting_txes.values().map(|(_, stake)| *stake).collect();
+                        let remaining: u64 = TOTAL_VOTING_POWER - weights.iter().sum::<u64>();
+
+                        // better version of above
+                        let reason = if weights.iter().all(|w| remaining + w < QUORUM_THRESHOLD) {
+                            "equivocated until the next epoch"
+                        } else {
+                            "reserved for another transaction"
+                        };
+
+                        let retried_info = match retried_tx_status {
+                            Some((digest, success)) => {
+                                format!(
+                                    "Retried transaction {} ({}) because it was able to gather the necessary votes.",
+                                    digest,
+                                    if success { "succeeded" } else { "failed" }
+                                )
+                            }
+                            None => "".to_string(),
+                        };
+
                         let error_message = format!(
-                            "Failed to sign transaction by a quorum of validators because of locked objects. Retried a conflicting transaction {:?}, success: {:?}",
-                            retried_tx, retried_tx_success
+                            "Failed to sign transaction by a quorum of validators because one or more of its objects is {}. {} Other transactions locking these objects:\n{}",
+                            reason,
+                            retried_info,
+                            conflicting_txes
+                                .iter()
+                                .sorted_by(|(_, (_, a)), (_, (_, b))| b.cmp(a))
+                                .map(|(digest, (_, stake))| format!(
+                                    "- {} (stake {}.{})",
+                                    digest,
+                                    stake / 100,
+                                    stake % 100,
+                                ))
+                                .join("\n"),
                         );
 
                         let new_map = conflicting_txes
@@ -252,10 +276,14 @@ impl From<Error> for RpcError {
                             "NonRecoverableTransactionError should have at least one non-retryable error"
                         );
 
-                        let error_list = new_errors.join(", ");
+                        let mut error_list = vec![];
+                        for err in new_errors.iter() {
+                            error_list.push(format!("- {}", err));
+                        }
+
                         let error_msg = format!(
-                            "Transaction execution failed due to issues with transaction inputs, please review the errors and try again: {}.",
-                            error_list
+                            "Transaction execution failed due to issues with transaction inputs, please review the errors and try again:\n{}",
+                            error_list.join("\n")
                         );
 
                         let error_object = ErrorObject::owned::<()>(
@@ -432,16 +460,66 @@ mod tests {
                 TransactionDigest,
                 (Vec<(AuthorityName, ObjectRef)>, StakeUnit),
             > = BTreeMap::new();
-            let tx_digest = TransactionDigest::default();
+            let tx_digest = TransactionDigest::from([1; 32]);
             let object_ref = test_object_ref();
-            let stake_unit: StakeUnit = 10;
+            // 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi has enough stake to escape
+            // equivocation
+            let stake_unit: StakeUnit = 8000;
             let authority_name = AuthorityPublicKeyBytes([0; AuthorityPublicKey::LENGTH]);
+            conflicting_txes.insert(tx_digest, (vec![(authority_name, object_ref)], stake_unit));
+
+            // 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR stake below quorum threshold
+            let tx_digest = TransactionDigest::from([2; 32]);
+            let stake_unit: StakeUnit = 500;
+            let authority_name = AuthorityPublicKeyBytes([1; AuthorityPublicKey::LENGTH]);
             conflicting_txes.insert(tx_digest, (vec![(authority_name, object_ref)], stake_unit));
 
             let quorum_driver_error = QuorumDriverError::ObjectsDoubleUsed {
                 conflicting_txes,
-                retried_tx: Some(TransactionDigest::default()),
-                retried_tx_success: Some(true),
+                retried_tx_status: Some((TransactionDigest::from([1; 32]), true)),
+            };
+
+            let error_object: ErrorObjectOwned = Error::QuorumDriver(quorum_driver_error).into();
+
+            let expected_code = expect!["-32002"];
+            expected_code.assert_eq(&error_object.code().to_string());
+            let expected_message = expect![
+                "Failed to sign transaction by a quorum of validators because one or more of its objects is reserved for another transaction. Retried transaction 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi (succeeded) because it was able to gather the necessary votes. Other transactions locking these objects:\n- 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi (stake 80.0)\n- 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR (stake 5.0)"
+            ];
+            expected_message.assert_eq(error_object.message());
+            let expected_data = expect![[
+                r#"{"4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]],"8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]]}"#
+            ]];
+            let actual_data = error_object.data().unwrap().to_string();
+            expected_data.assert_eq(&actual_data);
+        }
+
+        #[test]
+        fn test_objects_double_used_equivocated() {
+            use iota_types::crypto::VerifyingKey;
+            let mut conflicting_txes: BTreeMap<
+                TransactionDigest,
+                (Vec<(AuthorityName, ObjectRef)>, StakeUnit),
+            > = BTreeMap::new();
+            let tx_digest = TransactionDigest::from([1; 32]);
+            let object_ref = test_object_ref();
+
+            // 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi has lower stake at 10
+            let stake_unit: StakeUnit = 4000;
+            let authority_name = AuthorityPublicKeyBytes([0; AuthorityPublicKey::LENGTH]);
+            conflicting_txes.insert(tx_digest, (vec![(authority_name, object_ref)], stake_unit));
+
+            // 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR is a higher stake and should be
+            // first in the list
+            let tx_digest = TransactionDigest::from([2; 32]);
+            let stake_unit: StakeUnit = 5000;
+            let authority_name = AuthorityPublicKeyBytes([1; AuthorityPublicKey::LENGTH]);
+            conflicting_txes.insert(tx_digest, (vec![(authority_name, object_ref)], stake_unit));
+
+            let quorum_driver_error = QuorumDriverError::ObjectsDoubleUsed {
+                conflicting_txes,
+                // below threshold
+                retried_tx_status: None,
             };
 
             let rpc_error: RpcError = Error::QuorumDriver(quorum_driver_error).into();
@@ -450,11 +528,11 @@ mod tests {
             let expected_code = expect!["-32002"];
             expected_code.assert_eq(&error_object.code().to_string());
             let expected_message = expect![
-                "Failed to sign transaction by a quorum of validators because of locked objects. Retried a conflicting transaction Some(TransactionDigest(11111111111111111111111111111111)), success: Some(true)"
+                "Failed to sign transaction by a quorum of validators because one or more of its objects is equivocated until the next epoch.  Other transactions locking these objects:\n- 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR (stake 50.0)\n- 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi (stake 40.0)"
             ];
             expected_message.assert_eq(error_object.message());
             let expected_data = expect![[
-                r#"{"11111111111111111111111111111111":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]]}"#
+                r#"{"4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]],"8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]]}"#
             ]];
             let actual_data = error_object.data().unwrap().to_string();
             expected_data.assert_eq(&actual_data);
@@ -493,7 +571,7 @@ mod tests {
             let expected_code = expect!["-32002"];
             expected_code.assert_eq(&error_object.code().to_string());
             let expected_message = expect![
-                "Transaction execution failed due to issues with transaction inputs, please review the errors and try again: Balance of gas object 10 is lower than the needed amount: 100, Object (0x0000000000000000000000000000000000000000000000000000000000000000, SequenceNumber(0), o#11111111111111111111111111111111) is not available for consumption, its current version: SequenceNumber(10)."
+                "Transaction execution failed due to issues with transaction inputs, please review the errors and try again:\n- Balance of gas object 10 is lower than the needed amount: 100\n- Object ID 0x0000000000000000000000000000000000000000000000000000000000000000 Version 0x0 Digest 11111111111111111111111111111111 is not available for consumption, current version: 0xa"
             ];
             expected_message.assert_eq(error_object.message());
         }
@@ -526,7 +604,7 @@ mod tests {
             let expected_code = expect!["-32002"];
             expected_code.assert_eq(&error_object.code().to_string());
             let expected_message = expect![
-                "Transaction execution failed due to issues with transaction inputs, please review the errors and try again: Could not find the referenced object 0x0000000000000000000000000000000000000000000000000000000000000000 at version None."
+                "Transaction execution failed due to issues with transaction inputs, please review the errors and try again:\n- Could not find the referenced object 0x0000000000000000000000000000000000000000000000000000000000000000 at version None"
             ];
             expected_message.assert_eq(error_object.message());
         }

--- a/crates/iota-json-rpc/src/error.rs
+++ b/crates/iota-json-rpc/src/error.rs
@@ -11,11 +11,9 @@ use iota_json_rpc_api::{
 };
 use iota_names::error::IotaNamesError;
 use iota_types::{
-    committee::{QUORUM_THRESHOLD, TOTAL_VOTING_POWER},
     error::{IotaError, IotaObjectResponseError, UserInputError},
     quorum_driver_types::QuorumDriverError,
 };
-use itertools::Itertools;
 use jsonrpsee::{
     core::{ClientError as RpcError, RegisterMethodError},
     types::{
@@ -159,71 +157,23 @@ impl From<Error> for RpcError {
                 }
             },
             Error::QuorumDriver(err) => {
+                let error_msg = err.to_error_message();
+
                 match err {
-                    QuorumDriverError::InvalidUserSignature(err) => {
+                    QuorumDriverError::InvalidUserSignature { .. }
+                    | QuorumDriverError::TxAlreadyFinalizedWithDifferentUserSignatures
+                    | QuorumDriverError::NonRecoverableTransactionError { .. } => {
                         let error_object = ErrorObject::owned::<()>(
                             TRANSACTION_EXECUTION_CLIENT_ERROR_CODE,
-                            format!("Invalid user signature: {err}"),
+                            error_msg,
                             None,
                         );
-                        RpcError::Call(error_object)
-                    }
-                    QuorumDriverError::TxAlreadyFinalizedWithDifferentUserSignatures => {
-                        let error_object = ErrorObject::owned::<()>(
-                            TRANSACTION_EXECUTION_CLIENT_ERROR_CODE,
-                            "The transaction is already finalized but with different user signatures",
-                            None,
-                        );
-                        RpcError::Call(error_object)
-                    }
-                    QuorumDriverError::TimeoutBeforeFinality
-                    | QuorumDriverError::FailedWithTransientErrorAfterMaximumAttempts { .. } => {
-                        let error_object =
-                            ErrorObject::owned::<()>(TRANSIENT_ERROR_CODE, err.to_string(), None);
                         RpcError::Call(error_object)
                     }
                     QuorumDriverError::ObjectsDoubleUsed {
                         conflicting_txes,
-                        retried_tx_status,
+                        retried_tx_status: _,
                     } => {
-                        let weights: Vec<u64> =
-                            conflicting_txes.values().map(|(_, stake)| *stake).collect();
-                        let remaining: u64 = TOTAL_VOTING_POWER - weights.iter().sum::<u64>();
-
-                        // better version of above
-                        let reason = if weights.iter().all(|w| remaining + w < QUORUM_THRESHOLD) {
-                            "equivocated until the next epoch"
-                        } else {
-                            "reserved for another transaction"
-                        };
-
-                        let retried_info = match retried_tx_status {
-                            Some((digest, success)) => {
-                                format!(
-                                    "Retried transaction {} ({}) because it was able to gather the necessary votes.",
-                                    digest,
-                                    if success { "succeeded" } else { "failed" }
-                                )
-                            }
-                            None => "".to_string(),
-                        };
-
-                        let error_message = format!(
-                            "Failed to sign transaction by a quorum of validators because one or more of its objects is {}. {} Other transactions locking these objects:\n{}",
-                            reason,
-                            retried_info,
-                            conflicting_txes
-                                .iter()
-                                .sorted_by(|(_, (_, a)), (_, (_, b))| b.cmp(a))
-                                .map(|(digest, (_, stake))| format!(
-                                    "- {} (stake {}.{})",
-                                    digest,
-                                    stake / 100,
-                                    stake % 100,
-                                ))
-                                .join("\n"),
-                        );
-
                         let new_map = conflicting_txes
                             .into_iter()
                             .map(|(digest, (pairs, _))| {
@@ -236,75 +186,22 @@ impl From<Error> for RpcError {
 
                         let error_object = ErrorObject::owned(
                             TRANSACTION_EXECUTION_CLIENT_ERROR_CODE,
-                            error_message,
+                            error_msg,
                             Some(new_map),
                         );
                         RpcError::Call(error_object)
                     }
-                    QuorumDriverError::NonRecoverableTransactionError { errors } => {
-                        let new_errors: Vec<String> = errors
-                            .into_iter()
-                            // sort by total stake, descending, so users see the most prominent one
-                            // first
-                            .sorted_by(|(_, a, _), (_, b, _)| b.cmp(a))
-                            .filter_map(|(err, _, _)| {
-                                match &err {
-                                    // Special handling of UserInputError:
-                                    // ObjectNotFound and DependentPackageNotFound are considered
-                                    // retryable errors but they have different treatment
-                                    // in AuthorityAggregator.
-                                    // The optimal fix would be to examine if the total stake
-                                    // of ObjectNotFound/DependentPackageNotFound exceeds the
-                                    // quorum threshold, but it takes a Committee here.
-                                    // So, we take an easier route and consider them non-retryable
-                                    // at all. Combining this with the sorting above, clients will
-                                    // see the dominant error first.
-                                    IotaError::UserInput { error } => Some(error.to_string()),
-                                    _ => {
-                                        if err.is_retryable().0 {
-                                            None
-                                        } else {
-                                            Some(err.to_string())
-                                        }
-                                    }
-                                }
-                            })
-                            .collect();
-
-                        assert!(
-                            !new_errors.is_empty(),
-                            "NonRecoverableTransactionError should have at least one non-retryable error"
-                        );
-
-                        let mut error_list = vec![];
-                        for err in new_errors.iter() {
-                            error_list.push(format!("- {}", err));
-                        }
-
-                        let error_msg = format!(
-                            "Transaction execution failed due to issues with transaction inputs, please review the errors and try again:\n{}",
-                            error_list.join("\n")
-                        );
-
-                        let error_object = ErrorObject::owned::<()>(
-                            TRANSACTION_EXECUTION_CLIENT_ERROR_CODE,
-                            error_msg,
-                            None,
-                        );
+                    QuorumDriverError::TimeoutBeforeFinality
+                    | QuorumDriverError::FailedWithTransientErrorAfterMaximumAttempts { .. }
+                    | QuorumDriverError::SystemOverload { .. }
+                    | QuorumDriverError::SystemOverloadRetryAfter { .. } => {
+                        let error_object =
+                            ErrorObject::owned::<()>(TRANSIENT_ERROR_CODE, error_msg, None);
                         RpcError::Call(error_object)
                     }
                     QuorumDriverError::QuorumDriverInternal(_) => {
-                        let error_object = ErrorObject::owned::<()>(
-                            INTERNAL_ERROR_CODE,
-                            "Internal error occurred while executing transaction.",
-                            None,
-                        );
-                        RpcError::Call(error_object)
-                    }
-                    QuorumDriverError::SystemOverload { .. }
-                    | QuorumDriverError::SystemOverloadRetryAfter { .. } => {
                         let error_object =
-                            ErrorObject::owned::<()>(TRANSIENT_ERROR_CODE, err.to_string(), None);
+                            ErrorObject::owned::<()>(INTERNAL_ERROR_CODE, error_msg, None);
                         RpcError::Call(error_object)
                     }
                 }

--- a/crates/iota-rest-api/src/error.rs
+++ b/crates/iota-rest-api/src/error.rs
@@ -88,8 +88,7 @@ impl From<iota_types::quorum_driver_types::QuorumDriverError> for RestError {
             }
             ObjectsDoubleUsed {
                 conflicting_txes,
-                retried_tx,
-                retried_tx_success,
+                retried_tx_status,
             } => {
                 let new_map = conflicting_txes
                     .into_iter()
@@ -103,7 +102,9 @@ impl From<iota_types::quorum_driver_types::QuorumDriverError> for RestError {
 
                 let message = format!(
                     "Failed to sign transaction by a quorum of validators because of locked objects. Retried a conflicting transaction {:?}, success: {:?}. Conflicting Transactions:\n{:#?}",
-                    retried_tx, retried_tx_success, new_map,
+                    retried_tx_status.map(|(tx, _)| tx),
+                    retried_tx_status.map(|(_, success)| success),
+                    new_map,
                 );
 
                 RestError::new(StatusCode::CONFLICT, message)

--- a/crates/iota-types/src/error.rs
+++ b/crates/iota-types/src/error.rs
@@ -104,7 +104,8 @@ pub enum UserInputError {
         version: Option<SequenceNumber>,
     },
     #[error(
-        "Object {provided_obj_ref:?} is not available for consumption, its current version: {current_version:?}"
+        "Object ID {} Version {} Digest {} is not available for consumption, current version: {current_version}",
+        .provided_obj_ref.0, .provided_obj_ref.1, .provided_obj_ref.2
     )]
     ObjectVersionUnavailableForConsumption {
         provided_obj_ref: ObjectRef,

--- a/crates/iota-types/src/quorum_driver_types.rs
+++ b/crates/iota-types/src/quorum_driver_types.rs
@@ -35,20 +35,19 @@ pub const NON_RECOVERABLE_ERROR_MSG: &str =
 /// Every invariant needs detailed documents to instruct client handling.
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Error, Hash, AsRefStr)]
 pub enum QuorumDriverError {
-    #[error("QuorumDriver internal error: {0:?}.")]
+    #[error("QuorumDriver internal error: {0}.")]
     QuorumDriverInternal(IotaError),
-    #[error("Invalid user signature: {0:?}.")]
+    #[error("Invalid user signature: {0}.")]
     InvalidUserSignature(IotaError),
     #[error(
         "Failed to sign transaction by a quorum of validators because of locked objects: {:?}, retried a conflicting transaction {:?}, success: {:?}",
         conflicting_txes,
-        retried_tx,
-        retried_tx_success
+        .retried_tx_status.map(|(tx, success)| tx),
+        .retried_tx_status.map(|(tx, success)| success),
     )]
     ObjectsDoubleUsed {
         conflicting_txes: BTreeMap<TransactionDigest, (Vec<(AuthorityName, ObjectRef)>, StakeUnit)>,
-        retried_tx: Option<TransactionDigest>,
-        retried_tx_success: Option<bool>,
+        retried_tx_status: Option<(TransactionDigest, bool)>,
     },
     #[error("Transaction timed out before reaching finality")]
     TimeoutBeforeFinality,

--- a/crates/iota-types/src/quorum_driver_types.rs
+++ b/crates/iota-types/src/quorum_driver_types.rs
@@ -5,13 +5,14 @@
 
 use std::collections::BTreeMap;
 
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use strum::AsRefStr;
 use thiserror::Error;
 
 use crate::{
     base_types::{AuthorityName, EpochId, ObjectRef, TransactionDigest},
-    committee::StakeUnit,
+    committee::{QUORUM_THRESHOLD, StakeUnit, TOTAL_VOTING_POWER},
     crypto::{AuthorityStrongQuorumSignInfo, ConciseAuthorityPublicKeyBytes},
     effects::{
         CertifiedTransactionEffects, TransactionEffects, TransactionEvents,
@@ -74,6 +75,114 @@ pub enum QuorumDriverError {
         errors: GroupedErrors,
         retry_after_secs: u64,
     },
+}
+
+impl QuorumDriverError {
+    pub fn to_error_message(&self) -> String {
+        match self {
+            QuorumDriverError::InvalidUserSignature(err) => {
+                format!("Invalid user signature: {err}")
+            }
+            QuorumDriverError::TxAlreadyFinalizedWithDifferentUserSignatures => {
+                "The transaction is already finalized but with different user signatures"
+                    .to_string()
+            }
+            QuorumDriverError::TimeoutBeforeFinality
+            | QuorumDriverError::FailedWithTransientErrorAfterMaximumAttempts { .. }
+            | QuorumDriverError::SystemOverload { .. }
+            | QuorumDriverError::SystemOverloadRetryAfter { .. } => self.to_string(),
+            QuorumDriverError::ObjectsDoubleUsed {
+                conflicting_txes,
+                retried_tx_status,
+            } => {
+                let weights: Vec<u64> =
+                    conflicting_txes.values().map(|(_, stake)| *stake).collect();
+                let remaining: u64 = TOTAL_VOTING_POWER - weights.iter().sum::<u64>();
+
+                // better version of above
+                let reason = if weights.iter().all(|w| remaining + w < QUORUM_THRESHOLD) {
+                    "equivocated until the next epoch"
+                } else {
+                    "reserved for another transaction"
+                };
+
+                let retried_info = match retried_tx_status {
+                    Some((digest, success)) => {
+                        format!(
+                            "Retried transaction {} ({}) because it was able to gather the necessary votes.",
+                            digest,
+                            if *success { "succeeded" } else { "failed" }
+                        )
+                    }
+                    None => "".to_string(),
+                };
+
+                format!(
+                    "Failed to sign transaction by a quorum of validators because one or more of its objects is {}. {} Other transactions locking these objects:\n{}",
+                    reason,
+                    retried_info,
+                    conflicting_txes
+                        .iter()
+                        .sorted_by(|(_, (_, a)), (_, (_, b))| b.cmp(a))
+                        .map(|(digest, (_, stake))| format!(
+                            "- {} (stake {}.{})",
+                            digest,
+                            stake / 100,
+                            stake % 100,
+                        ))
+                        .join("\n"),
+                )
+            }
+            QuorumDriverError::NonRecoverableTransactionError { errors } => {
+                let new_errors: Vec<String> = errors
+                    .iter()
+                    // sort by total stake, descending, so users see the most prominent one
+                    // first
+                    .sorted_by(|(_, a, _), (_, b, _)| b.cmp(a))
+                    .filter_map(|(err, _, _)| {
+                        match &err {
+                            // Special handling of UserInputError:
+                            // ObjectNotFound and DependentPackageNotFound are considered
+                            // retryable errors but they have different treatment
+                            // in AuthorityAggregator.
+                            // The optimal fix would be to examine if the total stake
+                            // of ObjectNotFound/DependentPackageNotFound exceeds the
+                            // quorum threshold, but it takes a Committee here.
+                            // So, we take an easier route and consider them non-retryable
+                            // at all. Combining this with the sorting above, clients will
+                            // see the dominant error first.
+                            IotaError::UserInput { error } => Some(error.to_string()),
+                            _ => {
+                                if err.is_retryable().0 {
+                                    None
+                                } else {
+                                    Some(err.to_string())
+                                }
+                            }
+                        }
+                    })
+                    .collect();
+
+                assert!(
+                    !new_errors.is_empty(),
+                    "NonRecoverableTransactionError should have at least one non-retryable error"
+                );
+
+                let mut error_list = vec![];
+                for err in new_errors.iter() {
+                    error_list.push(format!("- {}", err));
+                }
+
+                format!(
+                    "Transaction execution failed due to issues with transaction inputs, please review the errors and try again:\n{}",
+                    error_list.join("\n")
+                )
+            }
+            QuorumDriverError::QuorumDriverInternal { .. } => {
+                "Internal error occurred while executing transaction.".to_string()
+            }
+        }
+    }
 }
 
 pub type GroupedErrors = Vec<(IotaError, StakeUnit, Vec<ConciseAuthorityPublicKeyBytes>)>;


### PR DESCRIPTION
# Description of change

Port https://github.com/MystenLabs/sui/commit/cd6dfa41d32b92383e4b05ec4dbeac23941e1c15

From Sui's commit description:
The CLI and SDK rely on the QuorumDriverError type to handle errors from
the Quorum driver. This PR improves the clarity of errors for the
QuorumDriverError type and its usage in RPCs.
- a published transaction which has a conflict now provides the
conflicting transaction
- invalid user signature simplified 
- better formatting for object double used
- rely on display when possible

**Note that we removed `Error` from each variant in json-rpc Error**

## Links to any relevant issues

Part of #3990 

## Type of change

- Enhancement 


## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
