### PR TITLE
upstream(node): Add salt to TrafficSketch

### DIFF
--- a/crates/iota-core/src/traffic_controller/policies.rs
+++ b/crates/iota-core/src/traffic_controller/policies.rs
@@ -29,7 +29,11 @@ enum ClientType {
 }
 
 #[derive(Hash, Eq, PartialEq, Debug)]
-struct SketchKey(IpAddr, ClientType);
+struct SketchKey {
+    salt: u64,
+    ip_addr: IpAddr,
+    client_type: ClientType,
+}
 
 struct HighestRates {
     direct: BinaryHeap<Reverse<(u64, IpAddr)>>,
@@ -162,11 +166,11 @@ impl TrafficSketch {
     }
 
     fn update_highest_rates(&mut self, key: &SketchKey, rate: f64) {
-        match key.1 {
+        match key.client_type {
             ClientType::Direct => {
                 Self::update_highest_rate(
                     &mut self.highest_rates.direct,
-                    key.0,
+                    key.ip_addr,
                     rate,
                     self.highest_rates.capacity,
                 );
@@ -174,7 +178,7 @@ impl TrafficSketch {
             ClientType::ThroughFullnode => {
                 Self::update_highest_rate(
                     &mut self.highest_rates.proxied,
-                    key.0,
+                    key.ip_addr,
                     rate,
                     self.highest_rates.capacity,
                 );
@@ -327,6 +331,12 @@ pub struct FreqThresholdPolicy {
     sketch: TrafficSketch,
     client_threshold: u64,
     proxied_client_threshold: u64,
+    /// Unique salt to be added to all keys in the sketch. This
+    /// ensures that false positives are not correlated across
+    /// all nodes at the same time. For IOTA validators for example,
+    /// this means that false positives should not prevent the network
+    /// from achieving quorum.
+    salt: u64,
 }
 
 impl FreqThresholdPolicy {
@@ -355,6 +365,7 @@ impl FreqThresholdPolicy {
             sketch,
             client_threshold,
             proxied_client_threshold,
+            salt: rand::random(),
         }
     }
 
@@ -368,7 +379,11 @@ impl FreqThresholdPolicy {
 
     pub fn handle_tally(&mut self, tally: TrafficTally) -> PolicyResponse {
         let block_client = if let Some(source) = tally.direct {
-            let key = SketchKey(source, ClientType::Direct);
+            let key = SketchKey {
+                salt: self.salt,
+                ip_addr: source,
+                client_type: ClientType::Direct,
+            };
             self.sketch.increment_count(&key);
             if self.sketch.get_request_rate(&key) >= self.client_threshold as f64 {
                 Some(source)
@@ -379,7 +394,11 @@ impl FreqThresholdPolicy {
             None
         };
         let block_proxied_client = if let Some(source) = tally.through_fullnode {
-            let key = SketchKey(source, ClientType::ThroughFullnode);
+            let key = SketchKey {
+                salt: self.salt,
+                ip_addr: source,
+                client_type: ClientType::ThroughFullnode,
+            };
             self.sketch.increment_count(&key);
             if self.sketch.get_request_rate(&key) >= self.proxied_client_threshold as f64 {
                 Some(source)


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.37.4, v1.38.4)
- Port commit: https://github.com/MystenLabs/sui/commit/53dd080a841710c91f492de17f7312a29662235f
- Descriptions from commits
  False positives stem from IP collisions during traffic tallying. Because validators tend to see closely correlated transaction execution traffic patterns, it is possible that a false positive resulting in an erroneously blocked IP could be correlated across many validators at the same time. If this happens on a quorum of validators, this would result in an IP being effectively denied service until the TTL expires.

  Luckily, we can exploit this property to lower the effective false positive rate (as observed by the client) by removing this correlation. This PR adds a salt key to the `SketchKey`. The value is generated in memory at startup.


## Links to any relevant issues

Part of #4390  

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes