### PR TITLE
refactor(docs): fix few docs errors

### DIFF
--- a/docs/content/_snippets/operator/monitoring-logs.mdx
+++ b/docs/content/_snippets/operator/monitoring-logs.mdx
@@ -31,15 +31,27 @@ It is possible to change the logging configuration while a node is running using
 
 #### Verify Configured Logging Values
 
-To view the currently configured logging values:
-```sh
-curl -w "\n" localhost:1337/logging
-```
+<Tabs groupId="node-logs">
+  <TabItem label="Systemd" value="logs-systemd">
+    To view the currently configured logging values:
+    ```sh
+    curl -w "\n" localhost:1337/logging
+    ```
 
-To change the currently configured logging values:
-```sh
-curl localhost:1337/logging -d "info"
-```
+    To change the currently configured logging values:
+    ```sh
+    curl localhost:1337/logging -d "info"
+    ```
+  </TabItem>
+
+  <TabItem label="Docker Compose" value="logs-docker">
+    Note that the admin port (`1337`) is only exposed to `localhost` by default, so the commands must be executed inside the container.
+    ```sh
+    docker exec <FULLNODE_CONTAINER_NAME> curl -w "\n" localhost:1337/logging
+    ```
+    Replace `<FULLNODE_CONTAINER_NAME>` with your actual container name, such as `iota-fullnode-docker-setup-fullnode-1`.
+  </TabItem>
+</Tabs>
 
 #### Viewing Logs
 

--- a/docs/content/_snippets/operator/monitoring-logs.mdx
+++ b/docs/content/_snippets/operator/monitoring-logs.mdx
@@ -46,9 +46,17 @@ It is possible to change the logging configuration while a node is running using
 
   <TabItem label="Docker Compose" value="logs-docker">
     Note that the admin port (`1337`) is only exposed to `localhost` by default, so the commands must be executed inside the container.
+
+    To view the currently configured logging values:
     ```sh
     docker exec <FULLNODE_CONTAINER_NAME> curl -w "\n" localhost:1337/logging
     ```
+
+    To change the currently configured logging values:
+    ```sh
+    docker exec <FULLNODE_CONTAINER_NAME> curl localhost:1337/logging -d "info"
+    ```
+
     Replace `<FULLNODE_CONTAINER_NAME>` with your actual container name, such as `iota-fullnode-docker-setup-fullnode-1`.
   </TabItem>
 </Tabs>

--- a/docs/content/_snippets/operator/validator-generate-info.mdx
+++ b/docs/content/_snippets/operator/validator-generate-info.mdx
@@ -70,7 +70,7 @@ iota validator make-validator-info \
 ```
 
 - `name`: A human-readable validator name, e.g., `validator1`.
-- `description`: A human-readable validator description, e.g., `this is a validator`.
+- `description`: A human-readable validator description, e.g., `"this is a validator"`.
 - `image_url`: The validator image URL, e.g., `https://www.iota.org/favicon.png`.
 - `project_url`: The validator project URL, e.g., `https://www.iota.org`.
 - `host_name`: The host name that is used to generate the validator `network_address`, `p2p-address` and `primary_address`, e.g., `validator1.iota.org`.

--- a/docs/content/operator/common/snapshots.mdx
+++ b/docs/content/operator/common/snapshots.mdx
@@ -83,6 +83,7 @@ Follow these steps to change the configs for the node:
          aws-secret-access-key: "`<SHARED-KEY>`"
          aws-region: "`<BUCKET-REGION>`"
          object-store-connection-limit: 200
+      concurrency: 10
    ```
 
    </TabItem>
@@ -94,6 +95,7 @@ Follow these steps to change the configs for the node:
    - `aws-access-key-id` and `aws-secret-access-key`: AWS authentication information with write access to the bucket.
    - `aws-region`: Region where bucket exists.
    - `object-store-connection-limit`: Number of simultaneous connections to the object store.
+   - `concurrency`: Number of concurrent uploads of snapshots to the object store.
 
 3. Save the `fullnode.yaml` file and restart the node.
    


### PR DESCRIPTION
# Description of change

- Fixed the missing `concurrency` for `state-snapshot-write-config` in the docs.
- Explicitly explained the `Verify Configured Logging Values` for docker users.
- Added the quotation marks for validator command, `iota validator make-validator-info`, to avoid confusing.

## Links to any relevant issues

Fixes #6615

## Type of change

- Documentation Fix

## How the change has been tested

Ran and checked the generated docs locally.
