### PR TITLE
node-upstream-change([v1.32.2, v1.33.3)): Add a metric to track the number of managed files per column family in RocksDb

### DIFF
--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -83,6 +83,7 @@ impl SamplingInterval {
 pub struct ColumnFamilyMetrics {
     pub rocksdb_total_sst_files_size: IntGaugeVec,
     pub rocksdb_total_blob_files_size: IntGaugeVec,
+    pub rocksdb_total_num_files: IntGaugeVec,
     pub rocksdb_current_size_active_mem_tables: IntGaugeVec,
     pub rocksdb_size_all_mem_tables: IntGaugeVec,
     pub rocksdb_num_snapshots: IntGaugeVec,
@@ -118,6 +119,13 @@ impl ColumnFamilyMetrics {
             rocksdb_total_blob_files_size: register_int_gauge_vec_with_registry!(
                 "rocksdb_total_blob_files_size",
                 "The storage size occupied by the blob files in the column family",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_total_num_files: register_int_gauge_vec_with_registry!(
+                "rocksdb_total_num_files",
+                "Total number of files used in the column family",
                 &["cf_name"],
                 registry,
             )

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -31,7 +31,7 @@ use rocksdb::{
     ColumnFamilyDescriptor, CompactOptions, DBPinnableSlice, DBWithThreadMode, Error, ErrorKind,
     IteratorMode, LiveFile, MultiThreaded, OptimisticTransactionDB, OptimisticTransactionOptions,
     ReadOptions, SnapshotWithThreadMode, Transaction, WriteBatch, WriteBatchWithTransaction,
-    WriteOptions, checkpoint::Checkpoint, properties,
+    WriteOptions, checkpoint::Checkpoint, properties, properties::num_files_at_level,
 };
 use serde::{Serialize, de::DeserializeOwned};
 use tap::TapFallible;
@@ -938,7 +938,7 @@ impl<K, V> DBMap<K, V> {
     fn get_int_property(
         rocksdb: &RocksDB,
         cf: &impl AsColumnFamilyRef,
-        property_name: &'static std::ffi::CStr,
+        property_name: &std::ffi::CStr,
     ) -> Result<i64, TypedStoreError> {
         match rocksdb.property_int_value_cf(cf, property_name) {
             Ok(Some(value)) => Ok(value.min(i64::MAX as u64).try_into().unwrap_or_default()),
@@ -1020,6 +1020,20 @@ impl<K, V> DBMap<K, V> {
                 Self::get_int_property(rocksdb, &cf, ROCKSDB_PROPERTY_TOTAL_BLOB_FILES_SIZE)
                     .unwrap_or(METRICS_ERROR),
             );
+        // 7 is the default number of levels in RocksDB. If we ever change the number of
+        // levels using `set_num_levels`, we need to update here as well. Note
+        // that there isn't an API to query the DB to get the number of levels (yet).
+        let total_num_files: i64 = (0..=6)
+            .map(|level| {
+                Self::get_int_property(rocksdb, &cf, &num_files_at_level(level))
+                    .unwrap_or(METRICS_ERROR)
+            })
+            .sum();
+        db_metrics
+            .cf_metrics
+            .rocksdb_total_num_files
+            .with_label_values(&[cf_name])
+            .set(total_num_files);
         db_metrics
             .cf_metrics
             .rocksdb_current_size_active_mem_tables


### PR DESCRIPTION
# Description of change
Port [MystenLabs/sui@e1abe09](https://github.com/MystenLabs/sui/commit/e1abe0963b579d69471ce40bd465d63fb80f0f41)

Add a metric to track the number of managed files per column family in RocksDb (https://github.com/MystenLabs/sui/pull/19214). We don't add more detailed level to control the cardinality of the metrics.


## Links to any relevant issues

Part of https://github.com/iotaledger/iota/issues/3990

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

```
cargo r --bin iota-node -- --config-path fullnode.yaml
```
```
RUST_LOG=info cargo r --bin iota start --force-regenesis --with-faucet
```