### PR TITLE
upstream(indexer): Break dependency between pruner and epoch watermark

### DIFF
--- a/crates/iota-indexer/src/handlers/pruner.rs
+++ b/crates/iota-indexer/src/handlers/pruner.rs
@@ -39,21 +39,16 @@ impl Pruner {
     }
 
     pub async fn start(&self, cancel: CancellationToken) -> IndexerResult<()> {
-        loop {
-            if cancel.is_cancelled() {
-                info!("Pruner task cancelled.");
-                return Ok(());
-            }
-
-            let (mut min_epoch, mut max_epoch) = self.store.get_available_epoch_range().await?;
-            while min_epoch + self.epochs_to_keep > max_epoch {
-                if cancel.is_cancelled() {
-                    info!("Pruner task cancelled.");
-                    return Ok(());
-                }
+        let mut last_seen_max_epoch = 0;
+        // The first epoch that has not yet been pruned.
+        let mut next_prune_epoch = None;
+        while !cancel.is_cancelled() {
+            let (min_epoch, max_epoch) = self.store.get_available_epoch_range().await?;
+            if max_epoch == last_seen_max_epoch {
                 tokio::time::sleep(Duration::from_secs(5)).await;
-                (min_epoch, max_epoch) = self.store.get_available_epoch_range().await?;
+                continue;
             }
+            last_seen_max_epoch = max_epoch;
 
             // Not all partitioned tables are epoch-partitioned, so we need to filter them
             // out.
@@ -68,17 +63,20 @@ impl Pruner {
                 })
                 .collect();
 
+            let prune_to_epoch = last_seen_max_epoch.saturating_sub(self.epochs_to_keep - 1);
+
             for (table_name, (min_partition, max_partition)) in &table_partitions {
-                if max_epoch != *max_partition {
+                if last_seen_max_epoch != *max_partition {
                     error!(
                         "Epochs are out of sync for table {}: max_epoch={}, max_partition={}",
-                        table_name, max_epoch, max_partition
+                        table_name, last_seen_max_epoch, max_partition
                     );
                 }
-                // drop partitions if pruning is enabled afterwards, where all epochs before
-                // min_epoch would have been pruned already if the pruner was
-                // running.
-                for epoch in *min_partition..min_epoch {
+                for epoch in *min_partition..prune_to_epoch {
+                    if cancel.is_cancelled() {
+                        info!("Pruner task cancelled.");
+                        return Ok(());
+                    }
                     self.partition_manager
                         .drop_table_partition(table_name.clone(), epoch)?;
                     info!(
@@ -88,23 +86,24 @@ impl Pruner {
                 }
             }
 
-            for epoch in min_epoch..max_epoch.saturating_sub(self.epochs_to_keep - 1) {
+            let prune_start_epoch = next_prune_epoch.unwrap_or(min_epoch);
+
+            for epoch in prune_start_epoch..prune_to_epoch {
                 if cancel.is_cancelled() {
                     info!("Pruner task cancelled.");
                     return Ok(());
                 }
                 info!("Pruning epoch {}", epoch);
-                for table_name in table_partitions.keys() {
-                    self.partition_manager
-                        .drop_table_partition(table_name.clone(), epoch)?;
-                    info!("Dropped table partition {} epoch {}", table_name, epoch);
-                }
-                self.store.prune_epoch(epoch).await.unwrap_or_else(|e| {
-                    error!("Failed to prune epoch {}: {}", epoch, e);
-                });
+                if let Err(err) = self.store.prune_epoch(epoch).await {
+                    error!("Failed to prune epoch {}: {}", epoch, err);
+                    break;
+                };
                 self.metrics.last_pruned_epoch.set(epoch as i64);
                 info!("Pruned epoch {}", epoch);
+                next_prune_epoch = Some(epoch + 1);
             }
         }
+        info!("Pruner task cancelled.");
+        Ok(())
     }
 }

--- a/crates/iota-indexer/src/handlers/pruner.rs
+++ b/crates/iota-indexer/src/handlers/pruner.rs
@@ -95,7 +95,7 @@ impl Pruner {
                 }
                 info!("Pruning epoch {}", epoch);
                 if let Err(err) = self.store.prune_epoch(epoch).await {
-                    error!("Failed to prune epoch {}: {}", epoch, err);
+                    error!("Failed to prune epoch {epoch}: {err}");
                     break;
                 };
                 self.metrics.last_pruned_epoch.set(epoch as i64);

--- a/crates/iota-indexer/src/handlers/pruner.rs
+++ b/crates/iota-indexer/src/handlers/pruner.rs
@@ -68,8 +68,7 @@ impl Pruner {
             for (table_name, (min_partition, max_partition)) in &table_partitions {
                 if last_seen_max_epoch != *max_partition {
                     error!(
-                        "Epochs are out of sync for table {}: max_epoch={}, max_partition={}",
-                        table_name, last_seen_max_epoch, max_partition
+                        "Epochs are out of sync for table {table_name}: max_epoch={last_seen_max_epoch}, max_partition={max_partition}",
                     );
                 }
                 for epoch in *min_partition..prune_to_epoch {


### PR DESCRIPTION
# Description of change

Pull from upstream, original description:

This PR makes a few improvements to the pruner:

 1. It stops depending on the epochs table data range as the watermark for global pruning decisions. Instead, it keeps track of the next prune epoch and last seen max epoch locally in the task. Once we have the actual watermark table we probably could further improve it.
 2. It also fixes an issue where we ignore failed pruning error.


## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/7312

## How the change has been tested

Ran `cargo nextest run --features pg_integration -p iota-graphql-e2e-tests` which contains the `prune.move` test

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
