### PR TITLE
fix(iota-indexer): Return transactions that could not be resolved by the package resolver as of failing layouts

### DIFF
--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -1792,7 +1792,16 @@ impl IotaProgrammableTransactionBlock {
         value: ProgrammableTransaction,
         package_resolver: Arc<Resolver<impl PackageStore>>,
     ) -> Result<Self, anyhow::Error> {
-        let input_types = package_resolver.pure_input_layouts(&value).await?;
+        // If the pure input layouts cannot be built, we will use `None` for the input
+        // types.
+        let input_types = package_resolver
+            .pure_input_layouts(&value)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!("pure_input_layouts failed: {:?}", e);
+                vec![None; value.inputs.len()]
+            });
+
         let ProgrammableTransaction { inputs, commands } = value;
         Ok(IotaProgrammableTransactionBlock {
             inputs: inputs


### PR DESCRIPTION
# Description of change

Return transactions that could not be resolved by the package resolver as of failing layouts.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/5789

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

**The test has been manually tested as shown in the linked issue.**

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [x] Verification of API backward compatibility.

**Testing for following test classes are not necessary for this patch:**

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
