### PR TITLE
node-upstream-change([v1.33.3, v1.34.2)): Test MAX_PROTOCOL_VERSION is indeed the max supported version

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -2256,6 +2256,17 @@ mod test {
     }
 
     #[test]
+    #[should_panic(expected = "unsupported version")]
+    fn max_version_test() {
+        // When this does not panic, version higher than MAX_PROTOCOL_VERSION exists.
+        // To fix, bump MAX_PROTOCOL_VERSION or disable this check for the version.
+        let _ = ProtocolConfig::get_for_version_impl(
+            ProtocolVersion::new(MAX_PROTOCOL_VERSION + 1),
+            Chain::Unknown,
+        );
+    }
+
+    #[test]
     fn lookup_by_string_test() {
         let prot: ProtocolConfig =
             ProtocolConfig::get_for_version(ProtocolVersion::new(1), Chain::Mainnet);


### PR DESCRIPTION
# Description of change

Port [MystenLabs/sui@ee1af5f](https://github.com/MystenLabs/sui/commit/ee1af5fd6f57576b271c2fb234239ce50d41b1e0)

Test MAX_PROTOCOL_VERSION is indeed the max supported version. 
Otherwise it is relatively easy to miss updating the max protocol version.


## Links to any relevant issues

Part of https://github.com/iotaledger/iota/issues/3990

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested
```
cargo t -p iota-protocol-config
```