### PR TITLE
feat(consensus): adapt metrics commit sync

### DIFF
--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -284,6 +284,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
             .inc_by(total_blocks_fetched as u64);
         metrics
             .commit_sync_total_fetched_blocks_size
+            .with_label_values(&[&hostname.as_str()])
             .inc_by(total_blocks_size_bytes);
 
         let (commit_start, commit_end) = (

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -543,11 +543,18 @@ impl<C: NetworkClient> CommitSyncer<C> {
         commit_range: CommitRange,
         timeout: Duration,
     ) -> ConsensusResult<CertifiedCommits> {
+        let hostname = inner
+            .context
+            .committee
+            .authority(target_authority)
+            .hostname
+            .clone();
         let _timer = inner
             .context
             .metrics
             .node_metrics
             .commit_sync_fetch_once_latency
+            .with_label_values(&[hostname.as_str()])
             .start_timer();
 
         // 1. Fetch commits in the commit range from the target authority.

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -267,10 +267,16 @@ impl<C: NetworkClient> CommitSyncer<C> {
                             .sum::<usize>() as u64,
                 )
             });
-
+        let hostname = &self
+            .inner
+            .context
+            .committee
+            .authority(authority_index)
+            .hostname;
         let metrics = &self.inner.context.metrics.node_metrics;
         metrics
             .commit_sync_fetched_commits
+            .with_label_values(&[&hostname.as_str()])
             .inc_by(certified_commits.commits().len() as u64);
         metrics
             .commit_sync_fetched_blocks

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -280,6 +280,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
             .inc_by(certified_commits.commits().len() as u64);
         metrics
             .commit_sync_fetched_blocks
+            .with_label_values(&[&hostname.as_str()])
             .inc_by(total_blocks_fetched as u64);
         metrics
             .commit_sync_total_fetched_blocks_size

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -94,7 +94,7 @@ pub(crate) struct CommitSyncer<C: NetworkClient> {
     // States only used by the scheduler.
 
     // Inflight requests to fetch commits from different authorities.
-    inflight_fetches: JoinSet<(u32, CertifiedCommits)>,
+    inflight_fetches: JoinSet<(AuthorityIndex, u32, CertifiedCommits)>,
     // Additional ranges of commits to fetch.
     pending_fetches: BTreeSet<CommitRange>,
     // Fetched commits and blocks by commit range.
@@ -171,8 +171,8 @@ impl<C: NetworkClient> CommitSyncer<C> {
                         self.inflight_fetches.shutdown().await;
                         return;
                     }
-                    let (target_end, commits) = result.unwrap();
-                    self.handle_fetch_result(target_end, commits).await;
+                    let (authority, target_end, commits) = result.unwrap();
+                    self.handle_fetch_result(authority, target_end, commits).await;
                 }
                 _ = &mut rx_shutdown => {
                     // Shutdown requested.
@@ -248,6 +248,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
 
     async fn handle_fetch_result(
         &mut self,
+        authority_index: AuthorityIndex,
         target_end: CommitIndex,
         certified_commits: CertifiedCommits,
     ) {
@@ -432,7 +433,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
     async fn fetch_loop(
         inner: Arc<Inner<C>>,
         commit_range: CommitRange,
-    ) -> (CommitIndex, CertifiedCommits) {
+    ) -> (AuthorityIndex, CommitIndex, CertifiedCommits) {
         // Individual request base timeout.
         const TIMEOUT: Duration = Duration::from_secs(10);
         // Max per-request timeout will be base timeout times a multiplier.
@@ -492,7 +493,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
                 {
                     Ok(Ok(commits)) => {
                         info!("Finished fetching commits in {commit_range:?}",);
-                        return (commit_range.end(), commits);
+                        return (authority, commit_range.end(), commits);
                     }
                     Ok(Err(e)) => {
                         let hostname = inner

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -186,7 +186,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) commit_sync_local_index: IntGauge,
     pub(crate) commit_sync_gap_on_processing: IntCounter,
     pub(crate) commit_sync_fetch_loop_latency: Histogram,
-    pub(crate) commit_sync_fetch_once_latency: Histogram,
+    pub(crate) commit_sync_fetch_once_latency: HistogramVec,
     pub(crate) commit_sync_fetch_once_errors: IntCounterVec,
     pub(crate) commit_sync_fetch_missing_blocks: IntCounterVec,
     pub(crate) round_prober_received_quorum_round_gaps: IntGaugeVec,
@@ -697,9 +697,10 @@ impl NodeMetrics {
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             ).unwrap(),
-            commit_sync_fetch_once_latency: register_histogram_with_registry!(
+            commit_sync_fetch_once_latency: register_histogram_vec_with_registry!(
                 "commit_sync_fetch_once_latency",
-                "The time taken to fetch commits and blocks once",
+                "The time taken to fetch commits and blocks once, labeled by target authority.",
+                &["authority"],
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             ).unwrap(),

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -177,7 +177,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) commit_sync_inflight_fetches: IntGauge,
     pub(crate) commit_sync_pending_fetches: IntGauge,
     pub(crate) commit_sync_fetch_commits_handler_uncertified_skipped: IntCounter,
-    pub(crate) commit_sync_fetched_commits: IntCounter,
+    pub(crate) commit_sync_fetched_commits: IntCounterVec,
     pub(crate) commit_sync_fetched_blocks: IntCounter,
     pub(crate) commit_sync_total_fetched_blocks_size: IntCounter,
     pub(crate) commit_sync_quorum_index: IntGauge,
@@ -651,9 +651,10 @@ impl NodeMetrics {
                 "The number of pending fetches in commit syncer",
                 registry,
             ).unwrap(),
-            commit_sync_fetched_commits: register_int_counter_with_registry!(
+            commit_sync_fetched_commits: register_int_counter_vec_with_registry!(
                 "commit_sync_fetched_commits",
-                "The number of commits fetched via commit syncer",
+                "The number of commits fetched via commit syncer, labeled by authority.",
+                &["authority"],
                 registry,
             ).unwrap(),
             commit_sync_fetched_blocks: register_int_counter_with_registry!(

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -179,7 +179,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) commit_sync_fetch_commits_handler_uncertified_skipped: IntCounter,
     pub(crate) commit_sync_fetched_commits: IntCounterVec,
     pub(crate) commit_sync_fetched_blocks: IntCounterVec,
-    pub(crate) commit_sync_total_fetched_blocks_size: IntCounter,
+    pub(crate) commit_sync_total_fetched_blocks_size: IntCounterVec,
     pub(crate) commit_sync_quorum_index: IntGauge,
     pub(crate) commit_sync_highest_synced_index: IntGauge,
     pub(crate) commit_sync_highest_fetched_index: IntGauge,
@@ -663,9 +663,10 @@ impl NodeMetrics {
                 &["authority"],
                 registry,
             ).unwrap(),
-            commit_sync_total_fetched_blocks_size: register_int_counter_with_registry!(
+            commit_sync_total_fetched_blocks_size: register_int_counter_vec_with_registry!(
                 "commit_sync_total_fetched_blocks_size",
                 "The total size in bytes of blocks fetched via commit syncer",
+                &["authority"],
                 registry,
             ).unwrap(),
             commit_sync_quorum_index: register_int_gauge_with_registry!(

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -178,7 +178,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) commit_sync_pending_fetches: IntGauge,
     pub(crate) commit_sync_fetch_commits_handler_uncertified_skipped: IntCounter,
     pub(crate) commit_sync_fetched_commits: IntCounterVec,
-    pub(crate) commit_sync_fetched_blocks: IntCounter,
+    pub(crate) commit_sync_fetched_blocks: IntCounterVec,
     pub(crate) commit_sync_total_fetched_blocks_size: IntCounter,
     pub(crate) commit_sync_quorum_index: IntGauge,
     pub(crate) commit_sync_highest_synced_index: IntGauge,
@@ -657,9 +657,10 @@ impl NodeMetrics {
                 &["authority"],
                 registry,
             ).unwrap(),
-            commit_sync_fetched_blocks: register_int_counter_with_registry!(
+            commit_sync_fetched_blocks: register_int_counter_vec_with_registry!(
                 "commit_sync_fetched_blocks",
-                "The number of blocks fetched via commit syncer",
+                "The number of blocks fetched via commit syncer, labeled by authority",
+                &["authority"],
                 registry,
             ).unwrap(),
             commit_sync_total_fetched_blocks_size: register_int_counter_with_registry!(


### PR DESCRIPTION
# Description of change
This PR adds authority as a label to selected commit sync metrics. The label reflects the hostname of the peer from which commits are fetched. This provides finer-grained observability of sync behavior across authorities.

## Links to any relevant issues
closes #7101

## Type of change

- Enhancement (a non-breaking change which adds functionality)




