### PR TITLE
upstream(indexer): Support 2-day retention for objects_history table

### DIFF
--- a/crates/iota-indexer/src/handlers/pruner.rs
+++ b/crates/iota-indexer/src/handlers/pruner.rs
@@ -15,6 +15,10 @@ use crate::{
     types::IndexerResult,
 };
 
+/// The primary purpose of objects_history is to serve consistency query.
+/// A short retention is sufficient.
+const OBJECTS_HISTORY_EPOCHS_TO_KEEP: u64 = 2;
+
 pub struct Pruner {
     pub store: PgIndexerStore,
     pub partition_manager: PgPartitionManager,
@@ -63,8 +67,6 @@ impl Pruner {
                 })
                 .collect();
 
-            let prune_to_epoch = last_seen_max_epoch.saturating_sub(self.epochs_to_keep - 1);
-
             for (table_name, (min_partition, max_partition)) in &table_partitions {
                 if last_seen_max_epoch != *max_partition {
                     error!(
@@ -72,7 +74,14 @@ impl Pruner {
                         table_name, last_seen_max_epoch, max_partition
                     );
                 }
-                for epoch in *min_partition..prune_to_epoch {
+
+                let epochs_to_keep = if table_name == "objects_history" {
+                    OBJECTS_HISTORY_EPOCHS_TO_KEEP
+                } else {
+                    self.epochs_to_keep
+                };
+                for epoch in *min_partition..last_seen_max_epoch.saturating_sub(epochs_to_keep - 1)
+                {
                     if cancel.is_cancelled() {
                         info!("Pruner task cancelled.");
                         return Ok(());
@@ -86,8 +95,8 @@ impl Pruner {
                 }
             }
 
+            let prune_to_epoch = last_seen_max_epoch.saturating_sub(self.epochs_to_keep - 1);
             let prune_start_epoch = next_prune_epoch.unwrap_or(min_epoch);
-
             for epoch in prune_start_epoch..prune_to_epoch {
                 if cancel.is_cancelled() {
                     info!("Pruner task cancelled.");


### PR DESCRIPTION
# Description of change

Add support to override epoch retention for individual tables. This can be passed from the command line.
It only supports partitioned table today. For non-partitioned tables it will take some wiring to make it work and not urgent. We need this today mainly to prune the objects_history table more aggressively.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/7330

## How the change has been tested

`cargo nextest run -p iota-graphql-e2e-tests --features pg_integration -- run_test::prune/prune.move`

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
