### PR TITLE
feat(indexer): Make optimistic indexing commit all data in single transaction

### DIFF
--- a/crates/iota-indexer/src/errors.rs
+++ b/crates/iota-indexer/src/errors.rs
@@ -79,6 +79,9 @@ pub enum IndexerError {
     #[error(transparent)]
     Postgres(#[from] diesel::result::Error),
 
+    #[error("Indexer failed to assign TX global order with error: `{0}`")]
+    PostgresUniqueTxGlobalOrderViolation(String),
+
     #[error("Indexer failed to initialize fullnode Http client with error: `{0}`")]
     HttpClientInit(String),
 

--- a/crates/iota-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/iota-indexer/src/handlers/checkpoint_handler.rs
@@ -93,6 +93,14 @@ pub struct CheckpointHandler {
     indexed_checkpoint_sender: iota_metrics::metered_channel::Sender<CheckpointDataToCommit>,
 }
 
+pub type IndexedTransactionComponents = (
+    IndexedTransaction,
+    TxIndex,
+    Vec<IndexedEvent>,
+    Vec<EventIndex>,
+    BTreeMap<String, StoredDisplay>,
+);
+
 #[async_trait]
 impl Worker for CheckpointHandler {
     type Message = ();
@@ -420,13 +428,7 @@ impl CheckpointHandler {
         checkpoint_seq: CheckpointSequenceNumber,
         checkpoint_timestamp_ms: u64,
         metrics: &IndexerMetrics,
-    ) -> IndexerResult<(
-        IndexedTransaction,
-        TxIndex,
-        Vec<IndexedEvent>,
-        Vec<EventIndex>,
-        BTreeMap<String, StoredDisplay>,
-    )> {
+    ) -> IndexerResult<IndexedTransactionComponents> {
         let CheckpointTransaction {
             transaction: sender_signed_data,
             effects: fx,

--- a/crates/iota-indexer/src/models/event_indices.rs
+++ b/crates/iota-indexer/src/models/event_indices.rs
@@ -264,6 +264,7 @@ optimistic_from_into_checkpoint!(OptimisticEventStructInstantiation, StoredEvent
     sender,
 });
 
+#[derive(Clone)]
 pub struct OptimisticEventIndices {
     pub optimistic_event_emit_packages: Vec<OptimisticEventEmitPackage>,
     pub optimistic_event_emit_modules: Vec<OptimisticEventEmitModule>,

--- a/crates/iota-indexer/src/models/tx_indices.rs
+++ b/crates/iota-indexer/src/models/tx_indices.rs
@@ -288,6 +288,7 @@ optimistic_from_into_checkpoint!(OptimisticTxMod, StoredTxMod, { package, module
 optimistic_from_into_checkpoint!(OptimisticTxFun, StoredTxFun, { package, module, func, sender });
 optimistic_from_into_checkpoint!(OptimisticTxKind, StoredTxKind, { tx_kind });
 
+#[derive(Clone)]
 pub struct OptimisticTxIndices {
     pub optimistic_tx_senders: Vec<OptimisticTxSenders>,
     pub optimistic_tx_recipients: Vec<OptimisticTxRecipients>,

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use diesel::{OptionalExtension, RunQueryDsl, sql_query, sql_types};
+use diesel::{PgConnection, RunQueryDsl, result::DatabaseErrorKind, sql_query, sql_types};
 use downcast::Any;
 use fastcrypto::{encoding::Base64, error::FastCryptoError, traits::ToFromBytes};
 use iota_json_rpc_types::{IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions};
@@ -22,7 +22,9 @@ use crate::{
     errors::IndexerError,
     handlers::{
         TransactionObjectChangesToCommit,
-        checkpoint_handler::{CheckpointHandler, try_extract_df_kind},
+        checkpoint_handler::{
+            CheckpointHandler, IndexedTransactionComponents, try_extract_df_kind,
+        },
     },
     indexer_reader::IndexerReader,
     metrics::IndexerMetrics,
@@ -34,10 +36,10 @@ use crate::{
         tx_indices::OptimisticTxIndices,
     },
     store::{IndexerStore, PgIndexerStore},
-    transactional_blocking_with_retry,
+    transactional_blocking_with_retry_with_conditional_abort,
     types::{
-        EventIndex, IndexedDeletedObject, IndexedEvent, IndexedObject, IndexedTransaction,
-        IndexerResult, IotaTransactionBlockResponseWithOptions, TxIndex,
+        EventIndex, IndexedDeletedObject, IndexedObject, IndexerResult,
+        IotaTransactionBlockResponseWithOptions, TxIndex,
     },
 };
 
@@ -52,6 +54,7 @@ type TransactionDataToCommit = (
     TransactionObjectChangesToCommit,
 );
 
+#[derive(Clone)]
 pub(crate) struct OptimisticTransactionExecutor {
     rpc_client: iota_rest_api::Client,
     indexer_reader: IndexerReader,
@@ -160,7 +163,7 @@ impl OptimisticTransactionExecutor {
             input_objects,
             output_objects,
         };
-        self.index_transaction(&full_tx_data).await
+        self.index_transaction_in_blocking_task(&full_tx_data).await
     }
 
     /// Expensive operation that checks if all transactions
@@ -257,68 +260,92 @@ impl OptimisticTransactionExecutor {
         .await
     }
 
-    async fn index_transaction(
+    async fn index_transaction_in_blocking_task(
         &self,
         full_tx_data: &CheckpointTransaction,
     ) -> Result<(), IndexerError> {
-        let assigned_global_order = self
-            .assign_optimistic_tx_global_order(full_tx_data.transaction.digest())
-            .await?;
-
-        let Some(assigned_global_order) = assigned_global_order else {
-            // Global order was assigned earlier by other indexing process, we avoid double
-            // or concurrent indexing and return
-            return Ok(());
-        };
-
-        let extractor = TransactionExtractor::new(
-            full_tx_data,
-            assigned_global_order
-                .optimistic_sequence_number
-                .expect("Optimistic sequence number is always set for data read from DB")
-                .try_into()
-                .map_err(|e| {
-                    IndexerError::PersistentStorageDataCorruption(format!(
-                        "Failed to convert optimistic sequence number: {e}"
-                    ))
-                })?,
-            &self.metrics,
-        );
-
-        let tx_data_to_commit = extractor.to_transaction_data_to_commit().await?;
-
-        self.persist_optimistic_tx(tx_data_to_commit).await
+        tokio::task::spawn_blocking({
+            let this: OptimisticTransactionExecutor = self.clone();
+            let full_tx_data = full_tx_data.clone();
+            move || this.index_transaction(&full_tx_data)
+        })
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to join optimistic index_transaction: {e}");
+            IndexerError::from(e)
+        })?
+        .or_else(|e| match e {
+            // This error means that checkpoint indexing was faster than the optimistic
+            // indexing. Let's just return and let checkpoint indexing handle
+            // the transaction.
+            IndexerError::PostgresUniqueTxGlobalOrderViolation(_) => Ok(()),
+            _ => Err(e),
+        })
+        .map_err(|e| {
+            IndexerError::PostgresWrite(format!("Failed to persist optimistic tx: {:?}", e))
+        })
     }
 
-    async fn assign_optimistic_tx_global_order(
-        &self,
-        tx_digest: &TransactionDigest,
-    ) -> Result<Option<TxGlobalOrder>, IndexerError> {
-        let tx_digest_bytes = tx_digest.inner().to_vec();
-
-        let pool = self.indexer_reader.get_pool();
-
-        transactional_blocking_with_retry!(
+    fn index_transaction(&self, full_tx_data: &CheckpointTransaction) -> Result<(), IndexerError> {
+        let pool = self.store.blocking_cp();
+        transactional_blocking_with_retry_with_conditional_abort!(
             &pool,
-            |conn| {
-                sql_query(
-                    r#"
-                        INSERT INTO tx_global_order (tx_digest, global_sequence_number)
-                        SELECT $1, MAX(tx_sequence_number) FROM tx_digests
-                        ON CONFLICT (tx_digest) DO NOTHING
-                        RETURNING *;
-                    "#,
-                )
-                .bind::<sql_types::Bytea, _>(&tx_digest_bytes)
-                .get_result::<TxGlobalOrder>(conn)
-                .optional()
+            move |conn| {
+                let assigned_global_order =
+                    OptimisticTransactionExecutor::assign_optimistic_tx_global_order(
+                        conn,
+                        full_tx_data.transaction.digest(),
+                    )?;
+
+                let extractor = TransactionExtractor::new(
+                    full_tx_data,
+                    assigned_global_order
+                        .optimistic_sequence_number
+                        .expect("Optimistic sequence number is always set for data read from DB")
+                        .try_into()
+                        .map_err(|e| {
+                            IndexerError::PersistentStorageDataCorruption(format!(
+                                "Failed to convert optimistic sequence number: {e}"
+                            ))
+                        })?,
+                    &self.metrics,
+                );
+
+                let tx_data_to_commit = extractor.to_transaction_data_to_commit()?;
+
+                self.persist_optimistic_tx(conn, tx_data_to_commit)
             },
-            Duration::from_secs(30)
+            |e: &IndexerError| matches!(*e, IndexerError::PostgresUniqueTxGlobalOrderViolation(_)),
+            Duration::from_secs(3600)
         )
     }
 
-    async fn persist_optimistic_tx(
+    fn assign_optimistic_tx_global_order(
+        conn: &mut PgConnection,
+        tx_digest: &TransactionDigest,
+    ) -> Result<TxGlobalOrder, IndexerError> {
+        let tx_digest_bytes = tx_digest.inner().to_vec();
+
+        sql_query(
+            r#"
+                INSERT INTO tx_global_order (tx_digest, global_sequence_number)
+                SELECT $1, MAX(tx_sequence_number) FROM tx_digests
+                RETURNING *;
+            "#,
+        )
+        .bind::<sql_types::Bytea, _>(&tx_digest_bytes)
+        .get_result::<TxGlobalOrder>(conn)
+        .map_err(|e| match e {
+            diesel::result::Error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
+                IndexerError::PostgresUniqueTxGlobalOrderViolation(e.to_string())
+            }
+            _ => IndexerError::PostgresWrite(format!("Failed to assign global order: {e}")),
+        })
+    }
+
+    fn persist_optimistic_tx(
         &self,
+        conn: &mut PgConnection,
         tx_data_to_commit: TransactionDataToCommit,
     ) -> Result<(), IndexerError> {
         let (
@@ -330,23 +357,27 @@ impl OptimisticTransactionExecutor {
             object_changes,
         ) = tx_data_to_commit;
 
-        self.store.persist_objects(vec![object_changes]).await?;
-        self.store.persist_displays(indexed_displays).await?;
+        self.store
+            .persist_objects_in_existing_transaction(conn, vec![object_changes.clone()])?;
+        self.store.persist_displays_in_existing_transaction(
+            conn,
+            indexed_displays.values().collect::<Vec<_>>(),
+        )?;
 
         self.store
-            .persist_optimistic_transaction(optimistic_tx)
-            .await?;
+            .persist_optimistic_transaction_in_existing_transaction(conn, optimistic_tx.clone())?;
         self.store
-            .persist_optimistic_events(optimistic_events)
-            .await?;
+            .persist_optimistic_events_in_existing_transaction(conn, optimistic_events.clone())?;
         self.store
-            .persist_optimistic_event_indices(optimistic_event_indices)
-            .await?;
+            .persist_optimistic_event_indices_in_existing_transaction(
+                conn,
+                optimistic_event_indices.clone(),
+            )?;
         self.store
-            .persist_optimistic_tx_indices(optimistic_tx_indices)
-            .await?;
-
-        Ok(())
+            .persist_optimistic_tx_indices_in_existing_transaction(
+                conn,
+                optimistic_tx_indices.clone(),
+            )
     }
 }
 
@@ -401,29 +432,26 @@ impl<'a> TransactionExtractor<'a> {
         })
     }
 
-    async fn get_indexed_transactions_events_and_displays(
+    fn get_indexed_transactions_events_and_displays(
         &self,
-    ) -> IndexerResult<(
-        IndexedTransaction,
-        TxIndex,
-        Vec<IndexedEvent>,
-        Vec<EventIndex>,
-        BTreeMap<String, StoredDisplay>,
-    )> {
-        CheckpointHandler::index_transaction(
-            self.full_tx_data,
-            self.optimistic_sequence_number,
-            0, // checkpoint sequence number - unknown
-            0, // checkpoint timestamp - unknown
-            self.metrics,
-        )
-        .await
+    ) -> IndexerResult<IndexedTransactionComponents> {
+        let handle = tokio::runtime::Handle::current();
+        handle.block_on(async move {
+            CheckpointHandler::index_transaction(
+                self.full_tx_data,
+                self.optimistic_sequence_number,
+                0, // checkpoint sequence number - unknown
+                0, // checkpoint timestamp - unknown
+                self.metrics,
+            )
+            .await
+        })
     }
 
-    async fn to_transaction_data_to_commit(&self) -> IndexerResult<TransactionDataToCommit> {
+    fn to_transaction_data_to_commit(&self) -> IndexerResult<TransactionDataToCommit> {
         let object_changes = self.get_object_changes()?;
         let (indexed_tx, tx_indices, indexed_events, events_indices, indexed_displays) =
-            self.get_indexed_transactions_events_and_displays().await?;
+            self.get_indexed_transactions_events_and_displays()?;
 
         let optimistic_tx = StoredTransaction::from(&indexed_tx).into();
         let optimistic_tx_indices = Self::optimistic_tx_indices(tx_indices);

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -264,7 +264,7 @@ impl OptimisticTransactionExecutor {
         &self,
         full_tx_data: &CheckpointTransaction,
     ) -> Result<(), IndexerError> {
-        tokio::task::spawn_blocking({
+        match tokio::task::spawn_blocking({
             let this: OptimisticTransactionExecutor = self.clone();
             let full_tx_data = full_tx_data.clone();
             move || this.index_transaction(&full_tx_data)
@@ -273,17 +273,16 @@ impl OptimisticTransactionExecutor {
         .map_err(|e| {
             tracing::error!("Failed to join optimistic index_transaction: {e}");
             IndexerError::from(e)
-        })?
-        .or_else(|e| match e {
-            // This error means that checkpoint indexing was faster than the optimistic
-            // indexing. Let's just return and let checkpoint indexing handle
+        })? {
+            // The unique violation error means that checkpoint indexing was faster than the
+            // optimistic indexing. Let's just return and let checkpoint indexing handle
             // the transaction.
-            IndexerError::PostgresUniqueTxGlobalOrderViolation(_) => Ok(()),
-            _ => Err(e),
-        })
-        .map_err(|e| {
-            IndexerError::PostgresWrite(format!("Failed to persist optimistic tx: {:?}", e))
-        })
+            Ok(_) | Err(IndexerError::PostgresUniqueTxGlobalOrderViolation(_)) => Ok(()),
+            Err(e) => Err(IndexerError::PostgresWrite(format!(
+                "Failed to persist optimistic tx: {:?}",
+                e
+            ))),
+        }
     }
 
     fn index_transaction(&self, full_tx_data: &CheckpointTransaction) -> Result<(), IndexerError> {

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -5,6 +5,7 @@
 use std::{any::Any, collections::BTreeMap};
 
 use async_trait::async_trait;
+use diesel::PgConnection;
 
 use crate::{
     errors::IndexerError,
@@ -79,22 +80,25 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
         transactions: Vec<IndexedTransaction>,
     ) -> Result<(), IndexerError>;
 
-    async fn persist_optimistic_transaction(
+    fn persist_optimistic_transaction_in_existing_transaction(
         &self,
+        conn: &mut PgConnection,
         transaction: OptimisticTransaction,
     ) -> Result<(), IndexerError>;
 
     async fn persist_tx_indices(&self, indices: Vec<TxIndex>) -> Result<(), IndexerError>;
 
-    async fn persist_optimistic_tx_indices(
+    fn persist_optimistic_tx_indices_in_existing_transaction(
         &self,
+        conn: &mut PgConnection,
         indices: OptimisticTxIndices,
     ) -> Result<(), IndexerError>;
 
     async fn persist_events(&self, events: Vec<IndexedEvent>) -> Result<(), IndexerError>;
 
-    async fn persist_optimistic_events(
+    fn persist_optimistic_events_in_existing_transaction(
         &self,
+        conn: &mut PgConnection,
         events: Vec<OptimisticEvent>,
     ) -> Result<(), IndexerError>;
 
@@ -103,8 +107,9 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
         event_indices: Vec<EventIndex>,
     ) -> Result<(), IndexerError>;
 
-    async fn persist_optimistic_event_indices(
+    fn persist_optimistic_event_indices_in_existing_transaction(
         &self,
+        conn: &mut PgConnection,
         indices: OptimisticEventIndices,
     ) -> Result<(), IndexerError>;
 
@@ -130,10 +135,17 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
 
     fn as_any(&self) -> &dyn Any;
 
-    async fn get_transactions_with_global_order(
+    fn persist_displays_in_existing_transaction(
         &self,
-        digests: &[Vec<u8>],
-    ) -> Result<Vec<Vec<u8>>, IndexerError>;
+        conn: &mut PgConnection,
+        display_updates: Vec<&StoredDisplay>,
+    ) -> Result<(), IndexerError>;
+
+    fn persist_objects_in_existing_transaction(
+        &self,
+        conn: &mut PgConnection,
+        object_changes: Vec<TransactionObjectChangesToCommit>,
+    ) -> Result<(), IndexerError>;
 }
 
 #[async_trait]

--- a/crates/iota-indexer/src/store/mod.rs
+++ b/crates/iota-indexer/src/store/mod.rs
@@ -96,6 +96,49 @@ pub mod diesel_macro {
     }
 
     #[macro_export]
+    macro_rules! transactional_blocking_with_retry_with_conditional_abort {
+        ($pool:expr, $query:expr, $abort_condition:expr, $max_elapsed:expr) => {{
+            use $crate::{
+                db::{PoolConnection, get_pool_connection},
+                errors::IndexerError,
+            };
+            let mut backoff = backoff::ExponentialBackoff::default();
+            backoff.max_elapsed_time = Some($max_elapsed);
+            let result = match backoff::retry(backoff, || {
+                let mut pool_conn =
+                    get_pool_connection($pool).map_err(|e| backoff::Error::Transient {
+                        err: IndexerError::PostgresWrite(e.to_string()),
+                        retry_after: None,
+                    })?;
+                pool_conn
+                    .as_any_mut()
+                    .downcast_mut::<PoolConnection>()
+                    .unwrap()
+                    .build_transaction()
+                    .read_write()
+                    .run($query)
+                    .map_err(|e| {
+                        tracing::error!("Error with persisting data into DB: {:?}, retrying...", e);
+                        if $abort_condition(&e) {
+                            backoff::Error::Permanent(e)
+                        } else {
+                            backoff::Error::Transient {
+                                err: IndexerError::PostgresWrite(e.to_string()),
+                                retry_after: None,
+                            }
+                        }
+                    })
+            }) {
+                Ok(v) => Ok(v),
+                Err(backoff::Error::Transient { err, .. }) => Err(err),
+                Err(backoff::Error::Permanent(err)) => Err(err),
+            };
+
+            result
+        }};
+    }
+
+    #[macro_export]
     macro_rules! spawn_read_only_blocking {
         ($pool:expr, $query:expr, $repeatable_read:expr) => {{
             use downcast::Any;
@@ -239,9 +282,7 @@ pub mod diesel_macro {
             transactional_blocking_with_retry!(
                 $pool,
                 |conn| {
-                    for chunk in $chunk.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
-                        insert_or_ignore_into!($table, chunk, conn);
-                    }
+                    persist_chunk_into_table_in_existing_connection!($table, $chunk, conn);
                     Ok::<(), IndexerError>(())
                 },
                 PG_DB_COMMIT_SLEEP_DURATION
@@ -258,6 +299,15 @@ pub mod diesel_macro {
             .tap_err(|e| {
                 tracing::error!("Failed to persist {} with error: {}", stringify!($table), e);
             })
+        }};
+    }
+
+    #[macro_export]
+    macro_rules! persist_chunk_into_table_in_existing_connection {
+        ($table:expr, $chunk:expr, $conn:expr) => {{
+            for chunk in $chunk.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
+                insert_or_ignore_into!($table, chunk, $conn);
+            }
         }};
     }
 

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -11,7 +11,7 @@ use std::{
 
 use async_trait::async_trait;
 use diesel::{
-    ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl, SelectableHelper,
+    ExpressionMethods, OptionalExtension, PgConnection, QueryDsl, RunQueryDsl,
     dsl::{max, min},
     sql_types::{Array, BigInt, Bytea, Nullable, SmallInt, Text},
     upsert::excluded,
@@ -46,17 +46,15 @@ use crate::{
         packages::StoredPackage,
         transactions::{
             CheckpointTxGlobalOrder, IndexStatus, OptimisticTransaction, StoredTransaction,
-            TxGlobalOrder,
         },
         tx_indices::OptimisticTxIndices,
     },
     on_conflict_do_update, on_conflict_do_update_with_condition, persist_chunk_into_table,
-    read_only_blocking,
+    persist_chunk_into_table_in_existing_connection, read_only_blocking,
     rolling::transform::{
         CheckpointObjectChanges, LiveObject, RemovedObject,
         retain_latest_objects_from_checkpoint_batch,
     },
-    run_query_async,
     schema::{
         chain_identifier, checkpoints, display, epochs, event_emit_module, event_emit_package,
         event_senders, event_struct_instantiation, event_struct_module, event_struct_name,
@@ -72,7 +70,6 @@ use crate::{
         tx_changed_objects, tx_digests, tx_global_order, tx_input_objects, tx_kinds, tx_recipients,
         tx_senders,
     },
-    spawn_read_only_blocking,
     store::{
         IndexerStore, IndexerStoreExt,
         pg_partition_manager::{EpochPartitionData, PgPartitionManager},
@@ -316,20 +313,9 @@ impl PgIndexerStore {
     ) -> Result<(), IndexerError> {
         transactional_blocking_with_retry!(
             &self.blocking_cp,
-            |conn| {
-                on_conflict_do_update_with_condition!(
-                    display::table,
-                    display_updates.values().collect::<Vec<_>>(),
-                    display::object_type,
-                    (
-                        display::id.eq(excluded(display::id)),
-                        display::version.eq(excluded(display::version)),
-                        display::bcs.eq(excluded(display::bcs)),
-                    ),
-                    excluded(display::version).gt(display::version),
-                    conn
-                );
-                Ok::<(), IndexerError>(())
+            {
+                let value = display_updates.values().collect::<Vec<_>>();
+                |conn| self.persist_displays_in_existing_transaction(conn, value)
             },
             PG_DB_COMMIT_SLEEP_DURATION
         )?;
@@ -507,35 +493,46 @@ impl PgIndexerStore {
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {
-                on_conflict_do_update!(
-                    objects::table,
+                self.persist_object_mutation_chunk_in_existing_transaction(
+                    conn,
                     mutated_object_mutation_chunk.clone(),
-                    objects::object_id,
-                    (
-                        objects::object_id.eq(excluded(objects::object_id)),
-                        objects::object_version.eq(excluded(objects::object_version)),
-                        objects::object_digest.eq(excluded(objects::object_digest)),
-                        objects::owner_type.eq(excluded(objects::owner_type)),
-                        objects::owner_id.eq(excluded(objects::owner_id)),
-                        objects::object_type.eq(excluded(objects::object_type)),
-                        objects::serialized_object.eq(excluded(objects::serialized_object)),
-                        objects::coin_type.eq(excluded(objects::coin_type)),
-                        objects::coin_balance.eq(excluded(objects::coin_balance)),
-                        objects::df_kind.eq(excluded(objects::df_kind)),
-                    ),
-                    conn
-                );
-                Ok::<(), IndexerError>(())
+                )
             },
             PG_DB_COMMIT_SLEEP_DURATION
         )
         .tap_ok(|_| {
             let elapsed = guard.stop_and_record();
-            info!(elapsed, "Deleted {} chunked objects", len);
+            info!(elapsed, "Persisted {} chunked objects", len);
         })
         .tap_err(|e| {
             tracing::error!("Failed to persist object mutations with error: {}", e);
         })
+    }
+
+    fn persist_object_mutation_chunk_in_existing_transaction(
+        &self,
+        conn: &mut PgConnection,
+        mutated_object_mutation_chunk: Vec<StoredObject>,
+    ) -> Result<(), IndexerError> {
+        on_conflict_do_update!(
+            objects::table,
+            mutated_object_mutation_chunk,
+            objects::object_id,
+            (
+                objects::object_id.eq(excluded(objects::object_id)),
+                objects::object_version.eq(excluded(objects::object_version)),
+                objects::object_digest.eq(excluded(objects::object_digest)),
+                objects::owner_type.eq(excluded(objects::owner_type)),
+                objects::owner_id.eq(excluded(objects::owner_id)),
+                objects::object_type.eq(excluded(objects::object_type)),
+                objects::serialized_object.eq(excluded(objects::serialized_object)),
+                objects::coin_type.eq(excluded(objects::coin_type)),
+                objects::coin_balance.eq(excluded(objects::coin_balance)),
+                objects::df_kind.eq(excluded(objects::df_kind)),
+            ),
+            conn
+        );
+        Ok::<(), IndexerError>(())
     }
 
     fn persist_object_deletion_chunk(
@@ -550,21 +547,10 @@ impl PgIndexerStore {
         transactional_blocking_with_retry!(
             &self.blocking_cp,
             |conn| {
-                diesel::delete(
-                    objects::table.filter(
-                        objects::object_id.eq_any(
-                            deleted_objects_chunk
-                                .iter()
-                                .map(|o| o.object_id.clone())
-                                .collect::<Vec<_>>(),
-                        ),
-                    ),
+                self.persist_object_deletion_chunk_in_existing_transaction(
+                    conn,
+                    deleted_objects_chunk.clone(),
                 )
-                .execute(conn)
-                .map_err(IndexerError::from)
-                .context("Failed to write object deletion to PostgresDB")?;
-
-                Ok::<(), IndexerError>(())
             },
             PG_DB_COMMIT_SLEEP_DURATION
         )
@@ -575,6 +561,28 @@ impl PgIndexerStore {
         .tap_err(|e| {
             tracing::error!("Failed to persist object deletions with error: {}", e);
         })
+    }
+
+    fn persist_object_deletion_chunk_in_existing_transaction(
+        &self,
+        conn: &mut PgConnection,
+        deleted_objects_chunk: Vec<StoredDeletedObject>,
+    ) -> Result<(), IndexerError> {
+        diesel::delete(
+            objects::table.filter(
+                objects::object_id.eq_any(
+                    deleted_objects_chunk
+                        .iter()
+                        .map(|o| o.object_id.clone())
+                        .collect::<Vec<_>>(),
+                ),
+            ),
+        )
+        .execute(conn)
+        .map_err(IndexerError::from)
+        .context("Failed to write object deletion to PostgresDB")?;
+
+        Ok::<(), IndexerError>(())
     }
 
     fn backfill_objects_snapshot_chunk(
@@ -1868,6 +1876,31 @@ impl IndexerStore for PgIndexerStore {
         Ok(())
     }
 
+    fn persist_objects_in_existing_transaction(
+        &self,
+        conn: &mut PgConnection,
+        object_changes: Vec<TransactionObjectChangesToCommit>,
+    ) -> Result<(), IndexerError> {
+        if object_changes.is_empty() {
+            return Ok(());
+        }
+
+        let (indexed_mutations, indexed_deletions) = retain_latest_indexed_objects(object_changes);
+        let object_mutations = indexed_mutations
+            .into_iter()
+            .map(StoredObject::from)
+            .collect::<Vec<_>>();
+        let object_deletions = indexed_deletions
+            .into_iter()
+            .map(StoredDeletedObject::from)
+            .collect::<Vec<_>>();
+
+        self.persist_object_mutation_chunk_in_existing_transaction(conn, object_mutations)?;
+        self.persist_object_deletion_chunk_in_existing_transaction(conn, object_deletions)?;
+
+        Ok(())
+    }
+
     async fn persist_objects_snapshot(
         &self,
         object_changes: Vec<TransactionObjectChangesToCommit>,
@@ -2041,55 +2074,13 @@ impl IndexerStore for PgIndexerStore {
         Ok(())
     }
 
-    async fn persist_optimistic_transaction(
+    fn persist_optimistic_transaction_in_existing_transaction(
         &self,
+        conn: &mut PgConnection,
         transaction: OptimisticTransaction,
     ) -> Result<(), IndexerError> {
-        let sequence_number = transaction.sequence_number;
-
-        self.spawn_blocking_task(move |this| {
-            transactional_blocking_with_retry!(
-                &this.blocking_cp,
-                |conn| {
-                    insert_or_ignore_into!(optimistic_transactions::table, &transaction, conn);
-                    Ok::<(), IndexerError>(())
-                },
-                PG_DB_COMMIT_SLEEP_DURATION
-            )
-            .tap_err(|e| {
-                tracing::error!("Failed to persist transactions with error: {}", e);
-            })
-        })
-        .await
-        .map_err(|e| {
-            IndexerError::PostgresWrite(format!(
-                "Failed to persist optimistic transaction: {:?}",
-                e
-            ))
-        })??;
-
-        info!("Persisted optimistic transaction {sequence_number}");
+        insert_or_ignore_into!(optimistic_transactions::table, &transaction, conn);
         Ok(())
-    }
-
-    async fn get_transactions_with_global_order(
-        &self,
-        digests: &[Vec<u8>],
-    ) -> Result<Vec<Vec<u8>>, IndexerError> {
-        let digests = digests.to_vec();
-
-        let pool = self.blocking_cp.clone();
-        let indexing_status = run_query_async!(&pool, move |conn| {
-            tx_global_order::table
-                .select(TxGlobalOrder::as_select())
-                .filter(tx_global_order::tx_digest.eq_any(&digests))
-                .load::<TxGlobalOrder>(conn)
-        })
-        .context("Failed reading tx indexing status from PostgresDB")?
-        .into_iter()
-        .map(|tgo| tgo.tx_digest)
-        .collect();
-        Ok(indexing_status)
     }
 
     async fn persist_events(&self, events: Vec<IndexedEvent>) -> Result<(), IndexerError> {
@@ -2122,30 +2113,18 @@ impl IndexerStore for PgIndexerStore {
         Ok(())
     }
 
-    async fn persist_optimistic_events(
+    fn persist_optimistic_events_in_existing_transaction(
         &self,
+        conn: &mut PgConnection,
         events: Vec<OptimisticEvent>,
     ) -> Result<(), IndexerError> {
         if events.is_empty() {
             return Ok(());
         }
 
-        self.spawn_blocking_task(move |this| {
-            persist_chunk_into_table!(optimistic_events::table, events, &this.blocking_cp)
-        })
-        .await
-        .map_err(|e| {
-            tracing::error!(
-                "Failed to join persist_chunk_into_table in persist_optimistic_events: {e}"
-            );
-            IndexerError::from(e)
-        })?
-        .map_err(|e| {
-            IndexerError::PostgresWrite(format!(
-                "Failed to persist all optimistic events chunks: {:?}",
-                e
-            ))
-        })
+        persist_chunk_into_table_in_existing_connection!(optimistic_events::table, events, conn);
+
+        Ok(())
     }
 
     async fn persist_displays(
@@ -2158,6 +2137,31 @@ impl IndexerStore for PgIndexerStore {
 
         self.spawn_blocking_task(move |this| this.persist_display_updates(display_updates))
             .await?
+    }
+
+    fn persist_displays_in_existing_transaction(
+        &self,
+        conn: &mut PgConnection,
+        display_updates: Vec<&StoredDisplay>,
+    ) -> Result<(), IndexerError> {
+        if display_updates.is_empty() {
+            return Ok(());
+        }
+
+        on_conflict_do_update_with_condition!(
+            display::table,
+            display_updates,
+            display::object_type,
+            (
+                display::id.eq(excluded(display::id)),
+                display::version.eq(excluded(display::version)),
+                display::bcs.eq(excluded(display::bcs)),
+            ),
+            excluded(display::version).gt(display::version),
+            conn
+        );
+
+        Ok(())
     }
 
     async fn persist_packages(&self, packages: Vec<IndexedPackage>) -> Result<(), IndexerError> {
@@ -2204,8 +2208,9 @@ impl IndexerStore for PgIndexerStore {
         Ok(())
     }
 
-    async fn persist_optimistic_event_indices(
+    fn persist_optimistic_event_indices_in_existing_transaction(
         &self,
+        conn: &mut PgConnection,
         indices: OptimisticEventIndices,
     ) -> Result<(), IndexerError> {
         let OptimisticEventIndices {
@@ -2218,77 +2223,48 @@ impl IndexerStore for PgIndexerStore {
             optimistic_event_struct_instantiations,
         } = indices;
 
-        let mut futures = vec![];
-        futures.push(self.spawn_blocking_task(move |this| {
-            persist_chunk_into_table!(
-                optimistic_event_emit_package::table,
-                optimistic_event_emit_packages,
-                &this.blocking_cp
-            )
-        }));
+        persist_chunk_into_table_in_existing_connection!(
+            optimistic_event_emit_package::table,
+            optimistic_event_emit_packages,
+            conn
+        );
 
-        futures.push(self.spawn_blocking_task(move |this| {
-            persist_chunk_into_table!(
-                optimistic_event_emit_module::table,
-                optimistic_event_emit_modules,
-                &this.blocking_cp
-            )
-        }));
+        persist_chunk_into_table_in_existing_connection!(
+            optimistic_event_emit_module::table,
+            optimistic_event_emit_modules,
+            conn
+        );
 
-        futures.push(self.spawn_blocking_task(move |this| {
-            persist_chunk_into_table!(
-                optimistic_event_senders::table,
-                optimistic_event_senders,
-                &this.blocking_cp
-            )
-        }));
+        persist_chunk_into_table_in_existing_connection!(
+            optimistic_event_senders::table,
+            optimistic_event_senders,
+            conn
+        );
 
-        futures.push(self.spawn_blocking_task(move |this| {
-            persist_chunk_into_table!(
-                optimistic_event_struct_package::table,
-                optimistic_event_struct_packages,
-                &this.blocking_cp
-            )
-        }));
+        persist_chunk_into_table_in_existing_connection!(
+            optimistic_event_struct_package::table,
+            optimistic_event_struct_packages,
+            conn
+        );
 
-        futures.push(self.spawn_blocking_task(move |this| {
-            persist_chunk_into_table!(
-                optimistic_event_struct_module::table,
-                optimistic_event_struct_modules,
-                &this.blocking_cp
-            )
-        }));
+        persist_chunk_into_table_in_existing_connection!(
+            optimistic_event_struct_module::table,
+            optimistic_event_struct_modules,
+            conn
+        );
 
-        futures.push(self.spawn_blocking_task(move |this| {
-            persist_chunk_into_table!(
-                optimistic_event_struct_name::table,
-                optimistic_event_struct_names,
-                &this.blocking_cp
-            )
-        }));
+        persist_chunk_into_table_in_existing_connection!(
+            optimistic_event_struct_name::table,
+            optimistic_event_struct_names,
+            conn
+        );
 
-        futures.push(self.spawn_blocking_task(move |this| {
-            persist_chunk_into_table!(
-                optimistic_event_struct_instantiation::table,
-                optimistic_event_struct_instantiations,
-                &this.blocking_cp
-            )
-        }));
+        persist_chunk_into_table_in_existing_connection!(
+            optimistic_event_struct_instantiation::table,
+            optimistic_event_struct_instantiations,
+            conn
+        );
 
-        futures::future::try_join_all(futures)
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to join optimistic event indices futures: {e}");
-                IndexerError::from(e)
-            })?
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| {
-                IndexerError::PostgresWrite(format!(
-                    "Failed to persist all optimistic event indices: {e:?}",
-                ))
-            })?;
-        info!("Persisted optimistic event indices");
         Ok(())
     }
 
@@ -2327,8 +2303,9 @@ impl IndexerStore for PgIndexerStore {
         Ok(())
     }
 
-    async fn persist_optimistic_tx_indices(
+    fn persist_optimistic_tx_indices_in_existing_transaction(
         &self,
+        conn: &mut PgConnection,
         indices: OptimisticTxIndices,
     ) -> Result<(), IndexerError> {
         let OptimisticTxIndices {
@@ -2342,65 +2319,50 @@ impl IndexerStore for PgIndexerStore {
             optimistic_tx_kinds: kinds,
         } = indices;
 
-        let mut futures = vec![];
-        futures.push(self.spawn_blocking_task(move |this| {
-            persist_chunk_into_table!(optimistic_tx_senders::table, senders, &this.blocking_cp)
-        }));
+        persist_chunk_into_table_in_existing_connection!(
+            optimistic_tx_senders::table,
+            senders,
+            conn
+        );
 
-        futures.push(self.spawn_blocking_task(move |this| {
-            persist_chunk_into_table!(
-                optimistic_tx_recipients::table,
-                recipients,
-                &this.blocking_cp
-            )
-        }));
+        persist_chunk_into_table_in_existing_connection!(
+            optimistic_tx_recipients::table,
+            recipients,
+            conn
+        );
 
-        futures.push(self.spawn_blocking_task(move |this| {
-            persist_chunk_into_table!(
-                optimistic_tx_input_objects::table,
-                input_objects,
-                &this.blocking_cp
-            )
-        }));
+        persist_chunk_into_table_in_existing_connection!(
+            optimistic_tx_input_objects::table,
+            input_objects,
+            conn
+        );
 
-        futures.push(self.spawn_blocking_task(move |this| {
-            persist_chunk_into_table!(
-                optimistic_tx_changed_objects::table,
-                changed_objects,
-                &this.blocking_cp
-            )
-        }));
+        persist_chunk_into_table_in_existing_connection!(
+            optimistic_tx_changed_objects::table,
+            changed_objects,
+            conn
+        );
 
-        futures.push(self.spawn_blocking_task(move |this| {
-            persist_chunk_into_table!(optimistic_tx_calls_pkg::table, pkgs, &this.blocking_cp)
-        }));
+        persist_chunk_into_table_in_existing_connection!(
+            optimistic_tx_calls_pkg::table,
+            pkgs,
+            conn
+        );
 
-        futures.push(self.spawn_blocking_task(move |this| {
-            persist_chunk_into_table!(optimistic_tx_calls_mod::table, mods, &this.blocking_cp)
-        }));
+        persist_chunk_into_table_in_existing_connection!(
+            optimistic_tx_calls_mod::table,
+            mods,
+            conn
+        );
 
-        futures.push(self.spawn_blocking_task(move |this| {
-            persist_chunk_into_table!(optimistic_tx_calls_fun::table, funs, &this.blocking_cp)
-        }));
+        persist_chunk_into_table_in_existing_connection!(
+            optimistic_tx_calls_fun::table,
+            funs,
+            conn
+        );
 
-        futures.push(self.spawn_blocking_task(move |this| {
-            persist_chunk_into_table!(optimistic_tx_kinds::table, kinds, &this.blocking_cp)
-        }));
+        persist_chunk_into_table_in_existing_connection!(optimistic_tx_kinds::table, kinds, conn);
 
-        futures::future::try_join_all(futures)
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to join optimistic tx indices futures: {e}");
-                IndexerError::from(e)
-            })?
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| {
-                IndexerError::PostgresWrite(format!(
-                    "Failed to persist all optimistic tx indices: {e:?}",
-                ))
-            })?;
-        info!("Persisted optimistic tx indices");
         Ok(())
     }
 


### PR DESCRIPTION
# Description of change

This PR modifies optimistic indexing logic so that it commits all data related to execution of single TX inside of one DB transaction.
This means that the fact of optimistically indexing a TX is atomic and combined with unique columns check in tx_global_order table will ensure that given TX will either be indexed on optimistic path, or checkpoint path, but not both.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/7431

## How the change has been tested

`cargo test --profile dev-nodebug --package iota-indexer  --features pg_integration -- --test-threads=1`
`cargo test --profile dev-nodebug --package iota-indexer --test rpc-tests --all-features`

The change was manually tested by adding artificial delays inside of optimistic indexing logic:
 - inside optimistic indexing DB transaction, but **before** tx global order is assigned - results in unique constraint violation, and optimistic indexing is aborted - this is as expected
 - inside optimistic indexing DB transaction, but **after** tx global order is assigned - results in checkpoint indexing waiting until optimistic indexing for given TX finishes - this is correct from data consistency perspective, although a bit unexpected, still this should be a rather rare case

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
