### PR TITLE
upstream: remove unsupported events filters

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3990,18 +3990,7 @@ impl AuthorityState {
 
         let limit = limit + 1;
         let mut event_keys = match query {
-            EventFilter::All(filters) => {
-                if filters.is_empty() {
-                    index_store.all_events(tx_num, event_num, limit, descending)?
-                } else {
-                    return Err(IotaError::UserInput {
-                        error: UserInputError::Unsupported(
-                            "This query type does not currently support filter combinations"
-                                .to_string(),
-                        ),
-                    });
-                }
-            }
+            EventFilter::All([]) => index_store.all_events(tx_num, event_num, limit, descending)?,
             EventFilter::Transaction(digest) => {
                 index_store.events_by_transaction(&digest, tx_num, event_num, limit, descending)?
             }
@@ -4034,14 +4023,10 @@ impl AuthorityState {
                     descending,
                 )?,
             // not using "_ =>" because we want to make sure we remember to add new variants here
-            EventFilter::Package(_)
-            | EventFilter::MoveEventField { .. }
-            | EventFilter::Any(_)
-            | EventFilter::And(_, _)
-            | EventFilter::Or(_, _) => {
+            EventFilter::Any(_) => {
                 return Err(IotaError::UserInput {
                     error: UserInputError::Unsupported(
-                        "This query type is not supported by the full node.".to_string(),
+                        "'Any' queries are not supported by the full node.".to_string(),
                     ),
                 });
             }

--- a/crates/iota-e2e-tests/tests/sdk_stream_tests.rs
+++ b/crates/iota-e2e-tests/tests/sdk_stream_tests.rs
@@ -56,7 +56,7 @@ use test_cluster::TestClusterBuilder;
 //     let client = IotaClientBuilder::default().build(rpc_url).await?;
 //     let events = client
 //         .event_api()
-//         .get_events_stream(EventFilter::All(vec![]), None, true)
+//         .get_events_stream(EventFilter::All([]), None, true)
 //         .collect::<Vec<_>>()
 //         .await;
 
@@ -75,7 +75,7 @@ use test_cluster::TestClusterBuilder;
 
 //     let events = client
 //         .event_api()
-//         .get_events_stream(EventFilter::All(vec![]), None, true)
+//         .get_events_stream(EventFilter::All([]), None, true)
 //         .collect::<Vec<_>>()
 //         .await;
 //     assert_eq!(starting_event_count + 1, events.len());

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -1432,8 +1432,9 @@ impl IndexerReader {
                 .await;
         } else {
             let main_where_clause = match filter {
-                EventFilter::Package(package_id) => {
-                    format!("package = '\\x{}'::bytea", package_id.to_hex())
+                EventFilter::All([]) => {
+                    // No filter
+                    "TRUE".to_string()
                 }
                 EventFilter::MoveModule { package, module } => {
                     format!(
@@ -1458,12 +1459,7 @@ impl IndexerReader {
                     // Processed above
                     unreachable!()
                 }
-                EventFilter::MoveEventField { .. }
-                | EventFilter::All(_)
-                | EventFilter::Any(_)
-                | EventFilter::And(_, _)
-                | EventFilter::Or(_, _)
-                | EventFilter::TimeRange { .. } => {
+                EventFilter::TimeRange { .. } | EventFilter::Any(_) => {
                     return Err(IndexerError::NotSupported(
                         "This type of EventFilter is not supported.".into(),
                     ));

--- a/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
@@ -120,24 +120,12 @@ fn query_events_unsupported_events() {
         let ten_minutes_ago = now_millis - (10 * 60 * 1000); // 600 seconds = 10 minutes
 
         let unsupported_filters = vec![
-            EventFilter::All(vec![]),
             EventFilter::Any(vec![]),
-            EventFilter::And(
-                Box::new(EventFilter::Any(vec![])),
-                Box::new(EventFilter::Any(vec![])),
-            ),
-            EventFilter::Or(
-                Box::new(EventFilter::Any(vec![])),
-                Box::new(EventFilter::Any(vec![])),
-            ),
+
             EventFilter::TimeRange {
                 start_time: ten_minutes_ago as u64,
                 end_time: now_millis as u64,
-            },
-            EventFilter::MoveEventField {
-                path: String::default(),
-                value: serde_json::Value::Bool(true),
-            },
+            }
         ];
 
         for event_filter in unsupported_filters {
@@ -168,7 +156,6 @@ fn query_events_supported_events() {
         let supported_filters = vec![
             EventFilter::Sender(IotaAddress::ZERO),
             EventFilter::Transaction(TransactionDigest::ZERO),
-            EventFilter::Package(ObjectID::ZERO),
             EventFilter::MoveEventModule {
                 package: ObjectID::ZERO,
                 module: "x".parse().unwrap(),
@@ -178,6 +165,7 @@ fn query_events_supported_events() {
                 package: ObjectID::ZERO,
                 module: "x".parse().unwrap(),
             },
+            EventFilter::All([]),
         ];
 
         for event_filter in supported_filters {

--- a/crates/iota-json-rpc-tests/tests/indexer_api.rs
+++ b/crates/iota-json-rpc-tests/tests/indexer_api.rs
@@ -209,22 +209,7 @@ async fn query_events_unsupported_filters() {
 
     let client = cluster.rpc_client();
 
-    let unsupported_filters = vec![
-        EventFilter::Any(vec![]),
-        EventFilter::And(
-            Box::new(EventFilter::Any(vec![])),
-            Box::new(EventFilter::Any(vec![])),
-        ),
-        EventFilter::Or(
-            Box::new(EventFilter::Any(vec![])),
-            Box::new(EventFilter::Any(vec![])),
-        ),
-        EventFilter::MoveEventField {
-            path: String::default(),
-            value: true.into(),
-        },
-        EventFilter::Package(ObjectID::random()),
-    ];
+    let unsupported_filters = vec![EventFilter::Any(vec![])];
 
     for event_filter in unsupported_filters {
         let result = client.query_events(event_filter, None, None, None).await;
@@ -232,7 +217,7 @@ async fn query_events_unsupported_filters() {
         let err = result.unwrap_err();
         let msg = err.to_string();
 
-        assert!(msg.contains("This query type is not supported by the full node"));
+        assert!(msg.contains("not supported by the full node"));
     }
 }
 

--- a/crates/iota-json-rpc-types/src/iota_event.rs
+++ b/crates/iota-json-rpc-types/src/iota_event.rs
@@ -287,6 +287,11 @@ fn try_into_byte(v: &Value) -> Option<u8> {
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum EventFilter {
+    /// Return all events.
+    All([Box<EventFilter>; 0]),
+    /// Return events that match any of the given filters. Only supported on
+    /// event subscriptions.
+    Any(Vec<EventFilter>),
     /// Query by sender address.
     Sender(IotaAddress),
     /// Return events emitted by the given transaction.
@@ -294,8 +299,6 @@ pub enum EventFilter {
         /// digest of the transaction, as base-64 encoded string
         TransactionDigest,
     ),
-    /// Return events emitted in a specified Package.
-    Package(ObjectID),
     /// Return events emitted in a specified Move module.
     /// If the event is defined in Module A but emitted in a tx with Module B,
     /// query `MoveModule` by module B returns the event.
@@ -328,10 +331,6 @@ pub enum EventFilter {
         #[serde_as(as = "DisplayFromStr")]
         module: Identifier,
     },
-    MoveEventField {
-        path: String,
-        value: Value,
-    },
     /// Return events emitted in [start_time, end_time] interval
     #[serde(rename_all = "camelCase")]
     TimeRange {
@@ -344,32 +343,18 @@ pub enum EventFilter {
         #[serde_as(as = "BigInt<u64>")]
         end_time: u64,
     },
-
-    All(Vec<EventFilter>),
-    Any(Vec<EventFilter>),
-    And(Box<EventFilter>, Box<EventFilter>),
-    Or(Box<EventFilter>, Box<EventFilter>),
 }
 
-impl EventFilter {
-    fn try_matches(&self, item: &IotaEvent) -> IotaResult<bool> {
-        Ok(match self {
+impl Filter<IotaEvent> for EventFilter {
+    fn matches(&self, item: &IotaEvent) -> bool {
+        let _scope = monitored_scope("EventFilter::matches");
+        match self {
+            EventFilter::All([]) => true,
+            EventFilter::Any(filters) => filters.iter().any(|f| f.matches(item)),
             EventFilter::MoveEventType(event_type) => &item.type_ == event_type,
-            EventFilter::MoveEventField { path, value } => {
-                matches!(item.parsed_json.pointer(path), Some(v) if v == value)
-            }
             EventFilter::Sender(sender) => &item.sender == sender,
-            EventFilter::Package(object_id) => &item.package_id == object_id,
             EventFilter::MoveModule { package, module } => {
                 &item.transaction_module == module && &item.package_id == package
-            }
-            EventFilter::All(filters) => filters.iter().all(|f| f.matches(item)),
-            EventFilter::Any(filters) => filters.iter().any(|f| f.matches(item)),
-            EventFilter::And(f1, f2) => {
-                EventFilter::All(vec![*(*f1).clone(), *(*f2).clone()]).matches(item)
-            }
-            EventFilter::Or(f1, f2) => {
-                EventFilter::Any(vec![*(*f1).clone(), *(*f2).clone()]).matches(item)
             }
             EventFilter::Transaction(digest) => digest == &item.id.tx_digest,
 
@@ -386,21 +371,7 @@ impl EventFilter {
             EventFilter::MoveEventModule { package, module } => {
                 &item.type_.module == module && &ObjectID::from(item.type_.address) == package
             }
-        })
-    }
-
-    pub fn and(self, other_filter: EventFilter) -> Self {
-        Self::All(vec![self, other_filter])
-    }
-    pub fn or(self, other_filter: EventFilter) -> Self {
-        Self::Any(vec![self, other_filter])
-    }
-}
-
-impl Filter<IotaEvent> for EventFilter {
-    fn matches(&self, item: &IotaEvent) -> bool {
-        let _scope = monitored_scope("EventFilter::matches");
-        self.try_matches(item).unwrap_or_default()
+        }
     }
 }
 

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -7125,6 +7125,36 @@
       "EventFilter": {
         "oneOf": [
           {
+            "description": "Return all events.",
+            "type": "object",
+            "required": [
+              "All"
+            ],
+            "properties": {
+              "All": {
+                "type": "array",
+                "maxItems": 0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Return events that match any of the given filters. Only supported on event subscriptions.",
+            "type": "object",
+            "required": [
+              "Any"
+            ],
+            "properties": {
+              "Any": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EventFilter"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
             "description": "Query by sender address.",
             "type": "object",
             "required": [
@@ -7146,19 +7176,6 @@
             "properties": {
               "Transaction": {
                 "$ref": "#/components/schemas/TransactionDigest"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Return events emitted in a specified Package.",
-            "type": "object",
-            "required": [
-              "Package"
-            ],
-            "properties": {
-              "Package": {
-                "$ref": "#/components/schemas/ObjectID"
               }
             },
             "additionalProperties": false
@@ -7239,28 +7256,6 @@
             "additionalProperties": false
           },
           {
-            "type": "object",
-            "required": [
-              "MoveEventField"
-            ],
-            "properties": {
-              "MoveEventField": {
-                "type": "object",
-                "required": [
-                  "path",
-                  "value"
-                ],
-                "properties": {
-                  "path": {
-                    "type": "string"
-                  },
-                  "value": true
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
             "description": "Return events emitted in [start_time, end_time] interval",
             "type": "object",
             "required": [
@@ -7291,80 +7286,6 @@
                     ]
                   }
                 }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "All"
-            ],
-            "properties": {
-              "All": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/EventFilter"
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Any"
-            ],
-            "properties": {
-              "Any": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/EventFilter"
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "And"
-            ],
-            "properties": {
-              "And": {
-                "type": "array",
-                "items": [
-                  {
-                    "$ref": "#/components/schemas/EventFilter"
-                  },
-                  {
-                    "$ref": "#/components/schemas/EventFilter"
-                  }
-                ],
-                "maxItems": 2,
-                "minItems": 2
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Or"
-            ],
-            "properties": {
-              "Or": {
-                "type": "array",
-                "items": [
-                  {
-                    "$ref": "#/components/schemas/EventFilter"
-                  },
-                  {
-                    "$ref": "#/components/schemas/EventFilter"
-                  }
-                ],
-                "maxItems": 2,
-                "minItems": 2
               }
             },
             "additionalProperties": false

--- a/crates/iota-sdk/examples/event_api.rs
+++ b/crates/iota-sdk/examples/event_api.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let descending = true;
     let query_events = client
         .event_api()
-        .query_events(EventFilter::All(vec![]), None, 5, descending) // query first 5 events in descending order
+        .query_events(EventFilter::All([]), None, 5, descending) // query first 5 events in descending order
         .await?;
     println!(" *** Query events *** ");
     println!("{:?}", query_events);
@@ -41,10 +41,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .await?;
     println!("WS version {:?}", ws.api_version());
 
-    let mut subscribe = ws
-        .event_api()
-        .subscribe_event(EventFilter::All(vec![]))
-        .await?;
+    let mut subscribe = ws.event_api().subscribe_event(EventFilter::All([])).await?;
 
     loop {
         println!("{:?}", subscribe.next().await);

--- a/crates/iota-sdk/src/apis/event.rs
+++ b/crates/iota-sdk/src/apis/event.rs
@@ -48,7 +48,7 @@ impl EventApi {
     ///         .await?;
     ///     let mut subscribe_all = iota
     ///         .event_api()
-    ///         .subscribe_event(EventFilter::All(vec![]))
+    ///         .subscribe_event(EventFilter::All([]))
     ///         .await?;
     ///     loop {
     ///         println!("{:?}", subscribe_all.next().await);

--- a/docs/content/developer/iota-101/using-events.mdx
+++ b/docs/content/developer/iota-101/using-events.mdx
@@ -131,8 +131,8 @@ async fn main() -> Result<(), anyhow::Error> {
 </TabItem>
 <TabItem value="graphql" label="GraphQL">
 
-You can use GraphQL to query events instead of JSON RPC. The following example queries are in the 
-[`iota-graphql-rpc` crate](https://github.com/iotaledger/iota/tree/develop/crates/iota-graphql-rpc/examples/event_connection) in the IOTA repo. 
+You can use GraphQL to query events instead of JSON RPC. The following example queries are in the
+[`iota-graphql-rpc` crate](https://github.com/iotaledger/iota/tree/develop/crates/iota-graphql-rpc/examples/event_connection) in the IOTA repo.
 
 #### Event Connection
 
@@ -181,7 +181,7 @@ async fn main() -> Result<()> {
         .ws_url("wss://api.testnet.iota.cafe:443")
         .build("https://api.testnet.iota.cafe:443")
         .await.unwrap();
-    let mut subscribe_all = iota.event_api().subscribe_event(EventFilter::All(vec![])).await?;
+    let mut subscribe_all = iota.event_api().subscribe_event(EventFilter::All([])).await?;
     loop {
         println!("{:?}", subscribe_all.next().await);
     }
@@ -258,7 +258,7 @@ subscribeEvent {
 
 ## Monitoring Events
 
-Firing events is not very useful in a vacuum. You also need the ability to respond to those events. 
+Firing events is not very useful in a vacuum. You also need the ability to respond to those events.
 There are two methods from which to choose when you need to monitor on-chain events:
 - Incorporate a [custom indexer](../advanced/custom-indexer.mdx) to take advantage of IOTA's micro-data ingestion framework.
 - Poll the IOTA network on a schedule to query events.
@@ -276,7 +276,7 @@ The IOTA TypeScript SDK enables developers to interact with the IOTA Layer 1 blo
 
 ### Querying Events with `queryEvents`
 
-The `queryEvents` method allows you to retrieve specific events based on filters such as emitting package, module, or sender. 
+The `queryEvents` method allows you to retrieve specific events based on filters such as emitting package, module, or sender.
 
 While events provide high-level data on interactions, such as user actions, contract calls, or state changes, the `queryEvents` method allows you to retrieve these events from the blockchain. You can filter these events by various criteria, such as the emitting package, module, or sender address. This is particularly useful for tracking smart contract execution, monitoring state changes, or auditing blockchain interactions.
 
@@ -340,7 +340,7 @@ async function queryTransactionBlocks() {
       },
       limit: 3,
     });
-    
+
     console.log('Transaction Blocks:\n', JSON.stringify(blocks, null, 2));
   } catch (error) {
     console.error('Error querying transaction blocks:', error);


### PR DESCRIPTION
# Description of change

This PR follows the upstream changes of removing `EventFilters` from `JSON-RPC` that aren't supported already by fullnode-backed JSON-RPC:

- Combination filters (`All`, `Any`, `Not`, `And`, `Or`)
- `Package`
- `MoveEventField`

## Links to any relevant issues

fixes #7531.

## How the change has been tested

JSON RPC tests
```shell
cargo nextest run -p iota-json-rpc-tests --cargo-profile simulator -p iota-json-rpc-tests
```
Indexer tests

```shell
cargo test -p iota-indexer --profile simulator --features shared_test_runtime
```


Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

No QA tests were conducted since this upstream patch does not affect Indexer's sync behavior.
Nevertheless manual tests were conducted to assert that `EventFilter::All` works as expected for both Node & Indexer:

```shell
cargo run --features indexer --bin iota -- start --force-regenesis --with-indexer --with-faucet
```
- Waited 1 min in order for events to accumulate

fetched Fullnode

```shell
curl -LX POST  "http://localhost:9000" \
        --header 'Content-Type: application/json' \
        --data '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "iotax_queryEvents",
  "params": [
    {
      "All": []
    },
    null,
    50,
    true
  ]
}' | jq .
```
Fetched Indexer

```shell
curl -LX POST  "http://localhost:9124" \
        --header 'Content-Type: application/json' \
        --data '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "iotax_queryEvents",
  "params": [
    {
      "All": []
    },
    null,
    50,
    true
  ]
}' | jq .
```

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Remove unsupported compound filters from the JSON-RPC schema to prevent confusion, as these filters are not supported by the current event querying APIs.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
