### PR TITLE
upstream(node): Enable signed Discovery messages by default

### DIFF
--- a/crates/iota-config/src/p2p.rs
+++ b/crates/iota-config/src/p2p.rs
@@ -336,7 +336,7 @@ pub struct DiscoveryConfig {
     /// If true, Discovery will require all provided peer information to be
     /// signed by the originating peer.
     ///
-    /// If unspecified, this will default to false.
+    /// If unspecified, this will default to true.
     pub enable_node_info_signatures: Option<bool>,
 }
 
@@ -366,7 +366,7 @@ impl DiscoveryConfig {
     }
 
     pub fn enable_node_info_signatures(&self) -> bool {
-        self.enable_node_info_signatures.unwrap_or(false)
+        self.enable_node_info_signatures.unwrap_or(true)
     }
 }
 


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.35.4, v1.36.2)
- Port the Sui's commit: https://github.com/MystenLabs/sui/commit/c3562a362bc04802e7ae074ab9947fa9697e4488
- Enable signed Discovery messages by default

## Links to any relevant issues

Part of #3990 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Signed discovery messages are enabled by default
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
