### PR TITLE
feat(iota-package-resolver): generalize `Resolver::function_parameters`

### DIFF
--- a/crates/iota-package-resolver/src/lib.rs
+++ b/crates/iota-package-resolver/src/lib.rs
@@ -438,8 +438,6 @@ impl<S: PackageStore> Resolver<S> {
             ));
         };
 
-        let mut sigs = def.parameters.clone();
-
         // (1). Fetch all the information from this store that is necessary to resolve
         // types referenced by this tag.
         for sig in def.parameters.iter().chain(def.return_.iter()) {

--- a/crates/iota-package-resolver/src/lib.rs
+++ b/crates/iota-package-resolver/src/lib.rs
@@ -421,16 +421,16 @@ impl<S: PackageStore> Resolver<S> {
 
     /// Returns the signatures of parameters to function `pkg::module::function`
     /// in the package store, assuming the function exists.
-    pub async fn function_parameters(
+    pub async fn function_signature(
         &self,
         pkg: AccountAddress,
         module: &str,
         function: &str,
-    ) -> Result<Vec<OpenSignature>> {
+    ) -> Result<FunctionDef> {
         let mut context = ResolutionContext::new(self.limits.as_ref());
 
         let package = self.package_store.fetch(pkg).await?;
-        let Some(def) = package.module(module)?.function_def(function)? else {
+        let Some(mut def) = package.module(module)?.function_def(function)? else {
             return Err(Error::FunctionNotFound(
                 pkg,
                 module.to_string(),
@@ -442,7 +442,7 @@ impl<S: PackageStore> Resolver<S> {
 
         // (1). Fetch all the information from this store that is necessary to resolve
         // types referenced by this tag.
-        for sig in &sigs {
+        for sig in def.parameters.iter().chain(def.return_.iter()) {
             context
                 .add_signature(
                     sig.body.clone(),
@@ -455,11 +455,11 @@ impl<S: PackageStore> Resolver<S> {
         }
 
         // (2). Use that information to relocate package IDs in the signature.
-        for sig in &mut sigs {
+        for sig in def.parameters.iter_mut().chain(def.return_.iter_mut()) {
             context.relocate_signature(&mut sig.body)?;
         }
 
-        Ok(sigs)
+        Ok(def)
     }
 
     /// Attempts to infer the type layouts for pure inputs to the programmable
@@ -507,16 +507,14 @@ impl<S: PackageStore> Resolver<S> {
         for cmd in &tx.commands {
             match cmd {
                 Command::MoveCall(call) => {
-                    let Ok(params) = self
-                        .function_parameters(
+                    let params = self
+                        .function_signature(
                             call.package.into(),
                             call.module.as_str(),
                             call.function.as_str(),
                         )
-                        .await
-                    else {
-                        continue;
-                    };
+                        .await?
+                        .parameters;
 
                     for (open_sig, arg) in params.iter().zip(call.arguments.iter()) {
                         let sig = open_sig.instantiate(&call.type_arguments)?;
@@ -2311,9 +2309,9 @@ mod tests {
         let resolver = Resolver::new(cache);
         let c0 = addr("0xc0");
 
-        let foo = resolver.function_parameters(c0, "m", "foo").await.unwrap();
-        let bar = resolver.function_parameters(c0, "m", "bar").await.unwrap();
-        let baz = resolver.function_parameters(c0, "m", "baz").await.unwrap();
+        let foo = resolver.function_signature(c0, "m", "foo").await.unwrap();
+        let bar = resolver.function_signature(c0, "m", "bar").await.unwrap();
+        let baz = resolver.function_signature(c0, "m", "baz").await.unwrap();
 
         insta::assert_snapshot!(format!(
             "c0::m::foo: {foo:#?}\n\

--- a/crates/iota-package-resolver/src/snapshots/iota_package_resolver__tests__function_parameters.snap
+++ b/crates/iota-package-resolver/src/snapshots/iota_package_resolver__tests__function_parameters.snap
@@ -2,64 +2,96 @@
 source: crates/iota-package-resolver/src/lib.rs
 expression: "format!(\"c0::m::foo: {foo:#?}\\n\\\n             c0::m::bar: {bar:#?}\\n\\\n             c0::m::baz: {baz:#?}\")"
 ---
-c0::m::foo: []
-c0::m::bar: [
-    OpenSignature {
-        ref_: Some(
-            Immutable,
-        ),
-        body: Datatype(
-            DatatypeRef {
-                package: 00000000000000000000000000000000000000000000000000000000000000c0,
-                module: "m",
-                name: "T0",
-            },
-            [],
-        ),
-    },
-    OpenSignature {
-        ref_: Some(
-            Mutable,
-        ),
-        body: Datatype(
-            DatatypeRef {
-                package: 00000000000000000000000000000000000000000000000000000000000000a1,
-                module: "n",
-                name: "T1",
-            },
-            [],
-        ),
-    },
-    OpenSignature {
-        ref_: Some(
-            Immutable,
-        ),
-        body: Datatype(
-            DatatypeRef {
-                package: 00000000000000000000000000000000000000000000000000000000000000c0,
-                module: "m",
-                name: "E0",
-            },
-            [],
-        ),
-    },
-    OpenSignature {
-        ref_: Some(
-            Mutable,
-        ),
-        body: Datatype(
-            DatatypeRef {
-                package: 00000000000000000000000000000000000000000000000000000000000000a1,
-                module: "n",
-                name: "E1",
-            },
-            [],
-        ),
-    },
-]
-c0::m::baz: [
-    OpenSignature {
-        ref_: None,
-        body: U8,
-    },
-]
+c0::m::foo: FunctionDef {
+    visibility: Public,
+    is_entry: false,
+    type_params: [],
+    parameters: [],
+    return_: [],
+}
+c0::m::bar: FunctionDef {
+    visibility: Friend,
+    is_entry: false,
+    type_params: [],
+    parameters: [
+        OpenSignature {
+            ref_: Some(
+                Immutable,
+            ),
+            body: Datatype(
+                DatatypeRef {
+                    package: 00000000000000000000000000000000000000000000000000000000000000c0,
+                    module: "m",
+                    name: "T0",
+                },
+                [],
+            ),
+        },
+        OpenSignature {
+            ref_: Some(
+                Mutable,
+            ),
+            body: Datatype(
+                DatatypeRef {
+                    package: 00000000000000000000000000000000000000000000000000000000000000a1,
+                    module: "n",
+                    name: "T1",
+                },
+                [],
+            ),
+        },
+        OpenSignature {
+            ref_: Some(
+                Immutable,
+            ),
+            body: Datatype(
+                DatatypeRef {
+                    package: 00000000000000000000000000000000000000000000000000000000000000c0,
+                    module: "m",
+                    name: "E0",
+                },
+                [],
+            ),
+        },
+        OpenSignature {
+            ref_: Some(
+                Mutable,
+            ),
+            body: Datatype(
+                DatatypeRef {
+                    package: 00000000000000000000000000000000000000000000000000000000000000a1,
+                    module: "n",
+                    name: "E1",
+                },
+                [],
+            ),
+        },
+    ],
+    return_: [
+        OpenSignature {
+            ref_: None,
+            body: U64,
+        },
+    ],
+}
+c0::m::baz: FunctionDef {
+    visibility: Private,
+    is_entry: false,
+    type_params: [],
+    parameters: [
+        OpenSignature {
+            ref_: None,
+            body: U8,
+        },
+    ],
+    return_: [
+        OpenSignature {
+            ref_: None,
+            body: U16,
+        },
+        OpenSignature {
+            ref_: None,
+            body: U32,
+        },
+    ],
+}


### PR DESCRIPTION
# Description of change

Generalize `Resolver::function_parameters` so that it returns the fully
resolved function signature. Previously this function was used to infer
transaction input layouts, but we also need roughly the same logic for
returning a normalized move function.

According to [changes](https://github.com/MystenLabs/sui/commit/5024b1f#diff-76de243b84e1bcb523b9725574d3ae44530b9a49db102035ad19f2d8d6bb54c3).

## Links to any relevant issues

Fixes #7060 .

## How the change has been tested

Run

```
cargo nextest run -p iota-package-resolver
```