### PR TITLE
feat(ci): add lint pr to check for conventional commit titles

### DIFF
--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -1,0 +1,29 @@
+name: "Lint PR"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+        with:
+          types: |
+            feat
+            fix
+            refactor
+            chore
+            upstream
+          requireScope: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description of change

This introduces a new CI workflow to check for conventional commit in PR titles