### PR TITLE
fix(typed-store): [DB] remove min level to compress

### DIFF
--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -2642,7 +2642,6 @@ pub fn default_db_options() -> DBOptions {
     opt.set_table_cache_num_shard_bits(10);
 
     // LSM compression settings
-    opt.set_min_level_to_compress(2);
     opt.set_compression_type(rocksdb::DBCompressionType::Lz4);
     opt.set_bottommost_compression_type(rocksdb::DBCompressionType::Zstd);
     opt.set_bottommost_zstd_max_train_bytes(1024 * 1024, true);


### PR DESCRIPTION
## Description of change

Port [MystenLabs/sui@b751830](https://github.com/MystenLabs/sui/commit/b7518305c8fa3239c158ef793e8db37f3c817095)
Lz4 should be cheap enough to enable on level 1.

## Links to any relevant issues

Part of https://github.com/iotaledger/iota/issues/3990

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

```
cargo r --bin iota-node -- --config-path /tmp/fullnode.yaml
```