### PR TITLE
chore(indexer): feature gate import of Deserialize

### DIFF
--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -21,6 +21,7 @@ use move_core_types::{
     annotated_value::{MoveDatatypeLayout, MoveTypeLayout},
     language_storage::TypeTag,
 };
+#[cfg(feature = "shared_test_runtime")]
 use serde::Deserialize;
 
 use crate::{


### PR DESCRIPTION
# Description of change

This follows #6976 and configures conditional import of the `Deserialize` trait to silence local `clippy` warnings.

## How the change has been tested

```
$ cargo clippy -p iota-indexer
```
- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
