### PR TITLE
fix(explorer): Render active validator data over inactive if available

### DIFF
--- a/apps/explorer/src/pages/validator/ValidatorDetails.tsx
+++ b/apps/explorer/src/pages/validator/ValidatorDetails.tsx
@@ -185,7 +185,7 @@ function ValidatorDetails(): JSX.Element {
         return <PageLayout content={<LoadingIndicator />} />;
     }
 
-    if (inactiveValidatorData) {
+    if (inactiveValidatorData && !validatorData) {
         return (
             <PageLayout
                 content={

--- a/apps/explorer/src/pages/validator/ValidatorDetails.tsx
+++ b/apps/explorer/src/pages/validator/ValidatorDetails.tsx
@@ -170,7 +170,7 @@ function ValidatorDetails(): JSX.Element {
         return rewards ? Number(rewards) : null;
     })();
 
-    const validatorData = systemStateData?.activeValidators.find(
+    const activeValidatorData = systemStateData?.activeValidators.find(
         ({ iotaAddress, stakingPoolId }) => iotaAddress === id || stakingPoolId === id,
     );
 
@@ -185,7 +185,7 @@ function ValidatorDetails(): JSX.Element {
         return <PageLayout content={<LoadingIndicator />} />;
     }
 
-    if (inactiveValidatorData && !validatorData) {
+    if (inactiveValidatorData && !activeValidatorData) {
         return (
             <PageLayout
                 content={
@@ -205,7 +205,7 @@ function ValidatorDetails(): JSX.Element {
         );
     }
 
-    if (!validatorData || !systemStateData || !validatorEvents || !id) {
+    if (!activeValidatorData || !systemStateData || !validatorEvents || !id) {
         return (
             <PageLayout
                 content={
@@ -236,9 +236,9 @@ function ValidatorDetails(): JSX.Element {
         <PageLayout
             content={
                 <div className="flex flex-col gap-2xl">
-                    <ValidatorMeta validatorData={validatorData} />
+                    <ValidatorMeta validatorData={activeValidatorData} />
                     <ValidatorStats
-                        validatorData={validatorData}
+                        validatorData={activeValidatorData}
                         epoch={systemStateData.epoch}
                         epochRewards={validatorRewards}
                         apy={isApyApproxZero ? '~0' : apy}


### PR DESCRIPTION
On `/validator` page, if both activeValidator data and inactive is found, we render the active data.

## Links to any relevant issues

Closes https://github.com/iotaledger/iota/issues/6812

