### PR TITLE
fix(node): prevent discovery private info leak

### DIFF
--- a/crates/iota-network/src/discovery/mod.rs
+++ b/crates/iota-network/src/discovery/mod.rs
@@ -672,6 +672,7 @@ fn update_known_peers(
         }
 
         // If Peer is Private, and not in our allowlist, skip it.
+        // There should be no Private Peers. Keep this just in case.
         if peer_info.access_type == AccessType::Private
             && !allowlisted_peers.contains_key(&peer_info.peer_id)
         {

--- a/crates/iota-network/src/discovery/mod.rs
+++ b/crates/iota-network/src/discovery/mod.rs
@@ -672,7 +672,6 @@ fn update_known_peers(
         }
 
         // If Peer is Private, and not in our allowlist, skip it.
-        // There should be no Private Peers. Keep this just in case.
         if peer_info.access_type == AccessType::Private
             && !allowlisted_peers.contains_key(&peer_info.peer_id)
         {

--- a/crates/iota-network/src/discovery/server.rs
+++ b/crates/iota-network/src/discovery/server.rs
@@ -2,12 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-};
+use std::sync::{Arc, RwLock};
 
 use anemo::{Request, Response};
+use iota_config::p2p::AccessType;
 use rand::seq::IteratorRandom;
 use serde::{Deserialize, Serialize};
 
@@ -56,54 +54,30 @@ impl Discovery for Server {
             .clone()
             .ok_or_else(|| anemo::rpc::Status::internal("own_info has not been initialized yet"))?;
 
-        let known_peers = if state.known_peers.len() < MAX_PEERS_TO_SEND {
-            state
-                .known_peers
-                .values()
-                .map(|e| e.inner())
-                .cloned()
-                .collect()
-        } else {
-            let mut rng = rand::thread_rng();
-            // prefer returning peers that we are connected to as they are known-good
-            let mut known_peers = state
-                .connected_peers
-                .keys()
-                .filter_map(|peer_id| state.known_peers.get(peer_id))
-                .map(|info| (info.peer_id, info))
-                .choose_multiple(&mut rng, MAX_PEERS_TO_SEND)
-                .into_iter()
-                .collect::<HashMap<_, _>>();
-
-            if known_peers.len() <= MAX_PEERS_TO_SEND {
-                // Fill the remaining space with other peers, randomly sampling at most
-                // MAX_PEERS_TO_SEND
-                for info in state
-                    .known_peers
-                    .values()
-                    // This randomly samples the iterator stream but the order of elements after
-                    // sampling may not be random, this is ok though since we're just trying to do
-                    // best-effort on sharing info of peers we haven't connected with ourselves.
-                    .choose_multiple(&mut rng, MAX_PEERS_TO_SEND)
-                {
-                    if known_peers.len() >= MAX_PEERS_TO_SEND {
-                        break;
-                    }
-
-                    known_peers.insert(info.peer_id, info);
-                }
-            }
-
-            known_peers
-                .into_values()
-                .map(|e| e.inner())
-                .cloned()
-                .collect()
-        };
+        let mut rng = rand::thread_rng();
+        let mut known_connected_peers = state
+            .known_peers
+            .iter()
+            .filter_map(|(peer_id, peer_info)| {
+                (peer_info.access_type != AccessType::Private
+                    && state.connected_peers.contains_key(peer_id))
+                .then_some(peer_info.inner().clone())
+            })
+            .choose_multiple(&mut rng, MAX_PEERS_TO_SEND);
+        let mut known_not_connected_peers = state
+            .known_peers
+            .iter()
+            .filter_map(|(peer_id, peer_info)| {
+                (peer_info.access_type != AccessType::Private
+                    && !state.connected_peers.contains_key(peer_id))
+                .then_some(peer_info.inner().clone())
+            })
+            .choose_multiple(&mut rng, MAX_PEERS_TO_SEND - known_connected_peers.len());
+        known_connected_peers.append(&mut known_not_connected_peers);
 
         Ok(Response::new(GetKnownPeersResponseV2 {
             own_info,
-            known_peers,
+            known_peers: known_connected_peers,
         }))
     }
 }

--- a/crates/iota-network/src/discovery/server.rs
+++ b/crates/iota-network/src/discovery/server.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, RwLock};
 
 use anemo::{Request, Response};
 use iota_config::p2p::AccessType;
-use rand::seq::IteratorRandom;
+use rand::seq::{IteratorRandom, SliceRandom};
 use serde::{Deserialize, Serialize};
 
 use super::{Discovery, MAX_PEERS_TO_SEND, NodeInfo, SignedNodeInfo, State};
@@ -55,7 +55,8 @@ impl Discovery for Server {
             .ok_or_else(|| anemo::rpc::Status::internal("own_info has not been initialized yet"))?;
 
         let mut rng = rand::thread_rng();
-        let mut known_connected_peers = state
+        // Prefer connected peers
+        let mut known_peers = state
             .known_peers
             .iter()
             .filter_map(|(peer_id, peer_info)| {
@@ -72,12 +73,13 @@ impl Discovery for Server {
                     && !state.connected_peers.contains_key(peer_id))
                 .then_some(peer_info.inner().clone())
             })
-            .choose_multiple(&mut rng, MAX_PEERS_TO_SEND - known_connected_peers.len());
-        known_connected_peers.append(&mut known_not_connected_peers);
+            .choose_multiple(&mut rng, MAX_PEERS_TO_SEND - known_peers.len());
+        known_peers.append(&mut known_not_connected_peers);
+        known_peers.shuffle(&mut rng);
 
         Ok(Response::new(GetKnownPeersResponseV2 {
             own_info,
-            known_peers: known_connected_peers,
+            known_peers,
         }))
     }
 }

--- a/crates/iota-network/src/discovery/tests.rs
+++ b/crates/iota-network/src/discovery/tests.rs
@@ -278,15 +278,19 @@ async fn test_access_types() {
     //
     //
     // The topology:
-    //                                      ------------  11 (private, seed: 1,
-    // allowed: 7, 8)                                     /
+    //
+    //    11 (private, seed: 1, allowed: 7, 8)
+    //                             \
     //                       ------ 1 (public) ------
     //                      /                        \
-    //    2 (public, seed: 1, allowed: 7, 8)          3 (private, seed: 1, allowed:
-    // 4+, 5+)       |                                       /             \
-    //       |                 4 (private, allowed: 3+, 5, 6)     5 (private,
-    // allowed: 3, 4+)       |                                        \
-    //       |                                      6 (private, allowed: 4+)
+    //     2 (public, seed: 1, allowed: 7, 8)        |
+    //       |                                       /
+    //       |                          3 (private, seed: 1, allowed: 4+, 5+)
+    //       |                         /             \
+    //       |   4 (private, allowed: 3+, 5, 6)     5 (private, allowed: 3, 4+)
+    //       |                         \
+    //       |                       6 (private, allowed: 4+)
+    //       |
     //     7 (private, allowed: 2+, 8+)
     //       |
     //       |
@@ -318,7 +322,7 @@ async fn test_access_types() {
         ..Default::default()
     };
 
-    // None 1, public
+    // Node 1, public
     let (builder_1, network_1, key_1) = set_up_network(default_p2p_config.clone());
 
     let mut config = default_p2p_config.clone();
@@ -587,9 +591,9 @@ async fn test_access_types() {
         &network_7,
         &state_7,
         HashSet::from_iter(vec![peer_id_2, peer_id_8]),
-        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_8, peer_id_9, peer_id_11]),
         HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_8, peer_id_9]),
-        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_8, peer_id_9, peer_id_11]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_8, peer_id_9]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_8, peer_id_9]),
     );
 
     // Node 11 finds Node 8 via Node 2, and invites Node 8 to connect. Node 8 said
@@ -638,9 +642,9 @@ async fn test_access_types() {
         &network_11,
         &state_11,
         HashSet::from_iter(vec![peer_id_1, peer_id_7, peer_id_8]),
-        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_7, peer_id_9]),
-        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_7, peer_id_8, peer_id_9]),
-        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_7, peer_id_9]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_9]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_9]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_9]),
     );
 }
 

--- a/crates/iota-network/src/discovery/tests.rs
+++ b/crates/iota-network/src/discovery/tests.rs
@@ -287,7 +287,7 @@ async fn test_access_types() {
     //       |                                       /
     //       |                          3 (private, seed: 1, allowed: 4+, 5+)
     //       |                         /             \
-    //       |   4 (private, allowed: 3+, 5, 6)     5 (private, allowed: 3, 4+)
+    //       |   4 (private, allowed: 3+, 5, 6) --- 5 (private, allowed: 3, 4+)
     //       |                         \
     //       |                       6 (private, allowed: 4+)
     //       |
@@ -520,7 +520,7 @@ async fn test_access_types() {
         ]),
     );
 
-    // Node 1 is connected to everyone. But it does not "know" private nodes except
+    // Node 2 is connected to everyone. But it does not "know" private nodes except
     // the allowlisted ones 7 and 8.
     assert_peers(
         "Node 2",
@@ -584,8 +584,7 @@ async fn test_access_types() {
         HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_4, peer_id_9]),
     );
 
-    // Node 11 finds Node 7 via Node 2, and invites Node 7 to connect. Node 7 says
-    // yes.
+    // Node 11 can't find private Node 7 via Node 2.
     assert_peers(
         "Node 7",
         &network_7,
@@ -596,8 +595,7 @@ async fn test_access_types() {
         HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_8, peer_id_9]),
     );
 
-    // Node 11 finds Node 8 via Node 2, and invites Node 8 to connect. Node 8 said
-    // No because its `max_concurrent_connections` is 0.
+    // Node 11 can't find private Node 8 via Node 2.
     assert_peers(
         "Node 8",
         &network_8,


### PR DESCRIPTION
# Description of change

Nodes can advertise themselves as private during peer discovery. Previously, peers would leak info about their private known peers. This PR changes that logic, now, only public known peers are exposed during peer discovery.

## Links to any relevant issues

Fixes #6994.

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Prevent private peer info leaks during peer discovery.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
