### PR TITLE
feat(indexer): mark checkpoint transactions as indexed

### DIFF
--- a/crates/iota-indexer/src/handlers/committer.rs
+++ b/crates/iota-indexer/src/handlers/committer.rs
@@ -10,10 +10,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, instrument};
 
 use super::{CheckpointDataToCommit, EpochToCommit};
-use crate::{
-    metrics::IndexerMetrics, models::transactions::TxGlobalOrder, store::IndexerStore,
-    types::IndexerResult,
-};
+use crate::{metrics::IndexerMetrics, store::IndexerStore, types::IndexerResult};
 
 pub(crate) const CHECKPOINT_COMMIT_BATCH_SIZE: usize = 100;
 
@@ -124,10 +121,6 @@ async fn commit_checkpoints<S>(
     let guard = metrics.checkpoint_db_commit_latency.start_timer();
     let tx_batch = tx_batch.into_iter().flatten().collect::<Vec<_>>();
 
-    let tx_global_order_batch = tx_batch
-        .iter()
-        .map(Into::into)
-        .collect::<Vec<TxGlobalOrder>>();
     let tx_indices_batch = tx_indices_batch.into_iter().flatten().collect::<Vec<_>>();
     let events_batch = events_batch.into_iter().flatten().collect::<Vec<_>>();
     let event_indices_batch = event_indices_batch
@@ -147,7 +140,6 @@ async fn commit_checkpoints<S>(
         let mut persist_tasks = vec![
             state.persist_transactions(tx_batch),
             state.persist_tx_indices(tx_indices_batch),
-            state.persist_tx_global_order(tx_global_order_batch),
             state.persist_events(events_batch),
             state.persist_event_indices(event_indices_batch),
             state.persist_displays(display_updates_batch),

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -52,8 +52,10 @@ pub struct TxGlobalOrder {
     /// Monotonically increasing number that represents the order
     /// of execution of optimistic transactions.
     ///
-    /// To maintain these semantics the value should be `0` for
-    /// checkpointed transactions.
+    /// To maintain these semantics the value should be non-positive for
+    /// checkpointed transactions. More specifically we allow values
+    /// in the set `[0, -1]` to represent the index status of checkpointed
+    /// transactions. See also [`CheckpointTxGlobalOrder`].
     ///
     /// Optimistic transactions should set this value to `None`,
     /// so that it is auto-generated on the database.
@@ -71,16 +73,14 @@ impl From<&IndexedTransaction> for CheckpointTxGlobalOrder {
     }
 }
 
+/// Stored value for checkpointed transactions.
+///
+/// Differs from [`TxGlobalOrder`] in that it allows values
+/// for `optimistic_sequence_number` in the set `[0, -1]`
+/// that represent the index status.
 #[derive(Clone, Debug, Queryable, Insertable, QueryableByName, Selectable)]
 #[diesel(table_name = tx_global_order)]
 pub(crate) struct CheckpointTxGlobalOrder {
-    /// Number that represents the global ordering between optimistic and
-    /// checkpointed transactions.
-    ///
-    /// Optimistic transactions will share the same number as checkpointed
-    /// transactions. In this case, ties are resolved by the
-    /// `(global_sequence_number, optimistic_sequence_number)` pair that
-    /// guarantees deterministic ordering.
     pub(crate) global_sequence_number: i64,
     pub(crate) tx_digest: Vec<u8>,
     /// The index status of checkpointed transactions.

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -4,7 +4,14 @@
 
 use std::sync::Arc;
 
-use diesel::prelude::*;
+use diesel::{
+    backend::Backend,
+    deserialize::{FromSql, Result as DeserializeResult},
+    expression::AsExpression,
+    prelude::*,
+    serialize::{Output, Result as SerializeResult, ToSql},
+    sql_types::BigInt,
+};
 use iota_json_rpc_types::{
     BalanceChange, IotaEvent, IotaTransactionBlock, IotaTransactionBlockEffects,
     IotaTransactionBlockEvents, IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions,
@@ -54,12 +61,69 @@ pub struct TxGlobalOrder {
     pub optimistic_sequence_number: Option<i64>,
 }
 
-impl From<&IndexedTransaction> for TxGlobalOrder {
+impl From<&IndexedTransaction> for CheckpointTxGlobalOrder {
     fn from(tx: &IndexedTransaction) -> Self {
-        TxGlobalOrder {
+        Self {
             global_sequence_number: tx.tx_sequence_number as i64,
             tx_digest: tx.tx_digest.into_inner().to_vec(),
-            optimistic_sequence_number: Some(0),
+            index_status: Some(IndexStatus::Started),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Queryable, Insertable, QueryableByName, Selectable)]
+#[diesel(table_name = tx_global_order)]
+pub(crate) struct CheckpointTxGlobalOrder {
+    /// Number that represents the global ordering between optimistic and
+    /// checkpointed transactions.
+    ///
+    /// Optimistic transactions will share the same number as checkpointed
+    /// transactions. In this case, ties are resolved by the
+    /// `(global_sequence_number, optimistic_sequence_number)` pair that
+    /// guarantees deterministic ordering.
+    pub(crate) global_sequence_number: i64,
+    pub(crate) tx_digest: Vec<u8>,
+    /// The index status of checkpointed transactions.
+    ///
+    /// This essentially reserves the values `[0, -1]` of the
+    /// `optimistic_sequence_number` stored in the table for checkpointed
+    /// transactions, to distinguish from optimistic transactions, and
+    /// assign semantics related to the index status.
+    #[diesel(deserialize_as = IndexStatus, column_name = "optimistic_sequence_number")]
+    pub(crate) index_status: Option<IndexStatus>,
+}
+
+/// Index status.
+#[derive(Clone, Debug, Copy, AsExpression, PartialEq, Eq)]
+#[diesel(sql_type = BigInt)]
+pub(crate) enum IndexStatus {
+    Started,
+    Completed,
+}
+
+impl<DB> ToSql<BigInt, DB> for IndexStatus
+where
+    DB: Backend,
+    i64: ToSql<BigInt, DB>,
+{
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, DB>) -> SerializeResult {
+        match *self {
+            IndexStatus::Started => 0.to_sql(out),
+            IndexStatus::Completed => (-1).to_sql(out),
+        }
+    }
+}
+
+impl<DB> FromSql<BigInt, DB> for IndexStatus
+where
+    DB: Backend,
+    i64: FromSql<BigInt, DB>,
+{
+    fn from_sql(bytes: DB::RawValue<'_>) -> DeserializeResult<Self> {
+        match i64::from_sql(bytes)? {
+            0 => Ok(IndexStatus::Started),
+            -1 => Ok(IndexStatus::Completed),
+            other => Err(format!("invalid index status {other}").into()),
         }
     }
 }

--- a/crates/iota-indexer/src/rolling/persist.rs
+++ b/crates/iota-indexer/src/rolling/persist.rs
@@ -168,7 +168,7 @@ async fn commit_checkpoints(
         let mut persist_tasks = vec![
             state.persist_transactions(tx_batch),
             state.persist_tx_indices(tx_indices_batch),
-            state.persist_tx_global_order(tx_global_order_batch),
+            state.persist_tx_global_order(tx_global_order_batch.clone()),
             state.persist_events(events_batch),
             state.persist_event_indices(event_indices_batch),
             state.persist_displays(display_updates_batch),
@@ -192,6 +192,14 @@ async fn commit_checkpoints(
             .collect::<IndexerResult<Vec<_>>>()
             .expect("Persisting data into DB should not fail.");
     }
+
+    state
+        .update_tx_global_order_as_indexed(tx_global_order_batch)
+        .await
+        .inspect_err(|e| {
+            error!("failed to update tx global order as indexed with error: {e}");
+        })
+        .expect("updating tx global order as indexed should not fail.");
 
     let is_epoch_end = epoch.is_some();
 

--- a/crates/iota-indexer/src/rolling/persist.rs
+++ b/crates/iota-indexer/src/rolling/persist.rs
@@ -14,9 +14,7 @@ use tracing::{error, info, instrument};
 use crate::{
     handlers::{EpochToCommit, TransactionObjectChangesToCommit},
     metrics::IndexerMetrics,
-    models::{
-        display::StoredDisplay, obj_indices::StoredObjectVersion, transactions::TxGlobalOrder,
-    },
+    models::{display::StoredDisplay, obj_indices::StoredObjectVersion},
     rolling::transform::CheckpointObjectChanges,
     store::{IndexerStore, IndexerStoreExt, PgIndexerStore},
     types::{
@@ -145,10 +143,7 @@ async fn commit_checkpoints(
     let guard = metrics.checkpoint_db_commit_latency.start_timer();
     let tx_batch = tx_batch.into_iter().flatten().collect::<Vec<_>>();
 
-    let tx_global_order_batch = tx_batch
-        .iter()
-        .map(Into::into)
-        .collect::<Vec<TxGlobalOrder>>();
+    let tx_global_order_batch: Vec<_> = tx_batch.iter().map(Into::into).collect();
     let tx_indices_batch = tx_indices_batch.into_iter().flatten().collect::<Vec<_>>();
     let events_batch = events_batch.into_iter().flatten().collect::<Vec<_>>();
     let event_indices_batch = event_indices_batch
@@ -194,7 +189,7 @@ async fn commit_checkpoints(
     }
 
     state
-        .update_tx_global_order_as_indexed(tx_global_order_batch)
+        .update_status_for_checkpoint_transactions(tx_global_order_batch)
         .await
         .inspect_err(|e| {
             error!("failed to update tx global order as indexed with error: {e}");

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -15,7 +15,7 @@ use crate::{
         events::OptimisticEvent,
         obj_indices::StoredObjectVersion,
         objects::{StoredDeletedObject, StoredObject},
-        transactions::{OptimisticTransaction, TxGlobalOrder},
+        transactions::{CheckpointTxGlobalOrder, OptimisticTransaction},
         tx_indices::OptimisticTxIndices,
     },
     rolling::transform::CheckpointObjectChanges,
@@ -84,11 +84,6 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
         transaction: OptimisticTransaction,
     ) -> Result<(), IndexerError>;
 
-    async fn persist_tx_global_order(
-        &self,
-        tx_order: Vec<TxGlobalOrder>,
-    ) -> Result<(), IndexerError>;
-
     async fn persist_tx_indices(&self, indices: Vec<TxIndex>) -> Result<(), IndexerError>;
 
     async fn persist_optimistic_tx_indices(
@@ -148,8 +143,13 @@ pub(crate) trait IndexerStoreExt: IndexerStore {
         objects: Vec<CheckpointObjectChanges>,
     ) -> Result<(), IndexerError>;
 
-    async fn update_tx_global_order_as_indexed(
+    async fn update_status_for_checkpoint_transactions(
         &self,
-        tx_order: Vec<TxGlobalOrder>,
+        tx_order: Vec<CheckpointTxGlobalOrder>,
+    ) -> Result<(), IndexerError>;
+
+    async fn persist_tx_global_order(
+        &self,
+        tx_order: Vec<CheckpointTxGlobalOrder>,
     ) -> Result<(), IndexerError>;
 }

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -147,4 +147,9 @@ pub(crate) trait IndexerStoreExt: IndexerStore {
         &self,
         objects: Vec<CheckpointObjectChanges>,
     ) -> Result<(), IndexerError>;
+
+    async fn update_tx_global_order_as_indexed(
+        &self,
+        tx_order: Vec<TxGlobalOrder>,
+    ) -> Result<(), IndexerError>;
 }

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -907,11 +907,11 @@ impl PgIndexerStore {
             let elapsed = guard.stop_and_record();
             info!(
                 elapsed,
-                "Persisted {} chunked txs insertion order", num_transactions
+                "Updated {} chunked values of `tx_global_order`", num_transactions
             );
         })
         .tap_err(|e| {
-            tracing::error!("Failed to persist txs insertion order with error: {e}");
+            tracing::error!("Failed to update `tx_global_order` with error: {e}");
         })
     }
 
@@ -2682,14 +2682,16 @@ impl IndexerStoreExt for PgIndexerStore {
         futures::future::try_join_all(futures)
             .await
             .map_err(|e| {
-                tracing::error!("Failed to join update_tx_insertion_order_chunk futures: {e}",);
+                tracing::error!(
+                    "Failed to join update_status_for_checkpoint_transactions_chunk futures: {e}",
+                );
                 IndexerError::from(e)
             })?
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| {
                 IndexerError::PostgresWrite(format!(
-                    "Failed to update all txs insertion order chunks: {e:?}",
+                    "Failed to update all `tx_global_order` chunks: {e:?}",
                 ))
             })?;
         let elapsed = guard.stop_and_record();
@@ -2718,7 +2720,7 @@ impl IndexerStoreExt for PgIndexerStore {
         futures::future::try_join_all(futures)
             .await
             .map_err(|e| {
-                tracing::error!("Failed to join persist_tx_insertion_order_chunk futures: {e}",);
+                tracing::error!("Failed to join persist_tx_global_order_chunk futures: {e}",);
                 IndexerError::from(e)
             })?
             .into_iter()

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -44,7 +44,10 @@ use crate::{
             StoredObjects,
         },
         packages::StoredPackage,
-        transactions::{OptimisticTransaction, StoredTransaction, TxGlobalOrder},
+        transactions::{
+            CheckpointTxGlobalOrder, IndexStatus, OptimisticTransaction, StoredTransaction,
+            TxGlobalOrder,
+        },
         tx_indices::OptimisticTxIndices,
     },
     on_conflict_do_update, on_conflict_do_update_with_condition, persist_chunk_into_table,
@@ -839,7 +842,7 @@ impl PgIndexerStore {
 
     fn persist_tx_global_order_chunk(
         &self,
-        tx_order: Vec<TxGlobalOrder>,
+        tx_order: Vec<CheckpointTxGlobalOrder>,
     ) -> Result<(), IndexerError> {
         let guard = self
             .metrics
@@ -875,9 +878,9 @@ impl PgIndexerStore {
     /// Namely, checkpointed transactions (i.e. with `optimistic_sequence_number
     /// == 0`) are updated to `optimistic_sequence_number == -1` to indicate
     /// that they have been persisted in the database.
-    fn update_tx_global_order_chunk_as_indexed(
+    fn update_status_for_checkpoint_transactions_chunk(
         &self,
-        tx_order: Vec<TxGlobalOrder>,
+        tx_order: Vec<CheckpointTxGlobalOrder>,
     ) -> Result<(), IndexerError> {
         let guard = self
             .metrics
@@ -892,8 +895,8 @@ impl PgIndexerStore {
                     tx_global_order::table,
                     tx_order.clone(),
                     tx_global_order::tx_digest,
-                    tx_global_order::optimistic_sequence_number.eq(-1),
-                    tx_global_order::optimistic_sequence_number.eq(0),
+                    tx_global_order::optimistic_sequence_number.eq(IndexStatus::Completed),
+                    tx_global_order::optimistic_sequence_number.eq(IndexStatus::Started),
                     conn
                 );
                 Ok::<(), IndexerError>(())
@@ -2089,39 +2092,6 @@ impl IndexerStore for PgIndexerStore {
         Ok(indexing_status)
     }
 
-    async fn persist_tx_global_order(
-        &self,
-        tx_order: Vec<TxGlobalOrder>,
-    ) -> Result<(), IndexerError> {
-        let guard = self
-            .metrics
-            .checkpoint_db_commit_latency_tx_insertion_order
-            .start_timer();
-        let len = tx_order.len();
-
-        let chunks = chunk!(tx_order, self.config.parallel_chunk_size);
-        let futures = chunks
-            .into_iter()
-            .map(|c| self.spawn_blocking_task(move |this| this.persist_tx_global_order_chunk(c)));
-
-        futures::future::try_join_all(futures)
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to join persist_tx_insertion_order_chunk futures: {e}",);
-                IndexerError::from(e)
-            })?
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| {
-                IndexerError::PostgresWrite(format!(
-                    "Failed to persist all txs insertion order chunks: {e:?}",
-                ))
-            })?;
-        let elapsed = guard.stop_and_record();
-        info!(elapsed, "Persisted {len} txs insertion orders");
-        Ok(())
-    }
-
     async fn persist_events(&self, events: Vec<IndexedEvent>) -> Result<(), IndexerError> {
         if events.is_empty() {
             return Ok(());
@@ -2692,9 +2662,9 @@ impl IndexerStoreExt for PgIndexerStore {
         Ok(())
     }
 
-    async fn update_tx_global_order_as_indexed(
+    async fn update_status_for_checkpoint_transactions(
         &self,
-        tx_order: Vec<TxGlobalOrder>,
+        tx_order: Vec<CheckpointTxGlobalOrder>,
     ) -> Result<(), IndexerError> {
         let guard = self
             .metrics
@@ -2704,7 +2674,9 @@ impl IndexerStoreExt for PgIndexerStore {
 
         let chunks = chunk!(tx_order, self.config.parallel_chunk_size);
         let futures = chunks.into_iter().map(|c| {
-            self.spawn_blocking_task(move |this| this.update_tx_global_order_chunk_as_indexed(c))
+            self.spawn_blocking_task(move |this| {
+                this.update_status_for_checkpoint_transactions_chunk(c)
+            })
         });
 
         futures::future::try_join_all(futures)
@@ -2725,6 +2697,39 @@ impl IndexerStoreExt for PgIndexerStore {
             elapsed,
             "Updated index status for {len} txs insertion orders"
         );
+        Ok(())
+    }
+
+    async fn persist_tx_global_order(
+        &self,
+        tx_order: Vec<CheckpointTxGlobalOrder>,
+    ) -> Result<(), IndexerError> {
+        let guard = self
+            .metrics
+            .checkpoint_db_commit_latency_tx_insertion_order
+            .start_timer();
+        let len = tx_order.len();
+
+        let chunks = chunk!(tx_order, self.config.parallel_chunk_size);
+        let futures = chunks
+            .into_iter()
+            .map(|c| self.spawn_blocking_task(move |this| this.persist_tx_global_order_chunk(c)));
+
+        futures::future::try_join_all(futures)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to join persist_tx_insertion_order_chunk futures: {e}",);
+                IndexerError::from(e)
+            })?
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
+                IndexerError::PostgresWrite(format!(
+                    "Failed to persist all txs insertion order chunks: {e:?}",
+                ))
+            })?;
+        let elapsed = guard.stop_and_record();
+        info!(elapsed, "Persisted {len} txs insertion orders");
         Ok(())
     }
 }

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -869,6 +869,49 @@ impl PgIndexerStore {
         })
     }
 
+    /// We enfore index-status semantics for checkpointed transactions
+    /// in `tx_global_order`.
+    ///
+    /// Namely, checkpointed transactions (i.e. with `optimistic_sequence_number
+    /// == 0`) are updated to `optimistic_sequence_number == -1` to indicate
+    /// that they have been persisted in the database.
+    fn update_tx_global_order_chunk_as_indexed(
+        &self,
+        tx_order: Vec<TxGlobalOrder>,
+    ) -> Result<(), IndexerError> {
+        let guard = self
+            .metrics
+            .checkpoint_db_commit_latency_tx_insertion_order_chunks
+            .start_timer();
+
+        let num_transactions = tx_order.len();
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                on_conflict_do_update_with_condition!(
+                    tx_global_order::table,
+                    tx_order.clone(),
+                    tx_global_order::tx_digest,
+                    tx_global_order::optimistic_sequence_number.eq(-1),
+                    tx_global_order::optimistic_sequence_number.eq(0),
+                    conn
+                );
+                Ok::<(), IndexerError>(())
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+        .tap_ok(|_| {
+            let elapsed = guard.stop_and_record();
+            info!(
+                elapsed,
+                "Persisted {} chunked txs insertion order", num_transactions
+            );
+        })
+        .tap_err(|e| {
+            tracing::error!("Failed to persist txs insertion order with error: {e}");
+        })
+    }
+
     fn persist_events_chunk(&self, events: Vec<IndexedEvent>) -> Result<(), IndexerError> {
         let guard = self
             .metrics
@@ -2645,6 +2688,42 @@ impl IndexerStoreExt for PgIndexerStore {
         info!(
             elapsed,
             "Persisted objects with {mutation_len} mutations and {deletion_len} deletions",
+        );
+        Ok(())
+    }
+
+    async fn update_tx_global_order_as_indexed(
+        &self,
+        tx_order: Vec<TxGlobalOrder>,
+    ) -> Result<(), IndexerError> {
+        let guard = self
+            .metrics
+            .checkpoint_db_commit_latency_tx_insertion_order
+            .start_timer();
+        let len = tx_order.len();
+
+        let chunks = chunk!(tx_order, self.config.parallel_chunk_size);
+        let futures = chunks.into_iter().map(|c| {
+            self.spawn_blocking_task(move |this| this.update_tx_global_order_chunk_as_indexed(c))
+        });
+
+        futures::future::try_join_all(futures)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to join update_tx_insertion_order_chunk futures: {e}",);
+                IndexerError::from(e)
+            })?
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
+                IndexerError::PostgresWrite(format!(
+                    "Failed to update all txs insertion order chunks: {e:?}",
+                ))
+            })?;
+        let elapsed = guard.stop_and_record();
+        info!(
+            elapsed,
+            "Updated index status for {len} txs insertion orders"
         );
         Ok(())
     }

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -872,7 +872,7 @@ impl PgIndexerStore {
         })
     }
 
-    /// We enfore index-status semantics for checkpointed transactions
+    /// We enforce index-status semantics for checkpointed transactions
     /// in `tx_global_order`.
     ///
     /// Namely, checkpointed transactions (i.e. with `optimistic_sequence_number

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -276,7 +276,7 @@ mod ingestion_tests {
             stored_global_order.global_sequence_number,
             stored_tx_digest.tx_sequence_number
         );
-        let expected_optimistic_sequence_number = 0;
+        let expected_optimistic_sequence_number = -1;
         assert_eq!(
             stored_global_order.optimistic_sequence_number,
             Some(expected_optimistic_sequence_number)


### PR DESCRIPTION
# Description of change

This patch introduces an `IndexStatus` for checkpoint transactions that transitions from `Started -> Completed` after a transactions has been indexed. This is mediated through `tx_global_order.optimistic_sequence_number`.

## Links to any relevant issues

Fixes #7430, #7432

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)


### Infrastructure QA

This patch adds an additional db operation on top of existing indexing operations. As such it tested only through integration tests.

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.
