### PR TITLE
fix(graphql): correct calculation of epoch total checkpoints

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/epoch/epoch.move
+++ b/crates/iota-graphql-e2e-tests/tests/epoch/epoch.move
@@ -58,5 +58,16 @@
         digest
       }
     }
+    first_checkpoint: checkpoints(first: 1) {
+      nodes {
+        sequenceNumber
+      }
+    }
+    last_checkpoint: checkpoints(last: 1) {
+      nodes {
+        sequenceNumber
+      }
+    }
+    totalCheckpoints
   }
 }

--- a/crates/iota-graphql-e2e-tests/tests/epoch/epoch.snap
+++ b/crates/iota-graphql-e2e-tests/tests/epoch/epoch.snap
@@ -55,7 +55,7 @@ task 9, lines 32-33:
 //# advance-epoch
 Epoch advanced: 2
 
-task 10, lines 34-62:
+task 10, lines 34-73:
 //# run-graphql
 Response: {
   "data": {
@@ -93,7 +93,22 @@ Response: {
             "digest": "FdnPEGUzRm4MeHdXm9a5VQyzS1jSTEsAPsg3XMH7jb5N"
           }
         ]
-      }
+      },
+      "first_checkpoint": {
+        "nodes": [
+          {
+            "sequenceNumber": 5
+          }
+        ]
+      },
+      "last_checkpoint": {
+        "nodes": [
+          {
+            "sequenceNumber": 6
+          }
+        ]
+      },
+      "totalCheckpoints": 2
     }
   }
 }

--- a/crates/iota-graphql-rpc/src/types/epoch.rs
+++ b/crates/iota-graphql-rpc/src/types/epoch.rs
@@ -103,7 +103,7 @@ impl Epoch {
         };
 
         Ok(Some(UInt53::from(
-            last - self.stored.first_checkpoint_id as u64,
+            last - self.stored.first_checkpoint_id as u64 + 1,
         )))
     }
 


### PR DESCRIPTION
# Description of change

Fixes the incorrect calculation of epoch total checkpoints in GraphQL.

## Links to any relevant issues

Fixes #7322

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

Updated the `epoch.move` test in `iota-graphql-e2e-tests` to include the total number of checkpoints.

### Infrastructure QA

The patch specific test suffices, as we only change an arithmetic operation.

### Release Notes

- [x] GraphQL: Fixes calculation of the total number of checkpoints in an epoch
