### PR TITLE
feat(node): remove IotaHistogram metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8440,7 +8440,6 @@ dependencies = [
  "indexmap 2.5.0",
  "iota-enum-compat-util",
  "iota-macros",
- "iota-metrics",
  "iota-network-stack",
  "iota-protocol-config",
  "iota-rust-sdk",

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/metrics.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/metrics.rs
@@ -4,7 +4,6 @@
 
 use std::sync::Arc;
 
-use iota_metrics::histogram::Histogram as IotaHistogram;
 use prometheus::{
     Histogram, IntCounter, IntGauge, Registry, register_histogram_with_registry,
     register_int_counter_with_registry, register_int_gauge_with_registry,
@@ -21,11 +20,7 @@ pub struct CheckpointExecutorMetrics {
     pub checkpoint_prepare_latency: Histogram,
     pub checkpoint_transaction_count: Histogram,
     pub checkpoint_contents_age: Histogram,
-    // TODO: delete once users are migrated to non-Iota histogram.
-    pub checkpoint_contents_age_ms: IotaHistogram,
     pub last_executed_checkpoint_age: Histogram,
-    // TODO: delete once users are migrated to non-Iota histogram.
-    pub last_executed_checkpoint_age_ms: IotaHistogram,
 }
 
 impl CheckpointExecutorMetrics {
@@ -95,11 +90,6 @@ impl CheckpointExecutorMetrics {
                 registry,
             )
             .unwrap(),
-            checkpoint_contents_age_ms: IotaHistogram::new_in_registry(
-                "checkpoint_contents_age_ms",
-                "Age of checkpoints when they arrive for execution",
-                registry,
-            ),
             last_executed_checkpoint_age: register_histogram_with_registry!(
                 "last_executed_checkpoint_age",
                 "Age of the last executed checkpoint",
@@ -107,11 +97,6 @@ impl CheckpointExecutorMetrics {
                 registry
             )
             .unwrap(),
-            last_executed_checkpoint_age_ms: IotaHistogram::new_in_registry(
-                "last_executed_checkpoint_age_ms",
-                "Age of the last executed checkpoint",
-                registry,
-            ),
         };
         Arc::new(this)
     }

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -335,7 +335,7 @@ impl CheckpointExecutor {
                             sequence_number = ?checkpoint.sequence_number,
                             "Received checkpoint summary from state sync"
                         );
-                        checkpoint.report_checkpoint_age(&self.metrics.checkpoint_contents_age, &self.metrics.checkpoint_contents_age_ms);
+                        checkpoint.report_checkpoint_age(&self.metrics.checkpoint_contents_age);
                     },
                     Err(RecvError::Lagged(num_skipped)) => {
                         debug!(
@@ -419,10 +419,7 @@ impl CheckpointExecutor {
         self.metrics
             .last_executed_checkpoint_timestamp_ms
             .set(checkpoint.timestamp_ms as i64);
-        checkpoint.report_checkpoint_age(
-            &self.metrics.last_executed_checkpoint_age,
-            &self.metrics.last_executed_checkpoint_age_ms,
-        );
+        checkpoint.report_checkpoint_age(&self.metrics.last_executed_checkpoint_age);
     }
 
     /// Post processing and plumbing after we executed a checkpoint. This

--- a/crates/iota-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_output.rs
@@ -88,13 +88,6 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
                 .unwrap_or_default()
                 .as_secs_f64(),
         );
-        self.metrics.checkpoint_creation_latency_ms.observe(
-            summary
-                .timestamp()
-                .elapsed()
-                .unwrap_or_default()
-                .as_millis() as u64,
-        );
 
         let highest_verified_checkpoint = checkpoint_store
             .get_highest_verified_checkpoint()?

--- a/crates/iota-core/src/checkpoints/metrics.rs
+++ b/crates/iota-core/src/checkpoints/metrics.rs
@@ -4,7 +4,6 @@
 
 use std::sync::Arc;
 
-use iota_metrics::histogram::Histogram as IotaHistogram;
 use prometheus::{
     Histogram, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Registry,
     register_histogram_with_registry, register_int_counter_vec_with_registry,
@@ -25,16 +24,10 @@ pub struct CheckpointMetrics {
     pub last_ignored_checkpoint_signature_received: IntGauge,
     pub highest_accumulated_epoch: IntGauge,
     pub checkpoint_creation_latency: Histogram,
-    // TODO: delete once users are migrated to non-Iota histogram.
-    pub checkpoint_creation_latency_ms: IotaHistogram,
     pub remote_checkpoint_forks: IntCounter,
     pub split_brain_checkpoint_forks: IntCounter,
     pub last_created_checkpoint_age: Histogram,
-    // TODO: delete once users are migrated to non-Iota histogram.
-    pub last_created_checkpoint_age_ms: IotaHistogram,
     pub last_certified_checkpoint_age: Histogram,
-    // TODO: delete once users are migrated to non-Iota histogram.
-    pub last_certified_checkpoint_age_ms: IotaHistogram,
 }
 
 impl CheckpointMetrics {
@@ -58,22 +51,12 @@ impl CheckpointMetrics {
                 iota_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry
             ).unwrap(),
-            last_created_checkpoint_age_ms: IotaHistogram::new_in_registry(
-                "last_created_checkpoint_age_ms",
-                "Age of the last created checkpoint",
-                registry,
-            ),
             last_certified_checkpoint_age: register_histogram_with_registry!(
                 "last_certified_checkpoint_age",
                 "Age of the last certified checkpoint",
                 iota_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry
             ).unwrap(),
-            last_certified_checkpoint_age_ms: IotaHistogram::new_in_registry(
-                "last_certified_checkpoint_age_ms",
-                "Age of the last certified checkpoint",
-                registry,
-            ),
             checkpoint_errors: register_int_counter_with_registry!(
                 "checkpoint_errors",
                 "Checkpoints errors count",
@@ -136,11 +119,6 @@ impl CheckpointMetrics {
                 iota_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             ).unwrap(),
-            checkpoint_creation_latency_ms: IotaHistogram::new_in_registry(
-                "checkpoint_creation_latency_ms",
-                "Latency from consensus commit timestamp to local checkpoint creation in milliseconds",
-                registry,
-            ),
             remote_checkpoint_forks: register_int_counter_with_registry!(
                 "remote_checkpoint_forks",
                 "Number of remote checkpoints that forked from local checkpoints",

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1507,10 +1507,7 @@ impl CheckpointBuilder {
                 timestamp_ms,
                 matching_randomness_rounds,
             );
-            summary.report_checkpoint_age(
-                &self.metrics.last_created_checkpoint_age,
-                &self.metrics.last_created_checkpoint_age_ms,
-            );
+            summary.report_checkpoint_age(&self.metrics.last_created_checkpoint_age);
             if last_checkpoint_of_epoch {
                 info!(
                     checkpoint_seq = sequence_number,
@@ -1865,10 +1862,9 @@ impl CheckpointAggregator {
                     self.metrics
                         .last_certified_checkpoint
                         .set(current.summary.sequence_number as i64);
-                    current.summary.report_checkpoint_age(
-                        &self.metrics.last_certified_checkpoint_age,
-                        &self.metrics.last_certified_checkpoint_age_ms,
-                    );
+                    current
+                        .summary
+                        .report_checkpoint_age(&self.metrics.last_certified_checkpoint_age);
                     result.push(summary.into_inner());
                     self.current = None;
                     continue 'outer;

--- a/crates/iota-network/src/state_sync/metrics.rs
+++ b/crates/iota-network/src/state_sync/metrics.rs
@@ -4,7 +4,6 @@
 
 use std::sync::Arc;
 
-use iota_metrics::histogram::Histogram as IotaHistogram;
 use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 use prometheus::{
     Histogram, IntGauge, Registry, register_histogram_with_registry,
@@ -50,12 +49,9 @@ impl Metrics {
         }
     }
 
-    pub fn checkpoint_summary_age_metrics(&self) -> Option<(&Histogram, &IotaHistogram)> {
+    pub fn checkpoint_summary_age_metrics(&self) -> Option<&Histogram> {
         if let Some(inner) = &self.0 {
-            return Some((
-                &inner.checkpoint_summary_age,
-                &inner.checkpoint_summary_age_ms,
-            ));
+            return Some(&inner.checkpoint_summary_age);
         }
         None
     }
@@ -66,8 +62,6 @@ struct Inner {
     highest_verified_checkpoint: IntGauge,
     highest_synced_checkpoint: IntGauge,
     checkpoint_summary_age: Histogram,
-    // TODO: delete once users are migrated to non-Iota histogram.
-    checkpoint_summary_age_ms: IotaHistogram,
 }
 
 impl Inner {
@@ -101,11 +95,6 @@ impl Inner {
                 registry,
             )
             .unwrap(),
-            checkpoint_summary_age_ms: IotaHistogram::new_in_registry(
-                "checkpoint_summary_age_ms",
-                "Age of checkpoints summaries when they arrive and are verified.",
-                registry,
-            ),
         }
         .pipe(Arc::new)
     }

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -1152,13 +1152,8 @@ where
         };
 
         debug!(checkpoint_seq = ?checkpoint.sequence_number(), "verified checkpoint summary");
-        if let Some((checkpoint_summary_age_metric, checkpoint_summary_age_metric_deprecated)) =
-            metrics.checkpoint_summary_age_metrics()
-        {
-            checkpoint.report_checkpoint_age(
-                checkpoint_summary_age_metric,
-                checkpoint_summary_age_metric_deprecated,
-            );
+        if let Some(checkpoint_summary_age_metric) = metrics.checkpoint_summary_age_metrics() {
+            checkpoint.report_checkpoint_age(checkpoint_summary_age_metric);
         }
 
         current = checkpoint.clone();

--- a/crates/iota-types/Cargo.toml
+++ b/crates/iota-types/Cargo.toml
@@ -64,7 +64,6 @@ tracing.workspace = true
 consensus-config.workspace = true
 iota-enum-compat-util.workspace = true
 iota-macros.workspace = true
-iota-metrics.workspace = true
 iota-network-stack.workspace = true
 iota-protocol-config.workspace = true
 iota-stardust-sdk = { version = "1.1", default-features = false, features = ["irc_27", "irc_30", "std"], package = "iota-sdk" }

--- a/crates/iota-types/src/messages_checkpoint.rs
+++ b/crates/iota-types/src/messages_checkpoint.rs
@@ -10,7 +10,6 @@ use std::{
 
 use anyhow::Result;
 use fastcrypto::hash::MultisetHash;
-use iota_metrics::histogram::Histogram as IotaHistogram;
 use iota_protocol_config::ProtocolConfig;
 use once_cell::sync::OnceCell;
 use prometheus::Histogram;
@@ -258,12 +257,11 @@ impl CheckpointSummary {
             .map(|e| e.next_epoch_committee.as_slice())
     }
 
-    pub fn report_checkpoint_age(&self, metrics: &Histogram, metrics_deprecated: &IotaHistogram) {
+    pub fn report_checkpoint_age(&self, metrics: &Histogram) {
         SystemTime::now()
             .duration_since(self.timestamp())
             .map(|latency| {
                 metrics.observe(latency.as_secs_f64());
-                metrics_deprecated.report(latency.as_millis() as u64);
             })
             .tap_err(|err| {
                 warn!(

--- a/dev-tools/grafana-local/dashboards/cluster-status-dashboard.json
+++ b/dev-tools/grafana-local/dashboards/cluster-status-dashboard.json
@@ -2436,7 +2436,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "last_created_checkpoint_age_ms{host=~\"$validator\", pct=\"50\"}",
+          "expr": "last_created_checkpoint_age_bucket{host=~\"$validator\", le=\"60.0\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -2452,7 +2452,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "last_executed_checkpoint_age_ms{host=~\"$validator\", pct=\"50\"}",
+          "expr": "last_executed_checkpoint_age_bucket{host=~\"$validator\", le=\"60.0\"}",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -2469,7 +2469,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "last_certified_checkpoint_age_ms{host=~\"$validator\", pct=\"50\"}",
+          "expr": "last_certified_checkpoint_age_bucket{host=~\"$validator\", le=\"60.0\"}",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -2480,7 +2480,7 @@
           "useBackend": false
         }
       ],
-      "title": "Checkpoint Age (50%ile)",
+      "title": "Checkpoint Age (60%ile)",
       "type": "timeseries"
     },
     {
@@ -2761,7 +2761,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "last_created_checkpoint_age_ms{pct=\"95\", host=~\"$validator\"}",
+          "expr": "last_created_checkpoint_age_bucket{host=~\"$validator\", le=\"90.0\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -2778,7 +2778,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "last_executed_checkpoint_age_ms{host=~\"$validator\", pct=\"95\"}",
+          "expr": "last_executed_checkpoint_age_bucket{host=~\"$validator\", le=\"90.0\"}",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -2796,7 +2796,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "last_certified_checkpoint_age_ms{host=~\"$validator\", pct=\"95\"}",
+          "expr": "last_certified_checkpoint_age_bucket{host=~\"$validator\", le=\"90.0\"}",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -2808,7 +2808,7 @@
           "useBackend": false
         }
       ],
-      "title": "Checkpoint Age (95%ile)",
+      "title": "Checkpoint Age (90%ile)",
       "type": "timeseries"
     },
     {

--- a/docs/content/_snippets/operator/monitoring-health-metrics.mdx
+++ b/docs/content/_snippets/operator/monitoring-health-metrics.mdx
@@ -15,19 +15,23 @@ curl -s localhost:9184/metrics | grep -E "^last_executed_checkpoint|^highest_syn
 
 For instance, for a validator node, the output would be:
 ```sh
-consensus_proposed_blocks{force="false"} 840272
-consensus_proposed_blocks{force="true"} 2255
-consensus_threshold_clock_round 1318080
-highest_known_checkpoint 60575714
-highest_synced_checkpoint 60575710
-last_executed_checkpoint 60575714
-last_executed_checkpoint_age_ms{pct="50"} 0
-last_executed_checkpoint_age_ms{pct="95"} 0
-last_executed_checkpoint_age_ms{pct="99"} 0
-last_executed_checkpoint_age_ms_count 1342973
-last_executed_checkpoint_age_ms_sum 367068033
-last_executed_checkpoint_timestamp_ms 1745504535018
-uptime{chain_identifier="2304aa97",is_docker="false",os_version="Linux (Ubuntu 24.04)",process="validator",version="0.12.0-rc-7e49c58b826b"} 700369
+consensus_proposed_blocks{force="false"} 247
+consensus_proposed_blocks{force="true"} 1
+consensus_threshold_clock_round 257
+highest_known_checkpoint 555
+highest_synced_checkpoint 886
+last_executed_checkpoint 890
+last_executed_checkpoint_age_bucket{le="0.001"} 0
+last_executed_checkpoint_age_bucket{le="0.005"} 0
+last_executed_checkpoint_age_bucket{le="0.01"} 0
+...
+last_executed_checkpoint_age_bucket{le="60"} 891
+last_executed_checkpoint_age_bucket{le="90"} 891
+last_executed_checkpoint_age_bucket{le="+Inf"} 891
+last_executed_checkpoint_age_sum 156.52341099999992
+last_executed_checkpoint_age_count 891
+last_executed_checkpoint_timestamp_ms 1748335503888
+uptime{chain_identifier="b5d7e5c8",is_docker="false",os_version="macOS 15.5 Sequoia",process="validator",version="1.1.0"} 196
 ```
 
 ### Ensure node health using last checkpoint timestamp


### PR DESCRIPTION
# Description of change

Remove the remaining deprecated IotaHistogram metrics. There are a total of 6 metrics using IotaHistogram to report various time intervals in milliseconds; all of them already have counterpart metrics using prometheus Histogram and report time in seconds with fractions. The removed metrics are not used in community dashboard.

## Links to any relevant issues

Fixes #6766.

## Type of change

- Enhancement (a non-breaking change which removes deprecated functionality)

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Removed deprecated metrics. (last_created_checkpoint_age_ms, last_certified_checkpoint_age_ms, checkpoint_creation_latency_ms, checkpoint_contents_age_ms, last_executed_checkpoint_age_ms, checkpoint_summary_age_ms)
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
