### PR TITLE
feat(starfish): separate headers transaction storage

### DIFF
--- a/crates/starfish/core/src/block_manager.rs
+++ b/crates/starfish/core/src/block_manager.rs
@@ -115,7 +115,7 @@ impl BlockManager {
         for block_header in accepted_block_headers.iter() {
             if let Some(block) = self.suspended_blocks.remove(&block_header.reference()) {
                 // for this accepted header we already have a block, so we add it to dag_state
-                self.dag_state.write().add_block(block, live);
+                self.dag_state.write().add_transactions(block, live);
             } else {
                 accepted_block_header_refs.insert(block_header.reference());
             }
@@ -123,7 +123,7 @@ impl BlockManager {
         for block in blocks {
             let block_ref = &block.reference();
             if accepted_block_header_refs.remove(block_ref) {
-                self.dag_state.write().add_block(block, live);
+                self.dag_state.write().add_transactions(block, live);
             } else {
                 self.suspended_blocks.insert(block.reference(), block);
             }

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -877,7 +877,7 @@ mod tests {
             .map(|block| (block.reference(), block))
             .unzip();
         store
-            .write(WriteBatch::default().blocks(first_round_headers))
+            .write(WriteBatch::default().transactions(first_round_headers))
             .unwrap();
         blocks.append(&mut first_round_references.clone());
         // TODO: create some data for blocks in the first round
@@ -896,7 +896,7 @@ mod tests {
                         .build(),
                 );
                 store
-                    .write(WriteBatch::default().blocks(vec![block.clone()]))
+                    .write(WriteBatch::default().transactions(vec![block.clone()]))
                     .unwrap();
                 new_ancestors.push(block.reference());
                 blocks.push(block.reference());

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1244,7 +1244,7 @@ mod test {
         }
         // write them in store
         store
-            .write(WriteBatch::default().blocks(all_blocks))
+            .write(WriteBatch::default().transactions(all_blocks))
             .expect("Storage error");
 
         // create dag state after all blocks have been written to store
@@ -1368,7 +1368,7 @@ mod test {
 
         // write them in store
         store
-            .write(WriteBatch::default().blocks(all_blocks))
+            .write(WriteBatch::default().transactions(all_blocks))
             .expect("Storage error");
 
         // create dag state after all blocks have been written to store

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -55,8 +55,8 @@ pub(crate) struct DagState {
     // authority. Note: all uncommitted block headers are kept in memory.
     recent_block_headers: BTreeMap<BlockRef, VerifiedBlockHeader>,
 
-    // Contains recent blocks (together with transactions) within CACHED_ROUNDS from the last
-    // committed round per authority. Note: all uncommitted blocks are kept in memory.
+    // Contains recent transactions within CACHED_ROUNDS from the last
+    // committed round per authority. Note: all uncommitted transactions are kept in memory.
     recent_transactions: BTreeMap<BlockRef, VerifiedTransactions>,
 
     // Indexes recent block headers refs by their authorities.

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -19,7 +19,7 @@ use tracing::{debug, error, info};
 use crate::{
     block_header::{
         BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs, GENESIS_ROUND, Round, Slot,
-        VerifiedBlock, VerifiedBlockHeader, genesis_blocks,
+        VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions, genesis_blocks,
     },
     commit::{
         CommitAPI as _, CommitDigest, CommitIndex, CommitInfo, CommitRef, CommitVote,
@@ -57,18 +57,11 @@ pub(crate) struct DagState {
 
     // Contains recent blocks (together with transactions) within CACHED_ROUNDS from the last
     // committed round per authority. Note: all uncommitted blocks are kept in memory.
-    // TODO: should we relocate it to data manager?
-    // TODO: consider possibility to store only transactions to avoid duplication with
-    // recent_block_headers
-    recent_blocks: BTreeMap<BlockRef, VerifiedBlock>,
+    recent_transactions: BTreeMap<BlockRef, VerifiedTransactions>,
 
     // Indexes recent block headers refs by their authorities.
     // Vec position corresponds to the authority index.
     recent_headers_refs_by_authority: Vec<BTreeSet<BlockRef>>,
-
-    // Indexes recent block headers refs by their authorities.
-    // Vec position corresponds to the authority index.
-    recent_blocks_refs_by_authority: Vec<BTreeSet<BlockRef>>,
 
     // Keeps track of the threshold clock for proposing blocks.
     threshold_clock: ThresholdClock,
@@ -117,8 +110,8 @@ pub(crate) struct DagState {
     // to the authority, and not the ones that they already know.
     block_headers_not_known_by_authority: Vec<BTreeSet<BlockRef>>,
 
-    // Data to be flushed to storage.
-    blocks_to_write: Vec<VerifiedBlock>,
+    // Transactions to be flushed to storage.
+    transactions_to_write: Vec<VerifiedTransactions>,
     block_headers_to_write: Vec<VerifiedBlockHeader>,
     commits_to_write: Vec<TrustedCommit>,
 
@@ -195,16 +188,15 @@ impl DagState {
             context,
             genesis,
             recent_block_headers: BTreeMap::new(),
-            recent_blocks: BTreeMap::new(),
+            recent_transactions: BTreeMap::new(),
             recent_headers_refs_by_authority: vec![BTreeSet::new(); num_authorities],
-            recent_blocks_refs_by_authority: vec![BTreeSet::new(); num_authorities],
             threshold_clock,
             highest_accepted_round: 0,
             last_commit: last_commit.clone(),
             last_commit_round_advancement_time: None,
             last_committed_rounds: last_committed_rounds.clone(),
             pending_commit_votes: VecDeque::new(),
-            blocks_to_write: vec![],
+            transactions_to_write: vec![],
             block_headers_to_write: vec![],
             commits_to_write: vec![],
             commit_info_to_write: vec![],
@@ -301,10 +293,10 @@ impl DagState {
             .inc();
     }
 
-    pub(crate) fn add_block(&mut self, block: VerifiedBlock, live: bool) {
-        let block_ref = block.reference();
-        self.recent_blocks.insert(block_ref, block.clone());
-        self.recent_blocks_refs_by_authority[block_ref.author].insert(block_ref);
+    pub(crate) fn add_transactions(&mut self, transactions: VerifiedTransactions, live: bool) {
+        let block_ref = transactions.block_ref();
+        self.recent_transactions
+            .insert(block_ref, transactions.clone());
 
         // If a block is not very old, add it to pending acknowledgments
         let clock_round = self.threshold_clock_round();
@@ -313,7 +305,7 @@ impl DagState {
         if live && block_ref.round >= min_round {
             self.add_pending_acknowledgment(block_ref);
         }
-        self.blocks_to_write.push(block);
+        self.transactions_to_write.push(transactions);
     }
 
     /// Updates internal metadata for a block.
@@ -434,46 +426,45 @@ impl DagState {
         }
     }
 
-    /// Gets a block by checking cached recent blocks then storage.
-    /// Returns None when the block is not found.
-    pub(crate) fn get_block(&self, reference: &BlockRef) -> Option<VerifiedBlock> {
-        self.get_blocks(&[*reference])
+    /// Gets a transaction by checking cached recent transactions then storage.
+    /// Returns None when the transaction is not found.
+    pub(crate) fn get_transaction(&self, reference: &BlockRef) -> Option<VerifiedTransactions> {
+        self.get_transactions(&[*reference])
             .pop()
             .expect("Exactly one element should be returned")
     }
 
-    /// Gets a block header by checking cached recent blocks then storage.
-    /// Returns None when the block is not found.
-    pub(crate) fn get_block_header(&self, reference: &BlockRef) -> Option<VerifiedBlockHeader> {
-        self.get_block_headers(&[*reference])
-            .pop()
-            .expect("Exactly one element should be returned")
-    }
-
-    /// Gets blocks by checking genesis, cached recent blocks in memory, then
-    /// storage. An element is None when the corresponding block is not
+    /// Gets transactions by checking cached recent transactions in memory, then
+    /// storage. An element is None when the corresponding transaction is not
     /// found.
-    pub(crate) fn get_blocks(&self, block_refs: &[BlockRef]) -> Vec<Option<VerifiedBlock>> {
-        let mut blocks = vec![None; block_refs.len()];
+    pub(crate) fn get_transactions(
+        &self,
+        block_refs: &[BlockRef],
+    ) -> Vec<Option<VerifiedTransactions>> {
+        let mut transactions = vec![None; block_refs.len()];
         let mut missing = Vec::new();
 
         for (index, block_ref) in block_refs.iter().enumerate() {
             if block_ref.round == GENESIS_ROUND {
                 // Allow the caller to handle the invalid genesis ancestor error.
-                if let Some(block) = self.genesis.get(block_ref) {
-                    blocks[index] = Some(block.clone());
+                if let Some(transaction) = self
+                    .genesis
+                    .get(block_ref)
+                    .map(|block| block.verified_transactions.clone())
+                {
+                    transactions[index] = Some(transaction);
                 }
                 continue;
             }
-            if let Some(block) = self.recent_blocks.get(block_ref) {
-                blocks[index] = Some(block.clone());
+            if let Some(transaction) = self.recent_transactions.get(block_ref) {
+                transactions[index] = Some(transaction.clone());
                 continue;
             }
             missing.push((index, block_ref));
         }
 
         if missing.is_empty() {
-            return blocks;
+            return transactions;
         }
 
         let missing_refs = missing
@@ -482,20 +473,52 @@ impl DagState {
             .collect::<Vec<_>>();
         let store_results = self
             .store
-            .read_blocks(&missing_refs)
+            .read_transactions(&missing_refs)
             .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e));
         self.context
             .metrics
             .node_metrics
             .dag_state_store_read_count
-            .with_label_values(&["get_blocks"])
+            .with_label_values(&["get_transactions"])
             .inc();
 
         for ((index, _), result) in missing.into_iter().zip(store_results.into_iter()) {
-            blocks[index] = result;
+            transactions[index] = result;
         }
 
-        blocks
+        transactions
+    }
+
+    /// Gets a block by reconstructing it from its header and transactions.
+    /// Returns None when the block is not found.
+    pub(crate) fn get_block(&self, reference: &BlockRef) -> Option<VerifiedBlock> {
+        let header = self.get_block_header(reference)?;
+        let transactions = self.get_transaction(reference)?;
+        Some(VerifiedBlock::new(header, transactions))
+    }
+
+    /// Gets blocks by reconstructing them from their headers and transactions.
+    /// Returns None for elements where the block is not found.
+    pub(crate) fn get_blocks(&self, block_refs: &[BlockRef]) -> Vec<Option<VerifiedBlock>> {
+        let headers = self.get_block_headers(block_refs);
+        let transactions = self.get_transactions(block_refs);
+
+        headers
+            .into_iter()
+            .zip(transactions.into_iter())
+            .map(|(header, transaction)| match (header, transaction) {
+                (Some(header), Some(transaction)) => Some(VerifiedBlock::new(header, transaction)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Gets a block header by checking cached recent blocks then storage.
+    /// Returns None when the block is not found.
+    pub(crate) fn get_block_header(&self, reference: &BlockRef) -> Option<VerifiedBlockHeader> {
+        self.get_block_headers(&[*reference])
+            .pop()
+            .expect("Exactly one element should be returned")
     }
 
     /// Gets block headers by checking genesis, cached recent block headers in
@@ -641,12 +664,16 @@ impl DagState {
     /// Gets the last proposed block from this authority.
     /// If no block is proposed yet, returns Genesis block.
     pub(crate) fn get_last_proposed_block(&self) -> VerifiedBlock {
-        if let Some(last) = self.recent_blocks_refs_by_authority[self.context.own_index].last() {
-            return self
-                .recent_blocks
+        if let Some(last) = self.recent_headers_refs_by_authority[self.context.own_index].last() {
+            let header = self
+                .recent_block_headers
                 .get(last)
-                .expect("Block should be found in recent blocks")
-                .clone();
+                .expect("Block header should exist for the most recent blocks");
+            let transactions = self
+                .recent_transactions
+                .get(last)
+                .expect("Transactions should exist for the most recent blocks");
+            return VerifiedBlock::new(header.clone(), transactions.clone());
         }
 
         let (_, genesis_block) = self
@@ -698,15 +725,18 @@ impl DagState {
         start: Round,
     ) -> Vec<VerifiedBlock> {
         let mut blocks = vec![];
-        for block_ref in self.recent_blocks_refs_by_authority[authority].range((
+        for block_ref in self.recent_headers_refs_by_authority[authority].range((
             Included(BlockRef::new(start, authority, BlockHeaderDigest::MIN)),
             Unbounded,
         )) {
-            let block = self
-                .recent_blocks
-                .get(block_ref)
-                .expect("Block should exist in recent blocks");
-            blocks.push(block.clone());
+            // TODO: panic if header is missing and return vector of tuples with header and
+            //  option<transactions> as not all transactions must exist. Although this is
+            //  only used to load own blocks to stream, this should not be problematic.
+            if let Some(header) = self.recent_block_headers.get(block_ref) {
+                if let Some(transactions) = self.recent_transactions.get(block_ref) {
+                    blocks.push(VerifiedBlock::new(header.clone(), transactions.clone()));
+                }
+            }
         }
         blocks
     }
@@ -1224,70 +1254,76 @@ impl DagState {
             .scope_processing_time
             .with_label_values(&["DagState::flush"])
             .start_timer();
-        // Flush buffered data to storage.
-        let blocks = std::mem::take(&mut self.blocks_to_write);
+
+        // Take ownership of buffered data efficiently using mem::take
+        let transactions = std::mem::take(&mut self.transactions_to_write);
         let block_headers = std::mem::take(&mut self.block_headers_to_write);
         let commits = std::mem::take(&mut self.commits_to_write);
-        let commit_info_to_write = std::mem::take(&mut self.commit_info_to_write);
+        let commit_info = std::mem::take(&mut self.commit_info_to_write);
 
-        if blocks.is_empty() && commits.is_empty() && block_headers.is_empty() {
+        // Early return if there's nothing to flush
+        if transactions.is_empty()
+            && block_headers.is_empty()
+            && commits.is_empty()
+            && commit_info.is_empty()
+        {
             return;
         }
+
         debug!(
-            "Flushing {} blocks ({}), {} block headers ({}), {} commits ({}) and {} commit info ({}) to storage.",
-            blocks.len(),
-            blocks.iter().map(|b| b.reference().to_string()).join(","),
+            "Flushing {} block headers ({}), {} transactions ({}), {} commits ({}) and {} commit info ({}) to storage.",
             block_headers.len(),
             block_headers
                 .iter()
                 .map(|b| b.reference().to_string())
                 .join(","),
+            transactions.len(),
+            transactions
+                .iter()
+                .map(|b| b.transactions_commitment().to_string())
+                .join(","),
             commits.len(),
             commits.iter().map(|c| c.reference().to_string()).join(","),
-            commit_info_to_write.len(),
-            commit_info_to_write
+            commit_info.len(),
+            commit_info
                 .iter()
                 .map(|(commit_ref, _)| commit_ref.to_string())
                 .join(","),
         );
+
+        // Write all buffered data to storage
         self.store
             .write(WriteBatch::new(
-                blocks,
+                transactions,
                 block_headers,
                 commits,
-                commit_info_to_write,
+                commit_info,
             ))
             .unwrap_or_else(|e| panic!("Failed to write to storage: {:?}", e));
+
         self.context
             .metrics
             .node_metrics
             .dag_state_store_write_count
             .inc();
 
-        // Clean up old cached data. After flushing, all cached blocks are guaranteed to
-        // be persisted.
+        // Clean up old cached data for each authority after flushing, all cached blocks
+        // are guaranteed to be persisted.
         for (authority_index, _) in self.context.committee.authorities() {
             let eviction_round = self.calculate_authority_eviction_round(authority_index);
-            while let Some(block_ref) =
-                self.recent_headers_refs_by_authority[authority_index].first()
-            {
+            let recent_refs = &mut self.recent_headers_refs_by_authority[authority_index];
+
+            // Remove old entries from cached maps
+            while let Some(block_ref) = recent_refs.first() {
                 if block_ref.round <= eviction_round {
                     self.recent_block_headers.remove(block_ref);
-                    self.recent_headers_refs_by_authority[authority_index].pop_first();
+                    self.recent_transactions.remove(block_ref);
+                    recent_refs.pop_first();
                 } else {
                     break;
                 }
             }
-            while let Some(block_ref) =
-                self.recent_blocks_refs_by_authority[authority_index].first()
-            {
-                if block_ref.round <= eviction_round {
-                    self.recent_blocks.remove(block_ref);
-                    self.recent_blocks_refs_by_authority[authority_index].pop_first();
-                } else {
-                    break;
-                }
-            }
+
             self.evicted_rounds[authority_index] = eviction_round;
         }
 
@@ -1297,13 +1333,13 @@ impl DagState {
         // Clean up old cordial knowledge.
         self.evict_cordial_knowledge();
 
+        // Update metrics
         let metrics = &self.context.metrics.node_metrics;
-        // TODO: create similar metric for headers?
         metrics
             .dag_state_recent_blocks
             .set(self.recent_blocks.len() as i64);
         metrics.dag_state_recent_refs.set(
-            self.recent_blocks_refs_by_authority
+            self.recent_headers_refs_by_authority
                 .iter()
                 .map(BTreeSet::len)
                 .sum::<usize>() as i64,

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -118,7 +118,8 @@ pub(crate) struct NodeMetrics {
     pub(crate) highest_accepted_authority_round: IntGaugeVec,
     pub(crate) highest_accepted_round: IntGauge,
     pub(crate) accepted_blocks: IntCounterVec,
-    pub(crate) dag_state_recent_blocks: IntGauge,
+    pub(crate) dag_state_recent_transactions: IntGauge,
+    pub(crate) dag_state_recent_headers: IntGauge,
     pub(crate) dag_state_recent_refs: IntGauge,
     pub(crate) dag_state_store_read_count: IntCounterVec,
     pub(crate) dag_state_store_write_count: IntCounter,
@@ -301,9 +302,14 @@ impl NodeMetrics {
                 &["source"],
                 registry,
             ).unwrap(),
-            dag_state_recent_blocks: register_int_gauge_with_registry!(
-                "dag_state_recent_blocks",
-                "Number of recent blocks cached in the DagState",
+            dag_state_recent_transactions: register_int_gauge_with_registry!(
+                "dag_state_recent_transactions",
+                "Number of recent transactions cached in the DagState",
+                registry,
+            ).unwrap(),
+            dag_state_recent_headers: register_int_gauge_with_registry!(
+                "dag_state_recent_headers",
+                "Number of recent block headers cached in the DagState",
                 registry,
             ).unwrap(),
             dag_state_recent_refs: register_int_gauge_with_registry!(

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -117,7 +117,7 @@ impl Store for MemStore {
     }
 
     // TODO: Do we need this method or will DAGState always try to read both headers
-    // and transactions seaprately?
+    // and transactions separately?
     fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>> {
         // Ensure we have a read lock on the inner state across reading both headers and
         // transactions reads

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -14,7 +14,7 @@ use super::{Store, WriteBatch};
 use crate::{
     block_header::{
         BlockHeaderAPI as _, BlockHeaderDigest, BlockRef, Round, Slot, VerifiedBlock,
-        VerifiedBlockHeader,
+        VerifiedBlockHeader, VerifiedTransactions,
     },
     commit::{
         CommitAPI as _, CommitDigest, CommitIndex, CommitInfo, CommitRange, CommitRef,
@@ -29,7 +29,7 @@ pub(crate) struct MemStore {
 }
 
 struct Inner {
-    blocks: BTreeMap<(Round, AuthorityIndex, BlockHeaderDigest), VerifiedBlock>,
+    transactions: BTreeMap<(Round, AuthorityIndex, BlockHeaderDigest), VerifiedTransactions>,
     block_headers: BTreeMap<(Round, AuthorityIndex, BlockHeaderDigest), VerifiedBlockHeader>,
     digests_by_authorities: BTreeSet<(AuthorityIndex, Round, BlockHeaderDigest)>,
     commits: BTreeMap<(CommitIndex, CommitDigest), TrustedCommit>,
@@ -41,7 +41,7 @@ impl MemStore {
     pub(crate) fn new() -> Self {
         MemStore {
             inner: RwLock::new(Inner {
-                blocks: BTreeMap::new(),
+                transactions: BTreeMap::new(),
                 block_headers: BTreeMap::new(),
                 digests_by_authorities: BTreeSet::new(),
                 commits: BTreeMap::new(),
@@ -56,28 +56,7 @@ impl Store for MemStore {
     fn write(&self, write_batch: WriteBatch) -> ConsensusResult<()> {
         let mut inner = self.inner.write();
 
-        for block in write_batch.blocks {
-            let block_ref = block.reference();
-            inner.blocks.insert(
-                (block_ref.round, block_ref.author, block_ref.digest),
-                block.clone(),
-            );
-            inner.block_headers.insert(
-                (block_ref.round, block_ref.author, block_ref.digest),
-                block.verified_block_header.clone(),
-            );
-            inner.digests_by_authorities.insert((
-                block_ref.author,
-                block_ref.round,
-                block_ref.digest,
-            ));
-            for vote in block.commit_votes() {
-                inner
-                    .commit_votes
-                    .insert((vote.index, vote.digest, block_ref));
-            }
-        }
-
+        // Store block headers
         for block_header in write_batch.block_headers {
             let block_ref = block_header.reference();
             inner.block_headers.insert(
@@ -96,6 +75,15 @@ impl Store for MemStore {
             }
         }
 
+        // Store transactions data separately
+        for transaction in write_batch.transactions {
+            let block_ref = transaction.block_ref();
+            inner.transactions.insert(
+                (block_ref.round, block_ref.author, block_ref.digest),
+                transaction,
+            );
+        }
+
         for commit in write_batch.commits {
             inner
                 .commits
@@ -111,48 +99,54 @@ impl Store for MemStore {
         Ok(())
     }
 
-    fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>> {
-        let inner = self.inner.read();
-        let blocks = refs
-            .iter()
-            .map(|r| inner.blocks.get(&(r.round, r.author, r.digest)).cloned())
-            .collect();
-        Ok(blocks)
-    }
-
-    fn read_block_headers(
+    fn read_transactions(
         &self,
         refs: &[BlockRef],
-    ) -> ConsensusResult<Vec<Option<VerifiedBlockHeader>>> {
+    ) -> ConsensusResult<Vec<Option<VerifiedTransactions>>> {
         let inner = self.inner.read();
-        let block_headers = refs
+        let transactions = refs
             .iter()
             .map(|r| {
                 inner
-                    .block_headers
+                    .transactions
                     .get(&(r.round, r.author, r.digest))
                     .cloned()
             })
             .collect();
-        Ok(block_headers)
+        Ok(transactions)
     }
 
-    fn contains_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>> {
+    // TODO: Do we need this method or will DAGState always try to read both headers
+    // and transactions seaprately?
+    fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>> {
+        // Ensure we have a read lock on the inner state across reading both headers and
+        // transactions reads
         let inner = self.inner.read();
-        let exist = refs
-            .iter()
-            .map(|r| inner.blocks.contains_key(&(r.round, r.author, r.digest)))
-            .collect();
-        Ok(exist)
+        // Get both headers and transactions for the given references
+        let headers = self.read_block_headers(refs)?;
+        let transactions = self.read_transactions(refs)?;
+        drop(inner); // Explicitly drop the read lock before combining results
+
+        // Combine them into blocks if both parts exist
+        let mut blocks = Vec::with_capacity(refs.len());
+        for (header, transactions) in headers.into_iter().zip(transactions) {
+            match (header, transactions) {
+                (Some(hdr), Some(txs)) => {
+                    blocks.push(Some(VerifiedBlock::new(hdr, txs)));
+                }
+                _ => blocks.push(None),
+            }
+        }
+        Ok(blocks)
     }
 
-    fn contains_block_headers(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>> {
+    fn contains_transactions(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>> {
         let inner = self.inner.read();
         let exist = refs
             .iter()
             .map(|r| {
                 inner
-                    .block_headers
+                    .transactions
                     .contains_key(&(r.round, r.author, r.digest))
             })
             .collect();
@@ -173,28 +167,13 @@ impl Store for MemStore {
             refs.push(BlockRef::new(round, author, digest));
         }
         let results = self.read_blocks(refs.as_slice())?;
-        let mut blocks = vec![];
+        let mut blocks = Vec::with_capacity(refs.len());
         for (r, block) in refs.into_iter().zip(results.into_iter()) {
-            if let Some(block) = block {
-                blocks.push(block);
-            } else {
-                panic!("Block {:?} not found!", r);
-            }
+            blocks.push(
+                block.unwrap_or_else(|| panic!("Storage inconsistency: block {:?} not found!", r)),
+            );
         }
         Ok(blocks)
-    }
-
-    fn contains_block_at_slot(&self, slot: Slot) -> ConsensusResult<bool> {
-        let inner = self.inner.read();
-        let found = inner
-            .digests_by_authorities
-            .range((
-                Included((slot.authority, slot.round, BlockHeaderDigest::MIN)),
-                Included((slot.authority, slot.round, BlockHeaderDigest::MAX)),
-            ))
-            .next()
-            .is_some();
-        Ok(found)
     }
 
     fn scan_last_blocks_by_author(
@@ -205,6 +184,8 @@ impl Store for MemStore {
     ) -> ConsensusResult<Vec<VerifiedBlock>> {
         let before_round = before_round.unwrap_or(Round::MAX);
         let mut refs = VecDeque::new();
+
+        // Collect block references
         for &(author, round, digest) in self
             .inner
             .read()
@@ -218,6 +199,8 @@ impl Store for MemStore {
         {
             refs.push_front(BlockRef::new(round, author, digest));
         }
+
+        // Read and combine transactions and headers
         let results = self.read_blocks(refs.as_slices().0)?;
         let mut blocks = vec![];
         for (r, block) in refs.into_iter().zip(results.into_iter()) {
@@ -226,6 +209,36 @@ impl Store for MemStore {
             );
         }
         Ok(blocks)
+    }
+
+    fn read_block_headers(
+        &self,
+        refs: &[BlockRef],
+    ) -> ConsensusResult<Vec<Option<VerifiedBlockHeader>>> {
+        let inner = self.inner.read();
+        let block_headers = refs
+            .iter()
+            .map(|r| {
+                inner
+                    .block_headers
+                    .get(&(r.round, r.author, r.digest))
+                    .cloned()
+            })
+            .collect();
+        Ok(block_headers)
+    }
+
+    fn contains_block_at_slot(&self, slot: Slot) -> ConsensusResult<bool> {
+        let inner = self.inner.read();
+        let found = inner
+            .digests_by_authorities
+            .range((
+                Included((slot.authority, slot.round, BlockHeaderDigest::MIN)),
+                Included((slot.authority, slot.round, BlockHeaderDigest::MAX)),
+            ))
+            .next()
+            .is_some();
+        Ok(found)
     }
 
     fn scan_block_headers_by_author(
@@ -242,13 +255,11 @@ impl Store for MemStore {
             refs.push(BlockRef::new(round, author, digest));
         }
         let results = self.read_block_headers(refs.as_slice())?;
-        let mut block_headers = vec![];
+        let mut block_headers = Vec::with_capacity(refs.len());
         for (r, block_header) in refs.into_iter().zip(results.into_iter()) {
-            if let Some(block) = block_header {
-                block_headers.push(block);
-            } else {
-                panic!("Block Header {:?} not found!", r);
-            }
+            block_headers.push(block_header.unwrap_or_else(|| {
+                panic!("Storage inconsistency: block header {:?} not found!", r)
+            }));
         }
         Ok(block_headers)
     }
@@ -257,7 +268,8 @@ impl Store for MemStore {
         let inner = self.inner.read();
         Ok(inner
             .commits
-            .last_key_value()
+            .iter()
+            .next_back()
             .map(|(_, commit)| commit.clone()))
     }
 
@@ -290,7 +302,21 @@ impl Store for MemStore {
         let inner = self.inner.read();
         Ok(inner
             .commit_info
-            .last_key_value()
-            .map(|(k, v)| (CommitRef::new(k.0, k.1), v.clone())))
+            .iter()
+            .next_back()
+            .map(|((index, digest), info)| (CommitRef::new(*index, *digest), info.clone())))
+    }
+
+    fn contains_block_headers(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>> {
+        let inner = self.inner.read();
+        let exist = refs
+            .iter()
+            .map(|r| {
+                inner
+                    .block_headers
+                    .contains_key(&(r.round, r.author, r.digest))
+            })
+            .collect();
+        Ok(exist)
     }
 }

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -13,7 +13,7 @@ use starfish_config::AuthorityIndex;
 
 use crate::{
     CommitIndex,
-    block_header::{BlockRef, Round, VerifiedBlock, VerifiedBlockHeader},
+    block_header::{BlockRef, Round, VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions},
     commit::{CommitInfo, CommitRange, CommitRef, TrustedCommit},
     error::ConsensusResult,
 };
@@ -23,7 +23,8 @@ pub(crate) trait Store: Send + Sync {
     /// Writes blocks, consensus commits and other data to store atomically.
     fn write(&self, write_batch: WriteBatch) -> ConsensusResult<()>;
 
-    /// Reads blocks for the given refs.
+    /// Reads complete blocks by combining transactions and headers for the
+    /// given refs.
     fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>>;
 
     /// Reads block headers for the given refs.
@@ -32,9 +33,15 @@ pub(crate) trait Store: Send + Sync {
         refs: &[BlockRef],
     ) -> ConsensusResult<Vec<Option<VerifiedBlockHeader>>>;
 
-    /// Checks if blocks exist in the store.
+    /// Reads transactions for the given refs.
+    fn read_transactions(
+        &self,
+        refs: &[BlockRef],
+    ) -> ConsensusResult<Vec<Option<VerifiedTransactions>>>;
+
+    /// Checks if transactions exist in the store.
     #[cfg_attr(not(test), expect(dead_code))]
-    fn contains_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>>;
+    fn contains_transactions(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>>;
 
     /// Checks if block headers exist in the store.
     fn contains_block_headers(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>>;
@@ -85,7 +92,7 @@ pub(crate) trait Store: Send + Sync {
 /// Represents data to be written to the store together atomically.
 #[derive(Debug, Default)]
 pub(crate) struct WriteBatch {
-    pub(crate) blocks: Vec<VerifiedBlock>,
+    pub(crate) transactions: Vec<VerifiedTransactions>,
     pub(crate) block_headers: Vec<VerifiedBlockHeader>,
     pub(crate) commits: Vec<TrustedCommit>,
     pub(crate) commit_info: Vec<(CommitRef, CommitInfo)>,
@@ -93,13 +100,13 @@ pub(crate) struct WriteBatch {
 
 impl WriteBatch {
     pub(crate) fn new(
-        blocks: Vec<VerifiedBlock>,
+        transactions: Vec<VerifiedTransactions>,
         block_headers: Vec<VerifiedBlockHeader>,
         commits: Vec<TrustedCommit>,
         commit_info: Vec<(CommitRef, CommitInfo)>,
     ) -> Self {
         WriteBatch {
-            blocks,
+            transactions,
             block_headers,
             commits,
             commit_info,
@@ -109,8 +116,8 @@ impl WriteBatch {
     // Test setters.
 
     #[cfg(test)]
-    pub(crate) fn blocks(mut self, blocks: Vec<VerifiedBlock>) -> Self {
-        self.blocks = blocks;
+    pub(crate) fn transactions(mut self, transactions: Vec<VerifiedTransactions>) -> Self {
+        self.transactions = transactions;
         self
     }
 

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -17,8 +17,10 @@ use typed_store::{
 
 use super::{CommitInfo, Store, WriteBatch};
 use crate::{
+    Transaction,
     block_header::{
-        BlockHeaderAPI as _, BlockHeaderDigest, BlockRef, Round, VerifiedBlock, VerifiedBlockHeader,
+        BlockHeaderAPI as _, BlockHeaderDigest, BlockRef, Round, TransactionsCommitment,
+        VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions,
     },
     commit::{CommitAPI as _, CommitDigest, CommitIndex, CommitRange, CommitRef, TrustedCommit},
     error::{ConsensusError, ConsensusResult},
@@ -30,10 +32,10 @@ use crate::{
 // trying to read a block, assemble a full block by reading from two column
 // families.
 pub(crate) struct RocksDBStore {
-    /// Stores SignedBlock by refs.
-    transactions: DBMap<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
     /// Stores SignedBlockHeader by refs.
     block_headers: DBMap<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
+    /// Stores SignedBlock by refs.
+    transactions: DBMap<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
     /// A secondary index that orders refs first by authors.
     digests_by_authorities: DBMap<(AuthorityIndex, Round, BlockHeaderDigest), ()>,
     /// Maps commit index to Commit.
@@ -91,9 +93,16 @@ impl RocksDBStore {
         )
         .expect("Cannot open database");
 
-        let (blocks, block_headers, digests_by_authorities, commits, commit_votes, commit_info) = reopen!(&rocksdb,
-            Self::TRANSACTIONS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), bytes::Bytes>,
-            Self::BLOCK_HEADERS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), bytes::Bytes>,
+        let (
+            block_headers,
+            transactions,
+            digests_by_authorities,
+            commits,
+            commit_votes,
+            commit_info,
+        ) = reopen!(&rocksdb,
+            Self::BLOCK_HEADERS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
+            Self::TRANSACTIONS_CF;<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
             Self::DIGESTS_BY_AUTHORITIES_CF;<(AuthorityIndex, Round, BlockHeaderDigest), ()>,
             Self::COMMITS_CF;<(CommitIndex, CommitDigest), Bytes>,
             Self::COMMIT_VOTES_CF;<(CommitIndex, CommitDigest, BlockRef), ()>,
@@ -101,8 +110,8 @@ impl RocksDBStore {
         );
 
         Self {
-            transactions: blocks,
             block_headers,
+            transactions,
             digests_by_authorities,
             commits,
             commit_votes,
@@ -114,48 +123,14 @@ impl RocksDBStore {
 impl Store for RocksDBStore {
     fn write(&self, write_batch: WriteBatch) -> ConsensusResult<()> {
         fail_point!("consensus-store-before-write");
-
+        // TODO: does it matter which CF we use here?
         let mut batch = self.transactions.batch();
-        for block in write_batch.blocks {
-            let block_ref = block.reference();
-            let (serialized_block_header, serialized_transactions) = block.serialized();
-            batch
-                .insert_batch(
-                    &self.transactions,
-                    [(
-                        (block_ref.round, block_ref.author, block_ref.digest),
-                        serialized_transactions,
-                    )],
-                )
-                .map_err(ConsensusError::RocksDBFailure)?;
-            batch
-                .insert_batch(
-                    &self.block_headers,
-                    [(
-                        (block_ref.round, block_ref.author, block_ref.digest),
-                        serialized_block_header,
-                    )],
-                )
-                .map_err(ConsensusError::RocksDBFailure)?;
-            batch
-                .insert_batch(
-                    &self.digests_by_authorities,
-                    [((block_ref.author, block_ref.round, block_ref.digest), ())],
-                )
-                .map_err(ConsensusError::RocksDBFailure)?;
-            for vote in block.commit_votes() {
-                batch
-                    .insert_batch(
-                        &self.commit_votes,
-                        [((vote.index, vote.digest, block_ref), ())],
-                    )
-                    .map_err(ConsensusError::RocksDBFailure)?;
-            }
-        }
 
+        // Store block headers and their associated commit votes
         for block_header in write_batch.block_headers {
             let block_ref = block_header.reference();
             info!("block header {} pushed to store", block_header);
+            // Store the block header
             batch
                 .insert_batch(
                     &self.block_headers,
@@ -165,12 +140,14 @@ impl Store for RocksDBStore {
                     )],
                 )
                 .map_err(ConsensusError::RocksDBFailure)?;
+            // Store the authority digest
             batch
                 .insert_batch(
                     &self.digests_by_authorities,
                     [((block_ref.author, block_ref.round, block_ref.digest), ())],
                 )
                 .map_err(ConsensusError::RocksDBFailure)?;
+            // Store commit votes from this block header using the BlockHeaderAPI trait
             for vote in block_header.commit_votes() {
                 batch
                     .insert_batch(
@@ -181,6 +158,21 @@ impl Store for RocksDBStore {
             }
         }
 
+        // Store transactions data
+        for transaction in write_batch.transactions {
+            let block_ref = transaction.block_ref();
+            batch
+                .insert_batch(
+                    &self.transactions,
+                    [(
+                        (block_ref.round, block_ref.author, block_ref.digest),
+                        transaction.serialized(),
+                    )],
+                )
+                .map_err(ConsensusError::RocksDBFailure)?;
+        }
+
+        // Handle commits
         for commit in write_batch.commits {
             batch
                 .insert_batch(
@@ -190,6 +182,7 @@ impl Store for RocksDBStore {
                 .map_err(ConsensusError::RocksDBFailure)?;
         }
 
+        // Handle commit info
         for (commit_ref, commit_info) in write_batch.commit_info {
             batch
                 .insert_batch(
@@ -209,6 +202,9 @@ impl Store for RocksDBStore {
             .iter()
             .map(|r| (r.round, r.author, r.digest))
             .collect::<Vec<_>>();
+
+        // TODO: is consistency guaranteed here? what if there is a write between those
+        //  two reads?
         let serialized_vec_transactions = self.transactions.multi_get(keys.clone())?;
         let serialized_block_headers = self.block_headers.multi_get(keys)?;
         let mut blocks = vec![];
@@ -225,7 +221,7 @@ impl Store for RocksDBStore {
                     serialized_transactions,
                 })?;
 
-                // Makes sure block data is not corrupted, by comparing digests.
+                // Makes sure block data is not corrupted by comparing digests.
                 assert_eq!(*key, block.reference());
                 blocks.push(Some(block));
             } else {
@@ -249,7 +245,7 @@ impl Store for RocksDBStore {
             if let Some(serialized_block_header) = serialized_block_header {
                 let block_header = VerifiedBlockHeader::new_from_bytes(serialized_block_header)?;
 
-                // Makes sure block data is not corrupted, by comparing digests.
+                // Makes sure block data is not corrupted by comparing digests.
                 assert_eq!(*key, block_header.reference());
                 block_headers.push(Some(block_header));
             } else {
@@ -259,12 +255,37 @@ impl Store for RocksDBStore {
         Ok(block_headers)
     }
 
-    fn contains_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>> {
-        let refs = refs
+    fn read_transactions(
+        &self,
+        refs: &[BlockRef],
+    ) -> ConsensusResult<Vec<Option<VerifiedTransactions>>> {
+        let keys = refs
             .iter()
             .map(|r| (r.round, r.author, r.digest))
             .collect::<Vec<_>>();
-        let exist = self.transactions.multi_contains_keys(refs)?;
+        let serialized_transactions = self.transactions.multi_get(keys)?;
+        let mut result = Vec::with_capacity(refs.len());
+        for (i, serialized) in serialized_transactions.into_iter().enumerate() {
+            if let Some(bytes) = serialized {
+                let transactions: Vec<Transaction> =
+                    bcs::from_bytes(&bytes).map_err(ConsensusError::MalformedTransactions)?;
+                let commitment = TransactionsCommitment::compute_transactions_commitment(&bytes)
+                    .expect("computation of the transactions commitment should not fail");
+                let verified = VerifiedTransactions::new(transactions, refs[i], commitment, bytes);
+                result.push(Some(verified));
+            } else {
+                result.push(None);
+            }
+        }
+        Ok(result)
+    }
+
+    fn contains_transactions(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>> {
+        let keys = refs
+            .iter()
+            .map(|r| (r.round, r.author, r.digest))
+            .collect::<Vec<_>>();
+        let exist = self.transactions.multi_contains_keys(keys)?;
         Ok(exist)
     }
 

--- a/crates/starfish/core/src/storage/store_tests.rs
+++ b/crates/starfish/core/src/storage/store_tests.rs
@@ -43,7 +43,7 @@ fn new_mem_teststore() -> TestStore {
 
 #[rstest]
 #[tokio::test]
-async fn read_and_contain_blocks(
+async fn read_and_contain_block_headers(
     #[values(new_rocksdb_teststore(), new_mem_teststore())] test_store: TestStore,
 ) {
     let store = test_store.store();
@@ -54,80 +54,102 @@ async fn read_and_contain_blocks(
         VerifiedBlock::new_for_test(TestBlockHeader::new(1, 2).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(2, 3).build()),
     ];
+
+    // Write only headers
     store
-        .write(WriteBatch::default().blocks(written_blocks.clone()))
+        .write(
+            WriteBatch::default().block_headers(
+                written_blocks
+                    .iter()
+                    .map(|b| b.verified_block_header.clone())
+                    .collect(),
+            ),
+        )
         .unwrap();
 
-    {
-        let refs = vec![written_blocks[0].reference()];
-        let read_blocks = store
-            .read_blocks(&refs)
-            .expect("Read blocks should not fail");
-        assert_eq!(read_blocks.len(), 1);
-        assert_eq!(read_blocks[0].as_ref().unwrap(), &written_blocks[0]);
-    }
+    // Test basic header read
+    let refs = vec![written_blocks[0].reference()];
+    let read_headers = store
+        .read_block_headers(&refs)
+        .expect("Read headers should not fail");
+    assert_eq!(read_headers.len(), 1);
+    assert_eq!(
+        read_headers[0].as_ref().unwrap(),
+        &written_blocks[0].verified_block_header
+    );
 
-    {
-        let refs = vec![
-            written_blocks[2].reference(),
-            written_blocks[1].reference(),
-            written_blocks[1].reference(),
-        ];
-        let read_blocks = store
-            .read_blocks(&refs)
-            .expect("Read blocks should not fail");
-        assert_eq!(read_blocks.len(), 3);
-        assert_eq!(read_blocks[0].as_ref().unwrap(), &written_blocks[2]);
-        assert_eq!(read_blocks[1].as_ref().unwrap(), &written_blocks[1]);
-        assert_eq!(read_blocks[2].as_ref().unwrap(), &written_blocks[1]);
-    }
+    // Test multiple references including duplicates
+    let refs = vec![
+        written_blocks[2].reference(),
+        written_blocks[1].reference(),
+        written_blocks[1].reference(),
+    ];
+    let read_headers = store
+        .read_block_headers(&refs)
+        .expect("Read headers should not fail");
+    assert_eq!(read_headers.len(), 3);
+    assert_eq!(
+        read_headers[0].as_ref().unwrap(),
+        &written_blocks[2].verified_block_header
+    );
+    assert_eq!(
+        read_headers[1].as_ref().unwrap(),
+        &written_blocks[1].verified_block_header
+    );
+    assert_eq!(
+        read_headers[2].as_ref().unwrap(),
+        &written_blocks[1].verified_block_header
+    );
 
-    {
-        let refs = vec![
-            written_blocks[3].reference(),
-            BlockRef::new(
-                1,
-                AuthorityIndex::new_for_test(3),
-                BlockHeaderDigest::default(),
-            ),
-            written_blocks[2].reference(),
-        ];
-        let read_blocks = store
-            .read_blocks(&refs)
-            .expect("Read blocks should not fail");
-        assert_eq!(read_blocks.len(), 3);
-        assert_eq!(read_blocks[0].as_ref().unwrap(), &written_blocks[3]);
-        assert!(read_blocks[1].is_none());
-        assert_eq!(read_blocks[2].as_ref().unwrap(), &written_blocks[2]);
+    // Test with missing references
+    let refs = vec![
+        written_blocks[3].reference(),
+        BlockRef::new(
+            1,
+            AuthorityIndex::new_for_test(3),
+            BlockHeaderDigest::default(),
+        ),
+        written_blocks[2].reference(),
+    ];
+    let read_headers = store
+        .read_block_headers(&refs)
+        .expect("Read headers should not fail");
+    assert_eq!(read_headers.len(), 3);
+    assert_eq!(
+        read_headers[0].as_ref().unwrap(),
+        &written_blocks[3].verified_block_header
+    );
+    assert!(read_headers[1].is_none());
+    assert_eq!(
+        read_headers[2].as_ref().unwrap(),
+        &written_blocks[2].verified_block_header
+    );
 
-        let contain_blocks = store
-            .contains_blocks(&refs)
-            .expect("Contain blocks should not fail");
-        assert_eq!(contain_blocks.len(), 3);
-        assert!(contain_blocks[0]);
-        assert!(!contain_blocks[1]);
-        assert!(contain_blocks[2]);
-    }
+    let contains = store
+        .contains_block_headers(&refs)
+        .expect("Contains headers should not fail");
+    assert_eq!(contains.len(), 3);
+    assert!(contains[0]);
+    assert!(!contains[1]);
+    assert!(contains[2]);
 
-    {
-        for block in &written_blocks {
-            let found = store
-                .contains_block_at_slot(block.slot())
-                .expect("Read blocks should not fail");
-            assert!(found);
-        }
-
+    // Test slot existence
+    for block in &written_blocks {
         let found = store
-            .contains_block_at_slot(Slot::new(10, AuthorityIndex::new_for_test(0)))
-            .expect("Read blocks should not fail");
-        assert!(!found);
+            .contains_block_at_slot(block.slot())
+            .expect("Check slot should not fail");
+        assert!(found);
     }
+
+    let found = store
+        .contains_block_at_slot(Slot::new(10, AuthorityIndex::new_for_test(0)))
+        .expect("Check slot should not fail");
+    assert!(!found);
 }
 
-// TODO:make test a similar test for headers
 #[rstest]
 #[tokio::test]
-async fn scan_blocks(
+async fn scan_block_headers(
     #[values(new_rocksdb_teststore(), new_mem_teststore())] test_store: TestStore,
 ) {
     let store = test_store.store();
@@ -142,58 +164,77 @@ async fn scan_blocks(
         VerifiedBlock::new_for_test(TestBlockHeader::new(13, 2).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(13, 1).build()),
     ];
+
+    // Write block headers
     store
-        .write(WriteBatch::default().blocks(written_blocks.clone()))
+        .write(
+            WriteBatch::default().block_headers(
+                written_blocks
+                    .iter()
+                    .map(|b| b.verified_block_header.clone())
+                    .collect(),
+            ),
+        )
         .unwrap();
 
-    {
-        let scanned_blocks = store
-            .scan_blocks_by_author(AuthorityIndex::new_for_test(1), 20)
-            .expect("Scan blocks should not fail");
-        assert!(scanned_blocks.is_empty(), "{:?}", scanned_blocks);
-    }
+    // Test scanning with no results
+    let scanned_headers = store
+        .scan_block_headers_by_author(AuthorityIndex::new_for_test(4), 20)
+        .expect("Scan headers should not fail");
+    assert!(scanned_headers.is_empty(), "{:?}", scanned_blocks);
 
-    {
-        let scanned_blocks = store
-            .scan_blocks_by_author(AuthorityIndex::new_for_test(1), 12)
-            .expect("Scan blocks should not fail");
-        assert_eq!(scanned_blocks.len(), 2, "{:?}", scanned_blocks);
-        assert_eq!(
-            scanned_blocks,
-            vec![written_blocks[5].clone(), written_blocks[7].clone()]
-        );
-    }
+    // Test scanning with specific start round
+    let scanned_headers = store
+        .scan_block_headers_by_author(AuthorityIndex::new_for_test(1), 12)
+        .expect("Scan headers should not fail");
+    assert_eq!(scanned_headers.len(), 2, "{:?}", scanned_blocks);
+    assert_eq!(
+        scanned_headers,
+        vec![
+            written_blocks[5].verified_block_header.clone(),
+            written_blocks[7].verified_block_header.clone()
+        ]
+    );
 
+    // Add more headers and test scanning
     let additional_blocks = vec![
         VerifiedBlock::new_for_test(TestBlockHeader::new(14, 2).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(15, 0).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(15, 1).build()),
         VerifiedBlock::new_for_test(TestBlockHeader::new(16, 3).build()),
     ];
-    store
-        .write(WriteBatch::default().blocks(additional_blocks.clone()))
-        .unwrap();
 
+    // Write additional block headers
+    store
+        .write(
+            WriteBatch::default().block_headers(
+                additional_blocks
+                    .iter()
+                    .map(|b| b.verified_block_header.clone())
+                    .collect(),
+            ),
+        )
+        .unwrap();
     {
-        let scanned_blocks = store
-            .scan_blocks_by_author(AuthorityIndex::new_for_test(1), 10)
-            .expect("Scan blocks should not fail");
-        assert_eq!(scanned_blocks.len(), 5, "{:?}", scanned_blocks);
+        let scanned_headers = store
+            .scan_block_headers_by_author(AuthorityIndex::new_for_test(1), 10)
+            .expect("Scan headers should not fail");
+        assert_eq!(scanned_headers.len(), 5);
         assert_eq!(
-            scanned_blocks,
+            scanned_headers,
             vec![
-                written_blocks[2].clone(),
-                written_blocks[3].clone(),
-                written_blocks[5].clone(),
-                written_blocks[7].clone(),
-                additional_blocks[2].clone(),
+                written_blocks[2].verified_block_header.clone(),
+                written_blocks[3].verified_block_header.clone(),
+                written_blocks[5].verified_block_header.clone(),
+                written_blocks[7].verified_block_header.clone(),
+                additional_blocks[2].verified_block_header.clone(),
             ]
         );
     }
 
     {
         let scanned_blocks = store
-            .scan_last_blocks_by_author(AuthorityIndex::new_for_test(1), 2, None)
+            .scan_block_headers_by_author(AuthorityIndex::new_for_test(1), 2, None)
             .expect("Scan blocks should not fail");
         assert_eq!(scanned_blocks.len(), 2, "{:?}", scanned_blocks);
         assert_eq!(
@@ -202,10 +243,96 @@ async fn scan_blocks(
         );
 
         let scanned_blocks = store
-            .scan_last_blocks_by_author(AuthorityIndex::new_for_test(1), 0, None)
+            .scan_block_headers_by_author(AuthorityIndex::new_for_test(1), 0, None)
             .expect("Scan blocks should not fail");
         assert_eq!(scanned_blocks.len(), 0);
     }
+}
+
+#[rstest]
+#[tokio::test]
+async fn read_and_contain_transactions(
+    #[values(new_rocksdb_teststore(), new_mem_teststore())] test_store: TestStore,
+) {
+    let store = test_store.store();
+
+    let written_blocks = vec![
+        VerifiedBlock::new_for_test(TestBlockHeader::new(9, 0).build()),
+        VerifiedBlock::new_for_test(TestBlockHeader::new(10, 0).build()),
+        VerifiedBlock::new_for_test(TestBlockHeader::new(10, 1).build()),
+        VerifiedBlock::new_for_test(TestBlockHeader::new(11, 1).build()),
+        VerifiedBlock::new_for_test(TestBlockHeader::new(11, 3).build()),
+        VerifiedBlock::new_for_test(TestBlockHeader::new(12, 1).build()),
+    ];
+
+    let written_transactions: Vec<_> = written_blocks
+        .iter()
+        .map(|b| b.verified_transactions.clone())
+        .collect();
+    store
+        .write(WriteBatch::default().transactions(written_transactions))
+        .unwrap();
+
+    // Test reading all transactions
+    let refs: Vec<_> = written_blocks.iter().map(|b| b.reference()).collect();
+    let read_txs = store
+        .read_transactions(&refs)
+        .expect("Read txs should not fail");
+
+    assert_eq!(read_txs.len(), written_blocks.len());
+    for (i, tx_opt) in read_txs.iter().enumerate() {
+        let expected = &written_blocks[i].verified_transactions;
+        let actual = tx_opt.as_ref().unwrap();
+        assert_eq!(actual, expected);
+
+        // Verify block reference matches
+        assert_eq!(
+            tx_opt.as_ref().unwrap().block_ref(),
+            written_blocks[i].reference()
+        );
+    }
+
+    // Test reading subset of transactions
+    let subset_refs = vec![refs[1], refs[3], refs[5]];
+    let read_subset = store
+        .read_transactions(&subset_refs)
+        .expect("Read subset should not fail");
+    assert_eq!(read_subset.len(), 3);
+    assert_eq!(
+        read_subset[0].as_ref().unwrap(),
+        &written_blocks[1].verified_transactions
+    );
+    assert_eq!(
+        read_subset[1].as_ref().unwrap(),
+        &written_blocks[3].verified_transactions
+    );
+    assert_eq!(
+        read_subset[2].as_ref().unwrap(),
+        &written_blocks[5].verified_transactions
+    );
+
+    // Test existence checks
+    let contains = store
+        .contains_transactions(&refs)
+        .expect("Contains txs should not fail");
+    assert_eq!(contains, vec![true; refs.len()]);
+
+    // Test with missing reference
+    let missing_ref = BlockRef::new(
+        99,
+        AuthorityIndex::new_for_test(99),
+        BlockHeaderDigest::default(),
+    );
+    let read_missing = store
+        .read_transactions(&[missing_ref])
+        .expect("Read missing should not fail");
+    assert_eq!(read_missing.len(), 1);
+    assert!(read_missing[0].is_none());
+
+    let contains_missing = store
+        .contains_transactions(&[missing_ref])
+        .expect("Contains missing should not fail");
+    assert_eq!(contains_missing, vec![false]);
 }
 
 #[rstest]


### PR DESCRIPTION
# Description of change

This PR updates the interfaces of Store and DAGState to support separate BlockHeader and Transaction handling needed for Starfish implementation. 

## Links to any relevant issues

Resolves #6436 

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
