### PR TITLE
feat(protocol-config): enable new consensus features for mainnet

### DIFF
--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -58,7 +58,12 @@ pub const MAX_PROTOCOL_VERSION: u64 = 10;
 // Version 10: Enable min_free_execution_slot for the shared object congestion
 //             tracker in all networks.
 //             Increase the committee size to 80 on all networks.
-
+//             Enable round prober in consensus for mainnet.
+//             Enable probing for accepted rounds in round prober for mainnet.
+//             Switch to distributed vote scoring in consensus for mainnet.
+//             Enable the new consensus commit rule for mainnet.
+//             Enable consensus garbage collection for mainnet with GC depth set
+//             to 60 rounds
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -2004,6 +2009,23 @@ impl ProtocolConfig {
 
                     // Increase the committee size to 80 on all networks.
                     cfg.max_committee_members_count = Some(80);
+
+                    // Enable round prober in consensus.
+                    cfg.feature_flags.consensus_round_prober = true;
+                    // Enable probing for accepted rounds in round.
+                    cfg.feature_flags
+                        .consensus_round_prober_probe_accepted_rounds = true;
+                    // Enable distributed vote scoring.
+                    cfg.feature_flags
+                        .consensus_distributed_vote_scoring_strategy = true;
+                    // Enable the new consensus commit rule.
+                    cfg.feature_flags.consensus_linearize_subdag_v2 = true;
+
+                    // Enable consensus garbage collection
+                    // Assuming a round rate of max 15/sec, then using a gc depth of 60 allow
+                    // blocks within a window of ~4 seconds
+                    // to be included before be considered garbage collected.
+                    cfg.consensus_gc_depth = Some(60);
                 }
                 // Use this template when making changes:
                 //

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_10.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_10.snap
@@ -13,7 +13,11 @@ feature_flags:
   disallow_new_modules_in_deps_only_packages: true
   native_charging_v2: true
   convert_type_argument_error: true
+  consensus_round_prober: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_linearize_subdag_v2: true
   variant_nodes: true
+  consensus_round_prober_probe_accepted_rounds: true
   consensus_zstd_compression: true
   congestion_control_min_free_execution_slot: true
 max_tx_size_bytes: 131072
@@ -285,3 +289,4 @@ checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
 max_committee_members_count: 80
+consensus_gc_depth: 60


### PR DESCRIPTION
# Description of change

This PR enables new consensus features for the mainnet:

- Enable round prober in consensus for mainnet.
- Enable probing for accepted rounds in round prober for mainnet.
- Switch to distributed vote scoring in consensus for mainnet.
- Enable the new consensus commit rule for mainnet.
- Enable consensus garbage collection for mainnet with GC depth set to 60 rounds

## Links to any relevant issues

Fixes #7094 

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Enable new consensus features on the mainnet such as round prober, distributed vote scoring, new commit rule and garbage collection
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
