### PR TITLE
upstream(node): Porting node team related upstream changes in range mainnet-1.33.3 to mainnet-1.34.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6253,8 +6253,16 @@ dependencies = [
 name = "iota-common"
 version = "1.3.0-alpha"
 dependencies = [
+ "anyhow",
+ "fastcrypto",
  "futures",
+ "iota-metrics",
+ "iota-tls",
+ "iota-types",
  "parking_lot 0.12.3",
+ "prometheus",
+ "reqwest 0.12.7",
+ "snap",
  "tokio",
  "tracing",
 ]
@@ -7504,7 +7512,6 @@ dependencies = [
  "prometheus",
  "reqwest 0.12.7",
  "serde",
- "snap",
  "tap",
  "telemetry-subscribers",
  "tokio",

--- a/crates/iota-benchmark/src/drivers/bench_driver.rs
+++ b/crates/iota-benchmark/src/drivers/bench_driver.rs
@@ -752,11 +752,6 @@ async fn run_bench_worker(
                     .latency_squared_s
                     .with_label_values(&[&payload.to_string()])
                     .inc_by(square_latency_ms);
-
-                metrics_cloned
-                    .num_success
-                    .with_label_values(&[&payload.to_string()])
-                    .inc();
                 metrics_cloned
                     .num_in_flight
                     .with_label_values(&[&payload.to_string()])
@@ -764,10 +759,22 @@ async fn run_bench_worker(
 
                 let num_commands =
                     transaction.data().transaction_data().kind().num_commands() as u16;
-                metrics_cloned
-                    .num_success_cmds
-                    .with_label_values(&[&payload.to_string()])
-                    .inc_by(num_commands as u64);
+
+                if effects.is_ok() {
+                    metrics_cloned
+                        .num_success
+                        .with_label_values(&[&payload.to_string()])
+                        .inc();
+                    metrics_cloned
+                        .num_success_cmds
+                        .with_label_values(&[&payload.to_string()])
+                        .inc_by(num_commands as u64);
+                } else {
+                    metrics_cloned
+                        .num_error
+                        .with_label_values(&[&payload.to_string()])
+                        .inc();
+                }
 
                 if let Some(sig_info) = effects.quorum_sig() {
                     sig_info.authorities(&committee).for_each(|name| {

--- a/crates/iota-benchmark/src/drivers/bench_driver.rs
+++ b/crates/iota-benchmark/src/drivers/bench_driver.rs
@@ -97,7 +97,7 @@ impl BenchMetrics {
             num_error: register_int_counter_vec_with_registry!(
                 "num_error",
                 "Total number of transaction errors",
-                &["workload"],
+                &["workload", "type"],
                 registry,
             )
             .unwrap(),
@@ -772,7 +772,7 @@ async fn run_bench_worker(
                 } else {
                     metrics_cloned
                         .num_error
-                        .with_label_values(&[&payload.to_string()])
+                        .with_label_values(&[&payload.to_string(), &"execution".to_string()])
                         .inc();
                 }
 
@@ -813,7 +813,7 @@ async fn run_bench_worker(
                 } else {
                     metrics_cloned
                         .num_error
-                        .with_label_values(&[&payload.to_string()])
+                        .with_label_values(&[&payload.to_string(), &"rpc".to_string()])
                         .inc();
                     NextOp::Retry(Box::new((transaction, payload)))
                 }

--- a/crates/iota-benchmark/src/workloads/adversarial.rs
+++ b/crates/iota-benchmark/src/workloads/adversarial.rs
@@ -16,7 +16,6 @@ use iota_types::{
     transaction::{CallArg, Command, ObjectArg, Transaction, TransactionData},
     utils::to_sender_signed_transaction,
 };
-use itertools::Itertools;
 use move_core_types::identifier::Identifier;
 use rand::{
     Rng,
@@ -152,7 +151,7 @@ impl FromStr for AdversarialPayloadCfg {
         if !re.is_match(s) {
             return Err(anyhow!("invalid load config"));
         };
-        let toks = s.split('-').collect_vec();
+        let toks = s.split('-').collect::<Vec<_>>();
         let payload_type = AdversarialPayloadType::from_str(toks[0])?;
         let load_factor = toks[1].parse::<f32>().unwrap();
 

--- a/crates/iota-common/Cargo.toml
+++ b/crates/iota-common/Cargo.toml
@@ -7,10 +7,21 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
+# external dependencies
+anyhow.workspace = true
+fastcrypto.workspace = true
 futures.workspace = true
 parking_lot.workspace = true
+prometheus.workspace = true
+reqwest.workspace = true
+snap.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 tracing.workspace = true
+
+# internal dependencies
+iota-metrics.workspace = true
+iota-tls.workspace = true
+iota-types.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/crates/iota-common/src/lib.rs
+++ b/crates/iota-common/src/lib.rs
@@ -3,4 +3,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod logging;
+pub mod metrics;
 pub mod sync;

--- a/crates/iota-common/src/metrics.rs
+++ b/crates/iota-common/src/metrics.rs
@@ -2,11 +2,13 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use iota_metrics::RegistryService;
 use prometheus::Encoder;
 use tracing::{debug, error, info};
+
+const DEFAULT_METRICS_PUSH_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub struct MetricsPushClient {
     certificate: std::sync::Arc<iota_tls::SelfSignedCertificate>,
@@ -78,6 +80,7 @@ pub async fn push_metrics(
         .header(reqwest::header::CONTENT_ENCODING, "snappy")
         .header(reqwest::header::CONTENT_TYPE, prometheus::PROTOBUF_FORMAT)
         .body(compressed)
+        .timeout(DEFAULT_METRICS_PUSH_TIMEOUT)
         .send()
         .await?;
 

--- a/crates/iota-common/src/metrics.rs
+++ b/crates/iota-common/src/metrics.rs
@@ -1,0 +1,100 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use iota_metrics::RegistryService;
+use prometheus::Encoder;
+use tracing::{debug, error, info};
+
+pub struct MetricsPushClient {
+    certificate: std::sync::Arc<iota_tls::SelfSignedCertificate>,
+    client: reqwest::Client,
+}
+
+impl MetricsPushClient {
+    pub fn new(metrics_key: iota_types::crypto::NetworkKeyPair) -> Self {
+        use fastcrypto::traits::KeyPair;
+        let certificate = std::sync::Arc::new(iota_tls::SelfSignedCertificate::new(
+            metrics_key.private(),
+            iota_tls::IOTA_VALIDATOR_SERVER_NAME,
+        ));
+        let identity = certificate.reqwest_identity();
+        let client = reqwest::Client::builder()
+            .identity(identity)
+            .build()
+            .unwrap();
+
+        Self {
+            certificate,
+            client,
+        }
+    }
+
+    pub fn certificate(&self) -> &iota_tls::SelfSignedCertificate {
+        &self.certificate
+    }
+
+    pub fn client(&self) -> &reqwest::Client {
+        &self.client
+    }
+}
+
+pub async fn push_metrics(
+    client: &MetricsPushClient,
+    url: &reqwest::Url,
+    registry: &RegistryService,
+) -> Result<(), anyhow::Error> {
+    info!(push_url =% url, "pushing metrics to remote");
+
+    // now represents a collection timestamp for all of the metrics we send to the
+    // proxy
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64;
+
+    let mut metric_families = registry.gather_all();
+    for mf in metric_families.iter_mut() {
+        for m in mf.mut_metric() {
+            m.set_timestamp_ms(now);
+        }
+    }
+
+    let mut buf: Vec<u8> = vec![];
+    let encoder = prometheus::ProtobufEncoder::new();
+    encoder.encode(&metric_families, &mut buf)?;
+
+    let mut s = snap::raw::Encoder::new();
+    let compressed = s.compress_vec(&buf).map_err(|err| {
+        error!("unable to snappy encode; {err}");
+        err
+    })?;
+
+    let response = client
+        .client()
+        .post(url.to_owned())
+        .header(reqwest::header::CONTENT_ENCODING, "snappy")
+        .header(reqwest::header::CONTENT_TYPE, prometheus::PROTOBUF_FORMAT)
+        .body(compressed)
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = match response.text().await {
+            Ok(body) => body,
+            Err(error) => format!("couldn't decode response body; {error}"),
+        };
+        return Err(anyhow::anyhow!(
+            "metrics push failed: [{}]:{}",
+            status,
+            body
+        ));
+    }
+
+    debug!("successfully pushed metrics to {url}");
+
+    Ok(())
+}

--- a/crates/iota-core/src/authority_aggregator.rs
+++ b/crates/iota-core/src/authority_aggregator.rs
@@ -239,18 +239,6 @@ pub enum AggregatorProcessTransactionError {
     },
 
     #[error(
-        "Validators returned conflicting transactions but it is potentially recoverable. Locked objects: {:?}. Validator errors: {:?}",
-        conflicting_tx_digests,
-        errors
-    )]
-    RetryableConflictingTransaction {
-        conflicting_tx_digest_to_retry: Option<TransactionDigest>,
-        errors: GroupedErrors,
-        conflicting_tx_digests:
-            BTreeMap<TransactionDigest, (Vec<(AuthorityName, ObjectRef)>, StakeUnit)>,
-    },
-
-    #[error(
         "{} of the validators by stake are overloaded with transactions pending execution. Validator errors: {:?}",
         overloaded_stake,
         errors
@@ -368,40 +356,18 @@ struct ProcessTransactionState {
     overloaded_stake: StakeUnit,
     // Validators that are overloaded and request client to retry.
     retryable_overload_info: RetryableOverloadInfo,
-    // If there are conflicting transactions, we note them down and may attempt to retry
+    // If there are conflicting transactions, we note them down to report to user.
     conflicting_tx_digests:
         BTreeMap<TransactionDigest, (Vec<(AuthorityName, ObjectRef)>, StakeUnit)>,
     // As long as none of the exit criteria are met we consider the state retryable
     // 1) >= 2f+1 signatures
     // 2) >= f+1 non-retryable errors
     // 3) >= 2f+1 object not found errors
-    // Note: For conflicting transactions we collect as many responses as possible
-    // before we know for sure no tx can reach quorum. Namely, stake of the most
-    // promising tx + retryable stake < 2f+1.
     retryable: bool,
     tx_finalized_with_different_user_sig: bool,
-
-    conflicting_tx_total_stake: StakeUnit,
-    most_staked_conflicting_tx_stake: StakeUnit,
 }
 
 impl ProcessTransactionState {
-    /// Returns the conflicting transaction digest and its validators with the
-    /// most stake.
-    #[expect(clippy::type_complexity)]
-    pub fn conflicting_tx_digest_with_most_stake(
-        &self,
-    ) -> Option<(
-        TransactionDigest,
-        &Vec<(AuthorityName, ObjectRef)>,
-        StakeUnit,
-    )> {
-        self.conflicting_tx_digests
-            .iter()
-            .max_by_key(|(_, (_, stake))| *stake)
-            .map(|(digest, (validators, stake))| (*digest, validators, *stake))
-    }
-
     /// Records the conflicting transaction, returns `true` if there is any, and
     /// returns `false` otherwise.
     pub fn record_conflicting_transaction_if_any(
@@ -409,7 +375,7 @@ impl ProcessTransactionState {
         validator_name: AuthorityName,
         weight: StakeUnit,
         err: &IotaError,
-    ) -> bool {
+    ) {
         if let IotaError::ObjectLockConflict {
             obj_ref,
             pending_transaction: transaction,
@@ -421,13 +387,7 @@ impl ProcessTransactionState {
                 .or_insert((Vec::new(), 0));
             lock_records.push((validator_name, *obj_ref));
             *total_stake += weight;
-            self.conflicting_tx_total_stake += weight;
-            if *total_stake > self.most_staked_conflicting_tx_stake {
-                self.most_staked_conflicting_tx_stake = *total_stake;
-            }
-            return true;
         }
-        false
     }
 
     /// Checks if the error indicates that the transaction is already finalized.
@@ -1091,9 +1051,7 @@ where
             retryable_overload_info: Default::default(),
             retryable: true,
             conflicting_tx_digests: Default::default(),
-            conflicting_tx_total_stake: 0,
             tx_finalized_with_different_user_sig: false,
-            most_staked_conflicting_tx_stake: 0,
         };
 
         let transaction_ref = &transaction;
@@ -1135,6 +1093,8 @@ where
                                     .with_label_values(&[display_name.as_str(), err.as_ref()])
                                     .inc();
                                 Self::record_rpc_error_maybe(self.metrics.clone(), &display_name, &err);
+                                // Record conflicting transactions if any to report to user.
+                                state.record_conflicting_transaction_if_any(name, weight, &err);
                                 let (retryable, categorized) = err.is_retryable();
                                 if !categorized {
                                     // TODO: Should minimize possible uncategorized errors here
@@ -1167,9 +1127,7 @@ where
                                     // code path to handle both overload scenarios.
                                     state.retryable_overload_info.add_stake_retryable_overload(weight, Duration::from_secs(err.retry_after_secs()));
                                 }
-                                else if !retryable && !state.record_conflicting_transaction_if_any(name, weight, &err) {
-                                    // We don't count conflicting transactions as non-retryable errors here
-                                    // because its handling is a bit different.
+                                else if !retryable {
                                     state.non_retryable_stake += weight;
                                 }
                                 state.errors.push((err, vec![name], weight));
@@ -1179,12 +1137,10 @@ where
 
                         let retryable_stake = self.get_retryable_stake(&state);
                         let good_stake = std::cmp::max(state.tx_signatures.total_votes(), state.effects_map.total_votes());
-                        let stake_of_most_promising_tx = std::cmp::max(good_stake, state.most_staked_conflicting_tx_stake);
-                        if stake_of_most_promising_tx + retryable_stake < quorum_threshold {
+                        if good_stake + retryable_stake < quorum_threshold {
                             debug!(
                                 tx_digest = ?tx_digest,
                                 good_stake,
-                                most_staked_conflicting_tx_stake =? state.most_staked_conflicting_tx_stake,
                                 retryable_stake,
                                 "No chance for any tx to get quorum, exiting. Conflicting_txes: {:?}",
                                 state.conflicting_tx_digests
@@ -1217,7 +1173,7 @@ where
             Err(state) => {
                 self.record_process_transaction_metrics(tx_digest, &state);
                 let state = self.record_non_quorum_effects_maybe(tx_digest, state);
-                Err(self.handle_process_transaction_error(tx_digest, state))
+                Err(self.handle_process_transaction_error(state))
             }
         }
     }
@@ -1235,7 +1191,6 @@ where
     /// Handles the transaction processing error.
     fn handle_process_transaction_error(
         &self,
-        original_tx_digest: &TransactionDigest,
         state: ProcessTransactionState,
     ) -> AggregatorProcessTransactionError {
         let quorum_threshold = self.committee.quorum_threshold();
@@ -1248,49 +1203,6 @@ where
             };
         }
 
-        // Handle possible conflicts first as `FatalConflictingTransaction` is
-        // more meaningful than `FatalTransaction`.
-        if let Some((most_staked_conflicting_tx, validators, most_staked_conflicting_tx_stake)) =
-            state.conflicting_tx_digest_with_most_stake()
-        {
-            let good_stake = state.tx_signatures.total_votes();
-            let retryable_stake = self.get_retryable_stake(&state);
-
-            if good_stake + retryable_stake >= quorum_threshold {
-                return AggregatorProcessTransactionError::RetryableConflictingTransaction {
-                    errors: group_errors(state.errors),
-                    conflicting_tx_digest_to_retry: None,
-                    conflicting_tx_digests: state.conflicting_tx_digests,
-                };
-            }
-
-            if most_staked_conflicting_tx_stake + retryable_stake >= quorum_threshold {
-                return AggregatorProcessTransactionError::RetryableConflictingTransaction {
-                    errors: group_errors(state.errors),
-                    conflicting_tx_digest_to_retry: Some(most_staked_conflicting_tx),
-                    conflicting_tx_digests: state.conflicting_tx_digests,
-                };
-            }
-
-            warn!(
-                ?state.conflicting_tx_digests,
-                ?most_staked_conflicting_tx,
-                ?original_tx_digest,
-                original_tx_stake = good_stake,
-                most_staked_conflicting_tx_stake = most_staked_conflicting_tx_stake,
-                "Client double spend attempt detected: {:?}",
-                validators
-            );
-            self.metrics
-                .total_client_double_spend_attempts_detected
-                .inc();
-
-            return AggregatorProcessTransactionError::FatalConflictingTransaction {
-                errors: group_errors(state.errors),
-                conflicting_tx_digests: state.conflicting_tx_digests,
-            };
-        }
-
         if !state.retryable {
             if state.tx_finalized_with_different_user_sig
                 || state.check_if_error_indicates_tx_finalized_with_different_user_sig(
@@ -1299,6 +1211,25 @@ where
             {
                 return AggregatorProcessTransactionError::TxAlreadyFinalizedWithDifferentUserSignatures;
             }
+
+            // Handle conflicts first as `FatalConflictingTransaction` which is
+            // more meaningful than `FatalTransaction`
+            if !state.conflicting_tx_digests.is_empty() {
+                let good_stake = state.tx_signatures.total_votes();
+                warn!(
+                    ?state.conflicting_tx_digests,
+                    original_tx_stake = good_stake,
+                    "Client double spend attempt detected!",
+                );
+                self.metrics
+                    .total_client_double_spend_attempts_detected
+                    .inc();
+                return AggregatorProcessTransactionError::FatalConflictingTransaction {
+                    errors: group_errors(state.errors),
+                    conflicting_tx_digests: state.conflicting_tx_digests,
+                };
+            }
+
             return AggregatorProcessTransactionError::FatalTransaction {
                 errors: group_errors(state.errors),
             };
@@ -1324,8 +1255,7 @@ where
             };
         }
 
-        // No conflicting transaction, the system is not overloaded and transaction
-        // state is still retryable.
+        // The system is not overloaded and transaction state is still retryable.
         AggregatorProcessTransactionError::RetryableTransaction {
             errors: group_errors(state.errors),
         }
@@ -1537,7 +1467,6 @@ where
     /// Gets the retryable stake for the transaction.
     fn get_retryable_stake(&self, state: &ProcessTransactionState) -> StakeUnit {
         self.committee.total_votes()
-            - state.conflicting_tx_total_stake
             - state.non_retryable_stake
             - state.effects_map.total_votes()
             - state.tx_signatures.total_votes()

--- a/crates/iota-core/src/authority_aggregator.rs
+++ b/crates/iota-core/src/authority_aggregator.rs
@@ -109,6 +109,7 @@ pub struct AuthAggMetrics {
     pub cert_broadcasting_post_quorum_timeout: IntCounter,
     pub remaining_tasks_when_reaching_cert_quorum: Histogram,
     pub remaining_tasks_when_cert_broadcasting_post_quorum_timeout: Histogram,
+    pub quorum_reached_without_requested_objects: IntCounter,
 }
 
 impl AuthAggMetrics {
@@ -194,7 +195,13 @@ impl AuthAggMetrics {
                 "auth_agg_remaining_tasks_when_cert_broadcasting_post_quorum_timeout",
                 "Number of remaining tasks when post quorum certificate broadcasting times out",
                 registry,
-            ).unwrap()
+            ).unwrap(),
+            quorum_reached_without_requested_objects: register_int_counter_with_registry!(
+                "auth_agg_quorum_reached_without_requested_objects",
+                "Number of times quorum was reached without getting the requested objects back from at least 1 validator",
+                registry,
+            )
+            .unwrap(),
         }
     }
 
@@ -475,6 +482,7 @@ struct ProcessCertificateState {
     input_objects: Option<Vec<Object>>,
     output_objects: Option<Vec<Object>>,
     auxiliary_data: Option<Vec<u8>>,
+    request: HandleCertificateRequestV1,
 }
 
 /// The result of processing a transaction.
@@ -1553,6 +1561,7 @@ where
             input_objects: None,
             output_objects: None,
             auxiliary_data: None,
+            request: request.clone(),
         };
 
         // create a set of validators that we should sample to request input/output
@@ -1560,7 +1569,7 @@ where
         let validators_to_sample =
             if request.include_input_objects || request.include_output_objects {
                 // Number of validators to request input/output objects from
-                const NUMBER_TO_SAMPLE: usize = 5;
+                const NUMBER_TO_SAMPLE: usize = 10;
 
                 self.committee
                     .choose_multiple_weighted_iter(NUMBER_TO_SAMPLE)
@@ -1604,7 +1613,6 @@ where
                             request_ref
                         } else {
                             HandleCertificateRequestV1 {
-                                include_events: false,
                                 include_input_objects: false,
                                 include_output_objects: false,
                                 include_auxiliary_data: false,
@@ -1640,6 +1648,7 @@ where
                     // and return.
                     match AuthorityAggregator::<A>::handle_process_certificate_response(
                         committee_clone,
+                        &metrics,
                         &tx_digest, &mut state, response, name)
                     {
                         Ok(Some(effects)) => ReduceOutput::Success(effects),
@@ -1753,6 +1762,7 @@ where
     /// Handles the `HandleCertificateResponseV1` variants.
     fn handle_process_certificate_response(
         committee: Arc<Committee>,
+        metrics: &AuthAggMetrics,
         tx_digest: &TransactionDigest,
         state: &mut ProcessCertificateState,
         response: IotaResult<HandleCertificateResponseV1>,
@@ -1816,6 +1826,18 @@ where
                             signed_effects.into_data(),
                             cert_sig,
                         );
+
+                        if (state.request.include_input_objects && state.input_objects.is_none())
+                            || (state.request.include_output_objects
+                                && state.output_objects.is_none())
+                        {
+                            metrics.quorum_reached_without_requested_objects.inc();
+                            debug!(
+                                ?tx_digest,
+                                "Quorum Reached but requested input/output objects were not returned"
+                            );
+                        }
+
                         ct.verify(&committee).map(|ct| {
                             debug!(?tx_digest, "Got quorum for validators handle_certificate.");
                             Some(QuorumDriverResponse {

--- a/crates/iota-core/src/quorum_driver/metrics.rs
+++ b/crates/iota-core/src/quorum_driver/metrics.rs
@@ -29,10 +29,6 @@ pub struct QuorumDriverMetrics {
     // TODO: add histogram of attempt that tx succeeds
     pub(crate) current_requests_in_flight: IntGauge,
 
-    pub(crate) total_err_process_tx_responses_with_nonzero_conflicting_transactions: IntCounter,
-    pub(crate) total_attempts_retrying_conflicting_transaction: IntCounter,
-    pub(crate) total_successful_attempts_retrying_conflicting_transaction: IntCounter,
-    pub(crate) total_times_conflicting_transaction_already_finalized_when_retrying: IntCounter,
     pub(crate) total_retryable_overload_errors: IntCounter,
     pub(crate) transaction_retry_count: Histogram,
     pub(crate) current_transactions_in_retry: IntGauge,
@@ -73,34 +69,11 @@ impl QuorumDriverMetrics {
                 "Total attempt times of ok response",
                 iota_metrics::COUNT_BUCKETS.to_vec(),
                 registry,
-            ).unwrap(),
+            )
+            .unwrap(),
             current_requests_in_flight: register_int_gauge_with_registry!(
                 "current_requests_in_flight",
                 "Current number of requests being processed in QuorumDriver",
-                registry,
-            )
-            .unwrap(),
-            total_err_process_tx_responses_with_nonzero_conflicting_transactions: register_int_counter_with_registry!(
-                "quorum_driver_total_err_process_tx_responses_with_nonzero_conflicting_transactions",
-                "Total number of err process_tx responses with non empty conflicting transactions",
-                registry,
-            )
-            .unwrap(),
-            total_attempts_retrying_conflicting_transaction: register_int_counter_with_registry!(
-                "quorum_driver_total_attempts_trying_conflicting_transaction",
-                "Total number of attempts to retry a conflicting transaction",
-                registry,
-            )
-            .unwrap(),
-            total_successful_attempts_retrying_conflicting_transaction: register_int_counter_with_registry!(
-                "quorum_driver_total_successful_attempts_trying_conflicting_transaction",
-                "Total number of successful attempts to retry a conflicting transaction",
-                registry,
-            )
-            .unwrap(),
-            total_times_conflicting_transaction_already_finalized_when_retrying: register_int_counter_with_registry!(
-                "quorum_driver_total_times_conflicting_transaction_already_finalized_when_retrying",
-                "Total number of times the conflicting transaction is already finalized when retrying",
                 registry,
             )
             .unwrap(),
@@ -115,7 +88,8 @@ impl QuorumDriverMetrics {
                 "Histogram of transaction retry count",
                 iota_metrics::COUNT_BUCKETS.to_vec(),
                 registry,
-            ).unwrap(),
+            )
+            .unwrap(),
             current_transactions_in_retry: register_int_gauge_with_registry!(
                 "current_transactions_in_retry",
                 "Current number of transactions in retry loop in QuorumDriver",

--- a/crates/iota-core/src/quorum_driver/mod.rs
+++ b/crates/iota-core/src/quorum_driver/mod.rs
@@ -8,7 +8,6 @@ pub use metrics::*;
 pub mod reconfig_observer;
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
     fmt::{Debug, Formatter, Write},
     net::SocketAddr,
     sync::Arc,
@@ -22,11 +21,10 @@ use iota_metrics::{
     GaugeGuard, TX_TYPE_SHARED_OBJ_TX, TX_TYPE_SINGLE_WRITER_TX, spawn_monitored_task,
 };
 use iota_types::{
-    base_types::{AuthorityName, ObjectRef, TransactionDigest},
-    committee::{Committee, EpochId, StakeUnit},
+    base_types::TransactionDigest,
+    committee::{Committee, EpochId},
     error::{IotaError, IotaResult},
     messages_grpc::HandleCertificateRequestV1,
-    messages_safe_client::PlainTransactionInfoResponse,
     quorum_driver_types::{
         ExecuteTransactionRequestV1, QuorumDriverEffectsQueueResult, QuorumDriverError,
         QuorumDriverResponse, QuorumDriverResult,
@@ -309,8 +307,7 @@ where
         let tx_digest = *transaction.digest();
         let result = auth_agg.process_transaction(transaction, client_addr).await;
 
-        self.process_transaction_result(result, tx_digest, client_addr)
-            .await
+        self.process_transaction_result(result, tx_digest).await
     }
 
     #[instrument(level = "trace", skip_all)]
@@ -318,44 +315,9 @@ where
         &self,
         result: Result<ProcessTransactionResult, AggregatorProcessTransactionError>,
         tx_digest: TransactionDigest,
-        client_addr: Option<SocketAddr>,
     ) -> Result<ProcessTransactionResult, Option<QuorumDriverError>> {
         match result {
             Ok(resp) => Ok(resp),
-            Err(AggregatorProcessTransactionError::RetryableConflictingTransaction {
-                conflicting_tx_digest_to_retry,
-                errors,
-                conflicting_tx_digests,
-            }) => {
-                self.metrics
-                    .total_err_process_tx_responses_with_nonzero_conflicting_transactions
-                    .inc();
-                debug!(
-                    ?tx_digest,
-                    "Observed {} conflicting transactions: {:?}",
-                    conflicting_tx_digests.len(),
-                    conflicting_tx_digests
-                );
-
-                if let Some(conflicting_tx_digest) = conflicting_tx_digest_to_retry {
-                    self.process_conflicting_tx(
-                        tx_digest,
-                        conflicting_tx_digest,
-                        conflicting_tx_digests,
-                        client_addr,
-                    )
-                    .await
-                } else {
-                    // If no retryable conflicting transaction was returned that means we have >=
-                    // 2f+1 good stake for the original transaction + retryable
-                    // stake. Will continue to retry the original transaction.
-                    debug!(
-                        ?errors,
-                        "Observed Tx {tx_digest:} is still in retryable state. Conflicting Txes: {conflicting_tx_digests:?}",
-                    );
-                    Err(None)
-                }
-            }
 
             Err(AggregatorProcessTransactionError::FatalConflictingTransaction {
                 errors,
@@ -367,7 +329,6 @@ where
                 );
                 Err(Some(QuorumDriverError::ObjectsDoubleUsed {
                     conflicting_txes: conflicting_tx_digests,
-                    retried_tx_status: None,
                 }))
             }
 
@@ -426,66 +387,6 @@ where
         }
     }
 
-    #[instrument(level = "trace", skip_all)]
-    async fn process_conflicting_tx(
-        &self,
-        tx_digest: TransactionDigest,
-        conflicting_tx_digest: TransactionDigest,
-        conflicting_tx_digests: BTreeMap<
-            TransactionDigest,
-            (Vec<(AuthorityName, ObjectRef)>, StakeUnit),
-        >,
-        client_addr: Option<SocketAddr>,
-    ) -> Result<ProcessTransactionResult, Option<QuorumDriverError>> {
-        // Safe to unwrap because tx_digest_to_retry is generated from
-        // conflicting_tx_digests
-        // in ProcessTransactionState::conflicting_tx_digest_with_most_stake()
-        let (validators, _) = conflicting_tx_digests.get(&conflicting_tx_digest).unwrap();
-        let attempt_result = self
-            .attempt_conflicting_transaction(
-                &conflicting_tx_digest,
-                &tx_digest,
-                validators.iter().map(|(pub_key, _)| *pub_key).collect(),
-                client_addr,
-            )
-            .await;
-        self.metrics
-            .total_attempts_retrying_conflicting_transaction
-            .inc();
-
-        match attempt_result {
-            Err(err) => {
-                debug!(
-                    ?tx_digest,
-                    ?conflicting_tx_digest,
-                    "Encountered error while attempting conflicting transaction: {:?}",
-                    err
-                );
-                Err(Some(QuorumDriverError::ObjectsDoubleUsed {
-                    conflicting_txes: conflicting_tx_digests,
-                    retried_tx_status: None,
-                }))
-            }
-            Ok(success) => {
-                debug!(
-                    ?tx_digest,
-                    ?conflicting_tx_digest,
-                    "Retried conflicting transaction. Success: {}",
-                    success
-                );
-                if success {
-                    self.metrics
-                        .total_successful_attempts_retrying_conflicting_transaction
-                        .inc();
-                }
-                Err(Some(QuorumDriverError::ObjectsDoubleUsed {
-                    conflicting_txes: conflicting_tx_digests,
-                    retried_tx_status: Some((conflicting_tx_digest, success)),
-                }))
-            }
-        }
-    }
-
     #[instrument(level = "trace", skip_all, fields(tx_digest = ?request.certificate.digest()))]
     pub(crate) async fn process_certificate(
         &self,
@@ -529,99 +430,6 @@ where
             new_validators.committee
         );
         self.validators.store(new_validators);
-    }
-
-    /// Returns Some(true) if the conflicting transaction is executed
-    /// successfully (or already executed), or Some(false) if it did not.
-    #[instrument(level = "trace", skip_all)]
-    async fn attempt_conflicting_transaction(
-        &self,
-        tx_digest: &TransactionDigest,
-        original_tx_digest: &TransactionDigest,
-        validators: BTreeSet<AuthorityName>,
-        client_addr: Option<SocketAddr>,
-    ) -> IotaResult<bool> {
-        let response = self
-            .validators
-            .load()
-            .handle_transaction_info_request_from_some_validators(
-                tx_digest,
-                &validators,
-                Some(Duration::from_secs(10)),
-            )
-            .await?;
-
-        // If we are able to get a certificate right away, we use it and execute the
-        // cert; otherwise, we have to re-form a cert and execute it.
-        let transaction = match response {
-            PlainTransactionInfoResponse::ExecutedWithCert(cert, _, _) => {
-                self.metrics
-                    .total_times_conflicting_transaction_already_finalized_when_retrying
-                    .inc();
-                // We still want to ask validators to execute this certificate in case this
-                // certificate is not known to the rest of them (e.g. when
-                // *this* validator is bad).
-                let result = self
-                    .validators
-                    .load()
-                    .process_certificate(
-                        HandleCertificateRequestV1 {
-                            certificate: cert,
-                            include_events: true,
-                            include_input_objects: false,
-                            include_output_objects: false,
-                            include_auxiliary_data: false,
-                        },
-                        client_addr,
-                    )
-                    .await
-                    .tap_ok(|_resp| {
-                        debug!(
-                            ?tx_digest,
-                            ?original_tx_digest,
-                            "Retry conflicting transaction certificate succeeded."
-                        );
-                    })
-                    .tap_err(|err| {
-                        debug!(
-                            ?tx_digest,
-                            ?original_tx_digest,
-                            "Retry conflicting transaction certificate got an error: {:?}",
-                            err
-                        );
-                    });
-                // We only try it once.
-                return Ok(result.is_ok());
-            }
-            PlainTransactionInfoResponse::Signed(signed) => {
-                signed.verify_committee_sigs_only(&self.clone_committee())?;
-                signed.into_unsigned()
-            }
-            PlainTransactionInfoResponse::ExecutedWithoutCert(transaction, _, _) => transaction,
-        };
-        // Now ask validators to execute this transaction.
-        let result = self
-            .validators
-            .load()
-            .execute_transaction_block(&transaction, client_addr)
-            .await
-            .tap_ok(|_resp| {
-                debug!(
-                    ?tx_digest,
-                    ?original_tx_digest,
-                    "Retry conflicting transaction succeeded."
-                );
-            })
-            .tap_err(|err| {
-                debug!(
-                    ?tx_digest,
-                    ?original_tx_digest,
-                    "Retry conflicting transaction got an error: {:?}",
-                    err
-                );
-            });
-        // We only try it once
-        Ok(result.is_ok())
     }
 }
 

--- a/crates/iota-core/src/quorum_driver/mod.rs
+++ b/crates/iota-core/src/quorum_driver/mod.rs
@@ -367,8 +367,7 @@ where
                 );
                 Err(Some(QuorumDriverError::ObjectsDoubleUsed {
                     conflicting_txes: conflicting_tx_digests,
-                    retried_tx: None,
-                    retried_tx_success: None,
+                    retried_tx_status: None,
                 }))
             }
 
@@ -464,8 +463,7 @@ where
                 );
                 Err(Some(QuorumDriverError::ObjectsDoubleUsed {
                     conflicting_txes: conflicting_tx_digests,
-                    retried_tx: None,
-                    retried_tx_success: None,
+                    retried_tx_status: None,
                 }))
             }
             Ok(success) => {
@@ -482,8 +480,7 @@ where
                 }
                 Err(Some(QuorumDriverError::ObjectsDoubleUsed {
                     conflicting_txes: conflicting_tx_digests,
-                    retried_tx: Some(conflicting_tx_digest),
-                    retried_tx_success: Some(success),
+                    retried_tx_status: Some((conflicting_tx_digest, success)),
                 }))
             }
         }

--- a/crates/iota-core/src/quorum_driver/tests.rs
+++ b/crates/iota-core/src/quorum_driver/tests.rs
@@ -314,12 +314,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
     // there are not enough retryable errors to push the original tx or the most
     // staked conflicting tx >= 2f+1 stake. Neither transaction can be retried
     // due to client double spend and this is a fatal error.
-    if let Err(QuorumDriverError::ObjectsDoubleUsed {
-        conflicting_txes,
-        retried_tx_status,
-    }) = res
-    {
-        assert_eq!(retried_tx_status, None);
+    if let Err(QuorumDriverError::ObjectsDoubleUsed { conflicting_txes }) = res {
         assert_eq!(conflicting_txes.len(), 1);
         assert_eq!(conflicting_txes.iter().next().unwrap().0, tx.digest());
     } else {
@@ -360,12 +355,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
         .unwrap()
         .await;
     // Aggregator gets three bad responses, and tries tx, which should succeed.
-    if let Err(QuorumDriverError::ObjectsDoubleUsed {
-        conflicting_txes,
-        retried_tx_status,
-    }) = res
-    {
-        assert_eq!(retried_tx_status, Some((*tx.digest(), true)));
+    if let Err(QuorumDriverError::ObjectsDoubleUsed { conflicting_txes }) = res {
         assert_eq!(conflicting_txes.len(), 1);
         assert_eq!(conflicting_txes.iter().next().unwrap().0, tx.digest());
     } else {
@@ -428,21 +418,19 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
     let tx3 = make_tx(&gas, sender, &keypair, rgp);
 
     let res = quorum_driver
-        .submit_transaction(ExecuteTransactionRequestV1::new(tx3))
-        .await
-        .unwrap()
+        .submit_transaction(ExecuteTransactionRequestV1::new(tx3.clone()))
+        .await?
         .await;
 
-    if let Err(QuorumDriverError::ObjectsDoubleUsed {
-        conflicting_txes,
-        retried_tx_status,
-    }) = res
-    {
-        assert_eq!(retried_tx_status, None);
-        assert_eq!(conflicting_txes.len(), 2);
+    if let Err(QuorumDriverError::ObjectsDoubleUsed { conflicting_txes }) = res {
         let tx_stake = conflicting_txes.get(tx.digest()).unwrap().1;
-        assert!(tx_stake == 2500 || tx_stake == 5000);
-        assert_eq!(conflicting_txes.get(tx2.digest()).unwrap().1, 2500);
+        if tx_stake == 5000 {
+            assert_eq!(conflicting_txes.len(), 1);
+        } else {
+            assert_eq!(conflicting_txes.len(), 2);
+            assert_eq!(tx_stake, 2500);
+            assert_eq!(conflicting_txes.get(tx2.digest()).unwrap().1, 2500);
+        }
     } else {
         panic!(
             "expect Err(QuorumDriverError::ObjectsDoubleUsed) but got {:?}",
@@ -480,12 +468,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
         .unwrap()
         .await;
 
-    if let Err(QuorumDriverError::ObjectsDoubleUsed {
-        conflicting_txes,
-        retried_tx_status,
-    }) = res
-    {
-        assert_eq!(retried_tx_status, None);
+    if let Err(QuorumDriverError::ObjectsDoubleUsed { conflicting_txes }) = res {
         assert_eq!(conflicting_txes.len(), 1);
         assert_eq!(conflicting_txes.get(tx.digest()).unwrap().1, 5000);
     } else {
@@ -563,12 +546,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
         .unwrap()
         .await;
 
-    if let Err(QuorumDriverError::ObjectsDoubleUsed {
-        conflicting_txes,
-        retried_tx_status,
-    }) = res
-    {
-        assert_eq!(retried_tx_status, None);
+    if let Err(QuorumDriverError::ObjectsDoubleUsed { conflicting_txes }) = res {
         assert!(conflicting_txes.len() == 3 || conflicting_txes.len() == 2);
         assert!(
             conflicting_txes

--- a/crates/iota-core/src/quorum_driver/tests.rs
+++ b/crates/iota-core/src/quorum_driver/tests.rs
@@ -316,12 +316,10 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
     // due to client double spend and this is a fatal error.
     if let Err(QuorumDriverError::ObjectsDoubleUsed {
         conflicting_txes,
-        retried_tx,
-        retried_tx_success,
+        retried_tx_status,
     }) = res
     {
-        assert_eq!(retried_tx, None);
-        assert_eq!(retried_tx_success, None);
+        assert_eq!(retried_tx_status, None);
         assert_eq!(conflicting_txes.len(), 1);
         assert_eq!(conflicting_txes.iter().next().unwrap().0, tx.digest());
     } else {
@@ -364,12 +362,10 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
     // Aggregator gets three bad responses, and tries tx, which should succeed.
     if let Err(QuorumDriverError::ObjectsDoubleUsed {
         conflicting_txes,
-        retried_tx,
-        retried_tx_success,
+        retried_tx_status,
     }) = res
     {
-        assert_eq!(retried_tx, Some(*tx.digest()));
-        assert_eq!(retried_tx_success, Some(true));
+        assert_eq!(retried_tx_status, Some((*tx.digest(), true)));
         assert_eq!(conflicting_txes.len(), 1);
         assert_eq!(conflicting_txes.iter().next().unwrap().0, tx.digest());
     } else {
@@ -439,12 +435,10 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
 
     if let Err(QuorumDriverError::ObjectsDoubleUsed {
         conflicting_txes,
-        retried_tx,
-        retried_tx_success,
+        retried_tx_status,
     }) = res
     {
-        assert_eq!(retried_tx, None);
-        assert_eq!(retried_tx_success, None);
+        assert_eq!(retried_tx_status, None);
         assert_eq!(conflicting_txes.len(), 2);
         let tx_stake = conflicting_txes.get(tx.digest()).unwrap().1;
         assert!(tx_stake == 2500 || tx_stake == 5000);
@@ -488,12 +482,10 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
 
     if let Err(QuorumDriverError::ObjectsDoubleUsed {
         conflicting_txes,
-        retried_tx,
-        retried_tx_success,
+        retried_tx_status,
     }) = res
     {
-        assert_eq!(retried_tx, None);
-        assert_eq!(retried_tx_success, None);
+        assert_eq!(retried_tx_status, None);
         assert_eq!(conflicting_txes.len(), 1);
         assert_eq!(conflicting_txes.get(tx.digest()).unwrap().1, 5000);
     } else {
@@ -573,12 +565,10 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
 
     if let Err(QuorumDriverError::ObjectsDoubleUsed {
         conflicting_txes,
-        retried_tx,
-        retried_tx_success,
+        retried_tx_status,
     }) = res
     {
-        assert_eq!(retried_tx, None);
-        assert_eq!(retried_tx_success, None);
+        assert_eq!(retried_tx_status, None);
         assert!(conflicting_txes.len() == 3 || conflicting_txes.len() == 2);
         assert!(
             conflicting_txes

--- a/crates/iota-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_aggregator_tests.rs
@@ -1548,10 +1548,7 @@ async fn test_handle_conflicting_transaction_response() {
         |e| {
             matches!(
                 e,
-                AggregatorProcessTransactionError::RetryableConflictingTransaction {
-                    conflicting_tx_digest_to_retry,
-                    ..
-                } if conflicting_tx_digest_to_retry.is_none()
+                AggregatorProcessTransactionError::RetryableTransaction { .. }
             )
         },
         |e| matches!(e, IotaError::ObjectLockConflict { .. } | IotaError::Rpc(..)),
@@ -1576,17 +1573,14 @@ async fn test_handle_conflicting_transaction_response() {
         |e| {
             matches!(
                 e,
-                AggregatorProcessTransactionError::RetryableConflictingTransaction {
-                    conflicting_tx_digest_to_retry,
-                    ..
-                } if conflicting_tx_digest_to_retry.is_none()
+                AggregatorProcessTransactionError::RetryableTransaction { .. }
             )
         },
         |e| matches!(e, IotaError::ObjectLockConflict { .. } | IotaError::Rpc(..)),
     )
     .await;
 
-    println!("Case 2 - Non-retryable Tx but Retryable Conflicting Transaction");
+    println!("Case 2 - Non-retryable Tx1 due to conflicting Tx2");
     // Validators return >= f+1 conflicting Tx2
     set_retryable_tx_info_response_error(&mut clients, &authority_keys);
     for (name, _) in authority_keys.iter().skip(1) {
@@ -1603,10 +1597,10 @@ async fn test_handle_conflicting_transaction_response() {
         |e| {
             matches!(
                 e,
-                AggregatorProcessTransactionError::RetryableConflictingTransaction {
-                    conflicting_tx_digest_to_retry,
+                AggregatorProcessTransactionError::FatalConflictingTransaction {
+                    conflicting_tx_digests,
                     ..
-                } if *conflicting_tx_digest_to_retry == Some(*conflicting_tx2.digest())
+                } if conflicting_tx_digests.contains_key(conflicting_tx2.digest())
             )
         },
         |e| matches!(e, IotaError::ObjectLockConflict { .. } | IotaError::Rpc(..)),
@@ -1630,14 +1624,17 @@ async fn test_handle_conflicting_transaction_response() {
         |e| {
             matches!(
                 e,
-                AggregatorProcessTransactionError::FatalConflictingTransaction { .. }
+                AggregatorProcessTransactionError::FatalConflictingTransaction {
+                    conflicting_tx_digests,
+                    ..
+                } if conflicting_tx_digests.contains_key(conflicting_tx2.digest())
             )
         },
         |e| matches!(e, IotaError::ObjectLockConflict { .. }),
     )
     .await;
 
-    println!("Case 3 - Non-retryable Tx (Mixed Response - 2 conflicts, 1 signed, 1 non-retryable)");
+    println!("Case 4 - Non-retryable Tx (Mixed Response - 2 conflicts, 1 signed, 1 non-retryable)");
     // Validator 1 returns a signed tx1
     set_tx_info_response_with_signed_tx(&mut clients, &authority_keys, &tx1, 0);
     // Validator 2 returns a conflicting tx2
@@ -1675,7 +1672,10 @@ async fn test_handle_conflicting_transaction_response() {
         |e| {
             matches!(
                 e,
-                AggregatorProcessTransactionError::FatalConflictingTransaction { .. }
+                AggregatorProcessTransactionError::FatalConflictingTransaction {
+                    conflicting_tx_digests,
+                    ..
+                } if !conflicting_tx_digests.is_empty()
             )
         },
         |e| {
@@ -1689,7 +1689,7 @@ async fn test_handle_conflicting_transaction_response() {
     .await;
 
     println!(
-        "Case 3.1 - Non-retryable Tx (Mixed Response - 1 conflict, 1 signed, 1 non-retryable, 1 retryable)"
+        "Case 4.1 - Non-retryable Tx (Mixed Response - 1 conflict, 1 signed, 1 non-retryable, 1 retryable)"
     );
     // Validator 1 returns a signed tx1
     set_tx_info_response_with_signed_tx(&mut clients, &authority_keys, &tx1, 0);
@@ -1728,7 +1728,12 @@ async fn test_handle_conflicting_transaction_response() {
         |e| {
             matches!(
                 e,
-                AggregatorProcessTransactionError::FatalConflictingTransaction { .. }
+                AggregatorProcessTransactionError::FatalConflictingTransaction {
+                    conflicting_tx_digests,
+                    ..
+                } if conflicting_tx_digests.contains_key(conflicting_tx2.digest()) &&
+                conflicting_tx_digests.contains_key(conflicting_tx3.digest())
+
             )
         },
         |e| {
@@ -1741,7 +1746,7 @@ async fn test_handle_conflicting_transaction_response() {
     .await;
 
     println!(
-        "Case 3.2 - Non-retryable Tx (Mixed Response - 1 conflict, 1 signed, 1 non-retryable, 1 ObjectNotFoundError)"
+        "Case 4.2 - Non-retryable Tx (Mixed Response - 1 conflict, 1 signed, 1 non-retryable, 1 ObjectNotFoundError)"
     );
     // Validator 1 returns a signed tx1
     set_tx_info_response_with_signed_tx(&mut clients, &authority_keys, &tx1, 0);
@@ -1768,7 +1773,10 @@ async fn test_handle_conflicting_transaction_response() {
         |e| {
             matches!(
                 e,
-                AggregatorProcessTransactionError::FatalConflictingTransaction { .. }
+                AggregatorProcessTransactionError::FatalConflictingTransaction {
+                    conflicting_tx_digests,
+                    ..
+                } if conflicting_tx_digests.contains_key(conflicting_tx2.digest())
             )
         },
         |e| {
@@ -1782,7 +1790,7 @@ async fn test_handle_conflicting_transaction_response() {
     )
     .await;
 
-    println!("Case 4 - Successful Conflicting Transaction with Cert");
+    println!("Case 5 - Successful Conflicting Transaction with Cert");
     // All Validators gives signed-tx
     set_tx_info_response_with_signed_tx(&mut clients, &authority_keys, &tx1, 0);
 
@@ -1821,7 +1829,7 @@ async fn test_handle_conflicting_transaction_response() {
         .await
         .unwrap();
 
-    println!("Case 5 - Retryable Transaction (MissingCommitteeAtEpoch Error)");
+    println!("Case 6 - Retryable Transaction (MissingCommitteeAtEpoch Error)");
     // Validators return signed-tx with epoch 1
     set_tx_info_response_with_signed_tx(&mut clients, &authority_keys, &tx1, 1);
 
@@ -1864,7 +1872,7 @@ async fn test_handle_conflicting_transaction_response() {
         |e| {
             matches!(
                 e,
-                AggregatorProcessTransactionError::RetryableConflictingTransaction { .. }
+                AggregatorProcessTransactionError::RetryableTransaction { .. }
             )
         },
         |e| {
@@ -1876,7 +1884,7 @@ async fn test_handle_conflicting_transaction_response() {
     )
     .await;
 
-    println!("Case 5.1 - Retryable Transaction (WrongEpoch Error)");
+    println!("Case 6.1 - Retryable Transaction (WrongEpoch Error)");
     // Update committee store to epoch 2, now SafeClient will pass
     let committee_2 =
         Committee::new_for_testing_with_normalized_voting_power(2, authorities.clone());
@@ -1889,7 +1897,7 @@ async fn test_handle_conflicting_transaction_response() {
         |e| {
             matches!(
                 e,
-                AggregatorProcessTransactionError::RetryableConflictingTransaction { .. }
+                AggregatorProcessTransactionError::RetryableTransaction { .. }
             )
         },
         |e| {
@@ -1901,7 +1909,7 @@ async fn test_handle_conflicting_transaction_response() {
     )
     .await;
 
-    println!("Case 5.2 - Successful Cert Transaction");
+    println!("Case 6.2 - Successful Cert Transaction");
     // Update aggregator committee to epoch 2, and transaction will succeed.
     agg.committee = Arc::new(committee_2);
     agg.process_transaction(tx1.clone().into(), Some(client_ip))
@@ -2465,14 +2473,6 @@ async fn assert_resp_err<E, F>(
 {
     match agg.process_transaction(tx, Some(make_socket_addr())).await {
         Err(received_agg_err) if agg_err_checker(&received_agg_err) => match received_agg_err {
-            AggregatorProcessTransactionError::RetryableConflictingTransaction {
-                errors,
-                conflicting_tx_digest_to_retry: _,
-                conflicting_tx_digests,
-            } => {
-                assert!(!conflicting_tx_digests.is_empty());
-                assert!(errors.iter().map(|e| &e.0).all(iota_err_checker));
-            }
             AggregatorProcessTransactionError::TxAlreadyFinalizedWithDifferentUserSignatures => (),
             AggregatorProcessTransactionError::FatalConflictingTransaction {
                 errors,

--- a/crates/iota-json-rpc/src/error.rs
+++ b/crates/iota-json-rpc/src/error.rs
@@ -170,10 +170,7 @@ impl From<Error> for RpcError {
                         );
                         RpcError::Call(error_object)
                     }
-                    QuorumDriverError::ObjectsDoubleUsed {
-                        conflicting_txes,
-                        retried_tx_status: _,
-                    } => {
+                    QuorumDriverError::ObjectsDoubleUsed { conflicting_txes } => {
                         let new_map = conflicting_txes
                             .into_iter()
                             .map(|(digest, (pairs, _))| {
@@ -371,18 +368,17 @@ mod tests {
             let authority_name = AuthorityPublicKeyBytes([1; AuthorityPublicKey::LENGTH]);
             conflicting_txes.insert(tx_digest, (vec![(authority_name, object_ref)], stake_unit));
 
-            let quorum_driver_error = QuorumDriverError::ObjectsDoubleUsed {
-                conflicting_txes,
-                retried_tx_status: Some((TransactionDigest::from([1; 32]), true)),
-            };
+            let quorum_driver_error = QuorumDriverError::ObjectsDoubleUsed { conflicting_txes };
 
             let error_object: ErrorObjectOwned = Error::QuorumDriver(quorum_driver_error).into();
 
             let expected_code = expect!["-32002"];
             expected_code.assert_eq(&error_object.code().to_string());
-            let expected_message = expect![
-                "Failed to sign transaction by a quorum of validators because one or more of its objects is reserved for another transaction. Retried transaction 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi (succeeded) because it was able to gather the necessary votes. Other transactions locking these objects:\n- 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi (stake 80.0)\n- 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR (stake 5.0)"
-            ];
+            println!("error_object.message() {}", error_object.message());
+            let expected_message = expect![[r#"
+                Failed to sign transaction by a quorum of validators because one or more of its objects is reserved for another transaction. Other transactions locking these objects:
+                - 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi (stake 80.0)
+                - 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR (stake 5.0)"#]];
             expected_message.assert_eq(error_object.message());
             let expected_data = expect![[
                 r#"{"4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]],"8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]]}"#
@@ -413,20 +409,17 @@ mod tests {
             let authority_name = AuthorityPublicKeyBytes([1; AuthorityPublicKey::LENGTH]);
             conflicting_txes.insert(tx_digest, (vec![(authority_name, object_ref)], stake_unit));
 
-            let quorum_driver_error = QuorumDriverError::ObjectsDoubleUsed {
-                conflicting_txes,
-                // below threshold
-                retried_tx_status: None,
-            };
+            let quorum_driver_error = QuorumDriverError::ObjectsDoubleUsed { conflicting_txes };
 
             let rpc_error: RpcError = Error::QuorumDriver(quorum_driver_error).into();
 
             let error_object = error_object_from_rpc(rpc_error);
             let expected_code = expect!["-32002"];
             expected_code.assert_eq(&error_object.code().to_string());
-            let expected_message = expect![
-                "Failed to sign transaction by a quorum of validators because one or more of its objects is equivocated until the next epoch.  Other transactions locking these objects:\n- 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR (stake 50.0)\n- 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi (stake 40.0)"
-            ];
+            let expected_message = expect![[r#"
+                Failed to sign transaction by a quorum of validators because one or more of its objects is equivocated until the next epoch. Other transactions locking these objects:
+                - 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR (stake 50.0)
+                - 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi (stake 40.0)"#]];
             expected_message.assert_eq(error_object.message());
             let expected_data = expect![[
                 r#"{"4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]],"8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]]}"#

--- a/crates/iota-json-rpc/src/error.rs
+++ b/crates/iota-json-rpc/src/error.rs
@@ -14,7 +14,6 @@ use iota_types::{
     error::{IotaError, IotaObjectResponseError, UserInputError},
     quorum_driver_types::QuorumDriverError,
 };
-use itertools::Itertools;
 use jsonrpsee::{
     core::{ClientError as RpcError, RegisterMethodError},
     types::{
@@ -158,48 +157,23 @@ impl From<Error> for RpcError {
                 }
             },
             Error::QuorumDriver(err) => {
+                let error_msg = err.to_error_message();
+
                 match err {
-                    QuorumDriverError::InvalidUserSignature(err) => {
-                        let inner_error_str = match err {
-                            // TODO(wlmyng): update IotaError display trait to render UserInputError
-                            // with display
-                            IotaError::UserInput { error } => error.to_string(),
-                            _ => err.to_string(),
-                        };
-
-                        let error_message = format!("Invalid user signature: {inner_error_str}");
-
+                    QuorumDriverError::InvalidUserSignature { .. }
+                    | QuorumDriverError::TxAlreadyFinalizedWithDifferentUserSignatures
+                    | QuorumDriverError::NonRecoverableTransactionError { .. } => {
                         let error_object = ErrorObject::owned::<()>(
                             TRANSACTION_EXECUTION_CLIENT_ERROR_CODE,
-                            error_message,
+                            error_msg,
                             None,
                         );
-                        RpcError::Call(error_object)
-                    }
-                    QuorumDriverError::TxAlreadyFinalizedWithDifferentUserSignatures => {
-                        let error_object = ErrorObject::owned::<()>(
-                            TRANSACTION_EXECUTION_CLIENT_ERROR_CODE,
-                            "The transaction is already finalized but with different user signatures",
-                            None,
-                        );
-                        RpcError::Call(error_object)
-                    }
-                    QuorumDriverError::TimeoutBeforeFinality
-                    | QuorumDriverError::FailedWithTransientErrorAfterMaximumAttempts { .. } => {
-                        let error_object =
-                            ErrorObject::owned::<()>(TRANSIENT_ERROR_CODE, err.to_string(), None);
                         RpcError::Call(error_object)
                     }
                     QuorumDriverError::ObjectsDoubleUsed {
                         conflicting_txes,
-                        retried_tx,
-                        retried_tx_success,
+                        retried_tx_status: _,
                     } => {
-                        let error_message = format!(
-                            "Failed to sign transaction by a quorum of validators because of locked objects. Retried a conflicting transaction {:?}, success: {:?}",
-                            retried_tx, retried_tx_success
-                        );
-
                         let new_map = conflicting_txes
                             .into_iter()
                             .map(|(digest, (pairs, _))| {
@@ -212,71 +186,22 @@ impl From<Error> for RpcError {
 
                         let error_object = ErrorObject::owned(
                             TRANSACTION_EXECUTION_CLIENT_ERROR_CODE,
-                            error_message,
+                            error_msg,
                             Some(new_map),
                         );
                         RpcError::Call(error_object)
                     }
-                    QuorumDriverError::NonRecoverableTransactionError { errors } => {
-                        let new_errors: Vec<String> = errors
-                            .into_iter()
-                            // sort by total stake, descending, so users see the most prominent one
-                            // first
-                            .sorted_by(|(_, a, _), (_, b, _)| b.cmp(a))
-                            .filter_map(|(err, _, _)| {
-                                match &err {
-                                    // Special handling of UserInputError:
-                                    // ObjectNotFound and DependentPackageNotFound are considered
-                                    // retryable errors but they have different treatment
-                                    // in AuthorityAggregator.
-                                    // The optimal fix would be to examine if the total stake
-                                    // of ObjectNotFound/DependentPackageNotFound exceeds the
-                                    // quorum threshold, but it takes a Committee here.
-                                    // So, we take an easier route and consider them non-retryable
-                                    // at all. Combining this with the sorting above, clients will
-                                    // see the dominant error first.
-                                    IotaError::UserInput { error } => Some(error.to_string()),
-                                    _ => {
-                                        if err.is_retryable().0 {
-                                            None
-                                        } else {
-                                            Some(err.to_string())
-                                        }
-                                    }
-                                }
-                            })
-                            .collect();
-
-                        assert!(
-                            !new_errors.is_empty(),
-                            "NonRecoverableTransactionError should have at least one non-retryable error"
-                        );
-
-                        let error_list = new_errors.join(", ");
-                        let error_msg = format!(
-                            "Transaction execution failed due to issues with transaction inputs, please review the errors and try again: {}.",
-                            error_list
-                        );
-
-                        let error_object = ErrorObject::owned::<()>(
-                            TRANSACTION_EXECUTION_CLIENT_ERROR_CODE,
-                            error_msg,
-                            None,
-                        );
+                    QuorumDriverError::TimeoutBeforeFinality
+                    | QuorumDriverError::FailedWithTransientErrorAfterMaximumAttempts { .. }
+                    | QuorumDriverError::SystemOverload { .. }
+                    | QuorumDriverError::SystemOverloadRetryAfter { .. } => {
+                        let error_object =
+                            ErrorObject::owned::<()>(TRANSIENT_ERROR_CODE, error_msg, None);
                         RpcError::Call(error_object)
                     }
                     QuorumDriverError::QuorumDriverInternal(_) => {
-                        let error_object = ErrorObject::owned::<()>(
-                            INTERNAL_ERROR_CODE,
-                            "Internal error occurred while executing transaction.",
-                            None,
-                        );
-                        RpcError::Call(error_object)
-                    }
-                    QuorumDriverError::SystemOverload { .. }
-                    | QuorumDriverError::SystemOverloadRetryAfter { .. } => {
                         let error_object =
-                            ErrorObject::owned::<()>(TRANSIENT_ERROR_CODE, err.to_string(), None);
+                            ErrorObject::owned::<()>(INTERNAL_ERROR_CODE, error_msg, None);
                         RpcError::Call(error_object)
                     }
                 }
@@ -432,16 +357,66 @@ mod tests {
                 TransactionDigest,
                 (Vec<(AuthorityName, ObjectRef)>, StakeUnit),
             > = BTreeMap::new();
-            let tx_digest = TransactionDigest::default();
+            let tx_digest = TransactionDigest::from([1; 32]);
             let object_ref = test_object_ref();
-            let stake_unit: StakeUnit = 10;
+            // 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi has enough stake to escape
+            // equivocation
+            let stake_unit: StakeUnit = 8000;
             let authority_name = AuthorityPublicKeyBytes([0; AuthorityPublicKey::LENGTH]);
+            conflicting_txes.insert(tx_digest, (vec![(authority_name, object_ref)], stake_unit));
+
+            // 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR stake below quorum threshold
+            let tx_digest = TransactionDigest::from([2; 32]);
+            let stake_unit: StakeUnit = 500;
+            let authority_name = AuthorityPublicKeyBytes([1; AuthorityPublicKey::LENGTH]);
             conflicting_txes.insert(tx_digest, (vec![(authority_name, object_ref)], stake_unit));
 
             let quorum_driver_error = QuorumDriverError::ObjectsDoubleUsed {
                 conflicting_txes,
-                retried_tx: Some(TransactionDigest::default()),
-                retried_tx_success: Some(true),
+                retried_tx_status: Some((TransactionDigest::from([1; 32]), true)),
+            };
+
+            let error_object: ErrorObjectOwned = Error::QuorumDriver(quorum_driver_error).into();
+
+            let expected_code = expect!["-32002"];
+            expected_code.assert_eq(&error_object.code().to_string());
+            let expected_message = expect![
+                "Failed to sign transaction by a quorum of validators because one or more of its objects is reserved for another transaction. Retried transaction 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi (succeeded) because it was able to gather the necessary votes. Other transactions locking these objects:\n- 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi (stake 80.0)\n- 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR (stake 5.0)"
+            ];
+            expected_message.assert_eq(error_object.message());
+            let expected_data = expect![[
+                r#"{"4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]],"8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]]}"#
+            ]];
+            let actual_data = error_object.data().unwrap().to_string();
+            expected_data.assert_eq(&actual_data);
+        }
+
+        #[test]
+        fn test_objects_double_used_equivocated() {
+            use iota_types::crypto::VerifyingKey;
+            let mut conflicting_txes: BTreeMap<
+                TransactionDigest,
+                (Vec<(AuthorityName, ObjectRef)>, StakeUnit),
+            > = BTreeMap::new();
+            let tx_digest = TransactionDigest::from([1; 32]);
+            let object_ref = test_object_ref();
+
+            // 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi has lower stake at 10
+            let stake_unit: StakeUnit = 4000;
+            let authority_name = AuthorityPublicKeyBytes([0; AuthorityPublicKey::LENGTH]);
+            conflicting_txes.insert(tx_digest, (vec![(authority_name, object_ref)], stake_unit));
+
+            // 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR is a higher stake and should be
+            // first in the list
+            let tx_digest = TransactionDigest::from([2; 32]);
+            let stake_unit: StakeUnit = 5000;
+            let authority_name = AuthorityPublicKeyBytes([1; AuthorityPublicKey::LENGTH]);
+            conflicting_txes.insert(tx_digest, (vec![(authority_name, object_ref)], stake_unit));
+
+            let quorum_driver_error = QuorumDriverError::ObjectsDoubleUsed {
+                conflicting_txes,
+                // below threshold
+                retried_tx_status: None,
             };
 
             let rpc_error: RpcError = Error::QuorumDriver(quorum_driver_error).into();
@@ -450,11 +425,11 @@ mod tests {
             let expected_code = expect!["-32002"];
             expected_code.assert_eq(&error_object.code().to_string());
             let expected_message = expect![
-                "Failed to sign transaction by a quorum of validators because of locked objects. Retried a conflicting transaction Some(TransactionDigest(11111111111111111111111111111111)), success: Some(true)"
+                "Failed to sign transaction by a quorum of validators because one or more of its objects is equivocated until the next epoch.  Other transactions locking these objects:\n- 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR (stake 50.0)\n- 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi (stake 40.0)"
             ];
             expected_message.assert_eq(error_object.message());
             let expected_data = expect![[
-                r#"{"11111111111111111111111111111111":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]]}"#
+                r#"{"4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]],"8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]]}"#
             ]];
             let actual_data = error_object.data().unwrap().to_string();
             expected_data.assert_eq(&actual_data);
@@ -493,7 +468,7 @@ mod tests {
             let expected_code = expect!["-32002"];
             expected_code.assert_eq(&error_object.code().to_string());
             let expected_message = expect![
-                "Transaction execution failed due to issues with transaction inputs, please review the errors and try again: Balance of gas object 10 is lower than the needed amount: 100, Object (0x0000000000000000000000000000000000000000000000000000000000000000, SequenceNumber(0), o#11111111111111111111111111111111) is not available for consumption, its current version: SequenceNumber(10)."
+                "Transaction execution failed due to issues with transaction inputs, please review the errors and try again:\n- Balance of gas object 10 is lower than the needed amount: 100\n- Object ID 0x0000000000000000000000000000000000000000000000000000000000000000 Version 0x0 Digest 11111111111111111111111111111111 is not available for consumption, current version: 0xa"
             ];
             expected_message.assert_eq(error_object.message());
         }
@@ -526,7 +501,7 @@ mod tests {
             let expected_code = expect!["-32002"];
             expected_code.assert_eq(&error_object.code().to_string());
             let expected_message = expect![
-                "Transaction execution failed due to issues with transaction inputs, please review the errors and try again: Could not find the referenced object 0x0000000000000000000000000000000000000000000000000000000000000000 at version None."
+                "Transaction execution failed due to issues with transaction inputs, please review the errors and try again:\n- Could not find the referenced object 0x0000000000000000000000000000000000000000000000000000000000000000 at version None"
             ];
             expected_message.assert_eq(error_object.message());
         }

--- a/crates/iota-node/Cargo.toml
+++ b/crates/iota-node/Cargo.toml
@@ -28,7 +28,6 @@ humantime.workspace = true
 prometheus.workspace = true
 reqwest.workspace = true
 serde.workspace = true
-snap.workspace = true
 tap.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tower.workspace = true

--- a/crates/iota-node/src/metrics.rs
+++ b/crates/iota-node/src/metrics.rs
@@ -2,53 +2,16 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
-use axum::http::header;
+use iota_common::metrics::{MetricsPushClient, push_metrics};
 use iota_metrics::RegistryService;
 use iota_network::tonic::Code;
 use iota_network_stack::metrics::MetricsCallbackProvider;
 use prometheus::{
-    Encoder, HistogramVec, IntCounterVec, IntGaugeVec, PROTOBUF_FORMAT, Registry,
-    register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
-    register_int_gauge_vec_with_registry,
+    HistogramVec, IntCounterVec, IntGaugeVec, Registry, register_histogram_vec_with_registry,
+    register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry,
 };
-use tracing::error;
-
-const METRICS_PUSH_TIMEOUT: Duration = Duration::from_secs(45);
-
-pub struct MetricsPushClient {
-    certificate: std::sync::Arc<iota_tls::SelfSignedCertificate>,
-    client: reqwest::Client,
-}
-
-impl MetricsPushClient {
-    pub fn new(network_key: iota_types::crypto::NetworkKeyPair) -> Self {
-        use fastcrypto::traits::KeyPair;
-        let certificate = std::sync::Arc::new(iota_tls::SelfSignedCertificate::new(
-            network_key.private(),
-            iota_tls::IOTA_VALIDATOR_SERVER_NAME,
-        ));
-        let identity = certificate.reqwest_identity();
-        let client = reqwest::Client::builder()
-            .identity(identity)
-            .build()
-            .unwrap();
-
-        Self {
-            certificate,
-            client,
-        }
-    }
-
-    pub fn certificate(&self) -> &iota_tls::SelfSignedCertificate {
-        &self.certificate
-    }
-
-    pub fn client(&self) -> &reqwest::Client {
-        &self.client
-    }
-}
 
 /// Starts a task to periodically push metrics to a configured endpoint if a
 /// metrics push endpoint is configured.
@@ -76,63 +39,6 @@ pub fn start_metrics_push_task(config: &iota_config::NodeConfig, registry: Regis
     // metrics
     let config_copy = config.clone();
     let mut client = MetricsPushClient::new(config_copy.network_key_pair().copy());
-
-    async fn push_metrics(
-        client: &MetricsPushClient,
-        url: &reqwest::Url,
-        registry: &RegistryService,
-    ) -> Result<(), anyhow::Error> {
-        // now represents a collection timestamp for all of the metrics we send to the
-        // proxy
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as i64;
-
-        let mut metric_families = registry.gather_all();
-        for mf in metric_families.iter_mut() {
-            for m in mf.mut_metric() {
-                m.set_timestamp_ms(now);
-            }
-        }
-
-        let mut buf: Vec<u8> = vec![];
-        let encoder = prometheus::ProtobufEncoder::new();
-        encoder.encode(&metric_families, &mut buf)?;
-
-        let mut s = snap::raw::Encoder::new();
-        let compressed = s.compress_vec(&buf).map_err(|err| {
-            error!("unable to snappy encode; {err}");
-            err
-        })?;
-
-        let response = client
-            .client()
-            .post(url.to_owned())
-            .header(reqwest::header::CONTENT_ENCODING, "snappy")
-            .header(header::CONTENT_TYPE, PROTOBUF_FORMAT)
-            .body(compressed)
-            .timeout(METRICS_PUSH_TIMEOUT)
-            .send()
-            .await?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = match response.text().await {
-                Ok(body) => body,
-                Err(error) => format!("couldn't decode response body; {error}"),
-            };
-            return Err(anyhow::anyhow!(
-                "metrics push failed: [{}]:{}",
-                status,
-                body
-            ));
-        }
-
-        tracing::debug!("successfully pushed metrics to {url}");
-
-        Ok(())
-    }
 
     tokio::spawn(async move {
         tracing::info!(push_url =% url, interval =? interval, "Started Metrics Push Service");

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -2318,6 +2318,17 @@ mod test {
     }
 
     #[test]
+    #[should_panic(expected = "unsupported version")]
+    fn max_version_test() {
+        // When this does not panic, version higher than MAX_PROTOCOL_VERSION exists.
+        // To fix, bump MAX_PROTOCOL_VERSION or disable this check for the version.
+        let _ = ProtocolConfig::get_for_version_impl(
+            ProtocolVersion::new(MAX_PROTOCOL_VERSION + 1),
+            Chain::Unknown,
+        );
+    }
+
+    #[test]
     fn lookup_by_string_test() {
         let prot: ProtocolConfig =
             ProtocolConfig::get_for_version(ProtocolVersion::new(1), Chain::Mainnet);

--- a/crates/iota-proxy/src/admin.rs
+++ b/crates/iota-proxy/src/admin.rs
@@ -28,7 +28,7 @@ use crate::{
     handlers::publish_metrics,
     histogram_relay::HistogramRelay,
     middleware::{expect_content_length, expect_iota_proxy_header, expect_valid_public_key},
-    peers::{IotaNodeProvider, IotaPeer},
+    peers::{AllowedPeer, IotaNodeProvider},
     var,
 };
 
@@ -214,7 +214,7 @@ fn load_private_key(filename: &str) -> rustls::pki_types::PrivateKeyDer<'static>
 /// metrics
 fn load_static_peers(
     static_peers: Option<StaticPeerValidationConfig>,
-) -> Result<Vec<IotaPeer>, Error> {
+) -> Result<Vec<AllowedPeer>, Error> {
     let Some(static_peers) = static_peers else {
         return Ok(vec![]);
     };
@@ -224,7 +224,7 @@ fn load_static_peers(
         .map(|spk| {
             let peer_id = hex::decode(spk.peer_id).unwrap();
             let public_key = Ed25519PublicKey::from_bytes(peer_id.as_ref()).unwrap();
-            let s = IotaPeer {
+            let s = AllowedPeer {
                 name: spk.name.clone(),
                 public_key,
             };

--- a/crates/iota-proxy/src/handlers.rs
+++ b/crates/iota-proxy/src/handlers.rs
@@ -17,7 +17,7 @@ use crate::{
     consumer::{NodeMetric, convert_to_remote_write, populate_labels},
     histogram_relay::HistogramRelay,
     middleware::LenDelimProtobuf,
-    peers::IotaPeer,
+    peers::AllowedPeer,
 };
 
 static HANDLER_HITS: Lazy<CounterVec> = Lazy::new(|| {
@@ -51,7 +51,7 @@ pub async fn publish_metrics(
     Extension(labels): Extension<Labels>,
     Extension(client): Extension<ReqwestClient>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
-    Extension(IotaPeer { name, public_key }): Extension<IotaPeer>,
+    Extension(AllowedPeer { name, public_key }): Extension<AllowedPeer>,
     Extension(relay): Extension<HistogramRelay>,
     LenDelimProtobuf(data): LenDelimProtobuf,
 ) -> (StatusCode, &'static str) {

--- a/crates/iota-proxy/src/lib.rs
+++ b/crates/iota-proxy/src/lib.rs
@@ -168,7 +168,7 @@ mod tests {
         // successful
         allower.get_mut().write().unwrap().insert(
             client_pub_key.to_owned(),
-            peers::IotaPeer {
+            peers::AllowedPeer {
                 name: "some-node".into(),
                 public_key: client_pub_key.to_owned(),
             },
@@ -285,7 +285,7 @@ mod tests {
         // successful
         allower.get_mut().write().unwrap().insert(
             client_pub_key.to_owned(),
-            peers::IotaPeer {
+            peers::AllowedPeer {
                 name: "some-node".into(),
                 public_key: client_pub_key.to_owned(),
             },

--- a/crates/iota-proxy/src/peers.rs
+++ b/crates/iota-proxy/src/peers.rs
@@ -24,11 +24,11 @@ use iota_types::{
 use itertools::Itertools;
 use tracing::{debug, error, info};
 
-/// IotaPeers is a mapping of public key to IotaPeer data
-pub type IotaPeers = Arc<RwLock<HashMap<Ed25519PublicKey, IotaPeer>>>;
+/// AllowedPeers is a mapping of public key to AllowedPeer data
+pub type AllowedPeers = Arc<RwLock<HashMap<Ed25519PublicKey, AllowedPeer>>>;
 
 #[derive(Hash, PartialEq, Eq, Debug, Clone)]
-pub struct IotaPeer {
+pub struct AllowedPeer {
     pub name: String,
     pub public_key: Ed25519PublicKey,
 }
@@ -41,9 +41,9 @@ pub struct IotaPeer {
 /// extension to check incoming clients on the http api against known keys.
 #[derive(Debug, Clone)]
 pub struct IotaNodeProvider {
-    active_validator_nodes: IotaPeers,
-    pending_validator_nodes: IotaPeers,
-    static_nodes: IotaPeers,
+    active_validator_nodes: AllowedPeers,
+    pending_validator_nodes: AllowedPeers,
+    static_nodes: AllowedPeers,
     rpc_url: String,
     rpc_poll_interval: Duration,
 }
@@ -65,10 +65,14 @@ impl Allower for IotaNodeProvider {
 }
 
 impl IotaNodeProvider {
-    pub fn new(rpc_url: String, rpc_poll_interval: Duration, static_peers: Vec<IotaPeer>) -> Self {
+    pub fn new(
+        rpc_url: String,
+        rpc_poll_interval: Duration,
+        static_peers: Vec<AllowedPeer>,
+    ) -> Self {
         // build our hashmap with the static pub keys. we only do this one time at
         // binary startup.
-        let static_nodes: HashMap<Ed25519PublicKey, IotaPeer> = static_peers
+        let static_nodes: HashMap<Ed25519PublicKey, AllowedPeer> = static_peers
             .into_iter()
             .map(|v| (v.public_key.clone(), v))
             .collect();
@@ -85,25 +89,25 @@ impl IotaNodeProvider {
     }
 
     /// get is used to retrieve peer info in our handlers
-    pub fn get(&self, key: &Ed25519PublicKey) -> Option<IotaPeer> {
+    pub fn get(&self, key: &Ed25519PublicKey) -> Option<AllowedPeer> {
         debug!("look for {:?}", key);
         // check static nodes first
         if let Some(v) = self.static_nodes.read().unwrap().get(key) {
-            return Some(IotaPeer {
+            return Some(AllowedPeer {
                 name: v.name.to_owned(),
                 public_key: v.public_key.to_owned(),
             });
         }
         // check active validators
         if let Some(v) = self.active_validator_nodes.read().unwrap().get(key) {
-            return Some(IotaPeer {
+            return Some(AllowedPeer {
                 name: v.name.to_owned(),
                 public_key: v.public_key.to_owned(),
             });
         }
         // check pending validators
         if let Some(v) = self.pending_validator_nodes.read().unwrap().get(key) {
-            return Some(IotaPeer {
+            return Some(AllowedPeer {
                 name: v.name.to_owned(),
                 public_key: v.public_key.to_owned(),
             });
@@ -112,7 +116,7 @@ impl IotaNodeProvider {
     }
 
     /// Get a mutable reference to the allowed validator map
-    pub fn get_mut(&mut self) -> &mut IotaPeers {
+    pub fn get_mut(&mut self) -> &mut AllowedPeers {
         &mut self.active_validator_nodes
     }
 
@@ -260,7 +264,7 @@ impl IotaNodeProvider {
 /// list and let us communicate with those actual peers via tls.
 fn extract_validators_from_summaries(
     validator_summaries: &[IotaValidatorSummary],
-) -> impl Iterator<Item = (Ed25519PublicKey, IotaPeer)> + use<'_> {
+) -> impl Iterator<Item = (Ed25519PublicKey, AllowedPeer)> + use<'_> {
     validator_summaries.iter().filter_map(|vm| {
         match Ed25519PublicKey::from_bytes(&vm.network_pubkey_bytes) {
             Ok(public_key) => {
@@ -270,7 +274,7 @@ fn extract_validators_from_summaries(
                 );
                 Some((
                     public_key.clone(),
-                    IotaPeer {
+                    AllowedPeer {
                         name: vm.name.to_owned(),
                         public_key,
                     },

--- a/crates/iota-rest-api/src/error.rs
+++ b/crates/iota-rest-api/src/error.rs
@@ -86,10 +86,7 @@ impl From<iota_types::quorum_driver_types::QuorumDriverError> for RestError {
             QuorumDriverInternal(err) => {
                 RestError::new(StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
             }
-            ObjectsDoubleUsed {
-                conflicting_txes,
-                retried_tx_status,
-            } => {
+            ObjectsDoubleUsed { conflicting_txes } => {
                 let new_map = conflicting_txes
                     .into_iter()
                     .map(|(digest, (pairs, _))| {
@@ -101,10 +98,7 @@ impl From<iota_types::quorum_driver_types::QuorumDriverError> for RestError {
                     .collect::<std::collections::BTreeMap<_, Vec<_>>>();
 
                 let message = format!(
-                    "Failed to sign transaction by a quorum of validators because of locked objects. Retried a conflicting transaction {:?}, success: {:?}. Conflicting Transactions:\n{:#?}",
-                    retried_tx_status.map(|(tx, _)| tx),
-                    retried_tx_status.map(|(_, success)| success),
-                    new_map,
+                    "Failed to sign transaction by a quorum of validators because of locked objects. Conflicting Transactions:\n{new_map:#?}",
                 );
 
                 RestError::new(StatusCode::CONFLICT, message)

--- a/crates/iota-rest-api/src/error.rs
+++ b/crates/iota-rest-api/src/error.rs
@@ -88,8 +88,7 @@ impl From<iota_types::quorum_driver_types::QuorumDriverError> for RestError {
             }
             ObjectsDoubleUsed {
                 conflicting_txes,
-                retried_tx,
-                retried_tx_success,
+                retried_tx_status,
             } => {
                 let new_map = conflicting_txes
                     .into_iter()
@@ -103,7 +102,9 @@ impl From<iota_types::quorum_driver_types::QuorumDriverError> for RestError {
 
                 let message = format!(
                     "Failed to sign transaction by a quorum of validators because of locked objects. Retried a conflicting transaction {:?}, success: {:?}. Conflicting Transactions:\n{:#?}",
-                    retried_tx, retried_tx_success, new_map,
+                    retried_tx_status.map(|(tx, _)| tx),
+                    retried_tx_status.map(|(_, success)| success),
+                    new_map,
                 );
 
                 RestError::new(StatusCode::CONFLICT, message)

--- a/crates/iota-types/src/error.rs
+++ b/crates/iota-types/src/error.rs
@@ -104,7 +104,8 @@ pub enum UserInputError {
         version: Option<SequenceNumber>,
     },
     #[error(
-        "Object {provided_obj_ref:?} is not available for consumption, its current version: {current_version:?}"
+        "Object ID {} Version {} Digest {} is not available for consumption, current version: {current_version}",
+        .provided_obj_ref.0, .provided_obj_ref.1, .provided_obj_ref.2
     )]
     ObjectVersionUnavailableForConsumption {
         provided_obj_ref: ObjectRef,

--- a/crates/iota-types/src/object.rs
+++ b/crates/iota-types/src/object.rs
@@ -1198,77 +1198,86 @@ impl Display for PastObjectRead {
     }
 }
 
-// Ensure that object digest computation and bcs serialized format are not
-// inadvertently changed.
-#[test]
-fn test_object_digest_and_serialized_format() {
-    let g = GasCoin::new_for_testing_with_id(ObjectID::ZERO, 123).to_object(OBJECT_START_VERSION);
-    let o = Object::new_move(
-        g,
-        Owner::AddressOwner(IotaAddress::ZERO),
-        TransactionDigest::ZERO,
-    );
-    let bytes = bcs::to_bytes(&o).unwrap();
+#[cfg(test)]
+mod tests {
+    use crate::{
+        base_types::{IotaAddress, ObjectID, TransactionDigest},
+        gas_coin::GasCoin,
+        object::{OBJECT_START_VERSION, Object, Owner},
+    };
 
-    assert_eq!(
-        bytes,
-        [
-            0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-        ]
-    );
+    // Ensure that object digest computation and bcs serialized format are not
+    // inadvertently changed.
+    #[test]
+    fn test_object_digest_and_serialized_format() {
+        let g =
+            GasCoin::new_for_testing_with_id(ObjectID::ZERO, 123).to_object(OBJECT_START_VERSION);
+        let o = Object::new_move(
+            g,
+            Owner::AddressOwner(IotaAddress::ZERO),
+            TransactionDigest::ZERO,
+        );
+        let bytes = bcs::to_bytes(&o).unwrap();
 
-    let objref = format!("{:?}", o.compute_object_reference());
-    assert_eq!(
-        objref,
-        "(0x0000000000000000000000000000000000000000000000000000000000000000, SequenceNumber(1), o#Ba4YyVBcpc9jgX4PMLRoyt9dKLftYVSDvuKbtMr9f4NM)"
-    );
-}
-
-#[test]
-fn test_get_coin_value_unsafe() {
-    fn test_for_value(v: u64) {
-        let g = GasCoin::new_for_testing(v).to_object(OBJECT_START_VERSION);
-        assert_eq!(g.get_coin_value_unsafe(), v);
-        assert_eq!(GasCoin::try_from(&g).unwrap().value(), v);
+        assert_eq!(
+            bytes,
+            [
+                0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+            ]
+        );
+        let objref = format!("{:?}", o.compute_object_reference());
+        assert_eq!(
+            objref,
+            "(0x0000000000000000000000000000000000000000000000000000000000000000, SequenceNumber(1), o#Ba4YyVBcpc9jgX4PMLRoyt9dKLftYVSDvuKbtMr9f4NM)"
+        );
     }
 
-    test_for_value(0);
-    test_for_value(1);
-    test_for_value(8);
-    test_for_value(9);
-    test_for_value(u8::MAX as u64);
-    test_for_value(u8::MAX as u64 + 1);
-    test_for_value(u16::MAX as u64);
-    test_for_value(u16::MAX as u64 + 1);
-    test_for_value(u32::MAX as u64);
-    test_for_value(u32::MAX as u64 + 1);
-    test_for_value(u64::MAX);
-}
+    #[test]
+    fn test_get_coin_value_unsafe() {
+        fn test_for_value(v: u64) {
+            let g = GasCoin::new_for_testing(v).to_object(OBJECT_START_VERSION);
+            assert_eq!(g.get_coin_value_unsafe(), v);
+            assert_eq!(GasCoin::try_from(&g).unwrap().value(), v);
+        }
 
-#[test]
-fn test_set_coin_value_unsafe() {
-    fn test_for_value(v: u64) {
-        let mut g = GasCoin::new_for_testing(u64::MAX).to_object(OBJECT_START_VERSION);
-        g.set_coin_value_unsafe(v);
-        assert_eq!(g.get_coin_value_unsafe(), v);
-        assert_eq!(GasCoin::try_from(&g).unwrap().value(), v);
-        assert_eq!(g.version(), OBJECT_START_VERSION);
-        assert_eq!(g.contents().len(), 40);
+        test_for_value(0);
+        test_for_value(1);
+        test_for_value(8);
+        test_for_value(9);
+        test_for_value(u8::MAX as u64);
+        test_for_value(u8::MAX as u64 + 1);
+        test_for_value(u16::MAX as u64);
+        test_for_value(u16::MAX as u64 + 1);
+        test_for_value(u32::MAX as u64);
+        test_for_value(u32::MAX as u64 + 1);
+        test_for_value(u64::MAX);
     }
 
-    test_for_value(0);
-    test_for_value(1);
-    test_for_value(8);
-    test_for_value(9);
-    test_for_value(u8::MAX as u64);
-    test_for_value(u8::MAX as u64 + 1);
-    test_for_value(u16::MAX as u64);
-    test_for_value(u16::MAX as u64 + 1);
-    test_for_value(u32::MAX as u64);
-    test_for_value(u32::MAX as u64 + 1);
-    test_for_value(u64::MAX);
+    #[test]
+    fn test_set_coin_value_unsafe() {
+        fn test_for_value(v: u64) {
+            let mut g = GasCoin::new_for_testing(u64::MAX).to_object(OBJECT_START_VERSION);
+            g.set_coin_value_unsafe(v);
+            assert_eq!(g.get_coin_value_unsafe(), v);
+            assert_eq!(GasCoin::try_from(&g).unwrap().value(), v);
+            assert_eq!(g.version(), OBJECT_START_VERSION);
+            assert_eq!(g.contents().len(), 40);
+        }
+
+        test_for_value(0);
+        test_for_value(1);
+        test_for_value(8);
+        test_for_value(9);
+        test_for_value(u8::MAX as u64);
+        test_for_value(u8::MAX as u64 + 1);
+        test_for_value(u16::MAX as u64);
+        test_for_value(u16::MAX as u64 + 1);
+        test_for_value(u32::MAX as u64);
+        test_for_value(u32::MAX as u64 + 1);
+        test_for_value(u64::MAX);
+    }
 }

--- a/crates/iota-types/src/quorum_driver_types.rs
+++ b/crates/iota-types/src/quorum_driver_types.rs
@@ -41,14 +41,10 @@ pub enum QuorumDriverError {
     #[error("Invalid user signature: {0}.")]
     InvalidUserSignature(IotaError),
     #[error(
-        "Failed to sign transaction by a quorum of validators because of locked objects: {:?}, retried a conflicting transaction {:?}, success: {:?}",
-        conflicting_txes,
-        .retried_tx_status.map(|(tx, success)| tx),
-        .retried_tx_status.map(|(tx, success)| success),
+        "Failed to sign transaction by a quorum of validators because of locked objects: {conflicting_txes:?}"
     )]
     ObjectsDoubleUsed {
         conflicting_txes: BTreeMap<TransactionDigest, (Vec<(AuthorityName, ObjectRef)>, StakeUnit)>,
-        retried_tx_status: Option<(TransactionDigest, bool)>,
     },
     #[error("Transaction timed out before reaching finality")]
     TimeoutBeforeFinality,
@@ -91,10 +87,7 @@ impl QuorumDriverError {
             | QuorumDriverError::FailedWithTransientErrorAfterMaximumAttempts { .. }
             | QuorumDriverError::SystemOverload { .. }
             | QuorumDriverError::SystemOverloadRetryAfter { .. } => self.to_string(),
-            QuorumDriverError::ObjectsDoubleUsed {
-                conflicting_txes,
-                retried_tx_status,
-            } => {
+            QuorumDriverError::ObjectsDoubleUsed { conflicting_txes } => {
                 let weights: Vec<u64> =
                     conflicting_txes.values().map(|(_, stake)| *stake).collect();
                 let remaining: u64 = TOTAL_VOTING_POWER - weights.iter().sum::<u64>();
@@ -106,21 +99,9 @@ impl QuorumDriverError {
                     "reserved for another transaction"
                 };
 
-                let retried_info = match retried_tx_status {
-                    Some((digest, success)) => {
-                        format!(
-                            "Retried transaction {} ({}) because it was able to gather the necessary votes.",
-                            digest,
-                            if *success { "succeeded" } else { "failed" }
-                        )
-                    }
-                    None => "".to_string(),
-                };
-
                 format!(
-                    "Failed to sign transaction by a quorum of validators because one or more of its objects is {}. {} Other transactions locking these objects:\n{}",
+                    "Failed to sign transaction by a quorum of validators because one or more of its objects is {}. Other transactions locking these objects:\n{}",
                     reason,
-                    retried_info,
                     conflicting_txes
                         .iter()
                         .sorted_by(|(_, (_, a)), (_, (_, b))| b.cmp(a))

--- a/crates/iota-types/src/quorum_driver_types.rs
+++ b/crates/iota-types/src/quorum_driver_types.rs
@@ -5,13 +5,14 @@
 
 use std::collections::BTreeMap;
 
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use strum::AsRefStr;
 use thiserror::Error;
 
 use crate::{
     base_types::{AuthorityName, EpochId, ObjectRef, TransactionDigest},
-    committee::StakeUnit,
+    committee::{QUORUM_THRESHOLD, StakeUnit, TOTAL_VOTING_POWER},
     crypto::{AuthorityStrongQuorumSignInfo, ConciseAuthorityPublicKeyBytes},
     effects::{
         CertifiedTransactionEffects, TransactionEffects, TransactionEvents,
@@ -35,20 +36,19 @@ pub const NON_RECOVERABLE_ERROR_MSG: &str =
 /// Every invariant needs detailed documents to instruct client handling.
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Error, Hash, AsRefStr)]
 pub enum QuorumDriverError {
-    #[error("QuorumDriver internal error: {0:?}.")]
+    #[error("QuorumDriver internal error: {0}.")]
     QuorumDriverInternal(IotaError),
-    #[error("Invalid user signature: {0:?}.")]
+    #[error("Invalid user signature: {0}.")]
     InvalidUserSignature(IotaError),
     #[error(
         "Failed to sign transaction by a quorum of validators because of locked objects: {:?}, retried a conflicting transaction {:?}, success: {:?}",
         conflicting_txes,
-        retried_tx,
-        retried_tx_success
+        .retried_tx_status.map(|(tx, success)| tx),
+        .retried_tx_status.map(|(tx, success)| success),
     )]
     ObjectsDoubleUsed {
         conflicting_txes: BTreeMap<TransactionDigest, (Vec<(AuthorityName, ObjectRef)>, StakeUnit)>,
-        retried_tx: Option<TransactionDigest>,
-        retried_tx_success: Option<bool>,
+        retried_tx_status: Option<(TransactionDigest, bool)>,
     },
     #[error("Transaction timed out before reaching finality")]
     TimeoutBeforeFinality,
@@ -75,6 +75,114 @@ pub enum QuorumDriverError {
         errors: GroupedErrors,
         retry_after_secs: u64,
     },
+}
+
+impl QuorumDriverError {
+    pub fn to_error_message(&self) -> String {
+        match self {
+            QuorumDriverError::InvalidUserSignature(err) => {
+                format!("Invalid user signature: {err}")
+            }
+            QuorumDriverError::TxAlreadyFinalizedWithDifferentUserSignatures => {
+                "The transaction is already finalized but with different user signatures"
+                    .to_string()
+            }
+            QuorumDriverError::TimeoutBeforeFinality
+            | QuorumDriverError::FailedWithTransientErrorAfterMaximumAttempts { .. }
+            | QuorumDriverError::SystemOverload { .. }
+            | QuorumDriverError::SystemOverloadRetryAfter { .. } => self.to_string(),
+            QuorumDriverError::ObjectsDoubleUsed {
+                conflicting_txes,
+                retried_tx_status,
+            } => {
+                let weights: Vec<u64> =
+                    conflicting_txes.values().map(|(_, stake)| *stake).collect();
+                let remaining: u64 = TOTAL_VOTING_POWER - weights.iter().sum::<u64>();
+
+                // better version of above
+                let reason = if weights.iter().all(|w| remaining + w < QUORUM_THRESHOLD) {
+                    "equivocated until the next epoch"
+                } else {
+                    "reserved for another transaction"
+                };
+
+                let retried_info = match retried_tx_status {
+                    Some((digest, success)) => {
+                        format!(
+                            "Retried transaction {} ({}) because it was able to gather the necessary votes.",
+                            digest,
+                            if *success { "succeeded" } else { "failed" }
+                        )
+                    }
+                    None => "".to_string(),
+                };
+
+                format!(
+                    "Failed to sign transaction by a quorum of validators because one or more of its objects is {}. {} Other transactions locking these objects:\n{}",
+                    reason,
+                    retried_info,
+                    conflicting_txes
+                        .iter()
+                        .sorted_by(|(_, (_, a)), (_, (_, b))| b.cmp(a))
+                        .map(|(digest, (_, stake))| format!(
+                            "- {} (stake {}.{})",
+                            digest,
+                            stake / 100,
+                            stake % 100,
+                        ))
+                        .join("\n"),
+                )
+            }
+            QuorumDriverError::NonRecoverableTransactionError { errors } => {
+                let new_errors: Vec<String> = errors
+                    .iter()
+                    // sort by total stake, descending, so users see the most prominent one
+                    // first
+                    .sorted_by(|(_, a, _), (_, b, _)| b.cmp(a))
+                    .filter_map(|(err, _, _)| {
+                        match &err {
+                            // Special handling of UserInputError:
+                            // ObjectNotFound and DependentPackageNotFound are considered
+                            // retryable errors but they have different treatment
+                            // in AuthorityAggregator.
+                            // The optimal fix would be to examine if the total stake
+                            // of ObjectNotFound/DependentPackageNotFound exceeds the
+                            // quorum threshold, but it takes a Committee here.
+                            // So, we take an easier route and consider them non-retryable
+                            // at all. Combining this with the sorting above, clients will
+                            // see the dominant error first.
+                            IotaError::UserInput { error } => Some(error.to_string()),
+                            _ => {
+                                if err.is_retryable().0 {
+                                    None
+                                } else {
+                                    Some(err.to_string())
+                                }
+                            }
+                        }
+                    })
+                    .collect();
+
+                assert!(
+                    !new_errors.is_empty(),
+                    "NonRecoverableTransactionError should have at least one non-retryable error"
+                );
+
+                let mut error_list = vec![];
+                for err in new_errors.iter() {
+                    error_list.push(format!("- {}", err));
+                }
+
+                format!(
+                    "Transaction execution failed due to issues with transaction inputs, please review the errors and try again:\n{}",
+                    error_list.join("\n")
+                )
+            }
+            QuorumDriverError::QuorumDriverInternal { .. } => {
+                "Internal error occurred while executing transaction.".to_string()
+            }
+        }
+    }
 }
 
 pub type GroupedErrors = Vec<(IotaError, StakeUnit, Vec<ConciseAuthorityPublicKeyBytes>)>;


### PR DESCRIPTION
# Description of change

This PR contains a batch of node-team related upstream changes. The changes have been individually reviewed before squash-merging. None of them modify protocol parameters, so a new protocol version is not necessary.

This PR should be rebased on top of develop without squashing as it already contains squashed PRs.

## Links to any relevant issues

List of included PRs:

- #6388
- #6464
- #6714
- #6391
- #6826
- #6832
- #6850
- #6877
- #6894
- #6749
- #6740

List of included upstream commits:

- https://github.com/MystenLabs/sui/commit/5fb5da2a125644891de948e8a11d80ef572a7cc3
- https://github.com/MystenLabs/sui/commit/53244c1e46c63959b6f9c1685c41622bd709483a
- https://github.com/MystenLabs/sui/commit/495def8285fc4a44a8bab7f17ae1cf07a91cebdb
- https://github.com/MystenLabs/sui/commit/dec33d0a303a7f83e778fcc5a136ab9776162e68
- https://github.com/MystenLabs/sui/commit/ee1af5fd6f57576b271c2fb234239ce50d41b1e0
- https://github.com/MystenLabs/sui/commit/3fd78458acf96df386203dafc977df85fac6e894
- https://github.com/MystenLabs/sui/commit/89224b426815ce30e8dd3ac880749ef94395b117
- https://github.com/MystenLabs/sui/commit/13a60fe90abd8d5b3055938deff027f1ecdde719
- https://github.com/MystenLabs/sui/commit/c36d37a6b37db7df05bfb3417e4bedbfc26adddd
- https://github.com/MystenLabs/sui/commit/cd6dfa41d32b92383e4b05ec4dbeac23941e1c15
- https://github.com/MystenLabs/sui/commit/9b460365f8556dd2668b597317534fe2020892d6

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes):
  - Add error types to `num_error` metric
  - Add `auth_agg_quorum_reached_without_requested_objects` metric
  - `AuthorityAggregator`: always request for events when asked
  - Improve clarity of errors for `QuorumDriverError`
  - `QuorumDriver`: Remove conflicting tx retry logic
  - Remove metrics:
    - `quorum_driver_total_err_process_tx_responses_with_nonzero_conflicting_transactions`
    - `quorum_driver_total_attempts_trying_conflicting_transaction`
    - `quorum_driver_total_successful_attempts_trying_conflicting_transaction`
    - `quorum_driver_total_times_conflicting_transaction_already_finalized_when_retrying`
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API: