### PR TITLE
upstream(conensus): Sending to the subscription handler should not block execution

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2472,7 +2472,6 @@ impl AuthorityState {
             // Emit events
             self.subscription_handler
                 .process_tx(certificate.data().transaction_data(), &effects, &events)
-                .await
                 .tap_ok(|_| {
                     self.metrics
                         .post_processing_total_tx_had_event_processed

--- a/crates/iota-core/src/streamer.rs
+++ b/crates/iota-core/src/streamer.rs
@@ -24,6 +24,8 @@ type Subscribers<T, F> = Arc<RwLock<BTreeMap<String, (tokio::sync::mpsc::Sender<
 pub struct Streamer<T, S, F: Filter<T>> {
     streamer_queue: Sender<T>,
     subscribers: Subscribers<S, F>,
+    metrics: Arc<SubscriptionMetrics>,
+    metrics_label: &'static str,
 }
 
 impl<T, S, F> Streamer<T, S, F>
@@ -56,6 +58,8 @@ where
         let streamer = Self {
             streamer_queue: tx,
             subscribers: Default::default(),
+            metrics: metrics.clone(),
+            metrics_label,
         };
         let mut rx = rx;
         let subscribers = streamer.subscribers.clone();
@@ -137,12 +141,16 @@ where
         ReceiverStream::new(rx)
     }
 
-    pub async fn send(&self, data: T) -> Result<(), IotaError> {
-        self.streamer_queue
-            .send(data)
-            .await
-            .map_err(|e| IotaError::FailedToDispatchSubscription {
+    pub fn try_send(&self, data: T) -> Result<(), IotaError> {
+        self.streamer_queue.try_send(data).map_err(|e| {
+            self.metrics
+                .dropped_submissions
+                .with_label_values(&[self.metrics_label])
+                .inc();
+
+            IotaError::FailedToDispatchSubscription {
                 error: e.to_string(),
-            })
+            }
+        })
     }
 }

--- a/crates/iota-core/src/subscription_handler.rs
+++ b/crates/iota-core/src/subscription_handler.rs
@@ -28,6 +28,7 @@ pub struct SubscriptionMetrics {
     pub streaming_success: IntCounterVec,
     pub streaming_failure: IntCounterVec,
     pub streaming_active_subscriber_number: IntGaugeVec,
+    pub dropped_submissions: IntCounterVec,
 }
 
 impl SubscriptionMetrics {
@@ -54,6 +55,13 @@ impl SubscriptionMetrics {
                 registry,
             )
             .unwrap(),
+            dropped_submissions: register_int_counter_vec_with_registry!(
+                "streaming_dropped_submissions",
+                "Total number of submissions that are dropped",
+                &["type"],
+                registry,
+            )
+            .unwrap(),
         }
     }
 }
@@ -76,7 +84,7 @@ impl SubscriptionHandler {
 
 impl SubscriptionHandler {
     #[instrument(level = "trace", skip_all, fields(tx_digest =? effects.transaction_digest()), err)]
-    pub async fn process_tx(
+    pub fn process_tx(
         &self,
         input: &TransactionData,
         effects: &IotaTransactionBlockEffects,
@@ -88,20 +96,16 @@ impl SubscriptionHandler {
             "Processing tx/event subscription"
         );
 
-        if let Err(e) = self
-            .transaction_streamer
-            .send(EffectsWithInput {
-                input: input.clone(),
-                effects: effects.clone(),
-            })
-            .await
-        {
+        if let Err(e) = self.transaction_streamer.try_send(EffectsWithInput {
+            input: input.clone(),
+            effects: effects.clone(),
+        }) {
             error!(error =? e, "Failed to send transaction to dispatch");
         }
 
         // serially dispatch event processing to honor events' orders.
         for event in events.data.clone() {
-            if let Err(e) = self.event_streamer.send(event).await {
+            if let Err(e) = self.event_streamer.try_send(event) {
                 error!(error =? e, "Failed to send event to dispatch");
             }
         }


### PR DESCRIPTION
# Description of change

Upstream change: Sending to the subscription handler should not block execution (#21100) https://github.com/MystenLabs/sui/commit/a6b1d1dc15d55ab88b008798a4c53de371e18836 (PR: https://github.com/MystenLabs/sui/pull/21100)

> Subscriptions are already not 100% reliable, and this allows a slow
> subscription handler to block execution indefinitely, which we don't
> want.

## Links to any relevant issues

fixes #6583

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

CI

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

<!--
Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.
-->

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
