### PR TITLE
feat(consensus): [cherry-pick] Fetch own blocks and keep a quorum of connections 

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -215,8 +215,11 @@ where
 
         let highest_known_commit_at_startup = dag_state.read().last_commit_index();
 
+        // Sync last known own block is enabled when:
+        // 1. This is the first boot of the authority node (e.g. disable if the
+        //    validator was active in the previous epoch) and
+        // 2. The timeout for syncing last known own block is not set to zero.
         let sync_last_known_own_block = boot_counter == 0
-            && dag_state.read().highest_accepted_round() == 0
             && !context
                 .parameters
                 .sync_last_known_own_block_timeout

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -570,7 +570,22 @@ impl SubscriptionCounter {
     fn increment(&self, peer: AuthorityIndex) -> Result<(), ConsensusError> {
         let mut counter = self.counter.lock();
         counter.count += 1;
+        let original_subscription_by_peer = counter.subscriptions_by_authority[peer];
         counter.subscriptions_by_authority[peer] += 1;
+        let mut total_stake = 0;
+        for (authority_index, _) in self.context.committee.authorities() {
+            if counter.subscriptions_by_authority[authority_index] >= 1
+                || self.context.own_index == authority_index
+            {
+                total_stake += self.context.committee.stake(authority_index);
+            }
+        }
+        // Stake of subscriptions before a new peer was subscribed
+        let previous_stake = if original_subscription_by_peer == 0 {
+            total_stake - self.context.committee.stake(peer)
+        } else {
+            total_stake
+        };
 
         let peer_hostname = &self.context.committee.authority(peer).hostname;
         self.context
@@ -579,19 +594,39 @@ impl SubscriptionCounter {
             .subscribed_by
             .with_label_values(&[peer_hostname])
             .set(1);
-
-        if counter.count == 1 {
+        // If the subscription count reaches quorum, notify the dispatcher and get ready
+        // to propose blocks.
+        if !self.context.committee.reached_quorum(previous_stake)
+            && self.context.committee.reached_quorum(total_stake)
+        {
             self.dispatcher
-                .set_subscriber_exists(true)
+                .set_quorum_subscribers_exists(true)
                 .map_err(|_| ConsensusError::Shutdown)?;
         }
+        // Drop the counter after sending the command to the dispatcher
+        drop(counter);
         Ok(())
     }
 
     fn decrement(&self, peer: AuthorityIndex) -> Result<(), ConsensusError> {
         let mut counter = self.counter.lock();
         counter.count -= 1;
+        let original_subscription_by_peer = counter.subscriptions_by_authority[peer];
         counter.subscriptions_by_authority[peer] -= 1;
+        let mut total_stake = 0;
+        for (authority_index, _) in self.context.committee.authorities() {
+            if counter.subscriptions_by_authority[authority_index] >= 1
+                || self.context.own_index == authority_index
+            {
+                total_stake += self.context.committee.stake(authority_index);
+            }
+        }
+        // Stake of subscriptions before a peer was dropped
+        let previous_stake = if original_subscription_by_peer == 1 {
+            total_stake + self.context.committee.stake(peer)
+        } else {
+            total_stake
+        };
 
         if counter.subscriptions_by_authority[peer] == 0 {
             let peer_hostname = &self.context.committee.authority(peer).hostname;
@@ -603,11 +638,17 @@ impl SubscriptionCounter {
                 .set(0);
         }
 
-        if counter.count == 0 {
+        // If the subscription count drops below quorum, notify the dispatcher to stop
+        // proposing blocks.
+        if self.context.committee.reached_quorum(previous_stake)
+            && !self.context.committee.reached_quorum(total_stake)
+        {
             self.dispatcher
-                .set_subscriber_exists(false)
+                .set_quorum_subscribers_exists(false)
                 .map_err(|_| ConsensusError::Shutdown)?;
         }
+        // Drop the counter after sending the command to the dispatcher
+        drop(counter);
         Ok(())
     }
 }
@@ -782,7 +823,7 @@ mod tests {
             Ok(Default::default())
         }
 
-        fn set_subscriber_exists(&self, _exists: bool) -> Result<(), CoreError> {
+        fn set_quorum_subscribers_exists(&self, _exists: bool) -> Result<(), CoreError> {
             todo!()
         }
 

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -66,11 +66,11 @@ pub(crate) struct Core {
     /// dependencies when processing new blocks and accept them or suspend
     /// if we are missing their causal history
     block_manager: BlockManager,
-    /// Whether there are subscribers waiting for new blocks proposed by this
-    /// authority. Core stops proposing new blocks when there is no
-    /// subscriber, because new proposed blocks will likely contain only
-    /// stale info when they propagate to peers.
-    subscriber_exists: bool,
+    /// Whether there is a quorum of 2f+1 subscribers waiting for new blocks
+    /// proposed by this authority. Core stops proposing new blocks when
+    /// there is not enough subscribers, because new proposed blocks will
+    /// not be sufficiently propagated to the network.
+    quorum_subscribers_exists: bool,
     /// Estimated delay by round for propagating blocks to a quorum.
     /// Because of the nature of TCP and block streaming, propagation delay is
     /// expected to be 0 in most cases, even when the actual latency of
@@ -192,7 +192,7 @@ impl Core {
             leader_schedule,
             transaction_consumer,
             block_manager,
-            subscriber_exists,
+            quorum_subscribers_exists: subscriber_exists,
             propagation_delay: 0,
             committer,
             commit_observer,
@@ -944,11 +944,10 @@ impl Core {
         self.block_manager.missing_blocks()
     }
 
-    /// Sets if there is consumer available to consume blocks produced by the
-    /// core.
-    pub(crate) fn set_subscriber_exists(&mut self, exists: bool) {
-        info!("Block subscriber exists: {exists}");
-        self.subscriber_exists = exists;
+    /// Sets if there is 2f+1 subscriptions to the block stream.
+    pub(crate) fn set_quorum_subscribers_exists(&mut self, exists: bool) {
+        info!("A quorum of block subscribers exists: {exists}");
+        self.quorum_subscribers_exists = exists;
     }
 
     /// Sets the delay by round for propagating blocks to a quorum and the
@@ -1003,10 +1002,10 @@ impl Core {
         let clock_round = self.dag_state.read().threshold_clock_round();
         let core_skipped_proposals = &self.context.metrics.node_metrics.core_skipped_proposals;
 
-        if !self.subscriber_exists {
-            debug!("Skip proposing for round {clock_round}, no subscriber exists.");
+        if !self.quorum_subscribers_exists {
+            debug!("Skip proposing for round {clock_round}, don't have a quorum of subscribers.");
             core_skipped_proposals
-                .with_label_values(&["no_subscriber"])
+                .with_label_values(&["no_quorum_subscriber"])
                 .inc();
             return false;
         }
@@ -3093,7 +3092,7 @@ mod test {
         assert!(core.try_propose(true).unwrap().is_none());
 
         // Let Core know subscriber exists.
-        core.set_subscriber_exists(true);
+        core.set_quorum_subscribers_exists(true);
 
         // Proposing now would succeed.
         assert!(core.try_propose(true).unwrap().is_some());
@@ -3158,7 +3157,7 @@ mod test {
         core.set_propagation_delay_and_quorum_rounds(1000, vec![], vec![]);
 
         // Make propagation delay the only reason for not proposing.
-        core.set_subscriber_exists(true);
+        core.set_quorum_subscribers_exists(true);
 
         // There is no proposal even with forced proposing.
         assert!(core.try_propose(true).unwrap().is_none());

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -82,7 +82,7 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
     /// Informs the core whether consumer of produced blocks exists.
     /// This is only used by core to decide if it should propose new blocks.
     /// It is not a guarantee that produced blocks will be accepted by peers.
-    fn set_subscriber_exists(&self, exists: bool) -> Result<(), CoreError>;
+    fn set_quorum_subscribers_exists(&self, exists: bool) -> Result<(), CoreError>;
 
     /// Sets the estimated delay to propagate a block to a quorum of peers, in
     /// number of rounds, and the received & accepted quorum rounds for all
@@ -117,7 +117,7 @@ impl CoreThreadHandle {
 struct CoreThread {
     core: Core,
     receiver: Receiver<CoreThreadCommand>,
-    rx_subscriber_exists: watch::Receiver<bool>,
+    rx_quorum_subscribers_exists: watch::Receiver<bool>,
     rx_propagation_delay_and_quorum_rounds: watch::Receiver<PropagationDelayAndQuorumRounds>,
     rx_last_known_proposed_round: watch::Receiver<Round>,
     context: Arc<Context>,
@@ -167,11 +167,11 @@ impl CoreThread {
                     self.core.set_last_known_proposed_round(round);
                     self.core.new_block(round + 1, true)?;
                 }
-                _ = self.rx_subscriber_exists.changed() => {
+                _ = self.rx_quorum_subscribers_exists.changed() => {
                     let _scope = monitored_scope("CoreThread::loop::set_subscriber_exists");
                     let should_propose_before = self.core.should_propose();
-                    let exists = *self.rx_subscriber_exists.borrow();
-                    self.core.set_subscriber_exists(exists);
+                    let exists = *self.rx_quorum_subscribers_exists.borrow();
+                    self.core.set_quorum_subscribers_exists(exists);
                     if !should_propose_before && self.core.should_propose() {
                         // If core cannot propose before but can propose now, try to produce a new block to ensure liveness,
                         // because block proposal could have been skipped.
@@ -204,7 +204,7 @@ impl CoreThread {
 pub(crate) struct ChannelCoreThreadDispatcher {
     context: Arc<Context>,
     sender: WeakSender<CoreThreadCommand>,
-    tx_subscriber_exists: Arc<watch::Sender<bool>>,
+    tx_quorum_subscribers_exists: Arc<watch::Sender<bool>>,
     tx_propagation_delay_and_quorum_rounds: Arc<watch::Sender<PropagationDelayAndQuorumRounds>>,
     tx_last_known_proposed_round: Arc<watch::Sender<Round>>,
     highest_received_rounds: Arc<Vec<AtomicU32>>,
@@ -233,7 +233,7 @@ impl ChannelCoreThreadDispatcher {
         };
         let (sender, receiver) =
             channel("consensus_core_commands", CORE_THREAD_COMMANDS_CHANNEL_SIZE);
-        let (tx_subscriber_exists, mut rx_subscriber_exists) = watch::channel(false);
+        let (tx_quorum_subscribers_exists, mut rx_quorum_subscriber_exists) = watch::channel(false);
         let (tx_propagation_delay_and_quorum_rounds, mut rx_propagation_delay_and_quorum_rounds) =
             watch::channel(PropagationDelayAndQuorumRounds {
                 delay: 0,
@@ -241,13 +241,13 @@ impl ChannelCoreThreadDispatcher {
                 accepted_quorum_rounds: vec![(0, 0); context.committee.size()],
             });
         let (tx_last_known_proposed_round, mut rx_last_known_proposed_round) = watch::channel(0);
-        rx_subscriber_exists.mark_unchanged();
+        rx_quorum_subscriber_exists.mark_unchanged();
         rx_propagation_delay_and_quorum_rounds.mark_unchanged();
         rx_last_known_proposed_round.mark_unchanged();
         let core_thread = CoreThread {
             core,
             receiver,
-            rx_subscriber_exists,
+            rx_quorum_subscribers_exists: rx_quorum_subscriber_exists,
             rx_propagation_delay_and_quorum_rounds,
             rx_last_known_proposed_round,
             context: context.clone(),
@@ -270,7 +270,7 @@ impl ChannelCoreThreadDispatcher {
         let dispatcher = ChannelCoreThreadDispatcher {
             context,
             sender: sender.downgrade(),
-            tx_subscriber_exists: Arc::new(tx_subscriber_exists),
+            tx_quorum_subscribers_exists: Arc::new(tx_quorum_subscribers_exists),
             tx_propagation_delay_and_quorum_rounds: Arc::new(
                 tx_propagation_delay_and_quorum_rounds,
             ),
@@ -359,8 +359,8 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
         receiver.await.map_err(|e| Shutdown(e.to_string()))
     }
 
-    fn set_subscriber_exists(&self, exists: bool) -> Result<(), CoreError> {
-        self.tx_subscriber_exists
+    fn set_quorum_subscribers_exists(&self, exists: bool) -> Result<(), CoreError> {
+        self.tx_quorum_subscribers_exists
             .send(exists)
             .map_err(|e| Shutdown(e.to_string()))
     }
@@ -481,7 +481,7 @@ pub(crate) mod tests {
             Ok(result)
         }
 
-        fn set_subscriber_exists(&self, _exists: bool) -> Result<(), CoreError> {
+        fn set_quorum_subscribers_exists(&self, _exists: bool) -> Result<(), CoreError> {
             todo!()
         }
 

--- a/consensus/core/src/leader_timeout.rs
+++ b/consensus/core/src/leader_timeout.rs
@@ -197,7 +197,7 @@ mod tests {
             todo!()
         }
 
-        fn set_subscriber_exists(&self, _exists: bool) -> Result<(), CoreError> {
+        fn set_quorum_subscribers_exists(&self, _exists: bool) -> Result<(), CoreError> {
             todo!()
         }
 

--- a/consensus/core/src/round_prober.rs
+++ b/consensus/core/src/round_prober.rs
@@ -441,7 +441,7 @@ mod test {
             unimplemented!()
         }
 
-        fn set_subscriber_exists(&self, _exists: bool) -> Result<(), CoreError> {
+        fn set_quorum_subscribers_exists(&self, _exists: bool) -> Result<(), CoreError> {
             unimplemented!()
         }
 

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -33,7 +33,7 @@ use tracing::{debug, error, info, trace, warn};
 use crate::{
     BlockAPI, CommitIndex, Round,
     authority_service::COMMIT_LAG_MULTIPLIER,
-    block::{BlockRef, SignedBlock, VerifiedBlock},
+    block::{BlockRef, GENESIS_ROUND, SignedBlock, VerifiedBlock},
     block_verifier::BlockVerifier,
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
@@ -784,7 +784,12 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 };
 
                 // Get the highest of all the results. Retry until at least `f+1` results have been gathered.
-                let mut highest_round;
+                let mut highest_round = GENESIS_ROUND;
+                // Keep track of the received responses to avoid fetching the own block header from same peer
+                let mut received_response = vec![false; context.committee.size()];
+                // Assume that our node is not Byzantine
+                received_response[context.own_index] = true;
+                let mut total_stake = context.committee.stake(context.own_index);
                 let mut retries = 0;
                 let mut retry_delay_step = Duration::from_millis(500);
                 'main:loop {
@@ -794,14 +799,12 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                         break 'main;
                     }
 
-                    let mut total_stake = 0;
-                    highest_round = 0;
-
                     // Ask all the other peers about our last block
                     let mut results = FuturesUnordered::new();
 
                     for (authority_index, _authority) in context.committee.authorities() {
-                        if authority_index != context.own_index {
+                        // Skip our own index and the ones that have already responded
+                        if !received_response[authority_index] {
                             results.push(fetch_own_block(authority_index, Duration::from_millis(0)));
                         }
                     }
@@ -820,6 +823,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                                     Ok(result) => {
                                         match process_blocks(result, authority_index) {
                                             Ok(blocks) => {
+                                                received_response[authority_index] = true;
                                                 let max_round = blocks.into_iter().map(|b|b.round()).max().unwrap_or(0);
                                                 highest_round = highest_round.max(max_round);
 
@@ -843,10 +847,12 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                         }
                     }
 
-                    // Request at least f+1 stake to have replied back.
-                    if context.committee.reached_validity(total_stake) {
-                        info!("{} out of {} total stake returned acceptable results for our own last block with highest round {}, with {retries} retries.", total_stake, context.committee.total_stake(), highest_round);
+                    // Request at least a quorum of 2f+1 stake to have replied back.
+                    if context.committee.reached_quorum(total_stake) {
+                        info!("A quorum, {} out of {} total stake, returned acceptable results for our own last block with highest round {}, with {retries} retries.", total_stake, context.committee.total_stake(), highest_round);
                         break 'main;
+                    } else {
+                        info!("Only {} out of {} total stake returned acceptable results for our own last block with highest round {}, with {retries} retries.", total_stake, context.committee.total_stake(), highest_round);
                     }
 
                     retries += 1;
@@ -1810,7 +1816,7 @@ mod tests {
         let our_index = AuthorityIndex::new_for_test(0);
 
         // Create some test blocks
-        let mut expected_blocks = (9..=10)
+        let mut expected_blocks = (8..=10)
             .map(|round| VerifiedBlock::new_for_test(TestBlock::new(round, 0).build()))
             .collect::<Vec<_>>();
 
@@ -1822,7 +1828,7 @@ mod tests {
                 vec![block_1.clone()],
                 AuthorityIndex::new_for_test(1),
                 vec![our_index],
-                None,
+                Some(Duration::from_secs(10)),
             )
             .await;
         network_client
@@ -1853,10 +1859,11 @@ mod tests {
             )
             .await;
 
-        // For peer 3 we don't give any block - and it should return an empty vector
+        // For peer 3 we give a block with lowest round
+        let block_3 = expected_blocks.pop().unwrap();
         network_client
             .stub_fetch_latest_blocks(
-                vec![],
+                vec![block_3.clone()],
                 AuthorityIndex::new_for_test(3),
                 vec![our_index],
                 Some(Duration::from_secs(10)),
@@ -1864,7 +1871,7 @@ mod tests {
             .await;
         network_client
             .stub_fetch_latest_blocks(
-                vec![],
+                vec![block_3],
                 AuthorityIndex::new_for_test(3),
                 vec![our_index],
                 None,


### PR DESCRIPTION
# Description of change

Cherry pick from #7494 

Two main changes that are logically connected: 
1 - Fetching own block during startup: When starting the consensus node, we always try to fetch own latest block even if the consensus database is non-empty.
2 - Attempt to propose new blocks only with a quorum of subscriptions: Now we control the number of subscriptions to our block stream. Stop proposing blocks when there is no quorum of subscriptions.

Both changes are made to enhance the network's reliability following crashes and restarts. In particular, we propose and disseminate our own block only when we have a quorum of connections; thereby, if our block is disseminated to a quorum, we will fetch it from at least one connection during startup due to quorum intersection.

Why 1 is important: Some validators reported the creation of equivocating blocks after the restart. That could happen because if the node first erased the consensus db and then partially filled it with some blocks, it didn't ask the network about its latest block due to failed `dag_state.read().highest_accepted_round() == 0` condition. After creating a new block, it then attempted to add another block from the same slot that was already committed. **The change 1** ensures that we always fetch our own latest block from a quorum (by stake) of the network.

Why 2 is important: To propose a new block, we examine active connections - specifically, subscriptions for the produced block stream. Previously, one active subscription was enough to propose new blocks. However, we observed occasionally that when there are not enough active subscriptions, the node could spam the network with its long hidden chain of blocks, which eventually results in a big problem of block synchronization. The change 2 prevents this situation by requiring a quorum (by stake) of active subscriptions.

## Links to any relevant issues

Fixes #7251 

## How the change has been tested

CI

### Release Notes

- [x] Protocol: always fetch own block from a quorum of the network and stop proposing new blocks when a quorum of subscriptions is gone.
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
