### PR TITLE
fix(docs): wasm api reference broken link

### DIFF
--- a/docs/content/iota-identity/getting-started/wasm.mdx
+++ b/docs/content/iota-identity/getting-started/wasm.mdx
@@ -215,6 +215,4 @@ because of that **it will only be slow for the first time**.
 
 */}
 
-## [API Reference](../../references/iota-identity/wasm/api_ref.md)
-
 ## [Examples](https://github.com/iotaledger/identity.rs/blob/v1.6.0-beta/bindings/wasm/identity_wasm/examples/README.md)


### PR DESCRIPTION
# Description of change

This PR fixes wasm api reference broken link

## Links to any relevant issues

fixes #7324 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
