### PR TITLE
chore(protocol-research): update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,6 +20,7 @@
 /crates/iota-common/ @iotaledger/core-protocol
 /crates/iota-config/ @iotaledger/node
 /crates/iota-core/ @iotaledger/node @iotaledger/consensus
+/crates/iota-core/src/authority/ @iotaledger/research
 /crates/iota-cost/ @iotaledger/vm-language
 /crates/iota-data-ingestion*/ @iotaledger/infrastructure
 /crates/iota-e2e-tests/ @iotaledger/node @iotaledger/vm-language

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,7 @@
 /crates/iota-common/ @iotaledger/core-protocol
 /crates/iota-config/ @iotaledger/node
 /crates/iota-core/ @iotaledger/node @iotaledger/consensus
-/crates/iota-core/src/authority/ @iotaledger/research
+/crates/iota-core/src/authority/ @iotaledger/node @iotaledger/consensus @iotaledger/research
 /crates/iota-cost/ @iotaledger/vm-language
 /crates/iota-data-ingestion*/ @iotaledger/infrastructure
 /crates/iota-e2e-tests/ @iotaledger/node @iotaledger/vm-language


### PR DESCRIPTION
# Description of change

Added @iotaledger/research team as codeowners for `crates/iota-core/src/authority` to track upstream changes related to congestion control in this directory.

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
