### PR TITLE
upstream(node): benchmark - Add expected failure payloads

### DIFF
--- a/crates/iota-benchmark/src/drivers/bench_driver.rs
+++ b/crates/iota-benchmark/src/drivers/bench_driver.rs
@@ -57,6 +57,7 @@ pub struct BenchMetrics {
     pub benchmark_duration: IntGauge,
     pub num_success: IntCounterVec,
     pub num_error: IntCounterVec,
+    pub num_expected_error: IntCounterVec,
     pub num_submitted: IntCounterVec,
     pub num_in_flight: GaugeVec,
     pub latency_s: HistogramVec,
@@ -83,6 +84,13 @@ impl BenchMetrics {
             num_success: register_int_counter_vec_with_registry!(
                 "num_success",
                 "Total number of transaction success",
+                &["workload"],
+                registry,
+            )
+            .unwrap(),
+            num_expected_error: register_int_counter_vec_with_registry!(
+                "num_expected_error",
+                "Total number of transaction errors that were expected",
                 &["workload"],
                 registry,
             )
@@ -384,6 +392,7 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                 duration: Duration::ZERO,
                 num_error_txes: 0,
                 num_success_txes: 0,
+                num_expected_error_txes: 0,
                 num_success_cmds: 0,
                 total_gas_used: 0,
                 latency_ms: HistogramWrapper {
@@ -418,6 +427,7 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                 let mut total_cps: f32 = 0.0;
                 let mut num_success_txes: u64 = 0;
                 let mut num_error_txes: u64 = 0;
+                let mut num_expected_error_txes: u64 = 0;
                 let mut num_success_cmds = 0;
                 let mut latency_histogram =
                     hdrhistogram::Histogram::<u64>::new_with_max(120_000, 3).unwrap();
@@ -438,6 +448,7 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                     total_cps += v.bench_stats.num_success_cmds as f32 / duration;
                     num_success_txes += v.bench_stats.num_success_txes;
                     num_error_txes += v.bench_stats.num_error_txes;
+                    num_expected_error_txes += v.bench_stats.num_expected_error_txes;
                     num_success_cmds += v.bench_stats.num_success_cmds;
                     num_no_gas += v.num_no_gas;
                     num_submitted += v.num_submitted;
@@ -455,7 +466,9 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                 counter += 1;
                 if counter % num_workers == 0 {
                     stat = format!(
-                        "TPS = {}, CPS = {}, latency_ms(min/p50/p99/max) = {}/{}/{}/{}, num_success_tx = {}, num_error_tx = {}, num_success_cmds = {}, no_gas = {}, submitted = {}, in_flight = {}",
+                        "TPS = {}, CPS = {}, latency_ms(min/p50/p99/max) = {}/{}/{}/{}, \
+                        num_success_tx = {}, num_error_tx = {}, num_expected_error_tx = {}, \
+                        num_success_cmds = {}, no_gas = {}, submitted = {}, in_flight = {}",
                         total_qps,
                         total_cps,
                         latency_histogram.min(),
@@ -464,6 +477,7 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                         latency_histogram.max(),
                         num_success_txes,
                         num_error_txes,
+                        num_expected_error_txes,
                         num_success_cmds,
                         num_no_gas,
                         num_submitted,
@@ -709,6 +723,7 @@ async fn run_bench_worker(
     let request_delay_micros = 1_000_000 / worker.target_qps;
     let mut num_success_txes = 0;
     let mut num_error_txes = 0;
+    let mut num_expected_error_txes = 0;
     let mut num_success_cmds = 0;
     let mut num_no_gas = 0;
     let mut num_in_flight: u64 = 0;
@@ -736,6 +751,7 @@ async fn run_bench_worker(
      -> NextOp {
         match result {
             Ok(effects) => {
+                assert!(payload.get_failure_type().is_none());
                 let latency = start.elapsed();
                 let time_from_start = total_benchmark_start_time.elapsed();
 
@@ -795,27 +811,38 @@ async fn run_bench_worker(
             }
             Err(err) => {
                 error!("{}", err);
-                if err
-                    .downcast::<QuorumDriverError>()
-                    .and_then(|err| {
-                        if matches!(
-                            err,
-                            QuorumDriverError::NonRecoverableTransactionError { .. }
-                        ) {
-                            Err(err.into())
+                match payload.get_failure_type() {
+                    Some(_) => {
+                        metrics_cloned
+                            .num_expected_error
+                            .with_label_values(&[&payload.to_string()])
+                            .inc();
+                        NextOp::Retry(Box::new((transaction, payload)))
+                    }
+                    None => {
+                        if err
+                            .downcast::<QuorumDriverError>()
+                            .and_then(|err| {
+                                if matches!(
+                                    err,
+                                    QuorumDriverError::NonRecoverableTransactionError { .. }
+                                ) {
+                                    Err(err.into())
+                                } else {
+                                    Ok(())
+                                }
+                            })
+                            .is_err()
+                        {
+                            NextOp::Failure
                         } else {
-                            Ok(())
+                            metrics_cloned
+                                .num_error
+                                .with_label_values(&[&payload.to_string(), &"rpc".to_string()])
+                                .inc();
+                            NextOp::Retry(Box::new((transaction, payload)))
                         }
-                    })
-                    .is_err()
-                {
-                    NextOp::Failure
-                } else {
-                    metrics_cloned
-                        .num_error
-                        .with_label_values(&[&payload.to_string(), &"rpc".to_string()])
-                        .inc();
-                    NextOp::Retry(Box::new((transaction, payload)))
+                    }
                 }
             }
         }
@@ -870,6 +897,7 @@ async fn run_bench_worker(
                         bench_stats: BenchmarkStats {
                             duration:stat_start_time.elapsed(),
                             num_error_txes,
+                            num_expected_error_txes,
                             num_success_txes,
                             num_success_cmds,
                             latency_ms:HistogramWrapper{
@@ -884,6 +912,7 @@ async fn run_bench_worker(
                 }
                 num_success_txes = 0;
                 num_error_txes = 0;
+                num_expected_error_txes = 0;
                 num_success_cmds = 0;
                 num_no_gas = 0;
                 num_submitted = 0;
@@ -903,7 +932,11 @@ async fn run_bench_worker(
                 if let Some(b) = retry_queue.pop_front() {
                     let tx = b.0;
                     let payload = b.1;
-                    num_error_txes += 1;
+                    if payload.get_failure_type().is_some() {
+                        num_expected_error_txes += 1;
+                    } else {
+                        num_error_txes += 1;
+                    }
                     num_submitted += 1;
                     metrics_cloned.num_submitted.with_label_values(&[&payload.to_string()]).inc();
                     // TODO: clone committee for each request is not ideal.
@@ -987,6 +1020,7 @@ async fn run_bench_worker(
             bench_stats: BenchmarkStats {
                 duration: stat_start_time.elapsed(),
                 num_error_txes,
+                num_expected_error_txes,
                 num_success_txes,
                 num_success_cmds,
                 total_gas_used: worker_gas_used,

--- a/crates/iota-benchmark/src/drivers/mod.rs
+++ b/crates/iota-benchmark/src/drivers/mod.rs
@@ -124,6 +124,8 @@ pub struct BenchmarkStats {
     pub duration: Duration,
     /// Number of transactions that ended in an error
     pub num_error_txes: u64,
+    /// Number of transactions that ended in an error but were expected
+    pub num_expected_error_txes: u64,
     /// Number of transactions that were executed successfully
     pub num_success_txes: u64,
     /// Total number of commands in transactions that executed successfully
@@ -137,6 +139,7 @@ impl BenchmarkStats {
     pub fn update(&mut self, duration: Duration, sample_stat: &BenchmarkStats) {
         self.duration = duration;
         self.num_error_txes += sample_stat.num_error_txes;
+        self.num_expected_error_txes += sample_stat.num_expected_error_txes;
         self.num_success_txes += sample_stat.num_success_txes;
         self.num_success_cmds += sample_stat.num_success_cmds;
         self.total_gas_used += sample_stat.total_gas_used;
@@ -155,6 +158,7 @@ impl BenchmarkStats {
                 "tps",
                 "cps",
                 "error%",
+                "expected error%",
                 "latency (min)",
                 "latency (p50)",
                 "latency (p99)",
@@ -168,6 +172,10 @@ impl BenchmarkStats {
         row.add_cell(Cell::new(
             (100 * self.num_error_txes) as f32
                 / (self.num_error_txes + self.num_success_txes) as f32,
+        ));
+        row.add_cell(Cell::new(
+            (100 * self.num_expected_error_txes) as f32
+                / (self.num_expected_error_txes + self.num_success_txes) as f32,
         ));
         row.add_cell(Cell::new(self.latency_ms.histogram.min()));
         row.add_cell(Cell::new(self.latency_ms.histogram.value_at_quantile(0.5)));

--- a/crates/iota-benchmark/src/lib.rs
+++ b/crates/iota-benchmark/src/lib.rs
@@ -741,10 +741,9 @@ impl ValidatorProxy for FullNodeProxy {
                 .await
             {
                 Ok(resp) => {
-                    let effects = ExecutionEffects::IotaTransactionBlockEffects(
+                    return Ok(ExecutionEffects::IotaTransactionBlockEffects(
                         resp.effects.expect("effects field should not be None"),
-                    );
-                    return Ok(effects);
+                    ));
                 }
                 Err(err) => {
                     error!(

--- a/crates/iota-benchmark/src/options.rs
+++ b/crates/iota-benchmark/src/options.rs
@@ -187,6 +187,10 @@ pub enum RunSpec {
         #[arg(long, num_args(1..), value_delimiter = ',', default_values_t = [0])]
         randomness: Vec<u32>,
 
+        // relative weight of expected failure transactions in the benchmark workload
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0])]
+        expected_failure: Vec<u32>,
+
         // --- workload-specific options --- (TODO: use subcommands or similar)
         // 100 for max hotness i.e all requests target
         // just the same shared counter, 0 for no hotness
@@ -217,6 +221,11 @@ pub enum RunSpec {
         // for `adversarial_type`
         #[arg(long, num_args(1..), value_delimiter = ',', default_values_t = ["0-1.0".to_string()])]
         adversarial_cfg: Vec<String>,
+
+        // type of expected failure transactions in the benchmark workload.
+        // See `ExpectedFailureType` enum for `expected_failure_type`
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0])]
+        expected_failure_type: Vec<u32>,
 
         // --- generic options ---
         // Target qps

--- a/crates/iota-benchmark/src/workloads/adversarial.rs
+++ b/crates/iota-benchmark/src/workloads/adversarial.rs
@@ -36,7 +36,7 @@ use crate::{
     drivers::Interval,
     in_memory_wallet::{InMemoryWallet, move_call_pt_impl},
     system_state_observer::{SystemState, SystemStateObserver},
-    workloads::{Gas, GasCoinConfig, payload::Payload},
+    workloads::{Gas, GasCoinConfig, payload::Payload, workload::ExpectedFailureType},
 };
 
 /// Number of vectors to create in LargeTransientRuntimeVectors workload
@@ -196,6 +196,10 @@ impl Payload for AdversarialTestPayload {
                 .as_ref()
                 .expect("Protocol config not in system state"),
         )
+    }
+
+    fn get_failure_type(&self) -> Option<ExpectedFailureType> {
+        None
     }
 }
 

--- a/crates/iota-benchmark/src/workloads/batch_payment.rs
+++ b/crates/iota-benchmark/src/workloads/batch_payment.rs
@@ -24,7 +24,10 @@ use crate::{
     workloads::{
         Gas, GasCoinConfig, WorkloadBuilderInfo, WorkloadParams,
         payload::Payload,
-        workload::{ESTIMATED_COMPUTATION_COST, STORAGE_COST_PER_COIN, Workload, WorkloadBuilder},
+        workload::{
+            ESTIMATED_COMPUTATION_COST, ExpectedFailureType, STORAGE_COST_PER_COIN, Workload,
+            WorkloadBuilder,
+        },
     },
 };
 
@@ -124,6 +127,10 @@ impl Payload for BatchPaymentTestPayload {
                 .reference_gas_price,
             gas_budget,
         )
+    }
+
+    fn get_failure_type(&self) -> Option<ExpectedFailureType> {
+        None
     }
 }
 

--- a/crates/iota-benchmark/src/workloads/delegation.rs
+++ b/crates/iota-benchmark/src/workloads/delegation.rs
@@ -24,8 +24,8 @@ use crate::{
         Gas, GasCoinConfig, WorkloadBuilderInfo, WorkloadParams,
         payload::Payload,
         workload::{
-            ESTIMATED_COMPUTATION_COST, MAX_GAS_FOR_TESTING, STORAGE_COST_PER_COIN, Workload,
-            WorkloadBuilder,
+            ESTIMATED_COMPUTATION_COST, ExpectedFailureType, MAX_GAS_FOR_TESTING,
+            STORAGE_COST_PER_COIN, Workload, WorkloadBuilder,
         },
     },
 };
@@ -88,6 +88,10 @@ impl Payload for DelegationTestPayload {
                     .reference_gas_price,
             ),
         }
+    }
+
+    fn get_failure_type(&self) -> Option<ExpectedFailureType> {
+        None
     }
 }
 

--- a/crates/iota-benchmark/src/workloads/expected_failure.rs
+++ b/crates/iota-benchmark/src/workloads/expected_failure.rs
@@ -1,39 +1,37 @@
 // Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2024 IOTA Stiftung
+// Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, fmt, sync::Arc};
 
 use async_trait::async_trait;
 use iota_core::test_utils::make_transfer_object_transaction;
 use iota_types::{
     base_types::{IotaAddress, ObjectRef},
-    crypto::{AccountKeyPair, get_key_pair},
+    crypto::{AccountKeyPair, Ed25519IotaSignature, get_key_pair},
+    signature::GenericSignature,
     transaction::Transaction,
 };
 use rand::seq::IteratorRandom;
-use tracing::error;
+use tracing::debug;
 
 use crate::{
     ExecutionEffects, ValidatorProxy,
     drivers::Interval,
     system_state_observer::SystemStateObserver,
     workloads::{
-        Gas, GasCoinConfig, WorkloadBuilderInfo, WorkloadParams,
+        Gas, GasCoinConfig, Workload, WorkloadBuilderInfo, WorkloadParams,
         payload::Payload,
         workload::{
             ESTIMATED_COMPUTATION_COST, ExpectedFailureType, MAX_GAS_FOR_TESTING,
-            STORAGE_COST_PER_COIN, Workload, WorkloadBuilder,
+            STORAGE_COST_PER_COIN, WorkloadBuilder,
         },
     },
 };
 
-/// TODO: This should be the amount that is being transferred instead of
-/// MAX_GAS. Number of nanos sent to each address on each batch transfer
-const _TRANSFER_AMOUNT: u64 = 1;
-
-#[derive(Debug)]
-pub struct TransferObjectTestPayload {
+#[derive(Debug, Clone)]
+pub struct ExpectedFailurePayload {
+    failure_type: ExpectedFailureType,
     transfer_object: ObjectRef,
     transfer_from: IotaAddress,
     transfer_to: IotaAddress,
@@ -41,38 +39,43 @@ pub struct TransferObjectTestPayload {
     system_state_observer: Arc<SystemStateObserver>,
 }
 
-impl Payload for TransferObjectTestPayload {
-    fn make_new_payload(&mut self, effects: &ExecutionEffects) {
-        if !effects.is_ok() {
-            effects.print_gas_summary();
-            error!("Transfer tx failed... Status: {:?}", effects.status());
-        }
+#[derive(Debug, Clone)]
+pub struct ExpectedFailurePayloadCfg {
+    pub failure_type: ExpectedFailureType,
+}
 
-        let recipient = self.gas.iter().find(|x| x.1 != self.transfer_to).unwrap().1;
-        let updated_gas: Vec<Gas> = self
-            .gas
-            .iter()
-            .map(|x| {
-                if x.1 == self.transfer_from {
-                    (effects.gas_object().0, self.transfer_from, x.2.clone())
-                } else {
-                    x.clone()
-                }
-            })
-            .collect();
-        self.transfer_object = effects
-            .mutated()
-            .iter()
-            .find(|(object_ref, _)| object_ref.0 == self.transfer_object.0)
-            .map(|x| x.0)
-            .unwrap();
-        self.transfer_from = self.transfer_to;
-        self.transfer_to = recipient;
-        self.gas = updated_gas;
+impl Copy for ExpectedFailurePayloadCfg {}
+
+impl ExpectedFailurePayload {
+    fn create_failing_transaction(&self, mut tx: Transaction) -> Transaction {
+        match self.failure_type {
+            ExpectedFailureType::InvalidSignature => {
+                let signatures = tx.tx_signatures_mut_for_testing();
+                signatures.pop();
+                signatures.push(GenericSignature::Signature(
+                    iota_types::crypto::Signature::Ed25519IotaSignature(
+                        Ed25519IotaSignature::default(),
+                    ),
+                ));
+                tx
+            }
+            ExpectedFailureType::Random => unreachable!(),
+        }
     }
+}
+
+impl Payload for ExpectedFailurePayload {
+    fn make_new_payload(&mut self, _effects: &ExecutionEffects) {
+        // This should never be called, as an expected failure payload
+        // should fail (thereby having no effects) and be retried. Note
+        // that since these are failures rather than Move level errors,
+        // no gas should be consumed, nor any objects mutated.
+        unreachable!()
+    }
+
     fn make_transaction(&mut self) -> Transaction {
         let (gas_obj, _, keypair) = self.gas.iter().find(|x| x.1 == self.transfer_from).unwrap();
-        make_transfer_object_transaction(
+        let tx = make_transfer_object_transaction(
             self.transfer_object,
             *gas_obj,
             self.transfer_from,
@@ -82,32 +85,36 @@ impl Payload for TransferObjectTestPayload {
                 .state
                 .borrow()
                 .reference_gas_price,
-        )
+        );
+        self.create_failing_transaction(tx)
     }
+
     fn get_failure_type(&self) -> Option<ExpectedFailureType> {
-        None
+        Some(self.failure_type)
     }
 }
 
-impl std::fmt::Display for TransferObjectTestPayload {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "transfer_object")
+impl fmt::Display for ExpectedFailurePayload {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ExpectedFailurePayload({:?})", self.failure_type)
     }
 }
 
 #[derive(Debug)]
-pub struct TransferObjectWorkloadBuilder {
+pub struct ExpectedFailureWorkloadBuilder {
+    expected_failure_cfg: ExpectedFailurePayloadCfg,
     num_transfer_accounts: u64,
     num_payloads: u64,
 }
 
-impl TransferObjectWorkloadBuilder {
+impl ExpectedFailureWorkloadBuilder {
     pub fn from(
         workload_weight: f32,
         target_qps: u64,
         num_workers: u64,
         in_flight_ratio: u64,
         num_transfer_accounts: u64,
+        expected_failure_cfg: ExpectedFailurePayloadCfg,
         duration: Interval,
         group: u32,
     ) -> Option<WorkloadBuilderInfo> {
@@ -125,9 +132,10 @@ impl TransferObjectWorkloadBuilder {
                 group,
             };
             let workload_builder = Box::<dyn WorkloadBuilder<dyn Payload>>::from(Box::new(
-                TransferObjectWorkloadBuilder {
-                    num_transfer_accounts,
+                ExpectedFailureWorkloadBuilder {
+                    expected_failure_cfg,
                     num_payloads: max_ops,
+                    num_transfer_accounts,
                 },
             ));
             let builder_info = WorkloadBuilderInfo {
@@ -140,7 +148,7 @@ impl TransferObjectWorkloadBuilder {
 }
 
 #[async_trait]
-impl WorkloadBuilder<dyn Payload> for TransferObjectWorkloadBuilder {
+impl WorkloadBuilder<dyn Payload> for ExpectedFailureWorkloadBuilder {
     async fn generate_coin_config_for_init(&self) -> Vec<GasCoinConfig> {
         vec![]
     }
@@ -187,28 +195,35 @@ impl WorkloadBuilder<dyn Payload> for TransferObjectWorkloadBuilder {
         _init_gas: Vec<Gas>,
         payload_gas: Vec<Gas>,
     ) -> Box<dyn Workload<dyn Payload>> {
-        Box::<dyn Workload<dyn Payload>>::from(Box::new(TransferObjectWorkload {
+        debug!(
+            "Using `{:?}` expected failure workloads",
+            self.expected_failure_cfg.failure_type,
+        );
+
+        Box::<dyn Workload<dyn Payload>>::from(Box::new(ExpectedFailureWorkload {
             num_tokens: self.num_payloads,
             payload_gas,
+            expected_failure_cfg: self.expected_failure_cfg,
         }))
     }
 }
 
 #[derive(Debug)]
-pub struct TransferObjectWorkload {
+pub struct ExpectedFailureWorkload {
     num_tokens: u64,
     payload_gas: Vec<Gas>,
+    expected_failure_cfg: ExpectedFailurePayloadCfg,
 }
 
 #[async_trait]
-impl Workload<dyn Payload> for TransferObjectWorkload {
+impl Workload<dyn Payload> for ExpectedFailureWorkload {
     async fn init(
         &mut self,
         _proxy: Arc<dyn ValidatorProxy + Sync + Send>,
         _system_state_observer: Arc<SystemStateObserver>,
     ) {
-        return;
     }
+
     async fn make_test_payloads(
         &self,
         _proxy: Arc<dyn ValidatorProxy + Sync + Send>,
@@ -241,7 +256,8 @@ impl Workload<dyn Payload> for TransferObjectWorkload {
             .map(|(g, t)| {
                 let from = t.1;
                 let to = g.iter().find(|x| x.1 != from).unwrap().1;
-                Box::new(TransferObjectTestPayload {
+                Box::new(ExpectedFailurePayload {
+                    failure_type: self.expected_failure_cfg.failure_type,
                     transfer_object: t.0,
                     transfer_from: from,
                     transfer_to: to,

--- a/crates/iota-benchmark/src/workloads/mod.rs
+++ b/crates/iota-benchmark/src/workloads/mod.rs
@@ -5,6 +5,7 @@
 pub mod adversarial;
 pub mod batch_payment;
 pub mod delegation;
+pub mod expected_failure;
 pub mod payload;
 pub mod randomness;
 pub mod shared_counter;

--- a/crates/iota-benchmark/src/workloads/payload.rs
+++ b/crates/iota-benchmark/src/workloads/payload.rs
@@ -6,7 +6,7 @@ use std::fmt::Display;
 
 use iota_types::transaction::Transaction;
 
-use crate::ExecutionEffects;
+use crate::{ExecutionEffects, workloads::ExpectedFailureType};
 
 /// A Payload is a transaction wrapper of a particular type (transfer object,
 /// shared counter, etc). Calling `make_transaction()` on a payload produces the
@@ -16,4 +16,7 @@ use crate::ExecutionEffects;
 pub trait Payload: Send + Sync + std::fmt::Debug + Display {
     fn make_new_payload(&mut self, effects: &ExecutionEffects);
     fn make_transaction(&mut self) -> Transaction;
+    fn get_failure_type(&self) -> Option<ExpectedFailureType> {
+        None // Default implementation returns None
+    }
 }

--- a/crates/iota-benchmark/src/workloads/randomness.rs
+++ b/crates/iota-benchmark/src/workloads/randomness.rs
@@ -23,7 +23,10 @@ use crate::{
     workloads::{
         Gas, GasCoinConfig, WorkloadBuilderInfo, WorkloadParams,
         payload::Payload,
-        workload::{ESTIMATED_COMPUTATION_COST, MAX_GAS_FOR_TESTING, Workload, WorkloadBuilder},
+        workload::{
+            ESTIMATED_COMPUTATION_COST, ExpectedFailureType, MAX_GAS_FOR_TESTING, Workload,
+            WorkloadBuilder,
+        },
     },
 };
 
@@ -61,6 +64,9 @@ impl Payload for RandomnessTestPayload {
         TestTransactionBuilder::new(self.gas.1, self.gas.0, rgp)
             .call_emit_random(self.package_id, self.randomness_initial_shared_version)
             .build_and_sign(self.gas.2.as_ref())
+    }
+    fn get_failure_type(&self) -> Option<ExpectedFailureType> {
+        None
     }
 }
 

--- a/crates/iota-benchmark/src/workloads/shared_counter.rs
+++ b/crates/iota-benchmark/src/workloads/shared_counter.rs
@@ -24,8 +24,8 @@ use crate::{
         Gas, GasCoinConfig, WorkloadBuilderInfo, WorkloadParams,
         payload::Payload,
         workload::{
-            ESTIMATED_COMPUTATION_COST, MAX_GAS_FOR_TESTING, STORAGE_COST_PER_COUNTER, Workload,
-            WorkloadBuilder,
+            ESTIMATED_COMPUTATION_COST, ExpectedFailureType, MAX_GAS_FOR_TESTING,
+            STORAGE_COST_PER_COUNTER, Workload, WorkloadBuilder,
         },
     },
 };
@@ -76,6 +76,9 @@ impl Payload for SharedCounterTestPayload {
                 self.counter_initial_shared_version,
             )
             .build_and_sign(self.gas.2.as_ref())
+    }
+    fn get_failure_type(&self) -> Option<ExpectedFailureType> {
+        None
     }
 }
 

--- a/crates/iota-benchmark/src/workloads/shared_object_deletion.rs
+++ b/crates/iota-benchmark/src/workloads/shared_object_deletion.rs
@@ -24,8 +24,8 @@ use crate::{
         Gas, GasCoinConfig, WorkloadBuilderInfo, WorkloadParams,
         payload::Payload,
         workload::{
-            ESTIMATED_COMPUTATION_COST, MAX_GAS_FOR_TESTING, STORAGE_COST_PER_COUNTER, Workload,
-            WorkloadBuilder,
+            ESTIMATED_COMPUTATION_COST, ExpectedFailureType, MAX_GAS_FOR_TESTING,
+            STORAGE_COST_PER_COUNTER, Workload, WorkloadBuilder,
         },
     },
 };
@@ -122,6 +122,9 @@ impl Payload for SharedCounterDeletionTestPayload {
             _ => panic!("Invalid transaction selector"),
         }
         .build_and_sign(self.gas.2.as_ref())
+    }
+    fn get_failure_type(&self) -> Option<ExpectedFailureType> {
+        None
     }
 }
 

--- a/crates/iota-benchmark/src/workloads/workload.rs
+++ b/crates/iota-benchmark/src/workloads/workload.rs
@@ -2,10 +2,17 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 
+use anyhow::anyhow;
 use async_trait::async_trait;
 use iota_types::gas_coin::NANOS_PER_IOTA;
+use rand::{
+    Rng,
+    distributions::{Distribution, Standard},
+};
+use strum::{EnumCount, IntoEnumIterator};
+use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
 
 use crate::{
     ValidatorProxy,
@@ -26,6 +33,57 @@ pub const STORAGE_COST_PER_COIN: u64 = 130 * 76 * 100;
 pub const STORAGE_COST_PER_COUNTER: u64 = 341 * 76 * 100;
 /// Used to estimate the budget required for each transaction.
 pub const ESTIMATED_COMPUTATION_COST: u64 = 1_000_000;
+
+#[derive(Debug, EnumCountMacro, EnumIter, Clone, Copy)]
+pub enum ExpectedFailureType {
+    Random = 0,
+    InvalidSignature,
+    // TODO: Add other failure types
+}
+
+impl TryFrom<u32> for ExpectedFailureType {
+    type Error = anyhow::Error;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(rand::random()),
+            _ => ExpectedFailureType::iter()
+                .nth(value as usize)
+                .ok_or_else(|| {
+                    anyhow!(
+                        "Invalid failure type specifier. Valid options are {} to {}",
+                        0,
+                        ExpectedFailureType::COUNT
+                    )
+                }),
+        }
+    }
+}
+
+impl FromStr for ExpectedFailureType {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let v = u32::from_str(s).map(ExpectedFailureType::try_from);
+
+        if let Ok(Ok(q)) = v {
+            return Ok(q);
+        }
+
+        Err(anyhow!(
+            "Invalid input string. Valid values are 0 to {}",
+            ExpectedFailureType::COUNT
+        ))
+    }
+}
+
+impl Distribution<ExpectedFailureType> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> ExpectedFailureType {
+        // Exclude the "Random" variant
+        let n = rng.gen_range(1..ExpectedFailureType::COUNT);
+        ExpectedFailureType::iter().nth(n).unwrap()
+    }
+}
 
 #[async_trait]
 pub trait WorkloadBuilder<T: Payload + ?Sized>: Send + Sync + std::fmt::Debug {

--- a/crates/iota-benchmark/src/workloads/workload_configuration.rs
+++ b/crates/iota-benchmark/src/workloads/workload_configuration.rs
@@ -9,6 +9,7 @@ use tracing::info;
 
 use super::{
     adversarial::{AdversarialPayloadCfg, AdversarialWorkloadBuilder},
+    expected_failure::{ExpectedFailurePayloadCfg, ExpectedFailureWorkloadBuilder},
     randomness::RandomnessWorkloadBuilder,
     shared_object_deletion::SharedCounterDeletionWorkloadBuilder,
 };
@@ -18,12 +19,39 @@ use crate::{
     options::{Opts, RunSpec},
     system_state_observer::SystemStateObserver,
     workloads::{
-        GroupID, WorkloadBuilderInfo, WorkloadInfo, batch_payment::BatchPaymentWorkloadBuilder,
-        delegation::DelegationWorkloadBuilder, shared_counter::SharedCounterWorkloadBuilder,
+        ExpectedFailureType, GroupID, WorkloadBuilderInfo, WorkloadInfo,
+        batch_payment::BatchPaymentWorkloadBuilder, delegation::DelegationWorkloadBuilder,
+        shared_counter::SharedCounterWorkloadBuilder,
         transfer_object::TransferObjectWorkloadBuilder,
     },
 };
 
+pub struct WorkloadWeights {
+    pub shared_counter: u32,
+    pub transfer_object: u32,
+    pub delegation: u32,
+    pub batch_payment: u32,
+    pub shared_deletion: u32,
+    pub adversarial: u32,
+    pub expected_failure: u32,
+    pub randomness: u32,
+}
+
+pub struct WorkloadConfig {
+    pub group: u32,
+    pub num_workers: u64,
+    pub num_transfer_accounts: u64,
+    pub weights: WorkloadWeights,
+    pub adversarial_cfg: AdversarialPayloadCfg,
+    pub expected_failure_cfg: ExpectedFailurePayloadCfg,
+    pub batch_payment_size: u32,
+    pub shared_counter_hotness_factor: u32,
+    pub num_shared_counters: Option<u64>,
+    pub shared_counter_max_tip: u64,
+    pub target_qps: u64,
+    pub in_flight_ratio: u64,
+    pub duration: Interval,
+}
 pub struct WorkloadConfiguration;
 
 impl WorkloadConfiguration {
@@ -44,12 +72,14 @@ impl WorkloadConfiguration {
                 delegation,
                 batch_payment,
                 adversarial,
+                expected_failure,
                 randomness,
                 shared_counter_hotness_factor,
                 num_shared_counters,
                 shared_counter_max_tip,
                 batch_payment_size,
                 adversarial_cfg,
+                expected_failure_type,
                 target_qps,
                 num_workers,
                 in_flight_ratio,
@@ -65,28 +95,36 @@ impl WorkloadConfiguration {
                 // duration.
                 for workload_group in 0..num_of_benchmark_groups {
                     let i = workload_group as usize;
-                    let builders = Self::create_workload_builders(
-                        workload_group,
-                        num_workers[i],
-                        opts.num_transfer_accounts,
-                        shared_counter[i],
-                        transfer_object[i],
-                        delegation[i],
-                        batch_payment[i],
-                        shared_deletion[i],
-                        adversarial[i],
-                        AdversarialPayloadCfg::from_str(&adversarial_cfg[i]).unwrap(),
-                        randomness[i],
-                        batch_payment_size[i],
-                        shared_counter_hotness_factor[i],
-                        num_shared_counters.as_ref().map(|n| n[i]),
-                        shared_counter_max_tip[i],
-                        target_qps[i],
-                        in_flight_ratio[i],
-                        duration[i],
-                        system_state_observer.clone(),
-                    )
-                    .await;
+                    let config = WorkloadConfig {
+                        group: workload_group,
+                        num_workers: num_workers[i],
+                        num_transfer_accounts: opts.num_transfer_accounts,
+                        weights: WorkloadWeights {
+                            shared_counter: shared_counter[i],
+                            transfer_object: transfer_object[i],
+                            delegation: delegation[i],
+                            batch_payment: batch_payment[i],
+                            shared_deletion: shared_deletion[i],
+                            adversarial: adversarial[i],
+                            expected_failure: expected_failure[i],
+                            randomness: randomness[i],
+                        },
+                        adversarial_cfg: AdversarialPayloadCfg::from_str(&adversarial_cfg[i])
+                            .unwrap(),
+                        expected_failure_cfg: ExpectedFailurePayloadCfg {
+                            failure_type: ExpectedFailureType::try_from(expected_failure_type[i])
+                                .unwrap(),
+                        },
+                        batch_payment_size: batch_payment_size[i],
+                        shared_counter_hotness_factor: shared_counter_hotness_factor[i],
+                        num_shared_counters: num_shared_counters.as_ref().map(|n| n[i]),
+                        shared_counter_max_tip: shared_counter_max_tip[i],
+                        target_qps: target_qps[i],
+                        in_flight_ratio: in_flight_ratio[i],
+                        duration: duration[i],
+                    };
+                    let builders =
+                        Self::create_workload_builders(config, system_state_observer.clone()).await;
                     workload_builders.extend(builders);
                 }
 
@@ -144,37 +182,35 @@ impl WorkloadConfiguration {
     }
 
     pub async fn create_workload_builders(
-        workload_group: u32,
-        num_workers: u64,
-        num_transfer_accounts: u64,
-        shared_counter_weight: u32,
-        transfer_object_weight: u32,
-        delegation_weight: u32,
-        batch_payment_weight: u32,
-        shared_deletion_weight: u32,
-        adversarial_weight: u32,
-        adversarial_cfg: AdversarialPayloadCfg,
-        randomness_weight: u32,
-        batch_payment_size: u32,
-        shared_counter_hotness_factor: u32,
-        num_shared_counters: Option<u64>,
-        shared_counter_max_tip: u64,
-        target_qps: u64,
-        in_flight_ratio: u64,
-        duration: Interval,
+        WorkloadConfig {
+            group,
+            num_workers,
+            num_transfer_accounts,
+            weights,
+            adversarial_cfg,
+            expected_failure_cfg,
+            batch_payment_size,
+            shared_counter_hotness_factor,
+            num_shared_counters,
+            shared_counter_max_tip,
+            target_qps,
+            in_flight_ratio,
+            duration,
+        }: WorkloadConfig,
         system_state_observer: Arc<SystemStateObserver>,
     ) -> Vec<Option<WorkloadBuilderInfo>> {
-        let total_weight = shared_counter_weight
-            + shared_deletion_weight
-            + transfer_object_weight
-            + delegation_weight
-            + batch_payment_weight
-            + adversarial_weight
-            + randomness_weight;
+        let total_weight = weights.shared_counter
+            + weights.shared_deletion
+            + weights.transfer_object
+            + weights.delegation
+            + weights.batch_payment
+            + weights.adversarial
+            + weights.randomness
+            + weights.expected_failure;
         let reference_gas_price = system_state_observer.state.borrow().reference_gas_price;
         let mut workload_builders = vec![];
         let shared_workload = SharedCounterWorkloadBuilder::from(
-            shared_counter_weight as f32 / total_weight as f32,
+            weights.shared_counter as f32 / total_weight as f32,
             target_qps,
             num_workers,
             in_flight_ratio,
@@ -183,11 +219,11 @@ impl WorkloadConfiguration {
             shared_counter_max_tip,
             reference_gas_price,
             duration,
-            workload_group,
+            group,
         );
         workload_builders.push(shared_workload);
         let shared_deletion_workload = SharedCounterDeletionWorkloadBuilder::from(
-            shared_deletion_weight as f32 / total_weight as f32,
+            weights.shared_deletion as f32 / total_weight as f32,
             target_qps,
             num_workers,
             in_flight_ratio,
@@ -195,58 +231,69 @@ impl WorkloadConfiguration {
             shared_counter_max_tip,
             reference_gas_price,
             duration,
-            workload_group,
+            group,
         );
         workload_builders.push(shared_deletion_workload);
         let transfer_workload = TransferObjectWorkloadBuilder::from(
-            transfer_object_weight as f32 / total_weight as f32,
+            weights.transfer_object as f32 / total_weight as f32,
             target_qps,
             num_workers,
             in_flight_ratio,
             num_transfer_accounts,
             duration,
-            workload_group,
+            group,
         );
         workload_builders.push(transfer_workload);
         let delegation_workload = DelegationWorkloadBuilder::from(
-            delegation_weight as f32 / total_weight as f32,
+            weights.delegation as f32 / total_weight as f32,
             target_qps,
             num_workers,
             in_flight_ratio,
             duration,
-            workload_group,
+            group,
         );
         workload_builders.push(delegation_workload);
         let batch_payment_workload = BatchPaymentWorkloadBuilder::from(
-            batch_payment_weight as f32 / total_weight as f32,
+            weights.batch_payment as f32 / total_weight as f32,
             target_qps,
             num_workers,
             in_flight_ratio,
             batch_payment_size,
             duration,
-            workload_group,
+            group,
         );
         workload_builders.push(batch_payment_workload);
         let adversarial_workload = AdversarialWorkloadBuilder::from(
-            adversarial_weight as f32 / total_weight as f32,
+            weights.adversarial as f32 / total_weight as f32,
             target_qps,
             num_workers,
             in_flight_ratio,
             adversarial_cfg,
             duration,
-            workload_group,
+            group,
         );
         workload_builders.push(adversarial_workload);
         let randomness_workload = RandomnessWorkloadBuilder::from(
-            randomness_weight as f32 / total_weight as f32,
+            weights.randomness as f32 / total_weight as f32,
             target_qps,
             num_workers,
             in_flight_ratio,
             reference_gas_price,
             duration,
-            workload_group,
+            group,
         );
         workload_builders.push(randomness_workload);
+        let expected_failure_workload = ExpectedFailureWorkloadBuilder::from(
+            weights.expected_failure as f32 / total_weight as f32,
+            target_qps,
+            num_workers,
+            in_flight_ratio,
+            num_transfer_accounts,
+            expected_failure_cfg,
+            duration,
+            group,
+        );
+        workload_builders.push(expected_failure_workload);
 
         workload_builders
     }

--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -6,6 +6,7 @@
 mod test {
     use std::{
         collections::HashSet,
+        num::NonZeroUsize,
         path::PathBuf,
         str::FromStr,
         sync::{
@@ -22,7 +23,10 @@ mod test {
         system_state_observer::SystemStateObserver,
         util::get_ed25519_keypair_from_keystore,
         workloads::{
-            adversarial::AdversarialPayloadCfg, workload_configuration::WorkloadConfiguration,
+            adversarial::AdversarialPayloadCfg,
+            expected_failure::ExpectedFailurePayloadCfg,
+            workload::ExpectedFailureType,
+            workload_configuration::{WorkloadConfig, WorkloadConfiguration, WorkloadWeights},
         },
     };
     use iota_config::{AUTHORITIES_DB_NAME, IOTA_KEYSTORE_FILENAME, node::AuthorityOverloadConfig};
@@ -41,12 +45,14 @@ mod test {
     use iota_simulator::{SimConfig, configs::*, tempfile::TempDir};
     use iota_storage::blob::Blob;
     use iota_surfer::surf_strategy::SurfStrategy;
+    use iota_swarm_config::network_config_builder::ConfigBuilder;
     use iota_types::{
         base_types::{ConciseableName, ObjectID, SequenceNumber},
         digests::TransactionDigest,
         full_checkpoint_content::CheckpointData,
         messages_checkpoint::VerifiedCheckpoint,
         supported_protocol_versions::SupportedProtocolVersions,
+        traffic_control::{FreqThresholdConfig, PolicyConfig, PolicyType},
         transaction::{
             DEFAULT_VALIDATOR_GAS_PRICE, TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE,
         },
@@ -542,7 +548,64 @@ mod test {
             info!("Simulated load config: {:?}", simulated_load_config);
         }
 
-        test_simulated_load_with_test_config(test_cluster, 50, simulated_load_config).await;
+        test_simulated_load_with_test_config(test_cluster, 50, simulated_load_config, None, None)
+            .await;
+    }
+
+    // Tests cluster defense against failing transaction floods Traffic Control
+    #[sim_test(config = "test_config()")]
+    async fn test_simulated_load_expected_failure_traffic_control() {
+        // TODO: can we get away with significantly increasing this?
+        let target_qps = get_var("SIM_STRESS_TEST_QPS", 10);
+        let num_workers = get_var("SIM_STRESS_TEST_WORKERS", 10);
+
+        let expected_tps = target_qps * num_workers;
+        let error_policy_type = PolicyType::FreqThreshold(FreqThresholdConfig {
+            client_threshold: expected_tps / 2,
+            window_size_secs: 5,
+            update_interval_secs: 1,
+            ..Default::default()
+        });
+        info!(
+            "test_simulated_load_expected_failure_traffic_control setup.
+             Policy type: {:?}",
+            error_policy_type
+        );
+
+        let policy_config = PolicyConfig {
+            connection_blocklist_ttl_sec: 1,
+            error_policy_type,
+            dry_run: false,
+            ..Default::default()
+        };
+        let network_config = ConfigBuilder::new_with_temp_dir()
+            .committee_size(NonZeroUsize::new(4).unwrap())
+            .with_policy_config(Some(policy_config))
+            .with_epoch_duration(5000)
+            .build();
+        let test_cluster = Arc::new(
+            TestClusterBuilder::new()
+                .set_network_config(network_config)
+                .build()
+                .await,
+        );
+
+        let mut simulated_load_config = SimulatedLoadConfig::default();
+        {
+            simulated_load_config.expected_failure_weight = 20;
+            simulated_load_config.expected_failure_config.failure_type =
+                ExpectedFailureType::try_from(0).unwrap();
+            info!("Simulated load config: {:?}", simulated_load_config);
+        }
+
+        test_simulated_load_with_test_config(
+            test_cluster,
+            50,
+            simulated_load_config,
+            Some(target_qps),
+            Some(num_workers),
+        )
+        .await;
     }
 
     // Tests cluster liveness when DKG has failed.
@@ -852,6 +915,8 @@ mod test {
         num_shared_counters: Option<u64>,
         use_shared_counter_max_tip: bool,
         shared_counter_max_tip: u64,
+        expected_failure_weight: u32,
+        expected_failure_config: ExpectedFailurePayloadCfg,
     }
 
     impl Default for SimulatedLoadConfig {
@@ -868,6 +933,10 @@ mod test {
                 num_shared_counters: Some(1),
                 use_shared_counter_max_tip: false,
                 shared_counter_max_tip: 0,
+                expected_failure_weight: 0,
+                expected_failure_config: ExpectedFailurePayloadCfg {
+                    failure_type: ExpectedFailureType::try_from(0).unwrap(),
+                },
             }
         }
     }
@@ -877,6 +946,8 @@ mod test {
             test_cluster,
             test_duration_secs,
             SimulatedLoadConfig::default(),
+            None,
+            None,
         )
         .await;
     }
@@ -885,6 +956,8 @@ mod test {
         test_cluster: Arc<TestCluster>,
         test_duration_secs: u64,
         config: SimulatedLoadConfig,
+        target_qps: Option<u64>,
+        num_workers: Option<u64>,
     ) {
         let sender = test_cluster.get_address_0();
         let keystore_path = test_cluster.swarm.dir().join(IOTA_KEYSTORE_FILENAME);
@@ -917,17 +990,10 @@ mod test {
 
         // The default test parameters are somewhat conservative in order to keep the
         // running time of the test reasonable in CI.
-        let target_qps = get_var("SIM_STRESS_TEST_QPS", 10);
-        let num_workers = get_var("SIM_STRESS_TEST_WORKERS", 10);
+        let target_qps = target_qps.unwrap_or(get_var("SIM_STRESS_TEST_QPS", 10));
+        let num_workers = num_workers.unwrap_or(get_var("SIM_STRESS_TEST_WORKERS", 10));
         let in_flight_ratio = get_var("SIM_STRESS_TEST_IFR", 2);
         let batch_payment_size = get_var("SIM_BATCH_PAYMENT_SIZE", 15);
-        let shared_counter_weight = config.shared_counter_weight;
-        let transfer_object_weight = config.transfer_object_weight;
-        let num_transfer_accounts = config.num_transfer_accounts;
-        let delegation_weight = config.delegation_weight;
-        let batch_payment_weight = config.batch_payment_weight;
-        let shared_object_deletion_weight = config.shared_deletion_weight;
-        let randomness_weight = config.randomness_weight;
 
         // Run random payloads at 100% load
         let adversarial_cfg = AdversarialPayloadCfg::from_str("0-1.0").unwrap();
@@ -938,8 +1004,6 @@ mod test {
         // enabled. tests run for ever
         let adversarial_weight = 0;
 
-        let shared_counter_hotness_factor = config.shared_counter_hotness_factor;
-        let num_shared_counters = config.num_shared_counters;
         let shared_counter_max_tip = if config.use_shared_counter_max_tip {
             config.shared_counter_max_tip
         } else {
@@ -947,25 +1011,35 @@ mod test {
         };
         let gas_request_chunk_size = 100;
 
-        let workloads_builders = WorkloadConfiguration::create_workload_builders(
-            0,
+        let weights = WorkloadWeights {
+            shared_counter: config.shared_counter_weight,
+            transfer_object: config.transfer_object_weight,
+            delegation: config.delegation_weight,
+            batch_payment: config.batch_payment_weight,
+            shared_deletion: config.shared_deletion_weight,
+            randomness: config.randomness_weight,
+            adversarial: adversarial_weight,
+            expected_failure: config.expected_failure_weight,
+        };
+
+        let workload_config = WorkloadConfig {
+            group: 0,
             num_workers,
-            num_transfer_accounts,
-            shared_counter_weight,
-            transfer_object_weight,
-            delegation_weight,
-            batch_payment_weight,
-            shared_object_deletion_weight,
-            adversarial_weight,
+            num_transfer_accounts: config.num_transfer_accounts,
+            weights,
             adversarial_cfg,
-            randomness_weight,
+            expected_failure_cfg: config.expected_failure_config,
             batch_payment_size,
-            shared_counter_hotness_factor,
-            num_shared_counters,
+            shared_counter_hotness_factor: config.shared_counter_hotness_factor,
+            num_shared_counters: config.num_shared_counters,
             shared_counter_max_tip,
             target_qps,
             in_flight_ratio,
             duration,
+        };
+
+        let workloads_builders = WorkloadConfiguration::create_workload_builders(
+            workload_config,
             system_state_observer.clone(),
         )
         .await;


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.36.2, v1.37.4)
- Port commit: https://github.com/MystenLabs/sui/commit/16f2683a99e7b8824aa5879d3f20ffef936a7546
- Descriptions from commits
    Introduce a new payload type into the benchmark tool - `ExpectedFailurePayload`.

  This payload type is configured with some expected failure type (currently only one implemented - user signature failure - but others can be added with minimal scaffolding) such that `payload.make_transaction()` generates a transaction that will fail in this manner. Note that the failures that this payload type is concerned
  with are failures to execute the transaction itself, rather than during execution by the MoveVM. In other words, it is expected that the failure mode will not consume gas or produce effects.

  Note that for this reason, its failure mode is inverted. It will be tallied for metrics purposes as an `error` if it succeeds and tallied as an `expected_error` (which is a success) if it fails.

  Also note that transaction responses for this type are handled by producing a `NextOp::Retry` (with some additional logging/metrics) since it is functionally equivalent to a retryable error.


## Links to any relevant issues

Part of #3990 

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes