### PR TITLE
feat(indexer): wait for transaction dependencies

### DIFF
--- a/crates/iota-indexer/src/errors.rs
+++ b/crates/iota-indexer/src/errors.rs
@@ -147,6 +147,9 @@ pub enum IndexerError {
 
     #[error("Inconsistent migration records: {0}")]
     DbMigration(String),
+
+    #[error("Transaction dependencies have not been indexed")]
+    TransactionDependenciesNotIndexed,
 }
 
 pub trait Context<T> {

--- a/crates/iota-indexer/src/handlers/committer.rs
+++ b/crates/iota-indexer/src/handlers/committer.rs
@@ -10,10 +10,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, instrument};
 
 use super::{CheckpointDataToCommit, EpochToCommit};
-use crate::{
-    metrics::IndexerMetrics, models::transactions::TxGlobalOrder, store::IndexerStore,
-    types::IndexerResult,
-};
+use crate::{metrics::IndexerMetrics, store::IndexerStore, types::IndexerResult};
 
 pub(crate) const CHECKPOINT_COMMIT_BATCH_SIZE: usize = 100;
 
@@ -124,10 +121,6 @@ async fn commit_checkpoints<S>(
     let guard = metrics.checkpoint_db_commit_latency.start_timer();
     let tx_batch = tx_batch.into_iter().flatten().collect::<Vec<_>>();
 
-    let tx_global_order_batch = tx_batch
-        .iter()
-        .map(Into::into)
-        .collect::<Vec<TxGlobalOrder>>();
     let tx_indices_batch = tx_indices_batch.into_iter().flatten().collect::<Vec<_>>();
     let events_batch = events_batch.into_iter().flatten().collect::<Vec<_>>();
     let event_indices_batch = event_indices_batch
@@ -147,7 +140,6 @@ async fn commit_checkpoints<S>(
         let mut persist_tasks = vec![
             state.persist_transactions(tx_batch),
             state.persist_tx_indices(tx_indices_batch),
-            state.persist_tx_global_order(tx_global_order_batch),
             state.persist_events(events_batch),
             state.persist_event_indices(event_indices_batch),
             state.persist_displays(display_updates_batch),

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -630,33 +630,79 @@ impl IndexerReader {
         stored_txn.try_into_iota_transaction_effects()
     }
 
-    /// Count how many of the given transactions have been indexed.
+    /// Expensive check to assert whether all transactions
+    /// are indexed.
+    ///
+    /// It uses both the `tx_global_order` table
+    /// and the `checkpoints` table to cover old transactions.
+    fn deep_check_all_transactions_are_indexed(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> Result<bool, IndexerError> {
+        let (checkpointed, optimistic) = self
+            .multi_get_transactions(digests)?
+            .into_iter()
+            .partition::<Vec<_>, _>(|tx| tx.checkpoint_sequence_number >= 0);
+        if !optimistic.is_empty() {
+            let num_optimistic = optimistic.len();
+            let optimistic_digests = optimistic
+                .into_iter()
+                .map(|tx| tx.transaction_digest)
+                .collect::<HashSet<_>>();
+            let num_indexed =
+                self.count_indexed_tx_global_orders(optimistic_digests.into_iter())?;
+            if num_indexed as usize != num_optimistic {
+                return Ok(false);
+            }
+        }
+        let Some(max_transaction_checkpoint) = checkpointed
+            .iter()
+            .map(|tx| tx.checkpoint_sequence_number)
+            .max()
+        else {
+            return Ok(false);
+        };
+        Ok(self
+            .get_checkpoint(CheckpointId::SequenceNumber(
+                max_transaction_checkpoint as u64,
+            ))?
+            .is_some())
+    }
+
+    pub(crate) async fn deep_check_all_transactions_are_indexed_in_blocking_task(
+        &self,
+        digests: Vec<TransactionDigest>,
+    ) -> Result<bool, IndexerError> {
+        self.spawn_blocking(move |this| this.deep_check_all_transactions_are_indexed(&digests))
+            .await
+    }
+
+    /// Count how many entries in `tx_global_order` correspond
+    /// to indexed transactions.
     ///
     /// Any transaction with a non-zero optimistic sequence number
     /// is considered as indexed.
-    fn count_indexed_transactions(
+    fn count_indexed_tx_global_orders(
         &self,
-        digests: &[TransactionDigest],
+        digests: impl Iterator<Item = Vec<u8>>,
     ) -> Result<i64, IndexerError> {
-        let digests = digests
-            .iter()
-            .map(|digest| digest.inner().to_vec())
-            .collect::<HashSet<_>>();
         run_query!(&self.pool, |conn| {
             tx_global_order::table
-                .filter(tx_global_order::tx_digest.eq_any(&digests))
+                .filter(tx_global_order::tx_digest.eq_any(digests))
                 .filter(tx_global_order::optimistic_sequence_number.ne(IndexStatus::Started))
                 .count()
                 .get_result(conn)
         })
     }
 
-    pub(crate) async fn count_indexed_transactions_in_blocking_task(
+    pub(crate) async fn count_indexed_tx_global_orders_in_blocking_task(
         &self,
-        digests: Vec<TransactionDigest>,
+        digests: HashSet<TransactionDigest>,
     ) -> Result<i64, IndexerError> {
-        self.spawn_blocking(move |this| this.count_indexed_transactions(&digests))
-            .await
+        self.spawn_blocking(move |this| {
+            this.count_indexed_tx_global_orders(digests.into_iter().map(|d| d.inner().to_vec()))
+        })
+        .await
     }
 
     fn multi_get_transactions(

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -64,7 +64,7 @@ use crate::{
         objects::{CoinBalance, StoredHistoryObject, StoredObject},
         participation_metrics::StoredParticipationMetrics,
         transactions::{
-            OptimisticTransaction, StoredTransaction, StoredTransactionEvents,
+            IndexStatus, OptimisticTransaction, StoredTransaction, StoredTransactionEvents,
             stored_events_to_events, tx_events_to_iota_tx_events,
         },
         tx_indices::TxSequenceNumber,
@@ -628,6 +628,35 @@ impl IndexerReader {
         })?;
 
         stored_txn.try_into_iota_transaction_effects()
+    }
+
+    /// Count how many of the given transactions have been indexed.
+    ///
+    /// Any transaction with a non-zero optimistic sequence number
+    /// is considered as indexed.
+    fn count_indexed_transactions(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> Result<i64, IndexerError> {
+        let digests = digests
+            .iter()
+            .map(|digest| digest.inner().to_vec())
+            .collect::<HashSet<_>>();
+        run_query!(&self.pool, |conn| {
+            tx_global_order::table
+                .filter(tx_global_order::tx_digest.eq_any(&digests))
+                .filter(tx_global_order::optimistic_sequence_number.ne(IndexStatus::Started))
+                .count()
+                .get_result(conn)
+        })
+    }
+
+    pub(crate) async fn count_indexed_transactions_in_blocking_task(
+        &self,
+        digests: Vec<TransactionDigest>,
+    ) -> Result<i64, IndexerError> {
+        self.spawn_blocking(move |this| this.count_indexed_transactions(&digests))
+            .await
     }
 
     fn multi_get_transactions(

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -639,8 +639,11 @@ impl IndexerReader {
         &self,
         digests: &[TransactionDigest],
     ) -> Result<bool, IndexerError> {
-        let (checkpointed, optimistic) = self
-            .multi_get_transactions(digests)?
+        let stored_transactions = self.multi_get_transactions(digests)?;
+        if stored_transactions.len() != digests.len() {
+            return Ok(false);
+        }
+        let (checkpointed, optimistic) = stored_transactions
             .into_iter()
             .partition::<Vec<_>, _>(|tx| tx.checkpoint_sequence_number >= 0);
         if !optimistic.is_empty() {
@@ -660,7 +663,7 @@ impl IndexerReader {
             .map(|tx| tx.checkpoint_sequence_number)
             .max()
         else {
-            return Ok(false);
+            return Ok(true);
         };
         Ok(self
             .get_checkpoint(CheckpointId::SequenceNumber(

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -52,8 +52,10 @@ pub struct TxGlobalOrder {
     /// Monotonically increasing number that represents the order
     /// of execution of optimistic transactions.
     ///
-    /// To maintain these semantics the value should be `0` for
-    /// checkpointed transactions.
+    /// To maintain these semantics the value should be non-positive for
+    /// checkpointed transactions. More specifically we allow values
+    /// in the set `[0, -1]` to represent the index status of checkpointed
+    /// transactions. See also [`CheckpointTxGlobalOrder`].
     ///
     /// Optimistic transactions should set this value to `None`,
     /// so that it is auto-generated on the database.
@@ -71,16 +73,14 @@ impl From<&IndexedTransaction> for CheckpointTxGlobalOrder {
     }
 }
 
+/// Stored value for checkpointed transactions.
+///
+/// Differs from [`TxGlobalOrder`] in that it allows values
+/// for `optimistic_sequence_number` in the set `[0, -1]`
+/// that represent the index status.
 #[derive(Clone, Debug, Queryable, Insertable, QueryableByName, Selectable)]
 #[diesel(table_name = tx_global_order)]
 pub(crate) struct CheckpointTxGlobalOrder {
-    /// Number that represents the global ordering between optimistic and
-    /// checkpointed transactions.
-    ///
-    /// Optimistic transactions will share the same number as checkpointed
-    /// transactions. In this case, ties are resolved by the
-    /// `(global_sequence_number, optimistic_sequence_number)` pair that
-    /// guarantees deterministic ordering.
     pub(crate) global_sequence_number: i64,
     pub(crate) tx_digest: Vec<u8>,
     /// The index status of checkpointed transactions.

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -4,7 +4,14 @@
 
 use std::sync::Arc;
 
-use diesel::prelude::*;
+use diesel::{
+    backend::Backend,
+    deserialize::{FromSql, Result as DeserializeResult},
+    expression::AsExpression,
+    prelude::*,
+    serialize::{Output, Result as SerializeResult, ToSql},
+    sql_types::BigInt,
+};
 use iota_json_rpc_types::{
     BalanceChange, IotaEvent, IotaTransactionBlock, IotaTransactionBlockEffects,
     IotaTransactionBlockEvents, IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions,
@@ -54,12 +61,69 @@ pub struct TxGlobalOrder {
     pub optimistic_sequence_number: Option<i64>,
 }
 
-impl From<&IndexedTransaction> for TxGlobalOrder {
+impl From<&IndexedTransaction> for CheckpointTxGlobalOrder {
     fn from(tx: &IndexedTransaction) -> Self {
-        TxGlobalOrder {
+        Self {
             global_sequence_number: tx.tx_sequence_number as i64,
             tx_digest: tx.tx_digest.into_inner().to_vec(),
-            optimistic_sequence_number: Some(0),
+            index_status: Some(IndexStatus::Started),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Queryable, Insertable, QueryableByName, Selectable)]
+#[diesel(table_name = tx_global_order)]
+pub(crate) struct CheckpointTxGlobalOrder {
+    /// Number that represents the global ordering between optimistic and
+    /// checkpointed transactions.
+    ///
+    /// Optimistic transactions will share the same number as checkpointed
+    /// transactions. In this case, ties are resolved by the
+    /// `(global_sequence_number, optimistic_sequence_number)` pair that
+    /// guarantees deterministic ordering.
+    pub(crate) global_sequence_number: i64,
+    pub(crate) tx_digest: Vec<u8>,
+    /// The index status of checkpointed transactions.
+    ///
+    /// This essentially reserves the values `[0, -1]` of the
+    /// `optimistic_sequence_number` stored in the table for checkpointed
+    /// transactions, to distinguish from optimistic transactions, and
+    /// assign semantics related to the index status.
+    #[diesel(deserialize_as = IndexStatus, column_name = "optimistic_sequence_number")]
+    pub(crate) index_status: Option<IndexStatus>,
+}
+
+/// Index status.
+#[derive(Clone, Debug, Copy, AsExpression, PartialEq, Eq)]
+#[diesel(sql_type = BigInt)]
+pub(crate) enum IndexStatus {
+    Started,
+    Completed,
+}
+
+impl<DB> ToSql<BigInt, DB> for IndexStatus
+where
+    DB: Backend,
+    i64: ToSql<BigInt, DB>,
+{
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, DB>) -> SerializeResult {
+        match *self {
+            IndexStatus::Started => 0.to_sql(out),
+            IndexStatus::Completed => (-1).to_sql(out),
+        }
+    }
+}
+
+impl<DB> FromSql<BigInt, DB> for IndexStatus
+where
+    DB: Backend,
+    i64: FromSql<BigInt, DB>,
+{
+    fn from_sql(bytes: DB::RawValue<'_>) -> DeserializeResult<Self> {
+        match i64::from_sql(bytes)? {
+            0 => Ok(IndexStatus::Started),
+            -1 => Ok(IndexStatus::Completed),
+            other => Err(format!("invalid index status {other}").into()),
         }
     }
 }

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -38,6 +38,8 @@ use crate::{
     },
 };
 
+const WAIT_FOR_DEPS_MAX_ELAPSED_TIME: Duration = Duration::from_secs(3);
+
 type TransactionDataToCommit = (
     OptimisticTransaction,
     OptimisticTxIndices,
@@ -75,15 +77,23 @@ impl OptimisticTransactionExecutor {
         effects: &TransactionEffects,
     ) -> Result<(), IndexerError> {
         let expected_dependencies = effects.dependencies();
-        let mut count = 0;
-        while count as usize != expected_dependencies.len() {
-            count = self
+        let backoff = backoff::ExponentialBackoff {
+            max_elapsed_time: Some(WAIT_FOR_DEPS_MAX_ELAPSED_TIME),
+            ..Default::default()
+        };
+
+        backoff::future::retry(backoff, async || {
+            let count = self
                 .indexer_reader
                 .count_indexed_transactions_in_blocking_task(expected_dependencies.to_vec())
-                .await
-                .map_err(|e| IndexerError::Generic(e.to_string()))?;
-        }
-        Ok(())
+                .await?;
+            if count as usize != expected_dependencies.len() {
+                return Err(IndexerError::TransactionDependenciesNotIndexed)?;
+            }
+            Ok(())
+        })
+        .await
+        .or(Err(IndexerError::TransactionDependenciesNotIndexed))
     }
 
     pub(crate) async fn execute_and_index_transaction(
@@ -120,11 +130,11 @@ impl OptimisticTransactionExecutor {
             output_objects,
             ..
         } = response;
-        self.wait_for_tx_dependencies(&effects).await?;
         let tx_digest = *effects.transaction_digest();
+        let tx_deps_indexed = self.wait_for_tx_dependencies(&effects).await;
 
-        match (input_objects, output_objects) {
-            (Some(input_objects), Some(output_objects))
+        match (input_objects, output_objects, tx_deps_indexed) {
+            (Some(input_objects), Some(output_objects), Ok(_))
                 if !input_objects.is_empty() && !output_objects.is_empty() =>
             {
                 let full_tx_data = CheckpointTransaction {
@@ -135,6 +145,11 @@ impl OptimisticTransactionExecutor {
                     output_objects,
                 };
                 self.index_transaction(&full_tx_data).await?;
+            }
+            (Some(_), Some(_), Err(_)) => {
+                tracing::warn!(
+                    "Transaction {tx_digest} dependencies not indexed, skipping optimistic indexing"
+                );
             }
             _ => {
                 tracing::warn!(

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -143,17 +143,16 @@ impl OptimisticTransactionExecutor {
             );
             return Ok(());
         }
-        if self.wait_for_tx_dependencies(&effects).await.is_err()
-            && !self
-                .deep_check_all_dependencies_are_indexed(&effects)
-                .await?
-        {
-            tracing::warn!(
-                "Transaction {tx_digest} dependencies are not indexed, skipping optimistic indexing",
-            );
-            return Ok(());
-        }
-
+        tokio::select! {
+            Ok(_) = self.wait_for_tx_dependencies(&effects) => (),
+            Ok(_) = self.deep_check_all_dependencies_are_indexed(&effects) => (),
+            else => {
+                tracing::warn!(
+                    "Transaction {tx_digest} dependencies are not indexed, skipping optimistic indexing",
+                );
+                return Ok(());
+            }
+        };
         let full_tx_data = CheckpointTransaction {
             transaction,
             effects,

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -9,7 +9,7 @@ use iota_json_rpc_types::{IotaTransactionBlockResponse, IotaTransactionBlockResp
 use iota_rest_api::{ExecuteTransactionQueryParameters, client::TransactionExecutionResponse};
 use iota_types::{
     base_types::TransactionDigest,
-    effects::TransactionEffectsAPI,
+    effects::{TransactionEffects, TransactionEffectsAPI},
     full_checkpoint_content::CheckpointTransaction,
     signature::GenericSignature,
     transaction::{Transaction, TransactionData},
@@ -70,6 +70,22 @@ impl OptimisticTransactionExecutor {
         }
     }
 
+    pub(crate) async fn wait_for_tx_dependencies(
+        &self,
+        effects: &TransactionEffects,
+    ) -> Result<(), IndexerError> {
+        let expected_dependencies = effects.dependencies();
+        let mut count = 0;
+        while count as usize != expected_dependencies.len() {
+            count = self
+                .indexer_reader
+                .count_indexed_transactions_in_blocking_task(expected_dependencies.to_vec())
+                .await
+                .map_err(|e| IndexerError::Generic(e.to_string()))?;
+        }
+        Ok(())
+    }
+
     pub(crate) async fn execute_and_index_transaction(
         &self,
         tx_bytes: Base64,
@@ -104,6 +120,7 @@ impl OptimisticTransactionExecutor {
             output_objects,
             ..
         } = response;
+        self.wait_for_tx_dependencies(&effects).await?;
         let tx_digest = *effects.transaction_digest();
 
         match (input_objects, output_objects) {

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -1,6 +1,9 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
-use std::{collections::BTreeMap, time::Duration};
+use std::{
+    collections::{BTreeMap, HashSet},
+    time::Duration,
+};
 
 use diesel::{OptionalExtension, RunQueryDsl, sql_query, sql_types};
 use downcast::Any;
@@ -72,11 +75,22 @@ impl OptimisticTransactionExecutor {
         }
     }
 
+    /// Wait until all dependencies are indexed through the `tx_global_order`
+    /// table.
+    ///
+    /// It uses exponential backoff to retyro the check.
+    ///
+    /// This does not cover old transactions that do not have
+    /// entries in `tx_global_order`.
     pub(crate) async fn wait_for_tx_dependencies(
         &self,
         effects: &TransactionEffects,
     ) -> Result<(), IndexerError> {
-        let expected_dependencies = effects.dependencies();
+        let expected_dependencies = effects
+            .dependencies()
+            .iter()
+            .copied()
+            .collect::<HashSet<_>>();
         let backoff = backoff::ExponentialBackoff {
             max_elapsed_time: Some(WAIT_FOR_DEPS_MAX_ELAPSED_TIME),
             ..Default::default()
@@ -85,7 +99,7 @@ impl OptimisticTransactionExecutor {
         backoff::future::retry(backoff, async || {
             let count = self
                 .indexer_reader
-                .count_indexed_transactions_in_blocking_task(expected_dependencies.to_vec())
+                .count_indexed_tx_global_orders_in_blocking_task(expected_dependencies.clone())
                 .await?;
             if count as usize != expected_dependencies.len() {
                 return Err(IndexerError::TransactionDependenciesNotIndexed)?;
@@ -94,6 +108,78 @@ impl OptimisticTransactionExecutor {
         })
         .await
         .or(Err(IndexerError::TransactionDependenciesNotIndexed))
+    }
+
+    /// Index the executed transaction under the following conditions:
+    ///
+    /// * If the transaction has input and output objects, and
+    /// * If the transaction dependencies are already indexed.
+    ///
+    /// The latter is essential in avoiding race conditions while
+    /// indexing checkpointed transactions.
+    pub(crate) async fn maybe_index_executed_transaction(
+        &self,
+        transaction: Transaction,
+        execution_response: TransactionExecutionResponse,
+    ) -> Result<(), IndexerError> {
+        let TransactionExecutionResponse {
+            effects,
+            events,
+            input_objects,
+            output_objects,
+            ..
+        } = execution_response;
+        let tx_digest = transaction.digest();
+        let (Some(input_objects), Some(output_objects)) = (input_objects, output_objects) else {
+            tracing::warn!(
+                "Cannot optimistically index because of missing in/out objs for tx: {tx_digest}"
+            );
+            return Ok(());
+        };
+
+        if input_objects.is_empty() || output_objects.is_empty() {
+            tracing::warn!(
+                "Cannot optimistically index because of missing in/out objs for tx: {tx_digest}"
+            );
+            return Ok(());
+        }
+        if self.wait_for_tx_dependencies(&effects).await.is_err()
+            && !self
+                .deep_check_all_dependencies_are_indexed(&effects)
+                .await?
+        {
+            tracing::warn!(
+                "Transaction {tx_digest} dependencies are not indexed, skipping optimistic indexing",
+            );
+            return Ok(());
+        }
+
+        let full_tx_data = CheckpointTransaction {
+            transaction,
+            effects,
+            events,
+            input_objects,
+            output_objects,
+        };
+        self.index_transaction(&full_tx_data).await
+    }
+
+    /// Expensive operation that checks if all transactions
+    /// are indexed.
+    ///
+    /// This queries both `tx_global_order` which represents
+    /// the index status for newer transactions, and the `checkpoints`
+    /// table for older transactions that do not have entries
+    /// in `tx_global_order`.
+    pub(crate) async fn deep_check_all_dependencies_are_indexed(
+        &self,
+        effects: &TransactionEffects,
+    ) -> Result<bool, IndexerError> {
+        self.indexer_reader
+            .deep_check_all_transactions_are_indexed_in_blocking_task(
+                effects.dependencies().to_vec(),
+            )
+            .await
     }
 
     pub(crate) async fn execute_and_index_transaction(
@@ -123,41 +209,9 @@ impl OptimisticTransactionExecutor {
             .await
             .map_err(|e| IndexerError::Generic(e.to_string()))?;
 
-        let TransactionExecutionResponse {
-            effects,
-            events,
-            input_objects,
-            output_objects,
-            ..
-        } = response;
-        let tx_digest = *effects.transaction_digest();
-        let tx_deps_indexed = self.wait_for_tx_dependencies(&effects).await;
-
-        match (input_objects, output_objects, tx_deps_indexed) {
-            (Some(input_objects), Some(output_objects), Ok(_))
-                if !input_objects.is_empty() && !output_objects.is_empty() =>
-            {
-                let full_tx_data = CheckpointTransaction {
-                    transaction,
-                    effects,
-                    events,
-                    input_objects,
-                    output_objects,
-                };
-                self.index_transaction(&full_tx_data).await?;
-            }
-            (Some(_), Some(_), Err(_)) => {
-                tracing::warn!(
-                    "Transaction {tx_digest} dependencies not indexed, skipping optimistic indexing"
-                );
-            }
-            _ => {
-                tracing::warn!(
-                    "Cannot optimistically index because of missing in/out objs for tx: {tx_digest}"
-                );
-            }
-        }
-
+        let tx_digest = *response.effects.transaction_digest();
+        self.maybe_index_executed_transaction(transaction, response)
+            .await?;
         let tx_block_response = self
             .wait_for_local_indexing(tx_digest, options.clone())
             .await?;

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -78,7 +78,7 @@ impl OptimisticTransactionExecutor {
     /// Wait until all dependencies are indexed through the `tx_global_order`
     /// table.
     ///
-    /// It uses exponential backoff to retyro the check.
+    /// It uses exponential backoff to retry the check.
     ///
     /// This does not cover old transactions that do not have
     /// entries in `tx_global_order`.

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -145,7 +145,7 @@ impl OptimisticTransactionExecutor {
         }
         tokio::select! {
             Ok(_) = self.wait_for_tx_dependencies(&effects) => (),
-            Ok(_) = self.deep_check_all_dependencies_are_indexed(&effects) => (),
+            Ok(true) = self.deep_check_all_dependencies_are_indexed(&effects) => (),
             else => {
                 tracing::warn!(
                     "Transaction {tx_digest} dependencies are not indexed, skipping optimistic indexing",

--- a/crates/iota-indexer/src/rolling/persist.rs
+++ b/crates/iota-indexer/src/rolling/persist.rs
@@ -168,7 +168,7 @@ async fn commit_checkpoints(
         let mut persist_tasks = vec![
             state.persist_transactions(tx_batch),
             state.persist_tx_indices(tx_indices_batch),
-            state.persist_tx_global_order(tx_global_order_batch),
+            state.persist_tx_global_order(tx_global_order_batch.clone()),
             state.persist_events(events_batch),
             state.persist_event_indices(event_indices_batch),
             state.persist_displays(display_updates_batch),
@@ -192,6 +192,14 @@ async fn commit_checkpoints(
             .collect::<IndexerResult<Vec<_>>>()
             .expect("Persisting data into DB should not fail.");
     }
+
+    state
+        .update_tx_global_order_as_indexed(tx_global_order_batch)
+        .await
+        .inspect_err(|e| {
+            error!("failed to update tx global order as indexed with error: {e}");
+        })
+        .expect("updating tx global order as indexed should not fail.");
 
     let is_epoch_end = epoch.is_some();
 

--- a/crates/iota-indexer/src/rolling/persist.rs
+++ b/crates/iota-indexer/src/rolling/persist.rs
@@ -14,9 +14,7 @@ use tracing::{error, info, instrument};
 use crate::{
     handlers::{EpochToCommit, TransactionObjectChangesToCommit},
     metrics::IndexerMetrics,
-    models::{
-        display::StoredDisplay, obj_indices::StoredObjectVersion, transactions::TxGlobalOrder,
-    },
+    models::{display::StoredDisplay, obj_indices::StoredObjectVersion},
     rolling::transform::CheckpointObjectChanges,
     store::{IndexerStore, IndexerStoreExt, PgIndexerStore},
     types::{
@@ -145,10 +143,7 @@ async fn commit_checkpoints(
     let guard = metrics.checkpoint_db_commit_latency.start_timer();
     let tx_batch = tx_batch.into_iter().flatten().collect::<Vec<_>>();
 
-    let tx_global_order_batch = tx_batch
-        .iter()
-        .map(Into::into)
-        .collect::<Vec<TxGlobalOrder>>();
+    let tx_global_order_batch: Vec<_> = tx_batch.iter().map(Into::into).collect();
     let tx_indices_batch = tx_indices_batch.into_iter().flatten().collect::<Vec<_>>();
     let events_batch = events_batch.into_iter().flatten().collect::<Vec<_>>();
     let event_indices_batch = event_indices_batch
@@ -194,7 +189,7 @@ async fn commit_checkpoints(
     }
 
     state
-        .update_tx_global_order_as_indexed(tx_global_order_batch)
+        .update_status_for_checkpoint_transactions(tx_global_order_batch)
         .await
         .inspect_err(|e| {
             error!("failed to update tx global order as indexed with error: {e}");

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -15,7 +15,7 @@ use crate::{
         events::OptimisticEvent,
         obj_indices::StoredObjectVersion,
         objects::{StoredDeletedObject, StoredObject},
-        transactions::{OptimisticTransaction, TxGlobalOrder},
+        transactions::{CheckpointTxGlobalOrder, OptimisticTransaction},
         tx_indices::OptimisticTxIndices,
     },
     rolling::transform::CheckpointObjectChanges,
@@ -84,11 +84,6 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
         transaction: OptimisticTransaction,
     ) -> Result<(), IndexerError>;
 
-    async fn persist_tx_global_order(
-        &self,
-        tx_order: Vec<TxGlobalOrder>,
-    ) -> Result<(), IndexerError>;
-
     async fn persist_tx_indices(&self, indices: Vec<TxIndex>) -> Result<(), IndexerError>;
 
     async fn persist_optimistic_tx_indices(
@@ -148,8 +143,13 @@ pub(crate) trait IndexerStoreExt: IndexerStore {
         objects: Vec<CheckpointObjectChanges>,
     ) -> Result<(), IndexerError>;
 
-    async fn update_tx_global_order_as_indexed(
+    async fn update_status_for_checkpoint_transactions(
         &self,
-        tx_order: Vec<TxGlobalOrder>,
+        tx_order: Vec<CheckpointTxGlobalOrder>,
+    ) -> Result<(), IndexerError>;
+
+    async fn persist_tx_global_order(
+        &self,
+        tx_order: Vec<CheckpointTxGlobalOrder>,
     ) -> Result<(), IndexerError>;
 }

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -147,4 +147,9 @@ pub(crate) trait IndexerStoreExt: IndexerStore {
         &self,
         objects: Vec<CheckpointObjectChanges>,
     ) -> Result<(), IndexerError>;
+
+    async fn update_tx_global_order_as_indexed(
+        &self,
+        tx_order: Vec<TxGlobalOrder>,
+    ) -> Result<(), IndexerError>;
 }

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -907,11 +907,11 @@ impl PgIndexerStore {
             let elapsed = guard.stop_and_record();
             info!(
                 elapsed,
-                "Persisted {} chunked txs insertion order", num_transactions
+                "Updated {} chunked values of `tx_global_order`", num_transactions
             );
         })
         .tap_err(|e| {
-            tracing::error!("Failed to persist txs insertion order with error: {e}");
+            tracing::error!("Failed to update `tx_global_order` with error: {e}");
         })
     }
 
@@ -2682,14 +2682,16 @@ impl IndexerStoreExt for PgIndexerStore {
         futures::future::try_join_all(futures)
             .await
             .map_err(|e| {
-                tracing::error!("Failed to join update_tx_insertion_order_chunk futures: {e}",);
+                tracing::error!(
+                    "Failed to join update_status_for_checkpoint_transactions_chunk futures: {e}",
+                );
                 IndexerError::from(e)
             })?
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| {
                 IndexerError::PostgresWrite(format!(
-                    "Failed to update all txs insertion order chunks: {e:?}",
+                    "Failed to update all `tx_global_order` chunks: {e:?}",
                 ))
             })?;
         let elapsed = guard.stop_and_record();
@@ -2718,7 +2720,7 @@ impl IndexerStoreExt for PgIndexerStore {
         futures::future::try_join_all(futures)
             .await
             .map_err(|e| {
-                tracing::error!("Failed to join persist_tx_insertion_order_chunk futures: {e}",);
+                tracing::error!("Failed to join persist_tx_global_order_chunk futures: {e}",);
                 IndexerError::from(e)
             })?
             .into_iter()

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -44,7 +44,10 @@ use crate::{
             StoredObjects,
         },
         packages::StoredPackage,
-        transactions::{OptimisticTransaction, StoredTransaction, TxGlobalOrder},
+        transactions::{
+            CheckpointTxGlobalOrder, IndexStatus, OptimisticTransaction, StoredTransaction,
+            TxGlobalOrder,
+        },
         tx_indices::OptimisticTxIndices,
     },
     on_conflict_do_update, on_conflict_do_update_with_condition, persist_chunk_into_table,
@@ -839,7 +842,7 @@ impl PgIndexerStore {
 
     fn persist_tx_global_order_chunk(
         &self,
-        tx_order: Vec<TxGlobalOrder>,
+        tx_order: Vec<CheckpointTxGlobalOrder>,
     ) -> Result<(), IndexerError> {
         let guard = self
             .metrics
@@ -875,9 +878,9 @@ impl PgIndexerStore {
     /// Namely, checkpointed transactions (i.e. with `optimistic_sequence_number
     /// == 0`) are updated to `optimistic_sequence_number == -1` to indicate
     /// that they have been persisted in the database.
-    fn update_tx_global_order_chunk_as_indexed(
+    fn update_status_for_checkpoint_transactions_chunk(
         &self,
-        tx_order: Vec<TxGlobalOrder>,
+        tx_order: Vec<CheckpointTxGlobalOrder>,
     ) -> Result<(), IndexerError> {
         let guard = self
             .metrics
@@ -892,8 +895,8 @@ impl PgIndexerStore {
                     tx_global_order::table,
                     tx_order.clone(),
                     tx_global_order::tx_digest,
-                    tx_global_order::optimistic_sequence_number.eq(-1),
-                    tx_global_order::optimistic_sequence_number.eq(0),
+                    tx_global_order::optimistic_sequence_number.eq(IndexStatus::Completed),
+                    tx_global_order::optimistic_sequence_number.eq(IndexStatus::Started),
                     conn
                 );
                 Ok::<(), IndexerError>(())
@@ -2089,39 +2092,6 @@ impl IndexerStore for PgIndexerStore {
         Ok(indexing_status)
     }
 
-    async fn persist_tx_global_order(
-        &self,
-        tx_order: Vec<TxGlobalOrder>,
-    ) -> Result<(), IndexerError> {
-        let guard = self
-            .metrics
-            .checkpoint_db_commit_latency_tx_insertion_order
-            .start_timer();
-        let len = tx_order.len();
-
-        let chunks = chunk!(tx_order, self.config.parallel_chunk_size);
-        let futures = chunks
-            .into_iter()
-            .map(|c| self.spawn_blocking_task(move |this| this.persist_tx_global_order_chunk(c)));
-
-        futures::future::try_join_all(futures)
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to join persist_tx_insertion_order_chunk futures: {e}",);
-                IndexerError::from(e)
-            })?
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| {
-                IndexerError::PostgresWrite(format!(
-                    "Failed to persist all txs insertion order chunks: {e:?}",
-                ))
-            })?;
-        let elapsed = guard.stop_and_record();
-        info!(elapsed, "Persisted {len} txs insertion orders");
-        Ok(())
-    }
-
     async fn persist_events(&self, events: Vec<IndexedEvent>) -> Result<(), IndexerError> {
         if events.is_empty() {
             return Ok(());
@@ -2692,9 +2662,9 @@ impl IndexerStoreExt for PgIndexerStore {
         Ok(())
     }
 
-    async fn update_tx_global_order_as_indexed(
+    async fn update_status_for_checkpoint_transactions(
         &self,
-        tx_order: Vec<TxGlobalOrder>,
+        tx_order: Vec<CheckpointTxGlobalOrder>,
     ) -> Result<(), IndexerError> {
         let guard = self
             .metrics
@@ -2704,7 +2674,9 @@ impl IndexerStoreExt for PgIndexerStore {
 
         let chunks = chunk!(tx_order, self.config.parallel_chunk_size);
         let futures = chunks.into_iter().map(|c| {
-            self.spawn_blocking_task(move |this| this.update_tx_global_order_chunk_as_indexed(c))
+            self.spawn_blocking_task(move |this| {
+                this.update_status_for_checkpoint_transactions_chunk(c)
+            })
         });
 
         futures::future::try_join_all(futures)
@@ -2725,6 +2697,39 @@ impl IndexerStoreExt for PgIndexerStore {
             elapsed,
             "Updated index status for {len} txs insertion orders"
         );
+        Ok(())
+    }
+
+    async fn persist_tx_global_order(
+        &self,
+        tx_order: Vec<CheckpointTxGlobalOrder>,
+    ) -> Result<(), IndexerError> {
+        let guard = self
+            .metrics
+            .checkpoint_db_commit_latency_tx_insertion_order
+            .start_timer();
+        let len = tx_order.len();
+
+        let chunks = chunk!(tx_order, self.config.parallel_chunk_size);
+        let futures = chunks
+            .into_iter()
+            .map(|c| self.spawn_blocking_task(move |this| this.persist_tx_global_order_chunk(c)));
+
+        futures::future::try_join_all(futures)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to join persist_tx_insertion_order_chunk futures: {e}",);
+                IndexerError::from(e)
+            })?
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
+                IndexerError::PostgresWrite(format!(
+                    "Failed to persist all txs insertion order chunks: {e:?}",
+                ))
+            })?;
+        let elapsed = guard.stop_and_record();
+        info!(elapsed, "Persisted {len} txs insertion orders");
         Ok(())
     }
 }

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -869,6 +869,49 @@ impl PgIndexerStore {
         })
     }
 
+    /// We enfore index-status semantics for checkpointed transactions
+    /// in `tx_global_order`.
+    ///
+    /// Namely, checkpointed transactions (i.e. with `optimistic_sequence_number
+    /// == 0`) are updated to `optimistic_sequence_number == -1` to indicate
+    /// that they have been persisted in the database.
+    fn update_tx_global_order_chunk_as_indexed(
+        &self,
+        tx_order: Vec<TxGlobalOrder>,
+    ) -> Result<(), IndexerError> {
+        let guard = self
+            .metrics
+            .checkpoint_db_commit_latency_tx_insertion_order_chunks
+            .start_timer();
+
+        let num_transactions = tx_order.len();
+        transactional_blocking_with_retry!(
+            &self.blocking_cp,
+            |conn| {
+                on_conflict_do_update_with_condition!(
+                    tx_global_order::table,
+                    tx_order.clone(),
+                    tx_global_order::tx_digest,
+                    tx_global_order::optimistic_sequence_number.eq(-1),
+                    tx_global_order::optimistic_sequence_number.eq(0),
+                    conn
+                );
+                Ok::<(), IndexerError>(())
+            },
+            PG_DB_COMMIT_SLEEP_DURATION
+        )
+        .tap_ok(|_| {
+            let elapsed = guard.stop_and_record();
+            info!(
+                elapsed,
+                "Persisted {} chunked txs insertion order", num_transactions
+            );
+        })
+        .tap_err(|e| {
+            tracing::error!("Failed to persist txs insertion order with error: {e}");
+        })
+    }
+
     fn persist_events_chunk(&self, events: Vec<IndexedEvent>) -> Result<(), IndexerError> {
         let guard = self
             .metrics
@@ -2645,6 +2688,42 @@ impl IndexerStoreExt for PgIndexerStore {
         info!(
             elapsed,
             "Persisted objects with {mutation_len} mutations and {deletion_len} deletions",
+        );
+        Ok(())
+    }
+
+    async fn update_tx_global_order_as_indexed(
+        &self,
+        tx_order: Vec<TxGlobalOrder>,
+    ) -> Result<(), IndexerError> {
+        let guard = self
+            .metrics
+            .checkpoint_db_commit_latency_tx_insertion_order
+            .start_timer();
+        let len = tx_order.len();
+
+        let chunks = chunk!(tx_order, self.config.parallel_chunk_size);
+        let futures = chunks.into_iter().map(|c| {
+            self.spawn_blocking_task(move |this| this.update_tx_global_order_chunk_as_indexed(c))
+        });
+
+        futures::future::try_join_all(futures)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to join update_tx_insertion_order_chunk futures: {e}",);
+                IndexerError::from(e)
+            })?
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
+                IndexerError::PostgresWrite(format!(
+                    "Failed to update all txs insertion order chunks: {e:?}",
+                ))
+            })?;
+        let elapsed = guard.stop_and_record();
+        info!(
+            elapsed,
+            "Updated index status for {len} txs insertion orders"
         );
         Ok(())
     }

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -872,7 +872,7 @@ impl PgIndexerStore {
         })
     }
 
-    /// We enfore index-status semantics for checkpointed transactions
+    /// We enforce index-status semantics for checkpointed transactions
     /// in `tx_global_order`.
     ///
     /// Namely, checkpointed transactions (i.e. with `optimistic_sequence_number

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -276,7 +276,7 @@ mod ingestion_tests {
             stored_global_order.global_sequence_number,
             stored_tx_digest.tx_sequence_number
         );
-        let expected_optimistic_sequence_number = 0;
+        let expected_optimistic_sequence_number = -1;
         assert_eq!(
             stored_global_order.optimistic_sequence_number,
             Some(expected_optimistic_sequence_number)


### PR DESCRIPTION
# Description of change

This patch introduces logic to wait for the transaction dependencies while executing optimistically.

It also adds exponential backoff for checking the index status of the dependencies, to accommodate concurrent optimistic execution of the dependencies (e.g. in the case of shared objects).

## Links to any relevant issues

Fixes #6321 

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

No additional tests are considered necessary, as this affects the WriteAPI of the json-rpc server.

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [x] Verification of API backward compatibility.

