### PR TITLE
fix(iota-data-ingestion-core): rustdoc & add missing release notes

### DIFF
--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -63,8 +63,8 @@ pub enum RemoteUrl {
         /// "https://checkpoints.mainnet.iota.cafe"
         /// ```
         historical_url: String,
-        /// The URL path to the live object store that contains *.chk checkpoint
-        /// files.
+        /// The URL path to the live object store that contains `*.chk`
+        /// checkpoint files.
         ///
         /// # Example
         /// ```text


### PR DESCRIPTION
# Description of change

This PR adds the missing release notes for [PR 7424](https://github.com/iotaledger/iota/pull/7424), which was merged without them.

## Links to any relevant issues

#7424.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [x] Indexer: the `iota-data-ingestion-core` supports reading checkpoints from hybrid historical storages. More information and examples on how to use the new feature can be found in #7424.
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
