### PR TITLE
chore: fix clippy `large_enum_variant`

### DIFF
--- a/consensus/core/src/storage/store_tests.rs
+++ b/consensus/core/src/storage/store_tests.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 
 /// Test fixture for store tests. Wraps around various store implementations.
+#[expect(clippy::large_enum_variant)]
 enum TestStore {
     RocksDB((RocksDBStore, TempDir)),
     Mem(MemStore),

--- a/consensus/core/src/storage/store_tests.rs
+++ b/consensus/core/src/storage/store_tests.rs
@@ -13,16 +13,15 @@ use crate::{
 };
 
 /// Test fixture for store tests. Wraps around various store implementations.
-#[expect(clippy::large_enum_variant)]
 enum TestStore {
-    RocksDB((RocksDBStore, TempDir)),
+    RocksDB(Box<(RocksDBStore, TempDir)>),
     Mem(MemStore),
 }
 
 impl TestStore {
     fn store(&self) -> &dyn Store {
         match self {
-            TestStore::RocksDB((store, _)) => store,
+            TestStore::RocksDB(db) => &db.0,
             TestStore::Mem(store) => store,
         }
     }
@@ -30,10 +29,10 @@ impl TestStore {
 
 fn new_rocksdb_teststore() -> TestStore {
     let temp_dir = TempDir::new().unwrap();
-    TestStore::RocksDB((
+    TestStore::RocksDB(Box::new((
         RocksDBStore::new(temp_dir.path().to_str().unwrap()),
         temp_dir,
-    ))
+    )))
 }
 
 fn new_mem_teststore() -> TestStore {

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -951,7 +951,9 @@ pub struct Genesis {
 impl Genesis {
     pub fn new(genesis: genesis::Genesis) -> Self {
         Self {
-            location: Some(GenesisLocation::InPlace { genesis }),
+            location: Some(GenesisLocation::InPlace {
+                genesis: Box::new(genesis),
+            }),
             genesis: Default::default(),
         }
     }
@@ -985,12 +987,11 @@ impl Genesis {
     }
 }
 
-#[expect(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq)]
 #[serde(untagged)]
 enum GenesisLocation {
     InPlace {
-        genesis: genesis::Genesis,
+        genesis: Box<genesis::Genesis>,
     },
     File {
         #[serde(rename = "genesis-file-location")]

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -985,6 +985,7 @@ impl Genesis {
     }
 }
 
+#[expect(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq)]
 #[serde(untagged)]
 enum GenesisLocation {

--- a/crates/iota-core/src/authority_aggregator.rs
+++ b/crates/iota-core/src/authority_aggregator.rs
@@ -773,6 +773,7 @@ where
 
             type RequestResult<S> = Result<Result<S, IotaError>, tokio::time::error::Elapsed>;
 
+            #[expect(clippy::large_enum_variant)]
             enum Event<S> {
                 StartNext,
                 Request(AuthorityName, RequestResult<S>),

--- a/crates/iota-core/src/authority_aggregator.rs
+++ b/crates/iota-core/src/authority_aggregator.rs
@@ -773,10 +773,9 @@ where
 
             type RequestResult<S> = Result<Result<S, IotaError>, tokio::time::error::Elapsed>;
 
-            #[expect(clippy::large_enum_variant)]
             enum Event<S> {
                 StartNext,
-                Request(AuthorityName, RequestResult<S>),
+                Request(AuthorityName, Box<RequestResult<S>>),
             }
 
             let mut futures = FuturesUnordered::<BoxFuture<'a, Event<S>>>::new();
@@ -786,7 +785,7 @@ where
                 Box::pin(monitored_future!(async move {
                     trace!(name=?name.concise(), now = ?tokio::time::Instant::now() - start, "new request");
                     let map = map_each_authority(name, client);
-                    Event::Request(name, timeout(timeout_each_authority, map).await)
+                    Event::Request(name, Box::new(timeout(timeout_each_authority, map).await))
                 }))
             };
 
@@ -838,7 +837,7 @@ where
                         futures.push(schedule_next());
                     }
                     Event::Request(name, res) => {
-                        match res {
+                        match *res {
                             // timeout
                             Err(_) => {
                                 debug!(name=?name.concise(), "authority request timed out");

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -545,6 +545,7 @@ pub struct SequencedConsensusTransaction {
     pub transaction: SequencedConsensusTransactionKind,
 }
 
+#[expect(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum SequencedConsensusTransactionKind {
     External(ConsensusTransaction),
@@ -569,6 +570,7 @@ impl<'de> Deserialize<'de> for SequencedConsensusTransactionKind {
 // We can't serialize SequencedConsensusTransactionKind directly because it
 // contains a VerifiedExecutableTransaction, which is not serializable (by
 // design). This wrapper allows us to convert to a serializable format easily.
+#[expect(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 enum SerializableSequencedConsensusTransactionKind {
     External(ConsensusTransaction),

--- a/crates/iota-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/iota-graphql-rpc/src/types/dynamic_field.rs
@@ -37,6 +37,7 @@ pub(crate) struct DynamicField {
     pub super_: MoveObject,
 }
 
+#[expect(clippy::large_enum_variant)]
 #[derive(Union)]
 pub(crate) enum DynamicFieldValue {
     MoveObject(MoveObject), // DynamicObject

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -162,6 +162,7 @@ pub(crate) struct ObjectKey {
 }
 
 /// The object's owner type: Immutable, Shared, Parent, or Address.
+#[expect(clippy::large_enum_variant)]
 #[derive(Union, Clone)]
 pub(crate) enum ObjectOwner {
     Immutable(Immutable),

--- a/crates/iota-json-rpc-types/src/iota_object.rs
+++ b/crates/iota-json-rpc-types/src/iota_object.rs
@@ -1000,6 +1000,7 @@ impl IotaRawMovePackage {
     }
 }
 
+#[expect(clippy::large_enum_variant)]
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(tag = "status", content = "details", rename = "ObjectRead")]
 pub enum IotaPastObjectResponse {

--- a/crates/iota-replay/src/data_fetcher.rs
+++ b/crates/iota-replay/src/data_fetcher.rs
@@ -91,6 +91,7 @@ pub(crate) trait DataFetcher {
     ) -> Result<Object, ReplayEngineError>;
 }
 
+#[expect(clippy::large_enum_variant)]
 #[derive(Clone)]
 pub enum Fetchers {
     Remote(RemoteFetcher),

--- a/crates/iota-replay/src/types.rs
+++ b/crates/iota-replay/src/types.rs
@@ -264,6 +264,7 @@ impl From<anyhow::Error> for ReplayEngineError {
 }
 
 /// TODO: Limited set but will add more
+#[expect(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum ExecutionStoreEvent {
     BackingPackageGetPackageObject {

--- a/crates/iota-test-transaction-builder/src/lib.rs
+++ b/crates/iota-test-transaction-builder/src/lib.rs
@@ -399,6 +399,7 @@ impl TestTransactionBuilder {
     }
 }
 
+#[expect(clippy::large_enum_variant)]
 enum TestTransactionData {
     Move(MoveData),
     Transfer(TransferData),
@@ -416,6 +417,7 @@ struct MoveData {
     type_args: Vec<TypeTag>,
 }
 
+#[expect(clippy::large_enum_variant)]
 pub enum PublishData {
     /// Path to source code directory and with_unpublished_deps.
     /// with_unpublished_deps indicates whether to publish unpublished

--- a/crates/iota-types/src/messages_grpc.rs
+++ b/crates/iota-types/src/messages_grpc.rs
@@ -98,6 +98,7 @@ pub struct TransactionInfoRequest {
     pub transaction_digest: TransactionDigest,
 }
 
+#[expect(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum TransactionStatus {
     /// Signature over the transaction.

--- a/crates/iota/src/client_ptb/ptb.rs
+++ b/crates/iota/src/client_ptb/ptb.rs
@@ -57,6 +57,7 @@ pub struct Summary {
     pub gas_cost: GasCostSummary,
 }
 
+#[expect(clippy::large_enum_variant)]
 pub enum PTBCommandResult {
     Preview(PTBPreview),
     Summary(Summary),

--- a/crates/iota/src/keytool.rs
+++ b/crates/iota/src/keytool.rs
@@ -65,6 +65,7 @@ use crate::{
     },
 };
 
+#[expect(clippy::large_enum_variant)]
 #[derive(Subcommand)]
 pub enum KeyToolCommand {
     /// Convert private key in Hex or Base64 to new format (Bech32

--- a/crates/iota/src/name_commands.rs
+++ b/crates/iota/src/name_commands.rs
@@ -1184,6 +1184,7 @@ impl SubdomainCommand {
     }
 }
 
+#[expect(clippy::large_enum_variant)]
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum NameCommandResult {

--- a/crates/typed-store/src/sally/mod.rs
+++ b/crates/typed-store/src/sally/mod.rs
@@ -534,6 +534,7 @@ impl<V: DeserializeOwned> Iterator for SallyValues<'_, V> {
 }
 
 /// Options to configure a sally db instance at the global level
+#[expect(clippy::large_enum_variant)]
 pub enum SallyDBOptions {
     // Options when sally db instance is backed by a single rocksdb instance
     RocksDB(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.86"
+channel = "1.87"


### PR DESCRIPTION
Address the clippy lint `large_enum_variant` which has been made stable with 1.87.
The suggestion from clippy is to box the large variant, which is not always possible without breaking public API. For each instance you own, please confirm the right approach has been used.