### PR TITLE
feat(workflows): use speculos docker image for testing

### DIFF
--- a/.github/workflows/_ledgernano.yml
+++ b/.github/workflows/_ledgernano.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Pull and tag speculos docker image
+      - name: Pull speculos docker image
         run: |
           docker pull ghcr.io/ledgerhq/speculos
 

--- a/.github/workflows/_ledgernano.yml
+++ b/.github/workflows/_ledgernano.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Pull and tag speculos docker image
         run: |
           docker pull ghcr.io/ledgerhq/speculos
-          docker image tag ghcr.io/ledgerhq/speculos speculos
 
       - name: Download ledgernano bin
         run: |
@@ -37,7 +36,7 @@ jobs:
           mv nanos/iota sdk/ledgerjs-hw-app-iota/tests/iota
 
       - name: Start speculos simulator
-        run: docker run --rm -d -p 5000:5000 -v $(pwd)/sdk/ledgerjs-hw-app-iota/tests:/app speculos --api-port 5000 --display headless /app/iota
+        run: docker run --rm -d -p 5000:5000 -v $(pwd)/sdk/ledgerjs-hw-app-iota/tests:/app ghcr.io/ledgerhq/speculos --api-port 5000 --display headless /app/iota
 
       - name: Run TS SDK ledgernano tests
         run: pnpm --filter @iota/ledgerjs-hw-app-iota test

--- a/.github/workflows/_ledgernano.yml
+++ b/.github/workflows/_ledgernano.yml
@@ -24,8 +24,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Pull speculos docker image
-        run: |
-          docker pull ghcr.io/ledgerhq/speculos
+        run: docker pull ghcr.io/ledgerhq/speculos
 
       - name: Download ledgernano bin
         run: |

--- a/.github/workflows/_ledgernano.yml
+++ b/.github/workflows/_ledgernano.yml
@@ -26,11 +26,9 @@ jobs:
       - name: Pull speculos docker image
         run: docker pull ghcr.io/ledgerhq/speculos
 
-      - name: Download ledgernano bin
+      - name: Download ledgernano binary
         run: |
-          sudo apt-get install -y gh
-          gh release list --repo https://github.com/iotaledger/ledger-app-iota
-          gh release download --repo https://github.com/iotaledger/ledger-app-iota -p nanos.tar.gz ledger-app-iota-v0.9.2
+          curl -L -o nanos.tar.gz https://github.com/iotaledger/ledger-app-iota/releases/download/ledger-app-iota-v0.9.2/nanos.tar.gz
           tar -xvf nanos.tar.gz
           mv nanos/iota sdk/ledgerjs-hw-app-iota/tests/iota
 

--- a/.github/workflows/_ledgernano.yml
+++ b/.github/workflows/_ledgernano.yml
@@ -23,11 +23,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install ledgernano dependencies
+      - name: Pull and tag speculos docker image
         run: |
-          sudo apt-get install -y qemu-user-static
-          sudo apt-get install -y libxcb-xinerama0
-          sudo python3 -m pip install speculos
+          docker pull ghcr.io/ledgerhq/speculos
+          docker image tag ghcr.io/ledgerhq/speculos speculos
 
       - name: Download ledgernano bin
         run: |
@@ -38,7 +37,7 @@ jobs:
           mv nanos/iota sdk/ledgerjs-hw-app-iota/tests/iota
 
       - name: Start speculos simulator
-        run: speculos --api-port 5000 --display headless ./sdk/ledgerjs-hw-app-iota/tests/iota &
+        run: docker run --rm -d -p 5000:5000 -v $(pwd)/sdk/ledgerjs-hw-app-iota/tests:/app speculos --api-port 5000 --display headless /app/iota
 
       - name: Run TS SDK ledgernano tests
         run: pnpm --filter @iota/ledgerjs-hw-app-iota test

--- a/sdk/ledgerjs-hw-app-iota/src/Iota.ts
+++ b/sdk/ledgerjs-hw-app-iota/src/Iota.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
+
 /* eslint-disable no-restricted-globals */
 
 import type Transport from '@ledgerhq/hw-transport';


### PR DESCRIPTION
# Description of change

Use the official speculos docker image for testing in the CI instead of manually installing the speculos binary for simpler maintenance

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/6670

## How the change has been tested

Run these things locally
```
docker pull ghcr.io/ledgerhq/speculos

sudo apt-get install -y gh
gh release list --repo https://github.com/iotaledger/ledger-app-iota
gh release download --repo https://github.com/iotaledger/ledger-app-iota -p nanos.tar.gz ledger-app-iota-v0.9.2
tar -xvf nanos.tar.gz
mv nanos/iota sdk/ledgerjs-hw-app-iota/tests/iota

docker run --rm -d -p 5000:5000 -v $(pwd)/sdk/ledgerjs-hw-app-iota/tests:/app ghcr.io/ledgerhq/speculos --api-port 5000 --display headless /app/iota

pnpm --filter @iota/ledgerjs-hw-app-iota test
```

```
 ✓ tests/Iota.test.ts (5) 14732ms
   ✓ Test ledgerjs-hw-app-iota (5) 14732ms
     ✓ Iota init
     ✓ Test address generation 403ms
     ✓ Test address generation with display 2452ms
     ✓ Test signing 5788ms
     ✓ Test blind signing 6087ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
