### PR TITLE
upstream(core): Return BTreeMap<ObjectID, &Object> in checkpoint_input_objects

### DIFF
--- a/crates/iota-types/src/full_checkpoint_content.rs
+++ b/crates/iota-types/src/full_checkpoint_content.rs
@@ -94,7 +94,7 @@ pub struct CheckpointTransaction {
     pub transaction: Transaction,
     /// The effects produced by executing this transaction
     pub effects: TransactionEffects,
-    /// The events, if any, emitted by this transactions during execution
+    /// The events, if any, emitted by this transaction during execution
     pub events: Option<TransactionEvents>,
     /// The state of all inputs to this transaction as they were prior to
     /// execution.

--- a/crates/iota-types/src/full_checkpoint_content.rs
+++ b/crates/iota-types/src/full_checkpoint_content.rs
@@ -2,13 +2,13 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 use tap::Pipe;
 
 use crate::{
-    base_types::ObjectRef,
+    base_types::{ObjectID, ObjectRef},
     effects::{
         IDOperation, ObjectIn, ObjectOut, TransactionEffects, TransactionEffectsAPI,
         TransactionEvents,
@@ -57,11 +57,24 @@ impl CheckpointData {
         eventually_removed_object_refs.into_values().collect()
     }
 
-    pub fn input_objects(&self) -> Vec<&Object> {
-        self.transactions
-            .iter()
-            .flat_map(|tx| &tx.input_objects)
-            .collect()
+    /// Returns all objects that are used as input to the transactions in the
+    /// checkpoint, and already exist prior to the checkpoint.
+    pub fn checkpoint_input_objects(&self) -> BTreeMap<ObjectID, &Object> {
+        let mut output_objects_seen = HashSet::new();
+        let mut checkpoint_input_objects = BTreeMap::new();
+        for tx in self.transactions.iter() {
+            for obj in tx.input_objects.iter() {
+                let id = obj.id();
+                if output_objects_seen.contains(&id) || checkpoint_input_objects.contains_key(&id) {
+                    continue;
+                }
+                checkpoint_input_objects.insert(id, obj);
+            }
+            for obj in tx.output_objects.iter() {
+                output_objects_seen.insert(obj.id());
+            }
+        }
+        checkpoint_input_objects
     }
 
     pub fn all_objects(&self) -> Vec<&Object> {
@@ -79,7 +92,7 @@ pub struct CheckpointTransaction {
     pub transaction: Transaction,
     /// The effects produced by executing this transaction
     pub effects: TransactionEffects,
-    /// The events, if any, emitted by this transaction during execution
+    /// The events, if any, emitted by this transactions during execution
     pub events: Option<TransactionEvents>,
     /// The state of all inputs to this transaction as they were prior to
     /// execution.

--- a/crates/iota-types/src/full_checkpoint_content.rs
+++ b/crates/iota-types/src/full_checkpoint_content.rs
@@ -71,6 +71,8 @@ impl CheckpointData {
                 checkpoint_input_objects.insert(id, obj);
             }
             for obj in tx.output_objects.iter() {
+                // We want to track input objects that are not output objects
+                // in the previous transactions.
                 output_objects_seen.insert(obj.id());
             }
         }


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.38.4, v1.39.4)
- Port commit: https://github.com/MystenLabs/sui/commit/f66f5ea889eb046faf4cdd349643880fa19fe157

NOTE: we don't have iota-indexer-alt crate, so only changes in iota-types are applied.


## Links to any relevant issues

Part of #4390  

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

