### PR TITLE
fix(actions): enable corepack to run docs actions correctly

### DIFF
--- a/.github/workflows/_docusaurus.yml
+++ b/.github/workflows/_docusaurus.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           node-version: "20"
           cache: "pnpm"
+      - name: Enable corepack
+        run: corepack enable
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build

--- a/.github/workflows/preview_wiki.yml
+++ b/.github/workflows/preview_wiki.yml
@@ -37,6 +37,9 @@ jobs:
           node-version: 20
           cache: "pnpm"
 
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Install dependencies
         run: pnpm install
 

--- a/.github/workflows/release_wiki.yml
+++ b/.github/workflows/release_wiki.yml
@@ -26,6 +26,9 @@ jobs:
           node-version: 20
           cache: "pnpm"
 
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Install dependencies
         run: pnpm install
 


### PR DESCRIPTION
# Description of change

Fixed the docs actions which need core pack enabled to run which wasn't the case anymore since we switched to GitHub runners