### PR TITLE
chore(iota-sdk): use re-exports in examples and doc comments

### DIFF
--- a/crates/iota-sdk/examples/read_api/read_api_objects.rs
+++ b/crates/iota-sdk/examples/read_api/read_api_objects.rs
@@ -5,8 +5,7 @@
 //!
 //! cargo run --example read_api_objects
 
-use iota_json_rpc_types::IotaObjectDataOptions;
-use iota_sdk::IotaClientBuilder;
+use iota_sdk::{IotaClientBuilder, rpc_types::IotaObjectDataOptions};
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {

--- a/crates/iota-sdk/examples/read_api/read_api_transactions.rs
+++ b/crates/iota-sdk/examples/read_api/read_api_transactions.rs
@@ -7,8 +7,10 @@
 //! cargo run --example read_api_transactions
 
 use futures::StreamExt;
-use iota_json_rpc_types::{IotaTransactionBlockResponseQuery, TransactionFilter};
-use iota_sdk::IotaClientBuilder;
+use iota_sdk::{
+    IotaClientBuilder,
+    rpc_types::{IotaTransactionBlockResponseQuery, TransactionFilter},
+};
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {

--- a/crates/iota-sdk/examples/read_api/read_api_tx.rs
+++ b/crates/iota-sdk/examples/read_api/read_api_tx.rs
@@ -5,8 +5,10 @@
 //!
 //! cargo run --example read_api_tx
 
-use iota_json_rpc_types::{IotaObjectDataOptions, IotaTransactionBlockResponseOptions};
-use iota_sdk::IotaClientBuilder;
+use iota_sdk::{
+    IotaClientBuilder,
+    rpc_types::{IotaObjectDataOptions, IotaTransactionBlockResponseOptions},
+};
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {

--- a/crates/iota-sdk/examples/read_api/simulate_transaction.rs
+++ b/crates/iota-sdk/examples/read_api/simulate_transaction.rs
@@ -9,7 +9,7 @@
 #[path = "../utils.rs"]
 mod utils;
 
-use iota_types::{
+use iota_sdk::types::{
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::{TransactionData, TransactionKind},
 };

--- a/crates/iota-sdk/examples/read_api/transaction_subscription.rs
+++ b/crates/iota-sdk/examples/read_api/transaction_subscription.rs
@@ -10,8 +10,7 @@
 //! cargo run --example transaction_subscription
 
 use futures::stream::StreamExt;
-use iota_json_rpc_types::TransactionFilter;
-use iota_sdk::IotaClientBuilder;
+use iota_sdk::{IotaClientBuilder, rpc_types::TransactionFilter};
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {

--- a/crates/iota-sdk/examples/transaction_builder/batch_tx.rs
+++ b/crates/iota-sdk/examples/transaction_builder/batch_tx.rs
@@ -8,7 +8,7 @@
 #[path = "../utils.rs"]
 mod utils;
 
-use iota_json_rpc_types::{RPCTransactionRequestParams, TransferObjectParams};
+use iota_sdk::rpc_types::{RPCTransactionRequestParams, TransferObjectParams};
 use utils::{setup_for_write, sign_and_execute_transaction};
 
 #[tokio::main]

--- a/crates/iota-sdk/examples/transaction_builder/consolidate.rs
+++ b/crates/iota-sdk/examples/transaction_builder/consolidate.rs
@@ -10,10 +10,12 @@
 mod utils;
 
 use futures::StreamExt;
-use iota_json_rpc_types::ObjectChange;
-use iota_types::{
-    programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{Argument, Command, ObjectArg, TransactionData, TransactionKind},
+use iota_sdk::{
+    rpc_types::ObjectChange,
+    types::{
+        programmable_transaction_builder::ProgrammableTransactionBuilder,
+        transaction::{Argument, Command, ObjectArg, TransactionData, TransactionKind},
+    },
 };
 use utils::{setup_for_write, sign_and_execute_transaction};
 

--- a/crates/iota-sdk/examples/transaction_builder/move_package.rs
+++ b/crates/iota-sdk/examples/transaction_builder/move_package.rs
@@ -10,9 +10,8 @@ mod utils;
 
 use std::path::Path;
 
-use iota_json_rpc_types::ObjectChange;
 use iota_move_build::BuildConfig;
-use iota_types::move_package::UpgradeCap;
+use iota_sdk::{rpc_types::ObjectChange, types::move_package::UpgradeCap};
 use utils::{setup_for_write, sign_and_execute_transaction};
 
 #[tokio::main]

--- a/crates/iota-sdk/examples/transaction_builder/sign_tx_guide.rs
+++ b/crates/iota-sdk/examples/transaction_builder/sign_tx_guide.rs
@@ -23,14 +23,12 @@ use iota_sdk::{
     IotaClientBuilder,
     rpc_types::IotaTransactionBlockResponseOptions,
     types::{
+        base_types::IotaAddress,
+        crypto::{IotaKeyPair, IotaSignature, Signer, ToFromBytes, get_key_pair_from_rng},
         programmable_transaction_builder::ProgrammableTransactionBuilder,
+        signature::GenericSignature,
         transaction::TransactionData,
     },
-};
-use iota_types::{
-    base_types::IotaAddress,
-    crypto::{IotaKeyPair, IotaSignature, Signer, ToFromBytes, get_key_pair_from_rng},
-    signature::GenericSignature,
 };
 use rand::{SeedableRng, rngs::StdRng};
 use shared_crypto::intent::{Intent, IntentMessage};

--- a/crates/iota-sdk/examples/transaction_builder/single_move_call.rs
+++ b/crates/iota-sdk/examples/transaction_builder/single_move_call.rs
@@ -9,7 +9,7 @@
 mod utils;
 
 use iota_json::IotaJsonValue;
-use iota_types::{
+use iota_sdk::types::{
     programmable_transaction_builder::ProgrammableTransactionBuilder, transaction::TransactionData,
 };
 use serde_json::json;

--- a/crates/iota-sdk/examples/transaction_builder/stake.rs
+++ b/crates/iota-sdk/examples/transaction_builder/stake.rs
@@ -10,8 +10,10 @@
 mod utils;
 
 use futures::StreamExt;
-use iota_json_rpc_types::EventFilter;
-use iota_types::iota_system_state::iota_system_state_summary::IotaSystemStateSummary;
+use iota_sdk::{
+    rpc_types::EventFilter,
+    types::iota_system_state::iota_system_state_summary::IotaSystemStateSummary,
+};
 use utils::{setup_for_write, sign_and_execute_transaction};
 
 #[tokio::main]

--- a/crates/iota-sdk/examples/transaction_builder/timelocked_stake.rs
+++ b/crates/iota-sdk/examples/transaction_builder/timelocked_stake.rs
@@ -8,15 +8,18 @@
 #[path = "../utils.rs"]
 mod utils;
 
-use iota_json_rpc_types::{IotaObjectDataFilter, IotaObjectDataOptions, IotaObjectResponseQuery};
 use iota_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use iota_sdk::{
     IotaClientBuilder,
-    rpc_types::IotaTransactionBlockResponseOptions,
-    types::{quorum_driver_types::ExecuteTransactionRequestType, transaction::Transaction},
-};
-use iota_types::{
-    crypto::SignatureScheme, iota_system_state::iota_system_state_summary::IotaSystemStateSummary,
+    rpc_types::{
+        IotaObjectDataFilter, IotaObjectDataOptions, IotaObjectResponseQuery,
+        IotaTransactionBlockResponseOptions,
+    },
+    types::{
+        crypto::SignatureScheme,
+        iota_system_state::iota_system_state_summary::IotaSystemStateSummary,
+        quorum_driver_types::ExecuteTransactionRequestType, transaction::Transaction,
+    },
 };
 use shared_crypto::intent::Intent;
 use utils::request_tokens_from_faucet;

--- a/crates/iota-sdk/examples/transaction_builder/tx_data.rs
+++ b/crates/iota-sdk/examples/transaction_builder/tx_data.rs
@@ -9,7 +9,7 @@
 #[path = "../utils.rs"]
 mod utils;
 
-use iota_json_rpc_types::{IotaExecutionStatus, IotaTransactionBlockEffects};
+use iota_sdk::rpc_types::{IotaExecutionStatus, IotaTransactionBlockEffects};
 use utils::{setup_for_write, sign_and_execute_transaction};
 
 #[tokio::main]

--- a/crates/iota-sdk/examples/utils.rs
+++ b/crates/iota-sdk/examples/utils.rs
@@ -11,12 +11,14 @@ use futures::{future, stream::StreamExt};
 use iota_config::{
     Config, IOTA_CLIENT_CONFIG, IOTA_KEYSTORE_FILENAME, PersistedConfig, iota_config_dir,
 };
-use iota_json_rpc_types::{Coin, IotaObjectDataOptions, IotaTransactionBlockResponse};
 use iota_keys::keystore::{AccountKeystore, FileBasedKeystore};
 use iota_sdk::{
     IotaClient, IotaClientBuilder,
     iota_client_config::{IotaClientConfig, IotaEnv},
-    rpc_types::IotaTransactionBlockResponseOptions,
+    rpc_types::{
+        Coin, IotaObjectDataOptions, IotaTransactionBlockResponse,
+        IotaTransactionBlockResponseOptions,
+    },
     types::{
         base_types::{IotaAddress, ObjectID},
         crypto::SignatureScheme::ED25519,

--- a/crates/iota-sdk/src/apis/coin_read.rs
+++ b/crates/iota-sdk/src/apis/coin_read.rs
@@ -40,8 +40,7 @@ impl CoinReadApi {
     /// ```rust,no_run
     /// use std::str::FromStr;
     ///
-    /// use iota_sdk::IotaClientBuilder;
-    /// use iota_types::base_types::IotaAddress;
+    /// use iota_sdk::{IotaClientBuilder, types::base_types::IotaAddress};
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), anyhow::Error> {
@@ -77,8 +76,7 @@ impl CoinReadApi {
     /// ```rust,no_run
     /// use std::str::FromStr;
     ///
-    /// use iota_sdk::IotaClientBuilder;
-    /// use iota_types::base_types::IotaAddress;
+    /// use iota_sdk::{IotaClientBuilder, types::base_types::IotaAddress};
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), anyhow::Error> {
@@ -114,8 +112,7 @@ impl CoinReadApi {
     /// ```rust,no_run
     /// use std::str::FromStr;
     ///
-    /// use iota_sdk::IotaClientBuilder;
-    /// use iota_types::base_types::IotaAddress;
+    /// use iota_sdk::{IotaClientBuilder, types::base_types::IotaAddress};
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), anyhow::Error> {
@@ -178,8 +175,7 @@ impl CoinReadApi {
     /// ```rust,no_run
     /// use std::str::FromStr;
     ///
-    /// use iota_sdk::IotaClientBuilder;
-    /// use iota_types::base_types::IotaAddress;
+    /// use iota_sdk::{IotaClientBuilder, types::base_types::IotaAddress};
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), anyhow::Error> {
@@ -227,8 +223,7 @@ impl CoinReadApi {
     /// ```rust,no_run
     /// use std::str::FromStr;
     ///
-    /// use iota_sdk::IotaClientBuilder;
-    /// use iota_types::base_types::IotaAddress;
+    /// use iota_sdk::{IotaClientBuilder, types::base_types::IotaAddress};
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), anyhow::Error> {
@@ -254,8 +249,7 @@ impl CoinReadApi {
     /// ```rust,no_run
     /// use std::str::FromStr;
     ///
-    /// use iota_sdk::IotaClientBuilder;
-    /// use iota_types::base_types::IotaAddress;
+    /// use iota_sdk::{IotaClientBuilder, types::base_types::IotaAddress};
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), anyhow::Error> {
@@ -276,6 +270,7 @@ impl CoinReadApi {
     ///
     /// ```rust,no_run
     /// use iota_sdk::IotaClientBuilder;
+    ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), anyhow::Error> {
     ///     let iota = IotaClientBuilder::default().build_testnet().await?;

--- a/crates/iota-sdk/src/apis/event.rs
+++ b/crates/iota-sdk/src/apis/event.rs
@@ -38,9 +38,8 @@ impl EventApi {
     /// use std::str::FromStr;
     ///
     /// use futures::StreamExt;
-    /// use iota_json_rpc_types::EventFilter;
-    /// use iota_sdk::IotaClientBuilder;
-    /// use iota_types::base_types::IotaAddress;
+    /// use iota_sdk::{IotaClientBuilder, rpc_types::EventFilter, types::base_types::IotaAddress};
+    ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), anyhow::Error> {
     ///     let iota = IotaClientBuilder::default()

--- a/crates/iota-sdk/src/apis/read.rs
+++ b/crates/iota-sdk/src/apis/read.rs
@@ -58,8 +58,7 @@ impl ReadApi {
     /// ```rust,no_run
     /// use std::str::FromStr;
     ///
-    /// use iota_sdk::IotaClientBuilder;
-    /// use iota_types::base_types::IotaAddress;
+    /// use iota_sdk::{IotaClientBuilder, types::base_types::IotaAddress};
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), anyhow::Error> {
@@ -100,8 +99,10 @@ impl ReadApi {
     /// ```rust,no_run
     /// use std::str::FromStr;
     ///
-    /// use iota_sdk::IotaClientBuilder;
-    /// use iota_types::base_types::{IotaAddress, ObjectID};
+    /// use iota_sdk::{
+    ///     IotaClientBuilder,
+    ///     types::base_types::{IotaAddress, ObjectID},
+    /// };
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), anyhow::Error> {
@@ -182,9 +183,11 @@ impl ReadApi {
     /// ```rust,no_run
     /// use std::str::FromStr;
     ///
-    /// use iota_json_rpc_types::IotaObjectDataOptions;
-    /// use iota_sdk::IotaClientBuilder;
-    /// use iota_types::base_types::{IotaAddress, ObjectID};
+    /// use iota_sdk::{
+    ///     IotaClientBuilder,
+    ///     rpc_types::IotaObjectDataOptions,
+    ///     types::base_types::{IotaAddress, ObjectID},
+    /// };
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), anyhow::Error> {
@@ -247,9 +250,7 @@ impl ReadApi {
     /// ```rust,no_run
     /// use std::str::FromStr;
     ///
-    /// use iota_json_rpc_types::{IotaGetPastObjectRequest, IotaObjectDataOptions};
-    /// use iota_sdk::IotaClientBuilder;
-    /// use iota_types::base_types::{IotaAddress, ObjectID};
+    /// use iota_sdk::{types::base_types::{IotaAddress, ObjectID}IotaClientBuilder, rpc_types::{IotaGetPastObjectRequest, IotaObjectDataOptions}};
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), anyhow::Error> {
@@ -328,9 +329,9 @@ impl ReadApi {
     /// ```rust,no_run
     /// use std::str::FromStr;
     ///
-    /// use iota_json_rpc_types::IotaObjectDataOptions;
-    /// use iota_sdk::IotaClientBuilder;
-    /// use iota_types::base_types::IotaAddress;
+    /// use iota_sdk::{
+    ///     IotaClientBuilder, rpc_types::IotaObjectDataOptions, types::base_types::IotaAddress,
+    /// };
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), anyhow::Error> {
@@ -384,9 +385,10 @@ impl ReadApi {
     /// ```rust,no_run
     /// use std::str::FromStr;
     ///
-    /// use iota_json_rpc_types::IotaObjectDataOptions;
-    /// use iota_sdk::IotaClientBuilder;
-    /// use iota_types::base_types::IotaAddress;
+    /// use iota_sdk::{
+    ///     IotaClientBuilder, rpc_types::IotaObjectDataOptions, types::base_types::IotaAddress,
+    /// };
+    ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), anyhow::Error> {
     ///     let iota = IotaClientBuilder::default().build_testnet().await?;

--- a/crates/iota-sdk/src/apis/read.rs
+++ b/crates/iota-sdk/src/apis/read.rs
@@ -250,7 +250,11 @@ impl ReadApi {
     /// ```rust,no_run
     /// use std::str::FromStr;
     ///
-    /// use iota_sdk::{types::base_types::{IotaAddress, ObjectID}IotaClientBuilder, rpc_types::{IotaGetPastObjectRequest, IotaObjectDataOptions}};
+    /// use iota_sdk::{
+    ///     IotaClientBuilder,
+    ///     rpc_types::{IotaGetPastObjectRequest, IotaObjectDataOptions},
+    ///     types::base_types::{IotaAddress, ObjectID},
+    /// };
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), anyhow::Error> {

--- a/crates/iota-sdk/src/lib.rs
+++ b/crates/iota-sdk/src/lib.rs
@@ -149,6 +149,7 @@ pub const IOTA_MAINNET_URL: &str = "https://api.mainnet.iota.cafe";
 ///
 /// ```rust,no_run
 /// use iota_sdk::IotaClientBuilder;
+///
 /// #[tokio::main]
 /// async fn main() -> Result<(), anyhow::Error> {
 ///     let iota = IotaClientBuilder::default()


### PR DESCRIPTION
Fixes https://github.com/iotaledger/iota/issues/7049
So that it doesn't force people to import more crates than necessary.

`iota_config` and `iota_keys` could maybe be made re-exports as well?