### PR TITLE
feat(node): Prefix fallible storage methods with `try_`

### DIFF
--- a/crates/iota-analytics-indexer/src/handlers/transaction_handler.rs
+++ b/crates/iota-analytics-indexer/src/handlers/transaction_handler.rs
@@ -222,9 +222,9 @@ mod tests {
 
         // Create a checkpoint which should include the transaction we executed.
         let checkpoint = sim.create_checkpoint();
-        let checkpoint_data = sim.get_checkpoint_data(
+        let checkpoint_data = sim.try_get_checkpoint_data(
             checkpoint.clone(),
-            sim.get_checkpoint_contents_by_digest(&checkpoint.content_digest)?
+            sim.try_get_checkpoint_contents_by_digest(&checkpoint.content_digest)?
                 .unwrap(),
         )?;
         let shared_checkpoint_data = Arc::new(checkpoint_data);

--- a/crates/iota-archival/src/lib.rs
+++ b/crates/iota-archival/src/lib.rs
@@ -526,7 +526,7 @@ where
         latest_checkpoint_in_archive
     );
     let latest_checkpoint = store
-        .get_highest_synced_checkpoint()
+        .try_get_highest_synced_checkpoint()
         .map_err(|_| anyhow!("Failed to read highest synced checkpoint"))?
         .sequence_number;
     info!("Highest synced checkpoint in db: {latest_checkpoint}");
@@ -561,7 +561,7 @@ where
         tokio::spawn(async move {
             loop {
                 let latest_checkpoint = cloned_store
-                    .get_highest_synced_checkpoint()
+                    .try_get_highest_synced_checkpoint()
                     .map_err(|_| anyhow!("Failed to read highest synced checkpoint"))?
                     .sequence_number;
                 let percent = (latest_checkpoint * 100) / latest_checkpoint_in_archive;
@@ -588,7 +588,7 @@ where
         .await?;
     progress_bar.iter().for_each(|p| p.finish_and_clear());
     let end = store
-        .get_highest_synced_checkpoint()
+        .try_get_highest_synced_checkpoint()
         .map_err(|_| anyhow!("Failed to read watermark"))?
         .sequence_number;
     info!("Highest verified checkpoint: {}", end);

--- a/crates/iota-archival/src/reader.rs
+++ b/crates/iota-archival/src/reader.rs
@@ -555,7 +555,7 @@ impl ArchiveReader {
         S: WriteStore + Clone,
     {
         store
-            .get_checkpoint_by_sequence_number(certified_checkpoint.sequence_number)
+            .try_get_checkpoint_by_sequence_number(certified_checkpoint.sequence_number)
             .map_err(|e| anyhow!("Store op failed: {e}"))?
             .map(Ok::<VerifiedCheckpoint, anyhow::Error>)
             .unwrap_or_else(|| {
@@ -566,7 +566,7 @@ impl ArchiveReader {
                         .checked_sub(1)
                         .context("Checkpoint seq num underflow")?;
                     let prev_checkpoint = store
-                        .get_checkpoint_by_sequence_number(prev_checkpoint_seq_num)
+                        .try_get_checkpoint_by_sequence_number(prev_checkpoint_seq_num)
                         .map_err(|e| anyhow!("Store op failed: {e}"))?
                         .context(format!(
                             "Missing previous checkpoint {prev_checkpoint_seq_num} in store"

--- a/crates/iota-archival/src/reader.rs
+++ b/crates/iota-archival/src/reader.rs
@@ -470,11 +470,14 @@ impl ArchiveReader {
                                 VerifiedCheckpointContents::new_unchecked(contents.clone());
                             // Insert content
                             store
-                                .insert_checkpoint_contents(&verified_checkpoint, verified_contents)
+                                .try_insert_checkpoint_contents(
+                                    &verified_checkpoint,
+                                    verified_contents,
+                                )
                                 .map_err(|e| anyhow!("Failed to insert content: {e}"))?;
                             // Update highest synced watermark
                             store
-                                .update_highest_synced_checkpoint(&verified_checkpoint)
+                                .try_update_highest_synced_checkpoint(&verified_checkpoint)
                                 .map_err(|e| anyhow!("Failed to update watermark: {e}"))?;
                             txn_counter.fetch_add(contents.size() as u64, Ordering::Relaxed);
                             self.archive_reader_metrics
@@ -541,7 +544,7 @@ impl ArchiveReader {
         S: WriteStore + Clone,
     {
         store
-            .insert_checkpoint(VerifiedCheckpoint::new_unchecked(certified_checkpoint).borrow())
+            .try_insert_checkpoint(VerifiedCheckpoint::new_unchecked(certified_checkpoint).borrow())
             .map_err(|e| anyhow!("Failed to insert checkpoint: {e}"))
     }
 
@@ -579,11 +582,11 @@ impl ArchiveReader {
                 };
                 // Insert checkpoint summary
                 store
-                    .insert_checkpoint(&verified_checkpoint)
+                    .try_insert_checkpoint(&verified_checkpoint)
                     .map_err(|e| anyhow!("Failed to insert checkpoint: {e}"))?;
                 // Update highest verified checkpoint watermark
                 store
-                    .update_highest_verified_checkpoint(&verified_checkpoint)
+                    .try_update_highest_verified_checkpoint(&verified_checkpoint)
                     .expect("store operation should not fail");
                 Ok::<VerifiedCheckpoint, anyhow::Error>(verified_checkpoint)
             })

--- a/crates/iota-archival/src/tests.rs
+++ b/crates/iota-archival/src/tests.rs
@@ -224,10 +224,10 @@ async fn test_archive_reader_e2e() -> Result<(), anyhow::Error> {
     }
     ma::assert_ge!(latest_archived_checkpoint_seq_num, 10);
     let genesis_checkpoint = test_store
-        .get_checkpoint_by_sequence_number(0)?
+        .try_get_checkpoint_by_sequence_number(0)?
         .context("Missing genesis checkpoint")?;
     let genesis_checkpoint_content = test_store
-        .get_full_checkpoint_contents_by_sequence_number(0)?
+        .try_get_full_checkpoint_contents_by_sequence_number(0)?
         .context("Missing genesis checkpoint")?;
     let read_store = SharedInMemoryStore::default();
     read_store.inner_mut().insert_genesis_state(
@@ -250,12 +250,14 @@ async fn test_archive_reader_e2e() -> Result<(), anyhow::Error> {
         .await?;
     ma::assert_ge!(
         read_store
-            .get_highest_verified_checkpoint()?
+            .try_get_highest_verified_checkpoint()?
             .sequence_number,
         latest_archived_checkpoint_seq_num
     );
     ma::assert_ge!(
-        read_store.get_highest_synced_checkpoint()?.sequence_number,
+        read_store
+            .try_get_highest_synced_checkpoint()?
+            .sequence_number,
         latest_archived_checkpoint_seq_num
     );
     kill.send(())?;
@@ -283,10 +285,10 @@ async fn test_verify_archive_with_oneshot_store() -> Result<(), anyhow::Error> {
     }
     ma::assert_ge!(latest_archived_checkpoint_seq_num, 10);
     let genesis_checkpoint = test_store
-        .get_checkpoint_by_sequence_number(0)?
+        .try_get_checkpoint_by_sequence_number(0)?
         .context("Missing genesis checkpoint")?;
     let genesis_checkpoint_content = test_store
-        .get_full_checkpoint_contents_by_sequence_number(0)?
+        .try_get_full_checkpoint_contents_by_sequence_number(0)?
         .context("Missing genesis checkpoint")?;
     let mut read_store = SingleCheckpointSharedInMemoryStore::default();
     read_store.insert_genesis_state(
@@ -359,10 +361,10 @@ async fn test_verify_archive_with_oneshot_store_bad_data() -> Result<(), anyhow:
     }
     ma::assert_gt!(num_files_corrupted, 0);
     let genesis_checkpoint = test_store
-        .get_checkpoint_by_sequence_number(0)?
+        .try_get_checkpoint_by_sequence_number(0)?
         .context("Missing genesis checkpoint")?;
     let genesis_checkpoint_content = test_store
-        .get_full_checkpoint_contents_by_sequence_number(0)?
+        .try_get_full_checkpoint_contents_by_sequence_number(0)?
         .context("Missing genesis checkpoint")?;
     let mut read_store = SingleCheckpointSharedInMemoryStore::default();
     read_store.insert_genesis_state(

--- a/crates/iota-archival/src/writer.rs
+++ b/crates/iota-archival/src/writer.rs
@@ -441,11 +441,11 @@ impl ArchiveWriter {
 
         while kill.try_recv().is_err() {
             if let Some(checkpoint_summary) = store
-                .get_checkpoint_by_sequence_number(checkpoint_sequence_number)
+                .try_get_checkpoint_by_sequence_number(checkpoint_sequence_number)
                 .map_err(|_| anyhow!("Failed to read checkpoint summary from store"))?
             {
                 if let Some(checkpoint_contents) = store
-                    .get_full_checkpoint_contents(&checkpoint_summary.content_digest)
+                    .try_get_full_checkpoint_contents(&checkpoint_summary.content_digest)
                     .map_err(|_| anyhow!("Failed to read checkpoint content from store"))?
                 {
                     checkpoint_writer

--- a/crates/iota-config/src/genesis.rs
+++ b/crates/iota-config/src/genesis.rs
@@ -334,14 +334,14 @@ impl UnsignedGenesis {
 
     pub fn has_randomness_state_object(&self) -> bool {
         self.objects()
-            .get_object(&IOTA_RANDOMNESS_STATE_OBJECT_ID)
+            .try_get_object(&IOTA_RANDOMNESS_STATE_OBJECT_ID)
             .expect("read from genesis cannot fail")
             .is_some()
     }
 
     pub fn has_bridge_object(&self) -> bool {
         self.objects()
-            .get_object(&GENESIS_IOTA_BRIDGE_OBJECT_ID)
+            .try_get_object(&GENESIS_IOTA_BRIDGE_OBJECT_ID)
             .expect("read from genesis cannot fail")
             .is_some()
     }

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3122,7 +3122,7 @@ impl AuthorityState {
             epoch_supply_change,
         )?;
         self.get_reconfig_api()
-            .set_epoch_start_configuration(&epoch_start_configuration)?;
+            .try_set_epoch_start_configuration(&epoch_start_configuration)?;
         if let Some(checkpoint_path) = &self.db_checkpoint_config.checkpoint_path {
             if self
                 .db_checkpoint_config
@@ -3211,7 +3211,7 @@ impl AuthorityState {
         }
 
         self.get_reconfig_api()
-            .expensive_check_iota_conservation(cur_epoch_store, Some(epoch_supply_change))?;
+            .try_expensive_check_iota_conservation(cur_epoch_store, Some(epoch_supply_change))?;
 
         // check for root state hash consistency with live object set
         if expensive_safety_check_config.enable_state_consistency_check() {
@@ -3310,7 +3310,7 @@ impl AuthorityState {
             .checkpoint_db(&checkpoint_path_tmp.join("checkpoints"))?;
 
         self.get_reconfig_api()
-            .checkpoint_db(&store_checkpoint_path_tmp.join("perpetual"))?;
+            .try_checkpoint_db(&store_checkpoint_path_tmp.join("perpetual"))?;
 
         self.committee_store
             .checkpoint_db(&checkpoint_path_tmp.join("epochs"))?;
@@ -4124,7 +4124,7 @@ impl AuthorityState {
 
     pub async fn insert_genesis_object(&self, object: Object) {
         self.get_reconfig_api()
-            .insert_genesis_object(object)
+            .try_insert_genesis_object(object)
             .expect("Cannot insert genesis object")
     }
 
@@ -4885,7 +4885,7 @@ impl AuthorityState {
             }
             info!("Reverting {:?} at the end of epoch", digest);
             epoch_store.revert_executed_transaction(&digest)?;
-            self.get_reconfig_api().revert_state_update(&digest)?;
+            self.get_reconfig_api().try_revert_state_update(&digest)?;
         }
         info!("All uncommitted local transactions reverted");
         Ok(())
@@ -4941,7 +4941,7 @@ impl AuthorityState {
     /// use in prod
     pub async fn insert_objects_unsafe_for_testing_only(&self, objects: &[Object]) -> IotaResult {
         self.get_reconfig_api()
-            .bulk_insert_genesis_objects(objects)?;
+            .try_bulk_insert_genesis_objects(objects)?;
         self.get_object_cache_reader()
             .force_reload_system_packages(&BuiltInFramework::all_package_ids());
         self.get_reconfig_api()

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1081,7 +1081,7 @@ impl AuthorityState {
 
         let observed_effects = self
             .get_transaction_cache_reader()
-            .notify_read_executed_effects(&[digest])
+            .try_notify_read_executed_effects(&[digest])
             .instrument(tracing::debug_span!(
                 "notify_read_effects_in_execute_certificate_with_effects"
             ))
@@ -1173,7 +1173,7 @@ impl AuthorityState {
         // so check if the effects have already been written.
         if let Some(effects) = self
             .get_transaction_cache_reader()
-            .get_executed_effects(tx_digest)?
+            .try_get_executed_effects(tx_digest)?
         {
             if let Some(expected_effects_digest) = expected_effects_digest {
                 assert_eq!(
@@ -1256,7 +1256,7 @@ impl AuthorityState {
         certificate: &VerifiedCertificate,
     ) -> IotaResult<TransactionEffects> {
         self.get_transaction_cache_reader()
-            .notify_read_executed_effects(&[*certificate.digest()])
+            .try_notify_read_executed_effects(&[*certificate.digest()])
             .await
             .map(|mut r| r.pop().expect("must return correct number of effects"))
     }
@@ -2222,7 +2222,7 @@ impl AuthorityState {
 
     pub fn is_tx_already_executed(&self, digest: &TransactionDigest) -> IotaResult<bool> {
         self.get_transaction_cache_reader()
-            .is_tx_already_executed(digest)
+            .try_is_tx_already_executed(digest)
     }
 
     /// Indexes a transaction by updating various indexes in the `IndexStore`.
@@ -3717,7 +3717,7 @@ impl AuthorityState {
         digest: &TransactionEventsDigest,
     ) -> IotaResult<TransactionEvents> {
         self.get_transaction_cache_reader()
-            .get_events(digest)?
+            .try_get_events(digest)?
             .ok_or(IotaError::TransactionEventsNotFound { digest: *digest })
     }
 
@@ -4150,7 +4150,7 @@ impl AuthorityState {
         {
             if let Some(transaction) = self
                 .get_transaction_cache_reader()
-                .get_transaction_block(transaction_digest)?
+                .try_get_transaction_block(transaction_digest)?
             {
                 let cert_sig = epoch_store.get_transaction_cert_sig(transaction_digest)?;
                 let events = if let Some(digest) = effects.events_digest() {
@@ -4190,7 +4190,7 @@ impl AuthorityState {
     ) -> IotaResult<Option<VerifiedSignedTransactionEffects>> {
         let effects = self
             .get_transaction_cache_reader()
-            .get_executed_effects(transaction_digest)?;
+            .try_get_executed_effects(transaction_digest)?;
         match effects {
             Some(effects) => Ok(Some(self.sign_effects(effects, epoch_store)?)),
             None => Ok(None),
@@ -4787,7 +4787,7 @@ impl AuthorityState {
         // reconfiguration anyway.
         if self
             .get_transaction_cache_reader()
-            .is_tx_already_executed(tx_digest)
+            .try_is_tx_already_executed(tx_digest)
             .expect("read cannot fail")
         {
             warn!("change epoch tx has already been executed via state sync");
@@ -5030,7 +5030,7 @@ impl RandomnessRoundReceiver {
                 RANDOMNESS_STATE_UPDATE_EXECUTION_TIMEOUT,
                 authority_state
                     .get_transaction_cache_reader()
-                    .notify_read_executed_effects(&[digest]),
+                    .try_notify_read_executed_effects(&[digest]),
             )
             .await;
             let result = match result {
@@ -5048,7 +5048,7 @@ impl RandomnessRoundReceiver {
                     // Continue waiting as long as necessary in non-debug builds.
                     authority_state
                         .get_transaction_cache_reader()
-                        .notify_read_executed_effects(&[digest])
+                        .try_notify_read_executed_effects(&[digest])
                         .await
                 }
             };
@@ -5076,7 +5076,7 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
     ) -> IotaResult<KVStoreTransactionData> {
         let txns = if !transaction_keys.is_empty() {
             self.get_transaction_cache_reader()
-                .multi_get_transaction_blocks(transaction_keys)?
+                .try_multi_get_transaction_blocks(transaction_keys)?
                 .into_iter()
                 .map(|t| t.map(|t| (*t).clone().into_inner()))
                 .collect()
@@ -5086,7 +5086,7 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
 
         let fx = if !effects_keys.is_empty() {
             self.get_transaction_cache_reader()
-                .multi_get_executed_effects(effects_keys)?
+                .try_multi_get_executed_effects(effects_keys)?
         } else {
             vec![]
         };
@@ -5180,14 +5180,14 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
         }
         let events_digests: Vec<_> = self
             .get_transaction_cache_reader()
-            .multi_get_executed_effects(digests)?
+            .try_multi_get_executed_effects(digests)?
             .into_iter()
             .map(|t| t.and_then(|t| t.events_digest().cloned()))
             .collect();
         let non_empty_events: Vec<_> = events_digests.iter().filter_map(|e| *e).collect();
         let mut events = self
             .get_transaction_cache_reader()
-            .multi_get_events(&non_empty_events)?
+            .try_multi_get_events(&non_empty_events)?
             .into_iter();
         Ok(events_digests
             .into_iter()

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -4830,7 +4830,7 @@ impl AuthorityState {
         // able to deliver to the transaction to CheckpointExecutor after it is
         // included in a certified checkpoint.
         self.get_state_sync_store()
-            .insert_transaction_and_effects(&tx, &effects)
+            .try_insert_transaction_and_effects(&tx, &effects)
             .map_err(|err| {
                 let err: anyhow::Error = err.into();
                 err

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -915,7 +915,7 @@ impl AuthorityState {
         // and returns ConflictingTransaction error in case there is a lock on a
         // different existing transaction.
         self.get_cache_writer()
-            .acquire_transaction_locks(epoch_store, &owned_objects, signed_transaction.clone())
+            .try_acquire_transaction_locks(epoch_store, &owned_objects, signed_transaction.clone())
             .await?;
 
         Ok(signed_transaction)
@@ -1497,7 +1497,7 @@ impl AuthorityState {
             inner_temporary_store,
         );
         self.get_cache_writer()
-            .write_transaction_outputs(epoch_store.epoch(), transaction_outputs.into())
+            .try_write_transaction_outputs(epoch_store.epoch(), transaction_outputs.into())
             .await?;
 
         if certificate.transaction_data().is_end_of_epoch_tx() {

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -5143,7 +5143,7 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
         digest: TransactionDigest,
     ) -> IotaResult<Option<CheckpointSequenceNumber>> {
         self.get_checkpoint_cache()
-            .get_transaction_perpetual_checkpoint(&digest)
+            .try_get_transaction_perpetual_checkpoint(&digest)
             .map(|res| res.map(|(_epoch, checkpoint)| checkpoint))
     }
 
@@ -5162,7 +5162,7 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
     ) -> IotaResult<Vec<Option<CheckpointSequenceNumber>>> {
         let res = self
             .get_checkpoint_cache()
-            .multi_get_transactions_perpetual_checkpoints(digests)?;
+            .try_multi_get_transactions_perpetual_checkpoints(digests)?;
 
         Ok(res
             .into_iter()

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1263,7 +1263,7 @@ impl AuthorityState {
 
     fn check_owned_locks(&self, owned_object_refs: &[ObjectRef]) -> IotaResult {
         self.get_object_cache_reader()
-            .check_owned_objects_are_live(owned_object_refs)
+            .try_check_owned_objects_are_live(owned_object_refs)
     }
 
     /// This function captures the required state to debug a forked transaction.
@@ -3363,7 +3363,7 @@ impl AuthorityState {
     // This function is only used for testing.
     pub fn get_iota_system_state_object_for_testing(&self) -> IotaResult<IotaSystemState> {
         self.get_object_cache_reader()
-            .get_iota_system_state_object_unsafe()
+            .try_get_iota_system_state_object_unsafe()
     }
 
     #[instrument(level = "trace", skip_all)]
@@ -3397,7 +3397,7 @@ impl AuthorityState {
         Ok(
             match self
                 .get_object_cache_reader()
-                .get_latest_object_or_tombstone(*object_id)?
+                .try_get_latest_object_or_tombstone(*object_id)?
             {
                 Some((_, ObjectOrTombstone::Object(object))) => {
                     let layout = self.get_object_layout(&object)?;
@@ -3458,7 +3458,7 @@ impl AuthorityState {
         // Firstly we see if the object ever existed by getting its latest data
         let Some(obj_ref) = self
             .get_object_cache_reader()
-            .get_latest_object_ref_or_tombstone(*object_id)?
+            .try_get_latest_object_ref_or_tombstone(*object_id)?
         else {
             return Ok(PastObjectRead::ObjectNotExists(*object_id));
         };
@@ -3511,7 +3511,7 @@ impl AuthorityState {
     ) -> IotaResult<Option<(Object, Option<MoveStructLayout>)>> {
         let Some(object) = self
             .get_object_cache_reader()
-            .get_object_by_key(object_id, version)?
+            .try_get_object_by_key(object_id, version)?
         else {
             return Ok(None);
         };
@@ -4316,7 +4316,7 @@ impl AuthorityState {
     ) -> IotaResult<Option<VerifiedSignedTransaction>> {
         let lock_info = self
             .get_object_cache_reader()
-            .get_lock(*object_ref, epoch_store)?;
+            .try_get_lock(*object_ref, epoch_store)?;
         let lock_info = match lock_info {
             ObjectLockStatus::LockedAtDifferentVersion { locked_ref } => {
                 return Err(UserInputError::ObjectVersionUnavailableForConsumption {
@@ -4335,7 +4335,7 @@ impl AuthorityState {
     }
 
     pub async fn get_objects(&self, objects: &[ObjectID]) -> IotaResult<Vec<Option<Object>>> {
-        self.get_object_cache_reader().get_objects(objects)
+        self.get_object_cache_reader().try_get_objects(objects)
     }
 
     pub async fn get_object_or_tombstone(
@@ -4343,7 +4343,7 @@ impl AuthorityState {
         object_id: ObjectID,
     ) -> IotaResult<Option<ObjectRef>> {
         self.get_object_cache_reader()
-            .get_latest_object_ref_or_tombstone(object_id)
+            .try_get_latest_object_ref_or_tombstone(object_id)
     }
 
     /// Ordinarily, protocol upgrades occur when 2f + 1 + (f *
@@ -5153,7 +5153,7 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
         version: VersionNumber,
     ) -> IotaResult<Option<Object>> {
         self.get_object_cache_reader()
-            .get_object_by_key(&object_id, version)
+            .try_get_object_by_key(&object_id, version)
     }
 
     async fn multi_get_transactions_perpetual_checkpoints(

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2360,7 +2360,7 @@ impl AuthorityState {
                 // the old object must be present.
                 let Some(old_object) = self
                     .get_object_store()
-                    .get_object_by_key(id, *old_version)?
+                    .try_get_object_by_key(id, *old_version)?
                 else {
                     panic!(
                         "tx_digest={tx_digest:?}, error processing object owner index, cannot find owner for object {id:?} at version {old_version:?}"
@@ -2536,7 +2536,7 @@ impl AuthorityState {
                         // only allow to use it for genesis.
                         // reference: https://github.com/iotaledger/iota/issues/7267
                         self.get_object_store()
-                            .get_object(&object_id)?
+                            .try_get_object(&object_id)?
                             .ok_or_else(|| UserInputError::ObjectNotFound {
                                 object_id,
                                 version: Some(o.version()),
@@ -2544,7 +2544,7 @@ impl AuthorityState {
                     } else {
                         // Non-genesis object should be in the database with the given version.
                         self.get_object_store()
-                            .get_object_by_key(&object_id, o.version())?
+                            .try_get_object_by_key(&object_id, o.version())?
                             .ok_or_else(|| UserInputError::ObjectNotFound {
                                 object_id,
                                 version: Some(o.version()),
@@ -2709,7 +2709,7 @@ impl AuthorityState {
 
         let object = self
             .get_object_store()
-            .get_object_by_key(&request.object_id, requested_object_seq)?
+            .try_get_object_by_key(&request.object_id, requested_object_seq)?
             .ok_or_else(|| {
                 IotaError::from(UserInputError::ObjectNotFound {
                     object_id: request.object_id,
@@ -3348,7 +3348,7 @@ impl AuthorityState {
     #[instrument(level = "trace", skip_all)]
     pub async fn get_object(&self, object_id: &ObjectID) -> IotaResult<Option<Object>> {
         self.get_object_store()
-            .get_object(object_id)
+            .try_get_object(object_id)
             .map_err(Into::into)
     }
 
@@ -3543,7 +3543,7 @@ impl AuthorityState {
         version: SequenceNumber,
     ) -> IotaResult<Owner> {
         self.get_object_store()
-            .get_object_by_key(object_id, version)?
+            .try_get_object_by_key(object_id, version)?
             .ok_or_else(|| {
                 IotaError::from(UserInputError::ObjectNotFound {
                     object_id: *object_id,
@@ -3622,7 +3622,7 @@ impl AuthorityState {
 
         let objects = self
             .get_object_store()
-            .multi_get_objects_by_key(&object_ids)?;
+            .try_multi_get_objects_by_key(&object_ids)?;
 
         for (o, id) in objects.into_iter().zip(object_ids) {
             let object = o.ok_or_else(|| {
@@ -3733,7 +3733,7 @@ impl AuthorityState {
 
         let input_objects = self
             .get_object_store()
-            .multi_get_objects_by_key(&input_object_keys)?
+            .try_multi_get_objects_by_key(&input_object_keys)?
             .into_iter()
             .enumerate()
             .map(|(idx, maybe_object)| {
@@ -3761,7 +3761,7 @@ impl AuthorityState {
 
         let output_objects = self
             .get_object_store()
-            .multi_get_objects_by_key(&output_object_keys)?
+            .try_multi_get_objects_by_key(&output_object_keys)?
             .into_iter()
             .enumerate()
             .map(|(idx, maybe_object)| {
@@ -5376,7 +5376,7 @@ impl NodeStateDump {
         // Record all system packages at this version
         let mut relevant_system_packages = Vec::new();
         for sys_package_id in BuiltInFramework::all_package_ids() {
-            if let Some(w) = object_store.get_object(&sys_package_id)? {
+            if let Some(w) = object_store.try_get_object(&sys_package_id)? {
                 relevant_system_packages.push(ObjDumpFormat::new(w))
             }
         }
@@ -5386,7 +5386,7 @@ impl NodeStateDump {
         for kind in effects.input_shared_objects() {
             match kind {
                 InputSharedObject::Mutate(obj_ref) | InputSharedObject::ReadOnly(obj_ref) => {
-                    if let Some(w) = object_store.get_object_by_key(&obj_ref.0, obj_ref.1)? {
+                    if let Some(w) = object_store.try_get_object_by_key(&obj_ref.0, obj_ref.1)? {
                         shared_objects.push(ObjDumpFormat::new(w))
                     }
                 }
@@ -5401,7 +5401,7 @@ impl NodeStateDump {
         // Child objects which are read but not mutated are not tracked anywhere else
         let mut loaded_child_objects = Vec::new();
         for (id, meta) in &inner_temporary_store.loaded_runtime_objects {
-            if let Some(w) = object_store.get_object_by_key(id, meta.version)? {
+            if let Some(w) = object_store.try_get_object_by_key(id, meta.version)? {
                 loaded_child_objects.push(ObjDumpFormat::new(w))
             }
         }
@@ -5409,7 +5409,7 @@ impl NodeStateDump {
         // Record all modified objects
         let mut modified_at_versions = Vec::new();
         for (id, ver) in effects.modified_at_versions() {
-            if let Some(w) = object_store.get_object_by_key(&id, ver)? {
+            if let Some(w) = object_store.try_get_object_by_key(&id, ver)? {
                 modified_at_versions.push(ObjDumpFormat::new(w))
             }
         }

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1591,7 +1591,7 @@ impl AuthorityPerEpochStore {
                     // Note: we don't actually need to read from the transaction here, as no writer
                     // can update object_store until after get_or_init_next_object_versions
                     // completes.
-                    match cache_reader.get_object(id).expect("read cannot fail") {
+                    match cache_reader.try_get_object(id).expect("read cannot fail") {
                         Some(obj) => (*id, obj.version()),
                         None => (*id, *initial_version),
                     }

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -642,7 +642,7 @@ impl AuthorityStore {
     pub fn get_objects(&self, objects: &[ObjectID]) -> Result<Vec<Option<Object>>, IotaError> {
         let mut result = Vec::new();
         for id in objects {
-            result.push(self.get_object(id)?);
+            result.push(self.try_get_object(id)?);
         }
         Ok(result)
     }
@@ -1853,19 +1853,20 @@ impl AccumulatorStore for AuthorityStore {
 
 impl ObjectStore for AuthorityStore {
     /// Read an object and return it, or Ok(None) if the object was not found.
-    fn get_object(
+    fn try_get_object(
         &self,
         object_id: &ObjectID,
     ) -> Result<Option<Object>, iota_types::storage::error::Error> {
-        self.perpetual_tables.as_ref().get_object(object_id)
+        self.perpetual_tables.as_ref().try_get_object(object_id)
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
     ) -> Result<Option<Object>, iota_types::storage::error::Error> {
-        self.perpetual_tables.get_object_by_key(object_id, version)
+        self.perpetual_tables
+            .try_get_object_by_key(object_id, version)
     }
 }
 

--- a/crates/iota-core/src/authority/authority_store_tables.rs
+++ b/crates/iota-core/src/authority/authority_store_tables.rs
@@ -517,7 +517,7 @@ impl AuthorityPerpetualTables {
 
 impl ObjectStore for AuthorityPerpetualTables {
     /// Read an object and return it, or Ok(None) if the object was not found.
-    fn get_object(
+    fn try_get_object(
         &self,
         object_id: &ObjectID,
     ) -> Result<Option<Object>, iota_types::storage::error::Error> {
@@ -536,7 +536,7 @@ impl ObjectStore for AuthorityPerpetualTables {
         }
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: VersionNumber,

--- a/crates/iota-core/src/authority/test_authority_builder.rs
+++ b/crates/iota-core/src/authority/test_authority_builder.rs
@@ -367,7 +367,7 @@ impl<'a> TestAuthorityBuilder<'a> {
 
         state
             .get_cache_commit()
-            .commit_transaction_outputs(epoch_store.epoch(), &[*genesis.transaction().digest()])
+            .try_commit_transaction_outputs(epoch_store.epoch(), &[*genesis.transaction().digest()])
             .await
             .unwrap();
 

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -974,7 +974,7 @@ impl ValidatorService {
         let response = self
             .state
             .get_object_cache_reader()
-            .get_iota_system_state_object_unsafe()?;
+            .try_get_iota_system_state_object_unsafe()?;
         Ok((tonic::Response::new(response), Weight::one()))
     }
 

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/data_ingestion_handler.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/data_ingestion_handler.rs
@@ -31,14 +31,14 @@ pub(crate) fn load_checkpoint_data(
         .expect("checkpoint content has to be stored");
 
     let transactions = transaction_cache_reader
-        .multi_get_transaction_blocks(transaction_digests)?
+        .try_multi_get_transaction_blocks(transaction_digests)?
         .into_iter()
         .zip(transaction_digests)
         .map(|(tx, digest)| tx.ok_or(IotaError::TransactionNotFound { digest: *digest }))
         .collect::<IotaResult<Vec<_>>>()?;
 
     let effects = transaction_cache_reader
-        .multi_get_executed_effects(transaction_digests)?
+        .try_multi_get_executed_effects(transaction_digests)?
         .into_iter()
         .zip(transaction_digests)
         .map(|(effects, &digest)| effects.ok_or(IotaError::TransactionNotFound { digest }))
@@ -50,7 +50,7 @@ pub(crate) fn load_checkpoint_data(
         .collect::<Vec<_>>();
 
     let events = transaction_cache_reader
-        .multi_get_events(&event_digests)?
+        .try_multi_get_events(&event_digests)?
         .into_iter()
         .zip(&event_digests)
         .map(|(event, digest)| {

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/data_ingestion_handler.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/data_ingestion_handler.rs
@@ -75,7 +75,7 @@ pub(crate) fn load_checkpoint_data(
             .collect::<Vec<_>>();
 
         let input_objects = object_cache_reader
-            .multi_get_objects_by_key(&input_object_keys)?
+            .try_multi_get_objects_by_key(&input_object_keys)?
             .into_iter()
             .zip(&input_object_keys)
             .map(|(object, object_key)| {
@@ -95,7 +95,7 @@ pub(crate) fn load_checkpoint_data(
             .collect::<Vec<_>>();
 
         let output_objects = object_cache_reader
-            .multi_get_objects_by_key(&output_object_keys)?
+            .try_multi_get_objects_by_key(&output_object_keys)?
             .into_iter()
             .zip(&output_object_keys)
             .map(|(object, object_key)| {

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -440,7 +440,7 @@ impl CheckpointExecutor {
         let cache_commit = self.state.get_cache_commit();
         debug!("committing checkpoint transactions to disk");
         cache_commit
-            .commit_transaction_outputs(epoch_store.epoch(), all_tx_digests)
+            .try_commit_transaction_outputs(epoch_store.epoch(), all_tx_digests)
             .await
             .expect("commit_transaction_outputs cannot fail");
 
@@ -678,7 +678,7 @@ impl CheckpointExecutor {
 
                     let cache_commit = self.state.get_cache_commit();
                     cache_commit
-                        .commit_transaction_outputs(cur_epoch, &[change_epoch_tx_digest])
+                        .try_commit_transaction_outputs(cur_epoch, &[change_epoch_tx_digest])
                         .await
                         .expect("commit_transaction_outputs cannot fail");
                     fail_point_async!("prune-and-compact");

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -603,7 +603,7 @@ impl CheckpointExecutor {
     ) {
         let change_epoch_fx = self
             .transaction_cache_reader
-            .get_effects(&execution_digests.effects)
+            .try_get_effects(&execution_digests.effects)
             .expect("Fetching effects for change_epoch tx cannot fail")
             .expect("Change_epoch tx effects must exist");
 
@@ -699,7 +699,7 @@ impl CheckpointExecutor {
 
                     let effects = self
                         .transaction_cache_reader
-                        .notify_read_executed_effects(&all_tx_digests)
+                        .try_notify_read_executed_effects(&all_tx_digests)
                         .await
                         .expect("Failed to get executed effects for finalizing checkpoint");
 
@@ -844,7 +844,8 @@ async fn handle_execution_effects(
     // Whether the checkpoint is next to execute and blocking additional executions.
     let mut blocking_execution = false;
     loop {
-        let effects_future = transaction_cache_reader.notify_read_executed_effects(&all_tx_digests);
+        let effects_future =
+            transaction_cache_reader.try_notify_read_executed_effects(&all_tx_digests);
 
         match timeout(log_timeout_sec, effects_future).await {
             Err(_elapsed) => {
@@ -879,7 +880,7 @@ async fn handle_execution_effects(
                 // Only log details when the checkpoint is next to execute, but has not finished
                 // execution within log_timeout_sec.
                 let missing_digests: Vec<TransactionDigest> = transaction_cache_reader
-                    .multi_get_executed_effects_digests(&all_tx_digests)
+                    .try_multi_get_executed_effects_digests(&all_tx_digests)
                     .expect("multi_get_executed_effects cannot fail")
                     .iter()
                     .zip(all_tx_digests.clone())
@@ -961,7 +962,7 @@ fn assert_not_forked(
 ) {
     if *expected_digest != *actual_effects_digest {
         let actual_effects = cache_reader
-            .get_executed_effects(tx_digest)
+            .try_get_executed_effects(tx_digest)
             .expect("get_executed_effects cannot fail")
             .expect("actual effects should exist");
 
@@ -1013,7 +1014,7 @@ fn extract_end_of_epoch_tx(
         .expect("Final checkpoint must have at least one transaction");
 
     let change_epoch_tx = cache_reader
-        .get_transaction_block(&digests.transaction)
+        .try_get_transaction_block(&digests.transaction)
         .expect("read cannot fail");
 
     let change_epoch_tx = VerifiedExecutableTransaction::new_from_checkpoint(
@@ -1086,7 +1087,7 @@ fn get_unexecuted_transactions(
             .expect("Final checkpoint must have at least one transaction");
 
         let change_epoch_tx = cache_reader
-            .get_transaction_block(&digests.transaction)
+            .try_get_transaction_block(&digests.transaction)
             .expect("read cannot fail")
             .unwrap_or_else(||
                 panic!(
@@ -1117,7 +1118,7 @@ fn get_unexecuted_transactions(
                 .unwrap_or_default(),
         );
         if let Some(first_digest) = execution_digests.first() {
-            let maybe_randomness_tx = cache_reader.get_transaction_block(&first_digest.transaction)
+            let maybe_randomness_tx = cache_reader.try_get_transaction_block(&first_digest.transaction)
             .expect("read cannot fail")
             .unwrap_or_else(||
                 panic!(
@@ -1141,7 +1142,7 @@ fn get_unexecuted_transactions(
         execution_digests.iter().map(|tx| tx.transaction).collect();
 
     let executed_effects_digests = cache_reader
-        .multi_get_executed_effects_digests(&all_tx_digests)
+        .try_multi_get_executed_effects_digests(&all_tx_digests)
         .expect("failed to read executed_effects from store");
 
     let (unexecuted_txns, expected_effects_digests): (Vec<_>, Vec<_>) =
@@ -1186,7 +1187,7 @@ fn get_unexecuted_transactions(
             .collect()
     } else {
         cache_reader
-            .multi_get_transaction_blocks(&unexecuted_txns)
+            .try_multi_get_transaction_blocks(&unexecuted_txns)
             .expect("Failed to get checkpoint txes from store")
             .into_iter()
             .zip(expected_effects_digests)
@@ -1257,7 +1258,7 @@ async fn execute_transactions(
 
     let digest_to_effects: HashMap<TransactionDigest, TransactionEffects> =
         transaction_cache_reader
-            .multi_get_effects(&shared_effects_digests)?
+            .try_multi_get_effects(&shared_effects_digests)?
             .into_iter()
             .zip(shared_effects_digests)
             .map(|(fx, fx_digest)| {

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -1343,7 +1343,7 @@ async fn finalize_checkpoint(
     // TODO remove once we no longer need to support this table for read RPC
     state
         .get_checkpoint_cache()
-        .insert_finalized_transactions_perpetual_checkpoints(
+        .try_insert_finalized_transactions_perpetual_checkpoints(
             tx_digests,
             epoch_store.epoch(),
             checkpoint.sequence_number,

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -786,7 +786,7 @@ impl CheckpointStore {
             let fx_digests: Vec<_> = contents.iter().map(|digests| digests.effects).collect();
             let txns = cache
                 .try_multi_get_transaction_blocks(&tx_digests)
-                .expect("multi_get_transaction_blocks should not fail");
+                .expect("try_multi_get_transaction_blocks should not fail");
             for (tx, digest) in txns.iter().zip(tx_digests.iter()) {
                 if tx.is_none() {
                     panic!("transaction {digest:?} not found");
@@ -1702,7 +1702,7 @@ impl CheckpointBuilder {
         let root_txs = self
             .state
             .get_transaction_cache_reader()
-            .multi_get_transaction_blocks(root_digests)
+            .try_multi_get_transaction_blocks(root_digests)
             .unwrap();
         let ccps = root_txs
             .iter()
@@ -1724,7 +1724,7 @@ impl CheckpointBuilder {
         let txs = self
             .state
             .get_transaction_cache_reader()
-            .multi_get_transaction_blocks(
+            .try_multi_get_transaction_blocks(
                 &sorted
                     .iter()
                     .map(|tx| *tx.transaction_digest())

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -785,7 +785,7 @@ impl CheckpointStore {
             let tx_digests: Vec<_> = contents.iter().map(|digests| digests.transaction).collect();
             let fx_digests: Vec<_> = contents.iter().map(|digests| digests.effects).collect();
             let txns = cache
-                .multi_get_transaction_blocks(&tx_digests)
+                .try_multi_get_transaction_blocks(&tx_digests)
                 .expect("multi_get_transaction_blocks should not fail");
             for (tx, digest) in txns.iter().zip(tx_digests.iter()) {
                 if tx.is_none() {
@@ -834,7 +834,7 @@ impl CheckpointStore {
             });
 
             cache
-                .notify_read_executed_effects_digests(&tx_digests)
+                .try_notify_read_executed_effects_digests(&tx_digests)
                 .await
                 .expect("notify_read_executed_effects_digests should not fail");
 
@@ -1077,7 +1077,7 @@ impl CheckpointBuilder {
             .await?;
         let root_effects = self
             .effects_store
-            .notify_read_executed_effects(&root_digests)
+            .try_notify_read_executed_effects(&root_digests)
             .in_monitored_scope("CheckpointNotifyRead")
             .await?;
 
@@ -1156,7 +1156,7 @@ impl CheckpointBuilder {
         let first_tx = self
             .state
             .get_transaction_cache_reader()
-            .get_transaction_block(&root_digests[0])?
+            .try_get_transaction_block(&root_digests[0])?
             .expect("Transaction block must exist");
 
         Ok(match first_tx.transaction_data().kind() {
@@ -1346,7 +1346,7 @@ impl CheckpointBuilder {
         let transactions_and_sizes = self
             .state
             .get_transaction_cache_reader()
-            .get_transactions_and_serialized_sizes(&all_digests)?;
+            .try_get_transactions_and_serialized_sizes(&all_digests)?;
         let mut all_effects_and_transaction_sizes = Vec::with_capacity(all_effects.len());
         let mut transactions = Vec::with_capacity(all_effects.len());
         let mut transaction_keys = Vec::with_capacity(all_effects.len());
@@ -1670,7 +1670,9 @@ impl CheckpointBuilder {
                 break;
             }
             let pending = pending.into_iter().collect::<Vec<_>>();
-            let effects = self.effects_store.multi_get_executed_effects(&pending)?;
+            let effects = self
+                .effects_store
+                .try_multi_get_executed_effects(&pending)?;
             let effects = effects
                 .into_iter()
                 .zip(pending)
@@ -2710,7 +2712,7 @@ mod tests {
     }
 
     impl TransactionCacheRead for HashMap<TransactionDigest, TransactionEffects> {
-        fn notify_read_executed_effects(
+        fn try_notify_read_executed_effects(
             &self,
             digests: &[TransactionDigest],
         ) -> BoxFuture<'_, IotaResult<Vec<TransactionEffects>>> {
@@ -2721,7 +2723,7 @@ mod tests {
             .boxed()
         }
 
-        fn notify_read_executed_effects_digests(
+        fn try_notify_read_executed_effects_digests(
             &self,
             digests: &[TransactionDigest],
         ) -> BoxFuture<'_, IotaResult<Vec<TransactionEffectsDigest>>> {
@@ -2736,7 +2738,7 @@ mod tests {
             .boxed()
         }
 
-        fn multi_get_executed_effects(
+        fn try_multi_get_executed_effects(
             &self,
             digests: &[TransactionDigest],
         ) -> IotaResult<Vec<Option<TransactionEffects>>> {
@@ -2749,28 +2751,28 @@ mod tests {
         // (e.g. had to implement EFfectsNotifyRead for all ExecutionCacheRead
         // implementors).
 
-        fn multi_get_transaction_blocks(
+        fn try_multi_get_transaction_blocks(
             &self,
             _: &[TransactionDigest],
         ) -> IotaResult<Vec<Option<Arc<VerifiedTransaction>>>> {
             unimplemented!()
         }
 
-        fn multi_get_executed_effects_digests(
+        fn try_multi_get_executed_effects_digests(
             &self,
             _: &[TransactionDigest],
         ) -> IotaResult<Vec<Option<TransactionEffectsDigest>>> {
             unimplemented!()
         }
 
-        fn multi_get_effects(
+        fn try_multi_get_effects(
             &self,
             _: &[TransactionEffectsDigest],
         ) -> IotaResult<Vec<Option<TransactionEffects>>> {
             unimplemented!()
         }
 
-        fn multi_get_events(
+        fn try_multi_get_events(
             &self,
             _: &[TransactionEventsDigest],
         ) -> IotaResult<Vec<Option<TransactionEvents>>> {

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1225,7 +1225,7 @@ impl CheckpointBuilder {
         // can be removed.
         self.state
             .get_cache_commit()
-            .persist_transactions(&all_tx_digests)
+            .try_persist_transactions(&all_tx_digests)
             .await?;
 
         batch.write()?;

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -648,14 +648,14 @@ pub trait ExecutionCacheWrite: Send + Sync {
     /// Any write performed by this method immediately notifies any waiter that
     /// has previously called notify_read_objects_for_execution or
     /// notify_read_objects_for_signing for the object in question.
-    fn write_transaction_outputs(
+    fn try_write_transaction_outputs(
         &self,
         epoch_id: EpochId,
         tx_outputs: Arc<TransactionOutputs>,
     ) -> BoxFuture<'_, IotaResult>;
 
     /// Attempt to acquire object locks for all of the owned input locks.
-    fn acquire_transaction_locks<'a>(
+    fn try_acquire_transaction_locks<'a>(
         &'a self,
         epoch_store: &'a AuthorityPerEpochStore,
         owned_input_objects: &'a [ObjectRef],

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -197,47 +197,47 @@ pub trait ExecutionCacheCommit: Send + Sync {
 }
 
 pub trait ObjectCacheRead: Send + Sync {
-    fn get_package_object(&self, id: &ObjectID) -> IotaResult<Option<PackageObject>>;
+    fn try_get_package_object(&self, id: &ObjectID) -> IotaResult<Option<PackageObject>>;
     fn force_reload_system_packages(&self, system_package_ids: &[ObjectID]);
 
-    fn get_object(&self, id: &ObjectID) -> IotaResult<Option<Object>>;
+    fn try_get_object(&self, id: &ObjectID) -> IotaResult<Option<Object>>;
 
-    fn get_objects(&self, objects: &[ObjectID]) -> IotaResult<Vec<Option<Object>>> {
+    fn try_get_objects(&self, objects: &[ObjectID]) -> IotaResult<Vec<Option<Object>>> {
         let mut ret = Vec::with_capacity(objects.len());
         for object_id in objects {
-            ret.push(self.get_object(object_id)?);
+            ret.push(self.try_get_object(object_id)?);
         }
         Ok(ret)
     }
 
-    fn get_latest_object_ref_or_tombstone(
+    fn try_get_latest_object_ref_or_tombstone(
         &self,
         object_id: ObjectID,
     ) -> IotaResult<Option<ObjectRef>>;
 
-    fn get_latest_object_or_tombstone(
+    fn try_get_latest_object_or_tombstone(
         &self,
         object_id: ObjectID,
     ) -> IotaResult<Option<(ObjectKey, ObjectOrTombstone)>>;
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,
     ) -> IotaResult<Option<Object>>;
 
-    fn multi_get_objects_by_key(
+    fn try_multi_get_objects_by_key(
         &self,
         object_keys: &[ObjectKey],
     ) -> IotaResult<Vec<Option<Object>>>;
 
-    fn object_exists_by_key(
+    fn try_object_exists_by_key(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,
     ) -> IotaResult<bool>;
 
-    fn multi_object_exists_by_key(&self, object_keys: &[ObjectKey]) -> IotaResult<Vec<bool>>;
+    fn try_multi_object_exists_by_key(&self, object_keys: &[ObjectKey]) -> IotaResult<Vec<bool>>;
 
     /// Load a list of objects from the store by object reference.
     /// If they exist in the store, they are returned directly.
@@ -247,18 +247,18 @@ pub trait ObjectCacheRead: Send + Sync {
     /// ObjectVersionUnavailableForConsumption, which indicates this is not
     /// retriable. Otherwise, we return a ObjectNotFound error, which
     /// indicates this is retriable.
-    fn multi_get_objects_with_more_accurate_error_return(
+    fn try_multi_get_objects_with_more_accurate_error_return(
         &self,
         object_refs: &[ObjectRef],
     ) -> Result<Vec<Object>, IotaError> {
-        let objects = self.multi_get_objects_by_key(
+        let objects = self.try_multi_get_objects_by_key(
             &object_refs.iter().map(ObjectKey::from).collect::<Vec<_>>(),
         )?;
         let mut result = Vec::new();
         for (object_opt, object_ref) in objects.into_iter().zip(object_refs) {
             match object_opt {
                 None => {
-                    let live_objref = self._get_live_objref(object_ref.0)?;
+                    let live_objref = self._try_get_live_objref(object_ref.0)?;
                     let error = if live_objref.1 >= object_ref.1 {
                         UserInputError::ObjectVersionUnavailableForConsumption {
                             provided_obj_ref: *object_ref,
@@ -286,7 +286,7 @@ pub trait ObjectCacheRead: Send + Sync {
     /// markers to handle the case where an object will never become available
     /// (e.g. because it has been received by some other transaction
     /// already).
-    fn multi_input_objects_available(
+    fn try_multi_input_objects_available(
         &self,
         keys: &[InputKey],
         receiving_objects: HashSet<InputKey>,
@@ -299,7 +299,7 @@ pub trait ObjectCacheRead: Send + Sync {
 
         let mut versioned_results = vec![];
         for ((idx, input_key), has_key) in keys_with_version.iter().zip(
-            self.multi_object_exists_by_key(
+            self.try_multi_object_exists_by_key(
                 &keys_with_version
                     .iter()
                     .map(|(_, k)| ObjectKey(k.id(), k.version().unwrap()))
@@ -324,17 +324,17 @@ pub trait ObjectCacheRead: Send + Sync {
                 // exists or was deleted. We will then let mark it as available
                 // to let the transaction through so it can fail at execution.
                 let is_available = self
-                    .get_object(&input_key.id())?
+                    .try_get_object(&input_key.id())?
                     .map(|obj| obj.version() >= input_key.version().unwrap())
                     .unwrap_or(false)
-                    || self.have_deleted_owned_object_at_version_or_after(
+                    || self.try_have_deleted_owned_object_at_version_or_after(
                         &input_key.id(),
                         input_key.version().unwrap(),
                         epoch,
                     )?;
                 versioned_results.push((*idx, is_available));
             } else if self
-                .get_deleted_shared_object_previous_tx_digest(
+                .try_get_deleted_shared_object_previous_tx_digest(
                     &input_key.id(),
                     input_key.version().unwrap(),
                     epoch,
@@ -354,7 +354,7 @@ pub trait ObjectCacheRead: Send + Sync {
             (
                 idx,
                 match self
-                    .get_latest_object_ref_or_tombstone(key.id())
+                    .try_get_latest_object_ref_or_tombstone(key.id())
                     .expect("read cannot fail")
                 {
                     None => false,
@@ -376,29 +376,33 @@ pub trait ObjectCacheRead: Send + Sync {
     /// dynamic field child object. We do not store the version of the child
     /// object, but because of lamport timestamp, we know the child must
     /// have version number less then or eq to the parent.
-    fn find_object_lt_or_eq_version(
+    fn try_find_object_lt_or_eq_version(
         &self,
         object_id: ObjectID,
         version: SequenceNumber,
     ) -> IotaResult<Option<Object>>;
 
-    fn get_lock(&self, obj_ref: ObjectRef, epoch_store: &AuthorityPerEpochStore) -> IotaLockResult;
+    fn try_get_lock(
+        &self,
+        obj_ref: ObjectRef,
+        epoch_store: &AuthorityPerEpochStore,
+    ) -> IotaLockResult;
 
     // This method is considered "private" - only used by
     // multi_get_objects_with_more_accurate_error_return
-    fn _get_live_objref(&self, object_id: ObjectID) -> IotaResult<ObjectRef>;
+    fn _try_get_live_objref(&self, object_id: ObjectID) -> IotaResult<ObjectRef>;
 
     // Check that the given set of objects are live at the given version. This is
     // used as a safety check before execution, and could potentially be deleted
     // or changed to a debug_assert
-    fn check_owned_objects_are_live(&self, owned_object_refs: &[ObjectRef]) -> IotaResult;
+    fn try_check_owned_objects_are_live(&self, owned_object_refs: &[ObjectRef]) -> IotaResult;
 
-    fn get_iota_system_state_object_unsafe(&self) -> IotaResult<IotaSystemState>;
+    fn try_get_iota_system_state_object_unsafe(&self) -> IotaResult<IotaSystemState>;
 
     // Marker methods
 
     /// Get the marker at a specific version
-    fn get_marker_value(
+    fn try_get_marker_value(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,
@@ -406,7 +410,7 @@ pub trait ObjectCacheRead: Send + Sync {
     ) -> IotaResult<Option<MarkerValue>>;
 
     /// Get the latest marker for a given object.
-    fn get_latest_marker(
+    fn try_get_latest_marker(
         &self,
         object_id: &ObjectID,
         epoch_id: EpochId,
@@ -414,12 +418,12 @@ pub trait ObjectCacheRead: Send + Sync {
 
     /// If the shared object was deleted, return deletion info for the current
     /// live version
-    fn get_last_shared_object_deletion_info(
+    fn try_get_last_shared_object_deletion_info(
         &self,
         object_id: &ObjectID,
         epoch_id: EpochId,
     ) -> IotaResult<Option<(SequenceNumber, TransactionDigest)>> {
-        match self.get_latest_marker(object_id, epoch_id)? {
+        match self.try_get_latest_marker(object_id, epoch_id)? {
             Some((version, MarkerValue::SharedDeleted(digest))) => Ok(Some((version, digest))),
             _ => Ok(None),
         }
@@ -427,37 +431,37 @@ pub trait ObjectCacheRead: Send + Sync {
 
     /// If the shared object was deleted, return deletion info for the specified
     /// version.
-    fn get_deleted_shared_object_previous_tx_digest(
+    fn try_get_deleted_shared_object_previous_tx_digest(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,
         epoch_id: EpochId,
     ) -> IotaResult<Option<TransactionDigest>> {
-        match self.get_marker_value(object_id, version, epoch_id)? {
+        match self.try_get_marker_value(object_id, version, epoch_id)? {
             Some(MarkerValue::SharedDeleted(digest)) => Ok(Some(digest)),
             _ => Ok(None),
         }
     }
 
-    fn have_received_object_at_version(
+    fn try_have_received_object_at_version(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,
         epoch_id: EpochId,
     ) -> IotaResult<bool> {
-        match self.get_marker_value(object_id, version, epoch_id)? {
+        match self.try_get_marker_value(object_id, version, epoch_id)? {
             Some(MarkerValue::Received) => Ok(true),
             _ => Ok(false),
         }
     }
 
-    fn have_deleted_owned_object_at_version_or_after(
+    fn try_have_deleted_owned_object_at_version_or_after(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,
         epoch_id: EpochId,
     ) -> IotaResult<bool> {
-        match self.get_latest_marker(object_id, epoch_id)? {
+        match self.try_get_latest_marker(object_id, epoch_id)? {
             Some((marker_version, MarkerValue::OwnedDeleted)) if marker_version >= version => {
                 Ok(true)
             }
@@ -467,7 +471,7 @@ pub trait ObjectCacheRead: Send + Sync {
 
     /// Return the watermark for the highest checkpoint for which we've pruned
     /// objects.
-    fn get_highest_pruned_checkpoint(&self) -> IotaResult<CheckpointSequenceNumber>;
+    fn try_get_highest_pruned_checkpoint(&self) -> IotaResult<CheckpointSequenceNumber>;
 }
 
 pub trait TransactionCacheRead: Send + Sync {
@@ -745,7 +749,7 @@ macro_rules! implement_storage_traits {
     ($implementor: ident) => {
         impl ObjectStore for $implementor {
             fn try_get_object(&self, object_id: &ObjectID) -> StorageResult<Option<Object>> {
-                ObjectCacheRead::get_object(self, object_id).map_err(StorageError::custom)
+                ObjectCacheRead::try_get_object(self, object_id).map_err(StorageError::custom)
             }
 
             fn try_get_object_by_key(
@@ -753,7 +757,7 @@ macro_rules! implement_storage_traits {
                 object_id: &ObjectID,
                 version: iota_types::base_types::VersionNumber,
             ) -> StorageResult<Option<Object>> {
-                ObjectCacheRead::get_object_by_key(self, object_id, version)
+                ObjectCacheRead::try_get_object_by_key(self, object_id, version)
                     .map_err(StorageError::custom)
             }
         }
@@ -766,7 +770,7 @@ macro_rules! implement_storage_traits {
                 child_version_upper_bound: SequenceNumber,
             ) -> IotaResult<Option<Object>> {
                 let Some(child_object) =
-                    self.find_object_lt_or_eq_version(*child, child_version_upper_bound)?
+                    self.try_find_object_lt_or_eq_version(*child, child_version_upper_bound)?
                 else {
                     return Ok(None);
                 };
@@ -789,7 +793,7 @@ macro_rules! implement_storage_traits {
                 receive_object_at_version: SequenceNumber,
                 epoch_id: EpochId,
             ) -> IotaResult<Option<Object>> {
-                let Some(recv_object) = ObjectCacheRead::get_object_by_key(
+                let Some(recv_object) = ObjectCacheRead::try_get_object_by_key(
                     self,
                     receiving_object_id,
                     receive_object_at_version,
@@ -806,7 +810,7 @@ macro_rules! implement_storage_traits {
                 // forks in transaction replay due to possible reordering of
                 // transactions during replay.
                 if recv_object.owner != Owner::AddressOwner((*owner).into())
-                    || self.have_received_object_at_version(
+                    || self.try_have_received_object_at_version(
                         receiving_object_id,
                         receive_object_at_version,
                         epoch_id,
@@ -824,7 +828,7 @@ macro_rules! implement_storage_traits {
                 &self,
                 package_id: &ObjectID,
             ) -> IotaResult<Option<PackageObject>> {
-                ObjectCacheRead::get_package_object(self, package_id)
+                ObjectCacheRead::try_get_package_object(self, package_id)
             }
         }
     };

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -729,13 +729,13 @@ pub trait ExecutionCacheReconfigAPI: Send + Sync {
 // sync implies that it is certified output, and can be immediately persisted to
 // the store.
 pub trait StateSyncAPI: Send + Sync {
-    fn insert_transaction_and_effects(
+    fn try_insert_transaction_and_effects(
         &self,
         transaction: &VerifiedTransaction,
         transaction_effects: &TransactionEffects,
     ) -> IotaResult;
 
-    fn multi_insert_transaction_and_effects(
+    fn try_multi_insert_transaction_and_effects(
         &self,
         transactions_and_effects: &[VerifiedExecutionData],
     ) -> IotaResult;
@@ -926,7 +926,7 @@ macro_rules! implement_passthrough_traits {
         }
 
         impl StateSyncAPI for $implementor {
-            fn insert_transaction_and_effects(
+            fn try_insert_transaction_and_effects(
                 &self,
                 transaction: &VerifiedTransaction,
                 transaction_effects: &TransactionEffects,
@@ -936,7 +936,7 @@ macro_rules! implement_passthrough_traits {
                     .insert_transaction_and_effects(transaction, transaction_effects)?)
             }
 
-            fn multi_insert_transaction_and_effects(
+            fn try_multi_insert_transaction_and_effects(
                 &self,
                 transactions_and_effects: &[VerifiedExecutionData],
             ) -> IotaResult {

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -690,11 +690,11 @@ pub trait CheckpointCache: Send + Sync {
 }
 
 pub trait ExecutionCacheReconfigAPI: Send + Sync {
-    fn insert_genesis_object(&self, object: Object) -> IotaResult;
-    fn bulk_insert_genesis_objects(&self, objects: &[Object]) -> IotaResult;
+    fn try_insert_genesis_object(&self, object: Object) -> IotaResult;
+    fn try_bulk_insert_genesis_objects(&self, objects: &[Object]) -> IotaResult;
 
-    fn revert_state_update(&self, digest: &TransactionDigest) -> IotaResult;
-    fn set_epoch_start_configuration(
+    fn try_revert_state_update(&self, digest: &TransactionDigest) -> IotaResult;
+    fn try_set_epoch_start_configuration(
         &self,
         epoch_start_config: &EpochStartConfiguration,
     ) -> IotaResult;
@@ -703,13 +703,13 @@ pub trait ExecutionCacheReconfigAPI: Send + Sync {
 
     fn clear_state_end_of_epoch(&self, execution_guard: &ExecutionLockWriteGuard<'_>);
 
-    fn expensive_check_iota_conservation(
+    fn try_expensive_check_iota_conservation(
         &self,
         old_epoch_store: &AuthorityPerEpochStore,
         epoch_supply_change: Option<i64>,
     ) -> IotaResult;
 
-    fn checkpoint_db(&self, path: &Path) -> IotaResult;
+    fn try_checkpoint_db(&self, path: &Path) -> IotaResult;
 
     /// Reconfigure the cache itself.
     /// TODO: this is only needed for ProxyCache to switch between cache impls.
@@ -744,11 +744,11 @@ pub trait TestingAPI: Send + Sync {
 macro_rules! implement_storage_traits {
     ($implementor: ident) => {
         impl ObjectStore for $implementor {
-            fn get_object(&self, object_id: &ObjectID) -> StorageResult<Option<Object>> {
+            fn try_get_object(&self, object_id: &ObjectID) -> StorageResult<Option<Object>> {
                 ObjectCacheRead::get_object(self, object_id).map_err(StorageError::custom)
             }
 
-            fn get_object_by_key(
+            fn try_get_object_by_key(
                 &self,
                 object_id: &ObjectID,
                 version: iota_types::base_types::VersionNumber,
@@ -835,22 +835,22 @@ macro_rules! implement_storage_traits {
 macro_rules! implement_passthrough_traits {
     ($implementor: ident) => {
         impl CheckpointCache for $implementor {
-            fn get_transaction_perpetual_checkpoint(
+            fn try_get_transaction_perpetual_checkpoint(
                 &self,
                 digest: &TransactionDigest,
             ) -> IotaResult<Option<(EpochId, CheckpointSequenceNumber)>> {
                 self.store.get_transaction_perpetual_checkpoint(digest)
             }
 
-            fn multi_get_transactions_perpetual_checkpoints(
+            fn try_multi_get_transactions_perpetual_checkpoints(
                 &self,
                 digests: &[TransactionDigest],
             ) -> IotaResult<Vec<Option<(EpochId, CheckpointSequenceNumber)>>> {
-                self.store
-                    .multi_get_transactions_perpetual_checkpoints(digests)
+                self.store.
+                    multi_get_transactions_perpetual_checkpoints(digests)
             }
 
-            fn insert_finalized_transactions_perpetual_checkpoints(
+            fn try_insert_finalized_transactions_perpetual_checkpoints(
                 &self,
                 digests: &[TransactionDigest],
                 epoch: EpochId,
@@ -862,19 +862,19 @@ macro_rules! implement_passthrough_traits {
         }
 
         impl ExecutionCacheReconfigAPI for $implementor {
-            fn insert_genesis_object(&self, object: Object) -> IotaResult {
+            fn try_insert_genesis_object(&self, object: Object) -> IotaResult {
                 self.insert_genesis_object_impl(object)
             }
 
-            fn bulk_insert_genesis_objects(&self, objects: &[Object]) -> IotaResult {
+            fn try_bulk_insert_genesis_objects(&self, objects: &[Object]) -> IotaResult {
                 self.bulk_insert_genesis_objects_impl(objects)
             }
 
-            fn revert_state_update(&self, digest: &TransactionDigest) -> IotaResult {
+            fn try_revert_state_update(&self, digest: &TransactionDigest) -> IotaResult {
                 self.revert_state_update_impl(digest)
             }
 
-            fn set_epoch_start_configuration(
+            fn try_set_epoch_start_configuration(
                 &self,
                 epoch_start_config: &EpochStartConfiguration,
             ) -> IotaResult {
@@ -889,7 +889,7 @@ macro_rules! implement_passthrough_traits {
                 self.clear_state_end_of_epoch_impl(execution_guard)
             }
 
-            fn expensive_check_iota_conservation(
+            fn try_expensive_check_iota_conservation(
                 &self,
                 old_epoch_store: &AuthorityPerEpochStore,
                 epoch_supply_change: Option<i64>,
@@ -901,7 +901,7 @@ macro_rules! implement_passthrough_traits {
                 )
             }
 
-            fn checkpoint_db(&self, path: &std::path::Path) -> IotaResult {
+            fn try_checkpoint_db(&self, path: &std::path::Path) -> IotaResult {
                 self.store.perpetual_tables.checkpoint_db(path)
             }
 

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -173,7 +173,7 @@ pub trait ExecutionCacheCommit: Send + Sync {
     /// Durably commit the outputs of the given transactions to the database.
     /// Will be called by CheckpointExecutor to ensure that transaction outputs
     /// are written durably before marking a checkpoint as finalized.
-    fn commit_transaction_outputs<'a>(
+    fn try_commit_transaction_outputs<'a>(
         &'a self,
         epoch: EpochId,
         digests: &'a [TransactionDigest],
@@ -190,7 +190,7 @@ pub trait ExecutionCacheCommit: Send + Sync {
     /// After we have done that, crash recovery will be done by
     /// re-processing consensus commits and pending_consensus_transactions,
     /// and this method can be removed.
-    fn persist_transactions<'a>(
+    fn try_persist_transactions<'a>(
         &'a self,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, IotaResult>;
@@ -846,8 +846,8 @@ macro_rules! implement_passthrough_traits {
                 &self,
                 digests: &[TransactionDigest],
             ) -> IotaResult<Vec<Option<(EpochId, CheckpointSequenceNumber)>>> {
-                self.store.
-                    multi_get_transactions_perpetual_checkpoints(digests)
+                self.store
+                    .multi_get_transactions_perpetual_checkpoints(digests)
             }
 
             fn try_insert_finalized_transactions_perpetual_checkpoints(

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -475,16 +475,16 @@ pub trait ObjectCacheRead: Send + Sync {
 }
 
 pub trait TransactionCacheRead: Send + Sync {
-    fn multi_get_transaction_blocks(
+    fn try_multi_get_transaction_blocks(
         &self,
         digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Option<Arc<VerifiedTransaction>>>>;
 
-    fn get_transaction_block(
+    fn try_get_transaction_block(
         &self,
         digest: &TransactionDigest,
     ) -> IotaResult<Option<Arc<VerifiedTransaction>>> {
-        self.multi_get_transaction_blocks(&[*digest])
+        self.try_multi_get_transaction_blocks(&[*digest])
             .map(|mut blocks| {
                 blocks
                     .pop()
@@ -493,11 +493,11 @@ pub trait TransactionCacheRead: Send + Sync {
     }
 
     #[instrument(level = "trace", skip_all)]
-    fn get_transactions_and_serialized_sizes(
+    fn try_get_transactions_and_serialized_sizes(
         &self,
         digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Option<(VerifiedTransaction, usize)>>> {
-        let txns = self.multi_get_transaction_blocks(digests)?;
+        let txns = self.try_multi_get_transaction_blocks(digests)?;
         txns.into_iter()
             .map(|txn| {
                 txn.map(|txn| {
@@ -515,13 +515,13 @@ pub trait TransactionCacheRead: Send + Sync {
             .collect::<Result<Vec<_>, _>>()
     }
 
-    fn multi_get_executed_effects_digests(
+    fn try_multi_get_executed_effects_digests(
         &self,
         digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Option<TransactionEffectsDigest>>>;
 
-    fn is_tx_already_executed(&self, digest: &TransactionDigest) -> IotaResult<bool> {
-        self.multi_get_executed_effects_digests(&[*digest])
+    fn try_is_tx_already_executed(&self, digest: &TransactionDigest) -> IotaResult<bool> {
+        self.try_multi_get_executed_effects_digests(&[*digest])
             .map(|mut digests| {
                 digests
                     .pop()
@@ -530,11 +530,11 @@ pub trait TransactionCacheRead: Send + Sync {
             })
     }
 
-    fn multi_get_executed_effects(
+    fn try_multi_get_executed_effects(
         &self,
         digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Option<TransactionEffects>>> {
-        let effects_digests = self.multi_get_executed_effects_digests(digests)?;
+        let effects_digests = self.try_multi_get_executed_effects_digests(digests)?;
         assert_eq!(effects_digests.len(), digests.len());
 
         let mut results = vec![None; digests.len()];
@@ -548,7 +548,7 @@ pub trait TransactionCacheRead: Send + Sync {
             }
         }
 
-        let effects = self.multi_get_effects(&fetch_digests)?;
+        let effects = self.try_multi_get_effects(&fetch_digests)?;
         for (i, effects) in fetch_indices.into_iter().zip(effects.into_iter()) {
             results[i] = effects;
         }
@@ -556,11 +556,11 @@ pub trait TransactionCacheRead: Send + Sync {
         Ok(results)
     }
 
-    fn get_executed_effects(
+    fn try_get_executed_effects(
         &self,
         digest: &TransactionDigest,
     ) -> IotaResult<Option<TransactionEffects>> {
-        self.multi_get_executed_effects(&[*digest])
+        self.try_multi_get_executed_effects(&[*digest])
             .map(|mut effects| {
                 effects
                     .pop()
@@ -568,39 +568,39 @@ pub trait TransactionCacheRead: Send + Sync {
             })
     }
 
-    fn multi_get_effects(
+    fn try_multi_get_effects(
         &self,
         digests: &[TransactionEffectsDigest],
     ) -> IotaResult<Vec<Option<TransactionEffects>>>;
 
-    fn get_effects(
+    fn try_get_effects(
         &self,
         digest: &TransactionEffectsDigest,
     ) -> IotaResult<Option<TransactionEffects>> {
-        self.multi_get_effects(&[*digest]).map(|mut effects| {
+        self.try_multi_get_effects(&[*digest]).map(|mut effects| {
             effects
                 .pop()
                 .expect("multi-get must return correct number of items")
         })
     }
 
-    fn multi_get_events(
+    fn try_multi_get_events(
         &self,
         event_digests: &[TransactionEventsDigest],
     ) -> IotaResult<Vec<Option<TransactionEvents>>>;
 
-    fn get_events(
+    fn try_get_events(
         &self,
         digest: &TransactionEventsDigest,
     ) -> IotaResult<Option<TransactionEvents>> {
-        self.multi_get_events(&[*digest]).map(|mut events| {
+        self.try_multi_get_events(&[*digest]).map(|mut events| {
             events
                 .pop()
                 .expect("multi-get must return correct number of items")
         })
     }
 
-    fn notify_read_executed_effects_digests<'a>(
+    fn try_notify_read_executed_effects_digests<'a>(
         &'a self,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, IotaResult<Vec<TransactionEffectsDigest>>>;
@@ -613,14 +613,16 @@ pub trait TransactionCacheRead: Send + Sync {
     /// ExecutionLockReadGuard would also prevent reconfig from happening while
     /// waiting, but this is very dangerous, as it could prevent
     /// reconfiguration from ever occurring!
-    fn notify_read_executed_effects<'a>(
+    fn try_notify_read_executed_effects<'a>(
         &'a self,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, IotaResult<Vec<TransactionEffects>>> {
         async move {
-            let digests = self.notify_read_executed_effects_digests(digests).await?;
+            let digests = self
+                .try_notify_read_executed_effects_digests(digests)
+                .await?;
             // once digests are available, effects must be present as well
-            self.multi_get_effects(&digests).map(|effects| {
+            self.try_multi_get_effects(&digests).map(|effects| {
                 effects
                     .into_iter()
                     .map(|e| e.unwrap_or_else(|| fatal!("digests must exist")))

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -671,17 +671,17 @@ pub trait CheckpointCache: Send + Sync {
     // Currently, they are only used to implement `get_transaction_block`
     // for JSON RPC `ReadApi`.
 
-    fn get_transaction_perpetual_checkpoint(
+    fn try_get_transaction_perpetual_checkpoint(
         &self,
         digest: &TransactionDigest,
     ) -> IotaResult<Option<(EpochId, CheckpointSequenceNumber)>>;
 
-    fn multi_get_transactions_perpetual_checkpoints(
+    fn try_multi_get_transactions_perpetual_checkpoints(
         &self,
         digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Option<(EpochId, CheckpointSequenceNumber)>>>;
 
-    fn insert_finalized_transactions_perpetual_checkpoints(
+    fn try_insert_finalized_transactions_perpetual_checkpoints(
         &self,
         digests: &[TransactionDigest],
         epoch: EpochId,

--- a/crates/iota-core/src/execution_cache/object_locks.rs
+++ b/crates/iota-core/src/execution_cache/object_locks.rs
@@ -174,7 +174,7 @@ impl ObjectLocks {
         cache: &WritebackCache,
         object_ids: &[ObjectID],
     ) -> IotaResult<Vec<Object>> {
-        let objects = cache.multi_get_objects(object_ids)?;
+        let objects = cache.try_multi_get_objects(object_ids)?;
         let mut result = Vec::with_capacity(objects.len());
         for (i, object) in objects.into_iter().enumerate() {
             if let Some(object) = object {

--- a/crates/iota-core/src/execution_cache/object_locks.rs
+++ b/crates/iota-core/src/execution_cache/object_locks.rs
@@ -289,7 +289,7 @@ mod tests {
             let tx1 = s.make_signed_transaction(&outputs.transaction);
 
             s.cache
-                .acquire_transaction_locks(&s.epoch_store, &[new1, new2], tx1)
+                .try_acquire_transaction_locks(&s.epoch_store, &[new1, new2], tx1)
                 .await
                 .expect("locks should be available");
 
@@ -301,19 +301,19 @@ mod tests {
 
             // both locks are held by tx1, so this should fail
             s.cache
-                .acquire_transaction_locks(&s.epoch_store, &[new1, new2], tx2.clone())
+                .try_acquire_transaction_locks(&s.epoch_store, &[new1, new2], tx2.clone())
                 .await
                 .unwrap_err();
 
             // new3 is lockable, but new2 is not, so this should fail
             s.cache
-                .acquire_transaction_locks(&s.epoch_store, &[new3, new2], tx2.clone())
+                .try_acquire_transaction_locks(&s.epoch_store, &[new3, new2], tx2.clone())
                 .await
                 .unwrap_err();
 
             // new3 is unlocked
             s.cache
-                .acquire_transaction_locks(&s.epoch_store, &[new3], tx2)
+                .try_acquire_transaction_locks(&s.epoch_store, &[new3], tx2)
                 .await
                 .expect("new3 should be unlocked");
         })
@@ -342,14 +342,14 @@ mod tests {
 
             // fails because we are referring to an old object
             s.cache
-                .acquire_transaction_locks(&s.epoch_store, &[new1, old2], tx.clone())
+                .try_acquire_transaction_locks(&s.epoch_store, &[new1, old2], tx.clone())
                 .await
                 .unwrap_err();
 
             // succeeds because the above call releases the lock on new1 after failing
             // to get the lock on old2
             s.cache
-                .acquire_transaction_locks(&s.epoch_store, &[new1, new2], tx)
+                .try_acquire_transaction_locks(&s.epoch_store, &[new1, new2], tx)
                 .await
                 .expect("new1 should be unlocked after revert");
         })
@@ -378,7 +378,7 @@ mod tests {
 
             // fails because we are referring to an old object
             s.cache
-                .acquire_transaction_locks(&s.epoch_store, &[new1, old2], tx)
+                .try_acquire_transaction_locks(&s.epoch_store, &[new1, old2], tx)
                 .await
                 .unwrap_err();
 
@@ -391,7 +391,7 @@ mod tests {
             // succeeds because the above call releases the lock on new1 after failing
             // to get the lock on old2
             s.cache
-                .acquire_transaction_locks(&s.epoch_store, &[new1, new2], tx2)
+                .try_acquire_transaction_locks(&s.epoch_store, &[new1, new2], tx2)
                 .await
                 .expect("new1 should be unlocked after revert");
         })
@@ -417,7 +417,7 @@ mod tests {
             // assert that acquire_transaction_locks is sync in non-simtest, which causes
             // the fail_point_async! macros above to be elided
             s.cache
-                .acquire_transaction_locks(&s.epoch_store, &objects, tx2)
+                .try_acquire_transaction_locks(&s.epoch_store, &objects, tx2)
                 .now_or_never()
                 .unwrap()
                 .unwrap();

--- a/crates/iota-core/src/execution_cache/passthrough_cache.rs
+++ b/crates/iota-core/src/execution_cache/passthrough_cache.rs
@@ -323,7 +323,7 @@ impl AccumulatorStore for PassthroughCache {
 }
 
 impl ExecutionCacheCommit for PassthroughCache {
-    fn commit_transaction_outputs<'a>(
+    fn try_commit_transaction_outputs<'a>(
         &'a self,
         _epoch: EpochId,
         _digests: &'a [TransactionDigest],
@@ -333,7 +333,10 @@ impl ExecutionCacheCommit for PassthroughCache {
         async { Ok(()) }.boxed()
     }
 
-    fn persist_transactions(&self, _digests: &[TransactionDigest]) -> BoxFuture<'_, IotaResult> {
+    fn try_persist_transactions(
+        &self,
+        _digests: &[TransactionDigest],
+    ) -> BoxFuture<'_, IotaResult> {
         // Nothing needs to be done since they were already committed in
         // write_transaction_outputs
         async { Ok(()) }.boxed()

--- a/crates/iota-core/src/execution_cache/passthrough_cache.rs
+++ b/crates/iota-core/src/execution_cache/passthrough_cache.rs
@@ -101,7 +101,7 @@ impl ObjectCacheRead for PassthroughCache {
     }
 
     fn get_object(&self, id: &ObjectID) -> IotaResult<Option<Object>> {
-        self.store.get_object(id).map_err(Into::into)
+        self.store.try_get_object(id).map_err(Into::into)
     }
 
     fn get_object_by_key(
@@ -109,14 +109,14 @@ impl ObjectCacheRead for PassthroughCache {
         object_id: &ObjectID,
         version: SequenceNumber,
     ) -> IotaResult<Option<Object>> {
-        Ok(self.store.get_object_by_key(object_id, version)?)
+        Ok(self.store.try_get_object_by_key(object_id, version)?)
     }
 
     fn multi_get_objects_by_key(
         &self,
         object_keys: &[ObjectKey],
     ) -> Result<Vec<Option<Object>>, IotaError> {
-        Ok(self.store.multi_get_objects_by_key(object_keys)?)
+        Ok(self.store.try_multi_get_objects_by_key(object_keys)?)
     }
 
     fn object_exists_by_key(

--- a/crates/iota-core/src/execution_cache/passthrough_cache.rs
+++ b/crates/iota-core/src/execution_cache/passthrough_cache.rs
@@ -239,7 +239,7 @@ impl TransactionCacheRead for PassthroughCache {
 
 impl ExecutionCacheWrite for PassthroughCache {
     #[instrument(level = "debug", skip_all)]
-    fn write_transaction_outputs<'a>(
+    fn try_write_transaction_outputs<'a>(
         &'a self,
         epoch_id: EpochId,
         tx_outputs: Arc<TransactionOutputs>,
@@ -279,7 +279,7 @@ impl ExecutionCacheWrite for PassthroughCache {
         .boxed()
     }
 
-    fn acquire_transaction_locks<'a>(
+    fn try_acquire_transaction_locks<'a>(
         &'a self,
         epoch_store: &'a AuthorityPerEpochStore,
         owned_input_objects: &'a [ObjectRef],

--- a/crates/iota-core/src/execution_cache/passthrough_cache.rs
+++ b/crates/iota-core/src/execution_cache/passthrough_cache.rs
@@ -196,7 +196,7 @@ impl ObjectCacheRead for PassthroughCache {
 }
 
 impl TransactionCacheRead for PassthroughCache {
-    fn multi_get_transaction_blocks(
+    fn try_multi_get_transaction_blocks(
         &self,
         digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Option<Arc<VerifiedTransaction>>>> {
@@ -208,32 +208,32 @@ impl TransactionCacheRead for PassthroughCache {
             .collect())
     }
 
-    fn multi_get_executed_effects_digests(
+    fn try_multi_get_executed_effects_digests(
         &self,
         digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Option<TransactionEffectsDigest>>> {
         self.store.multi_get_executed_effects_digests(digests)
     }
 
-    fn multi_get_effects(
+    fn try_multi_get_effects(
         &self,
         digests: &[TransactionEffectsDigest],
     ) -> IotaResult<Vec<Option<TransactionEffects>>> {
         Ok(self.store.perpetual_tables.effects.multi_get(digests)?)
     }
 
-    fn notify_read_executed_effects_digests<'a>(
+    fn try_notify_read_executed_effects_digests<'a>(
         &'a self,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, IotaResult<Vec<TransactionEffectsDigest>>> {
         self.executed_effects_digests_notify_read
             .read(digests, |digests| {
-                self.multi_get_executed_effects_digests(digests)
+                self.try_multi_get_executed_effects_digests(digests)
             })
             .boxed()
     }
 
-    fn multi_get_events(
+    fn try_multi_get_events(
         &self,
         event_digests: &[TransactionEventsDigest],
     ) -> IotaResult<Vec<Option<TransactionEvents>>> {

--- a/crates/iota-core/src/execution_cache/passthrough_cache.rs
+++ b/crates/iota-core/src/execution_cache/passthrough_cache.rs
@@ -90,7 +90,7 @@ impl PassthroughCache {
 }
 
 impl ObjectCacheRead for PassthroughCache {
-    fn get_package_object(&self, package_id: &ObjectID) -> IotaResult<Option<PackageObject>> {
+    fn try_get_package_object(&self, package_id: &ObjectID) -> IotaResult<Option<PackageObject>> {
         self.package_cache
             .get_package_object(package_id, &*self.store)
     }
@@ -100,11 +100,11 @@ impl ObjectCacheRead for PassthroughCache {
             .force_reload_system_packages(system_package_ids.iter().cloned(), self);
     }
 
-    fn get_object(&self, id: &ObjectID) -> IotaResult<Option<Object>> {
+    fn try_get_object(&self, id: &ObjectID) -> IotaResult<Option<Object>> {
         self.store.try_get_object(id).map_err(Into::into)
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,
@@ -112,14 +112,14 @@ impl ObjectCacheRead for PassthroughCache {
         Ok(self.store.try_get_object_by_key(object_id, version)?)
     }
 
-    fn multi_get_objects_by_key(
+    fn try_multi_get_objects_by_key(
         &self,
         object_keys: &[ObjectKey],
     ) -> Result<Vec<Option<Object>>, IotaError> {
         Ok(self.store.try_multi_get_objects_by_key(object_keys)?)
     }
 
-    fn object_exists_by_key(
+    fn try_object_exists_by_key(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,
@@ -127,25 +127,25 @@ impl ObjectCacheRead for PassthroughCache {
         self.store.object_exists_by_key(object_id, version)
     }
 
-    fn multi_object_exists_by_key(&self, object_keys: &[ObjectKey]) -> IotaResult<Vec<bool>> {
+    fn try_multi_object_exists_by_key(&self, object_keys: &[ObjectKey]) -> IotaResult<Vec<bool>> {
         self.store.multi_object_exists_by_key(object_keys)
     }
 
-    fn get_latest_object_ref_or_tombstone(
+    fn try_get_latest_object_ref_or_tombstone(
         &self,
         object_id: ObjectID,
     ) -> IotaResult<Option<ObjectRef>> {
         self.store.get_latest_object_ref_or_tombstone(object_id)
     }
 
-    fn get_latest_object_or_tombstone(
+    fn try_get_latest_object_or_tombstone(
         &self,
         object_id: ObjectID,
     ) -> Result<Option<(ObjectKey, ObjectOrTombstone)>, IotaError> {
         self.store.get_latest_object_or_tombstone(object_id)
     }
 
-    fn find_object_lt_or_eq_version(
+    fn try_find_object_lt_or_eq_version(
         &self,
         object_id: ObjectID,
         version: SequenceNumber,
@@ -153,23 +153,27 @@ impl ObjectCacheRead for PassthroughCache {
         self.store.find_object_lt_or_eq_version(object_id, version)
     }
 
-    fn get_lock(&self, obj_ref: ObjectRef, epoch_store: &AuthorityPerEpochStore) -> IotaLockResult {
+    fn try_get_lock(
+        &self,
+        obj_ref: ObjectRef,
+        epoch_store: &AuthorityPerEpochStore,
+    ) -> IotaLockResult {
         self.store.get_lock(obj_ref, epoch_store)
     }
 
-    fn _get_live_objref(&self, object_id: ObjectID) -> IotaResult<ObjectRef> {
+    fn _try_get_live_objref(&self, object_id: ObjectID) -> IotaResult<ObjectRef> {
         self.store.get_latest_live_version_for_object_id(object_id)
     }
 
-    fn check_owned_objects_are_live(&self, owned_object_refs: &[ObjectRef]) -> IotaResult {
+    fn try_check_owned_objects_are_live(&self, owned_object_refs: &[ObjectRef]) -> IotaResult {
         self.store.check_owned_objects_are_live(owned_object_refs)
     }
 
-    fn get_iota_system_state_object_unsafe(&self) -> IotaResult<IotaSystemState> {
+    fn try_get_iota_system_state_object_unsafe(&self) -> IotaResult<IotaSystemState> {
         get_iota_system_state(self)
     }
 
-    fn get_marker_value(
+    fn try_get_marker_value(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,
@@ -178,7 +182,7 @@ impl ObjectCacheRead for PassthroughCache {
         self.store.get_marker_value(object_id, &version, epoch_id)
     }
 
-    fn get_latest_marker(
+    fn try_get_latest_marker(
         &self,
         object_id: &ObjectID,
         epoch_id: EpochId,
@@ -186,7 +190,7 @@ impl ObjectCacheRead for PassthroughCache {
         self.store.get_latest_marker(object_id, epoch_id)
     }
 
-    fn get_highest_pruned_checkpoint(&self) -> IotaResult<CheckpointSequenceNumber> {
+    fn try_get_highest_pruned_checkpoint(&self) -> IotaResult<CheckpointSequenceNumber> {
         self.store.perpetual_tables.get_highest_pruned_checkpoint()
     }
 }

--- a/crates/iota-core/src/execution_cache/proxy_cache.rs
+++ b/crates/iota-core/src/execution_cache/proxy_cache.rs
@@ -100,102 +100,106 @@ impl ProxyCache {
 }
 
 impl ObjectCacheRead for ProxyCache {
-    fn get_package_object(&self, package_id: &ObjectID) -> IotaResult<Option<PackageObject>> {
-        delegate_method!(self.get_package_object(package_id))
+    fn try_get_package_object(&self, package_id: &ObjectID) -> IotaResult<Option<PackageObject>> {
+        delegate_method!(self.try_get_package_object(package_id))
     }
 
     fn force_reload_system_packages(&self, system_package_ids: &[ObjectID]) {
         delegate_method!(self.force_reload_system_packages(system_package_ids))
     }
 
-    fn get_object(&self, id: &ObjectID) -> IotaResult<Option<Object>> {
-        delegate_method!(self.get_object(id))
+    fn try_get_object(&self, id: &ObjectID) -> IotaResult<Option<Object>> {
+        delegate_method!(self.try_get_object(id))
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,
     ) -> IotaResult<Option<Object>> {
-        delegate_method!(self.get_object_by_key(object_id, version))
+        delegate_method!(self.try_get_object_by_key(object_id, version))
     }
 
-    fn multi_get_objects_by_key(
+    fn try_multi_get_objects_by_key(
         &self,
         object_keys: &[ObjectKey],
     ) -> Result<Vec<Option<Object>>, IotaError> {
-        delegate_method!(self.multi_get_objects_by_key(object_keys))
+        delegate_method!(self.try_multi_get_objects_by_key(object_keys))
     }
 
-    fn object_exists_by_key(
+    fn try_object_exists_by_key(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,
     ) -> IotaResult<bool> {
-        delegate_method!(self.object_exists_by_key(object_id, version))
+        delegate_method!(self.try_object_exists_by_key(object_id, version))
     }
 
-    fn multi_object_exists_by_key(&self, object_keys: &[ObjectKey]) -> IotaResult<Vec<bool>> {
-        delegate_method!(self.multi_object_exists_by_key(object_keys))
+    fn try_multi_object_exists_by_key(&self, object_keys: &[ObjectKey]) -> IotaResult<Vec<bool>> {
+        delegate_method!(self.try_multi_object_exists_by_key(object_keys))
     }
 
-    fn get_latest_object_ref_or_tombstone(
+    fn try_get_latest_object_ref_or_tombstone(
         &self,
         object_id: ObjectID,
     ) -> IotaResult<Option<ObjectRef>> {
-        delegate_method!(self.get_latest_object_ref_or_tombstone(object_id))
+        delegate_method!(self.try_get_latest_object_ref_or_tombstone(object_id))
     }
 
-    fn get_latest_object_or_tombstone(
+    fn try_get_latest_object_or_tombstone(
         &self,
         object_id: ObjectID,
     ) -> Result<Option<(ObjectKey, ObjectOrTombstone)>, IotaError> {
-        delegate_method!(self.get_latest_object_or_tombstone(object_id))
+        delegate_method!(self.try_get_latest_object_or_tombstone(object_id))
     }
 
-    fn find_object_lt_or_eq_version(
+    fn try_find_object_lt_or_eq_version(
         &self,
         object_id: ObjectID,
         version: SequenceNumber,
     ) -> IotaResult<Option<Object>> {
-        delegate_method!(self.find_object_lt_or_eq_version(object_id, version))
+        delegate_method!(self.try_find_object_lt_or_eq_version(object_id, version))
     }
 
-    fn get_lock(&self, obj_ref: ObjectRef, epoch_store: &AuthorityPerEpochStore) -> IotaLockResult {
-        delegate_method!(self.get_lock(obj_ref, epoch_store))
+    fn try_get_lock(
+        &self,
+        obj_ref: ObjectRef,
+        epoch_store: &AuthorityPerEpochStore,
+    ) -> IotaLockResult {
+        delegate_method!(self.try_get_lock(obj_ref, epoch_store))
     }
 
-    fn _get_live_objref(&self, object_id: ObjectID) -> IotaResult<ObjectRef> {
-        delegate_method!(self._get_live_objref(object_id))
+    fn _try_get_live_objref(&self, object_id: ObjectID) -> IotaResult<ObjectRef> {
+        delegate_method!(self._try_get_live_objref(object_id))
     }
 
-    fn check_owned_objects_are_live(&self, owned_object_refs: &[ObjectRef]) -> IotaResult {
-        delegate_method!(self.check_owned_objects_are_live(owned_object_refs))
+    fn try_check_owned_objects_are_live(&self, owned_object_refs: &[ObjectRef]) -> IotaResult {
+        delegate_method!(self.try_check_owned_objects_are_live(owned_object_refs))
     }
 
-    fn get_iota_system_state_object_unsafe(&self) -> IotaResult<IotaSystemState> {
-        delegate_method!(self.get_iota_system_state_object_unsafe())
+    fn try_get_iota_system_state_object_unsafe(&self) -> IotaResult<IotaSystemState> {
+        delegate_method!(self.try_get_iota_system_state_object_unsafe())
     }
 
-    fn get_marker_value(
+    fn try_get_marker_value(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,
         epoch_id: EpochId,
     ) -> IotaResult<Option<MarkerValue>> {
-        delegate_method!(self.get_marker_value(object_id, version, epoch_id))
+        delegate_method!(self.try_get_marker_value(object_id, version, epoch_id))
     }
 
-    fn get_latest_marker(
+    fn try_get_latest_marker(
         &self,
         object_id: &ObjectID,
         epoch_id: EpochId,
     ) -> IotaResult<Option<(SequenceNumber, MarkerValue)>> {
-        delegate_method!(self.get_latest_marker(object_id, epoch_id))
+        delegate_method!(self.try_get_latest_marker(object_id, epoch_id))
     }
 
-    fn get_highest_pruned_checkpoint(&self) -> IotaResult<CheckpointSequenceNumber> {
-        delegate_method!(self.get_highest_pruned_checkpoint())
+    fn try_get_highest_pruned_checkpoint(&self) -> IotaResult<CheckpointSequenceNumber> {
+        delegate_method!(self.try_get_highest_pruned_checkpoint())
     }
 }
 

--- a/crates/iota-core/src/execution_cache/proxy_cache.rs
+++ b/crates/iota-core/src/execution_cache/proxy_cache.rs
@@ -237,21 +237,21 @@ impl TransactionCacheRead for ProxyCache {
 }
 
 impl ExecutionCacheWrite for ProxyCache {
-    fn write_transaction_outputs(
+    fn try_write_transaction_outputs(
         &self,
         epoch_id: EpochId,
         tx_outputs: Arc<TransactionOutputs>,
     ) -> BoxFuture<'_, IotaResult> {
-        delegate_method!(self.write_transaction_outputs(epoch_id, tx_outputs))
+        delegate_method!(self.try_write_transaction_outputs(epoch_id, tx_outputs))
     }
 
-    fn acquire_transaction_locks<'a>(
+    fn try_acquire_transaction_locks<'a>(
         &'a self,
         epoch_store: &'a AuthorityPerEpochStore,
         owned_input_objects: &'a [ObjectRef],
         transaction: VerifiedSignedTransaction,
     ) -> BoxFuture<'a, IotaResult> {
-        delegate_method!(self.acquire_transaction_locks(
+        delegate_method!(self.try_acquire_transaction_locks(
             epoch_store,
             owned_input_objects,
             transaction

--- a/crates/iota-core/src/execution_cache/proxy_cache.rs
+++ b/crates/iota-core/src/execution_cache/proxy_cache.rs
@@ -340,23 +340,23 @@ impl CheckpointCache for ProxyCache {
 }
 
 impl ExecutionCacheReconfigAPI for ProxyCache {
-    fn insert_genesis_object(&self, object: Object) -> IotaResult {
-        delegate_method!(self.insert_genesis_object(object))
+    fn try_insert_genesis_object(&self, object: Object) -> IotaResult {
+        delegate_method!(self.try_insert_genesis_object(object))
     }
 
-    fn bulk_insert_genesis_objects(&self, objects: &[Object]) -> IotaResult {
-        delegate_method!(self.bulk_insert_genesis_objects(objects))
+    fn try_bulk_insert_genesis_objects(&self, objects: &[Object]) -> IotaResult {
+        delegate_method!(self.try_bulk_insert_genesis_objects(objects))
     }
 
-    fn revert_state_update(&self, digest: &TransactionDigest) -> IotaResult {
-        delegate_method!(self.revert_state_update(digest))
+    fn try_revert_state_update(&self, digest: &TransactionDigest) -> IotaResult {
+        delegate_method!(self.try_revert_state_update(digest))
     }
 
-    fn set_epoch_start_configuration(
+    fn try_set_epoch_start_configuration(
         &self,
         epoch_start_config: &EpochStartConfiguration,
     ) -> IotaResult {
-        delegate_method!(self.set_epoch_start_configuration(epoch_start_config))
+        delegate_method!(self.try_set_epoch_start_configuration(epoch_start_config))
     }
 
     fn update_epoch_flags_metrics(&self, old: &[EpochFlag], new: &[EpochFlag]) {
@@ -367,18 +367,18 @@ impl ExecutionCacheReconfigAPI for ProxyCache {
         delegate_method!(self.clear_state_end_of_epoch(execution_guard))
     }
 
-    fn expensive_check_iota_conservation(
+    fn try_expensive_check_iota_conservation(
         &self,
         old_epoch_store: &AuthorityPerEpochStore,
         epoch_supply_change: Option<i64>,
     ) -> IotaResult {
         delegate_method!(
-            self.expensive_check_iota_conservation(old_epoch_store, epoch_supply_change)
+            self.try_expensive_check_iota_conservation(old_epoch_store, epoch_supply_change)
         )
     }
 
-    fn checkpoint_db(&self, path: &std::path::Path) -> IotaResult {
-        delegate_method!(self.checkpoint_db(path))
+    fn try_checkpoint_db(&self, path: &std::path::Path) -> IotaResult {
+        delegate_method!(self.try_checkpoint_db(path))
     }
 
     fn reconfigure_cache<'a>(

--- a/crates/iota-core/src/execution_cache/proxy_cache.rs
+++ b/crates/iota-core/src/execution_cache/proxy_cache.rs
@@ -313,28 +313,28 @@ impl ExecutionCacheCommit for ProxyCache {
 }
 
 impl CheckpointCache for ProxyCache {
-    fn get_transaction_perpetual_checkpoint(
+    fn try_get_transaction_perpetual_checkpoint(
         &self,
         digest: &TransactionDigest,
     ) -> IotaResult<Option<(EpochId, CheckpointSequenceNumber)>> {
-        delegate_method!(self.get_transaction_perpetual_checkpoint(digest))
+        delegate_method!(self.try_get_transaction_perpetual_checkpoint(digest))
     }
 
-    fn multi_get_transactions_perpetual_checkpoints(
+    fn try_multi_get_transactions_perpetual_checkpoints(
         &self,
         digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Option<(EpochId, CheckpointSequenceNumber)>>> {
-        delegate_method!(self.multi_get_transactions_perpetual_checkpoints(digests))
+        delegate_method!(self.try_multi_get_transactions_perpetual_checkpoints(digests))
     }
 
-    fn insert_finalized_transactions_perpetual_checkpoints(
+    fn try_insert_finalized_transactions_perpetual_checkpoints(
         &self,
         digests: &[TransactionDigest],
         epoch: EpochId,
         sequence: CheckpointSequenceNumber,
     ) -> IotaResult {
         delegate_method!(
-            self.insert_finalized_transactions_perpetual_checkpoints(digests, epoch, sequence)
+            self.try_insert_finalized_transactions_perpetual_checkpoints(digests, epoch, sequence)
         )
     }
 }

--- a/crates/iota-core/src/execution_cache/proxy_cache.rs
+++ b/crates/iota-core/src/execution_cache/proxy_cache.rs
@@ -296,19 +296,19 @@ impl AccumulatorStore for ProxyCache {
 }
 
 impl ExecutionCacheCommit for ProxyCache {
-    fn commit_transaction_outputs<'a>(
+    fn try_commit_transaction_outputs<'a>(
         &'a self,
         epoch: EpochId,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, IotaResult> {
-        delegate_method!(self.commit_transaction_outputs(epoch, digests))
+        delegate_method!(self.try_commit_transaction_outputs(epoch, digests))
     }
 
-    fn persist_transactions<'a>(
+    fn try_persist_transactions<'a>(
         &'a self,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, IotaResult> {
-        delegate_method!(self.persist_transactions(digests))
+        delegate_method!(self.try_persist_transactions(digests))
     }
 }
 

--- a/crates/iota-core/src/execution_cache/proxy_cache.rs
+++ b/crates/iota-core/src/execution_cache/proxy_cache.rs
@@ -394,19 +394,19 @@ impl ExecutionCacheReconfigAPI for ProxyCache {
 }
 
 impl StateSyncAPI for ProxyCache {
-    fn insert_transaction_and_effects(
+    fn try_insert_transaction_and_effects(
         &self,
         transaction: &VerifiedTransaction,
         transaction_effects: &TransactionEffects,
     ) -> IotaResult {
-        delegate_method!(self.insert_transaction_and_effects(transaction, transaction_effects))
+        delegate_method!(self.try_insert_transaction_and_effects(transaction, transaction_effects))
     }
 
-    fn multi_insert_transaction_and_effects(
+    fn try_multi_insert_transaction_and_effects(
         &self,
         transactions_and_effects: &[VerifiedExecutionData],
     ) -> IotaResult {
-        delegate_method!(self.multi_insert_transaction_and_effects(transactions_and_effects))
+        delegate_method!(self.try_multi_insert_transaction_and_effects(transactions_and_effects))
     }
 }
 

--- a/crates/iota-core/src/execution_cache/proxy_cache.rs
+++ b/crates/iota-core/src/execution_cache/proxy_cache.rs
@@ -204,39 +204,39 @@ impl ObjectCacheRead for ProxyCache {
 }
 
 impl TransactionCacheRead for ProxyCache {
-    fn multi_get_transaction_blocks(
+    fn try_multi_get_transaction_blocks(
         &self,
         digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Option<Arc<VerifiedTransaction>>>> {
-        delegate_method!(self.multi_get_transaction_blocks(digests))
+        delegate_method!(self.try_multi_get_transaction_blocks(digests))
     }
 
-    fn multi_get_executed_effects_digests(
+    fn try_multi_get_executed_effects_digests(
         &self,
         digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Option<TransactionEffectsDigest>>> {
-        delegate_method!(self.multi_get_executed_effects_digests(digests))
+        delegate_method!(self.try_multi_get_executed_effects_digests(digests))
     }
 
-    fn multi_get_effects(
+    fn try_multi_get_effects(
         &self,
         digests: &[TransactionEffectsDigest],
     ) -> IotaResult<Vec<Option<TransactionEffects>>> {
-        delegate_method!(self.multi_get_effects(digests))
+        delegate_method!(self.try_multi_get_effects(digests))
     }
 
-    fn notify_read_executed_effects_digests<'a>(
+    fn try_notify_read_executed_effects_digests<'a>(
         &'a self,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, IotaResult<Vec<TransactionEffectsDigest>>> {
-        delegate_method!(self.notify_read_executed_effects_digests(digests))
+        delegate_method!(self.try_notify_read_executed_effects_digests(digests))
     }
 
-    fn multi_get_events(
+    fn try_multi_get_events(
         &self,
         event_digests: &[TransactionEventsDigest],
     ) -> IotaResult<Vec<Option<TransactionEvents>>> {
-        delegate_method!(self.multi_get_events(event_digests))
+        delegate_method!(self.try_multi_get_events(event_digests))
     }
 }
 

--- a/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -345,7 +345,7 @@ impl Scenario {
         assert!(self.transactions.insert(tx), "transaction is not unique");
 
         self.cache()
-            .write_transaction_outputs(1 /* epoch */, outputs.clone())
+            .try_write_transaction_outputs(1 /* epoch */, outputs.clone())
             .await
             .expect("write_transaction_outputs failed");
 
@@ -1113,7 +1113,7 @@ async fn test_concurrent_lockers() {
             for (tx1, _, a_ref, b_ref) in txns {
                 results.push(
                     cache
-                        .acquire_transaction_locks(&epoch_store, &[a_ref, b_ref], tx1)
+                        .try_acquire_transaction_locks(&epoch_store, &[a_ref, b_ref], tx1)
                         .await,
                 );
                 barrier.wait().await;
@@ -1132,7 +1132,7 @@ async fn test_concurrent_lockers() {
             for (_, tx2, a_ref, b_ref) in txns {
                 results.push(
                     cache
-                        .acquire_transaction_locks(&epoch_store, &[a_ref, b_ref], tx2)
+                        .try_acquire_transaction_locks(&epoch_store, &[a_ref, b_ref], tx2)
                         .await,
                 );
                 barrier.wait().await;
@@ -1186,7 +1186,7 @@ async fn test_concurrent_lockers_same_tx() {
             for (tx1, a_ref, b_ref) in txns {
                 results.push(
                     cache
-                        .acquire_transaction_locks(&epoch_store, &[a_ref, b_ref], tx1)
+                        .try_acquire_transaction_locks(&epoch_store, &[a_ref, b_ref], tx1)
                         .await,
                 );
                 barrier.wait().await;
@@ -1205,7 +1205,7 @@ async fn test_concurrent_lockers_same_tx() {
             for (tx1, a_ref, b_ref) in txns {
                 results.push(
                     cache
-                        .acquire_transaction_locks(&epoch_store, &[a_ref, b_ref], tx1)
+                        .try_acquire_transaction_locks(&epoch_store, &[a_ref, b_ref], tx1)
                         .await,
                 );
                 barrier.wait().await;

--- a/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -1047,7 +1047,7 @@ async fn test_concurrent_readers() {
                 println!("parent: {parent_ref:?}");
                 loop {
                     let parent = cache
-                        .get_object_by_key(&parent_ref.0, parent_ref.1)
+                        .try_get_object_by_key(&parent_ref.0, parent_ref.1)
                         .unwrap();
                     if parent.is_none() {
                         tokio::task::yield_now().await;

--- a/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -399,13 +399,16 @@ impl Scenario {
             let version = expected.version();
             assert_eq!(
                 self.cache()
-                    .get_object_by_key(id, version)
+                    .try_get_object_by_key(id, version)
                     .unwrap()
                     .unwrap(),
                 *expected
             );
             assert_eq!(
-                self.cache().get_object(&expected.id()).unwrap().unwrap(),
+                self.cache()
+                    .try_get_object(&expected.id())
+                    .unwrap()
+                    .unwrap(),
                 *expected
             );
             // TODO: enable after lock caching is implemented
@@ -422,7 +425,7 @@ impl Scenario {
         for short_id in short_ids {
             let id = self.id_map.get(short_id).expect("no such object");
             self.cache()
-                .get_package_object(id)
+                .try_get_package_object(id)
                 .expect("no such package");
         }
     }
@@ -486,14 +489,14 @@ impl Scenario {
             let object = self.objects.get(id).expect("no such object");
             assert_eq!(
                 self.cache()
-                    .get_object_by_key(id, object.version())
+                    .try_get_object_by_key(id, object.version())
                     .unwrap()
                     .unwrap(),
                 *object
             );
             assert!(
                 self.cache()
-                    .have_received_object_at_version(id, object.version(), 1)
+                    .try_have_received_object_at_version(id, object.version(), 1)
                     .unwrap()
             );
         }
@@ -504,7 +507,7 @@ impl Scenario {
             let id = self.id_map.get(short_id).expect("no such id");
 
             assert!(
-                self.cache().get_object(id).unwrap().is_none(),
+                self.cache().try_get_object(id).unwrap().is_none(),
                 "object exists in cache"
             );
         }
@@ -715,7 +718,7 @@ async fn test_lt_or_eq() {
                 let v = SequenceNumber::from_u64(i);
                 assert_eq!(
                     s.cache()
-                        .find_object_lt_or_eq_version(s.obj_id(1), v)
+                        .try_find_object_lt_or_eq_version(s.obj_id(1), v)
                         .unwrap()
                         .unwrap()
                         .version(),
@@ -768,7 +771,7 @@ async fn test_lt_or_eq_caching() {
             let expected_version = SequenceNumber::from_u64(expected_version);
             assert_eq!(
                 s.cache()
-                    .find_object_lt_or_eq_version(s.obj_id(1), lookup_version)
+                    .try_find_object_lt_or_eq_version(s.obj_id(1), lookup_version)
                     .unwrap()
                     .unwrap()
                     .version(),
@@ -782,7 +785,7 @@ async fn test_lt_or_eq_caching() {
         // version <= 0 does not exist
         assert!(
             s.cache()
-                .find_object_lt_or_eq_version(s.obj_id(1), 0.into())
+                .try_find_object_lt_or_eq_version(s.obj_id(1), 0.into())
                 .unwrap()
                 .is_none()
         );
@@ -831,7 +834,7 @@ async fn test_lt_or_eq_with_cached_tombstone() {
             let lookup_version = SequenceNumber::from_u64(lookup_version);
             assert_eq!(
                 s.cache()
-                    .find_object_lt_or_eq_version(s.obj_id(1), lookup_version)
+                    .try_find_object_lt_or_eq_version(s.obj_id(1), lookup_version)
                     .unwrap()
                     .map(|v| v.version()),
                 expected_version.map(SequenceNumber::from_u64)
@@ -936,7 +939,7 @@ async fn test_revert_state_update_mutated() {
             let tx = s.do_tx().await;
             s.commit(tx).await.unwrap();
             s.cache()
-                .get_object(&s.obj_id(1))
+                .try_get_object(&s.obj_id(1))
                 .unwrap()
                 .unwrap()
                 .version()
@@ -950,7 +953,7 @@ async fn test_revert_state_update_mutated() {
 
         let version_after_revert = s
             .cache()
-            .get_object(&s.obj_id(1))
+            .try_get_object(&s.obj_id(1))
             .unwrap()
             .unwrap()
             .version();
@@ -975,7 +978,7 @@ async fn test_invalidate_package_cache_on_revert() {
 
         assert!(
             s.cache()
-                .get_package_object(&s.obj_id(2))
+                .try_get_package_object(&s.obj_id(2))
                 .unwrap()
                 .is_none()
         );

--- a/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -890,7 +890,7 @@ async fn test_revert_committed_tx_panics() {
         s.with_created(&[1]);
         let tx1 = s.do_tx().await;
         s.commit(tx1).await.unwrap();
-        s.cache().revert_state_update(&tx1).unwrap();
+        s.cache().try_revert_state_update(&tx1).unwrap();
     })
     .await;
 }
@@ -905,7 +905,7 @@ async fn test_revert_unexecuted_tx() {
         let random_digest = TransactionDigest::random();
         // must not panic - pending_consensus_transactions is a super set of
         // executed but un-checkpointed transactions
-        s.cache().revert_state_update(&random_digest).unwrap();
+        s.cache().try_revert_state_update(&random_digest).unwrap();
     })
     .await;
 }
@@ -919,7 +919,7 @@ async fn test_revert_state_update_created() {
         let tx1 = s.do_tx().await;
         s.assert_live(&[1]);
 
-        s.cache().revert_state_update(&tx1).unwrap();
+        s.cache().try_revert_state_update(&tx1).unwrap();
         s.clear_state_end_of_epoch().await;
 
         s.assert_not_exists(&[1]);
@@ -945,7 +945,7 @@ async fn test_revert_state_update_mutated() {
         s.with_mutated(&[1]);
         let tx = s.do_tx().await;
 
-        s.cache().revert_state_update(&tx).unwrap();
+        s.cache().try_revert_state_update(&tx).unwrap();
         s.clear_state_end_of_epoch().await;
 
         let version_after_revert = s
@@ -970,7 +970,7 @@ async fn test_invalidate_package_cache_on_revert() {
         s.assert_live(&[1]);
         s.assert_packages(&[2]);
 
-        s.cache().revert_state_update(&tx1).unwrap();
+        s.cache().try_revert_state_update(&tx1).unwrap();
         s.clear_state_end_of_epoch().await;
 
         assert!(

--- a/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -649,44 +649,44 @@ async fn test_extra_outputs() {
 
         let tx = s.do_tx().await;
 
-        s.cache.get_transaction_block(&tx).unwrap().unwrap();
-        let fx = s.cache.get_executed_effects(&tx).unwrap().unwrap();
+        s.cache.try_get_transaction_block(&tx).unwrap().unwrap();
+        let fx = s.cache.try_get_executed_effects(&tx).unwrap().unwrap();
         let events_digest = fx.events_digest().unwrap();
-        s.cache.get_events(events_digest).unwrap().unwrap();
+        s.cache.try_get_events(events_digest).unwrap().unwrap();
 
         s.commit(tx).await.unwrap();
 
-        s.cache.get_transaction_block(&tx).unwrap().unwrap();
-        s.cache.get_executed_effects(&tx).unwrap().unwrap();
-        s.cache.get_events(events_digest).unwrap().unwrap();
+        s.cache.try_get_transaction_block(&tx).unwrap().unwrap();
+        s.cache.try_get_executed_effects(&tx).unwrap().unwrap();
+        s.cache.try_get_events(events_digest).unwrap().unwrap();
 
         // clear cache
         s.reset_cache();
 
-        s.cache.get_transaction_block(&tx).unwrap().unwrap();
-        s.cache.get_executed_effects(&tx).unwrap().unwrap();
-        s.cache.get_events(events_digest).unwrap().unwrap();
+        s.cache.try_get_transaction_block(&tx).unwrap().unwrap();
+        s.cache.try_get_executed_effects(&tx).unwrap().unwrap();
+        s.cache.try_get_events(events_digest).unwrap().unwrap();
 
         s.with_created(&[3]);
         let tx = s.do_tx().await;
 
         // when Events is empty, it should be treated as None
-        let fx = s.cache.get_executed_effects(&tx).unwrap().unwrap();
+        let fx = s.cache.try_get_executed_effects(&tx).unwrap().unwrap();
         let events_digest = fx.events_digest().unwrap();
         assert!(
-            s.cache.get_events(events_digest).unwrap().is_none(),
+            s.cache.try_get_events(events_digest).unwrap().is_none(),
             "empty events should be none"
         );
 
         s.commit(tx).await.unwrap();
         assert!(
-            s.cache.get_events(events_digest).unwrap().is_none(),
+            s.cache.try_get_events(events_digest).unwrap().is_none(),
             "empty events should be none"
         );
 
         s.reset_cache();
         assert!(
-            s.cache.get_events(events_digest).unwrap().is_none(),
+            s.cache.try_get_events(events_digest).unwrap().is_none(),
             "empty events should be none"
         );
     })

--- a/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -355,7 +355,7 @@ impl Scenario {
 
     // commit a transaction to the database
     pub async fn commit(&mut self, tx: TransactionDigest) -> IotaResult {
-        let res = self.cache().commit_transaction_outputs(1, &[tx]).await;
+        let res = self.cache().try_commit_transaction_outputs(1, &[tx]).await;
         self.count_action();
         res
     }
@@ -559,7 +559,7 @@ async fn test_committed() {
         s.assert_live(&[1, 2]);
         s.assert_dirty(&[1, 2]);
         s.cache()
-            .commit_transaction_outputs(1, &[tx])
+            .try_commit_transaction_outputs(1, &[tx])
             .await
             .expect("commit failed");
         s.assert_not_dirty(&[1, 2]);

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -1141,7 +1141,9 @@ impl WritebackCache {
         // pending_consensus_transactions until after the transaction has executed.
         let Some((_, outputs)) = self.dirty.pending_transaction_writes.remove(tx) else {
             assert!(
-                !self.is_tx_already_executed(tx).expect("read cannot fail"),
+                !self
+                    .try_is_tx_already_executed(tx)
+                    .expect("read cannot fail"),
                 "attempt to revert committed transaction"
             );
 
@@ -1655,7 +1657,7 @@ impl ObjectCacheRead for WritebackCache {
 }
 
 impl TransactionCacheRead for WritebackCache {
-    fn multi_get_transaction_blocks(
+    fn try_multi_get_transaction_blocks(
         &self,
         digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Option<Arc<VerifiedTransaction>>>> {
@@ -1692,7 +1694,7 @@ impl TransactionCacheRead for WritebackCache {
         )
     }
 
-    fn multi_get_executed_effects_digests(
+    fn try_multi_get_executed_effects_digests(
         &self,
         digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Option<TransactionEffectsDigest>>> {
@@ -1728,7 +1730,7 @@ impl TransactionCacheRead for WritebackCache {
         )
     }
 
-    fn multi_get_effects(
+    fn try_multi_get_effects(
         &self,
         digests: &[TransactionEffectsDigest],
     ) -> IotaResult<Vec<Option<TransactionEffects>>> {
@@ -1764,18 +1766,18 @@ impl TransactionCacheRead for WritebackCache {
         )
     }
 
-    fn notify_read_executed_effects_digests<'a>(
+    fn try_notify_read_executed_effects_digests<'a>(
         &'a self,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, IotaResult<Vec<TransactionEffectsDigest>>> {
         self.executed_effects_digests_notify_read
             .read(digests, |digests| {
-                self.multi_get_executed_effects_digests(digests)
+                self.try_multi_get_executed_effects_digests(digests)
             })
             .boxed()
     }
 
-    fn multi_get_events(
+    fn try_multi_get_events(
         &self,
         event_digests: &[TransactionEventsDigest],
     ) -> IotaResult<Vec<Option<TransactionEvents>>> {

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -758,7 +758,7 @@ impl WritebackCache {
             CacheResult::Hit((_, object)) => Ok(Some(object)),
             CacheResult::NegativeHit => Ok(None),
             CacheResult::Miss => {
-                let obj = self.store.get_object(id)?;
+                let obj = self.store.try_get_object(id)?;
                 if let Some(obj) = &obj {
                     self.cache_latest_object_by_id(
                         id,
@@ -1218,7 +1218,7 @@ impl ObjectCacheRead for WritebackCache {
             .record_cache_request("package", "package_cache");
         if let Some(p) = self.packages.get(package_id) {
             if cfg!(debug_assertions) {
-                if let Some(store_package) = self.store.get_object(package_id).unwrap() {
+                if let Some(store_package) = self.store.try_get_object(package_id).unwrap() {
                     assert_eq!(
                         store_package.digest(),
                         p.object().digest(),
@@ -1278,7 +1278,7 @@ impl ObjectCacheRead for WritebackCache {
             CacheResult::NegativeHit => Ok(None),
             CacheResult::Miss => Ok(self
                 .record_db_get("object_by_version")
-                .get_object_by_key(object_id, version)?),
+                .try_get_object_by_key(object_id, version)?),
         }
     }
 

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -1213,7 +1213,7 @@ impl ExecutionCacheCommit for WritebackCache {
 }
 
 impl ObjectCacheRead for WritebackCache {
-    fn get_package_object(&self, package_id: &ObjectID) -> IotaResult<Option<PackageObject>> {
+    fn try_get_package_object(&self, package_id: &ObjectID) -> IotaResult<Option<PackageObject>> {
         self.metrics
             .record_cache_request("package", "package_cache");
         if let Some(p) = self.packages.get(package_id) {
@@ -1264,11 +1264,11 @@ impl ObjectCacheRead for WritebackCache {
 
     // get_object and variants.
 
-    fn get_object(&self, id: &ObjectID) -> IotaResult<Option<Object>> {
+    fn try_get_object(&self, id: &ObjectID) -> IotaResult<Option<Object>> {
         self.get_object_impl("object_latest", id)
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,
@@ -1282,7 +1282,7 @@ impl ObjectCacheRead for WritebackCache {
         }
     }
 
-    fn multi_get_objects_by_key(
+    fn try_multi_get_objects_by_key(
         &self,
         object_keys: &[ObjectKey],
     ) -> Result<Vec<Option<Object>>, IotaError> {
@@ -1302,7 +1302,7 @@ impl ObjectCacheRead for WritebackCache {
         )
     }
 
-    fn object_exists_by_key(
+    fn try_object_exists_by_key(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,
@@ -1316,7 +1316,7 @@ impl ObjectCacheRead for WritebackCache {
         }
     }
 
-    fn multi_object_exists_by_key(&self, object_keys: &[ObjectKey]) -> IotaResult<Vec<bool>> {
+    fn try_multi_object_exists_by_key(&self, object_keys: &[ObjectKey]) -> IotaResult<Vec<bool>> {
         do_fallback_lookup(
             object_keys,
             |key| {
@@ -1333,7 +1333,7 @@ impl ObjectCacheRead for WritebackCache {
         )
     }
 
-    fn get_latest_object_ref_or_tombstone(
+    fn try_get_latest_object_ref_or_tombstone(
         &self,
         object_id: ObjectID,
     ) -> IotaResult<Option<ObjectRef>> {
@@ -1350,7 +1350,7 @@ impl ObjectCacheRead for WritebackCache {
         }
     }
 
-    fn get_latest_object_or_tombstone(
+    fn try_get_latest_object_or_tombstone(
         &self,
         object_id: ObjectID,
     ) -> Result<Option<(ObjectKey, ObjectOrTombstone)>, IotaError> {
@@ -1385,7 +1385,7 @@ impl ObjectCacheRead for WritebackCache {
     }
 
     #[instrument(level = "trace", skip_all, fields(object_id, version_bound))]
-    fn find_object_lt_or_eq_version(
+    fn try_find_object_lt_or_eq_version(
         &self,
         object_id: ObjectID,
         version_bound: SequenceNumber,
@@ -1534,11 +1534,11 @@ impl ObjectCacheRead for WritebackCache {
         )
     }
 
-    fn get_iota_system_state_object_unsafe(&self) -> IotaResult<IotaSystemState> {
+    fn try_get_iota_system_state_object_unsafe(&self) -> IotaResult<IotaSystemState> {
         get_iota_system_state(self)
     }
 
-    fn get_marker_value(
+    fn try_get_marker_value(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,
@@ -1553,7 +1553,7 @@ impl ObjectCacheRead for WritebackCache {
         }
     }
 
-    fn get_latest_marker(
+    fn try_get_latest_marker(
         &self,
         object_id: &ObjectID,
         epoch_id: EpochId,
@@ -1569,7 +1569,11 @@ impl ObjectCacheRead for WritebackCache {
         }
     }
 
-    fn get_lock(&self, obj_ref: ObjectRef, epoch_store: &AuthorityPerEpochStore) -> IotaLockResult {
+    fn try_get_lock(
+        &self,
+        obj_ref: ObjectRef,
+        epoch_store: &AuthorityPerEpochStore,
+    ) -> IotaLockResult {
         match self.get_object_by_id_cache_only("lock", &obj_ref.0) {
             CacheResult::Hit((_, obj)) => {
                 let actual_objref = obj.compute_object_reference();
@@ -1604,7 +1608,7 @@ impl ObjectCacheRead for WritebackCache {
         }
     }
 
-    fn _get_live_objref(&self, object_id: ObjectID) -> IotaResult<ObjectRef> {
+    fn _try_get_live_objref(&self, object_id: ObjectID) -> IotaResult<ObjectRef> {
         let obj = self.get_object_impl("live_objref", &object_id)?.ok_or(
             UserInputError::ObjectNotFound {
                 object_id,
@@ -1614,7 +1618,7 @@ impl ObjectCacheRead for WritebackCache {
         Ok(obj.compute_object_reference())
     }
 
-    fn check_owned_objects_are_live(&self, owned_object_refs: &[ObjectRef]) -> IotaResult {
+    fn try_check_owned_objects_are_live(&self, owned_object_refs: &[ObjectRef]) -> IotaResult {
         do_fallback_lookup(
             owned_object_refs,
             |obj_ref| match self.get_object_by_id_cache_only("object_is_live", &obj_ref.0) {
@@ -1645,7 +1649,7 @@ impl ObjectCacheRead for WritebackCache {
         Ok(())
     }
 
-    fn get_highest_pruned_checkpoint(&self) -> IotaResult<CheckpointSequenceNumber> {
+    fn try_get_highest_pruned_checkpoint(&self) -> IotaResult<CheckpointSequenceNumber> {
         self.store.perpetual_tables.get_highest_pruned_checkpoint()
     }
 }

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -1826,7 +1826,7 @@ impl TransactionCacheRead for WritebackCache {
 }
 
 impl ExecutionCacheWrite for WritebackCache {
-    fn acquire_transaction_locks<'a>(
+    fn try_acquire_transaction_locks<'a>(
         &'a self,
         epoch_store: &'a AuthorityPerEpochStore,
         owned_input_objects: &'a [ObjectRef],
@@ -1837,7 +1837,7 @@ impl ExecutionCacheWrite for WritebackCache {
             .boxed()
     }
 
-    fn write_transaction_outputs(
+    fn try_write_transaction_outputs(
         &self,
         epoch_id: EpochId,
         tx_outputs: Arc<TransactionOutputs>,

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -1196,7 +1196,7 @@ impl WritebackCache {
 impl ExecutionCacheAPI for WritebackCache {}
 
 impl ExecutionCacheCommit for WritebackCache {
-    fn commit_transaction_outputs<'a>(
+    fn try_commit_transaction_outputs<'a>(
         &'a self,
         epoch: EpochId,
         digests: &'a [TransactionDigest],
@@ -1204,7 +1204,7 @@ impl ExecutionCacheCommit for WritebackCache {
         WritebackCache::commit_transaction_outputs(self, epoch, digests).boxed()
     }
 
-    fn persist_transactions<'a>(
+    fn try_persist_transactions<'a>(
         &'a self,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, IotaResult> {

--- a/crates/iota-core/src/storage.rs
+++ b/crates/iota-core/src/storage.rs
@@ -267,21 +267,21 @@ impl ReadStore for RocksDbStore {
 }
 
 impl ObjectStore for RocksDbStore {
-    fn get_object(
+    fn try_get_object(
         &self,
         object_id: &iota_types::base_types::ObjectID,
     ) -> iota_types::storage::error::Result<Option<Object>> {
-        self.cache_traits.object_store.get_object(object_id)
+        self.cache_traits.object_store.try_get_object(object_id)
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &iota_types::base_types::ObjectID,
         version: iota_types::base_types::VersionNumber,
     ) -> iota_types::storage::error::Result<Option<Object>> {
         self.cache_traits
             .object_store
-            .get_object_by_key(object_id, version)
+            .try_get_object_by_key(object_id, version)
     }
 }
 
@@ -379,19 +379,19 @@ impl RestReadStore {
 }
 
 impl ObjectStore for RestReadStore {
-    fn get_object(
+    fn try_get_object(
         &self,
         object_id: &iota_types::base_types::ObjectID,
     ) -> iota_types::storage::error::Result<Option<Object>> {
-        self.rocks.get_object(object_id)
+        self.rocks.try_get_object(object_id)
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &iota_types::base_types::ObjectID,
         version: iota_types::base_types::VersionNumber,
     ) -> iota_types::storage::error::Result<Option<Object>> {
-        self.rocks.get_object_by_key(object_id, version)
+        self.rocks.try_get_object_by_key(object_id, version)
     }
 }
 

--- a/crates/iota-core/src/storage.rs
+++ b/crates/iota-core/src/storage.rs
@@ -72,7 +72,7 @@ impl RocksDbStore {
 }
 
 impl ReadStore for RocksDbStore {
-    fn get_checkpoint_by_digest(
+    fn try_get_checkpoint_by_digest(
         &self,
         digest: &CheckpointDigest,
     ) -> Result<Option<VerifiedCheckpoint>, StorageError> {
@@ -81,7 +81,7 @@ impl ReadStore for RocksDbStore {
             .map_err(Into::into)
     }
 
-    fn get_checkpoint_by_sequence_number(
+    fn try_get_checkpoint_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Result<Option<VerifiedCheckpoint>, StorageError> {
@@ -90,7 +90,7 @@ impl ReadStore for RocksDbStore {
             .map_err(Into::into)
     }
 
-    fn get_highest_verified_checkpoint(&self) -> Result<VerifiedCheckpoint, StorageError> {
+    fn try_get_highest_verified_checkpoint(&self) -> Result<VerifiedCheckpoint, StorageError> {
         self.checkpoint_store
             .get_highest_verified_checkpoint()
             .map(|maybe_checkpoint| {
@@ -100,7 +100,7 @@ impl ReadStore for RocksDbStore {
             .map_err(Into::into)
     }
 
-    fn get_highest_synced_checkpoint(&self) -> Result<VerifiedCheckpoint, StorageError> {
+    fn try_get_highest_synced_checkpoint(&self) -> Result<VerifiedCheckpoint, StorageError> {
         self.checkpoint_store
             .get_highest_synced_checkpoint()
             .map(|maybe_checkpoint| {
@@ -110,7 +110,9 @@ impl ReadStore for RocksDbStore {
             .map_err(Into::into)
     }
 
-    fn get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber, StorageError> {
+    fn try_get_lowest_available_checkpoint(
+        &self,
+    ) -> Result<CheckpointSequenceNumber, StorageError> {
         let highest_pruned_cp = self
             .checkpoint_store
             .get_highest_pruned_checkpoint_seq_number()
@@ -123,7 +125,7 @@ impl ReadStore for RocksDbStore {
         }
     }
 
-    fn get_full_checkpoint_contents_by_sequence_number(
+    fn try_get_full_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Result<Option<FullCheckpointContents>, StorageError> {
@@ -132,7 +134,7 @@ impl ReadStore for RocksDbStore {
             .map_err(Into::into)
     }
 
-    fn get_full_checkpoint_contents(
+    fn try_get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
     ) -> Result<Option<FullCheckpointContents>, StorageError> {
@@ -164,7 +166,7 @@ impl ReadStore for RocksDbStore {
                 let mut transactions = Vec::with_capacity(contents.size());
                 for tx in contents.iter() {
                     if let (Some(t), Some(e)) = (
-                        self.get_transaction(&tx.transaction)?,
+                        self.try_get_transaction(&tx.transaction)?,
                         self.cache_traits
                             .transaction_cache_reader
                             .get_effects(&tx.effects)
@@ -193,14 +195,14 @@ impl ReadStore for RocksDbStore {
             .map_err(iota_types::storage::error::Error::custom)
     }
 
-    fn get_committee(
+    fn try_get_committee(
         &self,
         epoch: EpochId,
     ) -> Result<Option<Arc<Committee>>, iota_types::storage::error::Error> {
         Ok(self.committee_store.get_committee(&epoch).unwrap())
     }
 
-    fn get_transaction(
+    fn try_get_transaction(
         &self,
         digest: &TransactionDigest,
     ) -> Result<Option<Arc<VerifiedTransaction>>, StorageError> {
@@ -210,7 +212,7 @@ impl ReadStore for RocksDbStore {
             .map_err(StorageError::custom)
     }
 
-    fn get_transaction_effects(
+    fn try_get_transaction_effects(
         &self,
         digest: &TransactionDigest,
     ) -> Result<Option<TransactionEffects>, StorageError> {
@@ -220,7 +222,7 @@ impl ReadStore for RocksDbStore {
             .map_err(StorageError::custom)
     }
 
-    fn get_events(
+    fn try_get_events(
         &self,
         digest: &TransactionEventsDigest,
     ) -> Result<Option<TransactionEvents>, StorageError> {
@@ -230,7 +232,7 @@ impl ReadStore for RocksDbStore {
             .map_err(StorageError::custom)
     }
 
-    fn get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
+    fn try_get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
         self.checkpoint_store
             .get_highest_executed_checkpoint()
             .map_err(iota_types::storage::error::Error::custom)?
@@ -239,7 +241,7 @@ impl ReadStore for RocksDbStore {
             })
     }
 
-    fn get_checkpoint_contents_by_digest(
+    fn try_get_checkpoint_contents_by_digest(
         &self,
         digest: &CheckpointContentsDigest,
     ) -> iota_types::storage::error::Result<
@@ -250,15 +252,15 @@ impl ReadStore for RocksDbStore {
             .map_err(iota_types::storage::error::Error::custom)
     }
 
-    fn get_checkpoint_contents_by_sequence_number(
+    fn try_get_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<
         Option<iota_types::messages_checkpoint::CheckpointContents>,
     > {
-        match self.get_checkpoint_by_sequence_number(sequence_number) {
+        match self.try_get_checkpoint_by_sequence_number(sequence_number) {
             Ok(Some(checkpoint)) => {
-                self.get_checkpoint_contents_by_digest(&checkpoint.content_digest)
+                self.try_get_checkpoint_contents_by_digest(&checkpoint.content_digest)
             }
             Ok(None) => Ok(None),
             Err(e) => Err(e),
@@ -396,103 +398,103 @@ impl ObjectStore for RestReadStore {
 }
 
 impl ReadStore for RestReadStore {
-    fn get_committee(
+    fn try_get_committee(
         &self,
         epoch: EpochId,
     ) -> iota_types::storage::error::Result<Option<Arc<Committee>>> {
-        self.rocks.get_committee(epoch)
+        self.rocks.try_get_committee(epoch)
     }
 
-    fn get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
-        self.rocks.get_latest_checkpoint()
+    fn try_get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
+        self.rocks.try_get_latest_checkpoint()
     }
 
-    fn get_highest_verified_checkpoint(
+    fn try_get_highest_verified_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
-        self.rocks.get_highest_verified_checkpoint()
+        self.rocks.try_get_highest_verified_checkpoint()
     }
 
-    fn get_highest_synced_checkpoint(
+    fn try_get_highest_synced_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
-        self.rocks.get_highest_synced_checkpoint()
+        self.rocks.try_get_highest_synced_checkpoint()
     }
 
-    fn get_lowest_available_checkpoint(
+    fn try_get_lowest_available_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<CheckpointSequenceNumber> {
-        self.rocks.get_lowest_available_checkpoint()
+        self.rocks.try_get_lowest_available_checkpoint()
     }
 
-    fn get_checkpoint_by_digest(
+    fn try_get_checkpoint_by_digest(
         &self,
         digest: &CheckpointDigest,
     ) -> iota_types::storage::error::Result<Option<VerifiedCheckpoint>> {
-        self.rocks.get_checkpoint_by_digest(digest)
+        self.rocks.try_get_checkpoint_by_digest(digest)
     }
 
-    fn get_checkpoint_by_sequence_number(
+    fn try_get_checkpoint_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<Option<VerifiedCheckpoint>> {
         self.rocks
-            .get_checkpoint_by_sequence_number(sequence_number)
+            .try_get_checkpoint_by_sequence_number(sequence_number)
     }
 
-    fn get_checkpoint_contents_by_digest(
+    fn try_get_checkpoint_contents_by_digest(
         &self,
         digest: &CheckpointContentsDigest,
     ) -> iota_types::storage::error::Result<
         Option<iota_types::messages_checkpoint::CheckpointContents>,
     > {
-        self.rocks.get_checkpoint_contents_by_digest(digest)
+        self.rocks.try_get_checkpoint_contents_by_digest(digest)
     }
 
-    fn get_checkpoint_contents_by_sequence_number(
+    fn try_get_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<
         Option<iota_types::messages_checkpoint::CheckpointContents>,
     > {
         self.rocks
-            .get_checkpoint_contents_by_sequence_number(sequence_number)
+            .try_get_checkpoint_contents_by_sequence_number(sequence_number)
     }
 
-    fn get_transaction(
+    fn try_get_transaction(
         &self,
         digest: &TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<Arc<VerifiedTransaction>>> {
-        self.rocks.get_transaction(digest)
+        self.rocks.try_get_transaction(digest)
     }
 
-    fn get_transaction_effects(
+    fn try_get_transaction_effects(
         &self,
         digest: &TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<TransactionEffects>> {
-        self.rocks.get_transaction_effects(digest)
+        self.rocks.try_get_transaction_effects(digest)
     }
 
-    fn get_events(
+    fn try_get_events(
         &self,
         digest: &TransactionEventsDigest,
     ) -> iota_types::storage::error::Result<Option<TransactionEvents>> {
-        self.rocks.get_events(digest)
+        self.rocks.try_get_events(digest)
     }
 
-    fn get_full_checkpoint_contents_by_sequence_number(
+    fn try_get_full_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<Option<FullCheckpointContents>> {
         self.rocks
-            .get_full_checkpoint_contents_by_sequence_number(sequence_number)
+            .try_get_full_checkpoint_contents_by_sequence_number(sequence_number)
     }
 
-    fn get_full_checkpoint_contents(
+    fn try_get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
     ) -> iota_types::storage::error::Result<Option<FullCheckpointContents>> {
-        self.rocks.get_full_checkpoint_contents(digest)
+        self.rocks.try_get_full_checkpoint_contents(digest)
     }
 }
 

--- a/crates/iota-core/src/storage.rs
+++ b/crates/iota-core/src/storage.rs
@@ -63,7 +63,7 @@ impl RocksDbStore {
     pub fn get_objects(&self, object_keys: &[ObjectKey]) -> Result<Vec<Option<Object>>, IotaError> {
         self.cache_traits
             .object_cache_reader
-            .multi_get_objects_by_key(object_keys)
+            .try_multi_get_objects_by_key(object_keys)
     }
 
     pub fn get_last_executed_checkpoint(&self) -> Result<Option<VerifiedCheckpoint>, IotaError> {
@@ -515,7 +515,7 @@ impl RestStateReader for RestReadStore {
         let highest_pruned_cp = self
             .state
             .get_object_cache_reader()
-            .get_highest_pruned_checkpoint()
+            .try_get_highest_pruned_checkpoint()
             .map_err(StorageError::custom)?;
 
         if highest_pruned_cp == 0 {

--- a/crates/iota-core/src/storage.rs
+++ b/crates/iota-core/src/storage.rs
@@ -345,7 +345,7 @@ impl WriteStore for RocksDbStore {
     ) -> Result<(), iota_types::storage::error::Error> {
         self.cache_traits
             .state_sync_store
-            .multi_insert_transaction_and_effects(contents.transactions())
+            .try_multi_insert_transaction_and_effects(contents.transactions())
             .map_err(iota_types::storage::error::Error::custom)?;
         self.checkpoint_store
             .insert_verified_checkpoint_contents(checkpoint, contents)

--- a/crates/iota-core/src/storage.rs
+++ b/crates/iota-core/src/storage.rs
@@ -288,7 +288,7 @@ impl ObjectStore for RocksDbStore {
 }
 
 impl WriteStore for RocksDbStore {
-    fn insert_checkpoint(
+    fn try_insert_checkpoint(
         &self,
         checkpoint: &VerifiedCheckpoint,
     ) -> Result<(), iota_types::storage::error::Error> {
@@ -300,7 +300,7 @@ impl WriteStore for RocksDbStore {
             let next_committee = next_epoch_committee.iter().cloned().collect();
             let committee =
                 Committee::new(checkpoint.epoch().checked_add(1).unwrap(), next_committee);
-            self.insert_committee(committee)?;
+            self.try_insert_committee(committee)?;
         }
 
         self.checkpoint_store
@@ -308,7 +308,7 @@ impl WriteStore for RocksDbStore {
             .map_err(Into::into)
     }
 
-    fn update_highest_synced_checkpoint(
+    fn try_update_highest_synced_checkpoint(
         &self,
         checkpoint: &VerifiedCheckpoint,
     ) -> Result<(), iota_types::storage::error::Error> {
@@ -323,7 +323,7 @@ impl WriteStore for RocksDbStore {
         Ok(())
     }
 
-    fn update_highest_verified_checkpoint(
+    fn try_update_highest_verified_checkpoint(
         &self,
         checkpoint: &VerifiedCheckpoint,
     ) -> Result<(), iota_types::storage::error::Error> {
@@ -338,7 +338,7 @@ impl WriteStore for RocksDbStore {
         Ok(())
     }
 
-    fn insert_checkpoint_contents(
+    fn try_insert_checkpoint_contents(
         &self,
         checkpoint: &VerifiedCheckpoint,
         contents: VerifiedCheckpointContents,
@@ -352,7 +352,7 @@ impl WriteStore for RocksDbStore {
             .map_err(Into::into)
     }
 
-    fn insert_committee(
+    fn try_insert_committee(
         &self,
         new_committee: Committee,
     ) -> Result<(), iota_types::storage::error::Error> {

--- a/crates/iota-core/src/storage.rs
+++ b/crates/iota-core/src/storage.rs
@@ -169,7 +169,7 @@ impl ReadStore for RocksDbStore {
                         self.try_get_transaction(&tx.transaction)?,
                         self.cache_traits
                             .transaction_cache_reader
-                            .get_effects(&tx.effects)
+                            .try_get_effects(&tx.effects)
                             .map_err(iota_types::storage::error::Error::custom)?,
                     ) {
                         transactions.push(iota_types::base_types::ExecutionData::new(
@@ -208,7 +208,7 @@ impl ReadStore for RocksDbStore {
     ) -> Result<Option<Arc<VerifiedTransaction>>, StorageError> {
         self.cache_traits
             .transaction_cache_reader
-            .get_transaction_block(digest)
+            .try_get_transaction_block(digest)
             .map_err(StorageError::custom)
     }
 
@@ -218,7 +218,7 @@ impl ReadStore for RocksDbStore {
     ) -> Result<Option<TransactionEffects>, StorageError> {
         self.cache_traits
             .transaction_cache_reader
-            .get_executed_effects(digest)
+            .try_get_executed_effects(digest)
             .map_err(StorageError::custom)
     }
 
@@ -228,7 +228,7 @@ impl ReadStore for RocksDbStore {
     ) -> Result<Option<TransactionEvents>, StorageError> {
         self.cache_traits
             .transaction_cache_reader
-            .get_events(digest)
+            .try_get_events(digest)
             .map_err(StorageError::custom)
     }
 

--- a/crates/iota-core/src/test_utils.rs
+++ b/crates/iota-core/src/test_utils.rs
@@ -115,7 +115,7 @@ pub async fn wait_for_tx(digest: TransactionDigest, state: Arc<AuthorityState>) 
         WAIT_FOR_TX_TIMEOUT,
         state
             .get_transaction_cache_reader()
-            .notify_read_executed_effects(&[digest]),
+            .try_notify_read_executed_effects(&[digest]),
     )
     .await
     {
@@ -132,7 +132,7 @@ pub async fn wait_for_all_txes(digests: Vec<TransactionDigest>, state: Arc<Autho
         WAIT_FOR_TX_TIMEOUT,
         state
             .get_transaction_cache_reader()
-            .notify_read_executed_effects(&digests),
+            .try_notify_read_executed_effects(&digests),
     )
     .await
     {

--- a/crates/iota-core/src/transaction_input_loader.rs
+++ b/crates/iota-core/src/transaction_input_loader.rs
@@ -58,7 +58,8 @@ impl TransactionInputLoader {
             match kind {
                 // Packages are loaded one at a time via the cache
                 InputObjectKind::MovePackage(id) => {
-                    let Some(package) = self.cache.get_package_object(id)?.map(|o| o.into()) else {
+                    let Some(package) = self.cache.try_get_package_object(id)?.map(|o| o.into())
+                    else {
                         return Err(IotaError::from(kind.object_not_found_error()));
                     };
                     input_results[i] = Some(ObjectReadResult {
@@ -66,14 +67,17 @@ impl TransactionInputLoader {
                         object: ObjectReadResultKind::Object(package),
                     });
                 }
-                InputObjectKind::SharedMoveObject { id, .. } => match self.cache.get_object(id)? {
+                InputObjectKind::SharedMoveObject { id, .. } => match self
+                    .cache
+                    .try_get_object(id)?
+                {
                     Some(object) => {
                         input_results[i] = Some(ObjectReadResult::new(*kind, object.into()))
                     }
                     None => {
                         if let Some((version, digest)) = self
                             .cache
-                            .get_last_shared_object_deletion_info(id, epoch_id)?
+                            .try_get_last_shared_object_deletion_info(id, epoch_id)?
                         {
                             input_results[i] = Some(ObjectReadResult {
                                 input_object_kind: *kind,
@@ -93,7 +97,7 @@ impl TransactionInputLoader {
 
         let objects = self
             .cache
-            .multi_get_objects_with_more_accurate_error_return(&object_refs)?;
+            .try_multi_get_objects_with_more_accurate_error_return(&object_refs)?;
         assert_eq!(objects.len(), object_refs.len());
         for (index, object) in fetch_indices.into_iter().zip(objects.into_iter()) {
             input_results[index] = Some(ObjectReadResult {
@@ -153,7 +157,7 @@ impl TransactionInputLoader {
         for (i, input) in input_object_kinds.iter().enumerate() {
             match input {
                 InputObjectKind::MovePackage(id) => {
-                    let package = self.cache.get_package_object(id)?.unwrap_or_else(|| {
+                    let package = self.cache.try_get_package_object(id)?.unwrap_or_else(|| {
                         panic!("Executable transaction {tx_key:?} depends on non-existent package {id:?}")
                     });
 
@@ -206,7 +210,7 @@ impl TransactionInputLoader {
             }
         }
 
-        let objects = self.cache.multi_get_objects_by_key(&object_keys)?;
+        let objects = self.cache.try_multi_get_objects_by_key(&object_keys)?;
 
         assert!(objects.len() == object_keys.len() && objects.len() == fetches.len());
 
@@ -226,7 +230,7 @@ impl TransactionInputLoader {
                     let version = key.1;
                     if let Some(dependency) = self
                         .cache
-                        .get_deleted_shared_object_previous_tx_digest(id, version, epoch_id)?
+                        .try_get_deleted_shared_object_previous_tx_digest(id, version, epoch_id)?
                     {
                         ObjectReadResult {
                             input_object_kind: *input,
@@ -267,7 +271,7 @@ impl TransactionInputLoader {
 
             if self
                 .cache
-                .have_received_object_at_version(object_id, *version, epoch_id)?
+                .try_have_received_object_at_version(object_id, *version, epoch_id)?
             {
                 receiving_results.push(ReceivingObjectReadResult::new(
                     *objref,
@@ -276,7 +280,7 @@ impl TransactionInputLoader {
                 continue;
             }
 
-            let Some(object) = self.cache.get_object(object_id)? else {
+            let Some(object) = self.cache.try_get_object(object_id)? else {
                 return Err(UserInputError::ObjectNotFound {
                     object_id: *object_id,
                     version: Some(*version),

--- a/crates/iota-core/src/transaction_manager.rs
+++ b/crates/iota-core/src/transaction_manager.rs
@@ -520,7 +520,7 @@ impl TransactionManager {
         // So missing objects' availability are checked again after acquiring TM lock.
         let cache_miss_availability = self
             .object_cache_read
-            .multi_input_objects_available(
+            .try_multi_input_objects_available(
                 &input_object_cache_misses,
                 receiving_objects,
                 epoch_store.epoch(),

--- a/crates/iota-core/src/transaction_manager.rs
+++ b/crates/iota-core/src/transaction_manager.rs
@@ -419,7 +419,7 @@ impl TransactionManager {
                 // skip already executed txes
                 if self
                     .transaction_cache_read
-                    .is_tx_already_executed(&digest)
+                    .try_is_tx_already_executed(&digest)
                     .unwrap_or_else(|err| {
                         fatal!("Failed to check if tx is already executed: {:?}", err)
                     })
@@ -458,7 +458,7 @@ impl TransactionManager {
                             // remove the race.
                             if self
                                 .transaction_cache_read
-                                .is_tx_already_executed(cert.digest())
+                                .try_is_tx_already_executed(cert.digest())
                                 .expect("is_tx_already_executed cannot fail")
                             {
                                 return None;
@@ -618,7 +618,7 @@ impl TransactionManager {
             // skip already executed txes
             let is_tx_already_executed = self
                 .transaction_cache_read
-                .is_tx_already_executed(&digest)
+                .try_is_tx_already_executed(&digest)
                 .expect("Check if tx is already executed should not fail");
             if is_tx_already_executed {
                 self.metrics

--- a/crates/iota-core/src/transaction_orchestrator.rs
+++ b/crates/iota-core/src/transaction_orchestrator.rs
@@ -345,7 +345,7 @@ where
         let qd = self.clone_quorum_driver();
         Ok(async move {
             let digests = [tx_digest];
-            let effects_await = cache_reader.notify_read_executed_effects(&digests);
+            let effects_await = cache_reader.try_notify_read_executed_effects(&digests);
             // let-and-return necessary to satisfy borrow checker.
             let res = match select(ticket, effects_await.boxed()).await {
                 Either::Left((quorum_driver_response, _)) => Ok(quorum_driver_response),

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -3598,7 +3598,7 @@ async fn test_store_revert_transfer_iota() {
     let cache = authority_state.get_object_cache_reader();
     let tx_cache = authority_state.get_transaction_cache_reader();
     let reconfig_api = authority_state.get_reconfig_api();
-    reconfig_api.revert_state_update(&tx_digest).unwrap();
+    reconfig_api.try_revert_state_update(&tx_digest).unwrap();
     reconfig_api
         .clear_state_end_of_epoch(&authority_state.execution_lock_for_reconfiguration().await);
 
@@ -3681,7 +3681,7 @@ async fn test_store_revert_wrap_move_call() {
 
     let cache = &authority_state.get_object_cache_reader();
     let reconfig_api = authority_state.get_reconfig_api();
-    reconfig_api.revert_state_update(&wrap_digest).unwrap();
+    reconfig_api.try_revert_state_update(&wrap_digest).unwrap();
     reconfig_api
         .clear_state_end_of_epoch(&authority_state.execution_lock_for_reconfiguration().await);
 
@@ -3783,7 +3783,9 @@ async fn test_store_revert_unwrap_move_call() {
     let cache = &authority_state.get_object_cache_reader();
     let reconfig_api = authority_state.get_reconfig_api();
 
-    reconfig_api.revert_state_update(&unwrap_digest).unwrap();
+    reconfig_api
+        .try_revert_state_update(&unwrap_digest)
+        .unwrap();
     reconfig_api
         .clear_state_end_of_epoch(&authority_state.execution_lock_for_reconfiguration().await);
 
@@ -4069,7 +4071,7 @@ async fn test_store_revert_add_ofield() {
     assert_eq!(inner.version(), inner_v1.1);
     assert_eq!(inner.owner, Owner::ObjectOwner(field_v0.0.into()));
 
-    reconfig_api.revert_state_update(&add_digest).unwrap();
+    reconfig_api.try_revert_state_update(&add_digest).unwrap();
 
     reconfig_api
         .clear_state_end_of_epoch(&authority_state.execution_lock_for_reconfiguration().await);
@@ -4196,7 +4198,7 @@ async fn test_store_revert_remove_ofield() {
     assert_eq!(inner.version(), inner_v2.1);
 
     reconfig_api
-        .revert_state_update(&remove_ofield_digest)
+        .try_revert_state_update(&remove_ofield_digest)
         .unwrap();
     reconfig_api
         .clear_state_end_of_epoch(&authority_state.execution_lock_for_reconfiguration().await);

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -3636,7 +3636,7 @@ async fn test_store_revert_wrap_move_call() {
 
     authority_state
         .get_cache_commit()
-        .commit_transaction_outputs(
+        .try_commit_transaction_outputs(
             authority_state.epoch_store_for_testing().epoch(),
             &[*create_effects.transaction_digest()],
         )
@@ -3733,7 +3733,7 @@ async fn test_store_revert_unwrap_move_call() {
 
     authority_state
         .get_cache_commit()
-        .commit_transaction_outputs(
+        .try_commit_transaction_outputs(
             authority_state.epoch_store_for_testing().epoch(),
             &[
                 *create_effects.transaction_digest(),
@@ -4014,7 +4014,7 @@ async fn test_store_revert_add_ofield() {
 
     authority_state
         .get_cache_commit()
-        .commit_transaction_outputs(
+        .try_commit_transaction_outputs(
             authority_state.epoch_store_for_testing().epoch(),
             &[
                 *create_outer_effects.transaction_digest(),
@@ -4141,7 +4141,7 @@ async fn test_store_revert_remove_ofield() {
 
     authority_state
         .get_cache_commit()
-        .commit_transaction_outputs(
+        .try_commit_transaction_outputs(
             authority_state.epoch_store_for_testing().epoch(),
             &[
                 *create_outer_effects.transaction_digest(),

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -3603,12 +3603,12 @@ async fn test_store_revert_transfer_iota() {
         .clear_state_end_of_epoch(&authority_state.execution_lock_for_reconfiguration().await);
 
     assert_eq!(
-        cache.get_object(&gas_object_id).unwrap().unwrap().owner,
+        cache.try_get_object(&gas_object_id).unwrap().unwrap().owner,
         Owner::AddressOwner(sender),
     );
     assert_eq!(
         cache
-            .get_latest_object_ref_or_tombstone(gas_object_id)
+            .try_get_latest_object_ref_or_tombstone(gas_object_id)
             .unwrap()
             .unwrap(),
         gas_object_ref
@@ -3686,14 +3686,14 @@ async fn test_store_revert_wrap_move_call() {
         .clear_state_end_of_epoch(&authority_state.execution_lock_for_reconfiguration().await);
 
     // The wrapped object is unwrapped once again (accessible from storage).
-    let object = cache.get_object(&object_v0.0).unwrap().unwrap();
+    let object = cache.try_get_object(&object_v0.0).unwrap().unwrap();
     assert_eq!(object.version(), object_v0.1);
 
     // The wrapper doesn't exist
-    assert!(cache.get_object(&wrapper_v0.0).unwrap().is_none());
+    assert!(cache.try_get_object(&wrapper_v0.0).unwrap().is_none());
 
     // The gas is uncharged
-    let gas = cache.get_object(&gas_object_id).unwrap().unwrap();
+    let gas = cache.try_get_object(&gas_object_id).unwrap().unwrap();
     assert_eq!(gas.version(), create_effects.gas_object().0.1);
 }
 
@@ -3790,14 +3790,14 @@ async fn test_store_revert_unwrap_move_call() {
         .clear_state_end_of_epoch(&authority_state.execution_lock_for_reconfiguration().await);
 
     // The unwrapped object is wrapped once again
-    assert!(cache.get_object(&object_v0.0).unwrap().is_none());
+    assert!(cache.try_get_object(&object_v0.0).unwrap().is_none());
 
     // The wrapper exists
-    let wrapper = cache.get_object(&wrapper_v0.0).unwrap().unwrap();
+    let wrapper = cache.try_get_object(&wrapper_v0.0).unwrap().unwrap();
     assert_eq!(wrapper.version(), wrapper_v0.1);
 
     // The gas is uncharged
-    let gas = cache.get_object(&gas_object_id).unwrap().unwrap();
+    let gas = cache.try_get_object(&gas_object_id).unwrap().unwrap();
     assert_eq!(gas.version(), wrap_effects.gas_object().0.1);
 }
 
@@ -4061,13 +4061,13 @@ async fn test_store_revert_add_ofield() {
     let cache = authority_state.get_object_cache_reader();
     let reconfig_api = &authority_state.get_reconfig_api();
 
-    let outer = cache.get_object(&outer_v0.0).unwrap().unwrap();
+    let outer = cache.try_get_object(&outer_v0.0).unwrap().unwrap();
     assert_eq!(outer.version(), outer_v1.1);
 
-    let field = cache.get_object(&field_v0.0).unwrap().unwrap();
+    let field = cache.try_get_object(&field_v0.0).unwrap().unwrap();
     assert_eq!(field.owner, Owner::ObjectOwner(outer_v0.0.into()));
 
-    let inner = cache.get_object(&inner_v0.0).unwrap().unwrap();
+    let inner = cache.try_get_object(&inner_v0.0).unwrap().unwrap();
     assert_eq!(inner.version(), inner_v1.1);
     assert_eq!(inner.owner, Owner::ObjectOwner(field_v0.0.into()));
 
@@ -4076,13 +4076,13 @@ async fn test_store_revert_add_ofield() {
     reconfig_api
         .clear_state_end_of_epoch(&authority_state.execution_lock_for_reconfiguration().await);
 
-    let outer = cache.get_object(&outer_v0.0).unwrap().unwrap();
+    let outer = cache.try_get_object(&outer_v0.0).unwrap().unwrap();
     assert_eq!(outer.version(), outer_v0.1);
 
     // Field no longer exists
-    assert!(cache.get_object(&field_v0.0).unwrap().is_none());
+    assert!(cache.try_get_object(&field_v0.0).unwrap().is_none());
 
-    let inner = cache.get_object(&inner_v0.0).unwrap().unwrap();
+    let inner = cache.try_get_object(&inner_v0.0).unwrap().unwrap();
     assert_eq!(inner.version(), inner_v0.1);
     assert_eq!(inner.owner, Owner::AddressOwner(sender));
 }
@@ -4190,10 +4190,10 @@ async fn test_store_revert_remove_ofield() {
     let cache = &authority_state.get_object_cache_reader();
     let reconfig_api = &authority_state.get_reconfig_api();
 
-    let outer = cache.get_object(&outer_v0.0).unwrap().unwrap();
+    let outer = cache.try_get_object(&outer_v0.0).unwrap().unwrap();
     assert_eq!(outer.version(), outer_v2.1);
 
-    let inner = cache.get_object(&inner_v0.0).unwrap().unwrap();
+    let inner = cache.try_get_object(&inner_v0.0).unwrap().unwrap();
     assert_eq!(inner.owner, Owner::AddressOwner(sender));
     assert_eq!(inner.version(), inner_v2.1);
 
@@ -4203,13 +4203,13 @@ async fn test_store_revert_remove_ofield() {
     reconfig_api
         .clear_state_end_of_epoch(&authority_state.execution_lock_for_reconfiguration().await);
 
-    let outer = cache.get_object(&outer_v0.0).unwrap().unwrap();
+    let outer = cache.try_get_object(&outer_v0.0).unwrap().unwrap();
     assert_eq!(outer.version(), outer_v1.1);
 
-    let field = cache.get_object(&field_v0.0).unwrap().unwrap();
+    let field = cache.try_get_object(&field_v0.0).unwrap().unwrap();
     assert_eq!(field.owner, Owner::ObjectOwner(outer_v0.0.into()));
 
-    let inner = cache.get_object(&inner_v0.0).unwrap().unwrap();
+    let inner = cache.try_get_object(&inner_v0.0).unwrap().unwrap();
     assert_eq!(inner.owner, Owner::ObjectOwner(field_v0.0.into()));
     assert_eq!(inner.version(), inner_v1.1);
 }

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -3613,7 +3613,7 @@ async fn test_store_revert_transfer_iota() {
             .unwrap(),
         gas_object_ref
     );
-    assert!(!tx_cache.is_tx_already_executed(&tx_digest).unwrap());
+    assert!(!tx_cache.try_is_tx_already_executed(&tx_digest).unwrap());
 }
 
 #[tokio::test]
@@ -5215,7 +5215,7 @@ async fn test_consensus_message_processed() {
             authority2.try_execute_for_test(&certificate).await.unwrap();
             authority2
                 .get_transaction_cache_reader()
-                .get_executed_effects(transaction_digest)
+                .try_get_executed_effects(transaction_digest)
                 .unwrap()
                 .unwrap()
         };

--- a/crates/iota-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/iota-core/src/unit_tests/execution_driver_tests.rs
@@ -272,7 +272,7 @@ pub async fn do_cert_with_shared_objects(
     send_consensus(authority, cert).await;
     authority
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[*cert.digest()])
+        .try_notify_read_executed_effects(&[*cert.digest()])
         .await
         .unwrap()
         .pop()
@@ -453,7 +453,7 @@ async fn test_execution_with_dependencies() {
         .collect();
     authorities[3]
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&digests)
+        .try_notify_read_executed_effects(&digests)
         .await
         .unwrap();
 }
@@ -517,7 +517,7 @@ async fn test_per_object_overload() {
     for authority in authorities.iter().take(3) {
         authority
             .get_transaction_cache_reader()
-            .notify_read_executed_effects(&[*create_counter_cert.digest()])
+            .try_notify_read_executed_effects(&[*create_counter_cert.digest()])
             .await
             .unwrap()
             .pop()
@@ -532,7 +532,7 @@ async fn test_per_object_overload() {
     send_consensus(&authorities[3], &create_counter_cert).await;
     let create_counter_effects = authorities[3]
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[*create_counter_cert.digest()])
+        .try_notify_read_executed_effects(&[*create_counter_cert.digest()])
         .await
         .unwrap()
         .pop()
@@ -647,7 +647,7 @@ async fn test_txn_age_overload() {
     for authority in authorities.iter().take(3) {
         authority
             .get_transaction_cache_reader()
-            .notify_read_executed_effects(&[*create_counter_cert.digest()])
+            .try_notify_read_executed_effects(&[*create_counter_cert.digest()])
             .await
             .unwrap()
             .pop()
@@ -662,7 +662,7 @@ async fn test_txn_age_overload() {
     send_consensus(&authorities[3], &create_counter_cert).await;
     let create_counter_effects = authorities[3]
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[*create_counter_cert.digest()])
+        .try_notify_read_executed_effects(&[*create_counter_cert.digest()])
         .await
         .unwrap()
         .pop()

--- a/crates/iota-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/iota-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -324,7 +324,7 @@ async fn test_upgrade_package_happy_path() {
     let package = runner
         .authority_state
         .get_object_cache_reader()
-        .get_package_object(&runner.package.0)
+        .try_get_package_object(&runner.package.0)
         .unwrap()
         .unwrap();
     let config = ProtocolConfig::get_for_max_version_UNSAFE();
@@ -999,7 +999,7 @@ async fn test_publish_override_happy_path() {
     let package = runner
         .authority_state
         .get_object_cache_reader()
-        .get_package_object(&new_package.0)
+        .try_get_package_object(&new_package.0)
         .unwrap()
         .unwrap();
 
@@ -1053,7 +1053,7 @@ async fn test_publish_transitive_happy_path() {
     let root_move_package = runner
         .authority_state
         .get_object_cache_reader()
-        .get_package_object(&root_package.0)
+        .try_get_package_object(&root_package.0)
         .unwrap()
         .unwrap();
 
@@ -1145,7 +1145,7 @@ async fn test_publish_transitive_override_happy_path() {
     let root_move_package = runner
         .authority_state
         .get_object_cache_reader()
-        .get_package_object(&root_package.0)
+        .try_get_package_object(&root_package.0)
         .unwrap()
         .unwrap();
 

--- a/crates/iota-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/iota-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -411,7 +411,7 @@ async fn test_upgrade_introduces_type_then_uses_it() {
     let b = runner
         .authority_state
         .get_object_store()
-        .get_object_by_key(&created.0, created.1)
+        .try_get_object_by_key(&created.0, created.1)
         .unwrap()
         .unwrap();
 

--- a/crates/iota-core/src/unit_tests/shared_object_deletion_tests.rs
+++ b/crates/iota-core/src/unit_tests/shared_object_deletion_tests.rs
@@ -113,7 +113,7 @@ impl TestRunner {
     pub fn get_object_latest_version(&mut self, obj_id: ObjectID) -> SequenceNumber {
         self.authority_state
             .get_object_cache_reader()
-            .get_latest_object_ref_or_tombstone(obj_id)
+            .try_get_latest_object_ref_or_tombstone(obj_id)
             .unwrap()
             .unwrap()
             .1
@@ -560,7 +560,7 @@ impl TestRunner {
     ) -> Option<TransactionDigest> {
         self.authority_state
             .get_object_cache_reader()
-            .get_deleted_shared_object_previous_tx_digest(object_id, *version, epoch)
+            .try_get_deleted_shared_object_previous_tx_digest(object_id, *version, epoch)
             .unwrap()
     }
 }

--- a/crates/iota-core/src/unit_tests/transaction_deny_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_deny_tests.rs
@@ -367,7 +367,7 @@ async fn test_package_denied() {
 
     state
         .get_cache_commit()
-        .commit_transaction_outputs(
+        .try_commit_transaction_outputs(
             state.epoch_store_for_testing().epoch(),
             &[tx_c, tx_b, tx_a, tx_c_prime, tx_b_prime],
         )

--- a/crates/iota-core/src/unit_tests/transfer_to_object_tests.rs
+++ b/crates/iota-core/src/unit_tests/transfer_to_object_tests.rs
@@ -1749,10 +1749,10 @@ async fn test_have_deleted_owned_object() {
 
         let cache = runner.authority_state.get_object_cache_reader().clone();
 
-        assert!(cache.get_object(&new_child.0.0).unwrap().is_some());
+        assert!(cache.try_get_object(&new_child.0.0).unwrap().is_some());
         // Should not show as deleted for either versions
-        assert!(!cache.have_deleted_owned_object_at_version_or_after(&new_child.0.0, new_child.0.1, 0).unwrap());
-        assert!(!cache.have_deleted_owned_object_at_version_or_after(&new_child.0.0, child.0.1, 0).unwrap());
+        assert!(!cache.try_have_deleted_owned_object_at_version_or_after(&new_child.0.0, new_child.0.1, 0).unwrap());
+        assert!(!cache.try_have_deleted_owned_object_at_version_or_after(&new_child.0.0, child.0.1, 0).unwrap());
 
         let effects = runner
             .run({
@@ -1768,14 +1768,14 @@ async fn test_have_deleted_owned_object() {
             .await;
 
         let deleted_child = effects.deleted().into_iter().find(|(id, _, _)| *id == new_child.0 .0).unwrap();
-        assert!(cache.get_object(&deleted_child.0).unwrap().is_none());
-        assert!(cache.have_deleted_owned_object_at_version_or_after(&deleted_child.0, deleted_child.1, 0).unwrap());
-        assert!(cache.have_deleted_owned_object_at_version_or_after(&deleted_child.0, new_child.0.1, 0).unwrap());
-        assert!(cache.have_deleted_owned_object_at_version_or_after(&deleted_child.0, child.0.1, 0).unwrap());
+        assert!(cache.try_get_object(&deleted_child.0).unwrap().is_none());
+        assert!(cache.try_have_deleted_owned_object_at_version_or_after(&deleted_child.0, deleted_child.1, 0).unwrap());
+        assert!(cache.try_have_deleted_owned_object_at_version_or_after(&deleted_child.0, new_child.0.1, 0).unwrap());
+        assert!(cache.try_have_deleted_owned_object_at_version_or_after(&deleted_child.0, child.0.1, 0).unwrap());
         // Should not show as deleted for versions after this though
-        assert!(!cache.have_deleted_owned_object_at_version_or_after(&deleted_child.0, deleted_child.1.next(), 0).unwrap());
+        assert!(!cache.try_have_deleted_owned_object_at_version_or_after(&deleted_child.0, deleted_child.1.next(), 0).unwrap());
         // Should not show as deleted for other epochs outside of our current epoch too
-        assert!(!cache.have_deleted_owned_object_at_version_or_after(&deleted_child.0, deleted_child.1, 1).unwrap());
+        assert!(!cache.try_have_deleted_owned_object_at_version_or_after(&deleted_child.0, deleted_child.1, 1).unwrap());
     }
     }
 }

--- a/crates/iota-core/src/validator_tx_finalizer.rs
+++ b/crates/iota-core/src/validator_tx_finalizer.rs
@@ -215,7 +215,7 @@ where
             _ = tokio::time::sleep(tx_finalization_delay) => {
                 trace!(?tx_digest, "Waking up to finalize transaction");
             }
-            _ = cache_read.notify_read_executed_effects_digests(&digests) => {
+            _ = cache_read.try_notify_read_executed_effects_digests(&digests) => {
                 trace!(?tx_digest, "Transaction already finalized");
                 return Ok(false);
             }

--- a/crates/iota-e2e-tests/tests/dynamic_committee_tests.rs
+++ b/crates/iota-e2e-tests/tests/dynamic_committee_tests.rs
@@ -174,7 +174,7 @@ impl StressTestRunner {
         for (obj_ref, _) in effects.created() {
             let object_opt = state
                 .get_object_store()
-                .get_object_by_key(&obj_ref.0, obj_ref.1)
+                .try_get_object_by_key(&obj_ref.0, obj_ref.1)
                 .unwrap();
             let Some(object) = object_opt else { continue };
             let struct_tag = object.struct_tag().unwrap();
@@ -187,7 +187,7 @@ impl StressTestRunner {
         for (obj_ref, _) in effects.mutated() {
             let object = state
                 .get_object_store()
-                .get_object_by_key(&obj_ref.0, obj_ref.1)
+                .try_get_object_by_key(&obj_ref.0, obj_ref.1)
                 .unwrap()
                 .unwrap();
             let struct_tag = object.struct_tag().unwrap();
@@ -201,7 +201,7 @@ impl StressTestRunner {
             let (obj_id, version) = kind.id_and_version();
             let object = state
                 .get_object_store()
-                .get_object_by_key(&obj_id, version)
+                .try_get_object_by_key(&obj_id, version)
                 .unwrap()
                 .unwrap();
             let struct_tag = object.struct_tag().unwrap();
@@ -265,7 +265,7 @@ impl StressTestRunner {
             .iter()
             .filter_map(|(obj_ref, _)| {
                 let object = db
-                    .get_object_by_key(&obj_ref.0, obj_ref.1)
+                    .try_get_object_by_key(&obj_ref.0, obj_ref.1)
                     .unwrap()
                     .unwrap();
                 let struct_tag = object.struct_tag().unwrap();

--- a/crates/iota-e2e-tests/tests/full_node_tests.rs
+++ b/crates/iota-e2e-tests/tests/full_node_tests.rs
@@ -1238,7 +1238,7 @@ async fn test_access_old_object_pruned() {
                 assert!(
                     state
                         .database_for_testing()
-                        .get_object_by_key(&gas_object.0, gas_object.1)
+                        .try_get_object_by_key(&gas_object.0, gas_object.1)
                         .unwrap()
                         .is_none()
                 );

--- a/crates/iota-e2e-tests/tests/full_node_tests.rs
+++ b/crates/iota-e2e-tests/tests/full_node_tests.rs
@@ -68,7 +68,7 @@ async fn test_full_node_follows_txes() -> Result<(), anyhow::Error> {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[digest])
+        .try_notify_read_executed_effects(&[digest])
         .await
         .unwrap();
 
@@ -115,7 +115,7 @@ async fn test_full_node_shared_objects() -> Result<(), anyhow::Error> {
         .iota_node
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[digest])
+        .try_notify_read_executed_effects(&[digest])
         .await
         .unwrap();
 
@@ -484,7 +484,7 @@ async fn test_full_node_cold_sync() -> Result<(), anyhow::Error> {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[digest])
+        .try_notify_read_executed_effects(&[digest])
         .await
         .unwrap();
 
@@ -606,7 +606,7 @@ async fn do_test_full_node_sync_flood() {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&digests)
+        .try_notify_read_executed_effects(&digests)
         .await
         .unwrap();
 }
@@ -793,7 +793,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[digest])
+        .try_notify_read_executed_effects(&[digest])
         .await
         .unwrap();
     fullnode.state().get_executed_transaction_and_effects(digest, kv_store).await
@@ -1092,7 +1092,7 @@ async fn test_full_node_bootstrap_from_snapshot() -> Result<(), anyhow::Error> {
 
     node.state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[digest])
+        .try_notify_read_executed_effects(&[digest])
         .await
         .unwrap();
 
@@ -1112,7 +1112,7 @@ async fn test_full_node_bootstrap_from_snapshot() -> Result<(), anyhow::Error> {
         transfer_coin(&test_cluster.wallet).await?;
     node.state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[digest_after_restore])
+        .try_notify_read_executed_effects(&[digest_after_restore])
         .await
         .unwrap();
     Ok(())

--- a/crates/iota-e2e-tests/tests/protocol_version_tests.rs
+++ b/crates/iota-e2e-tests/tests/protocol_version_tests.rs
@@ -647,10 +647,10 @@ mod sim_only_tests {
         node_handle
             .with_async(|node| async {
                 let store = node.state().get_object_cache_reader().clone();
-                let framework = store.get_object(package);
+                let framework = store.try_get_object(package);
                 let digest = framework.unwrap().unwrap().previous_transaction;
                 let tx_store = node.state().get_transaction_cache_reader().clone();
-                let effects = tx_store.get_executed_effects(&digest);
+                let effects = tx_store.try_get_executed_effects(&digest);
                 effects.unwrap().unwrap()
             })
             .await
@@ -663,7 +663,7 @@ mod sim_only_tests {
             .with_async(|node| async {
                 node.state()
                     .get_object_cache_reader()
-                    .get_object(object_id)
+                    .try_get_object(object_id)
                     .unwrap()
                     .unwrap()
             })

--- a/crates/iota-e2e-tests/tests/randomness_tests.rs
+++ b/crates/iota-e2e-tests/tests/randomness_tests.rs
@@ -19,7 +19,7 @@ async fn test_check_randomness_state_object_exists() {
         h.with(|node| {
             node.state()
                 .get_object_cache_reader()
-                .get_latest_object_ref_or_tombstone(IOTA_RANDOMNESS_STATE_OBJECT_ID)
+                .try_get_latest_object_ref_or_tombstone(IOTA_RANDOMNESS_STATE_OBJECT_ID)
                 .unwrap()
                 .expect("randomness state object should exist");
         });

--- a/crates/iota-e2e-tests/tests/shared_objects_tests.rs
+++ b/crates/iota-e2e-tests/tests/shared_objects_tests.rs
@@ -141,7 +141,7 @@ async fn shared_object_deletion_multiple_times() {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&digests)
+        .try_notify_read_executed_effects(&digests)
         .await
         .unwrap();
 }
@@ -198,7 +198,7 @@ async fn shared_object_deletion_multiple_times_cert_racing() {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&digests)
+        .try_notify_read_executed_effects(&digests)
         .await
         .unwrap();
 }
@@ -314,7 +314,7 @@ async fn shared_object_deletion_multi_certs() {
     fullnode
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[inc_tx_a_digest, inc_tx_b_digest])
+        .try_notify_read_executed_effects(&[inc_tx_a_digest, inc_tx_b_digest])
         .await
         .unwrap();
 }

--- a/crates/iota-e2e-tests/tests/simulator_tests.rs
+++ b/crates/iota-e2e-tests/tests/simulator_tests.rs
@@ -139,7 +139,7 @@ async fn test_net_determinism() {
         .iota_node
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[digest])
+        .try_notify_read_executed_effects(&[digest])
         .await
         .unwrap();
 }

--- a/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/iota-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -59,7 +59,7 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     handle
         .state()
         .get_transaction_cache_reader()
-        .notify_read_executed_effects(&[digest])
+        .try_notify_read_executed_effects(&[digest])
         .await
         .unwrap();
 

--- a/crates/iota-e2e-tests/tests/validator_tx_finalizer_e2e_tests.rs
+++ b/crates/iota-e2e-tests/tests/validator_tx_finalizer_e2e_tests.rs
@@ -39,7 +39,7 @@ async fn test_validator_tx_finalizer_fastpath_tx() {
             node.with_async(|n| async {
                 n.state()
                     .get_transaction_cache_reader()
-                    .notify_read_executed_effects_digests(&tx_digests)
+                    .try_notify_read_executed_effects_digests(&tx_digests)
                     .await
                     .unwrap();
             })
@@ -78,7 +78,7 @@ async fn test_validator_tx_finalizer_consensus_tx() {
             node.with_async(|n| async {
                 n.state()
                     .get_transaction_cache_reader()
-                    .notify_read_executed_effects_digests(&tx_digests)
+                    .try_notify_read_executed_effects_digests(&tx_digests)
                     .await
                     .unwrap();
             })

--- a/crates/iota-e2e-tests/tests/zklogin_tests.rs
+++ b/crates/iota-e2e-tests/tests/zklogin_tests.rs
@@ -224,7 +224,7 @@ async fn test_zklogin_create_authenticator_state_object() {
             assert!(
                 node.state()
                     .get_object_cache_reader()
-                    .get_latest_object_ref_or_tombstone(IOTA_AUTHENTICATOR_STATE_OBJECT_ID)
+                    .try_get_latest_object_ref_or_tombstone(IOTA_AUTHENTICATOR_STATE_OBJECT_ID)
                     .unwrap()
                     .is_none()
             );
@@ -241,7 +241,7 @@ async fn test_zklogin_create_authenticator_state_object() {
         h.with(|node| {
             node.state()
                 .get_object_cache_reader()
-                .get_latest_object_ref_or_tombstone(IOTA_AUTHENTICATOR_STATE_OBJECT_ID)
+                .try_get_latest_object_ref_or_tombstone(IOTA_AUTHENTICATOR_STATE_OBJECT_ID)
                 .unwrap()
                 .expect("auth state object should exist");
         });

--- a/crates/iota-e2e-tests/tests/zklogin_tests.rs
+++ b/crates/iota-e2e-tests/tests/zklogin_tests.rs
@@ -287,7 +287,7 @@ async fn test_zklogin_conflicting_jwks() {
                 let digest = *tx.transaction_digest();
                 let tx = state
                     .get_transaction_cache_reader()
-                    .get_transaction_block(&digest)
+                    .try_get_transaction_block(&digest)
                     .unwrap()
                     .unwrap();
                 match &tx.data().intent_message().value.kind() {

--- a/crates/iota-framework/src/lib.rs
+++ b/crates/iota-framework/src/lib.rs
@@ -193,7 +193,7 @@ pub async fn compare_system_package<S: ObjectStore>(
     dependencies: Vec<ObjectID>,
     binary_config: &BinaryConfig,
 ) -> Option<ObjectRef> {
-    let cur_object = match object_store.get_object(id) {
+    let cur_object = match object_store.try_get_object(id) {
         Ok(Some(cur_object)) => cur_object,
 
         Ok(None) => {

--- a/crates/iota-indexer/src/handlers/tx_processor.rs
+++ b/crates/iota-indexer/src/handlers/tx_processor.rs
@@ -197,7 +197,7 @@ impl<'a> EpochEndIndexingObjectStore<'a> {
 }
 
 impl iota_types::storage::ObjectStore for EpochEndIndexingObjectStore<'_> {
-    fn get_object(
+    fn try_get_object(
         &self,
         object_id: &ObjectID,
     ) -> Result<Option<Object>, iota_types::storage::error::Error> {
@@ -209,7 +209,7 @@ impl iota_types::storage::ObjectStore for EpochEndIndexingObjectStore<'_> {
             .cloned())
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: iota_types::base_types::VersionNumber,

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -2039,7 +2039,7 @@ impl IndexerReader {
 }
 
 impl iota_types::storage::ObjectStore for IndexerReader {
-    fn get_object(
+    fn try_get_object(
         &self,
         object_id: &ObjectID,
     ) -> Result<Option<iota_types::object::Object>, iota_types::storage::error::Error> {
@@ -2047,7 +2047,7 @@ impl iota_types::storage::ObjectStore for IndexerReader {
             .map_err(iota_types::storage::error::Error::custom)
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: iota_types::base_types::VersionNumber,

--- a/crates/iota-indexer/tests/rpc-tests/extended_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/extended_api.rs
@@ -60,7 +60,7 @@ fn get_epochs() {
     } = get_or_init_shared_extended_api_simulacrum_env();
 
     runtime.block_on(async move {
-        let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        let last_checkpoint = sim.try_get_latest_checkpoint().unwrap();
         indexer_wait_for_checkpoint(store, last_checkpoint.sequence_number).await;
 
         let epochs = client.get_epochs(None, None, None).await.unwrap();
@@ -97,7 +97,7 @@ fn get_epochs_descending() {
     } = get_or_init_shared_extended_api_simulacrum_env();
 
     runtime.block_on(async move {
-        let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        let last_checkpoint = sim.try_get_latest_checkpoint().unwrap();
         indexer_wait_for_checkpoint(store, last_checkpoint.sequence_number).await;
 
         let epochs = client.get_epochs(None, None, Some(true)).await.unwrap();
@@ -124,7 +124,7 @@ fn get_epochs_paging() {
     } = get_or_init_shared_extended_api_simulacrum_env();
 
     runtime.block_on(async move {
-        let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        let last_checkpoint = sim.try_get_latest_checkpoint().unwrap();
         indexer_wait_for_checkpoint(store, last_checkpoint.sequence_number).await;
 
         let epochs = client.get_epochs(None, Some(2), None).await.unwrap();
@@ -166,7 +166,7 @@ fn get_epoch_metrics() {
     } = get_or_init_shared_extended_api_simulacrum_env();
 
     runtime.block_on(async move {
-        let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        let last_checkpoint = sim.try_get_latest_checkpoint().unwrap();
         indexer_wait_for_checkpoint(store, last_checkpoint.sequence_number).await;
 
         let epoch_metrics = client.get_epoch_metrics(None, None, None).await.unwrap();
@@ -203,7 +203,7 @@ fn get_epoch_metrics_descending() {
     } = get_or_init_shared_extended_api_simulacrum_env();
 
     runtime.block_on(async move {
-        let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        let last_checkpoint = sim.try_get_latest_checkpoint().unwrap();
         indexer_wait_for_checkpoint(store, last_checkpoint.sequence_number).await;
 
         let epochs = client
@@ -233,7 +233,7 @@ fn get_epoch_metrics_paging() {
     } = get_or_init_shared_extended_api_simulacrum_env();
 
     runtime.block_on(async move {
-        let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        let last_checkpoint = sim.try_get_latest_checkpoint().unwrap();
         indexer_wait_for_checkpoint(store, last_checkpoint.sequence_number).await;
 
         let epochs = client.get_epoch_metrics(None, Some(2), None).await.unwrap();
@@ -275,7 +275,7 @@ fn get_current_epoch() {
     } = get_or_init_shared_extended_api_simulacrum_env();
 
     runtime.block_on(async move {
-        let last_checkpoint = sim.get_latest_checkpoint().unwrap();
+        let last_checkpoint = sim.try_get_latest_checkpoint().unwrap();
         indexer_wait_for_checkpoint(store, last_checkpoint.sequence_number).await;
 
         let current_epoch = client.get_current_epoch().await.unwrap();
@@ -403,7 +403,7 @@ fn get_total_transactions() {
     } = get_or_init_shared_extended_api_simulacrum_env();
 
     runtime.block_on(async move {
-        let latest_checkpoint = sim.get_latest_checkpoint().unwrap();
+        let latest_checkpoint = sim.try_get_latest_checkpoint().unwrap();
         let total_transactions_count = latest_checkpoint.network_total_transactions;
         indexer_wait_for_checkpoint(store, latest_checkpoint.sequence_number).await;
 

--- a/crates/iota-json-rpc-tests/tests/read_api.rs
+++ b/crates/iota-json-rpc-tests/tests/read_api.rs
@@ -1475,7 +1475,7 @@ async fn try_get_past_object_version_not_found() {
             .with(|node| {
                 node.state()
                     .get_object_cache_reader()
-                    .object_exists_by_key(&mutated_obj_id, seq_num)
+                    .try_object_exists_by_key(&mutated_obj_id, seq_num)
             })
             .unwrap()
         {

--- a/crates/iota-json-rpc/src/authority_state.rs
+++ b/crates/iota-json-rpc/src/authority_state.rs
@@ -506,7 +506,7 @@ impl StateRead for AuthorityState {
     ) -> StateReadResult<Vec<Option<(EpochId, CheckpointSequenceNumber)>>> {
         Ok(self
             .get_checkpoint_cache()
-            .multi_get_transactions_perpetual_checkpoints(digests)?)
+            .try_multi_get_transactions_perpetual_checkpoints(digests)?)
     }
 
     fn get_transaction_perpetual_checkpoint(
@@ -515,7 +515,7 @@ impl StateRead for AuthorityState {
     ) -> StateReadResult<Option<(EpochId, CheckpointSequenceNumber)>> {
         Ok(self
             .get_checkpoint_cache()
-            .get_transaction_perpetual_checkpoint(digest)?)
+            .try_get_transaction_perpetual_checkpoint(digest)?)
     }
 
     fn multi_get_checkpoint_by_sequence_number(

--- a/crates/iota-json-rpc/src/authority_state.rs
+++ b/crates/iota-json-rpc/src/authority_state.rs
@@ -412,7 +412,7 @@ impl StateRead for AuthorityState {
     fn get_system_state(&self) -> StateReadResult<IotaSystemState> {
         Ok(self
             .get_cache_reader()
-            .get_iota_system_state_object_unsafe()?)
+            .try_get_iota_system_state_object_unsafe()?)
     }
 
     fn get_or_latest_committee(&self, epoch: Option<BigInt<u64>>) -> StateReadResult<Committee> {
@@ -569,7 +569,7 @@ impl<S: ?Sized + StateRead> ObjectProvider for Arc<S> {
     ) -> Result<Option<Object>, Self::Error> {
         Ok(self
             .get_cache_reader()
-            .find_object_lt_or_eq_version(*id, *version)?)
+            .try_find_object_lt_or_eq_version(*id, *version)?)
     }
 }
 
@@ -602,7 +602,7 @@ impl<S: ?Sized + StateRead> ObjectProvider for (Arc<S>, Arc<TransactionKeyValueS
         Ok(self
             .0
             .get_cache_reader()
-            .find_object_lt_or_eq_version(*id, *version)?)
+            .try_find_object_lt_or_eq_version(*id, *version)?)
     }
 }
 

--- a/crates/iota-light-client/src/checkpoint.rs
+++ b/crates/iota-light-client/src/checkpoint.rs
@@ -494,14 +494,14 @@ impl ReadStore for CheckpointSummaryFileStore<'_> {
 }
 
 impl ObjectStore for CheckpointSummaryFileStore<'_> {
-    fn get_object(
+    fn try_get_object(
         &self,
         _: &iota_types::base_types::ObjectID,
     ) -> iota_types::storage::error::Result<Option<iota_types::object::Object>> {
         unimplemented!()
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         _: &iota_types::base_types::ObjectID,
         _: iota_types::base_types::VersionNumber,

--- a/crates/iota-light-client/src/checkpoint.rs
+++ b/crates/iota-light-client/src/checkpoint.rs
@@ -390,51 +390,51 @@ impl WriteStore for CheckpointSummaryFileStore<'_> {
 }
 
 impl ReadStore for CheckpointSummaryFileStore<'_> {
-    fn get_committee(
+    fn try_get_committee(
         &self,
         _: iota_types::committee::EpochId,
     ) -> iota_types::storage::error::Result<Option<Arc<Committee>>> {
         unimplemented!()
     }
 
-    fn get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
+    fn try_get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
         unimplemented!()
     }
 
-    fn get_highest_verified_checkpoint(
+    fn try_get_highest_verified_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
         unimplemented!()
     }
 
-    fn get_highest_synced_checkpoint(
+    fn try_get_highest_synced_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
         unimplemented!()
     }
 
-    fn get_lowest_available_checkpoint(
+    fn try_get_lowest_available_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<iota_types::messages_checkpoint::CheckpointSequenceNumber>
     {
         unimplemented!()
     }
 
-    fn get_checkpoint_by_digest(
+    fn try_get_checkpoint_by_digest(
         &self,
         _: &iota_types::digests::CheckpointDigest,
     ) -> iota_types::storage::error::Result<Option<VerifiedCheckpoint>> {
         unimplemented!()
     }
 
-    fn get_checkpoint_by_sequence_number(
+    fn try_get_checkpoint_by_sequence_number(
         &self,
         _: iota_types::messages_checkpoint::CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<Option<VerifiedCheckpoint>> {
         unimplemented!()
     }
 
-    fn get_checkpoint_contents_by_digest(
+    fn try_get_checkpoint_contents_by_digest(
         &self,
         _: &iota_types::digests::CheckpointContentsDigest,
     ) -> iota_types::storage::error::Result<
@@ -443,7 +443,7 @@ impl ReadStore for CheckpointSummaryFileStore<'_> {
         unimplemented!()
     }
 
-    fn get_checkpoint_contents_by_sequence_number(
+    fn try_get_checkpoint_contents_by_sequence_number(
         &self,
         _: iota_types::messages_checkpoint::CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<
@@ -452,7 +452,7 @@ impl ReadStore for CheckpointSummaryFileStore<'_> {
         unimplemented!()
     }
 
-    fn get_transaction(
+    fn try_get_transaction(
         &self,
         _: &iota_types::digests::TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<Arc<iota_types::transaction::VerifiedTransaction>>>
@@ -460,21 +460,21 @@ impl ReadStore for CheckpointSummaryFileStore<'_> {
         unimplemented!()
     }
 
-    fn get_transaction_effects(
+    fn try_get_transaction_effects(
         &self,
         _: &iota_types::digests::TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<iota_types::effects::TransactionEffects>> {
         unimplemented!()
     }
 
-    fn get_events(
+    fn try_get_events(
         &self,
         _: &iota_types::digests::TransactionEventsDigest,
     ) -> iota_types::storage::error::Result<Option<iota_types::effects::TransactionEvents>> {
         unimplemented!()
     }
 
-    fn get_full_checkpoint_contents_by_sequence_number(
+    fn try_get_full_checkpoint_contents_by_sequence_number(
         &self,
         _: iota_types::messages_checkpoint::CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<
@@ -483,7 +483,7 @@ impl ReadStore for CheckpointSummaryFileStore<'_> {
         unimplemented!()
     }
 
-    fn get_full_checkpoint_contents(
+    fn try_get_full_checkpoint_contents(
         &self,
         _: &iota_types::digests::CheckpointContentsDigest,
     ) -> iota_types::storage::error::Result<

--- a/crates/iota-light-client/src/checkpoint.rs
+++ b/crates/iota-light-client/src/checkpoint.rs
@@ -346,7 +346,7 @@ impl<'a> CheckpointSummaryFileStore<'a> {
 }
 
 impl WriteStore for CheckpointSummaryFileStore<'_> {
-    fn insert_checkpoint(
+    fn try_insert_checkpoint(
         &self,
         checkpoint: &VerifiedCheckpoint,
     ) -> iota_types::storage::error::Result<()> {
@@ -362,21 +362,21 @@ impl WriteStore for CheckpointSummaryFileStore<'_> {
         Ok(())
     }
 
-    fn update_highest_synced_checkpoint(
+    fn try_update_highest_synced_checkpoint(
         &self,
         _: &iota_types::messages_checkpoint::VerifiedCheckpoint,
     ) -> iota_types::storage::error::Result<()> {
         unimplemented!()
     }
 
-    fn update_highest_verified_checkpoint(
+    fn try_update_highest_verified_checkpoint(
         &self,
         _: &iota_types::messages_checkpoint::VerifiedCheckpoint,
     ) -> iota_types::storage::error::Result<()> {
         unimplemented!()
     }
 
-    fn insert_checkpoint_contents(
+    fn try_insert_checkpoint_contents(
         &self,
         _: &iota_types::messages_checkpoint::VerifiedCheckpoint,
         _: iota_types::messages_checkpoint::VerifiedCheckpointContents,
@@ -384,7 +384,7 @@ impl WriteStore for CheckpointSummaryFileStore<'_> {
         unimplemented!()
     }
 
-    fn insert_committee(&self, _: Committee) -> iota_types::storage::error::Result<()> {
+    fn try_insert_committee(&self, _: Committee) -> iota_types::storage::error::Result<()> {
         unimplemented!()
     }
 }

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -553,7 +553,7 @@ where
     fn handle_checkpoint_from_consensus(&mut self, checkpoint: Box<VerifiedCheckpoint>) {
         // Always check previous_digest matches in case there is a gap between
         // state sync and consensus.
-        let prev_digest = *self.store.get_checkpoint_by_sequence_number(checkpoint.sequence_number() - 1)
+        let prev_digest = *self.store.try_get_checkpoint_by_sequence_number(checkpoint.sequence_number() - 1)
             .expect("store operation should not fail")
             .unwrap_or_else(|| panic!("Got checkpoint {} from consensus but cannot find checkpoint {} in certified_checkpoints", checkpoint.sequence_number(), checkpoint.sequence_number() - 1))
             .digest();
@@ -568,7 +568,7 @@ where
 
         let latest_checkpoint = self
             .store
-            .get_highest_verified_checkpoint()
+            .try_get_highest_verified_checkpoint()
             .expect("store operation should not fail");
 
         // If this is an older checkpoint, just ignore it
@@ -595,11 +595,11 @@ where
                 .map(|n| {
                     let checkpoint = self
                         .store
-                        .get_checkpoint_by_sequence_number(n)
+                        .try_get_checkpoint_by_sequence_number(n)
                         .expect("store operation should not fail")
                         .unwrap_or_else(|| panic!("store should contain checkpoint {n}"));
                     self.store
-                        .get_full_checkpoint_contents(&checkpoint.content_digest)
+                        .try_get_full_checkpoint_contents(&checkpoint.content_digest)
                         .expect("store operation should not fail")
                         .unwrap_or_else(|| {
                             panic!(
@@ -672,7 +672,7 @@ where
         if let Some(peer) = self.network.peer(peer_id) {
             let genesis_checkpoint_digest = *self
                 .store
-                .get_checkpoint_by_sequence_number(0)
+                .try_get_checkpoint_by_sequence_number(0)
                 .expect("store operation should not fail")
                 .expect("store should contain genesis checkpoint")
                 .digest();
@@ -711,7 +711,7 @@ where
 
         let highest_processed_checkpoint = self
             .store
-            .get_highest_verified_checkpoint()
+            .try_get_highest_verified_checkpoint()
             .expect("store operation should not fail");
 
         let highest_known_checkpoint = self
@@ -759,11 +759,11 @@ where
     ) {
         let highest_verified_checkpoint = self
             .store
-            .get_highest_verified_checkpoint()
+            .try_get_highest_verified_checkpoint()
             .expect("store operation should not fail");
         let highest_synced_checkpoint = self
             .store
-            .get_highest_synced_checkpoint()
+            .try_get_highest_synced_checkpoint()
             .expect("store operation should not fail");
 
         if highest_verified_checkpoint.sequence_number()
@@ -1028,7 +1028,7 @@ where
     metrics.set_highest_known_checkpoint(*checkpoint.sequence_number());
 
     let mut current = store
-        .get_highest_verified_checkpoint()
+        .try_get_highest_verified_checkpoint()
         .expect("store operation should not fail");
     if current.sequence_number() >= checkpoint.sequence_number() {
         bail!(
@@ -1195,7 +1195,7 @@ async fn sync_checkpoint_contents_from_archive<S>(
             .map(|(_p, state_sync_info)| state_sync_info.lowest)
             .min();
         let highest_synced = store
-            .get_highest_synced_checkpoint()
+            .try_get_highest_synced_checkpoint()
             .expect("store operation should not fail")
             .sequence_number;
         let sync_from_archive = if let Some(lowest_checkpoint_on_peers) = lowest_checkpoint_on_peers
@@ -1264,7 +1264,7 @@ async fn sync_checkpoint_contents<S>(
     S: WriteStore + Clone,
 {
     let mut highest_synced = store
-        .get_highest_synced_checkpoint()
+        .try_get_highest_synced_checkpoint()
         .expect("store operation should not fail");
 
     let mut current_sequence = highest_synced.sequence_number().checked_add(1).unwrap();
@@ -1330,7 +1330,7 @@ async fn sync_checkpoint_contents<S>(
             && checkpoint_contents_tasks.len() < checkpoint_content_download_concurrency
         {
             let next_checkpoint = store
-                .get_checkpoint_by_sequence_number(current_sequence)
+                .try_get_checkpoint_by_sequence_number(current_sequence)
                 .expect("store operation should not fail")
                 .expect(
                     "BUG: store should have all checkpoints older than highest_verified_checkpoint",
@@ -1386,7 +1386,7 @@ where
     // Check if we already have produced this checkpoint locally. If so, we don't
     // need to get it from peers anymore.
     if store
-        .get_highest_synced_checkpoint()
+        .try_get_highest_synced_checkpoint()
         .expect("store operation should not fail")
         .sequence_number()
         >= checkpoint.sequence_number()
@@ -1437,11 +1437,11 @@ where
 {
     let digest = checkpoint.content_digest;
     if let Some(contents) = store
-        .get_full_checkpoint_contents_by_sequence_number(*checkpoint.sequence_number())
+        .try_get_full_checkpoint_contents_by_sequence_number(*checkpoint.sequence_number())
         .expect("store operation should not fail")
         .or_else(|| {
             store
-                .get_full_checkpoint_contents(&digest)
+                .try_get_full_checkpoint_contents(&digest)
                 .expect("store operation should not fail")
         })
     {
@@ -1491,10 +1491,10 @@ where
     loop {
         tokio::select! {
              _now = interval.tick() => {
-                let highest_verified_checkpoint = store.get_highest_verified_checkpoint()
+                let highest_verified_checkpoint = store.try_get_highest_verified_checkpoint()
                     .expect("store operation should not fail");
                 metrics.set_highest_verified_checkpoint(highest_verified_checkpoint.sequence_number);
-                let highest_synced_checkpoint = store.get_highest_synced_checkpoint()
+                let highest_synced_checkpoint = store.try_get_highest_synced_checkpoint()
                     .expect("store operation should not fail");
                 metrics.set_highest_synced_checkpoint(highest_synced_checkpoint.sequence_number);
              },

--- a/crates/iota-network/src/state_sync/mod.rs
+++ b/crates/iota-network/src/state_sync/mod.rs
@@ -626,15 +626,15 @@ where
             let committee =
                 Committee::new(checkpoint.epoch().checked_add(1).unwrap(), next_committee);
             self.store
-                .insert_committee(committee)
+                .try_insert_committee(committee)
                 .expect("store operation should not fail");
         }
 
         self.store
-            .update_highest_verified_checkpoint(&checkpoint)
+            .try_update_highest_verified_checkpoint(&checkpoint)
             .expect("store operation should not fail");
         self.store
-            .update_highest_synced_checkpoint(&checkpoint)
+            .try_update_highest_synced_checkpoint(&checkpoint)
             .expect("store operation should not fail");
 
         // We don't care if no one is listening as this is a broadcast channel
@@ -1158,7 +1158,7 @@ where
         // Insert the newly verified checkpoint into our store, which will bump our
         // highest verified checkpoint watermark as well.
         store
-            .insert_checkpoint(&checkpoint)
+            .try_insert_checkpoint(&checkpoint)
             .expect("store operation should not fail");
     }
 
@@ -1293,7 +1293,7 @@ async fn sync_checkpoint_contents<S>(
                         let _: &VerifiedCheckpoint = &checkpoint;  // type hint
 
                         store
-                            .update_highest_synced_checkpoint(&checkpoint)
+                            .try_update_highest_synced_checkpoint(&checkpoint)
                             .expect("store operation should not fail");
                         // We don't care if no one is listening as this is a broadcast channel
                         let _ = checkpoint_event_sender.send(checkpoint.clone());
@@ -1469,7 +1469,7 @@ where
             if contents.verify_digests(digest).is_ok() {
                 let verified_contents = VerifiedCheckpointContents::new_unchecked(contents.clone());
                 store
-                    .insert_checkpoint_contents(checkpoint, verified_contents)
+                    .try_insert_checkpoint_contents(checkpoint, verified_contents)
                     .expect("store operation should not fail");
                 return Some(contents);
             }

--- a/crates/iota-network/src/state_sync/server.rs
+++ b/crates/iota-network/src/state_sync/server.rs
@@ -71,7 +71,7 @@ where
 
         let highest_verified_checkpoint = *self
             .store
-            .get_highest_verified_checkpoint()
+            .try_get_highest_verified_checkpoint()
             .map_err(|e| Status::internal(e.to_string()))?
             .sequence_number();
 
@@ -94,14 +94,14 @@ where
     ) -> Result<Response<Option<Checkpoint>>, Status> {
         let checkpoint = match request.inner() {
             GetCheckpointSummaryRequest::Latest => {
-                self.store.get_highest_synced_checkpoint().map(Some)
+                self.store.try_get_highest_synced_checkpoint().map(Some)
             }
             GetCheckpointSummaryRequest::ByDigest(digest) => {
-                self.store.get_checkpoint_by_digest(digest)
+                self.store.try_get_checkpoint_by_digest(digest)
             }
             GetCheckpointSummaryRequest::BySequenceNumber(sequence_number) => self
                 .store
-                .get_checkpoint_by_sequence_number(*sequence_number),
+                .try_get_checkpoint_by_sequence_number(*sequence_number),
         }
         .map_err(|e| Status::internal(e.to_string()))?
         .map(VerifiedCheckpoint::into_inner);
@@ -117,12 +117,12 @@ where
     ) -> Result<Response<GetCheckpointAvailabilityResponse>, Status> {
         let highest_synced_checkpoint = self
             .store
-            .get_highest_synced_checkpoint()
+            .try_get_highest_synced_checkpoint()
             .map_err(|e| Status::internal(e.to_string()))
             .map(VerifiedCheckpoint::into_inner)?;
         let lowest_available_checkpoint = self
             .store
-            .get_lowest_available_checkpoint()
+            .try_get_lowest_available_checkpoint()
             .map_err(|e| Status::internal(e.to_string()))?;
 
         Ok(Response::new(GetCheckpointAvailabilityResponse {
@@ -138,7 +138,7 @@ where
     ) -> Result<Response<Option<FullCheckpointContents>>, Status> {
         let contents = self
             .store
-            .get_full_checkpoint_contents(request.inner())
+            .try_get_full_checkpoint_contents(request.inner())
             .map_err(|e| Status::internal(e.to_string()))?;
         Ok(Response::new(contents))
     }

--- a/crates/iota-network/src/state_sync/tests.rs
+++ b/crates/iota-network/src/state_sync/tests.rs
@@ -506,7 +506,7 @@ async fn sync_with_checkpoints_being_inserted() {
     let mut checkpoint_iter = ordered_checkpoints.clone().into_iter().skip(1);
     let checkpoint = checkpoint_iter.next().unwrap();
     store_1
-        .insert_checkpoint_contents(&checkpoint, empty_contents())
+        .try_insert_checkpoint_contents(&checkpoint, empty_contents())
         .unwrap();
     store_1.insert_certified_checkpoint(&checkpoint);
     handle_1.send_checkpoint(checkpoint).await;
@@ -648,7 +648,7 @@ async fn sync_with_checkpoints_watermark() {
     let contents_1 = contents_iter.next().unwrap();
     let checkpoint_seq = checkpoint_1.sequence_number();
     store_1
-        .insert_checkpoint_contents(&checkpoint_1, contents_1.clone())
+        .try_insert_checkpoint_contents(&checkpoint_1, contents_1.clone())
         .unwrap();
     store_1.insert_certified_checkpoint(&checkpoint_1);
     handle_1.send_checkpoint(checkpoint_1.clone()).await;
@@ -711,7 +711,7 @@ async fn sync_with_checkpoints_watermark() {
     // Inject all the checkpoints to Peer 1
     for (checkpoint, contents) in checkpoint_iter.zip(contents_iter) {
         store_1
-            .insert_checkpoint_contents(&checkpoint, contents)
+            .try_insert_checkpoint_contents(&checkpoint, contents)
             .unwrap();
         store_1.insert_certified_checkpoint(&checkpoint);
         handle_1.send_checkpoint(checkpoint).await;

--- a/crates/iota-network/src/state_sync/tests.rs
+++ b/crates/iota-network/src/state_sync/tests.rs
@@ -245,7 +245,7 @@ async fn isolated_sync_job() {
         Some(
             event_loop_1
                 .store
-                .get_highest_verified_checkpoint()
+                .try_get_highest_verified_checkpoint()
                 .unwrap()
                 .data()
         )
@@ -668,28 +668,28 @@ async fn sync_with_checkpoints_watermark() {
 
     assert_eq!(
         store_1
-            .get_highest_synced_checkpoint()
+            .try_get_highest_synced_checkpoint()
             .unwrap()
             .sequence_number(),
         checkpoint_seq
     );
     assert_eq!(
         store_2
-            .get_highest_synced_checkpoint()
+            .try_get_highest_synced_checkpoint()
             .unwrap()
             .sequence_number(),
         checkpoint_seq
     );
     assert_eq!(
         store_1
-            .get_highest_verified_checkpoint()
+            .try_get_highest_verified_checkpoint()
             .unwrap()
             .sequence_number(),
         &1
     );
     assert_eq!(
         store_2
-            .get_highest_verified_checkpoint()
+            .try_get_highest_verified_checkpoint()
             .unwrap()
             .sequence_number(),
         &1
@@ -726,12 +726,12 @@ async fn sync_with_checkpoints_watermark() {
             assert_eq!(subscriber_1.recv().await.unwrap().data(), checkpoint.data());
             let content_digest = contents.into_checkpoint_contents_digest();
             store_1
-                .get_full_checkpoint_contents(&content_digest)
+                .try_get_full_checkpoint_contents(&content_digest)
                 .unwrap()
                 .unwrap();
             assert_eq!(
                 store_2
-                    .get_full_checkpoint_contents(&content_digest)
+                    .try_get_full_checkpoint_contents(&content_digest)
                     .unwrap(),
                 None
             );
@@ -743,14 +743,14 @@ async fn sync_with_checkpoints_watermark() {
 
     assert_eq!(
         store_1
-            .get_highest_synced_checkpoint()
+            .try_get_highest_synced_checkpoint()
             .unwrap()
             .sequence_number(),
         ordered_checkpoints.last().unwrap().sequence_number()
     );
     assert_eq!(
         store_2
-            .get_highest_synced_checkpoint()
+            .try_get_highest_synced_checkpoint()
             .unwrap()
             .sequence_number(),
         ordered_checkpoints[1].sequence_number()
@@ -758,7 +758,7 @@ async fn sync_with_checkpoints_watermark() {
 
     assert_eq!(
         store_1
-            .get_highest_verified_checkpoint()
+            .try_get_highest_verified_checkpoint()
             .unwrap()
             .sequence_number(),
         &last_checkpoint_seq
@@ -793,7 +793,7 @@ async fn sync_with_checkpoints_watermark() {
         );
         let content_digest = contents[1].clone().into_checkpoint_contents_digest();
         store_3
-            .get_full_checkpoint_contents(&content_digest)
+            .try_get_full_checkpoint_contents(&content_digest)
             .unwrap()
             .unwrap();
     })
@@ -804,14 +804,14 @@ async fn sync_with_checkpoints_watermark() {
 
     assert_eq!(
         store_2
-            .get_highest_synced_checkpoint()
+            .try_get_highest_synced_checkpoint()
             .unwrap()
             .sequence_number(),
         ordered_checkpoints[1].sequence_number(),
     );
     assert_eq!(
         store_3
-            .get_highest_synced_checkpoint()
+            .try_get_highest_synced_checkpoint()
             .unwrap()
             .sequence_number(),
         ordered_checkpoints[1].sequence_number(),
@@ -832,11 +832,11 @@ async fn sync_with_checkpoints_watermark() {
             assert_eq!(subscriber_3.recv().await.unwrap().data(), checkpoint.data());
             let content_digest = contents.into_checkpoint_contents_digest();
             store_2
-                .get_full_checkpoint_contents(&content_digest)
+                .try_get_full_checkpoint_contents(&content_digest)
                 .unwrap()
                 .unwrap();
             store_3
-                .get_full_checkpoint_contents(&content_digest)
+                .try_get_full_checkpoint_contents(&content_digest)
                 .unwrap()
                 .unwrap();
         }
@@ -845,28 +845,28 @@ async fn sync_with_checkpoints_watermark() {
     .unwrap();
     assert_eq!(
         store_2
-            .get_highest_synced_checkpoint()
+            .try_get_highest_synced_checkpoint()
             .unwrap()
             .sequence_number(),
         &last_checkpoint_seq
     );
     assert_eq!(
         store_3
-            .get_highest_synced_checkpoint()
+            .try_get_highest_synced_checkpoint()
             .unwrap()
             .sequence_number(),
         &last_checkpoint_seq
     );
     assert_eq!(
         store_2
-            .get_highest_verified_checkpoint()
+            .try_get_highest_verified_checkpoint()
             .unwrap()
             .sequence_number(),
         &last_checkpoint_seq
     );
     assert_eq!(
         store_3
-            .get_highest_verified_checkpoint()
+            .try_get_highest_verified_checkpoint()
             .unwrap()
             .sequence_number(),
         &last_checkpoint_seq
@@ -913,7 +913,7 @@ async fn sync_with_checkpoints_watermark() {
             assert_eq!(subscriber_4.recv().await.unwrap().data(), checkpoint.data());
             let content_digest = contents.into_checkpoint_contents_digest();
             store_4
-                .get_full_checkpoint_contents(&content_digest)
+                .try_get_full_checkpoint_contents(&content_digest)
                 .unwrap()
                 .unwrap();
         }
@@ -922,7 +922,7 @@ async fn sync_with_checkpoints_watermark() {
     .unwrap();
     assert_eq!(
         store_4
-            .get_highest_synced_checkpoint()
+            .try_get_highest_synced_checkpoint()
             .unwrap()
             .sequence_number(),
         &last_checkpoint_seq

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -575,7 +575,7 @@ impl IotaNode {
             // the expected_network_iota_amount table.
             cache_traits
                 .reconfig_api
-                .expensive_check_iota_conservation(&epoch_store, None)
+                .try_expensive_check_iota_conservation(&epoch_store, None)
                 .expect("IOTA conservation check cannot fail at genesis");
         }
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1753,7 +1753,7 @@ impl IotaNode {
             let latest_system_state = self
                 .state
                 .get_object_cache_reader()
-                .get_iota_system_state_object_unsafe()
+                .try_get_iota_system_state_object_unsafe()
                 .expect("Read IOTA System State object cannot fail");
 
             #[cfg(msim)]

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1606,7 +1606,7 @@ impl IotaNode {
             std::time::Duration::from_secs(timeout),
             state
                 .get_transaction_cache_reader()
-                .notify_read_executed_effects_digests(&digests),
+                .try_notify_read_executed_effects_digests(&digests),
         )
         .await
         .is_err()
@@ -1614,7 +1614,7 @@ impl IotaNode {
             // Log all the digests that were not executed to help debugging.
             if let Ok(executed_effects_digests) = state
                 .get_transaction_cache_reader()
-                .multi_get_executed_effects_digests(&digests)
+                .try_multi_get_executed_effects_digests(&digests)
             {
                 let pending_digests = digests
                     .iter()

--- a/crates/iota-replay/src/replay.rs
+++ b/crates/iota-replay/src/replay.rs
@@ -1935,7 +1935,7 @@ impl ChildObjectResolver for LocalExec {
             receiving_object_id: &ObjectID,
             receive_object_at_version: SequenceNumber,
         ) -> IotaResult<Option<Object>> {
-            let recv_object = match self_.get_object(receiving_object_id)? {
+            let recv_object = match self_.try_get_object(receiving_object_id)? {
                 None => return Ok(None),
                 Some(o) => o,
             };
@@ -2054,7 +2054,7 @@ impl ModuleResolver for &mut LocalExec {
 impl ObjectStore for LocalExec {
     /// The object must be present in store by normal process we used to
     /// backfill store in init We dont download if not present
-    fn get_object(
+    fn try_get_object(
         &self,
         object_id: &ObjectID,
     ) -> iota_types::storage::error::Result<Option<Object>> {
@@ -2077,7 +2077,7 @@ impl ObjectStore for LocalExec {
 
     /// The object must be present in store by normal process we used to
     /// backfill store in init We dont download if not present
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
@@ -2110,23 +2110,23 @@ impl ObjectStore for LocalExec {
 }
 
 impl ObjectStore for &mut LocalExec {
-    fn get_object(
+    fn try_get_object(
         &self,
         object_id: &ObjectID,
     ) -> iota_types::storage::error::Result<Option<Object>> {
         // Recording event here will be double-counting since its already recorded in
         // the get_module fn
-        (**self).get_object(object_id)
+        (**self).try_get_object(object_id)
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
     ) -> iota_types::storage::error::Result<Option<Object>> {
         // Recording event here will be double-counting since its already recorded in
         // the get_module fn
-        (**self).get_object_by_key(object_id, version)
+        (**self).try_get_object_by_key(object_id, version)
     }
 }
 

--- a/crates/iota-rest-api/src/checkpoints.rs
+++ b/crates/iota-rest-api/src/checkpoints.rs
@@ -85,7 +85,7 @@ async fn get_checkpoint(
         signature,
     } = match checkpoint_id {
         CheckpointId::SequenceNumber(s) => {
-            let oldest_checkpoint = state.inner().get_lowest_available_checkpoint()?;
+            let oldest_checkpoint = state.inner().try_get_lowest_available_checkpoint()?;
             if s < oldest_checkpoint {
                 return Err(crate::RestError::new(
                     axum::http::StatusCode::GONE,
@@ -93,9 +93,9 @@ async fn get_checkpoint(
                 ));
             }
 
-            state.inner().get_checkpoint_by_sequence_number(s)
+            state.inner().try_get_checkpoint_by_sequence_number(s)
         }
-        CheckpointId::Digest(d) => state.inner().get_checkpoint_by_digest(&d.into()),
+        CheckpointId::Digest(d) => state.inner().try_get_checkpoint_by_digest(&d.into()),
     }?
     .ok_or(CheckpointNotFoundError(checkpoint_id))?
     .into_inner()
@@ -105,7 +105,7 @@ async fn get_checkpoint(
         Some(
             state
                 .inner()
-                .get_checkpoint_contents_by_sequence_number(checkpoint.sequence_number)?
+                .try_get_checkpoint_contents_by_sequence_number(checkpoint.sequence_number)?
                 .ok_or(CheckpointNotFoundError(checkpoint_id))?
                 .try_into()?,
         )
@@ -262,8 +262,8 @@ async fn list_checkpoints(
     accept: AcceptFormat,
     State(state): State<StateReader>,
 ) -> Result<Page<CheckpointResponse, CheckpointSequenceNumber>> {
-    let latest_checkpoint = state.inner().get_latest_checkpoint()?.sequence_number;
-    let oldest_checkpoint = state.inner().get_lowest_available_checkpoint()?;
+    let latest_checkpoint = state.inner().try_get_latest_checkpoint()?.sequence_number;
+    let oldest_checkpoint = state.inner().try_get_lowest_available_checkpoint()?;
     let limit = parameters.limit();
     let start = parameters.start(latest_checkpoint);
     let direction = parameters.direction();
@@ -432,20 +432,20 @@ async fn get_full_checkpoint(
                 ));
             }
 
-            state.inner().get_checkpoint_by_sequence_number(s)
+            state.inner().try_get_checkpoint_by_sequence_number(s)
         }
-        CheckpointId::Digest(d) => state.inner().get_checkpoint_by_digest(&d.into()),
+        CheckpointId::Digest(d) => state.inner().try_get_checkpoint_by_digest(&d.into()),
     }?
     .ok_or(CheckpointNotFoundError(checkpoint_id))?;
 
     let checkpoint_contents = state
         .inner()
-        .get_checkpoint_contents_by_digest(&verified_summary.content_digest)?
+        .try_get_checkpoint_contents_by_digest(&verified_summary.content_digest)?
         .ok_or(CheckpointNotFoundError(checkpoint_id))?;
 
     let checkpoint_data = state
         .inner()
-        .get_checkpoint_data(verified_summary, checkpoint_contents)?;
+        .try_get_checkpoint_data(verified_summary, checkpoint_contents)?;
 
     Ok(Bcs(checkpoint_data))
 }
@@ -512,7 +512,7 @@ async fn list_full_checkpoints(
         }
     }
 
-    let latest_checkpoint = state.inner().get_latest_checkpoint()?.sequence_number;
+    let latest_checkpoint = state.inner().try_get_latest_checkpoint()?.sequence_number;
     let oldest_checkpoint = state.inner().get_lowest_available_checkpoint_objects()?;
     let limit = parameters.limit();
     let start = parameters.start(latest_checkpoint);
@@ -541,7 +541,7 @@ async fn list_full_checkpoints(
                 .and_then(|(checkpoint, contents)| {
                     state
                         .inner()
-                        .get_checkpoint_data(
+                        .try_get_checkpoint_data(
                             iota_types::messages_checkpoint::VerifiedCheckpoint::new_from_verified(
                                 checkpoint,
                             ),

--- a/crates/iota-rest-api/src/coins.rs
+++ b/crates/iota-rest-api/src/coins.rs
@@ -68,7 +68,7 @@ async fn get_coin_info(
     let metadata = if let Some(coin_metadata_object_id) = coin_metadata_object_id {
         state
             .inner()
-            .get_object(&coin_metadata_object_id)?
+            .try_get_object(&coin_metadata_object_id)?
             .map(iota_types::coin::CoinMetadata::try_from)
             .transpose()
             .map_err(|_| {
@@ -85,7 +85,7 @@ async fn get_coin_info(
     let treasury = if let Some(treasury_object_id) = treasury_object_id {
         state
             .inner()
-            .get_object(&treasury_object_id)?
+            .try_get_object(&treasury_object_id)?
             .map(iota_types::coin::TreasuryCap::try_from)
             .transpose()
             .map_err(|_| {

--- a/crates/iota-rest-api/src/committee.rs
+++ b/crates/iota-rest-api/src/committee.rs
@@ -52,7 +52,7 @@ async fn get_latest_committee(
     accept: AcceptFormat,
     State(state): State<StateReader>,
 ) -> Result<ResponseContent<ValidatorCommittee>> {
-    let current_epoch = state.inner().get_latest_checkpoint()?.epoch();
+    let current_epoch = state.inner().try_get_latest_checkpoint()?.epoch();
     let committee = state
         .get_committee(current_epoch)?
         .ok_or_else(|| CommitteeNotFoundError::new(current_epoch))?;

--- a/crates/iota-rest-api/src/health.rs
+++ b/crates/iota-rest-api/src/health.rs
@@ -72,7 +72,7 @@ async fn health(
     Query(Threshold { threshold_seconds }): Query<Threshold>,
     State(state): State<StateReader>,
 ) -> Result<impl IntoResponse> {
-    let summary = state.inner().get_latest_checkpoint()?;
+    let summary = state.inner().try_get_latest_checkpoint()?;
 
     // If we have a provided threshold, check that it's close to the current time
     if let Some(threshold_seconds) = threshold_seconds {

--- a/crates/iota-rest-api/src/info.rs
+++ b/crates/iota-rest-api/src/info.rs
@@ -52,11 +52,11 @@ impl ApiEndpoint<RestService> for GetNodeInfo {
 }
 
 async fn get_node_info(State(state): State<RestService>) -> Result<Json<NodeInfo>> {
-    let latest_checkpoint = state.reader.inner().get_latest_checkpoint()?;
+    let latest_checkpoint = state.reader.inner().try_get_latest_checkpoint()?;
     let lowest_available_checkpoint = state
         .reader
         .inner()
-        .get_lowest_available_checkpoint()?
+        .try_get_lowest_available_checkpoint()?
         .pipe(Some);
     let lowest_available_checkpoint_objects = state
         .reader

--- a/crates/iota-rest-api/src/reader.rs
+++ b/crates/iota-rest-api/src/reader.rs
@@ -50,7 +50,7 @@ impl StateReader {
 
     pub fn get_committee(&self, epoch: EpochId) -> Result<Option<ValidatorCommittee>> {
         self.inner
-            .get_committee(epoch)
+            .try_get_committee(epoch)
             .map(|maybe| maybe.map(|committee| (*committee).clone().into()))
     }
 
@@ -84,17 +84,17 @@ impl StateReader {
 
         let transaction = (*self
             .inner()
-            .get_transaction(&transaction_digest)?
+            .try_get_transaction(&transaction_digest)?
             .ok_or(TransactionNotFoundError(digest))?)
         .clone()
         .into_inner();
         let effects = self
             .inner()
-            .get_transaction_effects(&transaction_digest)?
+            .try_get_transaction_effects(&transaction_digest)?
             .ok_or(TransactionNotFoundError(digest))?;
         let events = if let Some(event_digest) = effects.events_digest() {
             self.inner()
-                .get_events(event_digest)?
+                .try_get_events(event_digest)?
                 .ok_or(TransactionNotFoundError(digest))?
                 .pipe(Some)
         } else {
@@ -124,7 +124,7 @@ impl StateReader {
         let checkpoint = self.inner().get_transaction_checkpoint(&(digest.into()))?;
         let timestamp_ms = if let Some(checkpoint) = checkpoint {
             self.inner()
-                .get_checkpoint_by_sequence_number(checkpoint)?
+                .try_get_checkpoint_by_sequence_number(checkpoint)?
                 .map(|checkpoint| checkpoint.timestamp_ms)
         } else {
             None
@@ -202,7 +202,7 @@ impl Iterator for CheckpointTransactionsIter {
                 let checkpoint = match self
                     .reader
                     .inner()
-                    .get_checkpoint_by_sequence_number(current_checkpoint)
+                    .try_get_checkpoint_by_sequence_number(current_checkpoint)
                 {
                     Ok(Some(checkpoint)) => checkpoint,
                     Ok(None) => return None,
@@ -211,7 +211,7 @@ impl Iterator for CheckpointTransactionsIter {
                 let contents = match self
                     .reader
                     .inner()
-                    .get_checkpoint_contents_by_sequence_number(checkpoint.sequence_number)
+                    .try_get_checkpoint_contents_by_sequence_number(checkpoint.sequence_number)
                 {
                     Ok(Some(contents)) => contents,
                     Ok(None) => return None,
@@ -311,7 +311,7 @@ impl Iterator for CheckpointIter {
         let checkpoint = match self
             .reader
             .inner()
-            .get_checkpoint_by_sequence_number(current_checkpoint)
+            .try_get_checkpoint_by_sequence_number(current_checkpoint)
         {
             Ok(Some(checkpoint)) => checkpoint,
             Ok(None) => return None,
@@ -321,7 +321,7 @@ impl Iterator for CheckpointIter {
         let contents = match self
             .reader
             .inner()
-            .get_checkpoint_contents_by_sequence_number(checkpoint.sequence_number)
+            .try_get_checkpoint_contents_by_sequence_number(checkpoint.sequence_number)
         {
             Ok(Some(contents)) => contents,
             Ok(None) => return None,

--- a/crates/iota-rest-api/src/reader.rs
+++ b/crates/iota-rest-api/src/reader.rs
@@ -32,7 +32,7 @@ impl StateReader {
 
     pub fn get_object(&self, object_id: ObjectId) -> crate::Result<Option<Object>> {
         self.inner
-            .get_object(&object_id.into())
+            .try_get_object(&object_id.into())
             .map_err(Into::into)
             .and_then(|maybe| maybe.map(TryInto::try_into).transpose().map_err(Into::into))
     }
@@ -43,7 +43,7 @@ impl StateReader {
         version: Version,
     ) -> crate::Result<Option<Object>> {
         self.inner
-            .get_object_by_key(&object_id.into(), version.into())
+            .try_get_object_by_key(&object_id.into(), version.into())
             .map_err(Into::into)
             .and_then(|maybe| maybe.map(TryInto::try_into).transpose().map_err(Into::into))
     }

--- a/crates/iota-rest-api/src/response.rs
+++ b/crates/iota-rest-api/src/response.rs
@@ -139,7 +139,7 @@ pub async fn append_info_headers(
         headers.insert(X_IOTA_CHAIN, chain);
     }
 
-    if let Ok(latest_checkpoint) = state.reader.inner().get_latest_checkpoint() {
+    if let Ok(latest_checkpoint) = state.reader.inner().try_get_latest_checkpoint() {
         headers.insert(X_IOTA_EPOCH, latest_checkpoint.epoch().into());
         headers.insert(
             X_IOTA_CHECKPOINT_HEIGHT,
@@ -148,7 +148,8 @@ pub async fn append_info_headers(
         headers.insert(X_IOTA_TIMESTAMP_MS, latest_checkpoint.timestamp_ms.into());
     }
 
-    if let Ok(lowest_available_checkpoint) = state.reader.inner().get_lowest_available_checkpoint()
+    if let Ok(lowest_available_checkpoint) =
+        state.reader.inner().try_get_lowest_available_checkpoint()
     {
         headers.insert(
             X_IOTA_LOWEST_AVAILABLE_CHECKPOINT,

--- a/crates/iota-rest-api/src/transactions/mod.rs
+++ b/crates/iota-rest-api/src/transactions/mod.rs
@@ -158,8 +158,8 @@ async fn list_transactions(
     accept: AcceptFormat,
     State(state): State<StateReader>,
 ) -> Result<Page<TransactionResponse, TransactionCursor>> {
-    let latest_checkpoint = state.inner().get_latest_checkpoint()?.sequence_number;
-    let oldest_checkpoint = state.inner().get_lowest_available_checkpoint()?;
+    let latest_checkpoint = state.inner().try_get_latest_checkpoint()?.sequence_number;
+    let oldest_checkpoint = state.inner().try_get_lowest_available_checkpoint()?;
     let limit = parameters.limit();
     let start = parameters.start(latest_checkpoint);
     let direction = parameters.direction();

--- a/crates/iota-rest-api/src/transactions/resolve.rs
+++ b/crates/iota-rest-api/src/transactions/resolve.rs
@@ -224,7 +224,7 @@ fn called_packages(
     {
         let package = reader
             .inner()
-            .get_object(&(move_call.package.into()))?
+            .try_get_object(&(move_call.package.into()))?
             .ok_or_else(|| ObjectNotFoundError::new(move_call.package))?
             .data
             .try_as_package()
@@ -322,13 +322,13 @@ fn resolve_object_reference(
     let (v, d) = if let Some(version) = version {
         let object = reader
             .inner()
-            .get_object_by_key(&id, version.into())?
+            .try_get_object_by_key(&id, version.into())?
             .ok_or_else(|| ObjectNotFoundError::new_with_version(object_id, version))?;
         (object.version(), object.digest())
     } else {
         let object = reader
             .inner()
-            .get_object(&id)?
+            .try_get_object(&id)?
             .ok_or_else(|| ObjectNotFoundError::new(object_id))?;
         (object.version(), object.digest())
     };
@@ -394,7 +394,7 @@ fn resolve_arg(
             let id = object_id.into();
             let object = reader
                 .inner()
-                .get_object(&id)?
+                .try_get_object(&id)?
                 .ok_or_else(|| ObjectNotFoundError::new(object_id))?;
 
             let initial_shared_version = if let iota_types::object::Owner::Shared {
@@ -566,7 +566,13 @@ fn select_gas(
         .account_owned_objects_info_iter(owner, None)?
         .filter(|info| info.type_.is_gas_coin())
         .filter(|info| !input_objects.contains(&info.object_id))
-        .filter_map(|info| reader.inner().get_object(&info.object_id).ok().flatten())
+        .filter_map(|info| {
+            reader
+                .inner()
+                .try_get_object(&info.object_id)
+                .ok()
+                .flatten()
+        })
         .filter_map(|object| {
             GasCoin::try_from(&object)
                 .ok()

--- a/crates/iota-single-node-benchmark/src/benchmark_context.rs
+++ b/crates/iota-single-node-benchmark/src/benchmark_context.rs
@@ -120,7 +120,7 @@ impl BenchmarkContext {
             self.validator()
                 .get_validator()
                 .get_cache_commit()
-                .commit_transaction_outputs(
+                .try_commit_transaction_outputs(
                     effects.executed_epoch(),
                     &[*effects.transaction_digest()],
                 )
@@ -195,7 +195,7 @@ impl BenchmarkContext {
             // For checkpoint executor, in order to commit a checkpoint it is required
             // previous versions of objects are already committed.
             cache_commit
-                .commit_transaction_outputs(epoch_id, &[*effects.transaction_digest()])
+                .try_commit_transaction_outputs(epoch_id, &[*effects.transaction_digest()])
                 .await
                 .unwrap();
         }

--- a/crates/iota-single-node-benchmark/src/benchmark_context.rs
+++ b/crates/iota-single-node-benchmark/src/benchmark_context.rs
@@ -415,7 +415,7 @@ impl BenchmarkContext {
                 .unwrap();
             state
                 .get_state_sync_store()
-                .multi_insert_transaction_and_effects(contents.transactions())
+                .try_multi_insert_transaction_and_effects(contents.transactions())
                 .unwrap();
             state
                 .get_checkpoint_store()

--- a/crates/iota-single-node-benchmark/src/mock_storage.rs
+++ b/crates/iota-single-node-benchmark/src/mock_storage.rs
@@ -63,7 +63,7 @@ impl InMemoryObjectStore {
             let obj: Option<Object> = match kind {
                 InputObjectKind::MovePackage(id) => self.get_package_object(id)?.map(|o| o.into()),
                 InputObjectKind::ImmOrOwnedMoveObject(objref) => {
-                    self.get_object_by_key(&objref.0, objref.1)?
+                    self.try_get_object_by_key(&objref.0, objref.1)?
                 }
 
                 InputObjectKind::SharedMoveObject { id, .. } => {
@@ -82,7 +82,7 @@ impl InMemoryObjectStore {
                         panic!("Shared object version should have been assigned. key: {tx_key:?}, obj id: {id:?}")
                     });
 
-                    self.get_object_by_key(id, *version)?
+                    self.try_get_object_by_key(id, *version)?
                 }
             };
 
@@ -109,7 +109,7 @@ impl InMemoryObjectStore {
 }
 
 impl ObjectStore for InMemoryObjectStore {
-    fn get_object(
+    fn try_get_object(
         &self,
         object_id: &ObjectID,
     ) -> Result<Option<Object>, iota_types::storage::error::Error> {
@@ -117,12 +117,12 @@ impl ObjectStore for InMemoryObjectStore {
         Ok(self.objects.read().unwrap().get(object_id).cloned())
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
     ) -> Result<Option<Object>, iota_types::storage::error::Error> {
-        Ok(self.get_object(object_id).unwrap().and_then(|o| {
+        Ok(self.try_get_object(object_id).unwrap().and_then(|o| {
             if o.version() == version {
                 Some(o.clone())
             } else {
@@ -145,7 +145,7 @@ impl ChildObjectResolver for InMemoryObjectStore {
         child: &ObjectID,
         child_version_upper_bound: SequenceNumber,
     ) -> IotaResult<Option<Object>> {
-        Ok(self.get_object(child).unwrap().and_then(|o| {
+        Ok(self.try_get_object(child).unwrap().and_then(|o| {
             if o.version() <= child_version_upper_bound
                 && o.owner == Owner::ObjectOwner((*parent).into())
             {

--- a/crates/iota-storage/src/lib.rs
+++ b/crates/iota-storage/src/lib.rs
@@ -238,7 +238,7 @@ where
     S: WriteStore,
 {
     let committee = store
-        .get_committee(checkpoint.epoch())
+        .try_get_committee(checkpoint.epoch())
         .expect("store operation should not fail")
         .unwrap_or_else(|| {
             panic!(
@@ -263,7 +263,7 @@ pub async fn verify_checkpoint_range<S>(
     futures::stream::iter(range_clone.into_iter().tuple_windows())
         .map(|(a, b)| {
             let current = store
-                .get_checkpoint_by_sequence_number(a)
+                .try_get_checkpoint_by_sequence_number(a)
                 .expect("store operation should not fail")
                 .unwrap_or_else(|| {
                     panic!(
@@ -271,7 +271,7 @@ pub async fn verify_checkpoint_range<S>(
                     );
                 });
             let next = store
-                .get_checkpoint_by_sequence_number(b)
+                .try_get_checkpoint_by_sequence_number(b)
                 .expect("store operation should not fail")
                 .unwrap_or_else(|| {
                     panic!(
@@ -279,7 +279,7 @@ pub async fn verify_checkpoint_range<S>(
                     );
                 });
             let committee = store
-                .get_committee(next.epoch())
+                .try_get_committee(next.epoch())
                 .expect("store operation should not fail")
                 .unwrap_or_else(|| {
                     panic!(
@@ -304,7 +304,7 @@ pub async fn verify_checkpoint_range<S>(
         .last()
         .expect("Received empty checkpoint range");
     let final_checkpoint = store
-        .get_checkpoint_by_sequence_number(last)
+        .try_get_checkpoint_by_sequence_number(last)
         .expect("Failed to fetch checkpoint")
         .expect("Expected end of checkpoint range to exist in store");
     store

--- a/crates/iota-storage/src/lib.rs
+++ b/crates/iota-storage/src/lib.rs
@@ -308,7 +308,7 @@ pub async fn verify_checkpoint_range<S>(
         .expect("Failed to fetch checkpoint")
         .expect("Expected end of checkpoint range to exist in store");
     store
-        .update_highest_verified_checkpoint(&final_checkpoint)
+        .try_update_highest_verified_checkpoint(&final_checkpoint)
         .expect("Failed to update highest verified checkpoint");
 }
 

--- a/crates/iota-storage/src/package_object_cache.rs
+++ b/crates/iota-storage/src/package_object_cache.rs
@@ -39,14 +39,14 @@ impl PackageObjectCache {
             #[cfg(debug_assertions)]
             {
                 assert_eq!(
-                    store.get_object(package_id).unwrap().unwrap().digest(),
+                    store.try_get_object(package_id).unwrap().unwrap().digest(),
                     p.object().digest(),
                     "Package object cache is inconsistent for package {package_id:?}"
                 )
             }
             return Ok(Some(p.clone()));
         }
-        if let Some(p) = store.get_object(package_id)? {
+        if let Some(p) = store.try_get_object(package_id)? {
             if p.is_package() {
                 let p = PackageObject::new(p);
                 self.cache.write().push(*package_id, p.clone());
@@ -70,7 +70,7 @@ impl PackageObjectCache {
     ) {
         for package_id in system_package_ids {
             if let Some(p) = store
-                .get_object(&package_id)
+                .try_get_object(&package_id)
                 .expect("Failed to update system packages")
             {
                 assert!(p.is_package());

--- a/crates/iota-tool/src/db_tool/mod.rs
+++ b/crates/iota-tool/src/db_tool/mod.rs
@@ -276,9 +276,9 @@ pub fn print_object(path: &Path, opt: PrintObjectOptions) -> anyhow::Result<()> 
     let perpetual_db = AuthorityPerpetualTables::open(&path.join("store"), None);
 
     let obj = if let Some(version) = opt.version {
-        perpetual_db.get_object_by_key(&opt.id, version.into())?
+        perpetual_db.try_get_object_by_key(&opt.id, version.into())?
     } else {
-        perpetual_db.get_object(&opt.id)?
+        perpetual_db.try_get_object(&opt.id)?
     };
 
     if let Some(obj) = obj {

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -756,7 +756,7 @@ fn start_summary_sync(
                         .get_checkpoint_by_sequence_number(*epoch_last_cp_seq_num)?
                         .ok_or(anyhow!("Failed to read checkpoint"))?;
                     let committee = state_sync_store
-                        .get_committee(cp_epoch as u64)
+                        .try_get_committee(cp_epoch as u64)
                         .expect("store operation should not fail")
                         .expect(
                             "Expected committee to exist after syncing all end of epoch checkpoints",
@@ -1160,7 +1160,7 @@ pub async fn dump_checkpoints_from_archive(
     {
         let mut content = serde_json::to_string(
             &store
-                .get_full_checkpoint_contents_by_sequence_number(key.sequence_number)?
+                .try_get_full_checkpoint_contents_by_sequence_number(key.sequence_number)?
                 .unwrap(),
         )?;
         content.truncate(max_content_length);

--- a/crates/iota-transactional-test-runner/src/args.rs
+++ b/crates/iota-transactional-test-runner/src/args.rs
@@ -448,9 +448,9 @@ impl IotaValue {
             None => bail!("INVALID TEST. Unknown object, object({})", fake_id),
         };
         let obj_res = if let Some(v) = version {
-            iota_types::storage::ObjectStore::get_object_by_key(&*test_adapter.executor, &id, v)
+            iota_types::storage::ObjectStore::try_get_object_by_key(&*test_adapter.executor, &id, v)
         } else {
-            iota_types::storage::ObjectStore::get_object(&*test_adapter.executor, &id)
+            iota_types::storage::ObjectStore::try_get_object(&*test_adapter.executor, &id)
         };
         let obj = match obj_res {
             Ok(Some(obj)) => obj,

--- a/crates/iota-transactional-test-runner/src/lib.rs
+++ b/crates/iota-transactional-test-runner/src/lib.rs
@@ -274,53 +274,53 @@ impl TransactionalAdapter for ValidatorWithFullnode {
 }
 
 impl ReadStore for ValidatorWithFullnode {
-    fn get_committee(
+    fn try_get_committee(
         &self,
         _epoch: EpochId,
     ) -> iota_types::storage::error::Result<Option<Arc<iota_types::committee::Committee>>> {
         todo!()
     }
 
-    fn get_latest_epoch_id(&self) -> iota_types::storage::error::Result<EpochId> {
+    fn try_get_latest_epoch_id(&self) -> iota_types::storage::error::Result<EpochId> {
         Ok(self.validator.epoch_store_for_testing().epoch())
     }
 
-    fn get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
+    fn try_get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
         let sequence_number = self
             .validator
             .get_latest_checkpoint_sequence_number()
             .unwrap();
-        self.get_checkpoint_by_sequence_number(sequence_number)
+        self.try_get_checkpoint_by_sequence_number(sequence_number)
             .map(|c| c.unwrap())
     }
 
-    fn get_highest_verified_checkpoint(
+    fn try_get_highest_verified_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
         todo!()
     }
 
-    fn get_highest_synced_checkpoint(
+    fn try_get_highest_synced_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
         todo!()
     }
 
-    fn get_lowest_available_checkpoint(
+    fn try_get_lowest_available_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<iota_types::messages_checkpoint::CheckpointSequenceNumber>
     {
         todo!()
     }
 
-    fn get_checkpoint_by_digest(
+    fn try_get_checkpoint_by_digest(
         &self,
         _digest: &iota_types::messages_checkpoint::CheckpointDigest,
     ) -> iota_types::storage::error::Result<Option<VerifiedCheckpoint>> {
         todo!()
     }
 
-    fn get_checkpoint_by_sequence_number(
+    fn try_get_checkpoint_by_sequence_number(
         &self,
         sequence_number: iota_types::messages_checkpoint::CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<Option<VerifiedCheckpoint>> {
@@ -330,7 +330,7 @@ impl ReadStore for ValidatorWithFullnode {
             .map_err(iota_types::storage::error::Error::custom)
     }
 
-    fn get_checkpoint_contents_by_digest(
+    fn try_get_checkpoint_contents_by_digest(
         &self,
         digest: &CheckpointContentsDigest,
     ) -> iota_types::storage::error::Result<
@@ -342,7 +342,7 @@ impl ReadStore for ValidatorWithFullnode {
             .map_err(iota_types::storage::error::Error::custom)
     }
 
-    fn get_checkpoint_contents_by_sequence_number(
+    fn try_get_checkpoint_contents_by_sequence_number(
         &self,
         _sequence_number: iota_types::messages_checkpoint::CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<
@@ -351,7 +351,7 @@ impl ReadStore for ValidatorWithFullnode {
         todo!()
     }
 
-    fn get_transaction(
+    fn try_get_transaction(
         &self,
         tx_digest: &TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<Arc<iota_types::transaction::VerifiedTransaction>>>
@@ -362,7 +362,7 @@ impl ReadStore for ValidatorWithFullnode {
             .map_err(iota_types::storage::error::Error::custom)
     }
 
-    fn get_transaction_effects(
+    fn try_get_transaction_effects(
         &self,
         tx_digest: &TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<TransactionEffects>> {
@@ -372,7 +372,7 @@ impl ReadStore for ValidatorWithFullnode {
             .map_err(iota_types::storage::error::Error::custom)
     }
 
-    fn get_events(
+    fn try_get_events(
         &self,
         event_digest: &TransactionEventsDigest,
     ) -> iota_types::storage::error::Result<Option<TransactionEvents>> {
@@ -382,7 +382,7 @@ impl ReadStore for ValidatorWithFullnode {
             .map_err(iota_types::storage::error::Error::custom)
     }
 
-    fn get_full_checkpoint_contents_by_sequence_number(
+    fn try_get_full_checkpoint_contents_by_sequence_number(
         &self,
         _sequence_number: iota_types::messages_checkpoint::CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<
@@ -391,7 +391,7 @@ impl ReadStore for ValidatorWithFullnode {
         todo!()
     }
 
-    fn get_full_checkpoint_contents(
+    fn try_get_full_checkpoint_contents(
         &self,
         _digest: &CheckpointContentsDigest,
     ) -> iota_types::storage::error::Result<

--- a/crates/iota-transactional-test-runner/src/lib.rs
+++ b/crates/iota-transactional-test-runner/src/lib.rs
@@ -358,7 +358,7 @@ impl ReadStore for ValidatorWithFullnode {
     {
         self.validator
             .get_transaction_cache_reader()
-            .get_transaction_block(tx_digest)
+            .try_get_transaction_block(tx_digest)
             .map_err(iota_types::storage::error::Error::custom)
     }
 
@@ -368,7 +368,7 @@ impl ReadStore for ValidatorWithFullnode {
     ) -> iota_types::storage::error::Result<Option<TransactionEffects>> {
         self.validator
             .get_transaction_cache_reader()
-            .get_executed_effects(tx_digest)
+            .try_get_executed_effects(tx_digest)
             .map_err(iota_types::storage::error::Error::custom)
     }
 
@@ -378,7 +378,7 @@ impl ReadStore for ValidatorWithFullnode {
     ) -> iota_types::storage::error::Result<Option<TransactionEvents>> {
         self.validator
             .get_transaction_cache_reader()
-            .get_events(event_digest)
+            .try_get_events(event_digest)
             .map_err(iota_types::storage::error::Error::custom)
     }
 

--- a/crates/iota-transactional-test-runner/src/lib.rs
+++ b/crates/iota-transactional-test-runner/src/lib.rs
@@ -402,21 +402,21 @@ impl ReadStore for ValidatorWithFullnode {
 }
 
 impl ObjectStore for ValidatorWithFullnode {
-    fn get_object(
+    fn try_get_object(
         &self,
         object_id: &ObjectID,
     ) -> Result<Option<Object>, iota_types::storage::error::Error> {
-        self.validator.get_object_store().get_object(object_id)
+        self.validator.get_object_store().try_get_object(object_id)
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
     ) -> Result<Option<Object>, iota_types::storage::error::Error> {
         self.validator
             .get_object_store()
-            .get_object_by_key(object_id, version)
+            .try_get_object_by_key(object_id, version)
     }
 }
 

--- a/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
@@ -550,14 +550,14 @@ impl ObjectStore for PersistedStoreInnerReadOnlyWrapper {
 }
 
 impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
-    fn get_committee(
+    fn try_get_committee(
         &self,
         _epoch: EpochId,
     ) -> iota_types::storage::error::Result<Option<std::sync::Arc<Committee>>> {
         todo!()
     }
 
-    fn get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
+    fn try_get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
         self.sync();
         self.inner
             .checkpoints
@@ -571,32 +571,32 @@ impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
             .map_err(iota_types::storage::error::Error::custom)
     }
 
-    fn get_highest_verified_checkpoint(
+    fn try_get_highest_verified_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
         todo!()
     }
 
-    fn get_highest_synced_checkpoint(
+    fn try_get_highest_synced_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
         todo!()
     }
 
-    fn get_lowest_available_checkpoint(
+    fn try_get_lowest_available_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<CheckpointSequenceNumber> {
         Ok(0)
     }
 
-    fn get_checkpoint_by_digest(
+    fn try_get_checkpoint_by_digest(
         &self,
         _digest: &CheckpointDigest,
     ) -> iota_types::storage::error::Result<Option<VerifiedCheckpoint>> {
         todo!()
     }
 
-    fn get_checkpoint_by_sequence_number(
+    fn try_get_checkpoint_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<Option<VerifiedCheckpoint>> {
@@ -609,7 +609,7 @@ impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
             .map(|checkpoint| checkpoint.into()))
     }
 
-    fn get_checkpoint_contents_by_digest(
+    fn try_get_checkpoint_contents_by_digest(
         &self,
         digest: &CheckpointContentsDigest,
     ) -> iota_types::storage::error::Result<Option<CheckpointContents>> {
@@ -622,14 +622,14 @@ impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
             .expect("Fatal: DB read failed"))
     }
 
-    fn get_checkpoint_contents_by_sequence_number(
+    fn try_get_checkpoint_contents_by_sequence_number(
         &self,
         _sequence_number: CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<Option<CheckpointContents>> {
         todo!()
     }
 
-    fn get_transaction(
+    fn try_get_transaction(
         &self,
         tx_digest: &TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<Arc<VerifiedTransaction>>> {
@@ -643,7 +643,7 @@ impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
             .map(|transaction| Arc::new(transaction.into())))
     }
 
-    fn get_transaction_effects(
+    fn try_get_transaction_effects(
         &self,
         tx_digest: &TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<TransactionEffects>> {
@@ -656,7 +656,7 @@ impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
             .expect("Fatal: DB read failed"))
     }
 
-    fn get_events(
+    fn try_get_events(
         &self,
         event_digest: &TransactionEventsDigest,
     ) -> iota_types::storage::error::Result<Option<TransactionEvents>> {
@@ -669,7 +669,7 @@ impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
             .expect("Fatal: DB read failed"))
     }
 
-    fn get_full_checkpoint_contents_by_sequence_number(
+    fn try_get_full_checkpoint_contents_by_sequence_number(
         &self,
         _sequence_number: CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<
@@ -678,7 +678,7 @@ impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
         todo!()
     }
 
-    fn get_full_checkpoint_contents(
+    fn try_get_full_checkpoint_contents(
         &self,
         _digest: &CheckpointContentsDigest,
     ) -> iota_types::storage::error::Result<
@@ -706,7 +706,7 @@ impl RestStateReader for PersistedStoreInnerReadOnlyWrapper {
         &self,
     ) -> iota_types::storage::error::Result<iota_types::digests::ChainIdentifier> {
         Ok((*self
-            .get_checkpoint_by_sequence_number(0)
+            .try_get_checkpoint_by_sequence_number(0)
             .unwrap()
             .unwrap()
             .digest())

--- a/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
@@ -501,14 +501,14 @@ impl ModuleResolver for PersistedStore {
 }
 
 impl ObjectStore for PersistedStore {
-    fn get_object(
+    fn try_get_object(
         &self,
         object_id: &ObjectID,
     ) -> Result<Option<Object>, iota_types::storage::error::Error> {
         Ok(SimulatorStore::get_object(self, object_id))
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: iota_types::base_types::VersionNumber,
@@ -518,7 +518,7 @@ impl ObjectStore for PersistedStore {
 }
 
 impl ObjectStore for PersistedStoreInnerReadOnlyWrapper {
-    fn get_object(
+    fn try_get_object(
         &self,
         object_id: &ObjectID,
     ) -> iota_types::storage::error::Result<Option<Object>> {
@@ -528,12 +528,12 @@ impl ObjectStore for PersistedStoreInnerReadOnlyWrapper {
             .live_objects
             .get(object_id)
             .expect("Fatal: DB read failed")
-            .map(|version| self.get_object_by_key(object_id, version))
+            .map(|version| self.try_get_object_by_key(object_id, version))
             .transpose()
             .map(|f| f.flatten())
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: VersionNumber,

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -1749,9 +1749,9 @@ impl IotaTestAdapter {
 
     fn get_object(&self, id: &ObjectID, version: Option<SequenceNumber>) -> anyhow::Result<Object> {
         let obj_res = if let Some(v) = version {
-            ObjectStore::get_object_by_key(&*self.executor, id, v)
+            ObjectStore::try_get_object_by_key(&*self.executor, id, v)
         } else {
-            ObjectStore::get_object(&*self.executor, id)
+            ObjectStore::try_get_object(&*self.executor, id)
         };
         match obj_res {
             Ok(Some(obj)) => Ok(obj),
@@ -2396,19 +2396,19 @@ async fn update_named_address_mapping(
 }
 
 impl ObjectStore for IotaTestAdapter {
-    fn get_object(
+    fn try_get_object(
         &self,
         object_id: &ObjectID,
     ) -> iota_types::storage::error::Result<Option<Object>> {
-        ObjectStore::get_object(&*self.executor, object_id)
+        ObjectStore::try_get_object(&*self.executor, object_id)
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
     ) -> iota_types::storage::error::Result<Option<Object>> {
-        ObjectStore::get_object_by_key(&*self.executor, object_id, version)
+        ObjectStore::try_get_object_by_key(&*self.executor, object_id, version)
     }
 }
 

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -616,7 +616,8 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                     .offchain_reader
                     .as_ref()
                     .ok_or_else(|| anyhow::anyhow!("Offchain reader not set"))?;
-                let highest_checkpoint = self.executor.get_latest_checkpoint_sequence_number()?;
+                let highest_checkpoint =
+                    self.executor.try_get_latest_checkpoint_sequence_number()?;
                 offchain_reader
                     .wait_for_checkpoint_catchup(highest_checkpoint, Duration::from_secs(60))
                     .await;
@@ -651,10 +652,10 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                 Ok(Some(output.join("\n")))
             }
             IotaSubcommand::ViewCheckpoint => {
-                let latest_chk = self.executor.get_latest_checkpoint_sequence_number()?;
+                let latest_chk = self.executor.try_get_latest_checkpoint_sequence_number()?;
                 let chk = self
                     .executor
-                    .get_checkpoint_by_sequence_number(latest_chk)?
+                    .try_get_checkpoint_by_sequence_number(latest_chk)?
                     .unwrap();
                 Ok(Some(format!("{}", chk.data())))
             }
@@ -662,14 +663,14 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                 for _ in 0..count.unwrap_or(1) {
                     self.executor.create_checkpoint().await?;
                 }
-                let latest_chk = self.executor.get_latest_checkpoint_sequence_number()?;
+                let latest_chk = self.executor.try_get_latest_checkpoint_sequence_number()?;
                 Ok(Some(format!("Checkpoint created: {latest_chk}")))
             }
             IotaSubcommand::AdvanceEpoch(AdvanceEpochCommand { count }) => {
                 for _ in 0..count.unwrap_or(1) {
                     self.executor.advance_epoch().await?;
                 }
-                let epoch = self.get_latest_epoch_id()?;
+                let epoch = self.try_get_latest_epoch_id()?;
                 Ok(Some(format!("Epoch advanced: {epoch}")))
             }
             IotaSubcommand::AdvanceClock(AdvanceClockCommand { duration_ns }) => {
@@ -686,7 +687,7 @@ impl MoveTestAdapter<'_> for IotaTestAdapter {
                 let random_bytes = Base64::decode(&random_bytes)
                     .map_err(|e| anyhow!("Failed to decode random bytes as Base64: {e}"))?;
 
-                let latest_epoch = self.get_latest_epoch_id()?;
+                let latest_epoch = self.try_get_latest_epoch_id()?;
                 let tx = VerifiedTransaction::new_randomness_state_update(
                     latest_epoch,
                     RandomnessRound(randomness_round),
@@ -2413,106 +2414,106 @@ impl ObjectStore for IotaTestAdapter {
 }
 
 impl ReadStore for IotaTestAdapter {
-    fn get_latest_epoch_id(&self) -> iota_types::storage::error::Result<EpochId> {
-        self.executor.get_latest_epoch_id()
+    fn try_get_latest_epoch_id(&self) -> iota_types::storage::error::Result<EpochId> {
+        self.executor.try_get_latest_epoch_id()
     }
 
-    fn get_committee(
+    fn try_get_committee(
         &self,
         epoch: iota_types::committee::EpochId,
     ) -> iota_types::storage::error::Result<Option<Arc<iota_types::committee::Committee>>> {
-        self.executor.get_committee(epoch)
+        self.executor.try_get_committee(epoch)
     }
 
-    fn get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
-        ReadStore::get_latest_checkpoint(&self.executor)
+    fn try_get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
+        ReadStore::try_get_latest_checkpoint(&self.executor)
     }
 
-    fn get_highest_verified_checkpoint(
+    fn try_get_highest_verified_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
-        self.executor.get_highest_verified_checkpoint()
+        self.executor.try_get_highest_verified_checkpoint()
     }
 
-    fn get_highest_synced_checkpoint(
+    fn try_get_highest_synced_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
-        self.executor.get_highest_synced_checkpoint()
+        self.executor.try_get_highest_synced_checkpoint()
     }
 
-    fn get_lowest_available_checkpoint(
+    fn try_get_lowest_available_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<CheckpointSequenceNumber> {
-        self.executor.get_lowest_available_checkpoint()
+        self.executor.try_get_lowest_available_checkpoint()
     }
 
-    fn get_checkpoint_by_digest(
+    fn try_get_checkpoint_by_digest(
         &self,
         digest: &iota_types::messages_checkpoint::CheckpointDigest,
     ) -> iota_types::storage::error::Result<Option<VerifiedCheckpoint>> {
-        self.executor.get_checkpoint_by_digest(digest)
+        self.executor.try_get_checkpoint_by_digest(digest)
     }
 
-    fn get_checkpoint_by_sequence_number(
+    fn try_get_checkpoint_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<Option<VerifiedCheckpoint>> {
         self.executor
-            .get_checkpoint_by_sequence_number(sequence_number)
+            .try_get_checkpoint_by_sequence_number(sequence_number)
     }
 
-    fn get_checkpoint_contents_by_digest(
+    fn try_get_checkpoint_contents_by_digest(
         &self,
         digest: &CheckpointContentsDigest,
     ) -> iota_types::storage::error::Result<Option<CheckpointContents>> {
-        self.executor.get_checkpoint_contents_by_digest(digest)
+        self.executor.try_get_checkpoint_contents_by_digest(digest)
     }
 
-    fn get_checkpoint_contents_by_sequence_number(
+    fn try_get_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<Option<CheckpointContents>> {
         self.executor
-            .get_checkpoint_contents_by_sequence_number(sequence_number)
+            .try_get_checkpoint_contents_by_sequence_number(sequence_number)
     }
 
-    fn get_transaction(
+    fn try_get_transaction(
         &self,
         tx_digest: &TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<Arc<VerifiedTransaction>>> {
-        self.executor.get_transaction(tx_digest)
+        self.executor.try_get_transaction(tx_digest)
     }
 
-    fn get_transaction_effects(
+    fn try_get_transaction_effects(
         &self,
         tx_digest: &TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<TransactionEffects>> {
-        self.executor.get_transaction_effects(tx_digest)
+        self.executor.try_get_transaction_effects(tx_digest)
     }
 
-    fn get_events(
+    fn try_get_events(
         &self,
         event_digest: &TransactionEventsDigest,
     ) -> iota_types::storage::error::Result<Option<TransactionEvents>> {
-        self.executor.get_events(event_digest)
+        self.executor.try_get_events(event_digest)
     }
 
-    fn get_full_checkpoint_contents_by_sequence_number(
+    fn try_get_full_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<
         Option<iota_types::messages_checkpoint::FullCheckpointContents>,
     > {
         self.executor
-            .get_full_checkpoint_contents_by_sequence_number(sequence_number)
+            .try_get_full_checkpoint_contents_by_sequence_number(sequence_number)
     }
 
-    fn get_full_checkpoint_contents(
+    fn try_get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
     ) -> iota_types::storage::error::Result<
         Option<iota_types::messages_checkpoint::FullCheckpointContents>,
     > {
-        self.executor.get_full_checkpoint_contents(digest)
+        self.executor.try_get_full_checkpoint_contents(digest)
     }
 }

--- a/crates/iota-types/src/authenticator_state.rs
+++ b/crates/iota-types/src/authenticator_state.rs
@@ -111,7 +111,7 @@ impl std::cmp::Ord for ActiveJwk {
 pub fn get_authenticator_state(
     object_store: impl ObjectStore,
 ) -> IotaResult<Option<AuthenticatorStateInner>> {
-    let outer = object_store.get_object(&IOTA_AUTHENTICATOR_STATE_OBJECT_ID)?;
+    let outer = object_store.try_get_object(&IOTA_AUTHENTICATOR_STATE_OBJECT_ID)?;
     let Some(outer) = outer else {
         return Ok(None);
     };
@@ -140,7 +140,7 @@ pub fn get_authenticator_state_obj_initial_shared_version(
     object_store: &dyn ObjectStore,
 ) -> IotaResult<Option<SequenceNumber>> {
     Ok(object_store
-        .get_object(&IOTA_AUTHENTICATOR_STATE_OBJECT_ID)?
+        .try_get_object(&IOTA_AUTHENTICATOR_STATE_OBJECT_ID)?
         .map(|obj| match obj.owner {
             Owner::Shared {
                 initial_shared_version,

--- a/crates/iota-types/src/deny_list_v1.rs
+++ b/crates/iota-types/src/deny_list_v1.rs
@@ -253,7 +253,7 @@ pub fn check_global_pause(
 }
 
 pub fn get_deny_list_root_object(object_store: &dyn ObjectStore) -> IotaResult<Object> {
-    match object_store.get_object(&IOTA_DENY_LIST_OBJECT_ID) {
+    match object_store.try_get_object(&IOTA_DENY_LIST_OBJECT_ID) {
         Ok(Some(obj)) => Ok(obj),
         Ok(None) => {
             error!("Deny list object not found");

--- a/crates/iota-types/src/dynamic_field.rs
+++ b/crates/iota-types/src/dynamic_field.rs
@@ -319,7 +319,7 @@ where
 {
     let id = derive_dynamic_field_id(parent_id, &K::get_type_tag(), &bcs::to_bytes(key).unwrap())
         .map_err(|err| IotaError::DynamicFieldRead(err.to_string()))?;
-    let object = object_store.get_object(&id)?.ok_or_else(|| {
+    let object = object_store.try_get_object(&id)?.ok_or_else(|| {
         IotaError::DynamicFieldRead(format!(
             "Dynamic field with key={key:?} and ID={id:?} not found on parent {parent_id:?}"
         ))

--- a/crates/iota-types/src/in_memory_storage.rs
+++ b/crates/iota-types/src/in_memory_storage.rs
@@ -104,11 +104,14 @@ impl ModuleResolver for &mut InMemoryStorage {
 }
 
 impl ObjectStore for InMemoryStorage {
-    fn get_object(&self, object_id: &ObjectID) -> crate::storage::error::Result<Option<Object>> {
+    fn try_get_object(
+        &self,
+        object_id: &ObjectID,
+    ) -> crate::storage::error::Result<Option<Object>> {
         Ok(self.persistent.get(object_id).cloned())
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
@@ -128,11 +131,14 @@ impl ObjectStore for InMemoryStorage {
 }
 
 impl ObjectStore for &mut InMemoryStorage {
-    fn get_object(&self, object_id: &ObjectID) -> crate::storage::error::Result<Option<Object>> {
+    fn try_get_object(
+        &self,
+        object_id: &ObjectID,
+    ) -> crate::storage::error::Result<Option<Object>> {
         Ok(self.persistent.get(object_id).cloned())
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: VersionNumber,

--- a/crates/iota-types/src/iota_system_state/mod.rs
+++ b/crates/iota-types/src/iota_system_state/mod.rs
@@ -235,7 +235,7 @@ pub fn get_iota_system_state_wrapper(
     object_store: &dyn ObjectStore,
 ) -> Result<IotaSystemStateWrapper, IotaError> {
     let wrapper = object_store
-        .get_object(&IOTA_SYSTEM_STATE_OBJECT_ID)?
+        .try_get_object(&IOTA_SYSTEM_STATE_OBJECT_ID)?
         // Don't panic here on None because object_store is a generic store.
         .ok_or_else(|| {
             IotaError::IotaSystemStateRead("IotaSystemStateWrapper object not found".to_owned())

--- a/crates/iota-types/src/messages_checkpoint.rs
+++ b/crates/iota-types/src/messages_checkpoint.rs
@@ -587,8 +587,8 @@ impl FullCheckpointContents {
         let mut transactions = Vec::with_capacity(contents.size());
         for tx in contents.iter() {
             if let (Some(t), Some(e)) = (
-                store.get_transaction(&tx.transaction)?,
-                store.get_transaction_effects(&tx.transaction)?,
+                store.try_get_transaction(&tx.transaction)?,
+                store.try_get_transaction_effects(&tx.transaction)?,
             ) {
                 transactions.push(ExecutionData::new((*t).clone().into_inner(), e))
             } else {

--- a/crates/iota-types/src/randomness_state.rs
+++ b/crates/iota-types/src/randomness_state.rs
@@ -28,7 +28,7 @@ pub fn get_randomness_state_obj_initial_shared_version(
     object_store: &dyn ObjectStore,
 ) -> IotaResult<SequenceNumber> {
     object_store
-        .get_object(&IOTA_RANDOMNESS_STATE_OBJECT_ID)?
+        .try_get_object(&IOTA_RANDOMNESS_STATE_OBJECT_ID)?
         .map(|obj| match obj.owner {
             Owner::Shared {
                 initial_shared_version,

--- a/crates/iota-types/src/storage/mod.rs
+++ b/crates/iota-types/src/storage/mod.rs
@@ -282,7 +282,7 @@ pub fn load_package_object_from_object_store(
     store: &impl ObjectStore,
     package_id: &ObjectID,
 ) -> IotaResult<Option<PackageObject>> {
-    let package = store.get_object(package_id)?;
+    let package = store.try_get_object(package_id)?;
     if let Some(obj) = &package {
         fp_ensure!(
             obj.is_package(),

--- a/crates/iota-types/src/storage/object_store_trait.rs
+++ b/crates/iota-types/src/storage/object_store_trait.rs
@@ -12,101 +12,113 @@ use crate::{
 };
 
 pub trait ObjectStore {
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>>;
+    fn try_get_object(&self, object_id: &ObjectID) -> Result<Option<Object>>;
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
     ) -> Result<Option<Object>>;
 
-    fn multi_get_objects(&self, object_ids: &[ObjectID]) -> Result<Vec<Option<Object>>> {
+    fn try_multi_get_objects(&self, object_ids: &[ObjectID]) -> Result<Vec<Option<Object>>> {
         object_ids
             .iter()
-            .map(|digest| self.get_object(digest))
+            .map(|digest| self.try_get_object(digest))
             .collect::<Result<Vec<_>, _>>()
     }
 
-    fn multi_get_objects_by_key(&self, object_keys: &[ObjectKey]) -> Result<Vec<Option<Object>>> {
+    fn try_multi_get_objects_by_key(
+        &self,
+        object_keys: &[ObjectKey],
+    ) -> Result<Vec<Option<Object>>> {
         object_keys
             .iter()
-            .map(|k| self.get_object_by_key(&k.0, k.1))
+            .map(|k| self.try_get_object_by_key(&k.0, k.1))
             .collect::<Result<Vec<_>, _>>()
     }
 }
 
 impl<T: ObjectStore + ?Sized> ObjectStore for &T {
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>> {
-        (*self).get_object(object_id)
+    fn try_get_object(&self, object_id: &ObjectID) -> Result<Option<Object>> {
+        (*self).try_get_object(object_id)
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
     ) -> Result<Option<Object>> {
-        (*self).get_object_by_key(object_id, version)
+        (*self).try_get_object_by_key(object_id, version)
     }
 
-    fn multi_get_objects(&self, object_ids: &[ObjectID]) -> Result<Vec<Option<Object>>> {
-        (*self).multi_get_objects(object_ids)
+    fn try_multi_get_objects(&self, object_ids: &[ObjectID]) -> Result<Vec<Option<Object>>> {
+        (*self).try_multi_get_objects(object_ids)
     }
 
-    fn multi_get_objects_by_key(&self, object_keys: &[ObjectKey]) -> Result<Vec<Option<Object>>> {
-        (*self).multi_get_objects_by_key(object_keys)
+    fn try_multi_get_objects_by_key(
+        &self,
+        object_keys: &[ObjectKey],
+    ) -> Result<Vec<Option<Object>>> {
+        (*self).try_multi_get_objects_by_key(object_keys)
     }
 }
 
 impl<T: ObjectStore + ?Sized> ObjectStore for Box<T> {
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>> {
-        (**self).get_object(object_id)
+    fn try_get_object(&self, object_id: &ObjectID) -> Result<Option<Object>> {
+        (**self).try_get_object(object_id)
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
     ) -> Result<Option<Object>> {
-        (**self).get_object_by_key(object_id, version)
+        (**self).try_get_object_by_key(object_id, version)
     }
 
-    fn multi_get_objects(&self, object_ids: &[ObjectID]) -> Result<Vec<Option<Object>>> {
-        (**self).multi_get_objects(object_ids)
+    fn try_multi_get_objects(&self, object_ids: &[ObjectID]) -> Result<Vec<Option<Object>>> {
+        (**self).try_multi_get_objects(object_ids)
     }
 
-    fn multi_get_objects_by_key(&self, object_keys: &[ObjectKey]) -> Result<Vec<Option<Object>>> {
-        (**self).multi_get_objects_by_key(object_keys)
+    fn try_multi_get_objects_by_key(
+        &self,
+        object_keys: &[ObjectKey],
+    ) -> Result<Vec<Option<Object>>> {
+        (**self).try_multi_get_objects_by_key(object_keys)
     }
 }
 
 impl<T: ObjectStore + ?Sized> ObjectStore for Arc<T> {
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>> {
-        (**self).get_object(object_id)
+    fn try_get_object(&self, object_id: &ObjectID) -> Result<Option<Object>> {
+        (**self).try_get_object(object_id)
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
     ) -> Result<Option<Object>> {
-        (**self).get_object_by_key(object_id, version)
+        (**self).try_get_object_by_key(object_id, version)
     }
 
-    fn multi_get_objects(&self, object_ids: &[ObjectID]) -> Result<Vec<Option<Object>>> {
-        (**self).multi_get_objects(object_ids)
+    fn try_multi_get_objects(&self, object_ids: &[ObjectID]) -> Result<Vec<Option<Object>>> {
+        (**self).try_multi_get_objects(object_ids)
     }
 
-    fn multi_get_objects_by_key(&self, object_keys: &[ObjectKey]) -> Result<Vec<Option<Object>>> {
-        (**self).multi_get_objects_by_key(object_keys)
+    fn try_multi_get_objects_by_key(
+        &self,
+        object_keys: &[ObjectKey],
+    ) -> Result<Vec<Option<Object>>> {
+        (**self).try_multi_get_objects_by_key(object_keys)
     }
 }
 
 impl ObjectStore for &[Object] {
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>> {
+    fn try_get_object(&self, object_id: &ObjectID) -> Result<Option<Object>> {
         Ok(self.iter().find(|o| o.id() == *object_id).cloned())
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
@@ -119,11 +131,11 @@ impl ObjectStore for &[Object] {
 }
 
 impl ObjectStore for BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)> {
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>> {
+    fn try_get_object(&self, object_id: &ObjectID) -> Result<Option<Object>> {
         Ok(self.get(object_id).map(|(_, obj, _)| obj).cloned())
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
@@ -142,11 +154,11 @@ impl ObjectStore for BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)> {
 }
 
 impl ObjectStore for BTreeMap<ObjectID, Object> {
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>> {
+    fn try_get_object(&self, object_id: &ObjectID) -> Result<Option<Object>> {
         Ok(self.get(object_id).cloned())
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: VersionNumber,

--- a/crates/iota-types/src/storage/read_store.rs
+++ b/crates/iota-types/src/storage/read_store.rs
@@ -225,7 +225,7 @@ pub trait ReadStore: ObjectStore {
                 .collect::<Vec<_>>();
 
             let input_objects = self
-                .multi_get_objects_by_key(&input_object_keys)?
+                .try_multi_get_objects_by_key(&input_object_keys)?
                 .into_iter()
                 .enumerate()
                 .map(|(idx, maybe_object)| {
@@ -246,7 +246,7 @@ pub trait ReadStore: ObjectStore {
                 .collect::<Vec<_>>();
 
             let output_objects = self
-                .multi_get_objects_by_key(&output_object_keys)?
+                .try_multi_get_objects_by_key(&output_object_keys)?
                 .into_iter()
                 .enumerate()
                 .map(|(idx, maybe_object)| {

--- a/crates/iota-types/src/storage/read_store.rs
+++ b/crates/iota-types/src/storage/read_store.rs
@@ -28,7 +28,7 @@ pub trait ReadStore: ObjectStore {
     // Committee Getters
     //
 
-    fn get_committee(&self, epoch: EpochId) -> Result<Option<Arc<Committee>>>;
+    fn try_get_committee(&self, epoch: EpochId) -> Result<Option<Arc<Committee>>>;
 
     // Checkpoint Getters
     //
@@ -38,31 +38,31 @@ pub trait ReadStore: ObjectStore {
     ///
     /// All transactions, effects, objects and events are guaranteed to be
     /// available for the returned checkpoint.
-    fn get_latest_checkpoint(&self) -> Result<VerifiedCheckpoint>;
+    fn try_get_latest_checkpoint(&self) -> Result<VerifiedCheckpoint>;
 
     /// Get the latest available checkpoint sequence number. This is the
     /// sequence number of the latest executed checkpoint.
-    fn get_latest_checkpoint_sequence_number(&self) -> Result<CheckpointSequenceNumber> {
-        let latest_checkpoint = self.get_latest_checkpoint()?;
+    fn try_get_latest_checkpoint_sequence_number(&self) -> Result<CheckpointSequenceNumber> {
+        let latest_checkpoint = self.try_get_latest_checkpoint()?;
         Ok(*latest_checkpoint.sequence_number())
     }
 
     /// Get the epoch of the latest checkpoint
-    fn get_latest_epoch_id(&self) -> Result<EpochId> {
-        let latest_checkpoint = self.get_latest_checkpoint()?;
+    fn try_get_latest_epoch_id(&self) -> Result<EpochId> {
+        let latest_checkpoint = self.try_get_latest_checkpoint()?;
         Ok(latest_checkpoint.epoch())
     }
 
     /// Get the highest verified checkpoint. This is the highest checkpoint
     /// summary that has been verified, generally by state-sync. Only the
     /// checkpoint header is guaranteed to be present in the store.
-    fn get_highest_verified_checkpoint(&self) -> Result<VerifiedCheckpoint>;
+    fn try_get_highest_verified_checkpoint(&self) -> Result<VerifiedCheckpoint>;
 
     /// Get the highest synced checkpoint. This is the highest checkpoint that
     /// has been synced from state-synce. The checkpoint header, contents,
     /// transactions, and effects of this checkpoint are guaranteed to be
     /// present in the store
-    fn get_highest_synced_checkpoint(&self) -> Result<VerifiedCheckpoint>;
+    fn try_get_highest_synced_checkpoint(&self) -> Result<VerifiedCheckpoint>;
 
     /// Lowest available checkpoint for which transaction and checkpoint data
     /// can be requested.
@@ -75,24 +75,24 @@ pub trait ReadStore: ObjectStore {
     ///  - events
     ///
     /// For object availability see `get_lowest_available_checkpoint_objects`.
-    fn get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber>;
+    fn try_get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber>;
 
-    fn get_checkpoint_by_digest(
+    fn try_get_checkpoint_by_digest(
         &self,
         digest: &CheckpointDigest,
     ) -> Result<Option<VerifiedCheckpoint>>;
 
-    fn get_checkpoint_by_sequence_number(
+    fn try_get_checkpoint_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Result<Option<VerifiedCheckpoint>>;
 
-    fn get_checkpoint_contents_by_digest(
+    fn try_get_checkpoint_contents_by_digest(
         &self,
         digest: &CheckpointContentsDigest,
     ) -> Result<Option<CheckpointContents>>;
 
-    fn get_checkpoint_contents_by_sequence_number(
+    fn try_get_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Result<Option<CheckpointContents>>;
@@ -100,48 +100,48 @@ pub trait ReadStore: ObjectStore {
     // Transaction Getters
     //
 
-    fn get_transaction(
+    fn try_get_transaction(
         &self,
         tx_digest: &TransactionDigest,
     ) -> Result<Option<Arc<VerifiedTransaction>>>;
 
-    fn multi_get_transactions(
+    fn try_multi_get_transactions(
         &self,
         tx_digests: &[TransactionDigest],
     ) -> Result<Vec<Option<Arc<VerifiedTransaction>>>> {
         tx_digests
             .iter()
-            .map(|digest| self.get_transaction(digest))
+            .map(|digest| self.try_get_transaction(digest))
             .collect::<Result<Vec<_>, _>>()
     }
 
-    fn get_transaction_effects(
+    fn try_get_transaction_effects(
         &self,
         tx_digest: &TransactionDigest,
     ) -> Result<Option<TransactionEffects>>;
 
-    fn multi_get_transaction_effects(
+    fn try_multi_get_transaction_effects(
         &self,
         tx_digests: &[TransactionDigest],
     ) -> Result<Vec<Option<TransactionEffects>>> {
         tx_digests
             .iter()
-            .map(|digest| self.get_transaction_effects(digest))
+            .map(|digest| self.try_get_transaction_effects(digest))
             .collect::<Result<Vec<_>, _>>()
     }
 
-    fn get_events(
+    fn try_get_events(
         &self,
         event_digest: &TransactionEventsDigest,
     ) -> Result<Option<TransactionEvents>>;
 
-    fn multi_get_events(
+    fn try_multi_get_events(
         &self,
         event_digests: &[TransactionEventsDigest],
     ) -> Result<Vec<Option<TransactionEvents>>> {
         event_digests
             .iter()
-            .map(|digest| self.get_events(digest))
+            .map(|digest| self.try_get_events(digest))
             .collect::<Result<Vec<_>, _>>()
     }
 
@@ -150,21 +150,21 @@ pub trait ReadStore: ObjectStore {
 
     /// Get a "full" checkpoint for purposes of state-sync
     /// "full" checkpoints include: header, contents, transactions, effects
-    fn get_full_checkpoint_contents_by_sequence_number(
+    fn try_get_full_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Result<Option<FullCheckpointContents>>;
 
     /// Get a "full" checkpoint for purposes of state-sync
     /// "full" checkpoints include: header, contents, transactions, effects
-    fn get_full_checkpoint_contents(
+    fn try_get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
     ) -> Result<Option<FullCheckpointContents>>;
 
     // Fetch all checkpoint data
     // TODO fix return type to not be anyhow
-    fn get_checkpoint_data(
+    fn try_get_checkpoint_data(
         &self,
         checkpoint: VerifiedCheckpoint,
         checkpoint_contents: CheckpointContents,
@@ -181,7 +181,7 @@ pub trait ReadStore: ObjectStore {
             .map(|execution_digests| execution_digests.transaction)
             .collect::<Vec<_>>();
         let transactions = self
-            .multi_get_transactions(&transaction_digests)?
+            .try_multi_get_transactions(&transaction_digests)?
             .into_iter()
             .map(|maybe_transaction| {
                 maybe_transaction.ok_or_else(|| anyhow::anyhow!("missing transaction"))
@@ -189,7 +189,7 @@ pub trait ReadStore: ObjectStore {
             .collect::<anyhow::Result<Vec<_>>>()?;
 
         let effects = self
-            .multi_get_transaction_effects(&transaction_digests)?
+            .try_multi_get_transaction_effects(&transaction_digests)?
             .into_iter()
             .map(|maybe_effects| maybe_effects.ok_or_else(|| anyhow::anyhow!("missing effects")))
             .collect::<anyhow::Result<Vec<_>>>()?;
@@ -200,7 +200,7 @@ pub trait ReadStore: ObjectStore {
             .collect::<Vec<_>>();
 
         let events = self
-            .multi_get_events(&event_digests)?
+            .try_multi_get_events(&event_digests)?
             .into_iter()
             .map(|maybe_event| maybe_event.ok_or_else(|| anyhow::anyhow!("missing event")))
             .collect::<anyhow::Result<Vec<_>>>()?;
@@ -282,368 +282,368 @@ pub trait ReadStore: ObjectStore {
 }
 
 impl<T: ReadStore + ?Sized> ReadStore for &T {
-    fn get_committee(&self, epoch: EpochId) -> Result<Option<Arc<Committee>>> {
-        (*self).get_committee(epoch)
+    fn try_get_committee(&self, epoch: EpochId) -> Result<Option<Arc<Committee>>> {
+        (*self).try_get_committee(epoch)
     }
 
-    fn get_latest_checkpoint(&self) -> Result<VerifiedCheckpoint> {
-        (*self).get_latest_checkpoint()
+    fn try_get_latest_checkpoint(&self) -> Result<VerifiedCheckpoint> {
+        (*self).try_get_latest_checkpoint()
     }
 
-    fn get_latest_checkpoint_sequence_number(&self) -> Result<CheckpointSequenceNumber> {
-        (*self).get_latest_checkpoint_sequence_number()
+    fn try_get_latest_checkpoint_sequence_number(&self) -> Result<CheckpointSequenceNumber> {
+        (*self).try_get_latest_checkpoint_sequence_number()
     }
 
-    fn get_latest_epoch_id(&self) -> Result<EpochId> {
-        (*self).get_latest_epoch_id()
+    fn try_get_latest_epoch_id(&self) -> Result<EpochId> {
+        (*self).try_get_latest_epoch_id()
     }
 
-    fn get_highest_verified_checkpoint(&self) -> Result<VerifiedCheckpoint> {
-        (*self).get_highest_verified_checkpoint()
+    fn try_get_highest_verified_checkpoint(&self) -> Result<VerifiedCheckpoint> {
+        (*self).try_get_highest_verified_checkpoint()
     }
 
-    fn get_highest_synced_checkpoint(&self) -> Result<VerifiedCheckpoint> {
-        (*self).get_highest_synced_checkpoint()
+    fn try_get_highest_synced_checkpoint(&self) -> Result<VerifiedCheckpoint> {
+        (*self).try_get_highest_synced_checkpoint()
     }
 
-    fn get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber> {
-        (*self).get_lowest_available_checkpoint()
+    fn try_get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber> {
+        (*self).try_get_lowest_available_checkpoint()
     }
 
-    fn get_checkpoint_by_digest(
+    fn try_get_checkpoint_by_digest(
         &self,
         digest: &CheckpointDigest,
     ) -> Result<Option<VerifiedCheckpoint>> {
-        (*self).get_checkpoint_by_digest(digest)
+        (*self).try_get_checkpoint_by_digest(digest)
     }
 
-    fn get_checkpoint_by_sequence_number(
+    fn try_get_checkpoint_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Result<Option<VerifiedCheckpoint>> {
-        (*self).get_checkpoint_by_sequence_number(sequence_number)
+        (*self).try_get_checkpoint_by_sequence_number(sequence_number)
     }
 
-    fn get_checkpoint_contents_by_digest(
+    fn try_get_checkpoint_contents_by_digest(
         &self,
         digest: &CheckpointContentsDigest,
     ) -> Result<Option<CheckpointContents>> {
-        (*self).get_checkpoint_contents_by_digest(digest)
+        (*self).try_get_checkpoint_contents_by_digest(digest)
     }
 
-    fn get_checkpoint_contents_by_sequence_number(
+    fn try_get_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Result<Option<CheckpointContents>> {
-        (*self).get_checkpoint_contents_by_sequence_number(sequence_number)
+        (*self).try_get_checkpoint_contents_by_sequence_number(sequence_number)
     }
 
-    fn get_transaction(
+    fn try_get_transaction(
         &self,
         tx_digest: &TransactionDigest,
     ) -> Result<Option<Arc<VerifiedTransaction>>> {
-        (*self).get_transaction(tx_digest)
+        (*self).try_get_transaction(tx_digest)
     }
 
-    fn multi_get_transactions(
+    fn try_multi_get_transactions(
         &self,
         tx_digests: &[TransactionDigest],
     ) -> Result<Vec<Option<Arc<VerifiedTransaction>>>> {
-        (*self).multi_get_transactions(tx_digests)
+        (*self).try_multi_get_transactions(tx_digests)
     }
 
-    fn get_transaction_effects(
+    fn try_get_transaction_effects(
         &self,
         tx_digest: &TransactionDigest,
     ) -> Result<Option<TransactionEffects>> {
-        (*self).get_transaction_effects(tx_digest)
+        (*self).try_get_transaction_effects(tx_digest)
     }
 
-    fn multi_get_transaction_effects(
+    fn try_multi_get_transaction_effects(
         &self,
         tx_digests: &[TransactionDigest],
     ) -> Result<Vec<Option<TransactionEffects>>> {
-        (*self).multi_get_transaction_effects(tx_digests)
+        (*self).try_multi_get_transaction_effects(tx_digests)
     }
 
-    fn get_events(
+    fn try_get_events(
         &self,
         event_digest: &TransactionEventsDigest,
     ) -> Result<Option<TransactionEvents>> {
-        (*self).get_events(event_digest)
+        (*self).try_get_events(event_digest)
     }
 
-    fn multi_get_events(
+    fn try_multi_get_events(
         &self,
         event_digests: &[TransactionEventsDigest],
     ) -> Result<Vec<Option<TransactionEvents>>> {
-        (*self).multi_get_events(event_digests)
+        (*self).try_multi_get_events(event_digests)
     }
 
-    fn get_full_checkpoint_contents_by_sequence_number(
+    fn try_get_full_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Result<Option<FullCheckpointContents>> {
-        (*self).get_full_checkpoint_contents_by_sequence_number(sequence_number)
+        (*self).try_get_full_checkpoint_contents_by_sequence_number(sequence_number)
     }
 
-    fn get_full_checkpoint_contents(
+    fn try_get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
     ) -> Result<Option<FullCheckpointContents>> {
-        (*self).get_full_checkpoint_contents(digest)
+        (*self).try_get_full_checkpoint_contents(digest)
     }
 
-    fn get_checkpoint_data(
+    fn try_get_checkpoint_data(
         &self,
         checkpoint: VerifiedCheckpoint,
         checkpoint_contents: CheckpointContents,
     ) -> anyhow::Result<CheckpointData> {
-        (*self).get_checkpoint_data(checkpoint, checkpoint_contents)
+        (*self).try_get_checkpoint_data(checkpoint, checkpoint_contents)
     }
 }
 
 impl<T: ReadStore + ?Sized> ReadStore for Box<T> {
-    fn get_committee(&self, epoch: EpochId) -> Result<Option<Arc<Committee>>> {
-        (**self).get_committee(epoch)
+    fn try_get_committee(&self, epoch: EpochId) -> Result<Option<Arc<Committee>>> {
+        (**self).try_get_committee(epoch)
     }
 
-    fn get_latest_checkpoint(&self) -> Result<VerifiedCheckpoint> {
-        (**self).get_latest_checkpoint()
+    fn try_get_latest_checkpoint(&self) -> Result<VerifiedCheckpoint> {
+        (**self).try_get_latest_checkpoint()
     }
 
-    fn get_latest_checkpoint_sequence_number(&self) -> Result<CheckpointSequenceNumber> {
-        (**self).get_latest_checkpoint_sequence_number()
+    fn try_get_latest_checkpoint_sequence_number(&self) -> Result<CheckpointSequenceNumber> {
+        (**self).try_get_latest_checkpoint_sequence_number()
     }
 
-    fn get_latest_epoch_id(&self) -> Result<EpochId> {
-        (**self).get_latest_epoch_id()
+    fn try_get_latest_epoch_id(&self) -> Result<EpochId> {
+        (**self).try_get_latest_epoch_id()
     }
 
-    fn get_highest_verified_checkpoint(&self) -> Result<VerifiedCheckpoint> {
-        (**self).get_highest_verified_checkpoint()
+    fn try_get_highest_verified_checkpoint(&self) -> Result<VerifiedCheckpoint> {
+        (**self).try_get_highest_verified_checkpoint()
     }
 
-    fn get_highest_synced_checkpoint(&self) -> Result<VerifiedCheckpoint> {
-        (**self).get_highest_synced_checkpoint()
+    fn try_get_highest_synced_checkpoint(&self) -> Result<VerifiedCheckpoint> {
+        (**self).try_get_highest_synced_checkpoint()
     }
 
-    fn get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber> {
-        (**self).get_lowest_available_checkpoint()
+    fn try_get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber> {
+        (**self).try_get_lowest_available_checkpoint()
     }
 
-    fn get_checkpoint_by_digest(
+    fn try_get_checkpoint_by_digest(
         &self,
         digest: &CheckpointDigest,
     ) -> Result<Option<VerifiedCheckpoint>> {
-        (**self).get_checkpoint_by_digest(digest)
+        (**self).try_get_checkpoint_by_digest(digest)
     }
 
-    fn get_checkpoint_by_sequence_number(
+    fn try_get_checkpoint_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Result<Option<VerifiedCheckpoint>> {
-        (**self).get_checkpoint_by_sequence_number(sequence_number)
+        (**self).try_get_checkpoint_by_sequence_number(sequence_number)
     }
 
-    fn get_checkpoint_contents_by_digest(
+    fn try_get_checkpoint_contents_by_digest(
         &self,
         digest: &CheckpointContentsDigest,
     ) -> Result<Option<CheckpointContents>> {
-        (**self).get_checkpoint_contents_by_digest(digest)
+        (**self).try_get_checkpoint_contents_by_digest(digest)
     }
 
-    fn get_checkpoint_contents_by_sequence_number(
+    fn try_get_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Result<Option<CheckpointContents>> {
-        (**self).get_checkpoint_contents_by_sequence_number(sequence_number)
+        (**self).try_get_checkpoint_contents_by_sequence_number(sequence_number)
     }
 
-    fn get_transaction(
+    fn try_get_transaction(
         &self,
         tx_digest: &TransactionDigest,
     ) -> Result<Option<Arc<VerifiedTransaction>>> {
-        (**self).get_transaction(tx_digest)
+        (**self).try_get_transaction(tx_digest)
     }
 
-    fn multi_get_transactions(
+    fn try_multi_get_transactions(
         &self,
         tx_digests: &[TransactionDigest],
     ) -> Result<Vec<Option<Arc<VerifiedTransaction>>>> {
-        (**self).multi_get_transactions(tx_digests)
+        (**self).try_multi_get_transactions(tx_digests)
     }
 
-    fn get_transaction_effects(
+    fn try_get_transaction_effects(
         &self,
         tx_digest: &TransactionDigest,
     ) -> Result<Option<TransactionEffects>> {
-        (**self).get_transaction_effects(tx_digest)
+        (**self).try_get_transaction_effects(tx_digest)
     }
 
-    fn multi_get_transaction_effects(
+    fn try_multi_get_transaction_effects(
         &self,
         tx_digests: &[TransactionDigest],
     ) -> Result<Vec<Option<TransactionEffects>>> {
-        (**self).multi_get_transaction_effects(tx_digests)
+        (**self).try_multi_get_transaction_effects(tx_digests)
     }
 
-    fn get_events(
+    fn try_get_events(
         &self,
         event_digest: &TransactionEventsDigest,
     ) -> Result<Option<TransactionEvents>> {
-        (**self).get_events(event_digest)
+        (**self).try_get_events(event_digest)
     }
 
-    fn multi_get_events(
+    fn try_multi_get_events(
         &self,
         event_digests: &[TransactionEventsDigest],
     ) -> Result<Vec<Option<TransactionEvents>>> {
-        (**self).multi_get_events(event_digests)
+        (**self).try_multi_get_events(event_digests)
     }
 
-    fn get_full_checkpoint_contents_by_sequence_number(
+    fn try_get_full_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Result<Option<FullCheckpointContents>> {
-        (**self).get_full_checkpoint_contents_by_sequence_number(sequence_number)
+        (**self).try_get_full_checkpoint_contents_by_sequence_number(sequence_number)
     }
 
-    fn get_full_checkpoint_contents(
+    fn try_get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
     ) -> Result<Option<FullCheckpointContents>> {
-        (**self).get_full_checkpoint_contents(digest)
+        (**self).try_get_full_checkpoint_contents(digest)
     }
 
-    fn get_checkpoint_data(
+    fn try_get_checkpoint_data(
         &self,
         checkpoint: VerifiedCheckpoint,
         checkpoint_contents: CheckpointContents,
     ) -> anyhow::Result<CheckpointData> {
-        (**self).get_checkpoint_data(checkpoint, checkpoint_contents)
+        (**self).try_get_checkpoint_data(checkpoint, checkpoint_contents)
     }
 }
 
 impl<T: ReadStore + ?Sized> ReadStore for Arc<T> {
-    fn get_committee(&self, epoch: EpochId) -> Result<Option<Arc<Committee>>> {
-        (**self).get_committee(epoch)
+    fn try_get_committee(&self, epoch: EpochId) -> Result<Option<Arc<Committee>>> {
+        (**self).try_get_committee(epoch)
     }
 
-    fn get_latest_checkpoint(&self) -> Result<VerifiedCheckpoint> {
-        (**self).get_latest_checkpoint()
+    fn try_get_latest_checkpoint(&self) -> Result<VerifiedCheckpoint> {
+        (**self).try_get_latest_checkpoint()
     }
 
-    fn get_latest_checkpoint_sequence_number(&self) -> Result<CheckpointSequenceNumber> {
-        (**self).get_latest_checkpoint_sequence_number()
+    fn try_get_latest_checkpoint_sequence_number(&self) -> Result<CheckpointSequenceNumber> {
+        (**self).try_get_latest_checkpoint_sequence_number()
     }
 
-    fn get_latest_epoch_id(&self) -> Result<EpochId> {
-        (**self).get_latest_epoch_id()
+    fn try_get_latest_epoch_id(&self) -> Result<EpochId> {
+        (**self).try_get_latest_epoch_id()
     }
 
-    fn get_highest_verified_checkpoint(&self) -> Result<VerifiedCheckpoint> {
-        (**self).get_highest_verified_checkpoint()
+    fn try_get_highest_verified_checkpoint(&self) -> Result<VerifiedCheckpoint> {
+        (**self).try_get_highest_verified_checkpoint()
     }
 
-    fn get_highest_synced_checkpoint(&self) -> Result<VerifiedCheckpoint> {
-        (**self).get_highest_synced_checkpoint()
+    fn try_get_highest_synced_checkpoint(&self) -> Result<VerifiedCheckpoint> {
+        (**self).try_get_highest_synced_checkpoint()
     }
 
-    fn get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber> {
-        (**self).get_lowest_available_checkpoint()
+    fn try_get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber> {
+        (**self).try_get_lowest_available_checkpoint()
     }
 
-    fn get_checkpoint_by_digest(
+    fn try_get_checkpoint_by_digest(
         &self,
         digest: &CheckpointDigest,
     ) -> Result<Option<VerifiedCheckpoint>> {
-        (**self).get_checkpoint_by_digest(digest)
+        (**self).try_get_checkpoint_by_digest(digest)
     }
 
-    fn get_checkpoint_by_sequence_number(
+    fn try_get_checkpoint_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Result<Option<VerifiedCheckpoint>> {
-        (**self).get_checkpoint_by_sequence_number(sequence_number)
+        (**self).try_get_checkpoint_by_sequence_number(sequence_number)
     }
 
-    fn get_checkpoint_contents_by_digest(
+    fn try_get_checkpoint_contents_by_digest(
         &self,
         digest: &CheckpointContentsDigest,
     ) -> Result<Option<CheckpointContents>> {
-        (**self).get_checkpoint_contents_by_digest(digest)
+        (**self).try_get_checkpoint_contents_by_digest(digest)
     }
 
-    fn get_checkpoint_contents_by_sequence_number(
+    fn try_get_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Result<Option<CheckpointContents>> {
-        (**self).get_checkpoint_contents_by_sequence_number(sequence_number)
+        (**self).try_get_checkpoint_contents_by_sequence_number(sequence_number)
     }
 
-    fn get_transaction(
+    fn try_get_transaction(
         &self,
         tx_digest: &TransactionDigest,
     ) -> Result<Option<Arc<VerifiedTransaction>>> {
-        (**self).get_transaction(tx_digest)
+        (**self).try_get_transaction(tx_digest)
     }
 
-    fn multi_get_transactions(
+    fn try_multi_get_transactions(
         &self,
         tx_digests: &[TransactionDigest],
     ) -> Result<Vec<Option<Arc<VerifiedTransaction>>>> {
-        (**self).multi_get_transactions(tx_digests)
+        (**self).try_multi_get_transactions(tx_digests)
     }
 
-    fn get_transaction_effects(
+    fn try_get_transaction_effects(
         &self,
         tx_digest: &TransactionDigest,
     ) -> Result<Option<TransactionEffects>> {
-        (**self).get_transaction_effects(tx_digest)
+        (**self).try_get_transaction_effects(tx_digest)
     }
 
-    fn multi_get_transaction_effects(
+    fn try_multi_get_transaction_effects(
         &self,
         tx_digests: &[TransactionDigest],
     ) -> Result<Vec<Option<TransactionEffects>>> {
-        (**self).multi_get_transaction_effects(tx_digests)
+        (**self).try_multi_get_transaction_effects(tx_digests)
     }
 
-    fn get_events(
+    fn try_get_events(
         &self,
         event_digest: &TransactionEventsDigest,
     ) -> Result<Option<TransactionEvents>> {
-        (**self).get_events(event_digest)
+        (**self).try_get_events(event_digest)
     }
 
-    fn multi_get_events(
+    fn try_multi_get_events(
         &self,
         event_digests: &[TransactionEventsDigest],
     ) -> Result<Vec<Option<TransactionEvents>>> {
-        (**self).multi_get_events(event_digests)
+        (**self).try_multi_get_events(event_digests)
     }
 
-    fn get_full_checkpoint_contents_by_sequence_number(
+    fn try_get_full_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Result<Option<FullCheckpointContents>> {
-        (**self).get_full_checkpoint_contents_by_sequence_number(sequence_number)
+        (**self).try_get_full_checkpoint_contents_by_sequence_number(sequence_number)
     }
 
-    fn get_full_checkpoint_contents(
+    fn try_get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
     ) -> Result<Option<FullCheckpointContents>> {
-        (**self).get_full_checkpoint_contents(digest)
+        (**self).try_get_full_checkpoint_contents(digest)
     }
 
-    fn get_checkpoint_data(
+    fn try_get_checkpoint_data(
         &self,
         checkpoint: VerifiedCheckpoint,
         checkpoint_contents: CheckpointContents,
     ) -> anyhow::Result<CheckpointData> {
-        (**self).get_checkpoint_data(checkpoint, checkpoint_contents)
+        (**self).try_get_checkpoint_data(checkpoint, checkpoint_contents)
     }
 }
 

--- a/crates/iota-types/src/storage/shared_in_memory_store.rs
+++ b/crates/iota-types/src/storage/shared_in_memory_store.rs
@@ -164,14 +164,14 @@ impl ReadStore for SharedInMemoryStore {
 }
 
 impl ObjectStore for SharedInMemoryStore {
-    fn get_object(
+    fn try_get_object(
         &self,
         _object_id: &crate::base_types::ObjectID,
     ) -> Result<Option<crate::object::Object>> {
         todo!()
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         _object_id: &crate::base_types::ObjectID,
         _version: crate::base_types::VersionNumber,
@@ -475,14 +475,14 @@ impl SingleCheckpointSharedInMemoryStore {
 }
 
 impl ObjectStore for SingleCheckpointSharedInMemoryStore {
-    fn get_object(
+    fn try_get_object(
         &self,
         _object_id: &crate::base_types::ObjectID,
     ) -> Result<Option<crate::object::Object>> {
         todo!()
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         _object_id: &crate::base_types::ObjectID,
         _version: crate::base_types::VersionNumber,

--- a/crates/iota-types/src/storage/shared_in_memory_store.rs
+++ b/crates/iota-types/src/storage/shared_in_memory_store.rs
@@ -35,7 +35,7 @@ impl SharedInMemoryStore {
 }
 
 impl ReadStore for SharedInMemoryStore {
-    fn get_checkpoint_by_digest(
+    fn try_get_checkpoint_by_digest(
         &self,
         digest: &CheckpointDigest,
     ) -> Result<Option<VerifiedCheckpoint>> {
@@ -45,7 +45,7 @@ impl ReadStore for SharedInMemoryStore {
             .pipe(Ok)
     }
 
-    fn get_checkpoint_by_sequence_number(
+    fn try_get_checkpoint_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Result<Option<VerifiedCheckpoint>> {
@@ -55,7 +55,7 @@ impl ReadStore for SharedInMemoryStore {
             .pipe(Ok)
     }
 
-    fn get_highest_verified_checkpoint(&self) -> Result<VerifiedCheckpoint> {
+    fn try_get_highest_verified_checkpoint(&self) -> Result<VerifiedCheckpoint> {
         self.inner()
             .get_highest_verified_checkpoint()
             .cloned()
@@ -63,7 +63,7 @@ impl ReadStore for SharedInMemoryStore {
             .pipe(Ok)
     }
 
-    fn get_highest_synced_checkpoint(&self) -> Result<VerifiedCheckpoint> {
+    fn try_get_highest_synced_checkpoint(&self) -> Result<VerifiedCheckpoint> {
         self.inner()
             .get_highest_synced_checkpoint()
             .cloned()
@@ -71,11 +71,11 @@ impl ReadStore for SharedInMemoryStore {
             .pipe(Ok)
     }
 
-    fn get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber> {
+    fn try_get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber> {
         Ok(self.inner().get_lowest_available_checkpoint())
     }
 
-    fn get_full_checkpoint_contents_by_sequence_number(
+    fn try_get_full_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Result<Option<FullCheckpointContents>> {
@@ -86,7 +86,7 @@ impl ReadStore for SharedInMemoryStore {
             .cloned())
     }
 
-    fn get_full_checkpoint_contents(
+    fn try_get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
     ) -> Result<Option<FullCheckpointContents>> {
@@ -109,7 +109,7 @@ impl ReadStore for SharedInMemoryStore {
             .map(|contents| contents.flatten())
     }
 
-    fn get_committee(&self, epoch: EpochId) -> Result<Option<Arc<Committee>>> {
+    fn try_get_committee(&self, epoch: EpochId) -> Result<Option<Arc<Committee>>> {
         self.inner()
             .get_committee_by_epoch(epoch)
             .cloned()
@@ -117,7 +117,7 @@ impl ReadStore for SharedInMemoryStore {
             .pipe(Ok)
     }
 
-    fn get_transaction(
+    fn try_get_transaction(
         &self,
         digest: &TransactionDigest,
     ) -> Result<Option<Arc<VerifiedTransaction>>> {
@@ -127,7 +127,7 @@ impl ReadStore for SharedInMemoryStore {
             .pipe(Ok)
     }
 
-    fn get_transaction_effects(
+    fn try_get_transaction_effects(
         &self,
         digest: &TransactionDigest,
     ) -> Result<Option<TransactionEffects>> {
@@ -137,25 +137,28 @@ impl ReadStore for SharedInMemoryStore {
             .pipe(Ok)
     }
 
-    fn get_events(&self, digest: &TransactionEventsDigest) -> Result<Option<TransactionEvents>> {
+    fn try_get_events(
+        &self,
+        digest: &TransactionEventsDigest,
+    ) -> Result<Option<TransactionEvents>> {
         self.inner()
             .get_transaction_events(digest)
             .cloned()
             .pipe(Ok)
     }
 
-    fn get_latest_checkpoint(&self) -> Result<VerifiedCheckpoint> {
+    fn try_get_latest_checkpoint(&self) -> Result<VerifiedCheckpoint> {
         todo!()
     }
 
-    fn get_checkpoint_contents_by_digest(
+    fn try_get_checkpoint_contents_by_digest(
         &self,
         _digest: &CheckpointContentsDigest,
     ) -> Result<Option<CheckpointContents>> {
         todo!()
     }
 
-    fn get_checkpoint_contents_by_sequence_number(
+    fn try_get_checkpoint_contents_by_sequence_number(
         &self,
         _sequence_number: CheckpointSequenceNumber,
     ) -> Result<Option<CheckpointContents>> {
@@ -492,81 +495,85 @@ impl ObjectStore for SingleCheckpointSharedInMemoryStore {
 }
 
 impl ReadStore for SingleCheckpointSharedInMemoryStore {
-    fn get_checkpoint_by_digest(
+    fn try_get_checkpoint_by_digest(
         &self,
         digest: &CheckpointDigest,
     ) -> Result<Option<VerifiedCheckpoint>> {
-        self.0.get_checkpoint_by_digest(digest)
+        self.0.try_get_checkpoint_by_digest(digest)
     }
 
-    fn get_checkpoint_by_sequence_number(
+    fn try_get_checkpoint_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Result<Option<VerifiedCheckpoint>> {
-        self.0.get_checkpoint_by_sequence_number(sequence_number)
+        self.0
+            .try_get_checkpoint_by_sequence_number(sequence_number)
     }
 
-    fn get_highest_verified_checkpoint(&self) -> Result<VerifiedCheckpoint> {
-        self.0.get_highest_verified_checkpoint()
+    fn try_get_highest_verified_checkpoint(&self) -> Result<VerifiedCheckpoint> {
+        self.0.try_get_highest_verified_checkpoint()
     }
 
-    fn get_highest_synced_checkpoint(&self) -> Result<VerifiedCheckpoint> {
-        self.0.get_highest_synced_checkpoint()
+    fn try_get_highest_synced_checkpoint(&self) -> Result<VerifiedCheckpoint> {
+        self.0.try_get_highest_synced_checkpoint()
     }
 
-    fn get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber> {
-        self.0.get_lowest_available_checkpoint()
+    fn try_get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber> {
+        self.0.try_get_lowest_available_checkpoint()
     }
 
-    fn get_full_checkpoint_contents_by_sequence_number(
+    fn try_get_full_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
     ) -> Result<Option<FullCheckpointContents>> {
         self.0
-            .get_full_checkpoint_contents_by_sequence_number(sequence_number)
+            .try_get_full_checkpoint_contents_by_sequence_number(sequence_number)
     }
 
-    fn get_full_checkpoint_contents(
+    fn try_get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
     ) -> Result<Option<FullCheckpointContents>> {
-        self.0.get_full_checkpoint_contents(digest)
+        self.0.try_get_full_checkpoint_contents(digest)
     }
 
-    fn get_committee(&self, epoch: EpochId) -> Result<Option<Arc<Committee>>> {
-        self.0.get_committee(epoch)
+    fn try_get_committee(&self, epoch: EpochId) -> Result<Option<Arc<Committee>>> {
+        self.0.try_get_committee(epoch)
     }
 
-    fn get_transaction(
+    fn try_get_transaction(
         &self,
         digest: &TransactionDigest,
     ) -> Result<Option<Arc<VerifiedTransaction>>> {
-        self.0.get_transaction(digest)
+        self.0.try_get_transaction(digest)
     }
 
-    fn get_transaction_effects(
+    fn try_get_transaction_effects(
         &self,
         digest: &TransactionDigest,
     ) -> Result<Option<TransactionEffects>> {
-        self.0.get_transaction_effects(digest)
+        self.0.try_get_transaction_effects(digest)
     }
 
-    fn get_events(&self, digest: &TransactionEventsDigest) -> Result<Option<TransactionEvents>> {
-        self.0.get_events(digest)
+    fn try_get_events(
+        &self,
+        digest: &TransactionEventsDigest,
+    ) -> Result<Option<TransactionEvents>> {
+        self.0.try_get_events(digest)
     }
 
-    fn get_latest_checkpoint(&self) -> Result<VerifiedCheckpoint> {
+    fn try_get_latest_checkpoint(&self) -> Result<VerifiedCheckpoint> {
         todo!()
     }
 
-    fn get_checkpoint_contents_by_digest(
+    fn try_get_checkpoint_contents_by_digest(
         &self,
         _digest: &CheckpointContentsDigest,
     ) -> Result<Option<CheckpointContents>> {
         todo!()
     }
 
-    fn get_checkpoint_contents_by_sequence_number(
+    fn try_get_checkpoint_contents_by_sequence_number(
         &self,
         _sequence_number: CheckpointSequenceNumber,
     ) -> Result<Option<CheckpointContents>> {

--- a/crates/iota-types/src/storage/shared_in_memory_store.rs
+++ b/crates/iota-types/src/storage/shared_in_memory_store.rs
@@ -184,24 +184,27 @@ impl ObjectStore for SharedInMemoryStore {
 }
 
 impl WriteStore for SharedInMemoryStore {
-    fn insert_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
+    fn try_insert_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
         self.inner_mut().insert_checkpoint(checkpoint);
         Ok(())
     }
 
-    fn update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
+    fn try_update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
         self.inner_mut()
             .update_highest_synced_checkpoint(checkpoint);
         Ok(())
     }
 
-    fn update_highest_verified_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
+    fn try_update_highest_verified_checkpoint(
+        &self,
+        checkpoint: &VerifiedCheckpoint,
+    ) -> Result<()> {
         self.inner_mut()
             .update_highest_verified_checkpoint(checkpoint);
         Ok(())
     }
 
-    fn insert_checkpoint_contents(
+    fn try_insert_checkpoint_contents(
         &self,
         checkpoint: &VerifiedCheckpoint,
         contents: VerifiedCheckpointContents,
@@ -211,7 +214,7 @@ impl WriteStore for SharedInMemoryStore {
         Ok(())
     }
 
-    fn insert_committee(&self, new_committee: Committee) -> Result<()> {
+    fn try_insert_committee(&self, new_committee: Committee) -> Result<()> {
         self.inner_mut().insert_committee(new_committee);
         Ok(())
     }
@@ -582,27 +585,30 @@ impl ReadStore for SingleCheckpointSharedInMemoryStore {
 }
 
 impl WriteStore for SingleCheckpointSharedInMemoryStore {
-    fn insert_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
+    fn try_insert_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
         {
             let mut locked = self.0.0.write().unwrap();
             locked.checkpoints.clear();
             locked.sequence_number_to_digest.clear();
         }
-        self.0.insert_checkpoint(checkpoint)?;
+        self.0.try_insert_checkpoint(checkpoint)?;
         Ok(())
     }
 
-    fn update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
-        self.0.update_highest_synced_checkpoint(checkpoint)?;
+    fn try_update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
+        self.0.try_update_highest_synced_checkpoint(checkpoint)?;
         Ok(())
     }
 
-    fn update_highest_verified_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
-        self.0.update_highest_verified_checkpoint(checkpoint)?;
+    fn try_update_highest_verified_checkpoint(
+        &self,
+        checkpoint: &VerifiedCheckpoint,
+    ) -> Result<()> {
+        self.0.try_update_highest_verified_checkpoint(checkpoint)?;
         Ok(())
     }
 
-    fn insert_checkpoint_contents(
+    fn try_insert_checkpoint_contents(
         &self,
         checkpoint: &VerifiedCheckpoint,
         contents: VerifiedCheckpointContents,
@@ -615,11 +621,12 @@ impl WriteStore for SingleCheckpointSharedInMemoryStore {
             locked.full_checkpoint_contents.clear();
             locked.checkpoint_contents.clear();
         }
-        self.0.insert_checkpoint_contents(checkpoint, contents)?;
+        self.0
+            .try_insert_checkpoint_contents(checkpoint, contents)?;
         Ok(())
     }
 
-    fn insert_committee(&self, new_committee: Committee) -> Result<()> {
-        self.0.insert_committee(new_committee)
+    fn try_insert_committee(&self, new_committee: Committee) -> Result<()> {
+        self.0.try_insert_committee(new_committee)
     }
 }

--- a/crates/iota-types/src/storage/write_store.rs
+++ b/crates/iota-types/src/storage/write_store.rs
@@ -12,92 +12,102 @@ use crate::{
 };
 
 pub trait WriteStore: ReadStore {
-    fn insert_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()>;
-    fn update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()>;
-    fn update_highest_verified_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()>;
-    fn insert_checkpoint_contents(
+    fn try_insert_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()>;
+    fn try_update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()>;
+    fn try_update_highest_verified_checkpoint(&self, checkpoint: &VerifiedCheckpoint)
+    -> Result<()>;
+    fn try_insert_checkpoint_contents(
         &self,
         checkpoint: &VerifiedCheckpoint,
         contents: VerifiedCheckpointContents,
     ) -> Result<()>;
 
-    fn insert_committee(&self, new_committee: Committee) -> Result<()>;
+    fn try_insert_committee(&self, new_committee: Committee) -> Result<()>;
 }
 
 impl<T: WriteStore + ?Sized> WriteStore for &T {
-    fn insert_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
-        (*self).insert_checkpoint(checkpoint)
+    fn try_insert_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
+        (*self).try_insert_checkpoint(checkpoint)
     }
 
-    fn update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
-        (*self).update_highest_synced_checkpoint(checkpoint)
+    fn try_update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
+        (*self).try_update_highest_synced_checkpoint(checkpoint)
     }
 
-    fn update_highest_verified_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
-        (*self).update_highest_verified_checkpoint(checkpoint)
+    fn try_update_highest_verified_checkpoint(
+        &self,
+        checkpoint: &VerifiedCheckpoint,
+    ) -> Result<()> {
+        (*self).try_update_highest_verified_checkpoint(checkpoint)
     }
 
-    fn insert_checkpoint_contents(
+    fn try_insert_checkpoint_contents(
         &self,
         checkpoint: &VerifiedCheckpoint,
         contents: VerifiedCheckpointContents,
     ) -> Result<()> {
-        (*self).insert_checkpoint_contents(checkpoint, contents)
+        (*self).try_insert_checkpoint_contents(checkpoint, contents)
     }
 
-    fn insert_committee(&self, new_committee: Committee) -> Result<()> {
-        (*self).insert_committee(new_committee)
+    fn try_insert_committee(&self, new_committee: Committee) -> Result<()> {
+        (*self).try_insert_committee(new_committee)
     }
 }
 
 impl<T: WriteStore + ?Sized> WriteStore for Box<T> {
-    fn insert_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
-        (**self).insert_checkpoint(checkpoint)
+    fn try_insert_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
+        (**self).try_insert_checkpoint(checkpoint)
     }
 
-    fn update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
-        (**self).update_highest_synced_checkpoint(checkpoint)
+    fn try_update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
+        (**self).try_update_highest_synced_checkpoint(checkpoint)
     }
 
-    fn update_highest_verified_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
-        (**self).update_highest_verified_checkpoint(checkpoint)
+    fn try_update_highest_verified_checkpoint(
+        &self,
+        checkpoint: &VerifiedCheckpoint,
+    ) -> Result<()> {
+        (**self).try_update_highest_verified_checkpoint(checkpoint)
     }
 
-    fn insert_checkpoint_contents(
+    fn try_insert_checkpoint_contents(
         &self,
         checkpoint: &VerifiedCheckpoint,
         contents: VerifiedCheckpointContents,
     ) -> Result<()> {
-        (**self).insert_checkpoint_contents(checkpoint, contents)
+        (**self).try_insert_checkpoint_contents(checkpoint, contents)
     }
 
-    fn insert_committee(&self, new_committee: Committee) -> Result<()> {
-        (**self).insert_committee(new_committee)
+    fn try_insert_committee(&self, new_committee: Committee) -> Result<()> {
+        (**self).try_insert_committee(new_committee)
     }
 }
 
 impl<T: WriteStore + ?Sized> WriteStore for Arc<T> {
-    fn insert_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
-        (**self).insert_checkpoint(checkpoint)
+    fn try_insert_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
+        (**self).try_insert_checkpoint(checkpoint)
     }
 
-    fn update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
-        (**self).update_highest_synced_checkpoint(checkpoint)
+    fn try_update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
+        (**self).try_update_highest_synced_checkpoint(checkpoint)
     }
 
-    fn update_highest_verified_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<()> {
-        (**self).update_highest_verified_checkpoint(checkpoint)
+    fn try_update_highest_verified_checkpoint(
+        &self,
+        checkpoint: &VerifiedCheckpoint,
+    ) -> Result<()> {
+        (**self).try_update_highest_verified_checkpoint(checkpoint)
     }
 
-    fn insert_checkpoint_contents(
+    fn try_insert_checkpoint_contents(
         &self,
         checkpoint: &VerifiedCheckpoint,
         contents: VerifiedCheckpointContents,
     ) -> Result<()> {
-        (**self).insert_checkpoint_contents(checkpoint, contents)
+        (**self).try_insert_checkpoint_contents(checkpoint, contents)
     }
 
-    fn insert_committee(&self, new_committee: Committee) -> Result<()> {
-        (**self).insert_committee(new_committee)
+    fn try_insert_committee(&self, new_committee: Committee) -> Result<()> {
+        (**self).try_insert_committee(new_committee)
     }
 }

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -433,19 +433,19 @@ impl ValidatorKeypairProvider for CommitteeWithKeys<'_> {
 }
 
 impl<T, V: store::SimulatorStore> ObjectStore for Simulacrum<T, V> {
-    fn get_object(
+    fn try_get_object(
         &self,
         object_id: &ObjectID,
     ) -> Result<Option<Object>, iota_types::storage::error::Error> {
         Ok(store::SimulatorStore::get_object(&self.store, object_id))
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
     ) -> Result<Option<Object>, iota_types::storage::error::Error> {
-        self.store.get_object_by_key(object_id, version)
+        self.store.try_get_object_by_key(object_id, version)
     }
 }
 

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -395,7 +395,7 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     ) -> anyhow::Result<()> {
         if let Some(path) = &self.data_ingestion_path {
             let file_name = format!("{}.chk", checkpoint.sequence_number);
-            let checkpoint_data = self.get_checkpoint_data(checkpoint, checkpoint_contents)?;
+            let checkpoint_data = self.try_get_checkpoint_data(checkpoint, checkpoint_contents)?;
             std::fs::create_dir_all(path)?;
             let blob = Blob::encode(&checkpoint_data, BlobEncoding::Bcs)?;
             std::fs::write(path.join(file_name), blob.to_bytes())?;
@@ -450,30 +450,30 @@ impl<T, V: store::SimulatorStore> ObjectStore for Simulacrum<T, V> {
 }
 
 impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
-    fn get_committee(
+    fn try_get_committee(
         &self,
         _epoch: iota_types::committee::EpochId,
     ) -> iota_types::storage::error::Result<Option<std::sync::Arc<Committee>>> {
         todo!()
     }
 
-    fn get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
+    fn try_get_latest_checkpoint(&self) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
         Ok(self.store().get_highest_checkpoint().unwrap())
     }
 
-    fn get_highest_verified_checkpoint(
+    fn try_get_highest_verified_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
         todo!()
     }
 
-    fn get_highest_synced_checkpoint(
+    fn try_get_highest_synced_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<VerifiedCheckpoint> {
         todo!()
     }
 
-    fn get_lowest_available_checkpoint(
+    fn try_get_lowest_available_checkpoint(
         &self,
     ) -> iota_types::storage::error::Result<iota_types::messages_checkpoint::CheckpointSequenceNumber>
     {
@@ -482,14 +482,14 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
         Ok(0)
     }
 
-    fn get_checkpoint_by_digest(
+    fn try_get_checkpoint_by_digest(
         &self,
         digest: &iota_types::messages_checkpoint::CheckpointDigest,
     ) -> iota_types::storage::error::Result<Option<VerifiedCheckpoint>> {
         Ok(self.store().get_checkpoint_by_digest(digest))
     }
 
-    fn get_checkpoint_by_sequence_number(
+    fn try_get_checkpoint_by_sequence_number(
         &self,
         sequence_number: iota_types::messages_checkpoint::CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<Option<VerifiedCheckpoint>> {
@@ -498,7 +498,7 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
             .get_checkpoint_by_sequence_number(sequence_number))
     }
 
-    fn get_checkpoint_contents_by_digest(
+    fn try_get_checkpoint_contents_by_digest(
         &self,
         digest: &iota_types::messages_checkpoint::CheckpointContentsDigest,
     ) -> iota_types::storage::error::Result<
@@ -507,7 +507,7 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
         Ok(self.store().get_checkpoint_contents(digest))
     }
 
-    fn get_checkpoint_contents_by_sequence_number(
+    fn try_get_checkpoint_contents_by_sequence_number(
         &self,
         _sequence_number: iota_types::messages_checkpoint::CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<
@@ -516,28 +516,28 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
         todo!()
     }
 
-    fn get_transaction(
+    fn try_get_transaction(
         &self,
         tx_digest: &iota_types::digests::TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<Arc<VerifiedTransaction>>> {
         Ok(self.store().get_transaction(tx_digest).map(Arc::new))
     }
 
-    fn get_transaction_effects(
+    fn try_get_transaction_effects(
         &self,
         tx_digest: &iota_types::digests::TransactionDigest,
     ) -> iota_types::storage::error::Result<Option<TransactionEffects>> {
         Ok(self.store().get_transaction_effects(tx_digest))
     }
 
-    fn get_events(
+    fn try_get_events(
         &self,
         event_digest: &iota_types::digests::TransactionEventsDigest,
     ) -> iota_types::storage::error::Result<Option<iota_types::effects::TransactionEvents>> {
         Ok(self.store().get_transaction_events(event_digest))
     }
 
-    fn get_full_checkpoint_contents_by_sequence_number(
+    fn try_get_full_checkpoint_contents_by_sequence_number(
         &self,
         _sequence_number: iota_types::messages_checkpoint::CheckpointSequenceNumber,
     ) -> iota_types::storage::error::Result<
@@ -546,7 +546,7 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
         todo!()
     }
 
-    fn get_full_checkpoint_contents(
+    fn try_get_full_checkpoint_contents(
         &self,
         _digest: &iota_types::messages_checkpoint::CheckpointContentsDigest,
     ) -> iota_types::storage::error::Result<

--- a/crates/simulacrum/src/store/in_mem_store.rs
+++ b/crates/simulacrum/src/store/in_mem_store.rs
@@ -310,14 +310,14 @@ impl ModuleResolver for InMemoryStore {
 }
 
 impl ObjectStore for InMemoryStore {
-    fn get_object(
+    fn try_get_object(
         &self,
         object_id: &ObjectID,
     ) -> Result<Option<Object>, iota_types::storage::error::Error> {
         Ok(self.get_object(object_id).cloned())
     }
 
-    fn get_object_by_key(
+    fn try_get_object_by_key(
         &self,
         object_id: &ObjectID,
         version: iota_types::base_types::VersionNumber,

--- a/crates/simulacrum/src/store/mod.rs
+++ b/crates/simulacrum/src/store/mod.rs
@@ -134,7 +134,7 @@ pub trait SimulatorStore:
                     crate::store::SimulatorStore::get_object(self, id)
                 }
                 InputObjectKind::ImmOrOwnedMoveObject(objref) => {
-                    self.get_object_by_key(&objref.0, objref.1)?
+                    self.try_get_object_by_key(&objref.0, objref.1)?
                 }
 
                 InputObjectKind::SharedMoveObject { id, .. } => {

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -533,7 +533,7 @@ impl TestCluster {
                         let digest = *tx.transaction_digest();
                         let tx = state
                             .get_transaction_cache_reader()
-                            .get_transaction_block(&digest)
+                            .try_get_transaction_block(&digest)
                             .unwrap()
                             .unwrap();
                         match &tx.data().intent_message().value.kind() {

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -278,7 +278,7 @@ impl TestCluster {
             .iota_node
             .state()
             .get_object_cache_reader()
-            .get_latest_object_ref_or_tombstone(object_id)
+            .try_get_latest_object_ref_or_tombstone(object_id)
             .unwrap()
             .unwrap()
     }

--- a/crates/transaction-fuzzer/src/account_universe.rs
+++ b/crates/transaction-fuzzer/src/account_universe.rs
@@ -136,7 +136,10 @@ pub fn assert_accounts_match(
         .type_layout_resolver(Box::new(backing_package_store.as_ref()));
     for (idx, account) in universe.accounts().iter().enumerate() {
         for (balance_idx, acc_object) in account.current_coins.iter().enumerate() {
-            let object = object_store.get_object(&acc_object.id()).unwrap().unwrap();
+            let object = object_store
+                .try_get_object(&acc_object.id())
+                .unwrap()
+                .unwrap();
             let total_iota_value =
                 object.get_total_iota(layout_resolver.as_mut()).unwrap() - object.storage_rebate;
             let account_balance_i = account.current_balances[balance_idx];

--- a/iota-execution/latest/iota-adapter/src/temporary_store.rs
+++ b/iota-execution/latest/iota-adapter/src/temporary_store.rs
@@ -608,7 +608,7 @@ impl TemporaryStore<'_> {
                 // For example, the ID is for a wrapped table or bag.
                 *container_id
             } else {
-                let Some(old_obj) = self.store.get_object(&to_authenticate)? else {
+                let Some(old_obj) = self.store.try_get_object(&to_authenticate)? else {
                     panic!(
                         "
                         Failed to load object {to_authenticate:?}. \n\
@@ -786,7 +786,7 @@ impl TemporaryStore<'_> {
             })
         } else {
             // not in input objects, must be a dynamic field
-            let Ok(Some(obj)) = self.store.get_object_by_key(id, expected_version) else {
+            let Ok(Some(obj)) = self.store.try_get_object_by_key(id, expected_version) else {
                 invariant_violation!(
                     "Failed looking up dynamic field {id} in IOTA conservation checking"
                 );


### PR DESCRIPTION
# Description of change

We want to add non-fallible functions to the storage traits, but therefore we need to clean up the existing interfaces first.
This PR is prefixing all fallible function in the stores and caches with `try_`.
This PR is renaming functions only, there are no changes of the logic. The fallible functions will be added in a follow-up PR.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes