### PR TITLE
fix(node): remove known peers shuffling during discovery (#7484)

### DIFF
--- a/crates/iota-network/src/discovery/server.rs
+++ b/crates/iota-network/src/discovery/server.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, RwLock};
 
 use anemo::{Request, Response};
 use iota_config::p2p::AccessType;
-use rand::seq::{IteratorRandom, SliceRandom};
+use rand::seq::IteratorRandom;
 use serde::{Deserialize, Serialize};
 
 use super::{Discovery, MAX_PEERS_TO_SEND, NodeInfo, SignedNodeInfo, State};
@@ -75,7 +75,6 @@ impl Discovery for Server {
             })
             .choose_multiple(&mut rng, MAX_PEERS_TO_SEND - known_peers.len());
         known_peers.append(&mut known_not_connected_peers);
-        known_peers.shuffle(&mut rng);
 
         Ok(Response::new(GetKnownPeersResponseV2 {
             own_info,


### PR DESCRIPTION
# Description of change

This PR fixes a regression in simtest `test_simulated_load_restarts`, the failure can be reproduced with:

```sh
MSIM_TEST_NUM=1 \
MSIM_TEST_SEED=271750284312 \
scripts/simtest/cargo-simtest simtest \
  --profile ci \
  --package iota-benchmark \
  --test simtest \
  -- test_simulated_load_restarts \
```

The test fails due to a node being unable to finalize transaction with message "Timed out waiting for effects digests to be executed".

For some reason shuffling known peers during peer discovery triggers the issue. A possible cause for the issue is an rare timeout setting causing a node to be isolated. The issue should be investigated further.

## Links to any relevant issues

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

