### PR TITLE
refactor(iota-names): Remove `PhantomData` from `iota_names::registry::Table`

### DIFF
--- a/crates/iota-names/src/registry.rs
+++ b/crates/iota-names/src/registry.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    marker::PhantomData,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -21,25 +20,19 @@ use crate::{
 
 /// Rust version of the Move `iota::table::Table` type.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct Table<K, V> {
+pub struct Table {
     pub id: ObjectID,
     pub size: u64,
-
-    // TODO: Are K & V actually necessary https://github.com/iotaledger/iota/issues/6529 ?
-    #[serde(skip)]
-    _key: PhantomData<K>,
-    #[serde(skip)]
-    _value: PhantomData<V>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Registry {
     /// The `registry` table maps `Domain` to `NameRecord`.
     /// Added / replaced in the `add_record` function.
-    registry: Table<Domain, NameRecord>,
+    registry: Table,
     /// The `reverse_registry` table maps `IotaAddress` to `Domain`.
     /// Updated in the `set_reverse_lookup` function.
-    reverse_registry: Table<IotaAddress, Domain>,
+    reverse_registry: Table,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/iota-names/src/registry.rs
+++ b/crates/iota-names/src/registry.rs
@@ -1,9 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use iota_types::{
     base_types::{IotaAddress, ObjectID},


### PR DESCRIPTION
# Description of change

Removes the generics and `PhantomData` in `iota_names::registry::Table` as they are not necessary. 

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/6529

## How the change has been tested

- [X] Basic tests (linting, compilation, formatting, unit/integration tests)
- [X] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked that new and existing unit tests pass locally with my changes

The patch was tested through integration testing using the Indexer. Test instructions:

First, run the test cluster without Indexer:
```sh
cargo run --features iota-names --bin iota start --with-faucet --force-regenesis
```

Fund your address:
```sh
iota client faucet
```

Switch to the `iota-names` repo. Deploy the IOTA-Names package:
```sh
pnpm ts-node init/init.ts localnet
```

Find the  `scripts/config/localnet-package-info.json` file for configuration parameters.
Change back to the iota repo and adjust the hardcoded parameters in  `iota/crates/iota-names/src/config.rs`.

**In order to start the indexer, a running postgres instance is required.**
You can start the postgres instance using the docker-compose file at https://github.com/iotaledger/iota-private/tree/0ac76d069a26a8c69499f3c2859fceda520e3f0d/dev-tools/pg-services-local by simply executing `docker compose up -d postgres` in its directory.

Then, start an Indexer sync worker instance:

```sh
cargo run --features iota-names  --bin iota-indexer -- --db-url "postgres://postgres:postgrespw@localhost/iota_indexer" --fullnode-sync-worker --reset-db
````

Start an Indexer RPC worker instance:

```sh
cargo run --features iota-names  --bin iota-indexer -- --db-url "postgres://postgres:postgrespw@localhost/iota_indexer" --rpc-server-worker --client-metric-port=9181 --rpc-server-port 9001
````

Switch to `crates/iota` and register a domain with:

`cargo run --features iota-names  --bin iota -- name register thoralf.iota`

**To resolve the name record:**
```sh
curl --location --request POST 'http://localhost:9001' \
--header 'Content-Type: application/json' \
--data-raw '{
 "jsonrpc": "2.0",
 "id": 1,
 "method": "iotax_iotaNamesLookup",
 "params":["thoralf.iota"] 
}'
```
`{"jsonrpc":"2.0","id":1,"result":{"nftId":"0x6e023a9c03959cd3b41f4167716af32d44d64bf7dc9018ee84420cecea4c4b87","expirationTimestamp_ms":1775057501583,"targetAddress":null,"data":{}}}`

**To set a target address for the domain:**

```
cargo run  --features iota-names --bin iota -- name set-target-address thoralf.iota 0xe7d17af68a24dce9e379b45d2ab903d970d97cdfcc10c208c9b1132d83cb73f3
```

```sh
curl --location --request POST 'http://localhost:9001' \
--header 'Content-Type: application/json' \
--data-raw '{
 "jsonrpc": "2.0",
 "id": 1,
 "method": "iotax_iotaNamesLookup",
 "params":["thoralf.iota"]
}'
```

`{"jsonrpc":"2.0","id":1,"result":{"nftId":"0x6e023a9c03959cd3b41f4167716af32d44d64bf7dc9018ee84420cecea4c4b87","expirationTimestampMs":1780586524278,"targetAddress":"0xe7d17af68a24dce9e379b45d2ab903d970d97cdfcc10c208c9b1132d83cb73f3","data":{}}}`

**To set the reverse look up for the domain:**

```
cargo run --features iota-names --bin iota -- name set-reverse-lookup thoralf.iota
```

```sh
curl --location --request POST 'http://localhost:9001' \
  --header 'Content-Type: application/json' \
  --data-raw '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "iotax_iotaNamesReverseLookup",
    "params":["0xe7d17af68a24dce9e379b45d2ab903d970d97cdfcc10c208c9b1132d83cb73f3"]
}'
```

`{"jsonrpc":"2.0","id":1,"result":"thoralf.iota"}`

**To find all registration NFTs:**

```sh
curl --location --request POST 'http://localhost:9001' \
--header 'Content-Type: application/json' \
--data-raw '{
 "jsonrpc": "2.0",
 "id": 1,
 "method": "iotax_iotaNamesFindAllRegistrationNFTs",
 "params":["0xe7d17af68a24dce9e379b45d2ab903d970d97cdfcc10c208c9b1132d83cb73f3"]                  
}'
```

`{"jsonrpc":"2.0","id":1,"result":{"data":[{"data":{"objectId":"0x6e023a9c03959cd3b41f4167716af32d44d64bf7dc9018ee84420cecea4c4b87","version":"3684","digest":"59Ht5T2XF16N6VErXBQ6tRNPpetjq3S25mgNH13WsRLX"}}],"nextCursor":"0x6e023a9c03959cd3b41f4167716af32d44d64bf7dc9018ee84420cecea4c4b87","hasNextPage":false}}`

---

## GraphQL tests:

First run the GraphQL server:

`cargo run --features iota-names --bin iota-graphql-rpc start-server`

**Lookup:**

Query:
```graphql
query {
  resolveIotaNamesAddress(domain: "thoralf.iota") {
    address
  }
}
```

Response:
```json
{
  "data": {
    "resolveIotaNamesAddress": {
      "address": "0xe7d17af68a24dce9e379b45d2ab903d970d97cdfcc10c208c9b1132d83cb73f3"
    }
  }
}
```

**Reverse look-up:**

```
cargo run --bin iota -- name set-reverse-lookup thoralf.iota
```

Query:
```graphql
query {
  address(
    address: "0xe7d17af68a24dce9e379b45d2ab903d970d97cdfcc10c208c9b1132d83cb73f3"
  ) {
    address
    balance(type: "0x2::iota::IOTA") {
      coinType {
        repr
      }
      coinObjectCount
      totalBalance
    }
     iotaNamesDefaultName
  }
}
```

Response:
```json
{
  "data": {
    "address": {
      "address": "0xe7d17af68a24dce9e379b45d2ab903d970d97cdfcc10c208c9b1132d83cb73f3",
      "balance": {
        "coinType": {
          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::iota::IOTA"
        },
        "coinObjectCount": 6,
        "totalBalance": "1999565194000"
      },
      "iotaNamesDefaultName": "thoralf.iota"
    }
  }
}
```

**To find all registration NFTs:**

Query:
```graphql
query {
  address(
    address: "0xe7d17af68a24dce9e379b45d2ab903d970d97cdfcc10c208c9b1132d83cb73f3"
  ) {
    address
    balance(type: "0x2::iota::IOTA") {
      coinType {
        repr
      }
      coinObjectCount
      totalBalance
    }
    iotaNamesRegistrations {
      edges {
        node {
          domain
          iotaNamesDefaultName
          digest
          storageRebate
          bcs
        }
      }
    }
  }
}
```

Response:
```json
{
  "data": {
    "address": {
      "address": "0xe7d17af68a24dce9e379b45d2ab903d970d97cdfcc10c208c9b1132d83cb73f3",
      "balance": {
        "coinType": {
          "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::iota::IOTA"
        },
        "coinObjectCount": 6,
        "totalBalance": "1999565194000"
      },
      "iotaNamesRegistrations": {
        "edges": [
          {
            "node": {
              "domain": "thoralf.iota",
              "iotaNamesDefaultName": null,
              "digest": "59Ht5T2XF16N6VErXBQ6tRNPpetjq3S25mgNH13WsRLX",
              "storageRebate": "1786000",
              "bcs": "AAC83BeSyO11L87gdyGAjVEdj0k5Pjy+g+ts+dhvraPcZRdpb3RhX25hbWVzX3JlZ2lzdHJhdGlvbhVJb3RhTmFtZXNSZWdpc3RyYXRpb24AZA4AAAAAAABDbgI6nAOVnNO0H0FncWrzLUTWS/fckBjuhEIM7OpMS4cCBGlvdGEHdGhvcmFsZgx0aG9yYWxmLmlvdGF2LjqTngEAAADn0Xr2iiTc6eN5tF0quQPZcNl838wQwgjJsRMtg8tz8yBJ/YF4YdlQgce20i3lIoS2cu3NatL9QhTyFoh7WIiopZBAGwAAAAAA"
            }
          }
        ]
      }
    }
  }
}
```

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
