### PR TITLE
upstream(node): Add nodes with unpruned history in simtest

### DIFF
--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -196,7 +196,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_small_committee_reconfig() {
         iota_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(1, 5_000 /* , 0 */).await;
+        let test_cluster = build_test_cluster(1, 5_000, 0).await;
         test_simulated_load(test_cluster, 120).await;
     }
 

--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -100,7 +100,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_with_reconfig() {
         iota_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(4, 1000).await;
+        let test_cluster = build_test_cluster(4, 1000, 1).await;
         test_simulated_load(test_cluster, 60).await;
     }
 
@@ -135,21 +135,21 @@ mod test {
         // TODO: enable this - right now it causes rocksdb errors when re-opening DBs
         // register_fail_point_if("correlated-crash-process-certificate", || true);
 
-        let test_cluster = build_test_cluster(4, 10000).await;
+        let test_cluster = build_test_cluster(4, 10000, 1).await;
         test_simulated_load(test_cluster, 60).await;
     }
 
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_basic() {
         iota_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(7, 0).await;
+        let test_cluster = build_test_cluster(7, 0, 1).await;
         test_simulated_load(test_cluster, 15).await;
     }
 
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_restarts() {
         iota_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(4, 0).await;
+        let test_cluster = build_test_cluster(4, 0, 1).await;
         let node_restarter = test_cluster
             .random_node_restarter()
             .with_kill_interval_secs(5, 15)
@@ -161,7 +161,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_rolling_restarts_all_validators() {
         iota_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(4, 330_000).await;
+        let test_cluster = build_test_cluster(4, 330_000, 1).await;
 
         let validators = test_cluster.get_validator_pubkeys();
         let test_cluster_clone = test_cluster.clone();
@@ -184,7 +184,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_reconfig_restarts() {
         iota_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(4, 5_000).await;
+        let test_cluster = build_test_cluster(4, 5_000, 1).await;
         let node_restarter = test_cluster
             .random_node_restarter()
             .with_kill_interval_secs(5, 15)
@@ -318,7 +318,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_reconfig_with_prune_and_compact() {
         iota_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(4, 1000).await;
+        let test_cluster = build_test_cluster(4, 1000, 0).await;
 
         let node_state = test_cluster.fullnode_handle.iota_node.clone().state();
         register_fail_point_async("prune-and-compact", move || {
@@ -437,7 +437,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_reconfig_crashes_during_epoch_change() {
         iota_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(4, 10000).await;
+        let test_cluster = build_test_cluster(4, 10000, 1).await;
 
         let dead_validator: Arc<Mutex<Option<DeadValidator>>> = Default::default();
         let keep_alive_nodes = get_keep_alive_nodes(&test_cluster);
@@ -455,7 +455,7 @@ mod test {
 
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_checkpoint_pruning() {
-        let test_cluster = build_test_cluster(10, 1000).await;
+        let test_cluster = build_test_cluster(10, 1000, 0).await;
         test_simulated_load(test_cluster.clone(), 30).await;
 
         let swarm_dir = test_cluster.swarm.dir().join(AUTHORITIES_DB_NAME);
@@ -531,7 +531,7 @@ mod test {
             config
         });
 
-        let test_cluster = build_test_cluster(4, 5000).await;
+        let test_cluster = build_test_cluster(4, 5000, 2).await;
         let mut simulated_load_config = SimulatedLoadConfig::default();
         {
             let mut rng = thread_rng();
@@ -616,7 +616,7 @@ mod test {
             config
         });
 
-        let test_cluster = build_test_cluster(4, 30_000).await;
+        let test_cluster = build_test_cluster(4, 30_000, 1).await;
         test_simulated_load(test_cluster, 120).await;
     }
 
@@ -656,7 +656,7 @@ mod test {
     // designed to test performance.
     #[sim_test(config = "test_config_low_latency()")]
     async fn test_simulated_load_large_consensus_commit_prologue_size() {
-        let test_cluster = build_test_cluster(4, 5_000).await;
+        let test_cluster = build_test_cluster(4, 5_000, 1).await;
 
         let mut additional_cancelled_txns = Vec::new();
         let num_txns = thread_rng().gen_range(500..2000);
@@ -687,7 +687,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_pruning() {
         let epoch_duration_ms = 5000;
-        let test_cluster = build_test_cluster(4, epoch_duration_ms).await;
+        let test_cluster = build_test_cluster(4, epoch_duration_ms, 0).await;
         test_simulated_load(test_cluster.clone(), 30).await;
 
         let swarm_dir = test_cluster.swarm.dir().join(AUTHORITIES_DB_NAME);
@@ -815,7 +815,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_randomness_partial_sig_failures() {
         iota_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(6, 20_000).await;
+        let test_cluster = build_test_cluster(6, 20_000, 1).await;
 
         // Network should continue as long as f+1 nodes (in this case 3/6) are sending
         // partial signatures.
@@ -836,7 +836,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_randomness_dkg_failures() {
         iota_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(6, 20_000).await;
+        let test_cluster = build_test_cluster(6, 20_000, 1).await;
 
         // Network should continue as long as nodes are participating in DKG
         // representing stake equal to 2f+1 PLUS proportion of stake represented
@@ -871,7 +871,12 @@ mod test {
     async fn build_test_cluster(
         default_num_validators: usize,
         default_epoch_duration_ms: u64,
+        default_num_of_unpruned_validators: usize,
     ) -> Arc<TestCluster> {
+        assert!(
+            default_num_of_unpruned_validators <= default_num_validators,
+            "Provided number of unpruned validators is greater than the total number of validators"
+        );
         init_test_cluster_builder(default_num_validators, default_epoch_duration_ms)
             .with_authority_overload_config(AuthorityOverloadConfig {
                 // Disable system overload checks for the test - during tests with crashes,
@@ -882,6 +887,7 @@ mod test {
                 ..Default::default()
             })
             .with_submit_delay_step_override_millis(3000)
+            .with_num_unpruned_validators(default_num_of_unpruned_validators)
             .build()
             .await
             .into()


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.38.4, v1.39.4)
- Port commit: https://github.com/MystenLabs/sui/commit/c27594503a7b129a2ca1ae1b03cf78a2b5388fbc
- Descriptions from commits
  Simtest `test_simulated_load_shared_object_congestion_control` seems to have been occasionally failing the assertion `assertion failed: results.num_successful_transactions > 0` , ex:

https://github.com/MystenLabs/sui/actions/runs/11949884838/job/33310255818

https://github.com/MystenLabs/sui/actions/runs/11082671210/job/30796002007

Investigating the issue this looks to be related to the Full Node falling behind on state sync from the rest of the network (due to connectivity issues etc) and when coming back effectively rest of the network has advanced and also pruned checkpoint history that would be necessary for the FN in order to advance. Any transactions at this point can not successfully execute as local state is missing dependencies which can never be fetched.

This PR is making two of the validators having unpruned history so if that happens FN can still sync state when falls behind.


## Links to any relevant issues

Part of #4390  

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes