### PR TITLE
chore(CLI): Better error for leaf `set-target-address`

### DIFF
--- a/crates/iota/src/name_commands.rs
+++ b/crates/iota/src/name_commands.rs
@@ -575,6 +575,11 @@ impl NameCommand {
                 opts,
             } => {
                 let entry = get_registry_entry(&domain, &iota_client).await?;
+                if entry.name_record.is_leaf_record() {
+                    bail!(
+                        "cannot set target address for leaf subdomain; try removing and recreating the subdomain instead."
+                    );
+                }
                 let new_address =
                     get_identity_address(new_address.map(KeyIdentity::Address), context)?;
                 if entry
@@ -584,11 +589,7 @@ impl NameCommand {
                 {
                     bail!("target address is already set to the given value");
                 }
-                let Some(nft) = get_proxy_nft_by_id_opt(entry.id, &domain, context).await? else {
-                    bail!(
-                        "cannot set target address for leaf subdomain; try removing and recreating the subdomain instead."
-                    );
-                };
+                let nft = get_proxy_nft_by_id(entry.id, &domain, context).await?;
                 let iota_names_config = get_iota_names_config(&iota_client).await?;
 
                 let res = IotaClientCommands::Call {
@@ -719,13 +720,14 @@ impl NameCommand {
                 verbose,
             } => {
                 let entry = get_registry_entry(&domain, &iota_client).await?;
+                if entry.name_record.is_leaf_record() {
+                    bail!("cannot unset target address for leaf subdomain");
+                }
                 if entry.name_record.target_address.is_none() {
                     bail!("target address is already unset");
                 }
 
-                let Some(nft) = get_proxy_nft_by_id_opt(entry.id, &domain, context).await? else {
-                    bail!("cannot unset target address for leaf subdomain");
-                };
+                let nft = get_proxy_nft_by_id(entry.id, &domain, context).await?;
                 let iota_names_config = get_iota_names_config(&iota_client).await?;
 
                 let res = IotaClientCommands::Call {
@@ -1836,32 +1838,29 @@ async fn get_owned_nfts<T: DeserializeOwned + IotaNamesNft>(
         .collect::<Result<_, _>>()
 }
 
-async fn get_owned_nft_by_id_opt<T: DeserializeOwned + IotaNamesNft>(
+async fn get_owned_nft_by_id<T: DeserializeOwned + IotaNamesNft>(
     nft_id: ObjectID,
     address: Option<IotaAddress>,
     context: &mut WalletContext,
-) -> anyhow::Result<Option<T>> {
+) -> anyhow::Result<T> {
     let client = context.get_client().await?;
     let address = get_identity_address(address.map(KeyIdentity::Address), context)?;
-    let Ok(res) = client
+    let res = client
         .read_api()
         .get_object_with_options(nft_id, IotaObjectDataOptions::bcs_lossless())
         .await
-    else {
-        return Ok(None);
-    };
+        .map_err(|_| anyhow::anyhow!("no owned {} found for {nft_id}", T::TYPE_NAME))?;
     if !matches!(res.owner(), Some(Owner::AddressOwner(a)) if a == address) {
         bail!("NFT {nft_id} is not owned by {address}");
     }
 
     let data = res.data.expect("missing object data");
-    Ok(Some(
-        data.bcs
-            .expect("missing bcs")
-            .try_as_move()
-            .expect("invalid move type")
-            .deserialize::<T>()?,
-    ))
+    Ok(data
+        .bcs
+        .expect("missing bcs")
+        .try_as_move()
+        .expect("invalid move type")
+        .deserialize::<T>()?)
 }
 
 #[derive(Copy, Clone)]
@@ -1932,19 +1931,15 @@ async fn get_proxy_nft_by_name(
     })
 }
 
-async fn get_proxy_nft_by_id_opt(
+async fn get_proxy_nft_by_id(
     nft_id: ObjectID,
     domain: &Domain,
     context: &mut WalletContext,
-) -> anyhow::Result<Option<IotaNamesNftProxy>> {
+) -> anyhow::Result<IotaNamesNftProxy> {
     Ok(if domain.is_sld() {
-        get_owned_nft_by_id_opt(nft_id, None, context)
-            .await?
-            .map(IotaNamesNftProxy::Domain)
+        IotaNamesNftProxy::Domain(get_owned_nft_by_id(nft_id, None, context).await?)
     } else {
-        get_owned_nft_by_id_opt(nft_id, None, context)
-            .await?
-            .map(IotaNamesNftProxy::Subdomain)
+        IotaNamesNftProxy::Subdomain(get_owned_nft_by_id(nft_id, None, context).await?)
     })
 }
 

--- a/crates/iota/src/name_commands.rs
+++ b/crates/iota/src/name_commands.rs
@@ -1855,12 +1855,11 @@ async fn get_owned_nft_by_id<T: DeserializeOwned + IotaNamesNft>(
     }
 
     let data = res.data.expect("missing object data");
-    Ok(data
-        .bcs
+    data.bcs
         .expect("missing bcs")
         .try_as_move()
         .expect("invalid move type")
-        .deserialize::<T>()?)
+        .deserialize::<T>()
 }
 
 #[derive(Copy, Clone)]

--- a/crates/iota/src/name_commands.rs
+++ b/crates/iota/src/name_commands.rs
@@ -32,7 +32,6 @@ use iota_types::{
     collection_types::{Entry, LinkedTable, LinkedTableNode, VecMap},
     digests::{ChainIdentifier, TransactionDigest},
     dynamic_field::Field,
-    object::Owner,
 };
 use move_core_types::{
     account_address::AccountAddress,
@@ -589,7 +588,7 @@ impl NameCommand {
                 {
                     bail!("target address is already set to the given value");
                 }
-                let nft = get_proxy_nft_by_id(entry.id, &domain, context).await?;
+                let nft = get_proxy_nft_by_name(&domain, context).await?;
                 let iota_names_config = get_iota_names_config(&iota_client).await?;
 
                 let res = IotaClientCommands::Call {
@@ -727,7 +726,7 @@ impl NameCommand {
                     bail!("target address is already unset");
                 }
 
-                let nft = get_proxy_nft_by_id(entry.id, &domain, context).await?;
+                let nft = get_proxy_nft_by_name(&domain, context).await?;
                 let iota_names_config = get_iota_names_config(&iota_client).await?;
 
                 let res = IotaClientCommands::Call {
@@ -1838,30 +1837,6 @@ async fn get_owned_nfts<T: DeserializeOwned + IotaNamesNft>(
         .collect::<Result<_, _>>()
 }
 
-async fn get_owned_nft_by_id<T: DeserializeOwned + IotaNamesNft>(
-    nft_id: ObjectID,
-    address: Option<IotaAddress>,
-    context: &mut WalletContext,
-) -> anyhow::Result<T> {
-    let client = context.get_client().await?;
-    let address = get_identity_address(address.map(KeyIdentity::Address), context)?;
-    let res = client
-        .read_api()
-        .get_object_with_options(nft_id, IotaObjectDataOptions::bcs_lossless())
-        .await
-        .map_err(|_| anyhow::anyhow!("no owned {} found for {nft_id}", T::TYPE_NAME))?;
-    if !matches!(res.owner(), Some(Owner::AddressOwner(a)) if a == address) {
-        bail!("NFT {nft_id} is not owned by {address}");
-    }
-
-    let data = res.data.expect("missing object data");
-    data.bcs
-        .expect("missing bcs")
-        .try_as_move()
-        .expect("invalid move type")
-        .deserialize::<T>()
-}
-
 #[derive(Copy, Clone)]
 pub struct Timestamp(u64);
 
@@ -1899,24 +1874,15 @@ async fn get_owned_nft_by_name<T: DeserializeOwned + IotaNamesNft>(
     domain: &Domain,
     context: &mut WalletContext,
 ) -> anyhow::Result<T> {
-    get_owned_nft_by_name_opt(domain, context)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("no matching owned {} found for {domain}", T::TYPE_NAME))
-}
-
-async fn get_owned_nft_by_name_opt<T: DeserializeOwned + IotaNamesNft>(
-    domain: &Domain,
-    context: &mut WalletContext,
-) -> anyhow::Result<Option<T>> {
     let domain = domain.to_string();
 
     for nft in get_owned_nfts::<T>(None, context).await? {
         if nft.domain_name() == domain {
-            return Ok(Some(nft));
+            return Ok(nft);
         }
     }
 
-    Ok(None)
+    bail!("no matching owned {} found for {domain}", T::TYPE_NAME)
 }
 
 async fn get_proxy_nft_by_name(
@@ -1927,18 +1893,6 @@ async fn get_proxy_nft_by_name(
         IotaNamesNftProxy::Domain(get_owned_nft_by_name(domain, context).await?)
     } else {
         IotaNamesNftProxy::Subdomain(get_owned_nft_by_name(domain, context).await?)
-    })
-}
-
-async fn get_proxy_nft_by_id(
-    nft_id: ObjectID,
-    domain: &Domain,
-    context: &mut WalletContext,
-) -> anyhow::Result<IotaNamesNftProxy> {
-    Ok(if domain.is_sld() {
-        IotaNamesNftProxy::Domain(get_owned_nft_by_id(nft_id, None, context).await?)
-    } else {
-        IotaNamesNftProxy::Subdomain(get_owned_nft_by_id(nft_id, None, context).await?)
     })
 }
 

--- a/crates/iota/src/name_commands.rs
+++ b/crates/iota/src/name_commands.rs
@@ -32,6 +32,7 @@ use iota_types::{
     collection_types::{Entry, LinkedTable, LinkedTableNode, VecMap},
     digests::{ChainIdentifier, TransactionDigest},
     dynamic_field::Field,
+    object::Owner,
 };
 use move_core_types::{
     account_address::AccountAddress,
@@ -583,13 +584,11 @@ impl NameCommand {
                 {
                     bail!("target address is already set to the given value");
                 }
-                let nft = get_proxy_nft_by_name_opt(&domain, context)
-                    .await?
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "cannot set target address for leaf subdomain; try removing and recreating the subdomain instead."
-                        )
-                    })?;
+                let Some(nft) = get_proxy_nft_by_id_opt(entry.id, &domain, context).await? else {
+                    bail!(
+                        "cannot set target address for leaf subdomain; try removing and recreating the subdomain instead."
+                    );
+                };
                 let iota_names_config = get_iota_names_config(&iota_client).await?;
 
                 let res = IotaClientCommands::Call {
@@ -724,11 +723,9 @@ impl NameCommand {
                     bail!("target address is already unset");
                 }
 
-                let nft = get_proxy_nft_by_name_opt(&domain, context)
-                    .await?
-                    .ok_or_else(|| {
-                        anyhow::anyhow!("cannot unset target address for leaf subdomain")
-                    })?;
+                let Some(nft) = get_proxy_nft_by_id_opt(entry.id, &domain, context).await? else {
+                    bail!("cannot unset target address for leaf subdomain");
+                };
                 let iota_names_config = get_iota_names_config(&iota_client).await?;
 
                 let res = IotaClientCommands::Call {
@@ -1839,6 +1836,34 @@ async fn get_owned_nfts<T: DeserializeOwned + IotaNamesNft>(
         .collect::<Result<_, _>>()
 }
 
+async fn get_owned_nft_by_id_opt<T: DeserializeOwned + IotaNamesNft>(
+    nft_id: ObjectID,
+    address: Option<IotaAddress>,
+    context: &mut WalletContext,
+) -> anyhow::Result<Option<T>> {
+    let client = context.get_client().await?;
+    let address = get_identity_address(address.map(KeyIdentity::Address), context)?;
+    let Ok(res) = client
+        .read_api()
+        .get_object_with_options(nft_id, IotaObjectDataOptions::bcs_lossless())
+        .await
+    else {
+        return Ok(None);
+    };
+    if !matches!(res.owner(), Some(Owner::AddressOwner(a)) if a == address) {
+        bail!("NFT {nft_id} is not owned by {address}");
+    }
+
+    let data = res.data.expect("missing object data");
+    Ok(Some(
+        data.bcs
+            .expect("missing bcs")
+            .try_as_move()
+            .expect("invalid move type")
+            .deserialize::<T>()?,
+    ))
+}
+
 #[derive(Copy, Clone)]
 pub struct Timestamp(u64);
 
@@ -1907,16 +1932,17 @@ async fn get_proxy_nft_by_name(
     })
 }
 
-async fn get_proxy_nft_by_name_opt(
+async fn get_proxy_nft_by_id_opt(
+    nft_id: ObjectID,
     domain: &Domain,
     context: &mut WalletContext,
 ) -> anyhow::Result<Option<IotaNamesNftProxy>> {
     Ok(if domain.is_sld() {
-        get_owned_nft_by_name_opt(domain, context)
+        get_owned_nft_by_id_opt(nft_id, None, context)
             .await?
             .map(IotaNamesNftProxy::Domain)
     } else {
-        get_owned_nft_by_name_opt(domain, context)
+        get_owned_nft_by_id_opt(nft_id, None, context)
             .await?
             .map(IotaNamesNftProxy::Subdomain)
     })

--- a/crates/iota/src/name_commands.rs
+++ b/crates/iota/src/name_commands.rs
@@ -583,7 +583,13 @@ impl NameCommand {
                 {
                     bail!("target address is already set to the given value");
                 }
-                let nft = get_proxy_nft_by_name(&domain, context).await?;
+                let nft = get_proxy_nft_by_name_opt(&domain, context)
+                    .await?
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "cannot set target address for leaf subdomain; try removing and recreating the subdomain instead."
+                        )
+                    })?;
                 let iota_names_config = get_iota_names_config(&iota_client).await?;
 
                 let res = IotaClientCommands::Call {
@@ -718,7 +724,11 @@ impl NameCommand {
                     bail!("target address is already unset");
                 }
 
-                let nft = get_proxy_nft_by_name(&domain, context).await?;
+                let nft = get_proxy_nft_by_name_opt(&domain, context)
+                    .await?
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("cannot unset target address for leaf subdomain")
+                    })?;
                 let iota_names_config = get_iota_names_config(&iota_client).await?;
 
                 let res = IotaClientCommands::Call {
@@ -1866,15 +1876,24 @@ async fn get_owned_nft_by_name<T: DeserializeOwned + IotaNamesNft>(
     domain: &Domain,
     context: &mut WalletContext,
 ) -> anyhow::Result<T> {
+    get_owned_nft_by_name_opt(domain, context)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("no matching owned {} found for {domain}", T::TYPE_NAME))
+}
+
+async fn get_owned_nft_by_name_opt<T: DeserializeOwned + IotaNamesNft>(
+    domain: &Domain,
+    context: &mut WalletContext,
+) -> anyhow::Result<Option<T>> {
     let domain = domain.to_string();
 
     for nft in get_owned_nfts::<T>(None, context).await? {
         if nft.domain_name() == domain {
-            return Ok(nft);
+            return Ok(Some(nft));
         }
     }
 
-    bail!("no matching owned {} found for {domain}", T::TYPE_NAME)
+    Ok(None)
 }
 
 async fn get_proxy_nft_by_name(
@@ -1885,6 +1904,21 @@ async fn get_proxy_nft_by_name(
         IotaNamesNftProxy::Domain(get_owned_nft_by_name(domain, context).await?)
     } else {
         IotaNamesNftProxy::Subdomain(get_owned_nft_by_name(domain, context).await?)
+    })
+}
+
+async fn get_proxy_nft_by_name_opt(
+    domain: &Domain,
+    context: &mut WalletContext,
+) -> anyhow::Result<Option<IotaNamesNftProxy>> {
+    Ok(if domain.is_sld() {
+        get_owned_nft_by_name_opt(domain, context)
+            .await?
+            .map(IotaNamesNftProxy::Domain)
+    } else {
+        get_owned_nft_by_name_opt(domain, context)
+            .await?
+            .map(IotaNamesNftProxy::Subdomain)
     })
 }
 


### PR DESCRIPTION
## Description 

Leaf subdomains cannot have their target addresses set or unset, so this PR adds an error when the registry entry exists but there is no NFT.

Closes #7505
