### PR TITLE
feat(iota-package-resolver): add a function to the package resolver to canonicalize a type

### DIFF
--- a/crates/iota-package-resolver/src/lib.rs
+++ b/crates/iota-package-resolver/src/lib.rs
@@ -365,6 +365,37 @@ impl<S> Resolver<S> {
 }
 
 impl<S: PackageStore> Resolver<S> {
+    /// The canonical form of a type refers to each type in terms of its
+    /// defining package ID. ThisAdd commentMore actions function takes a
+    /// non-canonical type and updates all its package IDs to the appropriate
+    /// defining ID.
+    ///
+    /// For every `package::module::datatype` in the input `tag`, `package` must
+    /// be an object on-chain, containing a move package that includes
+    /// `module`, and that module must define the `datatype`. In practice
+    /// this means the input type `tag` can refer to types at or after their
+    /// defining IDs.
+    pub async fn canonical_type(&self, mut tag: TypeTag) -> Result<TypeTag> {
+        let mut context = ResolutionContext::new(self.limits.as_ref());
+
+        // (1). Fetch all the information from this store that is necessary to relocate
+        // package IDs in the type.
+        context
+            .add_type_tag(
+                &mut tag,
+                &self.package_store,
+                // visit_fields
+                false,
+                // visit_phantoms
+                true,
+            )
+            .await?;
+
+        // (2). Use that information to relocate package IDs in the type.
+        context.canonicalize_type(&mut tag)?;
+        Ok(tag)
+    }
+
     /// Return the type layout corresponding to the given type tag.  The layout
     /// always refers to structs in terms of their defining ID (i.e. their
     /// package ID always points to the first package that introduced them).
@@ -1391,6 +1422,36 @@ impl<'l> ResolutionContext<'l> {
         Ok(())
     }
 
+        /// Translate runtime IDs in a type `tag` into defining IDs using only the informationAdd commentMore actions
+    /// contained in this context. Requires that the necessary information was added to the context
+    /// through calls to `add_type_tag`.
+    fn canonicalize_type(&self, tag: &mut TypeTag) -> Result<()> {
+        use TypeTag as T;
+
+        match tag {
+            T::Signer => return Err(Error::UnexpectedSigner),
+            T::Address | T::Bool | T::U8 | T::U16 | T::U32 | T::U64 | T::U128 | T::U256 => {
+                /* nop */
+            }
+
+            T::Vector(tag) => self.canonicalize_type(tag.as_mut())?,
+
+            T::Struct(s) => {
+                for tag in &mut s.type_params {
+                    self.canonicalize_type(tag)?;
+                }
+
+                // SAFETY: `add_type_tag` ensures `datatyps` has an element with this key.
+                let key = DatatypeRef::from(s.as_ref());
+                let def = &self.datatypes[&key];
+
+                s.address = def.defining_id;
+            }
+        }
+
+        Ok(())
+    }
+
     /// Translate a type `tag` into its layout using only the information
     /// contained in this context. Requires that the necessary information
     /// was added to the context through calls to `add_type_tag` and
@@ -1449,7 +1510,7 @@ impl<'l> ResolutionContext<'l> {
                     .type_params
                     .iter()
                     // Reduce the max depth because we know these type parameters will be nested
-                    // wthin this struct.
+                    // within this struct.
                     .map(|tag| self.resolve_type_layout(tag, max_depth - 1))
                     .collect::<Result<Vec<_>>>()?;
 
@@ -1765,10 +1826,91 @@ mod tests {
         format!("struct:\n{struct_layout:#}\n\nenum:\n{enum_layout:#}",)
     }
 
+    #[tokio::test]
+    async fn test_simple_canonical_type() {
+        let (_, cache) = package_cache([(1, build_package("a0").unwrap(), a0_types())]);
+        let package_resolver = Resolver::new(cache);
+
+        let input = type_("0xa0::m::T0");
+        let expect = input.clone();
+        let actual = package_resolver.canonical_type(input).await.unwrap();
+        assert_eq!(expect, actual);
+    }
+
+    #[tokio::test]
+    async fn test_upgraded_canonical_type() {
+        let (_, cache) = package_cache([
+            (1, build_package("a0").unwrap(), a0_types()),
+            (2, build_package("a1").unwrap(), a1_types()),
+        ]);
+
+        let package_resolver = Resolver::new(cache);
+
+        let input = type_("0xa1::m::T3");
+        let expect = input.clone();
+        let actual = package_resolver.canonical_type(input).await.unwrap();
+        assert_eq!(expect, actual);
+    }
+
+    #[tokio::test]
+    async fn test_latest_canonical_type() {
+        let (_, cache) = package_cache([
+            (1, build_package("a0").unwrap(), a0_types()),
+            (2, build_package("a1").unwrap(), a1_types()),
+        ]);
+
+        let package_resolver = Resolver::new(cache);
+
+        let input = type_("0xa1::m::T0");
+        let expect = type_("0xa0::m::T0");
+        let actual = package_resolver.canonical_type(input).await.unwrap();
+        assert_eq!(expect, actual);
+    }
+
+    #[tokio::test]
+    async fn test_type_param_canonical_type() {
+        let (_, cache) = package_cache([
+            (1, build_package("a0").unwrap(), a0_types()),
+            (2, build_package("a1").unwrap(), a1_types()),
+        ]);
+
+        let package_resolver = Resolver::new(cache);
+
+        let input = type_("0xa1::m::T1<0xa1::m::T0, 0xa1::m::T3>");
+        let expect = type_("0xa0::m::T1<0xa0::m::T0, 0xa1::m::T3>");
+        let actual = package_resolver.canonical_type(input).await.unwrap();
+        assert_eq!(expect, actual);
+    }
+
+    #[tokio::test]
+    async fn test_canonical_err_package_too_old() {
+        let (_, cache) = package_cache([
+            (1, build_package("a0").unwrap(), a0_types()),
+            (2, build_package("a1").unwrap(), a1_types()),
+        ]);
+
+        let package_resolver = Resolver::new(cache);
+
+        let input = type_("0xa0::m::T3");
+        let err = package_resolver.canonical_type(input).await.unwrap_err();
+        assert!(matches!(err, Error::DatatypeNotFound(_, _, _)));
+    }
+
+    #[tokio::test]
+    async fn test_canonical_err_signer() {
+        let (_, cache) = package_cache([(1, build_package("a0").unwrap(), a0_types())]);
+
+        let package_resolver = Resolver::new(cache);
+
+        let input = type_("0xa0::m::T1<0xa0::m::T0, signer>");
+        let err = package_resolver.canonical_type(input).await.unwrap_err();
+        assert!(matches!(err, Error::UnexpectedSigner));
+    }
+
     /// Layout for a type that only refers to base types or other types in the
     /// same module.
     #[tokio::test]
-    async fn test_simple_type() {
+    async fn test_simple_type_layout() {
         let (_, cache) = package_cache([(1, build_package("a0").unwrap(), a0_types())]);
         let package_resolver = Resolver::new(cache);
         let struct_layout = package_resolver
@@ -1784,7 +1926,7 @@ mod tests {
 
     /// A type that refers to types from other modules in the same package.
     #[tokio::test]
-    async fn test_cross_module() {
+    async fn test_cross_module_layout() {
         let (_, cache) = package_cache([(1, build_package("a0").unwrap(), a0_types())]);
         let resolver = Resolver::new(cache);
         let struct_layout = resolver.type_layout(type_("0xa0::n::T0")).await.unwrap();
@@ -1794,7 +1936,7 @@ mod tests {
 
     /// A type that refers to types a different package.
     #[tokio::test]
-    async fn test_cross_package() {
+    async fn test_cross_package_layout() {
         let (_, cache) = package_cache([
             (1, build_package("a0").unwrap(), a0_types()),
             (1, build_package("b0").unwrap(), b0_types()),
@@ -1809,7 +1951,7 @@ mod tests {
     /// A type from an upgraded package, mixing structs defined in the original
     /// package and the upgraded package.
     #[tokio::test]
-    async fn test_upgraded_package() {
+    async fn test_upgraded_package_layout() {
         let (_, cache) = package_cache([
             (1, build_package("a0").unwrap(), a0_types()),
             (2, build_package("a1").unwrap(), a1_types()),
@@ -1825,7 +1967,7 @@ mod tests {
     /// relative to linkage contexts from different versions of the same
     /// package.
     #[tokio::test]
-    async fn test_multiple_linkage_contexts() {
+    async fn test_multiple_linkage_contexts_layout() {
         let (_, cache) = package_cache([
             (1, build_package("a0").unwrap(), a0_types()),
             (2, build_package("a1").unwrap(), a1_types()),
@@ -1849,7 +1991,7 @@ mod tests {
     /// to using the ID of any package that declares it, rather than only the
     /// package that first declared it (whose ID is its defining ID).
     #[tokio::test]
-    async fn test_upgraded_package_non_defining_id() {
+    async fn test_upgraded_package_non_defining_id_layout() {
         let (_, cache) = package_cache([
             (1, build_package("a0").unwrap(), a0_types()),
             (2, build_package("a1").unwrap(), a1_types()),
@@ -1871,7 +2013,7 @@ mod tests {
     /// overrides its dependency on A from v1 to v2.  The type in C refers
     /// to types that were defined in both B, A v1, and A v2.
     #[tokio::test]
-    async fn test_relinking() {
+    async fn test_relinking_layout_layout() {
         let (_, cache) = package_cache([
             (1, build_package("a0").unwrap(), a0_types()),
             (2, build_package("a1").unwrap(), a1_types()),
@@ -1886,7 +2028,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_value_nesting_boundary() {
+    async fn test_value_nesting_boundary_layout() {
         let (_, cache) = package_cache([(1, build_package("a0").unwrap(), a0_types())]);
 
         let resolver = Resolver::new_with_limits(
@@ -1912,7 +2054,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_err_value_nesting_simple() {
+    async fn test_err_value_nesting_simple_layout() {
         let (_, cache) = package_cache([(1, build_package("a0").unwrap(), a0_types())]);
 
         let resolver = Resolver::new_with_limits(
@@ -1939,7 +2081,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_err_value_nesting_big_type_param() {
+    async fn test_err_value_nesting_big_type_param_layout() {
         let (_, cache) = package_cache([(1, build_package("a0").unwrap(), a0_types())]);
 
         let resolver = Resolver::new_with_limits(
@@ -1968,7 +2110,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_err_value_nesting_big_phantom_type_param() {
+    async fn test_err_value_nesting_big_phantom_type_param_layout() {
         let (_, cache) = package_cache([
             (1, build_package("iota").unwrap(), iota_types()),
             (1, build_package("d0").unwrap(), d0_types()),
@@ -2011,7 +2153,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_err_value_nesting_type_param_application() {
+    async fn test_err_value_nesting_type_param_application_layout() {
         let (_, cache) = package_cache([
             (1, build_package("iota").unwrap(), iota_types()),
             (1, build_package("d0").unwrap(), d0_types()),
@@ -2138,7 +2280,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_err_not_a_package() {
+    async fn test_err_not_a_package_layout() {
         let (_, cache) = package_cache([(1, build_package("a0").unwrap(), a0_types())]);
         let resolver = Resolver::new(cache);
         let err = resolver
@@ -2149,7 +2291,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_err_no_module() {
+    async fn test_err_no_module_layout() {
         let (_, cache) = package_cache([(1, build_package("a0").unwrap(), a0_types())]);
         let resolver = Resolver::new(cache);
         let err = resolver
@@ -2160,7 +2302,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_err_no_struct() {
+    async fn test_err_no_struct_layout() {
         let (_, cache) = package_cache([(1, build_package("a0").unwrap(), a0_types())]);
         let resolver = Resolver::new(cache);
 
@@ -2172,7 +2314,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_err_type_arity() {
+    async fn test_err_type_arity_layout() {
         let (_, cache) = package_cache([(1, build_package("a0").unwrap(), a0_types())]);
         let resolver = Resolver::new(cache);
 

--- a/crates/iota-package-resolver/src/lib.rs
+++ b/crates/iota-package-resolver/src/lib.rs
@@ -1422,8 +1422,9 @@ impl<'l> ResolutionContext<'l> {
         Ok(())
     }
 
-        /// Translate runtime IDs in a type `tag` into defining IDs using only the informationAdd commentMore actions
-    /// contained in this context. Requires that the necessary information was added to the context
+    /// Translate runtime IDs in a type `tag` into defining IDs using only the
+    /// informationAdd commentMore actions contained in this context.
+    /// Requires that the necessary information was added to the context
     /// through calls to `add_type_tag`.
     fn canonicalize_type(&self, tag: &mut TypeTag) -> Result<()> {
         use TypeTag as T;
@@ -1431,7 +1432,7 @@ impl<'l> ResolutionContext<'l> {
         match tag {
             T::Signer => return Err(Error::UnexpectedSigner),
             T::Address | T::Bool | T::U8 | T::U16 | T::U32 | T::U64 | T::U128 | T::U256 => {
-                /* nop */
+                // nop
             }
 
             T::Vector(tag) => self.canonicalize_type(tag.as_mut())?,

--- a/crates/iota-package-resolver/src/snapshots/iota_package_resolver__tests__cross_module_layout.snap
+++ b/crates/iota-package-resolver/src/snapshots/iota_package_resolver__tests__cross_module_layout.snap
@@ -1,7 +1,20 @@
 ---
 source: crates/iota-package-resolver/src/lib.rs
-expression: "format!(\"{layout:#}\")"
+expression: "fmt(struct_layout, enum_layout)"
 ---
+struct:
+struct 0xa0::n::T0 {
+    t: struct 0xa0::m::T1<u16, u32> {
+        a: address,
+        p: u16,
+        q: vector<u32>,
+    },
+    u: struct 0xa0::m::T2 {
+        x: u8,
+    },
+}
+
+enum:
 enum 0xa0::n::E0 {
     V0 {
         t: enum 0xa0::m::E1<u16, u32> {

--- a/crates/iota-package-resolver/src/snapshots/iota_package_resolver__tests__cross_package_layout.snap
+++ b/crates/iota-package-resolver/src/snapshots/iota_package_resolver__tests__cross_package_layout.snap
@@ -1,7 +1,25 @@
 ---
 source: crates/iota-package-resolver/src/lib.rs
-expression: "format!(\"{layout:#}\")"
+expression: "fmt(struct_layout, enum_layout)"
 ---
+struct:
+struct 0xb0::m::T0 {
+    m: struct 0xa0::m::T2 {
+        x: u8,
+    },
+    n: struct 0xa0::n::T0 {
+        t: struct 0xa0::m::T1<u16, u32> {
+            a: address,
+            p: u16,
+            q: vector<u32>,
+        },
+        u: struct 0xa0::m::T2 {
+            x: u8,
+        },
+    },
+}
+
+enum:
 enum 0xb0::m::E0 {
     V0 {
         m: struct 0xa0::m::T2 {

--- a/crates/iota-package-resolver/src/snapshots/iota_package_resolver__tests__multiple_linkage_contexts_layout.snap
+++ b/crates/iota-package-resolver/src/snapshots/iota_package_resolver__tests__multiple_linkage_contexts_layout.snap
@@ -1,0 +1,51 @@
+---
+source: crates/iota-package-resolver/src/lib.rs
+expression: "fmt(struct_layout, enum_layout)"
+---
+struct:
+struct 0xa0::m::T1<0xa0::m::T0, 0xa1::m::T3> {
+    a: address,
+    p: struct 0xa0::m::T0 {
+        b: bool,
+        v: vector<struct 0xa0::m::T1<0xa0::m::T2, u128> {
+            a: address,
+            p: struct 0xa0::m::T2 {
+                x: u8,
+            },
+            q: vector<u128>,
+        }>,
+    },
+    q: vector<struct 0xa1::m::T3 {
+        y: u16,
+    }>,
+}
+
+enum:
+enum 0xa0::m::E1<0xa0::m::E0, 0xa1::m::E3> {
+    V {
+        a: address,
+        p: enum 0xa0::m::E0 {
+            V {
+                b: bool,
+                v: vector<enum 0xa0::m::E1<0xa0::m::T1<0xa0::m::T2, u128>, u128> {
+                    V {
+                        a: address,
+                        p: struct 0xa0::m::T1<0xa0::m::T2, u128> {
+                            a: address,
+                            p: struct 0xa0::m::T2 {
+                                x: u8,
+                            },
+                            q: vector<u128>,
+                        },
+                        q: vector<u128>,
+                    },
+                }>,
+            },
+        },
+        q: vector<enum 0xa1::m::E3 {
+            V0 {
+                y: u16,
+            },
+        }>,
+    },
+}

--- a/crates/iota-package-resolver/src/snapshots/iota_package_resolver__tests__relinking_layout_layout.snap
+++ b/crates/iota-package-resolver/src/snapshots/iota_package_resolver__tests__relinking_layout_layout.snap
@@ -1,0 +1,476 @@
+---
+source: crates/iota-package-resolver/src/lib.rs
+expression: "fmt(struct_layout, enum_layout)"
+---
+struct:
+struct 0xc0::m::T0 {
+    t: struct 0xa0::n::T0 {
+        t: struct 0xa0::m::T1<u16, u32> {
+            a: address,
+            p: u16,
+            q: vector<u32>,
+        },
+        u: struct 0xa0::m::T2 {
+            x: u8,
+        },
+    },
+    u: struct 0xa1::n::T1 {
+        t: struct 0xa0::m::T1<0xa1::m::T3, u32> {
+            a: address,
+            p: struct 0xa1::m::T3 {
+                y: u16,
+            },
+            q: vector<u32>,
+        },
+        u: struct 0xa1::m::T4 {
+            z: u32,
+        },
+    },
+    v: struct 0xa0::m::T2 {
+        x: u8,
+    },
+    w: struct 0xa1::m::T3 {
+        y: u16,
+    },
+    x: struct 0xb0::m::T0 {
+        m: struct 0xa0::m::T2 {
+            x: u8,
+        },
+        n: struct 0xa0::n::T0 {
+            t: struct 0xa0::m::T1<u16, u32> {
+                a: address,
+                p: u16,
+                q: vector<u32>,
+            },
+            u: struct 0xa0::m::T2 {
+                x: u8,
+            },
+        },
+    },
+}
+
+enum:
+enum 0xc0::m::E0 {
+    EnumsAndStructs {
+        t: struct 0xa0::n::T0 {
+            t: struct 0xa0::m::T1<u16, u32> {
+                a: address,
+                p: u16,
+                q: vector<u32>,
+            },
+            u: struct 0xa0::m::T2 {
+                x: u8,
+            },
+        },
+        u: struct 0xa1::n::T1 {
+            t: struct 0xa0::m::T1<0xa1::m::T3, u32> {
+                a: address,
+                p: struct 0xa1::m::T3 {
+                    y: u16,
+                },
+                q: vector<u32>,
+            },
+            u: struct 0xa1::m::T4 {
+                z: u32,
+            },
+        },
+        v: struct 0xa0::m::T2 {
+            x: u8,
+        },
+        w: struct 0xa1::m::T3 {
+            y: u16,
+        },
+        x: struct 0xb0::m::T0 {
+            m: struct 0xa0::m::T2 {
+                x: u8,
+            },
+            n: struct 0xa0::n::T0 {
+                t: struct 0xa0::m::T1<u16, u32> {
+                    a: address,
+                    p: u16,
+                    q: vector<u32>,
+                },
+                u: struct 0xa0::m::T2 {
+                    x: u8,
+                },
+            },
+        },
+        et: enum 0xa0::n::E0 {
+            V0 {
+                t: enum 0xa0::m::E1<u16, u32> {
+                    V {
+                        a: address,
+                        p: u16,
+                        q: vector<u32>,
+                    },
+                },
+                u: struct 0xa0::m::T2 {
+                    x: u8,
+                },
+                l: enum 0xa0::m::E2 {
+                    V0 {
+                        x: u8,
+                    },
+                },
+            },
+        },
+        eu: enum 0xa1::n::E1 {
+            V0 {
+                t: struct 0xa0::m::T1<0xa1::m::T3, u32> {
+                    a: address,
+                    p: struct 0xa1::m::T3 {
+                        y: u16,
+                    },
+                    q: vector<u32>,
+                },
+                u: struct 0xa1::m::T4 {
+                    z: u32,
+                },
+                et: enum 0xa0::m::E1<0xa1::m::E3, u32> {
+                    V {
+                        a: address,
+                        p: enum 0xa1::m::E3 {
+                            V0 {
+                                y: u16,
+                            },
+                        },
+                        q: vector<u32>,
+                    },
+                },
+                eu: enum 0xa1::m::E4 {
+                    V0 {
+                        z: u32,
+                    },
+                },
+            },
+        },
+        ev: enum 0xa0::m::E2 {
+            V0 {
+                x: u8,
+            },
+        },
+        ew: enum 0xa1::m::E3 {
+            V0 {
+                y: u16,
+            },
+        },
+        ex: enum 0xb0::m::E0 {
+            V0 {
+                m: struct 0xa0::m::T2 {
+                    x: u8,
+                },
+                n: struct 0xa0::n::T0 {
+                    t: struct 0xa0::m::T1<u16, u32> {
+                        a: address,
+                        p: u16,
+                        q: vector<u32>,
+                    },
+                    u: struct 0xa0::m::T2 {
+                        x: u8,
+                    },
+                },
+                em: enum 0xa0::m::E2 {
+                    V0 {
+                        x: u8,
+                    },
+                },
+                en: enum 0xa0::n::E0 {
+                    V0 {
+                        t: enum 0xa0::m::E1<u16, u32> {
+                            V {
+                                a: address,
+                                p: u16,
+                                q: vector<u32>,
+                            },
+                        },
+                        u: struct 0xa0::m::T2 {
+                            x: u8,
+                        },
+                        l: enum 0xa0::m::E2 {
+                            V0 {
+                                x: u8,
+                            },
+                        },
+                    },
+                },
+            },
+            V1 {
+                em: enum 0xa0::m::E2 {
+                    V0 {
+                        x: u8,
+                    },
+                },
+                en: enum 0xa0::n::E0 {
+                    V0 {
+                        t: enum 0xa0::m::E1<u16, u32> {
+                            V {
+                                a: address,
+                                p: u16,
+                                q: vector<u32>,
+                            },
+                        },
+                        u: struct 0xa0::m::T2 {
+                            x: u8,
+                        },
+                        l: enum 0xa0::m::E2 {
+                            V0 {
+                                x: u8,
+                            },
+                        },
+                    },
+                },
+            },
+            V2 {
+                m: struct 0xa0::m::T2 {
+                    x: u8,
+                },
+                n: struct 0xa0::n::T0 {
+                    t: struct 0xa0::m::T1<u16, u32> {
+                        a: address,
+                        p: u16,
+                        q: vector<u32>,
+                    },
+                    u: struct 0xa0::m::T2 {
+                        x: u8,
+                    },
+                },
+                em: enum 0xa0::m::E2 {
+                    V0 {
+                        x: u8,
+                    },
+                },
+                en: enum 0xa0::n::E0 {
+                    V0 {
+                        t: enum 0xa0::m::E1<u16, u32> {
+                            V {
+                                a: address,
+                                p: u16,
+                                q: vector<u32>,
+                            },
+                        },
+                        u: struct 0xa0::m::T2 {
+                            x: u8,
+                        },
+                        l: enum 0xa0::m::E2 {
+                            V0 {
+                                x: u8,
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+    EnumsOnly {
+        et: enum 0xa0::n::E0 {
+            V0 {
+                t: enum 0xa0::m::E1<u16, u32> {
+                    V {
+                        a: address,
+                        p: u16,
+                        q: vector<u32>,
+                    },
+                },
+                u: struct 0xa0::m::T2 {
+                    x: u8,
+                },
+                l: enum 0xa0::m::E2 {
+                    V0 {
+                        x: u8,
+                    },
+                },
+            },
+        },
+        eu: enum 0xa1::n::E1 {
+            V0 {
+                t: struct 0xa0::m::T1<0xa1::m::T3, u32> {
+                    a: address,
+                    p: struct 0xa1::m::T3 {
+                        y: u16,
+                    },
+                    q: vector<u32>,
+                },
+                u: struct 0xa1::m::T4 {
+                    z: u32,
+                },
+                et: enum 0xa0::m::E1<0xa1::m::E3, u32> {
+                    V {
+                        a: address,
+                        p: enum 0xa1::m::E3 {
+                            V0 {
+                                y: u16,
+                            },
+                        },
+                        q: vector<u32>,
+                    },
+                },
+                eu: enum 0xa1::m::E4 {
+                    V0 {
+                        z: u32,
+                    },
+                },
+            },
+        },
+        ev: enum 0xa0::m::E2 {
+            V0 {
+                x: u8,
+            },
+        },
+        ew: enum 0xa1::m::E3 {
+            V0 {
+                y: u16,
+            },
+        },
+        ex: enum 0xb0::m::E0 {
+            V0 {
+                m: struct 0xa0::m::T2 {
+                    x: u8,
+                },
+                n: struct 0xa0::n::T0 {
+                    t: struct 0xa0::m::T1<u16, u32> {
+                        a: address,
+                        p: u16,
+                        q: vector<u32>,
+                    },
+                    u: struct 0xa0::m::T2 {
+                        x: u8,
+                    },
+                },
+                em: enum 0xa0::m::E2 {
+                    V0 {
+                        x: u8,
+                    },
+                },
+                en: enum 0xa0::n::E0 {
+                    V0 {
+                        t: enum 0xa0::m::E1<u16, u32> {
+                            V {
+                                a: address,
+                                p: u16,
+                                q: vector<u32>,
+                            },
+                        },
+                        u: struct 0xa0::m::T2 {
+                            x: u8,
+                        },
+                        l: enum 0xa0::m::E2 {
+                            V0 {
+                                x: u8,
+                            },
+                        },
+                    },
+                },
+            },
+            V1 {
+                em: enum 0xa0::m::E2 {
+                    V0 {
+                        x: u8,
+                    },
+                },
+                en: enum 0xa0::n::E0 {
+                    V0 {
+                        t: enum 0xa0::m::E1<u16, u32> {
+                            V {
+                                a: address,
+                                p: u16,
+                                q: vector<u32>,
+                            },
+                        },
+                        u: struct 0xa0::m::T2 {
+                            x: u8,
+                        },
+                        l: enum 0xa0::m::E2 {
+                            V0 {
+                                x: u8,
+                            },
+                        },
+                    },
+                },
+            },
+            V2 {
+                m: struct 0xa0::m::T2 {
+                    x: u8,
+                },
+                n: struct 0xa0::n::T0 {
+                    t: struct 0xa0::m::T1<u16, u32> {
+                        a: address,
+                        p: u16,
+                        q: vector<u32>,
+                    },
+                    u: struct 0xa0::m::T2 {
+                        x: u8,
+                    },
+                },
+                em: enum 0xa0::m::E2 {
+                    V0 {
+                        x: u8,
+                    },
+                },
+                en: enum 0xa0::n::E0 {
+                    V0 {
+                        t: enum 0xa0::m::E1<u16, u32> {
+                            V {
+                                a: address,
+                                p: u16,
+                                q: vector<u32>,
+                            },
+                        },
+                        u: struct 0xa0::m::T2 {
+                            x: u8,
+                        },
+                        l: enum 0xa0::m::E2 {
+                            V0 {
+                                x: u8,
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+    StructOnly {
+        t: struct 0xa0::n::T0 {
+            t: struct 0xa0::m::T1<u16, u32> {
+                a: address,
+                p: u16,
+                q: vector<u32>,
+            },
+            u: struct 0xa0::m::T2 {
+                x: u8,
+            },
+        },
+        u: struct 0xa1::n::T1 {
+            t: struct 0xa0::m::T1<0xa1::m::T3, u32> {
+                a: address,
+                p: struct 0xa1::m::T3 {
+                    y: u16,
+                },
+                q: vector<u32>,
+            },
+            u: struct 0xa1::m::T4 {
+                z: u32,
+            },
+        },
+        v: struct 0xa0::m::T2 {
+            x: u8,
+        },
+        w: struct 0xa1::m::T3 {
+            y: u16,
+        },
+        x: struct 0xb0::m::T0 {
+            m: struct 0xa0::m::T2 {
+                x: u8,
+            },
+            n: struct 0xa0::n::T0 {
+                t: struct 0xa0::m::T1<u16, u32> {
+                    a: address,
+                    p: u16,
+                    q: vector<u32>,
+                },
+                u: struct 0xa0::m::T2 {
+                    x: u8,
+                },
+            },
+        },
+    },
+}

--- a/crates/iota-package-resolver/src/snapshots/iota_package_resolver__tests__simple_type_layout.snap
+++ b/crates/iota-package-resolver/src/snapshots/iota_package_resolver__tests__simple_type_layout.snap
@@ -1,0 +1,35 @@
+---
+source: crates/iota-package-resolver/src/lib.rs
+expression: "fmt(struct_layout, enum_layout)"
+---
+struct:
+struct 0xa0::m::T0 {
+    b: bool,
+    v: vector<struct 0xa0::m::T1<0xa0::m::T2, u128> {
+        a: address,
+        p: struct 0xa0::m::T2 {
+            x: u8,
+        },
+        q: vector<u128>,
+    }>,
+}
+
+enum:
+enum 0xa0::m::E0 {
+    V {
+        b: bool,
+        v: vector<enum 0xa0::m::E1<0xa0::m::T1<0xa0::m::T2, u128>, u128> {
+            V {
+                a: address,
+                p: struct 0xa0::m::T1<0xa0::m::T2, u128> {
+                    a: address,
+                    p: struct 0xa0::m::T2 {
+                        x: u8,
+                    },
+                    q: vector<u128>,
+                },
+                q: vector<u128>,
+            },
+        }>,
+    },
+}

--- a/crates/iota-package-resolver/src/snapshots/iota_package_resolver__tests__upgraded_package_layout.snap
+++ b/crates/iota-package-resolver/src/snapshots/iota_package_resolver__tests__upgraded_package_layout.snap
@@ -1,7 +1,22 @@
 ---
 source: crates/iota-package-resolver/src/lib.rs
-expression: "format!(\"{layout:#}\")"
+expression: "fmt(struct_layout, enum_layout)"
 ---
+struct:
+struct 0xa1::n::T1 {
+    t: struct 0xa0::m::T1<0xa1::m::T3, u32> {
+        a: address,
+        p: struct 0xa1::m::T3 {
+            y: u16,
+        },
+        q: vector<u32>,
+    },
+    u: struct 0xa1::m::T4 {
+        z: u32,
+    },
+}
+
+enum:
 enum 0xa1::n::E1 {
     V0 {
         t: struct 0xa0::m::T1<0xa1::m::T3, u32> {

--- a/crates/iota-package-resolver/src/snapshots/iota_package_resolver__tests__upgraded_package_non_defining_id_layout.snap
+++ b/crates/iota-package-resolver/src/snapshots/iota_package_resolver__tests__upgraded_package_non_defining_id_layout.snap
@@ -1,0 +1,51 @@
+---
+source: crates/iota-package-resolver/src/lib.rs
+expression: "fmt(struct_layout, enum_layout)"
+---
+struct:
+struct 0xa0::m::T1<0xa1::m::T3, 0xa0::m::T0> {
+    a: address,
+    p: struct 0xa1::m::T3 {
+        y: u16,
+    },
+    q: vector<struct 0xa0::m::T0 {
+        b: bool,
+        v: vector<struct 0xa0::m::T1<0xa0::m::T2, u128> {
+            a: address,
+            p: struct 0xa0::m::T2 {
+                x: u8,
+            },
+            q: vector<u128>,
+        }>,
+    }>,
+}
+
+enum:
+enum 0xa0::m::E1<0xa1::m::E3, 0xa0::m::E0> {
+    V {
+        a: address,
+        p: enum 0xa1::m::E3 {
+            V0 {
+                y: u16,
+            },
+        },
+        q: vector<enum 0xa0::m::E0 {
+            V {
+                b: bool,
+                v: vector<enum 0xa0::m::E1<0xa0::m::T1<0xa0::m::T2, u128>, u128> {
+                    V {
+                        a: address,
+                        p: struct 0xa0::m::T1<0xa0::m::T2, u128> {
+                            a: address,
+                            p: struct 0xa0::m::T2 {
+                                x: u8,
+                            },
+                            q: vector<u128>,
+                        },
+                        q: vector<u128>,
+                    },
+                }>,
+            },
+        }>,
+    },
+}

--- a/crates/iota-package-resolver/src/snapshots/iota_package_resolver__tests__value_nesting_boundary_layout.snap
+++ b/crates/iota-package-resolver/src/snapshots/iota_package_resolver__tests__value_nesting_boundary_layout.snap
@@ -1,0 +1,19 @@
+---
+source: crates/iota-package-resolver/src/lib.rs
+expression: "fmt(struct_layout, enum_layout)"
+---
+struct:
+struct 0xa0::m::T1<u8, u8> {
+    a: address,
+    p: u8,
+    q: vector<u8>,
+}
+
+enum:
+enum 0xa0::m::E1<u8, u8> {
+    V {
+        a: address,
+        p: u8,
+        q: vector<u8>,
+    },
+}


### PR DESCRIPTION
# Description of change

Add a function to the package resolver to canonicalize a type (ensure
all the package IDs it mentions are defining IDs)
According to [changes](https://github.com/MystenLabs/sui/commit/778e78a#diff-000c960638af936148493636d55c8ea62676d2f051774239fc73e7fc1468bf32).

## Links to any relevant issues

Fixes #7078 .

## How the change has been tested

Run

```
cargo nextest run -p iota-package-resolver
```