### PR TITLE
feat(protocol-config): increase the committee size to 80

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -57,6 +57,7 @@ pub const MAX_PROTOCOL_VERSION: u64 = 10;
 //             Remove the iota-bridge from the framework.
 // Version 10: Enable min_free_execution_slot for the shared object congestion
 //             tracker in all networks.
+//             Increase the committee size to 80 on all networks.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -2000,6 +2001,9 @@ impl ProtocolConfig {
                     // Enable min_free_execution_slot for the shared object congestion tracker in
                     // all networks.
                     cfg.feature_flags.congestion_control_min_free_execution_slot = true;
+
+                    // Increase the committee size to 80 on all networks.
+                    cfg.max_committee_members_count = Some(80);
                 }
                 // Use this template when making changes:
                 //

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_10.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_10.snap
@@ -284,4 +284,4 @@ min_checkpoint_interval_ms: 200
 checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
-max_committee_members_count: 50
+max_committee_members_count: 80

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_10.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_10.snap
@@ -288,5 +288,5 @@ min_checkpoint_interval_ms: 200
 checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
-max_committee_members_count: 50
+max_committee_members_count: 80
 consensus_gc_depth: 60

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_10.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_10.snap
@@ -297,5 +297,5 @@ min_checkpoint_interval_ms: 200
 checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
-max_committee_members_count: 50
+max_committee_members_count: 80
 consensus_gc_depth: 60


### PR DESCRIPTION
# Description of change

Increase the committee size to 80 on all networks.

## Links to any relevant issues

Fixes #7095

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Increase the committee size to 80 on all networks
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
