### PR TITLE
upstream(node): Add cache size params to ExecutionCacheConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5723,6 +5723,7 @@ dependencies = [
  "csv",
  "dirs 5.0.1",
  "fastcrypto",
+ "iota-common",
  "iota-genesis-common",
  "iota-keys",
  "iota-names",

--- a/crates/iota-config/Cargo.toml
+++ b/crates/iota-config/Cargo.toml
@@ -29,6 +29,7 @@ tracing.workspace = true
 
 # internal dependencies
 consensus-config.workspace = true
+iota-common.workspace = true
 iota-genesis-common.workspace = true
 iota-keys.workspace = true
 iota-names.workspace = true

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -290,22 +290,27 @@ pub enum ExecutionCacheConfig {
 
 impl Default for ExecutionCacheConfig {
     fn default() -> Self {
-        ExecutionCacheConfig::WritebackCache {
-            max_cache_size: None,
-            package_cache_size: None,
-            object_cache_size: None,
-            marker_cache_size: None,
-            object_by_id_cache_size: None,
-            transaction_cache_size: None,
-            executed_effect_cache_size: None,
-            effect_cache_size: None,
-            events_cache_size: None,
-            transaction_objects_cache_size: None,
-        }
+        ExecutionCacheConfig::default_writeback_cache()
     }
 }
 
 impl ExecutionCacheConfig {
+    /// Creates a default `WritebackCache` configuration with sensible defaults.
+    pub fn default_writeback_cache() -> Self {
+        ExecutionCacheConfig::WritebackCache {
+            max_cache_size: None,                 // defaults to 10000
+            package_cache_size: None,             // defaults to 1000
+            object_cache_size: None,              // defaults to max_cache_size
+            marker_cache_size: None,              // defaults to object_cache_size
+            object_by_id_cache_size: None,        // defaults to object_cache_size
+            transaction_cache_size: None,         // defaults to max_cache_size
+            executed_effect_cache_size: None,     // defaults to transaction_cache_size
+            effect_cache_size: None,              // defaults to executed_effect_cache_size
+            events_cache_size: None,              // defaults to transaction_cache_size
+            transaction_objects_cache_size: None, // defaults to 1000
+        }
+    }
+
     pub fn max_cache_size(&self) -> u64 {
         match self {
             ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -307,127 +307,129 @@ impl Default for ExecutionCacheConfig {
 
 impl ExecutionCacheConfig {
     pub fn max_cache_size(&self) -> u64 {
-        std::env::var("IOTA_MAX_CACHE_SIZE")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or_else(|| match self {
-                ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
-                ExecutionCacheConfig::WritebackCache { max_cache_size, .. } => {
-                    max_cache_size.unwrap_or(100000)
-                }
-            })
+        match self {
+            ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
+            ExecutionCacheConfig::WritebackCache { max_cache_size, .. } => {
+                std::env::var("IOTA_MAX_CACHE_SIZE")
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or_else(|| max_cache_size.unwrap_or(100000))
+            }
+        }
     }
 
     pub fn package_cache_size(&self) -> u64 {
-        std::env::var("IOTA_PACKAGE_CACHE_SIZE")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or_else(|| match self {
-                ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
-                ExecutionCacheConfig::WritebackCache {
-                    package_cache_size, ..
-                } => package_cache_size.unwrap_or(1000),
-            })
+        match self {
+            ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
+            ExecutionCacheConfig::WritebackCache {
+                package_cache_size, ..
+            } => std::env::var("IOTA_PACKAGE_CACHE_SIZE")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or_else(|| package_cache_size.unwrap_or(1000)),
+        }
     }
 
     pub fn object_cache_size(&self) -> u64 {
-        std::env::var("IOTA_OBJECT_CACHE_SIZE")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or_else(|| match self {
-                ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
-                ExecutionCacheConfig::WritebackCache {
-                    object_cache_size, ..
-                } => object_cache_size.unwrap_or(self.max_cache_size()),
-            })
+        match self {
+            ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
+            ExecutionCacheConfig::WritebackCache {
+                object_cache_size, ..
+            } => std::env::var("IOTA_OBJECT_CACHE_SIZE")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or_else(|| object_cache_size.unwrap_or(self.max_cache_size())),
+        }
     }
 
     pub fn marker_cache_size(&self) -> u64 {
-        std::env::var("IOTA_MARKER_CACHE_SIZE")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or_else(|| match self {
-                ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
-                ExecutionCacheConfig::WritebackCache {
-                    marker_cache_size, ..
-                } => marker_cache_size.unwrap_or(self.object_cache_size()),
-            })
+        match self {
+            ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
+            ExecutionCacheConfig::WritebackCache {
+                marker_cache_size, ..
+            } => std::env::var("IOTA_MARKER_CACHE_SIZE")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or_else(|| marker_cache_size.unwrap_or(self.object_cache_size())),
+        }
     }
 
     pub fn object_by_id_cache_size(&self) -> u64 {
-        std::env::var("IOTA_OBJECT_BY_ID_CACHE_SIZE")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or_else(|| match self {
-                ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
-                ExecutionCacheConfig::WritebackCache {
-                    object_by_id_cache_size,
-                    ..
-                } => object_by_id_cache_size.unwrap_or(self.object_cache_size()),
-            })
+        match self {
+            ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
+            ExecutionCacheConfig::WritebackCache {
+                object_by_id_cache_size,
+                ..
+            } => std::env::var("IOTA_OBJECT_BY_ID_CACHE_SIZE")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or_else(|| object_by_id_cache_size.unwrap_or(self.object_cache_size())),
+        }
     }
 
     pub fn transaction_cache_size(&self) -> u64 {
-        std::env::var("IOTA_TRANSACTION_CACHE_SIZE")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or_else(|| match self {
-                ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
-                ExecutionCacheConfig::WritebackCache {
-                    transaction_cache_size,
-                    ..
-                } => transaction_cache_size.unwrap_or(self.max_cache_size()),
-            })
+        match self {
+            ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
+            ExecutionCacheConfig::WritebackCache {
+                transaction_cache_size,
+                ..
+            } => std::env::var("IOTA_TRANSACTION_CACHE_SIZE")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or_else(|| transaction_cache_size.unwrap_or(self.max_cache_size())),
+        }
     }
 
     pub fn executed_effect_cache_size(&self) -> u64 {
-        std::env::var("IOTA_EXECUTED_EFFECT_CACHE_SIZE")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or_else(|| match self {
-                ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
-                ExecutionCacheConfig::WritebackCache {
-                    executed_effect_cache_size,
-                    ..
-                } => executed_effect_cache_size.unwrap_or(self.transaction_cache_size()),
-            })
+        match self {
+            ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
+            ExecutionCacheConfig::WritebackCache {
+                executed_effect_cache_size,
+                ..
+            } => std::env::var("IOTA_EXECUTED_EFFECT_CACHE_SIZE")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or_else(|| {
+                    executed_effect_cache_size.unwrap_or(self.transaction_cache_size())
+                }),
+        }
     }
 
     pub fn effect_cache_size(&self) -> u64 {
-        std::env::var("IOTA_EFFECT_CACHE_SIZE")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or_else(|| match self {
-                ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
-                ExecutionCacheConfig::WritebackCache {
-                    effect_cache_size, ..
-                } => effect_cache_size.unwrap_or(self.executed_effect_cache_size()),
-            })
+        match self {
+            ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
+            ExecutionCacheConfig::WritebackCache {
+                effect_cache_size, ..
+            } => std::env::var("IOTA_EFFECT_CACHE_SIZE")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or_else(|| effect_cache_size.unwrap_or(self.executed_effect_cache_size())),
+        }
     }
 
     pub fn events_cache_size(&self) -> u64 {
-        std::env::var("IOTA_EVENTS_CACHE_SIZE")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or_else(|| match self {
-                ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
-                ExecutionCacheConfig::WritebackCache {
-                    events_cache_size, ..
-                } => events_cache_size.unwrap_or(self.transaction_cache_size()),
-            })
+        match self {
+            ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
+            ExecutionCacheConfig::WritebackCache {
+                events_cache_size, ..
+            } => std::env::var("IOTA_EVENTS_CACHE_SIZE")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or_else(|| events_cache_size.unwrap_or(self.transaction_cache_size())),
+        }
     }
 
     pub fn transaction_objects_cache_size(&self) -> u64 {
-        std::env::var("IOTA_TRANSACTION_OBJECTS_CACHE_SIZE")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or_else(|| match self {
-                ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
-                ExecutionCacheConfig::WritebackCache {
-                    transaction_objects_cache_size,
-                    ..
-                } => transaction_objects_cache_size.unwrap_or(1000),
-            })
+        match self {
+            ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
+            ExecutionCacheConfig::WritebackCache {
+                transaction_objects_cache_size,
+                ..
+            } => std::env::var("IOTA_TRANSACTION_OBJECTS_CACHE_SIZE")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or_else(|| transaction_objects_cache_size.unwrap_or(1000)),
+        }
     }
 }
 

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -13,6 +13,7 @@ use std::{
 
 use anyhow::Result;
 use consensus_config::Parameters as ConsensusParameters;
+use iota_common::fatal;
 use iota_keys::keypair_file::{read_authority_keypair_from_file, read_keypair_from_file};
 use iota_names::config::IotaNamesConfig;
 use iota_types::{
@@ -269,7 +270,21 @@ pub enum ExecutionCacheConfig {
     WritebackCache {
         /// Maximum number of entries in each cache. (There are several
         /// different caches). If None, the default of 10000 is used.
-        max_cache_size: Option<usize>,
+        max_cache_size: Option<u64>,
+
+        package_cache_size: Option<u64>, // defaults to 1000
+
+        object_cache_size: Option<u64>, // defaults to max_cache_size
+        marker_cache_size: Option<u64>, // defaults to object_cache_size
+        object_by_id_cache_size: Option<u64>, // defaults to object_cache_size
+
+        transaction_cache_size: Option<u64>, // defaults to max_cache_size
+        executed_effect_cache_size: Option<u64>, // defaults to transaction_cache_size
+        effect_cache_size: Option<u64>,      // defaults to executed_effect_cache_size
+
+        events_cache_size: Option<u64>, // defaults to transaction_cache_size
+
+        transaction_objects_cache_size: Option<u64>, // defaults to 1000
     },
 }
 
@@ -277,7 +292,142 @@ impl Default for ExecutionCacheConfig {
     fn default() -> Self {
         ExecutionCacheConfig::WritebackCache {
             max_cache_size: None,
+            package_cache_size: None,
+            object_cache_size: None,
+            marker_cache_size: None,
+            object_by_id_cache_size: None,
+            transaction_cache_size: None,
+            executed_effect_cache_size: None,
+            effect_cache_size: None,
+            events_cache_size: None,
+            transaction_objects_cache_size: None,
         }
+    }
+}
+
+impl ExecutionCacheConfig {
+    pub fn max_cache_size(&self) -> u64 {
+        std::env::var("IOTA_MAX_CACHE_SIZE")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| match self {
+                ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
+                ExecutionCacheConfig::WritebackCache { max_cache_size, .. } => {
+                    max_cache_size.unwrap_or(100000)
+                }
+            })
+    }
+
+    pub fn package_cache_size(&self) -> u64 {
+        std::env::var("IOTA_PACKAGE_CACHE_SIZE")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| match self {
+                ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
+                ExecutionCacheConfig::WritebackCache {
+                    package_cache_size, ..
+                } => package_cache_size.unwrap_or(1000),
+            })
+    }
+
+    pub fn object_cache_size(&self) -> u64 {
+        std::env::var("IOTA_OBJECT_CACHE_SIZE")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| match self {
+                ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
+                ExecutionCacheConfig::WritebackCache {
+                    object_cache_size, ..
+                } => object_cache_size.unwrap_or(self.max_cache_size()),
+            })
+    }
+
+    pub fn marker_cache_size(&self) -> u64 {
+        std::env::var("IOTA_MARKER_CACHE_SIZE")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| match self {
+                ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
+                ExecutionCacheConfig::WritebackCache {
+                    marker_cache_size, ..
+                } => marker_cache_size.unwrap_or(self.object_cache_size()),
+            })
+    }
+
+    pub fn object_by_id_cache_size(&self) -> u64 {
+        std::env::var("IOTA_OBJECT_BY_ID_CACHE_SIZE")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| match self {
+                ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
+                ExecutionCacheConfig::WritebackCache {
+                    object_by_id_cache_size,
+                    ..
+                } => object_by_id_cache_size.unwrap_or(self.object_cache_size()),
+            })
+    }
+
+    pub fn transaction_cache_size(&self) -> u64 {
+        std::env::var("IOTA_TRANSACTION_CACHE_SIZE")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| match self {
+                ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
+                ExecutionCacheConfig::WritebackCache {
+                    transaction_cache_size,
+                    ..
+                } => transaction_cache_size.unwrap_or(self.max_cache_size()),
+            })
+    }
+
+    pub fn executed_effect_cache_size(&self) -> u64 {
+        std::env::var("IOTA_EXECUTED_EFFECT_CACHE_SIZE")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| match self {
+                ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
+                ExecutionCacheConfig::WritebackCache {
+                    executed_effect_cache_size,
+                    ..
+                } => executed_effect_cache_size.unwrap_or(self.transaction_cache_size()),
+            })
+    }
+
+    pub fn effect_cache_size(&self) -> u64 {
+        std::env::var("IOTA_EFFECT_CACHE_SIZE")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| match self {
+                ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
+                ExecutionCacheConfig::WritebackCache {
+                    effect_cache_size, ..
+                } => effect_cache_size.unwrap_or(self.executed_effect_cache_size()),
+            })
+    }
+
+    pub fn events_cache_size(&self) -> u64 {
+        std::env::var("IOTA_EVENTS_CACHE_SIZE")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| match self {
+                ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
+                ExecutionCacheConfig::WritebackCache {
+                    events_cache_size, ..
+                } => events_cache_size.unwrap_or(self.transaction_cache_size()),
+            })
+    }
+
+    pub fn transaction_objects_cache_size(&self) -> u64 {
+        std::env::var("IOTA_TRANSACTION_OBJECTS_CACHE_SIZE")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| match self {
+                ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
+                ExecutionCacheConfig::WritebackCache {
+                    transaction_objects_cache_size,
+                    ..
+                } => transaction_objects_cache_size.unwrap_or(1000),
+            })
     }
 }
 

--- a/crates/iota-core/src/authority/test_authority_builder.rs
+++ b/crates/iota-core/src/authority/test_authority_builder.rs
@@ -240,8 +240,12 @@ impl<'a> TestAuthorityBuilder<'a> {
         .unwrap();
         let expensive_safety_checks = self.expensive_safety_checks.unwrap_or_default();
 
-        let cache_traits =
-            build_execution_cache(&epoch_start_configuration, &registry, &authority_store);
+        let cache_traits = build_execution_cache(
+            &Default::default(),
+            &epoch_start_configuration,
+            &registry,
+            &authority_store,
+        );
 
         let epoch_store = AuthorityPerEpochStore::new(
             name,

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -155,7 +155,12 @@ pub fn build_execution_cache_from_env(
         )
     } else {
         ExecutionCacheTraitPointers::new(
-            WritebackCache::new(&Default::default(), store.clone(), execution_cache_metrics).into(),
+            WritebackCache::new(
+                &ExecutionCacheConfig::default_writeback_cache(),
+                store.clone(),
+                execution_cache_metrics,
+            )
+            .into(),
         )
     }
 }

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -122,6 +122,7 @@ pub fn choose_execution_cache(config: &ExecutionCacheConfig) -> ExecutionCacheCo
 }
 
 pub fn build_execution_cache(
+    cache_config: &ExecutionCacheConfig,
     epoch_start_config: &EpochStartConfiguration,
     prometheus_registry: &Registry,
     store: &Arc<AuthorityStore>,
@@ -129,7 +130,13 @@ pub fn build_execution_cache(
     let execution_cache_metrics = Arc::new(ExecutionCacheMetrics::new(prometheus_registry));
 
     ExecutionCacheTraitPointers::new(
-        ProxyCache::new(epoch_start_config, store.clone(), execution_cache_metrics).into(),
+        ProxyCache::new(
+            cache_config,
+            epoch_start_config,
+            store.clone(),
+            execution_cache_metrics,
+        )
+        .into(),
     )
 }
 
@@ -148,7 +155,7 @@ pub fn build_execution_cache_from_env(
         )
     } else {
         ExecutionCacheTraitPointers::new(
-            WritebackCache::new(store.clone(), execution_cache_metrics).into(),
+            WritebackCache::new(&Default::default(), store.clone(), execution_cache_metrics).into(),
         )
     }
 }

--- a/crates/iota-core/src/execution_cache/proxy_cache.rs
+++ b/crates/iota-core/src/execution_cache/proxy_cache.rs
@@ -66,6 +66,19 @@ impl ProxyCache {
         let cache_type = epoch_start_config.execution_cache_type();
         tracing::info!("using cache impl {:?}", cache_type);
         let passthrough_cache = PassthroughCache::new(store.clone(), metrics.clone());
+
+        // we need to initialize both caches at startup, no matter which one is passed
+        // in the cache_config, because we may switch to the other one in the
+        // next epoch. If the cache_config is for a passthrough cache, we still
+        // need to create a writeback cache, so we replace the cache_config with
+        // the default one for writeback cache, otherwise the writeback cache would
+        // panic when it tries to access the settings.
+        let cache_config = match cache_type {
+            ExecutionCacheConfigType::WritebackCache => cache_config,
+            ExecutionCacheConfigType::PassthroughCache => {
+                &ExecutionCacheConfig::default_writeback_cache()
+            }
+        };
         let writeback_cache = WritebackCache::new(cache_config, store.clone(), metrics.clone());
 
         Self {

--- a/crates/iota-core/src/execution_cache/proxy_cache.rs
+++ b/crates/iota-core/src/execution_cache/proxy_cache.rs
@@ -20,9 +20,9 @@ use iota_types::{
 use parking_lot::RwLock;
 
 use super::{
-    CheckpointCache, ExecutionCacheCommit, ExecutionCacheConfigType, ExecutionCacheMetrics,
-    ExecutionCacheReconfigAPI, ExecutionCacheWrite, ObjectCacheRead, PassthroughCache,
-    StateSyncAPI, TestingAPI, TransactionCacheRead, WritebackCache,
+    CheckpointCache, ExecutionCacheCommit, ExecutionCacheConfig, ExecutionCacheConfigType,
+    ExecutionCacheMetrics, ExecutionCacheReconfigAPI, ExecutionCacheWrite, ObjectCacheRead,
+    PassthroughCache, StateSyncAPI, TestingAPI, TransactionCacheRead, WritebackCache,
 };
 use crate::{
     authority::{
@@ -58,6 +58,7 @@ pub struct ProxyCache {
 
 impl ProxyCache {
     pub fn new(
+        cache_config: &ExecutionCacheConfig,
         epoch_start_config: &EpochStartConfiguration,
         store: Arc<AuthorityStore>,
         metrics: Arc<ExecutionCacheMetrics>,
@@ -65,7 +66,7 @@ impl ProxyCache {
         let cache_type = epoch_start_config.execution_cache_type();
         tracing::info!("using cache impl {:?}", cache_type);
         let passthrough_cache = PassthroughCache::new(store.clone(), metrics.clone());
-        let writeback_cache = WritebackCache::new(store.clone(), metrics.clone());
+        let writeback_cache = WritebackCache::new(cache_config, store.clone(), metrics.clone());
 
         Self {
             passthrough_cache,

--- a/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -77,7 +77,7 @@ impl Scenario {
             once_cell::sync::Lazy::new(|| Arc::new(ExecutionCacheMetrics::new(default_registry())));
 
         let cache = Arc::new(WritebackCache::new(
-            &Default::default(),
+            &ExecutionCacheConfig::default_writeback_cache(),
             store.clone(),
             (*METRICS).clone(),
         ));
@@ -374,7 +374,7 @@ impl Scenario {
 
     pub fn reset_cache(&mut self) {
         self.cache = Arc::new(WritebackCache::new(
-            &Default::default(),
+            &ExecutionCacheConfig::default_writeback_cache(),
             self.store.clone(),
             self.cache.metrics.clone(),
         ));
@@ -1205,7 +1205,7 @@ async fn latest_object_cache_race_test() {
         once_cell::sync::Lazy::new(|| Arc::new(ExecutionCacheMetrics::new(default_registry())));
 
     let cache = Arc::new(WritebackCache::new(
-        &Default::default(),
+        &ExecutionCacheConfig::default_writeback_cache(),
         store.clone(),
         (*METRICS).clone(),
     ));

--- a/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -76,7 +76,11 @@ impl Scenario {
         static METRICS: once_cell::sync::Lazy<Arc<ExecutionCacheMetrics>> =
             once_cell::sync::Lazy::new(|| Arc::new(ExecutionCacheMetrics::new(default_registry())));
 
-        let cache = Arc::new(WritebackCache::new(store.clone(), (*METRICS).clone()));
+        let cache = Arc::new(WritebackCache::new(
+            &Default::default(),
+            store.clone(),
+            (*METRICS).clone(),
+        ));
         Self {
             authority,
             store,
@@ -370,6 +374,7 @@ impl Scenario {
 
     pub fn reset_cache(&mut self) {
         self.cache = Arc::new(WritebackCache::new(
+            &Default::default(),
             self.store.clone(),
             self.cache.metrics.clone(),
         ));
@@ -1199,7 +1204,11 @@ async fn latest_object_cache_race_test() {
     static METRICS: once_cell::sync::Lazy<Arc<ExecutionCacheMetrics>> =
         once_cell::sync::Lazy::new(|| Arc::new(ExecutionCacheMetrics::new(default_registry())));
 
-    let cache = Arc::new(WritebackCache::new(store.clone(), (*METRICS).clone()));
+    let cache = Arc::new(WritebackCache::new(
+        &Default::default(),
+        store.clone(),
+        (*METRICS).clone(),
+    ));
 
     let object_id = ObjectID::random();
     let owner = IotaAddress::random_for_testing_only();

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -56,6 +56,7 @@ use std::{
 use dashmap::{DashMap, mapref::entry::Entry as DashMapEntry};
 use futures::{FutureExt, future::BoxFuture};
 use iota_common::sync::notify_read::NotifyRead;
+use iota_config::ExecutionCacheConfig;
 use iota_macros::fail_point_async;
 use iota_types::{
     accumulator::Accumulator,
@@ -277,9 +278,6 @@ impl UncommittedData {
     }
 }
 
-// TODO: set this via the config
-static MAX_CACHE_SIZE: u64 = 10000;
-
 /// CachedData stores data that has been committed to the db, but is likely to
 /// be read soon.
 struct CachedCommittedData {
@@ -310,39 +308,32 @@ struct CachedCommittedData {
 }
 
 impl CachedCommittedData {
-    fn new() -> Self {
+    fn new(config: &ExecutionCacheConfig) -> Self {
         let object_cache = MokaCache::builder()
-            .max_capacity(MAX_CACHE_SIZE)
-            .max_capacity(MAX_CACHE_SIZE)
+            .max_capacity(config.object_cache_size())
             .build();
         let marker_cache = MokaCache::builder()
-            .max_capacity(MAX_CACHE_SIZE)
-            .max_capacity(MAX_CACHE_SIZE)
+            .max_capacity(config.marker_cache_size())
             .build();
         let transactions = MokaCache::builder()
-            .max_capacity(MAX_CACHE_SIZE)
-            .max_capacity(MAX_CACHE_SIZE)
+            .max_capacity(config.transaction_cache_size())
             .build();
         let transaction_effects = MokaCache::builder()
-            .max_capacity(MAX_CACHE_SIZE)
-            .max_capacity(MAX_CACHE_SIZE)
+            .max_capacity(config.effect_cache_size())
             .build();
         let transaction_events = MokaCache::builder()
-            .max_capacity(MAX_CACHE_SIZE)
-            .max_capacity(MAX_CACHE_SIZE)
+            .max_capacity(config.events_cache_size())
             .build();
         let executed_effects_digests = MokaCache::builder()
-            .max_capacity(MAX_CACHE_SIZE)
-            .max_capacity(MAX_CACHE_SIZE)
+            .max_capacity(config.executed_effect_cache_size())
             .build();
         let transaction_objects = MokaCache::builder()
-            .max_capacity(MAX_CACHE_SIZE)
-            .max_capacity(MAX_CACHE_SIZE)
+            .max_capacity(config.transaction_objects_cache_size())
             .build();
 
         Self {
             object_cache,
-            object_by_id_cache: MonotonicCache::new(MAX_CACHE_SIZE),
+            object_by_id_cache: MonotonicCache::new(config.object_by_id_cache_size()),
             marker_cache,
             transactions,
             transaction_effects,
@@ -444,14 +435,17 @@ macro_rules! check_cache_entry_by_latest {
 }
 
 impl WritebackCache {
-    pub fn new(store: Arc<AuthorityStore>, metrics: Arc<ExecutionCacheMetrics>) -> Self {
+    pub fn new(
+        config: &ExecutionCacheConfig,
+        store: Arc<AuthorityStore>,
+        metrics: Arc<ExecutionCacheMetrics>,
+    ) -> Self {
         let packages = MokaCache::builder()
-            .max_capacity(MAX_CACHE_SIZE)
-            .max_capacity(MAX_CACHE_SIZE)
+            .max_capacity(config.package_cache_size())
             .build();
         Self {
             dirty: UncommittedData::new(),
-            cached: CachedCommittedData::new(),
+            cached: CachedCommittedData::new(config),
             packages,
             object_locks: ObjectLocks::new(),
             executed_effects_digests_notify_read: NotifyRead::new(),
@@ -461,12 +455,20 @@ impl WritebackCache {
     }
 
     pub fn new_for_tests(store: Arc<AuthorityStore>, registry: &Registry) -> Self {
-        Self::new(store, ExecutionCacheMetrics::new(registry).into())
+        Self::new(
+            &Default::default(),
+            store,
+            ExecutionCacheMetrics::new(registry).into(),
+        )
     }
 
     #[cfg(test)]
     pub fn reset_for_test(&mut self) {
-        let mut new = Self::new(self.store.clone(), self.metrics.clone());
+        let mut new = Self::new(
+            &Default::default(),
+            self.store.clone(),
+            self.metrics.clone(),
+        );
         std::mem::swap(self, &mut new);
     }
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -526,8 +526,12 @@ impl IotaNode {
         let cache_metrics = Arc::new(ResolverMetrics::new(&prometheus_registry));
         let signature_verifier_metrics = SignatureVerifierMetrics::new(&prometheus_registry);
 
-        let cache_traits =
-            build_execution_cache(&epoch_start_configuration, &prometheus_registry, &store);
+        let cache_traits = build_execution_cache(
+            &config.execution_cache,
+            &epoch_start_configuration,
+            &prometheus_registry,
+            &store,
+        );
 
         let auth_agg = {
             let safe_client_metrics_base = SafeClientMetricsBase::new(&prometheus_registry);

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -11,7 +11,7 @@ use std::{
 
 use fastcrypto::traits::KeyPair;
 use iota_config::{
-    IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME,
+    ExecutionCacheConfig, IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME,
     genesis::{TokenAllocation, TokenDistributionScheduleBuilder},
     node::AuthorityOverloadConfig,
 };
@@ -86,6 +86,7 @@ pub struct ConfigBuilder<R = OsRng> {
     jwk_fetch_interval: Option<Duration>,
     num_unpruned_validators: Option<usize>,
     authority_overload_config: Option<AuthorityOverloadConfig>,
+    execution_cache_config: Option<ExecutionCacheConfig>,
     data_ingestion_dir: Option<PathBuf>,
     policy_config: Option<PolicyConfig>,
     firewall_config: Option<RemoteFirewallConfig>,
@@ -108,6 +109,7 @@ impl ConfigBuilder {
             jwk_fetch_interval: None,
             num_unpruned_validators: None,
             authority_overload_config: None,
+            execution_cache_config: None,
             data_ingestion_dir: None,
             policy_config: None,
             firewall_config: None,
@@ -250,6 +252,11 @@ impl<R> ConfigBuilder<R> {
         self
     }
 
+    pub fn with_execution_cache_config(mut self, c: ExecutionCacheConfig) -> Self {
+        self.execution_cache_config = Some(c);
+        self
+    }
+
     pub fn with_policy_config(mut self, config: Option<PolicyConfig>) -> Self {
         self.policy_config = config;
         self
@@ -285,6 +292,7 @@ impl<R> ConfigBuilder<R> {
             num_unpruned_validators: self.num_unpruned_validators,
             jwk_fetch_interval: self.jwk_fetch_interval,
             authority_overload_config: self.authority_overload_config,
+            execution_cache_config: self.execution_cache_config,
             data_ingestion_dir: self.data_ingestion_dir,
             policy_config: self.policy_config,
             firewall_config: self.firewall_config,
@@ -486,6 +494,10 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                 if let Some(authority_overload_config) = &self.authority_overload_config {
                     builder =
                         builder.with_authority_overload_config(authority_overload_config.clone());
+                }
+
+                if let Some(execution_cache_config) = &self.execution_cache_config {
+                    builder = builder.with_execution_cache_config(execution_cache_config.clone());
                 }
 
                 if let Some(path) = &self.data_ingestion_dir {

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -44,6 +44,7 @@ pub struct ValidatorConfigBuilder {
     force_unpruned_checkpoints: bool,
     jwk_fetch_interval: Option<Duration>,
     authority_overload_config: Option<AuthorityOverloadConfig>,
+    execution_cache_config: Option<ExecutionCacheConfig>,
     data_ingestion_dir: Option<PathBuf>,
     policy_config: Option<PolicyConfig>,
     firewall_config: Option<RemoteFirewallConfig>,
@@ -85,6 +86,11 @@ impl ValidatorConfigBuilder {
 
     pub fn with_authority_overload_config(mut self, config: AuthorityOverloadConfig) -> Self {
         self.authority_overload_config = Some(config);
+        self
+    }
+
+    pub fn with_execution_cache_config(mut self, config: ExecutionCacheConfig) -> Self {
+        self.execution_cache_config = Some(config);
         self
     }
 
@@ -223,11 +229,11 @@ impl ValidatorConfigBuilder {
                 .unwrap_or(3600),
             zklogin_oauth_providers: default_zklogin_oauth_providers(),
             authority_overload_config: self.authority_overload_config.unwrap_or_default(),
+            execution_cache: self.execution_cache_config.unwrap_or_default(),
             run_with_range: None,
             jsonrpc_server_type: None,
             policy_config: self.policy_config,
             firewall_config: self.firewall_config,
-            execution_cache: ExecutionCacheConfig::default(),
             enable_validator_tx_finalizer: true,
             verifier_signing_config: VerifierSigningConfig::default(),
             enable_db_write_stall: None,

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -127,6 +127,15 @@ validator_configs:
     execution-cache:
       writeback-cache:
         max_cache_size: ~
+        package_cache_size: ~
+        object_cache_size: ~
+        marker_cache_size: ~
+        object_by_id_cache_size: ~
+        transaction_cache_size: ~
+        executed_effect_cache_size: ~
+        effect_cache_size: ~
+        events_cache_size: ~
+        transaction_objects_cache_size: ~
     enable-validator-tx-finalizer: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
@@ -258,6 +267,15 @@ validator_configs:
     execution-cache:
       writeback-cache:
         max_cache_size: ~
+        package_cache_size: ~
+        object_cache_size: ~
+        marker_cache_size: ~
+        object_by_id_cache_size: ~
+        transaction_cache_size: ~
+        executed_effect_cache_size: ~
+        effect_cache_size: ~
+        events_cache_size: ~
+        transaction_objects_cache_size: ~
     enable-validator-tx-finalizer: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
@@ -389,6 +407,15 @@ validator_configs:
     execution-cache:
       writeback-cache:
         max_cache_size: ~
+        package_cache_size: ~
+        object_cache_size: ~
+        marker_cache_size: ~
+        object_by_id_cache_size: ~
+        transaction_cache_size: ~
+        executed_effect_cache_size: ~
+        effect_cache_size: ~
+        events_cache_size: ~
+        transaction_objects_cache_size: ~
     enable-validator-tx-finalizer: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
@@ -520,6 +547,15 @@ validator_configs:
     execution-cache:
       writeback-cache:
         max_cache_size: ~
+        package_cache_size: ~
+        object_cache_size: ~
+        marker_cache_size: ~
+        object_by_id_cache_size: ~
+        transaction_cache_size: ~
+        executed_effect_cache_size: ~
+        effect_cache_size: ~
+        events_cache_size: ~
+        transaction_objects_cache_size: ~
     enable-validator-tx-finalizer: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
@@ -651,6 +687,15 @@ validator_configs:
     execution-cache:
       writeback-cache:
         max_cache_size: ~
+        package_cache_size: ~
+        object_cache_size: ~
+        marker_cache_size: ~
+        object_by_id_cache_size: ~
+        transaction_cache_size: ~
+        executed_effect_cache_size: ~
+        effect_cache_size: ~
+        events_cache_size: ~
+        transaction_objects_cache_size: ~
     enable-validator-tx-finalizer: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
@@ -782,6 +827,15 @@ validator_configs:
     execution-cache:
       writeback-cache:
         max_cache_size: ~
+        package_cache_size: ~
+        object_cache_size: ~
+        marker_cache_size: ~
+        object_by_id_cache_size: ~
+        transaction_cache_size: ~
+        executed_effect_cache_size: ~
+        effect_cache_size: ~
+        events_cache_size: ~
+        transaction_objects_cache_size: ~
     enable-validator-tx-finalizer: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
@@ -913,6 +967,15 @@ validator_configs:
     execution-cache:
       writeback-cache:
         max_cache_size: ~
+        package_cache_size: ~
+        object_cache_size: ~
+        marker_cache_size: ~
+        object_by_id_cache_size: ~
+        transaction_cache_size: ~
+        executed_effect_cache_size: ~
+        effect_cache_size: ~
+        events_cache_size: ~
+        transaction_objects_cache_size: ~
     enable-validator-tx-finalizer: true
     verifier-signing-config:
       max-per-fun-meter-units: ~

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -14,7 +14,7 @@ use std::{
 use anyhow::Result;
 use futures::future::try_join_all;
 use iota_config::{
-    IOTA_GENESIS_FILENAME, NodeConfig,
+    ExecutionCacheConfig, IOTA_GENESIS_FILENAME, NodeConfig,
     node::{AuthorityOverloadConfig, DBCheckpointConfig, RunWithRange},
 };
 use iota_macros::nondeterministic;
@@ -60,6 +60,7 @@ pub struct SwarmBuilder<R = OsRng> {
     jwk_fetch_interval: Option<Duration>,
     num_unpruned_validators: Option<usize>,
     authority_overload_config: Option<AuthorityOverloadConfig>,
+    execution_cache_config: Option<ExecutionCacheConfig>,
     data_ingestion_dir: Option<PathBuf>,
     fullnode_run_with_range: Option<RunWithRange>,
     fullnode_policy_config: Option<PolicyConfig>,
@@ -90,6 +91,7 @@ impl SwarmBuilder {
             jwk_fetch_interval: None,
             num_unpruned_validators: None,
             authority_overload_config: None,
+            execution_cache_config: None,
             data_ingestion_dir: None,
             fullnode_run_with_range: None,
             fullnode_policy_config: None,
@@ -122,6 +124,7 @@ impl<R> SwarmBuilder<R> {
             jwk_fetch_interval: self.jwk_fetch_interval,
             num_unpruned_validators: self.num_unpruned_validators,
             authority_overload_config: self.authority_overload_config,
+            execution_cache_config: self.execution_cache_config,
             data_ingestion_dir: self.data_ingestion_dir,
             fullnode_run_with_range: self.fullnode_run_with_range,
             fullnode_policy_config: self.fullnode_policy_config,
@@ -268,6 +271,14 @@ impl<R> SwarmBuilder<R> {
         self
     }
 
+    pub fn with_execution_cache_config(
+        mut self,
+        execution_cache_config: ExecutionCacheConfig,
+    ) -> Self {
+        self.execution_cache_config = Some(execution_cache_config);
+        self
+    }
+
     pub fn with_data_ingestion_dir(mut self, path: PathBuf) -> Self {
         self.data_ingestion_dir = Some(path);
         self
@@ -352,6 +363,10 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
             if let Some(authority_overload_config) = self.authority_overload_config {
                 config_builder =
                     config_builder.with_authority_overload_config(authority_overload_config);
+            }
+
+            if let Some(execution_cache_config) = self.execution_cache_config {
+                config_builder = config_builder.with_execution_cache_config(execution_cache_config);
             }
 
             if let Some(path) = self.data_ingestion_dir {

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -13,8 +13,8 @@ use std::{
 
 use futures::{StreamExt, future::join_all};
 use iota_config::{
-    Config, IOTA_CLIENT_CONFIG, IOTA_KEYSTORE_FILENAME, IOTA_NETWORK_CONFIG, NodeConfig,
-    PersistedConfig,
+    Config, ExecutionCacheConfig, IOTA_CLIENT_CONFIG, IOTA_KEYSTORE_FILENAME, IOTA_NETWORK_CONFIG,
+    NodeConfig, PersistedConfig,
     genesis::Genesis,
     node::{AuthorityOverloadConfig, DBCheckpointConfig, RunWithRange},
 };
@@ -990,6 +990,7 @@ pub struct TestClusterBuilder {
     config_dir: Option<PathBuf>,
     default_jwks: bool,
     authority_overload_config: Option<AuthorityOverloadConfig>,
+    execution_cache_config: Option<ExecutionCacheConfig>,
     data_ingestion_dir: Option<PathBuf>,
     fullnode_run_with_range: Option<RunWithRange>,
     fullnode_policy_config: Option<PolicyConfig>,
@@ -1020,6 +1021,7 @@ impl TestClusterBuilder {
             config_dir: None,
             default_jwks: false,
             authority_overload_config: None,
+            execution_cache_config: None,
             data_ingestion_dir: None,
             fullnode_run_with_range: None,
             fullnode_policy_config: None,
@@ -1215,6 +1217,12 @@ impl TestClusterBuilder {
         self
     }
 
+    pub fn with_execution_cache_config(mut self, config: ExecutionCacheConfig) -> Self {
+        assert!(self.network_config.is_none());
+        self.execution_cache_config = Some(config);
+        self
+    }
+
     pub fn with_data_ingestion_dir(mut self, path: PathBuf) -> Self {
         self.data_ingestion_dir = Some(path);
         self
@@ -1344,6 +1352,10 @@ impl TestClusterBuilder {
 
         if let Some(authority_overload_config) = self.authority_overload_config.take() {
             builder = builder.with_authority_overload_config(authority_overload_config);
+        }
+
+        if let Some(execution_cache_config) = self.execution_cache_config.take() {
+            builder = builder.with_execution_cache_config(execution_cache_config);
         }
 
         if let Some(fullnode_rpc_addr) = self.fullnode_rpc_addr {


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.38.4, v1.39.4)
- Port commit: https://github.com/MystenLabs/sui/commit/01275fb3199fbd15628c03288525d2ef6c353762

## Links to any relevant issues

Part of #6147
  
## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): - Execution cache sizes can now be adjusted in the node config
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API: