### PR TITLE
upstream(indexer): insert protocol-configs in chunks

### DIFF
--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -2390,7 +2390,9 @@ impl IndexerStore for PgIndexerStore {
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {
-                insert_or_ignore_into!(protocol_configs::table, all_configs.clone(), conn);
+                for config_chunk in all_configs.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
+                    insert_or_ignore_into!(protocol_configs::table, config_chunk, conn);
+                }
                 insert_or_ignore_into!(feature_flags::table, all_flags.clone(), conn);
                 Ok::<(), IndexerError>(())
             },

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -2384,9 +2384,6 @@ impl IndexerStore for PgIndexerStore {
             all_flags.extend(feature_flags);
         }
 
-        // Now insert all of them into the db.
-        // TODO: right now the size of these updates is manageable but later we may
-        // consider batching.
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {


### PR DESCRIPTION
# Description of change

This patch follows upstream changes in inserting protocol configs in chunks.

## Links to any relevant issues

Closes #7125 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

```
$ cargo test --profile simulator -p iota-indexer --features shared_test_runtime
$ cargo test --features pg_integration --profile simulator -- --test-threads 1
```

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

This patch affects only the `protocol-configs` table which is inserted during genesis and is independent of migration objects.

- [x] Restart of indexer synchronization locally with a clean database.

### Release Notes

- [x] Indexer: Insert protocol configs in chunks
