### PR TITLE
chore: address clippy lints and bump rust toolchain to 1.87

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -14,3 +14,4 @@ disallowed-methods = [
   # bincode::deserialize_from is easy to shoot your foot with
   { path = "bincode::deserialize_from", reason = "use bincode::deserialize instead" },
 ]
+large-error-threshold = 256

--- a/consensus/core/src/storage/store_tests.rs
+++ b/consensus/core/src/storage/store_tests.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 
 /// Test fixture for store tests. Wraps around various store implementations.
+#[expect(clippy::large_enum_variant)]
 enum TestStore {
     RocksDB((RocksDBStore, TempDir)),
     Mem(MemStore),

--- a/crates/iota-benchmark/src/lib.rs
+++ b/crates/iota-benchmark/src/lib.rs
@@ -71,7 +71,6 @@ use tracing::{error, info};
 #[derive(Debug)]
 /// A wrapper on execution results to accommodate different types of
 /// responses from LocalValidatorAggregatorProxy and FullNodeProxy
-#[expect(clippy::large_enum_variant)]
 pub enum ExecutionEffects {
     CertifiedTransactionEffects(CertifiedTransactionEffects, TransactionEvents),
     IotaTransactionBlockEffects(IotaTransactionBlockEffects),

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -1004,7 +1004,9 @@ pub struct Genesis {
 impl Genesis {
     pub fn new(genesis: genesis::Genesis) -> Self {
         Self {
-            location: Some(GenesisLocation::InPlace { genesis }),
+            location: Some(GenesisLocation::InPlace {
+                genesis: Box::new(genesis),
+            }),
             genesis: Default::default(),
         }
     }
@@ -1042,7 +1044,7 @@ impl Genesis {
 #[serde(untagged)]
 enum GenesisLocation {
     InPlace {
-        genesis: genesis::Genesis,
+        genesis: Box<genesis::Genesis>,
     },
     File {
         #[serde(rename = "genesis-file-location")]

--- a/crates/iota-core/src/authority_aggregator.rs
+++ b/crates/iota-core/src/authority_aggregator.rs
@@ -740,6 +740,7 @@ where
 
             type RequestResult<S> = Result<Result<S, IotaError>, tokio::time::error::Elapsed>;
 
+            #[expect(clippy::large_enum_variant)]
             enum Event<S> {
                 StartNext,
                 Request(AuthorityName, RequestResult<S>),

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -2215,7 +2215,7 @@ pub trait CheckpointServiceNotify {
 }
 
 enum CheckpointServiceState {
-    Unstarted((CheckpointBuilder, CheckpointAggregator)),
+    Unstarted(Box<(CheckpointBuilder, CheckpointAggregator)>),
     Started,
 }
 
@@ -2225,7 +2225,7 @@ impl CheckpointServiceState {
         std::mem::swap(self, &mut state);
 
         match state {
-            CheckpointServiceState::Unstarted((builder, aggregator)) => (builder, aggregator),
+            CheckpointServiceState::Unstarted(tup) => (tup.0, tup.1),
             CheckpointServiceState::Started => panic!("CheckpointServiceState is already started"),
         }
     }
@@ -2312,7 +2312,9 @@ impl CheckpointService {
             highest_currently_built_seq_tx,
             highest_previously_built_seq,
             metrics,
-            state: Mutex::new(CheckpointServiceState::Unstarted((builder, aggregator))),
+            state: Mutex::new(CheckpointServiceState::Unstarted(Box::new((
+                builder, aggregator,
+            )))),
         })
     }
 

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -513,6 +513,7 @@ pub struct SequencedConsensusTransaction {
 }
 
 #[derive(Debug, Clone)]
+#[expect(clippy::large_enum_variant)]
 pub enum SequencedConsensusTransactionKind {
     External(ConsensusTransaction),
     System(VerifiedExecutableTransaction),
@@ -538,18 +539,20 @@ impl<'de> Deserialize<'de> for SequencedConsensusTransactionKind {
 // design). This wrapper allows us to convert to a serializable format easily.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 enum SerializableSequencedConsensusTransactionKind {
-    External(ConsensusTransaction),
-    System(TrustedExecutableTransaction),
+    External(Box<ConsensusTransaction>),
+    System(Box<TrustedExecutableTransaction>),
 }
 
 impl From<&SequencedConsensusTransactionKind> for SerializableSequencedConsensusTransactionKind {
     fn from(kind: &SequencedConsensusTransactionKind) -> Self {
         match kind {
             SequencedConsensusTransactionKind::External(ext) => {
-                SerializableSequencedConsensusTransactionKind::External(ext.clone())
+                SerializableSequencedConsensusTransactionKind::External(Box::new(ext.clone()))
             }
             SequencedConsensusTransactionKind::System(txn) => {
-                SerializableSequencedConsensusTransactionKind::System(txn.clone().serializable())
+                SerializableSequencedConsensusTransactionKind::System(Box::new(
+                    txn.clone().serializable(),
+                ))
             }
         }
     }
@@ -559,10 +562,10 @@ impl From<SerializableSequencedConsensusTransactionKind> for SequencedConsensusT
     fn from(kind: SerializableSequencedConsensusTransactionKind) -> Self {
         match kind {
             SerializableSequencedConsensusTransactionKind::External(ext) => {
-                SequencedConsensusTransactionKind::External(ext)
+                SequencedConsensusTransactionKind::External(*ext)
             }
             SerializableSequencedConsensusTransactionKind::System(txn) => {
-                SequencedConsensusTransactionKind::System(txn.into())
+                SequencedConsensusTransactionKind::System((*txn).into())
             }
         }
     }

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -360,7 +360,6 @@ where
                     Ok(unfinished_quorum_driver_task.await)
                 }
             };
-            #[expect(clippy::let_and_return)]
             res
         })
     }

--- a/crates/iota-graphql-rpc-client/src/response.rs
+++ b/crates/iota-graphql-rpc-client/src/response.rs
@@ -40,7 +40,6 @@ impl GraphqlResponse {
         })
     }
 
-    #[expect(clippy::result_large_err)]
     pub fn graphql_version(&self) -> Result<String, ClientError> {
         Ok(self
             .headers
@@ -91,7 +90,6 @@ impl GraphqlResponse {
         self.full_response.errors.clone()
     }
 
-    #[expect(clippy::result_large_err)]
     pub fn usage(&self) -> Result<Option<BTreeMap<String, u64>>, ClientError> {
         Ok(match self.full_response.extensions.get("usage").cloned() {
             Some(Value::Object(obj)) => Some(

--- a/crates/iota-graphql-rpc-client/src/simple_client.rs
+++ b/crates/iota-graphql-rpc-client/src/simple_client.rs
@@ -117,7 +117,7 @@ impl SimpleClient {
     }
 }
 
-#[expect(clippy::type_complexity, clippy::result_large_err)]
+#[expect(clippy::type_complexity)]
 pub fn resolve_variables(
     vars: &[GraphqlQueryVariable],
 ) -> Result<(BTreeMap<String, String>, BTreeMap<String, Value>), ClientError> {

--- a/crates/iota-graphql-rpc/src/types/dynamic_field.rs
+++ b/crates/iota-graphql-rpc/src/types/dynamic_field.rs
@@ -39,8 +39,8 @@ pub(crate) struct DynamicField {
 
 #[derive(Union)]
 pub(crate) enum DynamicFieldValue {
-    MoveObject(MoveObject), // DynamicObject
-    MoveValue(MoveValue),   // DynamicField
+    MoveObject(Box<MoveObject>), // DynamicObject
+    MoveValue(MoveValue),        // DynamicField
 }
 
 #[derive(InputObject)] // used as input object
@@ -131,7 +131,7 @@ impl DynamicField {
             .await
             .extend()?;
 
-            Ok(obj.map(DynamicFieldValue::MoveObject))
+            Ok(obj.map(|obj| DynamicFieldValue::MoveObject(Box::new(obj))))
         } else {
             Ok(Some(DynamicFieldValue::MoveValue(MoveValue::new(
                 value_layout.into(),

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -166,7 +166,7 @@ pub(crate) struct ObjectKey {
 pub(crate) enum ObjectOwner {
     Immutable(Immutable),
     Shared(Shared),
-    Parent(Parent),
+    Parent(Box<Parent>),
     Address(AddressOwner),
 }
 
@@ -643,7 +643,7 @@ impl ObjectImpl<'_> {
                 .ok()
                 .flatten();
 
-                Some(ObjectOwner::Parent(Parent { parent }))
+                Some(ObjectOwner::Parent(Box::new(Parent { parent })))
             }
             O::Shared {
                 initial_shared_version,

--- a/crates/iota-json-rpc-types/src/iota_object.rs
+++ b/crates/iota-json-rpc-types/src/iota_object.rs
@@ -999,6 +999,7 @@ impl IotaRawMovePackage {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(tag = "status", content = "details", rename = "ObjectRead")]
+#[expect(clippy::large_enum_variant)]
 pub enum IotaPastObjectResponse {
     /// The object exists and is found with this version
     VersionFound(IotaObjectData),

--- a/crates/iota-replay/src/data_fetcher.rs
+++ b/crates/iota-replay/src/data_fetcher.rs
@@ -92,6 +92,7 @@ pub(crate) trait DataFetcher {
 }
 
 #[derive(Clone)]
+#[expect(clippy::large_enum_variant)]
 pub enum Fetchers {
     Remote(RemoteFetcher),
     NodeStateDump(NodeStateDumpFetcher),

--- a/crates/iota-replay/src/fuzz.rs
+++ b/crates/iota-replay/src/fuzz.rs
@@ -183,7 +183,6 @@ impl ReplayFuzzer {
     }
 }
 
-#[expect(clippy::large_enum_variant)]
 #[derive(Debug, Error, Clone)]
 pub enum ReplayFuzzError {
     #[error(

--- a/crates/iota-replay/src/types.rs
+++ b/crates/iota-replay/src/types.rs
@@ -265,6 +265,7 @@ impl From<anyhow::Error> for ReplayEngineError {
 
 /// TODO: Limited set but will add more
 #[derive(Debug)]
+#[expect(clippy::large_enum_variant)]
 pub enum ExecutionStoreEvent {
     BackingPackageGetPackageObject {
         package_id: ObjectID,

--- a/crates/iota-storage/src/lib.rs
+++ b/crates/iota-storage/src/lib.rs
@@ -168,6 +168,7 @@ pub fn make_iterator<T: DeserializeOwned, R: Read + 'static>(
     }
 }
 
+#[expect(clippy::result_large_err)]
 pub fn verify_checkpoint_with_committee(
     committee: Arc<Committee>,
     current: &VerifiedCheckpoint,
@@ -227,6 +228,7 @@ pub fn verify_checkpoint_with_committee(
     Ok(VerifiedCheckpoint::new_unchecked(checkpoint))
 }
 
+#[expect(clippy::result_large_err)]
 pub fn verify_checkpoint<S>(
     current: &VerifiedCheckpoint,
     store: S,

--- a/crates/iota-test-transaction-builder/src/lib.rs
+++ b/crates/iota-test-transaction-builder/src/lib.rs
@@ -399,6 +399,7 @@ impl TestTransactionBuilder {
     }
 }
 
+#[expect(clippy::large_enum_variant)]
 enum TestTransactionData {
     Move(MoveData),
     Transfer(TransferData),
@@ -416,6 +417,7 @@ struct MoveData {
     type_args: Vec<TypeTag>,
 }
 
+#[expect(clippy::large_enum_variant)]
 pub enum PublishData {
     /// Path to source code directory and with_unpublished_deps.
     /// with_unpublished_deps indicates whether to publish unpublished

--- a/crates/iota-types/src/messages_grpc.rs
+++ b/crates/iota-types/src/messages_grpc.rs
@@ -98,6 +98,7 @@ pub struct TransactionInfoRequest {
     pub transaction_digest: TransactionDigest,
 }
 
+#[expect(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum TransactionStatus {
     /// Signature over the transaction.

--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -1730,7 +1730,7 @@ impl IotaClientCommands {
             }
             IotaClientCommands::PTB(ptb) => match ptb.execute(context).await? {
                 PTBCommandResult::CommandResult(iota_client_command_result) => {
-                    iota_client_command_result
+                    *iota_client_command_result
                 }
                 res => {
                     let s = res.to_styled_str();

--- a/crates/iota/src/client_ptb/ptb.rs
+++ b/crates/iota/src/client_ptb/ptb.rs
@@ -60,7 +60,7 @@ pub struct Summary {
 pub enum PTBCommandResult {
     Preview(PTBPreview),
     Summary(Summary),
-    CommandResult(IotaClientCommandResult),
+    CommandResult(Box<IotaClientCommandResult>),
     DevInspect(Box<DevInspectResults>),
     Json(serde_json::Value),
     Help { long: bool },
@@ -212,7 +212,7 @@ impl PTB {
             IotaClientCommandResult::DryRun(_)
             | IotaClientCommandResult::SerializedUnsignedTransaction(_)
             | IotaClientCommandResult::SerializedSignedTransaction(_) => {
-                return Ok(PTBCommandResult::CommandResult(res));
+                return Ok(PTBCommandResult::CommandResult(Box::new(res)));
             }
             IotaClientCommandResult::TransactionBlock(response) => response,
             IotaClientCommandResult::DevInspect(response) => {
@@ -259,9 +259,9 @@ impl PTB {
                 Ok(PTBCommandResult::Summary(summary))
             }
         } else {
-            Ok(PTBCommandResult::CommandResult(
+            Ok(PTBCommandResult::CommandResult(Box::new(
                 IotaClientCommandResult::TransactionBlock(transaction_response),
-            ))
+            )))
         }
     }
 

--- a/crates/iota/src/keytool.rs
+++ b/crates/iota/src/keytool.rs
@@ -66,6 +66,7 @@ use crate::{
 };
 
 #[derive(Subcommand)]
+#[expect(clippy::large_enum_variant)]
 pub enum KeyToolCommand {
     /// Convert private key in Hex or Base64 to new format (Bech32
     /// encoded 33 byte flag || private key starting with "iotaprivkey").

--- a/crates/iota/src/name_commands.rs
+++ b/crates/iota/src/name_commands.rs
@@ -557,9 +557,9 @@ impl NameCommand {
                     )
                     .await?
                     else {
-                        return Ok(NameCommandResult::CommandResult(
+                        return Ok(NameCommandResult::CommandResult(Box::new(
                             IotaClientCommandResult::TransactionBlock(res),
-                        ));
+                        )));
                     };
                     Ok(NameCommandResult::SetReverseLookup {
                         entry,
@@ -1314,7 +1314,7 @@ pub enum NameCommandResult {
         burned: IotaNamesRegistration,
         digest: TransactionDigest,
     },
-    CommandResult(IotaClientCommandResult),
+    CommandResult(Box<IotaClientCommandResult>),
     ExtendExpiration {
         record: NameRecord,
         nft: SubdomainRegistration,
@@ -2004,7 +2004,7 @@ where
             }
             fun(res).await?
         } else {
-            NameCommandResult::CommandResult(res)
+            NameCommandResult::CommandResult(Box::new(res))
         },
     )
 }

--- a/crates/iota/tests/cli_tests.rs
+++ b/crates/iota/tests/cli_tests.rs
@@ -4768,14 +4768,16 @@ async fn test_ptb_display_args() -> Result<(), anyhow::Error> {
     --make-move-vec <u8> "[1]"
     "#;
     let args = shlex::split(ptb_string).unwrap();
-    let PTBCommandResult::CommandResult(IotaClientCommandResult::TransactionBlock(res)) =
-        iota::client_ptb::ptb::PTB {
-            args,
-            display: HashSet::from([DisplayOption::Input]),
-        }
-        .execute(context)
-        .await?
+    let PTBCommandResult::CommandResult(res) = iota::client_ptb::ptb::PTB {
+        args,
+        display: HashSet::from([DisplayOption::Input]),
+    }
+    .execute(context)
+    .await?
     else {
+        panic!("unexpected PTB result");
+    };
+    let IotaClientCommandResult::TransactionBlock(res) = *res else {
         panic!("unexpected PTB result");
     };
 
@@ -4786,14 +4788,16 @@ async fn test_ptb_display_args() -> Result<(), anyhow::Error> {
         --make-move-vec <u8> "[1]"
         "#;
     let args = shlex::split(ptb_string).unwrap();
-    let PTBCommandResult::CommandResult(IotaClientCommandResult::TransactionBlock(res)) =
-        iota::client_ptb::ptb::PTB {
-            args,
-            display: HashSet::from([DisplayOption::Events]),
-        }
-        .execute(context)
-        .await?
+    let PTBCommandResult::CommandResult(res) = iota::client_ptb::ptb::PTB {
+        args,
+        display: HashSet::from([DisplayOption::Events]),
+    }
+    .execute(context)
+    .await?
     else {
+        panic!("unexpected PTB result");
+    };
+    let IotaClientCommandResult::TransactionBlock(res) = *res else {
         panic!("unexpected PTB result");
     };
     // `DisplayOption::Input` wasn't provided, so there is no `Transaction Data`

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.86"
+channel = "1.87"

--- a/scripts/generate_files/Dockerfile
+++ b/scripts/generate_files/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-bookworm
 
 # Accept a build argument for the Rust version
-ARG RUST_VERSION=1.86
+ARG RUST_VERSION=1.87
 
 # Get USER_ID from build-args
 ARG USER_ID=1000


### PR DESCRIPTION
## Description 

Ignores or in some cases fixes the new stable clippy `large_enum_variant` and `result_large_err` lints.
