### PR TITLE
fix(indexer, json-rpc): Support Coin Manager in `get_coin_metadata` RPC API

### DIFF
--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -31,6 +31,7 @@ use iota_types::{
     balance::Supply,
     base_types::{IotaAddress, ObjectID, SequenceNumber, VersionNumber},
     coin::{CoinMetadata, TreasuryCap},
+    coin_manager::CoinManager,
     committee::EpochId,
     digests::{ChainIdentifier, TransactionDigest},
     dynamic_field::{DynamicFieldInfo, DynamicFieldName, visitor as DFV},
@@ -828,6 +829,27 @@ impl IndexerReader {
             query
                 .load::<StoredObject>(conn)
                 .map_err(|e| IndexerError::PostgresRead(e.to_string()))
+        })
+    }
+
+    fn get_singleton_object(&self, struct_tag: StructTag) -> Result<Option<Object>, IndexerError> {
+        let object_type = struct_tag.to_canonical_string(/* with_prefix */ true);
+
+        run_query!(&self.pool, |conn| {
+            let object = match objects::dsl::objects
+                .filter(objects::object_type_package.eq(struct_tag.address.to_vec()))
+                .filter(objects::object_type_module.eq(struct_tag.module.to_string()))
+                .filter(objects::object_type_name.eq(struct_tag.name.to_string()))
+                .filter(objects::object_type.eq(object_type))
+                .first::<StoredObject>(conn)
+                .optional()
+                .map_err(|e| IndexerError::PostgresRead(e.to_string()))?
+            {
+                Some(object) => object,
+                None => return Ok::<Option<Object>, IndexerError>(None),
+            }
+            .try_into()?;
+            Ok(Some(object))
         })
     }
 
@@ -1966,23 +1988,41 @@ impl IndexerReader {
         &self,
         coin_struct: StructTag,
     ) -> Result<Option<IotaCoinMetadata>, IndexerError> {
-        let package_id = coin_struct.address.into();
-        let coin_metadata_type =
-            CoinMetadata::type_(coin_struct).to_canonical_string(/* with_prefix */ true);
-        let coin_metadata_obj_id = *self
-            .package_obj_type_cache
-            .lock()
-            .unwrap()
-            .cache_get_or_set_with(format!("{}{}", package_id, coin_metadata_type), || {
-                get_single_obj_id_from_package_publish(self, package_id, coin_metadata_type.clone())
-                    .unwrap()
-            });
-        if let Some(id) = coin_metadata_obj_id {
-            let metadata_object = self.get_object(&id, None)?;
-            Ok(metadata_object.and_then(|v| IotaCoinMetadata::try_from(v).ok()))
+        let coin_metadata_type = CoinMetadata::type_(coin_struct.clone());
+        let metadata_object = self
+            .get_singleton_object(coin_metadata_type)?
+            .and_then(|o| IotaCoinMetadata::try_from(o).ok());
+
+        if let Some(metadata_object) = metadata_object {
+            Ok(Some(metadata_object))
         } else {
-            Ok(None)
+            let coin_manager_obj = self.get_coin_manager_obj(coin_struct)?;
+            Ok(
+                coin_manager_obj.and_then(|m| match (m.metadata, m.immutable_metadata) {
+                    (Some(metadata), _) => Some(metadata.into()),
+                    (_, Some(immutable_metadata)) => Some(IotaCoinMetadata {
+                        decimals: immutable_metadata.decimals,
+                        name: immutable_metadata.name,
+                        symbol: immutable_metadata.symbol,
+                        description: immutable_metadata.description,
+                        icon_url: immutable_metadata.icon_url,
+                        id: None,
+                    }),
+                    (None, None) => None,
+                }),
+            )
         }
+    }
+
+    fn get_coin_manager_obj(
+        &self,
+        coin_type: StructTag,
+    ) -> Result<Option<CoinManager>, IndexerError> {
+        let coin_manager_type = CoinManager::type_(coin_type);
+        let coin_manager_object = self
+            .get_singleton_object(coin_manager_type)?
+            .and_then(|o| CoinManager::try_from(o).ok());
+        Ok(coin_manager_object)
     }
 
     pub async fn get_total_supply_in_blocking_task(

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -8,6 +8,7 @@ use std::{
     time::Duration,
 };
 
+use fastcrypto::traits::Signer;
 use iota_config::local_ip_utils::{get_available_port, new_local_tcp_socket_for_testing};
 use iota_indexer::{
     IndexerConfig,
@@ -22,7 +23,7 @@ use iota_json_rpc_types::{IotaTransactionBlockResponseOptions, TransactionBlockB
 use iota_metrics::init_metrics;
 use iota_types::{
     base_types::{ObjectID, SequenceNumber},
-    crypto::AccountKeyPair,
+    crypto::Signature,
     digests::TransactionDigest,
     utils::to_sender_signed_transaction,
 };
@@ -272,7 +273,7 @@ pub async fn execute_tx_and_wait_for_indexer(
     cluster: &TestCluster,
     store: &PgIndexerStore,
     tx_bytes: TransactionBlockBytes,
-    keypair: &AccountKeyPair,
+    keypair: &dyn Signer<Signature>,
 ) {
     let txn = to_sender_signed_transaction(tx_bytes.to_data().unwrap(), keypair);
     let res = cluster.wallet.execute_transaction_must_succeed(txn).await;

--- a/crates/iota-indexer/tests/data/coin_manager_coins/Move.toml
+++ b/crates/iota-indexer/tests/data/coin_manager_coins/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "Native Coin manager coins"
+version = "0.0.1"
+
+[dependencies]
+Iota = { local = "../../../../iota-framework/packages/iota-framework" }
+
+[addresses]
+coin_manager_coin = "0x0"

--- a/crates/iota-indexer/tests/data/coin_manager_coins/sources/immutable_metadata_coin.move
+++ b/crates/iota-indexer/tests/data/coin_manager_coins/sources/immutable_metadata_coin.move
@@ -1,0 +1,47 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+module coin_manager_coin::immutable_metadata_coin {
+    use iota::coin_manager;
+    use std::option;
+    use iota::coin::{Self, CoinMetadata};
+    use iota::transfer;
+    use iota::tx_context::{Self, TxContext};
+
+    struct IMMUTABLE_METADATA_COIN has drop {}
+
+    struct HiddenCoinMetadata<phantom T> has key, store {
+        id: iota::object::UID,
+        metadata: CoinMetadata<T>,
+    }
+
+    #[allow(lint(self_transfer, share_owned))]
+    fun init(witness: IMMUTABLE_METADATA_COIN, ctx: &mut TxContext) {
+        let (cap, meta) = coin::create_currency(
+            witness,
+            0,
+            b"IMMMETA",
+            b"Immutable Meta Coin",
+            b"Immutable Meta  description.",
+            option::none(),
+            ctx
+        );
+
+        let (cm_treasury_cap, manager) = coin_manager::new_with_immutable_metadata(cap, &meta, ctx);
+
+        // Hide metadata inside of some dummy object, so it's not accessible directly via ID.
+        // So that Node and Indexer will not be able to use it and will have to rely on CoinManager only.
+        let hidden = HiddenCoinMetadata {
+            id: iota::object::new(ctx),
+            metadata: meta,
+        };
+        transfer::public_transfer(hidden, tx_context::sender(ctx));
+
+        // Transfer the `CoinManagerTreasuryCap` to the creator of the `Coin`.
+        transfer::public_transfer(cm_treasury_cap, tx_context::sender(ctx));
+
+        // Publicly share the `CoinManager` object for convenient usage by anyone interested.
+        transfer::public_share_object(manager);
+    }
+}

--- a/crates/iota-indexer/tests/data/coin_manager_coins/sources/immutable_metadata_coin.move
+++ b/crates/iota-indexer/tests/data/coin_manager_coins/sources/immutable_metadata_coin.move
@@ -1,5 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 module coin_manager_coin::immutable_metadata_coin {

--- a/crates/iota-indexer/tests/data/coin_manager_coins/sources/normal_coin.move
+++ b/crates/iota-indexer/tests/data/coin_manager_coins/sources/normal_coin.move
@@ -1,5 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 module coin_manager_coin::normal_coin {

--- a/crates/iota-indexer/tests/data/coin_manager_coins/sources/normal_coin.move
+++ b/crates/iota-indexer/tests/data/coin_manager_coins/sources/normal_coin.move
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+module coin_manager_coin::normal_coin {
+    use iota::coin_manager;
+    use std::option;
+    use iota::transfer;
+    use iota::tx_context::{Self, TxContext};
+
+    struct NORMAL_COIN has drop {}
+
+    fun init(witness: NORMAL_COIN, ctx: &mut TxContext) {
+        // Create a `Coin` type and have it managed.
+        let (cm_treasury_cap, cm_meta_cap, manager) = coin_manager::create(
+            witness,
+            0,
+            b"NRML",
+            b"Normal Coin",
+            b"Normal description.",
+            option::none(),
+            ctx
+        );
+
+        // Transfer the `CoinManagerTreasuryCap` to the creator of the `Coin`.
+        transfer::public_transfer(cm_treasury_cap, tx_context::sender(ctx));
+
+        // Transfer the `CoinManagerMetadataCap` to the creator of the `Coin`.
+        transfer::public_transfer(cm_meta_cap, tx_context::sender(ctx));
+
+        // Publicly share the `CoinManager` object for convenient usage by anyone interested.
+        transfer::public_share_object(manager);
+    }
+}

--- a/crates/iota-indexer/tests/data/dummy_modules_publish/sources/immutable_metadata_trusted_coin.move
+++ b/crates/iota-indexer/tests/data/dummy_modules_publish/sources/immutable_metadata_trusted_coin.move
@@ -1,5 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2024 IOTA Stiftung
+// Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 /// Example coin with a trusted owner responsible for minting/burning (e.g., a stablecoin)

--- a/crates/iota-indexer/tests/data/dummy_modules_publish/sources/immutable_metadata_trusted_coin.move
+++ b/crates/iota-indexer/tests/data/dummy_modules_publish/sources/immutable_metadata_trusted_coin.move
@@ -1,0 +1,68 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+/// Example coin with a trusted owner responsible for minting/burning (e.g., a stablecoin)
+module examples::immutable_metadata_trusted_coin {
+    use std::option;
+    use iota::coin::{Self, TreasuryCap};
+    use iota::transfer;
+    use iota::tx_context::{Self, TxContext};
+    use iota::coin::CoinMetadata;
+
+    /// Name of the coin
+    struct IMMUTABLE_METADATA_TRUSTED_COIN has drop {}
+
+    struct HiddenCoinMetadata<phantom T> has key, store {
+        id: iota::object::UID,
+        metadata: CoinMetadata<T>,
+    }
+
+    /// Register the trusted currency to acquire its `TreasuryCap`. Because
+    /// this is a module initializer, it ensures the currency only gets
+    /// registered once.
+    fun init(witness: IMMUTABLE_METADATA_TRUSTED_COIN, ctx: &mut tx_context::TxContext) {
+        // Get a treasury cap for the coin and give it to the transaction
+        // sender
+        let (treasury_cap, metadata) = coin::create_currency<IMMUTABLE_METADATA_TRUSTED_COIN>(
+            witness,
+            2,
+            b"IMM_META_TRUSTED",
+            b"Immutable Metadata Trusted Coin",
+            b"Immutable Metadata Trusted Coin for test",
+            option::none(),
+            ctx
+        );
+        transfer::public_transfer(metadata, tx_context::sender(ctx));
+        transfer::public_transfer(treasury_cap, tx_context::sender(ctx))
+    }
+
+    public entry fun mint(treasury_cap: &mut TreasuryCap<IMMUTABLE_METADATA_TRUSTED_COIN>, amount: u64, ctx: &mut tx_context::TxContext) {
+        let coin = coin::mint<IMMUTABLE_METADATA_TRUSTED_COIN>(treasury_cap, amount, ctx);
+        transfer::public_transfer(coin, tx_context::sender(ctx));
+    }
+
+    public entry fun transfer(treasury_cap: TreasuryCap<IMMUTABLE_METADATA_TRUSTED_COIN>, recipient: address) {
+        transfer::public_transfer(treasury_cap, recipient);
+    }
+
+    #[allow(lint(self_transfer))]
+    public fun hide_metadata<T> (
+        metadata: CoinMetadata<T>,
+        ctx: &mut TxContext,
+    ) {
+
+        let hidden = HiddenCoinMetadata {
+            id: iota::object::new(ctx),
+            metadata: metadata,
+        };
+
+        transfer::public_transfer(hidden, tx_context::sender(ctx))
+    }
+
+    #[test_only]
+    /// Wrapper of module initializer for testing
+    public fun test_init(ctx: &mut TxContext) {
+        init(IMMUTABLE_METADATA_TRUSTED_COIN {}, ctx)
+    }
+}

--- a/crates/iota-indexer/tests/data/dummy_modules_publish/sources/trusted_coin.move
+++ b/crates/iota-indexer/tests/data/dummy_modules_publish/sources/trusted_coin.move
@@ -19,7 +19,7 @@ module examples::trusted_coin {
         // Get a treasury cap for the coin and give it to the transaction
         // sender
         let (treasury_cap, metadata) = coin::create_currency<TRUSTED_COIN>(witness, 2, b"TRUSTED", b"Trusted Coin", b"Trusted Coin for test", option::none(), ctx);
-        transfer::public_freeze_object(metadata);
+        transfer::public_transfer(metadata, tx_context::sender(ctx));
         transfer::public_transfer(treasury_cap, tx_context::sender(ctx))
     }
 

--- a/crates/iota-indexer/tests/data/migrate_to_coin_manager/Move.toml
+++ b/crates/iota-indexer/tests/data/migrate_to_coin_manager/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "Migrate to coin manager"
+version = "0.0.1"
+
+[dependencies]
+Iota = { local = "../../../../iota-framework/packages/iota-framework" }
+
+[addresses]
+migrate_coin = "0x0"

--- a/crates/iota-indexer/tests/data/migrate_to_coin_manager/sources/coin_manager_coin.move
+++ b/crates/iota-indexer/tests/data/migrate_to_coin_manager/sources/coin_manager_coin.move
@@ -1,5 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 module migrate_coin::coin_manager_coin {

--- a/crates/iota-indexer/tests/data/migrate_to_coin_manager/sources/coin_manager_coin.move
+++ b/crates/iota-indexer/tests/data/migrate_to_coin_manager/sources/coin_manager_coin.move
@@ -1,0 +1,51 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+module migrate_coin::coin_manager_coin {
+    use iota::coin_manager;
+    use iota::coin::{CoinMetadata, TreasuryCap};
+    use iota::transfer;
+    use iota::tx_context::{Self, TxContext};
+
+
+    /// Phantom parameter T can only be initialized in the `create_guardian`
+    /// function. But the types passed here must have `drop`.
+    struct Guardian<phantom T: drop> has key, store {
+        id: iota::object::UID
+    }
+
+    /// This type is the witness resource and is intended to be used only once.
+    struct COIN_MANAGER_COIN has drop {}
+
+    /// The first argument of this function is an actual instance of the
+    /// type T with `drop` ability. It is dropped as soon as received.
+    public fun create_guardian<T: drop>(
+        _witness: T, ctx: &mut TxContext
+     ): Guardian<T> {
+            Guardian { id: iota::object::new(ctx) }
+     }
+
+    /// Module initializer is the best way to ensure that the
+    /// code is called only once. With `Witness` pattern it is
+    /// often the best practice.
+    fun init(witness: COIN_MANAGER_COIN, ctx: &mut tx_context::TxContext) {
+        transfer::transfer(create_guardian(witness, ctx), tx_context::sender(ctx))
+     }
+
+    #[allow(lint(self_transfer, share_owned))]
+    public fun migrate_to_manager<T, S: drop> (otw:Guardian<S>, cap: TreasuryCap<T>, meta: CoinMetadata<T>, ctx: &mut tx_context::TxContext) {
+        transfer::public_freeze_object(otw);
+
+        let (cm_treasury_cap, cm_meta_cap, manager) = coin_manager::new(cap, meta, ctx);
+
+        // Transfer the `CoinManagerTreasuryCap` to the creator of the `Coin`.
+        transfer::public_transfer(cm_treasury_cap, tx_context::sender(ctx));
+
+        // Transfer the `CoinManagerMetadataCap` to the creator of the `Coin`.
+        transfer::public_transfer(cm_meta_cap, tx_context::sender(ctx));
+
+        // Publicly share the `CoinManager` object for convenient usage by anyone interested.
+        transfer::public_share_object(manager);
+    }
+}

--- a/crates/iota-indexer/tests/data/migrate_to_coin_manager/sources/immutable_metadata_coin_manager_coin.move
+++ b/crates/iota-indexer/tests/data/migrate_to_coin_manager/sources/immutable_metadata_coin_manager_coin.move
@@ -1,5 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 module migrate_coin::immutable_metadata_coin_manager_coin {

--- a/crates/iota-indexer/tests/data/migrate_to_coin_manager/sources/immutable_metadata_coin_manager_coin.move
+++ b/crates/iota-indexer/tests/data/migrate_to_coin_manager/sources/immutable_metadata_coin_manager_coin.move
@@ -1,0 +1,47 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+module migrate_coin::immutable_metadata_coin_manager_coin {
+    use iota::coin_manager;
+    use iota::coin::{CoinMetadata, TreasuryCap};
+    use iota::transfer;
+    use iota::tx_context::{Self, TxContext};
+
+    /// Phantom parameter T can only be initialized in the `create_guardian`
+    /// function. But the types passed here must have `drop`.
+    struct Guardian<phantom T: drop> has key, store {
+        id: iota::object::UID
+    }
+
+    /// This type is the witness resource and is intended to be used only once.
+    struct IMMUTABLE_METADATA_COIN_MANAGER_COIN has drop {}
+
+    /// The first argument of this function is an actual instance of the
+    /// type T with `drop` ability. It is dropped as soon as received.
+    public fun create_guardian<T: drop>(
+        _witness: T, ctx: &mut TxContext
+     ): Guardian<T> {
+            Guardian { id: iota::object::new(ctx) }
+     }
+
+    /// Module initializer is the best way to ensure that the
+    /// code is called only once. With `Witness` pattern it is
+    /// often the best practice.
+    fun init(witness: IMMUTABLE_METADATA_COIN_MANAGER_COIN, ctx: &mut tx_context::TxContext) {
+        transfer::transfer(create_guardian(witness, ctx), tx_context::sender(ctx))
+     }
+
+    #[allow(lint(self_transfer, share_owned))]
+    public fun migrate_to_manager<T, S: drop> (otw:Guardian<S>, cap: TreasuryCap<T>, meta: &CoinMetadata<T>, ctx: &mut tx_context::TxContext) {
+        transfer::public_freeze_object(otw);
+
+        let (cm_treasury_cap, manager) = coin_manager::new_with_immutable_metadata(cap, meta, ctx);
+
+        // Transfer the `CoinManagerTreasuryCap` to the creator of the `Coin`.
+        transfer::public_transfer(cm_treasury_cap, tx_context::sender(ctx));
+
+        // Publicly share the `CoinManager` object for convenient usage by anyone interested.
+        transfer::public_share_object(manager);
+    }
+}

--- a/crates/iota-indexer/tests/rpc-tests/coin_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/coin_api.rs
@@ -1,44 +1,53 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{path::PathBuf, str::FromStr};
+use std::{path::PathBuf, str::FromStr, sync::Arc};
 
 use iota_indexer::store::PgIndexerStore;
-use iota_json::{call_args, type_args};
-use iota_json_rpc_api::{CoinReadApiClient, TransactionBuilderClient, WriteApiClient};
-use iota_json_rpc_types::{
-    Balance, CoinPage, IotaCoinMetadata, IotaExecutionStatus, IotaObjectRef,
-    IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse,
-    IotaTransactionBlockResponseOptions, ObjectChange, TransactionBlockBytes,
+use iota_json::{IotaJsonValue, call_args, type_args};
+use iota_json_rpc_api::{
+    CoinReadApiClient, IndexerApiClient, TransactionBuilderClient, WriteApiClient,
 };
+use iota_json_rpc_types::{
+    Balance, CoinPage, IotaCoinMetadata, IotaObjectData, IotaObjectDataFilter, IotaObjectRef,
+    IotaObjectResponseQuery, IotaTransactionBlockEffectsAPI, IotaTransactionBlockResponse,
+    IotaTransactionBlockResponseOptions, IotaTypeTag, ObjectChange, TransactionBlockBytes,
+};
+use iota_keys::keystore::AccountKeystore;
 use iota_move_build::BuildConfig;
 use iota_types::{
-    IOTA_FRAMEWORK_ADDRESS,
+    IOTA_FRAMEWORK_ADDRESS, TypeTag,
     balance::Supply,
     base_types::{IotaAddress, ObjectID},
-    coin::{COIN_MODULE_NAME, TreasuryCap},
-    crypto::{AccountKeyPair, get_key_pair},
+    coin::{COIN_MODULE_NAME, CoinMetadata, TreasuryCap},
+    crypto::{AccountKeyPair, IotaKeyPair, get_key_pair},
     parse_iota_struct_tag,
     quorum_driver_types::ExecuteTransactionRequestType,
     utils::to_sender_signed_transaction,
 };
 use itertools::Itertools;
 use jsonrpsee::http_client::HttpClient;
+use move_core_types::{identifier::Identifier, language_storage::StructTag};
 use test_cluster::TestCluster;
-use tokio::sync::OnceCell;
+use tokio::sync::{Mutex, OnceCell};
 
-use crate::common::{ApiTestSetup, execute_tx_and_wait_for_indexer, indexer_wait_for_object};
+use crate::common::{
+    ApiTestSetup, execute_tx_and_wait_for_indexer, indexer_wait_for_object,
+    indexer_wait_for_transaction, start_test_cluster_with_read_write_indexer,
+};
 
-static COMMON_TESTING_ADDR_AND_CUSTOM_COIN_NAME: OnceCell<(IotaAddress, AccountKeyPair, String)> =
+static COMMON_TESTING_ADDR_AND_CUSTOM_COIN_NAME: OnceCell<(IotaAddress, IotaKeyPair, String)> =
     OnceCell::const_new();
+static PACKAGE_PUBLISH_LOCK: OnceCell<Arc<Mutex<i64>>> = OnceCell::const_new();
 
 async fn get_or_init_addr_and_custom_coins(
     cluster: &TestCluster,
     indexer_client: &HttpClient,
-) -> &'static (IotaAddress, AccountKeyPair, String) {
+) -> &'static (IotaAddress, IotaKeyPair, String) {
     COMMON_TESTING_ADDR_AND_CUSTOM_COIN_NAME
         .get_or_init(|| async {
             let (address, keypair): (_, AccountKeyPair) = get_key_pair();
+            let keypair = IotaKeyPair::Ed25519(keypair);
 
             for _ in 0..5 {
                 cluster
@@ -50,8 +59,12 @@ async fn get_or_init_addr_and_custom_coins(
                     .await;
             }
 
-            let (coin_name, coin_object_ref) =
-                create_and_mint_trusted_coin(cluster, address, &keypair, 100_000)
+            let (coin_name, _) = create_trusted_coins(cluster, address, &keypair)
+                .await
+                .unwrap();
+
+            let coin_object_ref =
+                mint_trusted_coin(cluster, coin_name.clone(), address, &keypair, 100_000)
                     .await
                     .unwrap();
 
@@ -354,6 +367,159 @@ fn get_coin_metadata() {
 }
 
 #[test]
+#[ignore = "https://github.com/iotaledger/iota/issues/7014"]
+fn fullnode_get_coin_metadata_with_migrated_coin_manager_coins() {
+    let ApiTestSetup {
+        runtime,
+        client,
+        cluster,
+        store,
+    } = ApiTestSetup::get_or_init();
+    runtime.block_on(async move {
+        let (address, address_kp, _) = get_or_init_addr_and_custom_coins(cluster, client).await;
+        let (coin_name, immutable_metadata_coin_name) =
+            create_migrated_coin_manager_coins(cluster, client, store, *address, address_kp)
+                .await
+                .unwrap();
+
+        let (result_fullnode, result_indexer) =
+            get_coin_metadata_fullnode_indexer(cluster, client, coin_name.to_string()).await;
+
+        assert!(result_fullnode.is_some());
+        assert_eq!(result_fullnode, result_indexer);
+
+        let (result_fullnode, result_indexer) = get_coin_metadata_fullnode_indexer(
+            cluster,
+            client,
+            immutable_metadata_coin_name.to_string(),
+        )
+        .await;
+
+        assert!(result_fullnode.is_some());
+        assert_eq!(result_fullnode, result_indexer);
+    });
+}
+
+#[test]
+fn indexer_get_coin_metadata_with_migrated_coin_manager_coins() {
+    let ApiTestSetup { runtime, .. } = ApiTestSetup::get_or_init();
+    runtime.block_on(async move {
+        let (cluster, store, client) = &start_test_cluster_with_read_write_indexer(
+            Some("indexer_get_coin_metadata_with_migrated_coin_manager_coins"),
+            None,
+            None,
+        )
+        .await;
+
+        let address = cluster.wallet.active_address().unwrap();
+        let address_kp = cluster
+            .wallet
+            .config()
+            .keystore()
+            .get_key(&address)
+            .unwrap();
+        let (coin_name, immutable_metadata_coin_name) =
+            create_migrated_coin_manager_coins(cluster, client, store, address, address_kp)
+                .await
+                .unwrap();
+
+        let (_, result_indexer) =
+            get_coin_metadata_fullnode_indexer(cluster, client, coin_name.to_string()).await;
+
+        assert!(result_indexer.is_some());
+        let result_indexer = result_indexer.unwrap();
+        assert_eq!(result_indexer.decimals, 2);
+        assert_eq!(result_indexer.name, "Trusted Coin");
+        assert_eq!(result_indexer.symbol, "TRUSTED");
+        assert_eq!(result_indexer.description, "Trusted Coin for test");
+        assert_eq!(result_indexer.icon_url, None);
+        assert!(result_indexer.id.is_some());
+
+        let (_, result_indexer) = get_coin_metadata_fullnode_indexer(
+            cluster,
+            client,
+            immutable_metadata_coin_name.to_string(),
+        )
+        .await;
+
+        assert!(result_indexer.is_some());
+        let result_indexer = result_indexer.unwrap();
+        assert_eq!(result_indexer.decimals, 2);
+        assert_eq!(result_indexer.name, "Immutable Metadata Trusted Coin");
+        assert_eq!(result_indexer.symbol, "IMM_META_TRUSTED");
+        assert_eq!(
+            result_indexer.description,
+            "Immutable Metadata Trusted Coin for test"
+        );
+        assert_eq!(result_indexer.icon_url, None);
+        assert!(result_indexer.id.is_none()); // Immutable data is stored in struct that doesn't have ID
+    });
+}
+
+#[test]
+fn get_coin_metadata_with_native_coin_manager_coins() {
+    let ApiTestSetup { runtime, .. } = ApiTestSetup::get_or_init();
+    runtime.block_on(async move {
+        let (cluster, store, client) = &start_test_cluster_with_read_write_indexer(
+            Some("get_coin_metadata_with_native_coin_manager_coins"),
+            None,
+            None,
+        )
+        .await;
+
+        let address = cluster.wallet.active_address().unwrap();
+        let address_kp = cluster
+            .wallet
+            .config()
+            .keystore()
+            .get_key(&address)
+            .unwrap();
+        let (coin_name, immutable_metadata_coin_name) =
+            create_native_coin_manager_coins(cluster, client, store, address, address_kp)
+                .await
+                .unwrap();
+
+        let (result_fullnode, result_indexer) =
+            get_coin_metadata_fullnode_indexer(cluster, client, coin_name.to_string()).await;
+
+        assert!(result_indexer.is_some());
+        assert_eq!(result_fullnode, result_indexer);
+        assert!(result_indexer.unwrap().id.is_some());
+
+        let (result_fullnode, result_indexer) = get_coin_metadata_fullnode_indexer(
+            cluster,
+            client,
+            immutable_metadata_coin_name.to_string(),
+        )
+        .await;
+
+        assert!(result_indexer.is_some());
+        assert_eq!(result_fullnode, result_indexer);
+        assert!(result_indexer.unwrap().id.is_none()); // Immutable data is stored in struct that doesn't have ID
+    });
+}
+
+#[test]
+fn get_coin_metadata_with_nonexistent_coin() {
+    let ApiTestSetup {
+        runtime,
+        client,
+        cluster,
+        ..
+    } = ApiTestSetup::get_or_init();
+    runtime.block_on(async move {
+        let (_, _, coin_name) = get_or_init_addr_and_custom_coins(cluster, client).await;
+        let nonexistent_coin = format!("{coin_name}_some_suffix");
+
+        let (result_fullnode, result_indexer) =
+            get_coin_metadata_fullnode_indexer(cluster, client, nonexistent_coin).await;
+
+        assert!(result_fullnode.is_none());
+        assert!(result_indexer.is_none());
+    });
+}
+
+#[test]
 fn get_total_supply() {
     let ApiTestSetup {
         runtime,
@@ -460,29 +626,284 @@ async fn get_total_supply_fullnode_indexer(
     (result_fullnode, result_indexer)
 }
 
-async fn create_and_mint_trusted_coin(
+async fn create_trusted_coins(
     cluster: &TestCluster,
     address: IotaAddress,
-    account_keypair: &AccountKeyPair,
-    amount: u64,
-) -> Result<(String, IotaObjectRef), anyhow::Error> {
+    account_keypair: &IotaKeyPair,
+) -> Result<(String, String), anyhow::Error> {
     let http_client = cluster.rpc_client();
-    let coins = http_client
+
+    let (package_id, _) = publish_test_move_package(
+        http_client,
+        address,
+        account_keypair,
+        "dummy_modules_publish",
+    )
+    .await?;
+
+    let coin_name = format!("{package_id}::trusted_coin::TRUSTED_COIN");
+    let imm_coin_name =
+        format!("{package_id}::immutable_metadata_trusted_coin::IMMUTABLE_METADATA_TRUSTED_COIN");
+
+    Ok((coin_name, imm_coin_name))
+}
+
+async fn execute_move_call(
+    client: &HttpClient,
+    address: IotaAddress,
+    account_keypair: &IotaKeyPair,
+    package_object_id: ObjectID,
+    module: String,
+    function: String,
+    type_arguments: Vec<IotaTypeTag>,
+    arguments: Vec<IotaJsonValue>,
+) -> Result<IotaTransactionBlockResponse, anyhow::Error> {
+    let coins = client
         .get_coins(address, None, None, Some(1))
         .await
         .unwrap()
         .data;
     let gas = &coins[0];
 
-    // Publish test coin package
+    let transaction_bytes: TransactionBlockBytes = client
+        .move_call(
+            address,
+            package_object_id,
+            module,
+            function,
+            type_arguments,
+            arguments,
+            Some(gas.coin_object_id),
+            10_000_000.into(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let signed_transaction =
+        to_sender_signed_transaction(transaction_bytes.to_data().unwrap(), account_keypair);
+    let (tx_bytes, signatures) = signed_transaction.to_tx_bytes_and_signatures();
+
+    Ok(client
+        .execute_transaction_block(
+            tx_bytes,
+            signatures,
+            Some(IotaTransactionBlockResponseOptions::new().with_effects()),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await
+        .unwrap())
+}
+
+async fn mint_trusted_coin(
+    cluster: &TestCluster,
+    coin_name: String,
+    address: IotaAddress,
+    account_keypair: &IotaKeyPair,
+    amount: u64,
+) -> Result<IotaObjectRef, anyhow::Error> {
+    let http_client = cluster.rpc_client();
+
+    let result: Supply = http_client
+        .get_total_supply(coin_name.clone())
+        .await
+        .unwrap();
+    assert_eq!(0, result.value);
+
+    let coin_type = parse_iota_struct_tag(&coin_name).unwrap();
+    let treasury_cap_type = TreasuryCap::type_(coin_type);
+    let treasury_cap = get_single_owned_object_by_type(http_client, address, treasury_cap_type)
+        .await
+        .object_id;
+
+    let tx_response = execute_move_call(
+        http_client,
+        address,
+        account_keypair,
+        IOTA_FRAMEWORK_ADDRESS.into(),
+        COIN_MODULE_NAME.to_string(),
+        "mint_and_transfer".into(),
+        type_args![coin_name.clone()].unwrap(),
+        call_args![treasury_cap, amount, address].unwrap(),
+    )
+    .await?;
+    assert_eq!(tx_response.status_ok(), Some(true));
+
+    let created_coin_obj_ref = tx_response.effects.unwrap().created()[0].reference.clone();
+
+    Ok(created_coin_obj_ref)
+}
+
+async fn create_migrated_coin_manager_coins(
+    cluster: &TestCluster,
+    indexer_client: &HttpClient,
+    pg_store: &PgIndexerStore,
+    address: IotaAddress,
+    account_keypair: &IotaKeyPair,
+) -> Result<(String, String), anyhow::Error> {
+    let (coin_name, immutable_metadata_coin_name) =
+        create_trusted_coins(cluster, address, account_keypair).await?;
+    mint_trusted_coin(
+        cluster,
+        coin_name.clone(),
+        address,
+        account_keypair,
+        100_000,
+    )
+    .await
+    .unwrap();
+
+    let http_client = cluster.rpc_client();
+    let (package_id, _) = publish_test_move_package(
+        http_client,
+        address,
+        account_keypair,
+        "migrate_to_coin_manager",
+    )
+    .await?;
+
+    {
+        let coin_type = parse_iota_struct_tag(&coin_name).unwrap();
+        let treasury_cap_type = TreasuryCap::type_(coin_type.clone());
+        let treasury_cap = get_single_owned_object_by_type(http_client, address, treasury_cap_type)
+            .await
+            .object_id;
+
+        let coin_metadata_type = CoinMetadata::type_(coin_type.clone());
+        let coin_metadata =
+            get_single_owned_object_by_type(http_client, address, coin_metadata_type)
+                .await
+                .object_id;
+
+        let guardian_type = StructTag {
+            address: *package_id,
+            module: Identifier::new("coin_manager_coin").unwrap(),
+            name: Identifier::new("Guardian").unwrap(),
+            type_params: vec![TypeTag::Struct(Box::new(StructTag {
+                address: *package_id,
+                module: Identifier::new("coin_manager_coin").unwrap(),
+                name: Identifier::new("COIN_MANAGER_COIN").unwrap(),
+                type_params: vec![],
+            }))],
+        };
+        let guardian = get_single_owned_object_by_type(http_client, address, guardian_type)
+            .await
+            .object_id;
+
+        let coin_manager_coin_name = format!("{package_id}::coin_manager_coin::COIN_MANAGER_COIN");
+        let tx_response = execute_move_call(
+            http_client,
+            address,
+            account_keypair,
+            package_id,
+            "coin_manager_coin".to_string(),
+            "migrate_to_manager".into(),
+            type_args![coin_name, coin_manager_coin_name].unwrap(),
+            call_args![guardian, treasury_cap, coin_metadata].unwrap(),
+        )
+        .await?;
+        assert_eq!(tx_response.status_ok(), Some(true));
+        indexer_wait_for_transaction(tx_response.digest, pg_store, indexer_client).await;
+    }
+
+    {
+        let imm_coin_type = parse_iota_struct_tag(&immutable_metadata_coin_name).unwrap();
+        let treasury_cap_type = TreasuryCap::type_(imm_coin_type.clone());
+        let treasury_cap = get_single_owned_object_by_type(http_client, address, treasury_cap_type)
+            .await
+            .object_id;
+
+        let coin_metadata = http_client
+            .get_coin_metadata(immutable_metadata_coin_name.clone())
+            .await
+            .unwrap()
+            .unwrap()
+            .id
+            .unwrap();
+
+        let guardian_type = StructTag {
+            address: *package_id,
+            module: Identifier::new("immutable_metadata_coin_manager_coin").unwrap(),
+            name: Identifier::new("Guardian").unwrap(),
+            type_params: vec![TypeTag::Struct(Box::new(StructTag {
+                address: *package_id,
+                module: Identifier::new("immutable_metadata_coin_manager_coin").unwrap(),
+                name: Identifier::new("IMMUTABLE_METADATA_COIN_MANAGER_COIN").unwrap(),
+                type_params: vec![],
+            }))],
+        };
+        let guardian = get_single_owned_object_by_type(http_client, address, guardian_type)
+            .await
+            .object_id;
+
+        let coin_manager_immutable_metadata_coin_name = format!(
+            "{package_id}::immutable_metadata_coin_manager_coin::IMMUTABLE_METADATA_COIN_MANAGER_COIN"
+        );
+        let tx_response = execute_move_call(
+            http_client,
+            address,
+            account_keypair,
+            package_id,
+            "immutable_metadata_coin_manager_coin".to_string(),
+            "migrate_to_manager".into(),
+            type_args![
+                immutable_metadata_coin_name,
+                coin_manager_immutable_metadata_coin_name
+            ]
+            .unwrap(),
+            call_args![guardian, treasury_cap, coin_metadata].unwrap(),
+        )
+        .await?;
+        assert_eq!(tx_response.status_ok(), Some(true));
+        indexer_wait_for_transaction(tx_response.digest, pg_store, indexer_client).await;
+
+        // Hide metadata of immutable coin, so that Node/Indexer can not use it.
+        let tx_response = execute_move_call(
+            http_client,
+            address,
+            account_keypair,
+            imm_coin_type.address.into(),
+            "immutable_metadata_trusted_coin".to_string(),
+            "hide_metadata".into(),
+            type_args![immutable_metadata_coin_name].unwrap(),
+            call_args![coin_metadata].unwrap(),
+        )
+        .await?;
+        assert_eq!(tx_response.status_ok(), Some(true));
+        indexer_wait_for_transaction(tx_response.digest, pg_store, indexer_client).await;
+    }
+
+    Ok((coin_name, immutable_metadata_coin_name))
+}
+
+async fn publish_test_move_package(
+    client: &HttpClient,
+    address: IotaAddress,
+    account_keypair: &IotaKeyPair,
+    test_package_name: &str,
+) -> Result<(ObjectID, IotaTransactionBlockResponse), anyhow::Error> {
+    let _lock = PACKAGE_PUBLISH_LOCK
+        .get_or_init(async || Arc::new(tokio::sync::Mutex::new(0)))
+        .await
+        .lock()
+        .await;
+
+    let coins = client
+        .get_coins(address, None, None, Some(1))
+        .await
+        .unwrap()
+        .data;
+    let gas = &coins[0];
+
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.extend(["tests", "data", "dummy_modules_publish"]);
+    path.extend(["tests", "data", test_package_name]);
+
     let compiled_package = BuildConfig::default().build(&path).unwrap();
     let with_unpublished_deps = false;
     let compiled_modules_bytes = compiled_package.get_package_base64(with_unpublished_deps);
     let dependencies = compiled_package.get_dependency_storage_package_ids();
 
-    let transaction_bytes: TransactionBlockBytes = http_client
+    let transaction_bytes: TransactionBlockBytes = client
         .publish(
             address,
             compiled_modules_bytes,
@@ -497,7 +918,7 @@ async fn create_and_mint_trusted_coin(
         to_sender_signed_transaction(transaction_bytes.to_data().unwrap(), account_keypair);
     let (tx_bytes, signatures) = signed_transaction.to_tx_bytes_and_signatures();
 
-    let tx_response: IotaTransactionBlockResponse = http_client
+    let tx_response: IotaTransactionBlockResponse = client
         .execute_transaction_block(
             tx_bytes,
             signatures,
@@ -520,70 +941,51 @@ async fn create_and_mint_trusted_coin(
         })
         .unwrap();
 
-    let coin_name = format!("{package_id}::trusted_coin::TRUSTED_COIN");
-    let result: Supply = http_client
-        .get_total_supply(coin_name.clone())
-        .await
-        .unwrap();
+    Ok((*package_id, tx_response))
+}
 
-    assert_eq!(0, result.value);
+async fn create_native_coin_manager_coins(
+    cluster: &TestCluster,
+    indexer_client: &HttpClient,
+    pg_store: &PgIndexerStore,
+    address: IotaAddress,
+    account_keypair: &IotaKeyPair,
+) -> Result<(String, String), anyhow::Error> {
+    let http_client = cluster.rpc_client();
 
-    let object_changes = tx_response.object_changes.as_ref().unwrap();
-    let treasury_cap = object_changes
-        .iter()
-        .filter_map(|change| match change {
-            ObjectChange::Created {
-                object_id,
-                object_type,
-                ..
-            } => Some((object_id, object_type)),
-            _ => None,
-        })
-        .find_map(|(object_id, object_type)| {
-            let coin_type = parse_iota_struct_tag(&coin_name).unwrap();
-            (&TreasuryCap::type_(coin_type) == object_type).then_some(object_id)
-        })
-        .unwrap();
+    let (package_id, tx_response) =
+        publish_test_move_package(http_client, address, account_keypair, "coin_manager_coins")
+            .await?;
+    indexer_wait_for_transaction(tx_response.digest, pg_store, indexer_client).await;
 
-    let transaction_bytes: TransactionBlockBytes = http_client
-        .move_call(
+    let coin_name = format!("{package_id}::normal_coin::NORMAL_COIN");
+    let immutable_metadata_coin_name =
+        format!("{package_id}::immutable_metadata_coin::IMMUTABLE_METADATA_COIN");
+    Ok((coin_name, immutable_metadata_coin_name))
+}
+
+async fn get_single_owned_object_by_type(
+    http_client: &HttpClient,
+    address: IotaAddress,
+    struct_tag: StructTag,
+) -> IotaObjectData {
+    http_client
+        .get_owned_objects(
             address,
-            IOTA_FRAMEWORK_ADDRESS.into(),
-            COIN_MODULE_NAME.to_string(),
-            "mint_and_transfer".into(),
-            type_args![coin_name.clone()].unwrap(),
-            call_args![treasury_cap, amount, address].unwrap(),
-            Some(gas.coin_object_id),
-            10_000_000.into(),
+            Some(IotaObjectResponseQuery::new(
+                Some(IotaObjectDataFilter::StructType(struct_tag)),
+                None,
+            )),
+            None,
             None,
         )
         .await
-        .unwrap();
-
-    let signed_transaction =
-        to_sender_signed_transaction(transaction_bytes.to_data().unwrap(), account_keypair);
-    let (tx_bytes, signatures) = signed_transaction.to_tx_bytes_and_signatures();
-
-    let tx_response = http_client
-        .execute_transaction_block(
-            tx_bytes,
-            signatures,
-            Some(IotaTransactionBlockResponseOptions::new().with_effects()),
-            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
-        )
-        .await
-        .unwrap();
-
-    let IotaTransactionBlockResponse { effects, .. } = tx_response;
-
-    assert_eq!(
-        IotaExecutionStatus::Success,
-        *effects.as_ref().unwrap().status()
-    );
-
-    let created_coin_obj_ref = effects.unwrap().created()[0].reference.clone();
-
-    Ok((coin_name, created_coin_obj_ref))
+        .unwrap()
+        .data
+        .pop()
+        .unwrap()
+        .data
+        .unwrap()
 }
 
 async fn transfer_all_coins(
@@ -591,7 +993,7 @@ async fn transfer_all_coins(
     indexer_client: &HttpClient,
     store: &PgIndexerStore,
     from_address: IotaAddress,
-    keypair: &AccountKeyPair,
+    keypair: &IotaKeyPair,
     to_address: IotaAddress,
 ) {
     let coins: Vec<_> = cluster

--- a/crates/iota-json-rpc-types/src/iota_coin.rs
+++ b/crates/iota-json-rpc-types/src/iota_coin.rs
@@ -82,6 +82,12 @@ impl TryFrom<Object> for IotaCoinMetadata {
     type Error = IotaError;
     fn try_from(object: Object) -> Result<Self, Self::Error> {
         let metadata: CoinMetadata = object.try_into()?;
+        Ok(metadata.into())
+    }
+}
+
+impl From<CoinMetadata> for IotaCoinMetadata {
+    fn from(metadata: CoinMetadata) -> Self {
         let CoinMetadata {
             decimals,
             name,
@@ -90,14 +96,14 @@ impl TryFrom<Object> for IotaCoinMetadata {
             icon_url,
             id,
         } = metadata;
-        Ok(Self {
+        Self {
             id: Some(*id.object_id()),
             decimals,
             name,
             symbol,
             description,
             icon_url,
-        })
+        }
     }
 }
 

--- a/crates/iota-json-rpc/src/coin_api.rs
+++ b/crates/iota-json-rpc/src/coin_api.rs
@@ -20,6 +20,7 @@ use iota_types::{
     balance::Supply,
     base_types::{IotaAddress, ObjectID},
     coin::{CoinMetadata, TreasuryCap},
+    coin_manager::CoinManager,
     effects::TransactionEffectsAPI,
     gas_coin::GAS,
     iota_system_state::{
@@ -217,11 +218,40 @@ impl CoinReadApiServer for CoinReadApi {
                 .internal
                 .find_package_object(
                     &coin_struct.address.into(),
-                    CoinMetadata::type_(coin_struct),
+                    CoinMetadata::type_(coin_struct.clone()),
                 )
                 .await
                 .ok();
-            Ok(metadata_object.and_then(|v: Object| v.try_into().ok()))
+            match metadata_object {
+                None => {
+                    let manager_object = self
+                        .internal
+                        .find_package_object(
+                            &coin_struct.address.into(),
+                            CoinManager::type_(coin_struct),
+                        )
+                        .await
+                        .ok();
+
+                    Ok(manager_object.and_then(|v| {
+                        CoinManager::try_from(v).ok().and_then(|m| {
+                            match (m.metadata, m.immutable_metadata) {
+                                (Some(metadata), _) => Some(metadata.into()),
+                                (_, Some(immutable_metadata)) => Some(IotaCoinMetadata {
+                                    decimals: immutable_metadata.decimals,
+                                    name: immutable_metadata.name,
+                                    symbol: immutable_metadata.symbol,
+                                    description: immutable_metadata.description,
+                                    icon_url: immutable_metadata.icon_url,
+                                    id: None,
+                                }),
+                                (None, None) => None,
+                            }
+                        })
+                    }))
+                }
+                Some(metadata_object) => Ok(metadata_object.try_into().ok()),
+            }
         }
         .trace()
         .await

--- a/crates/iota-types/src/base_types.rs
+++ b/crates/iota-types/src/base_types.rs
@@ -38,6 +38,7 @@ use crate::{
     IOTA_CLOCK_OBJECT_ID, IOTA_FRAMEWORK_ADDRESS, IOTA_SYSTEM_ADDRESS, MOVE_STDLIB_ADDRESS,
     balance::Balance,
     coin::{COIN_MODULE_NAME, COIN_STRUCT_NAME, Coin, CoinMetadata, TreasuryCap},
+    coin_manager::CoinManager,
     crypto::{
         AuthorityPublicKeyBytes, DefaultHash, IotaPublicKey, IotaSignature, PublicKey,
         SignatureScheme,
@@ -314,6 +315,15 @@ impl MoveObjectType {
                 false
             }
             MoveObjectType_::Other(s) => CoinMetadata::is_coin_metadata(s),
+        }
+    }
+
+    pub fn is_coin_manager(&self) -> bool {
+        match &self.0 {
+            MoveObjectType_::GasCoin | MoveObjectType_::StakedIota | MoveObjectType_::Coin(_) => {
+                false
+            }
+            MoveObjectType_::Other(s) => CoinManager::is_coin_manager(s),
         }
     }
 

--- a/crates/iota-types/src/base_types.rs
+++ b/crates/iota-types/src/base_types.rs
@@ -319,12 +319,7 @@ impl MoveObjectType {
     }
 
     pub fn is_coin_manager(&self) -> bool {
-        match &self.0 {
-            MoveObjectType_::GasCoin | MoveObjectType_::StakedIota | MoveObjectType_::Coin(_) => {
-                false
-            }
-            MoveObjectType_::Other(s) => CoinManager::is_coin_manager(s),
-        }
+        matches!(&self.0, MoveObjectType_::Other(struct_tag) if CoinManager::is_coin_manager(struct_tag))
     }
 
     pub fn is_treasury_cap(&self) -> bool {

--- a/crates/iota-types/src/coin_manager.rs
+++ b/crates/iota-types/src/coin_manager.rs
@@ -54,7 +54,7 @@ impl CoinManager {
 
     pub fn from_bcs_bytes(content: &[u8]) -> Result<Self, IotaError> {
         bcs::from_bytes(content).map_err(|err| IotaError::ObjectDeserialization {
-            error: format!("Unable to deserialize CoinManager object: {}", err),
+            error: format!("Unable to deserialize CoinManager object: {err}"),
         })
     }
 
@@ -110,17 +110,14 @@ impl TryFrom<Object> for CoinManager {
 impl TryFrom<&Object> for CoinManager {
     type Error = IotaError;
     fn try_from(object: &Object) -> Result<Self, Self::Error> {
-        match &object.data {
-            Data::Move(o) => {
-                if o.type_().is_coin_manager() {
-                    return CoinManager::from_bcs_bytes(o.contents());
-                }
+        if let Data::Move(o) = &object.data {
+            if o.type_().is_coin_manager() {
+                return CoinManager::from_bcs_bytes(o.contents());
             }
-            Data::Package(_) => {}
         }
 
         Err(IotaError::Type {
-            error: format!("Object type is not a CoinManager: {:?}", object),
+            error: format!("Object type is not a CoinManager: {object:?}"),
         })
     }
 }

--- a/crates/iota-types/src/coin_manager.rs
+++ b/crates/iota-types/src/coin_manager.rs
@@ -1,14 +1,16 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::{ident_str, identifier::IdentStr};
+use move_core_types::{ident_str, identifier::IdentStr, language_storage::TypeTag};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     IOTA_FRAMEWORK_ADDRESS, StructTag,
     coin::{CoinMetadata, TreasuryCap},
+    error::IotaError,
     id::UID,
+    object::{Data, Object},
 };
 
 pub const COIN_MANAGER_MODULE_NAME: &IdentStr = ident_str!("coin_manager");
@@ -49,6 +51,21 @@ impl CoinManager {
             && object_type.module.as_ident_str() == COIN_MANAGER_MODULE_NAME
             && object_type.name.as_ident_str() == COIN_MANAGER_STRUCT_NAME
     }
+
+    pub fn from_bcs_bytes(content: &[u8]) -> Result<Self, IotaError> {
+        bcs::from_bytes(content).map_err(|err| IotaError::ObjectDeserialization {
+            error: format!("Unable to deserialize CoinManager object: {}", err),
+        })
+    }
+
+    pub fn type_(type_param: StructTag) -> StructTag {
+        StructTag {
+            address: IOTA_FRAMEWORK_ADDRESS,
+            name: COIN_MANAGER_STRUCT_NAME.to_owned(),
+            module: COIN_MANAGER_MODULE_NAME.to_owned(),
+            type_params: vec![TypeTag::Struct(Box::new(type_param))],
+        }
+    }
 }
 
 /// The immutable version of CoinMetadata, used in case of migrating from frozen
@@ -80,5 +97,30 @@ impl CoinManagerTreasuryCap {
         object_type.address == IOTA_FRAMEWORK_ADDRESS
             && object_type.module.as_ident_str() == COIN_MANAGER_MODULE_NAME
             && object_type.name.as_ident_str() == COIN_MANAGER_TREASURY_CAP_STRUCT_NAME
+    }
+}
+
+impl TryFrom<Object> for CoinManager {
+    type Error = IotaError;
+    fn try_from(object: Object) -> Result<Self, Self::Error> {
+        TryFrom::try_from(&object)
+    }
+}
+
+impl TryFrom<&Object> for CoinManager {
+    type Error = IotaError;
+    fn try_from(object: &Object) -> Result<Self, Self::Error> {
+        match &object.data {
+            Data::Move(o) => {
+                if o.type_().is_coin_manager() {
+                    return CoinManager::from_bcs_bytes(o.contents());
+                }
+            }
+            Data::Package(_) => {}
+        }
+
+        Err(IotaError::Type {
+            error: format!("Object type is not a CoinManager: {:?}", object),
+        })
     }
 }


### PR DESCRIPTION
# Description of change

Fix RPC APIs always returning "null" for Coins created with Coin manager.

One case couldn't be supported by the node easily, a separate issue was created for this: https://github.com/iotaledger/iota/issues/7014

This PR only fixes the `get_coin_metadata` endpoint, the `get_total_supply` endpoint will be fixed in scope of https://github.com/iotaledger/iota/issues/7134

The size of the diff comes mostly from the tests.
The meat of the change which changes the logic is in:
 - [crates/iota-json-rpc/src/coin_api.rs](https://github.com/iotaledger/iota/pull/7052/files#diff-387356559ec229db00d1da4c92ca83f65cd112df1da6f0f8bd7d2173274f3905) for Node
 - [crates/iota-indexer/src/indexer_reader.rs](https://github.com/iotaledger/iota/pull/7052/files#diff-59c7fa0841ea58f4030d1040643d35471b08f0d570bd91d8a35607cdeb86ccc3) for Indexer

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/5772
fixes https://github.com/iotaledger/iota/issues/7100

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage) - **created patch-specific tests and ensured that they pass**

`cargo test --profile simulator --package iota-indexer --test rpc-tests --all-features -- coin_api`

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [x] Verification of API backward compatibility. - **Endpoint should behave without changes for standard coins**

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

<!--
Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.
-->

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [x] Indexer:
  - fixed CoinManager support in get_coin_metadata
- [x] JSON-RPC:
  - fixed support for native CoinManager coins in get_coin_metadata
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
