### PR TITLE
feat(starfish): eviction for linearizer

### DIFF
--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -375,19 +375,27 @@ pub struct SubDagBase {
 impl SubDagBase {
     /// Helper method to retrieve transaction acknowledgment references for each
     /// AuthorityIndex from the committed block headers.
-    pub(crate) fn transaction_acknowledgments(&self) -> HashMap<AuthorityIndex, Vec<BlockRef>> {
+    pub(crate) fn transaction_acknowledgments(
+        &self,
+    ) -> HashMap<(Round, AuthorityIndex), Vec<BlockRef>> {
         self.blocks
             .iter()
-            .map(|block| (block.author(), block.acknowledgments().to_vec()))
+            .map(|block| {
+                (
+                    (block.round(), block.author()),
+                    block.acknowledgments().to_vec(),
+                )
+            })
             .fold(
                 HashMap::new(),
-                |mut acc: HashMap<AuthorityIndex, HashSet<BlockRef>>, (auth, vec)| {
-                    acc.entry(auth).or_default().extend(vec);
+                |mut acc: HashMap<(Round, AuthorityIndex), HashSet<BlockRef>>,
+                 ((round, auth), vec)| {
+                    acc.entry((round, auth)).or_default().extend(vec);
                     acc
                 },
             )
             .into_iter()
-            .map(|(auth, set)| (auth, set.into_iter().collect()))
+            .map(|(round_auth, set)| (round_auth, set.into_iter().collect()))
             .collect()
     }
 

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -14,11 +14,11 @@ use crate::{
     block_header::{BlockHeaderAPI, VerifiedBlockHeader},
     commit::{CommitAPI, CommitIndex, PendingSubDag, load_pending_subdag_from_store},
     context::Context,
-    dag_state::DagState,
+    dag_state::{DagState, MAX_TRANSACTIONS_ACK_DEPTH},
     data_manager::DataManager,
     error::{ConsensusError, ConsensusResult},
     leader_schedule::LeaderSchedule,
-    linearizer::Linearizer,
+    linearizer::{Linearizer, MAX_LINEARIZER_DEPTH},
     storage::Store,
 };
 
@@ -50,11 +50,6 @@ pub(crate) struct CommitObserver {
     store: Arc<dyn Store>,
     leader_schedule: Arc<LeaderSchedule>,
 }
-
-// TODO: move those to protocol config
-// TODO: set sensible values
-const MAX_TRANSACTIONS_ACK_CHECK: u32 = 10;
-const MAX_LINEARIZER_DEPTH: u32 = 10;
 
 impl CommitObserver {
     pub(crate) fn new(
@@ -151,8 +146,11 @@ impl CommitObserver {
             // transactions that still have a chance of being committed is no higher than
             // `last_pending_commit_index - MAX_TRANSACTIONS_ACK_CHECK -
             // MAX_LINEARIZER_DEPTH`.
-            recovery_lower_bound = recovery_lower_bound
-                .min(last_commit_index - MAX_TRANSACTIONS_ACK_CHECK - MAX_LINEARIZER_DEPTH);
+
+            let commit_index_to_recover_acks =
+                last_commit_index.saturating_sub(MAX_TRANSACTIONS_ACK_DEPTH + MAX_LINEARIZER_DEPTH);
+
+            recovery_lower_bound = recovery_lower_bound.min(commit_index_to_recover_acks);
             assert!(last_commit_index >= last_processed_commit_index);
             if last_commit_index == last_processed_commit_index {
                 debug!(
@@ -205,11 +203,14 @@ impl CommitObserver {
             // Recover transaction acknowledgments tracker state by adding transaction
             // acknowledgments from all pending sub-dags that still might
             // correctly acknowledge transactions.
-            for (authority_idx, transaction_acknowledgments) in
+            for ((round, authority_idx), transaction_acknowledgments) in
                 pending_sub_dag.transaction_acknowledgments().into_iter()
             {
-                self.commit_interpreter
-                    .add_committed_transaction_acks(authority_idx, transaction_acknowledgments);
+                self.commit_interpreter.add_committed_transaction_acks(
+                    round,
+                    authority_idx,
+                    transaction_acknowledgments,
+                );
             }
             // Put all the pending sub-dags into the commit solidifier to make sure that
             // they are tracked there. The commit will be sent to IOTA here if all the

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -31,6 +31,9 @@ use crate::{
     threshold_clock::ThresholdClock,
 };
 
+// TODO: make it derivable from the protocol parameters
+pub(crate) const MAX_TRANSACTIONS_ACK_DEPTH: Round = 50;
+
 /// DagState provides the API to write and read accepted blocks from the DAG.
 /// Only uncommitted and last committed blocks are cached in memory.
 /// The rest of blocks are stored on disk.

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     sync::Arc,
 };
 
@@ -12,13 +12,19 @@ use parking_lot::RwLock;
 use starfish_config::AuthorityIndex;
 
 use crate::{
-    block_header::{BlockHeaderAPI, BlockRef, VerifiedBlockHeader},
+    Round,
+    block_header::{BlockHeaderAPI, BlockHeaderDigest, BlockRef, VerifiedBlockHeader},
     commit::{Commit, CommitAPI, PendingSubDag, TrustedCommit, sort_sub_dag_blocks},
     context::Context,
-    dag_state::DagState,
+    dag_state::{DagState, MAX_TRANSACTIONS_ACK_DEPTH},
     leader_schedule::LeaderSchedule,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
 };
+
+/// The maximum depth of the linearizer, i.e. how many rounds back it will
+/// traverse the DAG from a committed leader block
+// TODO: make it derivable from the protocol parameters
+pub(crate) const MAX_LINEARIZER_DEPTH: Round = 10;
 
 /// The `StorageAPI` trait provides an interface for the block store and has
 /// been mostly introduced for allowing to inject the test store in
@@ -46,7 +52,7 @@ pub(crate) struct Linearizer {
     //  max_linearizer_depth should be removed
     // TODO: should this be part of the Linearizer or
     //  its own component?
-    transactions_ack_tracker: HashMap<BlockRef, StakeAggregator<QuorumThreshold>>,
+    transactions_ack_tracker: BTreeMap<BlockRef, StakeAggregator<QuorumThreshold>>,
 }
 
 impl Linearizer {
@@ -59,7 +65,7 @@ impl Linearizer {
             dag_state,
             leader_schedule,
             context,
-            transactions_ack_tracker: HashMap::new(),
+            transactions_ack_tracker: BTreeMap::new(),
         }
     }
 
@@ -101,6 +107,7 @@ impl Linearizer {
             // using flat_map here to avoid nested vectors.
             .flat_map(|block| {
                 self.add_committed_transaction_acks(
+                    block.round(),
                     block.author(),
                     block.acknowledgments().to_vec(),
                 )
@@ -145,6 +152,7 @@ impl Linearizer {
         dag_state: &mut impl BlockStoreAPI,
     ) -> Vec<VerifiedBlockHeader> {
         let leader_block_ref = leader_block.reference();
+        let leader_round = leader_block.round();
         let mut buffer = vec![leader_block];
 
         let mut to_commit = Vec::new();
@@ -161,10 +169,13 @@ impl Linearizer {
                         .iter()
                         .copied()
                         .filter(|ancestor| {
-                            // We skip the block if we already committed it or we reached a
-                            // round that we already committed.
+                            // We skip the block if we already committed it or
+                            // we reached a round that we already committed or
+                            // we traverse too far back in the past
                             !committed.contains(ancestor)
                                 && last_committed_rounds[ancestor.author] < ancestor.round
+                                && ancestor.round
+                                    >= leader_round.saturating_sub(MAX_LINEARIZER_DEPTH)
                         })
                         .collect::<Vec<_>>(),
                 )
@@ -204,6 +215,13 @@ impl Linearizer {
             .leader_schedule_updated(&self.dag_state);
 
         let mut pending_sub_dags = vec![];
+
+        let max_round_committed_leader = committed_leaders
+            .iter()
+            .map(|block| block.round())
+            .max()
+            .expect("We should expect at least one leader block");
+
         for (i, leader_block) in committed_leaders.into_iter().enumerate() {
             let reputation_scores_desc = if schedule_updated && i == 0 {
                 self.leader_schedule
@@ -233,25 +251,46 @@ impl Linearizer {
         // storage.
         self.dag_state.write().flush();
 
+        // Evict old acknowledgments from the tracker of the linearizer.
+        self.evict_old_acknowledgments(max_round_committed_leader);
+
+        // TODO: we should resubmit transactions from own blocks that are not sequenced
+        // and below certain round
+
         pending_sub_dags
     }
 
-    // This function is called to add the transaction acknowledgments to the tracker
-    // and returns the vector of block refs to transactions that reached the quorum
-    // threshold after adding the acknowledgments.
+    /// This function evicts old acknowledgments from the tracker.
+    fn evict_old_acknowledgments(&mut self, committed_leader_round: Round) {
+        let lower_bound_round = committed_leader_round
+            .saturating_sub(MAX_LINEARIZER_DEPTH + MAX_TRANSACTIONS_ACK_DEPTH);
+        let lower_bound = BlockRef::new(
+            lower_bound_round + 1,
+            AuthorityIndex::ZERO,
+            BlockHeaderDigest::MIN,
+        );
+        self.transactions_ack_tracker = self.transactions_ack_tracker.split_off(&lower_bound);
+    }
+
+    /// This function is called to add the transaction acknowledgments to the
+    /// tracker and returns the vector of block refs to transactions that
+    /// reached the quorum threshold after adding the acknowledgments.
     pub(crate) fn add_committed_transaction_acks(
         &mut self,
+        round: Round,
         authority: AuthorityIndex,
         acknowledgments: Vec<BlockRef>,
     ) -> Vec<BlockRef> {
         let mut acknowledged_data = Vec::new();
         for block_ref in acknowledgments {
+            if block_ref.round < round.saturating_sub(MAX_TRANSACTIONS_ACK_DEPTH) {
+                continue; // Ignore acknowledgments for blocks that are too old
+            }
             let votes_collector = self
                 .transactions_ack_tracker
                 .entry(block_ref)
                 .or_insert_with(StakeAggregator::<QuorumThreshold>::new);
 
-            // TODO: check that the acknowlement is not too far in the past?
             if !votes_collector.reached_threshold(&self.context.committee)
                 && votes_collector.add(authority, &self.context.committee)
             {


### PR DESCRIPTION
# Description of change

Linearizer now respects two constants: `MAX_LINEARIZER_DEPTH` and `MAX_TRANSACTIONS_ACK_DEPTH`. It does not traverse from a committed leader below `MAX_LINEARIZER_DEPTH`. The acknowledgments below `MAX_TRANSACTIONS_ACK_DEPTH` from a given block are not considered valid and are not tracked in the tracker.

This allows for the eviction of the acknowledgment tracker at the end of each commit. 

## Links to any relevant issues

Fixes #7200 

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
