### PR TITLE
feat(starfish): adjust block manager for full blocks

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -407,6 +407,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         // Now check if an ancestor's round is higher than the one that the peer has. If
         // yes, then serve that ancestor blocks up to `MAX_ADDITIONAL_BLOCKS`.
         let mut ancestor_blocks = vec![];
+        // TODO: remove additional blocks and highest_accepted_rounds
         if !highest_accepted_rounds.is_empty() {
             let all_ancestors = blocks
                 .iter()

--- a/crates/starfish/core/src/block_manager.rs
+++ b/crates/starfish/core/src/block_manager.rs
@@ -116,7 +116,9 @@ impl BlockManager {
         let exists = self.dag_state.read().contains_block_headers(block_refs);
         for (i, block) in blocks.into_iter().enumerate() {
             if exists[i] {
-                self.dag_state.write().add_block(block, live);
+                self.dag_state
+                    .write()
+                    .add_transactions(block.verified_transactions, live);
             } else {
                 self.suspended_blocks.insert(block.reference(), block);
             }
@@ -200,7 +202,9 @@ impl BlockManager {
         for block_header in accepted_block_headers.iter() {
             if let Some(block) = self.suspended_blocks.remove(&block_header.reference()) {
                 // for this accepted header we already have a block, so we add it to dag_state
-                self.dag_state.write().add_block(block);
+                self.dag_state
+                    .write()
+                    .add_transactions(block.verified_transactions);
             }
         }
 

--- a/crates/starfish/core/src/block_manager.rs
+++ b/crates/starfish/core/src/block_manager.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashSet},
+    collections::{BTreeMap, BTreeSet},
     sync::Arc,
     time::Instant,
 };
@@ -22,7 +22,7 @@ use crate::{
 };
 
 struct SuspendedBlockHeader {
-    block: VerifiedBlockHeader,
+    block_header: VerifiedBlockHeader,
     missing_ancestors: BTreeSet<BlockRef>,
     timestamp: Instant,
 }
@@ -30,7 +30,7 @@ struct SuspendedBlockHeader {
 impl SuspendedBlockHeader {
     fn new(block: VerifiedBlockHeader, missing_ancestors: BTreeSet<BlockRef>) -> Self {
         Self {
-            block,
+            block_header: block,
             missing_ancestors,
             timestamp: Instant::now(),
         }
@@ -108,22 +108,15 @@ impl BlockManager {
             .collect();
         let (accepted_block_headers, missing_block_headers) =
             self.try_accept_block_headers_internal(block_headers);
-        // TODO: logic below should be applied also when headers are accepted. Need to
-        // move it to internal function.
 
-        let mut accepted_block_header_refs: HashSet<BlockRef> = HashSet::new();
-        for block_header in accepted_block_headers.iter() {
-            if let Some(block) = self.suspended_blocks.remove(&block_header.reference()) {
-                // for this accepted header we already have a block, so we add it to dag_state
-                self.dag_state.write().add_transactions(block, live);
-            } else {
-                accepted_block_header_refs.insert(block_header.reference());
-            }
-        }
-        for block in blocks {
-            let block_ref = &block.reference();
-            if accepted_block_header_refs.remove(block_ref) {
-                self.dag_state.write().add_transactions(block, live);
+        let block_refs = blocks
+            .iter()
+            .map(|b| b.verified_block_header.reference())
+            .collect();
+        let exists = self.dag_state.read().contains_block_headers(block_refs);
+        for (i, block) in blocks.into_iter().enumerate() {
+            if exists[i] {
+                self.dag_state.write().add_block(block, live);
             } else {
                 self.suspended_blocks.insert(block.reference(), block);
             }
@@ -163,8 +156,8 @@ impl BlockManager {
                 .join(",")
         );
 
-        let mut accepted_blocks = vec![];
-        let mut missing_blocks = BTreeSet::new();
+        let mut accepted_block_headers = vec![];
+        let mut missing_block_headers = BTreeSet::new();
 
         for block_header in block_headers {
             self.update_block_received_metrics(&block_header);
@@ -175,15 +168,15 @@ impl BlockManager {
             let mut to_verify_timestamps_and_accept = vec![];
 
             match self.try_accept_one_block_header(block_header) {
-                TryAcceptResult::Accepted(block) => {
-                    to_verify_timestamps_and_accept.push(block);
+                TryAcceptResult::Accepted(block_header) => {
+                    to_verify_timestamps_and_accept.push(block_header);
                 }
                 TryAcceptResult::Suspended(ancestors_to_fetch) => {
                     debug!(
                         "Missing ancestors to fetch for block {block_ref}: {}",
                         ancestors_to_fetch.iter().map(|b| b.to_string()).join(",")
                     );
-                    missing_blocks.extend(ancestors_to_fetch);
+                    missing_block_headers.extend(ancestors_to_fetch);
                     continue;
                 }
                 TryAcceptResult::Processed => continue,
@@ -196,13 +189,23 @@ impl BlockManager {
             // Verify block timestamps
             let blocks_to_accept =
                 self.verify_block_timestamps_and_accept(to_verify_timestamps_and_accept);
-            accepted_blocks.extend(blocks_to_accept);
+            accepted_block_headers.extend(blocks_to_accept);
         }
 
-        self.update_stats(missing_blocks.len() as u64);
+        self.update_stats(missing_block_headers.len() as u64);
+
+        // check if we already have blocks for this accepted header. If yes, add them to
+        // dag
+
+        for block_header in accepted_block_headers.iter() {
+            if let Some(block) = self.suspended_blocks.remove(&block_header.reference()) {
+                // for this accepted header we already have a block, so we add it to dag_state
+                self.dag_state.write().add_block(block);
+            }
+        }
 
         // Figure out the new missing blocks
-        (accepted_blocks, missing_blocks)
+        (accepted_block_headers, missing_block_headers)
     }
 
     /// Tries to find the provided block_refs in DagState and BlockManager,
@@ -352,8 +355,11 @@ impl BlockManager {
     /// have been already successfully accepted. If block is accepted then
     /// Some result is returned. None is returned when either the block is
     /// suspended or the block has been already accepted before.
-    fn try_accept_one_block_header(&mut self, block: VerifiedBlockHeader) -> TryAcceptResult {
-        let block_ref = block.reference();
+    fn try_accept_one_block_header(
+        &mut self,
+        block_header: VerifiedBlockHeader,
+    ) -> TryAcceptResult {
+        let block_ref = block_header.reference();
         let mut missing_ancestors = BTreeSet::new();
         let mut ancestors_to_fetch = BTreeSet::new();
         let dag_state = self.dag_state.read();
@@ -366,7 +372,7 @@ impl BlockManager {
             return TryAcceptResult::Processed;
         }
 
-        let ancestors = block.ancestors().to_vec();
+        let ancestors = block_header.ancestors().to_vec();
 
         // make sure that we have all the required ancestors in store
         for (found, ancestor) in dag_state
@@ -412,13 +418,13 @@ impl BlockManager {
         // Remove the block ref from the `missing_blocks` - if exists - since we now
         // have received the block. The block might still get suspended, but we
         // won't report it as missing in order to not re-fetch.
-        self.missing_blocks.remove(&block.reference());
+        self.missing_blocks.remove(&block_header.reference());
 
         if !missing_ancestors.is_empty() {
             let hostname = self
                 .context
                 .committee
-                .authority(block.author())
+                .authority(block_header.author())
                 .hostname
                 .as_str();
             self.context
@@ -429,12 +435,12 @@ impl BlockManager {
                 .inc();
             self.suspended_block_headers.insert(
                 block_ref,
-                SuspendedBlockHeader::new(block, missing_ancestors),
+                SuspendedBlockHeader::new(block_header, missing_ancestors),
             );
             return TryAcceptResult::Suspended(ancestors_to_fetch);
         }
 
-        TryAcceptResult::Accepted(block)
+        TryAcceptResult::Accepted(block_header)
     }
 
     /// Given an accepted block `accepted_block` it attempts to accept all the
@@ -455,7 +461,7 @@ impl BlockManager {
                     // to the queue so we can recursively try to unsuspend its
                     // children.
                     if let Some(block) = self.try_unsuspend_block(&r, &block_ref) {
-                        to_process_blocks.push(block.block.reference());
+                        to_process_blocks.push(block.block_header.reference());
                         unsuspended_blocks.push(block);
                     }
                 }
@@ -469,7 +475,7 @@ impl BlockManager {
             let hostname = self
                 .context
                 .committee
-                .authority(block.block.author())
+                .authority(block.block_header.author())
                 .hostname
                 .as_str();
             self.context
@@ -488,7 +494,7 @@ impl BlockManager {
 
         unsuspended_blocks
             .into_iter()
-            .map(|block| block.block)
+            .map(|block| block.block_header)
             .collect()
     }
 
@@ -510,7 +516,7 @@ impl BlockManager {
             block.missing_ancestors.remove(accepted_dependency),
             "Block reference {} should be present in missing dependencies of {:?}",
             block_ref,
-            block.block
+            block.block_header
         );
 
         if block.missing_ancestors.is_empty() {

--- a/crates/starfish/core/src/block_manager.rs
+++ b/crates/starfish/core/src/block_manager.rs
@@ -107,7 +107,7 @@ impl BlockManager {
             .map(|b| b.verified_block_header.clone())
             .collect();
         let (accepted_block_headers, missing_block_headers) =
-            self.try_accept_block_headers_internal(block_headers);
+            self.try_accept_block_headers_internal(block_headers, live);
 
         let block_refs = blocks
             .iter()
@@ -139,13 +139,17 @@ impl BlockManager {
         block_headers: Vec<VerifiedBlockHeader>,
     ) -> (Vec<VerifiedBlockHeader>, BTreeSet<BlockRef>) {
         let _s = monitored_scope("BlockManager::try_accept_block_headers");
-        self.try_accept_block_headers_internal(block_headers)
+        // Headers are only added through synchronizer and cordial dissemination. This
+        // means that any transactions that were suspended were also added during live
+        // processing, and we will need to acknowledge them.
+        self.try_accept_block_headers_internal(block_headers, true)
     }
 
     /// Attempts to accept the provided blocks.
     fn try_accept_block_headers_internal(
         &mut self,
         mut block_headers: Vec<VerifiedBlockHeader>,
+        live: bool,
     ) -> (Vec<VerifiedBlockHeader>, BTreeSet<BlockRef>) {
         let _s = monitored_scope("BlockManager::try_accept_block_headers_internal");
 
@@ -204,7 +208,7 @@ impl BlockManager {
                 // for this accepted header we already have a block, so we add it to dag_state
                 self.dag_state
                     .write()
-                    .add_transactions(block.verified_transactions);
+                    .add_transactions(block.verified_transactions, live);
             }
         }
 

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -866,7 +866,7 @@ mod tests {
         let num_authorities: u32 = 4;
 
         let mut blocks = Vec::new();
-        let (first_round_references, first_round_headers): (Vec<_>, Vec<_>) = context
+        let (first_round_references, first_round_blocks): (Vec<_>, Vec<_>) = context
             .committee
             .authorities()
             .map(|index| {
@@ -874,10 +874,22 @@ mod tests {
                 let block = TestBlockHeader::new(0, author_idx).build();
                 VerifiedBlock::new_for_test(block)
             })
-            .map(|block| (block.reference(), block))
+            .map(|block| {
+                (
+                    block.reference(),
+                    (block.verified_block_header, block.verified_transactions),
+                )
+            })
             .unzip();
+
+        let (first_round_headers, first_round_transactions) =
+            first_round_blocks.into_iter().unzip();
         store
-            .write(WriteBatch::default().transactions(first_round_headers))
+            .write(
+                WriteBatch::default()
+                    .block_headers(first_round_headers)
+                    .transactions(first_round_transactions),
+            )
             .unwrap();
         blocks.append(&mut first_round_references.clone());
         // TODO: create some data for blocks in the first round
@@ -896,7 +908,11 @@ mod tests {
                         .build(),
                 );
                 store
-                    .write(WriteBatch::default().transactions(vec![block.clone()]))
+                    .write(
+                        WriteBatch::default()
+                            .block_headers(vec![block.verified_block_header.clone()])
+                            .transactions(vec![block.verified_transactions.clone()]),
+                    )
                     .unwrap();
                 new_ancestors.push(block.reference());
                 blocks.push(block.reference());

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1243,8 +1243,16 @@ mod test {
             last_round_blocks = this_round_blocks;
         }
         // write them in store
+        let (block_headers, block_transactions) = all_blocks
+            .into_iter()
+            .map(|b| (b.verified_block_header, b.verified_transactions))
+            .unzip();
         store
-            .write(WriteBatch::default().transactions(all_blocks))
+            .write(
+                WriteBatch::default()
+                    .block_headers(block_headers)
+                    .transactions(block_transactions),
+            )
             .expect("Storage error");
 
         // create dag state after all blocks have been written to store
@@ -1367,8 +1375,16 @@ mod test {
         }
 
         // write them in store
+        let (block_headers, block_transactions) = all_blocks
+            .into_iter()
+            .map(|b| (b.verified_block_header, b.verified_transactions))
+            .unzip();
         store
-            .write(WriteBatch::default().transactions(all_blocks))
+            .write(
+                WriteBatch::default()
+                    .block_headers(block_headers)
+                    .transactions(block_transactions),
+            )
             .expect("Storage error");
 
         // create dag state after all blocks have been written to store

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -308,6 +308,13 @@ impl DagState {
         self.transactions_to_write.push(transactions);
     }
 
+    /// Adds a block to DagState by accepting its header and adding its
+    /// transactions.
+    pub(crate) fn add_block(&mut self, block: VerifiedBlock) {
+        self.accept_block_header(block.verified_block_header);
+        self.add_transactions(block.verified_transactions);
+    }
+
     /// Updates internal metadata for a block.
     fn update_block_metadata(&mut self, block_header: &VerifiedBlockHeader) {
         let block_ref = block_header.reference();

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -308,13 +308,6 @@ impl DagState {
         self.transactions_to_write.push(transactions);
     }
 
-    /// Adds a block to DagState by accepting its header and adding its
-    /// transactions.
-    pub(crate) fn add_block(&mut self, block: VerifiedBlock) {
-        self.accept_block_header(block.verified_block_header);
-        self.add_transactions(block.verified_transactions);
-    }
-
     /// Updates internal metadata for a block.
     fn update_block_metadata(&mut self, block_header: &VerifiedBlockHeader) {
         let block_ref = block_header.reference();
@@ -512,7 +505,7 @@ impl DagState {
 
         headers
             .into_iter()
-            .zip(transactions.into_iter())
+            .zip(transactions)
             .map(|(header, transaction)| match (header, transaction) {
                 (Some(header), Some(transaction)) => Some(VerifiedBlock::new(header, transaction)),
                 _ => None,

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -96,10 +96,11 @@ pub(crate) struct DagState {
     // availability of transaction data from the corresponding blocks
     pending_acknowledgments: BTreeSet<BlockRef>,
 
-    // Keeps track of the most recent BlockHeaderDAG cordial knowledge (who knows which blocks)
-    // for each authority. This is a helper structure that is used primarily for traversing the
-    // recent DAG. This struct is evicted after flushing the dag state to storage and is not
-    // persisted.
+    // TODO: add metrics for recent_dag_cordial_knowledge and block_headers_not_known_by_authority
+    // and pending_acknowledgments Keeps track of the most recent BlockHeaderDAG cordial
+    // knowledge (who knows which blocks) for each authority. This is a helper structure that
+    // is used primarily for traversing the recent DAG. This struct is evicted after flushing
+    // the dag state to storage and is not persisted.
     // To access the cordial knowledge of a given block_ref, one shall retrieve it from
     // `recent_dag_cordial_knowledge[block_ref.author][(block_ref.round, block_ref.digest)]`.
     // The value is a tuple of (parents, who knows the block header).
@@ -1336,8 +1337,11 @@ impl DagState {
         // Update metrics
         let metrics = &self.context.metrics.node_metrics;
         metrics
-            .dag_state_recent_blocks
-            .set(self.recent_blocks.len() as i64);
+            .dag_state_recent_headers
+            .set(self.recent_block_headers.len() as i64);
+        metrics
+            .dag_state_recent_transactions
+            .set(self.recent_transactions.len() as i64);
         metrics.dag_state_recent_refs.set(
             self.recent_headers_refs_by_authority
                 .iter()

--- a/crates/starfish/core/src/data_manager.rs
+++ b/crates/starfish/core/src/data_manager.rs
@@ -259,7 +259,7 @@ mod tests {
     #[test]
     #[ignore = "This test is ignored until transaction storage is implemented in DAG state"]
     fn test_missing_blocks_with_dag_builder() {
-        let (mut manager, dag_state, mut dag_builder) = setup_manager_and_dag_with_builder(2);
+        let (mut manager, _dag_state, dag_builder) = setup_manager_and_dag_with_builder(2);
         let block0s = dag_builder.block_headers(0..=0);
         let block2s = dag_builder.block_headers(2..=2);
         let leader = block2s[0].reference();
@@ -282,7 +282,7 @@ mod tests {
     #[test]
     #[ignore = "This test is ignored until transaction storage is implemented in DAG state"]
     fn test_commit_after_missing_blocks_arrive_with_dag_builder() {
-        let (mut manager, dag_state, mut dag_builder) = setup_manager_and_dag_with_builder(2);
+        let (mut manager, dag_state, dag_builder) = setup_manager_and_dag_with_builder(2);
         let block0s = dag_builder.block_headers(0..=0);
         let block2s = dag_builder.block_headers(2..=2);
         let leader = block2s[0].reference();
@@ -545,7 +545,7 @@ mod tests {
     #[should_panic(expected = "Duplicate missing blockref detected")]
     #[ignore = "This test is ignored until transaction storage is implemented in DAG state"]
     fn test_duplicate_missing_refs_panic() {
-        let (mut manager, dag_state, dag_builder) = setup_manager_and_dag_with_builder(3);
+        let (mut manager, _dag_state, dag_builder) = setup_manager_and_dag_with_builder(3);
         let block0s = dag_builder.block_headers(0..=0);
         let block1s = dag_builder.block_headers(1..=1);
         let block2s = dag_builder.block_headers(2..=2);

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -156,7 +156,7 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
 
     /// Handles the request to fetch blocks by references from the peer.
     /// The function returns Vec<Bytes>. Each element is a serialization of
-    /// header and transactions of a block.
+    /// header and transactions of a block. Used only in commit syncer.
     async fn handle_fetch_blocks(
         &self,
         peer: AuthorityIndex,

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -25,7 +25,7 @@ pub(crate) trait Store: Send + Sync {
 
     /// Reads complete blocks by combining transactions and headers for the
     /// given refs.
-    #[expect(dead_code)]
+    #[cfg_attr(not(test), expect(dead_code))]
     fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>>;
 
     /// Reads block headers for the given refs.
@@ -52,7 +52,7 @@ pub(crate) trait Store: Send + Sync {
     fn contains_block_at_slot(&self, slot: crate::block_header::Slot) -> ConsensusResult<bool>;
 
     /// Reads blocks for an authority, from start_round.
-    #[cfg_attr(not(test), expect(dead_code))]
+    #[expect(dead_code)]
     fn scan_blocks_by_author(
         &self,
         authority: AuthorityIndex,
@@ -63,7 +63,7 @@ pub(crate) trait Store: Send + Sync {
     // ascending order. When a `before_round` is defined then the blocks of
     // round `<=before_round` are returned. If not then the max value for round
     // will be used as cut off.
-    #[allow(dead_code)]
+    #[cfg_attr(not(test), expect(dead_code))]
     fn scan_last_blocks_by_author(
         &self,
         author: AuthorityIndex,

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -25,6 +25,7 @@ pub(crate) trait Store: Send + Sync {
 
     /// Reads complete blocks by combining transactions and headers for the
     /// given refs.
+    #[expect(dead_code)]
     fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>>;
 
     /// Reads block headers for the given refs.

--- a/crates/starfish/core/src/storage/store_tests.rs
+++ b/crates/starfish/core/src/storage/store_tests.rs
@@ -181,13 +181,13 @@ async fn scan_block_headers(
     let scanned_headers = store
         .scan_block_headers_by_author(AuthorityIndex::new_for_test(4), 20)
         .expect("Scan headers should not fail");
-    assert!(scanned_headers.is_empty(), "{:?}", scanned_blocks);
+    assert!(scanned_headers.is_empty(), "{:?}", scanned_headers);
 
     // Test scanning with specific start round
     let scanned_headers = store
         .scan_block_headers_by_author(AuthorityIndex::new_for_test(1), 12)
         .expect("Scan headers should not fail");
-    assert_eq!(scanned_headers.len(), 2, "{:?}", scanned_blocks);
+    assert_eq!(scanned_headers.len(), 2, "{:?}", scanned_headers);
     assert_eq!(
         scanned_headers,
         vec![
@@ -234,7 +234,7 @@ async fn scan_block_headers(
 
     {
         let scanned_blocks = store
-            .scan_block_headers_by_author(AuthorityIndex::new_for_test(1), 2, None)
+            .scan_last_blocks_by_author(AuthorityIndex::new_for_test(1), 2, None)
             .expect("Scan blocks should not fail");
         assert_eq!(scanned_blocks.len(), 2, "{:?}", scanned_blocks);
         assert_eq!(
@@ -243,7 +243,7 @@ async fn scan_block_headers(
         );
 
         let scanned_blocks = store
-            .scan_block_headers_by_author(AuthorityIndex::new_for_test(1), 0, None)
+            .scan_last_blocks_by_author(AuthorityIndex::new_for_test(1), 0, None)
             .expect("Scan blocks should not fail");
         assert_eq!(scanned_blocks.len(), 0);
     }

--- a/crates/starfish/core/src/synchronizer.rs
+++ b/crates/starfish/core/src/synchronizer.rs
@@ -534,6 +534,8 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             return Err(ConsensusError::TooManyFetchedBlocksReturned(peer_index));
         }
 
+        // TODO : check if header is already accepted or suspended
+
         // Verify all the fetched blocks
         let blocks = Handle::current()
             .spawn_blocking({


### PR DESCRIPTION
# Description of change

BlockManager can receive headers without transactions or a list of full blocks. In both cases, we try to accept headers. For all accepted headers, we check if we have suspended blocks for them. If yes, then we add the block to the DAG. Then, if we trying to accept blocks, we check for all blocks if the corresponding header is accepted. If yes, then we add the block to the DAG; otherwise, we add the block to suspended_blocks.

In subsequent PR, we are going to change suspended_blocks to suspended transactions to avoid data duplication.

Also added some TODOs.

## Links to any relevant issues

Resolves #6428 .

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
