### PR TITLE
upstream(consensus): Remove `GetSharedLocks` trait

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1073,7 +1073,7 @@ impl AuthorityState {
 
         if transaction.contains_shared_object() {
             epoch_store
-                .acquire_shared_locks_from_effects(
+                .acquire_shared_version_assignments_from_effects(
                     transaction,
                     effects.data(),
                     self.get_object_cache_reader().as_ref(),
@@ -1221,7 +1221,7 @@ impl AuthorityState {
             .start_timer();
         let input_objects = &certificate.data().transaction_data().input_objects()?;
         self.input_loader.read_objects_for_execution(
-            epoch_store.as_ref(),
+            epoch_store,
             &certificate.key(),
             tx_lock,
             input_objects,

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -53,7 +53,7 @@ use iota_types::{
         ConsensusTransactionKind, VersionedDkgConfirmation, check_total_jwk_size,
     },
     signature::GenericSignature,
-    storage::{BackingPackageStore, GetSharedLocks, InputKey, ObjectStore},
+    storage::{BackingPackageStore, InputKey, ObjectStore},
     transaction::{
         AuthenticatorStateUpdateV1, CertifiedTransaction, InputObjectKind, SenderSignedData,
         Transaction, TransactionDataAPI, TransactionKey, TransactionKind, VerifiedCertificate,
@@ -1291,31 +1291,31 @@ impl AuthorityPerEpochStore {
         key: &TransactionKey,
         objects: &[InputObjectKind],
     ) -> IotaResult<BTreeSet<InputKey>> {
-        let shared_locks =
+        let assigned_shared_versions =
             once_cell::unsync::OnceCell::<Option<HashMap<ObjectID, SequenceNumber>>>::new();
         objects
             .iter()
             .map(|kind| {
                 Ok(match kind {
                     InputObjectKind::SharedMoveObject { id, .. } => {
-                        let shared_locks = shared_locks
+                        let assigned_shared_versions = assigned_shared_versions
                             .get_or_init(|| {
-                                self.get_shared_locks(key)
-                                    .expect("reading shared locks should not fail")
-                                    .map(|locks| locks.into_iter().collect())
+                                self.get_assigned_shared_object_versions(key)
+                                    .expect("reading assigned shared versions should not fail")
+                                    .map(|versions| versions.into_iter().collect())
                             })
                             .as_ref()
                             // Shared version assignments could have been deleted if the tx just
                             // finished executing concurrently.
                             .ok_or(IotaError::GenericAuthority {
-                                error: "no shared locks".to_string(),
+                                error: "no assigned shared versions".to_string(),
                             })?;
-                        // If we found locks, but they are missing the assignment for this object,
-                        // it indicates a serious inconsistency!
-                        let Some(version) = shared_locks.get(id) else {
+                        // If we found assigned versions, but they are missing the assignment for
+                        // this object, it indicates a serious inconsistency!
+                        let Some(version) = assigned_shared_versions.get(id) else {
                             panic!(
-                                "Shared object locks should have been set. key: {key:?}, obj \
-                                id: {id:?}",
+                                "Shared object version should have been assigned. key: {key:?}, \
+                                obj id: {id:?}, assigned_shared_versions: {assigned_shared_versions:?}",
                             )
                         };
                         InputKey::VersionedObject {
@@ -1525,7 +1525,7 @@ impl AuthorityPerEpochStore {
     // computation of the transaction that created the shared object originally
     // - which transaction may not yet have been executed on this node).
     //
-    // Because all paths that assign shared locks for a shared object transaction
+    // Because all paths that assign shared versions for a shared object transaction
     // call this function, it is impossible for parent_sync to be updated before
     // this function completes successfully for each affected object id.
     pub(crate) async fn get_or_init_next_object_versions(
@@ -1598,6 +1598,13 @@ impl AuthorityPerEpochStore {
         })?;
 
         Ok(ret)
+    }
+
+    pub fn get_assigned_shared_object_versions(
+        &self,
+        key: &TransactionKey,
+    ) -> IotaResult<Option<Vec<(ObjectID, SequenceNumber)>>> {
+        Ok(self.tables()?.assigned_shared_object_versions.get(key)?)
     }
 
     async fn set_assigned_shared_object_versions_with_db_batch(
@@ -1790,13 +1797,13 @@ impl AuthorityPerEpochStore {
         }
     }
 
-    /// Lock a sequence number for the shared objects of the input transaction
+    /// Assign a sequence number for the shared objects of the input transaction
     /// based on the effects of that transaction.
     /// Used by full nodes who don't listen to consensus, and validators who
     /// catch up by state sync.
-    // TODO: We should be able to pass in a vector of certs/effects and lock them all at once.
+    // TODO: We should be able to pass in a vector of certs/effects and acquire them all at once.
     #[instrument(level = "trace", skip_all)]
-    pub async fn acquire_shared_locks_from_effects(
+    pub async fn acquire_shared_version_assignments_from_effects(
         &self,
         certificate: &VerifiedExecutableTransaction,
         effects: &TransactionEffects,
@@ -4152,15 +4159,6 @@ impl ConsensusCommitOutput {
         )?;
 
         Ok(())
-    }
-}
-
-impl GetSharedLocks for AuthorityPerEpochStore {
-    fn get_shared_locks(
-        &self,
-        key: &TransactionKey,
-    ) -> IotaResult<Option<Vec<(ObjectID, SequenceNumber)>>> {
-        Ok(self.tables()?.assigned_shared_object_versions.get(key)?)
     }
 }
 

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -580,13 +580,13 @@ impl CheckpointExecutor {
 
         if change_epoch_tx.contains_shared_object() {
             epoch_store
-                .acquire_shared_locks_from_effects(
+                .acquire_shared_version_assignments_from_effects(
                     &change_epoch_tx,
                     &change_epoch_fx,
                     self.object_cache_reader.as_ref(),
                 )
                 .await
-                .expect("Acquiring shared locks for change_epoch tx cannot fail");
+                .expect("Acquiring shared version assignments for change_epoch tx cannot fail");
         }
 
         self.tx_manager.enqueue_with_expected_effects_digest(
@@ -1240,7 +1240,7 @@ async fn execute_transactions(
     for (tx, _) in &executable_txns {
         if tx.contains_shared_object() {
             epoch_store
-                .acquire_shared_locks_from_effects(
+                .acquire_shared_version_assignments_from_effects(
                     tx,
                     digest_to_effects.get(tx.digest()).unwrap(),
                     object_cache_reader,

--- a/crates/iota-core/src/transaction_input_loader.rs
+++ b/crates/iota-core/src/transaction_input_loader.rs
@@ -8,7 +8,7 @@ use iota_common::fatal;
 use iota_types::{
     base_types::{EpochId, ObjectRef, TransactionDigest},
     error::{IotaError, IotaResult, UserInputError},
-    storage::{GetSharedLocks, ObjectKey},
+    storage::ObjectKey,
     transaction::{
         InputObjectKind, InputObjects, ObjectReadResult, ObjectReadResultKind,
         ReceivingObjectReadResult, ReceivingObjectReadResultKind, ReceivingObjects, TransactionKey,
@@ -19,7 +19,8 @@ use once_cell::unsync::OnceCell;
 use tracing::instrument;
 
 use crate::{
-    authority::authority_per_epoch_store::CertLockGuard, execution_cache::ObjectCacheRead,
+    authority::authority_per_epoch_store::{AuthorityPerEpochStore, CertLockGuard},
+    execution_cache::ObjectCacheRead,
 };
 
 pub(crate) struct TransactionInputLoader {
@@ -116,8 +117,7 @@ impl TransactionInputLoader {
 
     /// Read the inputs for a transaction that is ready to be executed.
     ///
-    /// shared_lock_store is used to resolve the versions of any shared input
-    /// objects.
+    /// epoch_store is used to resolve the versions of any shared input objects.
     ///
     /// This function panics if any inputs are not available, as
     /// TransactionManager should already have verified that the transaction
@@ -135,7 +135,7 @@ impl TransactionInputLoader {
     #[instrument(level = "trace", skip_all)]
     pub fn read_objects_for_execution(
         &self,
-        shared_lock_store: &impl GetSharedLocks,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
         tx_key: &TransactionKey,
         // Important to hold the _tx_lock, otherwise it would be possible for a concurrent
         // execution of the same tx to enter this point after the first execution has
@@ -144,7 +144,7 @@ impl TransactionInputLoader {
         input_object_kinds: &[InputObjectKind],
         epoch_id: EpochId,
     ) -> IotaResult<InputObjects> {
-        let shared_locks_cell: OnceCell<Option<HashMap<_, _>>> = OnceCell::new();
+        let assigned_shared_versions_cell: OnceCell<Option<HashMap<_, _>>> = OnceCell::new();
 
         let mut results = vec![None; input_object_kinds.len()];
         let mut object_keys = Vec::with_capacity(input_object_kinds.len());
@@ -168,22 +168,27 @@ impl TransactionInputLoader {
                     fetches.push((i, input));
                 }
                 InputObjectKind::SharedMoveObject { id, .. } => {
-                    let shared_locks = shared_locks_cell
+                    let assigned_shared_versions = assigned_shared_versions_cell
                         .get_or_init(|| {
-                            shared_lock_store
-                                .get_shared_locks(tx_key)
-                                .expect("loading shared locks should not fail")
-                                .map(|locks| locks.into_iter().collect())
+                            epoch_store
+                                .get_assigned_shared_object_versions(tx_key)
+                                .expect("loading assigned shared versions should not fail")
+                                .map(|versions| versions.into_iter().collect())
                         })
                         .as_ref()
                         .unwrap_or_else(|| {
-                            // _tx_lock is held, so this should not happen
-                            fatal!("Failed to get shared locks for transaction {tx_key:?}");
+                            // Important to hold the _tx_lock here - otherwise it would be possible
+                            // for a concurrent execution of the same tx to enter this point after
+                            // the first execution has finished and the assigned shared versions
+                            // have been deleted.
+                            fatal!(
+                                "Failed to get assigned shared versions for transaction {tx_key:?}"
+                            );
                         });
-                    // If we find a set of locks but an object is missing, it indicates a serious
-                    // inconsistency:
-                    let version = shared_locks.get(id).unwrap_or_else(|| {
-                        panic!("Shared object locks should have been set. key: {tx_key:?}, obj id: {id:?}")
+                    // If we find a set of assigned versions but an object is missing, it indicates
+                    // a serious inconsistency:
+                    let version = assigned_shared_versions.get(id).unwrap_or_else(|| {
+                        panic!("Shared object version should have been assigned. key: {tx_key:?}, obj id: {id:?}")
                     });
                     if version.is_cancelled() {
                         // Do not need to fetch shared object for cancelled transaction.

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -34,7 +34,6 @@ use iota_types::{
     object::{Data, GAS_VALUE_FOR_TESTING, OBJECT_START_VERSION, Owner},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     randomness_state::get_randomness_state_obj_initial_shared_version,
-    storage::GetSharedLocks,
     supported_protocol_versions::SupportedProtocolVersions,
     utils::{to_sender_signed_transaction, to_sender_signed_transaction_with_multi_signers},
 };
@@ -4745,9 +4744,9 @@ async fn test_shared_object_transaction_ok() {
     // Verify shared locks are now set for the transaction.
     let shared_object_version = authority
         .epoch_store_for_testing()
-        .get_shared_locks(&certificate.key())
-        .expect("failed to read shared locks")
-        .expect("locks are not set")
+        .get_assigned_shared_object_versions(&certificate.key())
+        .expect("Reading shared version assignments should not fail")
+        .expect("Versions should be set")
         .into_iter()
         .find_map(|(object_id, version)| {
             if object_id == shared_object_id {
@@ -4756,7 +4755,7 @@ async fn test_shared_object_transaction_ok() {
                 None
             }
         })
-        .expect("shared object is not locked");
+        .expect("shared object must be assigned a version");
     assert_eq!(shared_object_version, OBJECT_START_VERSION);
 
     // Finally (Re-)execute the contract should succeed.
@@ -4857,9 +4856,9 @@ async fn test_consensus_commit_prologue_generation() {
     let get_assigned_version = |txn_key: &TransactionKey| -> SequenceNumber {
         authority_state
             .epoch_store_for_testing()
-            .get_shared_locks(txn_key)
+            .get_assigned_shared_object_versions(txn_key)
             .unwrap()
-            .expect("locks are not set")
+            .expect("versions should be set")
             .iter()
             .filter_map(|(id, seq)| {
                 if id == &IOTA_CLOCK_OBJECT_ID {
@@ -4964,7 +4963,7 @@ async fn test_consensus_message_processed() {
         } else {
             let epoch_store = authority2.epoch_store_for_testing();
             epoch_store
-                .acquire_shared_locks_from_effects(
+                .acquire_shared_version_assignments_from_effects(
                     &VerifiedExecutableTransaction::new_from_certificate(certificate.clone()),
                     &effects1,
                     authority2.get_object_cache_reader().as_ref(),
@@ -6184,9 +6183,9 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
     // Check cancelled transaction shared locks.
     let shared_object_version = authority
         .epoch_store_for_testing()
-        .get_shared_locks(&cancelled_txn.key())
-        .expect("failed to read shared locks")
-        .expect("locks are not set")
+        .get_assigned_shared_object_versions(&cancelled_txn.key())
+        .expect("Reading shared version assignments should not fail")
+        .expect("Versions should be set")
         .into_iter()
         .collect::<HashMap<_, _>>();
     assert_eq!(
@@ -6203,7 +6202,7 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
     let input_loader = TransactionInputLoader::new(authority.get_object_cache_reader().clone());
     let input_objects = input_loader
         .read_objects_for_execution(
-            authority.epoch_store_for_testing().as_ref(),
+            &authority.epoch_store_for_testing(),
             &cancelled_txn.key(),
             &CertLockGuard::guard_for_tests(),
             &cancelled_txn

--- a/crates/iota-core/src/unit_tests/congestion_control_tests.rs
+++ b/crates/iota-core/src/unit_tests/congestion_control_tests.rs
@@ -366,7 +366,7 @@ async fn test_congestion_control_execution_cancellation() {
         .unwrap();
     authority_state_2
         .epoch_store_for_testing()
-        .acquire_shared_locks_from_effects(
+        .acquire_shared_version_assignments_from_effects(
             &VerifiedExecutableTransaction::new_from_certificate(cert.clone()),
             &effects,
             authority_state_2.get_object_cache_reader().as_ref(),

--- a/crates/iota-single-node-benchmark/src/mock_storage.rs
+++ b/crates/iota-single-node-benchmark/src/mock_storage.rs
@@ -7,6 +7,10 @@ use std::{
     sync::{Arc, RwLock},
 };
 
+use iota_core::authority::{
+    authority_per_epoch_store::AuthorityPerEpochStore,
+    epoch_start_configuration::EpochStartConfigTrait,
+};
 use iota_storage::package_object_cache::PackageObjectCache;
 use iota_types::{
     base_types::{EpochId, ObjectID, SequenceNumber, VersionNumber},
@@ -53,11 +57,11 @@ impl InMemoryObjectStore {
     // functions. (similarly the one in simulacrum)
     pub(crate) fn read_objects_for_execution(
         &self,
-        shared_locks: &dyn GetSharedLocks,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
         tx_key: &TransactionKey,
         input_object_kinds: &[InputObjectKind],
     ) -> IotaResult<InputObjects> {
-        let shared_locks_cell: OnceCell<Option<HashMap<_, _>>> = OnceCell::new();
+        let shared_version_assignments_cell: OnceCell<Option<HashMap<_, _>>> = OnceCell::new();
         let mut input_objects = Vec::new();
         for kind in input_object_kinds {
             let obj: Option<Object> = match kind {
@@ -67,19 +71,19 @@ impl InMemoryObjectStore {
                 }
 
                 InputObjectKind::SharedMoveObject { id, .. } => {
-                    let shared_locks = shared_locks_cell
+                    let shared_version_assignments = shared_version_assignments_cell
                         .get_or_init(|| {
-                            shared_locks
-                                .get_shared_locks(tx_key)
-                                .expect("get_shared_locks should not fail")
+                            epoch_store
+                                .get_assigned_shared_object_versions(tx_key)
+                                .expect("get_assigned_shared_object_versions should not fail")
                                 .map(|l| l.into_iter().collect())
                         })
                         .as_ref()
                         .ok_or_else(|| IotaError::GenericAuthority {
-                            error: "Shared object locks should have been set.".to_string(),
+                            error: "Shared object versions should have been assigned.".to_string(),
                         })?;
-                    let version = shared_locks.get(id).unwrap_or_else(|| {
-                        panic!("Shared object locks should have been set. key: {tx_key:?}, obj id: {id:?}")
+                    let version = shared_version_assignments.get(id).unwrap_or_else(|| {
+                        panic!("Shared object version should have been assigned. key: {tx_key:?}, obj id: {id:?}")
                     });
 
                     self.get_object_by_key(id, *version)?
@@ -173,14 +177,5 @@ impl GetModule for InMemoryObjectStore {
 
     fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<Self::Item>, Self::Error> {
         get_module_by_id(self, id)
-    }
-}
-
-impl GetSharedLocks for InMemoryObjectStore {
-    fn get_shared_locks(
-        &self,
-        _key: &TransactionKey,
-    ) -> IotaResult<Option<Vec<(ObjectID, SequenceNumber)>>> {
-        unreachable!()
     }
 }

--- a/crates/iota-single-node-benchmark/src/mock_storage.rs
+++ b/crates/iota-single-node-benchmark/src/mock_storage.rs
@@ -7,10 +7,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use iota_core::authority::{
-    authority_per_epoch_store::AuthorityPerEpochStore,
-    epoch_start_configuration::EpochStartConfigTrait,
-};
+use iota_core::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use iota_storage::package_object_cache::PackageObjectCache;
 use iota_types::{
     base_types::{EpochId, ObjectID, SequenceNumber, VersionNumber},
@@ -18,8 +15,7 @@ use iota_types::{
     inner_temporary_store::InnerTemporaryStore,
     object::{Object, Owner},
     storage::{
-        BackingPackageStore, ChildObjectResolver, GetSharedLocks, ObjectStore, PackageObject,
-        get_module_by_id,
+        BackingPackageStore, ChildObjectResolver, ObjectStore, PackageObject, get_module_by_id,
     },
     transaction::{InputObjectKind, InputObjects, ObjectReadResult, TransactionKey},
 };

--- a/crates/iota-single-node-benchmark/src/single_node.rs
+++ b/crates/iota-single-node-benchmark/src/single_node.rs
@@ -201,7 +201,7 @@ impl SingleValidator {
     ) -> TransactionEffects {
         let input_objects = transaction.transaction_data().input_objects().unwrap();
         let objects = store
-            .read_objects_for_execution(&*self.epoch_store, &transaction.key(), &input_objects)
+            .read_objects_for_execution(&self.epoch_store, &transaction.key(), &input_objects)
             .unwrap();
 
         let executable = VerifiedExecutableTransaction::new_from_certificate(

--- a/crates/iota-types/src/storage/mod.rs
+++ b/crates/iota-types/src/storage/mod.rs
@@ -34,7 +34,7 @@ use crate::{
     execution::{DynamicallyLoadedObjectMetadata, ExecutionResults},
     move_package::MovePackage,
     object::Object,
-    transaction::{SenderSignedData, TransactionDataAPI, TransactionKey},
+    transaction::{SenderSignedData, TransactionDataAPI},
 };
 
 /// A potential input to a transaction.
@@ -569,11 +569,4 @@ where
     fn as_object_store(&self) -> &dyn ObjectStore {
         self
     }
-}
-
-pub trait GetSharedLocks: Send + Sync {
-    fn get_shared_locks(
-        &self,
-        key: &TransactionKey,
-    ) -> IotaResult<Option<Vec<(ObjectID, SequenceNumber)>>>;
 }


### PR DESCRIPTION
# Description of change

Porting upstream change: https://github.com/MystenLabs/sui/commit/721c02f47c7a29fd180314b3a6cb03a1ae58824d

> It's only ever populated with `AuthorityPerEpochStore`.
> 
> Also corrects the misnomer of "shared locks" everywhere to "shared
> version assignments".

## Links to any relevant issues

Fixes #6568 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

CI

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
