### PR TITLE
feat(iota-sdk): add `tls_config` method to `IotaClientBuilder`

### DIFF
--- a/crates/iota-sdk/src/lib.rs
+++ b/crates/iota-sdk/src/lib.rs
@@ -213,7 +213,7 @@ impl IotaClientBuilder {
         self
     }
 
-    // Set a custom TLS configuration for the HTTP client.
+    /// Set a custom TLS configuration for the HTTP client.
     pub fn custom_tls_config(mut self, config: rustls::ClientConfig) -> Self {
         self.custom_tls_config = Some(config);
         self

--- a/crates/iota-sdk/src/lib.rs
+++ b/crates/iota-sdk/src/lib.rs
@@ -166,6 +166,7 @@ pub struct IotaClientBuilder {
     ws_url: Option<String>,
     ws_ping_interval: Option<Duration>,
     basic_auth: Option<(String, String)>,
+    custom_tls_config: Option<rustls::ClientConfig>,
 }
 
 impl Default for IotaClientBuilder {
@@ -176,6 +177,7 @@ impl Default for IotaClientBuilder {
             ws_url: None,
             ws_ping_interval: None,
             basic_auth: None,
+            custom_tls_config: None,
         }
     }
 }
@@ -208,6 +210,12 @@ impl IotaClientBuilder {
     /// Set the basic auth credentials for the HTTP client.
     pub fn basic_auth(mut self, username: impl AsRef<str>, password: impl AsRef<str>) -> Self {
         self.basic_auth = Some((username.as_ref().to_string(), password.as_ref().to_string()));
+        self
+    }
+
+    // Set a custom TLS configuration for the HTTP client.
+    pub fn custom_tls_config(mut self, config: rustls::ClientConfig) -> Self {
+        self.custom_tls_config = Some(config);
         self
     }
 
@@ -283,6 +291,10 @@ impl IotaClientBuilder {
 
         if let Some(max_concurrent_requests) = self.max_concurrent_requests {
             http_builder = http_builder.max_concurrent_requests(max_concurrent_requests);
+        }
+
+        if let Some(custom_tls_config) = self.custom_tls_config {
+            http_builder = http_builder.with_custom_cert_store(custom_tls_config);
         }
 
         let http = http_builder.build(http)?;

--- a/crates/iota-sdk/src/lib.rs
+++ b/crates/iota-sdk/src/lib.rs
@@ -166,7 +166,7 @@ pub struct IotaClientBuilder {
     ws_url: Option<String>,
     ws_ping_interval: Option<Duration>,
     basic_auth: Option<(String, String)>,
-    custom_tls_config: Option<rustls::ClientConfig>,
+    tls_config: Option<rustls::ClientConfig>,
 }
 
 impl Default for IotaClientBuilder {
@@ -177,7 +177,7 @@ impl Default for IotaClientBuilder {
             ws_url: None,
             ws_ping_interval: None,
             basic_auth: None,
-            custom_tls_config: None,
+            tls_config: None,
         }
     }
 }
@@ -213,9 +213,9 @@ impl IotaClientBuilder {
         self
     }
 
-    /// Set a custom TLS configuration for the HTTP client.
-    pub fn custom_tls_config(mut self, config: rustls::ClientConfig) -> Self {
-        self.custom_tls_config = Some(config);
+    /// Set a TLS configuration for the HTTP client.
+    pub fn tls_config(mut self, config: rustls::ClientConfig) -> Self {
+        self.tls_config = Some(config);
         self
     }
 
@@ -293,8 +293,8 @@ impl IotaClientBuilder {
             http_builder = http_builder.max_concurrent_requests(max_concurrent_requests);
         }
 
-        if let Some(custom_tls_config) = self.custom_tls_config {
-            http_builder = http_builder.with_custom_cert_store(custom_tls_config);
+        if let Some(tls_config) = self.tls_config {
+            http_builder = http_builder.with_custom_cert_store(tls_config);
         }
 
         let http = http_builder.build(http)?;


### PR DESCRIPTION
# Description of change

This change introduces a new method, `custom_tls_config(config: rustls::ClientConfig)`, to the `IotaClientBuilder`.

The reason for this change is to enable support for platforms like Android that require special TLS initialization. The SDK's upstream dependency, `jsonrpsee`, uses `rustls-platform-verifier`, which panics if used on Android without being initialized with the JNI context first.

Currently, as far as I am aware there is no way for a developer using `iota-sdk` to perform this required initialization and then pass the correctly configured TLS settings to the client.

This new method solves the problem by allowing a developer to create a fully-configured `rustls::ClientConfig` (using the platform verifier) and then inject it into the `IotaClientBuilder`. The builder then uses this config to create its internal HTTP client, resolving the panic and enabling proper, secure TLS connections on Android.

**Example Usage:**
```rust
use rustls::ClientConfig;
use rustls_platform_verifier::BuilderVerifierExt;

// (After platform verifier is initialized...)
let arc_crypto_provider = std::sync::Arc::new(rustls::crypto::ring::default_provider());
let config = ClientConfig::builder_with_provider(arc_crypto_provider)
    .with_safe_default_protocol_versions()
    .unwrap()
    .with_platform_verifier()
    .unwrap()
    .with_no_client_auth();

// The custom ClientConfig is provided to the builder.
let iota_mainnet = IotaClientBuilder::default()
    .custom_tls_config(config) 
    .build_mainnet()
    .await
    .unwrap();
```
## Links to any relevant issues

Fixes #7411

## How the change has been tested

The fix has been validated using a complete Tauri application on a physical Android device (Android 15).

Make sure to provide instructions for the maintainer as well as any relevant configurations.

**Instructions to reproduce the validation:**
1. Ensure you have completed the prerequisite setup from [the original issue description](https://github.com/iotaledger/iota/issues/7411#issue-3150119780).
2. In your local clone of my-app, checkout the new branch: `git checkout feat/initialize-rustls-platform-verifier`
3. Set the following environment variables (assuming you've set the `NDK_HOME` in step 1 described above):
```
export ANDROID_NDK_ROOT=$NDK_HOME
export ANDROID_NDK=$NDK_HOME
```
4. Navigate to the src-tauri directory and run `cargo clean` to ensure a fresh build.
5. Run cargo tauri android dev with an Android device connected.
6. The app will open, and the "Greet" button will now function correctly.

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](../../CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

### Release Notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [x] Rust SDK: **Added** `ClientBuilder::tls_config()` to allow custom `rustls` configurations. This is essential for platforms like Android that require special TLS initialization (e.g., using `rustls-platform-verifier`).
- [ ] REST API:
