### PR TITLE
upstream(node): jsonrpc - don't explicitly remove old tables

### DIFF
--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1003,7 +1003,14 @@ impl<K, V> DBMap<K, V> {
     }
 
     fn report_metrics(rocksdb: &Arc<RocksDB>, cf_name: &str, db_metrics: &Arc<DBMetrics>) {
-        let cf = rocksdb.cf_handle(cf_name).expect("Failed to get cf");
+        let Some(cf) = rocksdb.cf_handle(cf_name) else {
+            tracing::warn!(
+                "unable to report metrics for cf {cf_name:?} in db {:?}",
+                rocksdb.db_name()
+            );
+            return;
+        };
+
         db_metrics
             .cf_metrics
             .rocksdb_total_sst_files_size


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.36.2, v1.37.4)
- Port the following Sui's commit: https://github.com/MystenLabs/sui/commit/832da303fdcdbfde5dd0c43ee0b63f17dc4c3a1e
- Descriptions from commits
  Don't explicitly remove old jsonrpc index tables as well as remove a
possible panic when reporting rocksdb metrics.
- Notes
  - There's no file `crates/iota-core/src/jsonrpc_index.rs`, so the changes in this file are not ported.

## Links to any relevant issues

Part of #3990 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
