### PR TITLE
upstream(node): Lower per object queue age and length thresholds

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -941,7 +941,7 @@ fn default_max_transaction_manager_queue_length() -> usize {
 }
 
 fn default_max_transaction_manager_per_object_queue_length() -> usize {
-    100
+    20
 }
 
 impl Default for AuthorityOverloadConfig {

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -121,7 +121,7 @@ validator_configs:
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
-      max-transaction-manager-per-object-queue-length: 100
+      max-transaction-manager-per-object-queue-length: 20
     execution-cache: passthrough-cache
     enable-validator-tx-finalizer: true
     verifier-signing-config:
@@ -248,7 +248,7 @@ validator_configs:
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
-      max-transaction-manager-per-object-queue-length: 100
+      max-transaction-manager-per-object-queue-length: 20
     execution-cache: passthrough-cache
     enable-validator-tx-finalizer: true
     verifier-signing-config:
@@ -375,7 +375,7 @@ validator_configs:
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
-      max-transaction-manager-per-object-queue-length: 100
+      max-transaction-manager-per-object-queue-length: 20
     execution-cache: passthrough-cache
     enable-validator-tx-finalizer: true
     verifier-signing-config:
@@ -502,7 +502,7 @@ validator_configs:
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
-      max-transaction-manager-per-object-queue-length: 100
+      max-transaction-manager-per-object-queue-length: 20
     execution-cache: passthrough-cache
     enable-validator-tx-finalizer: true
     verifier-signing-config:
@@ -629,7 +629,7 @@ validator_configs:
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
-      max-transaction-manager-per-object-queue-length: 100
+      max-transaction-manager-per-object-queue-length: 20
     execution-cache: passthrough-cache
     enable-validator-tx-finalizer: true
     verifier-signing-config:
@@ -756,7 +756,7 @@ validator_configs:
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
-      max-transaction-manager-per-object-queue-length: 100
+      max-transaction-manager-per-object-queue-length: 20
     execution-cache: passthrough-cache
     enable-validator-tx-finalizer: true
     verifier-signing-config:
@@ -883,7 +883,7 @@ validator_configs:
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
-      max-transaction-manager-per-object-queue-length: 100
+      max-transaction-manager-per-object-queue-length: 20
     execution-cache: passthrough-cache
     enable-validator-tx-finalizer: true
     verifier-signing-config:


### PR DESCRIPTION
# Description of change

- Upstream range: [1.35.4-1.36.2)
- Port Sui's commit [Lower per object queue age and length thresholds (#19851)](https://github.com/MystenLabs/sui/commit/e920c3e0cfc8673e0858c69a94d8bbc261b0fa27)
- Description from Sui's commit: The original limits on the object queue are set with 1s checkpoint interval. Having the oldest transaction on an object queued for 1s is almost tolerable. In hindsight it should be lower than the checkpoint
interval to ensure healthy system. Now checkpoint interval is targeting 0.2s - 0.25s, so lowering the limits further to 0.2s, to ensure smooth checkpoint constructions.
- Notes
  - The `default_max_txn_age_in_queue` was already updated to be 500ms by a newer upstream change and merged in https://github.com/iotaledger/iota/issues/5181, where the `default_max_transaction_manager_per_object_queue_length` was 20 (see [here](https://github.com/MystenLabs/sui/blob/cedac9a012356f6fd9cd6b862521b3963f86bf3b/crates/sui-config/src/node.rs#L922)), hence in this porting we update `default_max_transaction_manager_per_object_queue_length` to be 20.
  - The snapshot file was updated to pass tests

## Links to any relevant issues

Part of #3990 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Ran the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`
