### PR TITLE
feat(node): [cherry-pick] Revert "remove known peers shuffling during discovery (#7484)" (#7706)

### DIFF
--- a/crates/iota-network/src/discovery/server.rs
+++ b/crates/iota-network/src/discovery/server.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, RwLock};
 
 use anemo::{Request, Response};
 use iota_config::p2p::AccessType;
-use rand::seq::IteratorRandom;
+use rand::seq::{IteratorRandom, SliceRandom};
 use serde::{Deserialize, Serialize};
 
 use super::{Discovery, MAX_PEERS_TO_SEND, NodeInfo, SignedNodeInfo, State};
@@ -75,6 +75,7 @@ impl Discovery for Server {
             })
             .choose_multiple(&mut rng, MAX_PEERS_TO_SEND - known_peers.len());
         known_peers.append(&mut known_not_connected_peers);
+        known_peers.shuffle(&mut rng);
 
         Ok(Response::new(GetKnownPeersResponseV2 {
             own_info,


### PR DESCRIPTION
# Description of change

This reverts commit 38d4d5d84694cf51fe449bec891b1ea3fab5b025.

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
