### PR TITLE
fix: graphql content-type in simple test

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/call/simple.snap
+++ b/crates/iota-graphql-e2e-tests/tests/call/simple.snap
@@ -115,7 +115,7 @@ Response: {
 task 15, lines 64-69:
 //# run-graphql --show-usage --show-headers --show-service-version
 Headers: {
-    "content-type": "application/json",
+    "content-type": "application/graphql-response+json",
     "x-iota-rpc-version": "1.2.0-testing-no-sha",
     "vary": "origin, access-control-request-method, access-control-request-headers",
     "access-control-allow-origin": "*",


### PR DESCRIPTION
# Description of change

The CI currently fails in our feature branch, which was rebased on develop. Seems like there was a breaking change on develop that wasn't detected? Maybe when we upgraded the libraries in https://github.com/iotaledger/iota/pull/6989?

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [x] GraphQL: header "content-type" changed from "application/json" to "application/graphql-response+json"
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
