### PR TITLE
refactor(devx): update the actors in the IOTA economy in docs

### DIFF
--- a/docs/content/about-iota/tokenomics/tokenomics.mdx
+++ b/docs/content/about-iota/tokenomics/tokenomics.mdx
@@ -18,7 +18,7 @@ Three main types of participants characterize the IOTA economy:
 
 - **Users** submit transactions to the IOTA platform to create, mutate, and transfer digital assets or interact with more sophisticated applications enabled by smart contracts, interoperability, and composability.
 - **Validators** manage transaction processing and execution on the IOTA platform.
-- **Delegators** are IOTA token holders who choose to delegate their tokens to validators in order to participate in the proof-of-stake mechanism. By holding IOTA tokens, they also gain the right to take part in the network’s governance.
+- **Delegators** are IOTA token holders who choose to delegate their tokens to validators to participate in the proof-of-stake mechanism. By holding IOTA tokens, they also gain the right to participate in the network’s governance.
 
 ## Tokenomics Overview
 

--- a/docs/content/about-iota/tokenomics/tokenomics.mdx
+++ b/docs/content/about-iota/tokenomics/tokenomics.mdx
@@ -18,7 +18,7 @@ Three main types of participants characterize the IOTA economy:
 
 - **Users** submit transactions to the IOTA platform to create, mutate, and transfer digital assets or interact with more sophisticated applications enabled by smart contracts, interoperability, and composability.
 - **Validators** manage transaction processing and execution on the IOTA platform.
-- **IOTA token holders** have the option of delegating their tokens to validators and participating in the proof-of-stake mechanism. Owners of IOTA tokens also hold the rights to participate in IOTA governance.
+- **Delegators** are IOTA token holders who choose to delegate their tokens to validators in order to participate in the proof-of-stake mechanism. By holding IOTA tokens, they also gain the right to take part in the network’s governance.
 
 ## Tokenomics Overview
 


### PR DESCRIPTION
# Description of change

This PR changes one of the tokenomics actors from `token holders` to `delegators` in the Docs.

## Links to any relevant issues

fixes [this issue](https://github.com/orgs/iotaledger/projects/45/views/16?pane=issue&itemId=104823794&issue=iotaledger%7Cdevx%7C530)

## Type of change

- Documentation Fix

## How the change has been tested

Preview tests passed locally.

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have checked that new and existing unit tests pass locally with my changes
