### PR TITLE
upstream(node): add CheckpointData to bcs iota.yaml description file

### DIFF
--- a/crates/iota-core/src/generate_format.rs
+++ b/crates/iota-core/src/generate_format.rs
@@ -9,38 +9,49 @@ use clap::*;
 use fastcrypto_zkp::{bn254::zk_login::OIDCProvider, zk_login_utils::Bn254FrElement};
 use iota_types::{
     base_types::{
-        self, MoveObjectType, MoveObjectType_, ObjectDigest, ObjectID, TransactionDigest,
-        TransactionEffectsDigest,
+        self, IotaAddress, MoveObjectType, MoveObjectType_, ObjectDigest, ObjectID,
+        TransactionDigest, TransactionEffectsDigest,
     },
     crypto::{
-        AccountKeyPair, AuthorityKeyPair, AuthorityPublicKeyBytes, AuthoritySignature, IotaKeyPair,
+        AccountKeyPair, AggregateAuthoritySignature, AuthorityKeyPair, AuthorityPublicKeyBytes,
+        AuthorityQuorumSignInfo, AuthoritySignature, AuthorityStrongQuorumSignInfo, IotaKeyPair,
         KeypairTraits, PublicKey, Signature, Signer, ZkLoginPublicIdentifier, get_key_pair,
         get_key_pair_from_rng,
     },
-    effects::{IDOperation, ObjectIn, ObjectOut, TransactionEffects, UnchangedSharedKind},
+    effects::{
+        IDOperation, ObjectIn, ObjectOut, TransactionEffects, TransactionEvents,
+        UnchangedSharedKind,
+    },
+    event::Event,
     execution_status::{
         CommandArgumentError, ExecutionFailureStatus, ExecutionStatus, PackageUpgradeError,
         TypeArgumentError,
     },
+    full_checkpoint_content::{CheckpointData, CheckpointTransaction},
     messages_checkpoint::{
-        CheckpointContents, CheckpointContentsDigest, CheckpointDigest, CheckpointSummary,
-        FullCheckpointContents,
+        CertifiedCheckpointSummary, CheckpointContents, CheckpointContentsDigest, CheckpointDigest,
+        CheckpointSummary, FullCheckpointContents,
     },
     messages_grpc::ObjectInfoRequestKind,
     move_package::TypeOrigin,
     multisig::{MultiSig, MultiSigPublicKey},
-    object::{Data, Owner},
+    object::{Data, Object, Owner},
     signature::GenericSignature,
     storage::DeleteKind,
     transaction::{
-        Argument, CallArg, Command, EndOfEpochTransactionKind, ObjectArg, TransactionExpiration,
-        TransactionKind,
+        Argument, CallArg, Command, EndOfEpochTransactionKind, ObjectArg, SenderSignedData,
+        TransactionData, TransactionExpiration, TransactionKind,
     },
     utils::DEFAULT_ADDRESS_SEED,
 };
-use move_core_types::language_storage::{StructTag, TypeTag};
+use move_core_types::{
+    account_address::AccountAddress,
+    identifier::Identifier,
+    language_storage::{ModuleId, StructTag, TypeTag},
+};
 use pretty_assertions::assert_str_eq;
 use rand::{SeedableRng, rngs::StdRng};
+use roaring::RoaringBitmap;
 use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};
 use shared_crypto::intent::{Intent, IntentMessage, PersonalMessage};
 use typed_store::TypedStoreError;
@@ -56,6 +67,13 @@ fn get_registry() -> Result<Registry> {
     // tracer.trace_value(&mut samples, ...)?;
     // with all the base types contained in messages, especially the ones with
     // custom serializers; or involving generics (see [serde_reflection documentation](https://novifinancial.github.io/serde-reflection/serde_reflection/index.html)).
+
+    let m = ModuleId::new(AccountAddress::ZERO, Identifier::new("foo").unwrap());
+    tracer.trace_value(&mut samples, &m).unwrap();
+    tracer
+        .trace_value(&mut samples, &Identifier::new("foo").unwrap())
+        .unwrap();
+
     let (addr, kp): (_, AuthorityKeyPair) = get_key_pair();
     let (s_addr, s_kp): (_, AccountKeyPair) = get_key_pair();
     let pk: AuthorityPublicKeyBytes = kp.public().into();
@@ -187,6 +205,47 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<FullCheckpointContents>(&samples)?;
     tracer.trace_type::<CheckpointContents>(&samples)?;
     tracer.trace_type::<CheckpointSummary>(&samples)?;
+
+    let sender_data = SenderSignedData::new(
+        TransactionData::new_with_gas_coins(
+            TransactionKind::EndOfEpochTransaction(Vec::new()),
+            IotaAddress::ZERO,
+            Vec::new(),
+            0,
+            0,
+        ),
+        Vec::new(),
+    );
+    tracer.trace_value(&mut samples, &sender_data).unwrap();
+
+    let quorum_sig: AuthorityStrongQuorumSignInfo = AuthorityQuorumSignInfo {
+        epoch: 0,
+        signature: AggregateAuthoritySignature::default(),
+        signers_map: RoaringBitmap::default(),
+    };
+    tracer.trace_value(&mut samples, &quorum_sig).unwrap();
+
+    tracer
+        .trace_type::<CertifiedCheckpointSummary>(&samples)
+        .unwrap();
+
+    let event = Event {
+        package_id: ObjectID::random(),
+        transaction_module: Identifier::new("foo").unwrap(),
+        sender: IotaAddress::ZERO,
+        type_: struct_tag.clone(),
+        contents: vec![0],
+    };
+    tracer.trace_value(&mut samples, &event).unwrap();
+
+    tracer.trace_type::<Object>(&samples).unwrap();
+
+    tracer.trace_type::<TransactionEvents>(&samples).unwrap();
+    tracer
+        .trace_type::<CheckpointTransaction>(&samples)
+        .unwrap();
+
+    tracer.trace_type::<CheckpointData>(&samples).unwrap();
 
     tracer.registry()
 }

--- a/crates/iota-core/tests/staged/iota.yaml
+++ b/crates/iota-core/tests/staged/iota.yaml
@@ -384,16 +384,6 @@ Event:
   STRUCT:
     - package_id:
         TYPENAME: ObjectID
-    - transaction_module: STR
-    - sender:
-        TYPENAME: IotaAddress
-    - type_:
-        TYPENAME: StructTag
-    - contents: BYTES
-Event:
-  STRUCT:
-    - package_id:
-        TYPENAME: ObjectID
     - transaction_module:
         TYPENAME: Identifier
     - sender:

--- a/crates/iota-core/tests/staged/iota.yaml
+++ b/crates/iota-core/tests/staged/iota.yaml
@@ -42,6 +42,14 @@ AuthenticatorStateUpdateV1:
         TYPENAME: SequenceNumber
 AuthorityPublicKeyBytes:
   NEWTYPESTRUCT: BYTES
+AuthorityQuorumSignInfo:
+  STRUCT:
+    - epoch: U64
+    - signature:
+        TUPLEARRAY:
+          CONTENT: U8
+          SIZE: 48
+    - signers_map: BYTES
 CallArg:
   ENUM:
     0:
@@ -116,6 +124,15 @@ CheckpointContentsV1:
         SEQ:
           SEQ:
             TYPENAME: GenericSignature
+CheckpointData:
+  STRUCT:
+    - checkpoint_summary:
+        TYPENAME: "iota_types::message_envelope::Envelope<iota_types::messages_checkpoint::CheckpointSummary, iota_types::crypto::AuthorityQuorumSignInfo<true>>"
+    - checkpoint_contents:
+        TYPENAME: CheckpointContents
+    - transactions:
+        SEQ:
+          TYPENAME: CheckpointTransaction
 CheckpointDigest:
   NEWTYPESTRUCT:
     TYPENAME: Digest
@@ -140,6 +157,21 @@ CheckpointSummary:
           TYPENAME: EndOfEpochData
     - version_specific_data:
         SEQ: U8
+CheckpointTransaction:
+  STRUCT:
+    - transaction:
+        TYPENAME: "iota_types::message_envelope::Envelope<iota_types::transaction::SenderSignedData, iota_types::crypto::EmptySignInfo>"
+    - effects:
+        TYPENAME: TransactionEffects
+    - events:
+        OPTION:
+          TYPENAME: TransactionEvents
+    - input_objects:
+        SEQ:
+          TYPENAME: Object
+    - output_objects:
+        SEQ:
+          TYPENAME: Object
 Command:
   ENUM:
     0:
@@ -348,12 +380,16 @@ EndOfEpochTransactionKind:
       BridgeCommitteeInit:
         NEWTYPE:
           TYPENAME: SequenceNumber
-Envelope:
+Event:
   STRUCT:
-    - data:
-        TYPENAME: SenderSignedData
-    - auth_signature:
-        TYPENAME: EmptySignInfo
+    - package_id:
+        TYPENAME: ObjectID
+    - transaction_module: STR
+    - sender:
+        TYPENAME: IotaAddress
+    - type_:
+        TYPENAME: StructTag
+    - contents: BYTES
 Event:
   STRUCT:
     - package_id:
@@ -368,7 +404,7 @@ Event:
 ExecutionData:
   STRUCT:
     - transaction:
-        TYPENAME: Envelope
+        TYPENAME: "iota_types::message_envelope::Envelope<iota_types::transaction::SenderSignedData, iota_types::crypto::EmptySignInfo>"
     - effects:
         TYPENAME: TransactionEffects
 ExecutionDigests:
@@ -670,6 +706,15 @@ MultiSigPublicKey:
             - TYPENAME: PublicKey
             - U8
     - threshold: U16
+Object:
+  STRUCT:
+    - data:
+        TYPENAME: Data
+    - owner:
+        TYPENAME: Owner
+    - previous_transaction:
+        TYPENAME: TransactionDigest
+    - storage_rebate: U64
 ObjectArg:
   ENUM:
     0:
@@ -926,6 +971,11 @@ TransactionEffectsV1:
     - aux_data_digest:
         OPTION:
           TYPENAME: EffectsAuxDataDigest
+TransactionEvents:
+  STRUCT:
+    - data:
+        SEQ:
+          TYPENAME: Event
 TransactionEventsDigest:
   NEWTYPESTRUCT:
     TYPENAME: Digest
@@ -1054,4 +1104,16 @@ ZkLoginAuthenticatorAsBytes:
 ZkLoginPublicIdentifier:
   NEWTYPESTRUCT:
     SEQ: U8
+"iota_types::message_envelope::Envelope<iota_types::messages_checkpoint::CheckpointSummary, iota_types::crypto::AuthorityQuorumSignInfo<true>>":
+  STRUCT:
+    - data:
+        TYPENAME: CheckpointSummary
+    - auth_signature:
+        TYPENAME: AuthorityQuorumSignInfo
+"iota_types::message_envelope::Envelope<iota_types::transaction::SenderSignedData, iota_types::crypto::EmptySignInfo>":
+  STRUCT:
+    - data:
+        TYPENAME: SenderSignedData
+    - auth_signature:
+        TYPENAME: EmptySignInfo
 

--- a/crates/iota-types/src/message_envelope.rs
+++ b/crates/iota-types/src/message_envelope.rs
@@ -10,6 +10,7 @@ use std::{
 use fastcrypto::traits::KeyPair;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde_name::{DeserializeNameAdapter, SerializeNameAdapter};
 use shared_crypto::intent::{Intent, IntentScope};
 
 use crate::{
@@ -37,12 +38,45 @@ pub trait Message {
 }
 
 #[derive(Clone, Debug, Eq, Serialize, Deserialize)]
+#[serde(remote = "Envelope")]
 pub struct Envelope<T: Message, S> {
     #[serde(skip)]
     digest: OnceCell<T::DigestType>,
 
     data: T,
     auth_signature: S,
+}
+
+impl<'de, T, S> Deserialize<'de> for Envelope<T, S>
+where
+    T: Message + Deserialize<'de>,
+    S: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        Envelope::deserialize(DeserializeNameAdapter::new(
+            deserializer,
+            std::any::type_name::<Self>(),
+        ))
+    }
+}
+
+impl<T, Sig> Serialize for Envelope<T, Sig>
+where
+    T: Message + Serialize,
+    Sig: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        Envelope::serialize(
+            self,
+            SerializeNameAdapter::new(serializer, std::any::type_name::<Self>()),
+        )
+    }
 }
 
 impl<T: Message, S> Envelope<T, S> {

--- a/crates/iota-types/src/object.rs
+++ b/crates/iota-types/src/object.rs
@@ -562,6 +562,7 @@ pub struct ObjectInner {
 }
 
 #[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize, Hash)]
+#[serde(from = "ObjectInner")]
 pub struct Object(Arc<ObjectInner>);
 
 impl From<ObjectInner> for Object {


### PR DESCRIPTION
## Description of change

Upstream range: [v1.34.2, v1.35.4)

Port [MystenLabs/sui@68497e3](https://github.com/MystenLabs/sui/commit/68497e32faf369ede9bbfb7ab7487c46058ff3d2)
Add CheckpointData to bcs iota.yaml description file

## Links to any relevant issues

Part of https://github.com/iotaledger/iota/issues/3990

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

```
cargo r --bin iota-node -- --config-path fullnode.yaml
```