### PR TITLE
upstream(node): Enable writeback cache by default

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -260,14 +260,23 @@ pub struct NodeConfig {
     pub iota_names_config: Option<IotaNamesConfig>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ExecutionCacheConfig {
-    #[default]
     PassthroughCache,
     WritebackCache {
+        /// Maximum number of entries in each cache. (There are several
+        /// different caches). If None, the default of 10000 is used.
         max_cache_size: Option<usize>,
     },
+}
+
+impl Default for ExecutionCacheConfig {
+    fn default() -> Self {
+        ExecutionCacheConfig::WritebackCache {
+            max_cache_size: None,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -4829,7 +4829,8 @@ impl AuthorityState {
     pub(crate) fn iter_live_object_set_for_testing(
         &self,
     ) -> impl Iterator<Item = authority_store_tables::LiveObject> + '_ {
-        self.get_accumulator_store().iter_live_object_set()
+        self.get_accumulator_store()
+            .iter_cached_live_object_set_for_testing()
     }
 
     #[cfg(test)]
@@ -4849,6 +4850,8 @@ impl AuthorityState {
             .bulk_insert_genesis_objects(objects)?;
         self.get_object_cache_reader()
             .force_reload_system_packages(&BuiltInFramework::all_package_ids());
+        self.get_reconfig_api()
+            .clear_state_end_of_epoch(&self.execution_lock_for_reconfiguration().await);
         Ok(())
     }
 }

--- a/crates/iota-core/src/authority/authority_test_utils.rs
+++ b/crates/iota-core/src/authority/authority_test_utils.rs
@@ -516,7 +516,7 @@ pub async fn publish_package_on_single_authority(
     dep_original_addresses: impl IntoIterator<Item = (&'static str, ObjectID)>,
     dep_ids: Vec<ObjectID>,
     state: &Arc<AuthorityState>,
-) -> IotaResult<(ObjectID, ObjectRef)> {
+) -> IotaResult<(TransactionDigest, (ObjectID, ObjectRef))> {
     let mut build_config = BuildConfig::new_for_testing();
     for (addr_name, obj_id) in dep_original_addresses {
         build_config
@@ -558,7 +558,7 @@ pub async fn publish_package_on_single_authority(
         .find(|c| matches!(c.1, Owner::AddressOwner(..)))
         .unwrap()
         .0;
-    Ok((package_id, cap_object))
+    Ok((*effects.transaction_digest(), (package_id, cap_object)))
 }
 
 pub async fn upgrade_package_on_single_authority(
@@ -571,7 +571,7 @@ pub async fn upgrade_package_on_single_authority(
     dep_original_addresses: impl IntoIterator<Item = (&'static str, ObjectID)>,
     dep_id_mapping: impl IntoIterator<Item = (&'static str, ObjectID)>,
     state: &Arc<AuthorityState>,
-) -> IotaResult<ObjectID> {
+) -> IotaResult<(TransactionDigest, ObjectID)> {
     let package = build_test_modules_with_dep_addr(path, dep_original_addresses, dep_id_mapping);
 
     let with_unpublished_deps = false;
@@ -603,5 +603,5 @@ pub async fn upgrade_package_on_single_authority(
         .unwrap()
         .0
         .0;
-    Ok(package_id)
+    Ok((*effects.transaction_digest(), package_id))
 }

--- a/crates/iota-core/src/authority/test_authority_builder.rs
+++ b/crates/iota-core/src/authority/test_authority_builder.rs
@@ -365,6 +365,12 @@ impl<'a> TestAuthorityBuilder<'a> {
             .await
             .unwrap();
 
+        state
+            .get_cache_commit()
+            .commit_transaction_outputs(epoch_store.epoch(), &[*genesis.transaction().digest()])
+            .await
+            .unwrap();
+
         // We want to insert these objects directly instead of relying on genesis
         // because genesis process would set the previous transaction field for
         // these objects, which would change their object digest. This makes it

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -104,7 +104,7 @@ impl ExecutionCacheTraitPointers {
     }
 }
 
-static ENABLE_WRITEBACK_CACHE_ENV_VAR: &str = "ENABLE_WRITEBACK_CACHE";
+static DISABLE_WRITEBACK_CACHE_ENV_VAR: &str = "DISABLE_WRITEBACK_CACHE";
 
 #[derive(Debug)]
 pub enum ExecutionCacheConfigType {
@@ -130,12 +130,12 @@ pub fn choose_execution_cache(config: &ExecutionCacheConfig) -> ExecutionCacheCo
         }
     }
 
-    if std::env::var(ENABLE_WRITEBACK_CACHE_ENV_VAR).is_ok()
-        || matches!(config, ExecutionCacheConfig::WritebackCache { .. })
+    if std::env::var(DISABLE_WRITEBACK_CACHE_ENV_VAR).is_ok()
+        || matches!(config, ExecutionCacheConfig::PassthroughCache)
     {
-        ExecutionCacheConfigType::WritebackCache
-    } else {
         ExecutionCacheConfigType::PassthroughCache
+    } else {
+        ExecutionCacheConfigType::WritebackCache
     }
 }
 
@@ -159,13 +159,13 @@ pub fn build_execution_cache_from_env(
 ) -> ExecutionCacheTraitPointers {
     let execution_cache_metrics = Arc::new(ExecutionCacheMetrics::new(prometheus_registry));
 
-    if std::env::var(ENABLE_WRITEBACK_CACHE_ENV_VAR).is_ok() {
+    if std::env::var(DISABLE_WRITEBACK_CACHE_ENV_VAR).is_ok() {
         ExecutionCacheTraitPointers::new(
-            WritebackCache::new(store.clone(), execution_cache_metrics).into(),
+            PassthroughCache::new(store.clone(), execution_cache_metrics).into(),
         )
     } else {
         ExecutionCacheTraitPointers::new(
-            PassthroughCache::new(store.clone(), execution_cache_metrics).into(),
+            WritebackCache::new(store.clone(), execution_cache_metrics).into(),
         )
     }
 }
@@ -867,11 +867,11 @@ macro_rules! implement_passthrough_traits {
 
         impl ExecutionCacheReconfigAPI for $implementor {
             fn insert_genesis_object(&self, object: Object) -> IotaResult {
-                self.store.insert_genesis_object(object)
+                self.insert_genesis_object_impl(object)
             }
 
             fn bulk_insert_genesis_objects(&self, objects: &[Object]) -> IotaResult {
-                self.store.bulk_insert_genesis_objects(objects)
+                self.bulk_insert_genesis_objects_impl(objects)
             }
 
             fn revert_state_update(&self, digest: &TransactionDigest) -> IotaResult {

--- a/crates/iota-core/src/execution_cache/object_locks.rs
+++ b/crates/iota-core/src/execution_cache/object_locks.rs
@@ -133,7 +133,6 @@ impl ObjectLocks {
 
         let live_digest = live_object.digest();
         if obj_ref.2 != live_digest {
-            debug!("object digest mismatch: {:?} vs {:?}", obj_ref, live_digest);
             return Err(IotaError::UserInput {
                 error: UserInputError::InvalidObjectDigest {
                     object_id: obj_ref.0,

--- a/crates/iota-core/src/execution_cache/passthrough_cache.rs
+++ b/crates/iota-core/src/execution_cache/passthrough_cache.rs
@@ -80,6 +80,14 @@ impl PassthroughCache {
             })
             .ok();
     }
+
+    fn bulk_insert_genesis_objects_impl(&self, objects: &[Object]) -> IotaResult {
+        self.store.bulk_insert_genesis_objects(objects)
+    }
+
+    fn insert_genesis_object_impl(&self, object: Object) -> IotaResult {
+        self.store.insert_genesis_object(object)
+    }
 }
 
 impl ObjectCacheRead for PassthroughCache {

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -1174,7 +1174,6 @@ impl WritebackCache {
     fn bulk_insert_genesis_objects_impl(&self, objects: &[Object]) -> IotaResult {
         self.store.bulk_insert_genesis_objects(objects)?;
         for obj in objects {
-            dbg!("invalidagted!", obj.id());
             self.cached.object_cache.invalidate(&obj.id());
             self.cached.object_by_id_cache.invalidate(&obj.id());
         }

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -1158,15 +1158,33 @@ impl WritebackCache {
                 self.packages.invalidate(object_id);
             }
             self.cached.object_by_id_cache.invalidate(object_id);
+            self.cached.object_cache.invalidate(object_id);
         }
 
         for ObjectKey(object_id, _) in outputs.deleted.iter().chain(outputs.wrapped.iter()) {
             self.cached.object_by_id_cache.invalidate(object_id);
+            self.cached.object_cache.invalidate(object_id);
         }
 
         // Note: individual object entries are removed when
         // clear_state_end_of_epoch_impl is called
         Ok(())
+    }
+
+    fn bulk_insert_genesis_objects_impl(&self, objects: &[Object]) -> IotaResult {
+        self.store.bulk_insert_genesis_objects(objects)?;
+        for obj in objects {
+            dbg!("invalidagted!", obj.id());
+            self.cached.object_cache.invalidate(&obj.id());
+            self.cached.object_by_id_cache.invalidate(&obj.id());
+        }
+        Ok(())
+    }
+
+    fn insert_genesis_object_impl(&self, object: Object) -> IotaResult {
+        self.cached.object_by_id_cache.invalidate(&object.id());
+        self.cached.object_cache.invalidate(&object.id());
+        self.store.insert_genesis_object(object)
     }
 
     pub fn clear_caches_and_assert_empty(&self) {

--- a/crates/iota-core/src/test_utils.rs
+++ b/crates/iota-core/src/test_utils.rs
@@ -79,9 +79,9 @@ pub async fn send_and_confirm_transaction(
     // We also check the incremental effects of the transaction on the live object
     // set against StateAccumulator for testing and regression detection
     let state_acc = StateAccumulator::new_for_tests(authority.get_accumulator_store().clone());
-    let mut state = state_acc.accumulate_live_object_set();
+    let mut state = state_acc.accumulate_cached_live_object_set_for_testing();
     let (result, _execution_error_opt) = authority.try_execute_for_test(&certificate).await?;
-    let state_after = state_acc.accumulate_live_object_set();
+    let state_after = state_acc.accumulate_cached_live_object_set_for_testing();
     let effects_acc = state_acc.accumulate_effects(vec![result.inner().data().clone()]);
     state.union(&effects_acc);
 

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -3418,23 +3418,25 @@ async fn test_store_revert_transfer_iota() {
         .await
         .unwrap();
 
-    let db = &authority_state.database_for_testing();
-    db.revert_state_update(&tx_digest).unwrap();
+    let cache = authority_state.get_object_cache_reader();
+    let tx_cache = authority_state.get_transaction_cache_reader();
+    let reconfig_api = authority_state.get_reconfig_api();
+    reconfig_api.revert_state_update(&tx_digest).unwrap();
+    reconfig_api
+        .clear_state_end_of_epoch(&authority_state.execution_lock_for_reconfiguration().await);
 
     assert_eq!(
-        db.get_object(&gas_object_id).unwrap().unwrap().owner,
+        cache.get_object(&gas_object_id).unwrap().unwrap().owner,
         Owner::AddressOwner(sender),
     );
     assert_eq!(
-        db.get_latest_object_ref_or_tombstone(gas_object_id)
+        cache
+            .get_latest_object_ref_or_tombstone(gas_object_id)
             .unwrap()
             .unwrap(),
         gas_object_ref
     );
-    // Transaction should not be deleted on revert in case it's needed
-    // to execute a future state sync checkpoint.
-    assert!(db.get_transaction_block(&tx_digest).unwrap().is_some());
-    assert!(!db.is_tx_already_executed(&tx_digest).unwrap());
+    assert!(!tx_cache.is_tx_already_executed(&tx_digest).unwrap());
 }
 
 #[tokio::test]
@@ -3454,6 +3456,15 @@ async fn test_store_revert_wrap_move_call() {
     )
     .await
     .unwrap();
+
+    authority_state
+        .get_cache_commit()
+        .commit_transaction_outputs(
+            authority_state.epoch_store_for_testing().epoch(),
+            &[*create_effects.transaction_digest()],
+        )
+        .await
+        .unwrap();
 
     assert!(create_effects.status().is_ok());
     assert_eq!(create_effects.created().len(), 1);
@@ -3491,18 +3502,21 @@ async fn test_store_revert_wrap_move_call() {
 
     let wrapper_v0 = wrap_effects.created()[0].0;
 
-    let db = &authority_state.database_for_testing();
-    db.revert_state_update(&wrap_digest).unwrap();
+    let cache = &authority_state.get_object_cache_reader();
+    let reconfig_api = authority_state.get_reconfig_api();
+    reconfig_api.revert_state_update(&wrap_digest).unwrap();
+    reconfig_api
+        .clear_state_end_of_epoch(&authority_state.execution_lock_for_reconfiguration().await);
 
     // The wrapped object is unwrapped once again (accessible from storage).
-    let object = db.get_object(&object_v0.0).unwrap().unwrap();
+    let object = cache.get_object(&object_v0.0).unwrap().unwrap();
     assert_eq!(object.version(), object_v0.1);
 
     // The wrapper doesn't exist
-    assert!(db.get_object(&wrapper_v0.0).unwrap().is_none());
+    assert!(cache.get_object(&wrapper_v0.0).unwrap().is_none());
 
     // The gas is uncharged
-    let gas = db.get_object(&gas_object_id).unwrap().unwrap();
+    let gas = cache.get_object(&gas_object_id).unwrap().unwrap();
     assert_eq!(gas.version(), create_effects.gas_object().0.1);
 }
 
@@ -3539,6 +3553,18 @@ async fn test_store_revert_unwrap_move_call() {
     )
     .await
     .unwrap();
+
+    authority_state
+        .get_cache_commit()
+        .commit_transaction_outputs(
+            authority_state.epoch_store_for_testing().epoch(),
+            &[
+                *create_effects.transaction_digest(),
+                *wrap_effects.transaction_digest(),
+            ],
+        )
+        .await
+        .unwrap();
 
     assert!(wrap_effects.status().is_ok());
     assert_eq!(wrap_effects.created().len(), 1);
@@ -3577,21 +3603,25 @@ async fn test_store_revert_unwrap_move_call() {
     assert_eq!(unwrap_effects.unwrapped().len(), 1);
     assert_eq!(unwrap_effects.unwrapped()[0].0.0, object_v0.0);
 
-    let db = &authority_state.database_for_testing();
+    let cache = &authority_state.get_object_cache_reader();
+    let reconfig_api = authority_state.get_reconfig_api();
 
-    db.revert_state_update(&unwrap_digest).unwrap();
+    reconfig_api.revert_state_update(&unwrap_digest).unwrap();
+    reconfig_api
+        .clear_state_end_of_epoch(&authority_state.execution_lock_for_reconfiguration().await);
 
     // The unwrapped object is wrapped once again
-    assert!(db.get_object(&object_v0.0).unwrap().is_none());
+    assert!(cache.get_object(&object_v0.0).unwrap().is_none());
 
     // The wrapper exists
-    let wrapper = db.get_object(&wrapper_v0.0).unwrap().unwrap();
+    let wrapper = cache.get_object(&wrapper_v0.0).unwrap().unwrap();
     assert_eq!(wrapper.version(), wrapper_v0.1);
 
     // The gas is uncharged
-    let gas = db.get_object(&gas_object_id).unwrap().unwrap();
+    let gas = cache.get_object(&gas_object_id).unwrap().unwrap();
     assert_eq!(gas.version(), wrap_effects.gas_object().0.1);
 }
+
 #[tokio::test]
 async fn test_store_get_dynamic_object() {
     let (_, fields) = create_and_retrieve_df_info(ident_str!("add_ofield")).await;
@@ -3804,6 +3834,18 @@ async fn test_store_revert_add_ofield() {
     let outer_v0 = create_outer_effects.created()[0].0;
     let inner_v0 = create_inner_effects.created()[0].0;
 
+    authority_state
+        .get_cache_commit()
+        .commit_transaction_outputs(
+            authority_state.epoch_store_for_testing().epoch(),
+            &[
+                *create_outer_effects.transaction_digest(),
+                *create_inner_effects.transaction_digest(),
+            ],
+        )
+        .await
+        .unwrap();
+
     let add_txn = to_sender_signed_transaction(
         TransactionData::new_move_call(
             sender,
@@ -3838,27 +3880,31 @@ async fn test_store_revert_add_ofield() {
     let outer_v1 = find_by_id(&add_effects.mutated(), outer_v0.0).unwrap();
     let inner_v1 = find_by_id(&add_effects.mutated(), inner_v0.0).unwrap();
 
-    let db = &authority_state.database_for_testing();
+    let cache = authority_state.get_object_cache_reader();
+    let reconfig_api = &authority_state.get_reconfig_api();
 
-    let outer = db.get_object(&outer_v0.0).unwrap().unwrap();
+    let outer = cache.get_object(&outer_v0.0).unwrap().unwrap();
     assert_eq!(outer.version(), outer_v1.1);
 
-    let field = db.get_object(&field_v0.0).unwrap().unwrap();
+    let field = cache.get_object(&field_v0.0).unwrap().unwrap();
     assert_eq!(field.owner, Owner::ObjectOwner(outer_v0.0.into()));
 
-    let inner = db.get_object(&inner_v0.0).unwrap().unwrap();
+    let inner = cache.get_object(&inner_v0.0).unwrap().unwrap();
     assert_eq!(inner.version(), inner_v1.1);
     assert_eq!(inner.owner, Owner::ObjectOwner(field_v0.0.into()));
 
-    db.revert_state_update(&add_digest).unwrap();
+    reconfig_api.revert_state_update(&add_digest).unwrap();
 
-    let outer = db.get_object(&outer_v0.0).unwrap().unwrap();
+    reconfig_api
+        .clear_state_end_of_epoch(&authority_state.execution_lock_for_reconfiguration().await);
+
+    let outer = cache.get_object(&outer_v0.0).unwrap().unwrap();
     assert_eq!(outer.version(), outer_v0.1);
 
     // Field no longer exists
-    assert!(db.get_object(&field_v0.0).unwrap().is_none());
+    assert!(cache.get_object(&field_v0.0).unwrap().is_none());
 
-    let inner = db.get_object(&inner_v0.0).unwrap().unwrap();
+    let inner = cache.get_object(&inner_v0.0).unwrap().unwrap();
     assert_eq!(inner.version(), inner_v0.1);
     assert_eq!(inner.owner, Owner::AddressOwner(sender));
 }
@@ -3915,6 +3961,19 @@ async fn test_store_revert_remove_ofield() {
     assert!(add_effects.status().is_ok());
     assert_eq!(add_effects.created().len(), 1);
 
+    authority_state
+        .get_cache_commit()
+        .commit_transaction_outputs(
+            authority_state.epoch_store_for_testing().epoch(),
+            &[
+                *create_outer_effects.transaction_digest(),
+                *create_inner_effects.transaction_digest(),
+                *add_effects.transaction_digest(),
+            ],
+        )
+        .await
+        .unwrap();
+
     let field_v0 = add_effects.created()[0].0;
     let outer_v1 = find_by_id(&add_effects.mutated(), outer_v0.0).unwrap();
     let inner_v1 = find_by_id(&add_effects.mutated(), inner_v0.0).unwrap();
@@ -3950,24 +4009,29 @@ async fn test_store_revert_remove_ofield() {
     let outer_v2 = find_by_id(&remove_effects.mutated(), outer_v0.0).unwrap();
     let inner_v2 = find_by_id(&remove_effects.mutated(), inner_v0.0).unwrap();
 
-    let db = &authority_state.database_for_testing();
+    let cache = &authority_state.get_object_cache_reader();
+    let reconfig_api = &authority_state.get_reconfig_api();
 
-    let outer = db.get_object(&outer_v0.0).unwrap().unwrap();
+    let outer = cache.get_object(&outer_v0.0).unwrap().unwrap();
     assert_eq!(outer.version(), outer_v2.1);
 
-    let inner = db.get_object(&inner_v0.0).unwrap().unwrap();
+    let inner = cache.get_object(&inner_v0.0).unwrap().unwrap();
     assert_eq!(inner.owner, Owner::AddressOwner(sender));
     assert_eq!(inner.version(), inner_v2.1);
 
-    db.revert_state_update(&remove_ofield_digest).unwrap();
+    reconfig_api
+        .revert_state_update(&remove_ofield_digest)
+        .unwrap();
+    reconfig_api
+        .clear_state_end_of_epoch(&authority_state.execution_lock_for_reconfiguration().await);
 
-    let outer = db.get_object(&outer_v0.0).unwrap().unwrap();
+    let outer = cache.get_object(&outer_v0.0).unwrap().unwrap();
     assert_eq!(outer.version(), outer_v1.1);
 
-    let field = db.get_object(&field_v0.0).unwrap().unwrap();
+    let field = cache.get_object(&field_v0.0).unwrap().unwrap();
     assert_eq!(field.owner, Owner::ObjectOwner(outer_v0.0.into()));
 
-    let inner = db.get_object(&inner_v0.0).unwrap().unwrap();
+    let inner = cache.get_object(&inner_v0.0).unwrap().unwrap();
     assert_eq!(inner.owner, Owner::ObjectOwner(field_v0.0.into()));
     assert_eq!(inner.version(), inner_v1.1);
 }

--- a/crates/iota-core/src/unit_tests/transaction_deny_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_deny_tests.rs
@@ -305,7 +305,7 @@ async fn test_package_denied() {
     // Publish 3 packages, where b depends on c, and a depends on b.
     // Also upgrade c to c', and upgrade b to b' (which will start using c' instead
     // of c as dependency).
-    let (package_c, cap_c) = publish_package_on_single_authority(
+    let (tx_c, (package_c, cap_c)) = publish_package_on_single_authority(
         &path.join("src/unit_tests/data/package_deny/c"),
         accounts[0].0,
         &accounts[0].1,
@@ -316,7 +316,7 @@ async fn test_package_denied() {
     )
     .await
     .unwrap();
-    let (package_b, cap_b) = publish_package_on_single_authority(
+    let (tx_b, (package_b, cap_b)) = publish_package_on_single_authority(
         &path.join("src/unit_tests/data/package_deny/b"),
         accounts[0].0,
         &accounts[0].1,
@@ -327,7 +327,7 @@ async fn test_package_denied() {
     )
     .await
     .unwrap();
-    let (package_a, cap_a) = publish_package_on_single_authority(
+    let (tx_a, (package_a, cap_a)) = publish_package_on_single_authority(
         &path.join("src/unit_tests/data/package_deny/a"),
         accounts[0].0,
         &accounts[0].1,
@@ -338,7 +338,7 @@ async fn test_package_denied() {
     )
     .await
     .unwrap();
-    let package_c_prime = upgrade_package_on_single_authority(
+    let (tx_c_prime, package_c_prime) = upgrade_package_on_single_authority(
         &path.join("src/unit_tests/data/package_deny/c"),
         accounts[0].0,
         &accounts[0].1,
@@ -351,7 +351,7 @@ async fn test_package_denied() {
     )
     .await
     .unwrap();
-    let package_b_prime = upgrade_package_on_single_authority(
+    let (tx_b_prime, package_b_prime) = upgrade_package_on_single_authority(
         &path.join("src/unit_tests/data/package_deny/b"),
         accounts[0].0,
         &accounts[0].1,
@@ -364,6 +364,15 @@ async fn test_package_denied() {
     )
     .await
     .unwrap();
+
+    state
+        .get_cache_commit()
+        .commit_transaction_outputs(
+            state.epoch_store_for_testing().epoch(),
+            &[tx_c, tx_b, tx_a, tx_c_prime, tx_b_prime],
+        )
+        .await
+        .unwrap();
 
     // Re-create the state such that we could deny package c.
     let state = reload_state_with_new_deny_config(

--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -901,7 +901,7 @@ async fn test_epoch_flag_upgrade() {
 
     test_cluster.wait_for_epoch_all_nodes(1).await;
 
-    // Make sure that all nodes have empty flags.
+    // Make sure that all nodes have non-empty flags.
     let all_non_empty = test_cluster.all_node_handles().iter().all(|node| {
         node.with(|node| {
             !node

--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -863,7 +863,7 @@ async fn test_epoch_flag_upgrade() {
     let initial_flags_nodes = Arc::new(Mutex::new(HashSet::new()));
     // Register a fail_point_arg, for which the handler is also placed in the
     // authority_store's open() function. When we start the first epoch, the
-    // following code will inject the new flags to the selected nodes once, so
+    // following code will inject the new empty flags to the selected nodes once, so
     // that we can later assert that the flags have changed.
     register_fail_point_arg("initial_epoch_flags", move || {
         // only alter flags on each node once
@@ -874,17 +874,35 @@ async fn test_epoch_flag_upgrade() {
         if initial_flags_nodes.len() >= 2 || !initial_flags_nodes.insert(current_node) {
             return None;
         }
-        // Apply a modified flag set for the first epoch after cluster is started.
-        Some(vec![EpochFlag::WritebackCacheEnabled])
+        // By default WritebackCache is enabled, use empty flag set for the first epoch
+        // after cluster is started.
+        Some(Vec::<EpochFlag>::new())
     });
 
-    // Start the cluster with 2 nodes with non-empty FlagSet and the rest with
-    // empty.
+    // Start the cluster with 2 nodes with empty epoch flag set and the rest with
+    // non-empty.
     let test_cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(30000)
         .build()
         .await;
-    let any_not_empty = test_cluster.all_node_handles().iter().any(|node| {
+    let any_empty = test_cluster.all_node_handles().iter().any(|node| {
+        node.with(|node| {
+            node.state()
+                .epoch_store_for_testing()
+                .epoch_start_config()
+                .flags()
+                .is_empty()
+        })
+    });
+    assert!(any_empty);
+
+    // When the epoch changes, flags on some nodes should be re-initialized to be
+    // non-empty.
+
+    test_cluster.wait_for_epoch_all_nodes(1).await;
+
+    // Make sure that all nodes have empty flags.
+    let all_non_empty = test_cluster.all_node_handles().iter().all(|node| {
         node.with(|node| {
             !node
                 .state()
@@ -894,24 +912,7 @@ async fn test_epoch_flag_upgrade() {
                 .is_empty()
         })
     });
-    assert!(any_not_empty);
-
-    // When the epoch changes, flags on some nodes should be re-initialized to be
-    // empty.
-
-    test_cluster.wait_for_epoch_all_nodes(1).await;
-
-    // Make sure that all nodes have empty flags.
-    let all_empty = test_cluster.all_node_handles().iter().all(|node| {
-        node.with(|node| {
-            node.state()
-                .epoch_store_for_testing()
-                .epoch_start_config()
-                .flags()
-                .is_empty()
-        })
-    });
-    assert!(all_empty);
+    assert!(all_non_empty);
 
     sleep(Duration::from_secs(15)).await;
 

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -122,7 +122,9 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 100
-    execution-cache: passthrough-cache
+    execution-cache:
+      writeback-cache:
+        max_cache_size: ~
     enable-validator-tx-finalizer: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
@@ -249,7 +251,9 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 100
-    execution-cache: passthrough-cache
+    execution-cache:
+      writeback-cache:
+        max_cache_size: ~
     enable-validator-tx-finalizer: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
@@ -376,7 +380,9 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 100
-    execution-cache: passthrough-cache
+    execution-cache:
+      writeback-cache:
+        max_cache_size: ~
     enable-validator-tx-finalizer: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
@@ -503,7 +509,9 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 100
-    execution-cache: passthrough-cache
+    execution-cache:
+      writeback-cache:
+        max_cache_size: ~
     enable-validator-tx-finalizer: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
@@ -630,7 +638,9 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 100
-    execution-cache: passthrough-cache
+    execution-cache:
+      writeback-cache:
+        max_cache_size: ~
     enable-validator-tx-finalizer: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
@@ -757,7 +767,9 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 100
-    execution-cache: passthrough-cache
+    execution-cache:
+      writeback-cache:
+        max_cache_size: ~
     enable-validator-tx-finalizer: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
@@ -884,7 +896,9 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 100
-    execution-cache: passthrough-cache
+    execution-cache:
+      writeback-cache:
+        max_cache_size: ~
     enable-validator-tx-finalizer: true
     verifier-signing-config:
       max-per-fun-meter-units: ~

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -2739,7 +2739,7 @@ pub struct ObjectReadResult {
     pub object: ObjectReadResultKind,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub enum ObjectReadResultKind {
     Object(Object),
     // The version of the object that the transaction intended to read, and the digest of the tx
@@ -2747,6 +2747,22 @@ pub enum ObjectReadResultKind {
     DeletedSharedObject(SequenceNumber, TransactionDigest),
     // A shared object in a cancelled transaction. The sequence number embeds cancellation reason.
     CancelledTransactionSharedObject(SequenceNumber),
+}
+
+impl std::fmt::Debug for ObjectReadResultKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ObjectReadResultKind::Object(obj) => {
+                write!(f, "Object({:?})", obj.compute_object_reference())
+            }
+            ObjectReadResultKind::DeletedSharedObject(seq, digest) => {
+                write!(f, "DeletedSharedObject({}, {:?})", seq, digest)
+            }
+            ObjectReadResultKind::CancelledTransactionSharedObject(seq) => {
+                write!(f, "CancelledTransactionSharedObject({})", seq)
+            }
+        }
+    }
 }
 
 impl From<Object> for ObjectReadResultKind {
@@ -2893,6 +2909,12 @@ impl ObjectReadResult {
 #[derive(Clone)]
 pub struct InputObjects {
     objects: Vec<ObjectReadResult>,
+}
+
+impl std::fmt::Debug for InputObjects {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list().entries(self.objects.iter()).finish()
+    }
 }
 
 // An InputObjects new-type that has been verified by iota-transaction-checks,

--- a/dev-tools/iota-network/docker-compose-antithesis.yaml
+++ b/dev-tools/iota-network/docker-compose-antithesis.yaml
@@ -65,6 +65,7 @@ services:
     container_name: validator3
     hostname: validator3
     environment:
+      - DISABLE_WRITEBACK_CACHE=1
       - RUST_BACKTRACE=1
       - RUST_LOG=info,iota_core=debug,iota_network=debug,iota_node=debug,consensus=debug,jsonrpsee=error
       - RPC_WORKER_THREAD=12
@@ -92,6 +93,7 @@ services:
     container_name: validator4
     hostname: validator4
     environment:
+      - DISABLE_WRITEBACK_CACHE=1
       - RUST_BACKTRACE=1
       - RUST_LOG=info,iota_core=debug,iota_network=debug,iota_node=debug,consensus=debug,jsonrpsee=error
       - RPC_WORKER_THREAD=12


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.34.2, v1.35.4)
- Port Sui's commit [Enable writeback cache by default (#19508)](https://github.com/MystenLabs/sui/commit/8761bf8b70de387bf9ec35025493688482793c60) and [Remove debug output (https://github.com/MystenLabs/sui/pull/19730)](https://github.com/MystenLabs/sui/commit/8ecb26f2e7115930b9931f382b87367bca1514b5) 
- Writeback cache has been stable on all mysten fullnodes plus our testnet validator for several months. Time to enable it by default everywhere
- Note that `iter_live_object_set` and `accumulate_cached_live_object_set_for_testing` do not include `wrapped_objects` anymore, which was addressed in https://github.com/iotaledger/iota/pull/3366

## Links to any relevant issues

Part of #3990 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Ran the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`
