### PR TITLE
fix(consensus): Timeout when establishing a subscription connection

### DIFF
--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -8,7 +8,10 @@ use consensus_config::AuthorityIndex;
 use futures::StreamExt;
 use iota_metrics::spawn_monitored_task;
 use parking_lot::{Mutex, RwLock};
-use tokio::{task::JoinHandle, time::sleep};
+use tokio::{
+    task::JoinHandle,
+    time::{sleep, timeout},
+};
 use tracing::{debug, error, info};
 
 use crate::{
@@ -158,33 +161,49 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
             }
             retries += 1;
 
-            let mut blocks = match network_client
-                .subscribe_blocks(peer, last_received, MAX_RETRY_INTERVAL)
-                .await
-            {
-                Ok(blocks) => {
+            // Wrap subscribe_blocks in a timeout and increment metric on timeout
+            let subscribe_future =
+                network_client.subscribe_blocks(peer, last_received, MAX_RETRY_INTERVAL);
+            let subscribe_result = timeout(MAX_RETRY_INTERVAL * 5, subscribe_future).await;
+            let mut blocks = match subscribe_result {
+                Ok(inner_result) => match inner_result {
+                    Ok(blocks) => {
+                        debug!(
+                            "Subscribed to peer {} {} after {} attempts",
+                            peer, peer_hostname, retries
+                        );
+                        context
+                            .metrics
+                            .node_metrics
+                            .subscriber_connection_attempts
+                            .with_label_values(&[peer_hostname.as_str(), "success"])
+                            .inc();
+                        blocks
+                    }
+                    Err(e) => {
+                        debug!(
+                            "Failed to subscribe to blocks from peer {} {}: {}",
+                            peer, peer_hostname, e
+                        );
+                        context
+                            .metrics
+                            .node_metrics
+                            .subscriber_connection_attempts
+                            .with_label_values(&[peer_hostname.as_str(), "failure"])
+                            .inc();
+                        continue 'subscription;
+                    }
+                },
+                Err(_) => {
                     debug!(
-                        "Subscribed to peer {} {} after {} attempts",
-                        peer, peer_hostname, retries
+                        "Timeout subscribing to blocks from peer {} {}",
+                        peer, peer_hostname
                     );
                     context
                         .metrics
                         .node_metrics
                         .subscriber_connection_attempts
-                        .with_label_values(&[peer_hostname.as_str(), "success"])
-                        .inc();
-                    blocks
-                }
-                Err(e) => {
-                    debug!(
-                        "Failed to subscribe to blocks from peer {} {}: {}",
-                        peer, peer_hostname, e
-                    );
-                    context
-                        .metrics
-                        .node_metrics
-                        .subscriber_connection_attempts
-                        .with_label_values(&[peer_hostname.as_str(), "failure"])
+                        .with_label_values(&[peer_hostname.as_str(), "timeout"])
                         .inc();
                     continue 'subscription;
                 }


### PR DESCRIPTION
# Description of change

Add a timeout when establishing a subscription connection to a peer takes too much time. This is done to avoid potentially hanging on this part.

## Links to any relevant issues

Partly resolves #ana

## How the change has been tested

CI, local network

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
