### PR TITLE
upstream(consensus): change MockConsensusClient to return error on overflow instead of panic

### DIFF
--- a/crates/iota-core/src/mock_consensus.rs
+++ b/crates/iota-core/src/mock_consensus.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Weak};
 
 use consensus_core::BlockRef;
 use iota_types::{
-    error::IotaResult,
+    error::{IotaError, IotaResult},
     messages_consensus::{ConsensusTransaction, ConsensusTransactionKind},
     transaction::VerifiedCertificate,
 };
@@ -103,7 +103,7 @@ impl MockConsensusClient {
         let transaction = &transactions[0];
         self.tx_sender
             .try_send(transaction.clone())
-            .expect("MockConsensusClient channel should not overflow");
+            .map_err(|_| IotaError::from("MockConsensusClient channel overflowed"))?;
         Ok(with_block_status(consensus_core::BlockStatus::Sequenced(
             BlockRef::MIN,
         )))


### PR DESCRIPTION
# Description of change

Upstream change: `change MockConsensusClient to return error on overflow instead of panic (#21284)` https://github.com/MystenLabs/sui/commit/0a4e0abc5872cb0ca53e03f107629e4b6151cce8.

Depends on [PR 7177](https://github.com/iotaledger/iota/pull/7177)

## Links to any relevant issues

Fixes #6585 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

CI

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
