### PR TITLE
feat(consensus): [cherry-pick] Improve synchronizer (#7371)

### DIFF
--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -749,7 +749,11 @@ async fn make_recv_future<T: Clone>(
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeSet, sync::Arc, time::Duration};
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        sync::Arc,
+        time::Duration,
+    };
 
     use async_trait::async_trait;
     use bytes::Bytes;
@@ -819,7 +823,9 @@ mod tests {
             Ok(())
         }
 
-        async fn get_missing_blocks(&self) -> Result<BTreeSet<BlockRef>, CoreError> {
+        async fn get_missing_blocks(
+            &self,
+        ) -> Result<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>, CoreError> {
             Ok(Default::default())
         }
 

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -3,11 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, btree_map::Entry},
     sync::Arc,
     time::Instant,
 };
 
+use consensus_config::AuthorityIndex;
 use iota_metrics::monitored_scope;
 use itertools::Itertools as _;
 use parking_lot::RwLock;
@@ -21,14 +22,15 @@ use crate::{
     dag_state::DagState,
 };
 
-struct SuspendedBlock {
+#[derive(Clone)]
+pub(crate) struct SuspendedBlock {
     block: VerifiedBlock,
     missing_ancestors: BTreeSet<BlockRef>,
     timestamp: Instant,
 }
 
 impl SuspendedBlock {
-    fn new(block: VerifiedBlock, missing_ancestors: BTreeSet<BlockRef>) -> Self {
+    pub(crate) fn new(block: VerifiedBlock, missing_ancestors: BTreeSet<BlockRef>) -> Self {
         Self {
             block,
             missing_ancestors,
@@ -59,10 +61,13 @@ pub(crate) struct BlockManager {
     /// already fetched but it self is still missing some of its ancestors to be
     /// processed.
     missing_ancestors: BTreeMap<BlockRef, BTreeSet<BlockRef>>,
-    /// Keeps all the blocks that we actually miss and haven't fetched them yet.
-    /// That set will basically contain all the keys from the
-    /// `missing_ancestors` minus any keys that exist in `suspended_blocks`.
-    missing_blocks: BTreeSet<BlockRef>,
+    /// A map of currently missing blocks to the set of authorities expected
+    /// to have them available locally. This set is approximated based on the
+    /// block's author and the authors of its direct children.
+    /// A block is considered missing if it appears in `missing_ancestors`
+    /// and has not yet been accepted or fetched. Blocks already stored or
+    /// present in `suspended_blocks` are excluded.
+    missing_blocks: BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
     /// A vector that holds a tuple of (lowest_round, highest_round) of received
     /// blocks per authority. This is used for metrics reporting purposes
     /// and resets during restarts.
@@ -82,7 +87,7 @@ impl BlockManager {
             block_verifier,
             suspended_blocks: BTreeMap::new(),
             missing_ancestors: BTreeMap::new(),
-            missing_blocks: BTreeSet::new(),
+            missing_blocks: BTreeMap::new(),
             received_block_rounds: vec![None; committee_size],
         }
     }
@@ -265,7 +270,11 @@ impl BlockManager {
             }
             // Fetches the block if it is not in dag state or suspended.
             missing_blocks.insert(*block_ref);
-            if self.missing_blocks.insert(*block_ref) {
+            if self
+                .missing_blocks
+                .insert(*block_ref, BTreeSet::from([block_ref.author]))
+                .is_none()
+            {
                 // We want to report this as a missing ancestor even if there is no block that
                 // is actually references it right now. That will allow us
                 // to seamlessly GC the block later if needed.
@@ -476,13 +485,23 @@ impl BlockManager {
                 if !self.suspended_blocks.contains_key(ancestor) {
                     // Fetches the block if it is not in dag state or suspended.
                     ancestors_to_fetch.insert(*ancestor);
-                    if self.missing_blocks.insert(*ancestor) {
-                        self.context
-                            .metrics
-                            .node_metrics
-                            .block_manager_missing_blocks_by_authority
-                            .with_label_values(&[ancestor_hostname])
-                            .inc();
+                    // We also want to keep track of the authorities that have this block.
+                    // This block could be already missing, so we just update the set  of
+                    // authorities who have it.
+                    let entry = self.missing_blocks.entry(*ancestor);
+                    match entry {
+                        Entry::Vacant(v) => {
+                            v.insert(BTreeSet::from([ancestor.author, block_ref.author]));
+                            self.context
+                                .metrics
+                                .node_metrics
+                                .block_manager_missing_blocks_by_authority
+                                .with_label_values(&[ancestor_hostname])
+                                .inc();
+                        }
+                        Entry::Occupied(mut o) => {
+                            o.get_mut().insert(block_ref.author);
+                        }
                     }
                 }
             }
@@ -678,9 +697,16 @@ impl BlockManager {
     }
 
     /// Returns all the blocks that are currently missing and needed in order to
-    /// accept suspended blocks.
-    pub(crate) fn missing_blocks(&self) -> BTreeSet<BlockRef> {
+    /// accept suspended blocks. For each block reference it returns the set of
+    /// authorities who have this block.
+    pub(crate) fn missing_blocks(&self) -> BTreeMap<BlockRef, BTreeSet<AuthorityIndex>> {
         self.missing_blocks.clone()
+    }
+
+    /// Returns all the block refs that are currently missing.
+    #[cfg(test)]
+    pub(crate) fn missing_block_refs(&self) -> BTreeSet<BlockRef> {
+        self.missing_blocks.keys().cloned().collect()
     }
 
     fn update_stats(&mut self, missing_blocks: u64) {
@@ -732,7 +758,7 @@ impl BlockManager {
     /// Returns all the suspended blocks whose causal history we miss hence we
     /// can't accept them yet.
     #[cfg(test)]
-    fn suspended_blocks(&self) -> Vec<BlockRef> {
+    fn suspended_blocks_refs(&self) -> BTreeSet<BlockRef> {
         self.suspended_blocks.keys().cloned().collect()
     }
 }
@@ -819,15 +845,32 @@ mod tests {
         // AND the missing blocks are the parents of the round 2 blocks. Since this is a
         // fully connected DAG taking the ancestors of the first element
         // suffices.
-        assert_eq!(block_manager.missing_blocks(), missing_block_refs);
+        assert_eq!(block_manager.missing_block_refs(), missing_block_refs);
 
         // AND suspended blocks should return the round_2_blocks
         assert_eq!(
-            block_manager.suspended_blocks(),
+            block_manager.suspended_blocks_refs(),
             round_2_blocks
                 .into_iter()
                 .map(|block| block.reference())
-                .collect::<Vec<_>>()
+                .collect::<BTreeSet<_>>()
+        );
+
+        // AND each missing block should be known to all authorities
+        let known_by_manager = block_manager
+            .missing_blocks()
+            .iter()
+            .next()
+            .expect("We should expect at least two elements there")
+            .1
+            .clone();
+        assert_eq!(
+            known_by_manager,
+            context
+                .committee
+                .authorities()
+                .map(|(a, _)| a)
+                .collect::<BTreeSet<_>>()
         );
     }
 
@@ -1111,6 +1154,81 @@ mod tests {
         }
     }
 
+    /// Tests that `missing_blocks()` correctly infers the authorities
+    /// referencing each missing block based on accepted blocks in the DAG.
+    #[tokio::test]
+    async fn authorities_that_know_missing_blocks() {
+        let (context, _key_pairs) = Context::new_for_test(4);
+
+        let context = Arc::new(context);
+
+        // create a DAG of rounds 1 ~ 3
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=3).build();
+
+        let all_blocks = dag_builder.blocks.values().cloned().collect::<Vec<_>>();
+
+        let blocks_round_2 = all_blocks
+            .iter()
+            .filter(|block| block.round() == 2)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let blocks_round_1 = all_blocks
+            .iter()
+            .filter(|block| block.round() == 1)
+            .map(|block| block.reference())
+            .collect::<BTreeSet<_>>();
+
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+
+        let mut block_manager =
+            BlockManager::new(context.clone(), dag_state, Arc::new(NoopBlockVerifier));
+
+        let (_, missing_blocks) = block_manager.try_accept_blocks(vec![blocks_round_2[0].clone()]);
+        // Blocks from round 1 are all missing, since the DAG is fully connected
+        assert_eq!(missing_blocks, blocks_round_1);
+
+        let missing_blocks_with_authorities = block_manager.missing_blocks();
+
+        let block_round_1_authority_0 = all_blocks
+            .iter()
+            .filter(|block| block.round() == 1 && block.author() == AuthorityIndex::new_for_test(0))
+            .map(|block| block.reference())
+            .next()
+            .unwrap();
+        let block_round_1_authority_1 = all_blocks
+            .iter()
+            .filter(|block| block.round() == 1 && block.author() == AuthorityIndex::new_for_test(1))
+            .map(|block| block.reference())
+            .next()
+            .unwrap();
+        assert_eq!(
+            missing_blocks_with_authorities[&block_round_1_authority_0],
+            BTreeSet::from([AuthorityIndex::new_for_test(0)])
+        );
+        assert_eq!(
+            missing_blocks_with_authorities[&block_round_1_authority_1],
+            BTreeSet::from([
+                AuthorityIndex::new_for_test(0),
+                AuthorityIndex::new_for_test(1)
+            ])
+        );
+
+        // Add a new block from round 2 from authority 1, which updates the set of
+        // authorities that are aware of the missing blocks
+        block_manager.try_accept_blocks(vec![blocks_round_2[1].clone()]);
+        let missing_blocks_with_authorities = block_manager.missing_blocks();
+        assert_eq!(
+            missing_blocks_with_authorities[&block_round_1_authority_0],
+            BTreeSet::from([
+                AuthorityIndex::new_for_test(0),
+                AuthorityIndex::new_for_test(1)
+            ])
+        );
+    }
+
     #[rstest]
     #[tokio::test]
     async fn unsuspend_blocks_for_latest_gc_round(#[values(5, 10, 14)] gc_depth: u32) {
@@ -1353,7 +1471,7 @@ mod tests {
 
         // Other blocks should be rejected and there should be no remaining suspended
         // block.
-        assert!(block_manager.suspended_blocks().is_empty());
+        assert!(block_manager.suspended_blocks_refs().is_empty());
     }
 
     #[tokio::test]
@@ -1405,7 +1523,7 @@ mod tests {
             missing_block_refs.iter().cloned().collect::<BTreeSet<_>>();
         assert_eq!(missing, missing_block_refs_from_accept);
         assert_eq!(
-            block_manager.missing_blocks(),
+            block_manager.missing_block_refs(),
             missing_block_refs_from_accept
         );
 
@@ -1436,7 +1554,7 @@ mod tests {
                 .all(|block_ref| block_ref.round == 3)
         );
         assert_eq!(
-            block_manager.missing_blocks(),
+            block_manager.missing_block_refs(),
             missing_block_refs_from_accept
                 .into_iter()
                 .chain(missing_block_refs_from_find.into_iter())

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -939,7 +939,7 @@ impl Core {
         Ok(committed_sub_dags)
     }
 
-    pub(crate) fn get_missing_blocks(&self) -> BTreeSet<BlockRef> {
+    pub(crate) fn get_missing_blocks(&self) -> BTreeMap<BlockRef, BTreeSet<AuthorityIndex>> {
         let _scope = monitored_scope("Core::get_missing_blocks");
         self.block_manager.missing_blocks()
     }

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     fmt::Debug,
     sync::{
         Arc,
@@ -12,6 +12,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use consensus_config::AuthorityIndex;
 use iota_metrics::{
     monitored_mpsc::{Receiver, Sender, WeakSender, channel},
     monitored_scope, spawn_logged_monitored_task,
@@ -48,8 +49,9 @@ enum CoreThreadCommand {
     /// any checks (ex leader existence of previous round). More information can
     /// be found on the `Core` component.
     NewBlock(Round, oneshot::Sender<()>, bool),
-    /// Request missing blocks that need to be synced.
-    GetMissing(oneshot::Sender<BTreeSet<BlockRef>>),
+    /// Request missing blocks that need to be synced together with authorities
+    /// that have these blocks.
+    GetMissingBlocks(oneshot::Sender<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>>),
 }
 
 #[derive(Error, Debug)]
@@ -77,7 +79,9 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
 
     async fn new_block(&self, round: Round, force: bool) -> Result<(), CoreError>;
 
-    async fn get_missing_blocks(&self) -> Result<BTreeSet<BlockRef>, CoreError>;
+    async fn get_missing_blocks(
+        &self,
+    ) -> Result<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>, CoreError>;
 
     /// Informs the core whether consumer of produced blocks exists.
     /// This is only used by core to decide if it should propose new blocks.
@@ -155,8 +159,8 @@ impl CoreThread {
                             self.core.new_block(round, force)?;
                             sender.send(()).ok();
                         }
-                        CoreThreadCommand::GetMissing(sender) => {
-                            let _scope = monitored_scope("CoreThread::loop::get_missing");
+                        CoreThreadCommand::GetMissingBlocks(sender) => {
+                            let _scope = monitored_scope("CoreThread::loop::get_missing_blocks");
                             sender.send(self.core.get_missing_blocks()).ok();
                         }
                     }
@@ -353,9 +357,11 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
         receiver.await.map_err(|e| Shutdown(e.to_string()))
     }
 
-    async fn get_missing_blocks(&self) -> Result<BTreeSet<BlockRef>, CoreError> {
+    async fn get_missing_blocks(
+        &self,
+    ) -> Result<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>, CoreError> {
         let (sender, receiver) = oneshot::channel();
-        self.send(CoreThreadCommand::GetMissing(sender)).await;
+        self.send(CoreThreadCommand::GetMissingBlocks(sender)).await;
         receiver.await.map_err(|e| Shutdown(e.to_string()))
     }
 
@@ -424,7 +430,7 @@ pub(crate) mod tests {
     #[derive(Default)]
     pub(crate) struct MockCoreThreadDispatcher {
         add_blocks: parking_lot::Mutex<Vec<VerifiedBlock>>,
-        missing_blocks: parking_lot::Mutex<BTreeSet<BlockRef>>,
+        missing_blocks: parking_lot::Mutex<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>>,
         last_known_proposed_round: parking_lot::Mutex<Vec<Round>>,
     }
 
@@ -436,7 +442,9 @@ pub(crate) mod tests {
 
         pub(crate) async fn stub_missing_blocks(&self, block_refs: BTreeSet<BlockRef>) {
             let mut missing_blocks = self.missing_blocks.lock();
-            missing_blocks.extend(block_refs);
+            for block_ref in &block_refs {
+                missing_blocks.insert(*block_ref, BTreeSet::from([block_ref.author]));
+            }
         }
 
         pub(crate) async fn get_last_own_proposed_round(&self) -> Vec<Round> {
@@ -474,7 +482,9 @@ pub(crate) mod tests {
             Ok(())
         }
 
-        async fn get_missing_blocks(&self) -> Result<BTreeSet<BlockRef>, CoreError> {
+        async fn get_missing_blocks(
+            &self,
+        ) -> Result<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>, CoreError> {
             let mut missing_blocks = self.missing_blocks.lock();
             let result = missing_blocks.clone();
             missing_blocks.clear();

--- a/consensus/core/src/leader_timeout.rs
+++ b/consensus/core/src/leader_timeout.rs
@@ -133,10 +133,14 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeSet, sync::Arc, time::Duration};
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        sync::Arc,
+        time::Duration,
+    };
 
     use async_trait::async_trait;
-    use consensus_config::Parameters;
+    use consensus_config::{AuthorityIndex, Parameters};
     use parking_lot::Mutex;
     use tokio::time::{Instant, sleep};
 
@@ -193,7 +197,9 @@ mod tests {
             Ok(())
         }
 
-        async fn get_missing_blocks(&self) -> Result<BTreeSet<BlockRef>, CoreError> {
+        async fn get_missing_blocks(
+            &self,
+        ) -> Result<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>, CoreError> {
             todo!()
         }
 

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -128,9 +128,11 @@ pub(crate) struct NodeMetrics {
     pub(crate) fetch_blocks_scheduler_inflight: IntGauge,
     pub(crate) fetch_blocks_scheduler_skipped: IntCounterVec,
     pub(crate) synchronizer_fetched_blocks_by_peer: IntCounterVec,
+    pub(crate) synchronizer_requested_blocks_by_peer: IntCounterVec,
     pub(crate) synchronizer_missing_blocks_by_authority: IntCounterVec,
     pub(crate) synchronizer_current_missing_blocks_by_authority: IntGaugeVec,
     pub(crate) synchronizer_fetched_blocks_by_authority: IntCounterVec,
+    pub(crate) synchronizer_requested_blocks_by_authority: IntCounterVec,
     pub(crate) network_received_excluded_ancestors_from_authority: IntCounterVec,
     pub(crate) network_excluded_ancestors_sent_to_fetch: IntCounterVec,
     pub(crate) network_excluded_ancestors_count_by_authority: IntCounterVec,
@@ -378,6 +380,12 @@ impl NodeMetrics {
                 &["peer", "type"],
                 registry,
             ).unwrap(),
+            synchronizer_requested_blocks_by_peer: register_int_counter_vec_with_registry!(
+                "synchronizer_requested_blocks_by_peer",
+                "Number of requested blocks per peer authority via the synchronizer and also by block authority",
+                &["peer", "type"],
+                registry,
+            ).unwrap(),
             synchronizer_missing_blocks_by_authority: register_int_counter_vec_with_registry!(
                 "synchronizer_missing_blocks_by_authority",
                 "Number of missing blocks per block author, as observed by the synchronizer during periodic sync.",
@@ -393,6 +401,12 @@ impl NodeMetrics {
             synchronizer_fetched_blocks_by_authority: register_int_counter_vec_with_registry!(
                 "synchronizer_fetched_blocks_by_authority",
                 "Number of fetched blocks per block author via the synchronizer",
+                &["authority", "type"],
+                registry,
+            ).unwrap(),
+            synchronizer_requested_blocks_by_authority: register_int_counter_vec_with_registry!(
+                "synchronizer_requested_blocks_by_authority",
+                "Number of requested blocks per block author via the synchronizer",
                 &["authority", "type"],
                 registry,
             ).unwrap(),

--- a/consensus/core/src/round_prober.rs
+++ b/consensus/core/src/round_prober.rs
@@ -359,7 +359,11 @@ fn compute_quorum_round(
 
 #[cfg(test)]
 mod test {
-    use std::{collections::BTreeSet, sync::Arc, time::Duration};
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        sync::Arc,
+        time::Duration,
+    };
 
     use async_trait::async_trait;
     use bytes::Bytes;
@@ -437,7 +441,9 @@ mod test {
             unimplemented!()
         }
 
-        async fn get_missing_blocks(&self) -> Result<BTreeSet<BlockRef>, CoreError> {
+        async fn get_missing_blocks(
+            &self,
+        ) -> Result<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>, CoreError> {
             unimplemented!()
         }
 

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     sync::Arc,
     time::Duration,
 };
@@ -20,7 +20,7 @@ use iota_metrics::{
 use itertools::Itertools as _;
 use parking_lot::{Mutex, RwLock};
 #[cfg(not(test))]
-use rand::{prelude::SliceRandom, rngs::ThreadRng};
+use rand::prelude::{IteratorRandom, SeedableRng, SliceRandom, StdRng};
 use tap::TapFallible;
 use tokio::{
     runtime::Handle,
@@ -55,7 +55,7 @@ const FETCH_FROM_PEERS_TIMEOUT: Duration = Duration::from_millis(4_000);
 /// can finish on hosts with good network using the timeouts above.
 const MAX_BLOCKS_PER_FETCH: usize = 32;
 
-const MAX_AUTHORITIES_TO_FETCH_PER_BLOCK: usize = 2;
+const MAX_AUTHORITIES_TO_FETCH_PER_BLOCK: usize = 3;
 
 /// The number of rounds above the highest accepted round that still willing to
 /// fetch missing blocks via the periodic synchronizer. Any missing blocks of
@@ -471,7 +471,33 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                     // get the highest accepted rounds
                     let highest_rounds = Self::get_highest_accepted_rounds(dag_state.clone(), &context);
 
-                    requests.push(Self::fetch_blocks_request(network_client.clone(), peer_index, blocks_guard, highest_rounds, FETCH_REQUEST_TIMEOUT, 1))
+                    // Record metrics for live synchronizer requests
+                    let metrics = &context.metrics.node_metrics;
+                    metrics
+                        .synchronizer_requested_blocks_by_peer
+                        .with_label_values(&[peer_hostname.as_str(), "live"])
+                        .inc_by(blocks_guard.block_refs.len() as u64);
+                    // Count requested blocks per authority and increment metric by one per authority
+                    let mut authors = HashSet::new();
+                    for block_ref in &blocks_guard.block_refs {
+                        authors.insert(block_ref.author);
+                    }
+                    for author in authors {
+                        let host = &context.committee.authority(author).hostname;
+                        metrics
+                            .synchronizer_requested_blocks_by_authority
+                            .with_label_values(&[host.as_str(), "live"])
+                            .inc();
+                    }
+
+                    requests.push(Self::fetch_blocks_request(
+                        network_client.clone(),
+                        peer_index,
+                        blocks_guard,
+                        highest_rounds,
+                        FETCH_REQUEST_TIMEOUT,
+                        1,
+                    ))
                 },
                 Some((response, blocks_guard, retries, _peer, highest_rounds)) = requests.next() => {
                     match response {
@@ -911,10 +937,10 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             let highest_accepted_round = dag_state.read().highest_accepted_round();
             missing_blocks = missing_blocks
                 .into_iter()
-                .take_while(|b| {
-                    b.round <= highest_accepted_round + SYNC_MISSING_BLOCK_ROUND_THRESHOLD
+                .take_while(|(block_ref, _)| {
+                    block_ref.round <= highest_accepted_round + SYNC_MISSING_BLOCK_ROUND_THRESHOLD
                 })
-                .collect::<BTreeSet<_>>();
+                .collect::<BTreeMap<_, _>>();
 
             // If no missing blocks are within the acceptable thresholds to sync while we
             // commit lag, then we disable the scheduler completely for this run.
@@ -1008,8 +1034,16 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         )
     }
 
-    /// Fetches the `missing_blocks` from available peers. The method will
-    /// attempt to split the load amongst multiple (random) peers.
+    /// Fetches the given `missing_blocks` from up to `MAX_PEERS` authorities in
+    /// parallel:
+    ///
+    /// Randomly select `MAX_PEERS - MAX_RANDOM_PEERS` peers from those who
+    /// are known to hold some missing block, requesting up to
+    /// `MAX_BLOCKS_PER_FETCH` block refs per peer.
+    ///
+    /// Randomly select `MAX_RANDOM_PEERS` additional peers from the
+    ///  committee (excluding self and those already selected).
+    ///
     /// The method returns a vector with the fetched blocks from each peer that
     /// successfully responded and any corresponding additional ancestor blocks.
     /// Each element of the vector is a tuple which contains the requested
@@ -1018,19 +1052,117 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         context: Arc<Context>,
         inflight_blocks: Arc<InflightBlocksMap>,
         network_client: Arc<C>,
-        missing_blocks: BTreeSet<BlockRef>,
+        missing_blocks: BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
         dag_state: Arc<RwLock<DagState>>,
     ) -> Vec<(BlocksGuard, Vec<Bytes>, AuthorityIndex)> {
-        const MAX_PEERS: usize = 3;
+        // The maximum number of peers which will be requested in periodic synchronizer
+        const MAX_PEERS: usize = 4;
+        // The maximum number of peers which are chosen totally random to fetch blocks
+        // from
+        const MAX_RANDOM_PEERS: usize = 2;
 
-        // Attempt to fetch only up to a max of blocks
-        let missing_blocks = missing_blocks
+        // Step 1: Map authorities to missing blocks that they are aware of
+        let mut authority_to_blocks: HashMap<AuthorityIndex, Vec<BlockRef>> = HashMap::new();
+        for (missing_block_ref, authorities) in &missing_blocks {
+            for author in authorities {
+                if author == &context.own_index {
+                    // Skip our own index as we don't want to fetch blocks from ourselves
+                    continue;
+                }
+                authority_to_blocks
+                    .entry(*author)
+                    .or_default()
+                    .push(*missing_block_ref);
+            }
+        }
+
+        // Step 2: Choose at most MAX_PEERS-MAX_RANDOM_PEERS peers from those who are
+        // aware of some missing blocks
+
+        #[cfg(not(test))]
+        let mut rng = StdRng::from_entropy();
+
+        // Randomly pick up MAX_PEERS - MAX_RANDOM_PEERS authorities that are aware of
+        // missing blocks
+        #[cfg(not(test))]
+        let mut chosen_peers_with_blocks: Vec<(AuthorityIndex, Vec<BlockRef>, &str)> =
+            authority_to_blocks
+                .iter()
+                .choose_multiple(&mut rng, MAX_PEERS - MAX_RANDOM_PEERS)
+                .into_iter()
+                .map(|(&peer, blocks)| {
+                    let limited_blocks =
+                        blocks.iter().copied().take(MAX_BLOCKS_PER_FETCH).collect();
+                    (peer, limited_blocks, "periodic_known")
+                })
+                .collect();
+        #[cfg(test)]
+        // Deterministically pick the smallest (MAX_PEERS - MAX_RANDOM_PEERS) authority indices
+        let mut chosen_peers_with_blocks: Vec<(AuthorityIndex, Vec<BlockRef>, &str)> = {
+            let mut items: Vec<(AuthorityIndex, Vec<BlockRef>, &str)> = authority_to_blocks
+                .iter()
+                .map(|(&peer, blocks)| {
+                    let limited_blocks =
+                        blocks.iter().copied().take(MAX_BLOCKS_PER_FETCH).collect();
+                    (peer, limited_blocks, "periodic_known")
+                })
+                .collect();
+            // Sort by AuthorityIndex (natural order), then take the first MAX_PEERS -
+            // MAX_RANDOM_PEERS
+            items.sort_by_key(|(peer, _, _)| *peer);
+            items
+                .into_iter()
+                .take(MAX_PEERS - MAX_RANDOM_PEERS)
+                .collect()
+        };
+
+        // Step 3: Choose at most two random peers not known to be aware of the missing
+        // blocks
+        let already_chosen: HashSet<AuthorityIndex> = chosen_peers_with_blocks
+            .iter()
+            .map(|(peer, _, _)| *peer)
+            .collect();
+
+        let random_candidates: Vec<_> = context
+            .committee
+            .authorities()
+            .filter_map(|(peer_index, _)| {
+                (peer_index != context.own_index && !already_chosen.contains(&peer_index))
+                    .then_some(peer_index)
+            })
+            .collect();
+        #[cfg(test)]
+        let random_peers: Vec<AuthorityIndex> = random_candidates
             .into_iter()
-            .take(MAX_PEERS * MAX_BLOCKS_PER_FETCH)
-            .collect::<Vec<_>>();
+            .take(MAX_RANDOM_PEERS)
+            .collect();
+        #[cfg(not(test))]
+        let random_peers: Vec<AuthorityIndex> = random_candidates
+            .into_iter()
+            .choose_multiple(&mut rng, MAX_RANDOM_PEERS);
 
+        #[cfg_attr(test, allow(unused_mut))]
+        let mut all_missing_blocks: Vec<BlockRef> = missing_blocks.keys().cloned().collect();
+        #[cfg(not(test))]
+        all_missing_blocks.shuffle(&mut rng);
+
+        let mut block_chunks = all_missing_blocks.chunks(MAX_BLOCKS_PER_FETCH);
+
+        for peer in random_peers {
+            if let Some(chunk) = block_chunks.next() {
+                chosen_peers_with_blocks.push((peer, chunk.to_vec(), "periodic_random"));
+            } else {
+                break;
+            }
+        }
+
+        let mut request_futures = FuturesUnordered::new();
+
+        let highest_rounds = Self::get_highest_accepted_rounds(dag_state, &context);
+
+        // Record the missing blocks per authority for metrics
         let mut missing_blocks_per_authority = vec![0; context.committee.size()];
-        for block in &missing_blocks {
+        for block in &all_missing_blocks {
             missing_blocks_per_authority[block.author] += 1;
         }
         for (missing, (_, authority)) in missing_blocks_per_authority
@@ -1051,32 +1183,36 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 .set(missing as i64);
         }
 
+        // Look at peers that were not chosen yet and try to fetch blocks from them if
+        // needed later
         #[cfg_attr(test, expect(unused_mut))]
-        let mut peers = context
+        let mut remaining_peers: Vec<_> = context
             .committee
             .authorities()
-            .filter_map(|(peer_index, _)| (peer_index != context.own_index).then_some(peer_index))
-            .collect::<Vec<_>>();
+            .filter_map(|(peer_index, _)| {
+                if peer_index != context.own_index
+                    && !chosen_peers_with_blocks
+                        .iter()
+                        .any(|(chosen_peer, _, _)| *chosen_peer == peer_index)
+                {
+                    Some(peer_index)
+                } else {
+                    None
+                }
+            })
+            .collect();
 
-        // In test, the order is not randomized
         #[cfg(not(test))]
-        peers.shuffle(&mut ThreadRng::default());
-
-        let mut peers = peers.into_iter();
-        let mut request_futures = FuturesUnordered::new();
-
-        let highest_rounds = Self::get_highest_accepted_rounds(dag_state, &context);
+        remaining_peers.shuffle(&mut rng);
+        let mut remaining_peers = remaining_peers.into_iter();
 
         // Send the initial requests
-        for blocks in missing_blocks.chunks(MAX_BLOCKS_PER_FETCH) {
-            let peer = peers
-                .next()
-                .expect("Possible misconfiguration as a peer should be found");
+        for (peer, blocks_to_request, label) in chosen_peers_with_blocks {
             let peer_hostname = &context.committee.authority(peer).hostname;
-            let block_refs = blocks.iter().cloned().collect::<BTreeSet<_>>();
+            let block_refs = blocks_to_request.iter().cloned().collect::<BTreeSet<_>>();
 
-            // lock the blocks to be fetched. If no lock can be acquired for any of the
-            // blocks then don't bother
+            // Lock the blocks to be fetched. If no lock can be acquired for any of the
+            // blocks then don't bother.
             if let Some(blocks_guard) = inflight_blocks.lock_blocks(block_refs.clone(), peer) {
                 info!(
                     "Periodic sync of {} missing blocks from peer {} {}: {}",
@@ -1089,6 +1225,19 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                         .collect::<Vec<_>>()
                         .join(", ")
                 );
+                // Record metrics about requested blocks
+                let metrics = &context.metrics.node_metrics;
+                metrics
+                    .synchronizer_requested_blocks_by_peer
+                    .with_label_values(&[peer_hostname.as_str(), label])
+                    .inc_by(block_refs.len() as u64);
+                for block_ref in &block_refs {
+                    let block_hostname = &context.committee.authority(block_ref.author).hostname;
+                    metrics
+                        .synchronizer_requested_blocks_by_authority
+                        .with_label_values(&[block_hostname.as_str(), label])
+                        .inc();
+                }
                 request_futures.push(Self::fetch_blocks_request(
                     network_client.clone(),
                     peer,
@@ -1121,7 +1270,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                         },
                         Err(_) => {
                             // try again if there is any peer left
-                            if let Some(next_peer) = peers.next() {
+                            if let Some(next_peer) = remaining_peers.next() {
                                 // do best effort to lock guards. If we can't lock then don't bother at this run.
                                 if let Some(blocks_guard) = inflight_blocks.swap_locks(blocks_guard, next_peer) {
                                     info!(
@@ -1134,6 +1283,21 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                                             .collect::<Vec<_>>()
                                             .join(", ")
                                     );
+                                    let block_refs = blocks_guard.block_refs.clone();
+                                    // Record metrics about requested blocks
+                                    let metrics = &context.metrics.node_metrics;
+                                    metrics
+                                        .synchronizer_requested_blocks_by_peer
+                                        .with_label_values(&[peer_hostname.as_str(), "periodic_retry"])
+                                        .inc_by(block_refs.len() as u64);
+                                    for block_ref in &block_refs {
+                                        let block_hostname =
+                                            &context.committee.authority(block_ref.author).hostname;
+                                        metrics
+                                            .synchronizer_requested_blocks_by_authority
+                                            .with_label_values(&[block_hostname.as_str(), "periodic_retry"])
+                                            .inc();
+                                    }
                                     request_futures.push(Self::fetch_blocks_request(
                                         network_client.clone(),
                                         next_peer,
@@ -1181,13 +1345,14 @@ mod tests {
         authority_service::COMMIT_LAG_MULTIPLIER,
         block::{BlockDigest, BlockRef, Round, TestBlock, VerifiedBlock},
         block_verifier::NoopBlockVerifier,
-        commit::{CommitRange, CommitVote, TrustedCommit},
+        commit::{CertifiedCommits, CommitRange, CommitVote, TrustedCommit},
         commit_vote_monitor::CommitVoteMonitor,
         context::Context,
-        core_thread::{CoreThreadDispatcher, tests::MockCoreThreadDispatcher},
+        core_thread::{CoreError, CoreThreadDispatcher, tests::MockCoreThreadDispatcher},
         dag_state::DagState,
         error::{ConsensusError, ConsensusResult},
         network::{BlockStream, NetworkClient},
+        round_prober::QuorumRound,
         storage::mem_store::MemStore,
         synchronizer::{
             FETCH_BLOCKS_CONCURRENCY, FETCH_REQUEST_TIMEOUT, InflightBlocksMap,
@@ -1355,8 +1520,8 @@ mod tests {
         {
             let mut all_guards = Vec::new();
 
-            // Try to acquire the block locks for authorities 1 & 2
-            for i in 1..=2 {
+            // Try to acquire the block locks for authorities 1 & 2 & 3
+            for i in 1..=3 {
                 let authority = AuthorityIndex::new_for_test(i);
 
                 let guard = map.lock_blocks(missing_block_refs.clone(), authority);
@@ -1372,16 +1537,16 @@ mod tests {
 
             // Trying to acquire for authority 3 it will fail - as we have maxed out the
             // number of allowed peers
-            let authority_3 = AuthorityIndex::new_for_test(3);
+            let authority_4 = AuthorityIndex::new_for_test(4);
 
-            let guard = map.lock_blocks(missing_block_refs.clone(), authority_3);
+            let guard = map.lock_blocks(missing_block_refs.clone(), authority_4);
             assert!(guard.is_none());
 
             // Explicitly drop the guard of authority 1 and try for authority 3 again - it
             // will now succeed
             drop(all_guards.remove(0));
 
-            let guard = map.lock_blocks(missing_block_refs.clone(), authority_3);
+            let guard = map.lock_blocks(missing_block_refs.clone(), authority_4);
             let guard = guard.expect("Guard should be successfully acquired");
 
             assert_eq!(guard.block_refs, missing_block_refs);
@@ -1571,7 +1736,7 @@ mod tests {
             false,
         );
 
-        sleep(2 * FETCH_REQUEST_TIMEOUT).await;
+        sleep(8 * FETCH_REQUEST_TIMEOUT).await;
 
         // THEN the missing blocks should now be fetched and added to core
         let added_blocks = core_dispatcher.get_add_blocks().await;
@@ -1747,7 +1912,7 @@ mod tests {
             commit_vote_monitor.observe_block(&block);
         }
 
-        // WHEN start the synchronizer and wait for a couple of seconds where normally
+        // Start the synchronizer and wait for a couple of seconds where normally
         // the synchronizer should have kicked in.
         let _handle = Synchronizer::start(
             network_client.clone(),
@@ -1917,5 +2082,296 @@ mod tests {
                 std::panic::resume_unwind(err.into_panic());
             }
         }
+    }
+    #[derive(Default)]
+    struct SyncMockDispatcher {
+        missing_blocks: Mutex<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>>,
+        added_blocks: Mutex<Vec<VerifiedBlock>>,
+    }
+
+    #[async_trait::async_trait]
+    impl CoreThreadDispatcher for SyncMockDispatcher {
+        async fn get_missing_blocks(
+            &self,
+        ) -> Result<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>, CoreError> {
+            Ok(self.missing_blocks.lock().await.clone())
+        }
+        async fn add_blocks(
+            &self,
+            blocks: Vec<VerifiedBlock>,
+        ) -> Result<BTreeSet<BlockRef>, CoreError> {
+            let mut guard = self.added_blocks.lock().await;
+            guard.extend(blocks.clone());
+            Ok(blocks.iter().map(|b| b.reference()).collect())
+        }
+
+        // Stub out the remaining CoreThreadDispatcher methods with defaults:
+
+        async fn check_block_refs(
+            &self,
+            block_refs: Vec<BlockRef>,
+        ) -> Result<BTreeSet<BlockRef>, CoreError> {
+            // Echo back the requested refs by default
+            Ok(block_refs.into_iter().collect())
+        }
+
+        async fn add_certified_commits(
+            &self,
+            _commits: CertifiedCommits,
+        ) -> Result<BTreeSet<BlockRef>, CoreError> {
+            // No additional certified-commit logic in tests
+            Ok(BTreeSet::new())
+        }
+
+        async fn new_block(&self, _round: Round, _force: bool) -> Result<(), CoreError> {
+            Ok(())
+        }
+
+        fn set_quorum_subscribers_exists(&self, _exists: bool) -> Result<(), CoreError> {
+            Ok(())
+        }
+
+        fn set_propagation_delay_and_quorum_rounds(
+            &self,
+            _delay: Round,
+            _received_quorum_rounds: Vec<QuorumRound>,
+            _accepted_quorum_rounds: Vec<QuorumRound>,
+        ) -> Result<(), CoreError> {
+            Ok(())
+        }
+
+        fn set_last_known_proposed_round(&self, _round: Round) -> Result<(), CoreError> {
+            Ok(())
+        }
+
+        fn highest_received_rounds(&self) -> Vec<Round> {
+            Vec::new()
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn known_before_random_peer_fetch() {
+        {
+            // 1) Setup 10‐node context and in‐mem DAG
+            let (ctx, _) = Context::new_for_test(10);
+            let context = Arc::new(ctx);
+            let store = Arc::new(MemStore::new());
+            let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+            let inflight = InflightBlocksMap::new();
+
+            // 2) One missing block
+            let missing_vb = VerifiedBlock::new_for_test(TestBlock::new(100, 3).build());
+            let missing_ref = missing_vb.reference();
+            let missing_blocks = BTreeMap::from([(
+                missing_ref,
+                BTreeSet::from([
+                    AuthorityIndex::new_for_test(2),
+                    AuthorityIndex::new_for_test(3),
+                    AuthorityIndex::new_for_test(4),
+                ]),
+            )]);
+
+            // 3) Prepare mocks and stubs
+            let network_client = Arc::new(MockNetworkClient::default());
+            // Stub *all*  authorities so none panic:
+            for i in 1..=9 {
+                let peer = AuthorityIndex::new_for_test(i);
+                if i == 1 || i == 4 {
+                    network_client
+                        .stub_fetch_blocks(
+                            vec![missing_vb.clone()],
+                            peer,
+                            Some(2 * FETCH_REQUEST_TIMEOUT),
+                        )
+                        .await;
+                    continue;
+                }
+                network_client
+                    .stub_fetch_blocks(vec![missing_vb.clone()], peer, None)
+                    .await;
+            }
+
+            // 4) Invoke knowledge-based fetch and random fallback selection
+            //    deterministically
+            let results = Synchronizer::<MockNetworkClient, NoopBlockVerifier, SyncMockDispatcher>
+        ::fetch_blocks_from_authorities(
+            context.clone(),
+            inflight.clone(),
+            network_client.clone(),
+            missing_blocks,
+            dag_state.clone(),
+        )
+            .await;
+
+            // 5) Assert we got exactly two fetches - two from the first two who are aware
+            //    of the missing block (authority 2 and 3)
+            assert_eq!(results.len(), 2);
+
+            // 6) The  knowledge-based‐fetch went to peer 2 and 3
+            let (_hot_guard, hot_bytes, hot_peer) = &results[0];
+            assert_eq!(*hot_peer, AuthorityIndex::new_for_test(2));
+            let (_periodic_guard, _periodic_bytes, periodic_peer) = &results[1];
+            assert_eq!(*periodic_peer, AuthorityIndex::new_for_test(3));
+            // 7) Verify the returned bytes correspond to that block
+            let expected = missing_vb.serialized().clone();
+            assert_eq!(hot_bytes, &vec![expected]);
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn known_before_periodic_peer_fetch_larger_scenario() {
+        use std::{
+            collections::{BTreeMap, BTreeSet},
+            sync::Arc,
+        };
+
+        use parking_lot::RwLock;
+
+        use crate::{
+            block::{Round, TestBlock, VerifiedBlock},
+            context::Context,
+        };
+
+        // 1) Setup a 10-node context, in-memory DAG, and inflight map
+        let (ctx, _) = Context::new_for_test(10);
+        let context = Arc::new(ctx);
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let inflight = InflightBlocksMap::new();
+        let network_client = Arc::new(MockNetworkClient::default());
+
+        // 2) Create 1000 missing blocks known by authorities 0, 2, and 3
+        let mut missing_blocks = BTreeMap::new();
+        let mut missing_vbs = Vec::new();
+        let known_number_blocks = 10;
+        for i in 0..1000 {
+            let vb = VerifiedBlock::new_for_test(TestBlock::new(1000 + i as Round, 0).build());
+            let r = vb.reference();
+            if i < known_number_blocks {
+                // First 10 blocks are known by authorities 0, 2
+                missing_blocks.insert(
+                    r,
+                    BTreeSet::from([
+                        AuthorityIndex::new_for_test(0),
+                        AuthorityIndex::new_for_test(2),
+                    ]),
+                );
+            } else if i >= known_number_blocks && i < 2 * known_number_blocks {
+                // Second 10 blocks are known by authorities 0, 3
+                missing_blocks.insert(
+                    r,
+                    BTreeSet::from([
+                        AuthorityIndex::new_for_test(0),
+                        AuthorityIndex::new_for_test(3),
+                    ]),
+                );
+            } else {
+                // The rest are only known by authority 0
+                missing_blocks.insert(r, BTreeSet::from([AuthorityIndex::new_for_test(0)]));
+            }
+            missing_vbs.push(vb);
+        }
+
+        // 3) Stub fetches for knowledge-based peers (2 and 3)
+        let known_peers = [2, 3].map(AuthorityIndex::new_for_test);
+        let known_vbs_by_peer: Vec<(AuthorityIndex, Vec<VerifiedBlock>)> = known_peers
+            .iter()
+            .map(|&peer| {
+                let vbs = missing_vbs
+                    .iter()
+                    .filter(|vb| missing_blocks.get(&vb.reference()).unwrap().contains(&peer))
+                    .take(MAX_BLOCKS_PER_FETCH)
+                    .cloned()
+                    .collect::<Vec<_>>();
+                (peer, vbs)
+            })
+            .collect();
+
+        for (peer, vbs) in known_vbs_by_peer {
+            if peer == AuthorityIndex::new_for_test(2) {
+                // Simulate timeout for peer 2, then fallback to peer 5
+                network_client
+                    .stub_fetch_blocks(vbs.clone(), peer, Some(2 * FETCH_REQUEST_TIMEOUT))
+                    .await;
+                network_client
+                    .stub_fetch_blocks(vbs.clone(), AuthorityIndex::new_for_test(5), None)
+                    .await;
+            } else {
+                network_client
+                    .stub_fetch_blocks(vbs.clone(), peer, None)
+                    .await;
+            }
+        }
+
+        // 4) Stub fetches from periodic path peers (1 and 4)
+        network_client
+            .stub_fetch_blocks(
+                missing_vbs[0..MAX_BLOCKS_PER_FETCH].to_vec(),
+                AuthorityIndex::new_for_test(1),
+                None,
+            )
+            .await;
+
+        network_client
+            .stub_fetch_blocks(
+                missing_vbs[MAX_BLOCKS_PER_FETCH..2 * MAX_BLOCKS_PER_FETCH].to_vec(),
+                AuthorityIndex::new_for_test(4),
+                None,
+            )
+            .await;
+
+        // 5) Execute the fetch logic
+        let results = Synchronizer::<
+            MockNetworkClient,
+            NoopBlockVerifier,
+            SyncMockDispatcher,
+        >::fetch_blocks_from_authorities(
+            context.clone(),
+            inflight.clone(),
+            network_client.clone(),
+            missing_blocks,
+            dag_state.clone(),
+        )
+            .await;
+
+        // 6) Assert we got 4 fetches: peer 2 (timed out), fallback to 5, then periodic
+        //    from 1 and 4
+        assert_eq!(results.len(), 4, "Expected 2 known + 2 random fetches");
+
+        // 7) First fetch from peer 3 (knowledge-based)
+        let (_guard3, bytes3, peer3) = &results[0];
+        assert_eq!(*peer3, AuthorityIndex::new_for_test(3));
+        let expected2 = missing_vbs[known_number_blocks..2 * known_number_blocks]
+            .iter()
+            .map(|vb| vb.serialized().clone())
+            .collect::<Vec<_>>();
+        assert_eq!(bytes3, &expected2);
+
+        // 8) Second fetch from peer 1 (periodic)
+        let (_guard1, bytes1, peer1) = &results[1];
+        assert_eq!(*peer1, AuthorityIndex::new_for_test(1));
+        let expected1 = missing_vbs[0..MAX_BLOCKS_PER_FETCH]
+            .iter()
+            .map(|vb| vb.serialized().clone())
+            .collect::<Vec<_>>();
+        assert_eq!(bytes1, &expected1);
+
+        // 9) Third fetch from peer 4 (periodic)
+        let (_guard4, bytes4, peer4) = &results[2];
+        assert_eq!(*peer4, AuthorityIndex::new_for_test(4));
+        let expected4 = missing_vbs[MAX_BLOCKS_PER_FETCH..2 * MAX_BLOCKS_PER_FETCH]
+            .iter()
+            .map(|vb| vb.serialized().clone())
+            .collect::<Vec<_>>();
+        assert_eq!(bytes4, &expected4);
+
+        // 10) Fourth fetch from peer 5 (fallback after peer 2 timeout)
+        let (_guard5, bytes5, peer5) = &results[3];
+        assert_eq!(*peer5, AuthorityIndex::new_for_test(5));
+        let expected5 = missing_vbs[0..known_number_blocks]
+            .iter()
+            .map(|vb| vb.serialized().clone())
+            .collect::<Vec<_>>();
+        assert_eq!(bytes5, &expected5);
     }
 }


### PR DESCRIPTION
Cherry-pick from #7371 for v1.3.0

# Description of change

This PR improves block sync performance when a single/few missing block
blocks may suspend many others.

Problem:
Random selection in the periodic synchronizer often takes too long to
locate blocks that are held by only a few authorities, leaving large
portions of the DAG stalled.

Fix:
Add a knowledge-based fetch path to the periodic synchronizer:

- Leverage extended missing_blocks map from BlockManager, which now
tracks for each missing block a set of authorities that are known to
have it.
- Prioritize “knowledge-based” peers in the scheduler: when requesting
missing blocks, first query exactly those authorities that should
already hold them, rather than picking peers at random.
- Issue random‐peer requests alongside the knowledge‐based queries

This change avoids long delays in recovering blocks that live on only a
few nodes by directing periodic sync requests to the right peers up
front.



## Links to any relevant issues

closes https://github.com/iotaledger/iota/issues/7370

## How the change has been tested

- X Basic tests (linting, compilation, formatting, unit/integration
tests)
- X Patch-specific tests (correctness, functionality coverage)
- X I have added tests that prove my fix is effective or that my feature
works
- X I have checked that new and existing unit tests pass locally with my
changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
