### PR TITLE
fix(node): authority_aggregator always requests for events when asked

### DIFF
--- a/crates/iota-core/src/authority_aggregator.rs
+++ b/crates/iota-core/src/authority_aggregator.rs
@@ -109,6 +109,7 @@ pub struct AuthAggMetrics {
     pub cert_broadcasting_post_quorum_timeout: IntCounter,
     pub remaining_tasks_when_reaching_cert_quorum: Histogram,
     pub remaining_tasks_when_cert_broadcasting_post_quorum_timeout: Histogram,
+    pub quorum_reached_without_requested_objects: IntCounter,
 }
 
 impl AuthAggMetrics {
@@ -194,7 +195,13 @@ impl AuthAggMetrics {
                 "auth_agg_remaining_tasks_when_cert_broadcasting_post_quorum_timeout",
                 "Number of remaining tasks when post quorum certificate broadcasting times out",
                 registry,
-            ).unwrap()
+            ).unwrap(),
+            quorum_reached_without_requested_objects: register_int_counter_with_registry!(
+                "auth_agg_quorum_reached_without_requested_objects",
+                "Number of times quorum was reached without getting the requested objects back from at least 1 validator",
+                registry,
+            )
+            .unwrap(),
         }
     }
 
@@ -475,6 +482,7 @@ struct ProcessCertificateState {
     input_objects: Option<Vec<Object>>,
     output_objects: Option<Vec<Object>>,
     auxiliary_data: Option<Vec<u8>>,
+    request: HandleCertificateRequestV1,
 }
 
 /// The result of processing a transaction.
@@ -1553,6 +1561,7 @@ where
             input_objects: None,
             output_objects: None,
             auxiliary_data: None,
+            request: request.clone(),
         };
 
         // create a set of validators that we should sample to request input/output
@@ -1560,7 +1569,7 @@ where
         let validators_to_sample =
             if request.include_input_objects || request.include_output_objects {
                 // Number of validators to request input/output objects from
-                const NUMBER_TO_SAMPLE: usize = 5;
+                const NUMBER_TO_SAMPLE: usize = 10;
 
                 self.committee
                     .choose_multiple_weighted_iter(NUMBER_TO_SAMPLE)
@@ -1604,7 +1613,6 @@ where
                             request_ref
                         } else {
                             HandleCertificateRequestV1 {
-                                include_events: false,
                                 include_input_objects: false,
                                 include_output_objects: false,
                                 include_auxiliary_data: false,
@@ -1640,6 +1648,7 @@ where
                     // and return.
                     match AuthorityAggregator::<A>::handle_process_certificate_response(
                         committee_clone,
+                        &metrics,
                         &tx_digest, &mut state, response, name)
                     {
                         Ok(Some(effects)) => ReduceOutput::Success(effects),
@@ -1753,6 +1762,7 @@ where
     /// Handles the `HandleCertificateResponseV1` variants.
     fn handle_process_certificate_response(
         committee: Arc<Committee>,
+        metrics: &AuthAggMetrics,
         tx_digest: &TransactionDigest,
         state: &mut ProcessCertificateState,
         response: IotaResult<HandleCertificateResponseV1>,
@@ -1816,6 +1826,18 @@ where
                             signed_effects.into_data(),
                             cert_sig,
                         );
+
+                        if (state.request.include_input_objects && state.input_objects.is_none())
+                            || (state.request.include_output_objects
+                                && state.output_objects.is_none())
+                        {
+                            metrics.quorum_reached_without_requested_objects.inc();
+                            debug!(
+                                ?tx_digest,
+                                "Quorum Reached but requested input/output objects were not returned"
+                            );
+                        }
+
                         ct.verify(&committee).map(|ct| {
                             debug!(?tx_digest, "Got quorum for validators handle_certificate.");
                             Some(QuorumDriverResponse {


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.33.3, v1.34.2)
- Port [Sui's commit #19249](https://github.com/MystenLabs/sui/commit/13a60fe90abd8d5b3055938deff027f1ecdde719)
- Change AuthorityAggregator to always pass through request_events flag, even to the validators we aren't sampling for objects. In addition, up the sample size of validators to 10 and log when we get unlucky and reach quorum without having recieved input or output objects.




## Links to any relevant issues

Part of #3990 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Ran the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`
