### PR TITLE
fix(docs): iota rpc page dark mode

### DIFF
--- a/docs/site/src/components/Cards/styles.module.css
+++ b/docs/site/src/components/Cards/styles.module.css
@@ -1,19 +1,3 @@
-:root {
-  --iota-cards-border-color: rgba(0, 0, 0, 0.1);
-  --iota-cards-background: #f6f8f9;
-  --iota-cards-header: #4da2ff;
-  --iota-cards-copy: #91a3b1;
-  --iota-cards-background-hover: #ebf1f5;
-}
-
-[data-theme="dark"] {
-  --iota-cards-border-color: rgba(255, 255, 255, 0.1);
-  --iota-cards-background: rgba(40, 40, 40, 0.8);
-  --iota-cards-background-hover: rgba(32, 32, 32, 0.8);
-  --iota-cards-header: #4da2ff;
-  --iota-cards-copy: #abbdcc;
-}
-
 .card {
   display: flex;
   flex-direction: column;

--- a/docs/site/src/components/Cards/styles.module.css
+++ b/docs/site/src/components/Cards/styles.module.css
@@ -1,15 +1,15 @@
 :root {
-  --iota-cards-border-color: transparent;
-  --iota-cards-background: #f5f8fa;
+  --iota-cards-border-color: rgba(0, 0, 0, 0.1);
+  --iota-cards-background: #f6f8f9;
   --iota-cards-header: #4da2ff;
   --iota-cards-copy: #91a3b1;
   --iota-cards-background-hover: #ebf1f5;
 }
 
 [data-theme="dark"] {
-  --iota-cards-border-color: rgba(247, 247, 248, 0.05);
-  --iota-cards-background: black;
-  --iota-cards-background-hover: rgba(247, 247, 248, 0.15);
+  --iota-cards-border-color: rgba(255, 255, 255, 0.1);
+  --iota-cards-background: rgba(40, 40, 40, 0.8);
+  --iota-cards-background-hover: rgba(32, 32, 32, 0.8);
   --iota-cards-header: #4da2ff;
   --iota-cards-copy: #abbdcc;
 }
@@ -29,6 +29,7 @@
 }
 .card:hover {
   background: var(--iota-cards-background-hover);
+  border-color: var(--iota-cards-border-color);
 }
 
 .card__header__copy {

--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -83,10 +83,23 @@
   --iota-line: rgba(247, 247, 248, 0.1);
   --iota-max-width-desktop: 1162px;
   --iota-dark-blue-bkg: #011829;
+  --iota-cards-border-color: rgba(0, 0, 0, 0.1);
+  --iota-cards-background: #f6f8f9;
+  --iota-cards-header: #4da2ff;
+  --iota-cards-copy: #91a3b1;
+  --iota-cards-background-hover: #ebf1f5;
 
   --primaryFont: "Inter", sans-serif;
   --headerFont: "Twkeverett", sans-serif;
   --monoFont: "Twkeverett Mono", monospace;
+}
+
+[data-theme="dark"] {
+  --iota-cards-border-color: rgba(255, 255, 255, 0.1);
+  --iota-cards-background: rgba(40, 40, 40, 0.8);
+  --iota-cards-background-hover: rgba(32, 32, 32, 0.8);
+  --iota-cards-header: #4da2ff;
+  --iota-cards-copy: #abbdcc;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */


### PR DESCRIPTION
# Description of change

This PR brings up fixes in the dark mode of the [page](https://docs.iota.org/references/#iota-software-development-kits).
## Links to any relevant issues

fixes #7241 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:

Before:

![image (1)](https://github.com/user-attachments/assets/e1a5101f-1e36-4635-b9e7-9e8585eb0daf)

After:

![Screenshot 2025-06-05 at 3 48 02 PM](https://github.com/user-attachments/assets/0156b279-6554-42d1-bdaa-51dff09e2e0a)
