### PR TITLE
refactor(core): Factor out parallel live object indexing

### DIFF
--- a/crates/iota-core/src/lib.rs
+++ b/crates/iota-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod mock_consensus;
 pub mod module_cache_metrics;
 pub mod mysticeti_adapter;
 pub mod overload_monitor;
+mod par_index_live_object_set;
 pub(crate) mod post_consensus_tx_reorder;
 pub mod quorum_driver;
 pub mod rest_index;

--- a/crates/iota-core/src/par_index_live_object_set.rs
+++ b/crates/iota-core/src/par_index_live_object_set.rs
@@ -1,0 +1,106 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Instant;
+
+use iota_types::{base_types::ObjectID, object::Object, storage::error::Error as StorageError};
+use tracing::info;
+
+use crate::authority::{AuthorityStore, authority_store_tables::LiveObject};
+
+/// Make `LiveObjectIndexer`s for parallel indexing of the live object set
+pub trait ParMakeLiveObjectIndexer: Sync {
+    type ObjectIndexer: LiveObjectIndexer;
+
+    fn make_live_object_indexer(&self) -> Self::ObjectIndexer;
+}
+
+/// Represents an instance of a indexer that operates on a subset of the live
+/// object set
+pub trait LiveObjectIndexer {
+    /// Called on each object in the range of the live object set this indexer
+    /// task is responsible for.
+    fn index_object(&mut self, object: Object) -> Result<(), StorageError>;
+
+    /// Called once the range of objects this indexer task is responsible for
+    /// have been processed by calling `index_object`.
+    fn finish(self) -> Result<(), StorageError>;
+}
+
+/// Utility for iterating over, and indexing, the live object set in parallel
+///
+/// This is done by dividing the addressable ObjectID space into smaller,
+/// disjoint sets and operating on each set in parallel in a separate thread.
+/// User's will need to implement the `ParMakeLiveObjectIndexer` trait which
+/// will be used to make N `LiveObjectIndexer`s which will then process one of
+/// the disjoint parts of the live object set.
+pub fn par_index_live_object_set<T: ParMakeLiveObjectIndexer>(
+    authority_store: &AuthorityStore,
+    make_indexer: &T,
+) -> Result<(), StorageError> {
+    info!("Indexing Live Object Set");
+    let start_time = Instant::now();
+    std::thread::scope(|s| -> Result<(), StorageError> {
+        let mut threads = Vec::new();
+        const BITS: u8 = 5;
+        for index in 0u8..(1 << BITS) {
+            threads.push(s.spawn(move || {
+                let object_indexer = make_indexer.make_live_object_indexer();
+                live_object_set_index_task(index, BITS, authority_store, object_indexer)
+            }));
+        }
+
+        // join threads
+        for thread in threads {
+            thread.join().unwrap()?;
+        }
+
+        Ok(())
+    })?;
+
+    info!(
+        "Indexing Live Object Set took {} seconds",
+        start_time.elapsed().as_secs()
+    );
+
+    Ok(())
+}
+
+fn live_object_set_index_task<T: LiveObjectIndexer>(
+    task_id: u8,
+    bits: u8,
+    authority_store: &AuthorityStore,
+    mut object_indexer: T,
+) -> Result<(), StorageError> {
+    let mut id_bytes = [0; ObjectID::LENGTH];
+    id_bytes[0] = task_id << (8 - bits);
+    let start_id = ObjectID::new(id_bytes);
+
+    id_bytes[0] |= (1 << (8 - bits)) - 1;
+    for element in id_bytes.iter_mut().skip(1) {
+        *element = u8::MAX;
+    }
+    let end_id = ObjectID::new(id_bytes);
+
+    let mut object_scanned: u64 = 0;
+    for object in authority_store
+        .perpetual_tables
+        .range_iter_live_object_set(Some(start_id), Some(end_id))
+        .filter_map(LiveObject::to_normal)
+    {
+        object_scanned += 1;
+        if object_scanned % 2_000_000 == 0 {
+            info!(
+                "[Index] Task {}: object scanned: {}",
+                task_id, object_scanned
+            );
+        }
+
+        object_indexer.index_object(object)?
+    }
+
+    object_indexer.finish()?;
+
+    Ok(())
+}

--- a/crates/iota-core/src/rest_index.rs
+++ b/crates/iota-core/src/rest_index.rs
@@ -32,11 +32,9 @@ use typed_store::{
 };
 
 use crate::{
-    authority::{
-        AuthorityStore, authority_per_epoch_store::AuthorityPerEpochStore,
-        authority_store_tables::LiveObject,
-    },
+    authority::{AuthorityStore, authority_per_epoch_store::AuthorityPerEpochStore},
     checkpoints::CheckpointStore,
+    par_index_live_object_set::{LiveObjectIndexer, ParMakeLiveObjectIndexer},
 };
 
 const CURRENT_DB_VERSION: u64 = 0;
@@ -227,40 +225,19 @@ impl IndexStoreTables {
 
         let coin_index = Mutex::new(HashMap::new());
 
-        info!("Indexing Live Object Set");
-        let start_time = Instant::now();
-        std::thread::scope(|s| -> Result<(), StorageError> {
-            let mut threads = Vec::new();
-            const BITS: u8 = 5;
-            for index in 0u8..(1 << BITS) {
-                let this = &self;
-                let coin_index = &coin_index;
-                threads.push(s.spawn(move || {
-                    this.live_object_set_index_task(
-                        index,
-                        BITS,
-                        authority_store,
-                        coin_index,
-                        epoch_store,
-                        package_store,
-                    )
-                }));
-            }
+        let make_live_object_indexer = RestParLiveObjectSetIndexer {
+            tables: self,
+            coin_index: &coin_index,
+            epoch_store,
+            package_store,
+        };
 
-            // join threads
-            for thread in threads {
-                thread.join().unwrap()?;
-            }
-
-            Ok(())
-        })?;
+        crate::par_index_live_object_set::par_index_live_object_set(
+            authority_store,
+            &make_live_object_indexer,
+        )?;
 
         self.coin.multi_insert(coin_index.into_inner().unwrap())?;
-
-        info!(
-            "Indexing Live Object Set took {} seconds",
-            start_time.elapsed().as_secs()
-        );
 
         self.meta.insert(
             &(),
@@ -271,92 +248,6 @@ impl IndexStoreTables {
 
         info!("Finished initializing REST indexes");
 
-        Ok(())
-    }
-
-    fn live_object_set_index_task(
-        &self,
-        task_id: u8,
-        bits: u8,
-        authority_store: &AuthorityStore,
-        coin_index: &Mutex<HashMap<CoinIndexKey, CoinIndexInfo>>,
-        epoch_store: &AuthorityPerEpochStore,
-        package_store: &Arc<dyn BackingPackageStore + Send + Sync>,
-    ) -> Result<(), StorageError> {
-        let mut id_bytes = [0; ObjectID::LENGTH];
-        id_bytes[0] = task_id << (8 - bits);
-        let start_id = ObjectID::new(id_bytes);
-
-        id_bytes[0] |= (1 << (8 - bits)) - 1;
-        for element in id_bytes.iter_mut().skip(1) {
-            *element = u8::MAX;
-        }
-        let end_id = ObjectID::new(id_bytes);
-
-        let mut resolver = epoch_store
-            .executor()
-            .type_layout_resolver(Box::new(package_store));
-        let mut batch = self.owner.batch();
-        let mut object_scanned: u64 = 0;
-        for object in authority_store
-            .perpetual_tables
-            .range_iter_live_object_set(Some(start_id), Some(end_id))
-            .filter_map(LiveObject::to_normal)
-        {
-            object_scanned += 1;
-            if object_scanned % 2_000_000 == 0 {
-                info!(
-                    "[Index] Task {}: object scanned: {}",
-                    task_id, object_scanned
-                );
-            }
-            match object.owner {
-                // Owner Index
-                Owner::AddressOwner(owner) => {
-                    let owner_key = OwnerIndexKey::new(owner, object.id());
-                    let owner_info = OwnerIndexInfo::new(&object);
-                    batch.insert_batch(&self.owner, [(owner_key, owner_info)])?;
-                }
-
-                // Dynamic Field Index
-                Owner::ObjectOwner(parent) => {
-                    if let Some(field_info) =
-                        try_create_dynamic_field_info(&object, resolver.as_mut())?
-                    {
-                        let field_key = DynamicFieldKey::new(parent, object.id());
-
-                        batch.insert_batch(&self.dynamic_field, [(field_key, field_info)])?;
-                    }
-                }
-
-                Owner::Shared { .. } | Owner::Immutable => {}
-            }
-
-            // Look for CoinMetadata<T> and TreasuryCap<T> objects
-            if let Some((key, value)) = try_create_coin_index_info(&object) {
-                use std::collections::hash_map::Entry;
-
-                match coin_index.lock().unwrap().entry(key) {
-                    Entry::Occupied(o) => {
-                        let (key, v) = o.remove_entry();
-                        let value = value.merge(v);
-                        batch.insert_batch(&self.coin, [(key, value)])?;
-                    }
-                    Entry::Vacant(v) => {
-                        v.insert(value);
-                    }
-                }
-            }
-
-            // If the batch size grows to greater that 256MB then write out to the DB so
-            // that the data we need to hold in memory doesn't grown unbounded.
-            if batch.size_in_bytes() >= 1 << 28 {
-                batch.write()?;
-                batch = self.owner.batch();
-            }
-        }
-
-        batch.write()?;
         Ok(())
     }
 
@@ -729,4 +620,91 @@ fn try_create_coin_index_info(object: &Object) -> Option<(CoinIndexKey, CoinInde
                         })
                 })
         })
+}
+
+struct RestParLiveObjectSetIndexer<'a> {
+    tables: &'a IndexStoreTables,
+    coin_index: &'a Mutex<HashMap<CoinIndexKey, CoinIndexInfo>>,
+    epoch_store: &'a AuthorityPerEpochStore,
+    package_store: &'a Arc<dyn BackingPackageStore + Send + Sync>,
+}
+
+struct RestLiveObjectIndexer<'a> {
+    tables: &'a IndexStoreTables,
+    batch: typed_store::rocks::DBBatch,
+    coin_index: &'a Mutex<HashMap<CoinIndexKey, CoinIndexInfo>>,
+    resolver: Box<dyn LayoutResolver + 'a>,
+}
+
+impl<'a> ParMakeLiveObjectIndexer for RestParLiveObjectSetIndexer<'a> {
+    type ObjectIndexer = RestLiveObjectIndexer<'a>;
+
+    fn make_live_object_indexer(&self) -> Self::ObjectIndexer {
+        RestLiveObjectIndexer {
+            tables: self.tables,
+            batch: self.tables.owner.batch(),
+            coin_index: self.coin_index,
+            resolver: self
+                .epoch_store
+                .executor()
+                .type_layout_resolver(Box::new(self.package_store)),
+        }
+    }
+}
+
+impl LiveObjectIndexer for RestLiveObjectIndexer<'_> {
+    fn index_object(&mut self, object: Object) -> Result<(), StorageError> {
+        match object.owner {
+            // Owner Index
+            Owner::AddressOwner(owner) => {
+                let owner_key = OwnerIndexKey::new(owner, object.id());
+                let owner_info = OwnerIndexInfo::new(&object);
+                self.batch
+                    .insert_batch(&self.tables.owner, [(owner_key, owner_info)])?;
+            }
+
+            // Dynamic Field Index
+            Owner::ObjectOwner(parent) => {
+                if let Some(field_info) =
+                    try_create_dynamic_field_info(&object, self.resolver.as_mut())?
+                {
+                    let field_key = DynamicFieldKey::new(parent, object.id());
+
+                    self.batch
+                        .insert_batch(&self.tables.dynamic_field, [(field_key, field_info)])?;
+                }
+            }
+
+            Owner::Shared { .. } | Owner::Immutable => {}
+        }
+
+        // Look for CoinMetadata<T> and TreasuryCap<T> objects
+        if let Some((key, value)) = try_create_coin_index_info(&object) {
+            use std::collections::hash_map::Entry;
+
+            match self.coin_index.lock().unwrap().entry(key) {
+                Entry::Occupied(o) => {
+                    let (key, v) = o.remove_entry();
+                    let value = value.merge(v);
+                    self.batch.insert_batch(&self.tables.coin, [(key, value)])?;
+                }
+                Entry::Vacant(v) => {
+                    v.insert(value);
+                }
+            }
+        }
+
+        // If the batch size grows to greater that 256MB then write out to the DB so
+        // that the data we need to hold in memory doesn't grown unbounded.
+        if self.batch.size_in_bytes() >= 1 << 28 {
+            std::mem::replace(&mut self.batch, self.tables.owner.batch()).write()?;
+        }
+
+        Ok(())
+    }
+
+    fn finish(self) -> Result<(), StorageError> {
+        self.batch.write()?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Description of change

Upstream range: [v1.35.4, v1.36.2)

Port [MystenLabs/sui@6159973](https://github.com/MystenLabs/sui/commit/6159973ae01f7b74505271d5ae76681f6594fe59)
Factor out the parallel live object indexing, used for initializing the rest indexes, into more general purpose and reusable logic.

## Links to any relevant issues

Part of https://github.com/iotaledger/iota/issues/3990

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Make sure Rest API is enabled in config:

```
...
// disabled by default, needs to be enabled in config:
// fullnode.yaml 
enable-rest-api: true
```

```
cargo r --bin iota-node -- --config-path /tmp/fullnode.yaml
```

Run any query to see Rest API works:
```
$ curl -s localhost:9000/api/v1/system | jq | grep -w safe_mode
```
`  "safe_mode": false,`

