### PR TITLE
feat(evm-bridge): Fix metamask version used in bridge tests to `12.20.0`

### DIFF
--- a/apps/evm-bridge/package.json
+++ b/apps/evm-bridge/package.json
@@ -2,6 +2,9 @@
     "name": "iota-evm-bridge",
     "version": "0.1.0",
     "private": true,
+    "config": {
+        "metamaskVersion": "12.20.0"
+    },
     "scripts": {
         "dev": "vite",
         "build": "tsc && vite build",

--- a/apps/evm-bridge/scripts/downloadWallet.js
+++ b/apps/evm-bridge/scripts/downloadWallet.js
@@ -2,9 +2,13 @@ import { execSync } from 'child_process';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
+import pkg from '../package.json';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
+const defaultVersion = '12.20.0';
+const metamaskVersion = pkg?.config?.metamaskVersion || defaultVersion;
 
 try {
     const scriptName = 'download_wallet_artifact_L2.sh';
@@ -12,6 +16,9 @@ try {
 
     execSync(`bash ${scriptPath}`, {
         stdio: 'inherit',
+        env: {
+            METAMASK_VERSION: metamaskVersion,
+        },
     });
 } catch (error) {
     console.error('Failed to download wallet artifact:', error);

--- a/apps/evm-bridge/scripts/download_wallet_artifact_L2.sh
+++ b/apps/evm-bridge/scripts/download_wallet_artifact_L2.sh
@@ -4,17 +4,11 @@ set -e
 
 OUTPUT_DIR="wallet-dist-L2"
 
-# URL of the MetaMask releases page
-RELEASES_URL="https://github.com/MetaMask/metamask-extension/releases"
-
-# Fetch the latest release page
-LATEST_RELEASE_PAGE=$(curl -s $RELEASES_URL | grep -o 'href="/MetaMask/metamask-extension/releases/tag/[^"]*"' | sed 's/href="//;s/"$//' | head -n 1)
-
-# Extract the latest release version
-LATEST_VERSION=$(echo $LATEST_RELEASE_PAGE | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' | sed 's/v//')
+VERSION="${METAMASK_VERSION}"
+echo "Using MetaMask version: $VERSION"
 
 # Construct the download URL for the MetaMask Chrome zip file
-DOWNLOAD_URL="https://github.com/MetaMask/metamask-extension/releases/download/v$LATEST_VERSION/metamask-chrome-$LATEST_VERSION.zip"
+DOWNLOAD_URL="https://github.com/MetaMask/metamask-extension/releases/download/v$VERSION/metamask-chrome-$VERSION.zip"
 
 mkdir -p "$OUTPUT_DIR"
 TEMP_FILE=$(mktemp)

--- a/apps/evm-bridge/tests/utils/utils.ts
+++ b/apps/evm-bridge/tests/utils/utils.ts
@@ -187,9 +187,60 @@ export async function addNetworkToMetaMask(l2WalletPage: Page) {
 }
 
 export async function addL1FundsThroughBridgeUI(page: Page, browser: BrowserContext) {
-    // Add funds to L1
-    await page.getByTestId('request-l1-funds-button').click();
-    await expect(page.getByText('Funds successfully sent.')).toBeVisible({ timeout: 30000 });
+    const maxRetries = 3; // Maximum number of retry attempts
+    let attempt = 1;
+    let success = false;
+
+    while (attempt <= maxRetries && !success) {
+        try {
+            console.log(`Attempt ${attempt}/${maxRetries} to add funds through bridge UI`);
+
+            // Add funds to L1
+            await page.getByTestId('request-l1-funds-button').click();
+
+            // Wait for transaction completion - look for either success or error message
+            const successPromise = page
+                .getByText('Funds successfully sent.')
+                .waitFor({ timeout: 30000 })
+                .then(() => 'success')
+                .catch(() => 'timeout');
+
+            const errorPromise = page
+                .getByText('Something went wrong while requesting funds.')
+                .waitFor({ timeout: 30000 })
+                .then(() => 'error')
+                .catch(() => 'timeout');
+
+            // Wait for either message to appear
+            const result = await Promise.race([successPromise, errorPromise]);
+
+            if (result === 'success') {
+                console.log('✅ Bridge funding transaction successful: Funds sent from faucet!');
+                success = true;
+            } else if (result === 'error') {
+                console.log(
+                    `❌ Bridge funding transaction failed on attempt ${attempt}/${maxRetries}, retrying...`,
+                );
+                await page.pause();
+                // Wait a bit before retrying
+                await page.waitForTimeout(3000);
+            } else {
+                console.log(
+                    '⏱️ Bridge funding transaction timed out on attempt ${attempt}/${maxRetries}, retrying...',
+                );
+                await page.waitForTimeout(3000);
+            }
+        } catch (error) {
+            console.error(`Error during attempt ${attempt}:`, error);
+        }
+
+        attempt++;
+    }
+
+    if (!success) {
+        throw new Error(`Failed to add funds trough bridge UI after ${maxRetries} attempts`);
+    }
+
     // Check the funds arrived (ui)
     const l1WalletExtension = await browser.newPage();
     const l1ExtensionUrl = await getExtensionUrl(browser);


### PR DESCRIPTION
# Description of change

* Fixes metamask version used in evm-bridge e2e tests (`12.20.0`)
* Also adds retries and debug logs to `addL1FundsThroughBridgeUI` function

resolves #7749

