### PR TITLE
fix(docs): Add link to wallet dashboard homepage

### DIFF
--- a/docs/content/about-iota/iota-wallet-dashboard/getting-started.mdx
+++ b/docs/content/about-iota/iota-wallet-dashboard/getting-started.mdx
@@ -19,7 +19,7 @@ The IOTA Wallet  Dashboard offers an easy-to-use platform for managing your digi
 
 ## Connect Your Wallet
 
-To connect your IOTA Wallet to the Dashboard, click on the `Connect Wallet` button.
+Once you have created an [IOTA Wallet](../iota-wallet/getting-started.mdx), connect it to the Dashboard by visiting the [IOTA Wallet Dashboard homepage](https://wallet-dashboard.iota.org/) and clicking the `Connect` button.
 
    ![Connect button](/img/about-iota/iota-wallet-dashboard/getting-started/connect-wallet.png)
 


### PR DESCRIPTION
# Description of change

Added a link to the https://wallet-dashboard.iota.org/ in the docs for the wallet dashboard. Previously, no link was provided to the wallet dashboard.


## Type of change

- Documentation Fix
