### PR TITLE
fix: increase re-execute/re-built timeouts during validator start

### DIFF
--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -2335,9 +2335,12 @@ impl CheckpointService {
 
         // If this times out, the validator may still start up. The worst that can
         // happen is that we will crash later on (due to missing transactions).
-        if tokio::time::timeout(Duration::from_secs(10), self.wait_for_rebuilt_checkpoints())
-            .await
-            .is_err()
+        if tokio::time::timeout(
+            Duration::from_secs(120),
+            self.wait_for_rebuilt_checkpoints(),
+        )
+        .await
+        .is_err()
         {
             debug_fatal!("Timed out waiting for checkpoints to be rebuilt");
         }

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1580,7 +1580,7 @@ impl IotaNode {
         // clients in some circumstances. However, the transactions are still in
         // pending_consensus_certificates, so we cannot lose any finality guarantees.
         if tokio::time::timeout(
-            std::time::Duration::from_secs(10),
+            std::time::Duration::from_secs(120),
             state
                 .get_transaction_cache_reader()
                 .notify_read_executed_effects_digests(&digests),


### PR DESCRIPTION
# Description of change

This PR should fix the flaky/failing nightly simtest `test_simulated_load_restarts`.
The timeouts seems to be too short for the CI runners. Before, this code was executed in a loop until the validators were ready, but this got changed in #7164, which is exactly the point the nightlies stopped working.

## Links to any relevant issues

#7499 

## How the change has been tested

I reran the nightlies several times.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes