### PR TITLE
feat: bump iota to v1.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,7 +1783,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "const-str",
  "git-version",
@@ -5787,7 +5787,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "iota"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5838,7 +5838,7 @@ dependencies = [
  "iota-package-management",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-simulator",
  "iota-source-validation",
  "iota-swarm",
@@ -5917,7 +5917,7 @@ dependencies = [
 
 [[package]]
 name = "iota-adapter-transactional-tests"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -5925,7 +5925,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -5976,7 +5976,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer-derive"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5985,7 +5985,7 @@ dependencies = [
 
 [[package]]
 name = "iota-archival"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6017,7 +6017,7 @@ dependencies = [
 
 [[package]]
 name = "iota-authority-aggregation"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "futures",
  "iota-metrics",
@@ -6028,7 +6028,7 @@ dependencies = [
 
 [[package]]
 name = "iota-aws-orchestrator"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6058,7 +6058,7 @@ dependencies = [
 
 [[package]]
 name = "iota-benchmark"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6080,7 +6080,7 @@ dependencies = [
  "iota-metrics",
  "iota-network",
  "iota-protocol-config",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-simulator",
  "iota-storage",
  "iota-surfer",
@@ -6108,7 +6108,7 @@ dependencies = [
 
 [[package]]
 name = "iota-bridge"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6130,7 +6130,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-keys",
  "iota-metrics",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-test-transaction-builder",
  "iota-types",
  "lru",
@@ -6157,7 +6157,7 @@ dependencies = [
 
 [[package]]
 name = "iota-bridge-cli"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -6168,7 +6168,7 @@ dependencies = [
  "iota-config",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-types",
  "move-core-types",
  "reqwest 0.12.7",
@@ -6183,7 +6183,7 @@ dependencies = [
 
 [[package]]
 name = "iota-bridge-indexer"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6199,7 +6199,7 @@ dependencies = [
  "iota-indexer-builder",
  "iota-json-rpc-types",
  "iota-metrics",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-test-transaction-builder",
  "iota-types",
  "prometheus",
@@ -6213,7 +6213,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cluster-test"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6231,7 +6231,7 @@ dependencies = [
  "iota-json",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-swarm",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -6253,7 +6253,7 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "futures",
  "parking_lot 0.12.3",
@@ -6263,7 +6263,7 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anemo",
  "anyhow",
@@ -6291,7 +6291,7 @@ dependencies = [
 
 [[package]]
 name = "iota-core"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anemo",
  "anyhow",
@@ -6393,7 +6393,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cost"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6448,7 +6448,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6485,7 +6485,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion-core"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6519,7 +6519,7 @@ dependencies = [
 
 [[package]]
 name = "iota-e2e-tests"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6549,7 +6549,7 @@ dependencies = [
  "iota-node",
  "iota-protocol-config",
  "iota-rest-api",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-simulator",
  "iota-storage",
  "iota-swarm",
@@ -6580,7 +6580,7 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "serde_yaml",
 ]
@@ -6619,7 +6619,7 @@ dependencies = [
 
 [[package]]
 name = "iota-faucet"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6635,7 +6635,7 @@ dependencies = [
  "iota-keys",
  "iota-metrics",
  "iota-network-stack",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-types",
  "parking_lot 0.12.3",
  "prometheus",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6681,7 +6681,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6698,7 +6698,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-tests"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "datatest-stable",
  "iota-adapter-latest",
@@ -6719,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-builder"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6771,7 +6771,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -6781,7 +6781,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-config"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6789,7 +6789,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-e2e-tests"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6802,7 +6802,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6842,7 +6842,7 @@ dependencies = [
  "iota-package-resolver",
  "iota-protocol-config",
  "iota-rest-api",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-swarm-config",
  "iota-test-transaction-builder",
  "iota-types",
@@ -6882,7 +6882,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-client"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6897,14 +6897,14 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-headers"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "axum 0.8.4",
 ]
 
 [[package]]
 name = "iota-http"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "axum 0.8.4",
  "bytes",
@@ -6925,7 +6925,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6956,7 +6956,7 @@ dependencies = [
  "iota-package-resolver",
  "iota-protocol-config",
  "iota-rest-api",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-swarm-config",
  "iota-test-transaction-builder",
  "iota-transaction-builder",
@@ -6987,7 +6987,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer-builder"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7003,7 +7003,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7022,7 +7022,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7080,7 +7080,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -7099,7 +7099,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-tests"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7118,7 +7118,7 @@ dependencies = [
  "iota-open-rpc",
  "iota-open-rpc-macros",
  "iota-protocol-config",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-simulator",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -7137,7 +7137,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7169,7 +7169,7 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "bip32",
@@ -7188,7 +7188,7 @@ dependencies = [
 
 [[package]]
 name = "iota-light-client"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7199,7 +7199,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-package-resolver",
  "iota-rest-api",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-types",
  "log",
  "move-core-types",
@@ -7214,7 +7214,7 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -7224,7 +7224,7 @@ dependencies = [
 
 [[package]]
 name = "iota-mainnet-unlocks"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7236,7 +7236,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metric-checker"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "backoff",
@@ -7257,7 +7257,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7282,7 +7282,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "better_any",
@@ -7325,7 +7325,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -7348,7 +7348,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-lsp"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "bin-version",
  "clap",
@@ -7379,7 +7379,7 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7391,7 +7391,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -7429,7 +7429,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anemo",
  "bcs",
@@ -7453,7 +7453,7 @@ dependencies = [
 
 [[package]]
 name = "iota-node"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7504,7 +7504,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7528,7 +7528,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -7540,7 +7540,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-dump"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7557,13 +7557,13 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-types",
  "move-core-types",
  "move-package",
@@ -7574,7 +7574,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7597,7 +7597,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -7607,7 +7607,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "clap",
  "insta",
@@ -7622,7 +7622,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7631,7 +7631,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proxy"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7647,7 +7647,7 @@ dependencies = [
  "hex",
  "hyper 1.4.1",
  "iota-metrics",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-tls",
  "iota-types",
  "itertools 0.13.0",
@@ -7677,7 +7677,7 @@ dependencies = [
 
 [[package]]
 name = "iota-replay"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7693,7 +7693,7 @@ dependencies = [
  "iota-json-rpc-api",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-storage",
  "iota-transaction-checks",
  "iota-types",
@@ -7724,7 +7724,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7755,7 +7755,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-kv"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -7781,7 +7781,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rosetta"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7799,7 +7799,7 @@ dependencies = [
  "iota-metrics",
  "iota-move-build",
  "iota-node",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-swarm-config",
  "iota-types",
  "move-core-types",
@@ -7823,7 +7823,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rpc-loadgen"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7833,7 +7833,7 @@ dependencies = [
  "futures",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-types",
  "itertools 0.13.0",
  "serde",
@@ -7908,7 +7908,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7946,7 +7946,7 @@ dependencies = [
 
 [[package]]
 name = "iota-simulator"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7968,7 +7968,7 @@ dependencies = [
 
 [[package]]
 name = "iota-single-node-benchmark"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "async-trait",
  "bcs",
@@ -8002,7 +8002,7 @@ dependencies = [
 
 [[package]]
 name = "iota-snapshot"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8030,7 +8030,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "colored",
@@ -8040,7 +8040,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-test-transaction-builder",
  "iota-types",
  "move-binary-format",
@@ -8062,7 +8062,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation-service"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -8078,7 +8078,7 @@ dependencies = [
  "iota-metrics",
  "iota-move",
  "iota-move-build",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-source-validation",
  "jsonrpsee",
  "move-compiler",
@@ -8101,7 +8101,7 @@ dependencies = [
 
 [[package]]
 name = "iota-storage"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8156,7 +8156,7 @@ dependencies = [
 
 [[package]]
 name = "iota-surfer"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "async-trait",
  "bcs",
@@ -8185,7 +8185,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "futures",
@@ -8210,7 +8210,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm-config"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8237,12 +8237,12 @@ dependencies = [
 
 [[package]]
 name = "iota-test-transaction-builder"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "bcs",
  "iota-genesis-builder",
  "iota-move-build",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-types",
  "move-core-types",
  "shared-crypto",
@@ -8250,7 +8250,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8272,7 +8272,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tool"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -8294,7 +8294,7 @@ dependencies = [
  "iota-package-dump",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-snapshot",
  "iota-storage",
  "iota-types",
@@ -8317,7 +8317,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8333,7 +8333,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-checks"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "fastcrypto-zkp",
  "iota-config",
@@ -8347,7 +8347,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transactional-test-runner"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8399,7 +8399,7 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8480,7 +8480,7 @@ dependencies = [
 
 [[package]]
 name = "iota-upgrade-compatibility-transactional-tests"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "datatest-stable",
@@ -8509,7 +8509,7 @@ dependencies = [
 
 [[package]]
 name = "iota-verifier-transactional-tests"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -11892,7 +11892,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -13706,7 +13706,7 @@ dependencies = [
 
 [[package]]
 name = "shared-crypto"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "bcs",
  "eyre",
@@ -13825,7 +13825,7 @@ dependencies = [
 
 [[package]]
 name = "simulacrum"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14541,7 +14541,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry-subscribers"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -14628,7 +14628,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-cluster"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14648,7 +14648,7 @@ dependencies = [
  "iota-metrics",
  "iota-node",
  "iota-protocol-config",
- "iota-sdk 1.2.2-rc",
+ "iota-sdk 1.2.2",
  "iota-simulator",
  "iota-swarm",
  "iota-swarm-config",
@@ -15459,7 +15459,7 @@ dependencies = [
 
 [[package]]
 name = "transaction-fuzzer"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "iota-core",
  "iota-move-build",
@@ -15551,7 +15551,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "async-trait",
  "bcs",
@@ -15582,7 +15582,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-derive"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -15592,7 +15592,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "serde",
  "thiserror 1.0.64",
@@ -15600,7 +15600,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-workspace-hack"
-version = "1.2.2-rc"
+version = "1.2.2"
 dependencies = [
  "libc",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by iota-core, iota-faucet, iota-node, iota-tools, iota-sdk, iota-move-build, and iota crates.
-version = "1.2.2-rc"
+version = "1.2.2"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/iotaledger/iota/main/LICENSE"
     },
-    "version": "1.2.2-rc"
+    "version": "1.2.2"
   },
   "methods": [
     {


### PR DESCRIPTION
Bump `v1.2.2-rc` to `v1.2.2` in preparation for mainnet release.