### PR TITLE
fix(external-crates/docs): fixed a typo in functions.md where “pbulic" was incorrectly used instead

### DIFF
--- a/external-crates/move/documentation/book/src/functions.md
+++ b/external-crates/move/documentation/book/src/functions.md
@@ -105,7 +105,7 @@ In addition to `public` functions, you might have some functions in your modules
 use as the entry point to execution. The `entry` modifier is designed to allow module functions to
 initiate execution, without having to expose the functionality to other modules.
 
-Essentially, the combination of `pbulic` and `entry` functions define the "main" functions of a
+Essentially, the combination of `public` and `entry` functions define the "main" functions of a
 module, and they specify where Move programs can start executing.
 
 Keep in mind though, an `entry` function _can_ still be called by other Move functions. So while


### PR DESCRIPTION
# Description of change

Fixed a typo in functions.md where "pbulic" was incorrectly used instead
of "public" in the entry functions section.
According to [changes](https://github.com/MystenLabs/sui/commit/da0201a7).

## Links to any relevant issues

Fixes #7069 .

## Type of change

- Documentation Fix
