### PR TITLE
fix: improve GraphQL examples with IOTA-specific addresses

### DIFF
--- a/crates/iota-graphql-rpc/examples/address/address.graphql
+++ b/crates/iota-graphql-rpc/examples/address/address.graphql
@@ -1,7 +1,7 @@
 # Get the address' balance and its coins' id and type
 {
   address(
-    address: "0x5094652429957619e6efa79a404a6714d1126e63f551f4b6c7fb76440f8118c9"
+    address: "0x479c602460ae68771dcb9bfcef607dccc678859fb72d7d8aa8d9ce58c9430747"
   ) {
     address
     balance {

--- a/crates/iota-graphql-rpc/examples/balance_connection/balance_connection.graphql
+++ b/crates/iota-graphql-rpc/examples/balance_connection/balance_connection.graphql
@@ -2,10 +2,10 @@
 # get the coin type, the number of objects, and the total balance
 {
   address(
-    address: "0x5094652429957619e6efa79a404a6714d1126e63f551f4b6c7fb76440f8118c9"
+    address: "0xd8c22c75ac470e99674fd6e73bb92955ce963c3c0b63c0100da3299f91759b07"
   ) {
     balance(
-      type: "0xc060006111016b8a020ad5b33834984a437aaa7d3c74c18e09a95d48aceab08c::coin::COIN"
+      type: "0x346778989a9f57480ec3fee15f2cd68409c73a62112d40a3efd13987997be68c::cert::CERT"
     ) {
       coinObjectCount
       totalBalance

--- a/crates/iota-graphql-rpc/examples/checkpoint/at_digest.graphql
+++ b/crates/iota-graphql-rpc/examples/checkpoint/at_digest.graphql
@@ -1,6 +1,6 @@
 # Get the checkpoint's information at a particular digest
 {
-  checkpoint(id: { digest: "GaDeWEfbSQCQ8FBQHUHVdm4KjrnbgMqEZPuhStoq5njU" }) {
+  checkpoint(id: { digest: "C7gxntU7eUyfTUPNgiuN4rwSdw2ddHojrtL14MezE1ou" }) {
     digest
     sequenceNumber
     validatorSignatures

--- a/crates/iota-graphql-rpc/examples/epoch/with_tx_block_connection.graphql
+++ b/crates/iota-graphql-rpc/examples/epoch/with_tx_block_connection.graphql
@@ -1,8 +1,8 @@
-# Fetch the first 20 transactions after tx 231220153 (encoded as a
-# cursor) in epoch 97.
+# Fetch the first 20 transactions after tx EDkHSZUwYFnHSLkWRQBJocgDxWogwvW8dmxFzbQjwFTp (encoded as a
+# cursor) in epoch 62.
 {
-  epoch(id: 97) {
-    transactionBlocks(first: 20, after:"eyJjIjoyNjkzMzc3OCwidCI6MjMxMjIwMTUzLCJ0YyI6ODAxMDg4NH0") {
+  epoch(id: 62) {
+    transactionBlocks(first: 20, after:"eyJjIjoyMzg5NDEzNSwidCI6MTA1MTI4NDEyLCJpIjpmYWxzZX0") {
       pageInfo {
         hasNextPage
         endCursor

--- a/crates/iota-graphql-rpc/examples/event_connection/event_connection.graphql
+++ b/crates/iota-graphql-rpc/examples/event_connection/event_connection.graphql
@@ -1,7 +1,8 @@
+# Retrieves all StakingRequestEvent events, showing the sender address, timestamp, event type, and additional metadata including the emitting module and raw data.
 {
   events(
     filter: {
-      eventType: "0x3164fcf73eb6b41ff3d2129346141bd68469964c2d95a5b1533e8d16e6ea6e13::Market::ChangePriceEvent<0x2::iota::IOTA>"
+      eventType: "0x3::validator::StakingRequestEvent"
     }
   ) {
     nodes {

--- a/crates/iota-graphql-rpc/examples/event_connection/filter_by_emitting_package.graphql
+++ b/crates/iota-graphql-rpc/examples/event_connection/filter_by_emitting_package.graphql
@@ -1,10 +1,8 @@
-query ByEmittingPackageModuleAndEventType {
+# Queries fetches all on-chain events emitted by the module `0x3::iota_system
+query ByEmittingPackageModule {
   events(
-    first: 1
-    after: "eyJ0eCI6Njc2MywiZSI6MCwiYyI6MjI4MDA3NDJ9"
     filter: {
       emittingModule: "0x3::iota_system",
-      eventType: "0x3::validator::StakingRequestEvent"
     }
   ) {
     pageInfo {

--- a/crates/iota-graphql-rpc/examples/event_connection/filter_by_emitting_package.graphql
+++ b/crates/iota-graphql-rpc/examples/event_connection/filter_by_emitting_package.graphql
@@ -1,4 +1,4 @@
-# Queries fetches all on-chain events emitted by the module `0x3::iota_system
+# Get all on-chain events emitted by the module `0x3::iota_system
 query ByEmittingPackageModule {
   events(
     filter: {

--- a/crates/iota-graphql-rpc/examples/event_connection/filter_by_event_type.graphql
+++ b/crates/iota-graphql-rpc/examples/event_connection/filter_by_event_type.graphql
@@ -1,0 +1,27 @@
+# Queries fetches all on-chain events of type StakingRequestEvent
+query ByEventType {
+  events(
+    filter: {
+      eventType: "0x3::validator::StakingRequestEvent"
+    }
+  ) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      sendingModule {
+        name
+      }
+      type {
+        repr
+      }
+      sender {
+        address
+      }
+      timestamp
+      json
+      bcs
+    }
+  }
+}

--- a/crates/iota-graphql-rpc/examples/event_connection/filter_by_sender.graphql
+++ b/crates/iota-graphql-rpc/examples/event_connection/filter_by_sender.graphql
@@ -1,8 +1,9 @@
+# Get the first event sent by the specified transaction sender address.
 query ByTxSender {
   events(
     first: 1
     filter: {
-      sender: "0xdff57c401e125a7e0e06606380560b459a179aacd08ed396d0162d57dbbdadfb"
+      sender: "0x0000000000000000000000000000000000000000000000000000000000000000"
     }
   ) {
     pageInfo {

--- a/crates/iota-graphql-rpc/examples/object/object.graphql
+++ b/crates/iota-graphql-rpc/examples/object/object.graphql
@@ -1,6 +1,7 @@
+# Get metadata for a specific on-chain object and the digest of the transaction block that last modified it
 {
   object(
-    address: "0x04e20ddf36af412a4096f9014f4a565af9e812db9a05cc40254846cf6ed0ad91"
+    address: "0x281b97c4303f1571f64499b214c35d933ea5ad21522a608daffd2a5b2bd318d8"
   ) {
     address
     version

--- a/crates/iota-graphql-rpc/examples/object_connection/filter_object_ids.graphql
+++ b/crates/iota-graphql-rpc/examples/object_connection/filter_object_ids.graphql
@@ -1,7 +1,7 @@
 # Filter on objectIds
 {
   objects(filter: { objectIds: [
-    "0x4bba2c7b9574129c272bca8f58594eba933af8001257aa6e0821ad716030f149"
+    "0x281b97c4303f1571f64499b214c35d933ea5ad21522a608daffd2a5b2bd318d8"
   ]}) {
     edges {
       node {

--- a/crates/iota-graphql-rpc/examples/object_connection/filter_on_type.graphql
+++ b/crates/iota-graphql-rpc/examples/object_connection/filter_on_type.graphql
@@ -1,3 +1,5 @@
+# Get all on-chain objects of type `StakedIota` from the staking pool module
+# and return their type representation.
 {
   objects(filter: {type: "0x3::staking_pool::StakedIota"}) {
     edges {

--- a/crates/iota-graphql-rpc/examples/object_connection/filter_owner.graphql
+++ b/crates/iota-graphql-rpc/examples/object_connection/filter_owner.graphql
@@ -1,7 +1,7 @@
 # Filter on owner
 {
   objects(filter: {
-    owner: "0x23b7b0e2badb01581ba9b3ab55587d8d9fdae087e0cfc79f2c72af36f5059439"
+    owner: "0x7d49a79ca16e3986b2221ee7bf93d9a34e2192517c7efea995b34f69615ee053"
   }) {
     edges {
       node {

--- a/crates/iota-graphql-rpc/examples/stake_connection/stake_connection.graphql
+++ b/crates/iota-graphql-rpc/examples/stake_connection/stake_connection.graphql
@@ -1,7 +1,7 @@
 # Get all the staked objects for this address and all the active validators at the epoch when the stake became active
 {
   address(
-    address: "0xc0a5b916d0e406ddde11a29558cd91b29c49e644eef597b7424a622955280e1e"
+    address: "0x906aaab49c5320ac9bf91214cb74ad5c64d44df3f90d7b6b7120302b155d1e96"
   ) {
     address
     balance(type: "0x2::iota::IOTA") {

--- a/crates/iota-graphql-rpc/examples/transaction_block/transaction_block.graphql
+++ b/crates/iota-graphql-rpc/examples/transaction_block/transaction_block.graphql
@@ -1,6 +1,6 @@
 # Get the data for a TransactionBlock by its digest
 {
-  transactionBlock(digest: "HvTjk3ELg8gRofmB1GgrpLHBFeA53QKmUKGEuhuypezg") {
+  transactionBlock(digest: "Dv5XRBjWvZTwiHVrhUetvDTgxyM8xVMb6P8pCAZv51tq") {
     sender {
       address
     }

--- a/crates/iota-graphql-rpc/examples/transaction_block/transaction_block_kind.graphql
+++ b/crates/iota-graphql-rpc/examples/transaction_block/transaction_block_kind.graphql
@@ -1,6 +1,12 @@
+# This query retrieves the previous transaction block for a given object address.
+# It includes:
+# - The sender's address.
+# - If the transaction is a ConsensusCommitPrologue: epoch info, round, timestamp, digest.
+# - If it's a GenesisTransaction: list of created object addresses.
+# - If it's a ProgrammableTransaction: Move call module and function names.
 {
   object(
-    address: "0xd6b9c261ab53d636760a104e4ab5f46c2a3e9cda58bd392488fc4efa6e43728c"
+    address: "0x5b890eaf2abcfa2ab90b77b8e6f3d5d8609586c3e583baf3dccd5af17edf48d1"
   ) {
     previousTransactionBlock {
       sender {
@@ -17,15 +23,24 @@
           commitTimestamp
           consensusCommitDigest
         }
-        ... on ChangeEpochTransaction {
-          computationCharge
-          storageCharge
-          startTimestamp
-          storageRebate
-        }
         ... on GenesisTransaction {
           objects {
-            nodes { address }
+            nodes {
+              address
+            }
+          }
+        }
+        ... on ProgrammableTransactionBlock {
+          transactions {
+            nodes {
+              __typename
+              ... on MoveCallTransaction {
+                module
+                function {
+                  name
+                }
+              }
+            }
           }
         }
       }

--- a/crates/iota-graphql-rpc/examples/transaction_block_connection/tx_ids_filter.graphql
+++ b/crates/iota-graphql-rpc/examples/transaction_block_connection/tx_ids_filter.graphql
@@ -1,7 +1,7 @@
 # Filter on transactionIds
 {
   transactionBlocks(
-    filter: { transactionIds: ["DtQ6v6iJW4wMLgadENPUCEUS5t8AP7qvdG5jX84T1akR"] }
+    filter: { transactionIds: ["H4SYwD3y62WFxhv5QHaXSg7j6zTnDEJ6SRZQdNZdzHfr"] }
   ) {
     nodes {
       sender {

--- a/crates/iota-graphql-rpc/examples/transaction_block_effects/transaction_block_effects.graphql
+++ b/crates/iota-graphql-rpc/examples/transaction_block_effects/transaction_block_effects.graphql
@@ -1,6 +1,8 @@
+# Retrieve metadata and transaction history for a specific on-chain object,
+# including its ownership and effects of the last transaction that modified it.
 {
   object(
-    address: "0x0bba1e7d907dc2832edfc3bf4468b6deacd9a2df435a35b17e640e135d2d5ddc"
+    address: "0x0000000000000000000000000000000000000000000000000000000000000008"
   ) {
     version
     owner {


### PR DESCRIPTION
This PR updates the example GraphQL queries to use valid IOTA mainnet addresses, making them directly usable for testing.

# Description of change

Replaced Sui addresses with real addresses from the IOTA network to make example queries functional. In some cases, added brief descriptions to clarify the purpose of the queries 

## How the change has been tested

- X Basic tests (linting, compilation, formatting, unit/integration tests)
