### PR TITLE
upstream(indexer): add indices to aid pruning

### DIFF
--- a/crates/iota-indexer/migrations/pg/2025-06-25-084756_event_emit_module_pruning_index/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084756_event_emit_module_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS event_emit_module_tx_sequence_number;

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084756_event_emit_module_pruning_index/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084756_event_emit_module_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084756_event_emit_module_pruning_index/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084756_event_emit_module_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    event_emit_module_tx_sequence_number
+    ON  event_emit_module (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084758_event_emit_package_pruning_index/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084758_event_emit_package_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS event_emit_package_tx_sequence_number;

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084758_event_emit_package_pruning_index/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084758_event_emit_package_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084758_event_emit_package_pruning_index/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084758_event_emit_package_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    event_emit_package_tx_sequence_number
+    ON  event_emit_package (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084800_event_senders_pruning_index/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084800_event_senders_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS event_senders_tx_sequence_number;

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084800_event_senders_pruning_index/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084800_event_senders_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084800_event_senders_pruning_index/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084800_event_senders_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    event_senders_tx_sequence_number
+    ON  event_senders (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084802_event_struct_instantiation_pruning_index/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084802_event_struct_instantiation_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS event_struct_instantiation_tx_sequence_number;

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084802_event_struct_instantiation_pruning_index/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084802_event_struct_instantiation_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084802_event_struct_instantiation_pruning_index/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084802_event_struct_instantiation_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    event_struct_instantiation_tx_sequence_number
+    ON  event_struct_instantiation (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084804_event_struct_module_pruning_index/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084804_event_struct_module_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS event_struct_module_tx_sequence_number;

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084804_event_struct_module_pruning_index/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084804_event_struct_module_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084804_event_struct_module_pruning_index/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084804_event_struct_module_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    event_struct_module_tx_sequence_number
+    ON  event_struct_module (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084806_event_struct_name_pruning_index/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084806_event_struct_name_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS event_struct_name_tx_sequence_number;

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084806_event_struct_name_pruning_index/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084806_event_struct_name_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084806_event_struct_name_pruning_index/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084806_event_struct_name_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    event_struct_name_tx_sequence_number
+    ON  event_struct_name (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084808_event_struct_package_pruning_index/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084808_event_struct_package_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS event_struct_package_tx_sequence_number;

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084808_event_struct_package_pruning_index/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084808_event_struct_package_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084808_event_struct_package_pruning_index/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084808_event_struct_package_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    event_struct_package_tx_sequence_number
+    ON  event_struct_package (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084810_tx_calls_fun_pruning_index/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084810_tx_calls_fun_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS tx_calls_fun_tx_sequence_number;

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084810_tx_calls_fun_pruning_index/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084810_tx_calls_fun_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084810_tx_calls_fun_pruning_index/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084810_tx_calls_fun_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    tx_calls_fun_tx_sequence_number
+    ON  tx_calls_fun (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084812_tx_calls_mod_pruning_index/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084812_tx_calls_mod_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS tx_calls_mod_tx_sequence_number;

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084812_tx_calls_mod_pruning_index/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084812_tx_calls_mod_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084812_tx_calls_mod_pruning_index/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084812_tx_calls_mod_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    tx_calls_mod_tx_sequence_number
+    ON  tx_calls_mod (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084814_tx_calls_pkg_pruning_index/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084814_tx_calls_pkg_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS tx_calls_pkg_tx_sequence_number;

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084814_tx_calls_pkg_pruning_index/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084814_tx_calls_pkg_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084814_tx_calls_pkg_pruning_index/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084814_tx_calls_pkg_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    tx_calls_pkg_tx_sequence_number
+    ON  tx_calls_pkg (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084816_tx_kinds_pruning_index/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084816_tx_kinds_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS tx_kinds_tx_sequence_number;

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084816_tx_kinds_pruning_index/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084816_tx_kinds_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084816_tx_kinds_pruning_index/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084816_tx_kinds_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    tx_kinds_tx_sequence_number
+    ON  tx_kinds (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084818_tx_recipients_pruning_index/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084818_tx_recipients_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS tx_recipients_tx_sequence_number;

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084818_tx_recipients_pruning_index/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084818_tx_recipients_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084818_tx_recipients_pruning_index/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084818_tx_recipients_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    tx_recipients_tx_sequence_number
+    ON  tx_recipients (tx_sequence_number);

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084820_tx_senders_pruning_index/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084820_tx_senders_pruning_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS tx_senders_tx_sequence_number;

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084820_tx_senders_pruning_index/metadata.toml
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084820_tx_senders_pruning_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/iota-indexer/migrations/pg/2025-06-25-084820_tx_senders_pruning_index/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-06-25-084820_tx_senders_pruning_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    tx_senders_tx_sequence_number
+    ON  tx_senders (tx_sequence_number);


### PR DESCRIPTION
# Description of change

All the transaction and events lookup tables are missing indices that allow the pruner to efficiently pick out the ranges of rows to remove.

Note that because these indices are being added to existing tables, they are being added using CONCURRENTLY IF NOT EXISTS, and because of that, they need to each be in their own migration file (concurrent index creation cannot go in a DB transaction).

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/7335

## How the change has been tested

`diesel database reset --database-url postgres://postgres:postgrespw@localhost:5432/iota_indexer --migration-dir migrations/pg/`
`cargo test --profile simulator --package iota-indexer --test rpc-tests --all-features`

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
