### PR TITLE
refactor(core): Update `async-graphql` to `7.0.17`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,8 +828,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql"
-version = "7.0.16"
-source = "git+https://github.com/async-graphql/async-graphql?rev=3001a02f6df29e259900cd85230547c2923dfcf3#3001a02f6df29e259900cd85230547c2923dfcf3"
+version = "7.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "036618f842229ba0b89652ffe425f96c7c16a49f7e3cb23b56fca7f61fd74980"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
@@ -866,8 +867,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-axum"
-version = "7.0.16"
-source = "git+https://github.com/async-graphql/async-graphql?rev=3001a02f6df29e259900cd85230547c2923dfcf3#3001a02f6df29e259900cd85230547c2923dfcf3"
+version = "7.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8725874ecfbf399e071150b8619c4071d7b2b7a2f117e173dddef53c6bdb6bb1"
 dependencies = [
  "async-graphql",
  "axum 0.8.4",
@@ -882,8 +884,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-derive"
-version = "7.0.16"
-source = "git+https://github.com/async-graphql/async-graphql?rev=3001a02f6df29e259900cd85230547c2923dfcf3#3001a02f6df29e259900cd85230547c2923dfcf3"
+version = "7.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd45deb3dbe5da5cdb8d6a670a7736d735ba65b455328440f236dfb113727a3d"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
@@ -898,8 +901,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-parser"
-version = "7.0.16"
-source = "git+https://github.com/async-graphql/async-graphql?rev=3001a02f6df29e259900cd85230547c2923dfcf3#3001a02f6df29e259900cd85230547c2923dfcf3"
+version = "7.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b7607e59424a35dadbc085b0d513aa54ec28160ee640cf79ec3b634eba66d3"
 dependencies = [
  "async-graphql-value",
  "pest",
@@ -909,8 +913,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-value"
-version = "7.0.16"
-source = "git+https://github.com/async-graphql/async-graphql?rev=3001a02f6df29e259900cd85230547c2923dfcf3#3001a02f6df29e259900cd85230547c2923dfcf3"
+version = "7.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ecdaff7c9cffa3614a9f9999bf9ee4c3078fe3ce4d6a6e161736b56febf2de"
 dependencies = [
  "bytes",
  "indexmap 2.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,7 +216,7 @@ anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "c4e7e4cb
 anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "c4e7e4cb4b624d7738c2016d7b7885c6774ff9c2" }
 anyhow = "1.0.71"
 arc-swap = { version = "1.5.1", features = ["serde"] }
-async-graphql = { git = "https://github.com/async-graphql/async-graphql", rev = "3001a02f6df29e259900cd85230547c2923dfcf3" }
+async-graphql = "7.0.17"
 async-recursion = "1.0.4"
 async-trait = "0.1.61"
 aws-config = "1.5.6"

--- a/crates/iota-graphql-rpc/Cargo.toml
+++ b/crates/iota-graphql-rpc/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 # external dependencies
 anyhow.workspace = true
 async-graphql = { workspace = true, features = ["dataloader", "apollo_tracing", "tracing", "opentelemetry"] }
-async-graphql-axum = { git = "https://github.com/async-graphql/async-graphql", rev = "3001a02f6df29e259900cd85230547c2923dfcf3" }
-async-graphql-value = { git = "https://github.com/async-graphql/async-graphql", rev = "3001a02f6df29e259900cd85230547c2923dfcf3" }
+async-graphql-axum = "7.0.17"
+async-graphql-value = "7.0.17"
 async-trait.workspace = true
 axum.workspace = true
 axum-extra.workspace = true


### PR DESCRIPTION
Closes https://github.com/iotaledger/iota/issues/6914

Uses the latest release of `async-graphql` which now also contains the graphiql fix

More info: https://github.com/iotaledger/iota/pull/6901