### PR TITLE
[cherry-pick] fix(node): gracefully clean up iota-node validator components (#6831)

### DIFF
--- a/crates/iota-core/src/consensus_manager/mod.rs
+++ b/crates/iota-core/src/consensus_manager/mod.rs
@@ -97,11 +97,10 @@ impl ConsensusManager {
         node_config: &NodeConfig,
         consensus_config: &ConsensusConfig,
         registry_service: &RegistryService,
+        metrics_registry: &Registry,
         consensus_client: Arc<UpdatableConsensusClient>,
     ) -> Self {
-        let metrics = Arc::new(ConsensusManagerMetrics::new(
-            &registry_service.default_registry(),
-        ));
+        let metrics = Arc::new(ConsensusManagerMetrics::new(metrics_registry));
         let mysticeti_client = Arc::new(LazyMysticetiClient::new());
         let mysticeti_manager = ProtocolManager::new_mysticeti(
             node_config,

--- a/crates/iota-metrics/src/histogram.rs
+++ b/crates/iota-metrics/src/histogram.rs
@@ -12,7 +12,7 @@ use std::{
 use futures::FutureExt;
 use parking_lot::Mutex;
 use prometheus::{
-    IntCounterVec, IntGaugeVec, Registry, opts, register_int_counter_vec_with_registry,
+    IntCounterVec, IntGaugeVec, Registry, register_int_counter_vec_with_registry,
     register_int_gauge_vec_with_registry,
 };
 use tokio::{
@@ -190,32 +190,6 @@ impl HistogramVec {
             labels,
             channel: self.channel.clone(),
         }
-    }
-
-    // HistogramVec uses asynchronous model to report metrics which makes
-    // it difficult to unregister counters in the usual manner. Here we
-    // re-create counters so that their `desc()`s match the ones created by
-    // HistogramVec and remove them from the registry. Counters can be safely
-    // unregistered even if they are still in use.
-    pub fn unregister(name: &str, desc: &str, labels: &[&str], registry: &Registry) {
-        let sum_name = format!("{}_sum", name);
-        let count_name = format!("{}_count", name);
-
-        let sum = IntCounterVec::new(opts!(sum_name, desc), labels).unwrap();
-        registry
-            .unregister(Box::new(sum))
-            .unwrap_or_else(|_| panic!("{}_sum counter is in prometheus registry", name));
-
-        let count = IntCounterVec::new(opts!(count_name, desc), labels).unwrap();
-        registry
-            .unregister(Box::new(count))
-            .unwrap_or_else(|_| panic!("{}_count counter is in prometheus registry", name));
-
-        let labels: Vec<_> = labels.iter().cloned().chain(["pct"]).collect();
-        let gauge = IntGaugeVec::new(opts!(name, desc), &labels).unwrap();
-        registry
-            .unregister(Box::new(gauge))
-            .unwrap_or_else(|_| panic!("{} gauge is in prometheus registry", name));
     }
 }
 


### PR DESCRIPTION
# Description of change

After a validator node leaves the committee, a few resources in validator components are leaked including metrics and grpc server. If the node will try to re-join the committee it will crash due to resources already being in use.

This PR:
- changes the way validator metrics are registered: a dedicated registry is used instead of default one;
- adds a graceful shutdown of validator grpc server and metrics registry clean up during reconfiguration when a validator leaves the committee;
- adds a reproducer test.

## Notes

There are a few ways to handle metrics issue:
- ignore `AlreadyReg` error while trying to re-register metrics with the default registry; requires special unwrap handling for each metric;
- unregister individual metrics with the default registry; the existing components do not provide such functionality; requires unregistering all individual metrics;
- use a dedicated registry and remove it entirely from the registry service once node is not validator anymore; this seems to be the easiest and cleanest way.

:warning: There may be other undetected resources leaking that do not cause error if validator components are re-created.

## Links to any relevant issues

Fixes #6277.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

```sh
scripts/simtest/cargo-simtest simtest --package iota-e2e-tests --test "reconfiguration_tests" --profile ci -- test_reconfig_with_same_validator
```

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Fixed a bug causing iota-node to crash after re-joining the consensus committee as validator.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API: