### PR TITLE
feat(iota-names): get `IotaNamesConfig` from env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7316,6 +7316,7 @@ dependencies = [
 name = "iota-names"
 version = "1.1.0-alpha"
 dependencies = [
+ "anyhow",
  "bcs",
  "iota-types",
  "move-core-types",

--- a/crates/iota-names/Cargo.toml
+++ b/crates/iota-names/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 # external dependencies
+anyhow.workspace = true
 bcs.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/iota-names/src/config.rs
+++ b/crates/iota-names/src/config.rs
@@ -52,6 +52,16 @@ impl IotaNamesConfig {
         }
     }
 
+    pub fn from_env() -> anyhow::Result<Self> {
+        Ok(Self::new(
+            std::env::var("IOTA_NAMES_PACKAGE_ADDRESS")?.parse()?,
+            std::env::var("IOTA_NAMES_OBJECT_ID")?.parse()?,
+            std::env::var("IOTA_NAMES_PAYMENTS_PACKAGE_ADDRESS")?.parse()?,
+            std::env::var("IOTA_NAMES_REGISTRY_ID")?.parse()?,
+            std::env::var("IOTA_NAMES_REVERSE_REGISTRY_ID")?.parse()?,
+        ))
+    }
+
     pub fn from_chain(chain: &Chain) -> Self {
         match chain {
             Chain::Mainnet => todo!("https://github.com/iotaledger/iota/issues/6532"),

--- a/crates/iota/src/name_commands.rs
+++ b/crates/iota/src/name_commands.rs
@@ -1164,12 +1164,16 @@ async fn get_reverse_registry_entry(
 }
 
 async fn get_iota_names_config(client: &IotaClient) -> anyhow::Result<IotaNamesConfig> {
-    let chain_identifier = client.read_api().get_chain_identifier().await?;
-    let chain = ChainIdentifier::from_chain_short_id(&chain_identifier)
-        .map(|c| c.chain())
-        .unwrap_or(Chain::Unknown);
+    Ok(if let Ok(config) = IotaNamesConfig::from_env() {
+        config
+    } else {
+        let chain_identifier = client.read_api().get_chain_identifier().await?;
+        let chain = ChainIdentifier::from_chain_short_id(&chain_identifier)
+            .map(|c| c.chain())
+            .unwrap_or(Chain::Unknown);
 
-    Ok(IotaNamesConfig::from_chain(&chain))
+        IotaNamesConfig::from_chain(&chain)
+    })
 }
 
 async fn fetch_pricing_config(context: &mut WalletContext) -> anyhow::Result<PricingConfig> {


### PR DESCRIPTION
Add `IotaNamesConfig::from_env` method.

Fixes https://github.com/iotaledger/iota-private/issues/109