### PR TITLE
feat(starfish): add transaction verification after receiving block from stream

### DIFF
--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -150,6 +150,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let transactions: Vec<Transaction> =
             bcs::from_bytes(&serialized_block_and_transactions.serialized_transactions)
                 .map_err(ConsensusError::MalformedTransactions)?;
+        self.block_verifier
+            .check_and_verify_transactions(&transactions)?;
         let verified_transactions = VerifiedTransactions::new(
             transactions,
             verified_block_header.reference(),
@@ -342,6 +344,10 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let transactions: Vec<Transaction> =
             bcs::from_bytes(&serialized_block_and_transactions.serialized_transactions)
                 .map_err(ConsensusError::MalformedTransactions)?;
+
+        self.block_verifier
+            .check_and_verify_transactions(&transactions)?;
+
         let verified_transactions = VerifiedTransactions::new(
             transactions,
             verified_block_header.reference(),

--- a/crates/starfish/core/src/block_manager.rs
+++ b/crates/starfish/core/src/block_manager.rs
@@ -614,16 +614,7 @@ mod tests {
     use rand::{SeedableRng, prelude::StdRng, seq::SliceRandom};
     use starfish_config::AuthorityIndex;
 
-    use crate::{
-        block_header::{BlockHeaderAPI, BlockRef, SignedBlockHeader, VerifiedBlockHeader},
-        block_manager::BlockManager,
-        block_verifier::{BlockVerifier, NoopBlockVerifier},
-        context::Context,
-        dag_state::DagState,
-        error::{ConsensusError, ConsensusResult},
-        storage::mem_store::MemStore,
-        test_dag_builder::DagBuilder,
-    };
+    use crate::{block_header::{BlockHeaderAPI, BlockRef, SignedBlockHeader, VerifiedBlockHeader}, block_manager::BlockManager, block_verifier::{BlockVerifier, NoopBlockVerifier}, context::Context, dag_state::DagState, error::{ConsensusError, ConsensusResult}, storage::mem_store::MemStore, test_dag_builder::DagBuilder, Transaction};
 
     #[tokio::test]
     async fn suspend_blocks_with_missing_ancestors() {
@@ -836,6 +827,10 @@ mod tests {
 
     impl BlockVerifier for TestBlockVerifier {
         fn verify(&self, _block: &SignedBlockHeader) -> ConsensusResult<()> {
+            Ok(())
+        }
+
+        fn check_and_verify_transactions(&self, transactions: &Vec<Transaction>)  -> ConsensusResult<()> {
             Ok(())
         }
 

--- a/crates/starfish/core/src/block_manager.rs
+++ b/crates/starfish/core/src/block_manager.rs
@@ -842,7 +842,7 @@ mod tests {
 
         fn check_and_verify_transactions(
             &self,
-            transactions: &Vec<Transaction>,
+            _transactions: &[Transaction],
         ) -> ConsensusResult<()> {
             Ok(())
         }

--- a/crates/starfish/core/src/block_manager.rs
+++ b/crates/starfish/core/src/block_manager.rs
@@ -614,7 +614,17 @@ mod tests {
     use rand::{SeedableRng, prelude::StdRng, seq::SliceRandom};
     use starfish_config::AuthorityIndex;
 
-    use crate::{block_header::{BlockHeaderAPI, BlockRef, SignedBlockHeader, VerifiedBlockHeader}, block_manager::BlockManager, block_verifier::{BlockVerifier, NoopBlockVerifier}, context::Context, dag_state::DagState, error::{ConsensusError, ConsensusResult}, storage::mem_store::MemStore, test_dag_builder::DagBuilder, Transaction};
+    use crate::{
+        Transaction,
+        block_header::{BlockHeaderAPI, BlockRef, SignedBlockHeader, VerifiedBlockHeader},
+        block_manager::BlockManager,
+        block_verifier::{BlockVerifier, NoopBlockVerifier},
+        context::Context,
+        dag_state::DagState,
+        error::{ConsensusError, ConsensusResult},
+        storage::mem_store::MemStore,
+        test_dag_builder::DagBuilder,
+    };
 
     #[tokio::test]
     async fn suspend_blocks_with_missing_ancestors() {
@@ -830,7 +840,10 @@ mod tests {
             Ok(())
         }
 
-        fn check_and_verify_transactions(&self, transactions: &Vec<Transaction>)  -> ConsensusResult<()> {
+        fn check_and_verify_transactions(
+            &self,
+            transactions: &Vec<Transaction>,
+        ) -> ConsensusResult<()> {
             Ok(())
         }
 

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -5,6 +5,7 @@
 use std::{collections::BTreeSet, sync::Arc};
 
 use crate::{
+    Transaction,
     block_header::{
         BlockHeaderAPI, BlockRef, BlockTimestampMs, GENESIS_ROUND, SignedBlockHeader,
         VerifiedBlockHeader, genesis_block_headers,
@@ -30,6 +31,8 @@ pub(crate) trait BlockVerifier: Send + Sync + 'static {
         block: &VerifiedBlockHeader,
         ancestors: &[Option<VerifiedBlockHeader>],
     ) -> ConsensusResult<()>;
+    fn check_and_verify_transactions(&self, transactions: &Vec<Transaction>)
+    -> ConsensusResult<()>;
 }
 
 /// `SignedBlockVerifier` checks the validity of a block.
@@ -40,10 +43,7 @@ pub(crate) trait BlockVerifier: Send + Sync + 'static {
 pub(crate) struct SignedBlockVerifier {
     context: Arc<Context>,
     genesis: BTreeSet<BlockRef>,
-    #[expect(dead_code)]
-    transaction_verifier: Arc<dyn TransactionVerifier>, /* Expected to be unused until
-                                                         * transaction verification is
-                                                         * implemented */
+    transaction_verifier: Arc<dyn TransactionVerifier>,
 }
 
 impl SignedBlockVerifier {
@@ -61,10 +61,7 @@ impl SignedBlockVerifier {
             transaction_verifier,
         }
     }
-
-    // TODO: enable this function when including the transactions in data flow
-    #[cfg_attr(not(test), expect(unused))]
-    pub(crate) fn check_transactions(&self, batch: &[&[u8]]) -> ConsensusResult<()> {
+    fn check_transactions(&self, batch: &[&[u8]]) -> ConsensusResult<()> {
         let max_transaction_size_limit =
             self.context.protocol_config.max_transaction_size_bytes() as usize;
         for t in batch {
@@ -188,6 +185,17 @@ impl BlockVerifier for SignedBlockVerifier {
         // TODO: transaction verification is removed from here. It should be done when
         // the transaction data gets available by Data/Transaction Manager
         Ok(())
+    }
+
+    fn check_and_verify_transactions(
+        &self,
+        transactions: &Vec<Transaction>,
+    ) -> ConsensusResult<()> {
+        let batch: Vec<_> = transactions.iter().map(|t| t.data()).collect();
+        self.check_transactions(&batch)?;
+        self.transaction_verifier
+            .verify_batch(&batch)
+            .map_err(|e| ConsensusError::InvalidTransaction(format!("{e:?}")))
     }
 
     fn check_ancestors(

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -31,8 +31,7 @@ pub(crate) trait BlockVerifier: Send + Sync + 'static {
         block: &VerifiedBlockHeader,
         ancestors: &[Option<VerifiedBlockHeader>],
     ) -> ConsensusResult<()>;
-    fn check_and_verify_transactions(&self, transactions: &Vec<Transaction>)
-    -> ConsensusResult<()>;
+    fn check_and_verify_transactions(&self, transactions: &[Transaction]) -> ConsensusResult<()>;
 }
 
 /// `SignedBlockVerifier` checks the validity of a block.
@@ -61,7 +60,7 @@ impl SignedBlockVerifier {
             transaction_verifier,
         }
     }
-    fn check_transactions(&self, batch: &[&[u8]]) -> ConsensusResult<()> {
+    pub(crate) fn check_transactions(&self, batch: &[&[u8]]) -> ConsensusResult<()> {
         let max_transaction_size_limit =
             self.context.protocol_config.max_transaction_size_bytes() as usize;
         for t in batch {
@@ -187,10 +186,7 @@ impl BlockVerifier for SignedBlockVerifier {
         Ok(())
     }
 
-    fn check_and_verify_transactions(
-        &self,
-        transactions: &Vec<Transaction>,
-    ) -> ConsensusResult<()> {
+    fn check_and_verify_transactions(&self, transactions: &[Transaction]) -> ConsensusResult<()> {
         let batch: Vec<_> = transactions.iter().map(|t| t.data()).collect();
         self.check_transactions(&batch)?;
         self.transaction_verifier
@@ -230,6 +226,10 @@ pub(crate) struct NoopBlockVerifier;
 #[cfg(test)]
 impl BlockVerifier for NoopBlockVerifier {
     fn verify(&self, _block: &SignedBlockHeader) -> ConsensusResult<()> {
+        Ok(())
+    }
+
+    fn check_and_verify_transactions(&self, _transactions: &[Transaction]) -> ConsensusResult<()> {
         Ok(())
     }
 

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -147,7 +147,6 @@ pub(crate) enum ConsensusError {
     #[error("Insufficient stake from parents: {parent_stakes} < {quorum}")]
     InsufficientParentStakes { parent_stakes: Stake, quorum: Stake },
 
-    #[expect(dead_code)]
     #[error("Invalid transaction: {0}")]
     InvalidTransaction(String), // TODO: To be used for transaction validation errors in tests
 


### PR DESCRIPTION
# Description of change

PR adds transaction verification after receiving a block from the stream.

## Links to any relevant issues

#7428 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
