### PR TITLE
feat(starfish): update commit syncer for a new block structure

### DIFF
--- a/crates/starfish/core/src/block_manager.rs
+++ b/crates/starfish/core/src/block_manager.rs
@@ -99,7 +99,6 @@ impl BlockManager {
     pub(crate) fn try_accept_blocks(
         &mut self,
         blocks: Vec<VerifiedBlock>,
-        live: bool,
     ) -> (Vec<VerifiedBlockHeader>, BTreeSet<BlockRef>) {
         let _s = monitored_scope("BlockManager::try_accept_blocks");
         let block_headers: Vec<_> = blocks
@@ -107,7 +106,7 @@ impl BlockManager {
             .map(|b| b.verified_block_header.clone())
             .collect();
         let (accepted_block_headers, missing_block_headers) =
-            self.try_accept_block_headers_internal(block_headers, live);
+            self.try_accept_block_headers_internal(block_headers);
 
         let block_refs = blocks
             .iter()
@@ -118,7 +117,7 @@ impl BlockManager {
             if exists[i] {
                 self.dag_state
                     .write()
-                    .add_transactions(block.verified_transactions, live);
+                    .add_transactions(block.verified_transactions);
             } else {
                 self.suspended_blocks.insert(block.reference(), block);
             }
@@ -139,17 +138,15 @@ impl BlockManager {
         block_headers: Vec<VerifiedBlockHeader>,
     ) -> (Vec<VerifiedBlockHeader>, BTreeSet<BlockRef>) {
         let _s = monitored_scope("BlockManager::try_accept_block_headers");
-        // Headers are only added through synchronizer and cordial dissemination. This
-        // means that any transactions that were suspended were also added during live
-        // processing, and we will need to acknowledge them.
-        self.try_accept_block_headers_internal(block_headers, true)
+        // Headers are added through synchronizer, commit syncer and cordial
+        // dissemination.
+        self.try_accept_block_headers_internal(block_headers)
     }
 
     /// Attempts to accept the provided blocks.
     fn try_accept_block_headers_internal(
         &mut self,
         mut block_headers: Vec<VerifiedBlockHeader>,
-        live: bool,
     ) -> (Vec<VerifiedBlockHeader>, BTreeSet<BlockRef>) {
         let _s = monitored_scope("BlockManager::try_accept_block_headers_internal");
 
@@ -208,7 +205,7 @@ impl BlockManager {
                 // for this accepted header we already have a block, so we add it to dag_state
                 self.dag_state
                     .write()
-                    .add_transactions(block.verified_transactions, live);
+                    .add_transactions(block.verified_transactions);
             }
         }
 

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -19,8 +19,8 @@ use starfish_config::{AuthorityIndex, DIGEST_LENGTH, DefaultHashFunction};
 
 use crate::{
     block_header::{
-        BlockHeaderAPI, BlockRef, BlockTimestampMs, Round, Slot, VerifiedBlock,
-        VerifiedBlockHeader, VerifiedTransactions,
+        BlockHeaderAPI, BlockRef, BlockTimestampMs, Round, Slot, VerifiedBlockHeader,
+        VerifiedTransactions,
     },
     leader_scoring::ReputationScores,
     storage::Store,
@@ -251,22 +251,22 @@ impl CertifiedCommits {
 #[derive(Clone, Debug)]
 pub(crate) struct CertifiedCommit {
     commit: Arc<TrustedCommit>,
-    verifier_blocks: Vec<VerifiedBlock>,
+    verified_block_headers: Vec<VerifiedBlockHeader>,
 }
 
 impl CertifiedCommit {
     pub(crate) fn new_certified(
         commit: TrustedCommit,
-        verified_blocks: Vec<VerifiedBlock>,
+        verified_block_headers: Vec<VerifiedBlockHeader>,
     ) -> Self {
         Self {
             commit: Arc::new(commit),
-            verifier_blocks: verified_blocks,
+            verified_block_headers,
         }
     }
 
-    pub fn blocks(&self) -> &[VerifiedBlock] {
-        &self.verifier_blocks
+    pub fn blocks(&self) -> &[VerifiedBlockHeader] {
+        &self.verified_block_headers
     }
 }
 

--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -31,7 +31,6 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    ops::Deref,
     sync::Arc,
     time::Duration,
 };
@@ -53,7 +52,7 @@ use tracing::{debug, info, warn};
 
 use crate::{
     CommitConsumerMonitor, CommitIndex, VerifiedBlockHeader,
-    block_header::{BlockHeaderAPI, SignedBlockHeader, VerifiedBlock},
+    block_header::{BlockHeaderAPI, SignedBlockHeader},
     block_verifier::BlockVerifier,
     commit::{
         CertifiedCommit, CertifiedCommits, Commit, CommitAPI as _, CommitDigest, CommitRange,
@@ -64,7 +63,7 @@ use crate::{
     core_thread::CoreThreadDispatcher,
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
-    network::{NetworkClient, SerializedBlock, SerializedHeaderAndTransactions},
+    network::NetworkClient,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
 };
 
@@ -263,7 +262,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
                     bytes
                         + c.blocks()
                             .iter()
-                            .map(|b| b.serialized().0.len() + b.serialized().1.len())
+                            .map(|b| b.serialized().len())
                             .sum::<usize>() as u64,
                 )
             });
@@ -273,10 +272,10 @@ impl<C: NetworkClient> CommitSyncer<C> {
             .commit_sync_fetched_commits
             .inc_by(certified_commits.commits().len() as u64);
         metrics
-            .commit_sync_fetched_blocks
+            .commit_sync_fetched_block_headers
             .inc_by(total_blocks_fetched as u64);
         metrics
-            .commit_sync_total_fetched_blocks_size
+            .commit_sync_total_fetched_block_headers_size
             .inc_by(total_blocks_size_bytes);
 
         let (commit_start, commit_end) = (
@@ -321,7 +320,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
             }
 
             debug!(
-                "Fetched certified blocks for commit range {:?}: {}",
+                "Fetched certified block headers for commit range {:?}: {}",
                 fetched_commit_range,
                 commits
                     .commits()
@@ -345,7 +344,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
                 Ok(missing) => {
                     if !missing.is_empty() {
                         warn!(
-                            "Fetched blocks have missing ancestors: {:?} for commit range {:?}",
+                            "Fetched block headers have missing ancestors: {:?} for commit range {:?}",
                             missing, fetched_commit_range
                         );
                     }
@@ -385,7 +384,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
 
     fn try_start_fetches(&mut self) {
         // Cap parallel fetches based on configured limit and committee size, to avoid
-        // overloading the network. Also when there are too many fetched blocks
+        // overloading the network. Also when there are too many fetched block headers
         // that cannot be sent to Core before an earlier fetch has not finished,
         // reduce parallelism so the earlier fetch can retry on a better host and
         // succeed.
@@ -427,9 +426,10 @@ impl<C: NetworkClient> CommitSyncer<C> {
             .set(self.synced_commit_index as i64);
     }
 
-    // Retries fetching commits and blocks from available authorities, until a
-    // request succeeds where at least a prefix of the commit range is fetched.
-    // Returns the fetched commits and blocks referenced by the commits.
+    // Retries fetching commits and block headers from available authorities, until
+    // a request succeeds where at least a prefix of the commit range is
+    // fetched. Returns the fetched commits and block headers referenced by the
+    // commits.
     async fn fetch_loop(
         inner: Arc<Inner<C>>,
         commit_range: CommitRange,
@@ -472,10 +472,10 @@ impl<C: NetworkClient> CommitSyncer<C> {
             // Increase timeout multiplier for each loop until MAX_TIMEOUT_MULTIPLIER.
             timeout_multiplier = (timeout_multiplier + 1).min(MAX_TIMEOUT_MULTIPLIER);
             let request_timeout = TIMEOUT * timeout_multiplier;
-            // Give enough overall timeout for fetching commits and blocks.
-            // - Timeout for fetching commits and commit certifying blocks.
-            // - Timeout for fetching blocks referenced by the commits.
-            // - Time spent on pipelining requests to fetch blocks.
+            // Give enough overall timeout for fetching commits and block headers.
+            // - Timeout for fetching commits and commit certifying block headers.
+            // - Timeout for fetching block headers referenced by the commits.
+            // - Time spent on pipelining requests to fetch block headers.
             // - Another headroom to allow fetch_once() to timeout gracefully if possible.
             let fetch_timeout = request_timeout * 4;
             // Try fetching from selected target authority.
@@ -552,16 +552,16 @@ impl<C: NetworkClient> CommitSyncer<C> {
             .start_timer();
 
         // 1. Fetch commits in the commit range from the target authority.
-        let (serialized_commits, serialized_block_headers) = inner
+        let (serialized_commits, serialized_voting_block_headers) = inner
             .network_client
             .fetch_commits(target_authority, commit_range.clone(), timeout)
             .await?;
 
-        // 2. Verify the response contains blocks that can certify the last returned
-        //    commit,
+        // 2. Verify the response contains block headers that can certify the last
+        //    returned commit,
         // and the returned commits are chained by digest, so earlier commits are
         // certified as well.
-        let (commits, vote_blocks) = Handle::current()
+        let (commits, voting_block_headers) = Handle::current()
             .spawn_blocking({
                 let inner = inner.clone();
                 move || {
@@ -569,14 +569,14 @@ impl<C: NetworkClient> CommitSyncer<C> {
                         target_authority,
                         commit_range,
                         serialized_commits,
-                        serialized_block_headers,
+                        serialized_voting_block_headers,
                     )
                 }
             })
             .await
             .expect("Spawn blocking should not fail")?;
 
-        // 3. Fetch blocks referenced by the commits, from the same authority.
+        // 3. Fetch block headers referenced by the commits, from the same authority.
         let block_refs: Vec<_> = commits.iter().flat_map(|c| c.blocks()).cloned().collect();
         let num_chunks = block_refs
             .len()
@@ -592,70 +592,68 @@ impl<C: NetworkClient> CommitSyncer<C> {
                     //    authority.
                     sleep(timeout * i as u32 / num_chunks).await;
                     // TODO: add some retries.
-                    let serialized_blocks = inner
+                    let serialized_block_headers = inner
                         .network_client
-                        .fetch_blocks(
+                        .fetch_block_headers(
                             target_authority,
                             request_block_refs.to_vec(),
                             vec![],
                             timeout,
                         )
                         .await?;
-                    // 5. Verify the same number of blocks are returned as requested.
-                    if request_block_refs.len() != serialized_blocks.len() {
-                        return Err(ConsensusError::UnexpectedNumberOfBlocksFetched {
+                    // 5. Verify the same number of block headers is returned as requested.
+                    if request_block_refs.len() != serialized_block_headers.len() {
+                        return Err(ConsensusError::UnexpectedNumberOfBlockHeadersFetched {
                             authority: target_authority,
                             requested: request_block_refs.len(),
-                            received_blocks: serialized_blocks.len(),
+                            received_block_headers: serialized_block_headers.len(),
                         });
                     }
-                    // 6. Verify returned blocks have valid formats.
-                    let verified_blocks = serialized_blocks
+                    // 6. Verify returned block headers have valid formats.
+                    let verified_block_headers = serialized_block_headers
                         .iter()
                         .cloned()
                         .zip(request_block_refs)
-                        .map(|(serialized_block, requested_block_ref)| {
-                            let block = VerifiedBlock::try_from(
-                                SerializedHeaderAndTransactions::try_from(SerializedBlock {
-                                    serialized_block,
-                                })?,
-                            )?;
+                        .map(|(serialized_block_header, requested_block_ref)| {
+                            // we don't verify the header, we only check the block reference below
+                            let block_header =
+                                VerifiedBlockHeader::new_from_bytes(serialized_block_header)?;
 
-                            // 7. Verify the returned blocks match the requested block refs.
-                            // If they do match, the returned blocks can be considered verified
-                            // as well.
-                            if *requested_block_ref != block.reference() {
+                            // 7. Verify the returned block headers match the requested block refs.
+                            // If they do match, the returned block headers can be considered
+                            // verified as well.
+                            if *requested_block_ref != block_header.reference() {
                                 return Err(ConsensusError::UnexpectedBlockForCommit {
                                     peer: target_authority,
                                     requested: *requested_block_ref,
-                                    received: block.reference(),
+                                    received: block_header.reference(),
                                 });
                             }
 
-                            Ok(block)
+                            Ok(block_header)
                         })
                         .collect::<ConsensusResult<Vec<_>>>()?;
 
-                    Ok(verified_blocks)
+                    Ok(verified_block_headers)
                 }
             })
             .collect();
 
-        let mut fetched_blocks = BTreeMap::new();
+        let mut fetched_block_headers = BTreeMap::new();
         while let Some(result) = requests.next().await {
-            for block in result? {
-                fetched_blocks.insert(block.reference(), block);
+            for block_header in result? {
+                fetched_block_headers.insert(block_header.reference(), block_header);
             }
         }
 
-        // 8. Make sure fetched block (and votes) timestamps are lower than current
-        //    time.
-        for block in vote_blocks
+        // 8. Make sure fetched block headers (and votes) timestamps are lower than
+        //    current time.
+        for block_header in voting_block_headers
             .iter()
-            .chain(fetched_blocks.values().map(Deref::deref))
+            .chain(fetched_block_headers.values())
         {
             let now_ms = inner.context.clock.timestamp_utc_ms();
-            let forward_drift = block.timestamp_ms().saturating_sub(now_ms);
+            let forward_drift = block_header.timestamp_ms().saturating_sub(now_ms);
             if forward_drift == 0 {
                 continue;
             };
@@ -670,28 +668,31 @@ impl<C: NetworkClient> CommitSyncer<C> {
             let forward_drift = Duration::from_millis(forward_drift);
             if forward_drift >= inner.context.parameters.max_forward_time_drift {
                 warn!(
-                    "Local clock is behind a quorum of peers: local ts {}, certified block ts {}",
+                    "Local clock is behind a quorum of peers: local ts {}, certified block header ts {}",
                     now_ms,
-                    block.timestamp_ms()
+                    block_header.timestamp_ms()
                 );
             }
             sleep(forward_drift).await;
         }
 
-        // 9. Now create the Certified commits by assigning the blocks to each commit
-        //    and retaining the commit votes history.
+        // 9. Now create the Certified commits by assigning the block headers to each
+        //    commit and retaining the commit votes history.
         let mut certified_commits = Vec::new();
         for commit in &commits {
-            let blocks = commit
+            let block_headers = commit
                 .blocks()
                 .iter()
                 .map(|block_ref| {
-                    fetched_blocks
+                    fetched_block_headers
                         .remove(block_ref)
                         .expect("Block should exist")
                 })
                 .collect::<Vec<_>>();
-            certified_commits.push(CertifiedCommit::new_certified(commit.clone(), blocks));
+            certified_commits.push(CertifiedCommit::new_certified(
+                commit.clone(),
+                block_headers,
+            ));
         }
 
         Ok(CertifiedCommits::new(certified_commits))

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -251,7 +251,6 @@ impl Core {
         self
     }
 
-    // TODO: modify to deal with transaction data
     /// Processes the provided blocks and accepts them if possible when their
     /// causal history exists. The method also uses the input bool variable if
     /// this call is known to be about not old blocks. The method returns:
@@ -275,13 +274,13 @@ impl Core {
             .node_metrics
             .core_add_blocks_batch_size
             .observe(blocks.len() as f64);
-        let (accepted_blocks, missing_block_refs) =
+        let (accepted_blocks_headers, missing_block_refs) =
             self.block_manager.try_accept_blocks(blocks, live);
 
-        if !accepted_blocks.is_empty() {
+        if !accepted_blocks_headers.is_empty() {
             debug!(
-                "Accepted blocks: {}",
-                accepted_blocks
+                "Accepted block headers: {}",
+                accepted_blocks_headers
                     .iter()
                     .map(|b| b.reference().to_string())
                     .join(",")
@@ -364,26 +363,22 @@ impl Core {
 
     // Adds the certified commits that have been synced via the commit syncer. We
     // are using the commit info in order to skip running the decision
-    // rule and immediately commit the corresponding leaders and sub dags. Pay
-    // attention that no block acceptance is happening here, but rather
-    // internally in the `try_commit` method which ensures that everytime only the
-    // blocks corresponding to the certified commits that are about to
-    // be committed are accepted.
+    // rule and immediately commit the corresponding leaders and sub dags.
     #[tracing::instrument(skip_all)]
     pub(crate) fn add_certified_commits(
         &mut self,
         certified_commits: CertifiedCommits,
     ) -> ConsensusResult<BTreeSet<BlockRef>> {
         let _scope = monitored_scope("Core::add_certified_commits");
-        let blocks = certified_commits
+        let block_headers = certified_commits
             .commits()
             .iter()
             .flat_map(|commit| commit.blocks())
             .cloned()
             .collect::<Vec<_>>();
 
-        // Add blocks in certified commits to the block manager.
-        self.add_blocks(blocks, false)
+        // Add block headers in certified commits to the block manager.
+        self.add_block_headers(block_headers)
     }
 
     /// If needed, signals a new clock round and sets up leader timeout.

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -259,7 +259,6 @@ impl Core {
     pub(crate) fn add_blocks(
         &mut self,
         blocks: Vec<VerifiedBlock>,
-        live: bool,
     ) -> ConsensusResult<BTreeSet<BlockRef>> {
         let _scope = monitored_scope("Core::add_blocks");
         let _s = self
@@ -275,7 +274,7 @@ impl Core {
             .core_add_blocks_batch_size
             .observe(blocks.len() as f64);
         let (accepted_blocks_headers, missing_block_refs) =
-            self.block_manager.try_accept_blocks(blocks, live);
+            self.block_manager.try_accept_blocks(blocks);
 
         if !accepted_blocks_headers.is_empty() {
             debug!(
@@ -651,7 +650,7 @@ impl Core {
         // Accept the block into BlockManager and DagState.
         let (accepted_blocks, missing) = self
             .block_manager
-            .try_accept_blocks(vec![verified_block.clone()], true);
+            .try_accept_blocks(vec![verified_block.clone()]);
         assert_eq!(accepted_blocks.len(), 1);
         assert!(missing.is_empty());
         // Ensure the new block and its ancestors are persisted, before broadcasting it.
@@ -1673,7 +1672,7 @@ mod test {
         // Wait for min round delay to allow blocks to be proposed.
         sleep(context.parameters.min_round_delay).await;
         // add blocks to trigger proposal.
-        _ = core.add_blocks(vec![verified_block], true);
+        _ = core.add_blocks(vec![verified_block]);
 
         assert_eq!(core.last_proposed_round(), 1);
         expected_ancestors.insert(core.last_proposed_block_header().reference());
@@ -1687,7 +1686,7 @@ mod test {
         // Wait for min round delay to allow blocks to be proposed.
         sleep(context.parameters.min_round_delay).await;
         // add blocks to trigger proposal.
-        _ = core.add_blocks(vec![block_3], true);
+        _ = core.add_blocks(vec![block_3]);
 
         assert_eq!(core.last_proposed_round(), 2);
 

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -142,7 +142,7 @@ impl CoreThread {
                     match command {
                         CoreThreadCommand::AddBlocks(blocks, sender) => {
                             let _scope = monitored_scope("CoreThread::loop::add_blocks");
-                            let missing_block_refs = self.core.add_blocks(blocks, true)?;
+                            let missing_block_refs = self.core.add_blocks(blocks)?;
                             sender.send(missing_block_refs).ok();
                         }
                         CoreThreadCommand::AddBlockHeaders(block_headers, sender) => {

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -305,7 +305,7 @@ impl DagState {
             .inc();
     }
 
-    pub(crate) fn add_transactions(&mut self, transactions: VerifiedTransactions, live: bool) {
+    pub(crate) fn add_transactions(&mut self, transactions: VerifiedTransactions) {
         let block_ref = transactions.block_ref();
         self.recent_transactions
             .insert(block_ref, transactions.clone());
@@ -314,7 +314,7 @@ impl DagState {
         let clock_round = self.threshold_clock_round();
         let min_round: Round = clock_round.saturating_sub(MAX_TRANSACTIONS_ACK_DEPTH);
 
-        if live && block_ref.round >= min_round {
+        if block_ref.round >= min_round {
             self.add_pending_acknowledgment(block_ref);
         }
         self.transactions_to_write.push(transactions);
@@ -2609,7 +2609,7 @@ mod test {
                     )
                     .unwrap();
             } else {
-                dag_state.add_transactions(block.verified_transactions.clone(), false);
+                dag_state.add_transactions(block.verified_transactions.clone());
             }
         });
 

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -60,12 +60,12 @@ pub(crate) enum ConsensusError {
     UnexpectedGenesisBlockHeaderRequested,
 
     #[error(
-        "Expected {requested} but received {received_blocks} blocks from authority {authority}"
+        "Expected {requested} but received {received_block_headers} block headers from authority {authority}"
     )]
-    UnexpectedNumberOfBlocksFetched {
+    UnexpectedNumberOfBlockHeadersFetched {
         authority: AuthorityIndex,
         requested: usize,
-        received_blocks: usize,
+        received_block_headers: usize,
     },
 
     #[error("Unexpected block returned while fetching missing blocks")]

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -171,8 +171,8 @@ pub(crate) struct NodeMetrics {
     pub(crate) commit_sync_pending_fetches: IntGauge,
     pub(crate) commit_sync_fetch_commits_handler_uncertified_skipped: IntCounter,
     pub(crate) commit_sync_fetched_commits: IntCounter,
-    pub(crate) commit_sync_fetched_blocks: IntCounter,
-    pub(crate) commit_sync_total_fetched_blocks_size: IntCounter,
+    pub(crate) commit_sync_fetched_block_headers: IntCounter,
+    pub(crate) commit_sync_total_fetched_block_headers_size: IntCounter,
     pub(crate) commit_sync_quorum_index: IntGauge,
     pub(crate) commit_sync_highest_synced_index: IntGauge,
     pub(crate) commit_sync_highest_fetched_index: IntGauge,
@@ -591,14 +591,14 @@ impl NodeMetrics {
                 "The number of commits fetched via commit syncer",
                 registry,
             ).unwrap(),
-            commit_sync_fetched_blocks: register_int_counter_with_registry!(
-                "commit_sync_fetched_blocks",
-                "The number of blocks fetched via commit syncer",
+            commit_sync_fetched_block_headers: register_int_counter_with_registry!(
+                "commit_sync_fetched_block_headers",
+                "The number of block headers fetched via commit syncer",
                 registry,
             ).unwrap(),
-            commit_sync_total_fetched_blocks_size: register_int_counter_with_registry!(
-                "commit_sync_total_fetched_blocks_size",
-                "The total size in bytes of blocks fetched via commit syncer",
+            commit_sync_total_fetched_block_headers_size: register_int_counter_with_registry!(
+                "commit_sync_total_fetched_block_headers_size",
+                "The total size in bytes of block headers fetched via commit syncer",
                 registry,
             ).unwrap(),
             commit_sync_quorum_index: register_int_gauge_with_registry!(

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -93,6 +93,7 @@ pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
     /// `highest_accepted_rounds` length should be equal to the committee
     /// size. If `highest_accepted_rounds` is empty then it will be simply
     /// ignored.
+    #[expect(dead_code)]
     async fn fetch_blocks(
         &self,
         peer: AuthorityIndex,

--- a/crates/starfish/core/src/synchronizer.rs
+++ b/crates/starfish/core/src/synchronizer.rs
@@ -1203,6 +1203,7 @@ mod tests {
 
     #[derive(Default)]
     struct MockNetworkClient {
+        #[allow(dead_code)]
         fetch_blocks_requests: Mutex<BTreeMap<FetchRequestKey, FetchRequestBlocksResponse>>,
         fetch_block_headers_requests: Mutex<BTreeMap<FetchRequestKey, FetchRequestHeadersResponse>>,
         fetch_latest_block_headers_requests:

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -16,7 +16,7 @@ use crate::{
     CommitRef, CommittedSubDag,
     block_header::{
         BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs, Round, Slot,
-        TestBlockHeader, Transaction, TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader,
+        TestBlockHeader, Transaction, TransactionsCommitment, VerifiedBlockHeader,
         VerifiedTransactions, genesis_block_headers,
     },
     commit::{CertifiedCommit, CommitDigest, TrustedCommit, WAVE_LENGTH},
@@ -259,12 +259,12 @@ impl DagBuilder {
             .map(|(sub_dag, commit)| {
                 // TODO: we need to request real blocks from sub_dag after we add the
                 // corresponding field and logic in sub_dag
-                let mut blocks = vec![];
+                let mut block_headers = vec![];
                 for block_header in sub_dag.blocks.iter() {
-                    blocks.push(VerifiedBlock::new_for_test((**block_header).clone()));
+                    block_headers.push(block_header.clone());
                 }
 
-                let certified_commit = CertifiedCommit::new_certified(commit, blocks);
+                let certified_commit = CertifiedCommit::new_certified(commit, block_headers);
                 (sub_dag, certified_commit)
             })
             .collect()

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -611,7 +611,7 @@ impl<'a> LayerBuilder<'a> {
         let mut dag_state = dag_state.write();
         dag_state.accept_block_headers(self.block_headers.clone());
         for transactions in self.transactions.clone() {
-            dag_state.add_transactions(transactions, true);
+            dag_state.add_transactions(transactions);
         }
     }
 


### PR DESCRIPTION
# Description of change

PR updates commit syncer to fetch headers, not blocks. Transactions will be fetched in DataSynchronization module.

PR also deprecates live parameter from add_block function, since the function is not used anynore in commit syncer, and parameter can be assumed to be always true.

## Links to any relevant issues

Fixes #6435 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
