### PR TITLE
fix(iota): name availability command

### DIFF
--- a/crates/iota/src/name_commands.rs
+++ b/crates/iota/src/name_commands.rs
@@ -235,21 +235,18 @@ impl NameCommand {
             Self::Availability { name } => {
                 let name_str = name.to_string();
 
-                let price = if iota_client
-                    .read_api()
-                    .iota_names_lookup(&name_str)
-                    .await?
-                    .is_some()
-                {
-                    None
-                } else {
-                    Some(if name.is_subname() {
+                let price = match get_registry_entry(&name, &iota_client).await {
+                    Ok(_) => None,
+                    Err(RpcError::IotaObjectResponse(IotaObjectResponseError::NotExists {
+                        ..
+                    })) => Some(if name.is_subname() {
                         0
                     } else {
                         fetch_pricing_config(&iota_client)
                             .await?
                             .get_price(name.label(1).unwrap())?
-                    })
+                    }),
+                    Err(e) => return Err(e.into()),
                 };
 
                 NameCommandResult::Availability {


### PR DESCRIPTION
# Description of change

Fix the command by relying on entry existence and not lookup.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #(issue)`.

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: Fix the `iota name availability` command by relying on entry existence and not target address set.
- [ ] Rust SDK:
- [ ] REST API:
