### PR TITLE
feat(cli): Enable the move test tracing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
         shell: bash
         # Currently building in release mode, but we could also have debug builds for testing
         run: |
-          [ -f ~/.cargo/env ] && source ~/.cargo/env ; cargo build --release --features indexer,gen-completions
+          [ -f ~/.cargo/env ] && source ~/.cargo/env ; cargo build --release --features indexer,gen-completions,tracing
 
       - name: Rename binaries for ${{ matrix.os_type }}
         shell: bash

--- a/scripts/homebrew/template.rb
+++ b/scripts/homebrew/template.rb
@@ -42,7 +42,7 @@ class Iota < Formula
     def install
         if @@arch == "source"
             ENV["GIT_REVISION"] = ""
-            system "cargo", "build", "--release", "--bin", "iota", "--bin", "iota-tool", "-F", "indexer,gen-completions"
+            system "cargo", "build", "--release", "--bin", "iota", "--bin", "iota-tool", "-F", "indexer,gen-completions,tracing"
             bin.install "target/release/iota" => "iota"
             bin.install "target/release/iota-tool" => "iota-tool"
         else


### PR DESCRIPTION
# Description of change

Adds the `tracing` feature in the release builds.

This would allow executing `iota move test --trace-execution` starting from the next release.