### PR TITLE
feat(starfish): evict transactions when last available committed dag is advanced

### DIFF
--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -476,6 +476,11 @@ impl CommittedSubDag {
         }
     }
 
+    /// Returns the leader round of the sub-dag.
+    pub(crate) fn leader_round(&self) -> Round {
+        self.base.leader.round
+    }
+
     /// Helper method to format transaction refs in a consistent way
     fn format_transaction_refs(&self) -> String {
         format_block_digests(

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -162,7 +162,7 @@ impl CommitObserver {
             }
         };
 
-        // Retrieve all the commits from the recover lower bound until the end..
+        // Retrieve all the commits from the recover lower bound until the end.
         let recovery_commits = self
             .store
             .scan_commits((recovery_lower_bound..=CommitIndex::MAX).into())

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -123,9 +123,9 @@ impl CommitObserver {
             );
             sent_sub_dags.push(solid_sub_dag);
         }
-
         self.report_metrics(&pending_sub_dags);
         tracing::trace!("Committed & sent {sent_sub_dags:#?}");
+
         Ok((pending_sub_dags, missing_transactions))
     }
 
@@ -181,11 +181,15 @@ impl CommitObserver {
         let mut next_commit_index_to_recover = recovery_lower_bound;
         let mut last_sent_commit_index = last_processed_commit_index;
         let num_recovery_commits = recovery_commits.len();
+
         for (index, commit) in recovery_commits.into_iter().enumerate() {
             let commit_index = commit.index();
             // Commit index must be continuous during recovert.
             assert_eq!(commit_index, next_commit_index_to_recover);
-
+            if index == 0 {
+                self.commit_solidifier
+                    .set_last_committed_index(commit_index.saturating_sub(1));
+            }
             // On recovery leader schedule will be updated with the current scores
             // and the scores will be passed along with the last commit sent to
             // iota so that the current scores are available for submission.
@@ -224,8 +228,8 @@ impl CommitObserver {
             // Only submit unprocessed commits to IOTA
             for solid_sub_dag in solid_sub_dags {
                 if solid_sub_dag.commit_ref.index > last_processed_commit_index {
-                    // Commit index must be continuous during recovert.
-                    assert_eq!(commit_index, last_sent_commit_index + 1);
+                    // Commit index must be continuous during recovery.
+                    assert_eq!(solid_sub_dag.commit_ref.index, last_sent_commit_index + 1);
                     info!(
                         "Sending solid commit {} during recovery",
                         solid_sub_dag.commit_ref.index

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -28,6 +28,7 @@ use crate::{
     },
     context::Context,
     leader_scoring::{ReputationScores, ScoringSubdag},
+    linearizer::MAX_LINEARIZER_DEPTH,
     storage::{Store, WriteBatch},
     threshold_clock::ThresholdClock,
 };
@@ -53,12 +54,13 @@ pub(crate) struct DagState {
     // The genesis blocks
     genesis: BTreeMap<BlockRef, VerifiedBlock>,
 
-    // Contains recent block headers within CACHED_ROUNDS from the last committed round per
+    // Contains recent block headers within CACHED_ROUNDS from the last traversed round per
     // authority. Note: all uncommitted block headers are kept in memory.
     recent_block_headers: BTreeMap<BlockRef, VerifiedBlockHeader>,
 
-    // Contains recent transactions within CACHED_ROUNDS from the last
-    // committed round per authority. Note: all uncommitted transactions are kept in memory.
+    // Contains recent transactions. It contains MAX_TRANSACTIONS_ACK_DEPTH+MAX_LINEARIZER_DEPTH
+    // from the round of the last consumed commit. Note: all transactions in blocks below that
+    // round are evicted from memory.
     recent_transactions: BTreeMap<BlockRef, VerifiedTransactions>,
 
     // Indexes recent block headers refs by their authorities.
@@ -68,10 +70,10 @@ pub(crate) struct DagState {
     // Keeps track of the threshold clock for proposing blocks.
     threshold_clock: ThresholdClock,
 
-    // Keeps track of the highest round that has been evicted for each authority. Any blocks that
-    // are of round <= evict_round should be considered evicted, and if any exist we should not
-    // consider the causauly complete in the order they appear. The `evicted_rounds` size
-    // should be the same as the committee size.
+    // Keeps track of the highest round that has been evicted for each authority. Any block header
+    // that are of round <= evict_round should be considered evicted, and if any exist we
+    // should not consider the causally complete in the order they appear. The `evicted_rounds`
+    // size should be the same as the committee size.
     evicted_rounds: Vec<Round>,
 
     // Highest round of blocks accepted.
@@ -83,8 +85,14 @@ pub(crate) struct DagState {
     // Last wall time when commit round advanced. Does not persist across restarts.
     last_commit_round_advancement_time: Option<std::time::Instant>,
 
-    // Last committed rounds per authority.
-    last_committed_rounds: Vec<Round>,
+    // Round of the last committed leader which created a consumed commit. Does not persist across
+    // restarts and after recovery, it is assumed that latest commit was consumed by the consensus
+    // handler. All transactions below this round minus MAX_TRANSACTIONS_ACK_DEPTH minus
+    // MAX_LINEARIZER_DEPTH are evicted from memory.
+    last_solid_leader_round: Option<Round>,
+
+    // Rounds for latest blocks traversed by linearizer per authority.
+    last_traversed_rounds: Vec<Round>,
 
     /// The committed subdags that have been scored but scores have not been
     /// used for leader schedule yet.
@@ -187,6 +195,16 @@ impl DagState {
 
         scoring_subdag.add_subdags(std::mem::take(&mut unscored_committed_subdags));
 
+        // Assume that the last commit that was generated was consumed by the consensus
+        // handler, i.e. all transactions were available and sent to the consensus
+        // handler.
+        let mut last_solid_leader_round: Option<Round> = None;
+        if let Some(last_commit) = last_commit.as_ref() {
+            // If we have a last commit, we can set the last solid leader round to the
+            // round of the last commit.
+            last_solid_leader_round = Some(last_commit.round());
+        }
+
         let mut state = Self {
             context,
             genesis,
@@ -197,7 +215,8 @@ impl DagState {
             highest_accepted_round: 0,
             last_commit: last_commit.clone(),
             last_commit_round_advancement_time: None,
-            last_committed_rounds: last_committed_rounds.clone(),
+            last_traversed_rounds: last_committed_rounds.clone(),
+            last_solid_leader_round,
             pending_commit_votes: VecDeque::new(),
             transactions_to_write: vec![],
             block_headers_to_write: vec![],
@@ -309,6 +328,11 @@ impl DagState {
             self.add_pending_acknowledgment(block_ref);
         }
         self.transactions_to_write.push(transactions);
+    }
+
+    pub fn update_last_solid_leader_round(&mut self, round: Round) {
+        info!("Last solid leader round is {}", round);
+        self.last_solid_leader_round = Some(round);
     }
 
     /// Updates internal metadata for a block.
@@ -1081,13 +1105,13 @@ impl DagState {
         }
 
         for block_ref in commit.blocks().iter() {
-            self.last_committed_rounds[block_ref.author] = max(
-                self.last_committed_rounds[block_ref.author],
+            self.last_traversed_rounds[block_ref.author] = max(
+                self.last_traversed_rounds[block_ref.author],
                 block_ref.round,
             );
         }
 
-        for (i, round) in self.last_committed_rounds.iter().enumerate() {
+        for (i, round) in self.last_traversed_rounds.iter().enumerate() {
             let index = self.context.committee.to_authority_index(i).unwrap();
             let hostname = &self.context.committee.authority(index).hostname;
             self.context
@@ -1109,7 +1133,7 @@ impl DagState {
         assert!(self.scoring_subdag.is_empty());
 
         let commit_info = CommitInfo {
-            committed_rounds: self.last_committed_rounds.clone(),
+            committed_rounds: self.last_traversed_rounds.clone(),
             reputation_scores,
         };
         let last_commit = self
@@ -1218,6 +1242,25 @@ impl DagState {
             votes.push(self.pending_commit_votes.pop_front().unwrap());
         }
         votes
+    }
+
+    /// Function removes stalled transactions that are older than
+    /// "last consume leader round minus MAX_TRANSACTIONS_ACK_DEPTH minus
+    /// MAX_LINEARIZER_DEPTH"
+    pub(crate) fn evict_transactions(&mut self) {
+        let last_solid_leader_round = self.last_solid_leader_round;
+        if let Some(round) = last_solid_leader_round {
+            let min_round: Round =
+                round.saturating_sub(MAX_TRANSACTIONS_ACK_DEPTH + MAX_LINEARIZER_DEPTH);
+
+            // Construct a dummy BlockRef with the minimum round to split on.
+            // All entries < dummy will be removed.
+            let lower_bound =
+                BlockRef::new(min_round + 1, AuthorityIndex::ZERO, BlockHeaderDigest::MIN);
+
+            // Remove entries with round < min_round
+            self.recent_transactions = self.recent_transactions.split_off(&lower_bound);
+        }
     }
 
     /// Function removes stalled pending acknowledgments that are older than
@@ -1334,7 +1377,7 @@ impl DagState {
 
     /// Last committed round per authority.
     pub(crate) fn last_committed_rounds(&self) -> Vec<Round> {
-        self.last_committed_rounds.clone()
+        self.last_traversed_rounds.clone()
     }
 
     /// After each flush, DagState becomes persisted in storage and it expected
@@ -1410,7 +1453,6 @@ impl DagState {
             while let Some(block_ref) = recent_refs.first() {
                 if block_ref.round <= eviction_round {
                     self.recent_block_headers.remove(block_ref);
-                    self.recent_transactions.remove(block_ref);
                     recent_refs.pop_first();
                 } else {
                     break;
@@ -1419,6 +1461,9 @@ impl DagState {
 
             self.evicted_rounds[authority_index] = eviction_round;
         }
+
+        // Clean up old transactions depending on the last solid leader round.
+        self.evict_transactions();
 
         // Clean up old acknowledgments.
         self.evict_pending_acknowledgments();
@@ -1481,7 +1526,7 @@ impl DagState {
     /// from that authority. For any round that is <= `last_evicted_round`
     /// we don't have such guarantees as out of order blocks might exist.
     fn calculate_authority_eviction_round(&self, authority_index: AuthorityIndex) -> Round {
-        let commit_round = self.last_committed_rounds[authority_index];
+        let commit_round = self.last_traversed_rounds[authority_index];
         Self::eviction_round(commit_round, self.cached_rounds)
     }
 

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -85,14 +85,13 @@ pub(crate) struct DagState {
     // Last wall time when commit round advanced. Does not persist across restarts.
     last_commit_round_advancement_time: Option<std::time::Instant>,
 
-    // Round of the last committed leader which created a consumed commit. Does not persist across
-    // restarts and after recovery, it is assumed that latest commit was consumed by the consensus
-    // handler. All transactions below this round minus MAX_TRANSACTIONS_ACK_DEPTH minus
-    // MAX_LINEARIZER_DEPTH are evicted from memory.
-    last_solid_leader_round: Option<Round>,
+    // Round of the last committed leader which created a commit with available transactions. Does
+    // not persist across restarts and after recovery. All transactions below this round minus
+    // MAX_TRANSACTIONS_ACK_DEPTH minus MAX_LINEARIZER_DEPTH are evicted from memory.
+    last_available_commit_leader_round: Option<Round>,
 
     // Rounds for latest blocks traversed by linearizer per authority.
-    last_traversed_rounds: Vec<Round>,
+    last_committed_rounds: Vec<Round>,
 
     /// The committed subdags that have been scored but scores have not been
     /// used for leader schedule yet.
@@ -195,10 +194,6 @@ impl DagState {
 
         scoring_subdag.add_subdags(std::mem::take(&mut unscored_committed_subdags));
 
-        // Set it to None. Later the commit observer might update this value during recovery process.
-        // It is needed mostly for eviction of transactions.
-        let mut last_solid_leader_round: Option<Round> = None;
-
         let mut state = Self {
             context,
             genesis,
@@ -209,8 +204,9 @@ impl DagState {
             highest_accepted_round: 0,
             last_commit: last_commit.clone(),
             last_commit_round_advancement_time: None,
-            last_traversed_rounds: last_committed_rounds.clone(),
-            last_solid_leader_round,
+            last_committed_rounds: last_committed_rounds.clone(),
+            last_available_commit_leader_round: None, /* Later the commit observer might update
+                                                       * this value during recovery process. */
             pending_commit_votes: VecDeque::new(),
             transactions_to_write: vec![],
             block_headers_to_write: vec![],
@@ -324,9 +320,12 @@ impl DagState {
         self.transactions_to_write.push(transactions);
     }
 
-    pub fn update_last_solid_leader_round(&mut self, round: Round) {
-        info!("Last solid leader round is {}", round);
-        self.last_solid_leader_round = Some(round);
+    pub fn update_last_available_commit_leader_round(&mut self, round: Round) {
+        info!(
+            "Last commit with available transactions has leader at round {}",
+            round
+        );
+        self.last_available_commit_leader_round = Some(round);
     }
 
     /// Updates internal metadata for a block.
@@ -1099,13 +1098,13 @@ impl DagState {
         }
 
         for block_ref in commit.blocks().iter() {
-            self.last_traversed_rounds[block_ref.author] = max(
-                self.last_traversed_rounds[block_ref.author],
+            self.last_committed_rounds[block_ref.author] = max(
+                self.last_committed_rounds[block_ref.author],
                 block_ref.round,
             );
         }
 
-        for (i, round) in self.last_traversed_rounds.iter().enumerate() {
+        for (i, round) in self.last_committed_rounds.iter().enumerate() {
             let index = self.context.committee.to_authority_index(i).unwrap();
             let hostname = &self.context.committee.authority(index).hostname;
             self.context
@@ -1127,7 +1126,7 @@ impl DagState {
         assert!(self.scoring_subdag.is_empty());
 
         let commit_info = CommitInfo {
-            committed_rounds: self.last_traversed_rounds.clone(),
+            committed_rounds: self.last_committed_rounds.clone(),
             reputation_scores,
         };
         let last_commit = self
@@ -1242,7 +1241,7 @@ impl DagState {
     /// "last consume leader round minus MAX_TRANSACTIONS_ACK_DEPTH minus
     /// MAX_LINEARIZER_DEPTH"
     pub(crate) fn evict_transactions(&mut self) {
-        let last_solid_leader_round = self.last_solid_leader_round;
+        let last_solid_leader_round = self.last_available_commit_leader_round;
         if let Some(round) = last_solid_leader_round {
             let min_round: Round =
                 round.saturating_sub(MAX_TRANSACTIONS_ACK_DEPTH + MAX_LINEARIZER_DEPTH);
@@ -1371,7 +1370,7 @@ impl DagState {
 
     /// Last committed round per authority.
     pub(crate) fn last_committed_rounds(&self) -> Vec<Round> {
-        self.last_traversed_rounds.clone()
+        self.last_committed_rounds.clone()
     }
 
     /// After each flush, DagState becomes persisted in storage and it expected
@@ -1520,7 +1519,7 @@ impl DagState {
     /// from that authority. For any round that is <= `last_evicted_round`
     /// we don't have such guarantees as out of order blocks might exist.
     fn calculate_authority_eviction_round(&self, authority_index: AuthorityIndex) -> Round {
-        let commit_round = self.last_traversed_rounds[authority_index];
+        let commit_round = self.last_committed_rounds[authority_index];
         Self::eviction_round(commit_round, self.cached_rounds)
     }
 

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -195,15 +195,9 @@ impl DagState {
 
         scoring_subdag.add_subdags(std::mem::take(&mut unscored_committed_subdags));
 
-        // Assume that the last commit that was generated was consumed by the consensus
-        // handler, i.e. all transactions were available and sent to the consensus
-        // handler.
+        // Set it to None. Later the commit observer might update this value during recovery process.
+        // It is needed mostly for eviction of transactions.
         let mut last_solid_leader_round: Option<Round> = None;
-        if let Some(last_commit) = last_commit.as_ref() {
-            // If we have a last commit, we can set the last solid leader round to the
-            // round of the last commit.
-            last_solid_leader_round = Some(last_commit.round());
-        }
 
         let mut state = Self {
             context,

--- a/crates/starfish/core/src/data_manager.rs
+++ b/crates/starfish/core/src/data_manager.rs
@@ -43,7 +43,7 @@ impl DataManager {
     /// # Returns
     /// A new `DataManager` instance.
     pub(crate) fn new(dag_state: Arc<RwLock<DagState>>) -> Self {
-        // last_committed_index is set during recovery process before the first usage of
+        // last_committed_index is set non-trivially during recovery process before the first usage of
         // try_commit method.
         let last_committed_index = 0;
         Self {
@@ -112,12 +112,14 @@ impl DataManager {
         // Update dag state with the round of the leader in the last committed subdag
         // This will allow to evict transactions from the DAG state
         if !committed.is_empty() {
-            self.dag_state.write().update_last_solid_leader_round(
-                committed
-                    .last()
-                    .expect("We should expect at least one committed subdag")
-                    .leader_round(),
-            );
+            self.dag_state
+                .write()
+                .update_last_available_commit_leader_round(
+                    committed
+                        .last()
+                        .expect("We should expect at least one committed subdag")
+                        .leader_round(),
+                );
         }
 
         // Update last_committed_index

--- a/crates/starfish/core/src/data_manager.rs
+++ b/crates/starfish/core/src/data_manager.rs
@@ -43,8 +43,8 @@ impl DataManager {
     /// # Returns
     /// A new `DataManager` instance.
     pub(crate) fn new(dag_state: Arc<RwLock<DagState>>) -> Self {
-        // last_committed_index is set non-trivially during recovery process before the first usage of
-        // try_commit method.
+        // last_committed_index is set non-trivially during recovery process before the
+        // first usage of try_commit method.
         let last_committed_index = 0;
         Self {
             dag_state,

--- a/crates/starfish/core/src/data_manager.rs
+++ b/crates/starfish/core/src/data_manager.rs
@@ -43,14 +43,18 @@ impl DataManager {
     /// # Returns
     /// A new `DataManager` instance.
     pub(crate) fn new(dag_state: Arc<RwLock<DagState>>) -> Self {
-        // TODO: last_committed_index should be initialized from the latest committed
-        // subdag, not always zero.
+        // last_committed_index is set during recovery process before the first usage of
+        // try_commit method.
         let last_committed_index = 0;
         Self {
             dag_state,
             pending_subdags: BTreeMap::new(),
             last_committed_index,
         }
+    }
+
+    pub(crate) fn set_last_committed_index(&mut self, index: u32) {
+        self.last_committed_index = index;
     }
 
     /// Attempts to retrieve transactions included in the newly created commits.
@@ -104,6 +108,18 @@ impl DataManager {
                 }
             }
         }
+
+        // Update dag state with the round of the leader in the last committed subdag
+        // This will allow to evict transactions from the DAG state
+        if !committed.is_empty() {
+            self.dag_state.write().update_last_solid_leader_round(
+                committed
+                    .last()
+                    .expect("We should expect at least one committed subdag")
+                    .leader_round(),
+            );
+        }
+
         // Update last_committed_index
         self.last_committed_index = last_committed;
 
@@ -125,6 +141,7 @@ impl DataManager {
                 }
             }
         }
+
         (committed, missing.into_iter().collect())
     }
 


### PR DESCRIPTION
# Description of change

We now track the round of latest committed leader block such that the corresponding sequenced transactions are locally available. Because of transaction data separation, block headers could be available and transactions not, we have two different methods to evict: for block headers, when a new pending committed dag is created; for transactions, when a new solid committed dag is created (all transaction data that is sequenced is locally available to us). 

Eviction of transactions is triggered when the required round is updated and the flush method is called

## Links to any relevant issues

Fixes #7239 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Proper eviction of transactions
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
