### PR TITLE
feat(node): Add `db_corrupted` flag to detect the DB inconsistency

### DIFF
--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -441,7 +441,7 @@ impl IotaNode {
         info!("IOTA chain identifier: {chain_identifier}");
 
         // Check and set the db_corrupted flag
-        let db_corrupted_path = &config.db_path().join("root");
+        let db_corrupted_path = &config.db_path().join("status");
         if let Err(err) = check_and_mark_db_corruption(db_corrupted_path) {
             panic!("Failed to check database corruption: {}", err);
         }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -128,7 +128,10 @@ use tokio::{
 };
 use tower::ServiceBuilder;
 use tracing::{Instrument, debug, error, error_span, info, warn};
-use typed_store::{DBMetrics, rocks::default_db_options};
+use typed_store::{
+    DBMetrics,
+    rocks::{check_and_mark_db_corruption, default_db_options, unmark_db_corruption},
+};
 
 use crate::metrics::{GrpcMetrics, IotaNodeMetrics};
 
@@ -437,6 +440,12 @@ impl IotaNode {
         let _ = CHAIN_IDENTIFIER.set(chain_identifier);
         info!("IOTA chain identifier: {chain_identifier}");
 
+        // Check and set the db_corrupted flag
+        let db_corrupted_path = &config.db_path().join("root");
+        if let Err(err) = check_and_mark_db_corruption(db_corrupted_path) {
+            panic!("Failed to check database corruption: {}", err);
+        }
+
         // Initialize metrics to track db usage before creating any stores
         DBMetrics::init(&prometheus_registry);
 
@@ -583,6 +592,9 @@ impl IotaNode {
             genesis.checkpoint_contents().clone(),
             &epoch_store,
         );
+
+        // Database has everything from genesis, set corrupted key to 0
+        unmark_db_corruption(db_corrupted_path)?;
 
         info!("creating state sync store");
         let state_sync_store = RocksDbStore::new(

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -84,6 +84,8 @@ const ENV_VAR_DB_PARALLELISM: &str = "DB_PARALLELISM";
 const ROCKSDB_PROPERTY_TOTAL_BLOB_FILES_SIZE: &CStr =
     unsafe { CStr::from_bytes_with_nul_unchecked("rocksdb.total-blob-file-size\0".as_bytes()) };
 
+const DB_CORRUPTED_KEY: &[u8] = b"db_corrupted";
+
 #[cfg(test)]
 mod tests;
 
@@ -595,6 +597,31 @@ impl RocksDB {
     pub fn live_files(&self) -> Result<Vec<LiveFile>, Error> {
         delegate_call!(self.live_files())
     }
+}
+
+// Check if the database is corrupted, and if so, panic.
+// If the corrupted key is not set, we set it to [1].
+pub fn check_and_mark_db_corruption(path: &Path) -> Result<(), String> {
+    let db = rocksdb::DB::open_default(path).map_err(|e| e.to_string())?;
+
+    db.get(DB_CORRUPTED_KEY)
+        .map_err(|e| format!("Failed to open database: {}", e))
+        .and_then(|value| match value {
+            Some(v) if v[0] == 1 => Err(
+                "Database is corrupted, please remove the current database and start clean!"
+                    .to_string(),
+            ),
+            Some(_) => Ok(()),
+            None => db
+                .put(DB_CORRUPTED_KEY, [1])
+                .map_err(|e| format!("Failed to set corrupted key in database: {}", e)),
+        })?;
+
+    Ok(())
+}
+
+pub fn unmark_db_corruption(path: &Path) -> Result<(), Error> {
+    rocksdb::DB::open_default(path)?.put(DB_CORRUPTED_KEY, [0])
 }
 
 pub enum RocksDBSnapshot<'a> {


### PR DESCRIPTION
# Description of change

Detect and handle the potential database inconsistency:
* Introduced a `db_corrupted` flag in the database.
* On node startup:
        1. Check the `db_corrupted` flag.
             * If it is **true**: Panic the node. Instruct the operator to start with a clean database.
             * If it is **false**:  The DB is safe to use
             * If the key does not exist: Set `db_corrupted` to true before initialization begins.
        2. After successful database initialization, set `db_corrupted` back to false.

More detailed investigation on database inconsistency are in #6997 


## Links to any relevant issues

Fixes #6997 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes):
  - Add database corruption check 
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
