### PR TITLE
upstream(core): Add support for callbacks on body chunks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,7 +221,7 @@ async-recursion = "1.0.4"
 async-trait = "0.1.61"
 aws-config = "1.5.6"
 aws-sdk-dynamodb = "1.42"
-axum = { version = "0.8", default-features = false, features = ["tokio", "http1", "http2", "json", "matched-path", "original-uri", "form", "query", "ws", "macros"] }
+axum = { version = "0.8", default-features = false, features = ["tokio", "http2", "json", "matched-path", "original-uri", "form", "query", "ws", "macros"] }
 axum-extra = { version = "0.10", features = ["typed-header"] }
 axum-server = { git = "https://github.com/bmwill/axum-server.git", rev = "f44323e271afdd1365fd0c8b0a4c0bbdf4956cb7", version = "0.6", default-features = false, features = ["tls-rustls"] }
 backoff = { version = "0.4.0", features = ["futures", "futures-core", "pin-project-lite", "tokio", "tokio_1"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,7 +274,7 @@ http = "1"
 http-body = "1"
 humantime = "2.1.0"
 hyper = "1"
-hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-roots", "http2", "ring", "tls12"] }
+hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-roots", "http1", "http2", "ring", "tls12"] }
 hyper-util = { version = "0.1.4", features = ["tokio", "server-auto", "service"] }
 im = "15"
 indexmap = { version = "2.1.0", features = ["serde"] }

--- a/consensus/core/src/network/metrics_layer.rs
+++ b/consensus/core/src/network/metrics_layer.rs
@@ -87,7 +87,7 @@ pub(crate) struct MetricsResponseCallback {
 
 impl MetricsResponseCallback {
     // Update response metrics.
-    pub(crate) fn on_response(self, response: &dyn SizedResponse) {
+    pub(crate) fn on_response(&mut self, response: &dyn SizedResponse) {
         let response_size = response.size();
         if response_size > 0 {
             self.metrics
@@ -110,7 +110,7 @@ impl MetricsResponseCallback {
         }
     }
 
-    pub(crate) fn on_error<E>(self, _error: &E) {
+    pub(crate) fn on_error<E>(&mut self, _error: &E) {
         self.metrics
             .errors
             .with_label_values(&[self.route.as_str(), "unknown"])

--- a/consensus/core/src/network/tonic_network.rs
+++ b/consensus/core/src/network/tonic_network.rs
@@ -1010,12 +1010,12 @@ impl MakeCallbackHandler for MetricsCallbackMaker {
 }
 
 impl ResponseHandler for MetricsResponseCallback {
-    fn on_response(self, response: &http::response::Parts) {
-        self.on_response(response)
+    fn on_response(&mut self, response: &http::response::Parts) {
+        MetricsResponseCallback::on_response(self, response)
     }
 
-    fn on_error<E>(self, err: &E) {
-        self.on_error(err)
+    fn on_error<E>(&mut self, err: &E) {
+        MetricsResponseCallback::on_error(self, err)
     }
 }
 

--- a/crates/iota-graphql-rpc/src/server/builder.rs
+++ b/crates/iota-graphql-rpc/src/server/builder.rs
@@ -597,13 +597,13 @@ struct MetricsCallbackHandler {
 }
 
 impl ResponseHandler for MetricsCallbackHandler {
-    fn on_response(self, response: &http::response::Parts) {
+    fn on_response(&mut self, response: &http::response::Parts) {
         if let Some(errors) = response.extensions.get::<GraphqlErrors>() {
             self.metrics.inc_errors(&errors.0);
         }
     }
 
-    fn on_error<E>(self, _error: &E) {
+    fn on_error<E>(&mut self, _error: &E) {
         // Do nothing if the whole service errored
         //
         // in Axum this isn't possible since all services are required to have

--- a/crates/iota-network-stack/src/callback/body.rs
+++ b/crates/iota-network-stack/src/callback/body.rs
@@ -1,0 +1,83 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    fmt,
+    pin::Pin,
+    task::{Context, Poll, ready},
+};
+
+use http_body::{Body, Frame};
+use pin_project_lite::pin_project;
+
+use super::ResponseHandler;
+
+pin_project! {
+    /// Response body for [`Callback`].
+    ///
+    /// [`Callback`]: super::Callback
+    pub struct ResponseBody<B, ResponseHandler> {
+        #[pin]
+        pub(crate) inner: B,
+        pub(crate) handler: ResponseHandler,
+    }
+}
+
+impl<B, ResponseHandlerT> Body for ResponseBody<B, ResponseHandlerT>
+where
+    B: Body,
+    B::Error: fmt::Display + 'static,
+    ResponseHandlerT: ResponseHandler,
+{
+    type Data = B::Data;
+    type Error = B::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        let this = self.project();
+        let result = ready!(this.inner.poll_frame(cx));
+
+        match result {
+            Some(Ok(frame)) => {
+                let frame = match frame.into_data() {
+                    Ok(chunk) => {
+                        this.handler.on_body_chunk(&chunk);
+                        Frame::data(chunk)
+                    }
+                    Err(frame) => frame,
+                };
+
+                let frame = match frame.into_trailers() {
+                    Ok(trailers) => {
+                        this.handler.on_end_of_stream(Some(&trailers));
+                        Frame::trailers(trailers)
+                    }
+                    Err(frame) => frame,
+                };
+
+                Poll::Ready(Some(Ok(frame)))
+            }
+            Some(Err(err)) => {
+                this.handler.on_error(&err);
+
+                Poll::Ready(Some(Err(err)))
+            }
+            None => {
+                this.handler.on_end_of_stream(None);
+
+                Poll::Ready(None)
+            }
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
+    }
+}

--- a/crates/iota-network-stack/src/callback/future.rs
+++ b/crates/iota-network-stack/src/callback/future.rs
@@ -11,7 +11,7 @@ use std::{
 use http::Response;
 use pin_project_lite::pin_project;
 
-use super::ResponseHandler;
+use super::{ResponseBody, ResponseHandler};
 
 pin_project! {
     /// Response future for [`Callback`].
@@ -27,20 +27,28 @@ pin_project! {
 impl<Fut, B, E, ResponseHandlerT> Future for ResponseFuture<Fut, ResponseHandlerT>
 where
     Fut: Future<Output = Result<Response<B>, E>>,
+    B: http_body::Body<Error: std::fmt::Display + 'static>,
+    E: std::fmt::Display + 'static,
     ResponseHandlerT: ResponseHandler,
 {
-    type Output = Result<Response<B>, E>;
+    type Output = Result<Response<ResponseBody<B, ResponseHandlerT>>, E>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
         let result = futures::ready!(this.inner.poll(cx));
-        let handler = this.handler.take().unwrap();
+        let mut handler = this.handler.take().unwrap();
 
         let result = match result {
             Ok(response) => {
                 let (head, body) = response.into_parts();
                 handler.on_response(&head);
-                Ok(Response::from_parts(head, body))
+                Ok(Response::from_parts(
+                    head,
+                    ResponseBody {
+                        inner: body,
+                        handler,
+                    },
+                ))
             }
             Err(error) => {
                 handler.on_error(&error);

--- a/crates/iota-network-stack/src/callback/mod.rs
+++ b/crates/iota-network-stack/src/callback/mod.rs
@@ -2,13 +2,16 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use http::{request, response};
+use http::{HeaderMap, request, response};
 
+mod body;
 mod future;
 mod layer;
 mod service;
 
-pub use self::{future::ResponseFuture, layer::CallbackLayer, service::Callback};
+pub use self::{
+    body::ResponseBody, future::ResponseFuture, layer::CallbackLayer, service::Callback,
+};
 
 pub trait MakeCallbackHandler {
     type Handler: ResponseHandler;
@@ -17,6 +20,19 @@ pub trait MakeCallbackHandler {
 }
 
 pub trait ResponseHandler {
-    fn on_response(self, response: &response::Parts);
-    fn on_error<E>(self, error: &E);
+    fn on_response(&mut self, response: &response::Parts);
+    fn on_error<E>(&mut self, error: &E)
+    where
+        E: std::fmt::Display + 'static;
+
+    fn on_body_chunk<B>(&mut self, _chunk: &B)
+    where
+        B: bytes::Buf,
+    {
+        // do nothing
+    }
+
+    fn on_end_of_stream(&mut self, _trailers: Option<&HeaderMap>) {
+        // do nothing
+    }
 }

--- a/crates/iota-network-stack/src/callback/service.rs
+++ b/crates/iota-network-stack/src/callback/service.rs
@@ -7,7 +7,7 @@ use std::task::{Context, Poll};
 use http::{Request, Response};
 use tower::Service;
 
-use super::{CallbackLayer, MakeCallbackHandler, ResponseFuture};
+use super::{CallbackLayer, MakeCallbackHandler, ResponseBody, ResponseFuture};
 
 /// Middleware that adds callbacks to a [`Service`].
 ///
@@ -56,12 +56,18 @@ impl<S, M> Callback<S, M> {
     }
 }
 
-impl<S, M, RequestBody, ResponseBody> Service<Request<RequestBody>> for Callback<S, M>
+impl<S, M, RequestBody, ResponseBodyT> Service<Request<RequestBody>> for Callback<S, M>
 where
-    S: Service<Request<RequestBody>, Response = Response<ResponseBody>>,
+    S: Service<
+            Request<RequestBody>,
+            Response = Response<ResponseBodyT>,
+            Error: std::fmt::Display + 'static,
+        >,
     M: MakeCallbackHandler,
+    RequestBody: http_body::Body<Error: std::fmt::Display + 'static>,
+    ResponseBodyT: http_body::Body<Error: std::fmt::Display + 'static>,
 {
-    type Response = Response<ResponseBody>;
+    type Response = Response<ResponseBody<ResponseBodyT, M::Handler>>;
     type Error = S::Error;
     type Future = ResponseFuture<S::Future, M::Handler>;
 

--- a/crates/iota-rest-api/src/metrics.rs
+++ b/crates/iota-rest-api/src/metrics.rs
@@ -99,7 +99,7 @@ pub struct RestMetricsCallbackHandler {
 }
 
 impl ResponseHandler for RestMetricsCallbackHandler {
-    fn on_response(mut self, response: &http::response::Parts) {
+    fn on_response(&mut self, response: &http::response::Parts) {
         self.metrics
             .num_requests
             .with_label_values(&[self.path.as_ref(), response.status.as_str()])
@@ -108,7 +108,7 @@ impl ResponseHandler for RestMetricsCallbackHandler {
         self.counted_response = true;
     }
 
-    fn on_error<E>(self, _error: &E) {
+    fn on_error<E>(&mut self, _error: &E) {
         // Do nothing if the whole service errored
         //
         // in Axum this isn't possible since all services are required to have


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.39.4, v1.40.3)
- Port commit: https://github.com/MystenLabs/sui/commit/9a50f393298d2aa038a674b107081be39760eb5d
- Description:
Add support for callbacks on body chunks. This also has the consequence that the callback handlers are now held until the response stream has concluded, meaning we'll be able to have a more accurate measurement of inflight requests than we previously did.


## Links to any relevant issues

Part of #6148   

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes