### PR TITLE
fix(metrics): Improve metrics push

### DIFF
--- a/crates/iota-common/src/metrics.rs
+++ b/crates/iota-common/src/metrics.rs
@@ -8,7 +8,7 @@ use iota_metrics::RegistryService;
 use prometheus::Encoder;
 use tracing::{debug, error, info};
 
-const DEFAULT_METRICS_PUSH_TIMEOUT: Duration = Duration::from_secs(30);
+const METRICS_PUSH_TIMEOUT: Duration = Duration::from_secs(45);
 
 pub struct MetricsPushClient {
     certificate: std::sync::Arc<iota_tls::SelfSignedCertificate>,
@@ -80,7 +80,7 @@ pub async fn push_metrics(
         .header(reqwest::header::CONTENT_ENCODING, "snappy")
         .header(reqwest::header::CONTENT_TYPE, prometheus::PROTOBUF_FORMAT)
         .body(compressed)
-        .timeout(DEFAULT_METRICS_PUSH_TIMEOUT)
+        .timeout(METRICS_PUSH_TIMEOUT)
         .send()
         .await?;
 


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.34.2, v1.35.4)
- Port Sui's commit [Improve metrics push (#19460)](https://github.com/MystenLabs/sui/commit/3ced52d87a6748ebaf7cdf79b1a679ccfa23d472)
- A few improvements to metrics push logic.
- Note: Part of the retry logics was merged in our develop branch already, so our `iota-node/src/metrics.rs` remains untouched.

## Links to any relevant issues

Part of #3990 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Ran the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`
