### PR TITLE
upstream(sdk): [sdk] improve typing of splitCoins and make splitCoins have a concrete size

### DIFF
--- a/.changeset/brown-gorillas-jam.md
+++ b/.changeset/brown-gorillas-jam.md
@@ -1,0 +1,5 @@
+---
+'@iota/iota-sdk': minor
+---
+
+Improve typing for the return type of splitCoins and update the splitCoins result type to have a concrete size

--- a/sdk/typescript/src/transactions/Transaction.ts
+++ b/sdk/typescript/src/transactions/Transaction.ts
@@ -37,7 +37,7 @@ export type TransactionObjectArgument =
 export type TransactionResult = Extract<Argument, { Result: unknown }> &
     Extract<Argument, { NestedResult: unknown }>[];
 
-function createTransactionResult(index: number) {
+function createTransactionResult(index: number, length = Infinity): TransactionResult {
     const baseResult = { $kind: 'Result' as const, Result: index };
 
     const nestedResults: {
@@ -74,7 +74,7 @@ function createTransactionResult(index: number) {
             if (property === Symbol.iterator) {
                 return function* () {
                     let i = 0;
-                    while (true) {
+                    while (i < length) {
                         yield nestedResultFor(i);
                         i++;
                     }
@@ -416,23 +416,32 @@ export class Transaction {
 
     // Method shorthands:
 
-    splitCoins(
-        coin: TransactionObjectArgument | string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        amounts: (TransactionArgument | SerializedBcs<any> | number | string | bigint)[],
-    ) {
-        return this.add(
-            Commands.SplitCoins(
-                typeof coin === 'string' ? this.object(coin) : this.#resolveArgument(coin),
-                amounts.map((amount) =>
-                    typeof amount === 'number' ||
-                    typeof amount === 'bigint' ||
-                    typeof amount === 'string'
-                        ? this.pure.u64(amount)
-                        : this.#normalizeTransactionArgument(amount),
-                ),
+    splitCoins<
+        const Amounts extends (
+            | TransactionArgument
+            | SerializedBcs<any>
+            | number
+            | string
+            | bigint
+        )[],
+    >(coin: TransactionObjectArgument | string, amounts: Amounts) {
+        const command = Commands.SplitCoins(
+            typeof coin === 'string' ? this.object(coin) : this.#resolveArgument(coin),
+            amounts.map((amount) =>
+                typeof amount === 'number' ||
+                typeof amount === 'bigint' ||
+                typeof amount === 'string'
+                    ? this.pure.u64(amount)
+                    : this.#normalizeTransactionArgument(amount),
             ),
         );
+        const index = this.#data.commands.push(command);
+        return createTransactionResult(index - 1, amounts.length) as Extract<
+            Argument,
+            { Result: unknown }
+        > & {
+            [K in keyof Amounts]: Extract<Argument, { NestedResult: unknown }>;
+        };
     }
     mergeCoins(
         destination: TransactionObjectArgument | string,


### PR DESCRIPTION
### Description

Port commit: https://github.com/MystenLabs/sui/commit/4f012b974e2c7fb65756bdc01cb8004d0180bab3
