### PR TITLE
fix(iota-core), chore(iota-execution): fix order of gas price feedback feature flag; downgrade toml_edit version

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -267,11 +267,6 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     consensus_zstd_compression: bool,
 
-    // To enable/disable the gas price feedback mechanism used for transactions
-    // cancelled due to shared object congestion
-    #[serde(skip_serializing_if = "is_false")]
-    congested_objects_gas_price_feedback_mechanism: bool,
-
     // Use the minimum free execution slot to schedule execution of a transaction in the shared
     // object congestion tracker.
     #[serde(skip_serializing_if = "is_false")]
@@ -280,6 +275,11 @@ struct FeatureFlags {
     // If true, multisig containing passkey sig is accepted.
     #[serde(skip_serializing_if = "is_false")]
     accept_passkey_in_multisig: bool,
+
+    // To enable/disable the gas price feedback mechanism used for transactions
+    // cancelled due to shared object congestion
+    #[serde(skip_serializing_if = "is_false")]
+    congested_objects_gas_price_feedback_mechanism: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1238,13 +1238,6 @@ impl ProtocolConfig {
         self.feature_flags.consensus_zstd_compression
     }
 
-    /// Check if the gas price feedback mechanism (which is used for
-    /// transactions cancelled due to shared object congestion) is enabled
-    pub fn congested_objects_gas_price_feedback_mechanism(&self) -> bool {
-        self.feature_flags
-            .congested_objects_gas_price_feedback_mechanism
-    }
-
     pub fn congestion_control_min_free_execution_slot(&self) -> bool {
         self.feature_flags
             .congestion_control_min_free_execution_slot
@@ -1252,6 +1245,13 @@ impl ProtocolConfig {
 
     pub fn accept_passkey_in_multisig(&self) -> bool {
         self.feature_flags.accept_passkey_in_multisig
+    }
+
+    /// Check if the gas price feedback mechanism (which is used for
+    /// transactions cancelled due to shared object congestion) is enabled
+    pub fn congested_objects_gas_price_feedback_mechanism(&self) -> bool {
+        self.feature_flags
+            .congested_objects_gas_price_feedback_mechanism
     }
 }
 

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_10.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_10.snap
@@ -23,9 +23,9 @@ feature_flags:
   variant_nodes: true
   consensus_round_prober_probe_accepted_rounds: true
   consensus_zstd_compression: true
-  congested_objects_gas_price_feedback_mechanism: true
   congestion_control_min_free_execution_slot: true
   accept_passkey_in_multisig: true
+  congested_objects_gas_price_feedback_mechanism: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/iota-execution/cut/Cargo.toml
+++ b/iota-execution/cut/Cargo.toml
@@ -11,7 +11,7 @@ anyhow.workspace = true
 clap.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-toml_edit = "0.22.27"
+toml_edit = "0.22"
 
 [dev-dependencies]
 expect-test.workspace = true


### PR DESCRIPTION
# Description of change

- `iota-core`: Place the new feature flag `congested_objects_gas_price_feedback_mechanism` at the bottom.
- `iota-execution`: Downgrade `toml_edit` to `0.22`. It seems it was unnecessary bumped to `0.22.27` on the feature branch.

See first three comments in https://github.com/iotaledger/iota/pull/7456.

## Links to any relevant issues

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
