### PR TITLE
feat(iota-types): introduce `CancelledTransactionsV2`

### DIFF
--- a/crates/iota-types/src/iota_sdk_types_conversions.rs
+++ b/crates/iota-types/src/iota_sdk_types_conversions.rs
@@ -389,6 +389,18 @@ impl TryFrom<crate::transaction::TransactionKind> for TransactionKind {
                                         .collect(),
                             }).collect()
                         },
+                    crate::messages_consensus::ConsensusDeterminedVersionAssignments::CancelledTransactionsV2(vec) =>
+                        ConsensusDeterminedVersionAssignments::CancelledTransactions {
+                            cancelled_transactions: vec.into_iter().map(|value| CancelledTransaction {
+                                digest: value.digest.into(),
+                                version_assignments:
+                                    value
+                                        .version_assignments
+                                        .into_iter()
+                                        .map(|value| VersionAssignment { object_id: value.object_id.into(), version: value.version.value() })
+                                        .collect(),
+                            }).collect()
+                        },
                 };
                 TransactionKind::ConsensusCommitPrologueV1(ConsensusCommitPrologueV1 {
                     epoch: consensus_commit_prologue_v1.epoch,

--- a/crates/iota-types/src/iota_serde.rs
+++ b/crates/iota-types/src/iota_serde.rs
@@ -318,6 +318,29 @@ where
     }
 }
 
+impl SerializeAs<crate::base_types::SequenceNumber> for BigInt<u64> {
+    fn serialize_as<S>(
+        value: &crate::base_types::SequenceNumber,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = value.value().to_string();
+        s.serialize(serializer)
+    }
+}
+
+impl<'de> DeserializeAs<'de, crate::base_types::SequenceNumber> for BigInt<u64> {
+    fn deserialize_as<D>(deserializer: D) -> Result<crate::base_types::SequenceNumber, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let b = BigInt::deserialize(deserializer)?;
+        Ok(crate::base_types::SequenceNumber::from_u64(*b))
+    }
+}
+
 #[serde_as]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Copy, JsonSchema)]
 pub struct SequenceNumber(#[schemars(with = "BigInt<u64>")] u64);

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -16,12 +16,14 @@ use fastcrypto_tbls::dkg_v1;
 use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
 use crate::{
     base_types::{
         AuthorityName, ConciseableName, ObjectID, ObjectRef, SequenceNumber, TransactionDigest,
     },
     digests::ConsensusCommitDigest,
+    iota_serde::BigInt,
     messages_checkpoint::{
         CheckpointSequenceNumber, CheckpointSignatureMessage, CheckpointTimestamp,
     },
@@ -31,12 +33,38 @@ use crate::{
     transaction::CertifiedTransaction,
 };
 
+/// Holds object ID and assigned version for cancelled shared objects.
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+pub struct VersionAssignment {
+    /// ID of shared object that appear in cancelled transactions.
+    pub object_id: ObjectID,
+
+    /// Version assigned to cancelled shared object. It embeds the
+    /// cancellation reason.
+    #[schemars(with = "BigInt<u64>")]
+    #[serde_as(as = "BigInt<u64>")]
+    pub version: SequenceNumber,
+}
+
+/// Holds digest of cancelled transaction and shared object version
+/// assignments.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+pub struct CancelledTransactionV2 {
+    /// Digest of cancelled transaction.
+    pub digest: TransactionDigest,
+
+    /// Version assignments for input shared objects.
+    pub version_assignments: Vec<VersionAssignment>,
+}
+
 /// Uses an enum to allow for future expansion of the
 /// ConsensusDeterminedVersionAssignments.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, JsonSchema)]
 pub enum ConsensusDeterminedVersionAssignments {
     // Cancelled transaction version assignment.
     CancelledTransactions(Vec<(TransactionDigest, Vec<(ObjectID, SequenceNumber)>)>),
+    CancelledTransactionsV2(Vec<CancelledTransactionV2>),
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
# Description of change

Currently existing (tuple) variant `CancelledTransactions(Vec<(TransactionDigest, Vec<(ObjectID, SequenceNumber)>)>)` looks complex and is not very readable and self-documented. This PR adds a new (struct) variant to the `ConsensusDeterminedVersionAssignments` enum. Additionally, since versions of cancelled objects are pretty big numbers (`larger than u64::MAX / 2`), this PR also adds serialization of `SequenceNumber` as `BigInt<u64>`. 

## Links to any relevant issues

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API: