### PR TITLE
fix(consensus): Fix missed `ConsensusTransactionKind` rename

### DIFF
--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1523,7 +1523,7 @@ impl IotaNode {
             .filter_map(|tx| {
                 match tx.kind {
                     // shared object txns will be re-executed by consensus replay
-                    ConsensusTransactionKind::UserTransaction(tx)
+                    ConsensusTransactionKind::CertifiedTransaction(tx)
                         if !tx.contains_shared_object() =>
                     {
                         let tx = *tx;


### PR DESCRIPTION
# Description of change

This PR fixes compilation error caused by missed `ConsensusTransactionKind` rename

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #(issue)`.

## How the change has been tested

CI

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
