### PR TITLE
node-upstream-change([v1.32.2, v1.33.3)): [rocksdb] add metric for num level 0 files

### DIFF
--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -84,6 +84,7 @@ pub struct ColumnFamilyMetrics {
     pub rocksdb_total_sst_files_size: IntGaugeVec,
     pub rocksdb_total_blob_files_size: IntGaugeVec,
     pub rocksdb_total_num_files: IntGaugeVec,
+    pub rocksdb_num_level0_files: IntGaugeVec,
     pub rocksdb_current_size_active_mem_tables: IntGaugeVec,
     pub rocksdb_size_all_mem_tables: IntGaugeVec,
     pub rocksdb_num_snapshots: IntGaugeVec,
@@ -126,6 +127,13 @@ impl ColumnFamilyMetrics {
             rocksdb_total_num_files: register_int_gauge_vec_with_registry!(
                 "rocksdb_total_num_files",
                 "Total number of files used in the column family",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_num_level0_files: register_int_gauge_vec_with_registry!(
+                "rocksdb_num_level0_files",
+                "Number of level 0 files in the column family",
                 &["cf_name"],
                 registry,
             )

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1036,6 +1036,14 @@ impl<K, V> DBMap<K, V> {
             .set(total_num_files);
         db_metrics
             .cf_metrics
+            .rocksdb_num_level0_files
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, &num_files_at_level(0))
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
             .rocksdb_current_size_active_mem_tables
             .with_label_values(&[cf_name])
             .set(


### PR DESCRIPTION
## Description of change

Port [MystenLabs/sui@262390b](https://github.com/MystenLabs/sui/commit/262390b27ca7befe9bd3a537aae6ebef9f569348)

Too many level 0 files can be a trigger to write stall & stop as well

## Links to any relevant issues

Part of https://github.com/iotaledger/iota/issues/3990

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested
```
cargo r --bin iota-node -- --config-path fullnode.yaml
```
```
RUST_LOG=info cargo r --bin iota start --force-regenesis --with-faucet
```