### PR TITLE
fix(node/ts-sdk): Fix graphql tests

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/call/simple.snap
+++ b/crates/iota-graphql-e2e-tests/tests/call/simple.snap
@@ -115,7 +115,7 @@ Response: {
 task 15, lines 64-69:
 //# run-graphql --show-usage --show-headers --show-service-version
 Headers: {
-    "content-type": "application/json",
+    "content-type": "application/graphql-response+json",
     "x-iota-rpc-version": "1.2.0-testing-no-sha",
     "vary": "origin, access-control-request-method, access-control-request-headers",
     "access-control-allow-origin": "*",

--- a/sdk/graphql-transport/test/compatibility.test.ts
+++ b/sdk/graphql-transport/test/compatibility.test.ts
@@ -388,6 +388,12 @@ describe('GraphQL IotaClient compatibility', () => {
                 },
             });
 
+        // Sorth both results to avoid any order difference
+        graphQLTransactions.data.sort(
+            (txA, txB) => Number(txA.timestampMs) - Number(txB.timestampMs),
+        );
+        rpcTransactions.data.sort((txA, txB) => Number(txA.timestampMs) - Number(txB.timestampMs));
+
         expect(graphQLTransactions).toEqual(rpcTransactions);
     });
 


### PR DESCRIPTION
Closes https://github.com/iotaledger/iota/issues/6914 (again)

- Seems like they made yet another breaking change in a patch release: https://github.com/async-graphql/async-graphql/commit/a9143a0df4848fcec03a606e90df42155c20ddc6
	So now the responses use a different content type
	Unfortunately this was not caught in https://github.com/iotaledger/iota/pull/6989 as the Github Actions API was not working correcty
- Updated a ts sdk test so that the incoming order does not make the test fail (https://github.com/iotaledger/iota/actions/runs/15249618267/job/42883183320)

[run-ci]