### PR TITLE
chore(shared-crypto): reserve the former bridge event intent scope

### DIFF
--- a/crates/shared-crypto/src/intent.rs
+++ b/crates/shared-crypto/src/intent.rs
@@ -66,7 +66,8 @@ pub enum IntentScope {
     SenderSignedTransaction = 4, // Used for an authority signature on a user signed transaction.
     ProofOfPossession = 5,       /* Used as a signature representing an authority's proof of
                                   * possession of its authority key. */
-    Reserved = 6, // it was thought for bridge purposes but it was never included in messages.
+    BridgeEventDeprecated = 6, /* Deprecated. Should not be reused. Introduced for bridge
+                                * purposes but was never included in messages. */
     ConsensusBlock = 7, // Used for consensus authority signature on block's digest.
 }
 

--- a/crates/shared-crypto/src/intent.rs
+++ b/crates/shared-crypto/src/intent.rs
@@ -66,8 +66,8 @@ pub enum IntentScope {
     SenderSignedTransaction = 4, // Used for an authority signature on a user signed transaction.
     ProofOfPossession = 5,       /* Used as a signature representing an authority's proof of
                                   * possession of its authority key. */
-    BridgeEventUnused = 6, // for bridge purposes but it's currently not included in messages.
-    ConsensusBlock = 7,    // Used for consensus authority signature on block's digest
+    Reserved = 6, // it was thought for bridge purposes but it was never included in messages.
+    ConsensusBlock = 7, // Used for consensus authority signature on block's digest.
 }
 
 impl TryFrom<u8> for IntentScope {


### PR DESCRIPTION
# Description of change

Renamed IntentScope variant `BridgeEventUnused` to `BridgeEventDeprecated`.

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
