### PR TITLE
feat(indexer): Fetch optimistic events in ReadApi::get_events

### DIFF
--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -1265,7 +1265,9 @@ impl IndexerReader {
         let iota_tx_events =
             tx_events_to_iota_tx_events(tx_events, self.package_resolver(), digest, timestamp_ms)
                 .await?;
-        Ok(iota_tx_events.map_or(vec![], |ste| ste.data))
+        Ok(iota_tx_events.map_or(vec![], |transaction_block_events| {
+            transaction_block_events.data
+        }))
     }
 
     pub async fn try_get_checkpointed_transaction_events(

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -1252,12 +1252,12 @@ impl IndexerReader {
     ) -> Result<Vec<iota_json_rpc_types::IotaEvent>, IndexerError> {
         let checkpointed_events = self.try_get_checkpointed_transaction_events(digest).await?;
 
-        let (timestamp_ms, serialized_events) = match checkpointed_events {
-            Some((timestamp_ms, serialized_events)) => {
-                (Some(timestamp_ms as u64), serialized_events)
-            }
-            None => (None, self.get_optimistic_transaction_events(digest).await?),
-        };
+        let (timestamp_ms, serialized_events) =
+            if let Some((timestamp, events)) = checkpointed_events {
+                (Some(timestamp as u64), events)
+            } else {
+                (None, self.get_optimistic_transaction_events(digest).await?)
+            };
 
         let events = stored_events_to_events(serialized_events)?;
         let tx_events = TransactionEvents { data: events };

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -1250,8 +1250,30 @@ impl IndexerReader {
         &self,
         digest: TransactionDigest,
     ) -> Result<Vec<iota_json_rpc_types::IotaEvent>, IndexerError> {
+        let checkpointed_events = self.try_get_checkpointed_transaction_events(digest).await?;
+
+        let (timestamp_ms, serialized_events) = match checkpointed_events {
+            Some((timestamp_ms, serialized_events)) => {
+                (Some(timestamp_ms as u64), serialized_events)
+            }
+            None => (None, self.get_optimistic_transaction_events(digest).await?),
+        };
+
+        let events = stored_events_to_events(serialized_events)?;
+        let tx_events = TransactionEvents { data: events };
+
+        let iota_tx_events =
+            tx_events_to_iota_tx_events(tx_events, self.package_resolver(), digest, timestamp_ms)
+                .await?;
+        Ok(iota_tx_events.map_or(vec![], |ste| ste.data))
+    }
+
+    pub async fn try_get_checkpointed_transaction_events(
+        &self,
+        digest: TransactionDigest,
+    ) -> Result<Option<(i64, StoredTransactionEvents)>, IndexerError> {
         let pool = self.get_pool();
-        let (timestamp_ms, serialized_events) = run_query_async!(&pool, move |conn| {
+        run_query_async!(&pool, move |conn| {
             transactions::table
                 .filter(
                     transactions::tx_sequence_number
@@ -1265,19 +1287,27 @@ impl IndexerReader {
                 )
                 .select((transactions::timestamp_ms, transactions::events))
                 .first::<(i64, StoredTransactionEvents)>(conn)
-        })?;
+                .optional()
+        })
+    }
 
-        let events = stored_events_to_events(serialized_events)?;
-        let tx_events = TransactionEvents { data: events };
-
-        let iota_tx_events = tx_events_to_iota_tx_events(
-            tx_events,
-            self.package_resolver(),
-            digest,
-            timestamp_ms as u64,
-        )
-        .await?;
-        Ok(iota_tx_events.map_or(vec![], |ste| ste.data))
+    pub async fn get_optimistic_transaction_events(
+        &self,
+        digest: TransactionDigest,
+    ) -> Result<StoredTransactionEvents, IndexerError> {
+        let pool = self.get_pool();
+        run_query_async!(&pool, move |conn| {
+            optimistic_transactions::table
+                .inner_join(
+                    tx_global_order::table.on(optimistic_transactions::sequence_number
+                        .eq(tx_global_order::optimistic_sequence_number)),
+                )
+                // we filter the `tx_global_order` table because it is indexed by digest,
+                // optimistic_transactions table is not
+                .filter(tx_global_order::tx_digest.eq(digest.into_inner().to_vec()))
+                .select(optimistic_transactions::events)
+                .first::<StoredTransactionEvents>(conn)
+        })
     }
 
     async fn query_events_by_tx_digest(

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -357,7 +357,8 @@ impl StoredTransaction {
             let timestamp = self.timestamp_ms as u64;
             let tx_events = TransactionEvents { data: events };
 
-            tx_events_to_iota_tx_events(tx_events, package_resolver, tx_digest, timestamp).await?
+            tx_events_to_iota_tx_events(tx_events, package_resolver, tx_digest, Some(timestamp))
+                .await?
         } else {
             None
         };
@@ -477,7 +478,7 @@ pub async fn tx_events_to_iota_tx_events(
     tx_events: TransactionEvents,
     package_resolver: Arc<Resolver<impl PackageStore>>,
     tx_digest: TransactionDigest,
-    timestamp: u64,
+    timestamp: Option<u64>,
 ) -> Result<Option<IotaTransactionBlockEvents>, IndexerError> {
     let mut iota_event_futures = vec![];
     let tx_events_data_len = tx_events.data.len();
@@ -520,7 +521,7 @@ pub async fn tx_events_to_iota_tx_events(
                 tx_event,
                 tx_digest,
                 seq as u64,
-                Some(timestamp),
+                timestamp,
                 move_datatype_layout,
             )
         })

--- a/crates/iota-indexer/tests/rpc-tests/coin_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/coin_api.rs
@@ -800,7 +800,11 @@ pub async fn execute_move_call(
         .execute_transaction_block(
             tx_bytes,
             signatures,
-            Some(IotaTransactionBlockResponseOptions::new().with_effects()),
+            Some(
+                IotaTransactionBlockResponseOptions::new()
+                    .with_effects()
+                    .with_events(),
+            ),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -8,6 +8,7 @@ use iota_indexer::{
     models::transactions::StoredTransaction, store::package_resolver::IndexerStorePackageResolver,
     test_utils::TestDatabase,
 };
+use iota_json::{call_args, type_args};
 use iota_json_rpc_api::{IndexerApiClient, ReadApiClient, TransactionBuilderClient};
 use iota_json_rpc_types::{
     CheckpointId, IotaGetPastObjectRequest, IotaObjectDataOptions, IotaObjectRef,
@@ -23,6 +24,7 @@ use iota_types::{
     digests::{ChainIdentifier, ObjectDigest, TransactionDigest},
     error::IotaObjectResponseError,
 };
+use itertools::Itertools;
 use serde_json::Value;
 
 use crate::{
@@ -32,7 +34,7 @@ use crate::{
         indexer_wait_for_transaction, rpc_call_error_msg_matches,
         start_test_cluster_with_read_write_indexer,
     },
-    write_api::{create_basic_object, deploy_basics_pkg, update_basic_object},
+    write_api::{create_basic_object, deploy_basics_pkg},
 };
 
 /// Utility function to convert hex strings in JSON values to byte arrays.
@@ -909,7 +911,7 @@ fn get_events() {
 }
 
 #[test]
-fn get_fresh_event() -> Result<(), anyhow::Error> {
+fn get_newly_created_optimistically_indexed_event() -> Result<(), anyhow::Error> {
     let ApiTestSetup {
         runtime,
         store,
@@ -933,17 +935,30 @@ fn get_fresh_event() -> Result<(), anyhow::Error> {
         let basic_obj_1 = create_basic_object(sender, &sender_kp, client, &package_id).await?;
         let basic_obj_2 = create_basic_object(sender, &sender_kp, client, &package_id).await?;
 
-        let (res, event_id) = update_basic_object(
+        // Update the object to generate new event
+        let res = crate::coin_api::execute_move_call(
+            client,
             sender,
             &sender_kp,
-            client,
-            &package_id,
-            &basic_obj_1,
-            &basic_obj_2,
+            package_id,
+            "object_basics".to_string(),
+            "update".to_string(),
+            type_args![].unwrap(),
+            call_args!(basic_obj_1, basic_obj_2).unwrap(),
+            None,
         )
-        .await
-        .unwrap();
+        .await?;
         assert_eq!(res.status_ok(), Some(true));
+
+        let event_id = res
+            .events
+            .as_ref()
+            .unwrap()
+            .data
+            .iter()
+            .exactly_one()
+            .unwrap()
+            .id;
 
         // despite the naming, there is no 100% guarantee that the result here comes
         // from optimistic indexing, but it's very likely

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -25,10 +25,14 @@ use iota_types::{
 };
 use serde_json::Value;
 
-use crate::common::{
-    ApiTestSetup, FIXTURES_DIR, execute_tx_and_wait_for_indexer, get_indexer_db_url,
-    indexer_wait_for_checkpoint, indexer_wait_for_checkpoint_pruned, indexer_wait_for_object,
-    rpc_call_error_msg_matches, start_test_cluster_with_read_write_indexer,
+use crate::{
+    common::{
+        ApiTestSetup, FIXTURES_DIR, execute_tx_and_wait_for_indexer, get_indexer_db_url,
+        indexer_wait_for_checkpoint, indexer_wait_for_checkpoint_pruned, indexer_wait_for_object,
+        indexer_wait_for_transaction, rpc_call_error_msg_matches,
+        start_test_cluster_with_read_write_indexer,
+    },
+    write_api::{create_basic_object, deploy_basics_pkg, update_basic_object},
 };
 
 /// Utility function to convert hex strings in JSON values to byte arrays.
@@ -252,7 +256,7 @@ fn multi_get_transaction_blocks_with_options(options: IotaTransactionBlockRespon
 async fn wait_for_objects_history() {
     // Objects history is not filled by optimistic indexing, this method waits a few
     // seconds so that checkpoint indexing has a chance to kick in
-    tokio::time::sleep(Duration::from_secs(3)).await
+    tokio::time::sleep(Duration::from_secs(3)).await;
 }
 
 #[test]
@@ -902,6 +906,81 @@ fn get_events() {
 
         assert!(!events.is_empty());
     });
+}
+
+#[test]
+fn get_fresh_event() -> Result<(), anyhow::Error> {
+    let ApiTestSetup {
+        runtime,
+        store,
+        cluster,
+        client,
+    } = ApiTestSetup::get_or_init();
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(store, 1).await;
+        let (sender, sender_kp): (_, AccountKeyPair) = get_key_pair();
+
+        let gas_ref = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(10_000_000_000),
+                sender,
+            )
+            .await;
+        indexer_wait_for_object(client, gas_ref.0, gas_ref.1).await;
+
+        let (_, package_id) = deploy_basics_pkg(sender, &sender_kp, client).await;
+        let basic_obj_1 = create_basic_object(sender, &sender_kp, client, &package_id).await?;
+        let basic_obj_2 = create_basic_object(sender, &sender_kp, client, &package_id).await?;
+
+        let (res, event_id) = update_basic_object(
+            sender,
+            &sender_kp,
+            client,
+            &package_id,
+            &basic_obj_1,
+            &basic_obj_2,
+        )
+        .await
+        .unwrap();
+        assert_eq!(res.status_ok(), Some(true));
+
+        // despite the naming, there is no 100% guarantee that the result here comes
+        // from optimistic indexing, but it's very likely
+        let result_optimistic = client.get_events(res.digest).await.unwrap();
+        assert_eq!(result_optimistic.len(), 1);
+        assert_eq!(result_optimistic[0].id, event_id);
+        let event_data_to_compare_opt = (
+            &result_optimistic[0].id,
+            &result_optimistic[0].package_id,
+            &result_optimistic[0].transaction_module,
+            &result_optimistic[0].sender,
+            &result_optimistic[0].type_,
+            &result_optimistic[0].parsed_json,
+            &result_optimistic[0].bcs,
+        );
+
+        indexer_wait_for_transaction(res.digest, store, client).await;
+
+        let result_checkpointed = client.get_events(res.digest).await.unwrap();
+        assert_eq!(result_checkpointed.len(), 1);
+        assert_eq!(result_checkpointed[0].id, event_id);
+        let event_data_to_compare_ckpt = (
+            &result_checkpointed[0].id,
+            &result_checkpointed[0].package_id,
+            &result_checkpointed[0].transaction_module,
+            &result_checkpointed[0].sender,
+            &result_checkpointed[0].type_,
+            &result_checkpointed[0].parsed_json,
+            &result_checkpointed[0].bcs,
+        );
+
+        assert_eq!(event_data_to_compare_opt, event_data_to_compare_ckpt);
+        // comparing only selected fields, because timestamp_ms changes from None to
+        // Some after checkpoint indexing kicks in
+
+        Ok(())
+    })
 }
 
 #[test]

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -29,6 +29,7 @@ use iota_types::{
     base_types::{IotaAddress, ObjectID, ObjectRef},
     crypto::{AccountKeyPair, get_key_pair},
     digests::TransactionDigest,
+    event::EventID,
     gas_coin::NANOS_PER_IOTA,
     object::Owner,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
@@ -876,7 +877,7 @@ fn test_repeatedly_update_display() {
     });
 }
 
-async fn create_basic_object(
+pub(crate) async fn create_basic_object(
     address: IotaAddress,
     address_kp: &AccountKeyPair,
     client: &HttpClient,
@@ -937,6 +938,40 @@ async fn wrap_basic_object(
         .object_id();
 
     Ok((res, wrapped_obj_id))
+}
+
+pub(crate) async fn update_basic_object(
+    address: IotaAddress,
+    address_kp: &AccountKeyPair,
+    client: &HttpClient,
+    package_id: &ObjectID,
+    object_id_1: &ObjectID,
+    object_id_2: &ObjectID,
+) -> Result<(IotaTransactionBlockResponse, EventID), anyhow::Error> {
+    let res = execute_move_call(
+        client,
+        address,
+        address_kp,
+        *package_id,
+        "object_basics".to_string(),
+        "update".to_string(),
+        type_args![].unwrap(),
+        call_args!(object_id_1, object_id_2).unwrap(),
+        None,
+    )
+    .await?;
+
+    let event_id = res
+        .events
+        .as_ref()
+        .unwrap()
+        .data
+        .iter()
+        .exactly_one()
+        .unwrap()
+        .id;
+
+    Ok((res, event_id))
 }
 
 async fn unwrap_basic_object(
@@ -1121,7 +1156,7 @@ async fn create_new_bear(
     Ok((res, bear_id))
 }
 
-async fn deploy_basics_pkg(
+pub(crate) async fn deploy_basics_pkg(
     address: IotaAddress,
     address_kp: &AccountKeyPair,
     client: &HttpClient,

--- a/crates/iota-indexer/tests/rpc-tests/write_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/write_api.rs
@@ -29,7 +29,6 @@ use iota_types::{
     base_types::{IotaAddress, ObjectID, ObjectRef},
     crypto::{AccountKeyPair, get_key_pair},
     digests::TransactionDigest,
-    event::EventID,
     gas_coin::NANOS_PER_IOTA,
     object::Owner,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
@@ -938,40 +937,6 @@ async fn wrap_basic_object(
         .object_id();
 
     Ok((res, wrapped_obj_id))
-}
-
-pub(crate) async fn update_basic_object(
-    address: IotaAddress,
-    address_kp: &AccountKeyPair,
-    client: &HttpClient,
-    package_id: &ObjectID,
-    object_id_1: &ObjectID,
-    object_id_2: &ObjectID,
-) -> Result<(IotaTransactionBlockResponse, EventID), anyhow::Error> {
-    let res = execute_move_call(
-        client,
-        address,
-        address_kp,
-        *package_id,
-        "object_basics".to_string(),
-        "update".to_string(),
-        type_args![].unwrap(),
-        call_args!(object_id_1, object_id_2).unwrap(),
-        None,
-    )
-    .await?;
-
-    let event_id = res
-        .events
-        .as_ref()
-        .unwrap()
-        .data
-        .iter()
-        .exactly_one()
-        .unwrap()
-        .id;
-
-    Ok((res, event_id))
 }
 
 async fn unwrap_basic_object(


### PR DESCRIPTION
# Description of change

Fetch optimistic events in ReadApi::get_events

Note that optimistically indexed event doesn't have **timestamp_ms** assigned yet, so from the API perspective event will have **timestamp_ms=None** at the beginning, and then value will be set to **Some(..)** after event is checkpoint indexed.

## Links to any relevant issues

fixes #7794

## How the change has been tested

`cargo test --profile dev-nodebug --package iota-indexer --test rpc-tests --all-features`

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
