### PR TITLE
fix(rest-api): Remove bridge from openapi spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7246,7 +7246,7 @@ dependencies = [
 [[package]]
 name = "iota-rust-sdk"
 version = "0.0.0"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=3e4a47351cdd774dd2895a2552a038fe2f4b6da5#3e4a47351cdd774dd2895a2552a038fe2f4b6da5"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=6bb6e45fea2c266f9c15dd89f26f68631c2d37a8#6bb6e45fea2c266f9c15dd89f26f68631c2d37a8"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -424,7 +424,7 @@ iota-rosetta = { path = "crates/iota-rosetta" }
 iota-rpc-loadgen = { path = "crates/iota-rpc-loadgen" }
 iota-sdk = { path = "crates/iota-sdk" }
 # core-types with json format for REST API
-iota-sdk2 = { package = "iota-rust-sdk", git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "3e4a47351cdd774dd2895a2552a038fe2f4b6da5", features = ["hash", "serde", "schemars"] }
+iota-sdk2 = { package = "iota-rust-sdk", git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "6bb6e45fea2c266f9c15dd89f26f68631c2d37a8", features = ["hash", "serde", "schemars"] }
 iota-simulator = { path = "crates/iota-simulator" }
 iota-snapshot = { path = "crates/iota-snapshot" }
 iota-source-validation = { path = "crates/iota-source-validation" }

--- a/crates/iota-rest-api/openapi/openapi.json
+++ b/crates/iota-rest-api/openapi/openapi.json
@@ -2408,44 +2408,6 @@
                 "format": "u64"
               }
             }
-          },
-          {
-            "type": "object",
-            "required": [
-              "chain_id",
-              "kind"
-            ],
-            "properties": {
-              "chain_id": {
-                "$ref": "#/components/schemas/CheckpointDigest"
-              },
-              "kind": {
-                "type": "string",
-                "enum": [
-                  "bridge_state_create"
-                ]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": [
-              "bridge_object_version",
-              "kind"
-            ],
-            "properties": {
-              "bridge_object_version": {
-                "description": "Radix-10 encoded 64-bit unsigned integer",
-                "type": "string",
-                "format": "u64"
-              },
-              "kind": {
-                "type": "string",
-                "enum": [
-                  "bridge_committee_init"
-                ]
-              }
-            }
           }
         ]
       },

--- a/crates/iota-types/src/iota_sdk_types_conversions.rs
+++ b/crates/iota-types/src/iota_sdk_types_conversions.rs
@@ -693,16 +693,6 @@ impl From<EndOfEpochTransactionKind> for crate::transaction::EndOfEpochTransacti
                         .into(),
                 })
             }
-            EndOfEpochTransactionKind::BridgeStateCreate { chain_id: _ } => {
-                todo!("Remove EndOfEpochTransactionKind::BridgeStateCreate from external rust SDK")
-            }
-            EndOfEpochTransactionKind::BridgeCommitteeInit {
-                bridge_object_version: _,
-            } => {
-                todo!(
-                    "Remove EndOfEpochTransactionKind::BridgeCommitteeInit from external rust SDK"
-                )
-            }
         }
     }
 }


### PR DESCRIPTION
# Description of change

- `iota-rust-sdk` dependency was updated to rev `6bb6e45fea2c266f9c15dd89f26f68631c2d37a8` (latest one, where bridge EndOfEpochTransactionKind variants were removed)
- an update to the sdk2 conversion (removing the bridge variants) was required
- finally, the openapi spec was updated (removing the bridge variants as well)

Fixes #7262 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
