### PR TITLE
upstream(consensus): update transaction outputs

### DIFF
--- a/crates/iota-core/src/transaction_outputs.rs
+++ b/crates/iota-core/src/transaction_outputs.rs
@@ -57,8 +57,7 @@ impl TransactionOutputs {
         let modified_at: HashSet<_> = effects.modified_at_versions().into_iter().collect();
         let possible_to_receive = transaction.transaction_data().receiving_objects();
         let received_objects = possible_to_receive
-            .iter()
-            .cloned()
+            .into_iter()
             .filter(|obj_ref| modified_at.contains(&(obj_ref.0, obj_ref.1)));
 
         // We record any received or deleted objects since they could be pruned, and


### PR DESCRIPTION
# Description of change

Porting upstream change: https://github.com/MystenLabs/sui/commit/a0b5616b05c2fb8750b20d8ac05a57cf779535a0


> 1. **`possible_to_receive.iter().clone()` ->
> `possible_to_receive.into_iter()`**:
> 
> This modification is generally appropriate and improves performance by
> avoiding unnecessary cloning of the `possible_to_receive` collection.
> Instead of cloning, it consumes the iterator, which is more efficient.


## Links to any relevant issues

Fixes #6569 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

CI

