### PR TITLE
fix(crates/iota-framework-snapshots, external-crates/tooling): removed duplicate "the the"

### DIFF
--- a/crates/iota-framework-snapshot/tests/compatibility_tests.rs
+++ b/crates/iota-framework-snapshot/tests/compatibility_tests.rs
@@ -71,7 +71,7 @@ mod compatibility_tests {
         );
     }
 
-    /// This test checks that the the `SinglePackage` entries in `manifest.json`
+    /// This test checks that the `SinglePackage` entries in `manifest.json`
     /// match the metadata in the `Move.toml` files in the repo.
     ///
     /// Note that this test currently assumes that no framework packages will be

--- a/external-crates/move/tooling/tree-sitter/tests/iota.move
+++ b/external-crates/move/tooling/tree-sitter/tests/iota.move
@@ -16,7 +16,7 @@ module iota::iota {
     const ENotSystemAddress: u64 = 1;
 
     #[allow(unused_const)]
-    /// The amount of Nanos per IOTA token based on the the fact that nanos is
+    /// The amount of Nanos per IOTA token based on the fact that nanos is
     /// 10^-9 of a IOTA token
     const NANOS_PER_IOTA: u64 = 1_000_000_000;
 


### PR DESCRIPTION
# Description of change

 Removed duplicate "the the”.
According to [changes](https://github.com/MystenLabs/sui/commit/3b36106).

## Links to any relevant issues

Fixes #7070 .

## Type of change

- Documentation Fix