### PR TITLE
feat(cli): allow upgrade-capability to be passed as `-c` short flag

### DIFF
--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -415,7 +415,7 @@ pub enum IotaClientCommands {
         #[arg(name = "package_path", global = true, default_value = ".")]
         package_path: PathBuf,
         /// ID of the upgrade capability for the package being upgraded.
-        #[arg(long)]
+        #[arg(long, short = 'c')]
         upgrade_capability: ObjectID,
         /// Package build options
         #[command(flatten)]


### PR DESCRIPTION
# Description of change

This PR adds `-c` as a short flag for `--upgrade-capability`.

## Links to any relevant issues

Upstream PR https://github.com/MystenLabs/sui/pull/22166

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: Added the `-c` short flag for the  `iota client upgrade` command to pass the upgrade capability.
- [ ] Rust SDK:
- [ ] REST API:
