### PR TITLE
node-upstream-change([v1.33.3, v1.34.2)): Rename IotaPeer to AllowedPeer

### DIFF
--- a/crates/iota-proxy/src/admin.rs
+++ b/crates/iota-proxy/src/admin.rs
@@ -28,7 +28,7 @@ use crate::{
     handlers::publish_metrics,
     histogram_relay::HistogramRelay,
     middleware::{expect_content_length, expect_iota_proxy_header, expect_valid_public_key},
-    peers::{IotaNodeProvider, IotaPeer},
+    peers::{AllowedPeer, IotaNodeProvider},
     var,
 };
 
@@ -214,7 +214,7 @@ fn load_private_key(filename: &str) -> rustls::pki_types::PrivateKeyDer<'static>
 /// metrics
 fn load_static_peers(
     static_peers: Option<StaticPeerValidationConfig>,
-) -> Result<Vec<IotaPeer>, Error> {
+) -> Result<Vec<AllowedPeer>, Error> {
     let Some(static_peers) = static_peers else {
         return Ok(vec![]);
     };
@@ -224,7 +224,7 @@ fn load_static_peers(
         .map(|spk| {
             let peer_id = hex::decode(spk.peer_id).unwrap();
             let public_key = Ed25519PublicKey::from_bytes(peer_id.as_ref()).unwrap();
-            let s = IotaPeer {
+            let s = AllowedPeer {
                 name: spk.name.clone(),
                 public_key,
             };

--- a/crates/iota-proxy/src/handlers.rs
+++ b/crates/iota-proxy/src/handlers.rs
@@ -17,7 +17,7 @@ use crate::{
     consumer::{NodeMetric, convert_to_remote_write, populate_labels},
     histogram_relay::HistogramRelay,
     middleware::LenDelimProtobuf,
-    peers::IotaPeer,
+    peers::AllowedPeer,
 };
 
 static HANDLER_HITS: Lazy<CounterVec> = Lazy::new(|| {
@@ -51,7 +51,7 @@ pub async fn publish_metrics(
     Extension(labels): Extension<Labels>,
     Extension(client): Extension<ReqwestClient>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
-    Extension(IotaPeer { name, public_key }): Extension<IotaPeer>,
+    Extension(AllowedPeer { name, public_key }): Extension<AllowedPeer>,
     Extension(relay): Extension<HistogramRelay>,
     LenDelimProtobuf(data): LenDelimProtobuf,
 ) -> (StatusCode, &'static str) {

--- a/crates/iota-proxy/src/lib.rs
+++ b/crates/iota-proxy/src/lib.rs
@@ -168,7 +168,7 @@ mod tests {
         // successful
         allower.get_mut().write().unwrap().insert(
             client_pub_key.to_owned(),
-            peers::IotaPeer {
+            peers::AllowedPeer {
                 name: "some-node".into(),
                 public_key: client_pub_key.to_owned(),
             },
@@ -285,7 +285,7 @@ mod tests {
         // successful
         allower.get_mut().write().unwrap().insert(
             client_pub_key.to_owned(),
-            peers::IotaPeer {
+            peers::AllowedPeer {
                 name: "some-node".into(),
                 public_key: client_pub_key.to_owned(),
             },

--- a/crates/iota-proxy/src/peers.rs
+++ b/crates/iota-proxy/src/peers.rs
@@ -24,11 +24,11 @@ use iota_types::{
 use itertools::Itertools;
 use tracing::{debug, error, info};
 
-/// IotaPeers is a mapping of public key to IotaPeer data
-pub type IotaPeers = Arc<RwLock<HashMap<Ed25519PublicKey, IotaPeer>>>;
+/// AllowedPeers is a mapping of public key to AllowedPeer data
+pub type AllowedPeers = Arc<RwLock<HashMap<Ed25519PublicKey, AllowedPeer>>>;
 
 #[derive(Hash, PartialEq, Eq, Debug, Clone)]
-pub struct IotaPeer {
+pub struct AllowedPeer {
     pub name: String,
     pub public_key: Ed25519PublicKey,
 }
@@ -41,9 +41,9 @@ pub struct IotaPeer {
 /// extension to check incoming clients on the http api against known keys.
 #[derive(Debug, Clone)]
 pub struct IotaNodeProvider {
-    active_validator_nodes: IotaPeers,
-    pending_validator_nodes: IotaPeers,
-    static_nodes: IotaPeers,
+    active_validator_nodes: AllowedPeers,
+    pending_validator_nodes: AllowedPeers,
+    static_nodes: AllowedPeers,
     rpc_url: String,
     rpc_poll_interval: Duration,
 }
@@ -65,10 +65,14 @@ impl Allower for IotaNodeProvider {
 }
 
 impl IotaNodeProvider {
-    pub fn new(rpc_url: String, rpc_poll_interval: Duration, static_peers: Vec<IotaPeer>) -> Self {
+    pub fn new(
+        rpc_url: String,
+        rpc_poll_interval: Duration,
+        static_peers: Vec<AllowedPeer>,
+    ) -> Self {
         // build our hashmap with the static pub keys. we only do this one time at
         // binary startup.
-        let static_nodes: HashMap<Ed25519PublicKey, IotaPeer> = static_peers
+        let static_nodes: HashMap<Ed25519PublicKey, AllowedPeer> = static_peers
             .into_iter()
             .map(|v| (v.public_key.clone(), v))
             .collect();
@@ -85,25 +89,25 @@ impl IotaNodeProvider {
     }
 
     /// get is used to retrieve peer info in our handlers
-    pub fn get(&self, key: &Ed25519PublicKey) -> Option<IotaPeer> {
+    pub fn get(&self, key: &Ed25519PublicKey) -> Option<AllowedPeer> {
         debug!("look for {:?}", key);
         // check static nodes first
         if let Some(v) = self.static_nodes.read().unwrap().get(key) {
-            return Some(IotaPeer {
+            return Some(AllowedPeer {
                 name: v.name.to_owned(),
                 public_key: v.public_key.to_owned(),
             });
         }
         // check active validators
         if let Some(v) = self.active_validator_nodes.read().unwrap().get(key) {
-            return Some(IotaPeer {
+            return Some(AllowedPeer {
                 name: v.name.to_owned(),
                 public_key: v.public_key.to_owned(),
             });
         }
         // check pending validators
         if let Some(v) = self.pending_validator_nodes.read().unwrap().get(key) {
-            return Some(IotaPeer {
+            return Some(AllowedPeer {
                 name: v.name.to_owned(),
                 public_key: v.public_key.to_owned(),
             });
@@ -112,7 +116,7 @@ impl IotaNodeProvider {
     }
 
     /// Get a mutable reference to the allowed validator map
-    pub fn get_mut(&mut self) -> &mut IotaPeers {
+    pub fn get_mut(&mut self) -> &mut AllowedPeers {
         &mut self.active_validator_nodes
     }
 
@@ -260,7 +264,7 @@ impl IotaNodeProvider {
 /// list and let us communicate with those actual peers via tls.
 fn extract_validators_from_summaries(
     validator_summaries: &[IotaValidatorSummary],
-) -> impl Iterator<Item = (Ed25519PublicKey, IotaPeer)> + use<'_> {
+) -> impl Iterator<Item = (Ed25519PublicKey, AllowedPeer)> + use<'_> {
     validator_summaries.iter().filter_map(|vm| {
         match Ed25519PublicKey::from_bytes(&vm.network_pubkey_bytes) {
             Ok(public_key) => {
@@ -270,7 +274,7 @@ fn extract_validators_from_summaries(
                 );
                 Some((
                     public_key.clone(),
-                    IotaPeer {
+                    AllowedPeer {
                         name: vm.name.to_owned(),
                         public_key,
                     },


### PR DESCRIPTION
# Description of change

Port [MystenLabs/sui@3fd7845](https://github.com/MystenLabs/sui/commit/3fd78458acf96df386203dafc977df85fac6e894) [sui-proxy] Allow sui bridge validator metrics

Most of the not-bridge-related upstream changes are already in our latest code.
**So, our changes in this PR are:**
Rename IotaPeer to AllowedPeer and update related references


## Links to any relevant issues

Part of https://github.com/iotaledger/iota/issues/3990

## Type of change

- Enhancement (a non-breaking change which adds functionality)
