### PR TITLE
feat(msim): Remove random cache init in simtests

### DIFF
--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -30,7 +30,7 @@ use crate::{
         AuthorityStore,
         authority_per_epoch_store::AuthorityPerEpochStore,
         authority_store::{ExecutionLockWriteGuard, IotaLockResult},
-        epoch_start_configuration::{EpochFlag, EpochStartConfigTrait, EpochStartConfiguration},
+        epoch_start_configuration::{EpochFlag, EpochStartConfiguration},
     },
     state_accumulator::AccumulatorStore,
     transaction_outputs::TransactionOutputs,
@@ -128,14 +128,9 @@ pub fn build_execution_cache(
 ) -> ExecutionCacheTraitPointers {
     let execution_cache_metrics = Arc::new(ExecutionCacheMetrics::new(prometheus_registry));
 
-    match epoch_start_config.execution_cache_type() {
-        ExecutionCacheConfigType::WritebackCache => ExecutionCacheTraitPointers::new(
-            WritebackCache::new(store.clone(), execution_cache_metrics).into(),
-        ),
-        ExecutionCacheConfigType::PassthroughCache => ExecutionCacheTraitPointers::new(
-            ProxyCache::new(epoch_start_config, store.clone(), execution_cache_metrics).into(),
-        ),
-    }
+    ExecutionCacheTraitPointers::new(
+        ProxyCache::new(epoch_start_config, store.clone(), execution_cache_metrics).into(),
+    )
 }
 
 /// Should only be used for iota-tool or tests. Nodes must use

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -23,14 +23,14 @@ use iota_types::{
     transaction::{VerifiedSignedTransaction, VerifiedTransaction},
 };
 use prometheus::Registry;
-use tracing::instrument;
+use tracing::{error, instrument};
 
 use crate::{
     authority::{
         AuthorityStore,
         authority_per_epoch_store::AuthorityPerEpochStore,
         authority_store::{ExecutionLockWriteGuard, IotaLockResult},
-        epoch_start_configuration::{EpochFlag, EpochStartConfiguration},
+        epoch_start_configuration::{EpochFlag, EpochStartConfigTrait, EpochStartConfiguration},
     },
     state_accumulator::AccumulatorStore,
     transaction_outputs::TransactionOutputs,
@@ -111,31 +111,12 @@ pub enum ExecutionCacheConfigType {
     PassthroughCache,
 }
 
-pub fn choose_execution_cache(config: &ExecutionCacheConfig) -> ExecutionCacheConfigType {
-    #[cfg(msim)]
-    {
-        let mut use_random_cache = None;
-        iota_macros::fail_point_if!("select-random-cache", || {
-            let random = rand::random::<bool>();
-            tracing::info!("Randomly selecting cache: {}", random);
-            use_random_cache = Some(random);
-        });
-        if let Some(random) = use_random_cache {
-            if random {
-                return ExecutionCacheConfigType::PassthroughCache;
-            } else {
-                return ExecutionCacheConfigType::WritebackCache;
-            }
-        }
+pub fn choose_execution_cache(_: &ExecutionCacheConfig) -> ExecutionCacheConfigType {
+    if std::env::var(DISABLE_WRITEBACK_CACHE_ENV_VAR).is_ok() {
+        error!("DISABLE_WRITEBACK_CACHE is no longer respected. WritebackCache is the default.");
     }
 
-    if std::env::var(DISABLE_WRITEBACK_CACHE_ENV_VAR).is_ok()
-        || matches!(config, ExecutionCacheConfig::PassthroughCache)
-    {
-        ExecutionCacheConfigType::PassthroughCache
-    } else {
-        ExecutionCacheConfigType::WritebackCache
-    }
+    ExecutionCacheConfigType::WritebackCache
 }
 
 pub fn build_execution_cache(
@@ -144,9 +125,15 @@ pub fn build_execution_cache(
     store: &Arc<AuthorityStore>,
 ) -> ExecutionCacheTraitPointers {
     let execution_cache_metrics = Arc::new(ExecutionCacheMetrics::new(prometheus_registry));
-    ExecutionCacheTraitPointers::new(
-        ProxyCache::new(epoch_start_config, store.clone(), execution_cache_metrics).into(),
-    )
+
+    match epoch_start_config.execution_cache_type() {
+        ExecutionCacheConfigType::WritebackCache => ExecutionCacheTraitPointers::new(
+            WritebackCache::new(store.clone(), execution_cache_metrics).into(),
+        ),
+        ExecutionCacheConfigType::PassthroughCache => ExecutionCacheTraitPointers::new(
+            ProxyCache::new(epoch_start_config, store.clone(), execution_cache_metrics).into(),
+        ),
+    }
 }
 
 /// Should only be used for iota-tool or tests. Nodes must use
@@ -910,15 +897,10 @@ macro_rules! implement_passthrough_traits {
                 &'a self,
                 _: &'a EpochStartConfiguration,
             ) -> BoxFuture<'a, ()> {
-                // If we call this method instead of ProxyCache::reconfigure_cache, it's a bug.
-                // Such a bug would almost certainly cause other test failures before reaching
-                // this point, but if it somehow slipped through it is better to crash
-                // than risk forking because ProxyCache::reconfigure_cache was not
-                // called.
-                panic!(
-                    "reconfigure_cache should not be called on a {}",
-                    stringify!($implementor)
-                );
+                // Since we now use WritebackCache directly at startup (if the epoch flag is
+                // set), this can be called at reconfiguration time. It is a no-op.
+                // TODO: remove this once we completely remove ProxyCache.
+                std::future::ready(()).boxed()
             }
         }
 

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -23,7 +23,7 @@ use iota_types::{
     transaction::{VerifiedSignedTransaction, VerifiedTransaction},
 };
 use prometheus::Registry;
-use tracing::{error, instrument};
+use tracing::instrument;
 
 use crate::{
     authority::{
@@ -111,12 +111,14 @@ pub enum ExecutionCacheConfigType {
     PassthroughCache,
 }
 
-pub fn choose_execution_cache(_: &ExecutionCacheConfig) -> ExecutionCacheConfigType {
-    if std::env::var(DISABLE_WRITEBACK_CACHE_ENV_VAR).is_ok() {
-        error!("DISABLE_WRITEBACK_CACHE is no longer respected. WritebackCache is the default.");
+pub fn choose_execution_cache(config: &ExecutionCacheConfig) -> ExecutionCacheConfigType {
+    if std::env::var(DISABLE_WRITEBACK_CACHE_ENV_VAR).is_ok()
+        || matches!(config, ExecutionCacheConfig::PassthroughCache)
+    {
+        ExecutionCacheConfigType::PassthroughCache
+    } else {
+        ExecutionCacheConfigType::WritebackCache
     }
-
-    ExecutionCacheConfigType::WritebackCache
 }
 
 pub fn build_execution_cache(

--- a/crates/iota-types/src/unit_tests/base_types_tests.rs
+++ b/crates/iota-types/src/unit_tests/base_types_tests.rs
@@ -30,6 +30,21 @@ use crate::{
 };
 
 #[test]
+fn test_bcs_enum() {
+    let address = Owner::AddressOwner(IotaAddress::random_for_testing_only());
+    let shared = Owner::Shared {
+        initial_shared_version: 1.into(),
+    };
+
+    let address_ser = bcs::to_bytes(&address).unwrap();
+    let shared_ser = bcs::to_bytes(&shared).unwrap();
+
+    println!("{:?}", address_ser);
+    println!("{:?}", shared_ser);
+    assert!(shared_ser.len() < address_ser.len());
+}
+
+#[test]
 fn test_signatures() {
     let (addr1, sec1): (_, AccountKeyPair) = get_key_pair();
     let (addr2, _sec2): (_, AccountKeyPair) = get_key_pair();


### PR DESCRIPTION
# Description of change

The cache in the simtests was randomly choosen, which might yield random failures/results. We want to avoid that.

- Upstream range: [v1.38.4, v1.39.4)
- Partly ported commit: https://github.com/MystenLabs/sui/commit/b09b0a8d36e1e03352811cc180d4bb92a2cb677f

## Links to any relevant issues

Part of #4390  

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes