### PR TITLE
fix(metrics): Add timeout and retries to metrics push task

### DIFF
--- a/crates/iota-common/src/metrics.rs
+++ b/crates/iota-common/src/metrics.rs
@@ -2,11 +2,13 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use iota_metrics::RegistryService;
 use prometheus::Encoder;
 use tracing::{debug, error, info};
+
+const DEFAULT_METRICS_PUSH_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub struct MetricsPushClient {
     certificate: std::sync::Arc<iota_tls::SelfSignedCertificate>,
@@ -78,6 +80,7 @@ pub async fn push_metrics(
         .header(reqwest::header::CONTENT_ENCODING, "snappy")
         .header(reqwest::header::CONTENT_TYPE, prometheus::PROTOBUF_FORMAT)
         .body(compressed)
+        .timeout(DEFAULT_METRICS_PUSH_TIMEOUT)
         .send()
         .await?;
 


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.33.3, v1.34.2)
- Port Sui's commit [[Metrics] add timeout and retries to metrics push task (#19399)](https://github.com/MystenLabs/sui/commit/c36d37a6b37db7df05bfb3417e4bedbfc26adddd)
- Description from the upstream commit:

    We have observed `mainnet` validators cannot push metrics until restart.
And metrics data points are dropped from some validators occasionally.
Adding request timeouts and retries hopefully should mitigate some of
these issues.

    Interval ticks are skipped if missed, so it is ok to retry until success
there.

- Note: Part of the newer retry logics (in (https://github.com/MystenLabs/sui/pull/19460)) was merged in our develop branch already, so our `iota-node/src/metrics.rs` remains untouched.

## Links to any relevant issues

Part of #3990 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Ran the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`
