### PR TITLE
fix(network): Limit the number of peers shared during discovery

### DIFF
--- a/crates/iota-network/src/discovery/mod.rs
+++ b/crates/iota-network/src/discovery/mod.rs
@@ -25,6 +25,9 @@ use tracing::{debug, info, trace};
 
 const TIMEOUT: Duration = Duration::from_secs(1);
 const ONE_DAY_MILLISECONDS: u64 = 24 * 60 * 60 * 1_000;
+const MAX_ADDRESS_LENGTH: usize = 300;
+const MAX_PEERS_TO_SEND: usize = 200;
+const MAX_ADDRESSES_PER_PEER: usize = 2;
 
 // Includes the generated Discovery code from the OUT_DIR
 mod generated {
@@ -550,7 +553,8 @@ fn update_known_peers(
     let now_unix = now_unix();
     let our_peer_id = state.read().unwrap().our_info.clone().unwrap().peer_id;
     let known_peers = &mut state.write().unwrap().known_peers;
-    for peer in found_peers {
+    // only take the first MAX_PEERS_TO_SEND peers
+    for peer in found_peers.into_iter().take(MAX_PEERS_TO_SEND) {
         // Skip peers whose timestamp is too far in the future from our clock
         // or that are too old
         if peer.timestamp_ms > now_unix.saturating_add(30 * 1_000) // 30 seconds
@@ -565,6 +569,21 @@ fn update_known_peers(
 
         // If Peer is Private, and not in our allowlist, skip it.
         if peer.access_type == AccessType::Private && !allowlisted_peers.contains_key(&peer.peer_id)
+        {
+            continue;
+        }
+
+        // Skip entries that have too many addresses as a means to cap the size of a
+        // node's info
+        if peer.addresses.len() > MAX_ADDRESSES_PER_PEER {
+            continue;
+        }
+
+        // verify that all addresses provided are valid anemo addresses
+        if !peer
+            .addresses
+            .iter()
+            .all(|addr| addr.len() < MAX_ADDRESS_LENGTH && addr.to_anemo_address().is_ok())
         {
             continue;
         }

--- a/crates/iota-network/src/discovery/server.rs
+++ b/crates/iota-network/src/discovery/server.rs
@@ -2,12 +2,16 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::{Arc, RwLock};
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
 
 use anemo::{Request, Response};
+use rand::seq::IteratorRandom;
 use serde::{Deserialize, Serialize};
 
-use super::{Discovery, NodeInfo, State};
+use super::{Discovery, MAX_PEERS_TO_SEND, NodeInfo, State};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetKnownPeersResponse {
@@ -30,7 +34,42 @@ impl Discovery for Server {
             .our_info
             .clone()
             .ok_or_else(|| anemo::rpc::Status::internal("own_info has not been initialized yet"))?;
-        let known_peers = state.known_peers.values().cloned().collect();
+
+        let known_peers = if state.known_peers.len() < MAX_PEERS_TO_SEND {
+            state.known_peers.values().cloned().collect()
+        } else {
+            let mut rng = rand::thread_rng();
+            // prefer returning peers that we are connected to as they are known-good
+            let mut known_peers = state
+                .connected_peers
+                .keys()
+                .filter_map(|peer_id| state.known_peers.get(peer_id))
+                .map(|info| (info.peer_id, info))
+                .choose_multiple(&mut rng, MAX_PEERS_TO_SEND)
+                .into_iter()
+                .collect::<HashMap<_, _>>();
+
+            if known_peers.len() <= MAX_PEERS_TO_SEND {
+                // Fill the remaining space with other peers, randomly sampling at most
+                // MAX_PEERS_TO_SEND
+                for info in state
+                    .known_peers
+                    .values()
+                    // This randomly samples the iterator stream but the order of elements after
+                    // sampling may not be random, this is ok though since we're just trying to do
+                    // best-effort on sharing info of peers we haven't connected with ourselves.
+                    .choose_multiple(&mut rng, MAX_PEERS_TO_SEND)
+                {
+                    if known_peers.len() >= MAX_PEERS_TO_SEND {
+                        break;
+                    }
+
+                    known_peers.insert(info.peer_id, info);
+                }
+            }
+
+            known_peers.into_values().cloned().collect()
+        };
 
         Ok(Response::new(GetKnownPeersResponse {
             own_info,


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.34.2, v1.35.4)
- Port Sui's commit [discovery: limit the number of peers shared during discovery (#19501)](https://github.com/MystenLabs/sui/commit/16e6c7b69d712712085013afab128d38d09e8d1b)

## Links to any relevant issues

Part of #3990 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Ran the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`
