### PR TITLE
fix(iota): display MultiSigCombinePartialSig details

### DIFF
--- a/crates/iota/src/keytool.rs
+++ b/crates/iota/src/keytool.rs
@@ -368,7 +368,7 @@ pub struct MultiSigAddress {
 #[serde(rename_all = "camelCase")]
 pub struct MultiSigCombinePartialSig {
     multisig_address: IotaAddress,
-    multisig_parsed: GenericSignature,
+    multisig_parsed: MultiSig,
     multisig_serialized: String,
 }
 
@@ -707,11 +707,10 @@ impl KeyToolCommand {
                 let multisig_pk = MultiSigPublicKey::new(pks, weights, threshold)?;
                 let address: IotaAddress = (&multisig_pk).into();
                 let multisig = MultiSig::combine(sigs, multisig_pk)?;
-                let generic_sig: GenericSignature = multisig.into();
-                let multisig_serialized = generic_sig.encode_base64();
+                let multisig_serialized = multisig.encode_base64();
                 CommandOutput::MultiSigCombinePartialSig(MultiSigCombinePartialSig {
                     multisig_address: address,
-                    multisig_parsed: generic_sig,
+                    multisig_parsed: multisig,
                     multisig_serialized,
                 })
             }
@@ -1265,6 +1264,26 @@ impl Display for CommandOutput {
                 table.with(Rotate::Left);
                 table.with(tabled::settings::Style::rounded().horizontals([]));
                 table.with(Modify::new(Rows::new(0..)).with(Width::wrap(160).keep_words()));
+                write!(formatter, "{table}")
+            }
+            CommandOutput::MultiSigCombinePartialSig(data) => {
+                // Build inner table for multisigParsed
+                let parsed_table = json_to_table(&json!(&data.multisig_parsed))
+                    .with(tabled::settings::Style::rounded().horizontals([]))
+                    .to_string();
+
+                let mut builder = Builder::default();
+                builder
+                    .set_header(["multisigSerialized", "multisigParsed", "multisigAddress"])
+                    .push_record([
+                        &data.multisig_serialized,
+                        &parsed_table,
+                        &data.multisig_address.to_string(),
+                    ]);
+                let mut table = builder.build();
+                table.with(Rotate::Left);
+                table.with(tabled::settings::Style::rounded().horizontals([]));
+                table.with(Modify::new(Rows::new(0..)).with(Width::wrap(126).keep_words()));
                 write!(formatter, "{table}")
             }
             CommandOutput::UpdateAlias(update) => {

--- a/crates/iota/src/unit_tests/keytool_tests.rs
+++ b/crates/iota/src/unit_tests/keytool_tests.rs
@@ -695,36 +695,36 @@ async fn test_multi_sig_combine_partial_sig() -> Result<(), anyhow::Error> {
     .execute(&mut keystore)
     .await?;
 
-    match output {
-        CommandOutput::MultiSigCombinePartialSig(data) => {
-            assert_eq!(
-                data.multisig_address.to_string(),
-                "0x9c3d1202a483f33cc340183df29ae9ffa55697947be431c963be78917e7fc538"
-            );
-            // Check parsed structure
-            let parsed_json = serde_json::to_value(&data.multisig_parsed).unwrap();
-            let expected_json = serde_json::json!({
-                "sigs": [
-                    {"Ed25519": "/nyhgGk1lGxHxF4MvTlH/fujyXm3z175F0EMh3vIDT47G38X+OV8LDxucVHn3rOFWL0I3X1tvRpamfxTRwQ1Cg=="},
-                    {"Ed25519": "gb4I88R+l8kL/UAxJet88aYniErufacZGntlOthbeY+AzrMYn696kaT4IvQX2KGfN0D74IzYNRQJg6/isetACg=="}
-                ],
-                "bitmap": 3,
-                "multisig_pk": {
-                    "pk_map": [
-                        [{"Ed25519": "gozT5bvC8/qmK1OAlBUHth+fagw7dpl3e+i2RvrHzuU="}, 1],
-                        [{"Ed25519": "gDjPdxj/tvNTP8qPWY97kj2TzaCkvcn9amlaOcHndIg="}, 1],
-                        [{"Ed25519": "8Ev1C4ojUyNI2fkm3TDTM5RZ0JDFufzhSUqYm0Zu5Tg="}, 1]
-                    ],
-                    "threshold": 2
-                }
-            });
-            assert_eq!(parsed_json, expected_json);
-            assert_eq!(
-                data.multisig_serialized,
-                "AwIA/nyhgGk1lGxHxF4MvTlH/fujyXm3z175F0EMh3vIDT47G38X+OV8LDxucVHn3rOFWL0I3X1tvRpamfxTRwQ1CgCBvgjzxH6XyQv9QDEl63zxpieISu59pxkae2U62Ft5j4DOsxifr3qRpPgi9BfYoZ83QPvgjNg1FAmDr+Kx60AKAwADAIKM0+W7wvP6pitTgJQVB7Yfn2oMO3aZd3votkb6x87lAQCAOM93GP+281M/yo9Zj3uSPZPNoKS9yf1qaVo5wed0iAEA8Ev1C4ojUyNI2fkm3TDTM5RZ0JDFufzhSUqYm0Zu5TgBAgA="
-            );
+    let CommandOutput::MultiSigCombinePartialSig(data) = output else {
+        panic!("unexpected output: {output:?}");
+    };
+
+    assert_eq!(
+        data.multisig_address.to_string(),
+        "0x9c3d1202a483f33cc340183df29ae9ffa55697947be431c963be78917e7fc538"
+    );
+    // Check parsed structure
+    let parsed_json = serde_json::to_value(&data.multisig_parsed).unwrap();
+    let expected_json = serde_json::json!({
+        "sigs": [
+            {"Ed25519": "/nyhgGk1lGxHxF4MvTlH/fujyXm3z175F0EMh3vIDT47G38X+OV8LDxucVHn3rOFWL0I3X1tvRpamfxTRwQ1Cg=="},
+            {"Ed25519": "gb4I88R+l8kL/UAxJet88aYniErufacZGntlOthbeY+AzrMYn696kaT4IvQX2KGfN0D74IzYNRQJg6/isetACg=="}
+        ],
+        "bitmap": 3,
+        "multisig_pk": {
+            "pk_map": [
+                [{"Ed25519": "gozT5bvC8/qmK1OAlBUHth+fagw7dpl3e+i2RvrHzuU="}, 1],
+                [{"Ed25519": "gDjPdxj/tvNTP8qPWY97kj2TzaCkvcn9amlaOcHndIg="}, 1],
+                [{"Ed25519": "8Ev1C4ojUyNI2fkm3TDTM5RZ0JDFufzhSUqYm0Zu5Tg="}, 1]
+            ],
+            "threshold": 2
         }
-        _ => panic!("unexpected output: {output:?}"),
-    }
+    });
+    assert_eq!(parsed_json, expected_json);
+    assert_eq!(
+        data.multisig_serialized,
+        "AwIA/nyhgGk1lGxHxF4MvTlH/fujyXm3z175F0EMh3vIDT47G38X+OV8LDxucVHn3rOFWL0I3X1tvRpamfxTRwQ1CgCBvgjzxH6XyQv9QDEl63zxpieISu59pxkae2U62Ft5j4DOsxifr3qRpPgi9BfYoZ83QPvgjNg1FAmDr+Kx60AKAwADAIKM0+W7wvP6pitTgJQVB7Yfn2oMO3aZd3votkb6x87lAQCAOM93GP+281M/yo9Zj3uSPZPNoKS9yf1qaVo5wed0iAEA8Ev1C4ojUyNI2fkm3TDTM5RZ0JDFufzhSUqYm0Zu5TgBAgA="
+    );
+
     Ok(())
 }

--- a/crates/iota/src/unit_tests/keytool_tests.rs
+++ b/crates/iota/src/unit_tests/keytool_tests.rs
@@ -15,9 +15,10 @@ use iota_types::{
     base_types::{IotaAddress, ObjectDigest, ObjectID, SequenceNumber},
     crypto::{
         AuthorityKeyPair, Ed25519IotaSignature, EncodeDecodeBase64, IotaKeyPair,
-        IotaSignatureInner, Secp256k1IotaSignature, Secp256r1IotaSignature, Signature,
+        IotaSignatureInner, PublicKey, Secp256k1IotaSignature, Secp256r1IotaSignature, Signature,
         SignatureScheme, get_key_pair, get_key_pair_from_rng,
     },
+    signature::GenericSignature,
     transaction::{TEST_ONLY_GAS_UNIT_FOR_TRANSFER, TransactionData},
 };
 use rand::{SeedableRng, rngs::StdRng};
@@ -665,5 +666,65 @@ async fn test_show() -> Result<(), anyhow::Error> {
         _ => panic!("unexpected output: {output:?}"),
     }
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_multi_sig_combine_partial_sig() -> Result<(), anyhow::Error> {
+    let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
+
+    // Public keys (Base64)
+    let pk1 = PublicKey::decode_base64("AIKM0+W7wvP6pitTgJQVB7Yfn2oMO3aZd3votkb6x87l").unwrap();
+    let pk2 = PublicKey::decode_base64("AIA4z3cY/7bzUz/Kj1mPe5I9k82gpL3J/WppWjnB53SI").unwrap();
+    let pk3 = PublicKey::decode_base64("APBL9QuKI1MjSNn5Jt0w0zOUWdCQxbn84UlKmJtGbuU4").unwrap();
+    let pks = vec![pk1, pk2, pk3];
+    let weights = vec![1, 1, 1];
+    let threshold = 2;
+
+    // Signatures (Base64)
+    let sig1 = GenericSignature::decode_base64("AP58oYBpNZRsR8ReDL05R/37o8l5t89e+RdBDId7yA0+Oxt/F/jlfCw8bnFR596zhVi9CN19bb0aWpn8U0cENQqCjNPlu8Lz+qYrU4CUFQe2H59qDDt2mXd76LZG+sfO5Q==").unwrap();
+    let sig2 = GenericSignature::decode_base64("AIG+CPPEfpfJC/1AMSXrfPGmJ4hK7n2nGRp7ZTrYW3mPgM6zGJ+vepGk+CL0F9ihnzdA++CM2DUUCYOv4rHrQAqAOM93GP+281M/yo9Zj3uSPZPNoKS9yf1qaVo5wed0iA==").unwrap();
+    let sigs = vec![sig1, sig2];
+
+    let output = KeyToolCommand::MultiSigCombinePartialSig {
+        sigs,
+        pks,
+        weights,
+        threshold,
+    }
+    .execute(&mut keystore)
+    .await?;
+
+    match output {
+        CommandOutput::MultiSigCombinePartialSig(data) => {
+            assert_eq!(
+                data.multisig_address.to_string(),
+                "0x9c3d1202a483f33cc340183df29ae9ffa55697947be431c963be78917e7fc538"
+            );
+            // Check parsed structure
+            let parsed_json = serde_json::to_value(&data.multisig_parsed).unwrap();
+            let expected_json = serde_json::json!({
+                "sigs": [
+                    {"Ed25519": "/nyhgGk1lGxHxF4MvTlH/fujyXm3z175F0EMh3vIDT47G38X+OV8LDxucVHn3rOFWL0I3X1tvRpamfxTRwQ1Cg=="},
+                    {"Ed25519": "gb4I88R+l8kL/UAxJet88aYniErufacZGntlOthbeY+AzrMYn696kaT4IvQX2KGfN0D74IzYNRQJg6/isetACg=="}
+                ],
+                "bitmap": 3,
+                "multisig_pk": {
+                    "pk_map": [
+                        [{"Ed25519": "gozT5bvC8/qmK1OAlBUHth+fagw7dpl3e+i2RvrHzuU="}, 1],
+                        [{"Ed25519": "gDjPdxj/tvNTP8qPWY97kj2TzaCkvcn9amlaOcHndIg="}, 1],
+                        [{"Ed25519": "8Ev1C4ojUyNI2fkm3TDTM5RZ0JDFufzhSUqYm0Zu5Tg="}, 1]
+                    ],
+                    "threshold": 2
+                }
+            });
+            assert_eq!(parsed_json, expected_json);
+            assert_eq!(
+                data.multisig_serialized,
+                "AwIA/nyhgGk1lGxHxF4MvTlH/fujyXm3z175F0EMh3vIDT47G38X+OV8LDxucVHn3rOFWL0I3X1tvRpamfxTRwQ1CgCBvgjzxH6XyQv9QDEl63zxpieISu59pxkae2U62Ft5j4DOsxifr3qRpPgi9BfYoZ83QPvgjNg1FAmDr+Kx60AKAwADAIKM0+W7wvP6pitTgJQVB7Yfn2oMO3aZd3votkb6x87lAQCAOM93GP+281M/yo9Zj3uSPZPNoKS9yf1qaVo5wed0iAEA8Ev1C4ojUyNI2fkm3TDTM5RZ0JDFufzhSUqYm0Zu5TgBAgA="
+            );
+        }
+        _ => panic!("unexpected output: {output:?}"),
+    }
     Ok(())
 }


### PR DESCRIPTION
# Description of change

Display MultiSigCombinePartialSig::multisigParsed details instead of bas64 (this is still displayed in MultiSigCombinePartialSig::multisigSerialized)

Looks like this now
```
iota keytool multi-sig-combine-partial-sig --pks AIKM0+W7wvP6pitTgJQVB7Yfn2oMO3aZd3votkb6x87l AIA4z3cY/7bzUz/Kj1mPe5I9k82gpL3J/WppWjnB53SI APBL9QuKI1MjSNn5Jt0w0zOUWdCQxbn84UlKmJtGbuU4 --weights 1 1 1 --threshold 2 --sigs AP58oYBpNZRsR8ReDL05R/37o8l5t89e+RdBDId7yA0+Oxt/F/jlfCw8bnFR596zhVi9CN19bb0aWpn8U0cENQqCjNPlu8Lz+qYrU4CUFQe2H59qDDt2mXd76LZG+sfO5Q== AIG+CPPEfpfJC/1AMSXrfPGmJ4hK7n2nGRp7ZTrYW3mPgM6zGJ+vepGk+CL0F9ihnzdA++CM2DUUCYOv4rHrQAqAOM93GP+281M/yo9Zj3uSPZPNoKS9yf1qaVo5wed0iA==`
╭────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ multisigAddress    │ 0x9c3d1202a483f33cc340183df29ae9ffa55697947be431c963be78917e7fc538                                                             │
│ multisigParsed     │ ╭─────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ │
│                    │ │ sigs        │ ╭──────────────────────────────────────────────────────────────────────────────────────────────────────────╮ │ │
│                    │ │             │ │ ╭─────────┬────────────────────────────────────────────────────────────────────────────────────────────╮ │ │ │
│                    │ │             │ │ │ Ed25519 │  /nyhgGk1lGxHxF4MvTlH/fujyXm3z175F0EMh3vIDT47G38X+OV8LDxucVHn3rOFWL0I3X1tvRpamfxTRwQ1Cg==  │ │ │ │
│                    │ │             │ │ ╰─────────┴────────────────────────────────────────────────────────────────────────────────────────────╯ │ │ │
│                    │ │             │ │ ╭─────────┬────────────────────────────────────────────────────────────────────────────────────────────╮ │ │ │
│                    │ │             │ │ │ Ed25519 │  gb4I88R+l8kL/UAxJet88aYniErufacZGntlOthbeY+AzrMYn696kaT4IvQX2KGfN0D74IzYNRQJg6/isetACg==  │ │ │ │
│                    │ │             │ │ ╰─────────┴────────────────────────────────────────────────────────────────────────────────────────────╯ │ │ │
│                    │ │             │ ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────╯ │ │
│                    │ │ bitmap      │  3                                                                                                           │ │
│                    │ │ multisig_pk │ ╭───────────┬──────────────────────────────────────────────────────────────────────╮                         │ │
│                    │ │             │ │ pk_map    │ ╭──────────────────────────────────────────────────────────────────╮ │                         │ │
│                    │ │             │ │           │ │ ╭──────────────────────────────────────────────────────────────╮ │ │                         │ │
│                    │ │             │ │           │ │ │ ╭─────────┬────────────────────────────────────────────────╮ │ │ │                         │ │
│                    │ │             │ │           │ │ │ │ Ed25519 │  gozT5bvC8/qmK1OAlBUHth+fagw7dpl3e+i2RvrHzuU=  │ │ │ │                         │ │
│                    │ │             │ │           │ │ │ ╰─────────┴────────────────────────────────────────────────╯ │ │ │                         │ │
│                    │ │             │ │           │ │ │  1                                                           │ │ │                         │ │
│                    │ │             │ │           │ │ ╰──────────────────────────────────────────────────────────────╯ │ │                         │ │
│                    │ │             │ │           │ │ ╭──────────────────────────────────────────────────────────────╮ │ │                         │ │
│                    │ │             │ │           │ │ │ ╭─────────┬────────────────────────────────────────────────╮ │ │ │                         │ │
│                    │ │             │ │           │ │ │ │ Ed25519 │  gDjPdxj/tvNTP8qPWY97kj2TzaCkvcn9amlaOcHndIg=  │ │ │ │                         │ │
│                    │ │             │ │           │ │ │ ╰─────────┴────────────────────────────────────────────────╯ │ │ │                         │ │
│                    │ │             │ │           │ │ │  1                                                           │ │ │                         │ │
│                    │ │             │ │           │ │ ╰──────────────────────────────────────────────────────────────╯ │ │                         │ │
│                    │ │             │ │           │ │ ╭──────────────────────────────────────────────────────────────╮ │ │                         │ │
│                    │ │             │ │           │ │ │ ╭─────────┬────────────────────────────────────────────────╮ │ │ │                         │ │
│                    │ │             │ │           │ │ │ │ Ed25519 │  8Ev1C4ojUyNI2fkm3TDTM5RZ0JDFufzhSUqYm0Zu5Tg=  │ │ │ │                         │ │
│                    │ │             │ │           │ │ │ ╰─────────┴────────────────────────────────────────────────╯ │ │ │                         │ │
│                    │ │             │ │           │ │ │  1                                                           │ │ │                         │ │
│                    │ │             │ │           │ │ ╰──────────────────────────────────────────────────────────────╯ │ │                         │ │
│                    │ │             │ │           │ ╰──────────────────────────────────────────────────────────────────╯ │                         │ │
│                    │ │             │ │ threshold │  2                                                                   │                         │ │
│                    │ │             │ ╰───────────┴──────────────────────────────────────────────────────────────────────╯                         │ │
│                    │ ╰─────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ │
│ multisigSerialized │ AwIA/nyhgGk1lGxHxF4MvTlH/fujyXm3z175F0EMh3vIDT47G38X+OV8LDxucVHn3rOFWL0I3X1tvRpamfxTRwQ1CgCBvgjzxH6XyQv9QDEl63zxpieISu59pxkae2 │
│                    │ U62Ft5j4DOsxifr3qRpPgi9BfYoZ83QPvgjNg1FAmDr+Kx60AKAwADAIKM0+W7wvP6pitTgJQVB7Yfn2oMO3aZd3votkb6x87lAQCAOM93GP+281M/yo9Zj3uSPZPN │
│                    │ oKS9yf1qaVo5wed0iAEA8Ev1C4ojUyNI2fkm3TDTM5RZ0JDFufzhSUqYm0Zu5TgBAgA=                                                           │
╰────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/7668

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: Fixed `iota keytool multi-sig-combine-partial-sig` output to display multisigParsed details instead of a base64 string (still available from multisigSerialized field)
- [ ] Rust SDK:
- [ ] REST API:
