### PR TITLE
chore: rename `IotaNamesRegistration` to `NameRegistration`

### DIFF
--- a/crates/iota-graphql-rpc/schema.graphql
+++ b/crates/iota-graphql-rpc/schema.graphql
@@ -95,10 +95,10 @@ type Address implements IOwner {
 	"""
 	iotaNamesDefaultName(format: NameFormat): String
 	"""
-	The IotaNamesRegistration NFTs owned by this address. These grant the
+	The NameRegistration NFTs owned by this address. These grant the
 	owner the capability to manage the associated name.
 	"""
-	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): IotaNamesRegistrationConnection!
+	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): NameRegistrationConnection!
 	"""
 	Similar behavior to the `transactionBlocks` in Query but supporting the
 	additional `AddressTransactionBlockRelationship` filter, which
@@ -591,10 +591,10 @@ type Coin implements IMoveObject & IObject & IOwner {
 	"""
 	iotaNamesDefaultName(format: NameFormat): String
 	"""
-	The IotaNamesRegistration NFTs owned by this object. These grant the
+	The NameRegistration NFTs owned by this object. These grant the
 	owner the capability to manage the associated name.
 	"""
-	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): IotaNamesRegistrationConnection!
+	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): NameRegistrationConnection!
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
@@ -768,10 +768,10 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
 	"""
 	iotaNamesDefaultName(format: NameFormat): String
 	"""
-	The IotaNamesRegistration NFTs owned by this object. These grant the
+	The NameRegistration NFTs owned by this object. These grant the
 	owner the capability to manage the associated name.
 	"""
-	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): IotaNamesRegistrationConnection!
+	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): NameRegistrationConnection!
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
@@ -1658,9 +1658,9 @@ interface IOwner {
 	"""
 	iotaNamesDefaultName(format: NameFormat): String
 	"""
-	The IotaNamesRegistration NFTs owned by this object or address. These grant the owner the capability to manage the associated name.
+	The NameRegistration NFTs owned by this object or address. These grant the owner the capability to manage the associated name.
 	"""
-	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): IotaNamesRegistrationConnection!
+	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): NameRegistrationConnection!
 }
 
 """
@@ -1686,187 +1686,6 @@ type Input {
 String containing 32B hex-encoded address, with a leading "0x". Leading zeroes can be omitted on input but will always appear in outputs (IotaAddress in output is guaranteed to be 66 characters long).
 """
 scalar IotaAddress
-
-type IotaNamesRegistration implements IMoveObject & IOwner {
-	address: IotaAddress!
-	"""
-	Objects owned by this object, optionally `filter`-ed.
-	"""
-	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection!
-	"""
-	Total balance of all coins with marker type owned by this object. If
-	type is not supplied, it defaults to `0x2::iota::IOTA`.
-	"""
-	balance(type: String): Balance
-	"""
-	The balances of all coin types owned by this object.
-	"""
-	balances(first: Int, after: String, last: Int, before: String): BalanceConnection!
-	"""
-	The coin objects for this object.
-	
-	`type` is a filter on the coin's type parameter, defaulting to
-	`0x2::iota::IOTA`.
-	"""
-	coins(first: Int, after: String, last: Int, before: String, type: String): CoinConnection!
-	"""
-	The `0x3::staking_pool::StakedIota` objects owned by this object.
-	"""
-	stakedIotas(first: Int, after: String, last: Int, before: String): StakedIotaConnection!
-	"""
-	The name explicitly configured as the default name pointing to this
-	object.
-	"""
-	iotaNamesDefaultName(format: NameFormat): String
-	"""
-	The IotaNamesRegistration NFTs owned by this object. These grant the
-	owner the capability to manage the associated name.
-	"""
-	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): IotaNamesRegistrationConnection!
-	version: UInt53!
-	"""
-	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
-	"""
-	status: ObjectKind!
-	"""
-	32-byte hash that identifies the object's contents, encoded as a Base58
-	string.
-	"""
-	digest: String
-	"""
-	The owner type of this object: Immutable, Shared, Parent, Address
-	"""
-	owner: ObjectOwner
-	"""
-	The transaction block that created this version of the object.
-	"""
-	previousTransactionBlock: TransactionBlock
-	"""
-	The amount of IOTA we would rebate if this object gets deleted or
-	mutated. This number is recalculated based on the present storage
-	gas price.
-	"""
-	storageRebate: BigInt
-	"""
-	The transaction blocks that sent objects to this object.
-	
-	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
-	
-	When the scan limit is reached the page will be returned even if it has
-	fewer than `first` results when paginating forward (`last` when
-	paginating backwards). If there are more transactions to scan,
-	`pageInfo.hasNextPage` (or `pageInfo.hasPreviousPage`) will be set to
-	`true`, and `PageInfo.endCursor` (or `PageInfo.startCursor`) will be set
-	to the last transaction that was scanned as opposed to the last (or
-	first) transaction in the page.
-	
-	Requesting the next (or previous) page after this cursor will resume the
-	search, scanning the next `scanLimit` many transactions in the
-	direction of pagination, and so on until all transactions in the
-	scanning range have been visited.
-	
-	By default, the scanning range includes all transactions known to
-	GraphQL, but it can be restricted by the `after` and `before`
-	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
-	`atCheckpoint` filters.
-	"""
-	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
-	"""
-	The Base64-encoded BCS serialization of the object's content.
-	"""
-	bcs: Base64
-	"""
-	Displays the contents of the Move object in a JSON string and through
-	GraphQL types. Also provides the flat representation of the type
-	signature, and the BCS of the corresponding data.
-	"""
-	contents: MoveValue
-	"""
-	Determines whether a transaction can transfer this object, using the
-	TransferObjects transaction command or
-	`iota::transfer::public_transfer`, both of which require the object to
-	have the `key` and `store` abilities.
-	"""
-	hasPublicTransfer: Boolean!
-	"""
-	The set of named templates defined on-chain for the type of this object,
-	to be handled off-chain. The server substitutes data from the object
-	into these templates to generate a display string per template.
-	"""
-	display: [DisplayEntry!]
-	"""
-	Access a dynamic field on an object using its name. Names are arbitrary
-	Move values whose type have `copy`, `drop`, and `store`, and are
-	specified using their type, and their BCS contents, Base64 encoded.
-	
-	Dynamic fields on wrapped objects can be accessed by using the same API
-	under the Owner type.
-	"""
-	dynamicField(name: DynamicFieldName!): DynamicField
-	"""
-	Access a dynamic object field on an object using its name. Names are
-	arbitrary Move values whose type have `copy`, `drop`, and `store`,
-	and are specified using their type, and their BCS contents, Base64
-	encoded. The value of a dynamic object field can also be accessed
-	off-chain directly via its address (e.g. using `Query.object`).
-	
-	Dynamic fields on wrapped objects can be accessed by using the same API
-	under the Owner type.
-	"""
-	dynamicObjectField(name: DynamicFieldName!): DynamicField
-	"""
-	The dynamic fields and dynamic object fields on an object.
-	
-	Dynamic fields on wrapped objects can be accessed by using the same API
-	under the Owner type.
-	"""
-	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection!
-	"""
-	Name of the IotaNamesRegistration object
-	"""
-	name: String!
-}
-
-type IotaNamesRegistrationConnection {
-	"""
-	Information to aid in pagination.
-	"""
-	pageInfo: PageInfo!
-	"""
-	A list of edges.
-	"""
-	edges: [IotaNamesRegistrationEdge!]!
-	"""
-	A list of nodes.
-	"""
-	nodes: [IotaNamesRegistration!]!
-}
-
-"""
-An edge in a connection.
-"""
-type IotaNamesRegistrationEdge {
-	"""
-	The item at the end of the edge
-	"""
-	node: IotaNamesRegistration!
-	"""
-	A cursor for use in pagination
-	"""
-	cursor: String!
-}
 
 """
 Arbitrary JSON data.
@@ -2323,10 +2142,10 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	"""
 	iotaNamesDefaultName(format: NameFormat): String
 	"""
-	The IotaNamesRegistration NFTs owned by this object. These grant the
+	The NameRegistration NFTs owned by this object. These grant the
 	owner the capability to manage the associated name.
 	"""
-	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): IotaNamesRegistrationConnection!
+	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): NameRegistrationConnection!
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
@@ -2443,7 +2262,7 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	Attempts to convert the Move object into a `0x2::coin::CoinMetadata`.
 	"""
 	asCoinMetadata: CoinMetadata
-	asIotaNamesRegistration: IotaNamesRegistration
+	asIotaNamesRegistration: NameRegistration
 }
 
 type MoveObjectConnection {
@@ -2527,13 +2346,13 @@ type MovePackage implements IObject & IOwner {
 	"""
 	iotaNamesDefaultName(format: NameFormat): String
 	"""
-	The IotaNamesRegistration NFTs owned by this package. These grant the
+	The NameRegistration NFTs owned by this package. These grant the
 	owner the capability to manage the associated name.
 	
 	Note that objects owned by a package are inaccessible, because packages
 	are immutable and cannot be owned by an address.
 	"""
-	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): IotaNamesRegistrationConnection!
+	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): NameRegistrationConnection!
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
@@ -2925,6 +2744,187 @@ enum NameFormat {
 	DOT
 }
 
+type NameRegistration implements IMoveObject & IOwner {
+	address: IotaAddress!
+	"""
+	Objects owned by this object, optionally `filter`-ed.
+	"""
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection!
+	"""
+	Total balance of all coins with marker type owned by this object. If
+	type is not supplied, it defaults to `0x2::iota::IOTA`.
+	"""
+	balance(type: String): Balance
+	"""
+	The balances of all coin types owned by this object.
+	"""
+	balances(first: Int, after: String, last: Int, before: String): BalanceConnection!
+	"""
+	The coin objects for this object.
+	
+	`type` is a filter on the coin's type parameter, defaulting to
+	`0x2::iota::IOTA`.
+	"""
+	coins(first: Int, after: String, last: Int, before: String, type: String): CoinConnection!
+	"""
+	The `0x3::staking_pool::StakedIota` objects owned by this object.
+	"""
+	stakedIotas(first: Int, after: String, last: Int, before: String): StakedIotaConnection!
+	"""
+	The name explicitly configured as the default name pointing to this
+	object.
+	"""
+	iotaNamesDefaultName(format: NameFormat): String
+	"""
+	The NameRegistration NFTs owned by this object. These grant the
+	owner the capability to manage the associated name.
+	"""
+	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): NameRegistrationConnection!
+	version: UInt53!
+	"""
+	The current status of the object as read from the off-chain store. The
+	possible states are: NOT_INDEXED, the object is loaded from
+	serialized data, such as the contents of a genesis or system package
+	upgrade transaction. LIVE, the version returned is the most recent for
+	the object, and it is not deleted or wrapped at that version.
+	HISTORICAL, the object was referenced at a specific version or
+	checkpoint, so is fetched from historical tables and may not be the
+	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
+	or wrapped and only partial information can be loaded."
+	"""
+	status: ObjectKind!
+	"""
+	32-byte hash that identifies the object's contents, encoded as a Base58
+	string.
+	"""
+	digest: String
+	"""
+	The owner type of this object: Immutable, Shared, Parent, Address
+	"""
+	owner: ObjectOwner
+	"""
+	The transaction block that created this version of the object.
+	"""
+	previousTransactionBlock: TransactionBlock
+	"""
+	The amount of IOTA we would rebate if this object gets deleted or
+	mutated. This number is recalculated based on the present storage
+	gas price.
+	"""
+	storageRebate: BigInt
+	"""
+	The transaction blocks that sent objects to this object.
+	
+	`scanLimit` restricts the number of candidate transactions scanned when
+	gathering a page of results. It is required for queries that apply
+	more than two complex filters (on function, kind, sender, recipient,
+	input object, changed object, or ids), and can be at most
+	`serviceConfig.maxScanLimit`.
+	
+	When the scan limit is reached the page will be returned even if it has
+	fewer than `first` results when paginating forward (`last` when
+	paginating backwards). If there are more transactions to scan,
+	`pageInfo.hasNextPage` (or `pageInfo.hasPreviousPage`) will be set to
+	`true`, and `PageInfo.endCursor` (or `PageInfo.startCursor`) will be set
+	to the last transaction that was scanned as opposed to the last (or
+	first) transaction in the page.
+	
+	Requesting the next (or previous) page after this cursor will resume the
+	search, scanning the next `scanLimit` many transactions in the
+	direction of pagination, and so on until all transactions in the
+	scanning range have been visited.
+	
+	By default, the scanning range includes all transactions known to
+	GraphQL, but it can be restricted by the `after` and `before`
+	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
+	`atCheckpoint` filters.
+	"""
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	"""
+	The Base64-encoded BCS serialization of the object's content.
+	"""
+	bcs: Base64
+	"""
+	Displays the contents of the Move object in a JSON string and through
+	GraphQL types. Also provides the flat representation of the type
+	signature, and the BCS of the corresponding data.
+	"""
+	contents: MoveValue
+	"""
+	Determines whether a transaction can transfer this object, using the
+	TransferObjects transaction command or
+	`iota::transfer::public_transfer`, both of which require the object to
+	have the `key` and `store` abilities.
+	"""
+	hasPublicTransfer: Boolean!
+	"""
+	The set of named templates defined on-chain for the type of this object,
+	to be handled off-chain. The server substitutes data from the object
+	into these templates to generate a display string per template.
+	"""
+	display: [DisplayEntry!]
+	"""
+	Access a dynamic field on an object using its name. Names are arbitrary
+	Move values whose type have `copy`, `drop`, and `store`, and are
+	specified using their type, and their BCS contents, Base64 encoded.
+	
+	Dynamic fields on wrapped objects can be accessed by using the same API
+	under the Owner type.
+	"""
+	dynamicField(name: DynamicFieldName!): DynamicField
+	"""
+	Access a dynamic object field on an object using its name. Names are
+	arbitrary Move values whose type have `copy`, `drop`, and `store`,
+	and are specified using their type, and their BCS contents, Base64
+	encoded. The value of a dynamic object field can also be accessed
+	off-chain directly via its address (e.g. using `Query.object`).
+	
+	Dynamic fields on wrapped objects can be accessed by using the same API
+	under the Owner type.
+	"""
+	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	"""
+	The dynamic fields and dynamic object fields on an object.
+	
+	Dynamic fields on wrapped objects can be accessed by using the same API
+	under the Owner type.
+	"""
+	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection!
+	"""
+	Name of the NameRegistration object
+	"""
+	name: String!
+}
+
+type NameRegistrationConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [NameRegistrationEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [NameRegistration!]!
+}
+
+"""
+An edge in a connection.
+"""
+type NameRegistrationEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: NameRegistration!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 """
 An object in IOTA is a package (set of Move bytecode modules) or object
 (typed data structure with fields) with additional metadata detailing its
@@ -2963,10 +2963,10 @@ type Object implements IObject & IOwner {
 	"""
 	iotaNamesDefaultName(format: NameFormat): String
 	"""
-	The IotaNamesRegistration NFTs owned by this address. These grant the
+	The NameRegistration NFTs owned by this address. These grant the
 	owner the capability to manage the associated name.
 	"""
-	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): IotaNamesRegistrationConnection!
+	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): NameRegistrationConnection!
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
@@ -3341,10 +3341,10 @@ type Owner implements IOwner {
 	"""
 	iotaNamesDefaultName(format: NameFormat): String
 	"""
-	The IotaNamesRegistration NFTs owned by this object or address. These
+	The NameRegistration NFTs owned by this object or address. These
 	grant the owner the capability to manage the associated name.
 	"""
-	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): IotaNamesRegistrationConnection!
+	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): NameRegistrationConnection!
 	asAddress: Address
 	asObject: Object
 	"""
@@ -4083,10 +4083,10 @@ type StakedIota implements IMoveObject & IObject & IOwner {
 	"""
 	iotaNamesDefaultName(format: NameFormat): String
 	"""
-	The IotaNamesRegistration NFTs owned by this object. These grant the
+	The NameRegistration NFTs owned by this object. These grant the
 	owner the capability to manage the associated name.
 	"""
-	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): IotaNamesRegistrationConnection!
+	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): NameRegistrationConnection!
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The

--- a/crates/iota-graphql-rpc/src/types/address.rs
+++ b/crates/iota-graphql-rpc/src/types/address.rs
@@ -11,7 +11,7 @@ use crate::{
         coin::Coin,
         cursor::Page,
         iota_address::IotaAddress,
-        iota_names_registration::{IotaNamesRegistration, NameFormat},
+        iota_names_registration::{NameFormat, NameRegistration},
         move_object::MoveObject,
         object::{self, ObjectFilter},
         owner::OwnerImpl,
@@ -129,7 +129,7 @@ impl Address {
             .await
     }
 
-    /// The IotaNamesRegistration NFTs owned by this address. These grant the
+    /// The NameRegistration NFTs owned by this address. These grant the
     /// owner the capability to manage the associated name.
     pub(crate) async fn iota_names_registrations(
         &self,
@@ -138,7 +138,7 @@ impl Address {
         after: Option<object::Cursor>,
         last: Option<u64>,
         before: Option<object::Cursor>,
-    ) -> Result<Connection<String, IotaNamesRegistration>> {
+    ) -> Result<Connection<String, NameRegistration>> {
         OwnerImpl::from(self)
             .iota_names_registrations(ctx, first, after, last, before)
             .await

--- a/crates/iota-graphql-rpc/src/types/coin.rs
+++ b/crates/iota-graphql-rpc/src/types/coin.rs
@@ -25,7 +25,7 @@ use crate::{
         display::DisplayEntry,
         dynamic_field::{DynamicField, DynamicFieldName},
         iota_address::IotaAddress,
-        iota_names_registration::{IotaNamesRegistration, NameFormat},
+        iota_names_registration::{NameFormat, NameRegistration},
         move_object::{MoveObject, MoveObjectImpl},
         move_value::MoveValue,
         object::{self, Object, ObjectFilter, ObjectImpl, ObjectOwner, ObjectStatus},
@@ -144,7 +144,7 @@ impl Coin {
             .await
     }
 
-    /// The IotaNamesRegistration NFTs owned by this object. These grant the
+    /// The NameRegistration NFTs owned by this object. These grant the
     /// owner the capability to manage the associated name.
     pub(crate) async fn iota_names_registrations(
         &self,
@@ -153,7 +153,7 @@ impl Coin {
         after: Option<object::Cursor>,
         last: Option<u64>,
         before: Option<object::Cursor>,
-    ) -> Result<Connection<String, IotaNamesRegistration>> {
+    ) -> Result<Connection<String, NameRegistration>> {
         OwnerImpl::from(&self.super_.super_)
             .iota_names_registrations(ctx, first, after, last, before)
             .await

--- a/crates/iota-graphql-rpc/src/types/coin_metadata.rs
+++ b/crates/iota-graphql-rpc/src/types/coin_metadata.rs
@@ -22,7 +22,7 @@ use crate::{
         display::DisplayEntry,
         dynamic_field::{DynamicField, DynamicFieldName},
         iota_address::IotaAddress,
-        iota_names_registration::{IotaNamesRegistration, NameFormat},
+        iota_names_registration::{NameFormat, NameRegistration},
         move_object::{MoveObject, MoveObjectImpl},
         move_value::MoveValue,
         object::{self, Object, ObjectFilter, ObjectImpl, ObjectOwner, ObjectStatus},
@@ -137,7 +137,7 @@ impl CoinMetadata {
             .await
     }
 
-    /// The IotaNamesRegistration NFTs owned by this object. These grant the
+    /// The NameRegistration NFTs owned by this object. These grant the
     /// owner the capability to manage the associated name.
     pub(crate) async fn iota_names_registrations(
         &self,
@@ -146,7 +146,7 @@ impl CoinMetadata {
         after: Option<object::Cursor>,
         last: Option<u64>,
         before: Option<object::Cursor>,
-    ) -> Result<Connection<String, IotaNamesRegistration>> {
+    ) -> Result<Connection<String, NameRegistration>> {
         OwnerImpl::from(&self.super_.super_)
             .iota_names_registrations(ctx, first, after, last, before)
             .await

--- a/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
+++ b/crates/iota-graphql-rpc/src/types/iota_names_registration.rs
@@ -59,7 +59,7 @@ pub enum NameFormat {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
-pub(crate) struct NativeIotaNamesRegistration {
+pub(crate) struct NativeNameRegistration {
     pub id: UID,
     pub name: NativeName,
     pub name_str: String,
@@ -67,12 +67,12 @@ pub(crate) struct NativeIotaNamesRegistration {
 }
 
 #[derive(Clone)]
-pub(crate) struct IotaNamesRegistration {
-    /// Representation of this IotaNamesRegistration as a generic Move object.
+pub(crate) struct NameRegistration {
+    /// Representation of this NameRegistration as a generic Move object.
     pub super_: MoveObject,
 
     /// The deserialized representation of the Move object's contents.
-    pub native: NativeIotaNamesRegistration,
+    pub native: NativeNameRegistration,
 }
 
 /// Represents the results of a query for a name's `NameRecord` and its
@@ -90,13 +90,13 @@ pub(crate) struct NameExpiration {
     pub checkpoint_timestamp_ms: u64,
 }
 
-pub(crate) enum IotaNamesRegistrationDowncastError {
-    NotAnIotaNamesRegistration,
+pub(crate) enum NameRegistrationDowncastError {
+    NotAnNameRegistration,
     Bcs(bcs::Error),
 }
 
 #[Object]
-impl IotaNamesRegistration {
+impl NameRegistration {
     pub(crate) async fn address(&self) -> IotaAddress {
         OwnerImpl::from(&self.super_.super_).address().await
     }
@@ -186,7 +186,7 @@ impl IotaNamesRegistration {
             .await
     }
 
-    /// The IotaNamesRegistration NFTs owned by this object. These grant the
+    /// The NameRegistration NFTs owned by this object. These grant the
     /// owner the capability to manage the associated name.
     pub(crate) async fn iota_names_registrations(
         &self,
@@ -195,7 +195,7 @@ impl IotaNamesRegistration {
         after: Option<object::Cursor>,
         last: Option<u64>,
         before: Option<object::Cursor>,
-    ) -> Result<Connection<String, IotaNamesRegistration>> {
+    ) -> Result<Connection<String, NameRegistration>> {
         OwnerImpl::from(&self.super_.super_)
             .iota_names_registrations(ctx, first, after, last, before)
             .await
@@ -371,7 +371,7 @@ impl IotaNamesRegistration {
             .await
     }
 
-    /// Name of the IotaNamesRegistration object
+    /// Name of the NameRegistration object
     async fn name(&self) -> &str {
         &self.native.name_str
     }
@@ -575,7 +575,7 @@ impl IotaNames {
     }
 }
 
-impl IotaNamesRegistration {
+impl NameRegistration {
     /// Query the database for a `page` of IOTA-Names registrations. The page
     /// uses the same cursor type as is used for `Object`, and is further
     /// filtered to a particular `owner`. `config` specifies where to find
@@ -591,8 +591,8 @@ impl IotaNamesRegistration {
         page: Page<object::Cursor>,
         owner: IotaAddress,
         checkpoint_viewed_at: u64,
-    ) -> Result<Connection<String, IotaNamesRegistration>, Error> {
-        let type_ = IotaNamesRegistration::type_(config.package_address.into());
+    ) -> Result<Connection<String, NameRegistration>, Error> {
+        let type_ = NameRegistration::type_(config.package_address.into());
 
         let filter = ObjectFilter {
             type_: Some(type_.clone().into()),
@@ -604,39 +604,39 @@ impl IotaNamesRegistration {
             let address = object.address;
             let move_object = MoveObject::try_from(&object).map_err(|_| {
                 Error::Internal(format!(
-                    "Expected {address} to be a IotaNamesRegistration, but it's not a Move Object.",
+                    "Expected {address} to be a NameRegistration, but it's not a Move Object.",
                 ))
             })?;
 
-            IotaNamesRegistration::try_from(&move_object, &type_).map_err(|_| {
+            NameRegistration::try_from(&move_object, &type_).map_err(|_| {
                 Error::Internal(format!(
-                    "Expected {address} to be a IotaNamesRegistration, but it is not."
+                    "Expected {address} to be a NameRegistration, but it is not."
                 ))
             })
         })
         .await
     }
 
-    /// Return the type representing a `IotaNamesRegistration` on chain. This
+    /// Return the type representing a `NameRegistration` on chain. This
     /// can change from chain to chain (mainnet, testnet, devnet etc).
     pub(crate) fn type_(package: IotaAddress) -> StructTag {
-        iota_names::IotaNamesRegistration::type_(package.into())
+        iota_names::NameRegistration::type_(package.into())
     }
 
-    // Because the type of the IotaNamesRegistration object is not constant,
+    // Because the type of the NameRegistration object is not constant,
     // we need to take it in as a param.
     pub(crate) fn try_from(
         move_object: &MoveObject,
         tag: &StructTag,
-    ) -> Result<Self, IotaNamesRegistrationDowncastError> {
+    ) -> Result<Self, NameRegistrationDowncastError> {
         if !move_object.native.is_type(tag) {
-            return Err(IotaNamesRegistrationDowncastError::NotAnIotaNamesRegistration);
+            return Err(NameRegistrationDowncastError::NotAnNameRegistration);
         }
 
         Ok(Self {
             super_: move_object.clone(),
             native: bcs::from_bytes(move_object.native.contents())
-                .map_err(IotaNamesRegistrationDowncastError::Bcs)?,
+                .map_err(NameRegistrationDowncastError::Bcs)?,
         })
     }
 }

--- a/crates/iota-graphql-rpc/src/types/move_object.rs
+++ b/crates/iota-graphql-rpc/src/types/move_object.rs
@@ -23,9 +23,7 @@ use crate::{
         display::DisplayEntry,
         dynamic_field::{DynamicField, DynamicFieldName},
         iota_address::IotaAddress,
-        iota_names_registration::{
-            IotaNamesRegistration, IotaNamesRegistrationDowncastError, NameFormat,
-        },
+        iota_names_registration::{NameFormat, NameRegistration, NameRegistrationDowncastError},
         move_type::MoveType,
         move_value::MoveValue,
         object::{self, Object, ObjectFilter, ObjectImpl, ObjectLookup, ObjectOwner, ObjectStatus},
@@ -114,7 +112,7 @@ pub(crate) enum IMoveObject {
     Coin(Coin),
     CoinMetadata(CoinMetadata),
     StakedIota(StakedIota),
-    IotaNamesRegistration(IotaNamesRegistration),
+    NameRegistration(NameRegistration),
 }
 
 /// The representation of an object as a Move Object, which exposes additional
@@ -209,7 +207,7 @@ impl MoveObject {
             .await
     }
 
-    /// The IotaNamesRegistration NFTs owned by this object. These grant the
+    /// The NameRegistration NFTs owned by this object. These grant the
     /// owner the capability to manage the associated name.
     pub(crate) async fn iota_names_registrations(
         &self,
@@ -218,7 +216,7 @@ impl MoveObject {
         after: Option<object::Cursor>,
         last: Option<u64>,
         before: Option<object::Cursor>,
-    ) -> Result<Connection<String, IotaNamesRegistration>> {
+    ) -> Result<Connection<String, NameRegistration>> {
         OwnerImpl::from(&self.super_)
             .iota_names_registrations(ctx, first, after, last, before)
             .await
@@ -415,20 +413,20 @@ impl MoveObject {
         }
     }
 
-    // Attempts to convert the Move object into a `IotaNamesRegistration` object.
+    // Attempts to convert the Move object into a `NameRegistration` object.
     async fn as_iota_names_registration(
         &self,
         ctx: &Context<'_>,
-    ) -> Result<Option<IotaNamesRegistration>> {
+    ) -> Result<Option<NameRegistration>> {
         let cfg: &IotaNamesConfig = ctx.data_unchecked();
-        let tag = IotaNamesRegistration::type_(cfg.package_address.into());
+        let tag = NameRegistration::type_(cfg.package_address.into());
 
-        match IotaNamesRegistration::try_from(self, &tag) {
+        match NameRegistration::try_from(self, &tag) {
             Ok(registration) => Ok(Some(registration)),
-            Err(IotaNamesRegistrationDowncastError::NotAnIotaNamesRegistration) => Ok(None),
-            Err(IotaNamesRegistrationDowncastError::Bcs(e)) => Err(Error::Internal(format!(
+            Err(NameRegistrationDowncastError::NotAnNameRegistration) => Ok(None),
+            Err(NameRegistrationDowncastError::Bcs(e)) => Err(Error::Internal(format!(
                 "Failed to deserialize
-     IotaNamesRegistration: {e}",
+     NameRegistration: {e}",
             )))
             .extend(),
         }

--- a/crates/iota-graphql-rpc/src/types/move_package.rs
+++ b/crates/iota-graphql-rpc/src/types/move_package.rs
@@ -32,7 +32,7 @@ use crate::{
         coin::Coin,
         cursor::{BcsCursor, JsonCursor, Page, RawPaginated, ScanLimited, Target},
         iota_address::{IotaAddress, addr},
-        iota_names_registration::{IotaNamesRegistration, NameFormat},
+        iota_names_registration::{NameFormat, NameRegistration},
         move_module::MoveModule,
         move_object::MoveObject,
         object::{self, Object, ObjectFilter, ObjectImpl, ObjectOwner, ObjectStatus},
@@ -289,7 +289,7 @@ impl MovePackage {
             .await
     }
 
-    /// The IotaNamesRegistration NFTs owned by this package. These grant the
+    /// The NameRegistration NFTs owned by this package. These grant the
     /// owner the capability to manage the associated name.
     ///
     /// Note that objects owned by a package are inaccessible, because packages
@@ -301,7 +301,7 @@ impl MovePackage {
         after: Option<object::Cursor>,
         last: Option<u64>,
         before: Option<object::Cursor>,
-    ) -> Result<Connection<String, IotaNamesRegistration>> {
+    ) -> Result<Connection<String, NameRegistration>> {
         OwnerImpl::from(&self.super_)
             .iota_names_registrations(ctx, first, after, last, before)
             .await

--- a/crates/iota-graphql-rpc/src/types/object.rs
+++ b/crates/iota-graphql-rpc/src/types/object.rs
@@ -51,7 +51,7 @@ use crate::{
         dynamic_field::{DynamicField, DynamicFieldName},
         intersect,
         iota_address::{IotaAddress, addr},
-        iota_names_registration::{IotaNamesRegistration, NameFormat},
+        iota_names_registration::{NameFormat, NameRegistration},
         move_object::MoveObject,
         move_package::MovePackage,
         owner::{Owner, OwnerImpl},
@@ -428,7 +428,7 @@ impl Object {
             .await
     }
 
-    /// The IotaNamesRegistration NFTs owned by this address. These grant the
+    /// The NameRegistration NFTs owned by this address. These grant the
     /// owner the capability to manage the associated name.
     pub(crate) async fn iota_names_registrations(
         &self,
@@ -437,7 +437,7 @@ impl Object {
         after: Option<Cursor>,
         last: Option<u64>,
         before: Option<Cursor>,
-    ) -> Result<Connection<String, IotaNamesRegistration>> {
+    ) -> Result<Connection<String, NameRegistration>> {
         OwnerImpl::from(self)
             .iota_names_registrations(ctx, first, after, last, before)
             .await

--- a/crates/iota-graphql-rpc/src/types/owner.rs
+++ b/crates/iota-graphql-rpc/src/types/owner.rs
@@ -16,7 +16,7 @@ use crate::{
         cursor::Page,
         dynamic_field::{DynamicField, DynamicFieldName},
         iota_address::IotaAddress,
-        iota_names_registration::{IotaNames, IotaNamesRegistration, NameFormat},
+        iota_names_registration::{IotaNames, NameFormat, NameRegistration},
         move_object::MoveObject,
         move_package::MovePackage,
         object::{self, Object, ObjectFilter},
@@ -125,8 +125,8 @@ pub(crate) struct OwnerImpl {
         arg(name = "after", ty = "Option<object::Cursor>"),
         arg(name = "last", ty = "Option<u64>"),
         arg(name = "before", ty = "Option<object::Cursor>"),
-        ty = "Connection<String, IotaNamesRegistration>",
-        desc = "The IotaNamesRegistration NFTs owned by this object or address. These grant the owner \
+        ty = "Connection<String, NameRegistration>",
+        desc = "The NameRegistration NFTs owned by this object or address. These grant the owner \
                     the capability to manage the associated name."
     )
 )]
@@ -139,7 +139,7 @@ pub(crate) enum IOwner {
     Coin(Coin),
     CoinMetadata(CoinMetadata),
     StakedIota(StakedIota),
-    IotaNamesRegistration(IotaNamesRegistration),
+    NameRegistration(NameRegistration),
 }
 
 /// An Owner is an entity that can own an object. Each Owner is identified by a
@@ -236,7 +236,7 @@ impl Owner {
             .await
     }
 
-    /// The IotaNamesRegistration NFTs owned by this object or address. These
+    /// The NameRegistration NFTs owned by this object or address. These
     /// grant the owner the capability to manage the associated name.
     pub(crate) async fn iota_names_registrations(
         &self,
@@ -245,7 +245,7 @@ impl Owner {
         after: Option<object::Cursor>,
         last: Option<u64>,
         before: Option<object::Cursor>,
-    ) -> Result<Connection<String, IotaNamesRegistration>> {
+    ) -> Result<Connection<String, NameRegistration>> {
         OwnerImpl::from(self)
             .iota_names_registrations(ctx, first, after, last, before)
             .await
@@ -454,9 +454,9 @@ impl OwnerImpl {
         after: Option<object::Cursor>,
         last: Option<u64>,
         before: Option<object::Cursor>,
-    ) -> Result<Connection<String, IotaNamesRegistration>> {
+    ) -> Result<Connection<String, NameRegistration>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
-        IotaNamesRegistration::paginate(
+        NameRegistration::paginate(
             ctx.data_unchecked::<Db>(),
             ctx.data_unchecked::<IotaNamesConfig>(),
             page,

--- a/crates/iota-graphql-rpc/src/types/stake.rs
+++ b/crates/iota-graphql-rpc/src/types/stake.rs
@@ -22,7 +22,7 @@ use crate::{
         dynamic_field::{DynamicField, DynamicFieldName},
         epoch::Epoch,
         iota_address::IotaAddress,
-        iota_names_registration::{IotaNamesRegistration, NameFormat},
+        iota_names_registration::{NameFormat, NameRegistration},
         move_object::{MoveObject, MoveObjectImpl},
         move_value::MoveValue,
         object,
@@ -153,7 +153,7 @@ impl StakedIota {
             .await
     }
 
-    /// The IotaNamesRegistration NFTs owned by this object. These grant the
+    /// The NameRegistration NFTs owned by this object. These grant the
     /// owner the capability to manage the associated name.
     pub(crate) async fn iota_names_registrations(
         &self,
@@ -162,7 +162,7 @@ impl StakedIota {
         after: Option<object::Cursor>,
         last: Option<u64>,
         before: Option<object::Cursor>,
-    ) -> Result<Connection<String, IotaNamesRegistration>> {
+    ) -> Result<Connection<String, NameRegistration>> {
         OwnerImpl::from(&self.super_.super_)
             .iota_names_registrations(ctx, first, after, last, before)
             .await

--- a/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
+++ b/crates/iota-graphql-rpc/tests/snapshots/snapshot_tests__schema_sdl_export.snap
@@ -99,10 +99,10 @@ type Address implements IOwner {
 	"""
 	iotaNamesDefaultName(format: NameFormat): String
 	"""
-	The IotaNamesRegistration NFTs owned by this address. These grant the
+	The NameRegistration NFTs owned by this address. These grant the
 	owner the capability to manage the associated name.
 	"""
-	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): IotaNamesRegistrationConnection!
+	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): NameRegistrationConnection!
 	"""
 	Similar behavior to the `transactionBlocks` in Query but supporting the
 	additional `AddressTransactionBlockRelationship` filter, which
@@ -595,10 +595,10 @@ type Coin implements IMoveObject & IObject & IOwner {
 	"""
 	iotaNamesDefaultName(format: NameFormat): String
 	"""
-	The IotaNamesRegistration NFTs owned by this object. These grant the
+	The NameRegistration NFTs owned by this object. These grant the
 	owner the capability to manage the associated name.
 	"""
-	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): IotaNamesRegistrationConnection!
+	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): NameRegistrationConnection!
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
@@ -772,10 +772,10 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
 	"""
 	iotaNamesDefaultName(format: NameFormat): String
 	"""
-	The IotaNamesRegistration NFTs owned by this object. These grant the
+	The NameRegistration NFTs owned by this object. These grant the
 	owner the capability to manage the associated name.
 	"""
-	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): IotaNamesRegistrationConnection!
+	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): NameRegistrationConnection!
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
@@ -1662,9 +1662,9 @@ interface IOwner {
 	"""
 	iotaNamesDefaultName(format: NameFormat): String
 	"""
-	The IotaNamesRegistration NFTs owned by this object or address. These grant the owner the capability to manage the associated name.
+	The NameRegistration NFTs owned by this object or address. These grant the owner the capability to manage the associated name.
 	"""
-	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): IotaNamesRegistrationConnection!
+	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): NameRegistrationConnection!
 }
 
 """
@@ -1690,187 +1690,6 @@ type Input {
 String containing 32B hex-encoded address, with a leading "0x". Leading zeroes can be omitted on input but will always appear in outputs (IotaAddress in output is guaranteed to be 66 characters long).
 """
 scalar IotaAddress
-
-type IotaNamesRegistration implements IMoveObject & IOwner {
-	address: IotaAddress!
-	"""
-	Objects owned by this object, optionally `filter`-ed.
-	"""
-	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection!
-	"""
-	Total balance of all coins with marker type owned by this object. If
-	type is not supplied, it defaults to `0x2::iota::IOTA`.
-	"""
-	balance(type: String): Balance
-	"""
-	The balances of all coin types owned by this object.
-	"""
-	balances(first: Int, after: String, last: Int, before: String): BalanceConnection!
-	"""
-	The coin objects for this object.
-	
-	`type` is a filter on the coin's type parameter, defaulting to
-	`0x2::iota::IOTA`.
-	"""
-	coins(first: Int, after: String, last: Int, before: String, type: String): CoinConnection!
-	"""
-	The `0x3::staking_pool::StakedIota` objects owned by this object.
-	"""
-	stakedIotas(first: Int, after: String, last: Int, before: String): StakedIotaConnection!
-	"""
-	The name explicitly configured as the default name pointing to this
-	object.
-	"""
-	iotaNamesDefaultName(format: NameFormat): String
-	"""
-	The IotaNamesRegistration NFTs owned by this object. These grant the
-	owner the capability to manage the associated name.
-	"""
-	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): IotaNamesRegistrationConnection!
-	version: UInt53!
-	"""
-	The current status of the object as read from the off-chain store. The
-	possible states are: NOT_INDEXED, the object is loaded from
-	serialized data, such as the contents of a genesis or system package
-	upgrade transaction. LIVE, the version returned is the most recent for
-	the object, and it is not deleted or wrapped at that version.
-	HISTORICAL, the object was referenced at a specific version or
-	checkpoint, so is fetched from historical tables and may not be the
-	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
-	or wrapped and only partial information can be loaded."
-	"""
-	status: ObjectKind!
-	"""
-	32-byte hash that identifies the object's contents, encoded as a Base58
-	string.
-	"""
-	digest: String
-	"""
-	The owner type of this object: Immutable, Shared, Parent, Address
-	"""
-	owner: ObjectOwner
-	"""
-	The transaction block that created this version of the object.
-	"""
-	previousTransactionBlock: TransactionBlock
-	"""
-	The amount of IOTA we would rebate if this object gets deleted or
-	mutated. This number is recalculated based on the present storage
-	gas price.
-	"""
-	storageRebate: BigInt
-	"""
-	The transaction blocks that sent objects to this object.
-	
-	`scanLimit` restricts the number of candidate transactions scanned when
-	gathering a page of results. It is required for queries that apply
-	more than two complex filters (on function, kind, sender, recipient,
-	input object, changed object, or ids), and can be at most
-	`serviceConfig.maxScanLimit`.
-	
-	When the scan limit is reached the page will be returned even if it has
-	fewer than `first` results when paginating forward (`last` when
-	paginating backwards). If there are more transactions to scan,
-	`pageInfo.hasNextPage` (or `pageInfo.hasPreviousPage`) will be set to
-	`true`, and `PageInfo.endCursor` (or `PageInfo.startCursor`) will be set
-	to the last transaction that was scanned as opposed to the last (or
-	first) transaction in the page.
-	
-	Requesting the next (or previous) page after this cursor will resume the
-	search, scanning the next `scanLimit` many transactions in the
-	direction of pagination, and so on until all transactions in the
-	scanning range have been visited.
-	
-	By default, the scanning range includes all transactions known to
-	GraphQL, but it can be restricted by the `after` and `before`
-	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
-	`atCheckpoint` filters.
-	"""
-	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
-	"""
-	The Base64-encoded BCS serialization of the object's content.
-	"""
-	bcs: Base64
-	"""
-	Displays the contents of the Move object in a JSON string and through
-	GraphQL types. Also provides the flat representation of the type
-	signature, and the BCS of the corresponding data.
-	"""
-	contents: MoveValue
-	"""
-	Determines whether a transaction can transfer this object, using the
-	TransferObjects transaction command or
-	`iota::transfer::public_transfer`, both of which require the object to
-	have the `key` and `store` abilities.
-	"""
-	hasPublicTransfer: Boolean!
-	"""
-	The set of named templates defined on-chain for the type of this object,
-	to be handled off-chain. The server substitutes data from the object
-	into these templates to generate a display string per template.
-	"""
-	display: [DisplayEntry!]
-	"""
-	Access a dynamic field on an object using its name. Names are arbitrary
-	Move values whose type have `copy`, `drop`, and `store`, and are
-	specified using their type, and their BCS contents, Base64 encoded.
-	
-	Dynamic fields on wrapped objects can be accessed by using the same API
-	under the Owner type.
-	"""
-	dynamicField(name: DynamicFieldName!): DynamicField
-	"""
-	Access a dynamic object field on an object using its name. Names are
-	arbitrary Move values whose type have `copy`, `drop`, and `store`,
-	and are specified using their type, and their BCS contents, Base64
-	encoded. The value of a dynamic object field can also be accessed
-	off-chain directly via its address (e.g. using `Query.object`).
-	
-	Dynamic fields on wrapped objects can be accessed by using the same API
-	under the Owner type.
-	"""
-	dynamicObjectField(name: DynamicFieldName!): DynamicField
-	"""
-	The dynamic fields and dynamic object fields on an object.
-	
-	Dynamic fields on wrapped objects can be accessed by using the same API
-	under the Owner type.
-	"""
-	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection!
-	"""
-	Name of the IotaNamesRegistration object
-	"""
-	name: String!
-}
-
-type IotaNamesRegistrationConnection {
-	"""
-	Information to aid in pagination.
-	"""
-	pageInfo: PageInfo!
-	"""
-	A list of edges.
-	"""
-	edges: [IotaNamesRegistrationEdge!]!
-	"""
-	A list of nodes.
-	"""
-	nodes: [IotaNamesRegistration!]!
-}
-
-"""
-An edge in a connection.
-"""
-type IotaNamesRegistrationEdge {
-	"""
-	The item at the end of the edge
-	"""
-	node: IotaNamesRegistration!
-	"""
-	A cursor for use in pagination
-	"""
-	cursor: String!
-}
 
 """
 Arbitrary JSON data.
@@ -2327,10 +2146,10 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	"""
 	iotaNamesDefaultName(format: NameFormat): String
 	"""
-	The IotaNamesRegistration NFTs owned by this object. These grant the
+	The NameRegistration NFTs owned by this object. These grant the
 	owner the capability to manage the associated name.
 	"""
-	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): IotaNamesRegistrationConnection!
+	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): NameRegistrationConnection!
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
@@ -2447,7 +2266,7 @@ type MoveObject implements IMoveObject & IObject & IOwner {
 	Attempts to convert the Move object into a `0x2::coin::CoinMetadata`.
 	"""
 	asCoinMetadata: CoinMetadata
-	asIotaNamesRegistration: IotaNamesRegistration
+	asIotaNamesRegistration: NameRegistration
 }
 
 type MoveObjectConnection {
@@ -2531,13 +2350,13 @@ type MovePackage implements IObject & IOwner {
 	"""
 	iotaNamesDefaultName(format: NameFormat): String
 	"""
-	The IotaNamesRegistration NFTs owned by this package. These grant the
+	The NameRegistration NFTs owned by this package. These grant the
 	owner the capability to manage the associated name.
 	
 	Note that objects owned by a package are inaccessible, because packages
 	are immutable and cannot be owned by an address.
 	"""
-	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): IotaNamesRegistrationConnection!
+	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): NameRegistrationConnection!
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
@@ -2929,6 +2748,187 @@ enum NameFormat {
 	DOT
 }
 
+type NameRegistration implements IMoveObject & IOwner {
+	address: IotaAddress!
+	"""
+	Objects owned by this object, optionally `filter`-ed.
+	"""
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection!
+	"""
+	Total balance of all coins with marker type owned by this object. If
+	type is not supplied, it defaults to `0x2::iota::IOTA`.
+	"""
+	balance(type: String): Balance
+	"""
+	The balances of all coin types owned by this object.
+	"""
+	balances(first: Int, after: String, last: Int, before: String): BalanceConnection!
+	"""
+	The coin objects for this object.
+	
+	`type` is a filter on the coin's type parameter, defaulting to
+	`0x2::iota::IOTA`.
+	"""
+	coins(first: Int, after: String, last: Int, before: String, type: String): CoinConnection!
+	"""
+	The `0x3::staking_pool::StakedIota` objects owned by this object.
+	"""
+	stakedIotas(first: Int, after: String, last: Int, before: String): StakedIotaConnection!
+	"""
+	The name explicitly configured as the default name pointing to this
+	object.
+	"""
+	iotaNamesDefaultName(format: NameFormat): String
+	"""
+	The NameRegistration NFTs owned by this object. These grant the
+	owner the capability to manage the associated name.
+	"""
+	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): NameRegistrationConnection!
+	version: UInt53!
+	"""
+	The current status of the object as read from the off-chain store. The
+	possible states are: NOT_INDEXED, the object is loaded from
+	serialized data, such as the contents of a genesis or system package
+	upgrade transaction. LIVE, the version returned is the most recent for
+	the object, and it is not deleted or wrapped at that version.
+	HISTORICAL, the object was referenced at a specific version or
+	checkpoint, so is fetched from historical tables and may not be the
+	latest version of the object. WRAPPED_OR_DELETED, the object is deleted
+	or wrapped and only partial information can be loaded."
+	"""
+	status: ObjectKind!
+	"""
+	32-byte hash that identifies the object's contents, encoded as a Base58
+	string.
+	"""
+	digest: String
+	"""
+	The owner type of this object: Immutable, Shared, Parent, Address
+	"""
+	owner: ObjectOwner
+	"""
+	The transaction block that created this version of the object.
+	"""
+	previousTransactionBlock: TransactionBlock
+	"""
+	The amount of IOTA we would rebate if this object gets deleted or
+	mutated. This number is recalculated based on the present storage
+	gas price.
+	"""
+	storageRebate: BigInt
+	"""
+	The transaction blocks that sent objects to this object.
+	
+	`scanLimit` restricts the number of candidate transactions scanned when
+	gathering a page of results. It is required for queries that apply
+	more than two complex filters (on function, kind, sender, recipient,
+	input object, changed object, or ids), and can be at most
+	`serviceConfig.maxScanLimit`.
+	
+	When the scan limit is reached the page will be returned even if it has
+	fewer than `first` results when paginating forward (`last` when
+	paginating backwards). If there are more transactions to scan,
+	`pageInfo.hasNextPage` (or `pageInfo.hasPreviousPage`) will be set to
+	`true`, and `PageInfo.endCursor` (or `PageInfo.startCursor`) will be set
+	to the last transaction that was scanned as opposed to the last (or
+	first) transaction in the page.
+	
+	Requesting the next (or previous) page after this cursor will resume the
+	search, scanning the next `scanLimit` many transactions in the
+	direction of pagination, and so on until all transactions in the
+	scanning range have been visited.
+	
+	By default, the scanning range includes all transactions known to
+	GraphQL, but it can be restricted by the `after` and `before`
+	cursors, and the `beforeCheckpoint`, `afterCheckpoint` and
+	`atCheckpoint` filters.
+	"""
+	receivedTransactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	"""
+	The Base64-encoded BCS serialization of the object's content.
+	"""
+	bcs: Base64
+	"""
+	Displays the contents of the Move object in a JSON string and through
+	GraphQL types. Also provides the flat representation of the type
+	signature, and the BCS of the corresponding data.
+	"""
+	contents: MoveValue
+	"""
+	Determines whether a transaction can transfer this object, using the
+	TransferObjects transaction command or
+	`iota::transfer::public_transfer`, both of which require the object to
+	have the `key` and `store` abilities.
+	"""
+	hasPublicTransfer: Boolean!
+	"""
+	The set of named templates defined on-chain for the type of this object,
+	to be handled off-chain. The server substitutes data from the object
+	into these templates to generate a display string per template.
+	"""
+	display: [DisplayEntry!]
+	"""
+	Access a dynamic field on an object using its name. Names are arbitrary
+	Move values whose type have `copy`, `drop`, and `store`, and are
+	specified using their type, and their BCS contents, Base64 encoded.
+	
+	Dynamic fields on wrapped objects can be accessed by using the same API
+	under the Owner type.
+	"""
+	dynamicField(name: DynamicFieldName!): DynamicField
+	"""
+	Access a dynamic object field on an object using its name. Names are
+	arbitrary Move values whose type have `copy`, `drop`, and `store`,
+	and are specified using their type, and their BCS contents, Base64
+	encoded. The value of a dynamic object field can also be accessed
+	off-chain directly via its address (e.g. using `Query.object`).
+	
+	Dynamic fields on wrapped objects can be accessed by using the same API
+	under the Owner type.
+	"""
+	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	"""
+	The dynamic fields and dynamic object fields on an object.
+	
+	Dynamic fields on wrapped objects can be accessed by using the same API
+	under the Owner type.
+	"""
+	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection!
+	"""
+	Name of the NameRegistration object
+	"""
+	name: String!
+}
+
+type NameRegistrationConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [NameRegistrationEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [NameRegistration!]!
+}
+
+"""
+An edge in a connection.
+"""
+type NameRegistrationEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: NameRegistration!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 """
 An object in IOTA is a package (set of Move bytecode modules) or object
 (typed data structure with fields) with additional metadata detailing its
@@ -2967,10 +2967,10 @@ type Object implements IObject & IOwner {
 	"""
 	iotaNamesDefaultName(format: NameFormat): String
 	"""
-	The IotaNamesRegistration NFTs owned by this address. These grant the
+	The NameRegistration NFTs owned by this address. These grant the
 	owner the capability to manage the associated name.
 	"""
-	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): IotaNamesRegistrationConnection!
+	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): NameRegistrationConnection!
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The
@@ -3345,10 +3345,10 @@ type Owner implements IOwner {
 	"""
 	iotaNamesDefaultName(format: NameFormat): String
 	"""
-	The IotaNamesRegistration NFTs owned by this object or address. These
+	The NameRegistration NFTs owned by this object or address. These
 	grant the owner the capability to manage the associated name.
 	"""
-	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): IotaNamesRegistrationConnection!
+	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): NameRegistrationConnection!
 	asAddress: Address
 	asObject: Object
 	"""
@@ -4087,10 +4087,10 @@ type StakedIota implements IMoveObject & IObject & IOwner {
 	"""
 	iotaNamesDefaultName(format: NameFormat): String
 	"""
-	The IotaNamesRegistration NFTs owned by this object. These grant the
+	The NameRegistration NFTs owned by this object. These grant the
 	owner the capability to manage the associated name.
 	"""
-	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): IotaNamesRegistrationConnection!
+	iotaNamesRegistrations(first: Int, after: String, last: Int, before: String): NameRegistrationConnection!
 	version: UInt53!
 	"""
 	The current status of the object as read from the off-chain store. The

--- a/crates/iota-indexer/src/apis/indexer_api.rs
+++ b/crates/iota-indexer/src/apis/indexer_api.rs
@@ -13,8 +13,8 @@ use iota_json_rpc_types::{
     IotaTransactionBlockResponseQuery, ObjectsPage, Page, TransactionBlocksPage, TransactionFilter,
 };
 use iota_names::{
-    IotaNamesNft, IotaNamesRegistration, config::IotaNamesConfig, error::IotaNamesError,
-    name::Name, registry::NameRecord,
+    IotaNamesNft, NameRegistration, config::IotaNamesConfig, error::IotaNamesError, name::Name,
+    registry::NameRecord,
 };
 use iota_open_rpc::Module;
 use iota_types::{
@@ -451,9 +451,9 @@ impl IndexerApiServer for IndexerApi {
         options: Option<IotaObjectDataOptions>,
     ) -> RpcResult<ObjectsPage> {
         let query = IotaObjectResponseQuery {
-            filter: Some(IotaObjectDataFilter::StructType(
-                IotaNamesRegistration::type_(self.iota_names_config.package_address.into()),
-            )),
+            filter: Some(IotaObjectDataFilter::StructType(NameRegistration::type_(
+                self.iota_names_config.package_address.into(),
+            ))),
             options,
         };
 

--- a/crates/iota-json-rpc/src/indexer_api.rs
+++ b/crates/iota-json-rpc/src/indexer_api.rs
@@ -21,8 +21,8 @@ use iota_json_rpc_types::{
 };
 use iota_metrics::spawn_monitored_task;
 use iota_names::{
-    IotaNamesNft, IotaNamesRegistration, config::IotaNamesConfig, error::IotaNamesError,
-    name::Name, registry::NameRecord,
+    IotaNamesNft, NameRegistration, config::IotaNamesConfig, error::IotaNamesError, name::Name,
+    registry::NameRecord,
 };
 use iota_open_rpc::Module;
 use iota_storage::key_value_store::TransactionKeyValueStore;
@@ -570,9 +570,9 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         options: Option<IotaObjectDataOptions>,
     ) -> RpcResult<ObjectsPage> {
         let query = IotaObjectResponseQuery {
-            filter: Some(IotaObjectDataFilter::StructType(
-                IotaNamesRegistration::type_(self.iota_names_config.package_address.into()),
-            )),
+            filter: Some(IotaObjectDataFilter::StructType(NameRegistration::type_(
+                self.iota_names_config.package_address.into(),
+            ))),
             options,
         };
 

--- a/crates/iota-names/src/config.rs
+++ b/crates/iota-names/src/config.rs
@@ -98,15 +98,15 @@ impl IotaNamesConfig {
     // Create a config based on the package and object ids published on devnet.
     pub fn devnet() -> Self {
         const PACKAGE_ADDRESS: &str =
-            "0xe1284870018484a7a12255aebb737b6b98b47d652b842ea2f324499ff163a648";
+            "0xb9d617f24c84826bf660a2f4031951678cc80c264aebc4413459fb2a95ada9ba";
         const OBJECT_ID: &str =
-            "0xa92a67ae8a8c644acfa6dd5a4d8098a20b07b6061cbf36aff8daef3ba892913f";
+            "0x07c59b37bd7d036bf78fa30561a2ab9f7a970837487656ec29466e817f879342";
         const PAYMENTS_PACKAGE_ADDRESS: &str =
-            "0x1efac8bf200acca64b62ce75557cd7232310fc8c4ea90960487d2908055fc94f";
+            "0x98b9b33b7c2347a8f4e8b8716fb4c7e6e1af846ec2ea063a47bba81ffe03b440";
         const REGISTRY_ID: &str =
-            "0x88fa01b1f2462f2f33b593eb205b88158e1f51594102b9748b73f134388a3f2d";
+            "0xe00b2f2400c33b4dbd3081c4dcf2e289d0544caba23a3d130b264bd756403c07";
         const REVERSE_REGISTRY_ID: &str =
-            "0x1b3840a267efdc30d11b2b7ad2e574cf8483cd4e06bdf7b39c61ee5717ac3fe6";
+            "0x1c1da17843cc453ad4079b05ce55e103b7a8cdd4db6ab42dc367b47ed6d8994d";
 
         let package_address = IotaAddress::from_str(PACKAGE_ADDRESS).unwrap();
         let object_id = ObjectID::from_str(OBJECT_ID).unwrap();

--- a/crates/iota-names/src/lib.rs
+++ b/crates/iota-names/src/lib.rs
@@ -72,7 +72,7 @@ pub trait IotaNamesNft {
 }
 
 impl IotaNamesNft for NameRegistration {
-    const MODULE: &IdentStr = ident_str!("iota_names_registration");
+    const MODULE: &IdentStr = ident_str!("name_registration");
     const TYPE_NAME: &IdentStr = ident_str!("NameRegistration");
 
     fn name(&self) -> &Name {

--- a/crates/iota-names/src/lib.rs
+++ b/crates/iota-names/src/lib.rs
@@ -20,7 +20,7 @@ use self::name::Name;
 
 /// An object to manage a second-level name (SLN).
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct IotaNamesRegistration {
+pub struct NameRegistration {
     id: ObjectID,
     name: Name,
     name_str: String,
@@ -31,16 +31,16 @@ pub struct IotaNamesRegistration {
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SubnameRegistration {
     id: ObjectID,
-    nft: IotaNamesRegistration,
+    nft: NameRegistration,
 }
 
 impl SubnameRegistration {
-    pub fn into_inner(self) -> IotaNamesRegistration {
+    pub fn into_inner(self) -> NameRegistration {
         self.nft
     }
 }
 
-/// Unifying trait for [`IotaNamesRegistration`] and [`SubnameRegistration`]
+/// Unifying trait for [`NameRegistration`] and [`SubnameRegistration`]
 pub trait IotaNamesNft {
     const MODULE: &IdentStr;
     const TYPE_NAME: &IdentStr;
@@ -71,9 +71,9 @@ pub trait IotaNamesNft {
     fn id(&self) -> ObjectID;
 }
 
-impl IotaNamesNft for IotaNamesRegistration {
+impl IotaNamesNft for NameRegistration {
     const MODULE: &IdentStr = ident_str!("iota_names_registration");
-    const TYPE_NAME: &IdentStr = ident_str!("IotaNamesRegistration");
+    const TYPE_NAME: &IdentStr = ident_str!("NameRegistration");
 
     fn name(&self) -> &Name {
         &self.name

--- a/crates/iota/src/name_commands.rs
+++ b/crates/iota/src/name_commands.rs
@@ -17,7 +17,7 @@ use iota_json_rpc_types::{
     IotaObjectResponseQuery, IotaTransactionBlockResponse,
 };
 use iota_names::{
-    IotaNamesNft, IotaNamesRegistration, SubnameRegistration,
+    IotaNamesNft, NameRegistration, SubnameRegistration,
     config::IotaNamesConfig,
     name::Name,
     registry::{NameRecord, RegistryEntry, ReverseRegistryEntry},
@@ -262,7 +262,7 @@ impl NameCommand {
                 verbose,
                 opts,
             } => {
-                let nft = get_owned_nft_by_name::<IotaNamesRegistration>(&name, context).await?;
+                let nft = get_owned_nft_by_name::<NameRegistration>(&name, context).await?;
 
                 if !nft.has_expired() {
                     let expiration_datetime = DateTime::<Utc>::from(nft.expiration_time())
@@ -324,7 +324,7 @@ impl NameCommand {
             }
             Self::List { address } => {
                 let address = get_identity_address(address, context).await?;
-                let mut nfts = get_owned_nfts::<IotaNamesRegistration>(address, context).await?;
+                let mut nfts = get_owned_nfts::<NameRegistration>(address, context).await?;
                 let subname_nfts = get_owned_nfts::<SubnameRegistration>(address, context).await?;
                 nfts.extend(subname_nfts.into_iter().map(|nft| nft.into_inner()));
                 NameCommandResult::List(nfts)
@@ -427,7 +427,7 @@ impl NameCommand {
                 handle_transaction_result(res, verbose, async |res| {
                     Ok(NameCommandResult::Register {
                         record: get_registry_entry(&name, &iota_client).await?.name_record,
-                        nft: get_owned_nft_by_name::<IotaNamesRegistration>(&name, context).await?,
+                        nft: get_owned_nft_by_name::<NameRegistration>(&name, context).await?,
                         digest: res.digest,
                     })
                 })
@@ -460,7 +460,7 @@ impl NameCommand {
                 let name_str = name.to_string();
                 let coin =
                     select_coin_arg_for_payment(name_str.as_str(), coin, price, context).await?;
-                let nft_id = get_owned_nft_by_name::<IotaNamesRegistration>(&name, context)
+                let nft_id = get_owned_nft_by_name::<NameRegistration>(&name, context)
                     .await?
                     .id();
                 let mut args = vec![
@@ -506,7 +506,7 @@ impl NameCommand {
                 handle_transaction_result(res, verbose, async |res| {
                     Ok(NameCommandResult::Renew {
                         record: get_registry_entry(&name, &iota_client).await?.name_record,
-                        nft: get_owned_nft_by_name::<IotaNamesRegistration>(&name, context).await?,
+                        nft: get_owned_nft_by_name::<NameRegistration>(&name, context).await?,
                         digest: res.digest,
                     })
                 })
@@ -934,7 +934,7 @@ impl AuctionCommand {
                 handle_transaction_result(res, verbose, async |res| {
                     Ok(NameCommandResult::AuctionClaim {
                         record: get_registry_entry(&name, &iota_client).await?.name_record,
-                        nft: get_owned_nft_by_name::<IotaNamesRegistration>(&name, context).await?,
+                        nft: get_owned_nft_by_name::<NameRegistration>(&name, context).await?,
                         digest: res.digest,
                     })
                 })
@@ -1284,7 +1284,7 @@ pub enum NameCommandResult {
     },
     AuctionClaim {
         record: NameRecord,
-        nft: IotaNamesRegistration,
+        nft: NameRegistration,
         digest: TransactionDigest,
     },
     AuctionMetadata(Auction),
@@ -1297,7 +1297,7 @@ pub enum NameCommandResult {
         price: Option<u64>,
     },
     Burn {
-        burned: IotaNamesRegistration,
+        burned: NameRegistration,
         digest: TransactionDigest,
     },
     CommandResult(Box<IotaClientCommandResult>),
@@ -1306,14 +1306,14 @@ pub enum NameCommandResult {
         nft: SubnameRegistration,
         digest: TransactionDigest,
     },
-    List(Vec<IotaNamesRegistration>),
+    List(Vec<NameRegistration>),
     Lookup {
         name: Name,
         target_address: Option<IotaAddress>,
     },
     Register {
         record: NameRecord,
-        nft: IotaNamesRegistration,
+        nft: NameRegistration,
         digest: TransactionDigest,
     },
     RegisterLeafSubname {
@@ -1327,7 +1327,7 @@ pub enum NameCommandResult {
     },
     Renew {
         record: NameRecord,
-        nft: IotaNamesRegistration,
+        nft: NameRegistration,
         digest: TransactionDigest,
     },
     ReverseLookup {
@@ -1717,7 +1717,7 @@ fn build_name_record_table(table_builder: &mut TableBuilder, record: &NameRecord
     }
 }
 
-fn format_nft(f: &mut std::fmt::Formatter, nft: &IotaNamesRegistration) -> std::fmt::Result {
+fn format_nft(f: &mut std::fmt::Formatter, nft: &NameRegistration) -> std::fmt::Result {
     let expiration_datetime = DateTime::<Utc>::from(nft.expiration_time())
         .format("%Y-%m-%d %H:%M:%S.%f UTC")
         .to_string();
@@ -1993,7 +1993,7 @@ where
 }
 
 pub enum IotaNamesNftProxy {
-    Name(IotaNamesRegistration),
+    Name(NameRegistration),
     Subname(SubnameRegistration),
 }
 
@@ -2017,7 +2017,7 @@ impl IotaNamesNftProxy {
 
     fn type_(&self, package_id: AccountAddress) -> StructTag {
         match self {
-            IotaNamesNftProxy::Name(_) => IotaNamesRegistration::type_(package_id),
+            IotaNamesNftProxy::Name(_) => NameRegistration::type_(package_id),
             IotaNamesNftProxy::Subname(_) => SubnameRegistration::type_(package_id),
         }
     }
@@ -2161,7 +2161,7 @@ pub struct Auction {
     pub end_timestamp_ms: u64,
     pub current_bidder: IotaAddress,
     pub current_bid: Coin,
-    pub nft: IotaNamesRegistration,
+    pub nft: NameRegistration,
 }
 
 impl Auction {


### PR DESCRIPTION
# Description of change

Rename IotaNamesRegistration to NameRegistration.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
