### PR TITLE
feat(iota-sdk): Support new transaction filter in the `IotaClient`

### DIFF
--- a/crates/iota-sdk/examples/read_api/read_api_transactions.rs
+++ b/crates/iota-sdk/examples/read_api/read_api_transactions.rs
@@ -9,7 +9,7 @@
 use futures::StreamExt;
 use iota_sdk::{
     IotaClientBuilder,
-    rpc_types::{IotaTransactionBlockResponseQuery, TransactionFilter},
+    rpc_types::{IotaTransactionBlockResponseQueryV2, TransactionFilterV2},
 };
 
 #[tokio::main]
@@ -19,7 +19,12 @@ async fn main() -> Result<(), anyhow::Error> {
     // Get the latest 5 transaction blocks, so we can use a digest of it as cursor
     let transactions_block_page = client
         .read_api()
-        .query_transaction_blocks(IotaTransactionBlockResponseQuery::default(), None, 5, true)
+        .query_transaction_blocks_v2(
+            IotaTransactionBlockResponseQueryV2::default(),
+            None,
+            5,
+            true,
+        )
         .await?;
 
     // Get the last ~5 transaction blocks as stream (the tx for the digest in the
@@ -27,8 +32,8 @@ async fn main() -> Result<(), anyhow::Error> {
     // new tx(s), so that there are 5 or even more)
     let mut txs = client
         .read_api()
-        .get_transactions_stream(
-            IotaTransactionBlockResponseQuery::default(),
+        .get_transactions_stream_v2(
+            IotaTransactionBlockResponseQueryV2::default(),
             transactions_block_page.data.last().unwrap().digest,
             false,
         )
@@ -41,15 +46,15 @@ async fn main() -> Result<(), anyhow::Error> {
     // Get a tx stream with a TransactionFilter
     let mut txs = client
         .read_api()
-        .get_transactions_stream(
-            IotaTransactionBlockResponseQuery::new_with_filter(
-                TransactionFilter::MoveFunction {
+        .get_transactions_stream_v2(
+            IotaTransactionBlockResponseQueryV2::new_with_filter(
+                TransactionFilterV2::MoveFunction {
                     package: "0x3".parse()?,
                     module: Some("iota_system".into()),
                     function: Some("request_add_stake".into()),
                 },
                 // There are also options for filtering txs, for example by address:
-                // TransactionFilter::FromOrToAddress {
+                // TransactionFilterV2::FromOrToAddress {
                 //     addr: "0x111111111504e9350e635d65cd38ccd2c029434c6a3a480d8947a9ba6a15b215"
                 //         .parse()?,
                 // },

--- a/crates/iota-sdk/src/apis/read.rs
+++ b/crates/iota-sdk/src/apis/read.rs
@@ -532,6 +532,22 @@ impl ReadApi {
             .await?)
     }
 
+    /// Get filtered transaction blocks information.
+    /// Results are paginated.
+    pub async fn query_transaction_blocks_v2(
+        &self,
+        query: IotaTransactionBlockResponseQueryV2,
+        cursor: impl Into<Option<TransactionDigest>>,
+        limit: impl Into<Option<usize>>,
+        descending_order: bool,
+    ) -> IotaRpcResult<TransactionBlocksPage> {
+        Ok(self
+            .api
+            .http
+            .query_transaction_blocks_v2(query, cursor.into(), limit.into(), Some(descending_order))
+            .await?)
+    }
+
     /// Get the first four bytes of the chain's genesis checkpoint digest in hex
     /// format.
     pub async fn get_chain_identifier(&self) -> IotaRpcResult<String> {
@@ -586,6 +602,41 @@ impl ReadApi {
                 } else if (cursor.is_none() && first) || cursor.is_some() {
                     let page = self
                         .query_transaction_blocks(
+                            query.clone(),
+                            cursor,
+                            Some(100),
+                            descending_order,
+                        )
+                        .await
+                        .ok()?;
+                    let mut data = page.data;
+                    data.reverse();
+                    data.pop()
+                        .map(|item| (item, (data, page.next_cursor, false, query)))
+                } else {
+                    None
+                }
+            },
+        )
+    }
+
+    /// Get a stream of transactions.
+    pub fn get_transactions_stream_v2(
+        &self,
+        query: IotaTransactionBlockResponseQueryV2,
+        cursor: impl Into<Option<TransactionDigest>>,
+        descending_order: bool,
+    ) -> impl Stream<Item = IotaTransactionBlockResponse> + '_ {
+        let cursor = cursor.into();
+
+        stream::unfold(
+            (vec![], cursor, true, query),
+            move |(mut data, cursor, first, query)| async move {
+                if let Some(item) = data.pop() {
+                    Some((item, (data, cursor, false, query)))
+                } else if (cursor.is_none() && first) || cursor.is_some() {
+                    let page = self
+                        .query_transaction_blocks_v2(
                             query.clone(),
                             cursor,
                             Some(100),

--- a/crates/iota-sdk/src/apis/read.rs
+++ b/crates/iota-sdk/src/apis/read.rs
@@ -520,16 +520,8 @@ impl ReadApi {
             filter: query.filter.as_ref().map(|f| f.as_v2()),
             options: query.options,
         };
-        Ok(self
-            .api
-            .http
-            .query_transaction_blocks_v2(
-                query_v2,
-                cursor.into(),
-                limit.into(),
-                Some(descending_order),
-            )
-            .await?)
+        self.query_transaction_blocks_v2(query_v2, cursor, limit, descending_order)
+            .await
     }
 
     /// Get filtered transaction blocks information.
@@ -592,32 +584,12 @@ impl ReadApi {
         cursor: impl Into<Option<TransactionDigest>>,
         descending_order: bool,
     ) -> impl Stream<Item = IotaTransactionBlockResponse> + '_ {
-        let cursor = cursor.into();
+        let query_v2 = IotaTransactionBlockResponseQueryV2 {
+            filter: query.filter.as_ref().map(|f| f.as_v2()),
+            options: query.options,
+        };
 
-        stream::unfold(
-            (vec![], cursor, true, query),
-            move |(mut data, cursor, first, query)| async move {
-                if let Some(item) = data.pop() {
-                    Some((item, (data, cursor, false, query)))
-                } else if (cursor.is_none() && first) || cursor.is_some() {
-                    let page = self
-                        .query_transaction_blocks(
-                            query.clone(),
-                            cursor,
-                            Some(100),
-                            descending_order,
-                        )
-                        .await
-                        .ok()?;
-                    let mut data = page.data;
-                    data.reverse();
-                    data.pop()
-                        .map(|item| (item, (data, page.next_cursor, false, query)))
-                } else {
-                    None
-                }
-            },
-        )
+        self.get_transactions_stream_v2(query_v2, cursor, descending_order)
     }
 
     /// Get a stream of transactions.


### PR DESCRIPTION
## Description 

Supports the new `TransactionFilterV2::WrappedOrDeletedObject` in the `IotaClient`.

Closes #7628

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [x] Rust SDK: Add `query_transaction_blocks_v2` and `get_transactions_stream_v2` to support `TransactionFilterV2`.