### PR TITLE
fix(node): gracefully clean up iota-node validator components

### DIFF
--- a/crates/iota-core/src/consensus_manager/mod.rs
+++ b/crates/iota-core/src/consensus_manager/mod.rs
@@ -97,11 +97,10 @@ impl ConsensusManager {
         node_config: &NodeConfig,
         consensus_config: &ConsensusConfig,
         registry_service: &RegistryService,
+        metrics_registry: &Registry,
         consensus_client: Arc<UpdatableConsensusClient>,
     ) -> Self {
-        let metrics = Arc::new(ConsensusManagerMetrics::new(
-            &registry_service.default_registry(),
-        ));
+        let metrics = Arc::new(ConsensusManagerMetrics::new(metrics_registry));
         let mysticeti_client = Arc::new(LazyMysticetiClient::new());
         let mysticeti_manager = ProtocolManager::new_mysticeti(
             node_config,

--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -682,8 +682,12 @@ async fn test_reconfig_with_same_validator() {
 
     // ValidatorGenesisConfig doesn't impl Clone
     // generate the same config with the same rng seed
-    let build_node_config =
-        || ValidatorGenesisConfigBuilder::new().build(&mut StdRng::seed_from_u64(0));
+    let node_ip = iota_config::local_ip_utils::get_new_ip();
+    let build_node_config = || {
+        ValidatorGenesisConfigBuilder::new()
+            .with_ip(node_ip.clone())
+            .build(&mut StdRng::seed_from_u64(0))
+    };
 
     // the node that will re-join committee
     let node_config = build_node_config();

--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -708,7 +708,6 @@ async fn test_reconfig_with_same_validator() {
     // create test cluster with 4 default validators
     let mut test_cluster = TestClusterBuilder::new()
         .with_num_validators(4)
-        // .with_validator_candidates(std::iter::once(node_address))
         .set_genesis_config(genesis_config)
         .build()
         .await;
@@ -753,7 +752,7 @@ async fn test_reconfig_with_same_validator() {
         // sync nodes
         test_cluster.wait_for_epoch_all_nodes(epoch).await;
 
-        // the running node acknowledges being or not a committee member
+        // the running node acknowledges being or not being a committee member
         node_handle.as_ref().unwrap().with(|node| {
             assert_eq!(
                 is_in_committee,

--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -685,6 +685,7 @@ async fn test_reconfig_with_same_validator() {
     let node_ip = iota_config::local_ip_utils::get_new_ip();
     let build_node_config = || {
         ValidatorGenesisConfigBuilder::new()
+            // the node_ip should always be the same value, otherwise the test will fail
             .with_ip(node_ip.clone())
             .build(&mut StdRng::seed_from_u64(0))
     };

--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -672,6 +672,101 @@ async fn test_reconfig_with_committee_change_basic() {
 }
 
 #[sim_test]
+async fn test_reconfig_with_same_validator() {
+    use iota_swarm_config::genesis_config::{AccountConfig, DEFAULT_GAS_AMOUNT, GenesisConfig};
+    use iota_types::{
+        crypto::{AuthorityPublicKeyBytes, KeypairTraits},
+        governance::MIN_VALIDATOR_JOINING_STAKE_NANOS,
+    };
+    use rand::{SeedableRng, rngs::StdRng};
+
+    // ValidatorGenesisConfig doesn't impl Clone
+    // generate the same config with the same rng seed
+    let build_node_config =
+        || ValidatorGenesisConfigBuilder::new().build(&mut StdRng::seed_from_u64(0));
+
+    // the node that will re-join committee
+    let node_config = build_node_config();
+    let node_name: AuthorityPublicKeyBytes = node_config.authority_key_pair.public().into();
+    let node_address = (&node_config.account_key_pair.public()).into();
+    let mut node_handle = None;
+
+    // add coins to the node at the genesis to avoid dealing with faucet
+    let mut genesis_config = GenesisConfig::default();
+    genesis_config
+        .accounts
+        .extend(std::iter::once(AccountConfig {
+            address: Some(node_address),
+            gas_amounts: vec![
+                DEFAULT_GAS_AMOUNT,
+                MIN_VALIDATOR_JOINING_STAKE_NANOS,
+                DEFAULT_GAS_AMOUNT,
+                MIN_VALIDATOR_JOINING_STAKE_NANOS,
+            ],
+        }));
+
+    // create test cluster with 4 default validators
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(4)
+        // .with_validator_candidates(std::iter::once(node_address))
+        .set_genesis_config(genesis_config)
+        .build()
+        .await;
+
+    // whether node is in committee in a corresponding epoch
+    // test a few join/leave/join cases
+    let node_schedule = [true, true, false, false, true, false, true];
+    // the node initially is not in the committee
+    let mut was_in_committee = false;
+
+    let mut epoch = 0;
+    for is_in_committee in node_schedule {
+        if !was_in_committee && is_in_committee {
+            // add node to committee
+            execute_add_validator_transactions(&test_cluster, &build_node_config()).await;
+        }
+        if was_in_committee && !is_in_committee {
+            // remove node from committee
+            execute_remove_validator_tx(&test_cluster, node_handle.as_ref().unwrap()).await;
+        }
+
+        // reconfiguration
+        test_cluster.force_new_epoch().await;
+        epoch += 1;
+
+        // check that node has joined or left the committee
+        test_cluster.fullnode_handle.iota_node.with(|node| {
+            assert_eq!(
+                is_in_committee,
+                node.state()
+                    .epoch_store_for_testing()
+                    .committee()
+                    .authority_exists(&node_name)
+            );
+        });
+
+        if node_handle.is_none() {
+            // spawn node if not already
+            node_handle = Some(test_cluster.spawn_new_validator(build_node_config()).await);
+        }
+
+        // sync nodes
+        test_cluster.wait_for_epoch_all_nodes(epoch).await;
+
+        // the running node acknowledges being or not a committee member
+        node_handle.as_ref().unwrap().with(|node| {
+            assert_eq!(
+                is_in_committee,
+                node.state()
+                    .is_validator(&node.state().epoch_store_for_testing())
+            );
+        });
+
+        was_in_committee = is_in_committee;
+    }
+}
+
+#[sim_test]
 async fn test_reconfig_with_committee_change_stress() {
     do_test_reconfig_with_committee_change_stress().await;
 }

--- a/crates/iota-metrics/src/histogram.rs
+++ b/crates/iota-metrics/src/histogram.rs
@@ -12,7 +12,7 @@ use std::{
 use futures::FutureExt;
 use parking_lot::Mutex;
 use prometheus::{
-    IntCounterVec, IntGaugeVec, Registry, opts, register_int_counter_vec_with_registry,
+    IntCounterVec, IntGaugeVec, Registry, register_int_counter_vec_with_registry,
     register_int_gauge_vec_with_registry,
 };
 use tokio::{
@@ -190,32 +190,6 @@ impl HistogramVec {
             labels,
             channel: self.channel.clone(),
         }
-    }
-
-    // HistogramVec uses asynchronous model to report metrics which makes
-    // it difficult to unregister counters in the usual manner. Here we
-    // re-create counters so that their `desc()`s match the ones created by
-    // HistogramVec and remove them from the registry. Counters can be safely
-    // unregistered even if they are still in use.
-    pub fn unregister(name: &str, desc: &str, labels: &[&str], registry: &Registry) {
-        let sum_name = format!("{}_sum", name);
-        let count_name = format!("{}_count", name);
-
-        let sum = IntCounterVec::new(opts!(sum_name, desc), labels).unwrap();
-        registry
-            .unregister(Box::new(sum))
-            .unwrap_or_else(|_| panic!("{}_sum counter is in prometheus registry", name));
-
-        let count = IntCounterVec::new(opts!(count_name, desc), labels).unwrap();
-        registry
-            .unregister(Box::new(count))
-            .unwrap_or_else(|_| panic!("{}_count counter is in prometheus registry", name));
-
-        let labels: Vec<_> = labels.iter().cloned().chain(["pct"]).collect();
-        let gauge = IntGaugeVec::new(opts!(name, desc), &labels).unwrap();
-        registry
-            .unregister(Box::new(gauge))
-            .unwrap_or_else(|_| panic!("{} gauge is in prometheus registry", name));
     }
 }
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1486,7 +1486,9 @@ impl IotaNode {
             .bind(config.network_address())
             .await
             .map_err(|err| anyhow!(err.to_string()))?;
-        let cancel_handle = server.take_cancel_handle().unwrap();
+        let cancel_handle = server
+            .take_cancel_handle()
+            .expect("GRPC server should still have a cancel handle");
         let local_addr = server.local_addr();
         info!("Listening to traffic on {local_addr}");
         let grpc_server = spawn_monitored_task!(server.serve().map_err(Into::into));

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -81,7 +81,7 @@ use iota_json_rpc::{
 use iota_json_rpc_api::JsonRpcMetrics;
 use iota_macros::{fail_point, fail_point_async, replay_log};
 use iota_metrics::{
-    RegistryService,
+    RegistryID, RegistryService,
     hardware_metrics::register_hardware_metrics,
     metrics_network::{MetricsMakeCallbackHandler, NetworkConnectionMetrics, NetworkMetrics},
     server_timing_middleware, spawn_monitored_task,
@@ -138,6 +138,7 @@ pub mod metrics;
 
 pub struct ValidatorComponents {
     validator_server_handle: JoinHandle<Result<()>>,
+    validator_server_cancel_handle: tokio::sync::oneshot::Sender<()>,
     validator_overload_monitor_handle: Option<JoinHandle<()>>,
     consensus_manager: ConsensusManager,
     consensus_store_pruner: ConsensusStorePruner,
@@ -146,6 +147,7 @@ pub struct ValidatorComponents {
     checkpoint_service_tasks: JoinSet<()>,
     checkpoint_metrics: Arc<CheckpointMetrics>,
     iota_tx_validator_metrics: Arc<IotaTxValidatorMetrics>,
+    validator_registry_id: RegistryID,
 }
 
 #[cfg(msim)]
@@ -1197,6 +1199,8 @@ impl IotaNode {
             .consensus_config
             .as_mut()
             .ok_or_else(|| anyhow!("Validator is missing consensus config"))?;
+        let validator_registry = Registry::new();
+        let validator_registry_id = registry_service.add(validator_registry.clone());
 
         let client = Arc::new(UpdatableConsensusClient::new());
         let consensus_adapter = Arc::new(Self::construct_consensus_adapter(
@@ -1204,11 +1208,16 @@ impl IotaNode {
             consensus_config,
             state.name,
             connection_monitor_status.clone(),
-            &registry_service.default_registry(),
+            &validator_registry,
             client.clone(),
         ));
-        let consensus_manager =
-            ConsensusManager::new(&config, consensus_config, registry_service, client);
+        let consensus_manager = ConsensusManager::new(
+            &config,
+            consensus_config,
+            registry_service,
+            &validator_registry,
+            client,
+        );
 
         // This only gets started up once, not on every epoch. (Make call to remove
         // every epoch.)
@@ -1216,20 +1225,20 @@ impl IotaNode {
             consensus_manager.get_storage_base_path(),
             consensus_config.db_retention_epochs(),
             consensus_config.db_pruner_period(),
-            &registry_service.default_registry(),
+            &validator_registry,
         );
 
-        let checkpoint_metrics = CheckpointMetrics::new(&registry_service.default_registry());
-        let iota_tx_validator_metrics =
-            IotaTxValidatorMetrics::new(&registry_service.default_registry());
+        let checkpoint_metrics = CheckpointMetrics::new(&validator_registry);
+        let iota_tx_validator_metrics = IotaTxValidatorMetrics::new(&validator_registry);
 
-        let validator_server_handle = Self::start_grpc_validator_service(
-            &config,
-            state.clone(),
-            consensus_adapter.clone(),
-            &registry_service.default_registry(),
-        )
-        .await?;
+        let (validator_server_handle, validator_server_cancel_handle) =
+            Self::start_grpc_validator_service(
+                &config,
+                state.clone(),
+                consensus_adapter.clone(),
+                &validator_registry,
+            )
+            .await?;
 
         // Starts an overload monitor that monitors the execution of the authority.
         // Don't start the overload monitor when max_load_shedding_percentage is 0.
@@ -1261,10 +1270,12 @@ impl IotaNode {
             consensus_store_pruner,
             accumulator,
             validator_server_handle,
+            validator_server_cancel_handle,
             validator_overload_monitor_handle,
             checkpoint_metrics,
             iota_node_metrics,
             iota_tx_validator_metrics,
+            validator_registry_id,
         )
         .await
     }
@@ -1283,10 +1294,12 @@ impl IotaNode {
         consensus_store_pruner: ConsensusStorePruner,
         accumulator: Weak<StateAccumulator>,
         validator_server_handle: JoinHandle<Result<()>>,
+        validator_server_cancel_handle: tokio::sync::oneshot::Sender<()>,
         validator_overload_monitor_handle: Option<JoinHandle<()>>,
         checkpoint_metrics: Arc<CheckpointMetrics>,
         iota_node_metrics: Arc<IotaNodeMetrics>,
         iota_tx_validator_metrics: Arc<IotaTxValidatorMetrics>,
+        validator_registry_id: RegistryID,
     ) -> Result<ValidatorComponents> {
         let (checkpoint_service, checkpoint_service_tasks) = Self::start_checkpoint_service(
             config,
@@ -1353,6 +1366,7 @@ impl IotaNode {
 
         Ok(ValidatorComponents {
             validator_server_handle,
+            validator_server_cancel_handle,
             validator_overload_monitor_handle,
             consensus_manager,
             consensus_store_pruner,
@@ -1360,6 +1374,7 @@ impl IotaNode {
             checkpoint_service_tasks,
             checkpoint_metrics,
             iota_tx_validator_metrics,
+            validator_registry_id,
         })
     }
 
@@ -1446,7 +1461,10 @@ impl IotaNode {
         state: Arc<AuthorityState>,
         consensus_adapter: Arc<ConsensusAdapter>,
         prometheus_registry: &Registry,
-    ) -> Result<tokio::task::JoinHandle<Result<()>>> {
+    ) -> Result<(
+        tokio::task::JoinHandle<Result<()>>,
+        tokio::sync::oneshot::Sender<()>,
+    )> {
         let validator_service = ValidatorService::new(
             state.clone(),
             consensus_adapter,
@@ -1464,15 +1482,16 @@ impl IotaNode {
 
         server_builder = server_builder.add_service(ValidatorServer::new(validator_service));
 
-        let server = server_builder
+        let mut server = server_builder
             .bind(config.network_address())
             .await
             .map_err(|err| anyhow!(err.to_string()))?;
+        let cancel_handle = server.take_cancel_handle().unwrap();
         let local_addr = server.local_addr();
         info!("Listening to traffic on {local_addr}");
         let grpc_server = spawn_monitored_task!(server.serve().map_err(Into::into));
 
-        Ok(grpc_server)
+        Ok((grpc_server, cancel_handle))
     }
 
     pub fn state(&self) -> Arc<AuthorityState> {
@@ -1656,6 +1675,7 @@ impl IotaNode {
 
             let new_validator_components = if let Some(ValidatorComponents {
                 validator_server_handle,
+                validator_server_cancel_handle,
                 validator_overload_monitor_handle,
                 consensus_manager,
                 consensus_store_pruner,
@@ -1663,6 +1683,7 @@ impl IotaNode {
                 mut checkpoint_service_tasks,
                 checkpoint_metrics,
                 iota_tx_validator_metrics,
+                validator_registry_id,
             }) = self.validator_components.lock().await.take()
             {
                 info!("Reconfiguring the validator.");
@@ -1724,15 +1745,28 @@ impl IotaNode {
                             consensus_store_pruner,
                             weak_accumulator,
                             validator_server_handle,
+                            validator_server_cancel_handle,
                             validator_overload_monitor_handle,
                             checkpoint_metrics,
                             self.metrics.clone(),
                             iota_tx_validator_metrics,
+                            validator_registry_id,
                         )
                         .await?,
                     )
                 } else {
                     info!("This node is no longer a validator after reconfiguration");
+                    if self.registry_service.remove(validator_registry_id) {
+                        debug!("Removed validator metrics registry");
+                    } else {
+                        warn!("Failed to remove validator metrics registry");
+                    }
+                    if validator_server_cancel_handle.send(()).is_ok() {
+                        debug!("Validator grpc server cancelled");
+                    } else {
+                        warn!("Failed to cancel validator grpc server");
+                    }
+
                     None
                 }
             } else {

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1733,11 +1733,6 @@ impl IotaNode {
                     )
                 } else {
                     info!("This node is no longer a validator after reconfiguration");
-
-                    consensus_adapter.unregister_consensus_adapter_metrics(
-                        &self.registry_service.default_registry(),
-                    );
-                    debug!("Unregistered consensus adapter metrics");
                     None
                 }
             } else {


### PR DESCRIPTION
# Description of change

After a validator node leaves the committee, a few resources in validator components are leaked including metrics and grpc server. If the node will try to re-join the committee it will crash due to resources already being in use.

This PR:
- changes the way validator metrics are registered: a dedicated registry is used instead of default one;
- adds a graceful shutdown of validator grpc server and metrics registry clean up during reconfiguration when a validator leaves the committee;
- adds a reproducer test.

## Notes

There are a few ways to handle metrics issue:
- ignore `AlreadyReg` error while trying to re-register metrics with the default registry; requires special unwrap handling for each metric;
- unregister individual metrics with the default registry; the existing components do not provide such functionality; requires unregistering all individual metrics;
- use a dedicated registry and remove it entirely from the registry service once node is not validator anymore; this seems to be the easiest and cleanest way.

:warning: There may be other undetected resources leaking that do not cause error if validator components are re-created.

## Links to any relevant issues

Fixes #6277.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

```sh
scripts/simtest/cargo-simtest simtest --package iota-e2e-tests --test "reconfiguration_tests" --profile ci -- test_reconfig_with_same_validator
```

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Fixed a bug causing iota-node to crash after re-joining the consensus committee as validator.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
