### PR TITLE
feat: first release, move tests FAILS

### DIFF
--- a/crates/iota-framework/packages/iota-framework/sources/deterministic_object_id.move
+++ b/crates/iota-framework/packages/iota-framework/sources/deterministic_object_id.move
@@ -4,142 +4,18 @@
 
 module iota::deterministic_object_id;
 
-use iota::tx_context::TxContext;
-
-// #[test_only]
-// /// Number of bytes in an tx hash (which will be the transaction digest)
-// const TX_HASH_LENGTH: u64 = 32;
-
-// #[test_only]
-// /// Expected an tx hash of length 32, but found a different length
-// const EBadTxHashLength: u64 = 0;
-
-// #[test_only]
-// /// Attempt to get the most recent created object ID when none has been created.
-// const ENoIDsCreated: u64 = 1;
-
-/// Information about the transaction currently being executed.
-/// This cannot be constructed by a transaction. It is a privileged object created by
-/// the VM and passed in to the entrypoint of the transaction as `&mut TxContext`.
-// public struct TxContext has drop {
-//     /// The address of the user that signed the current transaction
-//     sender: address,
-//     /// Hash of the current transaction
-//     tx_hash: vector<u8>,
-//     /// The current epoch number
-//     epoch: u64,
-//     /// Timestamp that the epoch started at
-//     epoch_timestamp_ms: u64,
-//     /// Counter recording the number of fresh id's created while executing
-//     /// this transaction. Always 0 at the start of a transaction
-//     ids_created: u64,
-// }
-
-/// Create an `address` that has not been used. As it is an object address, it will never
-/// occur as the address for a user.
-/// In other words, the generated address is a globally unique object ID.
-// public fun fresh_object_address_deterministically(ctx: &mut TxContext): address {
-//     // let ids_created = ctx.ids_created;
-//     let id = derive_id_with_salt(0, ctx.sender(), &ctx.digest());
-//     // ctx.ids_created = ids_created + 1;
-//     id
-// }
-
-// #[allow(unused_function)]
-// /// Return the number of id's created by the current transaction.
-// /// Hidden for now, but may expose later
-// // fun ids_created(self: &TxContext): u64 {
-// //     self.ids_created
-// // }
-
-
 /// Native function for deriving an ID deterministically via hash(flag, iota_address, salt)
 /// flag is a fixed byte that allows to avoid object id collisions
 /// iota_address can be any IOTA address, not necessarily the sender address
 /// salt is an arbitrary value provided by the sender 
-/// I'm sure there is a better way to do this and avoid having a public friend function
-native fun derive_id_with_salt(
+public native fun derive_id_with_salt(
     flag: u64,
     iota_address: address,
-    salt: &vector<u8>,
+    salt: vector<u8>,
 ): address;
 
-
-/// Computes a deterministic object ID using a fixed flag.
-/// This safely wraps the native function.
-public fun precomputed_object_id(iota_address: address, salt: &vector<u8>): address {
-    // Use 0xf2 or 123 — anything consistent to avoid collision with fresh_object_address
-    derive_id_with_salt(0xf2, iota_address, salt)
+#[test_only]
+public fun dummy_address(): address {
+    @0x0
 }
 
-// ==== test-only functions ====
-
-// #[test_only]
-// /// Create a `TxContext` for testing
-// public fun new(
-//     sender: address,
-//     tx_hash: vector<u8>,
-//     epoch: u64,
-//     epoch_timestamp_ms: u64,
-//     ids_created: u64,
-// ): TxContext {
-//     assert!(tx_hash.length() == TX_HASH_LENGTH, EBadTxHashLength);
-//     TxContext { sender, tx_hash, epoch, epoch_timestamp_ms, ids_created }
-// }
-
-// #[test_only]
-// /// Create a `TxContext` for testing, with a potentially non-zero epoch number.
-// public fun new_from_hint(
-//     addr: address,
-//     hint: u64,
-//     epoch: u64,
-//     epoch_timestamp_ms: u64,
-//     ids_created: u64,
-// ): TxContext {
-//     new(addr, dummy_tx_hash_with_hint(hint), epoch, epoch_timestamp_ms, ids_created)
-// }
-
-// #[test_only]
-// /// Create a dummy `TxContext` for testing
-// public fun dummy(): TxContext {
-//     let tx_hash = x"3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532";
-//     new(@0x0, tx_hash, 0, 0, 0)
-// }
-
-// #[test_only]
-// ///create a dummy address for testing
-// public fun dummy_address(): address {
-//     @0x0
-// }
-
-// #[test_only]
-// /// Utility for creating 256 unique input hashes.
-// /// These hashes are guaranteed to be unique given a unique `hint: u64`
-// fun dummy_tx_hash_with_hint(hint: u64): vector<u8> {
-//     let mut tx_hash = std::bcs::to_bytes(&hint);
-//     while (tx_hash.length() < TX_HASH_LENGTH) tx_hash.push_back(0);
-//     tx_hash
-// }
-
-// #[test_only]
-// public fun get_ids_created(self: &TxContext): u64 {
-//     ids_created(self)
-// }
-
-// #[test_only]
-// /// Return the most recent created object ID.
-// public fun last_created_object_id(self: &TxContext): address {
-//     let ids_created = self.ids_created;
-//     assert!(ids_created > 0, ENoIDsCreated);
-//     derive_id(*&self.tx_hash, ids_created - 1)
-// }
-
-// #[test_only]
-// public fun increment_epoch_number(self: &mut TxContext) {
-//     self.epoch = self.epoch + 1
-// }
-
-// #[test_only]
-// public fun increment_epoch_timestamp(self: &mut TxContext, delta_ms: u64) {
-//     self.epoch_timestamp_ms = self.epoch_timestamp_ms + delta_ms
-// }

--- a/crates/iota-framework/packages/iota-framework/sources/deterministic_object_id.move
+++ b/crates/iota-framework/packages/iota-framework/sources/deterministic_object_id.move
@@ -1,0 +1,145 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+module iota::deterministic_object_id;
+
+use iota::tx_context::TxContext;
+
+// #[test_only]
+// /// Number of bytes in an tx hash (which will be the transaction digest)
+// const TX_HASH_LENGTH: u64 = 32;
+
+// #[test_only]
+// /// Expected an tx hash of length 32, but found a different length
+// const EBadTxHashLength: u64 = 0;
+
+// #[test_only]
+// /// Attempt to get the most recent created object ID when none has been created.
+// const ENoIDsCreated: u64 = 1;
+
+/// Information about the transaction currently being executed.
+/// This cannot be constructed by a transaction. It is a privileged object created by
+/// the VM and passed in to the entrypoint of the transaction as `&mut TxContext`.
+// public struct TxContext has drop {
+//     /// The address of the user that signed the current transaction
+//     sender: address,
+//     /// Hash of the current transaction
+//     tx_hash: vector<u8>,
+//     /// The current epoch number
+//     epoch: u64,
+//     /// Timestamp that the epoch started at
+//     epoch_timestamp_ms: u64,
+//     /// Counter recording the number of fresh id's created while executing
+//     /// this transaction. Always 0 at the start of a transaction
+//     ids_created: u64,
+// }
+
+/// Create an `address` that has not been used. As it is an object address, it will never
+/// occur as the address for a user.
+/// In other words, the generated address is a globally unique object ID.
+// public fun fresh_object_address_deterministically(ctx: &mut TxContext): address {
+//     // let ids_created = ctx.ids_created;
+//     let id = derive_id_with_salt(0, ctx.sender(), &ctx.digest());
+//     // ctx.ids_created = ids_created + 1;
+//     id
+// }
+
+// #[allow(unused_function)]
+// /// Return the number of id's created by the current transaction.
+// /// Hidden for now, but may expose later
+// // fun ids_created(self: &TxContext): u64 {
+// //     self.ids_created
+// // }
+
+
+/// Native function for deriving an ID deterministically via hash(flag, iota_address, salt)
+/// flag is a fixed byte that allows to avoid object id collisions
+/// iota_address can be any IOTA address, not necessarily the sender address
+/// salt is an arbitrary value provided by the sender 
+/// I'm sure there is a better way to do this and avoid having a public friend function
+native fun derive_id_with_salt(
+    flag: u64,
+    iota_address: address,
+    salt: &vector<u8>,
+): address;
+
+
+/// Computes a deterministic object ID using a fixed flag.
+/// This safely wraps the native function.
+public fun precomputed_object_id(iota_address: address, salt: &vector<u8>): address {
+    // Use 0xf2 or 123 — anything consistent to avoid collision with fresh_object_address
+    derive_id_with_salt(0xf2, iota_address, salt)
+}
+
+// ==== test-only functions ====
+
+// #[test_only]
+// /// Create a `TxContext` for testing
+// public fun new(
+//     sender: address,
+//     tx_hash: vector<u8>,
+//     epoch: u64,
+//     epoch_timestamp_ms: u64,
+//     ids_created: u64,
+// ): TxContext {
+//     assert!(tx_hash.length() == TX_HASH_LENGTH, EBadTxHashLength);
+//     TxContext { sender, tx_hash, epoch, epoch_timestamp_ms, ids_created }
+// }
+
+// #[test_only]
+// /// Create a `TxContext` for testing, with a potentially non-zero epoch number.
+// public fun new_from_hint(
+//     addr: address,
+//     hint: u64,
+//     epoch: u64,
+//     epoch_timestamp_ms: u64,
+//     ids_created: u64,
+// ): TxContext {
+//     new(addr, dummy_tx_hash_with_hint(hint), epoch, epoch_timestamp_ms, ids_created)
+// }
+
+// #[test_only]
+// /// Create a dummy `TxContext` for testing
+// public fun dummy(): TxContext {
+//     let tx_hash = x"3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532";
+//     new(@0x0, tx_hash, 0, 0, 0)
+// }
+
+// #[test_only]
+// ///create a dummy address for testing
+// public fun dummy_address(): address {
+//     @0x0
+// }
+
+// #[test_only]
+// /// Utility for creating 256 unique input hashes.
+// /// These hashes are guaranteed to be unique given a unique `hint: u64`
+// fun dummy_tx_hash_with_hint(hint: u64): vector<u8> {
+//     let mut tx_hash = std::bcs::to_bytes(&hint);
+//     while (tx_hash.length() < TX_HASH_LENGTH) tx_hash.push_back(0);
+//     tx_hash
+// }
+
+// #[test_only]
+// public fun get_ids_created(self: &TxContext): u64 {
+//     ids_created(self)
+// }
+
+// #[test_only]
+// /// Return the most recent created object ID.
+// public fun last_created_object_id(self: &TxContext): address {
+//     let ids_created = self.ids_created;
+//     assert!(ids_created > 0, ENoIDsCreated);
+//     derive_id(*&self.tx_hash, ids_created - 1)
+// }
+
+// #[test_only]
+// public fun increment_epoch_number(self: &mut TxContext) {
+//     self.epoch = self.epoch + 1
+// }
+
+// #[test_only]
+// public fun increment_epoch_timestamp(self: &mut TxContext, delta_ms: u64) {
+//     self.epoch_timestamp_ms = self.epoch_timestamp_ms + delta_ms
+// }

--- a/crates/iota-framework/packages/iota-framework/sources/object.move
+++ b/crates/iota-framework/packages/iota-framework/sources/object.move
@@ -25,6 +25,7 @@ public use fun uid_to_address as UID.to_address;
 
 /// Allows calling `.to_bytes` on a `UID` to get a `vector<u8>`.
 public use fun uid_to_bytes as UID.to_bytes;
+use iota::deterministic_object_id;
 
 /// The hardcoded ID for the singleton IOTA System State Object.
 const IOTA_SYSTEM_STATE_OBJECT_ID: address = @0x5;
@@ -174,6 +175,14 @@ public fun new(ctx: &mut TxContext): UID {
     UID {
         id: ID { bytes: ctx.fresh_object_address() },
     }
+}
+
+/// Create a new object with a precomputed objectId.
+/// Using a fixed 123 to avoid collisions
+public fun new_precomputed(iota_address: address, salt: vector<u8>): UID {
+    let id = deterministic_object_id::precomputed_object_id(iota_address, &salt);
+    record_new_uid(id);
+    UID { id: ID { bytes: id } }
 }
 
 /// Delete the object and it's `UID`. This is the only way to eliminate a `UID`.

--- a/crates/iota-framework/packages/iota-framework/sources/object.move
+++ b/crates/iota-framework/packages/iota-framework/sources/object.move
@@ -48,6 +48,9 @@ const IOTA_BRIDGE_ID: address = @0x9;
 /// Sender is not @0x0 the system address.
 const ENotSystemAddress: u64 = 0;
 
+/// u64 flag used to produce precomputed object IDs.
+const PRECOMPUTED_OBJECT_ID_FLAG: u64 = 123;
+
 /// An object ID. This is used to reference IOTA Objects.
 /// This is *not* guaranteed to be globally unique--anyone can create an `ID` from a `UID` or
 /// from an object, and ID's can be freely copied and dropped.
@@ -180,7 +183,7 @@ public fun new(ctx: &mut TxContext): UID {
 /// Create a new object with a precomputed objectId.
 /// Using a fixed 123 to avoid collisions
 public fun new_precomputed(iota_address: address, salt: vector<u8>): UID {
-    let id = deterministic_object_id::precomputed_object_id(iota_address, &salt);
+    let id = deterministic_object_id::derive_id_with_salt(PRECOMPUTED_OBJECT_ID_FLAG,iota_address, salt);
     record_new_uid(id);
     UID { id: ID { bytes: id } }
 }

--- a/crates/iota-framework/packages/iota-framework/sources/tx_context.move
+++ b/crates/iota-framework/packages/iota-framework/sources/tx_context.move
@@ -4,6 +4,8 @@
 
 module iota::tx_context;
 
+use iota::deterministic_object_id;
+
 #[test_only]
 /// Number of bytes in an tx hash (which will be the transaction digest)
 const TX_HASH_LENGTH: u64 = 32;
@@ -62,6 +64,13 @@ public fun fresh_object_address(ctx: &mut TxContext): address {
     let ids_created = ctx.ids_created;
     let id = derive_id(*&ctx.tx_hash, ids_created);
     ctx.ids_created = ids_created + 1;
+    id
+}
+
+public fun fresh_object_address_deterministically(ctx: &mut TxContext): address {
+    let ids_created = ctx.ids_created;  // Direct field access works here!
+    let id = deterministic_object_id::precomputed_object_id(ctx.sender, &ctx.tx_hash);
+    ctx.ids_created = ids_created + 1;  // Direct field modification works here!
     id
 }
 

--- a/crates/iota-framework/packages/iota-framework/sources/tx_context.move
+++ b/crates/iota-framework/packages/iota-framework/sources/tx_context.move
@@ -4,8 +4,6 @@
 
 module iota::tx_context;
 
-use iota::deterministic_object_id;
-
 #[test_only]
 /// Number of bytes in an tx hash (which will be the transaction digest)
 const TX_HASH_LENGTH: u64 = 32;
@@ -64,13 +62,6 @@ public fun fresh_object_address(ctx: &mut TxContext): address {
     let ids_created = ctx.ids_created;
     let id = derive_id(*&ctx.tx_hash, ids_created);
     ctx.ids_created = ids_created + 1;
-    id
-}
-
-public fun fresh_object_address_deterministically(ctx: &mut TxContext): address {
-    let ids_created = ctx.ids_created;  // Direct field access works here!
-    let id = deterministic_object_id::precomputed_object_id(ctx.sender, &ctx.tx_hash);
-    ctx.ids_created = ids_created + 1;  // Direct field modification works here!
     id
 }
 

--- a/crates/iota-framework/packages/iota-framework/tests/deterministic_object_id_tests.move
+++ b/crates/iota-framework/packages/iota-framework/tests/deterministic_object_id_tests.move
@@ -4,23 +4,65 @@
 
 #[test_only]
 module iota::deterministic_object_id_tests;
-//TODO
 
 use iota::deterministic_object_id;
  #[test]
  fun test_id_generation() {
-        assert!(1 == 1); // Placeholder test to ensure the module compiles
+       let addr = deterministic_object_id::dummy_address();
+       let salt = vector[0x12, 0x34, 0xab, 0xcd];
+       let id1 = object::new_precomputed(addr, salt);
+       let id2 = object::new_precomputed(addr, salt);
+
+       assert!(&id1 == &id2);
+       id1.delete();
+       id2.delete();
  }
-//     let addr = deterministic_object_id::dummy_address();
-//     let salt: vector<u8> = vector[0x12, 0x34, 0xab, 0xcd];
 
-//     let id1 = object::new_precomputed(addr, salt);
-//     let id2 = object::new_precomputed(addr, salt);
+#[test]
+ fun test_different_salt_id_generation() {
+       let addr = deterministic_object_id::dummy_address();
+       let salt1 = vector[0x12, 0x34, 0xab, 0xcd];
+       let salt2 = vector[0x56, 0x78, 0xef, 0x90];
+       let id1 = object::new_precomputed(addr, salt1);
+       let id2 = object::new_precomputed(addr, salt2);
 
-//     // new_precomputed should return the same ID for the same address and salt
-//     assert!(&id1 == &id2);
-//     id1.delete();
-//     id2.delete();
-// }
+       assert!(&id1 != &id2);
+       id1.delete();
+       id2.delete();
+ }
+
+#[test]
+ fun test_different_address_id_generation() {
+       let addr1 = deterministic_object_id::dummy_address();
+       let addr2 = @0x2;
+       let salt = vector[0x12, 0x34, 0xab, 0xcd];
+       let id1 = object::new_precomputed(addr1, salt);
+       let id2 = object::new_precomputed(addr2, salt);
+
+       assert!(&id1 != &id2);
+       id1.delete();
+       id2.delete();
+ }
+
+ #[test]
+ fun test_mixed_salt_address_id_generation() {
+       let addr1 = deterministic_object_id::dummy_address();
+       let addr2 = @0x2;
+       let salt1 = vector[0x12, 0x34, 0xab, 0xcd];
+       let salt2 = vector[0x56, 0x78, 0xef, 0x90];
+       let id1 = object::new_precomputed(addr1, salt1);
+       let id2 = object::new_precomputed(addr2, salt2);
+
+       assert!(&id1 != &id2);
+       
+       let id3 = object::new_precomputed(addr1, salt2);
+
+       assert!(&id1 != &id3);
+
+       id1.delete();
+       id2.delete();
+       id3.delete();
+ }
+
 
 

--- a/crates/iota-framework/packages/iota-framework/tests/deterministic_object_id_tests.move
+++ b/crates/iota-framework/packages/iota-framework/tests/deterministic_object_id_tests.move
@@ -1,0 +1,26 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module iota::deterministic_object_id_tests;
+//TODO
+
+use iota::deterministic_object_id;
+ #[test]
+ fun test_id_generation() {
+        assert!(1 == 1); // Placeholder test to ensure the module compiles
+ }
+//     let addr = deterministic_object_id::dummy_address();
+//     let salt: vector<u8> = vector[0x12, 0x34, 0xab, 0xcd];
+
+//     let id1 = object::new_precomputed(addr, salt);
+//     let id2 = object::new_precomputed(addr, salt);
+
+//     // new_precomputed should return the same ID for the same address and salt
+//     assert!(&id1 == &id2);
+//     id1.delete();
+//     id2.delete();
+// }
+
+

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -806,6 +806,9 @@ pub struct ProtocolConfig {
     // Cost params for the Move native function `transfer_impl<T: key>(obj: T, recipient: address)`
     tx_context_derive_id_cost_base: Option<u64>,
 
+    //Deterministic Object Id
+    deterministic_object_id_derive_id_with_salt_cost_base: Option<u64>,
+
     // Types
     // Cost params for the Move native function `is_one_time_witness<T: drop>(_: &T): bool`
     types_is_one_time_witness_cost_base: Option<u64>,
@@ -1392,8 +1395,7 @@ impl ProtocolConfig {
         let mut cfg = Self {
             version,
 
-            feature_flags: Default::default(),
-
+            feature_flags: Default::default(), 
             max_tx_size_bytes: Some(128 * 1024),
             // We need this number to be at least 100x less than
             // `max_serialized_tx_effects_size_bytes`otherwise effects can be huge
@@ -1572,6 +1574,10 @@ impl ProtocolConfig {
             // address)`
             tx_context_derive_id_cost_base: Some(52),
 
+
+            // `deterministic_object_id` module
+            // Cost params for the Move native function `deterministic_object_id::derive_id_with_salt
+            deterministic_object_id_derive_id_with_salt_cost_base: Some(52),
             // `types` module
             // Cost params for the Move native function `is_one_time_witness<T: drop>(_: &T): bool`
             types_is_one_time_witness_cost_base: Some(52),

--- a/crates/iota-types/src/base_types.rs
+++ b/crates/iota-types/src/base_types.rs
@@ -1311,6 +1311,24 @@ impl ObjectID {
         ObjectID::try_from(&hash.as_ref()[0..ObjectID::LENGTH]).unwrap()
     }
 
+    /// Create an ObjectID deterministically
+    pub fn derive_id_with_salt(
+        flag: u64,
+        iota_address: IotaAddress,
+        salt: &[u8],
+    ) -> Result<ObjectID, ObjectIDParseError> {
+        let mut hasher = DefaultHash::default();
+        hasher.update([flag as u8]);
+        hasher.update(iota_address);
+        hasher.update(salt);
+        let hash = hasher.finalize();
+
+        // truncate into an ObjectID.
+        // OK to access slice because digest should never be shorter than
+        // ObjectID::LENGTH.
+        ObjectID::try_from(&hash.as_ref()[0..ObjectID::LENGTH])
+    }
+
     /// Increment the ObjectID by usize IDs, assuming the ObjectID hex is a
     /// number represented as an array of bytes
     pub fn advance(&self, step: usize) -> Result<ObjectID, anyhow::Error> {

--- a/iota-execution/latest/iota-move-natives/src/deterministic_object_id.rs
+++ b/iota-execution/latest/iota-move-natives/src/deterministic_object_id.rs
@@ -1,0 +1,66 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::VecDeque};
+
+use iota_types::base_types::{ObjectID};
+use move_binary_format::errors::PartialVMResult;
+use move_core_types::{account_address::AccountAddress, gas_algebra::InternalGas};
+use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
+use move_vm_types::{
+    loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
+};
+use smallvec::smallvec;
+
+use crate::{NativesCostTable, object_runtime::ObjectRuntime};
+
+#[derive(Clone)]
+pub struct DeterministicObjecIdDeriveIdWithSaltCostParams {
+    pub deterministic_object_id_derive_id_with_salt_cost_base: InternalGas,
+}
+
+
+/// ****************************************************************************
+/// ********************* native fun derive_id_with_salt
+/// Implementation of the Move native function `fun derive_id_with_salt(flag: u64, iota_address: address, salt: vector<u8>): address`
+/// gas cost: tx_context_derive_id_cost_base
+/// we operate on fixed size data structures
+/// ****************************************************************************
+/// ***********************************
+pub fn derive_id_with_salt(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 3);
+
+    let deterministic_object_id_derive_id_with_salt_cost_params = context
+        .extensions_mut()
+        .get::<NativesCostTable>()
+        .deterministic_object_id_derive_id_with_salt_cost_params
+        .clone();
+    native_charge_gas_early_exit!(
+        context,
+        deterministic_object_id_derive_id_with_salt_cost_params.deterministic_object_id_derive_id_with_salt_cost_base
+    );
+
+    let salt = pop_arg!(args, Vec<u8>);
+    let iota_address = pop_arg!(args, AccountAddress);
+    let flag = pop_arg!(args, u64);
+
+    let address = AccountAddress::from(ObjectID::derive_id_with_salt(
+        flag,
+        iota_address.into(),
+        salt.as_slice()
+    ).unwrap());
+    
+    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    obj_runtime.new_id(address.into())?;
+
+    Ok(NativeResult::ok(
+        context.gas_used(),
+        smallvec![Value::address(address)],
+    ))
+}

--- a/iota-execution/latest/iota-move-natives/src/lib.rs
+++ b/iota-execution/latest/iota-move-natives/src/lib.rs
@@ -64,16 +64,15 @@ use self::{
         TransferFreezeObjectCostParams, TransferInternalCostParams, TransferShareObjectCostParams,
     },
     tx_context::TxContextDeriveIdCostParams,
+    deterministic_object_id::DeterministicObjecIdDeriveIdWithSaltCostParams,
     types::TypesIsOneTimeWitnessCostParams,
     validator::ValidatorValidateMetadataBcsCostParams,
 };
-use crate::crypto::{
-    group_ops,
-    group_ops::GroupOpsCostParams,
+use crate::{crypto::{
+    group_ops::{self, GroupOpsCostParams},
     poseidon::PoseidonBN254CostParams,
-    zklogin,
-    zklogin::{CheckZkloginIdCostParams, CheckZkloginIssuerCostParams},
-};
+    zklogin::{self, CheckZkloginIdCostParams, CheckZkloginIssuerCostParams},
+}};
 
 mod address;
 mod config;
@@ -89,6 +88,7 @@ mod transfer;
 mod tx_context;
 mod types;
 mod validator;
+mod deterministic_object_id;
 
 #[derive(Tid)]
 pub struct NativesCostTable {
@@ -122,6 +122,8 @@ pub struct NativesCostTable {
     pub transfer_freeze_object_cost_params: TransferFreezeObjectCostParams,
     pub transfer_share_object_cost_params: TransferShareObjectCostParams,
 
+    // Deterministic Object ID
+    pub deterministic_object_id_derive_id_with_salt_cost_params: DeterministicObjecIdDeriveIdWithSaltCostParams,
     // TxContext
     pub tx_context_derive_id_cost_params: TxContextDeriveIdCostParams,
 
@@ -344,6 +346,11 @@ impl NativesCostTable {
             transfer_share_object_cost_params: TransferShareObjectCostParams {
                 transfer_share_object_cost_base: protocol_config
                     .transfer_share_object_cost_base()
+                    .into(),
+            },
+            deterministic_object_id_derive_id_with_salt_cost_params: DeterministicObjecIdDeriveIdWithSaltCostParams{
+                deterministic_object_id_derive_id_with_salt_cost_base: protocol_config
+                    .transfer_freeze_object_cost_base()
                     .into(),
             },
             tx_context_derive_id_cost_params: TxContextDeriveIdCostParams {
@@ -1020,6 +1027,11 @@ pub fn all_natives(silent: bool, protocol_config: &ProtocolConfig) -> NativeFunc
             "tx_context",
             "derive_id",
             make_native!(tx_context::derive_id),
+        ),
+        (
+            "deterministic_object_id",
+            "derive_id_with_salt",
+            make_native!(deterministic_object_id::derive_id_with_salt),
         ),
         (
             "types",


### PR DESCRIPTION
It seems there're some issues regarding linking between rust and move. Not entirely sure on how should I properly test the move native, since `iota move test` fails.

I tried following mainly `tx_context` flow to add:

- move module `deterministic_object_id.move`
- move native `derive_id_with_salt` 
- rust function `derive_id_with_salt` someway similar to`[`derive_id`](https://github.com/iotaledger/iota/blob/develop/crates/iota-types/src/base_types.rs#L1301)

Ahead of this current commit, I also tried

- Adding a few missing lines to `iota-framework` on [lib.rs](https://github.com/iotaledger/iota/blob/develop/crates/iota-framework/src/lib.rs) related to the native function.
- Followed this README: https://github.com/iotaledger/iota/tree/d17b7f77ee7d3217a4284db24259301c4110f716/crates/iota-framework, even though `all_natives` does not exist.
- Just in case, I also tried running `update_all_snapshots.sh` in [`iota/scripts/`](https://github.com/iotaledger/iota/blob/develop/scripts/update_all_snapshots.sh).

However, when I try to run `iota move test`, around **300 out of 500 tests** fail with the error:

UNEXPECTED_VERIFIER_ERROR (code 2017) and some reference to the native function I am trying to add.