### PR TITLE
feat(actions): re-enable chocolatey

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,26 +175,29 @@ jobs:
 
           tar -cvzf ./tmp/${{ steps.create-artifact.outputs.artifact_name }}.tgz -C ${{ env.TMP_BUILD_DIR }} .
 
-      #      - name: Publish Windows iota binary to Chocolatey
-      #        if: ${{ matrix.os == 'windows-latest' && github.event_name == 'release' &&  && contains(env.iota_ref, '-rc') }}
-      #        shell: bash
-      #        run: |
-      #          choco install checksum
-      #          export iota_sha=$(checksum -t sha256 ${{ env.TMP_BUILD_DIR }}/iota.exe)
-      #          cd chocolatey
-      #
-      #          cat <<EOF >>VERIFICATION.txt
-      #          IOTA Binary verification steps
-      #          1. Download https://github.com/iotaledger/iota/releases/download/${{ env.iota_ref }}/${{ env.artifact_name }}.tgz
-      #          2. Extract iota.exe
-      #          3. Verify binary: checksum.exe -t sha256 iota.exe: ${iota_sha}
-      #
-      #          File 'LICENSE.txt' is obtained from: https://github.com/iotaledger/iota/blob/develop/LICENSE
-      #          EOF
-      #
-      #          choco pack --version ${{ env.iota_ref }} configuration=release
-      #          choco apikey --api-key ${{ secrets.CHOCO_API_KEY }} --source https://push.chocolatey.org/
-      #          choco push iota.${{ env.iota_ref }}.nupkg --source https://push.chocolatey.org/
+      - name: Publish Windows iota binary to Chocolatey
+        if: ${{ matrix.os == 'windows-latest' && github.event_name == 'release' }}
+        shell: bash
+        run: |
+          choco install checksum
+          export iota_sha=$(checksum -t sha256 ${{ env.TMP_BUILD_DIR }}/iota.exe)
+          cd chocolatey
+
+          cat <<EOF >>VERIFICATION.txt
+          IOTA Binary verification steps
+          1. Download https://github.com/iotaledger/iota/releases/download/${{ env.iota_ref }}/${{ env.artifact_name }}.tgz
+          2. Extract iota.exe
+          3. Verify binary: checksum.exe -t sha256 iota.exe: ${iota_sha}
+          4. Verify file 'LICENSE.txt': https://github.com/iotaledger/iota/blob/develop/LICENSE
+          EOF
+
+          choco pack --version ${{ env.iota_ref }} configuration=release
+          choco apikey --api-key ${{ secrets.CHOCO_API_KEY }} --source https://push.chocolatey.org/
+          if [[ "${{ env.iota_ref }}" == *"-"* ]]; then
+            choco push iota.${{ env.iota_ref }}.nupkg --source https://push.chocolatey.org/ --pre
+          else
+            choco push iota.${{ env.iota_ref }}.nupkg --source https://push.chocolatey.org/
+          fi
 
       - name: Upload artifacts for ${{ matrix.os_type }} platform
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/chocolatey/iota.nuspec
+++ b/chocolatey/iota.nuspec
@@ -5,9 +5,9 @@ enclosed in quotation marks, you should use an editor that supports UTF-8, not t
 	<metadata>
 		<id>iota</id>
 		<version>$version$</version>
-		<owners>iota</owners>
-		<title>Main IOTA Binary</title>
-		<authors>iota</authors>
+		<owners>IOTA Foundation</owners>
+		<title>IOTA CLI</title>
+		<authors>iotaledger</authors>
 		<projectUrl>https://iota.org/</projectUrl>
 		<licenseUrl>https://github.com/iotaledger/iota/blob/develop/LICENSE</licenseUrl>
 		<iconUrl>https://assets-global.website-files.com/6425f546844727ce5fb9e5ab/643775f4a15c9a9e10426daa_Iota_Favicon_256.png</iconUrl>
@@ -15,12 +15,15 @@ enclosed in quotation marks, you should use an editor that supports UTF-8, not t
 		<bugTrackerUrl>https://github.com/iotaledger/iota/issues</bugTrackerUrl>
 		<tags>iota</tags>
 		<packageSourceUrl>https://community.chocolatey.org/packages/iota.portable</packageSourceUrl>
-		<summary>Run a local iota binary</summary>
-		<description>IOTA is the first internet-scale programmable blockchain platform</description>
+		<summary>IOTA CLI to interact with the IOTA network</summary>
+		<description>Bringing the real world to Web3 with a scalable, decentralized and programmable DLT infrastructure</description>
 		<releaseNotes>https://github.com/iotaledger/iota/releases/tag/mainnet-v$version$</releaseNotes>
 	</metadata>
+	<dependencies>
+    	<dependency id="postgresql" version="14.0.1" />
+	</dependencies>
 	<files>
-		<file src="../target/release/iota.exe" target="bin/iota.exe" />
+		<file src="../tmp/release/iota.exe" target="bin/iota.exe" />
 		<file src="../LICENSE" target="bin/LICENSE.txt" />
 		<file src="./VERIFICATION.txt" target="bin/VERIFICATION.txt" />
 	</files>


### PR DESCRIPTION
# Description of change

Re-enabled the chocolatey actions to make the cli available on it again.

## Links to any relevant issues

Fixes #5576.

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: Make CLI available on Chocolatey
- [ ] Rust SDK:
- [ ] REST API:
