### PR TITLE
chore: add dev-nodebug cargo profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,6 +201,10 @@ inherits = "test"
 opt-level = 1
 overflow-checks = true
 
+[profile.dev-nodebug]
+inherits = "simulator"
+debug = 0
+
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(msim)', 'cfg(fail_points)'] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,8 +202,8 @@ opt-level = 1
 overflow-checks = true
 
 [profile.dev-nodebug]
-inherits = "simulator"
 debug = 0
+inherits = "simulator"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(msim)', 'cfg(fail_points)'] }


### PR DESCRIPTION
# Description of change

Adds a `dev-nodebug` Cargo profile to enable faster compilation loops locally and smaller binary sizes.

Can be a candidate for using in the CI workflows as well.