### PR TITLE
upstream(node): [replay] Allow local override of framework

### DIFF
--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -476,8 +476,13 @@ impl LocalExec {
         objs: Vec<ObjectID>,
         protocol_version: u64,
     ) -> Result<Vec<Object>, ReplayEngineError> {
-        let syst_packages = self.system_package_versions_for_protocol_version(protocol_version)?;
-        let syst_packages_objs = self.multi_download(&syst_packages).await?;
+        let syst_packages_objs = if self.protocol_version.is_some_and(|i| i < 0) {
+            BuiltInFramework::genesis_objects().collect()
+        } else {
+            let syst_packages =
+                self.system_package_versions_for_protocol_version(protocol_version)?;
+            self.multi_download(&syst_packages).await?
+        };
 
         // Download latest version of all packages that are not system packages
         // This is okay since the versions can never change


### PR DESCRIPTION
# Description of change

Upstream range: [v1.36.2, v1.37.4)

Port https://github.com/MystenLabs/sui/commit/5fd33ae11bfc77bc16d72c7b849713e5d17c2d59
This allows the Sui replay tool to replay transaction's using a local version of the framework. This can be done by passing the protocol override version to use as `-1` -- so `replay -tx <tx_digest> -p -1`


## Links to any relevant issues

Part of https://github.com/iotaledger/iota/issues/3990

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

```
cargo t -p iota-replay
cargo r -p iota-replay --example make_sandbox_snapshot
```