### PR TITLE
fix(external-crates/docs): duplicate of "They cannot be bound to local variables." has been removed

### DIFF
--- a/external-crates/move/documentation/book/src/primitive-types/tuples.md
+++ b/external-crates/move/documentation/book/src/primitive-types/tuples.md
@@ -8,7 +8,6 @@ limited:
 
 - They can only appear in expressions (usually in the return position for a function).
 - They cannot be bound to local variables.
-- They cannot be bound to local variables.
 - They cannot be stored in structs.
 - Tuple types cannot be used to instantiate generics.
 


### PR DESCRIPTION
# Description of change

external-crates/move/documentation/book/src/primitive-types/tuples.md
- They cannot be bound to local variables.  - duplicate has been removed
According to [changes](https://github.com/MystenLabs/sui/commit/902efbb).

## Links to any relevant issues

Fixes #7072 .

## Type of change

- Documentation Fix