### PR TITLE
feat: bump iota to v1.4.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,7 +1752,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "const-str",
  "git-version",
@@ -5268,7 +5268,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "iota"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5318,7 +5318,7 @@ dependencies = [
  "iota-package-management",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.3.0-alpha",
+ "iota-sdk 1.4.0-alpha",
  "iota-simulator",
  "iota-source-validation",
  "iota-swarm",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "iota-adapter-transactional-tests"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -5405,7 +5405,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "arrow",
@@ -5456,7 +5456,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer-derive"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5465,7 +5465,7 @@ dependencies = [
 
 [[package]]
 name = "iota-archival"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -5496,7 +5496,7 @@ dependencies = [
 
 [[package]]
 name = "iota-authority-aggregation"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "futures",
  "iota-metrics",
@@ -5507,7 +5507,7 @@ dependencies = [
 
 [[package]]
 name = "iota-aws-orchestrator"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "iota-benchmark"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5559,7 +5559,7 @@ dependencies = [
  "iota-metrics",
  "iota-network",
  "iota-protocol-config",
- "iota-sdk 1.3.0-alpha",
+ "iota-sdk 1.4.0-alpha",
  "iota-simulator",
  "iota-storage",
  "iota-surfer",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cluster-test"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5604,7 +5604,7 @@ dependencies = [
  "iota-json",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 1.3.0-alpha",
+ "iota-sdk 1.4.0-alpha",
  "iota-swarm",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -5626,7 +5626,7 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5673,7 +5673,7 @@ dependencies = [
 
 [[package]]
 name = "iota-core"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5775,7 +5775,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cost"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5830,7 +5830,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5866,7 +5866,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion-core"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5900,7 +5900,7 @@ dependencies = [
 
 [[package]]
 name = "iota-e2e-tests"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5930,7 +5930,7 @@ dependencies = [
  "iota-protocol-config",
  "iota-rest-api",
  "iota-rust-sdk",
- "iota-sdk 1.3.0-alpha",
+ "iota-sdk 1.4.0-alpha",
  "iota-simulator",
  "iota-storage",
  "iota-swarm",
@@ -5961,7 +5961,7 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "serde_yaml",
 ]
@@ -6000,7 +6000,7 @@ dependencies = [
 
 [[package]]
 name = "iota-faucet"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6016,7 +6016,7 @@ dependencies = [
  "iota-keys",
  "iota-metrics",
  "iota-network-stack",
- "iota-sdk 1.3.0-alpha",
+ "iota-sdk 1.4.0-alpha",
  "iota-types",
  "parking_lot 0.12.3",
  "prometheus",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6062,7 +6062,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6080,7 +6080,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-tests"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "datatest-stable",
  "iota-adapter-latest",
@@ -6101,7 +6101,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-builder"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6153,7 +6153,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -6163,7 +6163,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-config"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6171,7 +6171,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-e2e-tests"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6224,7 +6224,7 @@ dependencies = [
  "iota-package-resolver",
  "iota-protocol-config",
  "iota-rest-api",
- "iota-sdk 1.3.0-alpha",
+ "iota-sdk 1.4.0-alpha",
  "iota-swarm-config",
  "iota-test-transaction-builder",
  "iota-types",
@@ -6264,7 +6264,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-client"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6279,14 +6279,14 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-headers"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "axum 0.8.4",
 ]
 
 [[package]]
 name = "iota-http"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "axum 0.8.4",
  "bytes",
@@ -6307,7 +6307,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6339,7 +6339,7 @@ dependencies = [
  "iota-package-resolver",
  "iota-protocol-config",
  "iota-rest-api",
- "iota-sdk 1.3.0-alpha",
+ "iota-sdk 1.4.0-alpha",
  "iota-swarm-config",
  "iota-test-transaction-builder",
  "iota-transaction-builder",
@@ -6370,7 +6370,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer-builder"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6386,7 +6386,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6405,7 +6405,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6463,7 +6463,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -6482,7 +6482,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-tests"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6501,7 +6501,7 @@ dependencies = [
  "iota-open-rpc",
  "iota-open-rpc-macros",
  "iota-protocol-config",
- "iota-sdk 1.3.0-alpha",
+ "iota-sdk 1.4.0-alpha",
  "iota-simulator",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -6520,7 +6520,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6552,7 +6552,7 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "bip32",
@@ -6571,7 +6571,7 @@ dependencies = [
 
 [[package]]
 name = "iota-light-client"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6588,7 +6588,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-package-resolver",
  "iota-rest-api",
- "iota-sdk 1.3.0-alpha",
+ "iota-sdk 1.4.0-alpha",
  "iota-types",
  "log",
  "move-core-types",
@@ -6608,7 +6608,7 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -6618,7 +6618,7 @@ dependencies = [
 
 [[package]]
 name = "iota-mainnet-unlocks"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6630,7 +6630,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metric-checker"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "backoff",
@@ -6651,7 +6651,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6676,7 +6676,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "better_any",
@@ -6719,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -6742,7 +6742,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-lsp"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "bin-version",
  "clap",
@@ -6773,7 +6773,7 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6785,7 +6785,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -6825,7 +6825,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anemo",
  "bcs",
@@ -6851,7 +6851,7 @@ dependencies = [
 
 [[package]]
 name = "iota-node"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6901,7 +6901,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6925,7 +6925,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -6937,7 +6937,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-dump"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6954,13 +6954,13 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.3.0-alpha",
+ "iota-sdk 1.4.0-alpha",
  "iota-types",
  "move-core-types",
  "move-package",
@@ -6971,7 +6971,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "async-trait",
  "bcs",
@@ -6994,7 +6994,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -7004,7 +7004,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "clap",
  "insta",
@@ -7019,7 +7019,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7028,7 +7028,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proxy"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7044,7 +7044,7 @@ dependencies = [
  "hex",
  "hyper 1.4.1",
  "iota-metrics",
- "iota-sdk 1.3.0-alpha",
+ "iota-sdk 1.4.0-alpha",
  "iota-tls",
  "iota-types",
  "itertools 0.13.0",
@@ -7074,7 +7074,7 @@ dependencies = [
 
 [[package]]
 name = "iota-replay"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7090,7 +7090,7 @@ dependencies = [
  "iota-json-rpc-api",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.3.0-alpha",
+ "iota-sdk 1.4.0-alpha",
  "iota-storage",
  "iota-transaction-checks",
  "iota-types",
@@ -7121,7 +7121,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7153,7 +7153,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-kv"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -7179,7 +7179,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rosetta"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7197,7 +7197,7 @@ dependencies = [
  "iota-metrics",
  "iota-move-build",
  "iota-node",
- "iota-sdk 1.3.0-alpha",
+ "iota-sdk 1.4.0-alpha",
  "iota-swarm-config",
  "iota-types",
  "move-core-types",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rpc-loadgen"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7231,7 +7231,7 @@ dependencies = [
  "futures",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 1.3.0-alpha",
+ "iota-sdk 1.4.0-alpha",
  "iota-types",
  "itertools 0.13.0",
  "serde",
@@ -7306,7 +7306,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7344,7 +7344,7 @@ dependencies = [
 
 [[package]]
 name = "iota-simulator"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7366,7 +7366,7 @@ dependencies = [
 
 [[package]]
 name = "iota-single-node-benchmark"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7400,7 +7400,7 @@ dependencies = [
 
 [[package]]
 name = "iota-snapshot"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7428,7 +7428,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "colored",
@@ -7438,7 +7438,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 1.3.0-alpha",
+ "iota-sdk 1.4.0-alpha",
  "iota-test-transaction-builder",
  "iota-types",
  "move-binary-format",
@@ -7460,7 +7460,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation-service"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7476,7 +7476,7 @@ dependencies = [
  "iota-metrics",
  "iota-move",
  "iota-move-build",
- "iota-sdk 1.3.0-alpha",
+ "iota-sdk 1.4.0-alpha",
  "iota-source-validation",
  "jsonrpsee",
  "move-compiler",
@@ -7499,7 +7499,7 @@ dependencies = [
 
 [[package]]
 name = "iota-storage"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7555,7 +7555,7 @@ dependencies = [
 
 [[package]]
 name = "iota-surfer"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7584,7 +7584,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "futures",
@@ -7609,7 +7609,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm-config"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -7637,12 +7637,12 @@ dependencies = [
 
 [[package]]
 name = "iota-test-transaction-builder"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "bcs",
  "iota-genesis-builder",
  "iota-move-build",
- "iota-sdk 1.3.0-alpha",
+ "iota-sdk 1.4.0-alpha",
  "iota-types",
  "move-core-types",
  "shared-crypto",
@@ -7650,7 +7650,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7672,7 +7672,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tool"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -7694,7 +7694,7 @@ dependencies = [
  "iota-package-dump",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.3.0-alpha",
+ "iota-sdk 1.4.0-alpha",
  "iota-snapshot",
  "iota-storage",
  "iota-types",
@@ -7717,7 +7717,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7733,7 +7733,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-checks"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "fastcrypto-zkp",
  "iota-config",
@@ -7747,7 +7747,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transactional-test-runner"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7799,7 +7799,7 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anemo",
  "anyhow",
@@ -7877,7 +7877,7 @@ dependencies = [
 
 [[package]]
 name = "iota-upgrade-compatibility-transactional-tests"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "datatest-stable",
@@ -7906,7 +7906,7 @@ dependencies = [
 
 [[package]]
 name = "iota-verifier-transactional-tests"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -11165,7 +11165,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -12900,7 +12900,7 @@ dependencies = [
 
 [[package]]
 name = "shared-crypto"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "bcs",
  "eyre",
@@ -13019,7 +13019,7 @@ dependencies = [
 
 [[package]]
 name = "simulacrum"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13682,7 +13682,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry-subscribers"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -13769,7 +13769,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-cluster"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13788,7 +13788,7 @@ dependencies = [
  "iota-metrics",
  "iota-node",
  "iota-protocol-config",
- "iota-sdk 1.3.0-alpha",
+ "iota-sdk 1.4.0-alpha",
  "iota-simulator",
  "iota-swarm",
  "iota-swarm-config",
@@ -14584,7 +14584,7 @@ dependencies = [
 
 [[package]]
 name = "transaction-fuzzer"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "iota-core",
  "iota-move-build",
@@ -14656,7 +14656,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "async-trait",
  "bcs",
@@ -14687,7 +14687,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-derive"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -14697,7 +14697,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "serde",
  "thiserror 1.0.64",
@@ -14705,7 +14705,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-workspace-hack"
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 dependencies = [
  "libc",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by iota-core, iota-faucet, iota-node, iota-tools, iota-sdk, iota-move-build, and iota crates.
-version = "1.3.0-alpha"
+version = "1.4.0-alpha"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/crates/iota-graphql-e2e-tests/tests/call/simple.snap
+++ b/crates/iota-graphql-e2e-tests/tests/call/simple.snap
@@ -116,12 +116,12 @@ task 15, lines 64-69:
 //# run-graphql --show-usage --show-headers --show-service-version
 Headers: {
     "content-type": "application/graphql-response+json",
-    "x-iota-rpc-version": "1.3.0-testing-no-sha",
+    "x-iota-rpc-version": "1.4.0-testing-no-sha",
     "vary": "origin, access-control-request-method, access-control-request-headers",
     "access-control-allow-origin": "*",
     "content-length": "157",
 }
-Service version: 1.3.0-testing-no-sha
+Service version: 1.4.0-testing-no-sha
 Response: {
   "data": {
     "checkpoint": {
@@ -378,7 +378,7 @@ Response: {
   "data": {
     "serviceConfig": {
       "availableVersions": [
-        "1.3"
+        "1.4"
       ]
     }
   }

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/iotaledger/iota/main/LICENSE"
     },
-    "version": "1.3.0-alpha"
+    "version": "1.4.0-alpha"
   },
   "methods": [
     {


### PR DESCRIPTION
Bumping the `iota` binary version after the creation of https://github.com/iotaledger/iota/tree/releases/iota-v1.3.0-release
