### PR TITLE
chore(CODEOWNERS): add `infra` team for some directories he owns in `dev-tools` 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -96,6 +96,9 @@
 /docker/ @iotaledger/infrastructure @iotaledger/node @iotaledger/devops-admin
 /dev-tools/ @iotaledger/infrastructure @iotaledger/node @iotaledger/devops-admin
 /dev-tools/iota-indexer-monitoring/ @iotaledger/infrastructure
+/dev-tools/iota-data-ingestion/ @iotaledger/infrastructure
+/dev-tools/iota-rest-kv/ @iotaledger/infrastructure
+/dev-tools/pg-services-local/ @iotaledger/infrastructure
 /setups/ @iotaledger/infrastructure @iotaledger/node @iotaledger/devops-admin
 
 # Frontend apps to be looked after by Boxfish Studio or the tooling team


### PR DESCRIPTION
# Description of change

Add `infrastructure` team as code owner for `Docker` & `docker-compose` files present in the `dev-tools` directory.

## Links to any relevant issues

fixes #6371 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

### Release Notes

<!--
Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.
-->

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
