### PR TITLE
feat(starfish): Update `Commit` creation to support transaction acknowledments

### DIFF
--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -292,7 +292,7 @@ impl ConsensusAuthority {
 mod tests {
     #![allow(non_snake_case)]
 
-    use std::{collections::BTreeMap, sync::Arc, time::Duration};
+    use std::{sync::Arc, time::Duration};
 
     use iota_metrics::monitored_mpsc::{UnboundedReceiver, unbounded_channel};
     use iota_protocol_config::ProtocolConfig;

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -292,7 +292,7 @@ impl ConsensusAuthority {
 mod tests {
     #![allow(non_snake_case)]
 
-    use std::{sync::Arc, time::Duration};
+    use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
     use iota_metrics::monitored_mpsc::{UnboundedReceiver, unbounded_channel};
     use iota_protocol_config::ProtocolConfig;
@@ -518,7 +518,7 @@ mod tests {
                 .await
                 .expect("Timed out while waiting for at least one committed block from authority 1")
         {
-            for block in result.blocks {
+            for block in &result.blocks {
                 if block.round() > GENESIS_ROUND && block.author() == index_1 {
                     break 'outer;
                 }
@@ -586,7 +586,7 @@ mod tests {
         // We wait until we see at least one committed block authored from this
         // authority
         'outer: while let Some(result) = receiver.recv().await {
-            for block in result.blocks {
+            for block in &result.blocks {
                 if block.round() > GENESIS_ROUND && block.author() == index_1 {
                     break 'outer;
                 }

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -648,6 +648,7 @@ mod tests {
         authority_service::AuthorityService,
         block_header::{
             BlockHeaderAPI, BlockRef, SignedBlockHeader, TestBlockHeader, VerifiedBlockHeader,
+            VerifiedTransactions,
         },
         commit::{CertifiedCommits, CommitRange},
         commit_vote_monitor::CommitVoteMonitor,
@@ -686,6 +687,17 @@ mod tests {
             let block_refs = blocks.iter().map(|b| b.reference()).collect();
             self.blocks.lock().extend(blocks);
             Ok(block_refs)
+        }
+
+        async fn add_data(
+            &self,
+            data: Vec<VerifiedTransactions>,
+        ) -> Result<BTreeSet<BlockRef>, CoreError> {
+            todo!()
+        }
+
+        async fn get_missing_data(&self) -> Result<BTreeSet<BlockRef>, CoreError> {
+            todo!()
         }
 
         async fn add_certified_commits(

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -691,7 +691,7 @@ mod tests {
 
         async fn add_data(
             &self,
-            data: Vec<VerifiedTransactions>,
+            _data: Vec<VerifiedTransactions>,
         ) -> Result<BTreeSet<BlockRef>, CoreError> {
             todo!()
         }

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -636,7 +636,6 @@ pub struct VerifiedTransactions {
     transactions: Vec<Transaction>,
 
     /// The block reference of the block that contains the transactions.
-    #[expect(dead_code)]
     block_ref: BlockRef,
 
     /// Commitment of transactions in the block
@@ -670,6 +669,10 @@ impl VerifiedTransactions {
 
     pub fn transactions_commitment(&self) -> TransactionsCommitment {
         self.transactions_commitment
+    }
+
+    pub fn block_ref(&self) -> BlockRef {
+        self.block_ref
     }
 }
 
@@ -736,6 +739,11 @@ impl TestBlockHeader {
 
     pub fn set_commit_votes(mut self, commit_votes: Vec<CommitVote>) -> Self {
         self.block_header.commit_votes = commit_votes;
+        self
+    }
+
+    pub fn set_acknowledgments(mut self, acknowledgments: Vec<BlockRef>) -> Self {
+        self.block_header.acknowledgments = acknowledgments;
         self
     }
 

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -630,6 +630,7 @@ impl fmt::Debug for VerifiedBlockHeader {
 }
 
 /// VerifiedTransactions are transactions that correspond to an existing block
+#[derive(Clone)]
 pub struct VerifiedTransactions {
     #[expect(dead_code)]
     transactions: Vec<Transaction>,
@@ -638,22 +639,37 @@ pub struct VerifiedTransactions {
     #[expect(dead_code)]
     block_ref: BlockRef,
 
+    /// Commitment of transactions in the block
+    transactions_commitment: TransactionsCommitment,
+
     /// The serialized bytes of the transactions.
     #[expect(dead_code)]
     serialized: Bytes,
+}
+
+impl PartialEq for VerifiedTransactions {
+    fn eq(&self, other: &Self) -> bool {
+        self.transactions_commitment() == other.transactions_commitment()
+    }
 }
 
 impl VerifiedTransactions {
     pub(crate) fn new(
         transactions: Vec<Transaction>,
         block_ref: BlockRef,
+        transactions_commitment: TransactionsCommitment,
         serialized: Bytes,
     ) -> Self {
         Self {
             transactions,
             block_ref,
+            transactions_commitment,
             serialized,
         }
+    }
+
+    pub fn transactions_commitment(&self) -> TransactionsCommitment {
+        self.transactions_commitment
     }
 }
 

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -4,6 +4,7 @@
 
 use std::{
     cmp::Ordering,
+    collections::{HashMap, HashSet},
     fmt::{self, Debug, Display, Formatter},
     hash::{Hash, Hasher},
     ops::{Deref, Range, RangeInclusive},
@@ -66,7 +67,6 @@ impl Commit {
         timestamp_ms: BlockTimestampMs,
         leader: BlockRef,
         blocks: Vec<BlockRef>,
-        transaction_acknowledgments: Vec<Vec<BlockRef>>,
         committed_transactions: Vec<BlockRef>,
     ) -> Self {
         Commit::V1(CommitV1 {
@@ -75,7 +75,6 @@ impl Commit {
             timestamp_ms,
             leader,
             blocks,
-            transaction_acknowledgments,
             committed_transactions,
         })
     }
@@ -95,8 +94,7 @@ pub(crate) trait CommitAPI {
     fn timestamp_ms(&self) -> BlockTimestampMs;
     fn leader(&self) -> BlockRef;
     fn blocks(&self) -> &[BlockRef];
-    fn transaction_acknowledgments(&self) -> Vec<Vec<BlockRef>>;
-    fn committed_transactions(&self) -> &[BlockRef];
+    fn committed_transactions(&self) -> Vec<BlockRef>;
 }
 
 /// Specifies one consensus commit.
@@ -118,10 +116,6 @@ pub(crate) struct CommitV1 {
     leader: BlockRef,
     /// Refs to committed blocks, in the commit order.
     blocks: Vec<BlockRef>,
-    // TODO: do we need this here? This can be recovered from storage by traversing this commit's
-    //  block headers. Putting it here for simplicity during recovery.
-    /// Refs to transactions in blocks acknowledged by blocks in this commit
-    transaction_acknowledgments: Vec<Vec<BlockRef>>,
     /// Refs to transactions in blocks for which quorum of acknowledgments has
     /// been collected in this and past commits.
     committed_transactions: Vec<BlockRef>,
@@ -152,12 +146,9 @@ impl CommitAPI for CommitV1 {
         &self.blocks
     }
 
-    fn transaction_acknowledgments(&self) -> Vec<Vec<BlockRef>> {
-        self.transaction_acknowledgments.clone()
-    }
-
-    fn committed_transactions(&self) -> &[BlockRef] {
-        &self.committed_transactions
+    // TODO: does this need to be a vector? block refs are a slice == less cloning?
+    fn committed_transactions(&self) -> Vec<BlockRef> {
+        self.committed_transactions.clone()
     }
 }
 
@@ -192,16 +183,15 @@ impl TrustedCommit {
         timestamp_ms: BlockTimestampMs,
         leader: BlockRef,
         blocks: Vec<BlockRef>,
+        committed_transactions: Vec<BlockRef>,
     ) -> Self {
-        // TODO: fill in vector of acknowledgments
         let commit = Commit::new(
             index,
             previous_digest,
             timestamp_ms,
             leader,
             blocks,
-            vec![],
-            vec![],
+            committed_transactions,
         );
         let serialized = commit.serialize().unwrap();
         Self::new_trusted(commit, serialized)
@@ -361,21 +351,14 @@ impl fmt::Debug for CommitRef {
 // Represents a vote on a Commit.
 pub type CommitVote = CommitRef;
 
-/// The output of consensus to execution is an ordered list of
-/// [`CommittedSubDag`]. Each CommittedSubDag contains the information needed to
-/// execution transactions in the consensus commit.
-///
-/// The application processing CommittedSubDag can arbitrarily sort the blocks
-/// within each sub-dag (but using a deterministic algorithm).
-// TODO: add transaction data to the sub-dag and use it in the consensus output.
+/// Base struct containing common fields shared between PendingSubDag and
+/// CommittedSubDag
 #[derive(Clone, PartialEq)]
-pub struct CommittedSubDag {
+pub struct SubDagBase {
     /// A reference to the leader of the sub-dag
     pub leader: BlockRef,
     /// All the committed blocks that are part of this sub-dag
     pub blocks: Vec<VerifiedBlockHeader>,
-    /// All the committed blocks that are part of this sub-dag
-    pub transactions: Vec<VerifiedTransactions>,
     /// The timestamp of the commit, obtained from the timestamp of the leader
     /// block.
     pub timestamp_ms: BlockTimestampMs,
@@ -389,28 +372,222 @@ pub struct CommittedSubDag {
     pub reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
 }
 
+impl SubDagBase {
+    /// Helper method to retrieve transaction acknowledgment references for each
+    /// AuthorityIndex from the committed block headers.
+    pub(crate) fn transaction_acknowledgments(&self) -> HashMap<AuthorityIndex, Vec<BlockRef>> {
+        self.blocks
+            .iter()
+            .map(|block| (block.author(), block.acknowledgments().to_vec()))
+            .fold(
+                HashMap::new(),
+                |mut acc: HashMap<AuthorityIndex, HashSet<BlockRef>>, (auth, vec)| {
+                    acc.entry(auth).or_default().extend(vec);
+                    acc
+                },
+            )
+            .into_iter()
+            .map(|(auth, set)| (auth, set.into_iter().collect()))
+            .collect()
+    }
+
+    /// Helper method to format blocks consistently for display
+    fn format_block_refs(&self) -> String {
+        format_block_digests(
+            &self
+                .blocks
+                .iter()
+                .map(|b| b.reference())
+                .collect::<Vec<_>>(),
+        )
+    }
+}
+
+impl Display for SubDagBase {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CommittedSubDag(leader={}, ref={}, blocks=[{}])",
+            self.leader,
+            self.commit_ref,
+            self.format_block_refs(),
+        )
+    }
+}
+
+impl fmt::Debug for SubDagBase {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}@{} ([{}];{}ms;rs{:?})",
+            self.leader,
+            self.commit_ref,
+            self.format_block_refs(),
+            self.timestamp_ms,
+            self.reputation_scores_desc
+        )
+    }
+}
+
+/// The output of consensus to execution is an ordered list of
+/// [`CommittedSubDag`]. Each CommittedSubDag contains the information needed to
+/// execution transactions in the consensus commit.
+///
+/// The application processing CommittedSubDag can arbitrarily sort the blocks
+/// within each sub-dag (but using a deterministic algorithm).
+#[derive(Clone, PartialEq)]
+pub struct CommittedSubDag {
+    /// Common fields shared with PendingSubDag
+    pub base: SubDagBase,
+    /// All the committed blocks that are part of this sub-dag
+    pub transactions: Vec<VerifiedTransactions>,
+}
+
 impl CommittedSubDag {
     /// Creates a new committed sub dag.
     pub fn new(
         leader: BlockRef,
         blocks: Vec<VerifiedBlockHeader>,
+        transactions: Vec<VerifiedTransactions>,
         timestamp_ms: BlockTimestampMs,
         commit_ref: CommitRef,
         reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
     ) -> Self {
         Self {
-            leader,
-            blocks,
-            transactions: vec![],
-            timestamp_ms,
-            commit_ref,
-            reputation_scores_desc,
+            base: SubDagBase {
+                leader,
+                blocks,
+                timestamp_ms,
+                commit_ref,
+                reputation_scores_desc,
+            },
+            transactions,
+        }
+    }
+
+    /// Helper method to format transaction refs in a consistent way
+    fn format_transaction_refs(&self) -> String {
+        format_block_digests(
+            &self
+                .transactions
+                .iter()
+                .map(|t| t.block_ref())
+                .collect::<Vec<_>>(),
+        )
+    }
+}
+
+impl Display for CommittedSubDag {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CommittedSubDag(leader={}, ref={}, blocks=[{}], committed_transactions=[{}])",
+            self.leader,
+            self.commit_ref,
+            self.base.format_block_refs(),
+            self.format_transaction_refs(),
+        )
+    }
+}
+
+impl fmt::Debug for CommittedSubDag {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}@{} ([{}];[{}];{}ms;rs{:?})",
+            self.leader,
+            self.commit_ref,
+            self.base.format_block_refs(),
+            self.format_transaction_refs(),
+            self.timestamp_ms,
+            self.reputation_scores_desc
+        )
+    }
+}
+
+// Implementation of common traits with field delegation
+impl std::ops::Deref for PendingSubDag {
+    type Target = SubDagBase;
+
+    fn deref(&self) -> &Self::Target {
+        &self.base
+    }
+}
+
+/// PendingSubDag is a structure used after creating a commit and making sure
+/// that all committed transactions are available. This struct is used to update
+/// the leader schedule as well as produce a CommittedSubDag once all the
+/// committed_transactions become available.
+#[derive(Clone, PartialEq)]
+pub struct PendingSubDag {
+    /// Common fields shared with CommittedSubDag
+    pub base: SubDagBase,
+    /// References to blocks whose transactions were committed as part of this
+    /// SubDag.
+    pub committed_transaction_refs: Vec<BlockRef>,
+}
+
+impl PendingSubDag {
+    /// Creates a new pending sub dag.
+    pub fn new(
+        leader: BlockRef,
+        blocks: Vec<VerifiedBlockHeader>,
+        committed_transaction_refs: Vec<BlockRef>,
+        timestamp_ms: BlockTimestampMs,
+        commit_ref: CommitRef,
+        reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
+    ) -> Self {
+        Self {
+            base: SubDagBase {
+                leader,
+                blocks,
+                timestamp_ms,
+                commit_ref,
+                reputation_scores_desc,
+            },
+            committed_transaction_refs,
         }
     }
 }
 
+impl std::ops::Deref for CommittedSubDag {
+    type Target = SubDagBase;
+
+    fn deref(&self) -> &Self::Target {
+        &self.base
+    }
+}
+
+impl Display for PendingSubDag {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "PendingSubDag(leader={}, ref={}, blocks=[{}], committed_transactions=[{}])",
+            self.leader,
+            self.commit_ref,
+            self.base.format_block_refs(),
+            format_block_digests(&self.committed_transaction_refs),
+        )
+    }
+}
+
+impl fmt::Debug for PendingSubDag {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}@{} ([{}];[{}];{}ms;rs{:?})",
+            self.leader,
+            self.commit_ref,
+            self.base.format_block_refs(),
+            format_block_digests(&self.committed_transaction_refs),
+            self.timestamp_ms,
+            self.reputation_scores_desc
+        )
+    }
+}
+
 // Sort the blocks of the sub-dag blocks by round number then authority index.
-// Any deterministic & stable algorithm works.
+// Any deterministic and stable algorithm works.
 pub(crate) fn sort_sub_dag_blocks(blocks: &mut [VerifiedBlockHeader]) {
     blocks.sort_by(|a, b| {
         a.round()
@@ -419,48 +596,17 @@ pub(crate) fn sort_sub_dag_blocks(blocks: &mut [VerifiedBlockHeader]) {
     })
 }
 
-impl Display for CommittedSubDag {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "CommittedSubDag(leader={}, ref={}, blocks=[",
-            self.leader, self.commit_ref
-        )?;
-        for (idx, block) in self.blocks.iter().enumerate() {
-            if idx > 0 {
-                write!(f, ", ")?;
-            }
-            write!(f, "{}", block.digest())?;
-        }
-        write!(f, "])")
-    }
-}
-
-impl fmt::Debug for CommittedSubDag {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}@{} ([", self.leader, self.commit_ref)?;
-        for block in &self.blocks {
-            write!(f, "{}, ", block.reference())?;
-        }
-        write!(
-            f,
-            "];{}ms;rs{:?})",
-            self.timestamp_ms, self.reputation_scores_desc
-        )
-    }
-}
-
 // Recovers the full CommittedSubDag from block store, based on Commit.
-pub fn load_committed_subdag_from_store(
+pub fn load_pending_subdag_from_store(
     store: &dyn Store,
     commit: TrustedCommit,
     reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
-) -> CommittedSubDag {
+) -> PendingSubDag {
     let mut leader_block_idx = None;
-    let commit_blocks = store
+    let commit_block_headers = store
         .read_blocks(commit.blocks())
         .expect("We should have the block referenced in the commit data");
-    let blocks = commit_blocks
+    let block_headers = commit_block_headers
         .into_iter()
         .enumerate()
         .map(|(idx, commit_block_opt)| {
@@ -473,14 +619,26 @@ pub fn load_committed_subdag_from_store(
         })
         .collect::<Vec<_>>();
     let leader_block_idx = leader_block_idx.expect("Leader block must be in the sub-dag");
-    let leader_block_ref = blocks[leader_block_idx].reference();
-    CommittedSubDag::new(
+    let leader_block_ref = block_headers[leader_block_idx].reference();
+    PendingSubDag::new(
         leader_block_ref,
-        blocks,
+        block_headers,
+        commit.committed_transactions().clone(),
         commit.timestamp_ms(),
         commit.reference(),
         reputation_scores_desc,
     )
+}
+
+fn format_block_digests(blocks: &[BlockRef]) -> String {
+    let mut result = String::new();
+    for (idx, block) in blocks.iter().enumerate() {
+        if idx > 0 {
+            result.push_str(", ");
+        }
+        result.push_str(&block.digest.to_string());
+    }
+    result
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -688,14 +846,13 @@ mod tests {
     async fn test_new_subdag_from_commit() {
         let store = Arc::new(MemStore::new());
         let context = Arc::new(Context::new_for_test(4).0);
-        let wave_length = WAVE_LENGTH;
 
         // Populate fully connected test blocks for round 0 ~ 3, authorities 0 ~ 3.
-        let first_wave_rounds: u32 = wave_length;
+        let first_wave_rounds: u32 = WAVE_LENGTH;
         let num_authorities: u32 = 4;
 
         let mut blocks = Vec::new();
-        let (genesis_references, genesis): (Vec<_>, Vec<_>) = context
+        let (first_round_references, first_round_headers): (Vec<_>, Vec<_>) = context
             .committee
             .authorities()
             .map(|index| {
@@ -705,11 +862,13 @@ mod tests {
             })
             .map(|block| (block.reference(), block))
             .unzip();
-        // TODO: avoid writing genesis blocks?
-        store.write(WriteBatch::default().blocks(genesis)).unwrap();
-        blocks.append(&mut genesis_references.clone());
+        store
+            .write(WriteBatch::default().blocks(first_round_headers))
+            .unwrap();
+        blocks.append(&mut first_round_references.clone());
+        // TODO: create some data for blocks in the first round
 
-        let mut ancestors = genesis_references;
+        let mut ancestors = first_round_references.clone();
         let mut leader = None;
         for round in 1..=first_wave_rounds {
             let mut new_ancestors = vec![];
@@ -719,6 +878,7 @@ mod tests {
                     TestBlockHeader::new(round, author)
                         .set_timestamp_ms(base_ts + (author + round) as u64)
                         .set_ancestors(ancestors.clone())
+                        .set_acknowledgments(ancestors.clone())
                         .build(),
                 );
                 store
@@ -746,13 +906,18 @@ mod tests {
             leader_block.timestamp_ms(),
             leader_ref,
             blocks.clone(),
+            first_round_references.clone(),
         );
-        let subdag = load_committed_subdag_from_store(store.as_ref(), commit.clone(), vec![]);
+
+        // The test skips transaction availability checks as it assumes that all
+        // transactions are available. It's supposed to check the
+        // CommittedSubDag creation logic.
+        let subdag = load_pending_subdag_from_store(store.as_ref(), commit.clone(), vec![]);
         assert_eq!(subdag.leader, leader_ref);
         assert_eq!(subdag.timestamp_ms, leader_block.timestamp_ms());
         assert_eq!(
             subdag.blocks.len(),
-            (num_authorities * wave_length) as usize + 1
+            (num_authorities * WAVE_LENGTH) as usize + 1
         );
         assert_eq!(subdag.commit_ref, commit.reference());
         assert_eq!(subdag.reputation_scores_desc, vec![]);

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -637,6 +637,8 @@ fn format_block_digests(blocks: &[BlockRef]) -> String {
             result.push_str(", ");
         }
         result.push_str(&block.digest.to_string());
+        result.push_str("@");
+        result.push_str(&block.round.to_string());
     }
     result
 }
@@ -843,7 +845,8 @@ mod tests {
     };
 
     #[tokio::test]
-    async fn test_new_subdag_from_commit() {
+    #[ignore = "Finish implementing this test when Transaction storage is ready"]
+    async fn test_new_committed_subdag_from_commit() {
         let store = Arc::new(MemStore::new());
         let context = Arc::new(Context::new_for_test(4).0);
 
@@ -909,9 +912,6 @@ mod tests {
             first_round_references.clone(),
         );
 
-        // The test skips transaction availability checks as it assumes that all
-        // transactions are available. It's supposed to check the
-        // CommittedSubDag creation logic.
         let subdag = load_pending_subdag_from_store(store.as_ref(), commit.clone(), vec![]);
         assert_eq!(subdag.leader, leader_ref);
         assert_eq!(subdag.timestamp_ms, leader_block.timestamp_ms());
@@ -920,7 +920,89 @@ mod tests {
             (num_authorities * WAVE_LENGTH) as usize + 1
         );
         assert_eq!(subdag.commit_ref, commit.reference());
+        assert_eq!(subdag.committed_transaction_refs, first_round_references);
         assert_eq!(subdag.reputation_scores_desc, vec![]);
+    }
+
+    #[tokio::test]
+    async fn test_new_pending_subdag_from_commit() {
+        let store = Arc::new(MemStore::new());
+        let context = Arc::new(Context::new_for_test(4).0);
+
+        // Populate fully connected test blocks for round 0 ~ 3, authorities 0 ~ 3.
+        let first_wave_rounds: u32 = WAVE_LENGTH;
+        let num_authorities: u32 = 4;
+
+        let mut blocks = Vec::new();
+        let (first_round_references, first_round_headers): (Vec<_>, Vec<_>) = context
+            .committee
+            .authorities()
+            .map(|index| {
+                let author_idx = index.0.value() as u32;
+                let block = TestBlockHeader::new(0, author_idx).build();
+                VerifiedBlockHeader::new_for_test(block)
+            })
+            .map(|block| (block.reference(), block))
+            .unzip();
+        store
+            .write(WriteBatch::default().blocks(first_round_headers))
+            .unwrap();
+        blocks.append(&mut first_round_references.clone());
+
+        let mut ancestors = first_round_references.clone();
+        let mut leader = None;
+        for round in 1..=first_wave_rounds {
+            let mut new_ancestors = vec![];
+            for author in 0..num_authorities {
+                let base_ts = round as BlockTimestampMs * 1000;
+                let block = VerifiedBlockHeader::new_for_test(
+                    TestBlockHeader::new(round, author)
+                        .set_timestamp_ms(base_ts + (author + round) as u64)
+                        .set_ancestors(ancestors.clone())
+                        .set_acknowledgments(ancestors.clone())
+                        .build(),
+                );
+                store
+                    .write(WriteBatch::default().blocks(vec![block.clone()]))
+                    .unwrap();
+                new_ancestors.push(block.reference());
+                blocks.push(block.reference());
+
+                // only write one block for the final round, which is the leader
+                // of the committed subdag.
+                if round == first_wave_rounds {
+                    leader = Some(block.clone());
+                    break;
+                }
+            }
+            ancestors = new_ancestors;
+        }
+
+        let leader_block = leader.unwrap();
+        let leader_ref = leader_block.reference();
+        let commit_index = 1;
+        let commit = TrustedCommit::new_for_test(
+            commit_index,
+            CommitDigest::MIN,
+            leader_block.timestamp_ms(),
+            leader_ref,
+            blocks.clone(),
+            first_round_references.clone(),
+        );
+
+        let pending_subdag = load_pending_subdag_from_store(store.as_ref(), commit.clone(), vec![]);
+        assert_eq!(pending_subdag.leader, leader_ref);
+        assert_eq!(pending_subdag.timestamp_ms, leader_block.timestamp_ms());
+        assert_eq!(
+            pending_subdag.blocks.len(),
+            (num_authorities * WAVE_LENGTH) as usize + 1
+        );
+        assert_eq!(pending_subdag.commit_ref, commit.reference());
+        assert_eq!(
+            pending_subdag.committed_transaction_refs,
+            first_round_references
+        );
+        assert_eq!(pending_subdag.reputation_scores_desc, vec![]);
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -637,7 +637,7 @@ fn format_block_digests(blocks: &[BlockRef]) -> String {
             result.push_str(", ");
         }
         result.push_str(&block.digest.to_string());
-        result.push_str("@");
+        result.push('@');
         result.push_str(&block.round.to_string());
     }
     result

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -17,7 +17,10 @@ use serde::{Deserialize, Serialize};
 use starfish_config::{AuthorityIndex, DIGEST_LENGTH, DefaultHashFunction};
 
 use crate::{
-    block_header::{BlockHeaderAPI, BlockRef, BlockTimestampMs, Round, Slot, VerifiedBlockHeader},
+    block_header::{
+        BlockHeaderAPI, BlockRef, BlockTimestampMs, Round, Slot, VerifiedBlockHeader,
+        VerifiedTransactions,
+    },
     leader_scoring::ReputationScores,
     storage::Store,
 };
@@ -63,6 +66,8 @@ impl Commit {
         timestamp_ms: BlockTimestampMs,
         leader: BlockRef,
         blocks: Vec<BlockRef>,
+        transaction_acknowledgments: Vec<Vec<BlockRef>>,
+        committed_transactions: Vec<BlockRef>,
     ) -> Self {
         Commit::V1(CommitV1 {
             index,
@@ -70,6 +75,8 @@ impl Commit {
             timestamp_ms,
             leader,
             blocks,
+            transaction_acknowledgments,
+            committed_transactions,
         })
     }
 
@@ -88,6 +95,8 @@ pub(crate) trait CommitAPI {
     fn timestamp_ms(&self) -> BlockTimestampMs;
     fn leader(&self) -> BlockRef;
     fn blocks(&self) -> &[BlockRef];
+    fn transaction_acknowledgments(&self) -> Vec<Vec<BlockRef>>;
+    fn committed_transactions(&self) -> &[BlockRef];
 }
 
 /// Specifies one consensus commit.
@@ -109,6 +118,13 @@ pub(crate) struct CommitV1 {
     leader: BlockRef,
     /// Refs to committed blocks, in the commit order.
     blocks: Vec<BlockRef>,
+    // TODO: do we need this here? This can be recovered from storage by traversing this commit's
+    //  block headers. Putting it here for simplicity during recovery.
+    /// Refs to transactions in blocks acknowledged by blocks in this commit
+    transaction_acknowledgments: Vec<Vec<BlockRef>>,
+    /// Refs to transactions in blocks for which quorum of acknowledgments has
+    /// been collected in this and past commits.
+    committed_transactions: Vec<BlockRef>,
 }
 
 impl CommitAPI for CommitV1 {
@@ -134,6 +150,14 @@ impl CommitAPI for CommitV1 {
 
     fn blocks(&self) -> &[BlockRef] {
         &self.blocks
+    }
+
+    fn transaction_acknowledgments(&self) -> Vec<Vec<BlockRef>> {
+        self.transaction_acknowledgments.clone()
+    }
+
+    fn committed_transactions(&self) -> &[BlockRef] {
+        &self.committed_transactions
     }
 }
 
@@ -169,7 +193,16 @@ impl TrustedCommit {
         leader: BlockRef,
         blocks: Vec<BlockRef>,
     ) -> Self {
-        let commit = Commit::new(index, previous_digest, timestamp_ms, leader, blocks);
+        // TODO: fill in vector of acknowledgments
+        let commit = Commit::new(
+            index,
+            previous_digest,
+            timestamp_ms,
+            leader,
+            blocks,
+            vec![],
+            vec![],
+        );
         let serialized = commit.serialize().unwrap();
         Self::new_trusted(commit, serialized)
     }
@@ -341,6 +374,8 @@ pub struct CommittedSubDag {
     pub leader: BlockRef,
     /// All the committed blocks that are part of this sub-dag
     pub blocks: Vec<VerifiedBlockHeader>,
+    /// All the committed blocks that are part of this sub-dag
+    pub transactions: Vec<VerifiedTransactions>,
     /// The timestamp of the commit, obtained from the timestamp of the leader
     /// block.
     pub timestamp_ms: BlockTimestampMs,
@@ -366,6 +401,7 @@ impl CommittedSubDag {
         Self {
             leader,
             blocks,
+            transactions: vec![],
             timestamp_ms,
             commit_ref,
             reputation_scores_desc,

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{ops::Deref, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use iota_metrics::monitored_mpsc::UnboundedSender;
 use parking_lot::RwLock;
@@ -10,9 +10,9 @@ use tokio::time::Instant;
 use tracing::{debug, info};
 
 use crate::{
-    CommitConsumer, CommittedSubDag,
+    BlockRef, CommitConsumer, CommittedSubDag,
     block_header::{BlockHeaderAPI, VerifiedBlockHeader},
-    commit::{CommitAPI, CommitIndex, load_committed_subdag_from_store},
+    commit::{CommitAPI, CommitIndex, PendingSubDag, load_pending_subdag_from_store},
     context::Context,
     dag_state::DagState,
     data_manager::DataManager,
@@ -84,7 +84,7 @@ impl CommitObserver {
     pub(crate) fn handle_commit(
         &mut self,
         committed_leaders: Vec<VerifiedBlockHeader>,
-    ) -> ConsensusResult<Vec<CommittedSubDag>> {
+    ) -> ConsensusResult<(Vec<PendingSubDag>, Vec<BlockRef>)> {
         let _s = self
             .context
             .metrics
@@ -93,15 +93,18 @@ impl CommitObserver {
             .with_label_values(&["CommitObserver::handle_commit"])
             .start_timer();
 
-        let committed_sub_dags = self.commit_interpreter.handle_commit(committed_leaders);
+        let pending_sub_dags = self.commit_interpreter.handle_commit(committed_leaders);
 
-        // First add the commits to the commit solidifier to make sure that the data is
+        // First, add the commits to the commit solidifier to make sure that the data is
         // available. This function returns not only the just-created commits but also
-        // any pending ones that became solid since the last commit.
-        // let solid_commits = self.commit_solidifier.try_commit(committed_sub_dags);
+        // any pending ones that'd become solid since the last commit.
+        let (solid_sub_dags, missing_transactions) =
+            self.commit_solidifier.try_commit(&pending_sub_dags);
 
-        let mut sent_sub_dags = Vec::with_capacity(committed_sub_dags.len());
-        for solid_sub_dag in committed_sub_dags.into_iter() {
+        tracing::trace!("Missing committed data {missing_transactions:#?}");
+
+        let mut sent_sub_dags = Vec::with_capacity(solid_sub_dags.len());
+        for solid_sub_dag in solid_sub_dags.into_iter() {
             // Failures in sender.send() are assumed to be permanent
             if let Err(err) = self.sender.send(solid_sub_dag.clone()) {
                 tracing::error!(
@@ -117,9 +120,9 @@ impl CommitObserver {
             sent_sub_dags.push(solid_sub_dag);
         }
 
-        self.report_metrics(&sent_sub_dags);
+        self.report_metrics(&pending_sub_dags);
         tracing::trace!("Committed & sent {sent_sub_dags:#?}");
-        Ok(sent_sub_dags)
+        Ok((pending_sub_dags, missing_transactions))
     }
 
     fn recover_and_send_commits(&mut self, last_processed_commit_index: CommitIndex) {
@@ -181,22 +184,25 @@ impl CommitObserver {
                 vec![]
             };
 
-            info!("Sending commit {} during recovery", commit.index());
+            info!("Processing commit {} during recovery", commit.index());
 
-            // let committed_sub_dag =
-            //     load_committed_subdag_from_store(self.store.as_ref(), commit,
-            // reputation_scores);
+            let pending_sub_dag =
+                load_pending_subdag_from_store(self.store.as_ref(), commit, reputation_scores);
 
-            // Recover transaction acknowledments for uncommitted transactions.
+            // Recover transaction acknowledments tracker state.
             self.commit_interpreter
-                .recover_transaction_ack_tracker(commit.transaction_acknowledgments());
+                .recover_transaction_ack_tracker(pending_sub_dag.transaction_acknowledgments());
 
             // Put all the committed subdags into the commit solidifier to make sure that
             // they are submitted to IOTA when they become solid.
-            let solid_sub_dag = self.commit_solidifier.try_commit_one(&commit);
+            let solid_sub_dag = self.commit_solidifier.try_commit_one(&pending_sub_dag);
             // Only submit unprocessed commits to IOTA
-            if commit.index() > last_processed_commit_index {
-                if let Some(solid_sub_dag) = solid_sub_dag {
+            if let Some(solid_sub_dag) = solid_sub_dag {
+                if solid_sub_dag.commit_ref.index > last_processed_commit_index {
+                    info!(
+                        "Sending solid commit {} during recovery",
+                        solid_sub_dag.commit_ref.index
+                    );
                     self.sender.send(solid_sub_dag).unwrap_or_else(|e| {
                         panic!(
                             "Failed to send commit during recovery, probably due to shutdown: {:?}",
@@ -215,7 +221,7 @@ impl CommitObserver {
         );
     }
 
-    fn report_metrics(&self, committed: &[CommittedSubDag]) {
+    fn report_metrics(&self, committed: &[PendingSubDag]) {
         let metrics = &self.context.metrics.node_metrics;
         let utc_now = self.context.clock.timestamp_utc_ms();
 
@@ -306,7 +312,8 @@ mod tests {
             .map(Option::unwrap)
             .collect::<Vec<_>>();
 
-        let commits = observer.handle_commit(leaders.clone()).unwrap();
+        let (commits, _missing_transactions_refs) =
+            observer.handle_commit(leaders.clone()).unwrap();
 
         // Check commits are returned by CommitObserver::handle_commit is accurate
         let mut expected_stored_refs: Vec<BlockRef> = vec![];
@@ -340,7 +347,7 @@ mod tests {
         // Check commits sent over consensus output channel is accurate
         let mut processed_subdag_index = 0;
         while let Ok(subdag) = receiver.try_recv() {
-            assert_eq!(subdag, commits[processed_subdag_index]);
+            assert_eq!(subdag.base, commits[processed_subdag_index].base);
             assert_eq!(subdag.reputation_scores_desc, vec![]);
             processed_subdag_index = subdag.commit_ref.index as usize;
             if processed_subdag_index == leaders.len() {
@@ -408,7 +415,7 @@ mod tests {
         // Commit first batch of leaders (2) and "receive" the subdags as the
         // consumer of the consensus output channel.
         let expected_last_processed_index: usize = 2;
-        let mut commits = observer
+        let (mut created_commits, _missing_transactions_refs) = observer
             .handle_commit(
                 leaders
                     .clone()
@@ -421,8 +428,8 @@ mod tests {
         // Check commits sent over consensus output channel is accurate
         let mut processed_subdag_index = 0;
         while let Ok(subdag) = receiver.try_recv() {
-            tracing::info!("Processed {subdag}");
-            assert_eq!(subdag, commits[processed_subdag_index]);
+            tracing::info!("Processed subdag with index {}", subdag.commit_ref.index);
+            assert_eq!(subdag.base, created_commits[processed_subdag_index].base);
             assert_eq!(subdag.reputation_scores_desc, vec![]);
             processed_subdag_index = subdag.commit_ref.index as usize;
             if processed_subdag_index == expected_last_processed_index {
@@ -443,7 +450,7 @@ mod tests {
         // Handle next batch of leaders (1), these will be sent by consensus but not
         // "processed" by consensus output channel. Simulating something happened on
         // the consumer side where the commits were not persisted.
-        commits.append(
+        created_commits.append(
             &mut observer
                 .handle_commit(
                     leaders
@@ -452,13 +459,14 @@ mod tests {
                         .skip(expected_last_processed_index)
                         .collect::<Vec<_>>(),
                 )
-                .unwrap(),
+                .unwrap()
+                .0,
         );
 
         let expected_last_sent_index = num_rounds as usize;
         while let Ok(subdag) = receiver.try_recv() {
             tracing::info!("{subdag} was sent but not processed by consumer");
-            assert_eq!(subdag, commits[processed_subdag_index]);
+            assert_eq!(subdag.base, created_commits[processed_subdag_index].base);
             assert_eq!(subdag.reputation_scores_desc, vec![]);
             processed_subdag_index = subdag.commit_ref.index as usize;
             if processed_subdag_index == expected_last_sent_index {
@@ -490,7 +498,7 @@ mod tests {
         processed_subdag_index = expected_last_processed_index;
         while let Ok(subdag) = receiver.try_recv() {
             tracing::info!("Processed {subdag} on resubmission");
-            assert_eq!(subdag, commits[processed_subdag_index]);
+            assert_eq!(subdag.base, created_commits[processed_subdag_index].base);
             assert_eq!(subdag.reputation_scores_desc, vec![]);
             processed_subdag_index = subdag.commit_ref.index as usize;
             if processed_subdag_index == expected_last_sent_index {
@@ -545,13 +553,14 @@ mod tests {
         // Commit all of the leaders and "receive" the subdags as the consumer of
         // the consensus output channel.
         let expected_last_processed_index: usize = 10;
-        let commits = observer.handle_commit(leaders.clone()).unwrap();
+        let (created_commits, _missing_transactions_refs) =
+            observer.handle_commit(leaders.clone()).unwrap();
 
         // Check commits sent over consensus output channel is accurate
         let mut processed_subdag_index = 0;
         while let Ok(subdag) = receiver.try_recv() {
-            tracing::info!("Processed {subdag}");
-            assert_eq!(subdag, commits[processed_subdag_index]);
+            tracing::info!("Processed subdag with index {}", subdag.commit_ref.index);
+            assert_eq!(subdag.base, created_commits[processed_subdag_index].base);
             assert_eq!(subdag.reputation_scores_desc, vec![]);
             processed_subdag_index = subdag.commit_ref.index as usize;
             if processed_subdag_index == expected_last_processed_index {

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -81,6 +81,15 @@ impl CommitObserver {
         observer
     }
 
+    /// Handles the creation of commits from a set of passed leaders.
+    ///
+    /// # Returns
+    /// A tuple containing:
+    /// - A vector of sub-dags, which include block references to committed
+    ///   transactions (but not the transactions themselves) created by the
+    ///   committed leaders.
+    /// - A vector of block references to transactions that were missing during
+    ///   the commit.
     pub(crate) fn handle_commit(
         &mut self,
         committed_leaders: Vec<VerifiedBlockHeader>,

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -147,6 +147,10 @@ impl CommitObserver {
         if let Some(last_commit) = &last_commit {
             let last_commit_index = last_commit.index();
 
+            // The earliest commit that still might acknowledge not-yet-committed
+            // transactions that still have a chance of being committed is no higher than
+            // `last_pending_commit_index - MAX_TRANSACTIONS_ACK_CHECK -
+            // MAX_LINEARIZER_DEPTH`.
             recovery_lower_bound = recovery_lower_bound
                 .min(last_commit_index - MAX_TRANSACTIONS_ACK_CHECK - MAX_LINEARIZER_DEPTH);
             assert!(last_commit_index >= last_processed_commit_index);
@@ -158,8 +162,7 @@ impl CommitObserver {
             }
         };
 
-        // We should not send the last processed commit again, so
-        // last_processed_commit_index+1
+        // Retrieve all the commits from the recover lower bound until the end..
         let recovery_commits = self
             .store
             .scan_commits((recovery_lower_bound..=CommitIndex::MAX).into())
@@ -172,7 +175,8 @@ impl CommitObserver {
             recovery_commits.len()
         );
 
-        // Resend all the committed subdags to the consensus output channel
+        // Recover transaction acknowledgment tracker in the linearizer using all the
+        // commits and resend all the committed sub-dags to the consensus output channel
         // for all the commits above the last processed index.
         let mut last_recovered_commit_index = last_processed_commit_index;
         let num_recovery_commits = recovery_commits.len();
@@ -198,12 +202,19 @@ impl CommitObserver {
             let pending_sub_dag =
                 load_pending_subdag_from_store(self.store.as_ref(), commit, reputation_scores);
 
-            // Recover transaction acknowledments tracker state.
-            self.commit_interpreter
-                .recover_transaction_ack_tracker(pending_sub_dag.transaction_acknowledgments());
-
-            // Put all the committed subdags into the commit solidifier to make sure that
-            // they are submitted to IOTA when they become solid.
+            // Recover transaction acknowledgments tracker state by adding transaction
+            // acknowledgments from all pending sub-dags that still might
+            // correctly acknowledge transactions.
+            for (authority_idx, transaction_acknowledgments) in
+                pending_sub_dag.transaction_acknowledgments().into_iter()
+            {
+                self.commit_interpreter
+                    .add_committed_transaction_acks(authority_idx, transaction_acknowledgments);
+            }
+            // Put all the pending sub-dags into the commit solidifier to make sure that
+            // they are tracked there. The commit will be sent to IOTA here if all the
+            // transactions are available, or will be kept in the buffer and sent later when
+            // the transactions become available.
             let solid_sub_dag = self.commit_solidifier.try_commit_one(&pending_sub_dag);
             // Only submit unprocessed commits to IOTA
             if let Some(solid_sub_dag) = solid_sub_dag {

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{sync::Arc, time::Duration};
+use std::{ops::Deref, sync::Arc, time::Duration};
 
 use iota_metrics::monitored_mpsc::UnboundedSender;
 use parking_lot::RwLock;
@@ -15,6 +15,7 @@ use crate::{
     commit::{CommitAPI, CommitIndex, load_committed_subdag_from_store},
     context::Context,
     dag_state::DagState,
+    data_manager::DataManager,
     error::{ConsensusError, ConsensusResult},
     leader_schedule::LeaderSchedule,
     linearizer::Linearizer,
@@ -40,6 +41,8 @@ pub(crate) struct CommitObserver {
     context: Arc<Context>,
     /// Component to deterministically collect subdags for committed leaders.
     commit_interpreter: Linearizer,
+    /// Component to deterministically collect subdags for committed leaders.
+    commit_solidifier: DataManager,
     /// An unbounded channel to send committed sub-dags to the consumer of
     /// consensus output.
     sender: UnboundedSender<CommittedSubDag>,
@@ -47,6 +50,11 @@ pub(crate) struct CommitObserver {
     store: Arc<dyn Store>,
     leader_schedule: Arc<LeaderSchedule>,
 }
+
+// TODO: move those to protocol config
+// TODO: set sensible values
+const MAX_TRANSACTIONS_ACK_CHECK: u32 = 10;
+const MAX_LINEARIZER_DEPTH: u32 = 10;
 
 impl CommitObserver {
     pub(crate) fn new(
@@ -62,6 +70,7 @@ impl CommitObserver {
                 dag_state.clone(),
                 leader_schedule.clone(),
             ),
+            commit_solidifier: DataManager::new(context.clone(), dag_state.clone()),
             context,
             sender: commit_consumer.sender,
             store,
@@ -85,10 +94,16 @@ impl CommitObserver {
             .start_timer();
 
         let committed_sub_dags = self.commit_interpreter.handle_commit(committed_leaders);
+
+        // First add the commits to the commit solidifier to make sure that the data is
+        // available. This function returns not only the just-created commits but also
+        // any pending ones that became solid since the last commit.
+        // let solid_commits = self.commit_solidifier.try_commit(committed_sub_dags);
+
         let mut sent_sub_dags = Vec::with_capacity(committed_sub_dags.len());
-        for committed_sub_dag in committed_sub_dags.into_iter() {
+        for solid_sub_dag in committed_sub_dags.into_iter() {
             // Failures in sender.send() are assumed to be permanent
-            if let Err(err) = self.sender.send(committed_sub_dag.clone()) {
+            if let Err(err) = self.sender.send(solid_sub_dag.clone()) {
                 tracing::error!(
                     "Failed to send committed sub-dag, probably due to shutdown: {err:?}"
                 );
@@ -96,10 +111,10 @@ impl CommitObserver {
             }
             tracing::debug!(
                 "Sending to execution commit {} leader {}",
-                committed_sub_dag.commit_ref,
-                committed_sub_dag.leader
+                solid_sub_dag.commit_ref,
+                solid_sub_dag.leader
             );
-            sent_sub_dags.push(committed_sub_dag);
+            sent_sub_dags.push(solid_sub_dag);
         }
 
         self.report_metrics(&sent_sub_dags);
@@ -115,43 +130,48 @@ impl CommitObserver {
             .read_last_commit()
             .expect("Reading the last commit should not fail");
 
+        // Value used to recover transactions_ack_tracker in the linearizer.
+        let mut recovery_lower_bound = last_processed_commit_index + 1;
         if let Some(last_commit) = &last_commit {
             let last_commit_index = last_commit.index();
 
+            recovery_lower_bound = recovery_lower_bound
+                .min(last_commit_index - MAX_TRANSACTIONS_ACK_CHECK - MAX_LINEARIZER_DEPTH);
             assert!(last_commit_index >= last_processed_commit_index);
             if last_commit_index == last_processed_commit_index {
                 debug!(
-                    "Nothing to recover for commit observer as commit index {last_commit_index} = {last_processed_commit_index} last processed index"
+                    "Nothing to recover for commit observer as commit index {last_commit_index} = \
+                    {last_processed_commit_index} last processed index"
                 );
-                return;
             }
         };
 
         // We should not send the last processed commit again, so
         // last_processed_commit_index+1
-        let unsent_commits = self
+        let recovery_commits = self
             .store
-            .scan_commits(((last_processed_commit_index + 1)..=CommitIndex::MAX).into())
+            .scan_commits((recovery_lower_bound..=CommitIndex::MAX).into())
             .expect("Scanning commits should not fail");
 
         info!(
-            "Recovering commit observer after index {last_processed_commit_index} with last commit {} and {} unsent commits",
+            "Recovering commit observer after last processed index {last_processed_commit_index} and \
+            recovery lower bound {recovery_lower_bound} with last commit {} and {} recovery commits",
             last_commit.map(|c| c.index()).unwrap_or_default(),
-            unsent_commits.len()
+            recovery_commits.len()
         );
 
         // Resend all the committed subdags to the consensus output channel
         // for all the commits above the last processed index.
-        let mut last_sent_commit_index = last_processed_commit_index;
-        let num_unsent_commits = unsent_commits.len();
-        for (index, commit) in unsent_commits.into_iter().enumerate() {
+        let mut last_recovered_commit_index = last_processed_commit_index;
+        let num_recovery_commits = recovery_commits.len();
+        for (index, commit) in recovery_commits.into_iter().enumerate() {
             // Commit index must be continuous.
-            assert_eq!(commit.index(), last_sent_commit_index + 1);
+            assert_eq!(commit.index(), last_recovered_commit_index + 1);
 
             // On recovery leader schedule will be updated with the current scores
             // and the scores will be passed along with the last commit sent to
             // iota so that the current scores are available for submission.
-            let reputation_scores = if index == num_unsent_commits - 1 {
+            let reputation_scores = if index == num_recovery_commits - 1 {
                 self.leader_schedule
                     .leader_swap_table
                     .read()
@@ -162,16 +182,31 @@ impl CommitObserver {
             };
 
             info!("Sending commit {} during recovery", commit.index());
-            let committed_sub_dag =
-                load_committed_subdag_from_store(self.store.as_ref(), commit, reputation_scores);
-            self.sender.send(committed_sub_dag).unwrap_or_else(|e| {
-                panic!(
-                    "Failed to send commit during recovery, probably due to shutdown: {:?}",
-                    e
-                )
-            });
 
-            last_sent_commit_index += 1;
+            // let committed_sub_dag =
+            //     load_committed_subdag_from_store(self.store.as_ref(), commit,
+            // reputation_scores);
+
+            // Recover transaction acknowledments for uncommitted transactions.
+            self.commit_interpreter
+                .recover_transaction_ack_tracker(commit.transaction_acknowledgments());
+
+            // Put all the committed subdags into the commit solidifier to make sure that
+            // they are submitted to IOTA when they become solid.
+            let solid_sub_dag = self.commit_solidifier.try_commit_one(&commit);
+            // Only submit unprocessed commits to IOTA
+            if commit.index() > last_processed_commit_index {
+                if let Some(solid_sub_dag) = solid_sub_dag {
+                    self.sender.send(solid_sub_dag).unwrap_or_else(|e| {
+                        panic!(
+                            "Failed to send commit during recovery, probably due to shutdown: {:?}",
+                            e
+                        )
+                    });
+                }
+            }
+
+            last_recovered_commit_index += 1;
         }
 
         info!(

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -24,6 +24,8 @@ use crate::{
     CommitConsumer, TransactionClient, block_verifier::NoopBlockVerifier,
     storage::mem_store::MemStore,
 };
+// TODO: remove this once CommittedSubDag is properly used again
+#[allow(unused_imports)]
 use crate::{
     CommittedSubDag, Transaction,
     block_header::{

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -4,6 +4,7 @@
 
 use std::{collections::BTreeSet, iter, sync::Arc, time::Duration, vec};
 
+use futures::channel;
 use iota_macros::fail_point;
 #[cfg(test)]
 use iota_metrics::monitored_mpsc::{UnboundedReceiver, unbounded_channel};
@@ -591,6 +592,7 @@ impl Core {
         let _verified_transactions = VerifiedTransactions::new(
             transactions,
             verified_block_header.reference(),
+            transactions_commitment,
             serialized_transactions,
         );
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -4,7 +4,6 @@
 
 use std::{collections::BTreeSet, iter, sync::Arc, time::Duration, vec};
 
-use futures::channel;
 use iota_macros::fail_point;
 #[cfg(test)]
 use iota_metrics::monitored_mpsc::{UnboundedReceiver, unbounded_channel};
@@ -26,14 +25,14 @@ use crate::{
     storage::mem_store::MemStore,
 };
 use crate::{
-    Transaction,
+    CommittedSubDag, Transaction,
     block_header::{
         BlockHeader, BlockHeaderAPI, BlockHeaderV1, BlockRef, BlockTimestampMs, GENESIS_ROUND,
         Round, SignedBlockHeader, Slot, TransactionsCommitment, VerifiedBlockHeader,
         VerifiedTransactions,
     },
     block_manager::BlockManager,
-    commit::{CertifiedCommits, CommittedSubDag},
+    commit::{CertifiedCommits, PendingSubDag},
     commit_observer::CommitObserver,
     context::Context,
     dag_state::DagState,
@@ -617,7 +616,7 @@ impl Core {
     /// Runs commit rule to attempt to commit additional blocks from the DAG. If
     /// any `certified_commits` are provided, then it will attempt to commit
     /// those first before trying to commit any further leaders.
-    fn try_commit(&mut self) -> ConsensusResult<Vec<CommittedSubDag>> {
+    fn try_commit(&mut self) -> ConsensusResult<Vec<PendingSubDag>> {
         let _s = self
             .context
             .metrics
@@ -706,9 +705,13 @@ impl Core {
             );
 
             // TODO: refcount subdags
-            let subdags = self.commit_observer.handle_commit(sequenced_leaders)?;
+            let (subdags, _missing_transactions_refs) =
+                self.commit_observer.handle_commit(sequenced_leaders)?;
 
-            self.dag_state.write().add_scoring_subdags(subdags.clone());
+            // Both pending and solid sub DAGs should be added to scoring subdags.
+            self.dag_state
+                .write()
+                .add_scoring_subdags(subdags.iter().map(|s| s.base.clone()).collect());
 
             committed_sub_dags.extend(subdags);
 

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -69,12 +69,14 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
 
     // The following method will be called from data synchronizer to trigger output
     // of commits that became solid in the DataManager
+    #[expect(unused)]
     async fn add_data(
         &self,
         data: Vec<VerifiedTransactions>,
     ) -> Result<BTreeSet<BlockRef>, CoreError>;
 
     // The following method will be used by the data synchronizer to get
+    #[expect(unused)]
     async fn get_missing_data(&self) -> Result<BTreeSet<BlockRef>, CoreError>;
 
     async fn add_certified_commits(
@@ -280,7 +282,7 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
 
     async fn add_data(
         &self,
-        data: Vec<VerifiedTransactions>,
+        _data: Vec<VerifiedTransactions>,
     ) -> Result<BTreeSet<BlockRef>, CoreError> {
         todo!()
     }
@@ -396,7 +398,7 @@ pub(crate) mod tests {
 
         async fn add_data(
             &self,
-            data: Vec<VerifiedTransactions>,
+            _data: Vec<VerifiedTransactions>,
         ) -> Result<BTreeSet<BlockRef>, CoreError> {
             todo!()
         }

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -67,15 +67,17 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
         blocks: Vec<VerifiedBlockHeader>,
     ) -> Result<BTreeSet<BlockRef>, CoreError>;
 
-    // The following method will be called from data synchronizer to trigger output
-    // of commits that became solid in the DataManager
+    // TODO: The following method will be called from transaction synchronizer to
+    //  trigger output  of commits that became solid in the DataManager
     #[expect(unused)]
     async fn add_data(
         &self,
         data: Vec<VerifiedTransactions>,
     ) -> Result<BTreeSet<BlockRef>, CoreError>;
 
-    // The following method will be used by the data synchronizer to get
+    // TODO: The following method will be used by the transaction synchronizer to
+    //  get references to missing transactions that has already been committed and
+    //  needs to be fetched before the commit is successfully output.
     #[expect(unused)]
     async fn get_missing_data(&self) -> Result<BTreeSet<BlockRef>, CoreError>;
 

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -23,7 +23,7 @@ use tracing::warn;
 
 use crate::{
     BlockHeaderAPI as _,
-    block_header::{BlockRef, Round, VerifiedBlockHeader},
+    block_header::{BlockRef, Round, VerifiedBlockHeader, VerifiedTransactions},
     commit::CertifiedCommits,
     context::Context,
     core::Core,
@@ -66,6 +66,16 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
         &self,
         blocks: Vec<VerifiedBlockHeader>,
     ) -> Result<BTreeSet<BlockRef>, CoreError>;
+
+    // The following method will be called from data synchronizer to trigger output
+    // of commits that became solid in the DataManager
+    async fn add_data(
+        &self,
+        data: Vec<VerifiedTransactions>,
+    ) -> Result<BTreeSet<BlockRef>, CoreError>;
+
+    // The following method will be used by the data synchronizer to get
+    async fn get_missing_data(&self) -> Result<BTreeSet<BlockRef>, CoreError>;
 
     async fn add_certified_commits(
         &self,
@@ -268,6 +278,17 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
         Ok(missing_block_refs)
     }
 
+    async fn add_data(
+        &self,
+        data: Vec<VerifiedTransactions>,
+    ) -> Result<BTreeSet<BlockRef>, CoreError> {
+        todo!()
+    }
+
+    async fn get_missing_data(&self) -> Result<BTreeSet<BlockRef>, CoreError> {
+        todo!()
+    }
+
     async fn add_certified_commits(
         &self,
         commits: CertifiedCommits,
@@ -371,6 +392,17 @@ pub(crate) mod tests {
             let mut add_blocks = self.add_blocks.lock();
             add_blocks.extend(blocks);
             Ok(BTreeSet::new())
+        }
+
+        async fn add_data(
+            &self,
+            data: Vec<VerifiedTransactions>,
+        ) -> Result<BTreeSet<BlockRef>, CoreError> {
+            todo!()
+        }
+
+        async fn get_missing_data(&self) -> Result<BTreeSet<BlockRef>, CoreError> {
+            todo!()
         }
 
         async fn add_certified_commits(

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -4,7 +4,7 @@
 
 use std::{
     cmp::max,
-    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     ops::Bound::{Excluded, Included, Unbounded},
     panic,
     sync::Arc,
@@ -17,18 +17,16 @@ use tokio::time::Instant;
 use tracing::{debug, error, info};
 
 use crate::{
-    CommittedSubDag,
     block_header::{
         BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs, GENESIS_ROUND, Round, Slot,
         VerifiedBlockHeader, genesis_block_headers,
     },
     commit::{
         CommitAPI as _, CommitDigest, CommitIndex, CommitInfo, CommitRef, CommitVote,
-        GENESIS_COMMIT_INDEX, TrustedCommit, load_committed_subdag_from_store,
+        GENESIS_COMMIT_INDEX, SubDagBase, TrustedCommit, load_pending_subdag_from_store,
     },
     context::Context,
     leader_scoring::{ReputationScores, ScoringSubdag},
-    stake_aggregator::{QuorumThreshold, StakeAggregator},
     storage::{Store, WriteBatch},
     threshold_clock::ThresholdClock,
 };
@@ -150,8 +148,8 @@ impl DagState {
                     }
 
                     let committed_subdag =
-                        load_committed_subdag_from_store(store.as_ref(), commit.clone(), vec![]); // We don't need to recover reputation scores for unscored_committed_subdags
-                    unscored_committed_subdags.push(committed_subdag);
+                        load_pending_subdag_from_store(store.as_ref(), commit.clone(), vec![]); // We don't need to recover reputation scores for unscored_committed_subdags
+                    unscored_committed_subdags.push(committed_subdag.base);
                 });
         }
 
@@ -946,7 +944,7 @@ impl DagState {
             .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e))
     }
 
-    pub(crate) fn add_scoring_subdags(&mut self, scoring_subdags: Vec<CommittedSubDag>) {
+    pub(crate) fn add_scoring_subdags(&mut self, scoring_subdags: Vec<SubDagBase>) {
         self.scoring_subdag.add_subdags(scoring_subdags);
     }
 
@@ -1489,6 +1487,7 @@ mod test {
                 .into_iter()
                 .map(|block| block.reference())
                 .collect::<Vec<_>>(),
+            vec![],
         ));
 
         dag_state.flush();
@@ -1773,6 +1772,7 @@ mod test {
             context.clock.timestamp_utc_ms(),
             dag_builder.leader_block(3).unwrap().reference(),
             vec![],
+            vec![],
         ));
 
         // WHEN search for the latest blocks
@@ -1888,6 +1888,7 @@ mod test {
                 .into_iter()
                 .map(|block| block.reference())
                 .collect::<Vec<_>>(),
+            vec![],
         ));
 
         // Flush the store so we keep in memory only the last 1 round from the last

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -4,7 +4,7 @@
 
 use std::{
     cmp::max,
-    collections::{BTreeMap, BTreeSet, VecDeque},
+    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
     ops::Bound::{Excluded, Included, Unbounded},
     panic,
     sync::Arc,
@@ -28,6 +28,7 @@ use crate::{
     },
     context::Context,
     leader_scoring::{ReputationScores, ScoringSubdag},
+    stake_aggregator::{QuorumThreshold, StakeAggregator},
     storage::{Store, WriteBatch},
     threshold_clock::ThresholdClock,
 };
@@ -83,8 +84,10 @@ pub(crate) struct DagState {
     // TODO: limit to 1st commit per round with multi-leader.
     pending_commit_votes: VecDeque<CommitVote>,
 
-    // Acknowledgments pending to be included in new blocks. These represent votes indicating
-    // availability of transaction data from the corresponding blocks
+    // TODO: during startup recover pending acknowledgements based on own blocks that are loaded to
+    //  memory upon startup Acknowledgments pending to be included in new blocks. These
+    //  represent votes indicating availability of transaction data from the corresponding
+    //  blocks
     pending_acknowledgments: Vec<BlockRef>,
 
     // Data to be flushed to storage.

--- a/crates/starfish/core/src/data_manager.rs
+++ b/crates/starfish/core/src/data_manager.rs
@@ -15,13 +15,15 @@ use crate::{
 /// without valid causal history we need to make sure that BlockManager takes
 /// care of that and avoid OOM (Out Of Memory) situations.
 pub(crate) struct DataManager {
-    context: Arc<Context>,
-    dag_state: Arc<RwLock<DagState>>,
+    // context: Arc<Context>,
+    // dag_state: Arc<RwLock<DagState>>,
 }
 
 impl DataManager {
-    pub(crate) fn new(context: Arc<Context>, dag_state: Arc<RwLock<DagState>>) -> Self {
-        Self { context, dag_state }
+    pub(crate) fn new(_context: Arc<Context>, _dag_state: Arc<RwLock<DagState>>) -> Self {
+        Self {
+            // context, dag_state
+        }
     }
 
     /// Commit the sub-dag to the global state

--- a/crates/starfish/core/src/data_manager.rs
+++ b/crates/starfish/core/src/data_manager.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 
-use crate::{CommittedSubDag, commit::Commit, context::Context, dag_state::DagState};
+use crate::{
+    BlockRef, CommittedSubDag, commit::PendingSubDag, context::Context, dag_state::DagState,
+};
 
 /// Block manager suspends incoming blocks until they are connected to the
 /// existing graph, returning newly connected blocks.
@@ -23,12 +25,14 @@ impl DataManager {
     }
 
     /// Commit the sub-dag to the global state
-
-    pub(crate) fn try_commit(&self, p0: Vec<Commit>) -> Vec<CommittedSubDag> {
+    pub(crate) fn try_commit(
+        &self,
+        _p0: &[PendingSubDag],
+    ) -> (Vec<CommittedSubDag>, Vec<BlockRef>) {
         todo!()
     }
 
-    pub(crate) fn try_commit_one(&self, p0: &Commit) -> Option<CommittedSubDag> {
+    pub(crate) fn try_commit_one(&self, _p0: &PendingSubDag) -> Option<CommittedSubDag> {
         todo!()
     }
 }

--- a/crates/starfish/core/src/data_manager.rs
+++ b/crates/starfish/core/src/data_manager.rs
@@ -9,11 +9,7 @@ use crate::{
     BlockRef, CommittedSubDag, commit::PendingSubDag, context::Context, dag_state::DagState,
 };
 
-/// Block manager suspends incoming blocks until they are connected to the
-/// existing graph, returning newly connected blocks.
-/// TODO: As it is possible to have Byzantine validators who produce Blocks
-/// without valid causal history we need to make sure that BlockManager takes
-/// care of that and avoid OOM (Out Of Memory) situations.
+// TODO: write docstring for DataManager
 pub(crate) struct DataManager {
     // context: Arc<Context>,
     // dag_state: Arc<RwLock<DagState>>,

--- a/crates/starfish/core/src/data_manager.rs
+++ b/crates/starfish/core/src/data_manager.rs
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use crate::{CommittedSubDag, commit::Commit, context::Context, dag_state::DagState};
+
+/// Block manager suspends incoming blocks until they are connected to the
+/// existing graph, returning newly connected blocks.
+/// TODO: As it is possible to have Byzantine validators who produce Blocks
+/// without valid causal history we need to make sure that BlockManager takes
+/// care of that and avoid OOM (Out Of Memory) situations.
+pub(crate) struct DataManager {
+    context: Arc<Context>,
+    dag_state: Arc<RwLock<DagState>>,
+}
+
+impl DataManager {
+    pub(crate) fn new(context: Arc<Context>, dag_state: Arc<RwLock<DagState>>) -> Self {
+        Self { context, dag_state }
+    }
+
+    /// Commit the sub-dag to the global state
+
+    pub(crate) fn try_commit(&self, p0: Vec<Commit>) -> Vec<CommittedSubDag> {
+        todo!()
+    }
+
+    pub(crate) fn try_commit_one(&self, p0: &Commit) -> Option<CommittedSubDag> {
+        todo!()
+    }
+}

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -784,7 +784,7 @@ mod tests {
             CommittedSubDag::new(
                 leader_ref,
                 blocks,
-                vec![],
+                vec![], // Committed transactions are not important for this test.
                 context.clock.timestamp_utc_ms(),
                 last_commit.reference(),
                 vec![],

--- a/crates/starfish/core/src/leader_schedule.rs
+++ b/crates/starfish/core/src/leader_schedule.rs
@@ -679,13 +679,17 @@ mod tests {
             context.clone(),
             Arc::new(MemStore::new()),
         )));
-        let unscored_subdags = vec![CommittedSubDag::new(
-            BlockRef::new(1, AuthorityIndex::ZERO, BlockHeaderDigest::MIN),
-            vec![],
-            context.clock.timestamp_utc_ms(),
-            CommitRef::new(1, CommitDigest::MIN),
-            vec![],
-        )];
+        let unscored_subdags = vec![
+            CommittedSubDag::new(
+                BlockRef::new(1, AuthorityIndex::ZERO, BlockHeaderDigest::MIN),
+                vec![],
+                vec![],
+                context.clock.timestamp_utc_ms(),
+                CommitRef::new(1, CommitDigest::MIN),
+                vec![],
+            )
+            .base,
+        ];
         dag_state.write().add_scoring_subdags(unscored_subdags);
 
         let commits_until_leader_schedule_update =
@@ -773,15 +777,20 @@ mod tests {
                 .iter()
                 .map(|block| block.reference())
                 .collect::<Vec<_>>(),
+            vec![],
         );
 
-        let unscored_subdags = vec![CommittedSubDag::new(
-            leader_ref,
-            blocks,
-            context.clock.timestamp_utc_ms(),
-            last_commit.reference(),
-            vec![],
-        )];
+        let unscored_subdags = vec![
+            CommittedSubDag::new(
+                leader_ref,
+                blocks,
+                vec![],
+                context.clock.timestamp_utc_ms(),
+                last_commit.reference(),
+                vec![],
+            )
+            .base,
+        ];
 
         let mut dag_state_write = dag_state.write();
         dag_state_write.set_last_commit(last_commit);

--- a/crates/starfish/core/src/leader_scoring.rs
+++ b/crates/starfish/core/src/leader_scoring.rs
@@ -13,7 +13,7 @@ use starfish_config::AuthorityIndex;
 
 use crate::{
     block_header::{BlockHeaderAPI, BlockRef},
-    commit::{CommitRange, CommittedSubDag},
+    commit::{CommitRange, SubDagBase},
     context::Context,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
 };
@@ -301,7 +301,7 @@ mod tests {
         let mut scoring_subdag = ScoringSubdag::new(context.clone());
 
         for (sub_dag, _commit) in dag_builder.get_sub_dag_and_commits(1..=4) {
-            scoring_subdag.add_subdags(vec![sub_dag]);
+            scoring_subdag.add_subdags(vec![sub_dag.base]);
         }
 
         let scores = scoring_subdag.calculate_distributed_vote_scores();

--- a/crates/starfish/core/src/leader_scoring.rs
+++ b/crates/starfish/core/src/leader_scoring.rs
@@ -99,7 +99,7 @@ impl ScoringSubdag {
         }
     }
 
-    pub(crate) fn add_subdags(&mut self, committed_subdags: Vec<CommittedSubDag>) {
+    pub(crate) fn add_subdags(&mut self, committed_subdags: Vec<SubDagBase>) {
         let _s = self
             .context
             .metrics

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -174,7 +174,7 @@ mod tests {
 
         async fn add_data(
             &self,
-            data: Vec<VerifiedTransactions>,
+            _data: Vec<VerifiedTransactions>,
         ) -> Result<BTreeSet<BlockRef>, CoreError> {
             todo!()
         }

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -142,7 +142,7 @@ mod tests {
     use tokio::time::{Instant, sleep};
 
     use crate::{
-        block_header::{BlockRef, Round, VerifiedBlockHeader},
+        block_header::{BlockRef, Round, VerifiedBlockHeader, VerifiedTransactions},
         commit::CertifiedCommits,
         context::Context,
         core::CoreSignals,
@@ -169,6 +169,17 @@ mod tests {
             &self,
             _blocks: Vec<VerifiedBlockHeader>,
         ) -> Result<BTreeSet<BlockRef>, CoreError> {
+            todo!()
+        }
+
+        async fn add_data(
+            &self,
+            data: Vec<VerifiedTransactions>,
+        ) -> Result<BTreeSet<BlockRef>, CoreError> {
+            todo!()
+        }
+
+        async fn get_missing_data(&self) -> Result<BTreeSet<BlockRef>, CoreError> {
             todo!()
         }
 

--- a/crates/starfish/core/src/lib.rs
+++ b/crates/starfish/core/src/lib.rs
@@ -44,6 +44,7 @@ mod universal_committer;
 #[path = "tests/randomized_tests.rs"]
 mod randomized_tests;
 
+mod data_manager;
 mod decoder;
 mod encoder;
 #[cfg(test)]

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -308,16 +308,30 @@ mod tests {
             assert_eq!(subdag.leader, leaders[idx].reference());
             assert_eq!(subdag.timestamp_ms, leaders[idx].timestamp_ms());
             if idx == 0 {
-                // First subdag includes the leader block only
+                // First subdag includes the leader block only and no committed data
                 assert_eq!(subdag.blocks.len(), 1);
+                assert_eq!(subdag.committed_transaction_refs.len(), 0);
+            } else if idx == 1 {
+                // Genesis blocks are included in the first commit
+                assert_eq!(subdag.blocks.len(), num_authorities);
+                // Transactions from genesis are not committed
+                assert_eq!(subdag.committed_transaction_refs.len(), 0);
             } else {
                 // Every subdag after will be missing the leader block from the previous
                 // committed subdag
                 assert_eq!(subdag.blocks.len(), num_authorities);
+                // Every subdag after the first one will have all the committed transactions
+                // from 2 rounds before the leader round
+                assert_eq!(subdag.committed_transaction_refs.len(), num_authorities);
             }
             for block in subdag.blocks.iter() {
                 assert!(block.round() <= leaders[idx].round());
             }
+
+            for committed_transactions_ref in subdag.committed_transaction_refs.iter() {
+                assert!(committed_transactions_ref.round == leaders[idx].round() - 2);
+            }
+
             assert_eq!(subdag.commit_ref.index, idx as CommitIndex + 1);
         }
     }
@@ -509,8 +523,7 @@ mod tests {
         telemetry_subscribers::init_for_testing();
 
         let num_authorities = 4;
-        let (mut context, _keys) = Context::new_for_test(num_authorities);
-        context.protocol_config.set_gc_depth_for_testing(0);
+        let (context, _keys) = Context::new_for_test(num_authorities);
 
         let context = Arc::new(context);
         let dag_state = Arc::new(RwLock::new(DagState::new(
@@ -571,8 +584,12 @@ mod tests {
             if idx == 0 {
                 // First subdag includes the leader block only
                 assert_eq!(subdag.blocks.len(), 1);
+                // First subdag does not commit any transactions
+                assert_eq!(subdag.committed_transaction_refs.len(), 0);
             } else if idx == 1 {
                 assert_eq!(subdag.blocks.len(), 3);
+                // The second subdag does not commit any transactions either yet
+                assert_eq!(subdag.committed_transaction_refs.len(), 0);
             } else if idx == 2 {
                 // We commit:
                 // * 1 block on round 4, the leader block
@@ -581,6 +598,12 @@ mod tests {
                 // * 2 blocks on round 2, again as no commit happened on round 3, we commit the
                 //   "sub dag" of leader of round 3, which will be another 2 blocks
                 assert_eq!(subdag.blocks.len(), 6);
+
+                // We commit transactions from:
+                // * 3 blocks on round 1, as no commit happened on round 3 since the leader was
+                //   missing
+                // * 3 blocks on round 2, commited without delay
+                assert_eq!(subdag.committed_transaction_refs.len(), 6);
             } else {
                 // we expect to see all blocks of round >= 1
                 assert_eq!(subdag.blocks.len(), 6);
@@ -588,9 +611,17 @@ mod tests {
                     subdag.blocks.iter().all(|block| block.round() >= 1),
                     "Found blocks that are of round < 1."
                 );
+
+                // The following subdag commits all data from round 3 (leader block was missing,
+                // so only 3 block refs)
+                assert_eq!(subdag.committed_transaction_refs.len(), 3);
             }
             for block in subdag.blocks.iter() {
                 assert!(block.round() <= leaders[idx].round());
+            }
+
+            for commited_transactions_ref in subdag.committed_transaction_refs.iter() {
+                assert!(commited_transactions_ref.round <= leaders[idx].round());
             }
             assert_eq!(subdag.commit_ref.index, idx as CommitIndex + 1);
         }

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -13,7 +13,7 @@ use starfish_config::AuthorityIndex;
 
 use crate::{
     block_header::{BlockHeaderAPI, BlockRef, VerifiedBlockHeader},
-    commit::{Commit, CommittedSubDag, TrustedCommit, sort_sub_dag_blocks},
+    commit::{Commit, CommitAPI, PendingSubDag, TrustedCommit, sort_sub_dag_blocks},
     context::Context,
     dag_state::DagState,
     leader_schedule::LeaderSchedule,
@@ -37,12 +37,15 @@ impl BlockStoreAPI
 
 /// Expand a committed sequence of leader into a sequence of sub-dags.
 pub(crate) struct Linearizer {
-    /// In memory block store representing the dag state
+    /// In-memory block store representing the dag state
     context: Arc<Context>,
     dag_state: Arc<RwLock<DagState>>,
     leader_schedule: Arc<LeaderSchedule>,
 
-    // TODO: prune this map - at twice eviction age?
+    // TODO: prune this map - any entries older than latest_leader.round() - max_ack_depth -
+    //  max_linearizer_depth should be removed
+    // TODO: should this be part of the Linearizer or
+    //  its own component?
     transactions_ack_tracker: HashMap<BlockRef, StakeAggregator<QuorumThreshold>>,
 }
 
@@ -67,7 +70,7 @@ impl Linearizer {
         &mut self,
         leader_block: VerifiedBlockHeader,
         reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
-    ) -> (CommittedSubDag, TrustedCommit) {
+    ) -> (PendingSubDag, TrustedCommit) {
         let _s = self
             .context
             .metrics
@@ -89,7 +92,6 @@ impl Linearizer {
 
         drop(dag_state);
 
-        let transaction_acks_per_authority = self.collect_acks_per_authority(&to_commit);
         // Create the Commit.
         let commit = Commit::new(
             last_commit_index + 1,
@@ -100,13 +102,14 @@ impl Linearizer {
                 .iter()
                 .map(|block| block.reference())
                 .collect::<Vec<_>>(),
-            transaction_acks_per_authority,
             to_commit
                 .iter()
-                .map(|block| {
-                    self.add_committed_data_acks(block.author(), block.acknowledgments().to_vec())
+                .flat_map(|block| {
+                    self.add_committed_transaction_acks(
+                        block.author(),
+                        block.acknowledgments().to_vec(),
+                    )
                 })
-                .flatten()
                 .unique()
                 .collect::<Vec<_>>(),
         );
@@ -116,44 +119,16 @@ impl Linearizer {
         let commit = TrustedCommit::new_trusted(commit, serialized);
 
         // Create the corresponding committed sub dag
-        let sub_dag = CommittedSubDag::new(
+        let sub_dag = PendingSubDag::new(
             leader_block.reference(),
             to_commit,
+            commit.committed_transactions(),
             timestamp_ms,
             commit.reference(),
             reputation_scores_desc,
         );
 
         (sub_dag, commit)
-    }
-
-    fn collect_acks_per_authority(
-        &mut self,
-        blocks_to_commit: &Vec<VerifiedBlockHeader>,
-    ) -> Vec<Vec<BlockRef>> {
-        let committee_size = self.context.committee.size();
-        let mut result = Vec::with_capacity(committee_size);
-
-        let transaction_acks_per_author = blocks_to_commit
-            .iter()
-            .map(|block| (block.author(), block.acknowledgments().to_vec()))
-            .fold(HashMap::new(), |mut acc, (auth, vec)| {
-                acc.entry(auth).or_insert_with(HashSet::new).extend(vec);
-                acc
-            })
-            .into_iter()
-            .map(|(auth, set)| (auth, set.into_iter().collect()))
-            .collect::<Vec<(AuthorityIndex, Vec<BlockRef>)>>();
-
-        for authority_index in 0..committee_size {
-            let v = transaction_acks_per_author
-                .iter()
-                .find(|(auth, _)| auth.value() == authority_index)
-                .map(|(_, v)| v.clone())
-                .unwrap_or_default();
-            result.push(v);
-        }
-        result
     }
 
     pub(crate) fn linearize_sub_dag(
@@ -209,7 +184,7 @@ impl Linearizer {
     pub(crate) fn handle_commit(
         &mut self,
         committed_leaders: Vec<VerifiedBlockHeader>,
-    ) -> Vec<CommittedSubDag> {
+    ) -> Vec<PendingSubDag> {
         if committed_leaders.is_empty() {
             return vec![];
         }
@@ -220,7 +195,7 @@ impl Linearizer {
             .leader_schedule
             .leader_schedule_updated(&self.dag_state);
 
-        let mut committed_sub_dags = vec![];
+        let mut pending_sub_dags = vec![];
         for (i, leader_block) in committed_leaders.into_iter().enumerate() {
             let reputation_scores_desc = if schedule_updated && i == 0 {
                 self.leader_schedule
@@ -232,10 +207,6 @@ impl Linearizer {
                 vec![]
             };
 
-            // TODO: don't create subdags here - it should only be created for solid commits
-            // in the data manager/commit solidifier Collect the sub-dag
-            // generated using each of these leaders and the corresponding
-            // commit.
             let (sub_dag, commit) =
                 self.collect_sub_dag_and_commit(leader_block, reputation_scores_desc);
 
@@ -243,7 +214,7 @@ impl Linearizer {
             // This also updates the last committed rounds.
             self.dag_state.write().add_commit(commit.clone());
 
-            committed_sub_dags.push(sub_dag);
+            pending_sub_dags.push(sub_dag);
         }
 
         // Committed blocks must be persisted to storage before sending them to IOTA and
@@ -254,10 +225,10 @@ impl Linearizer {
         // storage.
         self.dag_state.write().flush();
 
-        committed_sub_dags
+        pending_sub_dags
     }
 
-    pub(crate) fn add_committed_data_acks(
+    pub(crate) fn add_committed_transaction_acks(
         &mut self,
         authority: AuthorityIndex,
         acknowledgments: Vec<BlockRef>,
@@ -281,18 +252,10 @@ impl Linearizer {
 
     pub(crate) fn recover_transaction_ack_tracker(
         &mut self,
-        transactions_acknowledgments: Vec<Vec<BlockRef>>,
+        transactions_acknowledgments: HashMap<AuthorityIndex, Vec<BlockRef>>,
     ) {
-        for (authority_idx, transaction_acks) in
-            transactions_acknowledgments.into_iter().enumerate()
-        {
-            self.add_committed_data_acks(
-                self.context
-                    .committee
-                    .to_authority_index(authority_idx)
-                    .expect("authority_idx should be valid"),
-                transaction_acks,
-            );
+        for (authority_idx, transaction_acks) in transactions_acknowledgments.into_iter() {
+            self.add_committed_transaction_acks(authority_idx, transaction_acks);
         }
     }
 }
@@ -395,7 +358,9 @@ mod tests {
         let commits = linearizer.handle_commit(leaders.clone());
 
         // Write them in DagState
-        dag_state.write().add_scoring_subdags(commits);
+        dag_state
+            .write()
+            .add_scoring_subdags(commits.iter().map(|d| d.base.clone()).collect());
         // Now update the leader schedule
         leader_schedule.update_leader_schedule(&dag_state);
         assert!(
@@ -474,6 +439,7 @@ mod tests {
             0,
             first_leader.reference(),
             blocks.into_iter().map(|block| block.reference()).collect(),
+            vec![],
         );
         dag_state.write().add_commit(first_commit_data);
 
@@ -508,6 +474,7 @@ mod tests {
             0,
             leader.reference(),
             blocks.clone(),
+            vec![],
         );
 
         let commit = linearizer.handle_commit(vec![leader.clone()]);

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -265,7 +265,7 @@ mod tests {
     use super::*;
     use crate::{
         CommitIndex,
-        commit::{CommitAPI as _, CommitDigest, WAVE_LENGTH},
+        commit::{CommitDigest, WAVE_LENGTH},
         context::Context,
         leader_schedule::{LeaderSchedule, LeaderSwapTable},
         storage::mem_store::MemStore,

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -602,7 +602,7 @@ mod tests {
                 // We commit transactions from:
                 // * 3 blocks on round 1, as no commit happened on round 3 since the leader was
                 //   missing
-                // * 3 blocks on round 2, commited without delay
+                // * 3 blocks on round 2, committed without delay
                 assert_eq!(subdag.committed_transaction_refs.len(), 6);
             } else {
                 // we expect to see all blocks of round >= 1
@@ -620,8 +620,8 @@ mod tests {
                 assert!(block.round() <= leaders[idx].round());
             }
 
-            for commited_transactions_ref in subdag.committed_transaction_refs.iter() {
-                assert!(commited_transactions_ref.round <= leaders[idx].round());
+            for committed_transactions_ref in subdag.committed_transaction_refs.iter() {
+                assert!(committed_transactions_ref.round <= leaders[idx].round());
             }
             assert_eq!(subdag.commit_ref.index, idx as CommitIndex + 1);
         }

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -92,6 +92,23 @@ impl Linearizer {
 
         drop(dag_state);
 
+        // Collect all block references for transactions that reached quorum after
+        // adding acknowledgments
+        let committed_transactions = to_commit
+            .iter()
+            // Add the acknowledgments to the tracker and collect the ones that reached quorum.
+            // This will return a vector of block references that reached the quorum threshold, so
+            // using flat_map here to avoid nested vectors.
+            .flat_map(|block| {
+                self.add_committed_transaction_acks(
+                    block.author(),
+                    block.acknowledgments().to_vec(),
+                )
+            })
+            // Remove duplicate block references
+            .unique()
+            .collect::<Vec<BlockRef>>();
+
         // Create the Commit.
         let commit = Commit::new(
             last_commit_index + 1,
@@ -101,17 +118,8 @@ impl Linearizer {
             to_commit
                 .iter()
                 .map(|block| block.reference())
-                .collect::<Vec<_>>(),
-            to_commit
-                .iter()
-                .flat_map(|block| {
-                    self.add_committed_transaction_acks(
-                        block.author(),
-                        block.acknowledgments().to_vec(),
-                    )
-                })
-                .unique()
-                .collect::<Vec<_>>(),
+                .collect::<Vec<BlockRef>>(),
+            committed_transactions,
         );
         let serialized = commit
             .serialize()
@@ -228,6 +236,9 @@ impl Linearizer {
         pending_sub_dags
     }
 
+    // This function is called to add the transaction acknowledgments to the tracker
+    // and returns the vector of block refs to transactions that reached the quorum
+    // threshold after adding the acknowledgments.
     pub(crate) fn add_committed_transaction_acks(
         &mut self,
         authority: AuthorityIndex,
@@ -248,15 +259,6 @@ impl Linearizer {
             }
         }
         acknowledged_data
-    }
-
-    pub(crate) fn recover_transaction_ack_tracker(
-        &mut self,
-        transactions_acknowledgments: HashMap<AuthorityIndex, Vec<BlockRef>>,
-    ) {
-        for (authority_idx, transaction_acks) in transactions_acknowledgments.into_iter() {
-            self.add_committed_transaction_acks(authority_idx, transaction_acks);
-        }
     }
 }
 

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -2,8 +2,12 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
+use itertools::Itertools;
 use parking_lot::RwLock;
 use starfish_config::AuthorityIndex;
 
@@ -13,6 +17,7 @@ use crate::{
     context::Context,
     dag_state::DagState,
     leader_schedule::LeaderSchedule,
+    stake_aggregator::{QuorumThreshold, StakeAggregator},
 };
 
 /// The `StorageAPI` trait provides an interface for the block store and has
@@ -31,12 +36,14 @@ impl BlockStoreAPI
 }
 
 /// Expand a committed sequence of leader into a sequence of sub-dags.
-#[derive(Clone)]
 pub(crate) struct Linearizer {
     /// In memory block store representing the dag state
     context: Arc<Context>,
     dag_state: Arc<RwLock<DagState>>,
     leader_schedule: Arc<LeaderSchedule>,
+
+    // TODO: prune this map - at twice eviction age?
+    transactions_ack_tracker: HashMap<BlockRef, StakeAggregator<QuorumThreshold>>,
 }
 
 impl Linearizer {
@@ -49,6 +56,7 @@ impl Linearizer {
             dag_state,
             leader_schedule,
             context,
+            transactions_ack_tracker: HashMap::new(),
         }
     }
 
@@ -81,6 +89,7 @@ impl Linearizer {
 
         drop(dag_state);
 
+        let transaction_acks_per_authority = self.collect_acks_per_authority(&to_commit);
         // Create the Commit.
         let commit = Commit::new(
             last_commit_index + 1,
@@ -90,6 +99,15 @@ impl Linearizer {
             to_commit
                 .iter()
                 .map(|block| block.reference())
+                .collect::<Vec<_>>(),
+            transaction_acks_per_authority,
+            to_commit
+                .iter()
+                .map(|block| {
+                    self.add_committed_data_acks(block.author(), block.acknowledgments().to_vec())
+                })
+                .flatten()
+                .unique()
                 .collect::<Vec<_>>(),
         );
         let serialized = commit
@@ -107,6 +125,35 @@ impl Linearizer {
         );
 
         (sub_dag, commit)
+    }
+
+    fn collect_acks_per_authority(
+        &mut self,
+        blocks_to_commit: &Vec<VerifiedBlockHeader>,
+    ) -> Vec<Vec<BlockRef>> {
+        let committee_size = self.context.committee.size();
+        let mut result = Vec::with_capacity(committee_size);
+
+        let transaction_acks_per_author = blocks_to_commit
+            .iter()
+            .map(|block| (block.author(), block.acknowledgments().to_vec()))
+            .fold(HashMap::new(), |mut acc, (auth, vec)| {
+                acc.entry(auth).or_insert_with(HashSet::new).extend(vec);
+                acc
+            })
+            .into_iter()
+            .map(|(auth, set)| (auth, set.into_iter().collect()))
+            .collect::<Vec<(AuthorityIndex, Vec<BlockRef>)>>();
+
+        for authority_index in 0..committee_size {
+            let v = transaction_acks_per_author
+                .iter()
+                .find(|(auth, _)| auth.value() == authority_index)
+                .map(|(_, v)| v.clone())
+                .unwrap_or_default();
+            result.push(v);
+        }
+        result
     }
 
     pub(crate) fn linearize_sub_dag(
@@ -185,8 +232,10 @@ impl Linearizer {
                 vec![]
             };
 
-            // Collect the sub-dag generated using each of these leaders and the
-            // corresponding commit.
+            // TODO: don't create subdags here - it should only be created for solid commits
+            // in the data manager/commit solidifier Collect the sub-dag
+            // generated using each of these leaders and the corresponding
+            // commit.
             let (sub_dag, commit) =
                 self.collect_sub_dag_and_commit(leader_block, reputation_scores_desc);
 
@@ -207,11 +256,49 @@ impl Linearizer {
 
         committed_sub_dags
     }
+
+    pub(crate) fn add_committed_data_acks(
+        &mut self,
+        authority: AuthorityIndex,
+        acknowledgments: Vec<BlockRef>,
+    ) -> Vec<BlockRef> {
+        let mut acknowledged_data = Vec::new();
+        for block_ref in acknowledgments {
+            let votes_collector = self
+                .transactions_ack_tracker
+                .entry(block_ref)
+                .or_insert_with(StakeAggregator::<QuorumThreshold>::new);
+
+            // TODO: check that the acknowlement is not too far in the past?
+            if !votes_collector.reached_threshold(&self.context.committee)
+                && votes_collector.add(authority, &self.context.committee)
+            {
+                acknowledged_data.push(block_ref);
+            }
+        }
+        acknowledged_data
+    }
+
+    pub(crate) fn recover_transaction_ack_tracker(
+        &mut self,
+        transactions_acknowledgments: Vec<Vec<BlockRef>>,
+    ) {
+        for (authority_idx, transaction_acks) in
+            transactions_acknowledgments.into_iter().enumerate()
+        {
+            self.add_committed_data_acks(
+                self.context
+                    .committee
+                    .to_authority_index(authority_idx)
+                    .expect("authority_idx should be valid"),
+                transaction_acks,
+            );
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
     use crate::{
         CommitIndex,

--- a/crates/starfish/core/src/storage/store_tests.rs
+++ b/crates/starfish/core/src/storage/store_tests.rs
@@ -232,6 +232,7 @@ async fn read_and_scan_commits(
                 BlockHeaderDigest::default(),
             ),
             vec![],
+            vec![],
         ),
         TrustedCommit::new_for_test(
             2,
@@ -242,6 +243,7 @@ async fn read_and_scan_commits(
                 AuthorityIndex::new_for_test(0),
                 BlockHeaderDigest::default(),
             ),
+            vec![],
             vec![],
         ),
         TrustedCommit::new_for_test(
@@ -254,6 +256,7 @@ async fn read_and_scan_commits(
                 BlockHeaderDigest::default(),
             ),
             vec![],
+            vec![],
         ),
         TrustedCommit::new_for_test(
             4,
@@ -264,6 +267,7 @@ async fn read_and_scan_commits(
                 AuthorityIndex::new_for_test(0),
                 BlockHeaderDigest::default(),
             ),
+            vec![],
             vec![],
         ),
     ];

--- a/crates/starfish/core/src/synchronizer.rs
+++ b/crates/starfish/core/src/synchronizer.rs
@@ -1743,8 +1743,14 @@ mod tests {
         {
             let mut d = dag_state.write();
             for index in 1..=commit_index {
-                let commit =
-                    TrustedCommit::new_for_test(index, CommitDigest::MIN, 0, BlockRef::MIN, vec![]);
+                let commit = TrustedCommit::new_for_test(
+                    index,
+                    CommitDigest::MIN,
+                    0,
+                    BlockRef::MIN,
+                    vec![],
+                    vec![],
+                );
 
                 d.add_commit(commit);
             }

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     ops::{Bound::Included, RangeInclusive},
     sync::Arc,
 };
@@ -331,6 +331,8 @@ impl DagBuilder {
     pub(crate) fn layer_with_connections(
         &mut self,
         connections: Vec<(AuthorityIndex, Vec<BlockRef>)>,
+        transactions_acknowledgments: HashMap<AuthorityIndex, Vec<BlockRef>>,
+
         round: Round,
     ) {
         let mut references = Vec::new();
@@ -340,6 +342,12 @@ impl DagBuilder {
             let block = VerifiedBlockHeader::new_for_test(
                 TestBlockHeader::new(round, author)
                     .set_ancestors(ancestors)
+                    .set_acknowledgments(
+                        transactions_acknowledgments
+                            .get(&authority)
+                            .cloned()
+                            .unwrap_or_default(),
+                    )
                     .set_timestamp_ms(base_ts + author as u64)
                     .build(),
             );
@@ -409,7 +417,8 @@ pub struct LayerBuilder<'a> {
     // Add random weak links to the current layer using a seed, if provided
     random_weak_links: bool,
     random_weak_links_random_seed: Option<u64>,
-
+    // All transactions from the previous round will be linked in the current round.
+    fully_linked_acknowledgments: bool,
     // Ancestors to link to the current layer
     ancestors: Vec<BlockRef>,
 
@@ -440,6 +449,8 @@ impl<'a> LayerBuilder<'a> {
             min_ancestor_links_random_seed: None,
             random_weak_links: false,
             random_weak_links_random_seed: None,
+            fully_linked_acknowledgments: true,
+            // TODO: add more variations of transaction acknowledgment links
             ancestors,
             blocks: vec![],
         }
@@ -564,11 +575,18 @@ impl<'a> LayerBuilder<'a> {
                 vec![]
             };
 
+            // Do not acknowledge transactions in round 0 (genesis).
+            let acknowledgments = if round > 1 && self.fully_linked_acknowledgments {
+                self.configure_fully_linked_acknowledgments()
+            } else {
+                HashMap::new()
+            };
+
             if self.random_weak_links {
                 connections.append(&mut self.configure_random_weak_links());
             }
 
-            self.create_blocks(round, connections);
+            self.create_blocks(round, connections, acknowledgments);
         }
 
         self.dag_builder.last_ancestors = self.ancestors.clone();
@@ -676,6 +694,15 @@ impl<'a> LayerBuilder<'a> {
         self.configure_skipped_ancestor_links(authorities, missing_leaders)
     }
 
+    fn configure_fully_linked_acknowledgments(&mut self) -> HashMap<AuthorityIndex, Vec<BlockRef>> {
+        self.dag_builder
+            .context
+            .committee
+            .authorities()
+            .map(|authority| (authority.0, self.ancestors.clone()))
+            .collect()
+    }
+
     fn configure_fully_linked_ancestors(&mut self) -> Vec<(AuthorityIndex, Vec<BlockRef>)> {
         self.dag_builder
             .context
@@ -703,8 +730,13 @@ impl<'a> LayerBuilder<'a> {
     }
 
     // Creates the blocks for the new layer based on configured connections, also
-    // sets the ancestors for future layers to be linked to
-    fn create_blocks(&mut self, round: Round, connections: Vec<(AuthorityIndex, Vec<BlockRef>)>) {
+    // sets the ancestors and transaction acks for future layers to be linked to
+    fn create_blocks(
+        &mut self,
+        round: Round,
+        connections: Vec<(AuthorityIndex, Vec<BlockRef>)>,
+        transaction_acknowledgments: HashMap<AuthorityIndex, Vec<BlockRef>>,
+    ) {
         let mut references = Vec::new();
         for (authority, ancestors) in connections {
             if self.should_skip_block(round, authority) {
@@ -718,6 +750,12 @@ impl<'a> LayerBuilder<'a> {
                 let block = VerifiedBlockHeader::new_for_test(
                     TestBlockHeader::new(round, author)
                         .set_ancestors(ancestors.clone())
+                        .set_acknowledgments(
+                            transaction_acknowledgments
+                                .get(&authority)
+                                .cloned()
+                                .unwrap_or_default(),
+                        )
                         .set_timestamp_ms(base_ts + (author + round + num_block) as u64)
                         .build(),
                 );

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -210,6 +210,7 @@ impl DagBuilder {
                     .iter()
                     .map(|block| block.reference())
                     .collect::<Vec<_>>(),
+                vec![],
             );
 
             last_commit_ref = commit.reference();
@@ -217,6 +218,7 @@ impl DagBuilder {
             let sub_dag = CommittedSubDag::new(
                 leader_block_ref,
                 to_commit,
+                vec![],
                 last_timestamp_ms,
                 commit.reference(),
                 vec![],

--- a/crates/starfish/core/src/test_dag_parser.rs
+++ b/crates/starfish/core/src/test_dag_parser.rs
@@ -2,7 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use nom::{
     IResult,
@@ -63,8 +66,8 @@ pub(crate) fn parse_dag(dag_string: &str) -> IResult<&str, DagBuilder> {
     // Parse subsequent rounds
     loop {
         match parse_round(input, &dag_builder) {
-            Ok((new_input, (round, connections))) => {
-                dag_builder.layer_with_connections(connections, round);
+            Ok((new_input, (round, connections, transaction_acknowledgments))) => {
+                dag_builder.layer_with_connections(connections, transaction_acknowledgments, round);
                 input = new_input
             }
             Err(nom::Err::Error(_)) | Err(nom::Err::Failure(_)) => break,
@@ -79,7 +82,14 @@ pub(crate) fn parse_dag(dag_string: &str) -> IResult<&str, DagBuilder> {
 fn parse_round<'a>(
     input: &'a str,
     dag_builder: &DagBuilder,
-) -> IResult<&'a str, (Round, Vec<(AuthorityIndex, Vec<BlockRef>)>)> {
+) -> IResult<
+    &'a str,
+    (
+        Round,
+        Vec<(AuthorityIndex, Vec<BlockRef>)>,
+        HashMap<AuthorityIndex, Vec<BlockRef>>,
+    ),
+> {
     let (input, _) = tuple((multispace0, tag("Round"), space1))(input)?;
     let (input, round) = take_while1(|c: char| c.is_ascii_digit())(input)?;
 
@@ -88,7 +98,25 @@ fn parse_round<'a>(
         |input| parse_specified_connections(input, dag_builder),
     ))(input)?;
 
-    Ok((input, (round.parse().unwrap(), connections)))
+    // TODO: extend DAG parser with transaction acknowledgments. For now it's
+    //  assumed that transactions are available together with the block headers and
+    //  we acknowledge transactions of all ancestors.
+
+    //  If the round is "1", we assume no transactions in Round 0 (genesis) are
+    // acknowledged.
+    let transactions_acknowledgments: HashMap<AuthorityIndex, Vec<BlockRef>> = if round == "1" {
+        HashMap::new()
+    } else {
+        connections.clone().into_iter().collect()
+    };
+    Ok((
+        input,
+        (
+            round.parse().unwrap(),
+            connections,
+            transactions_acknowledgments,
+        ),
+    ))
 }
 
 fn parse_fully_connected<'a>(
@@ -404,12 +432,19 @@ mod tests {
         let dag_builder = DagBuilder::new(context);
         let result = parse_round(dag_str, &dag_builder);
         assert!(result.is_ok());
-        let (_, (round, connections)) = result.unwrap();
+        let (_, (round, connections, transactions_acknowledgments)) = result.unwrap();
 
         assert_eq!(round, 1);
         for (i, (authority, references)) in connections.into_iter().enumerate() {
             assert_eq!(authority, AuthorityIndex::new_for_test(i as u32));
             assert_eq!(references, dag_builder.last_ancestors);
+            assert_eq!(
+                transactions_acknowledgments
+                    .get(&authority)
+                    .cloned()
+                    .unwrap_or_default(),
+                dag_builder.last_ancestors
+            );
         }
     }
 
@@ -424,7 +459,7 @@ mod tests {
         let dag_builder = DagBuilder::new(context);
         let result = parse_round(dag_str, &dag_builder);
         assert!(result.is_ok());
-        let (_, (round, connections)) = result.unwrap();
+        let (_, (round, connections, transactions_acknowledgments)) = result.unwrap();
 
         let skipped_slot = Slot::new_for_test(0, 0); // A0
         let mut expected_references = [
@@ -443,6 +478,14 @@ mod tests {
             references.sort();
             expected_references[i].sort();
             assert_eq!(references, expected_references[i]);
+
+            let mut transactions_acks = transactions_acknowledgments
+                .get(&authority)
+                .cloned()
+                .unwrap_or_default();
+            transactions_acks.sort();
+
+            assert_eq!(transactions_acks, expected_references[i]);
         }
     }
 


### PR DESCRIPTION
# Description of change

This PR implements modifying Commit struct and commit creation flow to support separate block header and transactions acknowledgments. It also extends the `Linearizer` component to support keeping track of transaction acknowledments and including them in newly created commits when they reach quorum of acks. It also extends test DAG builder to support transaction acks in a basic form. 

The next step is implementation of `DataManager` (#6429) and data synchronizer (#6881) and covering the new logic with tests.

## Links to any relevant issues

Resolves #6437

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Fixed tests of the components. The tests need to be expanded in a future PR. 

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
