### PR TITLE
fix(node): Improve select_gas in REST-API

### DIFF
--- a/crates/iota-rest-api/src/transactions/resolve.rs
+++ b/crates/iota-rest-api/src/transactions/resolve.rs
@@ -581,17 +581,16 @@ fn select_gas(
     for (object_ref, value) in gas_coins {
         selected_gas.push(object_ref);
         selected_gas_value += value;
+        if selected_gas_value >= budget {
+            return Ok(selected_gas);
+        }
     }
 
-    if selected_gas_value >= budget {
-        Ok(selected_gas)
-    } else {
-        Err(RestError::new(
-            axum::http::StatusCode::BAD_REQUEST,
-            format!(
-                "unable to select sufficient gas coins from account {owner} \
-                    to satisfy required budget {budget}"
-            ),
-        ))
-    }
+    Err(RestError::new(
+        axum::http::StatusCode::BAD_REQUEST,
+        format!(
+            "unable to select sufficient gas coins from account {owner} \
+                to satisfy required budget {budget}"
+        ),
+    ))
 }

--- a/crates/iota-rest-api/src/transactions/resolve.rs
+++ b/crates/iota-rest-api/src/transactions/resolve.rs
@@ -572,6 +572,7 @@ fn select_gas(
                 .ok()
                 .map(|coin| (object.compute_object_reference(), coin.value()))
         })
+        .sorted_by(|object1, object2| object2.1.cmp(&object1.1))
         .take(max_gas_payment_objects as usize);
 
     let mut selected_gas = vec![];


### PR DESCRIPTION
# Description of change
Minor improvements to upstream merges:
* Sort gas coin by amount in `select_gas`, prevent account lockout by ensuring higher-value coins are considered during selection.
* Return the result in `select_gas` as soon as the condition is met.

## Links to any relevant issues

Fixes #7303 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
