### PR TITLE
fix(indexer): handle system-state v1 in IndexerReader::get_epoch_iota_system_state

### DIFF
--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -465,14 +465,7 @@ impl IndexerReader {
             None => return Err(IndexerError::InvalidArgument("Invalid epoch".into())),
         };
 
-        let system_state: IotaSystemStateSummary = bcs::from_bytes(&stored_epoch.system_state)
-            .map_err(|_| {
-                IndexerError::PersistentStorageDataCorruption(format!(
-                    "Failed to deserialize `system_state` for epoch {:?}",
-                    epoch,
-                ))
-            })?;
-        Ok(system_state)
+        (&stored_epoch).try_into()
     }
 
     pub async fn get_chain_identifier_in_blocking_task(


### PR DESCRIPTION

# Description of change

See #7362 

## Links to any relevant issues

Fixes #7362 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

Manual tests have been performed by launching `iota-graphql-rpc` to read the `validatorSet` for epochs previous to `136` in testnet.

### Release Notes

- [x] Indexer: Fixes deserialization of system-state v1 in IndexerReader
- [x] GraphQL: Fixes deserialization of `epoch.validatorSet` value for epochs stored before protocol version 5.