### PR TITLE
node-upstream-change([v1.33.3, v1.34.2)): Split out push_metrics into iota-common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6197,8 +6197,16 @@ dependencies = [
 name = "iota-common"
 version = "0.13.0-alpha"
 dependencies = [
+ "anyhow",
+ "fastcrypto",
  "futures",
+ "iota-metrics",
+ "iota-tls",
+ "iota-types",
  "parking_lot 0.12.3",
+ "prometheus",
+ "reqwest 0.12.7",
+ "snap",
  "tokio",
  "tracing",
 ]
@@ -7407,7 +7415,6 @@ dependencies = [
  "prometheus",
  "reqwest 0.12.7",
  "serde",
- "snap",
  "tap",
  "telemetry-subscribers",
  "tokio",

--- a/crates/iota-common/Cargo.toml
+++ b/crates/iota-common/Cargo.toml
@@ -7,18 +7,21 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
+# external dependencies
 anyhow.workspace = true
 fastcrypto.workspace = true
 futures.workspace = true
-iota-metrics.workspace = true
-iota-tls.workspace = true
-iota-types.workspace = true
 parking_lot.workspace = true
 prometheus.workspace = true
 reqwest.workspace = true
 snap.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 tracing.workspace = true
+
+# internal dependencies
+iota-metrics.workspace = true
+iota-tls.workspace = true
+iota-types.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/crates/iota-common/Cargo.toml
+++ b/crates/iota-common/Cargo.toml
@@ -7,8 +7,16 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
+anyhow.workspace = true
+fastcrypto.workspace = true
 futures.workspace = true
+iota-metrics.workspace = true
+iota-tls.workspace = true
+iota-types.workspace = true
 parking_lot.workspace = true
+prometheus.workspace = true
+reqwest.workspace = true
+snap.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 tracing.workspace = true
 

--- a/crates/iota-common/src/lib.rs
+++ b/crates/iota-common/src/lib.rs
@@ -3,4 +3,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod logging;
+pub mod metrics;
 pub mod sync;

--- a/crates/iota-common/src/metrics.rs
+++ b/crates/iota-common/src/metrics.rs
@@ -1,0 +1,100 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use iota_metrics::RegistryService;
+use prometheus::Encoder;
+use tracing::{debug, error, info};
+
+pub struct MetricsPushClient {
+    certificate: std::sync::Arc<iota_tls::SelfSignedCertificate>,
+    client: reqwest::Client,
+}
+
+impl MetricsPushClient {
+    pub fn new(metrics_key: iota_types::crypto::NetworkKeyPair) -> Self {
+        use fastcrypto::traits::KeyPair;
+        let certificate = std::sync::Arc::new(iota_tls::SelfSignedCertificate::new(
+            metrics_key.private(),
+            iota_tls::IOTA_VALIDATOR_SERVER_NAME,
+        ));
+        let identity = certificate.reqwest_identity();
+        let client = reqwest::Client::builder()
+            .identity(identity)
+            .build()
+            .unwrap();
+
+        Self {
+            certificate,
+            client,
+        }
+    }
+
+    pub fn certificate(&self) -> &iota_tls::SelfSignedCertificate {
+        &self.certificate
+    }
+
+    pub fn client(&self) -> &reqwest::Client {
+        &self.client
+    }
+}
+
+pub async fn push_metrics(
+    client: &MetricsPushClient,
+    url: &reqwest::Url,
+    registry: &RegistryService,
+) -> Result<(), anyhow::Error> {
+    info!(push_url =% url, "pushing metrics to remote");
+
+    // now represents a collection timestamp for all of the metrics we send to the
+    // proxy
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64;
+
+    let mut metric_families = registry.gather_all();
+    for mf in metric_families.iter_mut() {
+        for m in mf.mut_metric() {
+            m.set_timestamp_ms(now);
+        }
+    }
+
+    let mut buf: Vec<u8> = vec![];
+    let encoder = prometheus::ProtobufEncoder::new();
+    encoder.encode(&metric_families, &mut buf)?;
+
+    let mut s = snap::raw::Encoder::new();
+    let compressed = s.compress_vec(&buf).map_err(|err| {
+        error!("unable to snappy encode; {err}");
+        err
+    })?;
+
+    let response = client
+        .client()
+        .post(url.to_owned())
+        .header(reqwest::header::CONTENT_ENCODING, "snappy")
+        .header(reqwest::header::CONTENT_TYPE, prometheus::PROTOBUF_FORMAT)
+        .body(compressed)
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = match response.text().await {
+            Ok(body) => body,
+            Err(error) => format!("couldn't decode response body; {error}"),
+        };
+        return Err(anyhow::anyhow!(
+            "metrics push failed: [{}]:{}",
+            status,
+            body
+        ));
+    }
+
+    debug!("successfully pushed metrics to {url}");
+
+    Ok(())
+}

--- a/crates/iota-node/Cargo.toml
+++ b/crates/iota-node/Cargo.toml
@@ -28,7 +28,6 @@ humantime.workspace = true
 prometheus.workspace = true
 reqwest.workspace = true
 serde.workspace = true
-snap.workspace = true
 tap.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tower.workspace = true

--- a/crates/iota-node/src/metrics.rs
+++ b/crates/iota-node/src/metrics.rs
@@ -2,53 +2,16 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
-use axum::http::header;
+use iota_common::metrics::{MetricsPushClient, push_metrics};
 use iota_metrics::RegistryService;
 use iota_network::tonic::Code;
 use iota_network_stack::metrics::MetricsCallbackProvider;
 use prometheus::{
-    Encoder, HistogramVec, IntCounterVec, IntGaugeVec, PROTOBUF_FORMAT, Registry,
-    register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
-    register_int_gauge_vec_with_registry,
+    HistogramVec, IntCounterVec, IntGaugeVec, Registry, register_histogram_vec_with_registry,
+    register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry,
 };
-use tracing::error;
-
-const METRICS_PUSH_TIMEOUT: Duration = Duration::from_secs(45);
-
-pub struct MetricsPushClient {
-    certificate: std::sync::Arc<iota_tls::SelfSignedCertificate>,
-    client: reqwest::Client,
-}
-
-impl MetricsPushClient {
-    pub fn new(network_key: iota_types::crypto::NetworkKeyPair) -> Self {
-        use fastcrypto::traits::KeyPair;
-        let certificate = std::sync::Arc::new(iota_tls::SelfSignedCertificate::new(
-            network_key.private(),
-            iota_tls::IOTA_VALIDATOR_SERVER_NAME,
-        ));
-        let identity = certificate.reqwest_identity();
-        let client = reqwest::Client::builder()
-            .identity(identity)
-            .build()
-            .unwrap();
-
-        Self {
-            certificate,
-            client,
-        }
-    }
-
-    pub fn certificate(&self) -> &iota_tls::SelfSignedCertificate {
-        &self.certificate
-    }
-
-    pub fn client(&self) -> &reqwest::Client {
-        &self.client
-    }
-}
 
 /// Starts a task to periodically push metrics to a configured endpoint if a
 /// metrics push endpoint is configured.
@@ -76,63 +39,6 @@ pub fn start_metrics_push_task(config: &iota_config::NodeConfig, registry: Regis
     // metrics
     let config_copy = config.clone();
     let mut client = MetricsPushClient::new(config_copy.network_key_pair().copy());
-
-    async fn push_metrics(
-        client: &MetricsPushClient,
-        url: &reqwest::Url,
-        registry: &RegistryService,
-    ) -> Result<(), anyhow::Error> {
-        // now represents a collection timestamp for all of the metrics we send to the
-        // proxy
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as i64;
-
-        let mut metric_families = registry.gather_all();
-        for mf in metric_families.iter_mut() {
-            for m in mf.mut_metric() {
-                m.set_timestamp_ms(now);
-            }
-        }
-
-        let mut buf: Vec<u8> = vec![];
-        let encoder = prometheus::ProtobufEncoder::new();
-        encoder.encode(&metric_families, &mut buf)?;
-
-        let mut s = snap::raw::Encoder::new();
-        let compressed = s.compress_vec(&buf).map_err(|err| {
-            error!("unable to snappy encode; {err}");
-            err
-        })?;
-
-        let response = client
-            .client()
-            .post(url.to_owned())
-            .header(reqwest::header::CONTENT_ENCODING, "snappy")
-            .header(header::CONTENT_TYPE, PROTOBUF_FORMAT)
-            .body(compressed)
-            .timeout(METRICS_PUSH_TIMEOUT)
-            .send()
-            .await?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = match response.text().await {
-                Ok(body) => body,
-                Err(error) => format!("couldn't decode response body; {error}"),
-            };
-            return Err(anyhow::anyhow!(
-                "metrics push failed: [{}]:{}",
-                status,
-                body
-            ));
-        }
-
-        tracing::debug!("successfully pushed metrics to {url}");
-
-        Ok(())
-    }
 
     tokio::spawn(async move {
         tracing::info!(push_url =% url, interval =? interval, "Started Metrics Push Service");


### PR DESCRIPTION
# Description of change

Port [MystenLabs/sui@89224b4](https://github.com/MystenLabs/sui/commit/89224b426815ce30e8dd3ac880749ef94395b117)
Split out push_metrics into iota-common

## Links to any relevant issues

Part of https://github.com/iotaledger/iota/issues/3990

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Run fullnode with these PR changes and compare logs with normal fullnode logs. 
Compare "push metrics" logs. 

```
cargo r --bin iota-node -- --config-path fullnode.yaml
```