### PR TITLE
upstream(node): pruner - enable periodic compaction of individual SST files by default

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -719,7 +719,10 @@ pub struct AuthorityStorePruningConfig {
     /// modified time is older than `periodic_compaction_threshold_days`
     /// days. That ensures that all sst files eventually go through the
     /// compaction process
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default = "default_periodic_compaction_threshold_days",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub periodic_compaction_threshold_days: Option<usize>,
     /// number of epochs to keep the latest version of transactions and effects
     /// for
@@ -747,6 +750,10 @@ fn default_max_checkpoints_in_batch() -> usize {
 
 fn default_smoothing() -> bool {
     cfg!(not(test))
+}
+
+fn default_periodic_compaction_threshold_days() -> Option<usize> {
+    Some(1)
 }
 
 impl Default for AuthorityStorePruningConfig {


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.36.2, v1.37.4)
- Port commit: https://github.com/MystenLabs/sui/commit/65b02e203ad897f438f87d0e5cfe46c56a1d4247
- Descriptions from commits
  Enables periodic compaction of individual SST files by default


## Links to any relevant issues

Part of #3990 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
