### PR TITLE
upstream(iota,iota-cluster-test): remove dependency on `diesel`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5808,7 +5808,6 @@ dependencies = [
  "colored",
  "csv",
  "datatest-stable",
- "diesel",
  "expect-test",
  "fastcrypto",
  "fastcrypto-zkp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6219,7 +6219,6 @@ dependencies = [
  "async-trait",
  "clap",
  "derive_more 1.0.0",
- "diesel",
  "fastcrypto",
  "futures",
  "iota-config",

--- a/crates/iota-cluster-test/Cargo.toml
+++ b/crates/iota-cluster-test/Cargo.toml
@@ -12,7 +12,6 @@ anyhow = { workspace = true, features = ["backtrace"] }
 async-trait.workspace = true
 clap.workspace = true
 derive_more = { workspace = true, features = ["debug"] }
-diesel.workspace = true
 fastcrypto.workspace = true
 futures.workspace = true
 jsonrpsee.workspace = true
@@ -46,6 +45,5 @@ telemetry-subscribers.workspace = true
 test-cluster.workspace = true
 
 [features]
-default = ["postgres-feature"]
-postgres-feature = ["diesel/postgres", "diesel/postgres_backend"]
+default = []
 pg_integration = []

--- a/crates/iota/Cargo.toml
+++ b/crates/iota/Cargo.toml
@@ -28,7 +28,6 @@ clap_complete = { version = "4.5", optional = true }
 codespan-reporting.workspace = true
 colored.workspace = true
 csv.workspace = true
-diesel = { workspace = true, optional = true }
 fastcrypto.workspace = true
 fastcrypto-zkp.workspace = true
 futures.workspace = true
@@ -137,7 +136,7 @@ harness = false
 
 [features]
 gen-completions = ["dep:clap_complete"]
-indexer = ["dep:diesel", "dep:iota-indexer", "dep:iota-graphql-rpc"]
+indexer = ["dep:iota-indexer", "dep:iota-graphql-rpc"]
 iota-names = [
   "dep:chrono",
   "dep:iota-graphql-rpc-client",


### PR DESCRIPTION
# Description of change

This patch cleans unnecessary crate deps from `iota`, `iota-cluster-test` following upstream changes.

## Links to any relevant issues

Fixes #7120

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

Started a local instance of the network with indexer and graphql

```
$ iota start --with-faucet --force-regenesis --with-indexer --with-graphql
```

