### PR TITLE
chore: update CODEOWNERS for CI test scripts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -136,7 +136,7 @@ vercel.json @iotaledger/tooling
 
 # Scripts
 /scripts/cargo_sort/ @muXxer
-/scripts/ci_tests/ @nmrshll
+/scripts/ci_tests/ @iotaledger/node
 /scripts/codesearch/ @muXxer
 /scripts/generate_files/ @muXxer
 /scripts/tooling/ @iotaledger/tooling


### PR DESCRIPTION
# Description of change

This PR fixes the warning from github that the CODEOWNERS file is currently invalid.

## Type of change

- Enhancement (a non-breaking change which adds functionality)