### PR TITLE
refactor(devx): add new rpc url to the network page

### DIFF
--- a/docs/content/developer/network-overview.mdx
+++ b/docs/content/developer/network-overview.mdx
@@ -19,7 +19,7 @@ In general, all endpoints are load-balanced but also subject to rate limiting. I
 
 <NetworkInfo.L1 {...Networks['iota']}/>
 :::info
-[Nirvana Labs](https://nirvanalabs.io/) provides hosted RPC nodes, archival services, and indexers to support developers and applications building on IOTA Rebased.
+[Nirvana Labs](https://nirvanalabs.io/) provides hosted RPC nodes, archival services, and indexers to support developers and applications building on IOTA.
 :::
 
 ## IOTA Testnet

--- a/docs/content/developer/network-overview.mdx
+++ b/docs/content/developer/network-overview.mdx
@@ -18,6 +18,9 @@ In general, all endpoints are load-balanced but also subject to rate limiting. I
 ## IOTA Mainnet
 
 <NetworkInfo.L1 {...Networks['iota']}/>
+:::info
+[Nirvana Labs](https://nirvanalabs.io/) provides hosted RPC nodes, archival services, and indexers to support developers and applications building on IOTA Rebased.
+:::
 
 ## IOTA Testnet
 

--- a/docs/site/src/components/NetworkInfo/index.tsx
+++ b/docs/site/src/components/NetworkInfo/index.tsx
@@ -38,6 +38,7 @@ function L1(props: NetworkProps) {
           <th>JSON RPC URL</th>
             <td>
               <CodeBlock>{props.rpc.json.core}</CodeBlock>
+              <CodeBlock>{props.rpc.json.monochain}</CodeBlock>
               <tr>
                 <th>Websocket</th>
                 <td>

--- a/docs/site/src/components/constant.tsx
+++ b/docs/site/src/components/constant.tsx
@@ -7,6 +7,7 @@ export const Networks: Record<string, NetworkProps> = {
         core: 'https://api.mainnet.iota.cafe',
         websocket: 'wss://api.mainnet.iota.cafe',
         indexer: 'https://indexer.mainnet.iota.cafe',
+        monochain: 'https://rpc.mainnet.iota.monochain.p2p.org',
       },
       graphql: 'https://graphql.mainnet.iota.cafe',
     },
@@ -174,6 +175,7 @@ export interface Rpc {
     core: string;
     indexer: string;
     websocket: string;
+    monochain: string;
   };
   graphql: string;
 }


### PR DESCRIPTION
# Description of change

This PR adds a new RPC URL to the Mainnet section on the network page of the docs.

## Links to any relevant issues

fixes #6885 

## Type of change

- Documentation Fix

## How the change has been tested

Preview tests passed locally.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have checked that new and existing unit tests pass locally with my changes
