### PR TITLE
feat: Allow all name commands to be called on domains and subdomains

### DIFF
--- a/crates/iota/src/name_commands.rs
+++ b/crates/iota/src/name_commands.rs
@@ -479,7 +479,7 @@ impl NameCommand {
                 opts,
             } => {
                 // Check ownership of the name off-chain to avoid potentially wasting gas
-                get_owned_nft_by_name::<IotaNamesRegistration>(&domain, context).await?;
+                get_proxy_nft_by_name(&domain, context).await?;
                 let iota_names_config = get_iota_names_config(&iota_client).await?;
 
                 let res = IotaClientCommands::Call {
@@ -567,12 +567,12 @@ impl NameCommand {
                 verbose,
                 opts,
             } => {
-                let nft = get_owned_nft_by_name::<IotaNamesRegistration>(&domain, context).await?;
+                let nft = get_proxy_nft_by_name(&domain, context).await?;
                 let iota_names_config = get_iota_names_config(&iota_client).await?;
 
                 let res = IotaClientCommands::Call {
-                    package: iota_names_config.package_address.into(),
-                    module: "controller".to_owned(),
+                    package: nft.controller_package_id(&iota_client).await?,
+                    module: nft.controller_module_name().to_owned(),
                     function: "set_user_data".to_owned(),
                     type_args: vec![],
                     args: vec![
@@ -701,12 +701,12 @@ impl NameCommand {
                 verbose,
                 opts,
             } => {
-                let nft = get_owned_nft_by_name::<IotaNamesRegistration>(&domain, context).await?;
+                let nft = get_proxy_nft_by_name(&domain, context).await?;
                 let iota_names_config = get_iota_names_config(&iota_client).await?;
 
                 let res = IotaClientCommands::Call {
-                    package: iota_names_config.package_address.into(),
-                    module: "controller".to_owned(),
+                    package: nft.controller_package_id(&iota_client).await?,
+                    module: nft.controller_module_name().to_owned(),
                     function: "unset_user_data".to_owned(),
                     type_args: vec![],
                     args: vec![


### PR DESCRIPTION
# Description of change

Allows commands which can be run on both domains and subdomains to do so.

## Links to any relevant issues

Closes #7006

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)