### PR TITLE
feat(starfish): sending SerializedBlockBundles

### DIFF
--- a/crates/starfish/core/build.rs
+++ b/crates/starfish/core/build.rs
@@ -39,6 +39,17 @@ fn build_tonic_services(out_dir: &Path) {
         )
         .method(
             tonic_build::manual::Method::builder()
+                .name("subscribe_block_bundles")
+                .route_name("SubscribeBlockBundles")
+                .input_type("crate::network::tonic_network::SubscribeBlockBundlesRequest")
+                .output_type("crate::network::tonic_network::SubscribeBlockBundlesResponse")
+                .codec_path(codec_path)
+                .server_streaming()
+                .client_streaming()
+                .build(),
+        )
+        .method(
+            tonic_build::manual::Method::builder()
                 .name("fetch_block_headers")
                 .route_name("FetchBlockHeaders")
                 .input_type("crate::network::tonic_network::FetchBlockHeadersRequest")

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -27,7 +27,10 @@ use crate::{
     core_thread::CoreThreadDispatcher,
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
-    network::{BlockStream, NetworkService, SerializedBlock, SerializedHeaderAndTransactions},
+    network::{
+        BlockBundleStream, BlockStream, NetworkService, SerializedBlock, SerializedBlockBundle,
+        SerializedHeaderAndTransactions,
+    },
     stake_aggregator::{QuorumThreshold, StakeAggregator},
     storage::Store,
     synchronizer::SynchronizerHandle,
@@ -266,6 +269,14 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         Ok(())
     }
 
+    async fn handle_subscribed_block_bundles(
+        &self,
+        _peer: AuthorityIndex,
+        _serialized_block_bundle: SerializedBlockBundle,
+    ) -> ConsensusResult<()> {
+        unimplemented!("Unimplemented")
+    }
+
     async fn handle_subscribe_blocks(
         &self,
         peer: AuthorityIndex,
@@ -298,6 +309,14 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         Ok(Box::pin(missed_blocks.chain(
             broadcasted_blocks.map(|block| SerializedBlock::try_from(block).unwrap()),
         )))
+    }
+
+    async fn handle_subscribe_block_bundles_request(
+        &self,
+        _peer: AuthorityIndex,
+        _last_received: Round,
+    ) -> ConsensusResult<BlockBundleStream> {
+        unimplemented!("Unimplemented")
     }
 
     async fn handle_fetch_block_headers(
@@ -758,7 +777,7 @@ mod tests {
         core_thread::tests::MockCoreThreadDispatcher,
         dag_state::DagState,
         error::ConsensusResult,
-        network::{BlockStream, NetworkClient, NetworkService, SerializedBlock},
+        network::{BlockBundleStream, BlockStream, NetworkClient, NetworkService, SerializedBlock},
         storage::mem_store::MemStore,
         synchronizer::Synchronizer,
         test_dag_builder::DagBuilder,
@@ -775,6 +794,15 @@ mod tests {
             _last_received: Round,
             _timeout: Duration,
         ) -> ConsensusResult<BlockStream> {
+            unimplemented!("Unimplemented")
+        }
+
+        async fn subscribe_block_bundles(
+            &self,
+            _peer: AuthorityIndex,
+            _last_received: Round,
+            _timeout: Duration,
+        ) -> ConsensusResult<BlockBundleStream> {
             unimplemented!("Unimplemented")
         }
 

--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -845,7 +845,7 @@ mod tests {
         core_thread::tests::MockCoreThreadDispatcher,
         dag_state::DagState,
         error::ConsensusResult,
-        network::{BlockStream, NetworkClient},
+        network::{BlockBundleStream, BlockStream, NetworkClient},
         storage::mem_store::MemStore,
     };
 
@@ -860,6 +860,15 @@ mod tests {
             _last_received: Round,
             _timeout: Duration,
         ) -> ConsensusResult<BlockStream> {
+            unimplemented!("Unimplemented")
+        }
+
+        async fn subscribe_block_bundles(
+            &self,
+            _peer: AuthorityIndex,
+            _last_received: Round,
+            _timeout: Duration,
+        ) -> ConsensusResult<BlockBundleStream> {
             unimplemented!("Unimplemented")
         }
 

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -56,6 +56,9 @@ mod tonic_tls;
 
 /// A stream of serialized filtered blocks returned over the network.
 pub(crate) type BlockStream = Pin<Box<dyn Stream<Item = SerializedBlock> + Send>>;
+/// A stream of serialized blocks with additional information such as headers or
+/// shards.
+pub(crate) type BlockBundleStream = Pin<Box<dyn Stream<Item = SerializedBlockBundle> + Send>>;
 
 /// Network client for communicating with peers.
 ///
@@ -72,6 +75,14 @@ pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
         last_received: Round,
         timeout: Duration,
     ) -> ConsensusResult<BlockStream>;
+
+    /// Subscribes to blocks from a peer after last_received round.
+    async fn subscribe_block_bundles(
+        &self,
+        peer: AuthorityIndex,
+        last_received: Round,
+        timeout: Duration,
+    ) -> ConsensusResult<BlockBundleStream>;
 
     /// Fetches serialized `SerializedBlocks` from a peer. It also might
     /// return additional ancestor blocks of the requested blocks according
@@ -136,6 +147,15 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
         serialized_block: SerializedBlock,
     ) -> ConsensusResult<()>;
 
+    /// Handles the block and headers sent from the peer via subscription
+    /// stream. Peer value can be trusted to be a valid authority index. But
+    /// serialized_block must be verified before its contents are trusted.
+    async fn handle_subscribed_block_bundles(
+        &self,
+        peer: AuthorityIndex,
+        serialized_block_bundle: SerializedBlockBundle,
+    ) -> ConsensusResult<()>;
+
     /// Handles the subscription request from the peer.
     /// A stream of newly proposed blocks is returned to the peer.
     /// The stream continues until the end of epoch, peer unsubscribes, or a
@@ -145,6 +165,16 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
         peer: AuthorityIndex,
         last_received: Round,
     ) -> ConsensusResult<BlockStream>;
+
+    /// Handles the subscription request from the peer.
+    /// A stream of newly proposed blocks with additional data (headers or
+    /// shards) is returned to the peer. The stream continues until the end
+    /// of epoch, peer unsubscribes, or a network error / crash occurs.
+    async fn handle_subscribe_block_bundles_request(
+        &self,
+        peer: AuthorityIndex,
+        last_received: Round,
+    ) -> ConsensusResult<BlockBundleStream>;
 
     /// Handles the request to fetch block headers by references from the peer.
     async fn handle_fetch_block_headers(
@@ -254,4 +284,9 @@ impl TryFrom<SerializedBlock> for SerializedHeaderAndTransactions {
     fn try_from(serialized_block: SerializedBlock) -> ConsensusResult<Self> {
         bcs::from_bytes(&serialized_block.serialized_block).map_err(ConsensusError::MalformedBlock)
     }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct SerializedBlockBundle {
+    pub(crate) serialized_block_bundle: Bytes,
 }

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -77,6 +77,7 @@ pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
     ) -> ConsensusResult<BlockStream>;
 
     /// Subscribes to blocks from a peer after last_received round.
+    #[allow(dead_code)]
     async fn subscribe_block_bundles(
         &self,
         peer: AuthorityIndex,
@@ -150,6 +151,7 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
     /// Handles the block and headers sent from the peer via subscription
     /// stream. Peer value can be trusted to be a valid authority index. But
     /// serialized_block must be verified before its contents are trusted.
+    #[allow(dead_code)]
     async fn handle_subscribed_block_bundles(
         &self,
         peer: AuthorityIndex,

--- a/crates/starfish/core/src/network/test_network.rs
+++ b/crates/starfish/core/src/network/test_network.rs
@@ -13,7 +13,9 @@ use crate::{
     block_header::{BlockRef, VerifiedBlockHeader},
     commit::{CommitRange, TrustedCommit},
     error::ConsensusResult,
-    network::{BlockStream, NetworkService, SerializedBlock},
+    network::{
+        BlockBundleStream, BlockStream, NetworkService, SerializedBlock, SerializedBlockBundle,
+    },
 };
 
 pub(crate) struct TestService {
@@ -55,6 +57,14 @@ impl NetworkService for Mutex<TestService> {
         Ok(())
     }
 
+    async fn handle_subscribed_block_bundles(
+        &self,
+        _peer: AuthorityIndex,
+        _serialized_block_bundle: SerializedBlockBundle,
+    ) -> ConsensusResult<()> {
+        unimplemented!("Unimplemented")
+    }
+
     async fn handle_subscribe_blocks(
         &self,
         peer: AuthorityIndex,
@@ -70,6 +80,14 @@ impl NetworkService for Mutex<TestService> {
             .cloned()
             .collect::<Vec<_>>();
         Ok(Box::pin(stream::iter(own_blocks)))
+    }
+
+    async fn handle_subscribe_block_bundles_request(
+        &self,
+        _peer: AuthorityIndex,
+        _last_received: Round,
+    ) -> ConsensusResult<BlockBundleStream> {
+        unimplemented!("Unimplemented");
     }
 
     async fn handle_fetch_block_headers(

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -27,7 +27,8 @@ use tower_http::trace::{DefaultMakeSpan, DefaultOnFailure, TraceLayer};
 use tracing::{debug, error, info, trace, warn};
 
 use super::{
-    BlockStream, NetworkClient, NetworkService, SerializedBlock,
+    BlockBundleStream, BlockStream, NetworkClient, NetworkService, SerializedBlock,
+    SerializedBlockBundle,
     metrics_layer::{MetricsCallbackMaker, MetricsResponseCallback, SizedRequest, SizedResponse},
     tonic_gen::{
         consensus_service_client::ConsensusServiceClient,
@@ -121,6 +122,42 @@ impl NetworkClient for TonicClient {
                 match b {
                     Ok(response) => Some(SerializedBlock {
                         serialized_block: response.vec_serialized_blocks,
+                    }),
+                    Err(e) => {
+                        debug!("Network error received from {}: {e:?}", peer);
+                        None
+                    }
+                }
+            });
+        let rate_limited_stream =
+            tokio_stream::StreamExt::throttle(stream, self.context.parameters.min_round_delay / 2)
+                .boxed();
+        Ok(rate_limited_stream)
+    }
+
+    async fn subscribe_block_bundles(
+        &self,
+        peer: AuthorityIndex,
+        last_received: Round,
+        timeout: Duration,
+    ) -> ConsensusResult<BlockBundleStream> {
+        let mut client = self.get_client(peer, timeout).await?;
+        // TODO: add sampled block acknowledgments for latency measurements.
+        let request = Request::new(stream::once(async move {
+            SubscribeBlockBundlesRequest {
+                last_received_round: last_received,
+            }
+        }));
+        let response = client.subscribe_block_bundles(request).await.map_err(|e| {
+            ConsensusError::NetworkRequest(format!("subscribe_block_bundles failed: {e:?}"))
+        })?;
+        let stream = response
+            .into_inner()
+            .take_while(|b| futures::future::ready(b.is_ok()))
+            .filter_map(move |b| async move {
+                match b {
+                    Ok(response) => Some(SerializedBlockBundle {
+                        serialized_block_bundle: response.serialized_block_bundle,
                     }),
                     Err(e) => {
                         debug!("Network error received from {}: {e:?}", peer);
@@ -520,6 +557,50 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
             .map(|serialized_block| {
                 Ok(SubscribeBlocksResponse {
                     vec_serialized_blocks: serialized_block.serialized_block,
+                })
+            });
+        let rate_limited_stream =
+            tokio_stream::StreamExt::throttle(stream, self.context.parameters.min_round_delay / 2)
+                .boxed();
+        Ok(Response::new(rate_limited_stream))
+    }
+
+    type SubscribeBlockBundlesStream =
+        Pin<Box<dyn Stream<Item = Result<SubscribeBlockBundlesResponse, tonic::Status>> + Send>>;
+
+    async fn subscribe_block_bundles(
+        &self,
+        request: Request<Streaming<SubscribeBlockBundlesRequest>>,
+    ) -> Result<Response<Self::SubscribeBlockBundlesStream>, tonic::Status> {
+        let Some(peer_index) = request
+            .extensions()
+            .get::<PeerInfo>()
+            .map(|p| p.authority_index)
+        else {
+            return Err(tonic::Status::internal("PeerInfo not found"));
+        };
+        let mut request_stream = request.into_inner();
+        let first_request = match request_stream.next().await {
+            Some(Ok(r)) => r,
+            Some(Err(e)) => {
+                debug!(
+                    "subscribe_block_bundles() request from {} failed: {e:?}",
+                    peer_index
+                );
+                return Err(tonic::Status::invalid_argument("Request error"));
+            }
+            None => {
+                return Err(tonic::Status::invalid_argument("Missing request"));
+            }
+        };
+        let stream = self
+            .service
+            .handle_subscribe_block_bundles_request(peer_index, first_request.last_received_round)
+            .await
+            .map_err(|e| tonic::Status::internal(format!("{e:?}")))?
+            .map(|serialized_block_bundle| {
+                Ok(SubscribeBlockBundlesResponse {
+                    serialized_block_bundle: serialized_block_bundle.serialized_block_bundle,
                 })
             });
         let rate_limited_stream =
@@ -1092,13 +1173,16 @@ impl ResponseHandler for MetricsResponseCallback {
 
 /// Network message types.
 #[derive(Clone, prost::Message)]
-pub(crate) struct SendBlockRequest {
-    #[prost(bytes = "bytes", repeated, tag = "1")]
-    vec_serialized_blocks: Vec<Bytes>,
+pub(crate) struct SubscribeBlockBundlesRequest {
+    #[prost(uint32, tag = "1")]
+    last_received_round: Round,
 }
 
 #[derive(Clone, prost::Message)]
-pub(crate) struct SendBlockResponse {}
+pub(crate) struct SubscribeBlockBundlesResponse {
+    #[prost(bytes = "bytes", tag = "1")]
+    serialized_block_bundle: Bytes,
+}
 
 #[derive(Clone, prost::Message)]
 pub(crate) struct SubscribeBlocksRequest {

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -240,7 +240,7 @@ mod test {
         commit::CommitRange,
         error::ConsensusResult,
         network::{
-            BlockStream, SerializedBlock, SerializedHeaderAndTransactions,
+            BlockBundleStream, BlockStream, SerializedBlock, SerializedHeaderAndTransactions,
             test_network::TestService,
         },
         storage::mem_store::MemStore,
@@ -274,6 +274,15 @@ mod test {
             })
             .take(10);
             Ok(Box::pin(block_stream))
+        }
+
+        async fn subscribe_block_bundles(
+            &self,
+            _peer: AuthorityIndex,
+            _last_received: Round,
+            _timeout: Duration,
+        ) -> ConsensusResult<BlockBundleStream> {
+            unimplemented!("Unimplemented")
         }
 
         async fn fetch_blocks(

--- a/crates/starfish/core/src/synchronizer.rs
+++ b/crates/starfish/core/src/synchronizer.rs
@@ -1187,7 +1187,7 @@ mod tests {
         core_thread::{CoreThreadDispatcher, tests::MockCoreThreadDispatcher},
         dag_state::DagState,
         error::{ConsensusError, ConsensusResult},
-        network::{BlockStream, NetworkClient, SerializedBlock},
+        network::{BlockBundleStream, BlockStream, NetworkClient, SerializedBlock},
         storage::mem_store::MemStore,
         synchronizer::{
             FETCH_BLOCKS_CONCURRENCY, FETCH_REQUEST_TIMEOUT, InflightBlockHeadersMap,
@@ -1251,6 +1251,15 @@ mod tests {
             _last_received: Round,
             _timeout: Duration,
         ) -> ConsensusResult<BlockStream> {
+            unimplemented!("Unimplemented")
+        }
+
+        async fn subscribe_block_bundles(
+            &self,
+            _peer: AuthorityIndex,
+            _last_received: Round,
+            _timeout: Duration,
+        ) -> ConsensusResult<BlockBundleStream> {
             unimplemented!("Unimplemented")
         }
 


### PR DESCRIPTION
# Description of change

In Starfish, we want to send together with the blocks some additional information, such as headers of blocks the receiving peer is missing or some shards in the push version. This PR introduces the necessary changes in network functions to support such messages by sending SerializedBlockBundle. Logic that forms such bundles and works with them on the receiving side will be implemented in the next PRs.

## Links to any relevant issues

#7254 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
