### PR TITLE
refactor(package-resolver): Use canonical display for error messages

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/errors/clever_errors.snap
+++ b/crates/iota-graphql-e2e-tests/tests/errors/clever_errors.snap
@@ -251,7 +251,7 @@ Response: {
   },
   "errors": [
     {
-      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 056cabcc3fb21504d1e14590790d6e381e45d719e9646b69b05225a5eaa413e7",
+      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 0x056cabcc3fb21504d1e14590790d6e381e45d719e9646b69b05225a5eaa413e7",
       "locations": [
         {
           "line": 6,
@@ -267,7 +267,7 @@ Response: {
       ]
     },
     {
-      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 056cabcc3fb21504d1e14590790d6e381e45d719e9646b69b05225a5eaa413e7",
+      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 0x056cabcc3fb21504d1e14590790d6e381e45d719e9646b69b05225a5eaa413e7",
       "locations": [
         {
           "line": 6,
@@ -283,7 +283,7 @@ Response: {
       ]
     },
     {
-      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 056cabcc3fb21504d1e14590790d6e381e45d719e9646b69b05225a5eaa413e7",
+      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 0x056cabcc3fb21504d1e14590790d6e381e45d719e9646b69b05225a5eaa413e7",
       "locations": [
         {
           "line": 6,
@@ -299,7 +299,7 @@ Response: {
       ]
     },
     {
-      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 056cabcc3fb21504d1e14590790d6e381e45d719e9646b69b05225a5eaa413e7",
+      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 0x056cabcc3fb21504d1e14590790d6e381e45d719e9646b69b05225a5eaa413e7",
       "locations": [
         {
           "line": 6,
@@ -315,7 +315,7 @@ Response: {
       ]
     },
     {
-      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 056cabcc3fb21504d1e14590790d6e381e45d719e9646b69b05225a5eaa413e7",
+      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 0x056cabcc3fb21504d1e14590790d6e381e45d719e9646b69b05225a5eaa413e7",
       "locations": [
         {
           "line": 6,
@@ -331,7 +331,7 @@ Response: {
       ]
     },
     {
-      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 056cabcc3fb21504d1e14590790d6e381e45d719e9646b69b05225a5eaa413e7",
+      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 0x056cabcc3fb21504d1e14590790d6e381e45d719e9646b69b05225a5eaa413e7",
       "locations": [
         {
           "line": 6,
@@ -347,7 +347,7 @@ Response: {
       ]
     },
     {
-      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 056cabcc3fb21504d1e14590790d6e381e45d719e9646b69b05225a5eaa413e7",
+      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 0x056cabcc3fb21504d1e14590790d6e381e45d719e9646b69b05225a5eaa413e7",
       "locations": [
         {
           "line": 6,
@@ -363,7 +363,7 @@ Response: {
       ]
     },
     {
-      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 056cabcc3fb21504d1e14590790d6e381e45d719e9646b69b05225a5eaa413e7",
+      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 0x056cabcc3fb21504d1e14590790d6e381e45d719e9646b69b05225a5eaa413e7",
       "locations": [
         {
           "line": 6,
@@ -379,7 +379,7 @@ Response: {
       ]
     },
     {
-      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 056cabcc3fb21504d1e14590790d6e381e45d719e9646b69b05225a5eaa413e7",
+      "message": "Internal error occurred while processing request: Error resolving Move location: Linkage not found for package: 0x056cabcc3fb21504d1e14590790d6e381e45d719e9646b69b05225a5eaa413e7",
       "locations": [
         {
           "line": 6,

--- a/crates/iota-graphql-e2e-tests/tests/packages/types.snap
+++ b/crates/iota-graphql-e2e-tests/tests/packages/types.snap
@@ -185,7 +185,7 @@ Response: {
   "data": null,
   "errors": [
     {
-      "message": "Internal error occurred while processing request: Error calculating layout for 0x0000000000000000000000000000000000000000000000000000000000000042::not::Here: Package not found: 0000000000000000000000000000000000000000000000000000000000000042",
+      "message": "Internal error occurred while processing request: Error calculating layout for 0x0000000000000000000000000000000000000000000000000000000000000042::not::Here: Package not found: 0x0000000000000000000000000000000000000000000000000000000000000042",
       "locations": [
         {
           "line": 12,

--- a/crates/iota-package-resolver/src/error.rs
+++ b/crates/iota-package-resolver/src/error.rs
@@ -23,10 +23,16 @@ pub enum Error {
     #[error("{0}")]
     Deserialize(VMError),
 
-    #[error("Package has no modules: {0}")]
+    #[error(
+        "Package has no modules: {}",
+        .0.to_canonical_display(/* with_prefix */ true),
+    )]
     EmptyPackage(AccountAddress),
 
-    #[error("Function not found: {0}::{1}::{2}")]
+    #[error(
+        "Function not found: {}::{1}::{2}",
+        .0.to_canonical_display(/* with_prefix */ true),
+    )]
     FunctionNotFound(AccountAddress, String, String),
 
     #[error(
@@ -36,25 +42,43 @@ pub enum Error {
     )]
     InputTypeConflict(u16, TypeTag, TypeTag),
 
-    #[error("Linkage not found for package: {0}")]
+    #[error(
+        "Linkage not found for package: {}",
+        .0.to_canonical_display(/* with_prefix */ true),
+    )]
     LinkageNotFound(AccountAddress),
 
-    #[error("Module not found: {0}::{1}")]
+    #[error(
+        "Module not found: {}::{1}",
+        .0.to_canonical_display(/* with_prefix */ true),
+    )]
     ModuleNotFound(AccountAddress, String),
 
-    #[error("No origin package found for {0}::{1}::{2}")]
+    #[error(
+        "No origin package found for {}::{1}::{2}",
+        .0.to_canonical_display(/* with_prefix */ true),
+    )]
     NoTypeOrigin(AccountAddress, String, String),
 
-    #[error("Not a package: {0}")]
+    #[error(
+        "Not a package: {}",
+        .0.to_canonical_display(/* with_prefix */ true),
+    )]
     NotAPackage(AccountAddress),
 
     #[error("Not an identifier: '{0}'")]
     NotAnIdentifier(String),
 
-    #[error("Package not found: {0}")]
+    #[error(
+        "Package not found: {}",
+        .0.to_canonical_display(/* with_prefix */ true),
+    )]
     PackageNotFound(AccountAddress),
 
-    #[error("Datatype not found: {0}::{1}::{2}")]
+    #[error(
+        "Datatype not found: {}::{1}::{2}",
+        .0.to_canonical_display(/* with_prefix */ true),
+    )]
     DatatypeNotFound(AccountAddress, String, String),
 
     #[error("More than {0} struct definitions required to resolve type")]


### PR DESCRIPTION
# Description of change

Consistently use the canonical display format with prefix in error
messages from the package resolver.
According to [changes](https://github.com/MystenLabs/sui/commit/83f6f17#diff-b327546aaf3e64d31d006c18c86f8f9c478930d7cd6d69389ae0069f35b758f3).

Any snapshot changes haven’t been detected..

## Links to any relevant issues

Fixes #7062 .

## How the change has been tested

Run tests:
```
cargo nextest run         \
  -p iota-graphql-e2e-tests     \
  -p iota-package-resolver
```
