### PR TITLE
fix(ci): pass secret to reusable workflow

### DIFF
--- a/.github/workflows/turbo_nightly.yml
+++ b/.github/workflows/turbo_nightly.yml
@@ -8,5 +8,8 @@ on:
 jobs:
   e2e:
     uses: ./.github/workflows/_e2e.yml
+    secrets: 
+      EVM_BRIDGE_PREVIEW_DEFAULT_NETWORK: ${{ secrets.EVM_BRIDGE_PREVIEW_DEFAULT_NETWORK }}
+      EVM_BRIDGE_CONFIG: ${{ secrets.EVM_BRIDGE_CONFIG }}
   check-sri-integrity-webassets:
     uses: ./.github/workflows/check_sri.yml

--- a/.github/workflows/turbo_nightly.yml
+++ b/.github/workflows/turbo_nightly.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   e2e:
     uses: ./.github/workflows/_e2e.yml
-    secrets: 
+    secrets:
       EVM_BRIDGE_PREVIEW_DEFAULT_NETWORK: ${{ secrets.EVM_BRIDGE_PREVIEW_DEFAULT_NETWORK }}
       EVM_BRIDGE_CONFIG: ${{ secrets.EVM_BRIDGE_CONFIG }}
   check-sri-integrity-webassets:


### PR DESCRIPTION
# Description of change

Pass secret when calling reusable workflow as it is not passed automatically.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #(issue)`.

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
