### PR TITLE
upstream(node): move indexes from iota-storage to iota-core

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -45,8 +45,6 @@ use iota_metrics::{
     TX_TYPE_SHARED_OBJ_TX, TX_TYPE_SINGLE_WRITER_TX, monitored_scope, spawn_monitored_task,
 };
 use iota_storage::{
-    IndexStore,
-    indexes::{CoinInfo, ObjectIndexChanges},
     key_value_store::{
         KVStoreTransactionData, TransactionKeyValueStore, TransactionKeyValueStoreTrait,
     },
@@ -154,6 +152,7 @@ use crate::{
         TransactionCacheRead,
     },
     execution_driver::execution_process,
+    jsonrpc_index::{CoinInfo, IndexStore, ObjectIndexChanges},
     metrics::{LatencyObserver, RateTracker},
     module_cache_metrics::ResolverMetrics,
     overload_monitor::{AuthorityOverloadInfo, overload_monitor_accept_tx},

--- a/crates/iota-core/src/authority/test_authority_builder.rs
+++ b/crates/iota-core/src/authority/test_authority_builder.rs
@@ -19,7 +19,6 @@ use iota_config::{
 use iota_macros::nondeterministic;
 use iota_network::randomness;
 use iota_protocol_config::ProtocolConfig;
-use iota_storage::IndexStore;
 use iota_swarm_config::{genesis_config::AccountConfig, network_config::NetworkConfig};
 use iota_types::{
     base_types::{AuthorityName, ObjectID},
@@ -45,6 +44,7 @@ use crate::{
         committee_store::CommitteeStore, epoch_metrics::EpochMetrics, randomness::RandomnessManager,
     },
     execution_cache::build_execution_cache,
+    jsonrpc_index::IndexStore,
     mock_consensus::{ConsensusMode, MockConsensusClient},
     module_cache_metrics::ResolverMetrics,
     rest_index::RestIndexStore,

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -16,6 +16,7 @@ use std::{
 };
 
 use iota_json_rpc_types::{IotaObjectDataFilter, TransactionFilter};
+use iota_storage::{mutex_table::MutexTable, sharded_lru::ShardedLruCache};
 use iota_types::{
     base_types::{
         IotaAddress, ObjectDigest, ObjectID, ObjectInfo, ObjectRef, SequenceNumber,
@@ -43,8 +44,6 @@ use typed_store::{
     rocks::{DBBatch, DBMap, DBOptions, MetricConf, default_db_options, read_size_from_env},
     traits::{Map, TableSummary, TypedStoreDebug},
 };
-
-use crate::{mutex_table::MutexTable, sharded_lru::ShardedLruCache};
 
 type OwnerIndexKey = (IotaAddress, ObjectID);
 type CoinIndexKey = (IotaAddress, String, ObjectID);
@@ -1604,7 +1603,7 @@ mod tests {
     use move_core_types::account_address::AccountAddress;
     use prometheus::Registry;
 
-    use crate::{IndexStore, indexes::ObjectIndexChanges};
+    use super::{IndexStore, ObjectIndexChanges};
 
     #[tokio::test]
     async fn test_index_cache() -> anyhow::Result<()> {

--- a/crates/iota-core/src/lib.rs
+++ b/crates/iota-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod db_checkpoint_handler;
 pub mod epoch;
 pub mod execution_cache;
 mod execution_driver;
+pub mod jsonrpc_index;
 pub mod metrics;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod mock_consensus;

--- a/crates/iota-core/src/verify_indexes.rs
+++ b/crates/iota-core/src/verify_indexes.rs
@@ -5,12 +5,15 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use anyhow::{Result, anyhow, bail};
-use iota_storage::{IndexStore, indexes::CoinInfo};
 use iota_types::{base_types::ObjectInfo, object::Owner};
 use tracing::info;
 use typed_store::traits::Map;
 
-use crate::{authority::authority_store_tables::LiveObject, state_accumulator::AccumulatorStore};
+use crate::{
+    authority::authority_store_tables::LiveObject,
+    jsonrpc_index::{CoinInfo, IndexStore},
+    state_accumulator::AccumulatorStore,
+};
 
 /// This is a very expensive function that verifies some of the secondary
 /// indexes. This is done by iterating through the live object set and

--- a/crates/iota-json-rpc/src/authority_state.rs
+++ b/crates/iota-json-rpc/src/authority_state.rs
@@ -13,17 +13,15 @@ use async_trait::async_trait;
 use iota_core::{
     authority::{AuthorityState, authority_per_epoch_store::AuthorityPerEpochStore},
     execution_cache::ObjectCacheRead,
+    jsonrpc_index::TotalBalance,
     subscription_handler::SubscriptionHandler,
 };
 use iota_json_rpc_types::{
     Coin as IotaCoin, DevInspectResults, DryRunTransactionBlockResponse, EventFilter, IotaEvent,
     IotaObjectDataFilter, TransactionFilter,
 };
-use iota_storage::{
-    indexes::TotalBalance,
-    key_value_store::{
-        KVStoreTransactionData, TransactionKeyValueStore, TransactionKeyValueStoreTrait,
-    },
+use iota_storage::key_value_store::{
+    KVStoreTransactionData, TransactionKeyValueStore, TransactionKeyValueStoreTrait,
 };
 use iota_types::{
     base_types::{IotaAddress, MoveObjectType, ObjectID, ObjectInfo, ObjectRef, SequenceNumber},

--- a/crates/iota-json-rpc/src/coin_api.rs
+++ b/crates/iota-json-rpc/src/coin_api.rs
@@ -8,14 +8,14 @@ use anyhow::Result;
 use async_trait::async_trait;
 use cached::{SizedCache, proc_macro::cached};
 use chrono::DateTime;
-use iota_core::authority::AuthorityState;
+use iota_core::{authority::AuthorityState, jsonrpc_index::TotalBalance};
 use iota_json_rpc_api::{CoinReadApiOpenRpc, CoinReadApiServer, JsonRpcMetrics, cap_page_limit};
 use iota_json_rpc_types::{Balance, CoinPage, IotaCirculatingSupply, IotaCoinMetadata};
 use iota_mainnet_unlocks::MainnetUnlocksStore;
 use iota_metrics::spawn_monitored_task;
 use iota_open_rpc::Module;
 use iota_protocol_config::Chain;
-use iota_storage::{indexes::TotalBalance, key_value_store::TransactionKeyValueStore};
+use iota_storage::key_value_store::TransactionKeyValueStore;
 use iota_types::{
     balance::Supply,
     base_types::{IotaAddress, ObjectID},

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -61,6 +61,7 @@ use iota_core::{
         reconfiguration::ReconfigurationInitiator,
     },
     execution_cache::build_execution_cache,
+    jsonrpc_index::IndexStore,
     module_cache_metrics::ResolverMetrics,
     overload_monitor::overload_monitor,
     rest_index::RestIndexStore,
@@ -94,7 +95,7 @@ use iota_protocol_config::ProtocolConfig;
 use iota_rest_api::RestMetrics;
 use iota_snapshot::uploader::StateSnapshotUploader;
 use iota_storage::{
-    FileCompression, IndexStore, StorageFormat,
+    FileCompression, StorageFormat,
     http_key_value_store::HttpKVStore,
     key_value_store::{FallbackTransactionKVStore, TransactionKeyValueStore},
     key_value_store_metrics::KeyValueStoreMetrics,

--- a/crates/iota-storage/src/lib.rs
+++ b/crates/iota-storage/src/lib.rs
@@ -4,8 +4,6 @@
 
 #![allow(dead_code)]
 
-pub mod indexes;
-
 use std::{
     fs,
     fs::File,
@@ -24,7 +22,6 @@ use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use bytes::{Buf, Bytes};
 use fastcrypto::hash::{HashFunction, Sha3_256};
 use futures::StreamExt;
-pub use indexes::{IndexStore, IndexStoreTables};
 use iota_types::{
     committee::Committee,
     messages_checkpoint::{

--- a/crates/iota-tool/src/db_tool/db_dump.rs
+++ b/crates/iota-tool/src/db_tool/db_dump.rs
@@ -25,9 +25,10 @@ use iota_core::{
     },
     checkpoints::CheckpointStore,
     epoch::committee_store::CommitteeStoreTables,
+    jsonrpc_index::IndexStoreTables,
     rest_index::RestIndexStore,
 };
-use iota_storage::{IndexStoreTables, mutex_table::RwLockTable};
+use iota_storage::mutex_table::RwLockTable;
 use iota_types::base_types::{EpochId, ObjectID};
 use prometheus::Registry;
 use strum_macros::EnumString;

--- a/crates/iota-tool/src/db_tool/index_search.rs
+++ b/crates/iota-tool/src/db_tool/index_search.rs
@@ -5,7 +5,7 @@
 use std::{fmt::Debug, path::PathBuf, str::FromStr};
 
 use anyhow::anyhow;
-use iota_storage::IndexStoreTables;
+use iota_core::jsonrpc_index::IndexStoreTables;
 use iota_types::{
     Identifier, TypeTag,
     base_types::{IotaAddress, ObjectID, TxSequenceNumber},


### PR DESCRIPTION
# Description of change

- Upstream range: [1.35.4-1.36.2)
- Port Sui's commit: https://github.com/MystenLabs/sui/commit/4ad76b5679ec0e11b635537074b552cc96d584ba
- jsonrpc: move indexes from iota-storage to iota-core
- Notes
   - The type and usage of `KVStoreTransactionData ` was updated in https://github.com/iotaledger/iota/pull/5259 already, which contains a newer upstream commit.
   - The usage of `KVStoreCheckpointData` in `crates/iota-json-rpc/src/authority_state.rs` was removed in https://github.com/iotaledger/iota/pull/5215 already, which contains a newer upstream commit.
   - The usage of `use iota_protocol_config::Chain;` was introduced in https://github.com/iotaledger/iota/pull/6123 

## Links to any relevant issues

Part of #3990 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Ran the local network with `RUST_LOG=info cargo run --release --bin iota start --force-regenesis --with-faucet`
