### PR TITLE
fix(iota-indexer): reset db only for writer

### DIFF
--- a/crates/iota-indexer/src/db.rs
+++ b/crates/iota-indexer/src/db.rs
@@ -271,21 +271,6 @@ pub mod setup_postgres {
             );
             e
         })?;
-        if indexer_config.reset_db {
-            reset_database(&mut conn).map_err(|e| {
-                let db_err_msg = format!(
-                    "Failed resetting database with url: {:?} and error: {:?}",
-                    db_url, e
-                );
-                error!("{}", db_err_msg);
-                IndexerError::PostgresReset(db_err_msg)
-            })?;
-            info!("Reset Postgres database complete.");
-        } else {
-            conn.run_pending_migrations(MIGRATIONS)
-                .map_err(|e| anyhow!("Failed to run pending migrations {e}"))?;
-            info!("Database migrations are up to date.");
-        }
         let indexer_metrics = IndexerMetrics::new(&registry);
         iota_metrics::init_metrics(&registry);
 
@@ -309,6 +294,21 @@ pub mod setup_postgres {
         });
         if indexer_config.fullnode_sync_worker {
             let store = PgIndexerStore::new(blocking_cp, indexer_metrics.clone());
+            if indexer_config.reset_db {
+                reset_database(&mut conn).map_err(|e| {
+                    let db_err_msg = format!(
+                        "Failed resetting database with url: {:?} and error: {:?}",
+                        db_url, e
+                    );
+                    error!("{}", db_err_msg);
+                    IndexerError::PostgresReset(db_err_msg)
+                })?;
+                info!("Reset Postgres database complete.");
+            } else {
+                conn.run_pending_migrations(MIGRATIONS)
+                    .map_err(|e| anyhow!("Failed to run pending migrations {e}"))?;
+                info!("Database migrations are up to date.");
+            }
             return Indexer::start_writer(&indexer_config, store, indexer_metrics).await;
         } else if indexer_config.rpc_server_worker {
             return Indexer::start_reader(&indexer_config, &registry, db_url.to_string()).await;


### PR DESCRIPTION
# Description of change

Disable reset database and migration execution for indexer reader.

## Links to any relevant issues

#7215 

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
```shell
$ cargo test --features pg_integration -- --test-threads 1
$ cargo test --profile simulator --features shared_test_runtime
```

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- Checked locally if database was not reset when running the indexer reader. Besides this behavior the patch does not affect other parts of the indexer.

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [x] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
