### PR TITLE
fix(indexer): Disable persist tx insertion order (#6926)

### DIFF
--- a/crates/iota-indexer/src/handlers/committer.rs
+++ b/crates/iota-indexer/src/handlers/committer.rs
@@ -10,10 +10,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, instrument};
 
 use super::{CheckpointDataToCommit, EpochToCommit};
-use crate::{
-    metrics::IndexerMetrics, models::transactions::TxInsertionOrder, store::IndexerStore,
-    types::IndexerResult,
-};
+use crate::{metrics::IndexerMetrics, store::IndexerStore, types::IndexerResult};
 
 pub(crate) const CHECKPOINT_COMMIT_BATCH_SIZE: usize = 100;
 
@@ -123,13 +120,6 @@ async fn commit_checkpoints<S>(
 
     let guard = metrics.checkpoint_db_commit_latency.start_timer();
     let tx_batch = tx_batch.into_iter().flatten().collect::<Vec<_>>();
-    let tx_order_batch = tx_batch
-        .iter()
-        .map(|indexed_tx| TxInsertionOrder {
-            insertion_order: -1, // fill with any value since it's ignored upon insert
-            tx_digest: indexed_tx.tx_digest.into_inner().to_vec(),
-        })
-        .collect::<Vec<_>>();
     let tx_indices_batch = tx_indices_batch.into_iter().flatten().collect::<Vec<_>>();
     let events_batch = events_batch.into_iter().flatten().collect::<Vec<_>>();
     let event_indices_batch = event_indices_batch
@@ -148,7 +138,6 @@ async fn commit_checkpoints<S>(
         let _step_1_guard = metrics.checkpoint_db_commit_latency_step_1.start_timer();
         let mut persist_tasks = vec![
             state.persist_transactions(tx_batch),
-            state.persist_tx_insertion_order(tx_order_batch),
             state.persist_tx_indices(tx_indices_batch),
             state.persist_events(events_batch),
             state.persist_event_indices(event_indices_batch),

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -226,6 +226,7 @@ mod ingestion_tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/6668"]
     pub async fn test_tx_insertion_order_table() -> Result<(), IndexerError> {
         let mut sim = Simulacrum::new();
         let data_ingestion_path = tempdir().unwrap().into_path();
@@ -267,6 +268,7 @@ mod ingestion_tests {
     }
 
     #[tokio::test]
+    #[ignore = "https://github.com/iotaledger/iota/issues/6668"]
     pub async fn test_tx_insertion_order_table_for_existing_digest() -> Result<(), IndexerError> {
         let mut sim = Simulacrum::new();
         let data_ingestion_path = tempdir().unwrap().into_path();


### PR DESCRIPTION
# Description of change

Disable persist tx insertion order because of bug
https://github.com/iotaledger/iota/issues/6668
To reenable some time after bug is fixed.

## Links to any relevant issues

part of https://github.com/iotaledger/iota/issues/6668

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

clippy
formatting
`zen cargo nextest run -p iota-indexer --features pg_integration --test-threads 1`

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Release Notes

- [x] Indexer: Disable insertion order indexing (will be revisited while enabling optimistic indexing)

