### PR TITLE
upstream(node): Remove -q flag in update_all_snapshots.sh

### DIFF
--- a/crates/iota-core/tests/README.md
+++ b/crates/iota-core/tests/README.md
@@ -37,7 +37,7 @@ Now our code is modified in a way that will make the format test fail: let's upd
 
 ```
 huitseeker@Garillots-MBP.localdomain➜~/tmp/iota(main✗)» cd iota_core                                                                                                                                                                                                                                                                                                                                                                                                                    [8:43:38]
-huitseeker@Garillots-MBP.localdomain➜tmp/iota/iota_core(main✗)» cargo -q run --example generate-format -- print > tests/staged/iota.yaml
+huitseeker@Garillots-MBP.localdomain➜tmp/iota/iota_core(main✗)» cargo run --example generate-format -- print > tests/staged/iota.yaml
 ```
 
 Let's check that we pass the test again:

--- a/crates/iota-core/tests/format.rs
+++ b/crates/iota-core/tests/format.rs
@@ -7,7 +7,7 @@
 #[cfg_attr(msim, ignore)]
 fn test_format() {
     // If this test breaks and you intended a format change, you need to run to get
-    // the fresh format: # cargo -q run --example generate-format -- print >
+    // the fresh format: # cargo run --example generate-format -- print >
     // crates/iota-core/tests/staged/iota.yaml
 
     let status = std::process::Command::new("cargo")
@@ -20,7 +20,7 @@ fn test_format() {
         status.success(),
         "\n\
 If this test breaks and you intended a format change, you need to run to get the fresh format:\n\
-cargo -q run --example generate-format -- print > crates/iota-core/tests/staged/iota.yaml\n\
+cargo run --example generate-format -- print > crates/iota-core/tests/staged/iota.yaml\n\
         "
     );
 }

--- a/crates/iota-open-rpc/tests/generate-spec.rs
+++ b/crates/iota-open-rpc/tests/generate-spec.rs
@@ -6,7 +6,7 @@
 #[cfg_attr(msim, ignore)]
 fn test_json_rpc_spec() {
     // If this test breaks and you intended a json rpc schema change, you need to
-    // run to get the fresh schema: # cargo -q run --example
+    // run to get the fresh schema: # cargo run --example
     // generate-json-rpc-spec -- record
     let status = std::process::Command::new("cargo")
         .current_dir("..")
@@ -18,7 +18,7 @@ fn test_json_rpc_spec() {
         status.success(),
         "\n\
 If this test breaks and you intended a json rpc schema change, you need to run to get the fresh schema:\n\
-cargo -q run --example generate-json-rpc-spec -- record\n\
+cargo run --example generate-json-rpc-spec -- record\n\
         "
     );
 }

--- a/scripts/update_all_snapshots.sh
+++ b/scripts/update_all_snapshots.sh
@@ -16,6 +16,6 @@ cd "$ROOT/crates/iota-protocol-config" && cargo insta test --review
 cd "$ROOT/crates/iota-cost" && cargo insta test --review
 cd "$ROOT/crates/iota-swarm-config" && cargo insta test --review
 cd "$ROOT/crates/iota-open-rpc" && cargo run --example generate-json-rpc-spec -- record
-cd "$ROOT/crates/iota-core" && cargo -q run --example generate-format -- print > tests/staged/iota.yaml
+cd "$ROOT/crates/iota-core" && cargo run --example generate-format -- print > tests/staged/iota.yaml
 UPDATE=1 cargo test -p iota-framework --test build-system-packages
 UPDATE=1 cargo test -p iota-rest-api


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.39.4, v1.40.3)
- Port commit: https://github.com/MystenLabs/sui/commit/5c9709fac7eec229e4ffa1d1e3ea4b0138cac557

## Links to any relevant issues

Part of #6148  

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

