### PR TITLE
fix(iota-names): fix domain label validation

### DIFF
--- a/crates/iota-names/src/domain.rs
+++ b/crates/iota-names/src/domain.rs
@@ -226,10 +226,12 @@ pub fn validate_label(label: &str) -> Result<&str, IotaNamesError> {
     for (i, character) in bytes.iter().enumerate() {
         match character {
             b'a'..=b'z' | b'0'..=b'9' => continue,
-            b'-' if i == 0 || i == len - 1 => {
-                return Err(IotaNamesError::HyphensAsFirstOrLastLabelChar);
+            b'-' => {
+                if i == 0 || i == len - 1 {
+                    return Err(IotaNamesError::HyphensAsFirstOrLastLabelChar);
+                }
             }
-            _ => return Err(IotaNamesError::InvalidLabelChar),
+            _ => return Err(IotaNamesError::InvalidLabelChar((*character) as char, i)),
         };
     }
 
@@ -272,6 +274,13 @@ mod tests {
             "test.test.example.iota"
         );
         assert_eq!(
+            "test.test-with-hyphen@example-hyphen"
+                .parse::<Domain>()
+                .unwrap()
+                .to_string(),
+            "test.test-with-hyphen.example-hyphen.iota"
+        );
+        assert_eq!(
             "iota@iota".parse::<Domain>().unwrap().to_string(),
             "iota.iota.iota"
         );
@@ -283,6 +292,13 @@ mod tests {
         assert_eq!(
             "test.test.test.iota".parse::<Domain>().unwrap().to_string(),
             "test.test.test.iota"
+        );
+        assert_eq!(
+            "test.test-with-hyphen.test-with-hyphen.iota"
+                .parse::<Domain>()
+                .unwrap()
+                .to_string(),
+            "test.test-with-hyphen.test-with-hyphen.iota"
         );
     }
 
@@ -296,6 +312,12 @@ mod tests {
         assert!("test.test@example.iota".parse::<Domain>().is_err());
         assert!("test@test@example".parse::<Domain>().is_err());
         assert!("test.atoi".parse::<Domain>().is_err());
+        assert!("test.test@example-".parse::<Domain>().is_err());
+        assert!("test.test@-example".parse::<Domain>().is_err());
+        assert!("test.test-@example".parse::<Domain>().is_err());
+        assert!("test.-test@example".parse::<Domain>().is_err());
+        assert!("test.test-.iota".parse::<Domain>().is_err());
+        assert!("test.-test.iota".parse::<Domain>().is_err());
     }
 
     #[test]

--- a/crates/iota-names/src/error.rs
+++ b/crates/iota-names/src/error.rs
@@ -12,8 +12,10 @@ pub enum IotaNamesError {
     InvalidLabelLength(usize, usize, usize),
     #[error("Hyphens are not allowed as first or last character of a label")]
     HyphensAsFirstOrLastLabelChar,
-    #[error("Only lowercase letters, numbers, and hyphens are allowed as label characters")]
-    InvalidLabelChar,
+    #[error(
+        "Only lowercase letters, numbers, and hyphens are allowed as label characters. Got \"{0}\" at position {1}"
+    )]
+    InvalidLabelChar(char, usize),
     #[error("Domain must contain at least two labels, TLD and SLD")]
     NotEnoughLabels,
     #[error("Domain must include only one separator")]

--- a/crates/iota-names/src/error.rs
+++ b/crates/iota-names/src/error.rs
@@ -13,7 +13,7 @@ pub enum IotaNamesError {
     #[error("Hyphens are not allowed as first or last character of a label")]
     HyphensAsFirstOrLastLabelChar,
     #[error(
-        "Only lowercase letters, numbers, and hyphens are allowed as label characters. Got \"{0}\" at position {1}"
+        "Only lowercase letters, numbers, and hyphens are allowed as label characters. Got \'{0}\' at position {1}"
     )]
     InvalidLabelChar(char, usize),
     #[error("Domain must contain at least two labels, TLD and SLD")]


### PR DESCRIPTION
# Description of change

Fix domain label validation to allow hyphens in labels, when not at the beginning or end of the label.
So for example "this-works.iota"
Also changed the error, to print the char and position if something is wrong

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/7194

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

`cargo run --features=iota-names name register 3%e.iota` prints the expected error message
`error: invalid value '3%e.iota' for '<DOMAIN>': Only lowercase letters, numbers, and hyphens are allowed as label characters. Got '%' at position 1`
`cargo run --features=iota-names name register 30-chars-name----30-chars-name.iot` doesn't fail anymore for the domain validation

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

<!--
Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.
-->

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: Fixed domain validation for "-" in labels
- [ ] Rust SDK:
- [ ] REST API:
