### PR TITLE
refactor(iota-types, iota-adapter): minor improvements to Object::new_coin

### DIFF
--- a/crates/iota-types/src/base_types.rs
+++ b/crates/iota-types/src/base_types.rs
@@ -188,6 +188,14 @@ impl MoveObjectType {
         Self(MoveObjectType_::GasCoin)
     }
 
+    pub fn coin(coin_type: TypeTag) -> Self {
+        Self(if GAS::is_gas_type(&coin_type) {
+            MoveObjectType_::GasCoin
+        } else {
+            MoveObjectType_::Coin(coin_type)
+        })
+    }
+
     pub fn staked_iota() -> Self {
         Self(MoveObjectType_::StakedIota)
     }

--- a/crates/iota-types/src/coin.rs
+++ b/crates/iota-types/src/coin.rs
@@ -38,9 +38,9 @@ pub struct Coin {
 }
 
 impl Coin {
-    pub fn new(id: UID, value: u64) -> Self {
+    pub fn new(id: ObjectID, value: u64) -> Self {
         Self {
-            id,
+            id: UID::new(id),
             balance: Balance::new(value),
         }
     }
@@ -128,7 +128,7 @@ impl Coin {
     // Related coin objects need to be updated in temporary_store to persist the
     // changes, including creating the coin object related to the newly created
     // coin.
-    pub fn split(&mut self, amount: u64, new_coin_id: UID) -> Result<Coin, ExecutionError> {
+    pub fn split(&mut self, amount: u64, new_coin_id: ObjectID) -> Result<Coin, ExecutionError> {
         self.balance.withdraw(amount)?;
         Ok(Coin::new(new_coin_id, amount))
     }

--- a/crates/iota-types/src/gas_coin.rs
+++ b/crates/iota-types/src/gas_coin.rs
@@ -21,7 +21,6 @@ use crate::{
     base_types::{ObjectID, SequenceNumber},
     coin::{Coin, TreasuryCap},
     error::{ExecutionError, ExecutionErrorKind},
-    id::UID,
     object::{Data, MoveObject, Object},
 };
 
@@ -81,7 +80,7 @@ mod checked {
 
     impl GasCoin {
         pub fn new(id: ObjectID, value: u64) -> Self {
-            Self(Coin::new(UID::new(id), value))
+            Self(Coin::new(id, value))
         }
 
         pub fn value(&self) -> u64 {

--- a/crates/iota-types/src/object.rs
+++ b/crates/iota-types/src/object.rs
@@ -116,18 +116,13 @@ impl MoveObject {
         }
     }
 
-    pub fn new_coin(
-        coin_type: MoveObjectType,
-        version: SequenceNumber,
-        id: ObjectID,
-        value: u64,
-    ) -> Self {
+    pub fn new_coin(coin_type: TypeTag, version: SequenceNumber, id: ObjectID, value: u64) -> Self {
         // unwrap safe because coins are always smaller than the max object size
         {
             Self::new_from_execution_with_limit(
-                coin_type,
+                MoveObjectType::coin(coin_type),
                 version,
-                GasCoin::new(id, value).to_bcs_bytes(),
+                Coin::new(id, value).to_bcs_bytes(),
                 256,
             )
             .unwrap()

--- a/crates/iota-types/src/stardust/output/basic.rs
+++ b/crates/iota-types/src/stardust/output/basic.rs
@@ -173,7 +173,7 @@ impl BasicOutput {
         coin_type: &CoinType,
     ) -> Result<Object> {
         create_coin(
-            self.id,
+            *self.id.object_id(),
             owner,
             self.balance.value(),
             tx_context,
@@ -199,7 +199,7 @@ impl BasicOutput {
 }
 
 pub(crate) fn create_coin(
-    object_id: UID,
+    object_id: ObjectID,
     owner: IotaAddress,
     amount: u64,
     tx_context: &TxContext,

--- a/crates/iota-types/src/stardust/output/foundry.rs
+++ b/crates/iota-types/src/stardust/output/foundry.rs
@@ -6,7 +6,6 @@ use iota_stardust_sdk::types::block::output::{FoundryOutput, OutputId};
 
 use crate::{
     base_types::{ObjectID, SequenceNumber, TxContext},
-    id::UID,
     object::Object,
     stardust::{address::stardust_to_iota_address, coin_type::CoinType},
 };

--- a/crates/iota-types/src/stardust/output/foundry.rs
+++ b/crates/iota-types/src/stardust/output/foundry.rs
@@ -20,7 +20,7 @@ pub fn create_foundry_amount_coin(
     coin_type: &CoinType,
 ) -> anyhow::Result<Object> {
     crate::stardust::output::create_coin(
-        UID::new(ObjectID::new(output_id.hash())),
+        ObjectID::new(output_id.hash()),
         stardust_to_iota_address(*foundry.alias_address())?,
         foundry.amount(),
         tx_context,

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -25,7 +25,7 @@ mod checked {
         error::{ExecutionError, ExecutionErrorKind, command_argument_error},
         execution_config_utils::to_binary_config,
         execution_status::{CommandArgumentError, PackageUpgradeError},
-        id::{RESOLVED_IOTA_ID, UID},
+        id::RESOLVED_IOTA_ID,
         metrics::LimitsMetrics,
         move_package::{
             MovePackage, UpgradeCap, UpgradePolicy, UpgradeReceipt, UpgradeTicket,

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/execution.rs
@@ -259,7 +259,7 @@ mod checked {
                         let amount: u64 =
                             context.by_value_arg(CommandKind::SplitCoins, 1, amount_arg)?;
                         let new_coin_id = context.fresh_id()?;
-                        let new_coin = coin.split(amount, UID::new(new_coin_id))?;
+                        let new_coin = coin.split(amount, new_coin_id)?;
                         let coin_type = obj.type_.clone();
                         // safe because we are propagating the coin type, and relying on the
                         // internal invariant that coin values have a coin


### PR DESCRIPTION
[run-ci]

# Description of change

New_coin API should take the type_tag of the coin directly, instead of allowing arbitrary move types.
According to [changes](https://github.com/MystenLabs/sui/commit/8a28a6e).

## Links to any relevant issues

Fixes #7063 .

## Type of change

- Enhancement (a non-breaking change which adds functionality)
- Breaking changes

## How the change has been tested

