### PR TITLE
feat(starfish): send full block

### DIFF
--- a/crates/starfish/core/build.rs
+++ b/crates/starfish/core/build.rs
@@ -28,15 +28,6 @@ fn build_tonic_services(out_dir: &Path) {
         .comment("Consensus authority interface")
         .method(
             tonic_build::manual::Method::builder()
-                .name("send_block")
-                .route_name("SendBlock")
-                .input_type("crate::network::tonic_network::SendBlockRequest")
-                .output_type("crate::network::tonic_network::SendBlockResponse")
-                .codec_path(codec_path)
-                .build(),
-        )
-        .method(
-            tonic_build::manual::Method::builder()
                 .name("subscribe_blocks")
                 .route_name("SubscribeBlocks")
                 .input_type("crate::network::tonic_network::SubscribeBlocksRequest")
@@ -44,6 +35,16 @@ fn build_tonic_services(out_dir: &Path) {
                 .codec_path(codec_path)
                 .server_streaming()
                 .client_streaming()
+                .build(),
+        )
+        .method(
+            tonic_build::manual::Method::builder()
+                .name("fetch_block_headers")
+                .route_name("FetchBlockHeaders")
+                .input_type("crate::network::tonic_network::FetchBlockHeadersRequest")
+                .output_type("crate::network::tonic_network::FetchBlockHeadersResponse")
+                .codec_path(codec_path)
+                .server_streaming()
                 .build(),
         )
         .method(
@@ -67,10 +68,10 @@ fn build_tonic_services(out_dir: &Path) {
         )
         .method(
             tonic_build::manual::Method::builder()
-                .name("fetch_latest_blocks")
-                .route_name("FetchLatestBlocks")
-                .input_type("crate::network::tonic_network::FetchLatestBlocksRequest")
-                .output_type("crate::network::tonic_network::FetchLatestBlocksResponse")
+                .name("fetch_latest_block_headers")
+                .route_name("FetchLatestBlockHeaders")
+                .input_type("crate::network::tonic_network::FetchLatestBlockHeadersRequest")
+                .output_type("crate::network::tonic_network::FetchLatestBlockHeadersResponse")
                 .codec_path(codec_path)
                 .server_streaming()
                 .build(),

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -470,6 +470,7 @@ mod tests {
         }
     }
 
+    // TODO: test is not doing what is described in the comments
     #[rstest]
     #[tokio::test(flavor = "current_thread")]
     async fn test_amnesia_recovery_success() {

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -148,6 +148,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let verified_transactions = VerifiedTransactions::new(
             transactions,
             verified_block_header.reference(),
+            verified_block_header.transactions_commitment(),
             serialized_block.serialized_transactions,
         );
         let verified_block = VerifiedBlock::new(verified_block_header, verified_transactions);

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -15,8 +15,11 @@ use tokio_util::sync::ReusableBoxFuture;
 use tracing::{debug, info, warn};
 
 use crate::{
-    BlockHeaderAPI, CommitIndex, Round, VerifiedBlockHeader,
-    block_header::{BlockRef, GENESIS_ROUND, SignedBlockHeader},
+    BlockHeaderAPI, CommitIndex, Round, Transaction, VerifiedBlockHeader,
+    block_header::{
+        BlockRef, GENESIS_ROUND, SignedBlockHeader, TransactionsCommitment, VerifiedBlock,
+        VerifiedTransactions,
+    },
     block_verifier::BlockVerifier,
     commit::{CommitAPI as _, CommitRange, TrustedCommit},
     commit_vote_monitor::CommitVoteMonitor,
@@ -24,7 +27,7 @@ use crate::{
     core_thread::CoreThreadDispatcher,
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
-    network::{BlockStream, NetworkService},
+    network::{BlockStream, NetworkService, SerializedBlock},
     stake_aggregator::{QuorumThreshold, StakeAggregator},
     storage::Store,
     synchronizer::SynchronizerHandle,
@@ -40,7 +43,7 @@ pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
     block_verifier: Arc<dyn BlockVerifier>,
     synchronizer: Arc<SynchronizerHandle>,
     core_dispatcher: Arc<C>,
-    rx_block_broadcaster: broadcast::Receiver<VerifiedBlockHeader>,
+    rx_block_broadcaster: broadcast::Receiver<VerifiedBlock>,
     subscription_counter: Arc<SubscriptionCounter>,
     dag_state: Arc<RwLock<DagState>>,
     store: Arc<dyn Store>,
@@ -53,7 +56,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         commit_vote_monitor: Arc<CommitVoteMonitor>,
         synchronizer: Arc<SynchronizerHandle>,
         core_dispatcher: Arc<C>,
-        rx_block_broadcaster: broadcast::Receiver<VerifiedBlockHeader>,
+        rx_block_broadcaster: broadcast::Receiver<VerifiedBlock>,
         dag_state: Arc<RwLock<DagState>>,
         store: Arc<dyn Store>,
     ) -> Self {
@@ -77,21 +80,21 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
 
 #[async_trait]
 impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
-    async fn handle_send_block(
+    async fn handle_subscribed_block(
         &self,
         peer: AuthorityIndex,
-        serialized_block: Bytes,
+        serialized_block: SerializedBlock,
     ) -> ConsensusResult<()> {
         fail_point_async!("consensus-rpc-response");
 
         let peer_hostname = &self.context.committee.authority(peer).hostname;
 
-        // TODO: dedup block verifications, here and with fetched blocks.
-        let signed_block: SignedBlockHeader =
-            bcs::from_bytes(&serialized_block).map_err(ConsensusError::MalformedBlock)?;
+        let signed_block_header: SignedBlockHeader =
+            bcs::from_bytes(&serialized_block.serialized_block_header)
+                .map_err(ConsensusError::MalformedBlockHeader)?;
 
         // Reject blocks not produced by the peer.
-        if peer != signed_block.author() {
+        if peer != signed_block_header.author() {
             self.context
                 .metrics
                 .node_metrics
@@ -102,14 +105,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                     "UnexpectedAuthority",
                 ])
                 .inc();
-            let e = ConsensusError::UnexpectedAuthority(signed_block.author(), peer);
+            let e = ConsensusError::UnexpectedAuthority(signed_block_header.author(), peer);
             info!("Block with wrong authority from {}: {}", peer, e);
             return Err(e);
         }
-        let peer_hostname = &self.context.committee.authority(peer).hostname;
 
-        // Reject blocks failing validations.
-        if let Err(e) = self.block_verifier.verify(&signed_block) {
+        if let Err(e) = self.block_verifier.verify(&signed_block_header) {
             self.context
                 .metrics
                 .node_metrics
@@ -123,7 +124,34 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             info!("Invalid block from {}: {}", peer, e);
             return Err(e);
         }
-        let verified_block = VerifiedBlockHeader::new_verified(signed_block, serialized_block);
+
+        if signed_block_header.transactions_commitment()
+            != TransactionsCommitment::compute_transactions_commitment(
+                &serialized_block.serialized_transactions,
+            )
+            .expect("we should expect correct computation of the transactions commitment")
+        {
+            return Err(ConsensusError::TransactionCommitmentFailure {
+                round: signed_block_header.round(),
+                author: signed_block_header.author(),
+                peer,
+            });
+        }
+
+        let verified_block_header = VerifiedBlockHeader::new_verified(
+            signed_block_header,
+            serialized_block.serialized_block_header,
+        );
+        let transactions: Vec<Transaction> =
+            bcs::from_bytes(&serialized_block.serialized_transactions)
+                .map_err(ConsensusError::MalformedTransactions)?;
+        let verified_transactions = VerifiedTransactions::new(
+            transactions,
+            verified_block_header.reference(),
+            serialized_block.serialized_transactions,
+        );
+        let verified_block = VerifiedBlock::new(verified_block_header, verified_transactions);
+
         let block_ref = verified_block.reference();
         debug!("Received block {} via send block.", block_ref);
 
@@ -227,7 +255,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             // schedule the fetching of them from this peer
             if let Err(err) = self
                 .synchronizer
-                .fetch_blocks(missing_ancestors, peer)
+                .fetch_block_headers(missing_ancestors, peer)
                 .await
             {
                 warn!("Errored while trying to fetch missing ancestors via synchronizer: {err}");
@@ -252,7 +280,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             dag_state
                 .get_cached_blocks(self.context.own_index, last_received + 1)
                 .into_iter()
-                .map(|block| block.serialized().clone()),
+                .map(SerializedBlock::from),
         );
 
         let broadcasted_blocks = BroadcastedBlockStream::new(
@@ -263,9 +291,75 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         // Return a stream of blocks that first yields missed blocks as requested, then
         // new blocks.
-        Ok(Box::pin(missed_blocks.chain(
-            broadcasted_blocks.map(|block| block.serialized().clone()),
-        )))
+        Ok(Box::pin(
+            missed_blocks.chain(broadcasted_blocks.map(SerializedBlock::from)),
+        ))
+    }
+
+    async fn handle_fetch_block_headers(
+        &self,
+        peer: AuthorityIndex,
+        block_refs: Vec<BlockRef>,
+        highest_accepted_rounds: Vec<Round>,
+    ) -> ConsensusResult<Vec<Bytes>> {
+        fail_point_async!("consensus-rpc-response");
+
+        const MAX_ADDITIONAL_BLOCKS: usize = 10;
+        if block_refs.len() > self.context.parameters.max_blocks_per_fetch {
+            return Err(ConsensusError::TooManyFetchBlockHeadersRequested(peer));
+        }
+
+        if !highest_accepted_rounds.is_empty()
+            && highest_accepted_rounds.len() != self.context.committee.size()
+        {
+            return Err(ConsensusError::InvalidSizeOfHighestAcceptedRounds(
+                highest_accepted_rounds.len(),
+                self.context.committee.size(),
+            ));
+        }
+
+        // Some quick validation of the requested block refs
+        for block in &block_refs {
+            if !self.context.committee.is_valid_index(block.author) {
+                return Err(ConsensusError::InvalidAuthorityIndex {
+                    index: block.author,
+                    max: self.context.committee.size(),
+                });
+            }
+            if block.round == GENESIS_ROUND {
+                return Err(ConsensusError::UnexpectedGenesisBlockHeaderRequested);
+            }
+        }
+
+        // For now ask dag state directly
+        let block_headers = self.dag_state.read().get_block_headers(&block_refs);
+
+        // Now check if an ancestor's round is higher than the one that the peer has. If
+        // yes, then serve that ancestor blocks up to `MAX_ADDITIONAL_BLOCKS`.
+        let mut ancestor_block_headers = vec![];
+        if !highest_accepted_rounds.is_empty() {
+            let all_ancestors = block_headers
+                .iter()
+                .flatten()
+                .flat_map(|block| block.ancestors().to_vec())
+                .filter(|block_ref| highest_accepted_rounds[block_ref.author] < block_ref.round)
+                .take(MAX_ADDITIONAL_BLOCKS)
+                .collect::<Vec<_>>();
+
+            if !all_ancestors.is_empty() {
+                ancestor_block_headers = self.dag_state.read().get_block_headers(&all_ancestors);
+            }
+        }
+
+        // Return the serialised blocks & the ancestor blocks
+        let result = block_headers
+            .into_iter()
+            .chain(ancestor_block_headers)
+            .flatten()
+            .map(|block_header| block_header.serialized().clone())
+            .collect();
+
+        Ok(result)
     }
 
     async fn handle_fetch_blocks(
@@ -273,7 +367,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         peer: AuthorityIndex,
         block_refs: Vec<BlockRef>,
         highest_accepted_rounds: Vec<Round>,
-    ) -> ConsensusResult<Vec<Bytes>> {
+    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
         fail_point_async!("consensus-rpc-response");
 
         const MAX_ADDITIONAL_BLOCKS: usize = 10;
@@ -328,8 +422,11 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .into_iter()
             .chain(ancestor_blocks)
             .flatten()
-            .map(|block| block.serialized().clone())
-            .collect::<Vec<_>>();
+            .map(|block| {
+                let (serialized_header, serialized_transactions) = block.serialized();
+                (serialized_header.clone(), serialized_transactions.clone())
+            })
+            .collect();
 
         Ok(result)
     }
@@ -376,13 +473,13 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 commits.pop();
             }
         }
-        let certifier_blocks = self
+        let certifier_block_headers = self
             .store
-            .read_blocks(&certifier_block_refs)?
+            .read_block_headers(&certifier_block_refs)?
             .into_iter()
             .flatten()
             .collect();
-        Ok((commits, certifier_blocks))
+        Ok((commits, certifier_block_headers))
     }
 
     async fn handle_fetch_latest_blocks(
@@ -413,7 +510,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let mut blocks = vec![];
         let dag_state = self.dag_state.read();
         for authority in authorities {
-            let block = dag_state.get_last_block_for_authority(authority);
+            let block = dag_state.get_last_block_header_for_authority(authority);
 
             debug!("Latest block for {authority}: {block:?} as requested from {peer}");
 
@@ -441,13 +538,13 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         let mut highest_received_rounds = self.core_dispatcher.highest_received_rounds();
 
-        let blocks = self
+        let block_headers = self
             .dag_state
             .read()
-            .get_last_cached_block_per_authority(Round::MAX);
-        let highest_accepted_rounds = blocks
+            .get_last_cached_block_header_per_authority(Round::MAX);
+        let highest_accepted_rounds = block_headers
             .into_iter()
-            .map(|(block, _)| block.round())
+            .map(|(block_headers, _)| block_headers.round())
             .collect::<Vec<_>>();
 
         // Own blocks do not go through the core dispatcher, so they need to be set
@@ -541,7 +638,7 @@ impl SubscriptionCounter {
 
 /// Each broadcasted block stream wraps a broadcast receiver for blocks.
 /// It yields blocks that are broadcasted after the stream is created.
-type BroadcastedBlockStream = BroadcastStream<VerifiedBlockHeader>;
+type BroadcastedBlockStream = BroadcastStream<VerifiedBlock>;
 
 /// Adapted from `tokio_stream::wrappers::BroadcastStream`. The main difference
 /// is that this tolerates lags with only logging, without yielding errors.
@@ -635,11 +732,11 @@ async fn make_recv_future<T: Clone>(
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeSet, sync::Arc, time::Duration};
+    use std::{sync::Arc, time::Duration};
 
     use async_trait::async_trait;
     use bytes::Bytes;
-    use parking_lot::{Mutex, RwLock};
+    use parking_lot::RwLock;
     use starfish_config::AuthorityIndex;
     use tokio::{sync::broadcast, time::sleep};
 
@@ -647,101 +744,26 @@ mod tests {
         Round,
         authority_service::AuthorityService,
         block_header::{
-            BlockHeaderAPI, BlockRef, SignedBlockHeader, TestBlockHeader, VerifiedBlockHeader,
-            VerifiedTransactions,
+            BlockHeaderAPI, BlockRef, SignedBlockHeader, TestBlockHeader, VerifiedBlock,
+            VerifiedBlockHeader,
         },
-        commit::{CertifiedCommits, CommitRange},
+        commit::CommitRange,
         commit_vote_monitor::CommitVoteMonitor,
         context::Context,
-        core_thread::{CoreError, CoreThreadDispatcher},
+        core_thread::tests::MockCoreThreadDispatcher,
         dag_state::DagState,
         error::ConsensusResult,
-        network::{BlockStream, NetworkClient, NetworkService},
+        network::{BlockStream, NetworkClient, NetworkService, SerializedBlock},
         storage::mem_store::MemStore,
         synchronizer::Synchronizer,
         test_dag_builder::DagBuilder,
     };
-
-    struct FakeCoreThreadDispatcher {
-        blocks: Mutex<Vec<VerifiedBlockHeader>>,
-    }
-
-    impl FakeCoreThreadDispatcher {
-        fn new() -> Self {
-            Self {
-                blocks: Mutex::new(vec![]),
-            }
-        }
-
-        fn get_blocks(&self) -> Vec<VerifiedBlockHeader> {
-            self.blocks.lock().clone()
-        }
-    }
-
-    #[async_trait]
-    impl CoreThreadDispatcher for FakeCoreThreadDispatcher {
-        async fn add_blocks(
-            &self,
-            blocks: Vec<VerifiedBlockHeader>,
-        ) -> Result<BTreeSet<BlockRef>, CoreError> {
-            let block_refs = blocks.iter().map(|b| b.reference()).collect();
-            self.blocks.lock().extend(blocks);
-            Ok(block_refs)
-        }
-
-        async fn add_data(
-            &self,
-            _data: Vec<VerifiedTransactions>,
-        ) -> Result<BTreeSet<BlockRef>, CoreError> {
-            todo!()
-        }
-
-        async fn get_missing_data(&self) -> Result<BTreeSet<BlockRef>, CoreError> {
-            todo!()
-        }
-
-        async fn add_certified_commits(
-            &self,
-            _commits: CertifiedCommits,
-        ) -> Result<BTreeSet<BlockRef>, CoreError> {
-            todo!()
-        }
-
-        async fn new_block(&self, _round: Round, _force: bool) -> Result<(), CoreError> {
-            Ok(())
-        }
-
-        async fn get_missing_blocks(&self) -> Result<BTreeSet<BlockRef>, CoreError> {
-            Ok(Default::default())
-        }
-
-        fn set_subscriber_exists(&self, _exists: bool) -> Result<(), CoreError> {
-            todo!()
-        }
-
-        fn set_last_known_proposed_round(&self, _round: Round) -> Result<(), CoreError> {
-            todo!()
-        }
-
-        fn highest_received_rounds(&self) -> Vec<Round> {
-            todo!()
-        }
-    }
 
     #[derive(Default)]
     struct FakeNetworkClient {}
 
     #[async_trait]
     impl NetworkClient for FakeNetworkClient {
-        async fn send_block(
-            &self,
-            _peer: AuthorityIndex,
-            _block: &VerifiedBlockHeader,
-            _timeout: Duration,
-        ) -> ConsensusResult<()> {
-            unimplemented!("Unimplemented")
-        }
-
         async fn subscribe_blocks(
             &self,
             _peer: AuthorityIndex,
@@ -757,8 +779,19 @@ mod tests {
             _block_refs: Vec<BlockRef>,
             _highest_accepted_rounds: Vec<Round>,
             _timeout: Duration,
-        ) -> ConsensusResult<Vec<Bytes>> {
+        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
             unimplemented!("Unimplemented")
+        }
+
+        // Returns a vector of serialized block headers
+        async fn fetch_block_headers(
+            &self,
+            _peer: AuthorityIndex,
+            _block_refs: Vec<BlockRef>,
+            _highest_accepted_rounds: Vec<Round>,
+            _timeout: Duration,
+        ) -> ConsensusResult<Vec<Bytes>> {
+            unimplemented!();
         }
 
         async fn fetch_commits(
@@ -770,7 +803,7 @@ mod tests {
             unimplemented!("Unimplemented")
         }
 
-        async fn fetch_latest_blocks(
+        async fn fetch_latest_block_headers(
             &self,
             _peer: AuthorityIndex,
             _authorities: Vec<AuthorityIndex>,
@@ -781,12 +814,12 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_handle_send_block() {
+    async fn test_handle_subscribed_block() {
         let (context, _keys) = Context::new_for_test(4);
         let context = Arc::new(context);
         let block_verifier = Arc::new(crate::block_verifier::NoopBlockVerifier {});
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
-        let core_dispatcher = Arc::new(FakeCoreThreadDispatcher::new());
+        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());
@@ -814,18 +847,21 @@ mod tests {
         // Test delaying blocks with time drift.
         let now = context.clock.timestamp_utc_ms();
         let max_drift = context.parameters.max_forward_time_drift;
-        let input_block = VerifiedBlockHeader::new_for_test(
+        let input_block = VerifiedBlock::new_for_test(
             TestBlockHeader::new(9, 0)
                 .set_timestamp_ms(now + max_drift.as_millis() as u64)
                 .build(),
         );
 
         let service = authority_service.clone();
-        let serialized = input_block.serialized().clone();
+        let serialized_block = SerializedBlock::from(input_block.clone());
 
         tokio::spawn(async move {
             service
-                .handle_send_block(context.committee.to_authority_index(0).unwrap(), serialized)
+                .handle_subscribed_block(
+                    context.committee.to_authority_index(0).unwrap(),
+                    serialized_block,
+                )
                 .await
                 .unwrap();
         });
@@ -846,7 +882,7 @@ mod tests {
         let context = Arc::new(context);
         let block_verifier = Arc::new(crate::block_verifier::NoopBlockVerifier {});
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
-        let core_dispatcher = Arc::new(FakeCoreThreadDispatcher::new());
+        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
         let network_client = Arc::new(FakeNetworkClient::default());
         let store = Arc::new(MemStore::new());

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -417,7 +417,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             }
         }
 
-        // Return the serialised blocks & the ancestor blocks
+        // Return the serialised headers and transactions for blocks & their ancestors
         let result = blocks
             .into_iter()
             .chain(ancestor_blocks)
@@ -791,7 +791,7 @@ mod tests {
             _highest_accepted_rounds: Vec<Round>,
             _timeout: Duration,
         ) -> ConsensusResult<Vec<Bytes>> {
-            unimplemented!();
+            unimplemented!("Unimplemented")
         }
 
         async fn fetch_commits(

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -27,7 +27,7 @@ use crate::{
     core_thread::CoreThreadDispatcher,
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
-    network::{BlockStream, NetworkService, SerializedBlock},
+    network::{BlockStream, NetworkService, SerializedBlock, SerializedHeaderAndTransactions},
     stake_aggregator::{QuorumThreshold, StakeAggregator},
     storage::Store,
     synchronizer::SynchronizerHandle,
@@ -88,9 +88,10 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         fail_point_async!("consensus-rpc-response");
 
         let peer_hostname = &self.context.committee.authority(peer).hostname;
-
+        let serialized_block_and_transactions =
+            SerializedHeaderAndTransactions::try_from(serialized_block)?;
         let signed_block_header: SignedBlockHeader =
-            bcs::from_bytes(&serialized_block.serialized_block_header)
+            bcs::from_bytes(&serialized_block_and_transactions.serialized_block_header)
                 .map_err(ConsensusError::MalformedBlockHeader)?;
 
         // Reject blocks not produced by the peer.
@@ -127,7 +128,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         if signed_block_header.transactions_commitment()
             != TransactionsCommitment::compute_transactions_commitment(
-                &serialized_block.serialized_transactions,
+                &serialized_block_and_transactions.serialized_transactions,
             )
             .expect("we should expect correct computation of the transactions commitment")
         {
@@ -140,16 +141,16 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         let verified_block_header = VerifiedBlockHeader::new_verified(
             signed_block_header,
-            serialized_block.serialized_block_header,
+            serialized_block_and_transactions.serialized_block_header,
         );
         let transactions: Vec<Transaction> =
-            bcs::from_bytes(&serialized_block.serialized_transactions)
+            bcs::from_bytes(&serialized_block_and_transactions.serialized_transactions)
                 .map_err(ConsensusError::MalformedTransactions)?;
         let verified_transactions = VerifiedTransactions::new(
             transactions,
             verified_block_header.reference(),
             verified_block_header.transactions_commitment(),
-            serialized_block.serialized_transactions,
+            serialized_block_and_transactions.serialized_transactions,
         );
         let verified_block = VerifiedBlock::new(verified_block_header, verified_transactions);
 
@@ -281,7 +282,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             dag_state
                 .get_cached_blocks(self.context.own_index, last_received + 1)
                 .into_iter()
-                .map(SerializedBlock::from),
+                // TODO::deal with possible error in try_from
+                .map(|block| SerializedBlock::try_from(block).unwrap()),
         );
 
         let broadcasted_blocks = BroadcastedBlockStream::new(
@@ -292,9 +294,10 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         // Return a stream of blocks that first yields missed blocks as requested, then
         // new blocks.
-        Ok(Box::pin(
-            missed_blocks.chain(broadcasted_blocks.map(SerializedBlock::from)),
-        ))
+        // TODO::deal with possible error in try_from
+        Ok(Box::pin(missed_blocks.chain(
+            broadcasted_blocks.map(|block| SerializedBlock::try_from(block).unwrap()),
+        )))
     }
 
     async fn handle_fetch_block_headers(
@@ -368,7 +371,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         peer: AuthorityIndex,
         block_refs: Vec<BlockRef>,
         highest_accepted_rounds: Vec<Round>,
-    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
+    ) -> ConsensusResult<Vec<Bytes>> {
         fail_point_async!("consensus-rpc-response");
 
         const MAX_ADDITIONAL_BLOCKS: usize = 10;
@@ -424,8 +427,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .chain(ancestor_blocks)
             .flatten()
             .map(|block| {
-                let (serialized_header, serialized_transactions) = block.serialized();
-                (serialized_header.clone(), serialized_transactions.clone())
+                // TODO::propagate error correctly
+                SerializedBlock::try_from(block).unwrap().serialized_block
             })
             .collect();
 
@@ -780,7 +783,7 @@ mod tests {
             _block_refs: Vec<BlockRef>,
             _highest_accepted_rounds: Vec<Round>,
             _timeout: Duration,
-        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
+        ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Unimplemented")
         }
 
@@ -855,7 +858,7 @@ mod tests {
         );
 
         let service = authority_service.clone();
-        let serialized_block = SerializedBlock::from(input_block.clone());
+        let serialized_block = SerializedBlock::try_from(input_block.clone()).unwrap();
 
         tokio::spawn(async move {
             service

--- a/crates/starfish/core/src/base_committer.rs
+++ b/crates/starfish/core/src/base_committer.rs
@@ -236,7 +236,7 @@ impl BaseCommitter {
             let is_vote = if let Some(is_vote) = all_votes.get(reference) {
                 *is_vote
             } else {
-                let potential_vote = self.dag_state.read().get_block(reference);
+                let potential_vote = self.dag_state.read().get_block_header(reference);
 
                 let is_vote = {
                     let potential_vote = potential_vote

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -643,6 +643,7 @@ impl fmt::Debug for VerifiedBlockHeader {
 /// VerifiedTransactions are transactions that correspond to an existing block
 #[derive(Clone, Debug)]
 pub struct VerifiedTransactions {
+    #[expect(dead_code)]
     transactions: Vec<Transaction>,
 
     /// The block reference of the block that contains the transactions.

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -596,11 +596,6 @@ impl VerifiedBlockHeader {
         &self.serialized
     }
 
-    #[expect(dead_code)]
-    pub(crate) fn signed_block_header(&self) -> &SignedBlockHeader {
-        &self.signed_block_header
-    }
-
     /// Computes digest from the serialization of the signed block header.
     pub(crate) fn compute_digest(serialized: &[u8]) -> BlockHeaderDigest {
         let mut hasher = DefaultHashFunction::new();

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -586,7 +586,6 @@ impl VerifiedBlockHeader {
         self.digest
     }
 
-    #[cfg_attr(not(test), expect(unused))]
     pub(crate) fn transactions_commitment(&self) -> TransactionsCommitment {
         self.signed_block_header.inner.transactions_commitment()
     }
@@ -642,7 +641,7 @@ impl fmt::Debug for VerifiedBlockHeader {
 }
 
 /// VerifiedTransactions are transactions that correspond to an existing block
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct VerifiedTransactions {
     transactions: Vec<Transaction>,
 
@@ -685,7 +684,6 @@ impl VerifiedTransactions {
         self.block_ref
     }
 
-    #[expect(dead_code)]
     pub fn serialized(&self) -> &Bytes {
         &self.serialized
     }
@@ -723,6 +721,7 @@ impl VerifiedBlock {
                 verified_block_header.author(),
                 verified_block_header.digest(),
             ),
+            verified_block_header.transactions_commitment(),
             Bytes::from(bcs::to_bytes::<Vec<Transaction>>(&vec![]).unwrap()),
         );
         Self {
@@ -772,6 +771,7 @@ impl TryFrom<SerializedBlock> for VerifiedBlock {
         let verified_transactions = VerifiedTransactions::new(
             transactions,
             verified_block_header.reference(),
+            verified_block_header.transactions_commitment(),
             serialized_block.serialized_transactions,
         );
         // Assemble the block from the header and transactions
@@ -802,7 +802,8 @@ pub(crate) fn genesis_blocks(context: Arc<Context>) -> Vec<VerifiedBlock> {
                 verified_transactions: VerifiedTransactions {
                     transactions: vec![],
                     block_ref: verified_block_header.reference(),
-                    serialized: Bytes::new(),
+                    transactions_commitment: verified_block_header.transactions_commitment(),
+                    serialized: Bytes::from(bcs::to_bytes::<Vec<Transaction>>(&vec![]).unwrap()),
                 },
             }
         })

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -23,6 +23,7 @@ use crate::{
     context::Context,
     ensure,
     error::{ConsensusError, ConsensusResult},
+    network::SerializedBlock,
 };
 
 /// Round number of a block.
@@ -133,7 +134,7 @@ impl BlockHeaderV1 {
         }
     }
 
-    fn genesis_block(epoch: Epoch, author: AuthorityIndex) -> Self {
+    fn genesis_block_header(epoch: Epoch, author: AuthorityIndex) -> Self {
         Self {
             epoch,
             round: GENESIS_ROUND,
@@ -544,6 +545,17 @@ impl VerifiedBlockHeader {
         }
     }
 
+    pub(crate) fn new_from_bytes(serialized_block_header: Bytes) -> ConsensusResult<Self> {
+        let signed_block_header: SignedBlockHeader = bcs::from_bytes(&serialized_block_header)
+            .map_err(ConsensusError::MalformedBlockHeader)?;
+
+        // Only accepted blocks should have been written to storage.
+        Ok(VerifiedBlockHeader::new_verified(
+            signed_block_header,
+            serialized_block_header,
+        ))
+    }
+
     /// This method is public for testing in other crates.
     pub fn new_for_test(block_header: BlockHeader) -> Self {
         let signed_block_header = SignedBlockHeader {
@@ -582,6 +594,11 @@ impl VerifiedBlockHeader {
     /// Returns the serialization of the signed block header.
     pub(crate) fn serialized(&self) -> &Bytes {
         &self.serialized
+    }
+
+    #[expect(dead_code)]
+    pub(crate) fn signed_block_header(&self) -> &SignedBlockHeader {
+        &self.signed_block_header
     }
 
     /// Computes digest from the serialization of the signed block header.
@@ -632,7 +649,6 @@ impl fmt::Debug for VerifiedBlockHeader {
 /// VerifiedTransactions are transactions that correspond to an existing block
 #[derive(Clone)]
 pub struct VerifiedTransactions {
-    #[expect(dead_code)]
     transactions: Vec<Transaction>,
 
     /// The block reference of the block that contains the transactions.
@@ -642,7 +658,6 @@ pub struct VerifiedTransactions {
     transactions_commitment: TransactionsCommitment,
 
     /// The serialized bytes of the transactions.
-    #[expect(dead_code)]
     serialized: Bytes,
 }
 
@@ -674,17 +689,138 @@ impl VerifiedTransactions {
     pub fn block_ref(&self) -> BlockRef {
         self.block_ref
     }
+
+    #[expect(dead_code)]
+    pub fn serialized(&self) -> &Bytes {
+        &self.serialized
+    }
+}
+
+/// VerifiedBlock is a pair of verified block header and transactions. It is
+/// used for streaming and storing
+#[derive(Clone, Debug, PartialEq)]
+pub struct VerifiedBlock {
+    /// The block header.
+    pub verified_block_header: VerifiedBlockHeader,
+
+    /// The transactions in the block.
+    pub verified_transactions: VerifiedTransactions,
+}
+
+impl VerifiedBlock {
+    pub fn new(
+        verified_block_header: VerifiedBlockHeader,
+        verified_transactions: VerifiedTransactions,
+    ) -> Self {
+        Self {
+            verified_block_header,
+            verified_transactions,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn new_for_test(block_header: BlockHeader) -> Self {
+        let verified_block_header = VerifiedBlockHeader::new_for_test(block_header);
+        let verified_transactions = VerifiedTransactions::new(
+            vec![],
+            BlockRef::new(
+                verified_block_header.round(),
+                verified_block_header.author(),
+                verified_block_header.digest(),
+            ),
+            Bytes::from(bcs::to_bytes::<Vec<Transaction>>(&vec![]).unwrap()),
+        );
+        Self {
+            verified_block_header,
+            verified_transactions,
+        }
+    }
+
+    // This function returns a pair of serialized block header and serialized
+    // transactions
+    pub fn serialized(&self) -> (&Bytes, &Bytes) {
+        (
+            &self.verified_block_header.serialized,
+            &self.verified_transactions.serialized,
+        )
+    }
+}
+
+/// Allow quick access to the underlying BlockHeader without having to always
+/// refer to the inner block ref.
+impl Deref for VerifiedBlock {
+    type Target = VerifiedBlockHeader;
+
+    fn deref(&self) -> &Self::Target {
+        &self.verified_block_header
+    }
+}
+
+impl TryFrom<SerializedBlock> for VerifiedBlock {
+    type Error = ConsensusError;
+
+    fn try_from(serialized_block: SerializedBlock) -> ConsensusResult<Self> {
+        let signed_block_header: SignedBlockHeader =
+            bcs::from_bytes(&serialized_block.serialized_block_header)
+                .map_err(ConsensusError::MalformedBlockHeader)?;
+        let transactions: Vec<Transaction> =
+            bcs::from_bytes(&serialized_block.serialized_transactions)
+                .map_err(ConsensusError::MalformedTransactions)?;
+        // TODO: do we need to check the signature here?
+        let verified_block_header = VerifiedBlockHeader::new_verified(
+            signed_block_header,
+            serialized_block.serialized_block_header,
+        );
+
+        // TODO: we might need to check whether transaction commitment is consistent
+        // with the one in header
+        let verified_transactions = VerifiedTransactions::new(
+            transactions,
+            verified_block_header.reference(),
+            serialized_block.serialized_transactions,
+        );
+        // Assemble the block from the header and transactions
+        Ok(VerifiedBlock::new(
+            verified_block_header,
+            verified_transactions,
+        ))
+    }
 }
 
 /// Generates the genesis blocks for the current Committee.
 /// The blocks are returned in authority index order.
+pub(crate) fn genesis_blocks(context: Arc<Context>) -> Vec<VerifiedBlock> {
+    context
+        .committee
+        .authorities()
+        .map(|(authority_index, _)| {
+            let signed_block = SignedBlockHeader::new_genesis(BlockHeader::V1(
+                BlockHeaderV1::genesis_block_header(context.committee.epoch(), authority_index),
+            ));
+            let serialized = signed_block
+                .serialize()
+                .expect("Genesis block serialization failed.");
+            // Unnecessary to verify genesis block headers.
+            let verified_block_header = VerifiedBlockHeader::new_verified(signed_block, serialized);
+            VerifiedBlock {
+                verified_block_header: verified_block_header.clone(),
+                verified_transactions: VerifiedTransactions {
+                    transactions: vec![],
+                    block_ref: verified_block_header.reference(),
+                    serialized: Bytes::new(),
+                },
+            }
+        })
+        .collect::<Vec<VerifiedBlock>>()
+}
+
 pub(crate) fn genesis_block_headers(context: Arc<Context>) -> Vec<VerifiedBlockHeader> {
     context
         .committee
         .authorities()
         .map(|(authority_index, _)| {
             let signed_block = SignedBlockHeader::new_genesis(BlockHeader::V1(
-                BlockHeaderV1::genesis_block(context.committee.epoch(), authority_index),
+                BlockHeaderV1::genesis_block_header(context.committee.epoch(), authority_index),
             ));
             let serialized = signed_block
                 .serialize()
@@ -707,6 +843,10 @@ impl TestBlockHeader {
             block_header: BlockHeaderV1 {
                 round,
                 author: AuthorityIndex::new_for_test(author),
+                transactions_commitment: TransactionsCommitment::compute_transactions_commitment(
+                    &Bytes::from(bcs::to_bytes::<Vec<Transaction>>(&vec![]).unwrap()),
+                )
+                .unwrap(),
                 ..Default::default()
             },
         }

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -641,6 +641,7 @@ impl fmt::Debug for VerifiedBlockHeader {
 }
 
 /// VerifiedTransactions are transactions that correspond to an existing block
+// TODO: make a custom Debug implementation for more control over printed data
 #[derive(Clone, Debug)]
 pub struct VerifiedTransactions {
     #[expect(dead_code)]

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -23,7 +23,7 @@ use crate::{
     context::Context,
     ensure,
     error::{ConsensusError, ConsensusResult},
-    network::SerializedBlock,
+    network::SerializedHeaderAndTransactions,
 };
 
 /// Round number of a block.
@@ -750,10 +750,10 @@ impl Deref for VerifiedBlock {
     }
 }
 
-impl TryFrom<SerializedBlock> for VerifiedBlock {
+impl TryFrom<SerializedHeaderAndTransactions> for VerifiedBlock {
     type Error = ConsensusError;
 
-    fn try_from(serialized_block: SerializedBlock) -> ConsensusResult<Self> {
+    fn try_from(serialized_block: SerializedHeaderAndTransactions) -> ConsensusResult<Self> {
         let signed_block_header: SignedBlockHeader =
             bcs::from_bytes(&serialized_block.serialized_block_header)
                 .map_err(ConsensusError::MalformedBlockHeader)?;

--- a/crates/starfish/core/src/block_manager.rs
+++ b/crates/starfish/core/src/block_manager.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     sync::Arc,
     time::Instant,
 };
@@ -15,19 +15,19 @@ use tracing::{debug, warn};
 
 use crate::{
     Round,
-    block_header::{BlockHeaderAPI, BlockRef, VerifiedBlockHeader},
+    block_header::{BlockHeaderAPI, BlockRef, VerifiedBlock, VerifiedBlockHeader},
     block_verifier::BlockVerifier,
     context::Context,
     dag_state::DagState,
 };
 
-struct SuspendedBlock {
+struct SuspendedBlockHeader {
     block: VerifiedBlockHeader,
     missing_ancestors: BTreeSet<BlockRef>,
     timestamp: Instant,
 }
 
-impl SuspendedBlock {
+impl SuspendedBlockHeader {
     fn new(block: VerifiedBlockHeader, missing_ancestors: BTreeSet<BlockRef>) -> Self {
         Self {
             block,
@@ -47,11 +47,19 @@ pub(crate) struct BlockManager {
     dag_state: Arc<RwLock<DagState>>,
     block_verifier: Arc<dyn BlockVerifier>,
 
-    /// Keeps all the suspended blocks. A suspended block is a block that is
-    /// missing part of its causal history and thus can't be immediately
-    /// processed. A block will remain in this map until all its causal history
-    /// has been successfully processed.
-    suspended_blocks: BTreeMap<BlockRef, SuspendedBlock>,
+    /// Keeps all the suspended block headers. A suspended block header is a
+    /// header that is missing part of its causal history and thus can't be
+    /// immediately processed. A block header will remain in this map until
+    /// all its causal history has been successfully processed.
+    suspended_block_headers: BTreeMap<BlockRef, SuspendedBlockHeader>,
+    /// Keeps full blocks for suspended block headers
+    /// TODO: this set can grow to become too big, need to add some eviction
+    /// mechanism
+    suspended_blocks: BTreeMap<BlockRef, VerifiedBlock>,
+    // TODO: should it be here? need to discuss
+    // TODO: this set can grow to become too big, need to add some eviction mechanism
+    accepted_block_header_refs_without_data: HashSet<BlockRef>,
+
     /// A map that keeps all the blocks that we are missing (keys) and the
     /// corresponding blocks that reference the missing blocks as ancestors
     /// and need them to get unsuspended. It is possible for a missing
@@ -80,52 +88,101 @@ impl BlockManager {
             context,
             dag_state,
             block_verifier,
+            suspended_block_headers: BTreeMap::new(),
             suspended_blocks: BTreeMap::new(),
+            accepted_block_header_refs_without_data: HashSet::new(),
             missing_ancestors: BTreeMap::new(),
             missing_blocks: BTreeSet::new(),
             received_block_rounds: vec![None; committee_size],
         }
     }
 
-    /// Tries to accept the provided blocks assuming that all their causal
-    /// history exists. The method returns all the blocks that have been
-    /// successfully processed in round ascending order, that includes also
-    /// previously suspended blocks that have now been able to get accepted.
-    /// Method also returns a set with the missing ancestor blocks.
+    /// Does all the same things as try_accept_block_headers and additionally
+    /// saves blocks with transaction data into recent_blocks in DagState
     #[tracing::instrument(skip_all)]
     pub(crate) fn try_accept_blocks(
         &mut self,
-        blocks: Vec<VerifiedBlockHeader>,
+        blocks: Vec<VerifiedBlock>,
     ) -> (Vec<VerifiedBlockHeader>, BTreeSet<BlockRef>) {
         let _s = monitored_scope("BlockManager::try_accept_blocks");
-        self.try_accept_blocks_internal(blocks)
+        let block_headers: Vec<_> = blocks
+            .iter()
+            .map(|b| b.verified_block_header.clone())
+            .collect();
+        let (accepted_block_headers, missing_block_headers) =
+            self.try_accept_block_headers_internal(block_headers);
+        let mut accepted_block_header_refs: HashSet<BlockRef> = HashSet::new();
+        for block_header in accepted_block_headers.iter() {
+            if let Some(block) = self.suspended_blocks.remove(&block_header.reference()) {
+                // for this accepted header we already have a block, so we add it to dag_state
+                self.dag_state.write().add_block(block);
+            } else {
+                accepted_block_header_refs.insert(block_header.reference());
+            }
+        }
+        for block in blocks {
+            let block_ref = &block.reference();
+            if accepted_block_header_refs.remove(block_ref)
+                || self
+                    .accepted_block_header_refs_without_data
+                    .remove(block_ref)
+            {
+                self.dag_state.write().add_block(block);
+            } else {
+                self.suspended_blocks.insert(block.reference(), block);
+            }
+        }
+        for block_ref in accepted_block_header_refs {
+            self.accepted_block_header_refs_without_data
+                .insert(block_ref);
+        }
+
+        (accepted_block_headers, missing_block_headers)
+    }
+
+    /// Tries to accept the provided block headers assuming that all their
+    /// causal history exists. The method returns all the block headers that
+    /// have been successfully processed in round ascending order, that
+    /// includes also previously suspended block headers that have now been
+    /// able to get accepted. Method also returns a set with the missing
+    /// ancestor block headers.
+    #[tracing::instrument(skip_all)]
+    pub(crate) fn try_accept_block_headers(
+        &mut self,
+        block_headers: Vec<VerifiedBlockHeader>,
+    ) -> (Vec<VerifiedBlockHeader>, BTreeSet<BlockRef>) {
+        let _s = monitored_scope("BlockManager::try_accept_block_headers");
+        self.try_accept_block_headers_internal(block_headers)
     }
 
     /// Attempts to accept the provided blocks.
-    fn try_accept_blocks_internal(
+    fn try_accept_block_headers_internal(
         &mut self,
-        mut blocks: Vec<VerifiedBlockHeader>,
+        mut block_headers: Vec<VerifiedBlockHeader>,
     ) -> (Vec<VerifiedBlockHeader>, BTreeSet<BlockRef>) {
-        let _s = monitored_scope("BlockManager::try_accept_blocks_internal");
+        let _s = monitored_scope("BlockManager::try_accept_block_headers_internal");
 
-        blocks.sort_by_key(|b| b.round());
+        block_headers.sort_by_key(|b| b.round());
         debug!(
-            "Trying to accept blocks: {}",
-            blocks.iter().map(|b| b.reference().to_string()).join(",")
+            "Trying to accept block headers: {}",
+            block_headers
+                .iter()
+                .map(|b| b.reference().to_string())
+                .join(",")
         );
 
         let mut accepted_blocks = vec![];
         let mut missing_blocks = BTreeSet::new();
 
-        for block in blocks {
-            self.update_block_received_metrics(&block);
+        for block_header in block_headers {
+            self.update_block_received_metrics(&block_header);
 
             // Try to accept the input block.
-            let block_ref = block.reference();
+            let block_ref = block_header.reference();
 
             let mut to_verify_timestamps_and_accept = vec![];
 
-            match self.try_accept_one_block(block) {
+            match self.try_accept_one_block_header(block_header) {
                 TryAcceptResult::Accepted(block) => {
                     to_verify_timestamps_and_accept.push(block);
                 }
@@ -181,11 +238,11 @@ impl BlockManager {
         for (found, block_ref) in self
             .dag_state
             .read()
-            .contains_blocks(block_refs.clone())
+            .contains_block_headers(block_refs.clone())
             .into_iter()
             .zip(block_refs.iter())
         {
-            if found || self.suspended_blocks.contains_key(block_ref) {
+            if found || self.suspended_block_headers.contains_key(block_ref) {
                 continue;
             }
             // Fetches the block if it is not in dag state or suspended.
@@ -230,7 +287,7 @@ impl BlockManager {
         let mut blocks_to_reject: BTreeMap<BlockRef, VerifiedBlockHeader> = BTreeMap::new();
         {
             'block: for b in unsuspended_blocks {
-                let ancestors = self.dag_state.read().get_blocks(b.ancestors());
+                let ancestors = self.dag_state.read().get_block_headers(b.ancestors());
                 assert_eq!(b.ancestors().len(), ancestors.len());
                 let mut ancestor_blocks = vec![];
                 'ancestor: for (ancestor_ref, found) in
@@ -294,7 +351,7 @@ impl BlockManager {
         // ancestors do not get suspended.
         self.dag_state
             .write()
-            .accept_blocks(blocks_to_accept.clone());
+            .accept_block_headers(blocks_to_accept.clone());
 
         blocks_to_accept
     }
@@ -303,7 +360,7 @@ impl BlockManager {
     /// have been already successfully accepted. If block is accepted then
     /// Some result is returned. None is returned when either the block is
     /// suspended or the block has been already accepted before.
-    fn try_accept_one_block(&mut self, block: VerifiedBlockHeader) -> TryAcceptResult {
+    fn try_accept_one_block_header(&mut self, block: VerifiedBlockHeader) -> TryAcceptResult {
         let block_ref = block.reference();
         let mut missing_ancestors = BTreeSet::new();
         let mut ancestors_to_fetch = BTreeSet::new();
@@ -311,7 +368,9 @@ impl BlockManager {
 
         // If block has been already received and suspended, or already processed and
         // stored, or is a genesis block, then skip it.
-        if self.suspended_blocks.contains_key(&block_ref) || dag_state.contains_block(&block_ref) {
+        if self.suspended_block_headers.contains_key(&block_ref)
+            || dag_state.contains_block_header(&block_ref)
+        {
             return TryAcceptResult::Processed;
         }
 
@@ -319,7 +378,7 @@ impl BlockManager {
 
         // make sure that we have all the required ancestors in store
         for (found, ancestor) in dag_state
-            .contains_blocks(ancestors.clone())
+            .contains_block_headers(ancestors.clone())
             .into_iter()
             .zip(ancestors.iter())
         {
@@ -343,7 +402,7 @@ impl BlockManager {
                 // Add the ancestor to the missing blocks set only if it doesn't already exist
                 // in the suspended blocks - meaning that we already have its
                 // payload.
-                if !self.suspended_blocks.contains_key(ancestor) {
+                if !self.suspended_block_headers.contains_key(ancestor) {
                     // Fetches the block if it is not in dag state or suspended.
                     ancestors_to_fetch.insert(*ancestor);
                     if self.missing_blocks.insert(*ancestor) {
@@ -376,8 +435,10 @@ impl BlockManager {
                 .block_suspensions
                 .with_label_values(&[hostname])
                 .inc();
-            self.suspended_blocks
-                .insert(block_ref, SuspendedBlock::new(block, missing_ancestors));
+            self.suspended_block_headers.insert(
+                block_ref,
+                SuspendedBlockHeader::new(block, missing_ancestors),
+            );
             return TryAcceptResult::Suspended(ancestors_to_fetch);
         }
 
@@ -447,9 +508,9 @@ impl BlockManager {
         &mut self,
         block_ref: &BlockRef,
         accepted_dependency: &BlockRef,
-    ) -> Option<SuspendedBlock> {
+    ) -> Option<SuspendedBlockHeader> {
         let block = self
-            .suspended_blocks
+            .suspended_block_headers
             .get_mut(block_ref)
             .expect("Block should be in suspended map");
 
@@ -462,7 +523,7 @@ impl BlockManager {
 
         if block.missing_ancestors.is_empty() {
             // we have no missing dependency, so we unsuspend the block and return it
-            return self.suspended_blocks.remove(block_ref);
+            return self.suspended_block_headers.remove(block_ref);
         }
         None
     }
@@ -478,7 +539,7 @@ impl BlockManager {
         metrics.missing_blocks_total.inc_by(missing_blocks);
         metrics
             .block_manager_suspended_blocks
-            .set(self.suspended_blocks.len() as i64);
+            .set(self.suspended_block_headers.len() as i64);
         metrics
             .block_manager_missing_ancestors
             .set(self.missing_ancestors.len() as i64);
@@ -514,7 +575,7 @@ impl BlockManager {
     /// Checks if block manager is empty.
     #[cfg(test)]
     pub(crate) fn is_empty(&self) -> bool {
-        self.suspended_blocks.is_empty()
+        self.suspended_block_headers.is_empty()
             && self.missing_ancestors.is_empty()
             && self.missing_blocks.is_empty()
     }
@@ -523,7 +584,7 @@ impl BlockManager {
     /// can't accept them yet.
     #[cfg(test)]
     fn suspended_blocks(&self) -> Vec<BlockRef> {
-        self.suspended_blocks.keys().cloned().collect()
+        self.suspended_block_headers.keys().cloned().collect()
     }
 }
 
@@ -581,21 +642,22 @@ mod tests {
             .build();
 
         // Take only the blocks of round 2 and try to accept them
-        let round_2_blocks = dag_builder
-            .blocks
+        let round_2_block_headers = dag_builder
+            .block_headers
             .into_iter()
-            .filter_map(|(_, block)| (block.round() == 2).then_some(block))
+            .filter_map(|(_, block_header)| (block_header.round() == 2).then_some(block_header))
             .collect::<Vec<VerifiedBlockHeader>>();
 
         // WHEN
-        let (accepted_blocks, missing) = block_manager.try_accept_blocks(round_2_blocks.clone());
+        let (accepted_blocks, missing) =
+            block_manager.try_accept_block_headers(round_2_block_headers.clone());
 
         // THEN
         assert!(accepted_blocks.is_empty());
 
         // AND the returned missing ancestors should be the same as the provided block
         // ancestors
-        let missing_block_refs = round_2_blocks.first().unwrap().ancestors();
+        let missing_block_refs = round_2_block_headers.first().unwrap().ancestors();
         let missing_block_refs = missing_block_refs.iter().cloned().collect::<BTreeSet<_>>();
         assert_eq!(missing, missing_block_refs);
 
@@ -607,9 +669,9 @@ mod tests {
         // AND suspended blocks should return the round_2_blocks
         assert_eq!(
             block_manager.suspended_blocks(),
-            round_2_blocks
+            round_2_block_headers
                 .into_iter()
-                .map(|block| block.reference())
+                .map(|block_header| block_header.reference())
                 .collect::<Vec<_>>()
         );
     }
@@ -637,19 +699,24 @@ mod tests {
 
         // Take the blocks from round 4 up to 2 (included). Only the first block of each
         // round should return missing ancestors when try to accept
-        for (_, block) in dag_builder
-            .blocks
+        for (_, block_header) in dag_builder
+            .block_headers
             .into_iter()
             .rev()
-            .take_while(|(_, block)| block.round() >= 2)
+            .take_while(|(_, block_header)| block_header.round() >= 2)
         {
             // WHEN
-            let (accepted_blocks, missing) = block_manager.try_accept_blocks(vec![block.clone()]);
+            let (accepted_blocks, missing) =
+                block_manager.try_accept_block_headers(vec![block_header.clone()]);
 
             // THEN
             assert!(accepted_blocks.is_empty());
 
-            let block_ancestors = block.ancestors().iter().cloned().collect::<BTreeSet<_>>();
+            let block_ancestors = block_header
+                .ancestors()
+                .iter()
+                .cloned()
+                .collect::<BTreeSet<_>>();
             assert_eq!(missing, block_ancestors);
         }
     }
@@ -669,28 +736,33 @@ mod tests {
         let mut dag_builder = DagBuilder::new(context.clone());
         dag_builder.layers(1..=2).build();
 
-        let all_blocks = dag_builder.blocks.values().cloned().collect::<Vec<_>>();
+        let all_block_headers = dag_builder
+            .block_headers
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
 
         // WHEN
-        let (accepted_blocks, missing) = block_manager.try_accept_blocks(all_blocks.clone());
+        let (accepted_block_headers, missing) =
+            block_manager.try_accept_block_headers(all_block_headers.clone());
 
         // THEN
-        assert_eq!(accepted_blocks.len(), 8);
+        assert_eq!(accepted_block_headers.len(), 8);
         assert_eq!(
-            accepted_blocks,
-            all_blocks
+            accepted_block_headers,
+            all_block_headers
                 .iter()
-                .filter(|block| block.round() > 0)
+                .filter(|block_header| block_header.round() > 0)
                 .cloned()
                 .collect::<Vec<VerifiedBlockHeader>>()
         );
         assert!(missing.is_empty());
         assert!(block_manager.is_empty());
 
-        // WHEN trying to accept same blocks again, then none will be returned as those
-        // have been already accepted
-        let (accepted_blocks, _) = block_manager.try_accept_blocks(all_blocks);
-        assert!(accepted_blocks.is_empty());
+        // WHEN trying to accept same block headers again, then none will be returned as
+        // those have been already accepted
+        let (accepted_block_headers, _) = block_manager.try_accept_block_headers(all_block_headers);
+        assert!(accepted_block_headers.is_empty());
     }
 
     /// The test generate blocks for a well connected DAG and feed them to block
@@ -706,13 +778,17 @@ mod tests {
         let mut dag_builder = DagBuilder::new(context.clone());
         dag_builder.layers(1..=3).build();
 
-        let mut all_blocks = dag_builder.blocks.values().cloned().collect::<Vec<_>>();
+        let mut all_block_headers = dag_builder
+            .block_headers
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
 
         // Now randomize the sequence of sending the blocks to block manager. In the end
         // all the blocks should be uniquely suspended and no missing blocks
         // should exist.
         for seed in 0..100u8 {
-            all_blocks.shuffle(&mut StdRng::from_seed([seed; 32]));
+            all_block_headers.shuffle(&mut StdRng::from_seed([seed; 32]));
 
             let store = Arc::new(MemStore::new());
             let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
@@ -721,19 +797,20 @@ mod tests {
                 BlockManager::new(context.clone(), dag_state, Arc::new(NoopBlockVerifier));
 
             // WHEN
-            let mut all_accepted_blocks = vec![];
-            for block in &all_blocks {
-                let (accepted_blocks, _) = block_manager.try_accept_blocks(vec![block.clone()]);
+            let mut all_accepted_block_headers = vec![];
+            for block_header in &all_block_headers {
+                let (accepted_block_headers, _) =
+                    block_manager.try_accept_block_headers(vec![block_header.clone()]);
 
-                all_accepted_blocks.extend(accepted_blocks);
+                all_accepted_block_headers.extend(accepted_block_headers);
             }
 
             // THEN
-            all_accepted_blocks.sort_by_key(|b| b.reference());
-            all_blocks.sort_by_key(|b| b.reference());
+            all_accepted_block_headers.sort_by_key(|b| b.reference());
+            all_block_headers.sort_by_key(|b| b.reference());
 
             assert_eq!(
-                all_accepted_blocks, all_blocks,
+                all_accepted_block_headers, all_block_headers,
                 "Failed acceptance sequence for seed {}",
                 seed
             );
@@ -781,14 +858,18 @@ mod tests {
         let mut dag_builder = DagBuilder::new(context.clone());
         dag_builder.layers(1..=5).build();
 
-        let all_blocks = dag_builder.blocks.values().cloned().collect::<Vec<_>>();
+        let all_block_headers = dag_builder
+            .block_headers
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
 
         // Create a test verifier that fails the blocks of round 3
         let test_verifier = TestBlockVerifier::new(
-            all_blocks
+            all_block_headers
                 .iter()
-                .filter(|block| block.round() == 3)
-                .map(|block| block.reference())
+                .filter(|block_header| block_header.round() == 3)
+                .map(|block_header| block_header.reference())
                 .collect(),
         );
 
@@ -800,34 +881,34 @@ mod tests {
 
         // Try to accept blocks from round 2 ~ 5 into block manager. All of them should
         // be suspended.
-        let (accepted_blocks, missing_refs) = block_manager.try_accept_blocks(
-            all_blocks
+        let (accepted_block_headers, missing_refs) = block_manager.try_accept_block_headers(
+            all_block_headers
                 .iter()
-                .filter(|block| block.round() > 1)
+                .filter(|block_header| block_header.round() > 1)
                 .cloned()
                 .collect(),
         );
 
         // Missing refs should all come from round 1.
-        assert!(accepted_blocks.is_empty());
+        assert!(accepted_block_headers.is_empty());
         assert_eq!(missing_refs.len(), 4);
         missing_refs.iter().for_each(|missing_ref| {
             assert_eq!(missing_ref.round, 1);
         });
 
         // Now add round 1 blocks into block manager.
-        let (accepted_blocks, missing_refs) = block_manager.try_accept_blocks(
-            all_blocks
+        let (accepted_block_headers, missing_refs) = block_manager.try_accept_block_headers(
+            all_block_headers
                 .iter()
-                .filter(|block| block.round() == 1)
+                .filter(|block_header| block_header.round() == 1)
                 .cloned()
                 .collect(),
         );
 
         // Only round 1 and round 2 blocks should be accepted.
-        assert_eq!(accepted_blocks.len(), 8);
-        accepted_blocks.iter().for_each(|block| {
-            assert!(block.round() <= 2);
+        assert_eq!(accepted_block_headers.len(), 8);
+        accepted_block_headers.iter().for_each(|block_header| {
+            assert!(block_header.round() <= 2);
         });
         assert!(missing_refs.is_empty());
 
@@ -859,15 +940,21 @@ mod tests {
             .build();
 
         // Take only the blocks of round 2 and try to accept them
-        let round_2_blocks = dag_builder
-            .blocks
+        let round_2_block_headers = dag_builder
+            .block_headers
             .iter()
-            .filter_map(|(_, block)| (block.round() == 2).then_some(block.clone()))
+            .filter_map(|(_, block_headers)| {
+                (block_headers.round() == 2).then_some(block_headers.clone())
+            })
             .collect::<Vec<VerifiedBlockHeader>>();
 
         // All blocks should be missing
-        let missing_block_refs_from_find =
-            block_manager.try_find_blocks(round_2_blocks.iter().map(|b| b.reference()).collect());
+        let missing_block_refs_from_find = block_manager.try_find_blocks(
+            round_2_block_headers
+                .iter()
+                .map(|b| b.reference())
+                .collect(),
+        );
         assert_eq!(missing_block_refs_from_find.len(), 10);
         assert!(
             missing_block_refs_from_find
@@ -877,10 +964,11 @@ mod tests {
 
         // Try accept blocks which will cause blocks to be suspended and added to
         // missing in block manager.
-        let (accepted_blocks, missing) = block_manager.try_accept_blocks(round_2_blocks.clone());
-        assert!(accepted_blocks.is_empty());
+        let (accepted_blocks_headers, missing) =
+            block_manager.try_accept_block_headers(round_2_block_headers.clone());
+        assert!(accepted_blocks_headers.is_empty());
 
-        let missing_block_refs = round_2_blocks.first().unwrap().ancestors();
+        let missing_block_refs = round_2_block_headers.first().unwrap().ancestors();
         let missing_block_refs_from_accept =
             missing_block_refs.iter().cloned().collect::<BTreeSet<_>>();
         assert_eq!(missing, missing_block_refs_from_accept);
@@ -895,17 +983,19 @@ mod tests {
         // from newly created but not accepted round 3.
         dag_builder.layer(3).build();
 
-        let round_3_blocks = dag_builder
-            .blocks
+        let round_3_block_headers = dag_builder
+            .block_headers
             .iter()
-            .filter_map(|(_, block)| (block.round() == 3).then_some(block.reference()))
+            .filter_map(|(_, block_header)| {
+                (block_header.round() == 3).then_some(block_header.reference())
+            })
             .collect::<Vec<BlockRef>>();
 
         let missing_block_refs_from_find = block_manager.try_find_blocks(
-            round_2_blocks
+            round_2_block_headers
                 .iter()
                 .map(|b| b.reference())
-                .chain(round_3_blocks.into_iter())
+                .chain(round_3_block_headers.into_iter())
                 .collect(),
         );
 

--- a/crates/starfish/core/src/block_manager.rs
+++ b/crates/starfish/core/src/block_manager.rs
@@ -56,9 +56,6 @@ pub(crate) struct BlockManager {
     /// TODO: this set can grow to become too big, need to add some eviction
     /// mechanism
     suspended_blocks: BTreeMap<BlockRef, VerifiedBlock>,
-    // TODO: should it be here? need to discuss
-    // TODO: this set can grow to become too big, need to add some eviction mechanism
-    accepted_block_header_refs_without_data: HashSet<BlockRef>,
 
     /// A map that keeps all the blocks that we are missing (keys) and the
     /// corresponding blocks that reference the missing blocks as ancestors
@@ -90,7 +87,6 @@ impl BlockManager {
             block_verifier,
             suspended_block_headers: BTreeMap::new(),
             suspended_blocks: BTreeMap::new(),
-            accepted_block_header_refs_without_data: HashSet::new(),
             missing_ancestors: BTreeMap::new(),
             missing_blocks: BTreeSet::new(),
             received_block_rounds: vec![None; committee_size],
@@ -122,19 +118,11 @@ impl BlockManager {
         }
         for block in blocks {
             let block_ref = &block.reference();
-            if accepted_block_header_refs.remove(block_ref)
-                || self
-                    .accepted_block_header_refs_without_data
-                    .remove(block_ref)
-            {
+            if accepted_block_header_refs.remove(block_ref) {
                 self.dag_state.write().add_block(block);
             } else {
                 self.suspended_blocks.insert(block.reference(), block);
             }
-        }
-        for block_ref in accepted_block_header_refs {
-            self.accepted_block_header_refs_without_data
-                .insert(block_ref);
         }
 
         (accepted_block_headers, missing_block_headers)

--- a/crates/starfish/core/src/block_manager.rs
+++ b/crates/starfish/core/src/block_manager.rs
@@ -107,6 +107,9 @@ impl BlockManager {
             .collect();
         let (accepted_block_headers, missing_block_headers) =
             self.try_accept_block_headers_internal(block_headers);
+        // TODO: logic below should be applied also when headers are accepted. Need to
+        // move it to internal function.
+
         let mut accepted_block_header_refs: HashSet<BlockRef> = HashSet::new();
         for block_header in accepted_block_headers.iter() {
             if let Some(block) = self.suspended_blocks.remove(&block_header.reference()) {

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -19,8 +19,8 @@ use starfish_config::{AuthorityIndex, DIGEST_LENGTH, DefaultHashFunction};
 
 use crate::{
     block_header::{
-        BlockHeaderAPI, BlockRef, BlockTimestampMs, Round, Slot, VerifiedBlockHeader,
-        VerifiedTransactions,
+        BlockHeaderAPI, BlockRef, BlockTimestampMs, Round, Slot, VerifiedBlock,
+        VerifiedBlockHeader, VerifiedTransactions,
     },
     leader_scoring::ReputationScores,
     storage::Store,
@@ -948,7 +948,7 @@ mod tests {
             .map(|block| (block.reference(), block))
             .unzip();
         store
-            .write(WriteBatch::default().blocks(first_round_headers))
+            .write(WriteBatch::default().block_headers(first_round_headers))
             .unwrap();
         blocks.append(&mut first_round_references.clone());
 
@@ -966,7 +966,7 @@ mod tests {
                         .build(),
                 );
                 store
-                    .write(WriteBatch::default().blocks(vec![block.clone()]))
+                    .write(WriteBatch::default().block_headers(vec![block.clone()]))
                     .unwrap();
                 new_ancestors.push(block.reference());
                 blocks.push(block.reference());

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -251,7 +251,7 @@ impl CertifiedCommits {
 #[derive(Clone, Debug)]
 pub(crate) struct CertifiedCommit {
     commit: Arc<TrustedCommit>,
-    verified_blocks: Vec<VerifiedBlock>,
+    verifier_blocks: Vec<VerifiedBlock>,
 }
 
 impl CertifiedCommit {
@@ -261,12 +261,12 @@ impl CertifiedCommit {
     ) -> Self {
         Self {
             commit: Arc::new(commit),
-            verified_blocks,
+            verifier_blocks: verified_blocks,
         }
     }
 
     pub fn blocks(&self) -> &[VerifiedBlock] {
-        &self.verified_blocks
+        &self.verifier_blocks
     }
 }
 

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -251,19 +251,22 @@ impl CertifiedCommits {
 #[derive(Clone, Debug)]
 pub(crate) struct CertifiedCommit {
     commit: Arc<TrustedCommit>,
-    blocks: Vec<VerifiedBlockHeader>,
+    verified_blocks: Vec<VerifiedBlock>,
 }
 
 impl CertifiedCommit {
-    pub(crate) fn new_certified(commit: TrustedCommit, blocks: Vec<VerifiedBlockHeader>) -> Self {
+    pub(crate) fn new_certified(
+        commit: TrustedCommit,
+        verified_blocks: Vec<VerifiedBlock>,
+    ) -> Self {
         Self {
             commit: Arc::new(commit),
-            blocks,
+            verified_blocks,
         }
     }
 
-    pub fn blocks(&self) -> &[VerifiedBlockHeader] {
-        &self.blocks
+    pub fn blocks(&self) -> &[VerifiedBlock] {
+        &self.verified_blocks
     }
 }
 
@@ -604,7 +607,7 @@ pub fn load_pending_subdag_from_store(
 ) -> PendingSubDag {
     let mut leader_block_idx = None;
     let commit_block_headers = store
-        .read_blocks(commit.blocks())
+        .read_block_headers(commit.blocks())
         .expect("We should have the block referenced in the commit data");
     let block_headers = commit_block_headers
         .into_iter()
@@ -839,7 +842,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        block_header::TestBlockHeader,
+        block_header::{TestBlockHeader, VerifiedBlock},
         context::Context,
         storage::{WriteBatch, mem_store::MemStore},
     };
@@ -861,7 +864,7 @@ mod tests {
             .map(|index| {
                 let author_idx = index.0.value() as u32;
                 let block = TestBlockHeader::new(0, author_idx).build();
-                VerifiedBlockHeader::new_for_test(block)
+                VerifiedBlock::new_for_test(block)
             })
             .map(|block| (block.reference(), block))
             .unzip();
@@ -877,7 +880,7 @@ mod tests {
             let mut new_ancestors = vec![];
             for author in 0..num_authorities {
                 let base_ts = round as BlockTimestampMs * 1000;
-                let block = VerifiedBlockHeader::new_for_test(
+                let block = VerifiedBlock::new_for_test(
                     TestBlockHeader::new(round, author)
                         .set_timestamp_ms(base_ts + (author + round) as u64)
                         .set_ancestors(ancestors.clone())

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -357,9 +357,9 @@ mod tests {
                 // committed subdag
                 assert_eq!(subdag.blocks.len(), num_authorities);
             }
-            for block in subdag.blocks.iter() {
-                expected_stored_refs.push(block.reference());
-                assert!(block.round() <= leaders[idx].round());
+            for block_header in subdag.blocks.iter() {
+                expected_stored_refs.push(block_header.reference());
+                assert!(block_header.round() <= leaders[idx].round());
             }
             assert_eq!(subdag.commit_ref.index, idx as CommitIndex + 1);
         }
@@ -388,7 +388,9 @@ mod tests {
             .scan_commits((0..=CommitIndex::MAX).into())
             .unwrap();
         assert_eq!(all_stored_commits.len(), leaders.len());
-        let blocks_existence = mem_store.contains_blocks(&expected_stored_refs).unwrap();
+        let blocks_existence = mem_store
+            .contains_block_headers(&expected_stored_refs)
+            .unwrap();
         assert!(blocks_existence.iter().all(|exists| *exists));
     }
 

--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -31,6 +31,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
+    ops::Deref,
     sync::Arc,
     time::Duration,
 };
@@ -51,8 +52,8 @@ use tokio::{
 use tracing::{debug, info, warn};
 
 use crate::{
-    CommitConsumerMonitor, CommitIndex,
-    block_header::{BlockHeaderAPI, BlockRef, SignedBlockHeader, VerifiedBlockHeader},
+    CommitConsumerMonitor, CommitIndex, VerifiedBlockHeader,
+    block_header::{BlockHeaderAPI, SignedBlockHeader, VerifiedBlock},
     block_verifier::BlockVerifier,
     commit::{
         CertifiedCommit, CertifiedCommits, Commit, CommitAPI as _, CommitDigest, CommitRange,
@@ -63,7 +64,7 @@ use crate::{
     core_thread::CoreThreadDispatcher,
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
-    network::NetworkClient,
+    network::{NetworkClient, SerializedBlock},
     stake_aggregator::{QuorumThreshold, StakeAggregator},
 };
 
@@ -262,7 +263,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
                     bytes
                         + c.blocks()
                             .iter()
-                            .map(|b| b.serialized().len())
+                            .map(|b| b.serialized().0.len() + b.serialized().1.len())
                             .sum::<usize>() as u64,
                 )
             });
@@ -551,7 +552,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
             .start_timer();
 
         // 1. Fetch commits in the commit range from the target authority.
-        let (serialized_commits, serialized_blocks) = inner
+        let (serialized_commits, serialized_block_headers) = inner
             .network_client
             .fetch_commits(target_authority, commit_range.clone(), timeout)
             .await?;
@@ -568,7 +569,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
                         target_authority,
                         commit_range,
                         serialized_commits,
-                        serialized_blocks,
+                        serialized_block_headers,
                     )
                 }
             })
@@ -601,46 +602,50 @@ impl<C: NetworkClient> CommitSyncer<C> {
                         )
                         .await?;
                     // 5. Verify the same number of blocks are returned as requested.
-                    if request_block_refs.len() != serialized_blocks.len() {
+                    if request_block_refs.len() != serialized_blocks.0.len()
+                        || request_block_refs.len() != serialized_blocks.1.len()
+                    {
                         return Err(ConsensusError::UnexpectedNumberOfBlocksFetched {
                             authority: target_authority,
                             requested: request_block_refs.len(),
-                            received: serialized_blocks.len(),
+                            received_headers: serialized_blocks.0.len(),
+                            received_transactions: serialized_blocks.1.len(),
                         });
                     }
                     // 6. Verify returned blocks have valid formats.
-                    let signed_blocks = serialized_blocks
+                    let verified_blocks = serialized_blocks
+                        .0
                         .iter()
-                        .map(|serialized| {
-                            let block: SignedBlockHeader = bcs::from_bytes(serialized)
-                                .map_err(ConsensusError::MalformedBlock)?;
-                            Ok(block)
-                        })
+                        .cloned()
+                        .zip(serialized_blocks.1)
+                        .zip(request_block_refs)
+                        .map(
+                            |(
+                                (serialized_block_header, serialized_transactions),
+                                requested_block_ref,
+                            )| {
+                                let block = VerifiedBlock::try_from(SerializedBlock {
+                                    serialized_block_header,
+                                    serialized_transactions,
+                                })?;
+
+                                // 7. Verify the returned blocks match the requested block refs.
+                                // If they do match, the returned blocks can be considered verified
+                                // as well.
+                                if *requested_block_ref != block.reference() {
+                                    return Err(ConsensusError::UnexpectedBlockForCommit {
+                                        peer: target_authority,
+                                        requested: *requested_block_ref,
+                                        received: block.reference(),
+                                    });
+                                }
+
+                                Ok(block)
+                            },
+                        )
                         .collect::<ConsensusResult<Vec<_>>>()?;
-                    // 7. Verify the returned blocks match the requested block refs.
-                    // If they do match, the returned blocks can be considered verified as well.
-                    let mut blocks = Vec::new();
-                    for ((requested_block_ref, signed_block), serialized) in request_block_refs
-                        .iter()
-                        .zip(signed_blocks.into_iter())
-                        .zip(serialized_blocks.into_iter())
-                    {
-                        let signed_block_digest = VerifiedBlockHeader::compute_digest(&serialized);
-                        let received_block_ref = BlockRef::new(
-                            signed_block.round(),
-                            signed_block.author(),
-                            signed_block_digest,
-                        );
-                        if *requested_block_ref != received_block_ref {
-                            return Err(ConsensusError::UnexpectedBlockForCommit {
-                                peer: target_authority,
-                                requested: *requested_block_ref,
-                                received: received_block_ref,
-                            });
-                        }
-                        blocks.push(VerifiedBlockHeader::new_verified(signed_block, serialized));
-                    }
-                    Ok(blocks)
+
+                    Ok(verified_blocks)
                 }
             })
             .collect();
@@ -654,7 +659,10 @@ impl<C: NetworkClient> CommitSyncer<C> {
 
         // 8. Make sure fetched block (and votes) timestamps are lower than current
         //    time.
-        for block in fetched_blocks.values().chain(vote_blocks.iter()) {
+        for block in vote_blocks
+            .iter()
+            .chain(fetched_blocks.values().map(Deref::deref))
+        {
             let now_ms = inner.context.clock.timestamp_utc_ms();
             let forward_drift = block.timestamp_ms().saturating_sub(now_ms);
             if forward_drift == 0 {
@@ -748,7 +756,7 @@ impl<C: NetworkClient> Inner<C> {
         peer: AuthorityIndex,
         commit_range: CommitRange,
         serialized_commits: Vec<Bytes>,
-        serialized_vote_blocks: Vec<Bytes>,
+        serialized_vote_blocks_headers: Vec<Bytes>,
     ) -> ConsensusResult<(Vec<TrustedCommit>, Vec<VerifiedBlockHeader>)> {
         // Parse and verify commits.
         let mut commits = Vec::new();
@@ -792,18 +800,21 @@ impl<C: NetworkClient> Inner<C> {
         // Parse and verify blocks. Then accumulate votes on the end commit.
         let end_commit_ref = CommitRef::new(end_commit.index(), *end_commit_digest);
         let mut stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
-        let mut vote_blocks = Vec::new();
-        for serialized in serialized_vote_blocks {
-            let block: SignedBlockHeader =
-                bcs::from_bytes(&serialized).map_err(ConsensusError::MalformedBlock)?;
+        let mut vote_block_headers = Vec::new();
+        for serialized_block_header in serialized_vote_blocks_headers.into_iter() {
+            let signed_block_header: SignedBlockHeader = bcs::from_bytes(&serialized_block_header)
+                .map_err(ConsensusError::MalformedBlock)?;
             // The block signature needs to be verified.
-            self.block_verifier.verify(&block)?;
-            for vote in block.commit_votes() {
+            self.block_verifier.verify(&signed_block_header)?;
+            for vote in signed_block_header.commit_votes() {
                 if *vote == end_commit_ref {
-                    stake_aggregator.add(block.author(), &self.context.committee);
+                    stake_aggregator.add(signed_block_header.author(), &self.context.committee);
                 }
             }
-            vote_blocks.push(VerifiedBlockHeader::new_verified(block, serialized));
+            vote_block_headers.push(VerifiedBlockHeader::new_verified(
+                signed_block_header,
+                serialized_block_header,
+            ));
         }
 
         // Check if the end commit has enough votes.
@@ -820,7 +831,7 @@ impl<C: NetworkClient> Inner<C> {
             .zip(serialized_commits)
             .map(|((_d, c), s)| TrustedCommit::new_trusted(c, s))
             .collect();
-        Ok((trusted_commits, vote_blocks))
+        Ok((trusted_commits, vote_block_headers))
     }
 }
 
@@ -852,15 +863,6 @@ mod tests {
 
     #[async_trait::async_trait]
     impl NetworkClient for FakeNetworkClient {
-        async fn send_block(
-            &self,
-            _peer: AuthorityIndex,
-            _serialized_block: &VerifiedBlockHeader,
-            _timeout: Duration,
-        ) -> ConsensusResult<()> {
-            unimplemented!("Unimplemented")
-        }
-
         async fn subscribe_blocks(
             &self,
             _peer: AuthorityIndex,
@@ -876,8 +878,19 @@ mod tests {
             _block_refs: Vec<BlockRef>,
             _highest_accepted_rounds: Vec<Round>,
             _timeout: Duration,
-        ) -> ConsensusResult<Vec<Bytes>> {
+        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
             unimplemented!("Unimplemented")
+        }
+
+        // Returns a vector of serialized block headers
+        async fn fetch_block_headers(
+            &self,
+            _peer: AuthorityIndex,
+            _block_refs: Vec<BlockRef>,
+            _highest_accepted_rounds: Vec<Round>,
+            _timeout: Duration,
+        ) -> ConsensusResult<Vec<Bytes>> {
+            unimplemented!();
         }
 
         async fn fetch_commits(
@@ -889,7 +902,7 @@ mod tests {
             unimplemented!("Unimplemented")
         }
 
-        async fn fetch_latest_blocks(
+        async fn fetch_latest_block_headers(
             &self,
             _peer: AuthorityIndex,
             _authorities: Vec<AuthorityIndex>,

--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -64,7 +64,7 @@ use crate::{
     core_thread::CoreThreadDispatcher,
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
-    network::{NetworkClient, SerializedBlock},
+    network::{NetworkClient, SerializedBlock, SerializedHeaderAndTransactions},
     stake_aggregator::{QuorumThreshold, StakeAggregator},
 };
 
@@ -602,47 +602,38 @@ impl<C: NetworkClient> CommitSyncer<C> {
                         )
                         .await?;
                     // 5. Verify the same number of blocks are returned as requested.
-                    if request_block_refs.len() != serialized_blocks.0.len()
-                        || request_block_refs.len() != serialized_blocks.1.len()
-                    {
+                    if request_block_refs.len() != serialized_blocks.len() {
                         return Err(ConsensusError::UnexpectedNumberOfBlocksFetched {
                             authority: target_authority,
                             requested: request_block_refs.len(),
-                            received_headers: serialized_blocks.0.len(),
-                            received_transactions: serialized_blocks.1.len(),
+                            received_blocks: serialized_blocks.len(),
                         });
                     }
                     // 6. Verify returned blocks have valid formats.
                     let verified_blocks = serialized_blocks
-                        .0
                         .iter()
                         .cloned()
-                        .zip(serialized_blocks.1)
                         .zip(request_block_refs)
-                        .map(
-                            |(
-                                (serialized_block_header, serialized_transactions),
-                                requested_block_ref,
-                            )| {
-                                let block = VerifiedBlock::try_from(SerializedBlock {
-                                    serialized_block_header,
-                                    serialized_transactions,
-                                })?;
+                        .map(|(serialized_block, requested_block_ref)| {
+                            let block = VerifiedBlock::try_from(
+                                SerializedHeaderAndTransactions::try_from(SerializedBlock {
+                                    serialized_block,
+                                })?,
+                            )?;
 
-                                // 7. Verify the returned blocks match the requested block refs.
-                                // If they do match, the returned blocks can be considered verified
-                                // as well.
-                                if *requested_block_ref != block.reference() {
-                                    return Err(ConsensusError::UnexpectedBlockForCommit {
-                                        peer: target_authority,
-                                        requested: *requested_block_ref,
-                                        received: block.reference(),
-                                    });
-                                }
+                            // 7. Verify the returned blocks match the requested block refs.
+                            // If they do match, the returned blocks can be considered verified
+                            // as well.
+                            if *requested_block_ref != block.reference() {
+                                return Err(ConsensusError::UnexpectedBlockForCommit {
+                                    peer: target_authority,
+                                    requested: *requested_block_ref,
+                                    received: block.reference(),
+                                });
+                            }
 
-                                Ok(block)
-                            },
-                        )
+                            Ok(block)
+                        })
                         .collect::<ConsensusResult<Vec<_>>>()?;
 
                     Ok(verified_blocks)
@@ -878,7 +869,7 @@ mod tests {
             _block_refs: Vec<BlockRef>,
             _highest_accepted_rounds: Vec<Round>,
             _timeout: Duration,
-        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
+        ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Unimplemented")
         }
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -30,7 +30,7 @@ use crate::{
     CommittedSubDag, Transaction,
     block_header::{
         BlockHeader, BlockHeaderAPI, BlockHeaderV1, BlockRef, BlockTimestampMs, GENESIS_ROUND,
-        Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlockHeader,
+        Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader,
         VerifiedTransactions,
     },
     block_manager::BlockManager,
@@ -142,9 +142,9 @@ impl Core {
         .build();
 
         // Recover the last proposed block
-        let last_proposed_block = dag_state.read().get_last_proposed_block();
+        let last_proposed_block_header = dag_state.read().get_last_proposed_block_header();
 
-        let last_signaled_round = last_proposed_block.round();
+        let last_signaled_round = last_proposed_block_header.round();
 
         // Recover the last included ancestor rounds based on the last proposed block.
         // That will allow to perform the next block proposal by using ancestor
@@ -157,7 +157,7 @@ impl Core {
         // and it mostly matters just for this next proposal without any actual
         // penalties in performance or block proposal.
         let mut last_included_ancestors = vec![None; context.committee.size()];
-        for ancestor in last_proposed_block.ancestors() {
+        for ancestor in last_proposed_block_header.ancestors() {
             last_included_ancestors[ancestor.author] = Some(*ancestor);
         }
 
@@ -198,11 +198,11 @@ impl Core {
             .with_label_values(&["Core::recover"])
             .start_timer();
         // Ensure local time is after max ancestor timestamp.
-        let ancestor_blocks = self
+        let ancestor_block_headers = self
             .dag_state
             .read()
-            .get_last_cached_block_per_authority(Round::MAX);
-        let max_ancestor_timestamp = ancestor_blocks
+            .get_last_cached_block_header_per_authority(Round::MAX);
+        let max_ancestor_timestamp = ancestor_block_headers
             .iter()
             .fold(0, |ts, (b, _)| ts.max(b.timestamp_ms()));
         let wait_ms = max_ancestor_timestamp.saturating_sub(self.context.clock.timestamp_utc_ms());
@@ -219,20 +219,23 @@ impl Core {
         self.try_commit().unwrap();
         let last_proposed_block = if let Some(last_proposed_block) = self.try_propose(true).unwrap()
         {
-            last_proposed_block
+            Some(last_proposed_block)
         } else {
             let last_proposed_block = self.dag_state.read().get_last_proposed_block();
             if self.should_propose() {
                 assert!(
-                    last_proposed_block.round() > GENESIS_ROUND,
+                    last_proposed_block.is_some(),
                     "At minimum a block of round higher than genesis should have been produced during recovery"
                 );
             }
-
-            // if no new block proposed then just re-broadcast the last proposed one to
-            // ensure liveness.
-            self.signals.new_block(last_proposed_block.clone()).unwrap();
-            last_proposed_block
+            if let Some(last_proposed_block) = last_proposed_block {
+                // if no new block proposed then just re-broadcast the last proposed one to
+                // ensure liveness.
+                self.signals.new_block(last_proposed_block.clone()).unwrap();
+                Some(last_proposed_block)
+            } else {
+                None
+            }
         };
 
         // Try to set up leader timeout if needed.
@@ -248,13 +251,14 @@ impl Core {
         self
     }
 
+    // TODO: modify to deal with transaction data
     /// Processes the provided blocks and accepts them if possible when their
     /// causal history exists. The method returns:
     /// - The references of ancestors missing their block
     #[tracing::instrument(skip_all)]
     pub(crate) fn add_blocks(
         &mut self,
-        blocks: Vec<VerifiedBlockHeader>,
+        blocks: Vec<VerifiedBlock>,
     ) -> ConsensusResult<BTreeSet<BlockRef>> {
         let _scope = monitored_scope("Core::add_blocks");
         let _s = self
@@ -269,13 +273,66 @@ impl Core {
             .node_metrics
             .core_add_blocks_batch_size
             .observe(blocks.len() as f64);
-
         let (accepted_blocks, missing_block_refs) = self.block_manager.try_accept_blocks(blocks);
 
         if !accepted_blocks.is_empty() {
             debug!(
                 "Accepted blocks: {}",
                 accepted_blocks
+                    .iter()
+                    .map(|b| b.reference().to_string())
+                    .join(",")
+            );
+
+            // Try to commit the new blocks if possible.
+            self.try_commit()?;
+
+            // Try to propose now since there are new blocks accepted.
+            self.try_propose(false)?;
+
+            // Now set up leader timeout if needed.
+            // This needs to be called after try_commit() and try_propose(), which may
+            // have advanced the threshold clock round.
+            self.try_signal_new_round();
+        }
+
+        if !missing_block_refs.is_empty() {
+            trace!(
+                "Missing block refs: {}",
+                missing_block_refs.iter().map(|b| b.to_string()).join(", ")
+            );
+        }
+        Ok(missing_block_refs)
+    }
+
+    /// Processes the provided block headers and accepts them if possible when
+    /// their causal history exists. The method returns:
+    /// - The references of ancestors missing their block header
+    #[tracing::instrument(skip_all)]
+    pub(crate) fn add_block_headers(
+        &mut self,
+        block_headers: Vec<VerifiedBlockHeader>,
+    ) -> ConsensusResult<BTreeSet<BlockRef>> {
+        let _scope = monitored_scope("Core::add_block_header");
+        let _s = self
+            .context
+            .metrics
+            .node_metrics
+            .scope_processing_time
+            .with_label_values(&["Core::add_block_header"])
+            .start_timer();
+        self.context
+            .metrics
+            .node_metrics
+            .core_add_blocks_batch_size
+            .observe(block_headers.len() as f64);
+        let (accepted_block_headers, missing_block_refs) =
+            self.block_manager.try_accept_block_headers(block_headers);
+
+        if !accepted_block_headers.is_empty() {
+            debug!(
+                "Accepted block headers: {}",
+                accepted_block_headers
                     .iter()
                     .map(|b| b.reference().to_string())
                     .join(",")
@@ -356,7 +413,7 @@ impl Core {
         &mut self,
         round: Round,
         force: bool,
-    ) -> ConsensusResult<Option<VerifiedBlockHeader>> {
+    ) -> ConsensusResult<Option<VerifiedBlock>> {
         let _scope = monitored_scope("Core::new_block");
         if self.last_proposed_round() < round {
             self.context
@@ -376,7 +433,7 @@ impl Core {
     // Attempts to create a new block, persist and propose it to all peers.
     // When force is true, ignore if leader from the last round exists among
     // ancestors and if the minimum round delay has passed.
-    fn try_propose(&mut self, force: bool) -> ConsensusResult<Option<VerifiedBlockHeader>> {
+    fn try_propose(&mut self, force: bool) -> ConsensusResult<Option<VerifiedBlock>> {
         if !self.should_propose() {
             return Ok(None);
         }
@@ -395,7 +452,7 @@ impl Core {
     /// Attempts to propose a new block for the next round. If a block has
     /// already proposed for latest or earlier round, then no block is
     /// created and None is returned.
-    fn try_new_block(&mut self, force: bool) -> Option<VerifiedBlockHeader> {
+    fn try_new_block(&mut self, force: bool) -> Option<VerifiedBlock> {
         let _s = self
             .context
             .metrics
@@ -408,7 +465,7 @@ impl Core {
         let clock_round = {
             let dag_state = self.dag_state.read();
             let clock_round = dag_state.threshold_clock_round();
-            if clock_round <= dag_state.get_last_proposed_block().round() {
+            if clock_round <= dag_state.get_last_proposed_block_header().round() {
                 return None;
             }
             clock_round
@@ -565,8 +622,7 @@ impl Core {
             VerifiedBlockHeader::new_verified(signed_block_header, serialized_signed_block_header);
 
         // Record the interval from last proposal, before accepting the proposed block.
-        let last_proposed_block = self.last_proposed_block();
-        if last_proposed_block.round() > 0 {
+        if self.last_proposed_round() > 0 {
             self.context
                 .metrics
                 .node_metrics
@@ -575,35 +631,37 @@ impl Core {
                     Duration::from_millis(
                         verified_block_header
                             .timestamp_ms()
-                            .saturating_sub(last_proposed_block.timestamp_ms()),
+                            .saturating_sub(self.last_proposed_timestamp_ms()),
                     )
                     .as_secs_f64(),
                 );
         }
 
-        // Accept the block into BlockManager and DagState.
-        let (accepted_blocks, missing) = self
-            .block_manager
-            .try_accept_blocks(vec![verified_block_header.clone()]);
-        assert_eq!(accepted_blocks.len(), 1);
-        assert!(missing.is_empty());
-
         // Construct verified transactions to be used for storing and broadcasting
         // TODO: consume this transactions in the data manager and for broadcasting
-        let _verified_transactions = VerifiedTransactions::new(
+        let verified_transactions = VerifiedTransactions::new(
             transactions,
             verified_block_header.reference(),
             transactions_commitment,
             serialized_transactions,
         );
-
+        let verified_block = VerifiedBlock {
+            verified_block_header,
+            verified_transactions,
+        };
+        // Accept the block into BlockManager and DagState.
+        let (accepted_blocks, missing) = self
+            .block_manager
+            .try_accept_blocks(vec![verified_block.clone()]);
+        assert_eq!(accepted_blocks.len(), 1);
+        assert!(missing.is_empty());
         // Ensure the new block and its ancestors are persisted, before broadcasting it.
         self.dag_state.write().flush();
 
         // Now acknowledge the transactions for their inclusion to block
-        ack_transactions(verified_block_header.reference());
+        ack_transactions(verified_block.reference());
 
-        debug!("Created block {verified_block_header:?} for round {clock_round}");
+        debug!("Created block {verified_block:?} for round {clock_round}");
 
         self.context
             .metrics
@@ -612,7 +670,7 @@ impl Core {
             .with_label_values(&[&force.to_string()])
             .inc();
 
-        Some(verified_block_header)
+        Some(verified_block)
     }
 
     /// Runs commit rule to attempt to commit additional blocks from the DAG. If
@@ -834,7 +892,7 @@ impl Core {
         let all_ancestors = self
             .dag_state
             .read()
-            .get_last_cached_block_per_authority(clock_round);
+            .get_last_cached_block_header_per_authority(clock_round);
 
         assert_eq!(
             all_ancestors.len(),
@@ -846,7 +904,7 @@ impl Core {
 
         // Propose only ancestors of higher rounds than what has already been proposed.
         // And always include own last proposed block first among ancestors.
-        let included_ancestors = iter::once(self.last_proposed_block().clone())
+        let included_ancestors = iter::once(self.last_proposed_block_header().clone())
             .chain(all_ancestors.into_iter().flat_map(|(ancestor, _)| {
                 if ancestor.author() == self.context.own_index {
                     return None;
@@ -898,7 +956,7 @@ impl Core {
             // A linear search should be fine here as the set of elements is not expected to
             // be small enough and more sophisticated data structures might not
             // give us much here.
-            if !dag_state.contains_cached_block_at_slot(leader) {
+            if !dag_state.contains_cached_block_header_at_slot(leader) {
                 return false;
             }
         }
@@ -921,22 +979,27 @@ impl Core {
     }
 
     fn last_proposed_timestamp_ms(&self) -> BlockTimestampMs {
-        self.last_proposed_block().timestamp_ms()
+        self.last_proposed_block_header().timestamp_ms()
     }
 
     fn last_proposed_round(&self) -> Round {
-        self.last_proposed_block().round()
+        self.last_proposed_block_header().round()
     }
 
-    fn last_proposed_block(&self) -> VerifiedBlockHeader {
+    #[expect(dead_code)]
+    fn last_proposed_block(&self) -> Option<VerifiedBlock> {
         self.dag_state.read().get_last_proposed_block()
+    }
+
+    fn last_proposed_block_header(&self) -> VerifiedBlockHeader {
+        self.dag_state.read().get_last_proposed_block_header()
     }
 }
 
 /// Senders of signals from Core, for outputs and events (ex new block
 /// produced).
 pub(crate) struct CoreSignals {
-    tx_block_broadcast: broadcast::Sender<VerifiedBlockHeader>,
+    tx_block_broadcast: broadcast::Sender<VerifiedBlock>,
     new_round_sender: watch::Sender<Round>,
     context: Arc<Context>,
 }
@@ -946,7 +1009,7 @@ impl CoreSignals {
         // Blocks buffered in broadcast channel should be roughly equal to thosed cached
         // in dag state, since the underlying blocks are ref counted so a lower
         // buffer here will not reduce memory usage significantly.
-        let (tx_block_broadcast, rx_block_broadcast) = broadcast::channel::<VerifiedBlockHeader>(
+        let (tx_block_broadcast, rx_block_broadcast) = broadcast::channel::<VerifiedBlock>(
             context.parameters.dag_state_cached_rounds as usize,
         );
         let (new_round_sender, new_round_receiver) = watch::channel(0);
@@ -968,7 +1031,7 @@ impl CoreSignals {
     /// Sends a signal to all the waiters that a new block has been produced.
     /// The method will return true if block has reached even one
     /// subscriber, false otherwise.
-    pub(crate) fn new_block(&self, verified_block: VerifiedBlockHeader) -> ConsensusResult<()> {
+    pub(crate) fn new_block(&self, verified_block: VerifiedBlock) -> ConsensusResult<()> {
         // When there is only one authority in committee, it is unnecessary to broadcast
         // the block which will fail anyway without subscribers to the signal.
         if self.context.committee.size() > 1 {
@@ -1001,12 +1064,12 @@ impl CoreSignals {
 /// Intentionally un-cloneable. Components should only subscribe to channels
 /// they need.
 pub(crate) struct CoreSignalsReceivers {
-    rx_block_broadcast: broadcast::Receiver<VerifiedBlockHeader>,
+    rx_block_broadcast: broadcast::Receiver<VerifiedBlock>,
     new_round_receiver: watch::Receiver<Round>,
 }
 
 impl CoreSignalsReceivers {
-    pub(crate) fn block_broadcast_receiver(&self) -> broadcast::Receiver<VerifiedBlockHeader> {
+    pub(crate) fn block_broadcast_receiver(&self) -> broadcast::Receiver<VerifiedBlock> {
         self.rx_block_broadcast.resubscribe()
     }
 
@@ -1034,7 +1097,7 @@ pub(crate) fn create_cores(context: Context, authorities: Vec<Stake>) -> Vec<Cor
 pub(crate) struct CoreTextFixture {
     pub core: Core,
     pub signal_receivers: CoreSignalsReceivers,
-    pub block_receiver: broadcast::Receiver<VerifiedBlockHeader>,
+    pub block_receiver: broadcast::Receiver<VerifiedBlock>,
     #[expect(unused)]
     pub commit_receiver: UnboundedReceiver<CommittedSubDag>,
     pub store: Arc<MemStore>,
@@ -1126,6 +1189,7 @@ mod test {
         CommitConsumer, CommitIndex, Transaction,
         block_header::{
             BlockHeaderDigest, TestBlockHeader, TransactionsCommitment, genesis_block_headers,
+            genesis_blocks,
         },
         block_verifier::NoopBlockVerifier,
         commit::CommitAPI,
@@ -1150,12 +1214,12 @@ mod test {
 
         // Create test blocks for all the authorities for 4 rounds and populate them in
         // store
-        let mut last_round_blocks = genesis_block_headers(context.clone());
-        let mut all_blocks: Vec<VerifiedBlockHeader> = last_round_blocks.clone();
+        let mut last_round_blocks = genesis_blocks(context.clone());
+        let mut all_blocks: Vec<VerifiedBlock> = last_round_blocks.clone();
         for round in 1..=4 {
             let mut this_round_blocks = Vec::new();
             for (index, _authority) in context.committee.authorities() {
-                let block = VerifiedBlockHeader::new_for_test(
+                let block = VerifiedBlock::new_for_test(
                     TestBlockHeader::new(round, index.value() as u32)
                         .set_ancestors(last_round_blocks.iter().map(|b| b.reference()).collect())
                         .build(),
@@ -1274,7 +1338,7 @@ mod test {
         let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
 
         // Create test blocks for all authorities except our's (index = 0).
-        let mut last_round_blocks = genesis_block_headers(context.clone());
+        let mut last_round_blocks = genesis_blocks(context.clone());
         let mut all_blocks = last_round_blocks.clone();
         for round in 1..=4 {
             let mut this_round_blocks = Vec::new();
@@ -1292,7 +1356,7 @@ mod test {
                 let block = TestBlockHeader::new(round, index.value() as u32)
                     .set_ancestors(last_round_blocks.iter().map(|b| b.reference()).collect())
                     .build();
-                this_round_blocks.push(VerifiedBlockHeader::new_for_test(block));
+                this_round_blocks.push(VerifiedBlock::new_for_test(block));
             }
             all_blocks.extend(this_round_blocks.clone());
             last_round_blocks = this_round_blocks;
@@ -1588,21 +1652,21 @@ mod test {
         let mut expected_ancestors = BTreeSet::new();
 
         // Adding one block now will trigger the creation of new block for round 1
-        let block_1 = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(1, 1).build());
-        expected_ancestors.insert(block_1.reference());
+        let verified_block = VerifiedBlock::new_for_test(TestBlockHeader::new(1, 1).build());
+        expected_ancestors.insert(verified_block.reference());
         // Wait for min round delay to allow blocks to be proposed.
         sleep(context.parameters.min_round_delay).await;
         // add blocks to trigger proposal.
-        _ = core.add_blocks(vec![block_1]);
+        _ = core.add_blocks(vec![verified_block]);
 
         assert_eq!(core.last_proposed_round(), 1);
-        expected_ancestors.insert(core.last_proposed_block().reference());
+        expected_ancestors.insert(core.last_proposed_block_header().reference());
         // attempt to create a block - none will be produced.
         assert!(core.try_propose(false).unwrap().is_none());
 
         // Adding another block now forms a quorum for round 1, so block at round 2 will
         // proposed
-        let block_3 = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(1, 2).build());
+        let block_3 = VerifiedBlock::new_for_test(TestBlockHeader::new(1, 2).build());
         expected_ancestors.insert(block_3.reference());
         // Wait for min round delay to allow blocks to be proposed.
         sleep(context.parameters.min_round_delay).await;
@@ -1611,7 +1675,7 @@ mod test {
 
         assert_eq!(core.last_proposed_round(), 2);
 
-        let proposed_block = core.last_proposed_block();
+        let proposed_block = core.last_proposed_block_header();
         assert_eq!(proposed_block.round(), 2);
         assert_eq!(proposed_block.author(), context.own_index);
         assert_eq!(proposed_block.ancestors().len(), 3);
@@ -1690,10 +1754,10 @@ mod test {
         let mut builder = DagBuilder::new(context.clone());
         builder.layers(1..=10).build();
 
-        let blocks = builder.blocks.values().cloned().collect::<Vec<_>>();
+        let block_headers = builder.block_headers.values().cloned().collect::<Vec<_>>();
 
         // Process all the blocks
-        assert!(core.add_blocks(blocks).unwrap().is_empty());
+        assert!(core.add_block_headers(block_headers).unwrap().is_empty());
 
         // Try to propose - no block should be produced.
         assert!(core.try_propose(true).unwrap().is_none());
@@ -1759,7 +1823,7 @@ mod test {
 
                 core_fixture
                     .core
-                    .add_blocks(last_round_blocks.clone())
+                    .add_block_headers(last_round_blocks.clone())
                     .unwrap();
 
                 // Only when round > 1 and using non-genesis parents.
@@ -1779,7 +1843,7 @@ mod test {
 
                 assert_eq!(core_fixture.core.last_proposed_round(), round);
 
-                this_round_blocks.push(core_fixture.core.last_proposed_block());
+                this_round_blocks.push(core_fixture.core.last_proposed_block_header());
             }
 
             last_round_blocks = this_round_blocks;
@@ -1793,7 +1857,7 @@ mod test {
 
             core_fixture
                 .core
-                .add_blocks(last_round_blocks.clone())
+                .add_block_headers(last_round_blocks.clone())
                 .unwrap();
             assert!(core_fixture.core.try_propose(false).unwrap().is_none());
         }
@@ -1896,9 +1960,9 @@ mod test {
 
         // Now iterate over a few rounds and ensure the corresponding signals are
         // created while network advances
-        let mut last_round_blocks = Vec::new();
+        let mut last_round_block_headers = Vec::new();
         for round in 1..=30 {
-            let mut this_round_blocks = Vec::new();
+            let mut this_round_block_headers = Vec::new();
 
             // Wait for min round delay to allow blocks to be proposed.
             sleep(default_params.min_round_delay).await;
@@ -1909,7 +1973,7 @@ mod test {
                 // emitted
                 core_fixture
                     .core
-                    .add_blocks(last_round_blocks.clone())
+                    .add_block_headers(last_round_block_headers.clone())
                     .unwrap();
 
                 // A "new round" signal should be received given that all the blocks of previous
@@ -1933,29 +1997,30 @@ mod test {
                 assert_eq!(verified_block.author(), core_fixture.core.context.own_index);
 
                 // append the new block to this round blocks
-                this_round_blocks.push(core_fixture.core.last_proposed_block().clone());
+                this_round_block_headers
+                    .push(core_fixture.core.last_proposed_block_header().clone());
 
-                let block = core_fixture.core.last_proposed_block();
+                let block_header = core_fixture.core.last_proposed_block_header();
 
                 // ensure that produced block is referring to the blocks of last_round
                 assert_eq!(
-                    block.ancestors().len(),
+                    block_header.ancestors().len(),
                     core_fixture.core.context.committee.size()
                 );
-                for ancestor in block.ancestors() {
-                    if block.round() > 1 {
+                for ancestor in block_header.ancestors() {
+                    if block_header.round() > 1 {
                         // don't bother with round 1 block which just contains the genesis blocks.
                         assert!(
-                            last_round_blocks
+                            last_round_block_headers
                                 .iter()
-                                .any(|block| block.reference() == *ancestor),
+                                .any(|block_header| block_header.reference() == *ancestor),
                             "Reference from previous round should be added"
                         );
                     }
                 }
             }
 
-            last_round_blocks = this_round_blocks;
+            last_round_block_headers = this_round_block_headers;
         }
 
         for core_fixture in cores {
@@ -2037,10 +2102,10 @@ mod test {
         // Store all blocks up to round 6 which should be enough to decide up to leader
         // 4
         dag_builder.print();
-        let blocks = dag_builder.blocks(1..=6);
+        let block_headers = dag_builder.block_headers(1..=6);
 
-        for block in blocks {
-            core.dag_state.write().accept_block(block);
+        for block_header in block_headers {
+            core.dag_state.write().accept_block_header(block_header);
         }
 
         // Get all the committed sub dags up to round 10
@@ -2082,9 +2147,9 @@ mod test {
 
         // Now only add the blocks of rounds 8..=12. The blocks up to round 7 should be
         // accepted via the certified commits processing.
-        let blocks = dag_builder.blocks(8..=12);
-        for block in blocks {
-            core.dag_state.write().accept_block(block);
+        let block_headers = dag_builder.block_headers(8..=12);
+        for block_header in block_headers {
+            core.dag_state.write().accept_block_header(block_header);
         }
 
         // The corresponding blocks of the certified commits should be accepted and
@@ -2115,9 +2180,9 @@ mod test {
 
         // Now iterate over a few rounds and ensure the corresponding signals are
         // created while network advances
-        let mut last_round_blocks = Vec::new();
+        let mut last_round_block_headers = Vec::new();
         for round in 1..=33 {
-            let mut this_round_blocks = Vec::new();
+            let mut this_round_block_headers = Vec::new();
             // Wait for min round delay to allow blocks to be proposed.
             sleep(default_params.min_round_delay).await;
             for core_fixture in &mut cores {
@@ -2126,7 +2191,7 @@ mod test {
                 // emitted
                 core_fixture
                     .core
-                    .add_blocks(last_round_blocks.clone())
+                    .add_block_headers(last_round_block_headers.clone())
                     .unwrap();
                 // A "new round" signal should be received given that all the blocks of previous
                 // round have been processed
@@ -2148,18 +2213,19 @@ mod test {
                 assert_eq!(verified_block.author(), core_fixture.core.context.own_index);
 
                 // append the new block to this round blocks
-                this_round_blocks.push(core_fixture.core.last_proposed_block().clone());
-                let block = core_fixture.core.last_proposed_block();
+                this_round_block_headers
+                    .push(core_fixture.core.last_proposed_block_header().clone());
+                let block_header = core_fixture.core.last_proposed_block_header();
                 // ensure that produced block is referring to the blocks of last_round
                 assert_eq!(
-                    block.ancestors().len(),
+                    block_header.ancestors().len(),
                     core_fixture.core.context.committee.size()
                 );
-                for ancestor in block.ancestors() {
-                    if block.round() > 1 {
+                for ancestor in block_header.ancestors() {
+                    if block_header.round() > 1 {
                         // don't bother with round 1 block which just contains the genesis blocks.
                         assert!(
-                            last_round_blocks
+                            last_round_block_headers
                                 .iter()
                                 .any(|block| block.reference() == *ancestor),
                             "Reference from previous round should be added"
@@ -2167,7 +2233,7 @@ mod test {
                     }
                 }
             }
-            last_round_blocks = this_round_blocks;
+            last_round_block_headers = this_round_block_headers;
         }
         for core_fixture in cores {
             // Check commits have been persisted to store
@@ -2244,9 +2310,9 @@ mod test {
 
         // Now iterate over a few rounds and ensure the corresponding signals are
         // created while network advances
-        let mut last_round_blocks = Vec::new();
+        let mut last_round_block_headers = Vec::new();
         for round in 1..=10 {
-            let mut this_round_blocks = Vec::new();
+            let mut this_round_block_headers = Vec::new();
 
             // Wait for min round delay to allow blocks to be proposed.
             sleep(default_params.min_round_delay).await;
@@ -2257,7 +2323,7 @@ mod test {
                 // emitted
                 core_fixture
                     .core
-                    .add_blocks(last_round_blocks.clone())
+                    .add_block_headers(last_round_block_headers.clone())
                     .unwrap();
 
                 // A "new round" signal should be received given that all the blocks of previous
@@ -2281,29 +2347,30 @@ mod test {
                 assert_eq!(verified_block.author(), core_fixture.core.context.own_index);
 
                 // append the new block to this round blocks
-                this_round_blocks.push(core_fixture.core.last_proposed_block().clone());
+                this_round_block_headers
+                    .push(core_fixture.core.last_proposed_block_header().clone());
 
-                let block = core_fixture.core.last_proposed_block();
+                let block_header = core_fixture.core.last_proposed_block_header();
 
                 // ensure that produced block is referring to the blocks of last_round
                 assert_eq!(
-                    block.ancestors().len(),
+                    block_header.ancestors().len(),
                     core_fixture.core.context.committee.size()
                 );
-                for ancestor in block.ancestors() {
-                    if block.round() > 1 {
+                for ancestor in block_header.ancestors() {
+                    if block_header.round() > 1 {
                         // don't bother with round 1 block which just contains the genesis blocks.
                         assert!(
-                            last_round_blocks
+                            last_round_block_headers
                                 .iter()
-                                .any(|block| block.reference() == *ancestor),
+                                .any(|block_header| block_header.reference() == *ancestor),
                             "Reference from previous round should be added"
                         );
                     }
                 }
             }
 
-            last_round_blocks = this_round_blocks;
+            last_round_block_headers = this_round_block_headers;
         }
 
         for core_fixture in cores {
@@ -2334,13 +2401,13 @@ mod test {
         // create the cores and their signals for all the authorities
         let mut cores = create_cores(context, vec![1, 1, 1, 1]);
 
-        let mut last_round_blocks = Vec::new();
-        let mut all_blocks = Vec::new();
+        let mut last_round_block_headers = Vec::new();
+        let mut all_block_headers = Vec::new();
 
         let excluded_authority = AuthorityIndex::new_for_test(3);
 
         for round in 1..=10 {
-            let mut this_round_blocks = Vec::new();
+            let mut this_round_block_headers = Vec::new();
 
             for core_fixture in &mut cores {
                 // do not produce any block for authority 3
@@ -2352,19 +2419,19 @@ mod test {
                 // leader authority 3
                 core_fixture
                     .core
-                    .add_blocks(last_round_blocks.clone())
+                    .add_block_headers(last_round_block_headers.clone())
                     .unwrap();
                 core_fixture.core.new_block(round, true).unwrap();
 
-                let block = core_fixture.core.last_proposed_block();
-                assert_eq!(block.round(), round);
+                let block_header = core_fixture.core.last_proposed_block_header();
+                assert_eq!(block_header.round(), round);
 
                 // append the new block to this round blocks
-                this_round_blocks.push(block.clone());
+                this_round_block_headers.push(block_header.clone());
             }
 
-            last_round_blocks = this_round_blocks.clone();
-            all_blocks.extend(this_round_blocks);
+            last_round_block_headers = this_round_block_headers.clone();
+            all_block_headers.extend(this_round_block_headers);
         }
 
         // Now send all the produced blocks to core of authority 3. It should produce a
@@ -2376,15 +2443,18 @@ mod test {
         // Wait for min round delay to allow blocks to be proposed.
         sleep(default_params.min_round_delay).await;
         // add blocks to trigger proposal.
-        core_fixture.core.add_blocks(all_blocks).unwrap();
+        core_fixture
+            .core
+            .add_block_headers(all_block_headers)
+            .unwrap();
 
         // Assert that a block has been created for round 11 and it references to blocks
         // of round 10 for the other peers, and to round 1 for its own block
         // (created after recovery).
-        let block = core_fixture.core.last_proposed_block();
-        assert_eq!(block.round(), 11);
-        assert_eq!(block.ancestors().len(), 4);
-        for block_ref in block.ancestors() {
+        let block_header = core_fixture.core.last_proposed_block_header();
+        assert_eq!(block_header.round(), 11);
+        assert_eq!(block_header.ancestors().len(), 4);
+        for block_ref in block_header.ancestors() {
             if block_ref.author == excluded_authority {
                 assert_eq!(block_ref.round, 1);
             } else {
@@ -2461,7 +2531,7 @@ mod test {
 
         // Subscribe to all created "own" blocks. We know that for our node (A) we'll be
         // able to commit up to round 5.
-        for block in dag_builder.blocks(1..=5) {
+        for block in dag_builder.block_headers(1..=5) {
             if block.author() == context.own_index {
                 let subscription =
                     transaction_consumer.subscribe_for_block_status_testing(block.reference());
@@ -2471,7 +2541,7 @@ mod test {
 
         // write them in store
         store
-            .write(WriteBatch::default().blocks(dag_builder.blocks(1..=8)))
+            .write(WriteBatch::default().block_headers(dag_builder.block_headers(1..=8)))
             .expect("Storage error");
 
         // create dag state after all blocks have been written to store

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -224,11 +224,11 @@ impl Core {
             let last_proposed_block = self.dag_state.read().get_last_proposed_block();
             if self.should_propose() {
                 assert!(
-                    last_proposed_block.is_some(),
+                    last_proposed_block.round() != GENESIS_ROUND,
                     "At minimum a block of round higher than genesis should have been produced during recovery"
                 );
             }
-            if let Some(last_proposed_block) = last_proposed_block {
+            if last_proposed_block.round() != GENESIS_ROUND {
                 // if no new block proposed then just re-broadcast the last proposed one to
                 // ensure liveness.
                 self.signals.new_block(last_proposed_block.clone()).unwrap();
@@ -987,7 +987,7 @@ impl Core {
     }
 
     #[expect(dead_code)]
-    fn last_proposed_block(&self) -> Option<VerifiedBlock> {
+    fn last_proposed_block(&self) -> VerifiedBlock {
         self.dag_state.read().get_last_proposed_block()
     }
 

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -23,7 +23,7 @@ use tracing::warn;
 
 use crate::{
     BlockHeaderAPI as _, VerifiedBlockHeader,
-    block_header::{BlockRef, Round, VerifiedBlock},
+    block_header::{BlockRef, Round, VerifiedBlock, VerifiedTransactions},
     commit::CertifiedCommits,
     context::Context,
     core::Core,

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -22,8 +22,8 @@ use tokio::sync::{oneshot, watch};
 use tracing::warn;
 
 use crate::{
-    BlockHeaderAPI as _,
-    block_header::{BlockRef, Round, VerifiedBlockHeader, VerifiedTransactions},
+    BlockHeaderAPI as _, VerifiedBlockHeader,
+    block_header::{BlockRef, Round, VerifiedBlock},
     commit::CertifiedCommits,
     context::Context,
     core::Core,
@@ -36,7 +36,9 @@ const CORE_THREAD_COMMANDS_CHANNEL_SIZE: usize = 2000;
 
 enum CoreThreadCommand {
     /// Add blocks to be processed and accepted
-    AddBlocks(
+    AddBlocks(Vec<VerifiedBlock>, oneshot::Sender<BTreeSet<BlockRef>>),
+    /// Add block headers to be processed and accepted
+    AddBlockHeaders(
         Vec<VerifiedBlockHeader>,
         oneshot::Sender<BTreeSet<BlockRef>>,
     ),
@@ -62,7 +64,10 @@ pub enum CoreError {
 /// Also this allows the easier mocking during unit tests.
 #[async_trait]
 pub trait CoreThreadDispatcher: Sync + Send + 'static {
-    async fn add_blocks(
+    async fn add_blocks(&self, blocks: Vec<VerifiedBlock>)
+    -> Result<BTreeSet<BlockRef>, CoreError>;
+
+    async fn add_block_headers(
         &self,
         blocks: Vec<VerifiedBlockHeader>,
     ) -> Result<BTreeSet<BlockRef>, CoreError>;
@@ -140,6 +145,11 @@ impl CoreThread {
                             let missing_block_refs = self.core.add_blocks(blocks)?;
                             sender.send(missing_block_refs).ok();
                         }
+                        CoreThreadCommand::AddBlockHeaders(block_headers, sender) => {
+                            let _scope = monitored_scope("CoreThread::loop::add_block_headers");
+                            let missing_block_refs = self.core.add_block_headers(block_headers)?;
+                            sender.send(missing_block_refs).ok();
+                        }
                         CoreThreadCommand::AddCertifiedCommits(commits, sender) => {
                             let _scope = monitored_scope("CoreThread::loop::add_certified_commits");
                             let missing_block_refs = self.core.add_certified_commits(commits)?;
@@ -204,7 +214,7 @@ impl ChannelCoreThreadDispatcher {
                 .committee
                 .authorities()
                 .map(|(index, _)| {
-                    AtomicU32::new(dag_state.get_last_block_for_authority(index).round())
+                    AtomicU32::new(dag_state.get_last_block_header_for_authority(index).round())
                 })
                 .collect();
 
@@ -269,13 +279,25 @@ impl ChannelCoreThreadDispatcher {
 impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
     async fn add_blocks(
         &self,
-        blocks: Vec<VerifiedBlockHeader>,
+        blocks: Vec<VerifiedBlock>,
     ) -> Result<BTreeSet<BlockRef>, CoreError> {
         for block in &blocks {
             self.highest_received_rounds[block.author()].fetch_max(block.round(), Ordering::AcqRel);
         }
         let (sender, receiver) = oneshot::channel();
-        self.send(CoreThreadCommand::AddBlocks(blocks.clone(), sender))
+        self.send(CoreThreadCommand::AddBlocks(blocks, sender))
+            .await;
+        let missing_block_refs = receiver.await.map_err(|e| Shutdown(e.to_string()))?;
+
+        Ok(missing_block_refs)
+    }
+
+    async fn add_block_headers(
+        &self,
+        block_headers: Vec<VerifiedBlockHeader>,
+    ) -> Result<BTreeSet<BlockRef>, CoreError> {
+        let (sender, receiver) = oneshot::channel();
+        self.send(CoreThreadCommand::AddBlockHeaders(block_headers, sender))
             .await;
         let missing_block_refs = receiver.await.map_err(|e| Shutdown(e.to_string()))?;
 
@@ -346,11 +368,12 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
 #[cfg(test)]
 pub(crate) mod tests {
     use iota_metrics::monitored_mpsc::unbounded_channel;
-    use parking_lot::RwLock;
+    use parking_lot::{Mutex, RwLock};
+    use tokio::time::Instant;
 
     use super::*;
     use crate::{
-        CommitConsumer,
+        CommitConsumer, VerifiedBlockHeader,
         block_manager::BlockManager,
         block_verifier::NoopBlockVerifier,
         commit_observer::CommitObserver,
@@ -365,15 +388,31 @@ pub(crate) mod tests {
     // TODO: complete the Mock for thread dispatcher to be used from several tests
     #[derive(Default)]
     pub(crate) struct MockCoreThreadDispatcher {
-        add_blocks: parking_lot::Mutex<Vec<VerifiedBlockHeader>>,
-        missing_blocks: parking_lot::Mutex<BTreeSet<BlockRef>>,
-        last_known_proposed_round: parking_lot::Mutex<Vec<Round>>,
+        blocks: Mutex<Vec<VerifiedBlock>>,
+        block_headers: Mutex<Vec<VerifiedBlockHeader>>,
+        missing_blocks: Mutex<BTreeSet<BlockRef>>,
+        last_known_proposed_round: Mutex<Vec<Round>>,
+        new_block_calls: Arc<Mutex<Vec<(Round, bool, Instant)>>>,
     }
 
     impl MockCoreThreadDispatcher {
-        pub(crate) async fn get_add_blocks(&self) -> Vec<VerifiedBlockHeader> {
-            let mut add_blocks = self.add_blocks.lock();
-            add_blocks.drain(0..).collect()
+        pub(crate) async fn get_and_drain_blocks(&self) -> Vec<VerifiedBlock> {
+            let mut blocks = self.blocks.lock();
+            blocks.drain(0..).collect()
+        }
+
+        pub(crate) async fn get_and_drain_block_headers(&self) -> Vec<VerifiedBlockHeader> {
+            let mut block_headers = self.block_headers.lock();
+            block_headers.drain(0..).collect()
+        }
+
+        pub(crate) fn get_blocks(&self) -> Vec<VerifiedBlock> {
+            self.blocks.lock().clone()
+        }
+
+        #[expect(dead_code)]
+        pub(crate) fn get_block_headers(&self) -> Vec<VerifiedBlockHeader> {
+            self.block_headers.lock().clone()
         }
 
         pub(crate) async fn stub_missing_blocks(&self, block_refs: BTreeSet<BlockRef>) {
@@ -385,17 +424,32 @@ pub(crate) mod tests {
             let last_known_proposed_round = self.last_known_proposed_round.lock();
             last_known_proposed_round.clone()
         }
+
+        pub(crate) async fn get_new_block_calls(&self) -> Vec<(Round, bool, Instant)> {
+            let mut binding = self.new_block_calls.lock();
+            let all_calls = binding.drain(0..);
+            all_calls.into_iter().collect()
+        }
     }
 
     #[async_trait]
     impl CoreThreadDispatcher for MockCoreThreadDispatcher {
         async fn add_blocks(
             &self,
-            blocks: Vec<VerifiedBlockHeader>,
+            blocks: Vec<VerifiedBlock>,
         ) -> Result<BTreeSet<BlockRef>, CoreError> {
-            let mut add_blocks = self.add_blocks.lock();
-            add_blocks.extend(blocks);
-            Ok(BTreeSet::new())
+            let block_refs = blocks.iter().map(|b| b.reference()).collect();
+            self.blocks.lock().extend(blocks);
+            Ok(block_refs)
+        }
+
+        async fn add_block_headers(
+            &self,
+            block_headers: Vec<VerifiedBlockHeader>,
+        ) -> Result<BTreeSet<BlockRef>, CoreError> {
+            let block_refs = block_headers.iter().map(|b| b.reference()).collect();
+            self.block_headers.lock().extend(block_headers);
+            Ok(block_refs)
         }
 
         async fn add_data(
@@ -416,7 +470,10 @@ pub(crate) mod tests {
             todo!()
         }
 
-        async fn new_block(&self, _round: Round, _force: bool) -> Result<(), CoreError> {
+        async fn new_block(&self, round: Round, force: bool) -> Result<(), CoreError> {
+            self.new_block_calls
+                .lock()
+                .push((round, force, Instant::now()));
             Ok(())
         }
 
@@ -498,11 +555,16 @@ pub(crate) mod tests {
         assert!(dispatcher_1.add_blocks(vec![]).await.is_ok());
         assert!(dispatcher_2.add_blocks(vec![]).await.is_ok());
 
+        assert!(dispatcher_1.add_block_headers(vec![]).await.is_ok());
+        assert!(dispatcher_2.add_block_headers(vec![]).await.is_ok());
+
         // Now shutdown the dispatcher
         handle.stop().await;
 
         // Try to send some commands
         assert!(dispatcher_1.add_blocks(vec![]).await.is_err());
         assert!(dispatcher_2.add_blocks(vec![]).await.is_err());
+        assert!(dispatcher_1.add_block_headers(vec![]).await.is_err());
+        assert!(dispatcher_2.add_block_headers(vec![]).await.is_err());
     }
 }

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -19,7 +19,7 @@ use tracing::{debug, error, info};
 use crate::{
     block_header::{
         BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs, GENESIS_ROUND, Round, Slot,
-        VerifiedBlockHeader, genesis_block_headers,
+        VerifiedBlock, VerifiedBlockHeader, genesis_blocks,
     },
     commit::{
         CommitAPI as _, CommitDigest, CommitIndex, CommitInfo, CommitRef, CommitVote,
@@ -43,15 +43,26 @@ pub(crate) struct DagState {
     context: Arc<Context>,
 
     // The genesis blocks
-    genesis: BTreeMap<BlockRef, VerifiedBlockHeader>,
+    genesis: BTreeMap<BlockRef, VerifiedBlock>,
 
-    // Contains recent blocks within CACHED_ROUNDS from the last committed round per authority.
-    // Note: all uncommitted blocks are kept in memory.
-    recent_blocks: BTreeMap<BlockRef, VerifiedBlockHeader>,
+    // Contains recent block headers within CACHED_ROUNDS from the last committed round per
+    // authority. Note: all uncommitted block headers are kept in memory.
+    recent_block_headers: BTreeMap<BlockRef, VerifiedBlockHeader>,
 
-    // Indexes recent block refs by their authorities.
+    // Contains recent blocks (together with transactions) within CACHED_ROUNDS from the last
+    // committed round per authority. Note: all uncommitted blocks are kept in memory.
+    // TODO: should we relocate it to data manager?
+    // TODO: consider possibility to store only transactions to avoid duplication with
+    // recent_block_headers
+    recent_blocks: BTreeMap<BlockRef, VerifiedBlock>,
+
+    // Indexes recent block headers refs by their authorities.
     // Vec position corresponds to the authority index.
-    recent_refs_by_authority: Vec<BTreeSet<BlockRef>>,
+    recent_headers_refs_by_authority: Vec<BTreeSet<BlockRef>>,
+
+    // Indexes recent block headers refs by their authorities.
+    // Vec position corresponds to the authority index.
+    recent_blocks_refs_by_authority: Vec<BTreeSet<BlockRef>>,
 
     // Keeps track of the threshold clock for proposing blocks.
     threshold_clock: ThresholdClock,
@@ -89,7 +100,8 @@ pub(crate) struct DagState {
     pending_acknowledgments: Vec<BlockRef>,
 
     // Data to be flushed to storage.
-    blocks_to_write: Vec<VerifiedBlockHeader>,
+    blocks_to_write: Vec<VerifiedBlock>,
+    block_headers_to_write: Vec<VerifiedBlockHeader>,
     commits_to_write: Vec<TrustedCommit>,
 
     // Buffer the reputation scores & last_committed_rounds to be flushed with the
@@ -110,7 +122,7 @@ impl DagState {
         let cached_rounds = context.parameters.dag_state_cached_rounds as Round;
         let num_authorities = context.committee.size();
 
-        let genesis = genesis_block_headers(context.clone())
+        let genesis = genesis_blocks(context.clone())
             .into_iter()
             .map(|block| (block.reference(), block))
             .collect();
@@ -164,8 +176,10 @@ impl DagState {
         let mut state = Self {
             context,
             genesis,
+            recent_block_headers: BTreeMap::new(),
             recent_blocks: BTreeMap::new(),
-            recent_refs_by_authority: vec![BTreeSet::new(); num_authorities],
+            recent_headers_refs_by_authority: vec![BTreeSet::new(); num_authorities],
+            recent_blocks_refs_by_authority: vec![BTreeSet::new(); num_authorities],
             threshold_clock,
             highest_accepted_round: 0,
             last_commit: last_commit.clone(),
@@ -173,6 +187,7 @@ impl DagState {
             last_committed_rounds: last_committed_rounds.clone(),
             pending_commit_votes: VecDeque::new(),
             blocks_to_write: vec![],
+            block_headers_to_write: vec![],
             commits_to_write: vec![],
             commit_info_to_write: vec![],
             pending_acknowledgments: vec![],
@@ -184,26 +199,27 @@ impl DagState {
 
         for (i, round) in last_committed_rounds.into_iter().enumerate() {
             let authority_index = state.context.committee.to_authority_index(i).unwrap();
-            let (blocks, eviction_round) = {
+            let (block_headers, eviction_round) = {
                 let eviction_round = Self::eviction_round(round, cached_rounds);
-                let blocks = state
+                // TODO: scan for blocks?
+                let block_headers = state
                     .store
-                    .scan_blocks_by_author(authority_index, eviction_round + 1)
+                    .scan_block_headers_by_author(authority_index, eviction_round + 1)
                     .expect("Database error");
-                (blocks, eviction_round)
+                (block_headers, eviction_round)
             };
 
             state.evicted_rounds[authority_index] = eviction_round;
 
             // Update the block metadata for the authority.
-            for block in &blocks {
-                state.update_block_metadata(block);
+            for block_header in &block_headers {
+                state.update_block_metadata(block_header);
             }
 
             info!(
-                "Recovered blocks {}: {:?}",
+                "Recovered block headers {}: {:?}",
                 authority_index,
-                blocks
+                block_headers
                     .iter()
                     .map(|b| b.reference())
                     .collect::<Vec<BlockRef>>()
@@ -212,25 +228,25 @@ impl DagState {
         state
     }
 
-    /// Accepts a block into DagState and keeps it in memory.
-    pub(crate) fn accept_block(&mut self, block: VerifiedBlockHeader) {
+    /// Accepts a block header into DagState and keeps it in memory.
+    pub(crate) fn accept_block_header(&mut self, block_header: VerifiedBlockHeader) {
         assert_ne!(
-            block.round(),
+            block_header.round(),
             0,
             "Genesis block should not be accepted into DAG."
         );
 
-        let block_ref = block.reference();
-        if self.contains_block(&block_ref) {
+        let block_ref = block_header.reference();
+        if self.contains_block_header(&block_ref) {
             return;
         }
 
         let now = self.context.clock.timestamp_utc_ms();
-        if block.timestamp_ms() > now {
+        if block_header.timestamp_ms() > now {
             panic!(
                 "Block {:?} cannot be accepted! Block timestamp {} is greater than local timestamp {}.",
-                block,
-                block.timestamp_ms(),
+                block_header,
+                block_header.timestamp_ms(),
                 now,
             );
         }
@@ -241,17 +257,22 @@ impl DagState {
             let existing_blocks = self.get_uncommitted_blocks_at_slot(block_ref.into());
             assert!(
                 existing_blocks.is_empty(),
-                "Block Rejected! Attempted to add block {block:#?} to own slot where \
+                "Block Rejected! Attempted to add block header {block_header:#?} to own slot where \
                 block(s) {existing_blocks:#?} already exists."
             );
         }
-        self.update_block_metadata(&block);
-        self.blocks_to_write.push(block);
+        self.update_block_metadata(&block_header);
+        info!(
+            "block header {} pushed to write to store batch by {}",
+            block_header, self.context.own_index
+        );
+        self.block_headers_to_write.push(block_header);
         let source = if self.context.own_index == block_ref.author {
             "own"
         } else {
             "others"
         };
+        // TODO: rename to accepted block headers?
         self.context
             .metrics
             .node_metrics
@@ -260,20 +281,29 @@ impl DagState {
             .inc();
     }
 
-    /// Updates internal metadata for a block.
-    fn update_block_metadata(&mut self, block: &VerifiedBlockHeader) {
+    pub(crate) fn add_block(&mut self, block: VerifiedBlock) {
         let block_ref = block.reference();
         self.recent_blocks.insert(block_ref, block.clone());
-        self.recent_refs_by_authority[block_ref.author].insert(block_ref);
+        self.recent_blocks_refs_by_authority[block_ref.author].insert(block_ref);
+        self.blocks_to_write.push(block);
+    }
+
+    /// Updates internal metadata for a block.
+    fn update_block_metadata(&mut self, block_header: &VerifiedBlockHeader) {
+        let block_ref = block_header.reference();
+        self.recent_block_headers
+            .insert(block_ref, block_header.clone());
+        self.recent_headers_refs_by_authority[block_ref.author].insert(block_ref);
         self.threshold_clock.add_block(block_ref);
-        self.highest_accepted_round = max(self.highest_accepted_round, block.round());
+        self.highest_accepted_round = max(self.highest_accepted_round, block_header.round());
         self.context
             .metrics
             .node_metrics
             .highest_accepted_round
             .set(self.highest_accepted_round as i64);
 
-        let highest_accepted_round_for_author = self.recent_refs_by_authority[block_ref.author]
+        let highest_accepted_round_for_author = self.recent_headers_refs_by_authority
+            [block_ref.author]
             .last()
             .map(|block_ref| block_ref.round)
             .expect("There should be by now at least one block ref");
@@ -286,21 +316,29 @@ impl DagState {
             .set(highest_accepted_round_for_author as i64);
     }
 
-    /// Accepts a blocks into DagState and keeps it in memory.
-    pub(crate) fn accept_blocks(&mut self, blocks: Vec<VerifiedBlockHeader>) {
+    /// Accepts a block header into DagState and keeps it in memory.
+    pub(crate) fn accept_block_headers(&mut self, blocks: Vec<VerifiedBlockHeader>) {
         debug!(
             "Accepting blocks: {}",
             blocks.iter().map(|b| b.reference().to_string()).join(",")
         );
         for block in blocks {
-            self.accept_block(block);
+            self.accept_block_header(block);
         }
     }
 
     /// Gets a block by checking cached recent blocks then storage.
     /// Returns None when the block is not found.
-    pub(crate) fn get_block(&self, reference: &BlockRef) -> Option<VerifiedBlockHeader> {
+    pub(crate) fn get_block(&self, reference: &BlockRef) -> Option<VerifiedBlock> {
         self.get_blocks(&[*reference])
+            .pop()
+            .expect("Exactly one element should be returned")
+    }
+
+    /// Gets a block header by checking cached recent blocks then storage.
+    /// Returns None when the block is not found.
+    pub(crate) fn get_block_header(&self, reference: &BlockRef) -> Option<VerifiedBlockHeader> {
+        self.get_block_headers(&[*reference])
             .pop()
             .expect("Exactly one element should be returned")
     }
@@ -308,7 +346,7 @@ impl DagState {
     /// Gets blocks by checking genesis, cached recent blocks in memory, then
     /// storage. An element is None when the corresponding block is not
     /// found.
-    pub(crate) fn get_blocks(&self, block_refs: &[BlockRef]) -> Vec<Option<VerifiedBlockHeader>> {
+    pub(crate) fn get_blocks(&self, block_refs: &[BlockRef]) -> Vec<Option<VerifiedBlock>> {
         let mut blocks = vec![None; block_refs.len()];
         let mut missing = Vec::new();
 
@@ -353,6 +391,57 @@ impl DagState {
         blocks
     }
 
+    /// Gets block headers by checking genesis, cached recent block headers in
+    /// memory, then storage. An element is None when the corresponding
+    /// block header is not found.
+    pub(crate) fn get_block_headers(
+        &self,
+        block_refs: &[BlockRef],
+    ) -> Vec<Option<VerifiedBlockHeader>> {
+        let mut block_headers: Vec<Option<VerifiedBlockHeader>> = vec![None; block_refs.len()];
+        let mut missing_headers = Vec::new();
+        for (index, block_ref) in block_refs.iter().enumerate() {
+            if block_ref.round == GENESIS_ROUND {
+                // Allow the caller to handle the invalid genesis ancestor error.
+                if let Some(block) = self.genesis.get(block_ref) {
+                    block_headers[index] = Some((**block).clone());
+                }
+                continue;
+            }
+            if let Some(block) = self.recent_block_headers.get(block_ref) {
+                block_headers[index] = Some(block.clone());
+                continue;
+            }
+            missing_headers.push((index, block_ref));
+        }
+
+        if missing_headers.is_empty() {
+            return block_headers;
+        }
+
+        let missing_refs = missing_headers
+            .iter()
+            .map(|(_, block_ref)| **block_ref)
+            .collect::<Vec<_>>();
+        let store_results = self
+            .store
+            .read_block_headers(&missing_refs)
+            .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e));
+        // TODO:similar metric for header reads count
+        // self.context
+        // .metrics
+        // .node_metrics
+        // .dag_state_store_read_count
+        // .with_label_values(&["get_blocks"])
+        // .inc();
+
+        for ((index, _), result) in missing_headers.into_iter().zip(store_results.into_iter()) {
+            block_headers[index] = result;
+        }
+
+        block_headers
+    }
+
     /// Gets all uncommitted blocks in a slot.
     /// Uncommitted blocks must exist in memory, so only in-memory blocks are
     /// checked.
@@ -362,7 +451,7 @@ impl DagState {
         // to edge cases.
 
         let mut blocks = vec![];
-        for (_block_ref, block) in self.recent_blocks.range((
+        for (_block_ref, block) in self.recent_block_headers.range((
             Included(BlockRef::new(
                 slot.round,
                 slot.authority,
@@ -388,7 +477,7 @@ impl DagState {
         }
 
         let mut blocks = vec![];
-        for (_block_ref, block) in self.recent_blocks.range((
+        for (_block_ref, block) in self.recent_block_headers.range((
             Included(BlockRef::new(
                 round,
                 AuthorityIndex::ZERO,
@@ -420,8 +509,8 @@ impl DagState {
                 break;
             }
             let block_ref = linked.pop_last().unwrap();
-            let Some(block) = self.get_block(&block_ref) else {
-                panic!("Block {:?} should exist in DAG!", block_ref);
+            let Some(block) = self.get_block_header(&block_ref) else {
+                panic!("Block Header {:?} should exist in DAG!", block_ref);
             };
             linked.extend(block.ancestors().iter().cloned());
         }
@@ -435,7 +524,7 @@ impl DagState {
                 Unbounded,
             ))
             .map(|r| {
-                self.get_block(r)
+                self.get_block_header(r)
                     .unwrap_or_else(|| panic!("Block {:?} should exist in DAG!", r))
                     .clone()
             })
@@ -444,20 +533,35 @@ impl DagState {
 
     /// Gets the last proposed block from this authority.
     /// If no block is proposed yet, returns the genesis block.
-    pub(crate) fn get_last_proposed_block(&self) -> VerifiedBlockHeader {
-        self.get_last_block_for_authority(self.context.own_index)
+    pub(crate) fn get_last_proposed_block(&self) -> Option<VerifiedBlock> {
+        if let Some(last) = self.recent_blocks_refs_by_authority[self.context.own_index].last() {
+            return Some(
+                self.recent_blocks
+                    .get(last)
+                    .expect("Block should be found in recent blocks")
+                    .clone(),
+            );
+        }
+
+        None
+    }
+
+    /// Gets the last proposed block header from this authority.
+    /// If no block is proposed yet, returns the genesis block header.
+    pub(crate) fn get_last_proposed_block_header(&self) -> VerifiedBlockHeader {
+        self.get_last_block_header_for_authority(self.context.own_index)
     }
 
     /// Retrieves the last accepted block from the specified `authority`. If no
     /// block is found in cache then the genesis block is returned as no other
     /// block has been received from that authority.
-    pub(crate) fn get_last_block_for_authority(
+    pub(crate) fn get_last_block_header_for_authority(
         &self,
         authority: AuthorityIndex,
     ) -> VerifiedBlockHeader {
-        if let Some(last) = self.recent_refs_by_authority[authority].last() {
+        if let Some(last) = self.recent_headers_refs_by_authority[authority].last() {
             return self
-                .recent_blocks
+                .recent_block_headers
                 .get(last)
                 .expect("Block should be found in recent blocks")
                 .clone();
@@ -469,7 +573,7 @@ impl DagState {
             .iter()
             .find(|(block_ref, _)| block_ref.author == authority)
             .expect("Genesis should be found for authority {authority_index}");
-        genesis_block.clone()
+        (**genesis_block).clone()
     }
 
     /// Returns cached recent blocks from the specified authority.
@@ -481,9 +585,9 @@ impl DagState {
         &self,
         authority: AuthorityIndex,
         start: Round,
-    ) -> Vec<VerifiedBlockHeader> {
+    ) -> Vec<VerifiedBlock> {
         let mut blocks = vec![];
-        for block_ref in self.recent_refs_by_authority[authority].range((
+        for block_ref in self.recent_blocks_refs_by_authority[authority].range((
             Included(BlockRef::new(start, authority, BlockHeaderDigest::MIN)),
             Unbounded,
         )) {
@@ -496,10 +600,37 @@ impl DagState {
         blocks
     }
 
-    // Retrieves the cached block within the range [start_round, end_round) from a
-    // given authority. NOTE: end_round must be greater than GENESIS_ROUND.
+    /// Returns cached recent block headers from the specified authority.
+    /// Block headers returned are limited to round >= `start`, and cached.
+    /// NOTE: caller should not assume returned block headers are always
+    /// chained. "Disconnected" block headers can be returned when there are
+    /// byzantine block headers, or when received block headers are not
+    /// deduped.
+    #[cfg_attr(not(test), expect(dead_code))]
+    pub(crate) fn get_cached_block_headers(
+        &self,
+        authority: AuthorityIndex,
+        start: Round,
+    ) -> Vec<VerifiedBlockHeader> {
+        let mut block_headers = vec![];
+        for block_ref in self.recent_headers_refs_by_authority[authority].range((
+            Included(BlockRef::new(start, authority, BlockHeaderDigest::MIN)),
+            Unbounded,
+        )) {
+            let block_header = self
+                .recent_block_headers
+                .get(block_ref)
+                .expect("Block Header should exist in recent blocks headers");
+            block_headers.push(block_header.clone());
+        }
+        block_headers
+    }
+
+    // Retrieves the cached block header within the range [start_round, end_round)
+    // from a given authority. NOTE: end_round must be greater than
+    // GENESIS_ROUND.
     #[cfg(test)]
-    pub(crate) fn get_last_cached_block_in_range(
+    pub(crate) fn get_last_cached_block_header_in_range(
         &self,
         authority: AuthorityIndex,
         start_round: Round,
@@ -511,7 +642,7 @@ impl DagState {
             );
         }
 
-        let block_ref = self.recent_refs_by_authority[authority]
+        let block_ref = self.recent_headers_refs_by_authority[authority]
             .range((
                 Included(BlockRef::new(
                     start_round,
@@ -526,7 +657,7 @@ impl DagState {
             ))
             .last()?;
 
-        self.recent_blocks.get(block_ref).cloned()
+        self.recent_block_headers.get(block_ref).cloned()
     }
 
     /// Returns the last block proposed per authority with `evicted round <
@@ -537,12 +668,16 @@ impl DagState {
     /// earlier rounds. In case of equivocation for an authority's last
     /// slot, one block will be returned (the last in order) and the other
     /// equivocating blocks will be returned.
-    pub(crate) fn get_last_cached_block_per_authority(
+    pub(crate) fn get_last_cached_block_header_per_authority(
         &self,
         end_round: Round,
     ) -> Vec<(VerifiedBlockHeader, Vec<BlockRef>)> {
         // Initialize with the genesis blocks as fallback
-        let mut blocks = self.genesis.values().cloned().collect::<Vec<_>>();
+        let mut block_headers = self
+            .genesis
+            .values()
+            .map(|b| (**b).clone())
+            .collect::<Vec<VerifiedBlockHeader>>();
         let mut equivocating_blocks = vec![vec![]; self.context.committee.size()];
 
         if end_round == GENESIS_ROUND {
@@ -552,10 +687,12 @@ impl DagState {
         }
 
         if end_round == GENESIS_ROUND + 1 {
-            return blocks.into_iter().map(|b| (b, vec![])).collect();
+            return block_headers.into_iter().map(|b| (b, vec![])).collect();
         }
 
-        for (authority_index, block_refs) in self.recent_refs_by_authority.iter().enumerate() {
+        for (authority_index, block_refs) in
+            self.recent_headers_refs_by_authority.iter().enumerate()
+        {
             let authority_index = self
                 .context
                 .committee
@@ -588,11 +725,11 @@ impl DagState {
             for block_ref in block_ref_iter {
                 if last_round == 0 {
                     last_round = block_ref.round;
-                    let block = self
-                        .recent_blocks
+                    let block_header = self
+                        .recent_block_headers
                         .get(block_ref)
                         .expect("Block should exist in recent blocks");
-                    blocks[authority_index] = block.clone();
+                    block_headers[authority_index] = block_header.clone();
                     continue;
                 }
                 if block_ref.round < last_round {
@@ -602,13 +739,13 @@ impl DagState {
             }
         }
 
-        blocks.into_iter().zip(equivocating_blocks).collect()
+        block_headers.into_iter().zip(equivocating_blocks).collect()
     }
 
-    /// Checks whether a block exists in the slot. The method checks only
+    /// Checks whether a block header exists in the slot. The method checks only
     /// against the cached data. If the user asks for a slot that is not
     /// within the cached data then a panic is thrown.
-    pub(crate) fn contains_cached_block_at_slot(&self, slot: Slot) -> bool {
+    pub(crate) fn contains_cached_block_header_at_slot(&self, slot: Slot) -> bool {
         // Always return true for genesis slots.
         if slot.round == GENESIS_ROUND {
             return true;
@@ -624,7 +761,7 @@ impl DagState {
             );
         }
 
-        let mut result = self.recent_refs_by_authority[slot.authority].range((
+        let mut result = self.recent_headers_refs_by_authority[slot.authority].range((
             Included(BlockRef::new(
                 slot.round,
                 slot.authority,
@@ -639,15 +776,17 @@ impl DagState {
         result.next().is_some()
     }
 
-    /// Checks whether the required blocks are in cache, if exist, or otherwise
-    /// will check in store. The method is not caching back the results, so
-    /// its expensive if keep asking for cache missing blocks.
-    pub(crate) fn contains_blocks(&self, block_refs: Vec<BlockRef>) -> Vec<bool> {
+    // TODO: implement for blocks as well
+    /// Checks whether the required block headers are in cache, if exist, or
+    /// otherwise will check in store. The method is not caching back the
+    /// results, so its expensive if keep asking for cache missing block
+    /// headers.
+    pub(crate) fn contains_block_headers(&self, block_refs: Vec<BlockRef>) -> Vec<bool> {
         let mut exist = vec![false; block_refs.len()];
         let mut missing = Vec::new();
 
         for (index, block_ref) in block_refs.into_iter().enumerate() {
-            let recent_refs = &self.recent_refs_by_authority[block_ref.author];
+            let recent_refs = &self.recent_headers_refs_by_authority[block_ref.author];
             if recent_refs.contains(&block_ref) || self.genesis.contains_key(&block_ref) {
                 exist[index] = true;
             } else if recent_refs.is_empty() || recent_refs.last().unwrap().round < block_ref.round
@@ -672,13 +811,13 @@ impl DagState {
             .collect::<Vec<_>>();
         let store_results = self
             .store
-            .contains_blocks(&missing_refs)
+            .contains_block_headers(&missing_refs)
             .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e));
         self.context
             .metrics
             .node_metrics
             .dag_state_store_read_count
-            .with_label_values(&["contains_blocks"])
+            .with_label_values(&["contains_block_headers"])
             .inc();
 
         for ((index, _), result) in missing.into_iter().zip(store_results.into_iter()) {
@@ -688,8 +827,8 @@ impl DagState {
         exist
     }
 
-    pub(crate) fn contains_block(&self, block_ref: &BlockRef) -> bool {
-        let blocks = self.contains_blocks(vec![*block_ref]);
+    pub(crate) fn contains_block_header(&self, block_ref: &BlockRef) -> bool {
+        let blocks = self.contains_block_headers(vec![*block_ref]);
         blocks.first().cloned().unwrap()
     }
 
@@ -811,13 +950,13 @@ impl DagState {
             .partition(|x| x.round < clock_round);
 
         // Split below_clock_round into taken and leftover
-        let acknowlegments = below_clock_round.drain(..).take(limit).collect::<Vec<_>>();
+        let acknowledgments = below_clock_round.drain(..).take(limit).collect::<Vec<_>>();
 
         // Remaining acknowledgments go back to the queue
         below_clock_round.extend(at_least_clock_round);
         self.pending_acknowledgments = below_clock_round;
 
-        acknowlegments
+        acknowledgments
     }
 
     /// Index of the last commit.
@@ -884,16 +1023,22 @@ impl DagState {
             .start_timer();
         // Flush buffered data to storage.
         let blocks = std::mem::take(&mut self.blocks_to_write);
+        let block_headers = std::mem::take(&mut self.block_headers_to_write);
         let commits = std::mem::take(&mut self.commits_to_write);
         let commit_info_to_write = std::mem::take(&mut self.commit_info_to_write);
 
-        if blocks.is_empty() && commits.is_empty() {
+        if blocks.is_empty() && commits.is_empty() && block_headers.is_empty() {
             return;
         }
         debug!(
-            "Flushing {} blocks ({}), {} commits ({}) and {} commit info ({}) to storage.",
+            "Flushing {} blocks ({}), {} block headers ({}), {} commits ({}) and {} commit info ({}) to storage.",
             blocks.len(),
             blocks.iter().map(|b| b.reference().to_string()).join(","),
+            block_headers.len(),
+            block_headers
+                .iter()
+                .map(|b| b.reference().to_string())
+                .join(","),
             commits.len(),
             commits.iter().map(|c| c.reference().to_string()).join(","),
             commit_info_to_write.len(),
@@ -903,7 +1048,12 @@ impl DagState {
                 .join(","),
         );
         self.store
-            .write(WriteBatch::new(blocks, commits, commit_info_to_write))
+            .write(WriteBatch::new(
+                blocks,
+                block_headers,
+                commits,
+                commit_info_to_write,
+            ))
             .unwrap_or_else(|e| panic!("Failed to write to storage: {:?}", e));
         self.context
             .metrics
@@ -915,10 +1065,22 @@ impl DagState {
         // be persisted.
         for (authority_index, _) in self.context.committee.authorities() {
             let eviction_round = self.calculate_authority_eviction_round(authority_index);
-            while let Some(block_ref) = self.recent_refs_by_authority[authority_index].first() {
+            while let Some(block_ref) =
+                self.recent_headers_refs_by_authority[authority_index].first()
+            {
+                if block_ref.round <= eviction_round {
+                    self.recent_block_headers.remove(block_ref);
+                    self.recent_headers_refs_by_authority[authority_index].pop_first();
+                } else {
+                    break;
+                }
+            }
+            while let Some(block_ref) =
+                self.recent_blocks_refs_by_authority[authority_index].first()
+            {
                 if block_ref.round <= eviction_round {
                     self.recent_blocks.remove(block_ref);
-                    self.recent_refs_by_authority[authority_index].pop_first();
+                    self.recent_blocks_refs_by_authority[authority_index].pop_first();
                 } else {
                     break;
                 }
@@ -927,11 +1089,12 @@ impl DagState {
         }
 
         let metrics = &self.context.metrics.node_metrics;
+        // TODO: create similar metric for headers?
         metrics
             .dag_state_recent_blocks
             .set(self.recent_blocks.len() as i64);
         metrics.dag_state_recent_refs.set(
-            self.recent_refs_by_authority
+            self.recent_blocks_refs_by_authority
                 .iter()
                 .map(BTreeSet::len)
                 .sum::<usize>() as i64,
@@ -998,7 +1161,7 @@ impl DagState {
             (self.highest_accepted_round.saturating_sub(1)..=self.highest_accepted_round).rev()
         {
             if round == GENESIS_ROUND {
-                return self.genesis_blocks();
+                return self.genesis_block_headers();
             }
             use crate::stake_aggregator::{QuorumThreshold, StakeAggregator};
             let mut quorum = StakeAggregator::<QuorumThreshold>::new();
@@ -1016,9 +1179,17 @@ impl DagState {
         panic!("Fatal error, no quorum has been detected in our DAG on the last two rounds.");
     }
 
-    #[cfg(test)]
-    pub(crate) fn genesis_blocks(&self) -> Vec<VerifiedBlockHeader> {
+    #[expect(dead_code)]
+    pub(crate) fn genesis_blocks(&self) -> Vec<VerifiedBlock> {
         self.genesis.values().cloned().collect()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn genesis_block_headers(&self) -> Vec<VerifiedBlockHeader> {
+        self.genesis
+            .values()
+            .map(|b| (**b).clone())
+            .collect::<Vec<VerifiedBlockHeader>>()
     }
 
     #[cfg(test)]
@@ -1042,14 +1213,16 @@ mod test {
     use crate::{
         block_header::{
             BlockHeaderDigest, BlockRef, BlockTimestampMs, TestBlockHeader, VerifiedBlockHeader,
+            genesis_block_headers,
         },
         storage::{WriteBatch, mem_store::MemStore},
         test_dag_builder::DagBuilder,
         test_dag_parser::parse_dag,
     };
 
+    // TODO: create similar test for get_block
     #[tokio::test]
-    async fn test_get_blocks() {
+    async fn test_get_block_header() {
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
@@ -1072,7 +1245,7 @@ mod test {
                             .set_timestamp_ms(timestamp)
                             .build(),
                     );
-                    dag_state.accept_block(block.clone());
+                    dag_state.accept_block_header(block.clone());
                     blocks.insert(block.reference(), block);
 
                     // Only write one block per slot for own index
@@ -1085,7 +1258,7 @@ mod test {
 
         // Check uncommitted blocks that exist.
         for (r, block) in &blocks {
-            assert_eq!(&dag_state.get_block(r).unwrap(), block);
+            assert_eq!(&dag_state.get_block_header(r).unwrap(), block);
         }
 
         // Check uncommitted blocks that do not exist.
@@ -1296,7 +1469,7 @@ mod test {
             .chain(round_13.iter())
             .chain([anchor.clone()].iter())
         {
-            dag_state.accept_block(b.clone());
+            dag_state.accept_block_header(b.clone());
         }
 
         // Check ancestors connected to anchor.
@@ -1318,8 +1491,9 @@ mod test {
         );
     }
 
+    // TODO: make similar test for blocks
     #[tokio::test]
-    async fn test_contains_blocks_in_cache_or_store() {
+    async fn test_contains_block_headers_in_cache_or_store() {
         /// Only keep elements up to 2 rounds before the last committed round
         const CACHED_ROUNDS: Round = 2;
 
@@ -1333,36 +1507,36 @@ mod test {
         // Create test blocks for round 1 ~ 10
         let num_rounds: u32 = 10;
         let num_authorities: u32 = 4;
-        let mut blocks = Vec::new();
+        let mut block_headers = Vec::new();
 
         for round in 1..=num_rounds {
             for author in 0..num_authorities {
-                let block =
+                let block_header =
                     VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, author).build());
-                blocks.push(block);
+                block_headers.push(block_header);
             }
         }
 
-        // Now write in store the blocks from first 4 rounds and the rest to the dag
-        // state
-        blocks.clone().into_iter().for_each(|block| {
-            if block.round() <= 4 {
+        // Now write in store the block headers from first 4 rounds and the rest to the
+        // dag state
+        block_headers.clone().into_iter().for_each(|block_header| {
+            if block_header.round() <= 4 {
                 store
-                    .write(WriteBatch::default().blocks(vec![block]))
+                    .write(WriteBatch::default().block_headers(vec![block_header]))
                     .unwrap();
             } else {
-                dag_state.accept_blocks(vec![block]);
+                dag_state.accept_block_headers(vec![block_header]);
             }
         });
 
         // Now when trying to query whether we have all the blocks, we should
         // successfully retrieve a positive answer where the blocks of first 4
         // round should be found in DagState and the rest in store.
-        let mut block_refs = blocks
+        let mut block_refs = block_headers
             .iter()
             .map(|block| block.reference())
             .collect::<Vec<_>>();
-        let result = dag_state.contains_blocks(block_refs.clone());
+        let result = dag_state.contains_block_headers(block_refs.clone());
 
         // Ensure everything is found
         let mut expected = vec![true; (num_rounds * num_authorities) as usize];
@@ -1377,7 +1551,7 @@ mod test {
                 BlockHeaderDigest::default(),
             ),
         );
-        let result = dag_state.contains_blocks(block_refs.clone());
+        let result = dag_state.contains_block_headers(block_refs.clone());
 
         // Then all should be found apart from the last one
         expected.insert(3, false);
@@ -1385,7 +1559,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_contains_cached_block_at_slot() {
+    async fn test_contains_cached_block_header_at_slot() {
         /// Only keep elements up to 2 rounds before the last committed round
         const CACHED_ROUNDS: Round = 2;
 
@@ -1406,14 +1580,14 @@ mod test {
                 let block =
                     VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, author).build());
                 blocks.push(block.clone());
-                dag_state.accept_block(block);
+                dag_state.accept_block_header(block);
             }
         }
 
         // Query for genesis round 0, genesis blocks should be returned
         for (author, _) in context.committee.authorities() {
             assert!(
-                dag_state.contains_cached_block_at_slot(Slot::new(GENESIS_ROUND, author)),
+                dag_state.contains_cached_block_header_at_slot(Slot::new(GENESIS_ROUND, author)),
                 "Genesis should always be found"
             );
         }
@@ -1428,7 +1602,7 @@ mod test {
 
         for block_ref in block_refs.clone() {
             let slot = block_ref.into();
-            let found = dag_state.contains_cached_block_at_slot(slot);
+            let found = dag_state.contains_cached_block_header_at_slot(slot);
             assert!(found, "A block should be found at slot {}", slot);
         }
 
@@ -1448,7 +1622,7 @@ mod test {
         // Attempt to check the same for via the contains slot method
         for block_ref in block_refs {
             let slot = block_ref.into();
-            let found = dag_state.contains_cached_block_at_slot(slot);
+            let found = dag_state.contains_cached_block_header_at_slot(slot);
 
             assert_eq!(expected.remove(0), found);
         }
@@ -1474,7 +1648,7 @@ mod test {
         for round in 1..=10 {
             let block = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, 0).build());
             blocks.push(block.clone());
-            dag_state.accept_block(block);
+            dag_state.accept_block_header(block);
         }
 
         // Now add a commit to trigger an eviction
@@ -1495,8 +1669,8 @@ mod test {
         // When trying to request for authority 0 at block slot 8 it should panic, as
         // anything that is <= commit_round - cached_rounds = 10 - 2 = 8 should
         // be evicted
-        let _ =
-            dag_state.contains_cached_block_at_slot(Slot::new(8, AuthorityIndex::new_for_test(0)));
+        let _ = dag_state
+            .contains_cached_block_header_at_slot(Slot::new(8, AuthorityIndex::new_for_test(0)));
     }
 
     #[tokio::test]
@@ -1509,38 +1683,38 @@ mod test {
         // Create test blocks for round 1 ~ 10
         let num_rounds: u32 = 10;
         let num_authorities: u32 = 4;
-        let mut blocks = Vec::new();
+        let mut block_headers = Vec::new();
 
         for round in 1..=num_rounds {
             for author in 0..num_authorities {
                 let block =
                     VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, author).build());
-                blocks.push(block);
+                block_headers.push(block);
             }
         }
 
         // Now write in store the blocks from first 4 rounds and the rest to the dag
         // state
-        blocks.clone().into_iter().for_each(|block| {
-            if block.round() <= 4 {
+        block_headers.clone().into_iter().for_each(|block_header| {
+            if block_header.round() <= 4 {
                 store
-                    .write(WriteBatch::default().blocks(vec![block]))
+                    .write(WriteBatch::default().block_headers(vec![block_header]))
                     .unwrap();
             } else {
-                dag_state.accept_blocks(vec![block]);
+                dag_state.accept_block_headers(vec![block_header]);
             }
         });
 
         // Now when trying to query whether we have all the blocks, we should
         // successfully retrieve a positive answer where the blocks of first 4
         // round should be found in DagState and the rest in store.
-        let mut block_refs = blocks
+        let mut block_refs = block_headers
             .iter()
             .map(|block| block.reference())
             .collect::<Vec<_>>();
-        let result = dag_state.get_blocks(&block_refs);
+        let result = dag_state.get_block_headers(&block_refs);
 
-        let mut expected = blocks
+        let mut expected = block_headers
             .into_iter()
             .map(Some)
             .collect::<Vec<Option<VerifiedBlockHeader>>>();
@@ -1557,7 +1731,7 @@ mod test {
                 BlockHeaderDigest::default(),
             ),
         );
-        let result = dag_state.get_blocks(&block_refs);
+        let result = dag_state.get_block_headers(&block_refs);
 
         // Then all should be found apart from the last one
         expected.insert(3, None);
@@ -1584,7 +1758,7 @@ mod test {
 
         // Add the blocks from first 5 rounds and first 5 commits to the dag state
         let temp_commits = commits.split_off(5);
-        dag_state.accept_blocks(dag_builder.blocks(1..=5));
+        dag_state.accept_block_headers(dag_builder.block_headers(1..=5));
         for commit in commits.clone() {
             dag_state.add_commit(commit);
         }
@@ -1593,23 +1767,23 @@ mod test {
         dag_state.flush();
 
         // Add the rest of the blocks and commits to the dag state
-        dag_state.accept_blocks(dag_builder.blocks(6..=num_rounds));
+        dag_state.accept_block_headers(dag_builder.block_headers(6..=num_rounds));
         for commit in temp_commits.clone() {
             dag_state.add_commit(commit);
         }
 
         // All blocks should be found in DagState.
-        let all_blocks = dag_builder.blocks(6..=num_rounds);
-        let block_refs = all_blocks
+        let all_block_headers = dag_builder.block_headers(6..=num_rounds);
+        let block_refs = all_block_headers
             .iter()
             .map(|block| block.reference())
             .collect::<Vec<_>>();
         let result = dag_state
-            .get_blocks(&block_refs)
+            .get_block_headers(&block_refs)
             .into_iter()
             .map(|b| b.unwrap())
             .collect::<Vec<_>>();
-        assert_eq!(result, all_blocks);
+        assert_eq!(result, all_block_headers);
 
         // Last commit index should be 10.
         assert_eq!(dag_state.last_commit_index(), 10);
@@ -1625,26 +1799,26 @@ mod test {
         let dag_state = DagState::new(context.clone(), store.clone());
 
         // Blocks of first 5 rounds should be found in DagState.
-        let blocks = dag_builder.blocks(1..=5);
-        let block_refs = blocks
+        let block_headers = dag_builder.block_headers(1..=5);
+        let block_refs = block_headers
             .iter()
-            .map(|block| block.reference())
+            .map(|block_header| block_header.reference())
             .collect::<Vec<_>>();
         let result = dag_state
-            .get_blocks(&block_refs)
+            .get_block_headers(&block_refs)
             .into_iter()
             .map(|b| b.unwrap())
             .collect::<Vec<_>>();
-        assert_eq!(result, blocks);
+        assert_eq!(result, block_headers);
 
         // Blocks above round 5 should not be in DagState, because they are not flushed.
-        let missing_blocks = dag_builder.blocks(6..=num_rounds);
+        let missing_blocks = dag_builder.block_headers(6..=num_rounds);
         let block_refs = missing_blocks
             .iter()
             .map(|block| block.reference())
             .collect::<Vec<_>>();
         let retrieved_blocks = dag_state
-            .get_blocks(&block_refs)
+            .get_block_headers(&block_refs)
             .into_iter()
             .flatten()
             .collect::<Vec<_>>();
@@ -1665,7 +1839,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_get_cached_blocks() {
+    async fn test_get_cached_block_headers() {
         let (mut context, _) = Context::new_for_test(4);
         context.parameters.dag_state_cached_rounds = 5;
 
@@ -1683,41 +1857,41 @@ mod test {
                 let block =
                     VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, author).build());
                 all_blocks.push(block.clone());
-                dag_state.accept_block(block);
+                dag_state.accept_block_header(block);
             }
         }
 
-        let cached_blocks =
-            dag_state.get_cached_blocks(context.committee.to_authority_index(0).unwrap(), 0);
-        assert!(cached_blocks.is_empty());
+        let cached_block_headers =
+            dag_state.get_cached_block_headers(context.committee.to_authority_index(0).unwrap(), 0);
+        assert!(cached_block_headers.is_empty());
 
-        let cached_blocks =
-            dag_state.get_cached_blocks(context.committee.to_authority_index(1).unwrap(), 10);
-        assert_eq!(cached_blocks.len(), 1);
-        assert_eq!(cached_blocks[0].round(), 10);
+        let cached_block_headers = dag_state
+            .get_cached_block_headers(context.committee.to_authority_index(1).unwrap(), 10);
+        assert_eq!(cached_block_headers.len(), 1);
+        assert_eq!(cached_block_headers[0].round(), 10);
 
-        let cached_blocks =
-            dag_state.get_cached_blocks(context.committee.to_authority_index(2).unwrap(), 10);
-        assert_eq!(cached_blocks.len(), 2);
-        assert_eq!(cached_blocks[0].round(), 10);
-        assert_eq!(cached_blocks[1].round(), 11);
+        let cached_block_headers = dag_state
+            .get_cached_block_headers(context.committee.to_authority_index(2).unwrap(), 10);
+        assert_eq!(cached_block_headers.len(), 2);
+        assert_eq!(cached_block_headers[0].round(), 10);
+        assert_eq!(cached_block_headers[1].round(), 11);
 
-        let cached_blocks =
-            dag_state.get_cached_blocks(context.committee.to_authority_index(2).unwrap(), 11);
-        assert_eq!(cached_blocks.len(), 1);
-        assert_eq!(cached_blocks[0].round(), 11);
+        let cached_block_headers = dag_state
+            .get_cached_block_headers(context.committee.to_authority_index(2).unwrap(), 11);
+        assert_eq!(cached_block_headers.len(), 1);
+        assert_eq!(cached_block_headers[0].round(), 11);
 
-        let cached_blocks =
-            dag_state.get_cached_blocks(context.committee.to_authority_index(3).unwrap(), 10);
-        assert_eq!(cached_blocks.len(), 3);
-        assert_eq!(cached_blocks[0].round(), 10);
-        assert_eq!(cached_blocks[1].round(), 11);
-        assert_eq!(cached_blocks[2].round(), 12);
+        let cached_block_headers = dag_state
+            .get_cached_block_headers(context.committee.to_authority_index(3).unwrap(), 10);
+        assert_eq!(cached_block_headers.len(), 3);
+        assert_eq!(cached_block_headers[0].round(), 10);
+        assert_eq!(cached_block_headers[1].round(), 11);
+        assert_eq!(cached_block_headers[2].round(), 12);
 
-        let cached_blocks =
-            dag_state.get_cached_blocks(context.committee.to_authority_index(3).unwrap(), 12);
-        assert_eq!(cached_blocks.len(), 1);
-        assert_eq!(cached_blocks[0].round(), 12);
+        let cached_block_headers = dag_state
+            .get_cached_block_headers(context.committee.to_authority_index(3).unwrap(), 12);
+        assert_eq!(cached_block_headers.len(), 1);
+        assert_eq!(cached_block_headers[0].round(), 12);
     }
 
     #[rstest]
@@ -1758,12 +1932,12 @@ mod test {
         let block = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(2, 2).build());
 
         // Accept all blocks
-        for block in dag_builder
-            .all_blocks()
+        for block_header in dag_builder
+            .all_block_headers()
             .into_iter()
             .chain(std::iter::once(block))
         {
-            dag_state.accept_block(block);
+            dag_state.accept_block_header(block_header);
         }
 
         dag_state.add_commit(TrustedCommit::new_for_test(
@@ -1780,20 +1954,26 @@ mod test {
         let expected_rounds = vec![0, 1, 2, 3];
         let expected_excluded_and_equivocating_blocks = vec![0, 0, 1, 0];
         // THEN
-        let last_blocks = dag_state.get_last_cached_block_per_authority(end_round);
+        let last_block_headers = dag_state.get_last_cached_block_header_per_authority(end_round);
         assert_eq!(
-            last_blocks.iter().map(|b| b.0.round()).collect::<Vec<_>>(),
+            last_block_headers
+                .iter()
+                .map(|b| b.0.round())
+                .collect::<Vec<_>>(),
             expected_rounds
         );
         assert_eq!(
-            last_blocks.iter().map(|b| b.1.len()).collect::<Vec<_>>(),
+            last_block_headers
+                .iter()
+                .map(|b| b.1.len())
+                .collect::<Vec<_>>(),
             expected_excluded_and_equivocating_blocks
         );
 
         // THEN
         for (i, expected_round) in expected_rounds.iter().enumerate() {
             let round = dag_state
-                .get_last_cached_block_in_range(
+                .get_last_cached_block_header_in_range(
                     context.committee.to_authority_index(i).unwrap(),
                     0,
                     end_round,
@@ -1810,7 +1990,7 @@ mod test {
         // THEN
         for (i, expected_round) in expected_rounds.iter().enumerate() {
             let round = dag_state
-                .get_last_cached_block_in_range(
+                .get_last_cached_block_header_in_range(
                     context.committee.to_authority_index(i).unwrap(),
                     start_round,
                     end_round,
@@ -1831,16 +2011,19 @@ mod test {
         let expected_rounds = vec![0, 1, 2, 2];
 
         // THEN
-        let last_blocks = dag_state.get_last_cached_block_per_authority(end_round);
+        let last_block_headers = dag_state.get_last_cached_block_header_per_authority(end_round);
         assert_eq!(
-            last_blocks.iter().map(|b| b.0.round()).collect::<Vec<_>>(),
+            last_block_headers
+                .iter()
+                .map(|b| b.0.round())
+                .collect::<Vec<_>>(),
             expected_rounds
         );
 
         // THEN
         for (i, expected_round) in expected_rounds.iter().enumerate() {
             let round = dag_state
-                .get_last_cached_block_in_range(
+                .get_last_cached_block_header_in_range(
                     context.committee.to_authority_index(i).unwrap(),
                     0,
                     end_round,
@@ -1875,7 +2058,7 @@ mod test {
                 let block =
                     VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, author).build());
                 all_blocks.push(block.clone());
-                dag_state.accept_block(block);
+                dag_state.accept_block_header(block);
             }
         }
 
@@ -1898,7 +2081,7 @@ mod test {
         // THEN the method should panic, as some authorities have already evicted rounds
         // <= round 2
         let end_round = 2;
-        dag_state.get_last_cached_block_per_authority(end_round);
+        dag_state.get_last_cached_block_header_per_authority(end_round);
     }
 
     #[tokio::test]
@@ -1924,8 +2107,8 @@ mod test {
                 .layers(1..=4)
                 .build()
                 .persist_layers(dag_state.clone());
-            let round_4_blocks: Vec<_> = dag_builder
-                .blocks(4..=4)
+            let round_4_block_headers: Vec<_> = dag_builder
+                .block_headers(4..=4)
                 .into_iter()
                 .map(|block| block.reference())
                 .collect();
@@ -1935,23 +2118,24 @@ mod test {
             assert_eq!(
                 last_quorum
                     .into_iter()
-                    .map(|block| block.reference())
+                    .map(|block_header| block_header.reference())
                     .collect::<Vec<_>>(),
-                round_4_blocks
+                round_4_block_headers
             );
         }
 
         // WHEN adding one more block at round 5, still round 4 should be returned as
         // quorum
         {
-            let block = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(5, 0).build());
-            dag_state.write().accept_block(block);
+            let block_header =
+                VerifiedBlockHeader::new_for_test(TestBlockHeader::new(5, 0).build());
+            dag_state.write().accept_block_header(block_header);
 
-            let round_4_blocks = dag_state.read().get_uncommitted_blocks_at_round(4);
+            let round_4_block_headers = dag_state.read().get_uncommitted_blocks_at_round(4);
 
             let last_quorum = dag_state.read().last_quorum();
 
-            assert_eq!(last_quorum, round_4_blocks);
+            assert_eq!(last_quorum, round_4_block_headers);
         }
     }
 
@@ -1971,7 +2155,10 @@ mod test {
                 .find(|block| block.author() == context.own_index)
                 .unwrap();
 
-            assert_eq!(dag_state.read().get_last_proposed_block(), my_genesis);
+            assert_eq!(
+                dag_state.read().get_last_proposed_block_header(),
+                my_genesis
+            );
         }
 
         // WHEN adding some blocks for authorities, only the last ones should be
@@ -1986,17 +2173,17 @@ mod test {
 
             // add block 5 for authority 0
             let block = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(5, 0).build());
-            dag_state.write().accept_block(block);
+            dag_state.write().accept_block_header(block);
 
             let block = dag_state
                 .read()
-                .get_last_block_for_authority(AuthorityIndex::new_for_test(0));
+                .get_last_block_header_for_authority(AuthorityIndex::new_for_test(0));
             assert_eq!(block.round(), 5);
 
             for (authority_index, _) in context.committee.authorities() {
                 let block = dag_state
                     .read()
-                    .get_last_block_for_authority(authority_index);
+                    .get_last_block_header_for_authority(authority_index);
 
                 if authority_index.value() == 0 {
                     assert_eq!(block.round(), 5);

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -532,18 +532,22 @@ impl DagState {
     }
 
     /// Gets the last proposed block from this authority.
-    /// If no block is proposed yet, returns the genesis block.
-    pub(crate) fn get_last_proposed_block(&self) -> Option<VerifiedBlock> {
+    /// If no block is proposed yet, returns Genesis block.
+    pub(crate) fn get_last_proposed_block(&self) -> VerifiedBlock {
         if let Some(last) = self.recent_blocks_refs_by_authority[self.context.own_index].last() {
-            return Some(
-                self.recent_blocks
-                    .get(last)
-                    .expect("Block should be found in recent blocks")
-                    .clone(),
-            );
+            return self
+                .recent_blocks
+                .get(last)
+                .expect("Block should be found in recent blocks")
+                .clone();
         }
 
-        None
+        let (_, genesis_block) = self
+            .genesis
+            .iter()
+            .find(|(block_ref, _)| block_ref.author == self.context.own_index)
+            .expect("Genesis should be found for authority {authority_index}");
+        genesis_block.clone()
     }
 
     /// Gets the last proposed block header from this authority.
@@ -573,7 +577,7 @@ impl DagState {
             .iter()
             .find(|(block_ref, _)| block_ref.author == authority)
             .expect("Genesis should be found for authority {authority_index}");
-        (**genesis_block).clone()
+        genesis_block.verified_block_header.clone()
     }
 
     /// Returns cached recent blocks from the specified authority.

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -60,13 +60,12 @@ pub(crate) enum ConsensusError {
     UnexpectedGenesisBlockHeaderRequested,
 
     #[error(
-        "Expected {requested} but received {received_headers} block headers and {received_transactions} block transactions returned from authority {authority}"
+        "Expected {requested} but received {received_blocks} blocks from authority {authority}"
     )]
     UnexpectedNumberOfBlocksFetched {
         authority: AuthorityIndex,
         requested: usize,
-        received_headers: usize,
-        received_transactions: usize,
+        received_blocks: usize,
     },
 
     #[error("Unexpected block returned while fetching missing blocks")]

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -20,6 +20,12 @@ pub(crate) enum ConsensusError {
     #[error("Error deserializing block: {0}")]
     MalformedBlock(bcs::Error),
 
+    #[error("Error deserializing block header: {0}")]
+    MalformedBlockHeader(bcs::Error),
+
+    #[error("Error deserializing block transactions: {0}")]
+    MalformedTransactions(bcs::Error),
+
     #[error("Error deserializing commit: {0}")]
     MalformedCommit(bcs::Error),
 
@@ -50,13 +56,17 @@ pub(crate) enum ConsensusError {
     #[error("Genesis blocks should not be queried!")]
     UnexpectedGenesisBlockRequested,
 
+    #[error("Genesis block headers should not be queried!")]
+    UnexpectedGenesisBlockHeaderRequested,
+
     #[error(
-        "Expected {requested} but received {received} blocks returned from authority {authority}"
+        "Expected {requested} but received {received_headers} block headers and {received_transactions} block transactions returned from authority {authority}"
     )]
     UnexpectedNumberOfBlocksFetched {
         authority: AuthorityIndex,
         requested: usize,
-        received: usize,
+        received_headers: usize,
+        received_transactions: usize,
     },
 
     #[error("Unexpected block returned while fetching missing blocks")]
@@ -81,6 +91,9 @@ pub(crate) enum ConsensusError {
     #[error("Too many blocks have been requested from authority {0}")]
     TooManyFetchBlocksRequested(AuthorityIndex),
 
+    #[error("Too many block headers have been requested from authority {0}")]
+    TooManyFetchBlockHeadersRequested(AuthorityIndex),
+
     #[error("Too many authorities have been provided from authority {0}")]
     TooManyAuthoritiesProvided(AuthorityIndex),
 
@@ -97,6 +110,13 @@ pub(crate) enum ConsensusError {
 
     #[error("Failed to verify the block's signature: {0}")]
     SignatureVerificationFailure(FastCryptoError),
+
+    #[error("Wrong transaction commitment in B{round} by {author} received from {peer}")]
+    TransactionCommitmentFailure {
+        round: Round,
+        author: AuthorityIndex,
+        peer: AuthorityIndex,
+    },
 
     #[error("Synchronizer for fetching blocks directly from {0} is saturated")]
     SynchronizerSaturated(AuthorityIndex),

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -512,11 +512,11 @@ mod tests {
         let mut subdags = vec![];
         let mut expected_commits = vec![];
 
-        let mut blocks_to_write = vec![];
+        let mut block_headers_to_write = vec![];
 
         for (sub_dag, commit) in dag_builder.get_sub_dag_and_commits(1..=11) {
-            for block in sub_dag.blocks.iter() {
-                blocks_to_write.push(block.clone());
+            for block_headers in sub_dag.blocks.iter() {
+                block_headers_to_write.push(block_headers.clone());
             }
 
             expected_commits.push(commit);
@@ -541,7 +541,7 @@ mod tests {
             .write(
                 WriteBatch::default()
                     .commit_info(vec![(commit_ref, commit_info)])
-                    .blocks(blocks_to_write)
+                    .block_headers(block_headers_to_write)
                     .commits(expected_commits),
             )
             .unwrap();
@@ -641,7 +641,7 @@ mod tests {
         store
             .write(
                 WriteBatch::default()
-                    .blocks(blocks_to_write)
+                    .block_headers(blocks_to_write)
                     .commits(expected_commits),
             )
             .unwrap();

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -140,13 +140,11 @@ mod tests {
     use tokio::time::{Instant, sleep};
 
     use crate::{
-        block_header::{BlockRef, Round, VerifiedBlockHeader, VerifiedTransactions},
-        commit::CertifiedCommits,
         context::Context,
         core::CoreSignals,
-        core_thread::{CoreError, CoreThreadDispatcher},
         leader_timeout::LeaderTimeoutTask,
     };
+    use crate::core_thread::tests::MockCoreThreadDispatcher;
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn basic_leader_timeout() {

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -134,10 +134,8 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeSet, sync::Arc, time::Duration};
+    use std::{sync::Arc, time::Duration};
 
-    use async_trait::async_trait;
-    use parking_lot::Mutex;
     use starfish_config::Parameters;
     use tokio::time::{Instant, sleep};
 
@@ -149,70 +147,6 @@ mod tests {
         core_thread::{CoreError, CoreThreadDispatcher},
         leader_timeout::LeaderTimeoutTask,
     };
-
-    #[derive(Clone, Default)]
-    struct MockCoreThreadDispatcher {
-        new_block_calls: Arc<Mutex<Vec<(Round, bool, Instant)>>>,
-    }
-
-    impl MockCoreThreadDispatcher {
-        async fn get_new_block_calls(&self) -> Vec<(Round, bool, Instant)> {
-            let mut binding = self.new_block_calls.lock();
-            let all_calls = binding.drain(0..);
-            all_calls.into_iter().collect()
-        }
-    }
-
-    #[async_trait]
-    impl CoreThreadDispatcher for MockCoreThreadDispatcher {
-        async fn add_blocks(
-            &self,
-            _blocks: Vec<VerifiedBlockHeader>,
-        ) -> Result<BTreeSet<BlockRef>, CoreError> {
-            todo!()
-        }
-
-        async fn add_data(
-            &self,
-            _data: Vec<VerifiedTransactions>,
-        ) -> Result<BTreeSet<BlockRef>, CoreError> {
-            todo!()
-        }
-
-        async fn get_missing_data(&self) -> Result<BTreeSet<BlockRef>, CoreError> {
-            todo!()
-        }
-
-        async fn add_certified_commits(
-            &self,
-            _commits: CertifiedCommits,
-        ) -> Result<BTreeSet<BlockRef>, CoreError> {
-            todo!()
-        }
-
-        async fn new_block(&self, round: Round, force: bool) -> Result<(), CoreError> {
-            self.new_block_calls
-                .lock()
-                .push((round, force, Instant::now()));
-            Ok(())
-        }
-
-        async fn get_missing_blocks(&self) -> Result<BTreeSet<BlockRef>, CoreError> {
-            todo!()
-        }
-
-        fn set_subscriber_exists(&self, _exists: bool) -> Result<(), CoreError> {
-            todo!()
-        }
-
-        fn set_last_known_proposed_round(&self, _round: Round) -> Result<(), CoreError> {
-            todo!()
-        }
-
-        fn highest_received_rounds(&self) -> Vec<Round> {
-            todo!()
-        }
-    }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn basic_leader_timeout() {

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -140,11 +140,9 @@ mod tests {
     use tokio::time::{Instant, sleep};
 
     use crate::{
-        context::Context,
-        core::CoreSignals,
+        context::Context, core::CoreSignals, core_thread::tests::MockCoreThreadDispatcher,
         leader_timeout::LeaderTimeoutTask,
     };
-    use crate::core_thread::tests::MockCoreThreadDispatcher;
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn basic_leader_timeout() {

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -13,7 +13,7 @@ use starfish_config::AuthorityIndex;
 
 use crate::{
     block_header::{BlockHeaderAPI, BlockRef, VerifiedBlockHeader},
-    commit::{Commit, CommittedSubDag, TrustedCommit, sort_sub_dag_blocks},
+    commit::{Commit, CommitAPI, PendingSubDag, TrustedCommit, sort_sub_dag_blocks},
     context::Context,
     dag_state::DagState,
     leader_schedule::LeaderSchedule,

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -13,7 +13,7 @@ use starfish_config::AuthorityIndex;
 
 use crate::{
     block_header::{BlockHeaderAPI, BlockRef, VerifiedBlockHeader},
-    commit::{Commit, CommitAPI, PendingSubDag, TrustedCommit, sort_sub_dag_blocks},
+    commit::{Commit, CommittedSubDag, TrustedCommit, sort_sub_dag_blocks},
     context::Context,
     dag_state::DagState,
     leader_schedule::LeaderSchedule,
@@ -24,14 +24,19 @@ use crate::{
 /// been mostly introduced for allowing to inject the test store in
 /// `DagBuilder`.
 pub(crate) trait BlockStoreAPI {
-    fn get_blocks(&self, refs: &[BlockRef]) -> Vec<Option<VerifiedBlockHeader>>;
+    #[expect(dead_code)]
+    fn get_blocks(&self, refs: &[BlockRef]) -> Vec<Option<VerifiedBlock>>;
+    fn get_block_headers(&self, refs: &[BlockRef]) -> Vec<Option<VerifiedBlockHeader>>;
 }
 
 impl BlockStoreAPI
     for parking_lot::lock_api::RwLockWriteGuard<'_, parking_lot::RawRwLock, DagState>
 {
-    fn get_blocks(&self, refs: &[BlockRef]) -> Vec<Option<VerifiedBlockHeader>> {
+    fn get_blocks(&self, refs: &[BlockRef]) -> Vec<Option<VerifiedBlock>> {
         DagState::get_blocks(self, refs)
+    }
+    fn get_block_headers(&self, refs: &[BlockRef]) -> Vec<Option<VerifiedBlockHeader>> {
+        DagState::get_block_headers(self, refs)
     }
 }
 
@@ -156,7 +161,7 @@ impl Linearizer {
             to_commit.push(x.clone());
 
             let ancestors: Vec<VerifiedBlockHeader> = dag_state
-                .get_blocks(
+                .get_block_headers(
                     &x.ancestors()
                         .iter()
                         .copied()
@@ -437,13 +442,13 @@ mod tests {
         // Now retrieve all the blocks up to round leader_round_wave_1 - 1
         // And then only the leader of round leader_round_wave_1
         // Also store those to DagState
-        let mut blocks = dag_builder.blocks(0..=leader_round_wave_1 - 1);
+        let mut blocks = dag_builder.block_headers(0..=leader_round_wave_1 - 1);
         blocks.push(
             dag_builder
                 .leader_block(leader_round_wave_1)
                 .expect("Leader block should have been found"),
         );
-        dag_state.write().accept_blocks(blocks.clone());
+        dag_state.write().accept_block_headers(blocks.clone());
 
         let first_leader = dag_builder
             .leader_block(leader_round_wave_1)
@@ -461,7 +466,7 @@ mod tests {
 
         // Now take all the blocks from round `leader_round_wave_1` up to round
         // `leader_round_wave_2-1`
-        let mut blocks = dag_builder.blocks(leader_round_wave_1..=leader_round_wave_2 - 1);
+        let mut blocks = dag_builder.block_headers(leader_round_wave_1..=leader_round_wave_2 - 1);
         // Filter out leader block of round `leader_round_wave_1`
         blocks.retain(|block| {
             !(block.round() == leader_round_wave_1
@@ -474,7 +479,7 @@ mod tests {
                 .expect("Leader block should have been found"),
         );
         // Write them in dag state
-        dag_state.write().accept_blocks(blocks.clone());
+        dag_state.write().accept_block_headers(blocks.clone());
 
         let mut blocks: Vec<_> = blocks.into_iter().map(|block| block.reference()).collect();
 

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -24,17 +24,12 @@ use crate::{
 /// been mostly introduced for allowing to inject the test store in
 /// `DagBuilder`.
 pub(crate) trait BlockStoreAPI {
-    #[expect(dead_code)]
-    fn get_blocks(&self, refs: &[BlockRef]) -> Vec<Option<VerifiedBlock>>;
     fn get_block_headers(&self, refs: &[BlockRef]) -> Vec<Option<VerifiedBlockHeader>>;
 }
 
 impl BlockStoreAPI
     for parking_lot::lock_api::RwLockWriteGuard<'_, parking_lot::RawRwLock, DagState>
 {
-    fn get_blocks(&self, refs: &[BlockRef]) -> Vec<Option<VerifiedBlock>> {
-        DagState::get_blocks(self, refs)
-    }
     fn get_block_headers(&self, refs: &[BlockRef]) -> Vec<Option<VerifiedBlockHeader>> {
         DagState::get_block_headers(self, refs)
     }

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -127,12 +127,9 @@ pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
 /// Network service for handling requests from peers.
 #[async_trait]
 pub(crate) trait NetworkService: Send + Sync + 'static {
-    /// Handles the block sent from the peer via either unicast RPC or
-    /// subscription stream. Peer value can be trusted to be a valid
-    /// authority index. But serialized_block must be verified before its
-    /// contents are trusted.
-    /// Excluded ancestors are also included as part of an effort to further
-    /// propagate blocks to peers despite the current exclusion.
+    /// Handles the block sent from the peer via subscription stream. Peer value
+    /// can be trusted to be a valid authority index. But serialized_block
+    /// must be verified before its contents are trusted.
     async fn handle_subscribed_block(
         &self,
         peer: AuthorityIndex,
@@ -158,6 +155,9 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
     ) -> ConsensusResult<Vec<Bytes>>;
 
     /// Handles the request to fetch blocks by references from the peer.
+    /// The function returns pair of Vec<Bytes>. The first vector contains
+    /// serialization of the headers of blocks from block_refs
+    /// and the second contains serializations of transactions of these blocks.
     async fn handle_fetch_blocks(
         &self,
         peer: AuthorityIndex,

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -27,11 +27,12 @@ use std::{pin::Pin, time::Duration};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::Stream;
+use serde::{Deserialize, Serialize};
 use starfish_config::AuthorityIndex;
 
 use crate::{
     Round, VerifiedBlockHeader,
-    block_header::BlockRef,
+    block_header::{BlockRef, VerifiedBlock},
     commit::{CommitRange, TrustedCommit},
     error::ConsensusResult,
 };
@@ -54,7 +55,7 @@ pub mod tonic_network;
 mod tonic_tls;
 
 /// A stream of serialized filtered blocks returned over the network.
-pub(crate) type BlockStream = Pin<Box<dyn Stream<Item = Bytes> + Send>>;
+pub(crate) type BlockStream = Pin<Box<dyn Stream<Item = SerializedBlock> + Send>>;
 
 /// Network client for communicating with peers.
 ///
@@ -64,16 +65,6 @@ pub(crate) type BlockStream = Pin<Box<dyn Stream<Item = Bytes> + Send>>;
 ///   incoming requests.
 #[async_trait]
 pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
-    /// Sends a serialized SignedBlock to a peer.
-    // TODO: remove this method if after refactoring network code it's still not used.
-    #[cfg_attr(not(test), expect(unused))]
-    async fn send_block(
-        &self,
-        peer: AuthorityIndex,
-        block: &VerifiedBlockHeader,
-        timeout: Duration,
-    ) -> ConsensusResult<()>;
-
     /// Subscribes to blocks from a peer after last_received round.
     async fn subscribe_blocks(
         &self,
@@ -82,13 +73,28 @@ pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
         timeout: Duration,
     ) -> ConsensusResult<BlockStream>;
 
-    // TODO: add a parameter for maximum total size of blocks returned.
-    /// Fetches serialized `SignedBlock`s from a peer. It also might return
-    /// additional ancestor blocks of the requested blocks according to the
-    /// provided `highest_accepted_rounds`. The `highest_accepted_rounds`
-    /// length should be equal to the committee size. If
-    /// `highest_accepted_rounds` is empty then it will be simply ignored.
+    /// Fetches serialized `SerializedBlocks` from a peer. It also might
+    /// return additional ancestor blocks of the requested blocks according
+    /// to the provided `highest_accepted_rounds`. The
+    /// `highest_accepted_rounds` length should be equal to the committee
+    /// size. If `highest_accepted_rounds` is empty then it will be simply
+    /// ignored.
     async fn fetch_blocks(
+        &self,
+        peer: AuthorityIndex,
+        block_refs: Vec<BlockRef>,
+        highest_accepted_rounds: Vec<Round>,
+        timeout: Duration,
+    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)>;
+
+    // TODO: add a parameter for maximum total size of blocks returned.
+    /// Fetches serialized `SignedBlockHeader`s from a peer. It also might
+    /// return additional ancestor blocks of the requested blocks according
+    /// to the provided `highest_accepted_rounds`. The
+    /// `highest_accepted_rounds` length should be equal to the committee
+    /// size. If `highest_accepted_rounds` is empty then it will be simply
+    /// ignored.
+    async fn fetch_block_headers(
         &self,
         peer: AuthorityIndex,
         block_refs: Vec<BlockRef>,
@@ -110,7 +116,7 @@ pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
     /// The latest blocks are returned in the serialised format of
     /// `SignedBlocks`. The method can return multiple blocks per peer as
     /// its possible to have equivocations.
-    async fn fetch_latest_blocks(
+    async fn fetch_latest_block_headers(
         &self,
         peer: AuthorityIndex,
         authorities: Vec<AuthorityIndex>,
@@ -127,7 +133,11 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
     /// contents are trusted.
     /// Excluded ancestors are also included as part of an effort to further
     /// propagate blocks to peers despite the current exclusion.
-    async fn handle_send_block(&self, peer: AuthorityIndex, block: Bytes) -> ConsensusResult<()>;
+    async fn handle_subscribed_block(
+        &self,
+        peer: AuthorityIndex,
+        serialized_block: SerializedBlock,
+    ) -> ConsensusResult<()>;
 
     /// Handles the subscription request from the peer.
     /// A stream of newly proposed blocks is returned to the peer.
@@ -139,13 +149,21 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
         last_received: Round,
     ) -> ConsensusResult<BlockStream>;
 
+    /// Handles the request to fetch block headers by references from the peer.
+    async fn handle_fetch_block_headers(
+        &self,
+        peer: AuthorityIndex,
+        block_refs: Vec<BlockRef>,
+        highest_accepted_rounds: Vec<Round>,
+    ) -> ConsensusResult<Vec<Bytes>>;
+
     /// Handles the request to fetch blocks by references from the peer.
     async fn handle_fetch_blocks(
         &self,
         peer: AuthorityIndex,
         block_refs: Vec<BlockRef>,
         highest_accepted_rounds: Vec<Round>,
-    ) -> ConsensusResult<Vec<Bytes>>;
+    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)>;
 
     /// Handles the request to fetch commits by index range from the peer.
     async fn handle_fetch_commits(
@@ -168,4 +186,30 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
         &self,
         peer: AuthorityIndex,
     ) -> ConsensusResult<(Vec<Round>, Vec<Round>)>;
+}
+
+#[derive(Clone, PartialEq, Eq, Default, Serialize, Deserialize, Debug)]
+pub(crate) struct SerializedBlock {
+    pub(crate) serialized_block_header: Bytes,
+    pub(crate) serialized_transactions: Bytes,
+}
+
+impl SerializedBlock {
+    #[cfg(test)]
+    pub(crate) fn new_for_test(bytes: Bytes) -> Self {
+        Self {
+            serialized_block_header: bytes.clone(),
+            serialized_transactions: bytes,
+        }
+    }
+}
+
+impl From<VerifiedBlock> for SerializedBlock {
+    fn from(verified_block: VerifiedBlock) -> Self {
+        let (serialized_block_header, serialized_transactions) = verified_block.serialized();
+        Self {
+            serialized_block_header: serialized_block_header.clone(),
+            serialized_transactions: serialized_transactions.clone(),
+        }
+    }
 }

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -34,7 +34,7 @@ use crate::{
     Round, VerifiedBlockHeader,
     block_header::{BlockRef, VerifiedBlock},
     commit::{CommitRange, TrustedCommit},
-    error::ConsensusResult,
+    error::{ConsensusError, ConsensusResult},
 };
 
 // Tonic generated RPC stubs.
@@ -85,7 +85,7 @@ pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
         block_refs: Vec<BlockRef>,
         highest_accepted_rounds: Vec<Round>,
         timeout: Duration,
-    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)>;
+    ) -> ConsensusResult<Vec<Bytes>>;
 
     // TODO: add a parameter for maximum total size of blocks returned.
     /// Fetches serialized `SignedBlockHeader`s from a peer. It also might
@@ -155,15 +155,14 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
     ) -> ConsensusResult<Vec<Bytes>>;
 
     /// Handles the request to fetch blocks by references from the peer.
-    /// The function returns pair of Vec<Bytes>. The first vector contains
-    /// serialization of the headers of blocks from block_refs
-    /// and the second contains serializations of transactions of these blocks.
+    /// The function returns Vec<Bytes>. Each element is a serialization of
+    /// header and transactions of a block.
     async fn handle_fetch_blocks(
         &self,
         peer: AuthorityIndex,
         block_refs: Vec<BlockRef>,
         highest_accepted_rounds: Vec<Round>,
-    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)>;
+    ) -> ConsensusResult<Vec<Bytes>>;
 
     /// Handles the request to fetch commits by index range from the peer.
     async fn handle_fetch_commits(
@@ -188,13 +187,48 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
     ) -> ConsensusResult<(Vec<Round>, Vec<Round>)>;
 }
 
-#[derive(Clone, PartialEq, Eq, Default, Serialize, Deserialize, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct SerializedBlock {
+    pub(crate) serialized_block: Bytes,
+}
+
+impl TryFrom<SerializedHeaderAndTransactions> for SerializedBlock {
+    type Error = ConsensusError;
+
+    fn try_from(
+        serialized_header_and_transactions: SerializedHeaderAndTransactions,
+    ) -> ConsensusResult<Self> {
+        let bytes = bcs::to_bytes(&serialized_header_and_transactions)
+            .map_err(ConsensusError::SerializationFailure)?;
+        Ok(Self {
+            serialized_block: Bytes::from(bytes),
+        })
+    }
+}
+
+impl TryFrom<VerifiedBlock> for SerializedBlock {
+    type Error = ConsensusError;
+    fn try_from(verified_block: VerifiedBlock) -> ConsensusResult<Self> {
+        let (serialized_block_header, serialized_transactions) = verified_block.serialized();
+        let serialized_header_and_transactions = SerializedHeaderAndTransactions {
+            serialized_block_header: serialized_block_header.clone(),
+            serialized_transactions: serialized_transactions.clone(),
+        };
+        let bytes = bcs::to_bytes(&serialized_header_and_transactions)
+            .map_err(ConsensusError::SerializationFailure)?;
+        Ok(Self {
+            serialized_block: Bytes::from(bytes),
+        })
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Default, Serialize, Deserialize, Debug)]
+pub(crate) struct SerializedHeaderAndTransactions {
     pub(crate) serialized_block_header: Bytes,
     pub(crate) serialized_transactions: Bytes,
 }
 
-impl SerializedBlock {
+impl SerializedHeaderAndTransactions {
     #[cfg(test)]
     pub(crate) fn new_for_test(bytes: Bytes) -> Self {
         Self {
@@ -204,12 +238,20 @@ impl SerializedBlock {
     }
 }
 
-impl From<VerifiedBlock> for SerializedBlock {
+impl From<VerifiedBlock> for SerializedHeaderAndTransactions {
     fn from(verified_block: VerifiedBlock) -> Self {
         let (serialized_block_header, serialized_transactions) = verified_block.serialized();
         Self {
             serialized_block_header: serialized_block_header.clone(),
             serialized_transactions: serialized_transactions.clone(),
         }
+    }
+}
+
+impl TryFrom<SerializedBlock> for SerializedHeaderAndTransactions {
+    type Error = ConsensusError;
+
+    fn try_from(serialized_block: SerializedBlock) -> ConsensusResult<Self> {
+        bcs::from_bytes(&serialized_block.serialized_block).map_err(ConsensusError::MalformedBlock)
     }
 }

--- a/crates/starfish/core/src/network/network_tests.rs
+++ b/crates/starfish/core/src/network/network_tests.rs
@@ -10,15 +10,17 @@ use parking_lot::Mutex;
 use rstest::rstest;
 
 use super::{
-    NetworkClient, SerializedBlock, test_network::TestService, tonic_network::TonicManager,
+    NetworkClient, SerializedBlock, SerializedHeaderAndTransactions, test_network::TestService,
+    tonic_network::TonicManager,
 };
 use crate::{Round, context::Context};
 
 fn serialized_block_for_round(round: Round) -> SerializedBlock {
-    SerializedBlock {
+    SerializedBlock::try_from(SerializedHeaderAndTransactions {
         serialized_block_header: Bytes::from(vec![round as u8; 16]),
         serialized_transactions: Bytes::from(vec![round as u8; 16]),
-    }
+    })
+    .unwrap()
 }
 
 fn service_with_own_blocks() -> Arc<Mutex<TestService>> {

--- a/crates/starfish/core/src/network/network_tests.rs
+++ b/crates/starfish/core/src/network/network_tests.rs
@@ -8,17 +8,17 @@ use bytes::Bytes;
 use futures::StreamExt as _;
 use parking_lot::Mutex;
 use rstest::rstest;
-use tokio::time::sleep;
 
-use super::{NetworkClient, test_network::TestService, tonic_network::TonicManager};
-use crate::{
-    Round,
-    block_header::{TestBlockHeader, VerifiedBlockHeader},
-    context::Context,
+use super::{
+    NetworkClient, SerializedBlock, test_network::TestService, tonic_network::TonicManager,
 };
+use crate::{Round, context::Context};
 
-fn block_for_round(round: Round) -> Bytes {
-    Bytes::from(vec![round as u8; 16])
+fn serialized_block_for_round(round: Round) -> SerializedBlock {
+    SerializedBlock {
+        serialized_block_header: Bytes::from(vec![round as u8; 16]),
+        serialized_transactions: Bytes::from(vec![round as u8; 16]),
+    }
 }
 
 fn service_with_own_blocks() -> Arc<Mutex<TestService>> {
@@ -26,114 +26,11 @@ fn service_with_own_blocks() -> Arc<Mutex<TestService>> {
     {
         let mut service = service.lock();
         let own_blocks = (0..=100u8)
-            .map(|i| block_for_round(i as Round))
+            .map(|i| serialized_block_for_round(i as Round))
             .collect::<Vec<_>>();
         service.add_own_blocks(own_blocks);
     }
     service
-}
-
-// TODO: figure out the issue with using simulated time with tonic in this test.
-// When waiting for the server to become ready, it may need to use
-// std::thread::sleep() instead of tokio::time::sleep().
-#[rstest]
-#[tokio::test]
-async fn send_and_receive_blocks_with_auth() {
-    let (context, keys) = Context::new_for_test(4);
-
-    let context_0 = Arc::new(
-        context
-            .clone()
-            .with_authority_index(context.committee.to_authority_index(0).unwrap()),
-    );
-    let mut manager_0 = TonicManager::new(context_0.clone(), keys[0].0.clone());
-    let client_0 = manager_0.client();
-    let service_0 = service_with_own_blocks();
-    manager_0.install_service(service_0.clone()).await;
-
-    let context_1 = Arc::new(
-        context
-            .clone()
-            .with_authority_index(context.committee.to_authority_index(1).unwrap()),
-    );
-    let mut manager_1 = TonicManager::new(context_1.clone(), keys[1].0.clone());
-    let client_1 = manager_1.client();
-    let service_1 = service_with_own_blocks();
-    manager_1.install_service(service_1.clone()).await;
-
-    // Wait for tonic to initialize.
-    sleep(Duration::from_secs(5)).await;
-
-    // Test that servers can receive client RPCs.
-    let test_block_0 = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(9, 0).build());
-    client_0
-        .send_block(
-            context.committee.to_authority_index(1).unwrap(),
-            &test_block_0,
-            Duration::from_secs(5),
-        )
-        .await
-        .unwrap();
-    let test_block_1 = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(9, 1).build());
-    client_1
-        .send_block(
-            context.committee.to_authority_index(0).unwrap(),
-            &test_block_1,
-            Duration::from_secs(5),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(service_0.lock().handle_send_block.len(), 1);
-    assert_eq!(service_0.lock().handle_send_block[0].0.value(), 1);
-    assert_eq!(
-        service_0.lock().handle_send_block[0].1,
-        test_block_1.serialized().clone(),
-    );
-    assert_eq!(service_1.lock().handle_send_block.len(), 1);
-    assert_eq!(service_1.lock().handle_send_block[0].0.value(), 0);
-    assert_eq!(
-        service_1.lock().handle_send_block[0].1,
-        test_block_0.serialized().clone()
-    );
-
-    // `Committee` is generated with the same random seed in
-    // Context::new_for_test(), so the first 4 authorities are the same.
-    let (context_4, keys_4) = Context::new_for_test(5);
-    let context_4 = Arc::new(
-        context_4
-            .clone()
-            .with_authority_index(context_4.committee.to_authority_index(4).unwrap()),
-    );
-    let mut manager_4 = TonicManager::new(context_4.clone(), keys_4[4].0.clone());
-    let client_4 = manager_4.client();
-    let service_4 = service_with_own_blocks();
-    manager_4.install_service(service_4.clone()).await;
-
-    // client_4 should not be able to reach service_0 or service_1, because of the
-    // AllowedPeers filter.
-    let test_block_2 = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(9, 2).build());
-    assert!(
-        client_4
-            .send_block(
-                context.committee.to_authority_index(0).unwrap(),
-                &test_block_2,
-                Duration::from_secs(5),
-            )
-            .await
-            .is_err()
-    );
-    let test_block_3 = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(9, 3).build());
-    assert!(
-        client_4
-            .send_block(
-                context.committee.to_authority_index(1).unwrap(),
-                &test_block_3,
-                Duration::from_secs(5),
-            )
-            .await
-            .is_err()
-    );
 }
 
 #[rstest]
@@ -174,7 +71,10 @@ async fn subscribe_and_receive_blocks() {
     let count = receive_stream_0
         .enumerate()
         .then(|(i, item)| async move {
-            assert_eq!(item, block_for_round(client_0_round + i as Round + 1));
+            assert_eq!(
+                item,
+                serialized_block_for_round(client_0_round + i as Round + 1)
+            );
             1
         })
         .fold(0, |a, b| async move { a + b })

--- a/crates/starfish/core/src/network/test_network.rs
+++ b/crates/starfish/core/src/network/test_network.rs
@@ -89,9 +89,9 @@ impl NetworkService for Mutex<TestService> {
         peer: AuthorityIndex,
         block_refs: Vec<BlockRef>,
         _highest_accepted_rounds: Vec<Round>,
-    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
+    ) -> ConsensusResult<Vec<Bytes>> {
         self.lock().handle_fetch_blocks.push((peer, block_refs));
-        Ok((vec![], vec![]))
+        Ok(vec![])
     }
 
     async fn handle_fetch_commits(

--- a/crates/starfish/core/src/network/test_network.rs
+++ b/crates/starfish/core/src/network/test_network.rs
@@ -13,21 +13,23 @@ use crate::{
     block_header::{BlockRef, VerifiedBlockHeader},
     commit::{CommitRange, TrustedCommit},
     error::ConsensusResult,
-    network::{BlockStream, NetworkService},
+    network::{BlockStream, NetworkService, SerializedBlock},
 };
 
 pub(crate) struct TestService {
-    pub(crate) handle_send_block: Vec<(AuthorityIndex, Bytes)>,
+    pub(crate) handle_send_block: Vec<(AuthorityIndex, SerializedBlock)>,
+    pub(crate) handle_fetch_block_headers: Vec<(AuthorityIndex, Vec<BlockRef>)>,
     pub(crate) handle_fetch_blocks: Vec<(AuthorityIndex, Vec<BlockRef>)>,
     pub(crate) handle_subscribe_blocks: Vec<(AuthorityIndex, Round)>,
     pub(crate) handle_fetch_commits: Vec<(AuthorityIndex, CommitRange)>,
-    pub(crate) own_blocks: Vec<Bytes>,
+    pub(crate) own_blocks: Vec<SerializedBlock>,
 }
 
 impl TestService {
     pub(crate) fn new() -> Self {
         Self {
             handle_send_block: Vec::new(),
+            handle_fetch_block_headers: Vec::new(),
             handle_fetch_blocks: Vec::new(),
             handle_subscribe_blocks: Vec::new(),
             handle_fetch_commits: Vec::new(),
@@ -36,16 +38,20 @@ impl TestService {
     }
 
     #[cfg_attr(msim, allow(dead_code))]
-    pub(crate) fn add_own_blocks(&mut self, blocks: Vec<Bytes>) {
+    pub(crate) fn add_own_blocks(&mut self, blocks: Vec<SerializedBlock>) {
         self.own_blocks.extend(blocks);
     }
 }
 
 #[async_trait]
 impl NetworkService for Mutex<TestService> {
-    async fn handle_send_block(&self, peer: AuthorityIndex, block: Bytes) -> ConsensusResult<()> {
+    async fn handle_subscribed_block(
+        &self,
+        peer: AuthorityIndex,
+        serialized_block: SerializedBlock,
+    ) -> ConsensusResult<()> {
         let mut state = self.lock();
-        state.handle_send_block.push((peer, block));
+        state.handle_send_block.push((peer, serialized_block));
         Ok(())
     }
 
@@ -66,14 +72,26 @@ impl NetworkService for Mutex<TestService> {
         Ok(Box::pin(stream::iter(own_blocks)))
     }
 
-    async fn handle_fetch_blocks(
+    async fn handle_fetch_block_headers(
         &self,
         peer: AuthorityIndex,
         block_refs: Vec<BlockRef>,
         _highest_accepted_rounds: Vec<Round>,
     ) -> ConsensusResult<Vec<Bytes>> {
-        self.lock().handle_fetch_blocks.push((peer, block_refs));
+        self.lock()
+            .handle_fetch_block_headers
+            .push((peer, block_refs));
         Ok(vec![])
+    }
+
+    async fn handle_fetch_blocks(
+        &self,
+        peer: AuthorityIndex,
+        block_refs: Vec<BlockRef>,
+        _highest_accepted_rounds: Vec<Round>,
+    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
+        self.lock().handle_fetch_blocks.push((peer, block_refs));
+        Ok((vec![], vec![]))
     }
 
     async fn handle_fetch_commits(

--- a/crates/starfish/core/src/network/test_network.rs
+++ b/crates/starfish/core/src/network/test_network.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 pub(crate) struct TestService {
-    pub(crate) handle_send_block: Vec<(AuthorityIndex, SerializedBlock)>,
+    pub(crate) handle_subscribed_block: Vec<(AuthorityIndex, SerializedBlock)>,
     pub(crate) handle_fetch_block_headers: Vec<(AuthorityIndex, Vec<BlockRef>)>,
     pub(crate) handle_fetch_blocks: Vec<(AuthorityIndex, Vec<BlockRef>)>,
     pub(crate) handle_subscribe_blocks: Vec<(AuthorityIndex, Round)>,
@@ -28,7 +28,7 @@ pub(crate) struct TestService {
 impl TestService {
     pub(crate) fn new() -> Self {
         Self {
-            handle_send_block: Vec::new(),
+            handle_subscribed_block: Vec::new(),
             handle_fetch_block_headers: Vec::new(),
             handle_fetch_blocks: Vec::new(),
             handle_subscribe_blocks: Vec::new(),
@@ -51,7 +51,7 @@ impl NetworkService for Mutex<TestService> {
         serialized_block: SerializedBlock,
     ) -> ConsensusResult<()> {
         let mut state = self.lock();
-        state.handle_send_block.push((peer, serialized_block));
+        state.handle_subscribed_block.push((peer, serialized_block));
         Ok(())
     }
 

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -27,7 +27,7 @@ use tower_http::trace::{DefaultMakeSpan, DefaultOnFailure, TraceLayer};
 use tracing::{debug, error, info, trace, warn};
 
 use super::{
-    BlockStream, NetworkClient, NetworkService,
+    BlockStream, NetworkClient, NetworkService, SerializedBlock,
     metrics_layer::{MetricsCallbackMaker, MetricsResponseCallback, SizedRequest, SizedResponse},
     tonic_gen::{
         consensus_service_client::ConsensusServiceClient,
@@ -37,7 +37,7 @@ use super::{
 };
 use crate::{
     CommitIndex, Round,
-    block_header::{BlockRef, VerifiedBlockHeader},
+    block_header::BlockRef,
     commit::CommitRange,
     context::Context,
     error::{ConsensusError, ConsensusResult},
@@ -98,24 +98,6 @@ impl TonicClient {
 // otherwise.
 #[async_trait]
 impl NetworkClient for TonicClient {
-    async fn send_block(
-        &self,
-        peer: AuthorityIndex,
-        block: &VerifiedBlockHeader,
-        timeout: Duration,
-    ) -> ConsensusResult<()> {
-        let mut client = self.get_client(peer, timeout).await?;
-        let mut request = Request::new(SendBlockRequest {
-            block: block.serialized().clone(),
-        });
-        request.set_timeout(timeout);
-        client
-            .send_block(request)
-            .await
-            .map_err(|e| ConsensusError::NetworkRequest(format!("send_block failed: {e:?}")))?;
-        Ok(())
-    }
-
     async fn subscribe_blocks(
         &self,
         peer: AuthorityIndex,
@@ -137,7 +119,10 @@ impl NetworkClient for TonicClient {
             .take_while(|b| futures::future::ready(b.is_ok()))
             .filter_map(move |b| async move {
                 match b {
-                    Ok(response) => Some(response.block),
+                    Ok(response) => Some(SerializedBlock {
+                        serialized_block_header: response.serialized_block_header,
+                        serialized_transactions: response.serialized_transactions,
+                    }),
                     Err(e) => {
                         debug!("Network error received from {}: {e:?}", peer);
                         None
@@ -150,13 +135,14 @@ impl NetworkClient for TonicClient {
         Ok(rate_limited_stream)
     }
 
+    // Returns a vector of serialized blocks. Used by commit synchronizer
     async fn fetch_blocks(
         &self,
         peer: AuthorityIndex,
         block_refs: Vec<BlockRef>,
         highest_accepted_rounds: Vec<Round>,
         timeout: Duration,
-    ) -> ConsensusResult<Vec<Bytes>> {
+    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
         let mut client = self.get_client(peer, timeout).await?;
         let mut request = Request::new(FetchBlocksRequest {
             block_refs: block_refs
@@ -183,15 +169,20 @@ impl NetworkClient for TonicClient {
                 }
             })?
             .into_inner();
-        let mut blocks = vec![];
+        let mut vec_serialized_block_header = vec![];
+        let mut vec_serialized_block_transactions = vec![];
         let mut total_fetched_bytes = 0;
         loop {
             match stream.message().await {
                 Ok(Some(response)) => {
-                    for b in &response.blocks {
+                    for b in &response.vec_serialized_block_header {
                         total_fetched_bytes += b.len();
                     }
-                    blocks.extend(response.blocks);
+                    for b in &response.vec_serialized_transactions {
+                        total_fetched_bytes += b.len();
+                    }
+                    vec_serialized_block_header.extend(response.vec_serialized_block_header);
+                    vec_serialized_block_transactions.extend(response.vec_serialized_transactions);
                     if total_fetched_bytes > MAX_TOTAL_FETCHED_BYTES {
                         info!(
                             "fetch_blocks() fetched bytes exceeded limit: {} > {}, terminating stream.",
@@ -204,7 +195,7 @@ impl NetworkClient for TonicClient {
                     break;
                 }
                 Err(e) => {
-                    if blocks.is_empty() {
+                    if vec_serialized_block_header.is_empty() {
                         if e.code() == tonic::Code::DeadlineExceeded {
                             return Err(ConsensusError::NetworkRequestTimeout(format!(
                                 "fetch_blocks failed mid-stream: {e:?}"
@@ -220,7 +211,84 @@ impl NetworkClient for TonicClient {
                 }
             }
         }
-        Ok(blocks)
+        Ok((
+            vec_serialized_block_header,
+            vec_serialized_block_transactions,
+        ))
+    }
+
+    // Returns a vector of serialized block headers
+    async fn fetch_block_headers(
+        &self,
+        peer: AuthorityIndex,
+        block_refs: Vec<BlockRef>,
+        highest_accepted_rounds: Vec<Round>,
+        timeout: Duration,
+    ) -> ConsensusResult<Vec<Bytes>> {
+        let mut client = self.get_client(peer, timeout).await?;
+        let mut request = Request::new(FetchBlockHeadersRequest {
+            block_refs: block_refs
+                .iter()
+                .filter_map(|r| match bcs::to_bytes(r) {
+                    Ok(serialized) => Some(serialized),
+                    Err(e) => {
+                        debug!("Failed to serialize block ref {:?}: {e:?}", r);
+                        None
+                    }
+                })
+                .collect(),
+            highest_accepted_rounds,
+        });
+        request.set_timeout(timeout);
+        let mut stream = client
+            .fetch_block_headers(request)
+            .await
+            .map_err(|e| {
+                if e.code() == tonic::Code::DeadlineExceeded {
+                    ConsensusError::NetworkRequestTimeout(format!("fetch_blocks failed: {e:?}"))
+                } else {
+                    ConsensusError::NetworkRequest(format!("fetch_blocks failed: {e:?}"))
+                }
+            })?
+            .into_inner();
+        let mut vec_serialized_block_header = vec![];
+        let mut total_fetched_bytes = 0;
+        loop {
+            match stream.message().await {
+                Ok(Some(response)) => {
+                    for b in &response.vec_serialized_block_header {
+                        total_fetched_bytes += b.len();
+                    }
+                    vec_serialized_block_header.extend(response.vec_serialized_block_header);
+                    if total_fetched_bytes > MAX_TOTAL_FETCHED_BYTES {
+                        info!(
+                            "fetch_blocks() fetched bytes exceeded limit: {} > {}, terminating stream.",
+                            total_fetched_bytes, MAX_TOTAL_FETCHED_BYTES,
+                        );
+                        break;
+                    }
+                }
+                Ok(None) => {
+                    break;
+                }
+                Err(e) => {
+                    if vec_serialized_block_header.is_empty() {
+                        if e.code() == tonic::Code::DeadlineExceeded {
+                            return Err(ConsensusError::NetworkRequestTimeout(format!(
+                                "fetch_block_headers failed mid-stream: {e:?}"
+                            )));
+                        }
+                        return Err(ConsensusError::NetworkRequest(format!(
+                            "fetch_block_headers failed mid-stream: {e:?}"
+                        )));
+                    } else {
+                        warn!("fetch_block_headers failed mid-stream: {e:?}");
+                        break;
+                    }
+                }
+            }
+        }
+        Ok(vec_serialized_block_header)
     }
 
     async fn fetch_commits(
@@ -240,17 +308,17 @@ impl NetworkClient for TonicClient {
             .await
             .map_err(|e| ConsensusError::NetworkRequest(format!("fetch_commits failed: {e:?}")))?;
         let response = response.into_inner();
-        Ok((response.commits, response.certifier_blocks))
+        Ok((response.commits, response.certifier_block_headers))
     }
 
-    async fn fetch_latest_blocks(
+    async fn fetch_latest_block_headers(
         &self,
         peer: AuthorityIndex,
         authorities: Vec<AuthorityIndex>,
         timeout: Duration,
     ) -> ConsensusResult<Vec<Bytes>> {
         let mut client = self.get_client(peer, timeout).await?;
-        let mut request = Request::new(FetchLatestBlocksRequest {
+        let mut request = Request::new(FetchLatestBlockHeadersRequest {
             authorities: authorities
                 .iter()
                 .map(|authority| authority.value() as u32)
@@ -258,13 +326,17 @@ impl NetworkClient for TonicClient {
         });
         request.set_timeout(timeout);
         let mut stream = client
-            .fetch_latest_blocks(request)
+            .fetch_latest_block_headers(request)
             .await
             .map_err(|e| {
                 if e.code() == tonic::Code::DeadlineExceeded {
-                    ConsensusError::NetworkRequestTimeout(format!("fetch_blocks failed: {e:?}"))
+                    ConsensusError::NetworkRequestTimeout(format!(
+                        "fetch_latest_block_headers failed: {e:?}"
+                    ))
                 } else {
-                    ConsensusError::NetworkRequest(format!("fetch_blocks failed: {e:?}"))
+                    ConsensusError::NetworkRequest(format!(
+                        "fetch_latest_block_headers failed: {e:?}"
+                    ))
                 }
             })?
             .into_inner();
@@ -273,10 +345,11 @@ impl NetworkClient for TonicClient {
         loop {
             match stream.message().await {
                 Ok(Some(response)) => {
-                    for b in &response.blocks {
+                    let vec_serialized_block_headers = response.vec_serialized_block_header;
+                    for b in &vec_serialized_block_headers {
                         total_fetched_bytes += b.len();
                     }
-                    blocks.extend(response.blocks);
+                    blocks.extend(vec_serialized_block_headers);
                     if total_fetched_bytes > MAX_TOTAL_FETCHED_BYTES {
                         info!(
                             "fetch_blocks() fetched bytes exceeded limit: {} > {}, terminating stream.",
@@ -420,25 +493,6 @@ impl<S: NetworkService> TonicServiceProxy<S> {
 
 #[async_trait]
 impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
-    async fn send_block(
-        &self,
-        request: Request<SendBlockRequest>,
-    ) -> Result<Response<SendBlockResponse>, tonic::Status> {
-        let Some(peer_index) = request
-            .extensions()
-            .get::<PeerInfo>()
-            .map(|p| p.authority_index)
-        else {
-            return Err(tonic::Status::internal("PeerInfo not found"));
-        };
-        let block = request.into_inner().block;
-        self.service
-            .handle_send_block(peer_index, block)
-            .await
-            .map_err(|e| tonic::Status::invalid_argument(format!("{e:?}")))?;
-        Ok(Response::new(SendBlockResponse {}))
-    }
-
     type SubscribeBlocksStream =
         Pin<Box<dyn Stream<Item = Result<SubscribeBlocksResponse, tonic::Status>> + Send>>;
 
@@ -472,11 +526,62 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
             .handle_subscribe_blocks(peer_index, first_request.last_received_round)
             .await
             .map_err(|e| tonic::Status::internal(format!("{e:?}")))?
-            .map(|block| Ok(SubscribeBlocksResponse { block }));
+            .map(|block| {
+                Ok(SubscribeBlocksResponse {
+                    serialized_block_header: block.serialized_block_header,
+                    serialized_transactions: block.serialized_transactions,
+                })
+            });
         let rate_limited_stream =
             tokio_stream::StreamExt::throttle(stream, self.context.parameters.min_round_delay / 2)
                 .boxed();
         Ok(Response::new(rate_limited_stream))
+    }
+
+    type FetchBlockHeadersStream =
+        Iter<std::vec::IntoIter<Result<FetchBlockHeadersResponse, tonic::Status>>>;
+
+    async fn fetch_block_headers(
+        &self,
+        request: Request<FetchBlockHeadersRequest>,
+    ) -> Result<Response<Self::FetchBlockHeadersStream>, tonic::Status> {
+        let Some(peer_index) = request
+            .extensions()
+            .get::<PeerInfo>()
+            .map(|p| p.authority_index)
+        else {
+            return Err(tonic::Status::internal("PeerInfo not found"));
+        };
+        let inner = request.into_inner();
+        let block_refs = inner
+            .block_refs
+            .into_iter()
+            .filter_map(|serialized| match bcs::from_bytes(&serialized) {
+                Ok(r) => Some(r),
+                Err(e) => {
+                    debug!("Failed to deserialize block ref {:?}: {e:?}", serialized);
+                    None
+                }
+            })
+            .collect();
+        let highest_accepted_rounds = inner.highest_accepted_rounds;
+        let blocks = self
+            .service
+            .handle_fetch_block_headers(peer_index, block_refs, highest_accepted_rounds)
+            .await
+            .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;
+        let responses: std::vec::IntoIter<Result<FetchBlockHeadersResponse, tonic::Status>> =
+            chunk_block_headers(blocks, MAX_FETCH_RESPONSE_BYTES)
+                .into_iter()
+                .map(|block_headers| {
+                    Ok(FetchBlockHeadersResponse {
+                        vec_serialized_block_header: block_headers,
+                    })
+                })
+                .collect::<Vec<_>>()
+                .into_iter();
+        let stream = iter(responses);
+        Ok(Response::new(stream))
     }
 
     type FetchBlocksStream = Iter<std::vec::IntoIter<Result<FetchBlocksResponse, tonic::Status>>>;
@@ -513,7 +618,12 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
         let responses: std::vec::IntoIter<Result<FetchBlocksResponse, tonic::Status>> =
             chunk_blocks(blocks, MAX_FETCH_RESPONSE_BYTES)
                 .into_iter()
-                .map(|blocks| Ok(FetchBlocksResponse { blocks }))
+                .map(|(block_headers, block_transactions)| {
+                    Ok(FetchBlocksResponse {
+                        vec_serialized_block_header: block_headers,
+                        vec_serialized_transactions: block_transactions,
+                    })
+                })
                 .collect::<Vec<_>>()
                 .into_iter();
         let stream = iter(responses);
@@ -532,7 +642,7 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
             return Err(tonic::Status::internal("PeerInfo not found"));
         };
         let request = request.into_inner();
-        let (commits, certifier_blocks) = self
+        let (commits, certifier_block_headers) = self
             .service
             .handle_fetch_commits(peer_index, (request.start..=request.end).into())
             .await
@@ -541,23 +651,23 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
             .into_iter()
             .map(|c| c.serialized().clone())
             .collect();
-        let certifier_blocks = certifier_blocks
+        let certifier_block_headers = certifier_block_headers
             .into_iter()
-            .map(|b| b.serialized().clone())
+            .map(|bh| bh.serialized().clone())
             .collect();
         Ok(Response::new(FetchCommitsResponse {
             commits,
-            certifier_blocks,
+            certifier_block_headers,
         }))
     }
 
-    type FetchLatestBlocksStream =
-        Iter<std::vec::IntoIter<Result<FetchLatestBlocksResponse, tonic::Status>>>;
+    type FetchLatestBlockHeadersStream =
+        Iter<std::vec::IntoIter<Result<FetchLatestBlockHeadersResponse, tonic::Status>>>;
 
-    async fn fetch_latest_blocks(
+    async fn fetch_latest_block_headers(
         &self,
-        request: Request<FetchLatestBlocksRequest>,
-    ) -> Result<Response<Self::FetchLatestBlocksStream>, tonic::Status> {
+        request: Request<FetchLatestBlockHeadersRequest>,
+    ) -> Result<Response<Self::FetchLatestBlockHeadersStream>, tonic::Status> {
         let Some(peer_index) = request
             .extensions()
             .get::<PeerInfo>()
@@ -587,10 +697,14 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
             .handle_fetch_latest_blocks(peer_index, authorities)
             .await
             .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;
-        let responses: std::vec::IntoIter<Result<FetchLatestBlocksResponse, tonic::Status>> =
-            chunk_blocks(blocks, MAX_FETCH_RESPONSE_BYTES)
+        let responses: std::vec::IntoIter<Result<FetchLatestBlockHeadersResponse, tonic::Status>> =
+            chunk_block_headers(blocks, MAX_FETCH_RESPONSE_BYTES)
                 .into_iter()
-                .map(|blocks| Ok(FetchLatestBlocksResponse { blocks }))
+                .map(|block_headers| {
+                    Ok(FetchLatestBlockHeadersResponse {
+                        vec_serialized_block_header: block_headers,
+                    })
+                })
                 .collect::<Vec<_>>()
                 .into_iter();
         let stream = iter(responses);
@@ -990,9 +1104,11 @@ impl ResponseHandler for MetricsResponseCallback {
 /// Network message types.
 #[derive(Clone, prost::Message)]
 pub(crate) struct SendBlockRequest {
-    // Serialized SignedBlock.
+    // Serialized SignedBlockHeader and transactions.
     #[prost(bytes = "bytes", tag = "1")]
-    block: Bytes,
+    serialized_block_header: Bytes,
+    #[prost(bytes = "bytes", tag = "2")]
+    serialized_transactions: Bytes,
 }
 
 #[derive(Clone, prost::Message)]
@@ -1007,7 +1123,25 @@ pub(crate) struct SubscribeBlocksRequest {
 #[derive(Clone, prost::Message)]
 pub(crate) struct SubscribeBlocksResponse {
     #[prost(bytes = "bytes", tag = "1")]
-    block: Bytes,
+    serialized_block_header: Bytes,
+    #[prost(bytes = "bytes", tag = "2")]
+    serialized_transactions: Bytes,
+}
+
+#[derive(Clone, prost::Message)]
+pub(crate) struct FetchBlockHeadersRequest {
+    #[prost(bytes = "vec", repeated, tag = "1")]
+    block_refs: Vec<Vec<u8>>,
+    // The highest accepted round per authority. The vector represents the round for each authority
+    // and its length should be the same as the committee size.
+    #[prost(uint32, repeated, tag = "2")]
+    highest_accepted_rounds: Vec<Round>,
+}
+
+#[derive(Clone, prost::Message)]
+pub(crate) struct FetchBlockHeadersResponse {
+    #[prost(bytes = "bytes", repeated, tag = "1")]
+    vec_serialized_block_header: Vec<Bytes>,
 }
 
 #[derive(Clone, prost::Message)]
@@ -1022,9 +1156,10 @@ pub(crate) struct FetchBlocksRequest {
 
 #[derive(Clone, prost::Message)]
 pub(crate) struct FetchBlocksResponse {
-    // The response of the requested blocks as Serialized SignedBlock.
     #[prost(bytes = "bytes", repeated, tag = "1")]
-    blocks: Vec<Bytes>,
+    vec_serialized_block_header: Vec<Bytes>,
+    #[prost(bytes = "bytes", repeated, tag = "2")]
+    vec_serialized_transactions: Vec<Bytes>,
 }
 
 #[derive(Clone, prost::Message)]
@@ -1040,22 +1175,21 @@ pub(crate) struct FetchCommitsResponse {
     // Serialized consecutive Commit.
     #[prost(bytes = "bytes", repeated, tag = "1")]
     commits: Vec<Bytes>,
-    // Serialized SignedBlock that certify the last commit from above.
+    // Serialized SignedBlockHeader that certify the last commit from above.
     #[prost(bytes = "bytes", repeated, tag = "2")]
-    certifier_blocks: Vec<Bytes>,
+    certifier_block_headers: Vec<Bytes>,
 }
 
 #[derive(Clone, prost::Message)]
-pub(crate) struct FetchLatestBlocksRequest {
+pub(crate) struct FetchLatestBlockHeadersRequest {
     #[prost(uint32, repeated, tag = "1")]
     authorities: Vec<u32>,
 }
 
 #[derive(Clone, prost::Message)]
-pub(crate) struct FetchLatestBlocksResponse {
-    // The response of the requested blocks as Serialized SignedBlock.
+pub(crate) struct FetchLatestBlockHeadersResponse {
     #[prost(bytes = "bytes", repeated, tag = "1")]
-    blocks: Vec<Bytes>,
+    vec_serialized_block_header: Vec<Bytes>,
 }
 
 #[derive(Clone, prost::Message)]
@@ -1071,22 +1205,56 @@ pub(crate) struct GetLatestRoundsResponse {
     highest_accepted: Vec<u32>,
 }
 
-fn chunk_blocks(blocks: Vec<Bytes>, chunk_limit: usize) -> Vec<Vec<Bytes>> {
+fn chunk_block_headers(block_headers: Vec<Bytes>, chunk_limit: usize) -> Vec<Vec<Bytes>> {
     let mut chunks = vec![];
     let mut chunk = vec![];
     let mut chunk_size = 0;
-    for block in blocks {
-        let block_size = block.len();
+    for (i, block) in block_headers.iter().enumerate() {
+        let data = &block_headers[i];
+        // Compute the size of block
+        // TODO: this line doesn't make sense
+        let block_size = block.len() + data.len();
         if !chunk.is_empty() && chunk_size + block_size > chunk_limit {
             chunks.push(chunk);
             chunk = vec![];
             chunk_size = 0;
         }
-        chunk.push(block);
+        chunk.push(block.clone());
         chunk_size += block_size;
     }
     if !chunk.is_empty() {
         chunks.push(chunk);
+    }
+    chunks
+}
+
+fn chunk_blocks(
+    serialized_blocks: (Vec<Bytes>, Vec<Bytes>),
+    chunk_limit: usize,
+) -> Vec<(Vec<Bytes>, Vec<Bytes>)> {
+    let mut chunks = vec![];
+    let mut chunk_header = vec![];
+    let mut chunk_transactions = vec![];
+    let mut chunk_size = 0;
+    let serialized_block_headers = serialized_blocks.0;
+    let serialized_block_transactions = serialized_blocks.1;
+    for (block_header, block_transactions) in serialized_block_headers
+        .iter()
+        .zip(serialized_block_transactions)
+    {
+        let block_size = block_header.len() + block_transactions.len();
+        if !chunk_header.is_empty() && chunk_size + block_size > chunk_limit {
+            chunks.push((chunk_header, chunk_transactions));
+            chunk_header = vec![];
+            chunk_transactions = vec![];
+            chunk_size = 0;
+        }
+        chunk_header.push(block_header.clone());
+        chunk_transactions.push(block_transactions.clone());
+        chunk_size += block_size;
+    }
+    if !chunk_header.is_empty() {
+        chunks.push((chunk_header, chunk_transactions));
     }
     chunks
 }

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -1209,17 +1209,14 @@ fn chunk_block_headers(block_headers: Vec<Bytes>, chunk_limit: usize) -> Vec<Vec
     let mut chunks = vec![];
     let mut chunk = vec![];
     let mut chunk_size = 0;
-    for (i, block) in block_headers.iter().enumerate() {
-        let data = &block_headers[i];
-        // Compute the size of block
-        // TODO: this line doesn't make sense
-        let block_size = block.len() + data.len();
+    for block in block_headers.into_iter() {
+        let block_size = block.len();
         if !chunk.is_empty() && chunk_size + block_size > chunk_limit {
             chunks.push(chunk);
             chunk = vec![];
             chunk_size = 0;
         }
-        chunk.push(block.clone());
+        chunk.push(block);
         chunk_size += block_size;
     }
     if !chunk.is_empty() {

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -517,10 +517,7 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
             .handle_subscribe_blocks(peer_index, first_request.last_received_round)
             .await
             .map_err(|e| tonic::Status::internal(format!("{e:?}")))?
-            .map(|block| {
-                let serialized_block = SerializedBlock::try_from(block)
-                    .map_err(|e| tonic::Status::internal(format!("serialization error: {e:?}")))?;
-
+            .map(|serialized_block| {
                 Ok(SubscribeBlocksResponse {
                     vec_serialized_blocks: serialized_block.serialized_block,
                 })

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -120,8 +120,7 @@ impl NetworkClient for TonicClient {
             .filter_map(move |b| async move {
                 match b {
                     Ok(response) => Some(SerializedBlock {
-                        serialized_block_header: response.serialized_block_header,
-                        serialized_transactions: response.serialized_transactions,
+                        serialized_block: response.vec_serialized_blocks,
                     }),
                     Err(e) => {
                         debug!("Network error received from {}: {e:?}", peer);
@@ -142,7 +141,7 @@ impl NetworkClient for TonicClient {
         block_refs: Vec<BlockRef>,
         highest_accepted_rounds: Vec<Round>,
         timeout: Duration,
-    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
+    ) -> ConsensusResult<Vec<Bytes>> {
         let mut client = self.get_client(peer, timeout).await?;
         let mut request = Request::new(FetchBlocksRequest {
             block_refs: block_refs
@@ -169,20 +168,14 @@ impl NetworkClient for TonicClient {
                 }
             })?
             .into_inner();
-        let mut vec_serialized_block_header = vec![];
-        let mut vec_serialized_block_transactions = vec![];
         let mut total_fetched_bytes = 0;
+        let mut vec_serialized_blocks = vec![];
         loop {
             match stream.message().await {
                 Ok(Some(response)) => {
-                    for b in &response.vec_serialized_block_header {
+                    for b in &response.vec_serialized_blocks {
                         total_fetched_bytes += b.len();
                     }
-                    for b in &response.vec_serialized_transactions {
-                        total_fetched_bytes += b.len();
-                    }
-                    vec_serialized_block_header.extend(response.vec_serialized_block_header);
-                    vec_serialized_block_transactions.extend(response.vec_serialized_transactions);
                     if total_fetched_bytes > MAX_TOTAL_FETCHED_BYTES {
                         info!(
                             "fetch_blocks() fetched bytes exceeded limit: {} > {}, terminating stream.",
@@ -190,12 +183,13 @@ impl NetworkClient for TonicClient {
                         );
                         break;
                     }
+                    vec_serialized_blocks.extend(response.vec_serialized_blocks);
                 }
                 Ok(None) => {
                     break;
                 }
                 Err(e) => {
-                    if vec_serialized_block_header.is_empty() {
+                    if total_fetched_bytes == 0 {
                         if e.code() == tonic::Code::DeadlineExceeded {
                             return Err(ConsensusError::NetworkRequestTimeout(format!(
                                 "fetch_blocks failed mid-stream: {e:?}"
@@ -211,10 +205,7 @@ impl NetworkClient for TonicClient {
                 }
             }
         }
-        Ok((
-            vec_serialized_block_header,
-            vec_serialized_block_transactions,
-        ))
+        Ok(vec_serialized_blocks)
     }
 
     // Returns a vector of serialized block headers
@@ -527,9 +518,11 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
             .await
             .map_err(|e| tonic::Status::internal(format!("{e:?}")))?
             .map(|block| {
+                let serialized_block = SerializedBlock::try_from(block)
+                    .map_err(|e| tonic::Status::internal(format!("serialization error: {e:?}")))?;
+
                 Ok(SubscribeBlocksResponse {
-                    serialized_block_header: block.serialized_block_header,
-                    serialized_transactions: block.serialized_transactions,
+                    vec_serialized_blocks: serialized_block.serialized_block,
                 })
             });
         let rate_limited_stream =
@@ -571,7 +564,7 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
             .await
             .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;
         let responses: std::vec::IntoIter<Result<FetchBlockHeadersResponse, tonic::Status>> =
-            chunk_block_headers(blocks, MAX_FETCH_RESPONSE_BYTES)
+            chunk_data(blocks, MAX_FETCH_RESPONSE_BYTES)
                 .into_iter()
                 .map(|block_headers| {
                     Ok(FetchBlockHeadersResponse {
@@ -616,12 +609,11 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
             .await
             .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;
         let responses: std::vec::IntoIter<Result<FetchBlocksResponse, tonic::Status>> =
-            chunk_blocks(blocks, MAX_FETCH_RESPONSE_BYTES)
+            chunk_data(blocks, MAX_FETCH_RESPONSE_BYTES)
                 .into_iter()
-                .map(|(block_headers, block_transactions)| {
+                .map(|serialized_block| {
                     Ok(FetchBlocksResponse {
-                        vec_serialized_block_header: block_headers,
-                        vec_serialized_transactions: block_transactions,
+                        vec_serialized_blocks: serialized_block,
                     })
                 })
                 .collect::<Vec<_>>()
@@ -698,7 +690,7 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
             .await
             .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;
         let responses: std::vec::IntoIter<Result<FetchLatestBlockHeadersResponse, tonic::Status>> =
-            chunk_block_headers(blocks, MAX_FETCH_RESPONSE_BYTES)
+            chunk_data(blocks, MAX_FETCH_RESPONSE_BYTES)
                 .into_iter()
                 .map(|block_headers| {
                     Ok(FetchLatestBlockHeadersResponse {
@@ -1104,11 +1096,8 @@ impl ResponseHandler for MetricsResponseCallback {
 /// Network message types.
 #[derive(Clone, prost::Message)]
 pub(crate) struct SendBlockRequest {
-    // Serialized SignedBlockHeader and transactions.
-    #[prost(bytes = "bytes", tag = "1")]
-    serialized_block_header: Bytes,
-    #[prost(bytes = "bytes", tag = "2")]
-    serialized_transactions: Bytes,
+    #[prost(bytes = "bytes", repeated, tag = "1")]
+    vec_serialized_blocks: Vec<Bytes>,
 }
 
 #[derive(Clone, prost::Message)]
@@ -1123,9 +1112,7 @@ pub(crate) struct SubscribeBlocksRequest {
 #[derive(Clone, prost::Message)]
 pub(crate) struct SubscribeBlocksResponse {
     #[prost(bytes = "bytes", tag = "1")]
-    serialized_block_header: Bytes,
-    #[prost(bytes = "bytes", tag = "2")]
-    serialized_transactions: Bytes,
+    vec_serialized_blocks: Bytes,
 }
 
 #[derive(Clone, prost::Message)]
@@ -1157,9 +1144,7 @@ pub(crate) struct FetchBlocksRequest {
 #[derive(Clone, prost::Message)]
 pub(crate) struct FetchBlocksResponse {
     #[prost(bytes = "bytes", repeated, tag = "1")]
-    vec_serialized_block_header: Vec<Bytes>,
-    #[prost(bytes = "bytes", repeated, tag = "2")]
-    vec_serialized_transactions: Vec<Bytes>,
+    vec_serialized_blocks: Vec<Bytes>,
 }
 
 #[derive(Clone, prost::Message)]
@@ -1205,53 +1190,25 @@ pub(crate) struct GetLatestRoundsResponse {
     highest_accepted: Vec<u32>,
 }
 
-fn chunk_block_headers(block_headers: Vec<Bytes>, chunk_limit: usize) -> Vec<Vec<Bytes>> {
+// Splits a list of byte sequences into chunks where each chunk's total size
+// does not exceed the specified `chunk_limit`.
+// Returns a vector of chunks, each being a vector of `Bytes`.
+fn chunk_data(data: Vec<Bytes>, chunk_limit: usize) -> Vec<Vec<Bytes>> {
     let mut chunks = vec![];
     let mut chunk = vec![];
     let mut chunk_size = 0;
-    for block in block_headers.into_iter() {
-        let block_size = block.len();
-        if !chunk.is_empty() && chunk_size + block_size > chunk_limit {
+    for piece in data.into_iter() {
+        let piece_size = piece.len();
+        if !chunk.is_empty() && chunk_size + piece_size > chunk_limit {
             chunks.push(chunk);
             chunk = vec![];
             chunk_size = 0;
         }
-        chunk.push(block);
-        chunk_size += block_size;
+        chunk.push(piece);
+        chunk_size += piece_size;
     }
     if !chunk.is_empty() {
         chunks.push(chunk);
-    }
-    chunks
-}
-
-fn chunk_blocks(
-    serialized_blocks: (Vec<Bytes>, Vec<Bytes>),
-    chunk_limit: usize,
-) -> Vec<(Vec<Bytes>, Vec<Bytes>)> {
-    let mut chunks = vec![];
-    let mut chunk_header = vec![];
-    let mut chunk_transactions = vec![];
-    let mut chunk_size = 0;
-    let serialized_block_headers = serialized_blocks.0;
-    let serialized_block_transactions = serialized_blocks.1;
-    for (block_header, block_transactions) in serialized_block_headers
-        .iter()
-        .zip(serialized_block_transactions)
-    {
-        let block_size = block_header.len() + block_transactions.len();
-        if !chunk_header.is_empty() && chunk_size + block_size > chunk_limit {
-            chunks.push((chunk_header, chunk_transactions));
-            chunk_header = vec![];
-            chunk_transactions = vec![];
-            chunk_size = 0;
-        }
-        chunk_header.push(block_header.clone());
-        chunk_transactions.push(block_transactions.clone());
-        chunk_size += block_size;
-    }
-    if !chunk_header.is_empty() {
-        chunks.push((chunk_header, chunk_transactions));
     }
     chunks
 }

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -13,7 +13,8 @@ use starfish_config::AuthorityIndex;
 use super::{Store, WriteBatch};
 use crate::{
     block_header::{
-        BlockHeaderAPI as _, BlockHeaderDigest, BlockRef, Round, Slot, VerifiedBlockHeader,
+        BlockHeaderAPI as _, BlockHeaderDigest, BlockRef, Round, Slot, VerifiedBlock,
+        VerifiedBlockHeader,
     },
     commit::{
         CommitAPI as _, CommitDigest, CommitIndex, CommitInfo, CommitRange, CommitRef,
@@ -28,7 +29,8 @@ pub(crate) struct MemStore {
 }
 
 struct Inner {
-    blocks: BTreeMap<(Round, AuthorityIndex, BlockHeaderDigest), VerifiedBlockHeader>,
+    blocks: BTreeMap<(Round, AuthorityIndex, BlockHeaderDigest), VerifiedBlock>,
+    block_headers: BTreeMap<(Round, AuthorityIndex, BlockHeaderDigest), VerifiedBlockHeader>,
     digests_by_authorities: BTreeSet<(AuthorityIndex, Round, BlockHeaderDigest)>,
     commits: BTreeMap<(CommitIndex, CommitDigest), TrustedCommit>,
     commit_votes: BTreeSet<(CommitIndex, CommitDigest, BlockRef)>,
@@ -40,6 +42,7 @@ impl MemStore {
         MemStore {
             inner: RwLock::new(Inner {
                 blocks: BTreeMap::new(),
+                block_headers: BTreeMap::new(),
                 digests_by_authorities: BTreeSet::new(),
                 commits: BTreeMap::new(),
                 commit_votes: BTreeSet::new(),
@@ -59,12 +62,34 @@ impl Store for MemStore {
                 (block_ref.round, block_ref.author, block_ref.digest),
                 block.clone(),
             );
+            inner.block_headers.insert(
+                (block_ref.round, block_ref.author, block_ref.digest),
+                block.verified_block_header.clone(),
+            );
             inner.digests_by_authorities.insert((
                 block_ref.author,
                 block_ref.round,
                 block_ref.digest,
             ));
             for vote in block.commit_votes() {
+                inner
+                    .commit_votes
+                    .insert((vote.index, vote.digest, block_ref));
+            }
+        }
+
+        for block_header in write_batch.block_headers {
+            let block_ref = block_header.reference();
+            inner.block_headers.insert(
+                (block_ref.round, block_ref.author, block_ref.digest),
+                block_header.clone(),
+            );
+            inner.digests_by_authorities.insert((
+                block_ref.author,
+                block_ref.round,
+                block_ref.digest,
+            ));
+            for vote in block_header.commit_votes() {
                 inner
                     .commit_votes
                     .insert((vote.index, vote.digest, block_ref));
@@ -86,13 +111,30 @@ impl Store for MemStore {
         Ok(())
     }
 
-    fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlockHeader>>> {
+    fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>> {
         let inner = self.inner.read();
         let blocks = refs
             .iter()
             .map(|r| inner.blocks.get(&(r.round, r.author, r.digest)).cloned())
             .collect();
         Ok(blocks)
+    }
+
+    fn read_block_headers(
+        &self,
+        refs: &[BlockRef],
+    ) -> ConsensusResult<Vec<Option<VerifiedBlockHeader>>> {
+        let inner = self.inner.read();
+        let block_headers = refs
+            .iter()
+            .map(|r| {
+                inner
+                    .block_headers
+                    .get(&(r.round, r.author, r.digest))
+                    .cloned()
+            })
+            .collect();
+        Ok(block_headers)
     }
 
     fn contains_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>> {
@@ -104,11 +146,24 @@ impl Store for MemStore {
         Ok(exist)
     }
 
+    fn contains_block_headers(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>> {
+        let inner = self.inner.read();
+        let exist = refs
+            .iter()
+            .map(|r| {
+                inner
+                    .block_headers
+                    .contains_key(&(r.round, r.author, r.digest))
+            })
+            .collect();
+        Ok(exist)
+    }
+
     fn scan_blocks_by_author(
         &self,
         author: AuthorityIndex,
         start_round: Round,
-    ) -> ConsensusResult<Vec<VerifiedBlockHeader>> {
+    ) -> ConsensusResult<Vec<VerifiedBlock>> {
         let inner = self.inner.read();
         let mut refs = vec![];
         for &(author, round, digest) in inner.digests_by_authorities.range((
@@ -147,7 +202,7 @@ impl Store for MemStore {
         author: AuthorityIndex,
         num_of_rounds: u64,
         before_round: Option<Round>,
-    ) -> ConsensusResult<Vec<VerifiedBlockHeader>> {
+    ) -> ConsensusResult<Vec<VerifiedBlock>> {
         let before_round = before_round.unwrap_or(Round::MAX);
         let mut refs = VecDeque::new();
         for &(author, round, digest) in self
@@ -171,6 +226,31 @@ impl Store for MemStore {
             );
         }
         Ok(blocks)
+    }
+
+    fn scan_block_headers_by_author(
+        &self,
+        author: AuthorityIndex,
+        start_round: Round,
+    ) -> ConsensusResult<Vec<VerifiedBlockHeader>> {
+        let inner = self.inner.read();
+        let mut refs = vec![];
+        for &(author, round, digest) in inner.digests_by_authorities.range((
+            Included((author, start_round, BlockHeaderDigest::MIN)),
+            Included((author, Round::MAX, BlockHeaderDigest::MAX)),
+        )) {
+            refs.push(BlockRef::new(round, author, digest));
+        }
+        let results = self.read_block_headers(refs.as_slice())?;
+        let mut block_headers = vec![];
+        for (r, block_header) in refs.into_iter().zip(results.into_iter()) {
+            if let Some(block) = block_header {
+                block_headers.push(block);
+            } else {
+                panic!("Block Header {:?} not found!", r);
+            }
+        }
+        Ok(block_headers)
     }
 
     fn read_last_commit(&self) -> ConsensusResult<Option<TrustedCommit>> {

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -23,9 +23,10 @@ pub(crate) trait Store: Send + Sync {
     /// Writes blocks, consensus commits and other data to store atomically.
     fn write(&self, write_batch: WriteBatch) -> ConsensusResult<()>;
 
+    /// Reads blocks for the given refs.
     fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>>;
 
-    /// Reads blocks headers for the given refs.
+    /// Reads block headers for the given refs.
     fn read_block_headers(
         &self,
         refs: &[BlockRef],

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -13,7 +13,7 @@ use starfish_config::AuthorityIndex;
 
 use crate::{
     CommitIndex,
-    block_header::{BlockRef, Round, VerifiedBlockHeader},
+    block_header::{BlockRef, Round, VerifiedBlock, VerifiedBlockHeader},
     commit::{CommitInfo, CommitRange, CommitRef, TrustedCommit},
     error::ConsensusResult,
 };
@@ -23,22 +23,32 @@ pub(crate) trait Store: Send + Sync {
     /// Writes blocks, consensus commits and other data to store atomically.
     fn write(&self, write_batch: WriteBatch) -> ConsensusResult<()>;
 
-    /// Reads blocks for the given refs.
-    fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlockHeader>>>;
+    fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>>;
+
+    /// Reads blocks headers for the given refs.
+    fn read_block_headers(
+        &self,
+        refs: &[BlockRef],
+    ) -> ConsensusResult<Vec<Option<VerifiedBlockHeader>>>;
 
     /// Checks if blocks exist in the store.
+    #[cfg_attr(not(test), expect(dead_code))]
     fn contains_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>>;
+
+    /// Checks if block headers exist in the store.
+    fn contains_block_headers(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>>;
 
     /// Checks whether there is any block at the given slot
     #[allow(dead_code)]
     fn contains_block_at_slot(&self, slot: crate::block_header::Slot) -> ConsensusResult<bool>;
 
     /// Reads blocks for an authority, from start_round.
+    #[cfg_attr(not(test), expect(dead_code))]
     fn scan_blocks_by_author(
         &self,
         authority: AuthorityIndex,
         start_round: Round,
-    ) -> ConsensusResult<Vec<VerifiedBlockHeader>>;
+    ) -> ConsensusResult<Vec<VerifiedBlock>>;
 
     // The method returns the last `num_of_rounds` rounds blocks by author in round
     // ascending order. When a `before_round` is defined then the blocks of
@@ -50,6 +60,12 @@ pub(crate) trait Store: Send + Sync {
         author: AuthorityIndex,
         num_of_rounds: u64,
         before_round: Option<Round>,
+    ) -> ConsensusResult<Vec<VerifiedBlock>>;
+
+    fn scan_block_headers_by_author(
+        &self,
+        author: AuthorityIndex,
+        start_round: Round,
     ) -> ConsensusResult<Vec<VerifiedBlockHeader>>;
 
     /// Reads the last commit.
@@ -68,19 +84,22 @@ pub(crate) trait Store: Send + Sync {
 /// Represents data to be written to the store together atomically.
 #[derive(Debug, Default)]
 pub(crate) struct WriteBatch {
-    pub(crate) blocks: Vec<VerifiedBlockHeader>,
+    pub(crate) blocks: Vec<VerifiedBlock>,
+    pub(crate) block_headers: Vec<VerifiedBlockHeader>,
     pub(crate) commits: Vec<TrustedCommit>,
     pub(crate) commit_info: Vec<(CommitRef, CommitInfo)>,
 }
 
 impl WriteBatch {
     pub(crate) fn new(
-        blocks: Vec<VerifiedBlockHeader>,
+        blocks: Vec<VerifiedBlock>,
+        block_headers: Vec<VerifiedBlockHeader>,
         commits: Vec<TrustedCommit>,
         commit_info: Vec<(CommitRef, CommitInfo)>,
     ) -> Self {
         WriteBatch {
             blocks,
+            block_headers,
             commits,
             commit_info,
         }
@@ -89,8 +108,14 @@ impl WriteBatch {
     // Test setters.
 
     #[cfg(test)]
-    pub(crate) fn blocks(mut self, blocks: Vec<VerifiedBlockHeader>) -> Self {
+    pub(crate) fn blocks(mut self, blocks: Vec<VerifiedBlock>) -> Self {
         self.blocks = blocks;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn block_headers(mut self, block_headers: Vec<VerifiedBlockHeader>) -> Self {
+        self.block_headers = block_headers;
         self
     }
 

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     commit::{CommitAPI as _, CommitDigest, CommitIndex, CommitRange, CommitRef, TrustedCommit},
     error::{ConsensusError, ConsensusResult},
-    network::SerializedBlock,
+    network::SerializedHeaderAndTransactions,
 };
 
 /// Persistent storage with RocksDB.
@@ -220,7 +220,7 @@ impl Store for RocksDBStore {
             if let (Some(serialized_block_header), Some(serialized_transactions)) =
                 (serialized_block_header, serialized_transactions)
             {
-                let block = VerifiedBlock::try_from(SerializedBlock {
+                let block = VerifiedBlock::try_from(SerializedHeaderAndTransactions {
                     serialized_block_header,
                     serialized_transactions,
                 })?;

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -7,6 +7,7 @@ use std::{ops::Bound::Included, time::Duration};
 use bytes::Bytes;
 use iota_macros::fail_point;
 use starfish_config::AuthorityIndex;
+use tracing::info;
 use typed_store::{
     Map as _,
     metrics::SamplingInterval,
@@ -17,17 +18,22 @@ use typed_store::{
 use super::{CommitInfo, Store, WriteBatch};
 use crate::{
     block_header::{
-        BlockHeaderAPI as _, BlockHeaderDigest, BlockRef, Round, SignedBlockHeader,
-        VerifiedBlockHeader,
+        BlockHeaderAPI as _, BlockHeaderDigest, BlockRef, Round, VerifiedBlock, VerifiedBlockHeader,
     },
     commit::{CommitAPI as _, CommitDigest, CommitIndex, CommitRange, CommitRef, TrustedCommit},
     error::{ConsensusError, ConsensusResult},
+    network::SerializedBlock,
 };
 
 /// Persistent storage with RocksDB.
+// TODO: Store block_headers and separately transaction data (not blocks). When
+// trying to read a block, assemble a full block by reading from two column
+// families.
 pub(crate) struct RocksDBStore {
     /// Stores SignedBlock by refs.
-    blocks: DBMap<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
+    transactions: DBMap<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
+    /// Stores SignedBlockHeader by refs.
+    block_headers: DBMap<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
     /// A secondary index that orders refs first by authors.
     digests_by_authorities: DBMap<(AuthorityIndex, Round, BlockHeaderDigest), ()>,
     /// Maps commit index to Commit.
@@ -40,7 +46,8 @@ pub(crate) struct RocksDBStore {
 }
 
 impl RocksDBStore {
-    const BLOCKS_CF: &'static str = "blocks";
+    const TRANSACTIONS_CF: &'static str = "transactions";
+    const BLOCK_HEADERS_CF: &'static str = "block_headers";
     const DIGESTS_BY_AUTHORITIES_CF: &'static str = "digests";
     const COMMITS_CF: &'static str = "commits";
     const COMMIT_VOTES_CF: &'static str = "commit_votes";
@@ -56,10 +63,18 @@ impl RocksDBStore {
         let cf_options = default_db_options().optimize_for_write_throughput().options;
         let column_family_options = vec![
             (
-                Self::BLOCKS_CF,
+                Self::TRANSACTIONS_CF,
                 default_db_options()
                     .optimize_for_write_throughput_no_deletion()
                     // Using larger block is ok since there is not much point reads on the cf.
+                    .set_block_options(512, 128 << 10)
+                    .options,
+            ),
+            (
+                Self::BLOCK_HEADERS_CF,
+                default_db_options()
+                    .optimize_for_write_throughput_no_deletion()
+                    // TODO:think about these constants, for now it is a copy from blocks
                     .set_block_options(512, 128 << 10)
                     .options,
             ),
@@ -76,8 +91,9 @@ impl RocksDBStore {
         )
         .expect("Cannot open database");
 
-        let (blocks, digests_by_authorities, commits, commit_votes, commit_info) = reopen!(&rocksdb,
-            Self::BLOCKS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), bytes::Bytes>,
+        let (blocks, block_headers, digests_by_authorities, commits, commit_votes, commit_info) = reopen!(&rocksdb,
+            Self::TRANSACTIONS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), bytes::Bytes>,
+            Self::BLOCK_HEADERS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), bytes::Bytes>,
             Self::DIGESTS_BY_AUTHORITIES_CF;<(AuthorityIndex, Round, BlockHeaderDigest), ()>,
             Self::COMMITS_CF;<(CommitIndex, CommitDigest), Bytes>,
             Self::COMMIT_VOTES_CF;<(CommitIndex, CommitDigest, BlockRef), ()>,
@@ -85,7 +101,8 @@ impl RocksDBStore {
         );
 
         Self {
-            blocks,
+            transactions: blocks,
+            block_headers,
             digests_by_authorities,
             commits,
             commit_votes,
@@ -98,15 +115,25 @@ impl Store for RocksDBStore {
     fn write(&self, write_batch: WriteBatch) -> ConsensusResult<()> {
         fail_point!("consensus-store-before-write");
 
-        let mut batch = self.blocks.batch();
+        let mut batch = self.transactions.batch();
         for block in write_batch.blocks {
             let block_ref = block.reference();
+            let (serialized_block_header, serialized_transactions) = block.serialized();
             batch
                 .insert_batch(
-                    &self.blocks,
+                    &self.transactions,
                     [(
                         (block_ref.round, block_ref.author, block_ref.digest),
-                        block.serialized(),
+                        serialized_transactions,
+                    )],
+                )
+                .map_err(ConsensusError::RocksDBFailure)?;
+            batch
+                .insert_batch(
+                    &self.block_headers,
+                    [(
+                        (block_ref.round, block_ref.author, block_ref.digest),
+                        serialized_block_header,
                     )],
                 )
                 .map_err(ConsensusError::RocksDBFailure)?;
@@ -117,6 +144,34 @@ impl Store for RocksDBStore {
                 )
                 .map_err(ConsensusError::RocksDBFailure)?;
             for vote in block.commit_votes() {
+                batch
+                    .insert_batch(
+                        &self.commit_votes,
+                        [((vote.index, vote.digest, block_ref), ())],
+                    )
+                    .map_err(ConsensusError::RocksDBFailure)?;
+            }
+        }
+
+        for block_header in write_batch.block_headers {
+            let block_ref = block_header.reference();
+            info!("block header {} pushed to store", block_header);
+            batch
+                .insert_batch(
+                    &self.block_headers,
+                    [(
+                        (block_ref.round, block_ref.author, block_ref.digest),
+                        block_header.serialized(),
+                    )],
+                )
+                .map_err(ConsensusError::RocksDBFailure)?;
+            batch
+                .insert_batch(
+                    &self.digests_by_authorities,
+                    [((block_ref.author, block_ref.round, block_ref.digest), ())],
+                )
+                .map_err(ConsensusError::RocksDBFailure)?;
+            for vote in block_header.commit_votes() {
                 batch
                     .insert_batch(
                         &self.commit_votes,
@@ -149,19 +204,27 @@ impl Store for RocksDBStore {
         Ok(())
     }
 
-    fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlockHeader>>> {
+    fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>> {
         let keys = refs
             .iter()
             .map(|r| (r.round, r.author, r.digest))
             .collect::<Vec<_>>();
-        let serialized = self.blocks.multi_get(keys)?;
+        let serialized_vec_transactions = self.transactions.multi_get(keys.clone())?;
+        let serialized_block_headers = self.block_headers.multi_get(keys)?;
         let mut blocks = vec![];
-        for (key, serialized) in refs.iter().zip(serialized) {
-            if let Some(serialized) = serialized {
-                let signed_block: SignedBlockHeader =
-                    bcs::from_bytes(&serialized).map_err(ConsensusError::MalformedBlock)?;
-                // Only accepted blocks should have been written to storage.
-                let block = VerifiedBlockHeader::new_verified(signed_block, serialized);
+        for ((key, serialized_block_header), serialized_transactions) in refs
+            .iter()
+            .zip(serialized_block_headers)
+            .zip(serialized_vec_transactions)
+        {
+            if let (Some(serialized_block_header), Some(serialized_transactions)) =
+                (serialized_block_header, serialized_transactions)
+            {
+                let block = VerifiedBlock::try_from(SerializedBlock {
+                    serialized_block_header,
+                    serialized_transactions,
+                })?;
+
                 // Makes sure block data is not corrupted, by comparing digests.
                 assert_eq!(*key, block.reference());
                 blocks.push(Some(block));
@@ -172,12 +235,45 @@ impl Store for RocksDBStore {
         Ok(blocks)
     }
 
+    fn read_block_headers(
+        &self,
+        refs: &[BlockRef],
+    ) -> ConsensusResult<Vec<Option<VerifiedBlockHeader>>> {
+        let keys = refs
+            .iter()
+            .map(|r| (r.round, r.author, r.digest))
+            .collect::<Vec<_>>();
+        let serialized_block_headers = self.block_headers.multi_get(keys)?;
+        let mut block_headers = vec![];
+        for (key, serialized_block_header) in refs.iter().zip(serialized_block_headers) {
+            if let Some(serialized_block_header) = serialized_block_header {
+                let block_header = VerifiedBlockHeader::new_from_bytes(serialized_block_header)?;
+
+                // Makes sure block data is not corrupted, by comparing digests.
+                assert_eq!(*key, block_header.reference());
+                block_headers.push(Some(block_header));
+            } else {
+                block_headers.push(None);
+            }
+        }
+        Ok(block_headers)
+    }
+
     fn contains_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>> {
         let refs = refs
             .iter()
             .map(|r| (r.round, r.author, r.digest))
             .collect::<Vec<_>>();
-        let exist = self.blocks.multi_contains_keys(refs)?;
+        let exist = self.transactions.multi_contains_keys(refs)?;
+        Ok(exist)
+    }
+
+    fn contains_block_headers(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>> {
+        let refs = refs
+            .iter()
+            .map(|r| (r.round, r.author, r.digest))
+            .collect::<Vec<_>>();
+        let exist = self.block_headers.multi_contains_keys(refs)?;
         Ok(exist)
     }
 
@@ -193,11 +289,34 @@ impl Store for RocksDBStore {
         Ok(found)
     }
 
-    fn scan_blocks_by_author(
+    fn scan_block_headers_by_author(
         &self,
         author: AuthorityIndex,
         start_round: Round,
     ) -> ConsensusResult<Vec<VerifiedBlockHeader>> {
+        let mut refs = vec![];
+        for kv in self.digests_by_authorities.safe_range_iter((
+            Included((author, start_round, BlockHeaderDigest::MIN)),
+            Included((author, Round::MAX, BlockHeaderDigest::MAX)),
+        )) {
+            let ((author, round, digest), _) = kv?;
+            refs.push(BlockRef::new(round, author, digest));
+        }
+        let results = self.read_block_headers(refs.as_slice())?;
+        let mut block_headers = Vec::with_capacity(refs.len());
+        for (r, block) in refs.into_iter().zip(results.into_iter()) {
+            block_headers.push(
+                block.unwrap_or_else(|| panic!("Storage inconsistency: block {:?} not found!", r)),
+            );
+        }
+        Ok(block_headers)
+    }
+
+    fn scan_blocks_by_author(
+        &self,
+        author: AuthorityIndex,
+        start_round: Round,
+    ) -> ConsensusResult<Vec<VerifiedBlock>> {
         let mut refs = vec![];
         for kv in self.digests_by_authorities.safe_range_iter((
             Included((author, start_round, BlockHeaderDigest::MIN)),
@@ -225,7 +344,7 @@ impl Store for RocksDBStore {
         author: AuthorityIndex,
         num_of_rounds: u64,
         before_round: Option<Round>,
-    ) -> ConsensusResult<Vec<VerifiedBlockHeader>> {
+    ) -> ConsensusResult<Vec<VerifiedBlock>> {
         let before_round = before_round.unwrap_or(Round::MAX);
         let mut refs = std::collections::VecDeque::new();
         for kv in self

--- a/crates/starfish/core/src/storage/store_tests.rs
+++ b/crates/starfish/core/src/storage/store_tests.rs
@@ -9,7 +9,7 @@ use tempfile::TempDir;
 use super::{Store, WriteBatch, mem_store::MemStore, rocksdb_store::RocksDBStore};
 use crate::{
     block_header::{
-        BlockHeaderAPI, BlockHeaderDigest, BlockRef, Slot, TestBlockHeader, VerifiedBlockHeader,
+        BlockHeaderAPI, BlockHeaderDigest, BlockRef, Slot, TestBlockHeader, VerifiedBlock,
     },
     commit::{CommitDigest, TrustedCommit},
 };
@@ -48,11 +48,11 @@ async fn read_and_contain_blocks(
 ) {
     let store = test_store.store();
 
-    let written_blocks: Vec<VerifiedBlockHeader> = vec![
-        VerifiedBlockHeader::new_for_test(TestBlockHeader::new(1, 1).build()),
-        VerifiedBlockHeader::new_for_test(TestBlockHeader::new(1, 0).build()),
-        VerifiedBlockHeader::new_for_test(TestBlockHeader::new(1, 2).build()),
-        VerifiedBlockHeader::new_for_test(TestBlockHeader::new(2, 3).build()),
+    let written_blocks: Vec<VerifiedBlock> = vec![
+        VerifiedBlock::new_for_test(TestBlockHeader::new(1, 1).build()),
+        VerifiedBlock::new_for_test(TestBlockHeader::new(1, 0).build()),
+        VerifiedBlock::new_for_test(TestBlockHeader::new(1, 2).build()),
+        VerifiedBlock::new_for_test(TestBlockHeader::new(2, 3).build()),
     ];
     store
         .write(WriteBatch::default().blocks(written_blocks.clone()))
@@ -124,6 +124,7 @@ async fn read_and_contain_blocks(
     }
 }
 
+// TODO:make test a similar test for headers
 #[rstest]
 #[tokio::test]
 async fn scan_blocks(
@@ -132,14 +133,14 @@ async fn scan_blocks(
     let store = test_store.store();
 
     let written_blocks = vec![
-        VerifiedBlockHeader::new_for_test(TestBlockHeader::new(9, 0).build()),
-        VerifiedBlockHeader::new_for_test(TestBlockHeader::new(10, 0).build()),
-        VerifiedBlockHeader::new_for_test(TestBlockHeader::new(10, 1).build()),
-        VerifiedBlockHeader::new_for_test(TestBlockHeader::new(11, 1).build()),
-        VerifiedBlockHeader::new_for_test(TestBlockHeader::new(11, 3).build()),
-        VerifiedBlockHeader::new_for_test(TestBlockHeader::new(12, 1).build()),
-        VerifiedBlockHeader::new_for_test(TestBlockHeader::new(13, 2).build()),
-        VerifiedBlockHeader::new_for_test(TestBlockHeader::new(13, 1).build()),
+        VerifiedBlock::new_for_test(TestBlockHeader::new(9, 0).build()),
+        VerifiedBlock::new_for_test(TestBlockHeader::new(10, 0).build()),
+        VerifiedBlock::new_for_test(TestBlockHeader::new(10, 1).build()),
+        VerifiedBlock::new_for_test(TestBlockHeader::new(11, 1).build()),
+        VerifiedBlock::new_for_test(TestBlockHeader::new(11, 3).build()),
+        VerifiedBlock::new_for_test(TestBlockHeader::new(12, 1).build()),
+        VerifiedBlock::new_for_test(TestBlockHeader::new(13, 2).build()),
+        VerifiedBlock::new_for_test(TestBlockHeader::new(13, 1).build()),
     ];
     store
         .write(WriteBatch::default().blocks(written_blocks.clone()))
@@ -164,10 +165,10 @@ async fn scan_blocks(
     }
 
     let additional_blocks = vec![
-        VerifiedBlockHeader::new_for_test(TestBlockHeader::new(14, 2).build()),
-        VerifiedBlockHeader::new_for_test(TestBlockHeader::new(15, 0).build()),
-        VerifiedBlockHeader::new_for_test(TestBlockHeader::new(15, 1).build()),
-        VerifiedBlockHeader::new_for_test(TestBlockHeader::new(16, 3).build()),
+        VerifiedBlock::new_for_test(TestBlockHeader::new(14, 2).build()),
+        VerifiedBlock::new_for_test(TestBlockHeader::new(15, 0).build()),
+        VerifiedBlock::new_for_test(TestBlockHeader::new(15, 1).build()),
+        VerifiedBlock::new_for_test(TestBlockHeader::new(16, 3).build()),
     ];
     store
         .write(WriteBatch::default().blocks(additional_blocks.clone()))

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -328,7 +328,7 @@ mod test {
         for _ in 0..10 {
             tokio::time::sleep(Duration::from_secs(1)).await;
             let service = authority_service.lock();
-            if service.handle_send_block.len() >= 100 {
+            if service.handle_subscribed_block.len() >= 100 {
                 break;
             }
         }
@@ -336,8 +336,8 @@ mod test {
         // Even if the stream ends after 10 blocks, the subscriber should retry and get
         // enough blocks eventually.
         let service = authority_service.lock();
-        assert!(service.handle_send_block.len() >= 100);
-        for (p, block) in service.handle_send_block.iter() {
+        assert!(service.handle_subscribed_block.len() >= 100);
+        for (p, block) in service.handle_subscribed_block.iter() {
             assert_eq!(*p, peer);
             assert_eq!(
                 *block,

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -239,7 +239,10 @@ mod test {
         block_header::BlockRef,
         commit::CommitRange,
         error::ConsensusResult,
-        network::{BlockStream, SerializedBlock, test_network::TestService},
+        network::{
+            BlockStream, SerializedBlock, SerializedHeaderAndTransactions,
+            test_network::TestService,
+        },
         storage::mem_store::MemStore,
     };
 
@@ -261,7 +264,13 @@ mod test {
         ) -> ConsensusResult<BlockStream> {
             let block_stream = stream::unfold((), |_| async {
                 sleep(Duration::from_millis(1)).await;
-                Some((SerializedBlock::new_for_test(Bytes::from(vec![1u8; 8])), ()))
+                Some((
+                    SerializedBlock::try_from(SerializedHeaderAndTransactions::new_for_test(
+                        Bytes::from(vec![1u8; 8]),
+                    ))
+                    .unwrap(),
+                    (),
+                ))
             })
             .take(10);
             Ok(Box::pin(block_stream))
@@ -273,7 +282,7 @@ mod test {
             _block_refs: Vec<BlockRef>,
             _highest_accepted_rounds: Vec<Round>,
             _timeout: Duration,
-        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
+        ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Unimplemented")
         }
 
@@ -341,7 +350,10 @@ mod test {
             assert_eq!(*p, peer);
             assert_eq!(
                 *block,
-                SerializedBlock::new_for_test(Bytes::from(vec![1u8; 8]))
+                SerializedBlock::try_from(SerializedHeaderAndTransactions::new_for_test(
+                    Bytes::from(vec![1u8; 8])
+                ))
+                .unwrap()
             );
         }
     }

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -62,7 +62,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
         let authority_service = self.authority_service.clone();
         let last_received = {
             let dag_state = self.dag_state.read();
-            dag_state.get_last_block_for_authority(peer).round()
+            dag_state.get_last_block_header_for_authority(peer).round()
         };
 
         let mut subscriptions = self.subscriptions.lock();
@@ -193,7 +193,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
                             .with_label_values(&[peer_hostname])
                             .inc();
                         let result = authority_service
-                            .handle_send_block(peer, block.clone())
+                            .handle_subscribed_block(peer, block.clone())
                             .await;
                         if let Err(e) = result {
                             match e {
@@ -236,11 +236,10 @@ mod test {
 
     use super::*;
     use crate::{
-        VerifiedBlockHeader,
         block_header::BlockRef,
         commit::CommitRange,
         error::ConsensusResult,
-        network::{BlockStream, test_network::TestService},
+        network::{BlockStream, SerializedBlock, test_network::TestService},
         storage::mem_store::MemStore,
     };
 
@@ -254,15 +253,6 @@ mod test {
 
     #[async_trait]
     impl NetworkClient for SubscriberTestClient {
-        async fn send_block(
-            &self,
-            _peer: AuthorityIndex,
-            _block: &VerifiedBlockHeader,
-            _timeout: Duration,
-        ) -> ConsensusResult<()> {
-            unimplemented!("Unimplemented")
-        }
-
         async fn subscribe_blocks(
             &self,
             _peer: AuthorityIndex,
@@ -271,13 +261,23 @@ mod test {
         ) -> ConsensusResult<BlockStream> {
             let block_stream = stream::unfold((), |_| async {
                 sleep(Duration::from_millis(1)).await;
-                Some((Bytes::from(vec![1u8; 8]), ()))
+                Some((SerializedBlock::new_for_test(Bytes::from(vec![1u8; 8])), ()))
             })
             .take(10);
             Ok(Box::pin(block_stream))
         }
 
         async fn fetch_blocks(
+            &self,
+            _peer: AuthorityIndex,
+            _block_refs: Vec<BlockRef>,
+            _highest_accepted_rounds: Vec<Round>,
+            _timeout: Duration,
+        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
+            unimplemented!("Unimplemented")
+        }
+
+        async fn fetch_block_headers(
             &self,
             _peer: AuthorityIndex,
             _block_refs: Vec<BlockRef>,
@@ -296,7 +296,7 @@ mod test {
             unimplemented!("Unimplemented")
         }
 
-        async fn fetch_latest_blocks(
+        async fn fetch_latest_block_headers(
             &self,
             _peer: AuthorityIndex,
             _authorities: Vec<AuthorityIndex>,
@@ -339,7 +339,10 @@ mod test {
         assert!(service.handle_send_block.len() >= 100);
         for (p, block) in service.handle_send_block.iter() {
             assert_eq!(*p, peer);
-            assert_eq!(*block, Bytes::from(vec![1u8; 8]),);
+            assert_eq!(
+                *block,
+                SerializedBlock::new_for_test(Bytes::from(vec![1u8; 8]))
+            );
         }
     }
 }

--- a/crates/starfish/core/src/synchronizer.rs
+++ b/crates/starfish/core/src/synchronizer.rs
@@ -1185,7 +1185,7 @@ mod tests {
         core_thread::{CoreThreadDispatcher, tests::MockCoreThreadDispatcher},
         dag_state::DagState,
         error::{ConsensusError, ConsensusResult},
-        network::{BlockStream, NetworkClient},
+        network::{BlockStream, NetworkClient, SerializedBlock},
         storage::mem_store::MemStore,
         synchronizer::{
             FETCH_BLOCKS_CONCURRENCY, FETCH_REQUEST_TIMEOUT, InflightBlockHeadersMap,
@@ -1258,18 +1258,15 @@ mod tests {
             block_refs: Vec<BlockRef>,
             _highest_accepted_rounds: Vec<Round>,
             _timeout: Duration,
-        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
+        ) -> ConsensusResult<Vec<Bytes>> {
             let mut lock = self.fetch_blocks_requests.lock().await;
             let response = lock
                 .remove(&(block_refs, peer))
                 .expect("Unexpected fetch blocks request made");
 
-            let mut serialized_headers = vec![];
-            let mut serialized_block_transactions = vec![];
+            let mut serialized_blocks = vec![];
             for block in response.0.into_iter() {
-                let (serialized_header, serialized_transactions) = block.serialized();
-                serialized_headers.push(serialized_header.clone());
-                serialized_block_transactions.push(serialized_transactions.clone());
+                serialized_blocks.push(SerializedBlock::try_from(block).unwrap().serialized_block);
             }
 
             drop(lock);
@@ -1278,7 +1275,7 @@ mod tests {
                 sleep(latency).await;
             }
 
-            Ok((serialized_headers, serialized_block_transactions))
+            Ok(serialized_blocks)
         }
 
         async fn fetch_block_headers(

--- a/crates/starfish/core/src/synchronizer.rs
+++ b/crates/starfish/core/src/synchronizer.rs
@@ -66,7 +66,7 @@ const MAX_AUTHORITIES_TO_FETCH_PER_BLOCK: usize = 2;
 const SYNC_MISSING_BLOCK_ROUND_THRESHOLD: u32 = 50;
 
 struct BlocksGuard {
-    map: Arc<InflightBlocksMap>,
+    map: Arc<InflightBlockHeadersMap>,
     block_refs: BTreeSet<BlockRef>,
     peer: AuthorityIndex,
 }
@@ -82,11 +82,11 @@ impl Drop for BlocksGuard {
 // there is a maximum number of authorities that can concurrently fetch it. The
 // authority ids that are currently fetching a block are set on the
 // corresponding `BTreeSet` and basically they act as "locks".
-struct InflightBlocksMap {
+struct InflightBlockHeadersMap {
     inner: Mutex<HashMap<BlockRef, BTreeSet<AuthorityIndex>>>,
 }
 
-impl InflightBlocksMap {
+impl InflightBlockHeadersMap {
     fn new() -> Arc<Self> {
         Arc::new(Self {
             inner: Mutex::new(HashMap::new()),
@@ -179,12 +179,12 @@ impl InflightBlocksMap {
 }
 
 enum Command {
-    FetchBlocks {
+    FetchBlockHeaders {
         missing_block_refs: BTreeSet<BlockRef>,
         peer_index: AuthorityIndex,
         result: oneshot::Sender<Result<(), ConsensusError>>,
     },
-    FetchOwnLastBlock,
+    FetchOwnLastBlockHeader,
     KickOffScheduler,
 }
 
@@ -196,14 +196,14 @@ pub(crate) struct SynchronizerHandle {
 impl SynchronizerHandle {
     /// Explicitly asks from the synchronizer to fetch the blocks - provided the
     /// block_refs set - from the peer authority.
-    pub(crate) async fn fetch_blocks(
+    pub(crate) async fn fetch_block_headers(
         &self,
         missing_block_refs: BTreeSet<BlockRef>,
         peer_index: AuthorityIndex,
     ) -> ConsensusResult<()> {
         let (sender, receiver) = oneshot::channel();
         self.commands_sender
-            .send(Command::FetchBlocks {
+            .send(Command::FetchBlockHeaders {
                 missing_block_refs,
                 peer_index,
                 result: sender,
@@ -260,7 +260,7 @@ pub(crate) struct Synchronizer<C: NetworkClient, V: BlockVerifier, D: CoreThread
     fetch_own_last_block_task: JoinSet<()>,
     network_client: Arc<C>,
     block_verifier: Arc<V>,
-    inflight_blocks_map: Arc<InflightBlocksMap>,
+    inflight_block_headers_map: Arc<InflightBlockHeadersMap>,
     commands_sender: Sender<Command>,
 }
 
@@ -278,7 +278,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
     ) -> Arc<SynchronizerHandle> {
         let (commands_sender, commands_receiver) =
             channel("consensus_synchronizer_commands", 1_000);
-        let inflight_blocks_map = InflightBlocksMap::new();
+        let inflight_block_headers_map = InflightBlockHeadersMap::new();
 
         // Spawn the tasks to fetch the blocks from the others
         let mut fetch_block_senders = BTreeMap::new();
@@ -289,7 +289,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             }
             let (sender, receiver) =
                 channel("consensus_synchronizer_fetches", FETCH_BLOCKS_CONCURRENCY);
-            let fetch_blocks_from_authority_async = Self::fetch_blocks_from_authority(
+            let fetch_blocks_from_authority_async = Self::fetch_block_headers_from_authority(
                 index,
                 network_client.clone(),
                 block_verifier.clone(),
@@ -308,7 +308,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
         if sync_last_known_own_block {
             commands_sender
-                .try_send(Command::FetchOwnLastBlock)
+                .try_send(Command::FetchOwnLastBlockHeader)
                 .expect("Failed to sync our last block");
         }
 
@@ -324,7 +324,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 fetch_own_last_block_task: JoinSet::new(),
                 network_client,
                 block_verifier,
-                inflight_blocks_map,
+                inflight_block_headers_map,
                 commands_sender: commands_sender_clone,
                 dag_state,
             };
@@ -350,9 +350,9 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             tokio::select! {
                 Some(command) = self.commands_receiver.recv() => {
                     match command {
-                        Command::FetchBlocks{ missing_block_refs, peer_index, result } => {
+                        Command::FetchBlockHeaders{ missing_block_refs, peer_index, result } => {
                             if peer_index == self.context.own_index {
-                                error!("We should never attempt to fetch blocks from our own node");
+                                error!("We should never attempt to fetch block headers from our own node");
                                 continue;
                             }
 
@@ -363,7 +363,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                                 .take(MAX_BLOCKS_PER_FETCH)
                                 .collect();
 
-                            let blocks_guard = self.inflight_blocks_map.lock_blocks(missing_block_refs, peer_index);
+                            let blocks_guard = self.inflight_block_headers_map.lock_blocks(missing_block_refs, peer_index);
                             let Some(blocks_guard) = blocks_guard else {
                                 result.send(Ok(())).ok();
                                 continue;
@@ -385,7 +385,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
                             result.send(r).ok();
                         }
-                        Command::FetchOwnLastBlock => {
+                        Command::FetchOwnLastBlockHeader => {
                             if self.fetch_own_last_block_task.is_empty() {
                                 self.start_fetch_own_last_block_task();
                             }
@@ -449,7 +449,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         }
     }
 
-    async fn fetch_blocks_from_authority(
+    async fn fetch_block_headers_from_authority(
         peer_index: AuthorityIndex,
         network_client: Arc<C>,
         block_verifier: Arc<V>,
@@ -471,12 +471,12 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                     // get the highest accepted rounds
                     let highest_rounds = Self::get_highest_accepted_rounds(dag_state.clone(), &context);
 
-                    requests.push(Self::fetch_blocks_request(network_client.clone(), peer_index, blocks_guard, highest_rounds, FETCH_REQUEST_TIMEOUT, 1))
+                    requests.push(Self::fetch_block_headers_request(network_client.clone(), peer_index, blocks_guard, highest_rounds, FETCH_REQUEST_TIMEOUT, 1))
                 },
                 Some((response, blocks_guard, retries, _peer, highest_rounds)) = requests.next() => {
                     match response {
                         Ok(blocks) => {
-                            if let Err(err) = Self::process_fetched_blocks(blocks,
+                            if let Err(err) = Self::process_fetched_block_headers(blocks,
                                 peer_index,
                                 blocks_guard,
                                 core_dispatcher.clone(),
@@ -491,7 +491,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                         },
                         Err(_) => {
                             if retries <= MAX_RETRIES {
-                                requests.push(Self::fetch_blocks_request(network_client.clone(), peer_index, blocks_guard, highest_rounds, FETCH_REQUEST_TIMEOUT, retries))
+                                requests.push(Self::fetch_block_headers_request(network_client.clone(), peer_index, blocks_guard, highest_rounds, FETCH_REQUEST_TIMEOUT, retries))
                             } else {
                                 warn!("Max retries {retries} reached while trying to fetch blocks from peer {peer_index} {peer_hostname}.");
                                 // we don't necessarily need to do, but dropping the guard here to unlock the blocks
@@ -511,8 +511,8 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
     /// Processes the requested raw fetched blocks from peer `peer_index`. If no
     /// error is returned then the verified blocks are immediately sent to
     /// Core for processing.
-    async fn process_fetched_blocks(
-        serialized_blocks: Vec<Bytes>,
+    async fn process_fetched_block_headers(
+        serialized_headers: Vec<Bytes>,
         peer_index: AuthorityIndex,
         requested_blocks_guard: BlocksGuard,
         core_dispatcher: Arc<D>,
@@ -528,7 +528,8 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
         // Ensure that all the returned blocks do not go over the total max allowed
         // returned blocks
-        if serialized_blocks.len() > requested_blocks_guard.block_refs.len() + MAX_ADDITIONAL_BLOCKS
+        if serialized_headers.len()
+            > requested_blocks_guard.block_refs.len() + MAX_ADDITIONAL_BLOCKS
         {
             return Err(ConsensusError::TooManyFetchedBlocksReturned(peer_index));
         }
@@ -538,7 +539,14 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             .spawn_blocking({
                 let block_verifier = block_verifier.clone();
                 let context = context.clone();
-                move || Self::verify_blocks(serialized_blocks, block_verifier, &context, peer_index)
+                move || {
+                    Self::verify_block_headers(
+                        serialized_headers,
+                        block_verifier,
+                        &context,
+                        peer_index,
+                    )
+                }
             })
             .await
             .expect("Spawn blocking should not fail")?;
@@ -594,7 +602,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         // we don't want this mechanism to keep feedback looping on fetching
         // more blocks. The periodic synchronization will take care of that.
         let missing_blocks = core_dispatcher
-            .add_blocks(blocks)
+            .add_block_headers(blocks)
             .await
             .map_err(|_| ConsensusError::Shutdown)?;
 
@@ -624,31 +632,30 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         dag_state: Arc<RwLock<DagState>>,
         context: &Arc<Context>,
     ) -> Vec<Round> {
-        let blocks = dag_state
+        let block_headers = dag_state
             .read()
-            .get_last_cached_block_per_authority(Round::MAX);
-        assert_eq!(blocks.len(), context.committee.size());
+            .get_last_cached_block_header_per_authority(Round::MAX);
+        assert_eq!(block_headers.len(), context.committee.size());
 
-        blocks
+        block_headers
             .into_iter()
             .map(|(block, _)| block.round())
             .collect::<Vec<_>>()
     }
 
-    fn verify_blocks(
-        serialized_blocks: Vec<Bytes>,
+    fn verify_block_headers(
+        serialized_block_headers: Vec<Bytes>,
         block_verifier: Arc<V>,
         context: &Context,
         peer_index: AuthorityIndex,
     ) -> ConsensusResult<Vec<VerifiedBlockHeader>> {
-        let mut verified_blocks = Vec::new();
+        let mut verified_block_headers = Vec::new();
 
-        for serialized_block in serialized_blocks {
-            let signed_block: SignedBlockHeader =
-                bcs::from_bytes(&serialized_block).map_err(ConsensusError::MalformedBlock)?;
-
-            // TODO: dedup block verifications, here and with fetched blocks.
-            if let Err(e) = block_verifier.verify(&signed_block) {
+        for serialized_block_header in serialized_block_headers.clone().into_iter() {
+            let signed_block_header: SignedBlockHeader = bcs::from_bytes(&serialized_block_header)
+                .map_err(ConsensusError::MalformedBlockHeader)?;
+            // TODO: dedup block verifications, here and with fetched blocks??
+            if let Err(e) = block_verifier.verify(&signed_block_header) {
                 // TODO: we might want to use a different metric to track the invalid "served"
                 // blocks from the invalid "proposed" ones.
                 let hostname = context.committee.authority(peer_index).hostname.clone();
@@ -662,29 +669,31 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 warn!("Invalid block received from {}: {}", peer_index, e);
                 return Err(e);
             }
-            let verified_block = VerifiedBlockHeader::new_verified(signed_block, serialized_block);
+
+            let verified_block_header =
+                VerifiedBlockHeader::new_verified(signed_block_header, serialized_block_header);
 
             // Dropping is ok because the block will be refetched.
             // TODO: improve efficiency, maybe suspend and continue processing the block
             // asynchronously.
             let now = context.clock.timestamp_utc_ms();
-            if now < verified_block.timestamp_ms() {
+            if now < verified_block_header.timestamp_ms() {
                 warn!(
                     "Synced block {} timestamp {} is in the future (now={}). Ignoring.",
-                    verified_block.reference(),
-                    verified_block.timestamp_ms(),
+                    verified_block_header.reference(),
+                    verified_block_header.timestamp_ms(),
                     now
                 );
                 continue;
             }
 
-            verified_blocks.push(verified_block);
+            verified_block_headers.push(verified_block_header);
         }
 
-        Ok(verified_blocks)
+        Ok(verified_block_headers)
     }
 
-    async fn fetch_blocks_request(
+    async fn fetch_block_headers_request(
         network_client: Arc<C>,
         peer: AuthorityIndex,
         blocks_guard: BlocksGuard,
@@ -701,7 +710,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         let start = Instant::now();
         let resp = timeout(
             request_timeout,
-            network_client.fetch_blocks(
+            network_client.fetch_block_headers(
                 peer,
                 blocks_guard
                     .block_refs
@@ -754,7 +763,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                     let own_index = context.own_index;
                     async move {
                         sleep(fetch_own_block_delay).await;
-                        let r = network_client_cloned.fetch_latest_blocks(authority_index, vec![own_index], FETCH_REQUEST_TIMEOUT).await;
+                        let r = network_client_cloned.fetch_latest_block_headers(authority_index, vec![own_index], FETCH_REQUEST_TIMEOUT).await;
                         (r, authority_index)
                     }
                 };
@@ -789,7 +798,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 let mut retry_delay_step = Duration::from_millis(500);
                 'main:loop {
                     if context.committee.size() == 1 {
-                        highest_round = dag_state.read().get_last_proposed_block().round();
+                        highest_round = dag_state.read().get_last_proposed_block_header().round();
                         info!("Only one node in the network, will not try fetching own last block from peers.");
                         break 'main;
                     }
@@ -885,7 +894,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         let block_verifier = self.block_verifier.clone();
         let commit_vote_monitor = self.commit_vote_monitor.clone();
         let core_dispatcher = self.core_dispatcher.clone();
-        let blocks_to_fetch = self.inflight_blocks_map.clone();
+        let blocks_to_fetch = self.inflight_block_headers_map.clone();
         let commands_sender = self.commands_sender.clone();
         let dag_state = self.dag_state.clone();
 
@@ -932,7 +941,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 fail_point_async!("consensus-delay");
 
                 // Fetch blocks from peers
-                let results = Self::fetch_blocks_from_authorities(
+                let results = Self::fetch_block_headers_from_authorities(
                     context.clone(),
                     blocks_to_fetch.clone(),
                     network_client,
@@ -955,7 +964,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 for (blocks_guard, fetched_blocks, peer) in results {
                     total_fetched += fetched_blocks.len();
 
-                    if let Err(err) = Self::process_fetched_blocks(
+                    if let Err(err) = Self::process_fetched_block_headers(
                         fetched_blocks,
                         peer,
                         blocks_guard,
@@ -1000,9 +1009,9 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
     /// successfully responded and any corresponding additional ancestor blocks.
     /// Each element of the vector is a tuple which contains the requested
     /// missing block refs, the returned blocks and the peer authority index.
-    async fn fetch_blocks_from_authorities(
+    async fn fetch_block_headers_from_authorities(
         context: Arc<Context>,
-        inflight_blocks: Arc<InflightBlocksMap>,
+        inflight_block_headers: Arc<InflightBlockHeadersMap>,
         network_client: Arc<C>,
         missing_blocks: BTreeSet<BlockRef>,
         dag_state: Arc<RwLock<DagState>>,
@@ -1063,7 +1072,8 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
             // lock the blocks to be fetched. If no lock can be acquired for any of the
             // blocks then don't bother
-            if let Some(blocks_guard) = inflight_blocks.lock_blocks(block_refs.clone(), peer) {
+            if let Some(blocks_guard) = inflight_block_headers.lock_blocks(block_refs.clone(), peer)
+            {
                 info!(
                     "Periodic sync of {} missing blocks from peer {} {}: {}",
                     block_refs.len(),
@@ -1075,7 +1085,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                         .collect::<Vec<_>>()
                         .join(", ")
                 );
-                request_futures.push(Self::fetch_blocks_request(
+                request_futures.push(Self::fetch_block_headers_request(
                     network_client.clone(),
                     peer,
                     blocks_guard,
@@ -1109,7 +1119,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                             // try again if there is any peer left
                             if let Some(next_peer) = peers.next() {
                                 // do best effort to lock guards. If we can't lock then don't bother at this run.
-                                if let Some(blocks_guard) = inflight_blocks.swap_locks(blocks_guard, next_peer) {
+                                if let Some(blocks_guard) = inflight_block_headers.swap_locks(blocks_guard, next_peer) {
                                     info!(
                                         "Retrying syncing {} missing blocks from peer {}: {}",
                                         blocks_guard.block_refs.len(),
@@ -1120,7 +1130,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                                             .collect::<Vec<_>>()
                                             .join(", ")
                                     );
-                                    request_futures.push(Self::fetch_blocks_request(
+                                    request_futures.push(Self::fetch_block_headers_request(
                                         network_client.clone(),
                                         next_peer,
                                         blocks_guard,
@@ -1165,7 +1175,9 @@ mod tests {
     use crate::{
         BlockHeaderAPI, CommitDigest, CommitIndex,
         authority_service::COMMIT_LAG_MULTIPLIER,
-        block_header::{BlockHeaderDigest, BlockRef, Round, TestBlockHeader, VerifiedBlockHeader},
+        block_header::{
+            BlockHeaderDigest, BlockRef, Round, TestBlockHeader, VerifiedBlock, VerifiedBlockHeader,
+        },
         block_verifier::NoopBlockVerifier,
         commit::{CommitRange, CommitVote, TrustedCommit},
         commit_vote_monitor::CommitVoteMonitor,
@@ -1176,68 +1188,61 @@ mod tests {
         network::{BlockStream, NetworkClient},
         storage::mem_store::MemStore,
         synchronizer::{
-            FETCH_BLOCKS_CONCURRENCY, FETCH_REQUEST_TIMEOUT, InflightBlocksMap,
+            FETCH_BLOCKS_CONCURRENCY, FETCH_REQUEST_TIMEOUT, InflightBlockHeadersMap,
             MAX_BLOCKS_PER_FETCH, SYNC_MISSING_BLOCK_ROUND_THRESHOLD, Synchronizer,
         },
     };
 
     type FetchRequestKey = (Vec<BlockRef>, AuthorityIndex);
-    type FetchRequestResponse = (Vec<VerifiedBlockHeader>, Option<Duration>);
+    type FetchRequestHeadersResponse = (Vec<VerifiedBlockHeader>, Option<Duration>);
+    type FetchRequestBlocksResponse = (Vec<VerifiedBlock>, Option<Duration>);
     type FetchLatestBlockKey = (AuthorityIndex, Vec<AuthorityIndex>);
-    type FetchLatestBlockResponse = (Vec<VerifiedBlockHeader>, Option<Duration>);
+    type FetchLatestHeaderResponse = (Vec<VerifiedBlockHeader>, Option<Duration>);
 
     #[derive(Default)]
     struct MockNetworkClient {
-        fetch_blocks_requests: Mutex<BTreeMap<FetchRequestKey, FetchRequestResponse>>,
-        fetch_latest_blocks_requests:
-            Mutex<BTreeMap<FetchLatestBlockKey, Vec<FetchLatestBlockResponse>>>,
+        fetch_blocks_requests: Mutex<BTreeMap<FetchRequestKey, FetchRequestBlocksResponse>>,
+        fetch_block_headers_requests: Mutex<BTreeMap<FetchRequestKey, FetchRequestHeadersResponse>>,
+        fetch_latest_block_headers_requests:
+            Mutex<BTreeMap<FetchLatestBlockKey, Vec<FetchLatestHeaderResponse>>>,
     }
 
     impl MockNetworkClient {
-        async fn stub_fetch_blocks(
+        async fn stub_fetch_block_headers(
             &self,
-            blocks: Vec<VerifiedBlockHeader>,
+            block_headers: Vec<VerifiedBlockHeader>,
             peer: AuthorityIndex,
             latency: Option<Duration>,
         ) {
-            let mut lock = self.fetch_blocks_requests.lock().await;
-            let block_refs = blocks
+            let mut lock = self.fetch_block_headers_requests.lock().await;
+            let block_refs = block_headers
                 .iter()
                 .map(|block| block.reference())
                 .collect::<Vec<_>>();
-            lock.insert((block_refs, peer), (blocks, latency));
+            lock.insert((block_refs, peer), (block_headers, latency));
         }
 
-        async fn stub_fetch_latest_blocks(
+        async fn stub_fetch_latest_block_headers(
             &self,
             blocks: Vec<VerifiedBlockHeader>,
             peer: AuthorityIndex,
             authorities: Vec<AuthorityIndex>,
             latency: Option<Duration>,
         ) {
-            let mut lock = self.fetch_latest_blocks_requests.lock().await;
+            let mut lock = self.fetch_latest_block_headers_requests.lock().await;
             lock.entry((peer, authorities))
                 .or_default()
                 .push((blocks, latency));
         }
 
-        async fn fetch_latest_blocks_pending_calls(&self) -> usize {
-            let lock = self.fetch_latest_blocks_requests.lock().await;
+        async fn fetch_latest_block_headers_pending_calls(&self) -> usize {
+            let lock = self.fetch_latest_block_headers_requests.lock().await;
             lock.len()
         }
     }
 
     #[async_trait]
     impl NetworkClient for MockNetworkClient {
-        async fn send_block(
-            &self,
-            _peer: AuthorityIndex,
-            _serialized_block: &VerifiedBlockHeader,
-            _timeout: Duration,
-        ) -> ConsensusResult<()> {
-            unimplemented!("Unimplemented")
-        }
-
         async fn subscribe_blocks(
             &self,
             _peer: AuthorityIndex,
@@ -1253,17 +1258,19 @@ mod tests {
             block_refs: Vec<BlockRef>,
             _highest_accepted_rounds: Vec<Round>,
             _timeout: Duration,
-        ) -> ConsensusResult<Vec<Bytes>> {
+        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
             let mut lock = self.fetch_blocks_requests.lock().await;
             let response = lock
                 .remove(&(block_refs, peer))
                 .expect("Unexpected fetch blocks request made");
 
-            let serialised = response
-                .0
-                .into_iter()
-                .map(|block| block.serialized().clone())
-                .collect::<Vec<_>>();
+            let mut serialized_headers = vec![];
+            let mut serialized_block_transactions = vec![];
+            for block in response.0.into_iter() {
+                let (serialized_header, serialized_transactions) = block.serialized();
+                serialized_headers.push(serialized_header.clone());
+                serialized_block_transactions.push(serialized_transactions.clone());
+            }
 
             drop(lock);
 
@@ -1271,7 +1278,33 @@ mod tests {
                 sleep(latency).await;
             }
 
-            Ok(serialised)
+            Ok((serialized_headers, serialized_block_transactions))
+        }
+
+        async fn fetch_block_headers(
+            &self,
+            peer: AuthorityIndex,
+            block_refs: Vec<BlockRef>,
+            _highest_accepted_rounds: Vec<Round>,
+            _timeout: Duration,
+        ) -> ConsensusResult<Vec<Bytes>> {
+            let mut lock = self.fetch_block_headers_requests.lock().await;
+            let response = lock
+                .remove(&(block_refs, peer))
+                .expect("Unexpected fetch block headers request made");
+
+            let mut block_headers = vec![];
+            for block_header in response.0.into_iter() {
+                block_headers.push(block_header.serialized().clone());
+            }
+
+            drop(lock);
+
+            if let Some(latency) = response.1 {
+                sleep(latency).await;
+            }
+
+            Ok(block_headers)
         }
 
         async fn fetch_commits(
@@ -1283,23 +1316,23 @@ mod tests {
             unimplemented!("Unimplemented")
         }
 
-        async fn fetch_latest_blocks(
+        async fn fetch_latest_block_headers(
             &self,
             peer: AuthorityIndex,
             authorities: Vec<AuthorityIndex>,
             _timeout: Duration,
         ) -> ConsensusResult<Vec<Bytes>> {
-            let mut lock = self.fetch_latest_blocks_requests.lock().await;
+            let mut lock = self.fetch_latest_block_headers_requests.lock().await;
             let mut responses = lock
                 .remove(&(peer, authorities.clone()))
                 .expect("Unexpected fetch blocks request made");
 
             let response = responses.remove(0);
-            let serialised = response
-                .0
-                .into_iter()
-                .map(|block| block.serialized().clone())
-                .collect::<Vec<_>>();
+            let mut serialized_headers = vec![];
+            for block in response.0.into_iter() {
+                let serialized_header = block.serialized();
+                serialized_headers.push(serialized_header.clone());
+            }
 
             if !responses.is_empty() {
                 lock.insert((peer, authorities), responses);
@@ -1311,14 +1344,14 @@ mod tests {
                 sleep(latency).await;
             }
 
-            Ok(serialised)
+            Ok(serialized_headers)
         }
     }
 
     #[test]
     fn inflight_blocks_map() {
         // GIVEN
-        let map = InflightBlocksMap::new();
+        let map = InflightBlockHeadersMap::new();
         let some_block_refs = [
             BlockRef::new(1, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN),
             BlockRef::new(10, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN),
@@ -1419,17 +1452,22 @@ mod tests {
         // AND stub the fetch_blocks request from peer 1
         let peer = AuthorityIndex::new_for_test(1);
         network_client
-            .stub_fetch_blocks(expected_blocks.clone(), peer, None)
+            .stub_fetch_block_headers(expected_blocks.clone(), peer, None)
             .await;
 
         // WHEN request missing blocks from peer 1
-        assert!(handle.fetch_blocks(missing_blocks, peer).await.is_ok());
+        assert!(
+            handle
+                .fetch_block_headers(missing_blocks, peer)
+                .await
+                .is_ok()
+        );
 
         // Wait a little bit until those have been added in core
         sleep(Duration::from_millis(1_000)).await;
 
         // THEN ensure those ended up in Core
-        let added_blocks = core_dispatcher.get_add_blocks().await;
+        let added_blocks = core_dispatcher.get_and_drain_block_headers().await;
         assert_eq!(added_blocks, expected_blocks);
     }
 
@@ -1469,7 +1507,7 @@ mod tests {
             // stub the fetch_blocks request from peer 1 and give some high response latency
             // so requests can start blocking the peer task.
             network_client
-                .stub_fetch_blocks(
+                .stub_fetch_block_headers(
                     vec![block.clone()],
                     peer,
                     Some(Duration::from_millis(5_000)),
@@ -1482,14 +1520,19 @@ mod tests {
             // WHEN requesting to fetch the blocks, it should not succeed for the last
             // request and get an error with "saturated" synchronizer
             if iter.peek().is_none() {
-                match handle.fetch_blocks(missing_blocks, peer).await {
+                match handle.fetch_block_headers(missing_blocks, peer).await {
                     Err(ConsensusError::SynchronizerSaturated(index)) => {
                         assert_eq!(index, peer);
                     }
                     _ => panic!("A saturated synchronizer error was expected"),
                 }
             } else {
-                assert!(handle.fetch_blocks(missing_blocks, peer).await.is_ok());
+                assert!(
+                    handle
+                        .fetch_block_headers(missing_blocks, peer)
+                        .await
+                        .is_ok()
+                );
             }
         }
     }
@@ -1524,14 +1567,14 @@ mod tests {
         // Make the first authority timeout, so the second will be called. "We" are
         // authority = 0, so we are skipped anyways.
         network_client
-            .stub_fetch_blocks(
+            .stub_fetch_block_headers(
                 expected_blocks.clone(),
                 AuthorityIndex::new_for_test(1),
                 Some(FETCH_REQUEST_TIMEOUT),
             )
             .await;
         network_client
-            .stub_fetch_blocks(
+            .stub_fetch_block_headers(
                 expected_blocks.clone(),
                 AuthorityIndex::new_for_test(2),
                 None,
@@ -1552,7 +1595,7 @@ mod tests {
         sleep(2 * FETCH_REQUEST_TIMEOUT).await;
 
         // THEN the missing blocks should now be fetched and added to core
-        let added_blocks = core_dispatcher.get_add_blocks().await;
+        let added_blocks = core_dispatcher.get_and_drain_block_headers().await;
         assert_eq!(added_blocks, expected_blocks);
 
         // AND missing blocks should have been consumed by the stub
@@ -1601,7 +1644,7 @@ mod tests {
 
         for chunk in expected_blocks.chunks(MAX_BLOCKS_PER_FETCH) {
             network_client
-                .stub_fetch_blocks(
+                .stub_fetch_block_headers(
                     chunk.to_vec(),
                     AuthorityIndex::new_for_test(1),
                     Some(FETCH_REQUEST_TIMEOUT),
@@ -1609,7 +1652,7 @@ mod tests {
                 .await;
 
             network_client
-                .stub_fetch_blocks(chunk.to_vec(), AuthorityIndex::new_for_test(2), None)
+                .stub_fetch_block_headers(chunk.to_vec(), AuthorityIndex::new_for_test(2), None)
                 .await;
         }
 
@@ -1649,7 +1692,7 @@ mod tests {
 
         // We should be in commit lag mode, but since there are missing blocks within
         // the acceptable round thresholds those ones should be fetched. Nothing above.
-        let mut added_blocks = core_dispatcher.get_add_blocks().await;
+        let mut added_blocks = core_dispatcher.get_and_drain_block_headers().await;
 
         added_blocks.sort_by_key(|block| block.reference());
         expected_blocks.sort_by_key(|block| block.reference());
@@ -1688,14 +1731,14 @@ mod tests {
         // authority = 0, so we are skipped anyways.
         for chunk in expected_blocks.chunks(MAX_BLOCKS_PER_FETCH) {
             network_client
-                .stub_fetch_blocks(
+                .stub_fetch_block_headers(
                     chunk.to_vec(),
                     AuthorityIndex::new_for_test(1),
                     Some(FETCH_REQUEST_TIMEOUT),
                 )
                 .await;
             network_client
-                .stub_fetch_blocks(chunk.to_vec(), AuthorityIndex::new_for_test(2), None)
+                .stub_fetch_block_headers(chunk.to_vec(), AuthorityIndex::new_for_test(2), None)
                 .await;
         }
 
@@ -1735,7 +1778,7 @@ mod tests {
 
         // Since we should be in commit lag mode none of the missed blocks should have
         // been fetched - hence nothing should be sent to core for processing.
-        let added_blocks = core_dispatcher.get_add_blocks().await;
+        let added_blocks = core_dispatcher.get_and_drain_blocks().await;
         assert_eq!(added_blocks, vec![]);
 
         // AND advance now the local commit index by adding a new commit that matches
@@ -1769,7 +1812,7 @@ mod tests {
         sleep(2 * FETCH_REQUEST_TIMEOUT).await;
 
         // THEN the missing blocks should now be fetched and added to core
-        let mut added_blocks = core_dispatcher.get_add_blocks().await;
+        let mut added_blocks = core_dispatcher.get_and_drain_block_headers().await;
 
         added_blocks.sort_by_key(|block| block.reference());
         expected_blocks.sort_by_key(|block| block.reference());
@@ -1802,7 +1845,7 @@ mod tests {
         // For peer 1 we give the block of round 10 (highest)
         let block_1 = expected_blocks.pop().unwrap();
         network_client
-            .stub_fetch_latest_blocks(
+            .stub_fetch_latest_block_headers(
                 vec![block_1.clone()],
                 AuthorityIndex::new_for_test(1),
                 vec![our_index],
@@ -1810,7 +1853,7 @@ mod tests {
             )
             .await;
         network_client
-            .stub_fetch_latest_blocks(
+            .stub_fetch_latest_block_headers(
                 vec![block_1],
                 AuthorityIndex::new_for_test(1),
                 vec![our_index],
@@ -1821,7 +1864,7 @@ mod tests {
         // For peer 2 we give the block of round 9
         let block_2 = expected_blocks.pop().unwrap();
         network_client
-            .stub_fetch_latest_blocks(
+            .stub_fetch_latest_block_headers(
                 vec![block_2.clone()],
                 AuthorityIndex::new_for_test(2),
                 vec![our_index],
@@ -1829,7 +1872,7 @@ mod tests {
             )
             .await;
         network_client
-            .stub_fetch_latest_blocks(
+            .stub_fetch_latest_block_headers(
                 vec![block_2],
                 AuthorityIndex::new_for_test(2),
                 vec![our_index],
@@ -1839,7 +1882,7 @@ mod tests {
 
         // For peer 3 we don't give any block - and it should return an empty vector
         network_client
-            .stub_fetch_latest_blocks(
+            .stub_fetch_latest_block_headers(
                 vec![],
                 AuthorityIndex::new_for_test(3),
                 vec![our_index],
@@ -1847,7 +1890,7 @@ mod tests {
             )
             .await;
         network_client
-            .stub_fetch_latest_blocks(
+            .stub_fetch_latest_block_headers(
                 vec![],
                 AuthorityIndex::new_for_test(3),
                 vec![our_index],
@@ -1876,7 +1919,12 @@ mod tests {
         );
 
         // Ensure that all the requests have been called
-        assert_eq!(network_client.fetch_latest_blocks_pending_calls().await, 0);
+        assert_eq!(
+            network_client
+                .fetch_latest_block_headers_pending_calls()
+                .await,
+            0
+        );
 
         // And we got one retry
         assert_eq!(

--- a/crates/starfish/core/src/test_dag.rs
+++ b/crates/starfish/core/src/test_dag.rs
@@ -67,7 +67,7 @@ pub(crate) fn build_dag(
                 (block.reference(), block)
             })
             .unzip();
-        dag_state.write().accept_blocks(blocks);
+        dag_state.write().accept_block_headers(blocks);
         ancestors = references;
     }
 
@@ -91,7 +91,7 @@ pub(crate) fn build_dag_layer(
                 .build(),
         );
         references.push(block.reference());
-        dag_state.write().accept_block(block);
+        dag_state.write().accept_block_header(block);
     }
     references
 }

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -171,10 +171,6 @@ impl DagBuilder {
                     })
                     .collect()
             }
-
-            fn get_blocks(&self, _refs: &[BlockRef]) -> Vec<Option<VerifiedBlock>> {
-                unimplemented!()
-            }
         }
         let mut storage = BlockStorage {
             block_headers: self

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -16,7 +16,7 @@ use crate::{
     CommitRef, CommittedSubDag,
     block_header::{
         BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs, Round, Slot,
-        TestBlockHeader, VerifiedBlockHeader, genesis_block_headers,
+        TestBlockHeader, VerifiedBlock, VerifiedBlockHeader, genesis_block_headers,
     },
     commit::{CertifiedCommit, CommitDigest, TrustedCommit, WAVE_LENGTH},
     context::Context,
@@ -86,7 +86,7 @@ pub(crate) struct DagBuilder {
     pub(crate) last_ancestors: Vec<BlockRef>,
     // All blocks created by dag builder. Will be used to pretty print or to be
     // retrieved for testing/persiting to dag state.
-    pub(crate) blocks: BTreeMap<BlockRef, VerifiedBlockHeader>,
+    pub(crate) block_headers: BTreeMap<BlockRef, VerifiedBlockHeader>,
     // All the committed sub dags created by the dag builder.
     pub(crate) committed_sub_dags: Vec<(CommittedSubDag, TrustedCommit)>,
     pub(crate) last_committed_rounds: Vec<Round>,
@@ -114,29 +114,31 @@ impl DagBuilder {
             pipeline: false,
             genesis,
             last_ancestors,
-            blocks: BTreeMap::new(),
+            block_headers: BTreeMap::new(),
             committed_sub_dags: vec![],
         }
     }
 
-    pub(crate) fn blocks(&self, rounds: RangeInclusive<Round>) -> Vec<VerifiedBlockHeader> {
+    pub(crate) fn block_headers(&self, rounds: RangeInclusive<Round>) -> Vec<VerifiedBlockHeader> {
         assert!(
-            !self.blocks.is_empty(),
+            !self.block_headers.is_empty(),
             "No blocks have been created, please make sure that you have called build method"
         );
-        self.blocks
+        self.block_headers
             .iter()
-            .filter_map(|(block_ref, block)| rounds.contains(&block_ref.round).then_some(block))
+            .filter_map(|(block_ref, block_header)| {
+                rounds.contains(&block_ref.round).then_some(block_header)
+            })
             .cloned()
             .collect::<Vec<VerifiedBlockHeader>>()
     }
 
-    pub(crate) fn all_blocks(&self) -> Vec<VerifiedBlockHeader> {
+    pub(crate) fn all_block_headers(&self) -> Vec<VerifiedBlockHeader> {
         assert!(
-            !self.blocks.is_empty(),
-            "No blocks have been created, please make sure that you have called build method"
+            !self.block_headers.is_empty(),
+            "No block headers have been created, please make sure that you have called build method"
         );
-        self.blocks.values().cloned().collect()
+        self.block_headers.values().cloned().collect()
     }
 
     pub(crate) fn get_sub_dag_and_commits(
@@ -155,25 +157,28 @@ impl DagBuilder {
             };
 
         struct BlockStorage {
-            blocks: BTreeMap<BlockRef, (VerifiedBlockHeader, bool)>, /* the tuple represents the
-                                                                      * block
-                                                                      * and whether it is
-                                                                      * committed */
+            // the tuple represents the block and whether it is committed
+            // blocks: BTreeMap<BlockRef, (VerifiedBlock, bool)>,
+            block_headers: BTreeMap<BlockRef, (VerifiedBlockHeader, bool)>,
         }
         impl BlockStoreAPI for BlockStorage {
-            fn get_blocks(&self, refs: &[BlockRef]) -> Vec<Option<VerifiedBlockHeader>> {
+            fn get_block_headers(&self, refs: &[BlockRef]) -> Vec<Option<VerifiedBlockHeader>> {
                 refs.iter()
                     .map(|block_ref| {
-                        self.blocks
+                        self.block_headers
                             .get(block_ref)
                             .map(|(block, _committed)| block.clone())
                     })
                     .collect()
             }
+
+            fn get_blocks(&self, _refs: &[BlockRef]) -> Vec<Option<VerifiedBlock>> {
+                unimplemented!()
+            }
         }
         let mut storage = BlockStorage {
-            blocks: self
-                .blocks
+            block_headers: self
+                .block_headers
                 .clone()
                 .into_iter()
                 .map(|(k, v)| (k, (v, false)))
@@ -238,7 +243,7 @@ impl DagBuilder {
         rounds: RangeInclusive<Round>,
     ) -> Vec<Option<VerifiedBlockHeader>> {
         assert!(
-            !self.blocks.is_empty(),
+            !self.block_headers.is_empty(),
             "No blocks have been created, please make sure that you have called build method"
         );
         rounds
@@ -255,8 +260,14 @@ impl DagBuilder {
         commits
             .into_iter()
             .map(|(sub_dag, commit)| {
-                let certified_commit =
-                    CertifiedCommit::new_certified(commit, sub_dag.blocks.clone());
+                // TODO: we need to request real blocks from sub_dag after we add the
+                // corresponding field and logic in sub_dag
+                let mut blocks = vec![];
+                for block_header in sub_dag.blocks.iter() {
+                    blocks.push(VerifiedBlock::new_for_test((**block_header).clone()));
+                }
+
+                let certified_commit = CertifiedCommit::new_certified(commit, blocks);
                 (sub_dag, certified_commit)
             })
             .collect()
@@ -264,10 +275,10 @@ impl DagBuilder {
 
     pub(crate) fn leader_block(&self, round: Round) -> Option<VerifiedBlockHeader> {
         assert!(
-            !self.blocks.is_empty(),
+            !self.block_headers.is_empty(),
             "No blocks have been created, please make sure that you have called build method"
         );
-        self.blocks.iter().find_map(|(block_ref, block)| {
+        self.block_headers.iter().find_map(|(block_ref, block)| {
             (block_ref.round == round
                 && block_ref.author == self.leader_schedule.elect_leader(round, 0))
             .then_some(block.clone())
@@ -305,14 +316,14 @@ impl DagBuilder {
     pub(crate) fn persist_all_blocks(&self, dag_state: Arc<RwLock<DagState>>) {
         dag_state
             .write()
-            .accept_blocks(self.blocks.values().cloned().collect());
+            .accept_block_headers(self.block_headers.values().cloned().collect());
     }
 
     pub(crate) fn print(&self) {
         let mut dag_str = "DAG {\n".to_string();
 
         let mut round = 0;
-        for block in self.blocks.values() {
+        for block in self.block_headers.values() {
             if block.round() > round {
                 round = block.round();
                 dag_str.push_str(&format!("Round {round} : \n"));
@@ -352,7 +363,7 @@ impl DagBuilder {
                     .build(),
             );
             references.push(block.reference());
-            self.blocks.insert(block.reference(), block.clone());
+            self.block_headers.insert(block.reference(), block.clone());
         }
         self.last_ancestors = references;
     }
@@ -360,7 +371,7 @@ impl DagBuilder {
     /// Gets all uncommitted blocks in a slot.
     pub(crate) fn get_uncommitted_blocks_at_slot(&self, slot: Slot) -> Vec<VerifiedBlockHeader> {
         let mut blocks = vec![];
-        for (_block_ref, block) in self.blocks.range((
+        for (_block_ref, block) in self.block_headers.range((
             Included(BlockRef::new(
                 slot.round,
                 slot.authority,
@@ -423,7 +434,7 @@ pub struct LayerBuilder<'a> {
     ancestors: Vec<BlockRef>,
 
     // Accumulated blocks to write to dag state
-    blocks: Vec<VerifiedBlockHeader>,
+    block_headers: Vec<VerifiedBlockHeader>,
 }
 
 #[expect(unused)]
@@ -452,7 +463,7 @@ impl<'a> LayerBuilder<'a> {
             fully_linked_acknowledgments: true,
             // TODO: add more variations of transaction acknowledgment links
             ancestors,
-            blocks: vec![],
+            block_headers: vec![],
         }
     }
 
@@ -595,10 +606,12 @@ impl<'a> LayerBuilder<'a> {
 
     pub fn persist_layers(&self, dag_state: Arc<RwLock<DagState>>) {
         assert!(
-            !self.blocks.is_empty(),
+            !self.block_headers.is_empty(),
             "Called to persist layers although no blocks have been created. Make sure you have called build before."
         );
-        dag_state.write().accept_blocks(self.blocks.clone());
+        dag_state
+            .write()
+            .accept_block_headers(self.block_headers.clone());
     }
 
     // Layer round is minimally and randomly connected with ancestors.
@@ -761,9 +774,9 @@ impl<'a> LayerBuilder<'a> {
                 );
                 references.push(block.reference());
                 self.dag_builder
-                    .blocks
+                    .block_headers
                     .insert(block.reference(), block.clone());
-                self.blocks.push(block);
+                self.block_headers.push(block);
             }
         }
         self.ancestors = references;

--- a/crates/starfish/core/src/test_dag_parser.rs
+++ b/crates/starfish/core/src/test_dag_parser.rs
@@ -348,7 +348,7 @@ mod tests {
 
         let (_, dag_builder) = result.unwrap();
         assert_eq!(dag_builder.genesis.len(), 4);
-        assert_eq!(dag_builder.blocks.len(), 23);
+        assert_eq!(dag_builder.block_headers.len(), 23);
 
         // Check the blocks were correctly parsed in Round 6
         let blocks_a6 = dag_builder

--- a/crates/starfish/core/src/tests/base_committer_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_tests.rs
@@ -633,7 +633,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block(byzantine_block_c13_1.clone());
+        .accept_block_header(byzantine_block_c13_1.clone());
 
     let byzantine_block_c13_2 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(13, 2)
@@ -642,7 +642,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block(byzantine_block_c13_2.clone());
+        .accept_block_header(byzantine_block_c13_2.clone());
 
     let byzantine_block_c13_3 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(13, 2)
@@ -651,7 +651,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block(byzantine_block_c13_3.clone());
+        .accept_block_header(byzantine_block_c13_3.clone());
 
     // Ancestors of decision blocks in round 14 should include multiple byzantine
     // non-votes C13 but there are enough good votes to prevent a skip.
@@ -662,7 +662,9 @@ async fn test_byzantine_direct_commit() {
             .set_ancestors(good_references_voting_round_wave_4.clone())
             .build(),
     );
-    dag_state.write().accept_block(decision_block_a14.clone());
+    dag_state
+        .write()
+        .accept_block_header(decision_block_a14.clone());
 
     let good_references_voting_round_wave_4_without_c13 = good_references_voting_round_wave_4
         .into_iter()
@@ -680,7 +682,9 @@ async fn test_byzantine_direct_commit() {
             )
             .build(),
     );
-    dag_state.write().accept_block(decision_block_b14.clone());
+    dag_state
+        .write()
+        .accept_block_header(decision_block_b14.clone());
 
     let decision_block_c14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 2)
@@ -693,7 +697,9 @@ async fn test_byzantine_direct_commit() {
             )
             .build(),
     );
-    dag_state.write().accept_block(decision_block_c14.clone());
+    dag_state
+        .write()
+        .accept_block_header(decision_block_c14.clone());
 
     let decision_block_d14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 3)
@@ -706,7 +712,9 @@ async fn test_byzantine_direct_commit() {
             )
             .build(),
     );
-    dag_state.write().accept_block(decision_block_d14.clone());
+    dag_state
+        .write()
+        .accept_block_header(decision_block_d14.clone());
 
     // DagState Update:
     // - We have A13, B13, D13 & C13 as good votes in the voting round of wave 4

--- a/crates/starfish/core/src/tests/pipelined_committer_tests.rs
+++ b/crates/starfish/core/src/tests/pipelined_committer_tests.rs
@@ -628,7 +628,7 @@ async fn test_byzantine_validator() {
     );
     dag_state
         .write()
-        .accept_block(byzantine_block_b13_1.clone());
+        .accept_block_header(byzantine_block_b13_1.clone());
 
     // Make equivocation through timestamp
     let timestamp = byzantine_block_b13_1.timestamp_ms();
@@ -641,7 +641,7 @@ async fn test_byzantine_validator() {
     );
     dag_state
         .write()
-        .accept_block(byzantine_block_b13_2.clone());
+        .accept_block_header(byzantine_block_b13_2.clone());
 
     let byzantine_block_b13_3 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(13, 1)
@@ -651,7 +651,7 @@ async fn test_byzantine_validator() {
     );
     dag_state
         .write()
-        .accept_block(byzantine_block_b13_3.clone());
+        .accept_block_header(byzantine_block_b13_3.clone());
 
     // Ancestors of decision blocks in round 14 should include multiple byzantine
     // non-votes B13 but there are enough good votes to prevent a skip.
@@ -664,7 +664,9 @@ async fn test_byzantine_validator() {
             .build(),
     );
     references_round_14.push(decision_block_a14.reference());
-    dag_state.write().accept_block(decision_block_a14.clone());
+    dag_state
+        .write()
+        .accept_block_header(decision_block_a14.clone());
 
     let good_references_voting_round_wave_4_without_b13 = good_references_voting_round_wave_4
         .into_iter()
@@ -683,7 +685,9 @@ async fn test_byzantine_validator() {
             .build(),
     );
     references_round_14.push(decision_block_b14.reference());
-    dag_state.write().accept_block(decision_block_b14.clone());
+    dag_state
+        .write()
+        .accept_block_header(decision_block_b14.clone());
 
     let decision_block_c14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 2)
@@ -697,7 +701,9 @@ async fn test_byzantine_validator() {
             .build(),
     );
     references_round_14.push(decision_block_c14.reference());
-    dag_state.write().accept_block(decision_block_c14.clone());
+    dag_state
+        .write()
+        .accept_block_header(decision_block_c14.clone());
 
     let decision_block_d14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 3)
@@ -711,7 +717,9 @@ async fn test_byzantine_validator() {
             .build(),
     );
     references_round_14.push(decision_block_d14.reference());
-    dag_state.write().accept_block(decision_block_d14.clone());
+    dag_state
+        .write()
+        .accept_block_header(decision_block_d14.clone());
 
     // DagState Update:
     // - We have A13, B13, D13 & C13 as good votes in the voting round of leader A12

--- a/crates/starfish/core/src/tests/randomized_tests.rs
+++ b/crates/starfish/core/src/tests/randomized_tests.rs
@@ -110,7 +110,11 @@ async fn test_randomized_dag_and_decision_sequence() {
             "Running test with committee size {num_authorities} & {NUM_ROUNDS} rounds in the DAG..."
         );
 
-        let mut all_blocks = dag_builder.blocks.values().cloned().collect::<Vec<_>>();
+        let mut all_blocks = dag_builder
+            .block_headers
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
         all_blocks.shuffle(&mut random_test_setup.seeded_rng);
 
         let mut sequenced_leaders_1 = vec![];
@@ -122,7 +126,9 @@ async fn test_randomized_dag_and_decision_sequence() {
                 .gen_range(1..=(all_blocks.len() - i));
             let chunk = &all_blocks[i..i + chunk_size];
 
-            let _ = authority_1.block_manager.try_accept_blocks(chunk.to_vec());
+            let _ = authority_1
+                .block_manager
+                .try_accept_block_headers(chunk.to_vec());
             let sequence = authority_1.committer.try_decide(last_decided);
 
             if !sequence.is_empty() {
@@ -139,7 +145,11 @@ async fn test_randomized_dag_and_decision_sequence() {
         // Setup for Authority 2
         let mut authority_2 = authority_setup(num_authorities, 2);
 
-        let mut all_blocks = dag_builder.blocks.values().cloned().collect::<Vec<_>>();
+        let mut all_blocks = dag_builder
+            .block_headers
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
         all_blocks.shuffle(&mut random_test_setup.seeded_rng);
 
         let mut sequenced_leaders_2 = vec![];
@@ -151,7 +161,9 @@ async fn test_randomized_dag_and_decision_sequence() {
                 .gen_range(1..=(all_blocks.len() - i));
             let chunk = &all_blocks[i..i + chunk_size];
 
-            let _ = authority_2.block_manager.try_accept_blocks(chunk.to_vec());
+            let _ = authority_2
+                .block_manager
+                .try_accept_block_headers(chunk.to_vec());
             let sequence = authority_2.committer.try_decide(last_decided);
 
             if !sequence.is_empty() {

--- a/crates/starfish/core/src/tests/universal_committer_tests.rs
+++ b/crates/starfish/core/src/tests/universal_committer_tests.rs
@@ -622,7 +622,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block(byzantine_block_c13_1.clone());
+        .accept_block_header(byzantine_block_c13_1.clone());
 
     let byzantine_block_c13_2 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(13, 2)
@@ -631,7 +631,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block(byzantine_block_c13_2.clone());
+        .accept_block_header(byzantine_block_c13_2.clone());
 
     let byzantine_block_c13_3 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(13, 2)
@@ -640,7 +640,7 @@ async fn test_byzantine_direct_commit() {
     );
     dag_state
         .write()
-        .accept_block(byzantine_block_c13_3.clone());
+        .accept_block_header(byzantine_block_c13_3.clone());
 
     // Ancestors of certifying blocks in round 14 should include multiple byzantine
     // non-votes C13 but there are enough good votes to prevent a skip.
@@ -651,7 +651,9 @@ async fn test_byzantine_direct_commit() {
             .set_ancestors(good_references_voting_round_for_round_12.clone())
             .build(),
     );
-    dag_state.write().accept_block(certifying_block_a14.clone());
+    dag_state
+        .write()
+        .accept_block_header(certifying_block_a14.clone());
 
     let good_references_voting_round_for_round_12_without_c13 =
         good_references_voting_round_for_round_12
@@ -670,7 +672,9 @@ async fn test_byzantine_direct_commit() {
             )
             .build(),
     );
-    dag_state.write().accept_block(certifying_block_b14.clone());
+    dag_state
+        .write()
+        .accept_block_header(certifying_block_b14.clone());
 
     let certifying_block_c14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 2)
@@ -683,7 +687,9 @@ async fn test_byzantine_direct_commit() {
             )
             .build(),
     );
-    dag_state.write().accept_block(certifying_block_c14.clone());
+    dag_state
+        .write()
+        .accept_block_header(certifying_block_c14.clone());
 
     let certifying_block_d14 = VerifiedBlockHeader::new_for_test(
         TestBlockHeader::new(14, 3)
@@ -696,7 +702,9 @@ async fn test_byzantine_direct_commit() {
             )
             .build(),
     );
-    dag_state.write().accept_block(certifying_block_d14.clone());
+    dag_state
+        .write()
+        .accept_block_header(certifying_block_d14.clone());
 
     // DagState Update:
     // - We have A13, B13, D13 & C13 as good votes in the voting round for round-12


### PR DESCRIPTION
# Description of change

This PR introduces a full block structure, which contains a header and transactions.

Changes in network communications:
In streaming we now use SerialiedBlocks structure which contain serialization of a header and serializetion of transactions.
In synchronizer Functions fetching blocks are removed or changed to fetch headers. The only place where we still fetch blocks is in the commitSyncer.

Commit:
Certified commit contains blocks, CommittedSubDag contains only headers for now, blocks should be added later. In stake verification we use only headers, since it is enough.

CoreThreadDispatcher: a new command AddBlockHeaders was added. Several Fake/Mock dispatchers were merged into one.

Storage: we store now both headers and full blocks. If blocks are written to disk then their headers are written there too. There is a possibility to read blocks or only headers. Changes implemented both for mem_store and RocksDB.

Linearizer now operates with headers.

DagState and BlockManager:
DagState works with headers now since for building DAG only headers are important. However, we still store recent_blocks since we need to request blocks for fetching. 
Functions such as accept block work with headers now. However, there can be situations when we already have data but the corresponding block header is not accepted yet. We can also have accepted header without data. Structures for storing such blocks and headers were added to BlockManager. They should be cleaned at some point, it is something to be done in future PRs.


## Links to any relevant issues

closes #6707.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
