### PR TITLE
chore(node): Disable writeback cache, enable passthrough cache by default.

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -275,9 +275,7 @@ pub enum ExecutionCacheConfig {
 
 impl Default for ExecutionCacheConfig {
     fn default() -> Self {
-        ExecutionCacheConfig::WritebackCache {
-            max_cache_size: None,
-        }
+        ExecutionCacheConfig::PassthroughCache
     }
 }
 

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -262,21 +262,16 @@ pub struct NodeConfig {
     pub iota_names_config: Option<IotaNamesConfig>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ExecutionCacheConfig {
+    #[default]
     PassthroughCache,
     WritebackCache {
         /// Maximum number of entries in each cache. (There are several
         /// different caches). If None, the default of 10000 is used.
         max_cache_size: Option<usize>,
     },
-}
-
-impl Default for ExecutionCacheConfig {
-    fn default() -> Self {
-        ExecutionCacheConfig::PassthroughCache
-    }
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -103,7 +103,7 @@ impl ExecutionCacheTraitPointers {
     }
 }
 
-static DISABLE_WRITEBACK_CACHE_ENV_VAR: &str = "DISABLE_WRITEBACK_CACHE";
+static ENABLE_WRITEBACK_CACHE_ENV_VAR: &str = "ENABLE_WRITEBACK_CACHE";
 
 #[derive(Debug)]
 pub enum ExecutionCacheConfigType {
@@ -129,7 +129,7 @@ pub fn choose_execution_cache(config: &ExecutionCacheConfig) -> ExecutionCacheCo
         }
     }
 
-    if std::env::var(DISABLE_WRITEBACK_CACHE_ENV_VAR).is_ok()
+    if !std::env::var(ENABLE_WRITEBACK_CACHE_ENV_VAR).is_ok()
         || matches!(config, ExecutionCacheConfig::PassthroughCache)
     {
         ExecutionCacheConfigType::PassthroughCache
@@ -158,7 +158,7 @@ pub fn build_execution_cache_from_env(
 ) -> ExecutionCacheTraitPointers {
     let execution_cache_metrics = Arc::new(ExecutionCacheMetrics::new(prometheus_registry));
 
-    if std::env::var(DISABLE_WRITEBACK_CACHE_ENV_VAR).is_ok() {
+    if !std::env::var(ENABLE_WRITEBACK_CACHE_ENV_VAR).is_ok() {
         ExecutionCacheTraitPointers::new(
             PassthroughCache::new(store.clone(), execution_cache_metrics).into(),
         )

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -129,7 +129,7 @@ pub fn choose_execution_cache(config: &ExecutionCacheConfig) -> ExecutionCacheCo
         }
     }
 
-    if !std::env::var(ENABLE_WRITEBACK_CACHE_ENV_VAR).is_ok()
+    if std::env::var(ENABLE_WRITEBACK_CACHE_ENV_VAR).is_err()
         || matches!(config, ExecutionCacheConfig::PassthroughCache)
     {
         ExecutionCacheConfigType::PassthroughCache
@@ -158,7 +158,7 @@ pub fn build_execution_cache_from_env(
 ) -> ExecutionCacheTraitPointers {
     let execution_cache_metrics = Arc::new(ExecutionCacheMetrics::new(prometheus_registry));
 
-    if !std::env::var(ENABLE_WRITEBACK_CACHE_ENV_VAR).is_ok() {
+    if std::env::var(ENABLE_WRITEBACK_CACHE_ENV_VAR).is_err() {
         ExecutionCacheTraitPointers::new(
             PassthroughCache::new(store.clone(), execution_cache_metrics).into(),
         )

--- a/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/iota-e2e-tests/tests/reconfiguration_tests.rs
@@ -863,7 +863,7 @@ async fn test_epoch_flag_upgrade() {
     let initial_flags_nodes = Arc::new(Mutex::new(HashSet::new()));
     // Register a fail_point_arg, for which the handler is also placed in the
     // authority_store's open() function. When we start the first epoch, the
-    // following code will inject the new empty flags to the selected nodes once, so
+    // following code will inject the new flags to the selected nodes once, so
     // that we can later assert that the flags have changed.
     register_fail_point_arg("initial_epoch_flags", move || {
         // only alter flags on each node once
@@ -874,35 +874,17 @@ async fn test_epoch_flag_upgrade() {
         if initial_flags_nodes.len() >= 2 || !initial_flags_nodes.insert(current_node) {
             return None;
         }
-        // By default WritebackCache is enabled, use empty flag set for the first epoch
-        // after cluster is started.
-        Some(Vec::<EpochFlag>::new())
+        // Apply a modified flag set for the first epoch after cluster is started.
+        Some(vec![EpochFlag::WritebackCacheEnabled])
     });
 
-    // Start the cluster with 2 nodes with empty epoch flag set and the rest with
-    // non-empty.
+    // Start the cluster with 2 nodes with non-empty FlagSet and the rest with
+    // empty.
     let test_cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(30000)
         .build()
         .await;
-    let any_empty = test_cluster.all_node_handles().iter().any(|node| {
-        node.with(|node| {
-            node.state()
-                .epoch_store_for_testing()
-                .epoch_start_config()
-                .flags()
-                .is_empty()
-        })
-    });
-    assert!(any_empty);
-
-    // When the epoch changes, flags on some nodes should be re-initialized to be
-    // non-empty.
-
-    test_cluster.wait_for_epoch_all_nodes(1).await;
-
-    // Make sure that all nodes have non-empty flags.
-    let all_non_empty = test_cluster.all_node_handles().iter().all(|node| {
+    let any_non_empty = test_cluster.all_node_handles().iter().any(|node| {
         node.with(|node| {
             !node
                 .state()
@@ -912,7 +894,24 @@ async fn test_epoch_flag_upgrade() {
                 .is_empty()
         })
     });
-    assert!(all_non_empty);
+    assert!(any_non_empty);
+
+    // When the epoch changes, flags on some nodes should be re-initialized to be
+    // empty.
+
+    test_cluster.wait_for_epoch_all_nodes(1).await;
+
+    // Make sure that all nodes have empty flags.
+    let all_empty = test_cluster.all_node_handles().iter().all(|node| {
+        node.with(|node| {
+            node.state()
+                .epoch_store_for_testing()
+                .epoch_start_config()
+                .flags()
+                .is_empty()
+        })
+    });
+    assert!(all_empty);
 
     sleep(Duration::from_secs(15)).await;
 

--- a/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/iota-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -124,9 +124,7 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 20
-    execution-cache:
-      writeback-cache:
-        max_cache_size: ~
+    execution-cache: passthrough-cache
     enable-validator-tx-finalizer: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
@@ -255,9 +253,7 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 20
-    execution-cache:
-      writeback-cache:
-        max_cache_size: ~
+    execution-cache: passthrough-cache
     enable-validator-tx-finalizer: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
@@ -386,9 +382,7 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 20
-    execution-cache:
-      writeback-cache:
-        max_cache_size: ~
+    execution-cache: passthrough-cache
     enable-validator-tx-finalizer: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
@@ -517,9 +511,7 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 20
-    execution-cache:
-      writeback-cache:
-        max_cache_size: ~
+    execution-cache: passthrough-cache
     enable-validator-tx-finalizer: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
@@ -648,9 +640,7 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 20
-    execution-cache:
-      writeback-cache:
-        max_cache_size: ~
+    execution-cache: passthrough-cache
     enable-validator-tx-finalizer: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
@@ -779,9 +769,7 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 20
-    execution-cache:
-      writeback-cache:
-        max_cache_size: ~
+    execution-cache: passthrough-cache
     enable-validator-tx-finalizer: true
     verifier-signing-config:
       max-per-fun-meter-units: ~
@@ -910,9 +898,7 @@ validator_configs:
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
       max-transaction-manager-per-object-queue-length: 20
-    execution-cache:
-      writeback-cache:
-        max_cache_size: ~
+    execution-cache: passthrough-cache
     enable-validator-tx-finalizer: true
     verifier-signing-config:
       max-per-fun-meter-units: ~


### PR DESCRIPTION
# Description of change

This PR reverts enabling Writeback cache by default, now Passthrough cache is enabled by default.

## Links to any relevant issues

Fixes #7577.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
