### PR TITLE
upstream(node): Add support for TLS connections with self-signed cert on validator gRPC interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,9 +936,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -947,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6344,6 +6344,7 @@ dependencies = [
  "iota-storage",
  "iota-swarm-config",
  "iota-test-transaction-builder",
+ "iota-tls",
  "iota-transaction-checks",
  "iota-types",
  "itertools 0.13.0",
@@ -7452,12 +7453,14 @@ name = "iota-network-stack"
 version = "1.3.0-alpha"
 dependencies = [
  "anemo",
+ "async-stream",
  "bcs",
  "bytes",
  "eyre",
  "futures",
  "http 1.1.0",
  "http-body 1.0.1",
+ "hyper-rustls 0.27.3",
  "hyper-util",
  "multiaddr",
  "once_cell",
@@ -7465,6 +7468,7 @@ dependencies = [
  "serde",
  "snap",
  "tokio",
+ "tokio-rustls 0.26.0",
  "tokio-stream",
  "tonic 0.13.1",
  "tonic-health",
@@ -8220,6 +8224,7 @@ dependencies = [
  "iota-protocol-config",
  "iota-simulator",
  "iota-swarm-config",
+ "iota-tls",
  "iota-types",
  "prometheus",
  "rand 0.8.5",
@@ -8321,6 +8326,7 @@ dependencies = [
  "iota-sdk 1.3.0-alpha",
  "iota-snapshot",
  "iota-storage",
+ "iota-tls",
  "iota-types",
  "itertools 0.13.0",
  "move-core-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,6 +218,7 @@ anyhow = "1.0.71"
 arc-swap = { version = "1.5.1", features = ["serde"] }
 async-graphql = "7.0.17"
 async-recursion = "1.0.4"
+async-stream = "0.3.6"
 async-trait = "0.1.61"
 aws-config = "1.5.6"
 aws-sdk-dynamodb = "1.42"

--- a/consensus/core/src/network/tonic_network.rs
+++ b/consensus/core/src/network/tonic_network.rs
@@ -20,6 +20,7 @@ use iota_network_stack::{
     callback::{CallbackLayer, MakeCallbackHandler, ResponseHandler},
     multiaddr::Protocol,
 };
+use iota_tls::AllowPublicKeys;
 use parking_lot::RwLock;
 use tokio_stream::{Iter, iter};
 use tonic::{Request, Response, Streaming, codec::CompressionEncoding};
@@ -33,7 +34,6 @@ use super::{
         consensus_service_client::ConsensusServiceClient,
         consensus_service_server::ConsensusService,
     },
-    tonic_tls::create_rustls_client_config,
 };
 use crate::{
     CommitIndex, Round,
@@ -43,7 +43,7 @@ use crate::{
     error::{ConsensusError, ConsensusResult},
     network::{
         tonic_gen::consensus_service_server::ConsensusServiceServer,
-        tonic_tls::create_rustls_server_config,
+        tonic_tls::certificate_server_name,
     },
 };
 
@@ -374,7 +374,16 @@ impl ChannelPool {
         let address = format!("https://{address}");
         let config = &self.context.parameters.tonic;
         let buffer_size = config.connection_buffer_size;
-        let client_tls_config = create_rustls_client_config(&self.context, network_keypair, peer);
+        let client_tls_config = iota_tls::create_rustls_client_config(
+            self.context
+                .committee
+                .authority(peer)
+                .network_key
+                .clone()
+                .into_inner(),
+            certificate_server_name(&self.context),
+            Some(network_keypair.private_key().into_inner()),
+        );
         let endpoint = tonic_rustls::Channel::from_shared(address.clone())
             .unwrap()
             .connect_timeout(timeout)
@@ -748,8 +757,17 @@ impl<S: NetworkService> NetworkManager<S> for TonicManager {
             .into_axum_router()
             .route_layer(layers);
 
-        let tls_server_config =
-            create_rustls_server_config(&self.context, self.network_keypair.clone());
+        let tls_server_config = iota_tls::create_rustls_server_config(
+            self.network_keypair.clone().private_key().into_inner(),
+            certificate_server_name(&self.context),
+            AllowPublicKeys::new(
+                self.context
+                    .committee
+                    .authorities()
+                    .map(|(_i, a)| a.network_key.clone().into_inner())
+                    .collect(),
+            ),
+        );
 
         // Calculate some metrics around send/recv buffer sizes for the current
         // machine/OS

--- a/consensus/core/src/network/tonic_tls.rs
+++ b/consensus/core/src/network/tonic_tls.rs
@@ -2,65 +2,8 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use consensus_config::{AuthorityIndex, NetworkKeyPair};
-use iota_tls::AllowPublicKeys;
-use tokio_rustls::rustls::{ClientConfig, ServerConfig};
-
 use crate::context::Context;
 
-pub(crate) fn create_rustls_server_config(
-    context: &Context,
-    network_keypair: NetworkKeyPair,
-) -> ServerConfig {
-    let allower = AllowPublicKeys::new(
-        context
-            .committee
-            .authorities()
-            .map(|(_i, a)| a.network_key.clone().into_inner())
-            .collect(),
-    );
-    let verifier = iota_tls::ClientCertVerifier::new(allower, certificate_server_name(context));
-    // TODO: refactor to use key bytes
-    let self_signed_cert = iota_tls::SelfSignedCertificate::new(
-        network_keypair.private_key().into_inner(),
-        &certificate_server_name(context),
-    );
-    let tls_cert = self_signed_cert.rustls_certificate();
-    let tls_private_key = self_signed_cert.rustls_private_key();
-    let mut tls_config = verifier
-        .rustls_server_config(vec![tls_cert], tls_private_key)
-        .unwrap_or_else(|e| panic!("Failed to create TLS server config: {:?}", e));
-    tls_config.alpn_protocols = vec![b"h2".to_vec()];
-    tls_config
-}
-
-pub(crate) fn create_rustls_client_config(
-    context: &Context,
-    network_keypair: NetworkKeyPair,
-    target: AuthorityIndex,
-) -> ClientConfig {
-    let target_public_key = context
-        .committee
-        .authority(target)
-        .network_key
-        .clone()
-        .into_inner();
-    let self_signed_cert = iota_tls::SelfSignedCertificate::new(
-        network_keypair.private_key().into_inner(),
-        &certificate_server_name(context),
-    );
-    let tls_cert = self_signed_cert.rustls_certificate();
-    let tls_private_key = self_signed_cert.rustls_private_key();
-    let mut tls_config =
-        iota_tls::ServerCertVerifier::new(target_public_key, certificate_server_name(context))
-            .rustls_client_config(vec![tls_cert], tls_private_key)
-            .unwrap_or_else(|e| panic!("Failed to create TLS client config: {:?}", e));
-    // ServerCertVerifier sets alpn for completeness, but alpn cannot be predefined
-    // when using HttpsConnector from hyper-rustls, as in TonicManager.
-    tls_config.alpn_protocols = vec![];
-    tls_config
-}
-
-fn certificate_server_name(context: &Context) -> String {
+pub(crate) fn certificate_server_name(context: &Context) -> String {
     format!("consensus_epoch_{}", context.committee.epoch())
 }

--- a/crates/iota-core/Cargo.toml
+++ b/crates/iota-core/Cargo.toml
@@ -81,6 +81,7 @@ iota-protocol-config.workspace = true
 iota-simulator.workspace = true
 iota-storage.workspace = true
 iota-swarm-config.workspace = true
+iota-tls.workspace = true
 iota-transaction-checks.workspace = true
 iota-types.workspace = true
 move-binary-format.workspace = true

--- a/crates/iota-core/src/authority_client.rs
+++ b/crates/iota-core/src/authority_client.rs
@@ -16,6 +16,7 @@ use iota_network_stack::config::Config;
 use iota_types::{
     base_types::AuthorityName,
     committee::CommitteeWithNetworkMetadata,
+    crypto::NetworkPublicKey,
     error::{IotaError, IotaResult},
     iota_system_state::IotaSystemState,
     messages_checkpoint::{CheckpointRequest, CheckpointResponse},
@@ -87,17 +88,32 @@ pub struct NetworkAuthorityClient {
 }
 
 impl NetworkAuthorityClient {
-    /// Connects to a client address.
-    pub async fn connect(address: &Multiaddr) -> anyhow::Result<Self> {
-        let channel = iota_network_stack::client::connect(address)
+    pub async fn connect(
+        address: &Multiaddr,
+        tls_target: Option<NetworkPublicKey>,
+    ) -> anyhow::Result<Self> {
+        let tls_config = tls_target.map(|tls_target| {
+            iota_tls::create_rustls_client_config(
+                tls_target,
+                iota_tls::IOTA_VALIDATOR_SERVER_NAME.to_string(),
+                None,
+            )
+        });
+        let channel = iota_network_stack::client::connect(address, tls_config)
             .await
             .map_err(|err| anyhow!(err.to_string()))?;
         Ok(Self::new(channel))
     }
 
-    /// Connects to a client address lazily.
-    pub fn connect_lazy(address: &Multiaddr) -> Self {
-        let client: IotaResult<_> = iota_network_stack::client::connect_lazy(address)
+    pub fn connect_lazy(address: &Multiaddr, tls_target: Option<NetworkPublicKey>) -> Self {
+        let tls_config = tls_target.map(|tls_target| {
+            iota_tls::create_rustls_client_config(
+                tls_target,
+                iota_tls::IOTA_VALIDATOR_SERVER_NAME.to_string(),
+                None,
+            )
+        });
+        let client: IotaResult<_> = iota_network_stack::client::connect_lazy(address, tls_config)
             .map(ValidatorClient::new)
             .map_err(|err| err.to_string().into());
         Self { client }
@@ -232,7 +248,18 @@ pub fn make_network_authority_clients_with_network_config(
     for (name, (_state, network_metadata)) in committee.validators() {
         let address = network_metadata.network_address.clone();
         let address = address.rewrite_udp_to_tcp();
-        let maybe_channel = network_config.connect_lazy(&address).map_err(|e| {
+        // TODO: Enable TLS on this interface with below config, once support is rolled
+        // out to validators. let tls_config =
+        // network_metadata.network_public_key.as_ref().map(|key| {
+        //     iota_tls::create_rustls_client_config(
+        //         key.clone(),
+        //         iota_tls::IOTA_VALIDATOR_SERVER_NAME.to_string(),
+        //         None,
+        //     )
+        // });
+        // TODO: Change below code to generate a IotaError if no valid TLS config is
+        // available.
+        let maybe_channel = network_config.connect_lazy(&address, None).map_err(|e| {
             tracing::error!(
                 address = %address,
                 name = %name,

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -12,12 +12,14 @@ use std::{
 
 use anyhow::Result;
 use async_trait::async_trait;
+use fastcrypto::traits::KeyPair;
 use iota_config::local_ip_utils::new_local_tcp_address_for_testing;
 use iota_metrics::spawn_monitored_task;
 use iota_network::{
     api::{Validator, ValidatorServer},
     tonic,
 };
+use iota_network_stack::server::IOTA_TLS_SERVER_NAME;
 use iota_types::{
     effects::TransactionEffectsAPI,
     error::*,
@@ -145,6 +147,11 @@ impl AuthorityServer {
         self,
         address: Multiaddr,
     ) -> Result<AuthorityServerHandle, io::Error> {
+        let tls_config = iota_tls::create_rustls_server_config(
+            self.state.config.network_key_pair().copy().private(),
+            IOTA_TLS_SERVER_NAME.to_string(),
+            iota_tls::AllowAll,
+        );
         let mut server = iota_network_stack::config::Config::new()
             .server_builder()
             .add_service(ValidatorServer::new(ValidatorService::new_for_tests(
@@ -152,7 +159,7 @@ impl AuthorityServer {
                 self.consensus_adapter,
                 self.metrics,
             )))
-            .bind(&address)
+            .bind(&address, Some(tls_config))
             .await
             .unwrap();
         let local_addr = server.local_addr().to_owned();

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -1199,9 +1199,18 @@ async fn test_handle_transfer_transaction_bad_signature() {
 
     let server_handle = server.spawn_for_test().await.unwrap();
 
-    let client = NetworkAuthorityClient::connect(server_handle.address())
-        .await
-        .unwrap();
+    let client = NetworkAuthorityClient::connect(
+        server_handle.address(),
+        Some(
+            authority_state
+                .config
+                .network_key_pair()
+                .public()
+                .to_owned(),
+        ),
+    )
+    .await
+    .unwrap();
 
     let (_unknown_address, unknown_key): (_, AccountKeyPair) = get_key_pair();
     let mut bad_signature_transfer_transaction = transfer_transaction.clone().into_inner();

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -22,13 +22,22 @@ async fn test_simple_request() {
 
     // The following two fields are only needed for shared objects (not by this
     // bench).
-    let server = AuthorityServer::new_for_test(authority_state);
+    let server = AuthorityServer::new_for_test(authority_state.clone());
 
     let server_handle = server.spawn_for_test().await.unwrap();
 
-    let client = NetworkAuthorityClient::connect(server_handle.address())
-        .await
-        .unwrap();
+    let client = NetworkAuthorityClient::connect(
+        server_handle.address(),
+        Some(
+            authority_state
+                .config
+                .network_key_pair()
+                .public()
+                .to_owned(),
+        ),
+    )
+    .await
+    .unwrap();
 
     let req =
         ObjectInfoRequest::latest_object_info_request(object_id, LayoutGenerationOption::Generate);

--- a/crates/iota-core/src/unit_tests/transaction_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_tests.rs
@@ -410,9 +410,18 @@ async fn do_transaction_test_impl(
 
     let server_handle = server.spawn_for_test().await.unwrap();
 
-    let client = NetworkAuthorityClient::connect(server_handle.address())
-        .await
-        .unwrap();
+    let client = NetworkAuthorityClient::connect(
+        server_handle.address(),
+        Some(
+            authority_state
+                .config
+                .network_key_pair()
+                .public()
+                .to_owned(),
+        ),
+    )
+    .await
+    .unwrap();
 
     post_sign_mutations(&mut transfer_transaction);
     post_sign_mutations(&mut move_call_transaction);
@@ -1034,9 +1043,18 @@ async fn setup_zklogin_network(
 
     let server_handle = server.spawn_for_test().await.unwrap();
 
-    let client = NetworkAuthorityClient::connect(server_handle.address())
-        .await
-        .unwrap();
+    let client = NetworkAuthorityClient::connect(
+        server_handle.address(),
+        Some(
+            authority_state
+                .config
+                .network_key_pair()
+                .public()
+                .to_owned(),
+        ),
+    )
+    .await
+    .unwrap();
     Ok((
         object_ids,
         gas_object_ids,
@@ -1331,9 +1349,18 @@ async fn execute_transaction_assert_err(
 
     let server_handle = server.spawn_for_test().await.unwrap();
 
-    let client = NetworkAuthorityClient::connect(server_handle.address())
-        .await
-        .unwrap();
+    let client = NetworkAuthorityClient::connect(
+        server_handle.address(),
+        Some(
+            authority_state
+                .config
+                .network_key_pair()
+                .public()
+                .to_owned(),
+        ),
+    )
+    .await
+    .unwrap();
     let err = client
         .handle_transaction(txn.clone(), Some(make_socket_addr()))
         .await;
@@ -1383,9 +1410,18 @@ async fn test_oversized_txn() {
 
     let server_handle = server.spawn_for_test().await.unwrap();
 
-    let client = NetworkAuthorityClient::connect(server_handle.address())
-        .await
-        .unwrap();
+    let client = NetworkAuthorityClient::connect(
+        server_handle.address(),
+        Some(
+            authority_state
+                .config
+                .network_key_pair()
+                .public()
+                .to_owned(),
+        ),
+    )
+    .await
+    .unwrap();
 
     let res = client
         .handle_transaction(txn, Some(make_socket_addr()))
@@ -1435,9 +1471,18 @@ async fn test_very_large_certificate() {
 
     let server_handle = server.spawn_for_test().await.unwrap();
 
-    let client = NetworkAuthorityClient::connect(server_handle.address())
-        .await
-        .unwrap();
+    let client = NetworkAuthorityClient::connect(
+        server_handle.address(),
+        Some(
+            authority_state
+                .config
+                .network_key_pair()
+                .public()
+                .to_owned(),
+        ),
+    )
+    .await
+    .unwrap();
     let socket_addr = make_socket_addr();
 
     let auth_sig = client
@@ -1519,9 +1564,18 @@ async fn test_handle_certificate_errors() {
 
     let server_handle = server.spawn_for_test().await.unwrap();
 
-    let client = NetworkAuthorityClient::connect(server_handle.address())
-        .await
-        .unwrap();
+    let client = NetworkAuthorityClient::connect(
+        server_handle.address(),
+        Some(
+            authority_state
+                .config
+                .network_key_pair()
+                .public()
+                .to_owned(),
+        ),
+    )
+    .await
+    .unwrap();
 
     // Test handle certificate from the wrong epoch
     let epoch_store = authority_state.epoch_store_for_testing();
@@ -1711,9 +1765,12 @@ async fn test_handle_soft_bundle_certificates() {
     let server = AuthorityServer::new_for_test_with_consensus_adapter(authority.clone(), adapter);
     let _metrics = server.metrics.clone();
     let server_handle = server.spawn_for_test().await.unwrap();
-    let client = NetworkAuthorityClient::connect(server_handle.address())
-        .await
-        .unwrap();
+    let client = NetworkAuthorityClient::connect(
+        server_handle.address(),
+        Some(authority.config.network_key_pair().public().to_owned()),
+    )
+    .await
+    .unwrap();
 
     let signed_tx_into_certificate = |transaction: Transaction| async {
         let epoch_store = authority.load_epoch_store_one_call_per_task();
@@ -1871,9 +1928,12 @@ async fn test_handle_soft_bundle_certificates_errors() {
     let authority = server.state.clone();
     let _metrics = server.metrics.clone();
     let server_handle = server.spawn_for_test().await.unwrap();
-    let client = NetworkAuthorityClient::connect(server_handle.address())
-        .await
-        .unwrap();
+    let client = NetworkAuthorityClient::connect(
+        server_handle.address(),
+        Some(authority.config.network_key_pair().public().to_owned()),
+    )
+    .await
+    .unwrap();
 
     let signed_tx_into_certificate = |transaction: Transaction| async {
         let epoch_store = authority.load_epoch_store_one_call_per_task();

--- a/crates/iota-network-stack/Cargo.toml
+++ b/crates/iota-network-stack/Cargo.toml
@@ -9,12 +9,14 @@ description = "IOTA's network tooling"
 
 [dependencies]
 anemo.workspace = true
+async-stream.workspace = true
 bcs.workspace = true
 bytes.workspace = true
 eyre.workspace = true
 futures.workspace = true
 http.workspace = true
 http-body.workspace = true
+hyper-rustls.workspace = true
 hyper-util.workspace = true
 multiaddr = "0.17.0"
 once_cell.workspace = true
@@ -22,6 +24,7 @@ pin-project-lite = "0.2.13"
 serde.workspace = true
 snap.workspace = true
 tokio = { workspace = true, features = ["sync", "rt", "macros"] }
+tokio-rustls.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true
 tonic-health.workspace = true

--- a/crates/iota-network-stack/src/client.rs
+++ b/crates/iota-network-stack/src/client.rs
@@ -19,6 +19,7 @@ use eyre::{Context, Result, eyre};
 use hyper_util::client::legacy::connect::{HttpConnector, dns::Name};
 use once_cell::sync::OnceCell;
 use tokio::task::JoinHandle;
+use tokio_rustls::rustls::ClientConfig;
 use tonic::transport::{Channel, Endpoint, Uri};
 use tower::Service;
 use tracing::{info, trace};
@@ -28,49 +29,62 @@ use crate::{
     multiaddr::{Multiaddr, Protocol, parse_dns, parse_ip4, parse_ip6},
 };
 
-pub async fn connect(address: &Multiaddr) -> Result<Channel> {
-    let channel = endpoint_from_multiaddr(address)?.connect().await?;
+pub async fn connect(address: &Multiaddr, tls_config: Option<ClientConfig>) -> Result<Channel> {
+    let channel = endpoint_from_multiaddr(address, tls_config)?
+        .connect()
+        .await?;
     Ok(channel)
 }
 
-pub fn connect_lazy(address: &Multiaddr) -> Result<Channel> {
-    let channel = endpoint_from_multiaddr(address)?.connect_lazy();
+pub fn connect_lazy(address: &Multiaddr, tls_config: Option<ClientConfig>) -> Result<Channel> {
+    let channel = endpoint_from_multiaddr(address, tls_config)?.connect_lazy();
     Ok(channel)
 }
 
-pub(crate) async fn connect_with_config(address: &Multiaddr, config: &Config) -> Result<Channel> {
-    let channel = endpoint_from_multiaddr(address)?
+pub(crate) async fn connect_with_config(
+    address: &Multiaddr,
+    tls_config: Option<ClientConfig>,
+    config: &Config,
+) -> Result<Channel> {
+    let channel = endpoint_from_multiaddr(address, tls_config)?
         .apply_config(config)
         .connect()
         .await?;
     Ok(channel)
 }
 
-pub(crate) fn connect_lazy_with_config(address: &Multiaddr, config: &Config) -> Result<Channel> {
-    let channel = endpoint_from_multiaddr(address)?
+pub(crate) fn connect_lazy_with_config(
+    address: &Multiaddr,
+    tls_config: Option<ClientConfig>,
+    config: &Config,
+) -> Result<Channel> {
+    let channel = endpoint_from_multiaddr(address, tls_config)?
         .apply_config(config)
         .connect_lazy();
     Ok(channel)
 }
 
-fn endpoint_from_multiaddr(addr: &Multiaddr) -> Result<MyEndpoint> {
+fn endpoint_from_multiaddr(
+    addr: &Multiaddr,
+    tls_config: Option<ClientConfig>,
+) -> Result<MyEndpoint> {
     let mut iter = addr.iter();
 
     let channel = match iter.next().ok_or_else(|| eyre!("address is empty"))? {
         Protocol::Dns(_) => {
             let (dns_name, tcp_port, http_or_https) = parse_dns(addr)?;
             let uri = format!("{http_or_https}://{dns_name}:{tcp_port}");
-            MyEndpoint::try_from_uri(uri)?
+            MyEndpoint::try_from_uri(uri, tls_config)?
         }
         Protocol::Ip4(_) => {
             let (socket_addr, http_or_https) = parse_ip4(addr)?;
             let uri = format!("{http_or_https}://{socket_addr}");
-            MyEndpoint::try_from_uri(uri)?
+            MyEndpoint::try_from_uri(uri, tls_config)?
         }
         Protocol::Ip6(_) => {
             let (socket_addr, http_or_https) = parse_ip6(addr)?;
             let uri = format!("{http_or_https}://{socket_addr}");
-            MyEndpoint::try_from_uri(uri)?
+            MyEndpoint::try_from_uri(uri, tls_config)?
         }
         unsupported => return Err(eyre!("unsupported protocol {unsupported}")),
     };
@@ -80,21 +94,25 @@ fn endpoint_from_multiaddr(addr: &Multiaddr) -> Result<MyEndpoint> {
 
 struct MyEndpoint {
     endpoint: Endpoint,
+    tls_config: Option<ClientConfig>,
 }
 
 static DISABLE_CACHING_RESOLVER: OnceCell<bool> = OnceCell::new();
 
 impl MyEndpoint {
-    fn new(endpoint: Endpoint) -> Self {
-        Self { endpoint }
+    fn new(endpoint: Endpoint, tls_config: Option<ClientConfig>) -> Self {
+        Self {
+            endpoint,
+            tls_config,
+        }
     }
 
-    fn try_from_uri(uri: String) -> Result<Self> {
+    fn try_from_uri(uri: String, tls_config: Option<ClientConfig>) -> Result<Self> {
         let uri: Uri = uri
             .parse()
             .with_context(|| format!("unable to create Uri from '{uri}'"))?;
         let endpoint = Endpoint::from(uri);
-        Ok(Self::new(endpoint))
+        Ok(Self::new(endpoint, tls_config))
     }
 
     fn apply_config(mut self, config: &Config) -> Self {
@@ -110,7 +128,17 @@ impl MyEndpoint {
         });
 
         if disable_caching_resolver {
-            self.endpoint.connect_lazy()
+            if let Some(tls_config) = self.tls_config {
+                self.endpoint.connect_with_connector_lazy(
+                    hyper_rustls::HttpsConnectorBuilder::new()
+                        .with_tls_config(tls_config)
+                        .https_only()
+                        .enable_http2()
+                        .build(),
+                )
+            } else {
+                self.endpoint.connect_lazy()
+            }
         } else {
             let mut http = HttpConnector::new_with_resolver(CachingResolver::new());
             http.enforce_http(false);
@@ -118,12 +146,33 @@ impl MyEndpoint {
             http.set_keepalive(None);
             http.set_connect_timeout(None);
 
-            self.endpoint.connect_with_connector_lazy(http)
+            if let Some(tls_config) = self.tls_config {
+                let https = hyper_rustls::HttpsConnectorBuilder::new()
+                    .with_tls_config(tls_config)
+                    .https_only()
+                    .enable_http1()
+                    .wrap_connector(http);
+                self.endpoint.connect_with_connector_lazy(https)
+            } else {
+                self.endpoint.connect_with_connector_lazy(http)
+            }
         }
     }
 
     async fn connect(self) -> Result<Channel> {
-        self.endpoint.connect().await.map_err(Into::into)
+        if let Some(tls_config) = self.tls_config {
+            let https_connector = hyper_rustls::HttpsConnectorBuilder::new()
+                .with_tls_config(tls_config)
+                .https_only()
+                .enable_http2()
+                .build();
+            self.endpoint
+                .connect_with_connector(https_connector)
+                .await
+                .map_err(Into::into)
+        } else {
+            self.endpoint.connect().await.map_err(Into::into)
+        }
     }
 }
 

--- a/crates/iota-network-stack/src/config.rs
+++ b/crates/iota-network-stack/src/config.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 
 use eyre::Result;
 use serde::{Deserialize, Serialize};
+use tokio_rustls::rustls::ClientConfig;
 use tonic::transport::Channel;
 
 use crate::{
@@ -97,11 +98,19 @@ impl Config {
         ServerBuilder::from_config(self, metrics_provider)
     }
 
-    pub async fn connect(&self, addr: &Multiaddr) -> Result<Channel> {
-        connect_with_config(addr, self).await
+    pub async fn connect(
+        &self,
+        addr: &Multiaddr,
+        tls_config: Option<ClientConfig>,
+    ) -> Result<Channel> {
+        connect_with_config(addr, tls_config, self).await
     }
 
-    pub fn connect_lazy(&self, addr: &Multiaddr) -> Result<Channel> {
-        connect_lazy_with_config(addr, self)
+    pub fn connect_lazy(
+        &self,
+        addr: &Multiaddr,
+        tls_config: Option<ClientConfig>,
+    ) -> Result<Channel> {
+        connect_lazy_with_config(addr, tls_config, self)
     }
 }

--- a/crates/iota-network-stack/src/server.rs
+++ b/crates/iota-network-stack/src/server.rs
@@ -5,13 +5,18 @@
 use std::{
     convert::Infallible,
     net::SocketAddr,
+    pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
 };
 
 use eyre::{Result, eyre};
-use futures::FutureExt;
-use tokio::net::{TcpListener, ToSocketAddrs};
-use tokio_stream::wrappers::TcpListenerStream;
+use futures::{FutureExt, Stream, StreamExt, stream::FuturesUnordered};
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    net::{TcpListener, TcpStream, ToSocketAddrs},
+};
+use tokio_rustls::{TlsAcceptor, rustls::ServerConfig, server::TlsStream};
 use tonic::{
     body::Body,
     codegen::{
@@ -34,6 +39,7 @@ use tower_http::{
     set_header::SetRequestHeaderLayer,
     trace::{DefaultMakeSpan, DefaultOnBodyChunk, DefaultOnEos, TraceLayer},
 };
+use tracing::debug;
 
 use crate::{
     config::Config,
@@ -164,46 +170,48 @@ impl<M: MetricsCallbackProvider> ServerBuilder<M> {
         self
     }
 
-    pub async fn bind(self, addr: &Multiaddr) -> Result<Server> {
+    pub async fn bind(self, addr: &Multiaddr, tls_config: Option<ServerConfig>) -> Result<Server> {
         let mut iter = addr.iter();
 
         let (tx_cancellation, rx_cancellation) = tokio::sync::oneshot::channel();
         let rx_cancellation = rx_cancellation.map(|_| ());
-        let (local_addr, server): (Multiaddr, BoxFuture<(), tonic::transport::Error>) =
-            match iter.next().ok_or_else(|| eyre!("malformed addr"))? {
-                Protocol::Dns(_) => {
-                    let (dns_name, tcp_port, _http_or_https) = parse_dns(addr)?;
-                    let (local_addr, incoming) =
-                        tcp_listener_and_update_multiaddr(addr, (dns_name.as_ref(), tcp_port))
-                            .await?;
-                    let server = Box::pin(
-                        self.router
-                            .serve_with_incoming_shutdown(incoming, rx_cancellation),
-                    );
-                    (local_addr, server)
-                }
-                Protocol::Ip4(_) => {
-                    let (socket_addr, _http_or_https) = parse_ip4(addr)?;
-                    let (local_addr, incoming) =
-                        tcp_listener_and_update_multiaddr(addr, socket_addr).await?;
-                    let server = Box::pin(
-                        self.router
-                            .serve_with_incoming_shutdown(incoming, rx_cancellation),
-                    );
-                    (local_addr, server)
-                }
-                Protocol::Ip6(_) => {
-                    let (socket_addr, _http_or_https) = parse_ip6(addr)?;
-                    let (local_addr, incoming) =
-                        tcp_listener_and_update_multiaddr(addr, socket_addr).await?;
-                    let server = Box::pin(
-                        self.router
-                            .serve_with_incoming_shutdown(incoming, rx_cancellation),
-                    );
-                    (local_addr, server)
-                }
-                unsupported => return Err(eyre!("unsupported protocol {unsupported}")),
-            };
+        let (local_addr, server): (Multiaddr, BoxFuture<(), tonic::transport::Error>) = match iter
+            .next()
+            .ok_or_else(|| eyre!("malformed addr"))?
+        {
+            Protocol::Dns(_) => {
+                let (dns_name, tcp_port, _http_or_https) = parse_dns(addr)?;
+                let (local_addr, incoming) =
+                    listen_and_update_multiaddr(addr, (dns_name.to_string(), tcp_port), tls_config)
+                        .await?;
+                let server = Box::pin(
+                    self.router
+                        .serve_with_incoming_shutdown(incoming, rx_cancellation),
+                );
+                (local_addr, server)
+            }
+            Protocol::Ip4(_) => {
+                let (socket_addr, _http_or_https) = parse_ip4(addr)?;
+                let (local_addr, incoming) =
+                    listen_and_update_multiaddr(addr, socket_addr, tls_config).await?;
+                let server = Box::pin(
+                    self.router
+                        .serve_with_incoming_shutdown(incoming, rx_cancellation),
+                );
+                (local_addr, server)
+            }
+            Protocol::Ip6(_) => {
+                let (socket_addr, _http_or_https) = parse_ip6(addr)?;
+                let (local_addr, incoming) =
+                    listen_and_update_multiaddr(addr, socket_addr, tls_config).await?;
+                let server = Box::pin(
+                    self.router
+                        .serve_with_incoming_shutdown(incoming, rx_cancellation),
+                );
+                (local_addr, server)
+            }
+            unsupported => return Err(eyre!("unsupported protocol {unsupported}")),
+        };
 
         Ok(Server {
             server,
@@ -214,21 +222,155 @@ impl<M: MetricsCallbackProvider> ServerBuilder<M> {
     }
 }
 
-async fn tcp_listener_and_update_multiaddr<T: ToSocketAddrs>(
+async fn listen_and_update_multiaddr<T: ToSocketAddrs>(
     address: &Multiaddr,
     socket_addr: T,
-) -> Result<(Multiaddr, TcpListenerStream)> {
-    let (local_addr, incoming) = tcp_listener(socket_addr).await?;
+    tls_config: Option<ServerConfig>,
+) -> Result<(
+    Multiaddr,
+    impl Stream<Item = std::io::Result<TcpOrTlsStream>>,
+)> {
+    let listener = TcpListener::bind(socket_addr).await?;
+    let local_addr = listener.local_addr()?;
     let local_addr = update_tcp_port_in_multiaddr(address, local_addr.port());
-    Ok((local_addr, incoming))
+
+    let tls_acceptor = tls_config.map(|tls_config| TlsAcceptor::from(Arc::new(tls_config)));
+    let incoming = TcpOrTlsListener::new(listener, tls_acceptor);
+    let stream = async_stream::stream! {
+        let mut new_connections = FuturesUnordered::new();
+        loop {
+            tokio::select! {
+                result = incoming.accept_raw() => {
+                    match result {
+                        Ok((stream, addr)) => {
+                            new_connections.push(incoming.maybe_upgrade(stream, addr));
+                        }
+                        Err(e) => yield Err(e),
+                    }
+                }
+                Some(result) = new_connections.next() => {
+                    yield result;
+                }
+            }
+        }
+    };
+
+    Ok((local_addr, stream))
 }
 
-async fn tcp_listener<T: ToSocketAddrs>(address: T) -> Result<(SocketAddr, TcpListenerStream)> {
-    let listener = TcpListener::bind(address).await?;
-    let local_addr = listener.local_addr()?;
-    let incoming = TcpListenerStream::new(listener);
-    Ok((local_addr, incoming))
+pub struct TcpOrTlsListener {
+    listener: TcpListener,
+    tls_acceptor: Option<TlsAcceptor>,
 }
+
+impl TcpOrTlsListener {
+    fn new(listener: TcpListener, tls_acceptor: Option<TlsAcceptor>) -> Self {
+        Self {
+            listener,
+            tls_acceptor,
+        }
+    }
+
+    async fn accept_raw(&self) -> std::io::Result<(TcpStream, SocketAddr)> {
+        self.listener.accept().await
+    }
+
+    async fn maybe_upgrade(
+        &self,
+        stream: TcpStream,
+        addr: SocketAddr,
+    ) -> std::io::Result<TcpOrTlsStream> {
+        if self.tls_acceptor.is_none() {
+            return Ok(TcpOrTlsStream::Tcp(stream, addr));
+        }
+
+        // Determine whether new connection is TLS.
+        let mut buf = [0; 1];
+        // `peek` blocks until at least some data is available, so if there is no error
+        // then it must return the one byte we are requesting.
+        stream.peek(&mut buf).await?;
+        if buf[0] == 0x16 {
+            // First byte of a TLS handshake is 0x16.
+            debug!("accepting TLS connection from {addr:?}");
+            let stream = self.tls_acceptor.as_ref().unwrap().accept(stream).await?;
+            Ok(TcpOrTlsStream::Tls(stream, addr))
+        } else {
+            debug!("accepting TCP connection from {addr:?}");
+            Ok(TcpOrTlsStream::Tcp(stream, addr))
+        }
+    }
+}
+
+pub enum TcpOrTlsStream {
+    Tcp(TcpStream, SocketAddr),
+    Tls(TlsStream<TcpStream>, SocketAddr),
+}
+
+impl AsyncRead for TcpOrTlsStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf,
+    ) -> Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            TcpOrTlsStream::Tcp(stream, _) => Pin::new(stream).poll_read(cx, buf),
+            TcpOrTlsStream::Tls(stream, _) => Pin::new(stream).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for TcpOrTlsStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::result::Result<usize, std::io::Error>> {
+        match self.get_mut() {
+            TcpOrTlsStream::Tcp(stream, _) => Pin::new(stream).poll_write(cx, buf),
+            TcpOrTlsStream::Tls(stream, _) => Pin::new(stream).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<std::result::Result<(), std::io::Error>> {
+        match self.get_mut() {
+            TcpOrTlsStream::Tcp(stream, _) => Pin::new(stream).poll_flush(cx),
+            TcpOrTlsStream::Tls(stream, _) => Pin::new(stream).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<std::result::Result<(), std::io::Error>> {
+        match self.get_mut() {
+            TcpOrTlsStream::Tcp(stream, _) => Pin::new(stream).poll_shutdown(cx),
+            TcpOrTlsStream::Tls(stream, _) => Pin::new(stream).poll_shutdown(cx),
+        }
+    }
+}
+
+impl tonic::transport::server::Connected for TcpOrTlsStream {
+    type ConnectInfo = tonic::transport::server::TcpConnectInfo;
+
+    fn connect_info(&self) -> Self::ConnectInfo {
+        match self {
+            TcpOrTlsStream::Tcp(stream, addr) => Self::ConnectInfo {
+                local_addr: stream.local_addr().ok(),
+                remote_addr: Some(*addr),
+            },
+            TcpOrTlsStream::Tls(stream, addr) => Self::ConnectInfo {
+                local_addr: stream.get_ref().0.local_addr().ok(),
+                remote_addr: Some(*addr),
+            },
+        }
+    }
+}
+
+/// TLS server name to use for the public IOTA validator interface.
+pub const IOTA_TLS_SERVER_NAME: &str = "iota";
 
 pub struct Server {
     server: BoxFuture<(), tonic::transport::Error>,
@@ -328,14 +470,14 @@ mod test {
 
         let mut server = config
             .server_builder_with_metrics(metrics.clone())
-            .bind(&address)
+            .bind(&address, None)
             .await
             .unwrap();
 
         let address = server.local_addr().to_owned();
         let cancel_handle = server.take_cancel_handle().unwrap();
         let server_handle = tokio::spawn(server.serve());
-        let channel = config.connect(&address).await.unwrap();
+        let channel = config.connect(&address, None).await.unwrap();
         let mut client = HealthClient::new(channel);
 
         client
@@ -391,14 +533,14 @@ mod test {
 
         let mut server = config
             .server_builder_with_metrics(metrics.clone())
-            .bind(&address)
+            .bind(&address, None)
             .await
             .unwrap();
 
         let address = server.local_addr().to_owned();
         let cancel_handle = server.take_cancel_handle().unwrap();
         let server_handle = tokio::spawn(server.serve());
-        let channel = config.connect(&address).await.unwrap();
+        let channel = config.connect(&address, None).await.unwrap();
         let mut client = HealthClient::new(channel);
 
         // Call the healthcheck for a service that doesn't exist
@@ -418,11 +560,11 @@ mod test {
 
     async fn test_multiaddr(address: Multiaddr) {
         let config = Config::new();
-        let mut server = config.server_builder().bind(&address).await.unwrap();
+        let mut server = config.server_builder().bind(&address, None).await.unwrap();
         let address = server.local_addr().to_owned();
         let cancel_handle = server.take_cancel_handle().unwrap();
         let server_handle = tokio::spawn(server.serve());
-        let channel = config.connect(&address).await.unwrap();
+        let channel = config.connect(&address, None).await.unwrap();
         let mut client = HealthClient::new(channel);
 
         client

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -90,7 +90,7 @@ use iota_metrics::{
 use iota_network::{
     api::ValidatorServer, discovery, discovery::TrustedPeerChangeEvent, randomness, state_sync,
 };
-use iota_network_stack::server::ServerBuilder;
+use iota_network_stack::server::{IOTA_TLS_SERVER_NAME, ServerBuilder};
 use iota_protocol_config::ProtocolConfig;
 use iota_rest_api::RestMetrics;
 use iota_snapshot::uploader::StateSnapshotUploader;
@@ -1488,8 +1488,13 @@ impl IotaNode {
 
         server_builder = server_builder.add_service(ValidatorServer::new(validator_service));
 
+        let tls_config = iota_tls::create_rustls_server_config(
+            config.network_key_pair().copy().private(),
+            IOTA_TLS_SERVER_NAME.to_string(),
+            iota_tls::AllowAll,
+        );
         let mut server = server_builder
-            .bind(config.network_address())
+            .bind(config.network_address(), Some(tls_config))
             .await
             .map_err(|err| anyhow!(err.to_string()))?;
         let cancel_handle = server

--- a/crates/iota-swarm/Cargo.toml
+++ b/crates/iota-swarm/Cargo.toml
@@ -29,6 +29,7 @@ iota-network-stack.workspace = true
 iota-node.workspace = true
 iota-protocol-config.workspace = true
 iota-swarm-config.workspace = true
+iota-tls.workspace = true
 iota-types.workspace = true
 telemetry-subscribers.workspace = true
 

--- a/crates/iota-swarm/src/memory/node.rs
+++ b/crates/iota-swarm/src/memory/node.rs
@@ -7,7 +7,10 @@ use std::sync::{Mutex, MutexGuard};
 use anyhow::{Result, anyhow};
 use iota_config::NodeConfig;
 use iota_node::IotaNodeHandle;
-use iota_types::base_types::{AuthorityName, ConciseableName};
+use iota_types::{
+    base_types::{AuthorityName, ConciseableName},
+    crypto::KeypairTraits,
+};
 use tap::TapFallible;
 use tracing::{error, info};
 
@@ -106,7 +109,12 @@ impl Node {
 
         if is_validator {
             let network_address = self.config().network_address().clone();
-            let channel = iota_network_stack::client::connect(&network_address)
+            let tls_config = iota_tls::create_rustls_client_config(
+                self.config().network_key_pair().public().to_owned(),
+                iota_tls::IOTA_VALIDATOR_SERVER_NAME.to_string(),
+                None,
+            );
+            let channel = iota_network_stack::client::connect(&network_address, Some(tls_config))
                 .await
                 .map_err(|err| anyhow!(err.to_string()))
                 .map_err(HealthCheckError::Failure)

--- a/crates/iota-tls/src/lib.rs
+++ b/crates/iota-tls/src/lib.rs
@@ -6,15 +6,53 @@ mod acceptor;
 mod certgen;
 mod verifier;
 
-pub const IOTA_VALIDATOR_SERVER_NAME: &str = "iota";
-
 pub use acceptor::{TlsAcceptor, TlsConnectionInfo};
 pub use certgen::SelfSignedCertificate;
+use fastcrypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 pub use rustls;
+use rustls::ClientConfig;
+use tokio_rustls::rustls::ServerConfig;
 pub use verifier::{
     AllowAll, AllowPublicKeys, Allower, ClientCertVerifier, ServerCertVerifier,
     public_key_from_certificate,
 };
+
+pub const IOTA_VALIDATOR_SERVER_NAME: &str = "iota";
+
+pub fn create_rustls_server_config<A: Allower + 'static>(
+    private_key: Ed25519PrivateKey,
+    server_name: String,
+    allower: A,
+) -> ServerConfig {
+    let verifier = ClientCertVerifier::new(allower, server_name.clone());
+    // TODO: refactor to use key bytes
+    let self_signed_cert = SelfSignedCertificate::new(private_key, server_name.as_str());
+    let tls_cert = self_signed_cert.rustls_certificate();
+    let tls_private_key = self_signed_cert.rustls_private_key();
+    let mut tls_config = verifier
+        .rustls_server_config(vec![tls_cert], tls_private_key)
+        .unwrap_or_else(|e| panic!("Failed to create TLS server config: {:?}", e));
+    tls_config.alpn_protocols = vec![b"h2".to_vec()];
+    tls_config
+}
+
+pub fn create_rustls_client_config(
+    target_public_key: Ed25519PublicKey,
+    server_name: String,
+    client_key: Option<Ed25519PrivateKey>, // optional self-signed cert for client verification
+) -> ClientConfig {
+    let tls_config = ServerCertVerifier::new(target_public_key, server_name.clone());
+    let tls_config = if let Some(private_key) = client_key {
+        let self_signed_cert = SelfSignedCertificate::new(private_key, server_name.as_str());
+        let tls_cert = self_signed_cert.rustls_certificate();
+        let tls_private_key = self_signed_cert.rustls_private_key();
+        tls_config.rustls_client_config_with_client_auth(vec![tls_cert], tls_private_key)
+    } else {
+        tls_config.rustls_client_config_with_no_client_auth()
+    }
+    .unwrap_or_else(|e| panic!("Failed to create TLS client config: {e:?}"));
+    tls_config
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/iota-tls/src/verifier.rs
+++ b/crates/iota-tls/src/verifier.rs
@@ -182,20 +182,30 @@ impl ServerCertVerifier {
         Self { public_key, name }
     }
 
-    pub fn rustls_client_config(
+    pub fn rustls_client_config_with_client_auth(
         self,
         certificates: Vec<CertificateDer<'static>>,
         private_key: PrivateKeyDer<'static>,
     ) -> Result<rustls::ClientConfig, rustls::Error> {
-        let mut config = rustls::ClientConfig::builder_with_provider(Arc::new(
+        rustls::ClientConfig::builder_with_provider(Arc::new(
             rustls::crypto::ring::default_provider(),
         ))
         .with_safe_default_protocol_versions()?
         .dangerous()
         .with_custom_certificate_verifier(std::sync::Arc::new(self))
-        .with_client_auth_cert(certificates, private_key)?;
-        config.alpn_protocols = vec![b"h2".to_vec()];
-        Ok(config)
+        .with_client_auth_cert(certificates, private_key)
+    }
+
+    pub fn rustls_client_config_with_no_client_auth(
+        self,
+    ) -> Result<rustls::ClientConfig, rustls::Error> {
+        Ok(rustls::ClientConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_safe_default_protocol_versions()?
+        .dangerous()
+        .with_custom_certificate_verifier(std::sync::Arc::new(self))
+        .with_no_client_auth())
     }
 }
 

--- a/crates/iota-tool/Cargo.toml
+++ b/crates/iota-tool/Cargo.toml
@@ -45,6 +45,7 @@ iota-replay.workspace = true
 iota-sdk.workspace = true
 iota-snapshot.workspace = true
 iota-storage.workspace = true
+iota-tls.workspace = true
 iota-types.workspace = true
 move-core-types.workspace = true
 telemetry-subscribers.workspace = true

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -113,9 +113,18 @@ async fn make_clients(
         .await?;
 
     for committee_member in state.iter_committee_members() {
-        let net_addr = Multiaddr::try_from(committee_member.net_address.clone())?;
+        let net_addr = Multiaddr::try_from(committee_member.net_address).unwrap();
+        // TODO: Enable TLS on this interface with below config, once support is rolled
+        // out to validators.
+        // ```
+        // let tls_config = iota_tls::create_rustls_client_config(
+        //     iota_types::crypto::NetworkPublicKey::from_bytes(&committee_member.network_pubkey_bytes)?,
+        //     iota_tls::IOTA_VALIDATOR_SERVER_NAME.to_string(),
+        //     None,
+        // );
+        // ```
         let channel = net_config
-            .connect_lazy(&net_addr)
+            .connect_lazy(&net_addr, None)
             .map_err(|err| anyhow!(err.to_string()))?;
         let client = NetworkAuthorityClient::new(channel);
         let public_key_bytes =

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -113,7 +113,7 @@ async fn make_clients(
         .await?;
 
     for committee_member in state.iter_committee_members() {
-        let net_addr = Multiaddr::try_from(committee_member.net_address).unwrap();
+        let net_addr = Multiaddr::try_from(committee_member.net_address.clone()).unwrap();
         // TODO: Enable TLS on this interface with below config, once support is rolled
         // out to validators.
         // ```

--- a/crates/iota-types/src/committee.rs
+++ b/crates/iota-types/src/committee.rs
@@ -21,7 +21,9 @@ use serde::{Deserialize, Serialize};
 
 use super::base_types::*;
 use crate::{
-    crypto::{AuthorityKeyPair, AuthorityPublicKey, random_committee_key_pairs_of_size},
+    crypto::{
+        AuthorityKeyPair, AuthorityPublicKey, NetworkPublicKey, random_committee_key_pairs_of_size,
+    },
     error::{IotaError, IotaResult},
     multiaddr::Multiaddr,
 };
@@ -369,6 +371,7 @@ pub trait CommitteeTrait<K: Ord> {
 pub struct NetworkMetadata {
     pub network_address: Multiaddr,
     pub primary_address: Multiaddr,
+    pub network_public_key: Option<NetworkPublicKey>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/iota-types/src/iota_system_state/epoch_start_iota_system_state.rs
+++ b/crates/iota-types/src/iota_system_state/epoch_start_iota_system_state.rs
@@ -167,6 +167,7 @@ impl EpochStartSystemStateTrait for EpochStartSystemStateV1 {
                         NetworkMetadata {
                             network_address: validator.iota_net_address.clone(),
                             primary_address: validator.primary_address.clone(),
+                            network_public_key: Some(validator.network_pubkey.clone()),
                         },
                     ),
                 )

--- a/crates/iota-types/src/iota_system_state/iota_system_state_inner_v1.rs
+++ b/crates/iota-types/src/iota_system_state/iota_system_state_inner_v1.rs
@@ -516,6 +516,7 @@ impl IotaSystemStateTrait for IotaSystemStateV1 {
                         NetworkMetadata {
                             network_address: verified_metadata.net_address.clone(),
                             primary_address: verified_metadata.primary_address.clone(),
+                            network_public_key: Some(verified_metadata.network_pubkey.clone()),
                         },
                     ),
                 )

--- a/crates/iota-types/src/iota_system_state/iota_system_state_inner_v2.rs
+++ b/crates/iota-types/src/iota_system_state/iota_system_state_inner_v2.rs
@@ -151,6 +151,7 @@ impl IotaSystemStateTrait for IotaSystemStateV2 {
                         NetworkMetadata {
                             network_address: verified_metadata.net_address.clone(),
                             primary_address: verified_metadata.primary_address.clone(),
+                            network_public_key: Some(verified_metadata.network_pubkey.clone()),
                         },
                     ),
                 )

--- a/crates/iota-types/src/iota_system_state/iota_system_state_summary.rs
+++ b/crates/iota-types/src/iota_system_state/iota_system_state_summary.rs
@@ -12,6 +12,7 @@ use super::{IotaSystemState, IotaSystemStateTrait};
 use crate::{
     base_types::{AuthorityName, IotaAddress, ObjectID},
     committee::{CommitteeWithNetworkMetadata, NetworkMetadata},
+    crypto::NetworkPublicKey,
     dynamic_field::get_dynamic_field_from_store,
     error::IotaError,
     id::ID,
@@ -405,6 +406,10 @@ impl IotaSystemStateSummaryV1 {
                                 .unwrap(),
                             primary_address: Multiaddr::try_from(validator.primary_address.clone())
                                 .unwrap(),
+                            network_public_key: NetworkPublicKey::from_bytes(
+                                &validator.network_pubkey_bytes,
+                            )
+                            .ok(),
                         },
                     ),
                 )
@@ -441,6 +446,10 @@ impl IotaSystemStateSummaryV2 {
                                 .unwrap(),
                             primary_address: Multiaddr::try_from(validator.primary_address.clone())
                                 .unwrap(),
+                            network_public_key: NetworkPublicKey::from_bytes(
+                                &validator.network_pubkey_bytes,
+                            )
+                            .ok(),
                         },
                     ),
                 )

--- a/crates/iota-types/src/iota_system_state/simtest_iota_system_state_inner.rs
+++ b/crates/iota-types/src/iota_system_state/simtest_iota_system_state_inner.rs
@@ -177,6 +177,7 @@ impl IotaSystemStateTrait for SimTestIotaSystemStateV1 {
                         NetworkMetadata {
                             network_address: verified_metadata.net_address.clone(),
                             primary_address: verified_metadata.primary_address.clone(),
+                            network_public_key: Some(verified_metadata.network_pubkey.clone()),
                         },
                     ),
                 )
@@ -294,6 +295,7 @@ impl IotaSystemStateTrait for SimTestIotaSystemStateShallowV1 {
                         NetworkMetadata {
                             network_address: verified_metadata.net_address.clone(),
                             primary_address: verified_metadata.primary_address.clone(),
+                            network_public_key: Some(verified_metadata.network_pubkey.clone()),
                         },
                     ),
                 )
@@ -440,6 +442,7 @@ impl IotaSystemStateTrait for SimTestIotaSystemStateDeepV1 {
                         NetworkMetadata {
                             network_address: verified_metadata.net_address.clone(),
                             primary_address: verified_metadata.primary_address.clone(),
+                            network_public_key: Some(verified_metadata.network_pubkey.clone()),
                         },
                     ),
                 )


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.37.4, v1.38.4)
- Port part of the commit: https://github.com/MystenLabs/sui/commit/c03132d75e80b569c2fd8447539ac0b7bddc8ecc
- Descriptions from commits
  - Add support for TLS connections with self-signed cert on validator gRPC interface #20238
  - Client side use of TLS will be enabled-by-default in a future PR.
  - This has corrected TLS upgrade behavior compared to older PR #19796

## Links to any relevant issues

Part of https://github.com/iotaledger/iota/issues/4390

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Add support for TLS connections with self-signed cert on validator gRPC interface.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
