### PR TITLE
feat(starfish): read headers to send with a block

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -313,8 +313,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
     async fn handle_subscribe_block_bundles_request(
         &self,
-        _peer: AuthorityIndex,
-        _last_received: Round,
+        peer: AuthorityIndex,
+        last_received: Round,
     ) -> ConsensusResult<BlockBundleStream> {
         fail_point_async!("consensus-rpc-response");
 
@@ -343,11 +343,11 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         // TODO::deal with possible error in try_from
         Ok(Box::pin(missed_blocks.chain({
             let dag_state = Arc::clone(&self.dag_state);
-            let peer = peer;
 
             broadcasted_blocks.map(move |block| {
                 let mut dag_state_guard = dag_state.write();
-                let block_headers = dag_state_guard.take_unknown_headers_for_authority(peer);
+                let block_headers =
+                    dag_state_guard.take_unknown_headers_for_authority(peer, block.round());
                 let block_bundle = BlockBundle {
                     verified_block: block,
                     verified_headers: block_headers,
@@ -702,7 +702,6 @@ impl SubscriptionCounter {
 /// It yields blocks that are broadcasted after the stream is created.
 type BroadcastedBlockStream = BroadcastStream<VerifiedBlock>;
 
-type BroadcastedBlockBundleStream = BroadcastStream<BlockBundle>;
 /// Adapted from `tokio_stream::wrappers::BroadcastStream`. The main difference
 /// is that this tolerates lags with only logging, without yielding errors.
 struct BroadcastStream<T> {

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -28,8 +28,8 @@ use crate::{
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
     network::{
-        BlockBundleStream, BlockStream, NetworkService, SerializedBlock, SerializedBlockBundle,
-        SerializedHeaderAndTransactions,
+        BlockBundle, BlockBundleStream, BlockStream, NetworkService, SerializedBlock,
+        SerializedBlockBundle, SerializedHeaderAndTransactions,
     },
     stake_aggregator::{QuorumThreshold, StakeAggregator},
     storage::Store,
@@ -316,7 +316,45 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         _peer: AuthorityIndex,
         _last_received: Round,
     ) -> ConsensusResult<BlockBundleStream> {
-        unimplemented!("Unimplemented")
+        fail_point_async!("consensus-rpc-response");
+
+        let dag_state = self.dag_state.read();
+        // Find recent own blocks that have not been received by the peer.
+        // If last_received is a valid and more blocks have been proposed since then,
+        // this call is guaranteed to return at least some recent blocks, which
+        // will help with liveness.
+        // TODO:: do we need to add some headers here?
+        let missed_blocks = stream::iter(
+            dag_state
+                .get_cached_blocks(self.context.own_index, last_received + 1)
+                .into_iter()
+                // TODO::deal with possible error in try_from
+                .map(|block| SerializedBlockBundle::try_from(block).unwrap()),
+        );
+
+        let broadcasted_blocks = BroadcastedBlockStream::new(
+            peer,
+            self.rx_block_broadcaster.resubscribe(),
+            self.subscription_counter.clone(),
+        );
+
+        // Return a stream of blocks that first yields missed blocks as requested, then
+        // new blocks.
+        // TODO::deal with possible error in try_from
+        Ok(Box::pin(missed_blocks.chain({
+            let dag_state = Arc::clone(&self.dag_state);
+            let peer = peer;
+
+            broadcasted_blocks.map(move |block| {
+                let mut dag_state_guard = dag_state.write();
+                let block_headers = dag_state_guard.take_unknown_headers_for_authority(peer);
+                let block_bundle = BlockBundle {
+                    verified_block: block,
+                    verified_headers: block_headers,
+                };
+                SerializedBlockBundle::try_from(block_bundle).unwrap()
+            })
+        })))
     }
 
     async fn handle_fetch_block_headers(
@@ -664,6 +702,7 @@ impl SubscriptionCounter {
 /// It yields blocks that are broadcasted after the stream is created.
 type BroadcastedBlockStream = BroadcastStream<VerifiedBlock>;
 
+type BroadcastedBlockBundleStream = BroadcastStream<BlockBundle>;
 /// Adapted from `tokio_stream::wrappers::BroadcastStream`. The main difference
 /// is that this tolerates lags with only logging, without yielding errors.
 struct BroadcastStream<T> {

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    cmp::max,
+    cmp::{max, min},
     collections::{BTreeMap, BTreeSet, HashSet, VecDeque},
     mem,
     ops::Bound::{Excluded, Included, Unbounded},
@@ -1122,24 +1122,34 @@ impl DagState {
             .expect("We expect authority index should be valid") = new_map;
     }
 
+    /// Takes a batch of at most MAX_HEADERS_PER_BUNDLE unknown headers for the
+    /// given authority, but only from round smaller than
+    /// round_upper_bound_exclusive. Marks these headers as known to the
+    /// authority.
     pub(crate) fn take_unknown_headers_for_authority(
         &mut self,
         authority_index: AuthorityIndex,
+        round_upper_bound_exclusive: Round,
     ) -> Vec<VerifiedBlockHeader> {
         let mut set =
             mem::take(&mut self.block_headers_not_known_by_authority[authority_index.value()]);
-        let block_refs: Vec<BlockRef> = {
-            if set.len() <= MAX_HEADERS_PER_BUNDLE {
-                mem::take(&mut set).into_iter().collect()
-            } else {
-                let cut_off = *set.iter().nth(MAX_HEADERS_PER_BUNDLE).unwrap();
-                let head = set.split_off(&cut_off);
-                let result = set.into_iter().collect();
-                set = head;
-                result
-            }
+
+        let split_point = {
+            let round_bound = BlockRef::new(
+                round_upper_bound_exclusive,
+                AuthorityIndex::MIN,
+                BlockHeaderDigest::MIN,
+            );
+            let nth_element = set
+                .iter()
+                .nth(MAX_HEADERS_PER_BUNDLE)
+                .map_or(round_bound, |x| *x);
+            min(nth_element, round_bound)
         };
-        self.block_headers_not_known_by_authority[authority_index.value()] = set;
+
+        let remaining = set.split_off(&split_point);
+        let block_refs: Vec<BlockRef> = set.into_iter().collect();
+        self.block_headers_not_known_by_authority[authority_index.value()] = remaining;
         for block_ref in block_refs.iter() {
             let (_, who_knows_given_block) = self.recent_dag_cordial_knowledge
                 [block_ref.author.value()]

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1147,10 +1147,11 @@ impl DagState {
             min(nth_element, round_bound)
         };
 
-        let remaining = set.split_off(&split_point);
-        let block_refs: Vec<BlockRef> = set.into_iter().collect();
-        self.block_headers_not_known_by_authority[authority_index.value()] = remaining;
-        for block_ref in block_refs.iter() {
+        self.block_headers_not_known_by_authority[authority_index.value()] =
+            set.split_off(&split_point);
+        let mut block_refs: Vec<BlockRef> = vec![];
+        for block_ref in set.into_iter() {
+            block_refs.push(block_ref);
             let (_, who_knows_given_block) = self.recent_dag_cordial_knowledge
                 [block_ref.author.value()]
             .get_mut(&(block_ref.round, block_ref.digest))

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -5,6 +5,7 @@
 use std::{
     cmp::max,
     collections::{BTreeMap, BTreeSet, HashSet, VecDeque},
+    mem,
     ops::Bound::{Excluded, Included, Unbounded},
     panic,
     sync::Arc,
@@ -36,6 +37,7 @@ use crate::{
 /// block.
 // TODO: make it derivable from the protocol parameters
 pub(crate) const MAX_TRANSACTIONS_ACK_DEPTH: Round = 50;
+const MAX_HEADERS_PER_BUNDLE: usize = 10;
 
 /// DagState provides the API to write and read accepted blocks from the DAG.
 /// Only uncommitted and last committed blocks are cached in memory.
@@ -1118,6 +1120,37 @@ impl DagState {
             .recent_dag_cordial_knowledge
             .get_mut(authority_index)
             .expect("We expect authority index should be valid") = new_map;
+    }
+
+    pub(crate) fn take_unknown_headers_for_authority(
+        &mut self,
+        authority_index: AuthorityIndex,
+    ) -> Vec<VerifiedBlockHeader> {
+        let mut set =
+            mem::take(&mut self.block_headers_not_known_by_authority[authority_index.value()]);
+        let block_refs: Vec<BlockRef> = {
+            if set.len() <= MAX_HEADERS_PER_BUNDLE {
+                mem::take(&mut set).into_iter().collect()
+            } else {
+                let cut_off = *set.iter().nth(MAX_HEADERS_PER_BUNDLE).unwrap();
+                let head = set.split_off(&cut_off);
+                let result = set.into_iter().collect();
+                set = head;
+                result
+            }
+        };
+        self.block_headers_not_known_by_authority[authority_index.value()] = set;
+        for block_ref in block_refs.iter() {
+            let (_, who_knows_given_block) = self.recent_dag_cordial_knowledge
+                [block_ref.author.value()]
+            .get_mut(&(block_ref.round, block_ref.digest))
+            .expect("We expect block ref to be in recent dag cordial knowledge");
+            who_knows_given_block.insert(authority_index);
+        }
+        self.get_block_headers(&block_refs)
+            .into_iter()
+            .map(|opt| opt.expect("All headers should be in DagState or on disk"))
+            .collect()
     }
 
     pub(crate) fn take_commit_votes(&mut self, limit: usize) -> Vec<CommitVote> {

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -289,6 +289,83 @@ impl TryFrom<SerializedBlock> for SerializedHeaderAndTransactions {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub(crate) struct BlockBundle {
+    pub(crate) verified_block: VerifiedBlock,
+    pub(crate) verified_headers: Vec<VerifiedBlockHeader>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub(crate) struct SerializedBlockAndHeaders {
+    pub(crate) serialized_block: Bytes,
+    pub(crate) serialized_headers: Vec<Bytes>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct SerializedBlockBundle {
     pub(crate) serialized_block_bundle: Bytes,
+}
+
+impl TryFrom<VerifiedBlock> for SerializedBlockAndHeaders {
+    type Error = ConsensusError;
+    fn try_from(verified_block: VerifiedBlock) -> ConsensusResult<Self> {
+        let (serialized_block_header, serialized_transactions) = verified_block.serialized();
+        let serialized_header_and_transactions = SerializedHeaderAndTransactions {
+            serialized_block_header: serialized_block_header.clone(),
+            serialized_transactions: serialized_transactions.clone(),
+        };
+        let bytes = bcs::to_bytes(&serialized_header_and_transactions)
+            .map_err(ConsensusError::SerializationFailure)?;
+        Ok(Self {
+            serialized_block: Bytes::from(bytes),
+            serialized_headers: vec![],
+        })
+    }
+}
+
+impl TryFrom<BlockBundle> for SerializedBlockAndHeaders {
+    type Error = ConsensusError;
+    fn try_from(block_bundle: BlockBundle) -> ConsensusResult<Self> {
+        let (serialized_block_header, serialized_transactions) =
+            block_bundle.verified_block.serialized();
+        let serialized_header_and_transactions = SerializedHeaderAndTransactions {
+            serialized_block_header: serialized_block_header.clone(),
+            serialized_transactions: serialized_transactions.clone(),
+        };
+        let bytes = bcs::to_bytes(&serialized_header_and_transactions)
+            .map_err(ConsensusError::SerializationFailure)?;
+        let mut serialized_block_headers = vec![];
+        for block_header in block_bundle.verified_headers.into_iter() {
+            serialized_block_headers.push(block_header.serialized().clone());
+        }
+
+        Ok(Self {
+            serialized_block: Bytes::from(bytes),
+            serialized_headers: serialized_block_headers,
+        })
+    }
+}
+
+impl TryFrom<SerializedBlockAndHeaders> for SerializedBlockBundle {
+    type Error = ConsensusError;
+    fn try_from(serialized_block_and_headers: SerializedBlockAndHeaders) -> ConsensusResult<Self> {
+        let bytes = bcs::to_bytes(&serialized_block_and_headers)
+            .map_err(ConsensusError::SerializationFailure)?;
+        Ok(Self {
+            serialized_block_bundle: Bytes::from(bytes),
+        })
+    }
+}
+
+impl TryFrom<VerifiedBlock> for SerializedBlockBundle {
+    type Error = ConsensusError;
+    fn try_from(verified_block: VerifiedBlock) -> ConsensusResult<Self> {
+        SerializedBlockBundle::try_from(SerializedBlockAndHeaders::try_from(verified_block)?)
+    }
+}
+
+impl TryFrom<BlockBundle> for SerializedBlockBundle {
+    type Error = ConsensusError;
+    fn try_from(block_bundle: BlockBundle) -> ConsensusResult<Self> {
+        SerializedBlockBundle::try_from(SerializedBlockAndHeaders::try_from(block_bundle)?)
+    }
 }


### PR DESCRIPTION
# Description of change

The PR modifies block streaming to include headers unknown to the peer.

## Links to any relevant issues

#7368 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
