### PR TITLE
upstream(consensus): enable softbundle byte-size checks in API

### DIFF
--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -781,7 +781,7 @@ impl ValidatorService {
             protocol_config.consensus_max_transactions_in_block_bytes() / 2;
         fp_ensure!(
             total_size_bytes <= soft_bundle_max_size_bytes,
-            IotaError::UserInputError {
+            IotaError::UserInput {
                 error: UserInputError::SoftBundleTooLarge {
                     size: total_size_bytes,
                     limit: soft_bundle_max_size_bytes,

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -868,7 +868,7 @@ impl ValidatorService {
 
         self.metrics
             .handle_soft_bundle_certificates_size_bytes
-            .observe(total_size_bytes as u64);
+            .observe(total_size_bytes);
 
         // Now that individual certificates are valid, we check if the bundle is valid.
         self.soft_bundle_validity_check(&certificates, &epoch_store, total_size_bytes)

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -752,6 +752,7 @@ impl ValidatorService {
         &self,
         certificates: &NonEmpty<CertifiedTransaction>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
+        total_size_bytes: u64,
     ) -> Result<(), tonic::Status> {
         let protocol_config = epoch_store.protocol_config();
 
@@ -760,6 +761,7 @@ impl ValidatorService {
         // - All certs must not be already executed.
         // - All certs must have the same gas price.
         // - Number of certs must not exceed the max allowed.
+        // - Total size of all certs must not exceed the max allowed.
         fp_ensure!(
             certificates.len() as u64 <= protocol_config.max_soft_bundle_size(),
             IotaError::UserInput {
@@ -769,6 +771,25 @@ impl ValidatorService {
             }
             .into()
         );
+
+        // We set the soft bundle max size to be half of the consensus max transactions
+        // in block size. We do this to account for serialization overheads and
+        // to ensure that the soft bundle is not too large when is attempted to be
+        // posted via consensus. Although half the block size is on the extreme
+        // side, it's should be good enough for now.
+        let soft_bundle_max_size_bytes =
+            protocol_config.consensus_max_transactions_in_block_bytes() / 2;
+        fp_ensure!(
+            total_size_bytes <= soft_bundle_max_size_bytes,
+            IotaError::UserInputError {
+                error: UserInputError::SoftBundleTooLarge {
+                    size: total_size_bytes,
+                    limit: soft_bundle_max_size_bytes,
+                },
+            }
+            .into()
+        );
+
         let mut gas_price = None;
         for certificate in certificates {
             let tx_digest = *certificate.digest();
@@ -836,8 +857,9 @@ impl ValidatorService {
         let mut total_size_bytes = 0;
         for certificate in &certificates {
             // We need to check this first because we haven't verified the cert signature.
-            total_size_bytes +=
-                certificate.validity_check(epoch_store.protocol_config(), epoch_store.epoch())?;
+            total_size_bytes += certificate
+                .validity_check(epoch_store.protocol_config(), epoch_store.epoch())?
+                as u64;
         }
 
         self.metrics
@@ -849,11 +871,11 @@ impl ValidatorService {
             .observe(total_size_bytes as u64);
 
         // Now that individual certificates are valid, we check if the bundle is valid.
-        self.soft_bundle_validity_check(&certificates, &epoch_store)
+        self.soft_bundle_validity_check(&certificates, &epoch_store, total_size_bytes)
             .await?;
 
         info!(
-            "Received Soft Bundle with {} certificates, from {}, tx digests are [{}]",
+            "Received Soft Bundle with {} certificates, from {}, tx digests are [{}], total size [{}]bytes",
             certificates.len(),
             client_addr
                 .map(|x| x.to_string())
@@ -862,7 +884,8 @@ impl ValidatorService {
                 .iter()
                 .map(|x| x.digest().to_string())
                 .collect::<Vec<_>>()
-                .join(", ")
+                .join(", "),
+            total_size_bytes
         );
 
         let span = error_span!("handle_soft_bundle_certificates_v1");

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -1817,7 +1817,7 @@ async fn test_handle_soft_bundle_certificates_errors() {
     let mut senders = Vec::new();
     let mut gas_objects = Vec::new();
     let mut owned_objects = Vec::new();
-    for _i in 0..10 {
+    for _i in 0..15 {
         let (sender, keypair): (_, AccountKeyPair) = get_key_pair();
         let mut objects = create_gas_objects(2, sender);
         senders.push((sender, keypair));
@@ -1828,6 +1828,7 @@ async fn test_handle_soft_bundle_certificates_errors() {
     let mut protocol_config =
         ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
     protocol_config.set_max_soft_bundle_size_for_testing(3);
+    protocol_config.set_consensus_max_transactions_in_block_bytes_for_testing(10_000);
     let authority = TestAuthorityBuilder::new()
         .with_reference_gas_price(1000)
         .with_protocol_config(protocol_config)
@@ -1899,6 +1900,7 @@ async fn test_handle_soft_bundle_certificates_errors() {
     let rgp = authority.reference_gas_price_for_testing().unwrap();
 
     // Case 0: submit an empty soft bundle.
+    println!("Case 0: submit an empty soft bundle.");
     {
         let response = client
             .handle_soft_bundle_certificates_v1(
@@ -1919,6 +1921,7 @@ async fn test_handle_soft_bundle_certificates_errors() {
 
     // Case 1: submit a soft bundle with more txs than the limit.
     // The bundle should be rejected.
+    println!("Case 1: submit a soft bundle with more txs than the limit.");
     {
         let mut certificates: Vec<CertifiedTransaction> = vec![];
         for i in 0..5 {
@@ -1969,6 +1972,7 @@ async fn test_handle_soft_bundle_certificates_errors() {
 
     // Case 2: submit a soft bundle with tx containing no shared object.
     // The bundle should be rejected.
+    println!("Case 2: submit a soft bundle with tx containing no shared object.");
     {
         let owned_object_ref = authority
             .get_object(&owned_objects[5].id())
@@ -2015,6 +2019,7 @@ async fn test_handle_soft_bundle_certificates_errors() {
 
     // Case 3: submit a soft bundle with txs of different gas prices.
     // The bundle should be rejected.
+    println!("Case 3: submit a soft bundle with txs of different gas prices.");
     {
         let cert0 = {
             let gas_object_ref = authority
@@ -2102,6 +2107,7 @@ async fn test_handle_soft_bundle_certificates_errors() {
 
     // Case 4: submit a soft bundle with txs whose consensus message has been
     // processed. The bundle should be rejected.
+    println!("Case 4: submit a soft bundle with txs whose consensus message has been processed.");
     {
         let cert0 = {
             let gas_object_ref = authority
@@ -2185,6 +2191,75 @@ async fn test_handle_soft_bundle_certificates_errors() {
             response.unwrap_err(),
             IotaError::UserInput {
                 error: UserInputError::CertificateAlreadyProcessed,
+            }
+        );
+    }
+
+    // Case 5: submit a soft bundle with total tx size exceeding the block size
+    // limit. The bundle should be rejected.
+    println!("Case 5: submit a soft bundle with total tx size exceeding the block size limit.");
+    {
+        let mut certificates: Vec<CertifiedTransaction> = vec![];
+
+        for i in 11..14 {
+            let owned_object_ref = authority
+                .get_object(&owned_objects[i].id())
+                .await
+                .unwrap()
+                .compute_object_reference();
+            let gas_object_ref = authority
+                .get_object(&gas_objects[i].id())
+                .await
+                .unwrap()
+                .compute_object_reference();
+            let sender = &senders[i];
+            let recipient = &senders[i + 1].0;
+
+            // Construct an oversized txn.
+            let pt = {
+                let mut builder = ProgrammableTransactionBuilder::new();
+                // Put a lot of commands in the txn so it's large.
+                for _ in 0..1000 {
+                    builder
+                        .transfer_object(*recipient, owned_object_ref)
+                        .unwrap();
+                }
+                builder.finish()
+            };
+
+            let data = TransactionData::new_programmable(
+                sender.0,
+                vec![gas_object_ref],
+                pt,
+                rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+                rgp,
+            );
+
+            let signed = to_sender_signed_transaction(data, &sender.1);
+            certificates.push(signed_tx_into_certificate(signed).await.into());
+        }
+
+        let response = client
+            .handle_soft_bundle_certificates_v3(
+                HandleSoftBundleCertificatesRequestV3 {
+                    certificates,
+                    wait_for_effects: true,
+                    include_events: false,
+                    include_auxiliary_data: false,
+                    include_input_objects: false,
+                    include_output_objects: false,
+                },
+                None,
+            )
+            .await;
+        assert!(response.is_err());
+        assert_matches!(
+            response.unwrap_err(),
+            IotaError::UserInputError {
+                error: UserInputError::SoftBundleTooLarge {
+                    size: 25116,
+                    limit: 5000
+                },
             }
         );
     }

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -2206,10 +2206,12 @@ async fn test_handle_soft_bundle_certificates_errors() {
                 .get_object(&owned_objects[i].id())
                 .await
                 .unwrap()
+                .unwrap()
                 .compute_object_reference();
             let gas_object_ref = authority
                 .get_object(&gas_objects[i].id())
                 .await
+                .unwrap()
                 .unwrap()
                 .compute_object_reference();
             let sender = &senders[i];
@@ -2240,8 +2242,8 @@ async fn test_handle_soft_bundle_certificates_errors() {
         }
 
         let response = client
-            .handle_soft_bundle_certificates_v3(
-                HandleSoftBundleCertificatesRequestV3 {
+            .handle_soft_bundle_certificates_v1(
+                HandleSoftBundleCertificatesRequestV1 {
                     certificates,
                     wait_for_effects: true,
                     include_events: false,
@@ -2255,7 +2257,7 @@ async fn test_handle_soft_bundle_certificates_errors() {
         assert!(response.is_err());
         assert_matches!(
             response.unwrap_err(),
-            IotaError::UserInputError {
+            IotaError::UserInput {
                 error: UserInputError::SoftBundleTooLarge {
                     size: 25116,
                     limit: 5000

--- a/crates/iota-types/src/error.rs
+++ b/crates/iota-types/src/error.rs
@@ -280,6 +280,12 @@ pub enum UserInputError {
         limit
     )]
     TooManyTransactionsInSoftBundle { limit: u64 },
+    #[error(
+        "Total transactions size ({:?})bytes exceeds the maximum allowed ({:?})bytes in a Soft Bundle",
+        size,
+        limit
+    )]
+    SoftBundleTooLarge { size: u64, limit: u64 },
     #[error("Transaction {:?} in Soft Bundle contains no shared objects", digest)]
     NoSharedObject { digest: TransactionDigest },
     #[error("Transaction {:?} in Soft Bundle has already been executed", digest)]


### PR DESCRIPTION
# Description of change

Porting upstream PR: https://github.com/MystenLabs/sui/commit/f0ade5e8c2435e8f5c6b7a53ac90b201a1e23cca

> this PR is essential to ensure that submitted soft bundle transactions
> will make it through consensus and won't be rejected due to excessive
> size (for the edge cases). Now the API will return a
> `SoftBundleTooLarge` error if the soft bundle in size bytes is ` >
> consensus_block_size/2` .

## Links to any relevant issues

Fixes #6567

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

CI

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
