### PR TITLE
upstream(node): Reduce log verbosity for object writes

### DIFF
--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -952,7 +952,7 @@ impl AuthorityStore {
             .iter()
             .map(|(id, new_object)| {
                 let version = new_object.version();
-                debug!(?id, ?version, "writing object");
+                trace!(?id, ?version, "writing object");
                 let StoreObjectPair(store_object, indirect_object) =
                     get_store_object_pair(new_object.clone(), self.indirect_objects_threshold);
                 (

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -477,7 +477,7 @@ impl WritebackCache {
         version: SequenceNumber,
         object: ObjectEntry,
     ) {
-        debug!(?object_id, ?version, ?object, "inserting object entry");
+        trace!(?object_id, ?version, ?object, "inserting object entry");
         fail_point_async!("write_object_entry");
         self.metrics.record_cache_write("object");
 


### PR DESCRIPTION
# Description of change

- Upstream range: [1.35.4-1.36.2)
- Port Sui's commit [Reduce log verbosity for object writes (#19776)](https://github.com/MystenLabs/sui/commit/8be878a684054c26362049e097c464c75d157f43)
- Individual object writes should log at TRACE

## Links to any relevant issues

Part of #3990 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Ran the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`
