### PR TITLE
chore(iota): Fix CLI `iota-names` feature not enabling sdk feature

### DIFF
--- a/crates/iota/Cargo.toml
+++ b/crates/iota/Cargo.toml
@@ -138,5 +138,10 @@ harness = false
 [features]
 gen-completions = ["dep:clap_complete"]
 indexer = ["dep:diesel", "dep:iota-indexer", "dep:iota-graphql-rpc"]
-iota-names = ["dep:chrono", "dep:iota-graphql-rpc-client", "dep:iota-names", "iota-sdk/iota-names"]
+iota-names = [
+  "dep:chrono",
+  "dep:iota-graphql-rpc-client",
+  "dep:iota-names",
+  "iota-sdk/iota-names",
+]
 tracing = ["iota-types/tracing", "iota-execution/tracing"]

--- a/crates/iota/Cargo.toml
+++ b/crates/iota/Cargo.toml
@@ -138,5 +138,5 @@ harness = false
 [features]
 gen-completions = ["dep:clap_complete"]
 indexer = ["dep:diesel", "dep:iota-indexer", "dep:iota-graphql-rpc"]
-iota-names = ["dep:chrono", "dep:iota-graphql-rpc-client", "dep:iota-names"]
+iota-names = ["dep:chrono", "dep:iota-graphql-rpc-client", "dep:iota-names", "iota-sdk/iota-names"]
 tracing = ["iota-types/tracing", "iota-execution/tracing"]


### PR DESCRIPTION
# Description of change

The `iota-names` feature in the CLI crate did not enable the same feature in the sdk crate. Now it does.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
