### PR TITLE
feat(consensus): Disable consensus features on the mainnet and testnet

### DIFF
--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -2589,7 +2589,13 @@ mod test {
             sleep(wait_time).await;
         }
 
-        let (context, _) = Context::new_for_test(4);
+        let (mut context, _) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_smart_ancestor_selection_for_testing(true);
+        context
+            .protocol_config
+            .set_consensus_distributed_vote_scoring_strategy_for_testing(true);
 
         // Create the cores for all authorities
         let mut all_cores = create_cores(context, vec![1, 1, 1, 1]);
@@ -2681,7 +2687,13 @@ mod test {
     #[tokio::test]
     async fn test_smart_ancestor_selection() {
         telemetry_subscribers::init_for_testing();
-        let (context, mut key_pairs) = Context::new_for_test(7);
+        let (mut context, mut key_pairs) = Context::new_for_test(7);
+        context
+            .protocol_config
+            .set_consensus_smart_ancestor_selection_for_testing(true);
+        context
+            .protocol_config
+            .set_consensus_distributed_vote_scoring_strategy_for_testing(true);
         let context = Arc::new(context.with_parameters(Parameters {
             sync_last_known_own_block_timeout: Duration::from_millis(2_000),
             ..Default::default()
@@ -2929,7 +2941,13 @@ mod test {
     #[tokio::test]
     async fn test_excluded_ancestor_limit() {
         telemetry_subscribers::init_for_testing();
-        let (context, mut key_pairs) = Context::new_for_test(4);
+        let (mut context, mut key_pairs) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_smart_ancestor_selection_for_testing(true);
+        context
+            .protocol_config
+            .set_consensus_distributed_vote_scoring_strategy_for_testing(true);
         let context = Arc::new(context.with_parameters(Parameters {
             sync_last_known_own_block_timeout: Duration::from_millis(2_000),
             ..Default::default()

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -51,12 +51,8 @@ pub const MAX_PROTOCOL_VERSION: u64 = 9;
 //            Enable the new consensus commit rule for testnet.
 //            Enable min_free_execution_slot for the shared object congestion
 //            tracker in devnet.
-// Version 9: Enable smart ancestor selection for mainnet.
-//            Enable probing for accepted rounds in round prober for mainnet.
-//            Switch to distributed vote scoring in consensus in mainnet.
+// Version 9: Disable smart ancestor selection for the testnet.
 //            Enable zstd compression for consensus tonic network in mainnet.
-//            Enable consensus garbage collection for mainnet
-//            Enable the new consensus commit rule for mainnet.
 //            Increase the committee size to 80.
 //            Enable passkey auth in multisig for devnet.
 
@@ -1997,23 +1993,13 @@ impl ProtocolConfig {
                     }
                 }
                 9 => {
-                    // Enable round prober in consensus.
-                    cfg.feature_flags.consensus_round_prober = true;
-                    // Enable distributed vote scoring.
-                    cfg.feature_flags
-                        .consensus_distributed_vote_scoring_strategy = true;
-                    cfg.feature_flags.consensus_linearize_subdag_v2 = true;
-                    // Enable smart ancestor selection
-                    cfg.feature_flags.consensus_smart_ancestor_selection = true;
-                    // Enable probing for accepted rounds in round prober
-                    cfg.feature_flags
-                        .consensus_round_prober_probe_accepted_rounds = true;
+                    if chain != Chain::Mainnet {
+                        // Disable smart ancestor selection in the testnet and devnet.
+                        cfg.feature_flags.consensus_smart_ancestor_selection = false;
+                    }
+
                     // Enable zstd compression for consensus
                     cfg.feature_flags.consensus_zstd_compression = true;
-                    // Assuming a round rate of max 15/sec, then using a gc depth of 60 allow
-                    // blocks within a window of ~4 seconds
-                    // to be included before be considered garbage collected.
-                    cfg.consensus_gc_depth = Some(60);
 
                     cfg.max_committee_members_count = Some(80);
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -53,7 +53,6 @@ pub const MAX_PROTOCOL_VERSION: u64 = 9;
 //            tracker in devnet.
 // Version 9: Disable smart ancestor selection for the testnet.
 //            Enable zstd compression for consensus tonic network in mainnet.
-//            Increase the committee size to 80.
 //            Enable passkey auth in multisig for devnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -2000,8 +1999,6 @@ impl ProtocolConfig {
 
                     // Enable zstd compression for consensus
                     cfg.feature_flags.consensus_zstd_compression = true;
-
-                    cfg.max_committee_members_count = Some(80);
 
                     // Enable passkey in multisig in devnet.
                     if chain != Chain::Testnet && chain != Chain::Mainnet {

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -2153,6 +2153,10 @@ impl ProtocolConfig {
     pub fn set_accept_passkey_in_multisig_for_testing(&mut self, val: bool) {
         self.feature_flags.accept_passkey_in_multisig = val;
     }
+
+    pub fn set_consensus_smart_ancestor_selection_for_testing(&mut self, val: bool) {
+        self.feature_flags.consensus_smart_ancestor_selection = val;
+    }
 }
 
 type OverrideFn = dyn Fn(ProtocolVersion, ProtocolConfig) -> ProtocolConfig + Send + Sync;

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_9.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_9.snap
@@ -283,4 +283,4 @@ checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: false
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
-max_committee_members_count: 80
+max_committee_members_count: 50

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_9.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_9.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/iota-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
-snapshot_kind: text
 ---
 version: 9
 feature_flags:
@@ -13,12 +12,7 @@ feature_flags:
   disallow_new_modules_in_deps_only_packages: true
   native_charging_v2: true
   convert_type_argument_error: true
-  consensus_round_prober: true
-  consensus_distributed_vote_scoring_strategy: true
-  consensus_linearize_subdag_v2: true
   variant_nodes: true
-  consensus_smart_ancestor_selection: true
-  consensus_round_prober_probe_accepted_rounds: true
   consensus_zstd_compression: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
@@ -290,4 +284,3 @@ max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: false
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
 max_committee_members_count: 80
-consensus_gc_depth: 60

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_9.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_9.snap
@@ -287,5 +287,5 @@ checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: true
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
-max_committee_members_count: 80
+max_committee_members_count: 50
 consensus_gc_depth: 60

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_9.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_9.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/iota-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
-snapshot_kind: text
 ---
 version: 9
 feature_flags:
@@ -17,7 +16,6 @@ feature_flags:
   consensus_distributed_vote_scoring_strategy: true
   consensus_linearize_subdag_v2: true
   variant_nodes: true
-  consensus_smart_ancestor_selection: true
   consensus_round_prober_probe_accepted_rounds: true
   consensus_zstd_compression: true
 max_tx_size_bytes: 131072

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_9.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_9.snap
@@ -297,5 +297,5 @@ checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: true
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
-max_committee_members_count: 80
+max_committee_members_count: 50
 consensus_gc_depth: 60

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_9.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_9.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/iota-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
-snapshot_kind: text
 ---
 version: 9
 feature_flags:
@@ -22,7 +21,6 @@ feature_flags:
   consensus_distributed_vote_scoring_strategy: true
   consensus_linearize_subdag_v2: true
   variant_nodes: true
-  consensus_smart_ancestor_selection: true
   consensus_round_prober_probe_accepted_rounds: true
   consensus_zstd_compression: true
   congestion_control_min_free_execution_slot: true


### PR DESCRIPTION
# Description of change

This PR disables all new consensus features, previously planned to be enabled on the mainnet, due to observed issues on the testnet. 

This PR also disables smart ancestor selection on the testnet to test the stability without this feature enabled as it was the main reason for instability of the testnet. 

## Links to any relevant issues


## How the change has been tested

CI, local network with both mainnet and testnet network settings. 

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol: Disable smart ancestor selection for the testnet. Do not enable smart ancestor selection, round prober, garbage collection, distributed vote scoring and new consensus commit rule on the mainnet. 
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
