### PR TITLE
feat(starfish): handle additional headers on receiving end

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -420,7 +420,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 self.context
                     .metrics
                     .node_metrics
-                    .invalid_header_in_a_bundle
+                    .invalid_headers_in_a_bundle
                     .with_label_values(&[
                         peer_hostname.as_str(),
                         "handle_subscribed_block_bundle",
@@ -439,7 +439,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 self.context
                     .metrics
                     .node_metrics
-                    .invalid_header_in_a_bundle
+                    .invalid_headers_in_a_bundle
                     .with_label_values(&[
                         peer_hostname.as_str(),
                         "handle_subscribed_block_bundle",
@@ -455,6 +455,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             let verified_block_header =
                 VerifiedBlockHeader::new_verified(signed_block_header, serialized_header);
             additional_block_headers.push(verified_block_header);
+            self.context
+                .metrics
+                .node_metrics
+                .valid_headers_in_a_bundle
+                .with_label_values(&[peer_hostname.as_str(), "handle_subscribed_block_bundle"])
+                .inc();
         }
 
         // 5. Observe headers and the block for the commit votes. When local commit is
@@ -465,6 +471,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         self.commit_vote_monitor.observe_block(&verified_block);
 
         // TODO:: add filtering for already processed blocks/headers
+        // TODO:: add metric for filtered blocks/headers
 
         // 6. Reject blocks when local commit index is lagging too far from quorum
         //    commit
@@ -513,6 +520,19 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         //    them
         // Normally, there should be no missing ancestors, as the headers are sent in
         // order of increasing rounds.
+
+        // TODO::Uncomment when the filter for headers is implemented, and already
+        // processed headers are removed from additional_block_headers. Before that it
+        // is incorrect
+        // self.context
+        // .metrics
+        // .node_metrics
+        // .received_unique_headers_from_a_bundle
+        // .with_label_values(&[
+        // peer_hostname.as_str(),
+        // "handle_subscribed_block_bundle",
+        // ])
+        // .inc_by(additional_block_headers.len() as u64);
 
         let mut missing_ancestors = self
             .core_dispatcher

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -83,6 +83,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
 
 #[async_trait]
 impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
+    #[cfg(test)]
     async fn handle_subscribed_block(
         &self,
         peer: AuthorityIndex,
@@ -271,8 +272,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
     async fn handle_subscribed_block_bundle(
         &self,
-        _peer: AuthorityIndex,
-        _serialized_block_bundle: SerializedBlockBundle,
+        peer: AuthorityIndex,
+        serialized_block_bundle: SerializedBlockBundle,
     ) -> ConsensusResult<()> {
         fail_point_async!("consensus-rpc-response");
 

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -543,7 +543,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         // 8. Add block to dag, add its missing ancestors to the set
         // TODO:: consider possible optimization:
         // first try to accept the block. If it fails, try to find missing ancestors
-        // among additional headers and add only them.
+        // among additional headers and from block_round-1 add only them. From the
+        // rounds < block_round-1 add all headers
         missing_ancestors.extend(
             self.core_dispatcher
                 .add_blocks(vec![verified_block])

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -413,17 +413,33 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .map_err(ConsensusError::MalformedBlockHeader)?;
             let header_round = signed_block_header.round();
             if header_round >= verified_block.round() {
-                return Err(ConsensusError::TooBigHeaderRoundInABundle {
+                let e = Err(ConsensusError::TooBigHeaderRoundInABundle {
                     header_round,
                     block_round: verified_block.round(),
                 });
+                self.context
+                    .metrics
+                    .node_metrics
+                    .invalid_header_in_a_bundle
+                    .with_label_values(&[
+                        peer_hostname.as_str(),
+                        "handle_subscribed_block_bundle",
+                        "invalid round in header",
+                    ])
+                    .inc();
+                info!(
+                    "Invalid additional block header from {}: {}",
+                    peer,
+                    e.as_ref().unwrap_err()
+                );
+                return e;
             }
 
             if let Err(e) = self.block_verifier.verify(&signed_block_header) {
                 self.context
                     .metrics
                     .node_metrics
-                    .invalid_blocks
+                    .invalid_header_in_a_bundle
                     .with_label_values(&[
                         peer_hostname.as_str(),
                         "handle_subscribed_block_bundle",

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -25,7 +25,7 @@ use crate::{
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
     core_thread::CoreThreadDispatcher,
-    dag_state::DagState,
+    dag_state::{DagState, MAX_HEADERS_PER_BUNDLE},
     error::{ConsensusError, ConsensusResult},
     network::{
         BlockBundle, BlockBundleStream, BlockStream, NetworkService, SerializedBlock,
@@ -400,10 +400,24 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         // 4. Create block headers from bytes from a bundle
 
+        if serialized_block_and_headers.serialized_headers.len() > MAX_HEADERS_PER_BUNDLE {
+            return Err(ConsensusError::TooManyHeadersInABundle {
+                count: serialized_block_and_headers.serialized_headers.len(),
+                limit: MAX_HEADERS_PER_BUNDLE,
+            });
+        }
+
         let mut additional_block_headers = vec![];
         for serialized_header in serialized_block_and_headers.serialized_headers {
             let signed_block_header: SignedBlockHeader = bcs::from_bytes(&serialized_header)
                 .map_err(ConsensusError::MalformedBlockHeader)?;
+            let header_round = signed_block_header.round();
+            if header_round >= verified_block.round() {
+                return Err(ConsensusError::TooBigHeaderRoundInABundle {
+                    header_round,
+                    block_round: verified_block.round(),
+                });
+            }
 
             if let Err(e) = self.block_verifier.verify(&signed_block_header) {
                 self.context
@@ -491,6 +505,9 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .map_err(|_| ConsensusError::Shutdown)?;
 
         // 8. Add block to dag, add its missing ancestors to the set
+        // TODO:: consider possible optimization:
+        // first try to accept the block. If it fails, try to find missing ancestors
+        // among additional headers and add only them.
         missing_ancestors.extend(
             self.core_dispatcher
                 .add_blocks(vec![verified_block])

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -29,7 +29,7 @@ use crate::{
     error::{ConsensusError, ConsensusResult},
     network::{
         BlockBundle, BlockBundleStream, BlockStream, NetworkService, SerializedBlock,
-        SerializedBlockBundle, SerializedHeaderAndTransactions,
+        SerializedBlockAndHeaders, SerializedBlockBundle, SerializedHeaderAndTransactions,
     },
     stake_aggregator::{QuorumThreshold, StakeAggregator},
     storage::Store,
@@ -105,7 +105,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .invalid_blocks
                 .with_label_values(&[
                     peer_hostname.as_str(),
-                    "handle_send_block",
+                    "handle_subscribed_block",
                     "UnexpectedAuthority",
                 ])
                 .inc();
@@ -121,7 +121,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .invalid_blocks
                 .with_label_values(&[
                     peer_hostname.as_str(),
-                    "handle_send_block",
+                    "handle_subscribed_block",
                     e.clone().name(),
                 ])
                 .inc();
@@ -158,7 +158,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let verified_block = VerifiedBlock::new(verified_block_header, verified_transactions);
 
         let block_ref = verified_block.reference();
-        debug!("Received block {} via send block.", block_ref);
+        debug!("Received block {} via subscribed block.", block_ref);
 
         // Reject block with timestamp too far in the future.
         let now = self.context.clock.timestamp_utc_ms();
@@ -193,7 +193,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .metrics
                 .node_metrics
                 .block_timestamp_drift_wait_ms
-                .with_label_values(&[peer_hostname.as_str(), "handle_send_block"])
+                .with_label_values(&[peer_hostname.as_str(), "handle_subscribed_block"])
                 .inc_by(forward_time_drift.as_millis() as u64);
             debug!(
                 "Block {:?} timestamp ({} > {}) is in the future, waiting for {}ms",
@@ -269,12 +269,239 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         Ok(())
     }
 
-    async fn handle_subscribed_block_bundles(
+    async fn handle_subscribed_block_bundle(
         &self,
         _peer: AuthorityIndex,
         _serialized_block_bundle: SerializedBlockBundle,
     ) -> ConsensusResult<()> {
-        unimplemented!("Unimplemented")
+        fail_point_async!("consensus-rpc-response");
+
+        let peer_hostname = &self.context.committee.authority(peer).hostname;
+        // 1. Create a verified block and make some preliminary checks
+        let serialized_block_and_headers =
+            SerializedBlockAndHeaders::try_from(serialized_block_bundle)?;
+        let serialized_block_and_transactions =
+            SerializedHeaderAndTransactions::try_from(SerializedBlock {
+                serialized_block: serialized_block_and_headers.serialized_block,
+            })?;
+
+        let signed_block_header: SignedBlockHeader =
+            bcs::from_bytes(&serialized_block_and_transactions.serialized_block_header)
+                .map_err(ConsensusError::MalformedBlockHeader)?;
+
+        // Reject blocks not produced by the peer.
+        if peer != signed_block_header.author() {
+            self.context
+                .metrics
+                .node_metrics
+                .invalid_blocks
+                .with_label_values(&[
+                    peer_hostname.as_str(),
+                    "handle_subscribed_block_bundle",
+                    "UnexpectedAuthority",
+                ])
+                .inc();
+            let e = ConsensusError::UnexpectedAuthority(signed_block_header.author(), peer);
+            info!("Block with wrong authority from {}: {}", peer, e);
+            return Err(e);
+        }
+
+        if let Err(e) = self.block_verifier.verify(&signed_block_header) {
+            self.context
+                .metrics
+                .node_metrics
+                .invalid_blocks
+                .with_label_values(&[
+                    peer_hostname.as_str(),
+                    "handle_subscribed_block_bundle",
+                    e.clone().name(),
+                ])
+                .inc();
+            info!("Invalid block header from {}: {}", peer, e);
+            return Err(e);
+        }
+
+        if signed_block_header.transactions_commitment()
+            != TransactionsCommitment::compute_transactions_commitment(
+                &serialized_block_and_transactions.serialized_transactions,
+            )
+            .expect("we should expect correct computation of the transactions commitment")
+        {
+            return Err(ConsensusError::TransactionCommitmentFailure {
+                round: signed_block_header.round(),
+                author: signed_block_header.author(),
+                peer,
+            });
+        }
+
+        let verified_block_header = VerifiedBlockHeader::new_verified(
+            signed_block_header,
+            serialized_block_and_transactions.serialized_block_header,
+        );
+        let transactions: Vec<Transaction> =
+            bcs::from_bytes(&serialized_block_and_transactions.serialized_transactions)
+                .map_err(ConsensusError::MalformedTransactions)?;
+        let verified_transactions = VerifiedTransactions::new(
+            transactions,
+            verified_block_header.reference(),
+            verified_block_header.transactions_commitment(),
+            serialized_block_and_transactions.serialized_transactions,
+        );
+        let verified_block = VerifiedBlock::new(verified_block_header, verified_transactions);
+
+        let block_ref = verified_block.reference();
+        debug!("Received block {} via send block.", block_ref);
+
+        // 2. Reject block with timestamp too far in the future.
+        let now = self.context.clock.timestamp_utc_ms();
+        let forward_time_drift =
+            Duration::from_millis(verified_block.timestamp_ms().saturating_sub(now));
+        if forward_time_drift > self.context.parameters.max_forward_time_drift {
+            self.context
+                .metrics
+                .node_metrics
+                .rejected_future_blocks
+                .with_label_values(&[peer_hostname])
+                .inc();
+            debug!(
+                "Block {:?} timestamp ({} > {}) is too far in the future, rejected.",
+                block_ref,
+                verified_block.timestamp_ms(),
+                now,
+            );
+            return Err(ConsensusError::BlockRejected {
+                block_ref,
+                reason: format!(
+                    "Block timestamp is too far in the future: {} > {}",
+                    verified_block.timestamp_ms(),
+                    now
+                ),
+            });
+        }
+
+        // 3. Wait until the block's timestamp is current.
+        if forward_time_drift > Duration::ZERO {
+            self.context
+                .metrics
+                .node_metrics
+                .block_timestamp_drift_wait_ms
+                .with_label_values(&[peer_hostname.as_str(), "handle_subscribed_block_bundle"])
+                .inc_by(forward_time_drift.as_millis() as u64);
+            debug!(
+                "Block {:?} timestamp ({} > {}) is in the future, waiting for {}ms",
+                block_ref,
+                verified_block.timestamp_ms(),
+                now,
+                forward_time_drift.as_millis(),
+            );
+            sleep(forward_time_drift).await;
+        }
+
+        // 4. Create block headers from bytes from a bundle
+
+        let mut additional_block_headers = vec![];
+        for serialized_header in serialized_block_and_headers.serialized_headers {
+            let signed_block_header: SignedBlockHeader = bcs::from_bytes(&serialized_header)
+                .map_err(ConsensusError::MalformedBlockHeader)?;
+
+            if let Err(e) = self.block_verifier.verify(&signed_block_header) {
+                self.context
+                    .metrics
+                    .node_metrics
+                    .invalid_blocks
+                    .with_label_values(&[
+                        peer_hostname.as_str(),
+                        "handle_subscribed_block_bundle",
+                        e.clone().name(),
+                    ])
+                    .inc();
+                info!("Invalid additional block header from {}: {}", peer, e);
+                // TODO: should we continue to work with other headers or return error?
+                // return Err(e);
+                continue;
+            }
+
+            let verified_block_header =
+                VerifiedBlockHeader::new_verified(signed_block_header, serialized_header);
+            additional_block_headers.push(verified_block_header);
+        }
+
+        // Observe headers and the block for the commit votes. When local commit is
+        // lagging too much, commit sync loop will trigger fetching.
+        for block_header in additional_block_headers.iter() {
+            self.commit_vote_monitor.observe_block(block_header);
+        }
+        self.commit_vote_monitor.observe_block(&verified_block);
+
+        // Reject blocks when local commit index is lagging too far from quorum commit
+        // index.
+        //
+        // IMPORTANT: this must be done after observing votes from the block, otherwise
+        // observed quorum commit will no longer progress.
+        //
+        // Since the main issue with too many suspended blocks is memory usage not CPU,
+        // it is ok to reject after block verifications instead of before.
+        let last_commit_index = self.dag_state.read().last_commit_index();
+        let quorum_commit_index = self.commit_vote_monitor.quorum_commit_index();
+        // The threshold to ignore block should be larger than commit_sync_batch_size,
+        // to avoid excessive block rejections and synchronizations.
+
+        // TODO::  should we still process headers even if the block is rejected?
+        if last_commit_index
+            + self.context.parameters.commit_sync_batch_size * COMMIT_LAG_MULTIPLIER
+            < quorum_commit_index
+        {
+            self.context
+                .metrics
+                .node_metrics
+                .rejected_blocks
+                .with_label_values(&["commit_lagging"])
+                .inc();
+            debug!(
+                "Block {:?} is rejected because last commit index is lagging quorum commit index too much ({} < {})",
+                block_ref, last_commit_index, quorum_commit_index,
+            );
+            return Err(ConsensusError::BlockRejected {
+                block_ref,
+                reason: format!(
+                    "Last commit index is lagging quorum commit index too much ({} < {})",
+                    last_commit_index, quorum_commit_index,
+                ),
+            });
+        }
+
+        // handle headers
+
+        self.context
+            .metrics
+            .node_metrics
+            .verified_blocks
+            .with_label_values(&[peer_hostname])
+            .inc();
+
+        let mut missing_ancestors = self
+            .core_dispatcher
+            .add_block_headers(additional_block_headers)
+            .await
+            .map_err(|_| ConsensusError::Shutdown)?;
+
+        missing_ancestors.extend(
+            self.core_dispatcher
+                .add_blocks(vec![verified_block])
+                .await
+                .map_err(|_| ConsensusError::Shutdown)?,
+        );
+        if !missing_ancestors.is_empty() {
+            // schedule the fetching of them from this peer
+            if let Err(err) = self
+                .synchronizer
+                .fetch_block_headers(missing_ancestors, peer)
+                .await
+            {
+                warn!("Errored while trying to fetch missing ancestors via synchronizer: {err}");
+            }
+        }
+        Ok(())
     }
 
     async fn handle_subscribe_blocks(

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -426,21 +426,22 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             additional_block_headers.push(verified_block_header);
         }
 
-        // Observe headers and the block for the commit votes. When local commit is
+        // 5. Observe headers and the block for the commit votes. When local commit is
         // lagging too much, commit sync loop will trigger fetching.
         for block_header in additional_block_headers.iter() {
             self.commit_vote_monitor.observe_block(block_header);
         }
         self.commit_vote_monitor.observe_block(&verified_block);
 
-        // Reject blocks when local commit index is lagging too far from quorum commit
+        // TODO:: add filtering for already processed blocks/headers
+
+        // 6. Reject blocks when local commit index is lagging too far from quorum
+        //    commit
         // index.
         //
         // IMPORTANT: this must be done after observing votes from the block, otherwise
         // observed quorum commit will no longer progress.
-        //
-        // Since the main issue with too many suspended blocks is memory usage not CPU,
-        // it is ok to reject after block verifications instead of before.
+
         let last_commit_index = self.dag_state.read().last_commit_index();
         let quorum_commit_index = self.commit_vote_monitor.quorum_commit_index();
         // The threshold to ignore block should be larger than commit_sync_batch_size,
@@ -470,8 +471,6 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             });
         }
 
-        // handle headers
-
         self.context
             .metrics
             .node_metrics
@@ -479,12 +478,18 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             .with_label_values(&[peer_hostname])
             .inc();
 
+        // 7. Add additional headers from bundle to dag, receive missing ancestors for
+        //    them
+        // Normally, there should be no missing ancestors, as the headers are sent in
+        // order of increasing rounds.
+
         let mut missing_ancestors = self
             .core_dispatcher
             .add_block_headers(additional_block_headers)
             .await
             .map_err(|_| ConsensusError::Shutdown)?;
 
+        // 8. Add block to dag, add its missing ancestors to the set
         missing_ancestors.extend(
             self.core_dispatcher
                 .add_blocks(vec![verified_block])
@@ -492,7 +497,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 .map_err(|_| ConsensusError::Shutdown)?,
         );
         if !missing_ancestors.is_empty() {
-            // schedule the fetching of them from this peer
+            // 9. schedule the fetching of missing ancestors from this peer
             if let Err(err) = self
                 .synchronizer
                 .fetch_block_headers(missing_ancestors, peer)

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -37,7 +37,7 @@ use crate::{
 /// block.
 // TODO: make it derivable from the protocol parameters
 pub(crate) const MAX_TRANSACTIONS_ACK_DEPTH: Round = 50;
-const MAX_HEADERS_PER_BUNDLE: usize = 10;
+pub(crate) const MAX_HEADERS_PER_BUNDLE: usize = 50;
 
 /// DagState provides the API to write and read accepted blocks from the DAG.
 /// Only uncommitted and last committed blocks are cached in memory.

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -229,6 +229,17 @@ pub(crate) enum ConsensusError {
 
     #[error("Vector of shards is too small: {0} bytes found, at least {1} bytes needed")]
     ShardsVecIsTooSmall(usize, usize),
+
+    #[error("Block bundle contains too many additional headers: {count} > {limit}")]
+    TooManyHeadersInABundle { count: usize, limit: usize },
+
+    #[error(
+        "Round of the header in a bundle is greater or equal to the block round: {header_round} >= {block_round}"
+    )]
+    TooBigHeaderRoundInABundle {
+        header_round: Round,
+        block_round: Round,
+    },
 }
 
 impl ConsensusError {

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -130,6 +130,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) synchronizer_current_missing_blocks_by_authority: IntGaugeVec,
     pub(crate) synchronizer_fetched_blocks_by_authority: IntCounterVec,
     pub(crate) invalid_blocks: IntCounterVec,
+    pub(crate) invalid_header_in_a_bundle: IntCounterVec,
     pub(crate) rejected_blocks: IntCounterVec,
     pub(crate) rejected_future_blocks: IntCounterVec,
     pub(crate) subscribed_blocks: IntCounterVec,
@@ -377,6 +378,12 @@ impl NodeMetrics {
             invalid_blocks: register_int_counter_vec_with_registry!(
                 "invalid_blocks",
                 "Number of invalid blocks per peer authority",
+                &["authority", "source", "error"],
+                registry,
+            ).unwrap(),
+            invalid_header_in_a_bundle: register_int_counter_vec_with_registry!(
+                "invalid_header_in_a_bundle",
+                "Number of invalid block headers in block bundles per peer authority",
                 &["authority", "source", "error"],
                 registry,
             ).unwrap(),

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -130,7 +130,10 @@ pub(crate) struct NodeMetrics {
     pub(crate) synchronizer_current_missing_blocks_by_authority: IntGaugeVec,
     pub(crate) synchronizer_fetched_blocks_by_authority: IntCounterVec,
     pub(crate) invalid_blocks: IntCounterVec,
-    pub(crate) invalid_header_in_a_bundle: IntCounterVec,
+    pub(crate) invalid_headers_in_a_bundle: IntCounterVec,
+    pub(crate) valid_headers_in_a_bundle: IntCounterVec,
+    #[allow(dead_code)]
+    pub(crate) received_unique_headers_from_a_bundle: IntCounterVec,
     pub(crate) rejected_blocks: IntCounterVec,
     pub(crate) rejected_future_blocks: IntCounterVec,
     pub(crate) subscribed_blocks: IntCounterVec,
@@ -381,10 +384,22 @@ impl NodeMetrics {
                 &["authority", "source", "error"],
                 registry,
             ).unwrap(),
-            invalid_header_in_a_bundle: register_int_counter_vec_with_registry!(
-                "invalid_header_in_a_bundle",
-                "Number of invalid block headers in block bundles per peer authority",
+            invalid_headers_in_a_bundle: register_int_counter_vec_with_registry!(
+                "invalid_headers_in_a_bundle",
+                "Number of invalid block headers received from block bundles per peer authority",
                 &["authority", "source", "error"],
+                registry,
+            ).unwrap(),
+            valid_headers_in_a_bundle: register_int_counter_vec_with_registry!(
+                "valid_headers_in_a_bundle",
+                "Number of valid block headers received from block bundles per peer authority",
+                &["authority", "source"],
+                registry,
+            ).unwrap(),
+            received_unique_headers_from_a_bundle: register_int_counter_vec_with_registry!(
+                "received_unique_headers_from_a_bundle",
+                "Number of unique block headers received from block bundles per sender peer authority",
+                &["authority", "source"],
                 registry,
             ).unwrap(),
             rejected_blocks: register_int_counter_vec_with_registry!(

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -69,6 +69,7 @@ pub(crate) type BlockBundleStream = Pin<Box<dyn Stream<Item = SerializedBlockBun
 #[async_trait]
 pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
     /// Subscribes to blocks from a peer after last_received round.
+    // TODO:: remove when block bundles logic is finalized
     async fn subscribe_blocks(
         &self,
         peer: AuthorityIndex,
@@ -142,6 +143,7 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
     /// Handles the block sent from the peer via subscription stream. Peer value
     /// can be trusted to be a valid authority index. But serialized_block
     /// must be verified before its contents are trusted.
+    // TODO:: remove when block bundles logic is finalized
     async fn handle_subscribed_block(
         &self,
         peer: AuthorityIndex,
@@ -151,8 +153,7 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
     /// Handles the block and headers sent from the peer via subscription
     /// stream. Peer value can be trusted to be a valid authority index. But
     /// serialized_block must be verified before its contents are trusted.
-    #[allow(dead_code)]
-    async fn handle_subscribed_block_bundles(
+    async fn handle_subscribed_block_bundle(
         &self,
         peer: AuthorityIndex,
         serialized_block_bundle: SerializedBlockBundle,
@@ -353,6 +354,14 @@ impl TryFrom<SerializedBlockAndHeaders> for SerializedBlockBundle {
         Ok(Self {
             serialized_block_bundle: Bytes::from(bytes),
         })
+    }
+}
+
+impl TryFrom<SerializedBlockBundle> for SerializedBlockAndHeaders {
+    type Error = ConsensusError;
+    fn try_from(bundle: SerializedBlockBundle) -> ConsensusResult<Self> {
+        bcs::from_bytes(&bundle.serialized_block_bundle)
+            .map_err(ConsensusError::DeserializationFailure)
     }
 }
 

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -70,6 +70,7 @@ pub(crate) type BlockBundleStream = Pin<Box<dyn Stream<Item = SerializedBlockBun
 pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
     /// Subscribes to blocks from a peer after last_received round.
     // TODO:: remove when block bundles logic is finalized
+    #[allow(dead_code)]
     async fn subscribe_blocks(
         &self,
         peer: AuthorityIndex,
@@ -144,6 +145,7 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
     /// can be trusted to be a valid authority index. But serialized_block
     /// must be verified before its contents are trusted.
     // TODO:: remove when block bundles logic is finalized
+    #[cfg(test)]
     async fn handle_subscribed_block(
         &self,
         peer: AuthorityIndex,

--- a/crates/starfish/core/src/network/test_network.rs
+++ b/crates/starfish/core/src/network/test_network.rs
@@ -57,7 +57,7 @@ impl NetworkService for Mutex<TestService> {
         Ok(())
     }
 
-    async fn handle_subscribed_block_bundles(
+    async fn handle_subscribed_block_bundle(
         &self,
         _peer: AuthorityIndex,
         _serialized_block_bundle: SerializedBlockBundle,

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -143,8 +143,8 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
             }
             retries += 1;
 
-            let mut blocks = match network_client
-                .subscribe_blocks(peer, last_received, MAX_RETRY_INTERVAL)
+            let mut block_bundles = match network_client
+                .subscribe_block_bundles(peer, last_received, MAX_RETRY_INTERVAL)
                 .await
             {
                 Ok(blocks) => {
@@ -184,8 +184,9 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
                 .set(1);
 
             'stream: loop {
-                match blocks.next().await {
+                match block_bundles.next().await {
                     Some(block) => {
+                        // TODO:: make new metric for bundle, rename, or leave it as it is?
                         context
                             .metrics
                             .node_metrics
@@ -193,7 +194,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
                             .with_label_values(&[peer_hostname])
                             .inc();
                         let result = authority_service
-                            .handle_subscribed_block(peer, block.clone())
+                            .handle_subscribed_block_bundle(peer, block.clone())
                             .await;
                         if let Err(e) = result {
                             match e {


### PR DESCRIPTION
# Description of change

PR adds logic that handles headers received with a block in a block bundle.

## Links to any relevant issues

#7420 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
