### PR TITLE
fix(iota-json): remove string parsing of vecu8

### DIFF
--- a/crates/iota-json/src/lib.rs
+++ b/crates/iota-json/src/lib.rs
@@ -140,47 +140,21 @@ impl IotaJsonValue {
         layout: Option<&MoveTypeLayout>,
         bytes: &[u8],
     ) -> Result<Self, anyhow::Error> {
-        let json = if let Some(layout) = layout {
-            // Try to convert Vec<u8> inputs into string
-            fn try_parse_string(layout: &MoveTypeLayout, bytes: &[u8]) -> Option<String> {
-                if let MoveTypeLayout::Vector(t) = layout {
-                    if let MoveTypeLayout::U8 = **t {
-                        return bcs::from_bytes::<String>(bytes).ok();
-                    }
-                }
-                None
-            }
-            if let Some(s) = try_parse_string(layout, bytes) {
-                json!(s)
-            } else {
-                let result = BoundedVisitor::deserialize_value(bytes, layout).map_or_else(
-                    |_| {
-                        // fallback to array[u8] if fail to convert to json.
-                        JsonValue::Array(
-                            bytes
-                                .iter()
-                                .map(|b| JsonValue::Number(Number::from(*b)))
-                                .collect(),
-                        )
-                    },
-                    |move_value| {
-                        move_value_to_json(&move_value).unwrap_or_else(|| {
-                            // fallback to array[u8] if fail to convert to json.
-                            JsonValue::Array(
-                                bytes
-                                    .iter()
-                                    .map(|b| JsonValue::Number(Number::from(*b)))
-                                    .collect(),
-                            )
-                        })
-                    },
-                );
-                result
-            }
-        } else {
-            json!(bytes)
+        let Some(layout) = layout else {
+            return IotaJsonValue::new(json!(bytes));
         };
-        IotaJsonValue::new(json)
+        if let Ok(Some(value)) = BoundedVisitor::deserialize_value(bytes, layout)
+            .map(|move_value| move_value_to_json(&move_value))
+        {
+            return IotaJsonValue::new(value);
+        }
+        let value = JsonValue::Array(
+            bytes
+                .iter()
+                .map(|b| JsonValue::Number(Number::from(*b)))
+                .collect(),
+        );
+        IotaJsonValue::new(value)
     }
 
     pub fn to_json_value(&self) -> JsonValue {

--- a/crates/iota-json/src/tests.rs
+++ b/crates/iota-json/src/tests.rs
@@ -792,3 +792,35 @@ fn test_string_vec_df_name_child_id_eq() {
         child_id.to_string()
     );
 }
+
+#[test]
+fn test_convert_u8_vec() {
+    let layout = MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8));
+    let bcs_valid_utf8 = [
+        122, 121, 2, 15, 48, 120, 50, 58, 58, 105, 111, 116, 97, 58, 58, 73, 79, 84, 65, 64, 66,
+        15, 0, 0, 0, 0, 0, 86, 48, 120, 98, 50, 49, 56, 53, 51, 100, 55, 51, 56, 48, 102, 97, 56,
+        51, 54, 48, 97, 97, 98, 102, 100, 97, 56, 52, 49, 51, 102, 56, 50, 53, 102, 100, 102, 99,
+        51, 102, 51, 101, 97, 55, 101, 56, 48, 49, 98, 56, 101, 54, 50, 98, 100, 100, 102, 99, 98,
+        57, 97, 50, 53, 99, 51, 55, 55, 58, 58, 116, 101, 115, 116, 99, 111, 105, 110, 58, 58, 84,
+        69, 83, 84, 67, 79, 73, 78, 10, 0, 0, 0, 0, 0, 0, 0, 0,
+    ];
+    let json = IotaJsonValue::from_bcs_bytes(Some(&layout), &bcs_valid_utf8).unwrap();
+    assert_eq!(&bcs_valid_utf8[1..], json_into_vec_u8(json.0).as_slice());
+    let bcs_invalid_utf8 = [
+        28, 27, 1, 1, 15, 48, 120, 50, 58, 58, 105, 111, 116, 97, 58, 58, 73, 79, 84, 65, 210, 4,
+        0, 0, 0, 0, 0, 0, 0,
+    ];
+    let json = IotaJsonValue::from_bcs_bytes(Some(&layout), &bcs_invalid_utf8).unwrap();
+    assert_eq!(&bcs_invalid_utf8[1..], json_into_vec_u8(json.0).as_slice());
+}
+
+fn json_into_vec_u8(value: Value) -> Vec<u8> {
+    let Value::Array(vector) = value else {
+        panic!("{value:?} is not an array");
+    };
+    vector
+        .into_iter()
+        .filter_map(|num| num.as_i64())
+        .filter_map(|num| u8::try_from(num).ok())
+        .collect()
+}


### PR DESCRIPTION
# Description of change

This patch removes the logic that tries to parse `vector<u8>` transaction inputs first as strings and then falls back to converting to raw vectors.

Move strings are `vector<u8>` with valid utf8 code points, but vectors with valid utf8 code points as elements are not necessarily strings.

## Links to any relevant issues

Fixes #7705 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

Not affecting common ingestion workflows.

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [x] Verification of API backward compatibility.

### Release Notes

- [x] JSON-RPC: `vector<u8>` values for transaction inputs are parsed as raw vectors into the rpc response. Previously vectors with valid utf-8 codepoints were parsed as strings, which was error prone.