### PR TITLE
feat(indexer): Do not reindex objects in checkpoint indexing, fix race conditions for display table

### DIFF
--- a/crates/iota-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/iota-indexer/src/handlers/checkpoint_handler.rs
@@ -33,12 +33,15 @@ use crate::{
     db::ConnectionPool,
     errors::IndexerError,
     handlers::{
-        CheckpointDataToCommit, EpochToCommit, TransactionObjectChangesToCommit,
-        committer::start_tx_checkpoint_commit_task,
+        EpochToCommit, TransactionObjectChangesToCommit,
         tx_processor::{EpochEndIndexingObjectStore, TxChangesProcessor},
     },
     metrics::IndexerMetrics,
     models::{display::StoredDisplay, obj_indices::StoredObjectVersion},
+    rolling::{
+        persist::{CheckpointDataToCommit, start_tx_checkpoint_commit_task},
+        transform::CheckpointObjectChanges,
+    },
     store::{IndexerStore, PgIndexerStore},
     types::{
         EventIndex, IndexedCheckpoint, IndexedDeletedObject, IndexedEpochInfo, IndexedEvent,
@@ -278,8 +281,7 @@ impl CheckpointHandler {
         let epoch = Self::index_epoch(state, data).await?;
 
         // Index Objects
-        let object_changes: TransactionObjectChangesToCommit =
-            Self::index_objects(data, &metrics).await?;
+        let object_changes = Self::index_checkpoint_objects(data, &metrics).await?;
         let object_history_changes: TransactionObjectChangesToCommit =
             Self::index_objects_history(data).await?;
         let object_versions = Self::derive_object_versions(&object_history_changes);
@@ -555,6 +557,14 @@ impl CheckpointHandler {
             db_event_indices,
             db_displays,
         ))
+    }
+
+    pub(crate) async fn index_checkpoint_objects(
+        data: &CheckpointData,
+        metrics: &IndexerMetrics,
+    ) -> Result<CheckpointObjectChanges, IndexerError> {
+        let _timer = metrics.indexing_objects_latency.start_timer();
+        data.try_into()
     }
 
     pub(crate) async fn index_objects(

--- a/crates/iota-indexer/src/handlers/committer.rs
+++ b/crates/iota-indexer/src/handlers/committer.rs
@@ -2,17 +2,22 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
-use iota_types::messages_checkpoint::CheckpointSequenceNumber;
+use iota_types::{
+    base_types::{ObjectID, SequenceNumber},
+    messages_checkpoint::CheckpointSequenceNumber,
+};
 use tap::tap::TapFallible;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, instrument};
 
-use super::{CheckpointDataToCommit, EpochToCommit};
+use super::{CheckpointDataToCommit, EpochToCommit, TransactionObjectChangesToCommit};
 use crate::{
-    metrics::IndexerMetrics, models::transactions::TxGlobalOrder, store::IndexerStore,
-    types::IndexerResult,
+    metrics::IndexerMetrics,
+    models::transactions::TxGlobalOrder,
+    store::IndexerStore,
+    types::{IndexedTransaction, IndexerResult},
 };
 
 pub(crate) const CHECKPOINT_COMMIT_BATCH_SIZE: usize = 100;
@@ -128,6 +133,10 @@ async fn commit_checkpoints<S>(
         .iter()
         .map(Into::into)
         .collect::<Vec<TxGlobalOrder>>();
+    let tx_digests = tx_batch
+        .iter()
+        .map(|t| t.tx_digest.into_inner().to_vec())
+        .collect::<Vec<_>>();
     let tx_indices_batch = tx_indices_batch.into_iter().flatten().collect::<Vec<_>>();
     let events_batch = events_batch.into_iter().flatten().collect::<Vec<_>>();
     let event_indices_batch = event_indices_batch
@@ -141,6 +150,17 @@ async fn commit_checkpoints<S>(
     let packages_batch = packages_batch.into_iter().flatten().collect::<Vec<_>>();
     let checkpoint_num = checkpoint_batch.len();
     let tx_count = tx_batch.len();
+
+    let transactions_with_global_order = state
+        .get_transactions_with_global_order(&tx_digests)
+        .await
+        .expect("Getting transactions with global order should not fail");
+
+    let object_changes_batch = cut_out_already_indexed_object_changes(
+        &transactions_with_global_order,
+        &tx_batch,
+        object_changes_batch,
+    );
 
     {
         let _step_1_guard = metrics.checkpoint_db_commit_latency_step_1.start_timer();
@@ -242,4 +262,47 @@ async fn commit_checkpoints<S>(
     metrics
         .thousand_transaction_avg_db_commit_latency
         .observe(elapsed * 1000.0 / tx_count as f64);
+}
+
+fn cut_out_already_indexed_object_changes(
+    already_indexed_txs: &[Vec<u8>],
+    transactions_to_commit: &[IndexedTransaction],
+    object_changes_to_commit: Vec<TransactionObjectChangesToCommit>,
+) -> Vec<TransactionObjectChangesToCommit> {
+    let already_indexed_txs: HashSet<Vec<u8>> = already_indexed_txs.iter().cloned().collect();
+
+    let already_processed_obj_versions: HashSet<(ObjectID, SequenceNumber)> =
+        transactions_to_commit
+            .iter()
+            .filter(|tx| already_indexed_txs.contains(tx.tx_digest.inner().as_slice()))
+            .flat_map(|tx| {
+                let modified_objs = tx.effects.all_changed_objects();
+                let deleted_objs = tx.effects.all_tombstones();
+                modified_objs
+                    .into_iter()
+                    .map(|o| (o.0.0, o.0.1))
+                    .chain(deleted_objs)
+            })
+            .collect();
+
+    object_changes_to_commit
+        .into_iter()
+        .map(|ocb| TransactionObjectChangesToCommit {
+            changed_objects: ocb
+                .changed_objects
+                .into_iter()
+                .filter(|o| {
+                    !already_processed_obj_versions.contains(&(o.object.id(), o.object.version()))
+                })
+                .collect(),
+            deleted_objects: ocb
+                .deleted_objects
+                .into_iter()
+                .filter(|o| {
+                    !already_processed_obj_versions
+                        .contains(&(o.object_id, SequenceNumber::from_u64(o.object_version)))
+                })
+                .collect(),
+        })
+        .collect()
 }

--- a/crates/iota-indexer/src/handlers/committer.rs
+++ b/crates/iota-indexer/src/handlers/committer.rs
@@ -2,22 +2,17 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 
-use iota_types::{
-    base_types::{ObjectID, SequenceNumber},
-    messages_checkpoint::CheckpointSequenceNumber,
-};
+use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 use tap::tap::TapFallible;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, instrument};
 
-use super::{CheckpointDataToCommit, EpochToCommit, TransactionObjectChangesToCommit};
+use super::{CheckpointDataToCommit, EpochToCommit};
 use crate::{
-    metrics::IndexerMetrics,
-    models::transactions::TxGlobalOrder,
-    store::IndexerStore,
-    types::{IndexedTransaction, IndexerResult},
+    metrics::IndexerMetrics, models::transactions::TxGlobalOrder, store::IndexerStore,
+    types::IndexerResult,
 };
 
 pub(crate) const CHECKPOINT_COMMIT_BATCH_SIZE: usize = 100;
@@ -133,10 +128,6 @@ async fn commit_checkpoints<S>(
         .iter()
         .map(Into::into)
         .collect::<Vec<TxGlobalOrder>>();
-    let tx_digests = tx_batch
-        .iter()
-        .map(|t| t.tx_digest.into_inner().to_vec())
-        .collect::<Vec<_>>();
     let tx_indices_batch = tx_indices_batch.into_iter().flatten().collect::<Vec<_>>();
     let events_batch = events_batch.into_iter().flatten().collect::<Vec<_>>();
     let event_indices_batch = event_indices_batch
@@ -150,17 +141,6 @@ async fn commit_checkpoints<S>(
     let packages_batch = packages_batch.into_iter().flatten().collect::<Vec<_>>();
     let checkpoint_num = checkpoint_batch.len();
     let tx_count = tx_batch.len();
-
-    let transactions_with_global_order = state
-        .get_transactions_with_global_order(&tx_digests)
-        .await
-        .expect("Getting transactions with global order should not fail");
-
-    let object_changes_batch = cut_out_already_indexed_object_changes(
-        &transactions_with_global_order,
-        &tx_batch,
-        object_changes_batch,
-    );
 
     {
         let _step_1_guard = metrics.checkpoint_db_commit_latency_step_1.start_timer();
@@ -262,47 +242,4 @@ async fn commit_checkpoints<S>(
     metrics
         .thousand_transaction_avg_db_commit_latency
         .observe(elapsed * 1000.0 / tx_count as f64);
-}
-
-fn cut_out_already_indexed_object_changes(
-    already_indexed_txs: &[Vec<u8>],
-    transactions_to_commit: &[IndexedTransaction],
-    object_changes_to_commit: Vec<TransactionObjectChangesToCommit>,
-) -> Vec<TransactionObjectChangesToCommit> {
-    let already_indexed_txs: HashSet<Vec<u8>> = already_indexed_txs.iter().cloned().collect();
-
-    let already_processed_obj_versions: HashSet<(ObjectID, SequenceNumber)> =
-        transactions_to_commit
-            .iter()
-            .filter(|tx| already_indexed_txs.contains(tx.tx_digest.inner().as_slice()))
-            .flat_map(|tx| {
-                let modified_objs = tx.effects.all_changed_objects();
-                let deleted_objs = tx.effects.all_tombstones();
-                modified_objs
-                    .into_iter()
-                    .map(|o| (o.0.0, o.0.1))
-                    .chain(deleted_objs)
-            })
-            .collect();
-
-    object_changes_to_commit
-        .into_iter()
-        .map(|ocb| TransactionObjectChangesToCommit {
-            changed_objects: ocb
-                .changed_objects
-                .into_iter()
-                .filter(|o| {
-                    !already_processed_obj_versions.contains(&(o.object.id(), o.object.version()))
-                })
-                .collect(),
-            deleted_objects: ocb
-                .deleted_objects
-                .into_iter()
-                .filter(|o| {
-                    !already_processed_obj_versions
-                        .contains(&(o.object_id, SequenceNumber::from_u64(o.object_version)))
-                })
-                .collect(),
-        })
-        .collect()
 }

--- a/crates/iota-indexer/src/handlers/mod.rs
+++ b/crates/iota-indexer/src/handlers/mod.rs
@@ -41,7 +41,7 @@ pub struct CheckpointDataToCommit {
     pub epoch: Option<EpochToCommit>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct TransactionObjectChangesToCommit {
     pub changed_objects: Vec<IndexedObject>,
     pub deleted_objects: Vec<IndexedDeletedObject>,

--- a/crates/iota-indexer/src/lib.rs
+++ b/crates/iota-indexer/src/lib.rs
@@ -40,6 +40,7 @@ pub mod metrics;
 pub mod models;
 mod optimistic_indexing;
 pub mod processors;
+pub(crate) mod rolling;
 pub mod schema;
 pub mod store;
 pub mod system_package_task;

--- a/crates/iota-indexer/src/models/objects.rs
+++ b/crates/iota-indexer/src/models/objects.rs
@@ -446,6 +446,72 @@ impl StoredObject {
     }
 }
 
+/// Holds a granular collection of [`StoredObject`] fields.
+///
+/// This can be used to consume an iterator of [`StoredObject`]
+/// to construct the collection of the individual fields.
+///
+/// ## Examples
+///
+/// ```ignore
+/// use iota_indexer::models::objects::{StoredObject, StoredObjects};
+/// fn construct_data() -> Vec<StoredObject> {
+///     Default::default()
+/// }
+///
+/// let mut stored_objects = StoredObjects::default();
+/// stored_objects.extend(construct_data());
+/// ```
+///
+/// Or using [`unzip`][std::iter::Iterator::unzip]:
+///
+/// ```ignore
+/// use iota_indexer::models::objects::{StoredObject, StoredObjects};
+/// use iota_types::digests::TransactionDigest;
+///
+/// fn construct_data() -> Vec<(StoredObject, TransactionDigest)> {
+///     Default::default()
+/// }
+///
+/// let (objects, digests): (StoredObjects, Vec<_>) = construct_data().into_iter().unzip();
+/// ```
+#[derive(Debug, Clone, Default)]
+pub(crate) struct StoredObjects {
+    pub(crate) object_ids: Vec<Vec<u8>>,
+    pub(crate) object_versions: Vec<i64>,
+    pub(crate) object_digests: Vec<Vec<u8>>,
+    pub(crate) owner_types: Vec<i16>,
+    pub(crate) owner_ids: Vec<Option<Vec<u8>>>,
+    pub(crate) object_types: Vec<Option<String>>,
+    pub(crate) object_type_packages: Vec<Option<Vec<u8>>>,
+    pub(crate) object_type_modules: Vec<Option<String>>,
+    pub(crate) object_type_names: Vec<Option<String>>,
+    pub(crate) serialized_objects: Vec<Vec<u8>>,
+    pub(crate) coin_types: Vec<Option<String>>,
+    pub(crate) coin_balances: Vec<Option<i64>>,
+    pub(crate) df_kinds: Vec<Option<i16>>,
+}
+
+impl Extend<StoredObject> for StoredObjects {
+    fn extend<T: IntoIterator<Item = StoredObject>>(&mut self, iter: T) {
+        for object in iter {
+            self.object_ids.push(object.object_id);
+            self.object_versions.push(object.object_version);
+            self.object_digests.push(object.object_digest);
+            self.owner_types.push(object.owner_type);
+            self.owner_ids.push(object.owner_id);
+            self.object_types.push(object.object_type);
+            self.object_type_packages.push(object.object_type_package);
+            self.object_type_modules.push(object.object_type_module);
+            self.object_type_names.push(object.object_type_name);
+            self.serialized_objects.push(object.serialized_object);
+            self.coin_types.push(object.coin_type);
+            self.coin_balances.push(object.coin_balance);
+            self.df_kinds.push(object.df_kind);
+        }
+    }
+}
+
 impl TryFrom<StoredObject> for IotaCoin {
     type Error = IndexerError;
 

--- a/crates/iota-indexer/src/rolling/error.rs
+++ b/crates/iota-indexer/src/rolling/error.rs
@@ -1,0 +1,6 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+pub(crate) use crate::errors::*;
+
+pub type IndexerResult<T> = Result<T, IndexerError>;

--- a/crates/iota-indexer/src/rolling/extract.rs
+++ b/crates/iota-indexer/src/rolling/extract.rs
@@ -1,0 +1,52 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Types and associated logic to use while extracting
+//! from network checkpoints.
+
+use std::collections::BTreeMap;
+
+use iota_types::{
+    base_types::ObjectRef, digests::TransactionDigest, full_checkpoint_content::CheckpointData,
+    object::Object,
+};
+
+#[derive(Clone, Debug)]
+pub(crate) struct Extractor<'chk> {
+    checkpoint: &'chk CheckpointData,
+}
+
+impl<'chk> Extractor<'chk> {
+    pub fn new(checkpoint: &'chk CheckpointData) -> Self {
+        Self { checkpoint }
+    }
+
+    pub(crate) fn iter_live_objects(&'chk self) -> impl Iterator<Item = &'chk Object> + 'chk {
+        let mut latest_live_objects = BTreeMap::new();
+        for tx in self.checkpoint.transactions.iter() {
+            for obj in tx.output_objects.iter() {
+                latest_live_objects.insert(obj.id(), obj);
+            }
+            for obj_ref in tx.removed_object_refs_post_version() {
+                latest_live_objects.remove(&(obj_ref.0));
+            }
+        }
+        latest_live_objects.into_values()
+    }
+
+    pub(crate) fn iter_removed_objects(
+        &'chk self,
+    ) -> impl Iterator<Item = (ObjectRef, TransactionDigest)> + 'chk {
+        let mut eventually_removed_object_refs = BTreeMap::new();
+        for tx in self.checkpoint.transactions.iter() {
+            let digest = tx.transaction.digest();
+            for obj_ref in tx.removed_object_refs_post_version() {
+                eventually_removed_object_refs.insert(obj_ref.0, (obj_ref, *digest));
+            }
+            for obj in tx.output_objects.iter() {
+                eventually_removed_object_refs.remove(&(obj.id()));
+            }
+        }
+        eventually_removed_object_refs.into_values()
+    }
+}

--- a/crates/iota-indexer/src/rolling/mod.rs
+++ b/crates/iota-indexer/src/rolling/mod.rs
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Rolling version of the library.
+//!
+//! This is to phase in breaking changes that may or may not
+//! include refactoring of the existing API.
+//!
+//! This will remain private until the versioning scheme is stabilized.
+//!
+//! In cases where the [`rolling`] module is used in other modules above, it
+//! MUST be used only in private APIs, or in inner implementations.
+
+pub(crate) mod error;
+pub(crate) mod extract;
+pub(crate) mod persist;
+pub(crate) mod transform;

--- a/crates/iota-indexer/src/rolling/persist.rs
+++ b/crates/iota-indexer/src/rolling/persist.rs
@@ -1,0 +1,265 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Types and associated logic to use while persisting
+//! data to the database.
+
+use std::collections::{BTreeMap, HashMap};
+
+use iota_types::messages_checkpoint::CheckpointSequenceNumber;
+use tap::tap::TapFallible;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, instrument};
+
+use crate::{
+    handlers::{EpochToCommit, TransactionObjectChangesToCommit},
+    metrics::IndexerMetrics,
+    models::{
+        display::StoredDisplay, obj_indices::StoredObjectVersion, transactions::TxGlobalOrder,
+    },
+    rolling::transform::CheckpointObjectChanges,
+    store::{IndexerStore, IndexerStoreExt, PgIndexerStore},
+    types::{
+        EventIndex, IndexedCheckpoint, IndexedEvent, IndexedPackage, IndexedTransaction,
+        IndexerResult, TxIndex,
+    },
+};
+
+#[derive(Debug)]
+pub(crate) struct CheckpointDataToCommit {
+    pub(crate) checkpoint: IndexedCheckpoint,
+    pub(crate) transactions: Vec<IndexedTransaction>,
+    pub(crate) events: Vec<IndexedEvent>,
+    pub(crate) event_indices: Vec<EventIndex>,
+    pub(crate) tx_indices: Vec<TxIndex>,
+    pub(crate) display_updates: BTreeMap<String, StoredDisplay>,
+    pub(crate) object_changes: CheckpointObjectChanges,
+    pub(crate) object_history_changes: TransactionObjectChangesToCommit,
+    pub(crate) object_versions: Vec<StoredObjectVersion>,
+    pub(crate) packages: Vec<IndexedPackage>,
+    pub(crate) epoch: Option<EpochToCommit>,
+}
+
+pub(crate) const CHECKPOINT_COMMIT_BATCH_SIZE: usize = 100;
+
+pub(crate) async fn start_tx_checkpoint_commit_task(
+    state: PgIndexerStore,
+    metrics: IndexerMetrics,
+    tx_indexing_receiver: iota_metrics::metered_channel::Receiver<CheckpointDataToCommit>,
+    mut next_checkpoint_sequence_number: CheckpointSequenceNumber,
+    cancel: CancellationToken,
+) -> IndexerResult<()> {
+    use futures::StreamExt;
+
+    info!("Indexer checkpoint commit task started...");
+    let checkpoint_commit_batch_size = std::env::var("CHECKPOINT_COMMIT_BATCH_SIZE")
+        .unwrap_or(CHECKPOINT_COMMIT_BATCH_SIZE.to_string())
+        .parse::<usize>()
+        .unwrap();
+    info!("Using checkpoint commit batch size {checkpoint_commit_batch_size}");
+
+    let mut stream = iota_metrics::metered_channel::ReceiverStream::new(tx_indexing_receiver)
+        .ready_chunks(checkpoint_commit_batch_size);
+
+    let mut unprocessed = HashMap::new();
+    let mut batch = vec![];
+
+    while let Some(indexed_checkpoint_batch) = stream.next().await {
+        if cancel.is_cancelled() {
+            break;
+        }
+
+        // split the batch into smaller batches per epoch to handle partitioning
+        for checkpoint in indexed_checkpoint_batch {
+            unprocessed.insert(checkpoint.checkpoint.sequence_number, checkpoint);
+        }
+        while let Some(checkpoint) = unprocessed.remove(&next_checkpoint_sequence_number) {
+            let epoch = checkpoint.epoch.clone();
+            batch.push(checkpoint);
+            next_checkpoint_sequence_number += 1;
+            if batch.len() == checkpoint_commit_batch_size || epoch.is_some() {
+                commit_checkpoints(&state, batch, epoch, &metrics).await;
+                batch = vec![];
+            }
+        }
+        if !batch.is_empty() && unprocessed.is_empty() {
+            commit_checkpoints(&state, batch, None, &metrics).await;
+            batch = vec![];
+        }
+    }
+    Ok(())
+}
+
+// Unwrap: Caller needs to make sure indexed_checkpoint_batch is not empty
+#[instrument(skip_all, fields(
+    first = indexed_checkpoint_batch.first().as_ref().unwrap().checkpoint.sequence_number,
+    last = indexed_checkpoint_batch.last().as_ref().unwrap().checkpoint.sequence_number
+))]
+async fn commit_checkpoints(
+    state: &PgIndexerStore,
+    indexed_checkpoint_batch: Vec<CheckpointDataToCommit>,
+    epoch: Option<EpochToCommit>,
+    metrics: &IndexerMetrics,
+) {
+    let batch_len = indexed_checkpoint_batch.len();
+    let mut checkpoint_batch = Vec::with_capacity(batch_len);
+    let mut tx_batch = Vec::with_capacity(batch_len);
+    let mut events_batch = Vec::with_capacity(batch_len);
+    let mut tx_indices_batch = Vec::with_capacity(batch_len);
+    let mut event_indices_batch = Vec::with_capacity(batch_len);
+    let mut display_updates_batch = BTreeMap::new();
+    let mut object_changes_batch = Vec::with_capacity(batch_len);
+    let mut object_history_changes_batch = Vec::with_capacity(batch_len);
+    let mut object_versions_batch = Vec::with_capacity(batch_len);
+    let mut packages_batch = Vec::with_capacity(batch_len);
+
+    for indexed_checkpoint in indexed_checkpoint_batch {
+        let CheckpointDataToCommit {
+            checkpoint,
+            transactions,
+            events,
+            event_indices,
+            tx_indices,
+            display_updates,
+            object_changes,
+            object_history_changes,
+            object_versions,
+            packages,
+            ..
+        } = indexed_checkpoint;
+        checkpoint_batch.push(checkpoint);
+        tx_batch.push(transactions);
+        events_batch.push(events);
+        tx_indices_batch.push(tx_indices);
+        event_indices_batch.push(event_indices);
+        display_updates_batch.extend(display_updates.into_iter());
+        object_changes_batch.push(object_changes);
+        object_history_changes_batch.push(object_history_changes);
+        object_versions_batch.push(object_versions);
+        packages_batch.push(packages);
+    }
+
+    let first_checkpoint_seq = checkpoint_batch.first().as_ref().unwrap().sequence_number;
+    let last_checkpoint_seq = checkpoint_batch.last().as_ref().unwrap().sequence_number;
+
+    let guard = metrics.checkpoint_db_commit_latency.start_timer();
+    let tx_batch = tx_batch.into_iter().flatten().collect::<Vec<_>>();
+
+    let tx_global_order_batch = tx_batch
+        .iter()
+        .map(Into::into)
+        .collect::<Vec<TxGlobalOrder>>();
+    let tx_indices_batch = tx_indices_batch.into_iter().flatten().collect::<Vec<_>>();
+    let events_batch = events_batch.into_iter().flatten().collect::<Vec<_>>();
+    let event_indices_batch = event_indices_batch
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    let object_versions_batch = object_versions_batch
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    let packages_batch = packages_batch.into_iter().flatten().collect::<Vec<_>>();
+    let checkpoint_num = checkpoint_batch.len();
+    let tx_count = tx_batch.len();
+
+    {
+        let _step_1_guard = metrics.checkpoint_db_commit_latency_step_1.start_timer();
+        let mut persist_tasks = vec![
+            state.persist_transactions(tx_batch),
+            state.persist_tx_indices(tx_indices_batch),
+            state.persist_tx_global_order(tx_global_order_batch),
+            state.persist_events(events_batch),
+            state.persist_event_indices(event_indices_batch),
+            state.persist_displays(display_updates_batch),
+            state.persist_packages(packages_batch),
+            state.persist_checkpoint_objects(object_changes_batch),
+            state.persist_object_history(object_history_changes_batch.clone()),
+            state.persist_object_versions(object_versions_batch.clone()),
+        ];
+        if let Some(epoch_data) = epoch.clone() {
+            persist_tasks.push(state.persist_epoch(epoch_data));
+        }
+        futures::future::join_all(persist_tasks)
+            .await
+            .into_iter()
+            .map(|res| {
+                if res.is_err() {
+                    error!("Failed to persist data with error: {:?}", res);
+                }
+                res
+            })
+            .collect::<IndexerResult<Vec<_>>>()
+            .expect("Persisting data into DB should not fail.");
+    }
+
+    let is_epoch_end = epoch.is_some();
+
+    // handle partitioning on epoch boundary
+    if let Some(epoch_data) = epoch {
+        state
+            .advance_epoch(epoch_data)
+            .await
+            .tap_err(|e| {
+                error!("Failed to advance epoch with error: {}", e.to_string());
+            })
+            .expect("Advancing epochs in DB should not fail.");
+        metrics.total_epoch_committed.inc();
+
+        // Refresh participation metrics after advancing epoch
+        state
+            .refresh_participation_metrics()
+            .await
+            .tap_err(|e| {
+                error!("Failed to update participation metrics: {e}");
+            })
+            .expect("Updating participation metrics should not fail.");
+    }
+
+    state
+        .persist_checkpoints(checkpoint_batch)
+        .await
+        .tap_err(|e| {
+            error!(
+                "Failed to persist checkpoint data with error: {}",
+                e.to_string()
+            );
+        })
+        .expect("Persisting data into DB should not fail.");
+
+    if is_epoch_end {
+        // The epoch has advanced so we update the configs for the new protocol version,
+        // if it has changed.
+        let chain_id = <PgIndexerStore as IndexerStore>::get_chain_identifier(state)
+            .await
+            .expect("Failed to get chain identifier")
+            .expect("Chain identifier should have been indexed at this point");
+        let _ = state.persist_protocol_configs_and_feature_flags(chain_id);
+    }
+
+    let elapsed = guard.stop_and_record();
+
+    info!(
+        elapsed,
+        "Checkpoint {}-{} committed with {} transactions.",
+        first_checkpoint_seq,
+        last_checkpoint_seq,
+        tx_count,
+    );
+    metrics
+        .latest_tx_checkpoint_sequence_number
+        .set(last_checkpoint_seq as i64);
+    metrics
+        .total_tx_checkpoint_committed
+        .inc_by(checkpoint_num as u64);
+    metrics.total_transaction_committed.inc_by(tx_count as u64);
+    metrics
+        .transaction_per_checkpoint
+        .observe(tx_count as f64 / (last_checkpoint_seq - first_checkpoint_seq + 1) as f64);
+    // 1000.0 is not necessarily the batch size, it's to roughly map average tx
+    // commit latency to [0.1, 1] seconds, which is well covered by
+    // DB_COMMIT_LATENCY_SEC_BUCKETS.
+    metrics
+        .thousand_transaction_avg_db_commit_latency
+        .observe(elapsed * 1000.0 / tx_count as f64);
+}

--- a/crates/iota-indexer/src/rolling/transform.rs
+++ b/crates/iota-indexer/src/rolling/transform.rs
@@ -1,0 +1,187 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Types and associated logic to use while
+//! transforming data from network checkpoints.
+
+use iota_types::{
+    base_types::{ObjectID, ObjectRef},
+    digests::TransactionDigest,
+    full_checkpoint_content::CheckpointData,
+    messages_checkpoint::CheckpointSequenceNumber,
+    object::Object,
+};
+
+use crate::{
+    handlers::checkpoint_handler::try_extract_df_kind,
+    rolling::{
+        error::{IndexerError, IndexerResult},
+        extract,
+    },
+    types::{IndexedDeletedObject, IndexedObject},
+};
+/// Represent an object that is live at a certain snapshot
+/// of the network.
+#[derive(Clone, Debug)]
+pub(crate) struct LiveObject {
+    pub(crate) indexed_object: IndexedObject,
+    /// The transaction that mutated the object.
+    pub(crate) transaction_digest: TransactionDigest,
+}
+
+impl LiveObject {
+    pub fn new(
+        checkpoint_sequence_number: CheckpointSequenceNumber,
+        transaction_digest: TransactionDigest,
+        object: Object,
+    ) -> IndexerResult<Self> {
+        let df_kind = try_extract_df_kind(&object)?;
+        let indexed_object =
+            IndexedObject::from_object(checkpoint_sequence_number, object, df_kind);
+        Ok(Self {
+            indexed_object,
+            transaction_digest,
+        })
+    }
+
+    pub(crate) fn split(self) -> (IndexedObject, TransactionDigest) {
+        (self.indexed_object, self.transaction_digest)
+    }
+
+    pub(crate) fn object(&self) -> &Object {
+        &self.indexed_object.object
+    }
+}
+
+/// Represent an object that is wrapped or deleted at a certain snapshot
+/// of the network.
+#[derive(Clone, Debug)]
+pub(crate) struct RemovedObject {
+    pub(crate) indexed_object: IndexedDeletedObject,
+    /// The transaction that mutated the object.
+    pub(crate) transaction_digest: TransactionDigest,
+}
+
+impl RemovedObject {
+    pub fn new(
+        checkpoint_sequence_number: CheckpointSequenceNumber,
+        transaction_digest: TransactionDigest,
+        object_ref: ObjectRef,
+    ) -> Self {
+        let (object_id, object_version, _) = object_ref;
+        let indexed_object = IndexedDeletedObject {
+            checkpoint_sequence_number,
+            object_id,
+            object_version: object_version.into(),
+        };
+        Self {
+            indexed_object,
+            transaction_digest,
+        }
+    }
+
+    pub(crate) fn version(&self) -> u64 {
+        self.indexed_object.object_version
+    }
+
+    pub(crate) fn object_id(&self) -> ObjectID {
+        self.indexed_object.object_id
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct CheckpointObjectChanges {
+    pub(crate) changed_objects: Vec<LiveObject>,
+    pub(crate) deleted_objects: Vec<RemovedObject>,
+}
+
+impl TryFrom<&CheckpointData> for CheckpointObjectChanges {
+    type Error = IndexerError;
+    fn try_from(data: &CheckpointData) -> Result<Self, Self::Error> {
+        let checkpoint_seq = data.checkpoint_summary.sequence_number;
+        let extractor = extract::Extractor::new(data);
+
+        let deleted_objects = extractor
+            .iter_removed_objects()
+            .map(|(obj_ref, digest)| RemovedObject::new(checkpoint_seq, digest, obj_ref))
+            .collect();
+
+        let changed_objects = extractor
+            .iter_live_objects()
+            .map(|obj| {
+                LiveObject::new(
+                    checkpoint_seq,
+                    obj.as_inner().previous_transaction,
+                    obj.clone(),
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            changed_objects,
+            deleted_objects,
+        })
+    }
+}
+
+/// Retain the live and removed objects with the largest versions from
+/// a set of consecutive checkpoints.
+pub(crate) fn retain_latest_objects_from_checkpoint_batch(
+    checkpoint_batch_object_changes: Vec<CheckpointObjectChanges>,
+) -> CheckpointObjectChanges {
+    use std::collections::HashMap;
+
+    let mut mutations = HashMap::<ObjectID, LiveObject>::new();
+    let mut deletions = HashMap::<ObjectID, RemovedObject>::new();
+
+    for change in checkpoint_batch_object_changes {
+        // Remove mutation / deletion with a following deletion / mutation,
+        // as we expect that following deletion / mutation has a higher version.
+        // Technically, assertions below are not required, double check just in case.
+        for mutation in change.changed_objects {
+            let id = mutation.object().id();
+            let version = mutation.object().version();
+
+            if let Some(existing) = deletions.remove(&id) {
+                assert!(
+                    existing.version() < version.value(),
+                    "Mutation version ({version:?}) should be greater than existing deletion version ({:?}) for object {id:?}",
+                    existing.version()
+                );
+            }
+
+            if let Some(existing) = mutations.insert(id, mutation) {
+                assert!(
+                    existing.object().version() < version,
+                    "Mutation version ({version:?}) should be greater than existing mutation version ({:?}) for object {id:?}",
+                    existing.object().version()
+                );
+            }
+        }
+        // Handle deleted objects
+        for deletion in change.deleted_objects {
+            let id = deletion.object_id();
+            let version = deletion.version();
+
+            if let Some(existing) = mutations.remove(&id) {
+                assert!(
+                    existing.object().version().value() < version,
+                    "Deletion version ({version:?}) should be greater than existing mutation version ({:?}) for object {id:?}",
+                    existing.object().version(),
+                );
+            }
+
+            if let Some(existing) = deletions.insert(id, deletion) {
+                assert!(
+                    existing.version() < version,
+                    "Deletion version ({version:?}) should be greater than existing deletion version ({:?}) for object {id:?}",
+                    existing.version()
+                );
+            }
+        }
+    }
+
+    CheckpointObjectChanges {
+        changed_objects: mutations.into_values().collect(),
+        deleted_objects: deletions.into_values().collect(),
+    }
+}

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -133,4 +133,9 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
     async fn refresh_participation_metrics(&self) -> Result<(), IndexerError>;
 
     fn as_any(&self) -> &dyn Any;
+
+    async fn get_transactions_with_global_order(
+        &self,
+        digests: &[Vec<u8>],
+    ) -> Result<Vec<Vec<u8>>, IndexerError>;
 }

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -18,6 +18,7 @@ use crate::{
         transactions::{OptimisticTransaction, TxGlobalOrder},
         tx_indices::OptimisticTxIndices,
     },
+    rolling::transform::CheckpointObjectChanges,
     types::{
         EventIndex, IndexedCheckpoint, IndexedEvent, IndexedPackage, IndexedTransaction, TxIndex,
     },
@@ -138,4 +139,12 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
         &self,
         digests: &[Vec<u8>],
     ) -> Result<Vec<Vec<u8>>, IndexerError>;
+}
+
+#[async_trait]
+pub(crate) trait IndexerStoreExt: IndexerStore {
+    async fn persist_checkpoint_objects(
+        &self,
+        objects: Vec<CheckpointObjectChanges>,
+    ) -> Result<(), IndexerError>;
 }

--- a/crates/iota-indexer/src/store/mod.rs
+++ b/crates/iota-indexer/src/store/mod.rs
@@ -167,6 +167,21 @@ pub mod diesel_macro {
     }
 
     #[macro_export]
+    macro_rules! on_conflict_do_update_with_condition {
+        ($table:expr, $values:expr, $target:expr, $pg_columns:expr, $condition:expr, $conn:expr) => {{
+            use diesel::{ExpressionMethods, RunQueryDsl, query_dsl::methods::FilterDsl};
+
+            diesel::insert_into($table)
+                .values($values)
+                .on_conflict($target)
+                .do_update()
+                .set($pg_columns)
+                .filter($condition)
+                .execute($conn)?;
+        }};
+    }
+
+    #[macro_export]
     macro_rules! run_query {
         ($pool:expr, $query:expr) => {{
             blocking_call_is_ok_or_panic!();

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -11,7 +11,7 @@ use std::{
 
 use async_trait::async_trait;
 use diesel::{
-    ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl,
+    ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl, SelectableHelper,
     dsl::{max, min},
     upsert::excluded,
 };
@@ -48,7 +48,8 @@ use crate::{
         transactions::{OptimisticTransaction, StoredTransaction, TxGlobalOrder},
         tx_indices::OptimisticTxIndices,
     },
-    on_conflict_do_update, persist_chunk_into_table, read_only_blocking,
+    on_conflict_do_update, on_conflict_do_update_with_condition, persist_chunk_into_table,
+    read_only_blocking, run_query_async,
     schema::{
         chain_identifier, checkpoints, display, epochs, event_emit_module, event_emit_package,
         event_senders, event_struct_instantiation, event_struct_module, event_struct_name,
@@ -64,7 +65,7 @@ use crate::{
         tx_changed_objects, tx_digests, tx_global_order, tx_input_objects, tx_kinds, tx_recipients,
         tx_senders,
     },
-    transactional_blocking_with_retry,
+    spawn_read_only_blocking, transactional_blocking_with_retry,
     types::{
         EventIndex, IndexedCheckpoint, IndexedDeletedObject, IndexedEvent, IndexedObject,
         IndexedPackage, IndexedTransaction, TxIndex,
@@ -304,7 +305,7 @@ impl PgIndexerStore {
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {
-                on_conflict_do_update!(
+                on_conflict_do_update_with_condition!(
                     display::table,
                     display_updates.values().collect::<Vec<_>>(),
                     display::object_type,
@@ -313,6 +314,7 @@ impl PgIndexerStore {
                         display::version.eq(excluded(display::version)),
                         display::bcs.eq(excluded(display::bcs)),
                     ),
+                    excluded(display::version).gt(display::version),
                     conn
                 );
                 Ok::<(), IndexerError>(())
@@ -1855,6 +1857,26 @@ impl IndexerStore for PgIndexerStore {
 
         info!("Persisted optimistic transaction {sequence_number}");
         Ok(())
+    }
+
+    async fn get_transactions_with_global_order(
+        &self,
+        digests: &[Vec<u8>],
+    ) -> Result<Vec<Vec<u8>>, IndexerError> {
+        let digests = digests.to_vec();
+
+        let pool = self.blocking_cp.clone();
+        let indexing_status = run_query_async!(&pool, move |conn| {
+            tx_global_order::table
+                .select(TxGlobalOrder::as_select())
+                .filter(tx_global_order::tx_digest.eq_any(&digests))
+                .load::<TxGlobalOrder>(conn)
+        })
+        .context("Failed reading tx indexing status from PostgresDB")?
+        .into_iter()
+        .map(|tgo| tgo.tx_digest)
+        .collect();
+        Ok(indexing_status)
     }
 
     async fn persist_tx_global_order(

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -5,7 +5,7 @@
 use core::result::Result::Ok;
 use std::{
     any::Any as StdAny,
-    collections::{BTreeMap, HashMap},
+    collections::BTreeMap,
     time::{Duration, Instant},
 };
 
@@ -13,10 +13,10 @@ use async_trait::async_trait;
 use diesel::{
     ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl, SelectableHelper,
     dsl::{max, min},
+    sql_types::{Array, BigInt, Bytea, Nullable, SmallInt, Text},
     upsert::excluded,
 };
 use downcast::Any;
-use futures::future::Either;
 use iota_protocol_config::ProtocolConfig;
 use iota_types::{
     base_types::ObjectID,
@@ -26,10 +26,6 @@ use itertools::Itertools;
 use tap::TapFallible;
 use tracing::info;
 
-use super::{
-    IndexerStore,
-    pg_partition_manager::{EpochPartitionData, PgPartitionManager},
-};
 use crate::{
     db::ConnectionPool,
     errors::{Context, IndexerError},
@@ -43,13 +39,21 @@ use crate::{
         event_indices::OptimisticEventIndices,
         events::{OptimisticEvent, StoredEvent},
         obj_indices::StoredObjectVersion,
-        objects::{StoredDeletedObject, StoredHistoryObject, StoredObject, StoredObjectSnapshot},
+        objects::{
+            StoredDeletedObject, StoredHistoryObject, StoredObject, StoredObjectSnapshot,
+            StoredObjects,
+        },
         packages::StoredPackage,
         transactions::{OptimisticTransaction, StoredTransaction, TxGlobalOrder},
         tx_indices::OptimisticTxIndices,
     },
     on_conflict_do_update, on_conflict_do_update_with_condition, persist_chunk_into_table,
-    read_only_blocking, run_query_async,
+    read_only_blocking,
+    rolling::transform::{
+        CheckpointObjectChanges, LiveObject, RemovedObject,
+        retain_latest_objects_from_checkpoint_batch,
+    },
+    run_query_async,
     schema::{
         chain_identifier, checkpoints, display, epochs, event_emit_module, event_emit_package,
         event_senders, event_struct_instantiation, event_struct_module, event_struct_name,
@@ -65,7 +69,12 @@ use crate::{
         tx_changed_objects, tx_digests, tx_global_order, tx_input_objects, tx_kinds, tx_recipients,
         tx_senders,
     },
-    spawn_read_only_blocking, transactional_blocking_with_retry,
+    spawn_read_only_blocking,
+    store::{
+        IndexerStore, IndexerStoreExt,
+        pg_partition_manager::{EpochPartitionData, PgPartitionManager},
+    },
+    transactional_blocking_with_retry,
     types::{
         EventIndex, IndexedCheckpoint, IndexedDeletedObject, IndexedEvent, IndexedObject,
         IndexedPackage, IndexedTransaction, TxIndex,
@@ -325,6 +334,164 @@ impl PgIndexerStore {
         Ok(())
     }
 
+    fn persist_changed_objects(&self, objects: Vec<LiveObject>) -> Result<(), IndexerError> {
+        let guard = self
+            .metrics
+            .checkpoint_db_commit_latency_objects_chunks
+            .start_timer();
+        let len = objects.len();
+        let raw_query = r#"
+            INSERT INTO objects (
+                object_id,
+                object_version,
+                object_digest,
+                owner_type,
+                owner_id,
+                object_type,
+                object_type_package,
+                object_type_module,
+                object_type_name,
+                serialized_object,
+                coin_type,
+                coin_balance,
+                df_kind
+            )
+            SELECT
+                u.object_id,
+                u.object_version,
+                u.object_digest,
+                u.owner_type,
+                u.owner_id,
+                u.object_type,
+                u.object_type_package,
+                u.object_type_module,
+                u.object_type_name,
+                u.serialized_object,
+                u.coin_type,
+                u.coin_balance,
+                u.df_kind
+            FROM UNNEST(
+                $1::BYTEA[],
+                $2::BIGINT[],
+                $3::BYTEA[],
+                $4::SMALLINT[],
+                $5::BYTEA[],
+                $6::TEXT[],
+                $7::BYTEA[],
+                $8::TEXT[],
+                $9::TEXT[],
+                $10::BYTEA[],
+                $11::TEXT[],
+                $12::BIGINT[],
+                $13::SMALLINT[],
+                $14::BYTEA[]
+            ) AS u(object_id, object_version, object_digest, owner_type, owner_id, object_type, object_type_package, object_type_module, object_type_name, serialized_object, coin_type, coin_balance, df_kind, tx_digest)
+            LEFT JOIN tx_global_order o ON o.tx_digest = u.tx_digest
+            WHERE o.optimistic_sequence_number IS NULL OR o.optimistic_sequence_number = 0
+            ON CONFLICT (object_id) DO UPDATE
+            SET
+                object_version = EXCLUDED.object_version,
+                object_digest = EXCLUDED.object_digest,
+                owner_type = EXCLUDED.owner_type,
+                owner_id = EXCLUDED.owner_id,
+                object_type = EXCLUDED.object_type,
+                object_type_package = EXCLUDED.object_type_package,
+                object_type_module = EXCLUDED.object_type_module,
+                object_type_name = EXCLUDED.object_type_name,
+                serialized_object = EXCLUDED.serialized_object,
+                coin_type = EXCLUDED.coin_type,
+                coin_balance = EXCLUDED.coin_balance,
+                df_kind = EXCLUDED.df_kind
+        "#;
+        let (objects, tx_digests): (StoredObjects, Vec<_>) = objects
+            .into_iter()
+            .map(LiveObject::split)
+            .map(|(indexed_object, tx_digest)| {
+                (
+                    StoredObject::from(indexed_object),
+                    tx_digest.into_inner().to_vec(),
+                )
+            })
+            .unzip();
+        let query = diesel::sql_query(raw_query)
+            .bind::<Array<Bytea>, _>(objects.object_ids)
+            .bind::<Array<BigInt>, _>(objects.object_versions)
+            .bind::<Array<Bytea>, _>(objects.object_digests)
+            .bind::<Array<SmallInt>, _>(objects.owner_types)
+            .bind::<Array<Nullable<Bytea>>, _>(objects.owner_ids)
+            .bind::<Array<Nullable<Text>>, _>(objects.object_types)
+            .bind::<Array<Nullable<Bytea>>, _>(objects.object_type_packages)
+            .bind::<Array<Nullable<Text>>, _>(objects.object_type_modules)
+            .bind::<Array<Nullable<Text>>, _>(objects.object_type_names)
+            .bind::<Array<Bytea>, _>(objects.serialized_objects)
+            .bind::<Array<Nullable<Text>>, _>(objects.coin_types)
+            .bind::<Array<Nullable<BigInt>>, _>(objects.coin_balances)
+            .bind::<Array<Nullable<SmallInt>>, _>(objects.df_kinds)
+            .bind::<Array<Bytea>, _>(tx_digests);
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                query.clone().execute(conn)?;
+                Ok::<(), IndexerError>(())
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+        .tap_ok(|_| {
+            let elapsed = guard.stop_and_record();
+            info!(elapsed, "Persisted {len} chunked objects");
+        })
+        .tap_err(|e| {
+            tracing::error!("Failed to persist object mutations with error: {e}");
+        })
+    }
+
+    fn persist_removed_objects(&self, objects: Vec<RemovedObject>) -> Result<(), IndexerError> {
+        let guard = self
+            .metrics
+            .checkpoint_db_commit_latency_objects_chunks
+            .start_timer();
+        let len = objects.len();
+        let raw_query = r#"
+            DELETE FROM objects
+            WHERE object_id IN (
+                SELECT u.object_id
+                FROM UNNEST(
+                    $1::BYTEA[],
+                    $2::BYTEA[]
+                ) AS u(object_id, tx_digest)
+                LEFT JOIN tx_global_order o ON o.tx_digest = u.tx_digest
+                WHERE o.optimistic_sequence_number IS NULL OR o.optimistic_sequence_number = 0
+            )
+        "#;
+        let (object_ids, tx_digests): (Vec<_>, Vec<_>) = objects
+            .into_iter()
+            .map(|removed_object| {
+                (
+                    removed_object.object_id().to_vec(),
+                    removed_object.transaction_digest.into_inner().to_vec(),
+                )
+            })
+            .unzip();
+        let query = diesel::sql_query(raw_query)
+            .bind::<Array<Bytea>, _>(object_ids)
+            .bind::<Array<Bytea>, _>(tx_digests);
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                query.clone().execute(conn)?;
+                Ok::<(), IndexerError>(())
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+        .tap_ok(|_| {
+            let elapsed = guard.stop_and_record();
+            info!(elapsed, "Deleted {len} chunked objects");
+        })
+        .tap_err(|e| {
+            tracing::error!("Failed to persist object deletions with error: {e}");
+        })
+    }
+
     fn persist_object_mutation_chunk(
         &self,
         mutated_object_mutation_chunk: Vec<StoredObject>,
@@ -361,7 +528,7 @@ impl PgIndexerStore {
         )
         .tap_ok(|_| {
             let elapsed = guard.stop_and_record();
-            info!(elapsed, "Persisted {} chunked objects", len);
+            info!(elapsed, "Deleted {} chunked objects", len);
         })
         .tap_err(|e| {
             tracing::error!("Failed to persist object mutations with error: {}", e);
@@ -2411,6 +2578,78 @@ impl IndexerStore for PgIndexerStore {
     }
 }
 
+#[async_trait]
+impl IndexerStoreExt for PgIndexerStore {
+    async fn persist_checkpoint_objects(
+        &self,
+        objects: Vec<CheckpointObjectChanges>,
+    ) -> Result<(), IndexerError> {
+        if objects.is_empty() {
+            return Ok(());
+        }
+        let guard = self
+            .metrics
+            .checkpoint_db_commit_latency_objects
+            .start_timer();
+        let CheckpointObjectChanges {
+            changed_objects: mutations,
+            deleted_objects: deletions,
+        } = retain_latest_objects_from_checkpoint_batch(objects);
+        let mutation_len = mutations.len();
+        let deletion_len = deletions.len();
+
+        let mutation_chunks = chunk!(mutations, self.config.parallel_objects_chunk_size);
+        let deletion_chunks = chunk!(deletions, self.config.parallel_objects_chunk_size);
+        let mutation_futures = mutation_chunks
+            .into_iter()
+            .map(|c| self.spawn_blocking_task(move |this| this.persist_changed_objects(c)));
+        futures::future::try_join_all(mutation_futures)
+            .await
+            .map_err(|e| {
+                tracing::error!(
+                    "Failed to join persist_object_mutation_chunk futures: {}",
+                    e
+                );
+                IndexerError::from(e)
+            })?
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
+                IndexerError::PostgresWrite(format!(
+                    "Failed to persist all object mutation chunks: {:?}",
+                    e
+                ))
+            })?;
+        let deletion_futures = deletion_chunks
+            .into_iter()
+            .map(|c| self.spawn_blocking_task(move |this| this.persist_removed_objects(c)));
+        futures::future::try_join_all(deletion_futures)
+            .await
+            .map_err(|e| {
+                tracing::error!(
+                    "Failed to join persist_object_deletion_chunk futures: {}",
+                    e
+                );
+                IndexerError::from(e)
+            })?
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
+                IndexerError::PostgresWrite(format!(
+                    "Failed to persist all object deletion chunks: {:?}",
+                    e
+                ))
+            })?;
+
+        let elapsed = guard.stop_and_record();
+        info!(
+            elapsed,
+            "Persisted objects with {mutation_len} mutations and {deletion_len} deletions",
+        );
+        Ok(())
+    }
+}
+
 fn make_objects_history_to_commit(
     tx_object_changes: Vec<TransactionObjectChangesToCommit>,
 ) -> Vec<StoredHistoryObject> {
@@ -2436,69 +2675,58 @@ fn make_objects_history_to_commit(
 fn retain_latest_indexed_objects(
     tx_object_changes: Vec<TransactionObjectChangesToCommit>,
 ) -> (Vec<IndexedObject>, Vec<IndexedDeletedObject>) {
-    // Only the last deleted / mutated object will be in the map,
-    // b/c tx_object_changes are in order and versions always increment,
-    let (mutations, deletions) = tx_object_changes
-        .into_iter()
-        .flat_map(|change| {
-            change
-                .changed_objects
-                .into_iter()
-                .map(Either::Left)
-                .chain(
-                    change
-                        .deleted_objects
-                        .into_iter()
-                        .map(Either::Right),
-                )
-        })
-        .fold(
-            (HashMap::<ObjectID, IndexedObject>::new(), HashMap::<ObjectID, IndexedDeletedObject>::new()),
-            |(mut mutations, mut deletions), either_change| {
-                match either_change {
-                    // Remove mutation / deletion with a following deletion / mutation,
-                    // b/c following deletion / mutation always has a higher version.
-                    // Technically, assertions below are not required, double check just in case.
-                    Either::Left(mutation) => {
-                        let id = mutation.object.id();
-                        let mutation_version = mutation.object.version();
-                        if let Some(existing) = deletions.remove(&id) {
-                            assert!(
-                                existing.object_version < mutation_version.value(),
-                                "Mutation version ({mutation_version:?}) should be greater than existing deletion version ({:?}) for object {id:?}",
-                                existing.object_version
-                            );
-                        }
-                        if let Some(existing) = mutations.insert(id, mutation) {
-                            assert!(
-                                existing.object.version() < mutation_version,
-                                "Mutation version ({mutation_version:?}) should be greater than existing mutation version ({:?}) for object {id:?}",
-                                existing.object.version()
-                            );
-                        }
-                    }
-                    Either::Right(deletion) => {
-                        let id = deletion.object_id;
-                        let deletion_version = deletion.object_version;
-                        if let Some(existing) = mutations.remove(&id) {
-                            assert!(
-                                existing.object.version().value() < deletion_version,
-                                "Deletion version ({deletion_version:?}) should be greater than existing mutation version ({:?}) for object {id:?}",
-                                existing.object.version(),
-                            );
-                        }
-                        if let Some(existing) = deletions.insert(id, deletion) {
-                            assert!(
-                                existing.object_version < deletion_version,
-                                "Deletion version ({deletion_version:?}) should be greater than existing deletion version ({:?}) for object {id:?}",
-                                existing.object_version
-                            );
-                        }
-                    }
-                }
-                (mutations, deletions)
-            },
-        );
+    use std::collections::HashMap;
+
+    let mut mutations = HashMap::<ObjectID, IndexedObject>::new();
+    let mut deletions = HashMap::<ObjectID, IndexedDeletedObject>::new();
+
+    for change in tx_object_changes {
+        // Remove mutation / deletion with a following deletion / mutation,
+        // as we expect that following deletion / mutation has a higher version.
+        // Technically, assertions below are not required, double check just in case.
+        for mutation in change.changed_objects {
+            let id = mutation.object.id();
+            let version = mutation.object.version();
+
+            if let Some(existing) = deletions.remove(&id) {
+                assert!(
+                    existing.object_version < version.value(),
+                    "Mutation version ({version:?}) should be greater than existing deletion version ({:?}) for object {id:?}",
+                    existing.object_version
+                );
+            }
+
+            if let Some(existing) = mutations.insert(id, mutation) {
+                assert!(
+                    existing.object.version() < version,
+                    "Mutation version ({version:?}) should be greater than existing mutation version ({:?}) for object {id:?}",
+                    existing.object.version()
+                );
+            }
+        }
+        // Handle deleted objects
+        for deletion in change.deleted_objects {
+            let id = deletion.object_id;
+            let version = deletion.object_version;
+
+            if let Some(existing) = mutations.remove(&id) {
+                assert!(
+                    existing.object.version().value() < version,
+                    "Deletion version ({version:?}) should be greater than existing mutation version ({:?}) for object {id:?}",
+                    existing.object.version(),
+                );
+            }
+
+            if let Some(existing) = deletions.insert(id, deletion) {
+                assert!(
+                    existing.object_version < version,
+                    "Deletion version ({version:?}) should be greater than existing deletion version ({:?}) for object {id:?}",
+                    existing.object_version
+                );
+            }
+        }
+    }
+
     (
         mutations.into_values().collect(),
         deletions.into_values().collect(),

--- a/crates/iota-indexer/tests/rpc-tests/coin_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/coin_api.rs
@@ -3,6 +3,7 @@
 
 use std::{path::PathBuf, str::FromStr, sync::Arc};
 
+use fastcrypto::traits::Signer;
 use iota_indexer::store::PgIndexerStore;
 use iota_json::{IotaJsonValue, call_args, type_args};
 use iota_json_rpc_api::{
@@ -20,7 +21,7 @@ use iota_types::{
     balance::Supply,
     base_types::{IotaAddress, ObjectID},
     coin::{COIN_MODULE_NAME, CoinMetadata, TreasuryCap},
-    crypto::{AccountKeyPair, IotaKeyPair, get_key_pair},
+    crypto::{AccountKeyPair, IotaKeyPair, Signature, get_key_pair},
     parse_iota_struct_tag,
     quorum_driver_types::ExecuteTransactionRequestType,
     utils::to_sender_signed_transaction,
@@ -648,10 +649,10 @@ async fn create_trusted_coins(
     Ok((coin_name, imm_coin_name))
 }
 
-async fn execute_move_call(
+pub async fn execute_move_call(
     client: &HttpClient,
     address: IotaAddress,
-    account_keypair: &IotaKeyPair,
+    account_keypair: &dyn Signer<Signature>,
     package_object_id: ObjectID,
     module: String,
     function: String,

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{fs::File, path::Path, str::FromStr, sync::Arc};
+use std::{fs::File, path::Path, str::FromStr, sync::Arc, time::Duration};
 
 use hex::FromHex;
 use iota_indexer::{
@@ -27,8 +27,7 @@ use serde_json::Value;
 
 use crate::common::{
     ApiTestSetup, FIXTURES_DIR, execute_tx_and_wait_for_indexer, get_indexer_db_url,
-    indexer_wait_for_checkpoint, indexer_wait_for_checkpoint_pruned, indexer_wait_for_object,
-    indexer_wait_for_transaction, rpc_call_error_msg_matches,
+    indexer_wait_for_checkpoint, indexer_wait_for_checkpoint_pruned, rpc_call_error_msg_matches,
     start_test_cluster_with_read_write_indexer,
 };
 
@@ -248,6 +247,12 @@ fn multi_get_transaction_blocks_with_options(options: IotaTransactionBlockRespon
             "indexer multi transaction blocks assertion failed"
         );
     });
+}
+
+async fn wait_for_objects_history() {
+    // Objects history is not filled by optimistic indexing, this method waits a few
+    // seconds so that checkpoint indexing has a chance to kick in
+    tokio::time::sleep(Duration::from_secs(3)).await
 }
 
 #[test]
@@ -1315,7 +1320,7 @@ fn try_get_past_object_version_found() {
             )
             .await;
 
-        indexer_wait_for_object(client, gas_ref.0, gas_ref.1).await;
+        wait_for_objects_history().await;
 
         let result = client
             .try_get_past_object(gas_ref.0, gas_ref.1, None)
@@ -1357,7 +1362,7 @@ fn try_get_past_object_version_not_found() {
             )
             .await;
 
-        indexer_wait_for_object(client, gas_ref.0, gas_ref.1).await;
+        wait_for_objects_history().await;
 
         let missing_version = gas_ref.1.one_before().expect("Version should be > 0");
 
@@ -1396,7 +1401,7 @@ fn try_get_past_object_version_too_high() {
             )
             .await;
 
-        indexer_wait_for_object(client, gas_ref.0, gas_ref.1).await;
+        wait_for_objects_history().await;
 
         let latest_version = gas_ref.1;
         let asked_version = latest_version.next();
@@ -1434,16 +1439,14 @@ fn try_get_past_object_object_deleted() {
         let context = &cluster.wallet;
         let (package_id, _, _) = publish_nfts_package(context).await;
 
-        let (sender, nft_object_id, tx_digest) = create_nft(context, package_id).await;
-
-        indexer_wait_for_transaction(tx_digest, store, client).await;
+        let (sender, nft_object_id, _) = create_nft(context, package_id).await;
 
         // Retrieve the latest object reference (which includes version) for deletion.
         let nft_object_ref = cluster.get_latest_object_ref(&nft_object_id).await;
 
         // Delete the NFT
-        let delete_tx = delete_nft(context, sender, package_id, nft_object_ref).await;
-        indexer_wait_for_transaction(delete_tx.digest, store, client).await;
+        delete_nft(context, sender, package_id, nft_object_ref).await;
+        wait_for_objects_history().await;
 
         let deleted_version = nft_object_ref.1.next();
 
@@ -1567,8 +1570,7 @@ fn try_multi_get_past_objects() {
             )
             .await;
 
-        indexer_wait_for_object(client, gas_ref_1.0, gas_ref_1.1).await;
-        indexer_wait_for_object(client, gas_ref_2.0, gas_ref_2.1).await;
+        wait_for_objects_history().await;
 
         let requests = vec![
             IotaGetPastObjectRequest {
@@ -1671,9 +1673,6 @@ fn try_get_object_before_version() {
             )
             .await;
 
-        indexer_wait_for_object(client, gas_ref.0, gas_ref.1).await;
-        indexer_wait_for_object(client, object_to_send.0, object_to_send.1).await;
-
         let tx_bytes = client
             .transfer_object(
                 sender,
@@ -1685,6 +1684,7 @@ fn try_get_object_before_version() {
             .await
             .expect("Transfer should succeed");
         execute_tx_and_wait_for_indexer(client, cluster, store, tx_bytes, &keypair).await;
+        wait_for_objects_history().await;
 
         let (latest_object, latest_version, _) = cluster.get_latest_object_ref(&gas_ref.0).await;
 

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -27,8 +27,8 @@ use serde_json::Value;
 
 use crate::common::{
     ApiTestSetup, FIXTURES_DIR, execute_tx_and_wait_for_indexer, get_indexer_db_url,
-    indexer_wait_for_checkpoint, indexer_wait_for_checkpoint_pruned, rpc_call_error_msg_matches,
-    start_test_cluster_with_read_write_indexer,
+    indexer_wait_for_checkpoint, indexer_wait_for_checkpoint_pruned, indexer_wait_for_object,
+    rpc_call_error_msg_matches, start_test_cluster_with_read_write_indexer,
 };
 
 /// Utility function to convert hex strings in JSON values to byte arrays.
@@ -1665,18 +1665,21 @@ fn try_get_object_before_version() {
                 sender,
             )
             .await;
-        let object_to_send = cluster
+        let (object_id, object_version, _) = cluster
             .fund_address_and_return_gas(
                 cluster.get_reference_gas_price().await,
                 Some(10_000_000_000),
                 sender,
             )
             .await;
+        // we need the object to be indexed before we can
+        // create a transaction that uses it as an input
+        indexer_wait_for_object(client, object_id, object_version).await;
 
         let tx_bytes = client
             .transfer_object(
                 sender,
-                object_to_send.0,
+                object_id,
                 Some(gas_ref.0),
                 100_000_000.into(),
                 receiver,

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -433,7 +433,7 @@ fn test_repeatedly_update_display() {
 
 async fn update_display_object(
     address: IotaAddress,
-    addres_kp: &AccountKeyPair,
+    address_kp: &AccountKeyPair,
     client: &HttpClient,
     display_object_id: &ObjectID,
     display_obj_type_tag: TypeTag,
@@ -443,7 +443,7 @@ async fn update_display_object(
     execute_move_call(
         client,
         address,
-        addres_kp,
+        address_kp,
         IOTA_FRAMEWORK_PACKAGE_ID,
         "display".to_string(),
         "edit".to_string(),
@@ -460,7 +460,7 @@ async fn update_display_object(
 
 async fn bump_display_object_version(
     address: IotaAddress,
-    addres_kp: &AccountKeyPair,
+    address_kp: &AccountKeyPair,
     client: &HttpClient,
     display_object_id: &ObjectID,
     display_obj_type_tag: TypeTag,
@@ -468,7 +468,7 @@ async fn bump_display_object_version(
     execute_move_call(
         client,
         address,
-        addres_kp,
+        address_kp,
         IOTA_FRAMEWORK_PACKAGE_ID,
         "display".to_string(),
         "update_version".to_string(),
@@ -562,7 +562,7 @@ async fn increment_counter(
 
 async fn create_new_bear(
     address: IotaAddress,
-    addres_kp: &AccountKeyPair,
+    address_kp: &AccountKeyPair,
     client: &HttpClient,
     package_id: &ObjectID,
     name: &str,
@@ -593,7 +593,7 @@ async fn create_new_bear(
 
     let tx_builder = TestTransactionBuilder::new(address, gas, 1000);
     let tx_data = tx_builder.programmable(pt).build();
-    let signed_transaction = to_sender_signed_transaction(tx_data, addres_kp);
+    let signed_transaction = to_sender_signed_transaction(tx_data, address_kp);
     let (tx_bytes, signatures) = signed_transaction.to_tx_bytes_and_signatures();
 
     let res = client
@@ -629,12 +629,12 @@ async fn deploy_basics_pkg(
 
 async fn deploy_bear_pkg(
     address: IotaAddress,
-    addres_kp: &AccountKeyPair,
+    address_kp: &AccountKeyPair,
     client: &HttpClient,
 ) -> (IotaTransactionBlockResponse, ObjectID) {
     deploy_package(
         address,
-        addres_kp,
+        address_kp,
         client,
         "../../examples/trading/contracts/demo",
     )

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -4,7 +4,9 @@ use std::{path::Path, str::FromStr};
 
 use fastcrypto::encoding::Base64;
 use iota_json::{call_args, type_args};
-use iota_json_rpc_api::{ReadApiClient, TransactionBuilderClient, WriteApiClient};
+use iota_json_rpc_api::{
+    CoinReadApiClient, ReadApiClient, TransactionBuilderClient, WriteApiClient,
+};
 use iota_json_rpc_types::{
     IotaExecutionStatus, IotaObjectDataOptions, IotaTransactionBlockEffectsAPI,
     IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions, ObjectChange,
@@ -13,19 +15,24 @@ use iota_json_rpc_types::{
 use iota_move_build::BuildConfig;
 use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
+    IOTA_FRAMEWORK_PACKAGE_ID, Identifier, TypeTag,
     base_types::{IotaAddress, ObjectID, ObjectRef},
     crypto::{AccountKeyPair, get_key_pair},
     gas_coin::NANOS_PER_IOTA,
     object::Owner,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     quorum_driver_types::ExecuteTransactionRequestType,
-    transaction::TransactionKind,
+    transaction::{CallArg, TransactionKind},
     utils::to_sender_signed_transaction,
 };
 use itertools::Itertools;
 use jsonrpsee::http_client::HttpClient;
+use move_core_types::{identifier::IdentStr, language_storage::StructTag};
 
-use crate::common::{ApiTestSetup, indexer_wait_for_checkpoint, indexer_wait_for_object};
+use crate::{
+    coin_api::execute_move_call,
+    common::{ApiTestSetup, indexer_wait_for_checkpoint, indexer_wait_for_object},
+};
 type TxBytes = Base64;
 type Signatures = Vec<Base64>;
 
@@ -325,25 +332,13 @@ fn test_execute_transactions_with_shared_objects() {
 
         indexer_wait_for_object(client, gas.0, gas.1).await;
 
-        let res = deploy_basics_pkg(sender, &sender_kp, client).await;
+        let (_, package_id) = deploy_basics_pkg(sender, &sender_kp, client).await;
 
-        let package_id = res
-            .object_changes
-            .as_ref()
-            .unwrap()
-            .iter()
-            .filter_map(|o| match o {
-                ObjectChange::Published { package_id, .. } => Some(package_id),
-                _ => None,
-            })
-            .exactly_one()
-            .unwrap();
-
-        let (_, counter_obj) = create_counter_object(sender, &sender_kp, client, package_id)
+        let (_, counter_obj) = create_counter_object(sender, &sender_kp, client, &package_id)
             .await
             .unwrap();
 
-        let res_1 = increment_counter(sender, &sender_kp, client, package_id, &counter_obj)
+        let res_1 = increment_counter(sender, &sender_kp, client, &package_id, &counter_obj)
             .await
             .unwrap();
         assert_eq!(res_1.status_ok(), Some(true));
@@ -351,6 +346,136 @@ fn test_execute_transactions_with_shared_objects() {
         // TODO: extend with subsequent call to the same object once race
         // conditions are fixed
     });
+}
+
+#[test]
+fn test_repeatedly_update_display() {
+    let ApiTestSetup {
+        runtime,
+        cluster,
+        store,
+        client,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async {
+        let consecutive_updates = 150;
+        indexer_wait_for_checkpoint(store, 1).await;
+
+        let (sender, sender_kp): (_, AccountKeyPair) = get_key_pair();
+
+        let gas = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(10_000_000_000),
+                sender,
+            )
+            .await;
+        indexer_wait_for_object(client, gas.0, gas.1).await;
+
+        let (res, package_id) = deploy_bear_pkg(sender, &sender_kp, client).await;
+        let display_obj_id = ObjectID::from_hex_literal(
+            res.events.unwrap().data[0].parsed_json.as_object().unwrap()["id"]
+                .as_str()
+                .unwrap(),
+        )
+        .unwrap();
+
+        let (_, bear_id) = create_new_bear(sender, &sender_kp, client, &package_id, "bear name")
+            .await
+            .unwrap();
+
+        let bear_type_tag = TypeTag::Struct(Box::new(StructTag {
+            address: (*package_id),
+            name: IdentStr::new("DemoBear").unwrap().into(),
+            module: IdentStr::new("demo_bear").unwrap().into(),
+            type_params: Vec::new(),
+        }));
+
+        for n in 0..consecutive_updates {
+            let new_bear_description = format!("Bear description {n}");
+
+            let res = update_display_object(
+                sender,
+                &sender_kp,
+                client,
+                &display_obj_id,
+                bear_type_tag.clone(),
+                "description",
+                &new_bear_description,
+            )
+            .await
+            .unwrap();
+            assert_eq!(res.status_ok(), Some(true));
+
+            let res = bump_display_object_version(
+                sender,
+                &sender_kp,
+                client,
+                &display_obj_id,
+                bear_type_tag.clone(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(res.status_ok(), Some(true));
+
+            let res = client
+                .get_object(bear_id, Some(IotaObjectDataOptions::new().with_display()))
+                .await
+                .unwrap();
+
+            let actual_description =
+                res.data.unwrap().display.unwrap().data.unwrap()["description"].clone();
+
+            assert_eq!(actual_description, new_bear_description);
+        }
+    });
+}
+
+async fn update_display_object(
+    address: IotaAddress,
+    addres_kp: &AccountKeyPair,
+    client: &HttpClient,
+    display_object_id: &ObjectID,
+    display_obj_type_tag: TypeTag,
+    name_to_update: &str,
+    new_value: &str,
+) -> Result<IotaTransactionBlockResponse, anyhow::Error> {
+    execute_move_call(
+        client,
+        address,
+        addres_kp,
+        IOTA_FRAMEWORK_PACKAGE_ID,
+        "display".to_string(),
+        "edit".to_string(),
+        type_args![display_obj_type_tag].unwrap(),
+        call_args!(
+            display_object_id,
+            name_to_update.to_string(),
+            new_value.to_string()
+        )
+        .unwrap(),
+    )
+    .await
+}
+
+async fn bump_display_object_version(
+    address: IotaAddress,
+    addres_kp: &AccountKeyPair,
+    client: &HttpClient,
+    display_object_id: &ObjectID,
+    display_obj_type_tag: TypeTag,
+) -> Result<IotaTransactionBlockResponse, anyhow::Error> {
+    execute_move_call(
+        client,
+        address,
+        addres_kp,
+        IOTA_FRAMEWORK_PACKAGE_ID,
+        "display".to_string(),
+        "update_version".to_string(),
+        type_args![display_obj_type_tag].unwrap(),
+        call_args!(display_object_id).unwrap(),
+    )
+    .await
 }
 
 async fn create_counter_object(
@@ -435,12 +560,85 @@ async fn increment_counter(
     Ok(res)
 }
 
+async fn create_new_bear(
+    address: IotaAddress,
+    addres_kp: &AccountKeyPair,
+    client: &HttpClient,
+    package_id: &ObjectID,
+    name: &str,
+) -> Result<(IotaTransactionBlockResponse, ObjectID), anyhow::Error> {
+    let module = "demo_bear".to_string();
+    let function = "new".to_string();
+
+    let gas = client
+        .get_all_coins(address, None, None)
+        .await
+        .unwrap()
+        .data[0]
+        .object_ref();
+
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let name_arg = builder.input(CallArg::Pure(bcs::to_bytes(name).unwrap()))?;
+        let bear = builder.programmable_move_call(
+            *package_id,
+            Identifier::from_str(&module)?,
+            Identifier::from_str(&function)?,
+            vec![],
+            vec![name_arg],
+        );
+        builder.transfer_arg(address, bear);
+        builder.finish()
+    };
+
+    let tx_builder = TestTransactionBuilder::new(address, gas, 1000);
+    let tx_data = tx_builder.programmable(pt).build();
+    let signed_transaction = to_sender_signed_transaction(tx_data, addres_kp);
+    let (tx_bytes, signatures) = signed_transaction.to_tx_bytes_and_signatures();
+
+    let res = client
+        .execute_transaction_block(
+            tx_bytes,
+            signatures,
+            Some(IotaTransactionBlockResponseOptions::full_content()),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await
+        .unwrap();
+
+    let bear_id = res
+        .effects
+        .as_ref()
+        .unwrap()
+        .created()
+        .iter()
+        .exactly_one()
+        .unwrap()
+        .object_id();
+
+    Ok((res, bear_id))
+}
+
 async fn deploy_basics_pkg(
     address: IotaAddress,
     address_kp: &AccountKeyPair,
     client: &HttpClient,
-) -> IotaTransactionBlockResponse {
+) -> (IotaTransactionBlockResponse, ObjectID) {
     deploy_package(address, address_kp, client, "../../examples/move/basics").await
+}
+
+async fn deploy_bear_pkg(
+    address: IotaAddress,
+    addres_kp: &AccountKeyPair,
+    client: &HttpClient,
+) -> (IotaTransactionBlockResponse, ObjectID) {
+    deploy_package(
+        address,
+        addres_kp,
+        client,
+        "../../examples/trading/contracts/demo",
+    )
+    .await
 }
 
 async fn deploy_package(
@@ -448,7 +646,7 @@ async fn deploy_package(
     address_kp: &AccountKeyPair,
     client: &HttpClient,
     pkg_path: &str,
-) -> IotaTransactionBlockResponse {
+) -> (IotaTransactionBlockResponse, ObjectID) {
     let compiled_package = BuildConfig::new_for_testing()
         .build(Path::new(pkg_path))
         .unwrap();
@@ -470,7 +668,7 @@ async fn deploy_package(
     let txn = to_sender_signed_transaction(tx_bytes.to_data().unwrap(), address_kp);
 
     let (tx_bytes, signatures) = txn.to_tx_bytes_and_signatures();
-    client
+    let res = client
         .execute_transaction_block(
             tx_bytes,
             signatures,
@@ -478,5 +676,19 @@ async fn deploy_package(
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await
+        .unwrap();
+
+    let package_id = *res
+        .object_changes
+        .as_ref()
         .unwrap()
+        .iter()
+        .filter_map(|o| match o {
+            ObjectChange::Published { package_id, .. } => Some(package_id),
+            _ => None,
+        })
+        .exactly_one()
+        .unwrap();
+
+    (res, package_id)
 }


### PR DESCRIPTION
# Description of change

Do not reindex objects in checkpoint indexing, fix race conditions for display table

In general this PR makes sure that it's safe to index old transactions, in a sense that newer data will not be overwritten by older data. (with an exception of concurrent indexing, and indexing transactions for which dependencies are not yet indexed)

This PR is a first step to fix race conditions on `objects` table. To fix them completely https://github.com/iotaledger/iota/issues/7290 and https://github.com/iotaledger/iota/issues/6321 would need to be completed.
This PR fixes race conditions on `display` table completely.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/7289

## How the change has been tested

`cargo test --profile simulator --package iota-indexer --test rpc-tests --all-features`

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage) - partially tested, race conditions on `display` table are fixed so they are tested, tests for `objects` table can be added later when remaining issues are closed

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
