### PR TITLE
feat(consensus): refactor `test_dag_parser` to separate `DagBuilder` from parsers

### DIFF
--- a/crates/starfish/config/src/committee.rs
+++ b/crates/starfish/config/src/committee.rs
@@ -188,6 +188,12 @@ impl AuthorityIndex {
     }
 }
 
+impl From<u32> for AuthorityIndex {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
 impl AuthorityIndex {
     pub fn new_for_test(index: u32) -> Self {
         Self(index)

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -366,15 +366,10 @@ pub struct Slot {
 }
 
 impl Slot {
-    pub fn new(round: Round, authority: AuthorityIndex) -> Self {
-        Self { round, authority }
-    }
-
-    #[cfg(test)]
-    pub fn new_for_test(round: Round, authority: u32) -> Self {
+    pub fn new(round: Round, authority: impl Into<AuthorityIndex>) -> Self {
         Self {
             round,
-            authority: AuthorityIndex::new_for_test(authority),
+            authority: authority.into(),
         }
     }
 }
@@ -874,7 +869,7 @@ impl TestBlockHeader {
         Self {
             block_header: BlockHeaderV1 {
                 round,
-                author: AuthorityIndex::new_for_test(author),
+                author: author.into(),
                 transactions_commitment: TransactionsCommitment::compute_transactions_commitment(
                     &Bytes::from(bcs::to_bytes::<Vec<Transaction>>(&vec![]).unwrap()),
                 )

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -2648,7 +2648,7 @@ mod test {
             Round 8 : { * },
         }";
 
-        let (_, dag_builder) = parse_dag(dag_str).expect("Invalid dag");
+        let dag_builder = parse_dag(dag_str).expect("Invalid dag");
         dag_builder.print();
 
         // Subscribe to all created "own" blocks. We know that for our node (A) we'll be

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -2305,7 +2305,7 @@ mod test {
             },
         }";
 
-        let (_, dag_builder) = parse_dag(dag_str).expect("Invalid dag");
+        let dag_builder = parse_dag(dag_str).expect("Invalid dag");
 
         // Add equivocating block for round 2 authority 3
         let block = VerifiedBlockHeader::new_for_test(TestBlockHeader::new(2, 2).build());

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -624,7 +624,7 @@ mod tests {
                 Round 5 : { * },
             }";
 
-        let (_, dag_builder) = parse_dag(dag_str).expect("Invalid dag");
+        let dag_builder = parse_dag(dag_str).expect("Invalid dag");
         dag_builder.print();
         dag_builder.persist_all_blocks(dag_state.clone());
 

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -388,7 +388,6 @@ impl DagBuilder {
         &mut self,
         connections: Vec<(AuthorityIndex, Vec<BlockRef>)>,
         transactions_acknowledgments: HashMap<AuthorityIndex, Vec<BlockRef>>,
-
         round: Round,
     ) {
         let mut references = Vec::new();
@@ -1092,6 +1091,12 @@ impl<'a> LayerBuilder<'a> {
             }
         }
     }
+}
+
+pub enum ConnectionSpec {
+    All,
+    Only(Vec<Slot>),
+    Skip(Vec<Slot>),
 }
 
 // TODO: add more unit tests

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -32,6 +32,9 @@ use crate::{
 ///
 /// DAG Building
 /// ```rust
+/// use std::sync::Arc;
+/// use super::context::Context;
+/// use super::test_dag_builder::DagBuilder;
 /// let context = Arc::new(Context::new_for_test(4).0);
 /// let mut dag_builder = DagBuilder::new(context);
 /// dag_builder.layer(1).build(); // Round 1 is fully connected with parents by default.
@@ -47,6 +50,11 @@ use crate::{
 ///
 /// Persisting to DagState by Layer
 /// ```rust
+/// use std::sync::{Arc, RwLock};
+///
+/// use super::{
+///     context::Context, dag_state::DagState, storage::MemStore, test_dag_builder::DagBuilder,
+/// };
 /// let dag_state = Arc::new(RwLock::new(DagState::new(
 ///     dag_builder.context.clone(),
 ///     Arc::new(MemStore::new()),
@@ -61,12 +69,18 @@ use crate::{
 ///
 /// Persisting entire DAG to DagState
 /// ```rust
+/// use std::sync::{Arc, RwLock};
+///
+/// use super::{
+///     context::Context, dag_state::DagState, storage::MemStore, test_dag_builder::DagBuilder,
+/// };
+/// let context = Arc::new(Context::new_for_test(4).0);
+/// let dag_builder = DagBuilder::new(context);
 /// let dag_state = Arc::new(RwLock::new(DagState::new(
 ///     dag_builder.context.clone(),
 ///     Arc::new(MemStore::new()),
 /// )));
-/// let context = Arc::new(Context::new_for_test(4).0);
-/// let dag_builder = DagBuilder::new(context);
+///
 /// dag_builder.layer(1).build();
 /// dag_builder.layers(2..10).build();
 /// dag_builder.persist_all_blocks(dag_state.clone()); // persist entire DAG
@@ -74,6 +88,9 @@ use crate::{
 ///
 /// Printing DAG
 /// ```rust
+/// use std::sync::Arc;
+///
+/// use super::{context::Context, test_dag_builder::DagBuilder};
 /// let context = Arc::new(Context::new_for_test(4).0);
 /// let dag_builder = DagBuilder::new(context);
 /// dag_builder.layer(1).build();
@@ -101,19 +118,21 @@ pub(crate) struct DagBuilder {
     // signature is used
     protocol_keypair: Option<Vec<ProtocolKeyPair>>,
 }
-/// The `AncestorSelection` enum is an interim data structure used to specify how ancestors
-/// should be selected for a block in the `DagBuilder`. `UseLast` equates to the "*" in the
-/// parser, while `IncludeFrom(Slot)` and `ExcludeFrom(Slot)` equate to "A3" and "-A3" respectively.
-#[derive(Clone, Copy, PartialEq, PartialOrd, Hash)]
+/// The `AncestorSelection` enum is an interim data structure used to specify
+/// how ancestors should be selected for a block in the `DagBuilder`. `UseLast`
+/// equates to the "*" in the parser, while `IncludeFrom(Slot)` and
+/// `ExcludeFrom(Slot)` equate to "A3" and "-A3" respectively.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Hash)]
 pub(crate) enum AncestorSelection {
     UseLast,
     IncludeFrom(Slot),
     ExcludeFrom(Slot),
 }
-/// The `AncestorConnectionSpec` enum is an interim data structure used to represent round
-/// definitions of the `test_dag_parser`, where `FullyConnected` equates to the { * } in the
-/// parser, while `AuthoritySpecific` equates to the { A -> [], B -> [] } in the parser.
-#[derive(Clone, PartialEq)]
+/// The `AncestorConnectionSpec` enum is an interim data structure used to
+/// represent round definitions of the `test_dag_parser`, where `FullyConnected`
+/// equates to the { * } in the parser, while `AuthoritySpecific` equates to the
+/// { A -> [], B -> [] } in the parser.
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) enum AncestorConnectionSpec {
     FullyConnected,
     AuthoritySpecific(
@@ -380,38 +399,6 @@ impl DagBuilder {
         tracing::info!("{dag_str}");
     }
 
-    // TODO: merge into layer builder?
-    // This method allows the user to specify specific links to ancestors. The
-    // layer is written to dag state and the blocks are cached in [`DagBuilder`]
-    // state.
-    pub(crate) fn layer_with_connections(
-        &mut self,
-        connections: Vec<(AuthorityIndex, Vec<BlockRef>)>,
-        transactions_acknowledgments: HashMap<AuthorityIndex, Vec<BlockRef>>,
-        round: Round,
-    ) {
-        let mut references = Vec::new();
-        for (authority, ancestors) in connections {
-            let author = authority.value() as u32;
-            let base_ts = round as BlockTimestampMs * 1000;
-            let block = VerifiedBlockHeader::new_for_test(
-                TestBlockHeader::new(round, author)
-                    .set_ancestors(ancestors)
-                    .set_acknowledgments(
-                        transactions_acknowledgments
-                            .get(&authority)
-                            .cloned()
-                            .unwrap_or_default(),
-                    )
-                    .set_timestamp_ms(base_ts + author as u64)
-                    .build(),
-            );
-            references.push(block.reference());
-            self.block_headers.insert(block.reference(), block.clone());
-        }
-        self.last_ancestors = references;
-    }
-
     /// Gets all uncommitted blocks in a slot.
     pub(crate) fn get_uncommitted_blocks_at_slot(&self, slot: Slot) -> Vec<VerifiedBlockHeader> {
         let mut blocks = vec![];
@@ -436,10 +423,11 @@ impl DagBuilder {
         self.genesis.keys().cloned().collect()
     }
 
-    // Refactor of the `get_blocks` function from the `test_dag_parser` into a method of the
-    // `DagBuilder` struct. Converts the slot into a block reference and retrieves the
-    // corresponding blocks from the `DagBuilder` state. Special case for genesis blocks as they
-    // are cached separately in the `genesis` field.
+    // Refactor of the `get_blocks` function from the `test_dag_parser` into a
+    // method of the `DagBuilder` struct. Converts the slot into a block
+    // reference and retrieves the corresponding blocks from the `DagBuilder`
+    // state. Special case for genesis blocks as they are cached separately in
+    // the `genesis` field.
     fn get_blocks(&self, slot: Slot) -> Vec<BlockRef> {
         // note: special case for genesis blocks as they are cached separately
         let block_refs = if slot.round == 0 {
@@ -455,11 +443,12 @@ impl DagBuilder {
         };
         block_refs
     }
-    // Refactor of the `parse_specified_connections` and 'parse_fully_connected' functions from the
-    // `test_dag_parser` into a single method of the `DagBuilder` struct using ancestor_selections
-    // instead of text. Converts the ancestor selections into block references from the DagBuilder's
+    // Refactor of the `parse_specified_connections` and 'parse_fully_connected'
+    // functions from the `test_dag_parser` into a single method of the
+    // `DagBuilder` struct using ancestor_selections instead of text. Converts
+    // the ancestor selections into block references from the DagBuilder's
     // last ancestors or from the blocks in the specified slots.
-    fn get_refences_from_ancestor_specs(
+    fn get_references_from_ancestor_specs(
         &self,
         ancestor_selections: Vec<AncestorSelection>,
     ) -> Vec<BlockRef> {
@@ -484,12 +473,11 @@ impl DagBuilder {
         block_refs
     }
 
-    // Refactor of the `layer_with_connections` method, using `AncestorConnectionSpec` instead of
-    // requiring the user to specify `DagBulder` connections manually. Uses the
-    // `get_refences_from_ancestor_specs` method to convert the ancestor selections into
-    // block references from the DagBuilder's last ancestors or from the blocks in the specified
-    // slots.
-    pub(crate) fn layer_with_ancestor_connections(
+    // TODO: merge into layer builder?
+    // This method allows the user to specify specific links to ancestors. The
+    // layer is written to dag state and the blocks are cached in [`DagBuilder`]
+    // state.
+    pub(crate) fn layer_with_connections(
         &mut self,
         ancestor_connection_spec: AncestorConnectionSpec,
         round: Round,
@@ -508,7 +496,7 @@ impl DagBuilder {
             AncestorConnectionSpec::AuthoritySpecific(ancestor_connections, _transaction_acks) => {
                 let mut output = vec![];
                 for (authority, ancestor_specs) in ancestor_connections {
-                    let block_refs = self.get_refences_from_ancestor_specs(ancestor_specs);
+                    let block_refs = self.get_references_from_ancestor_specs(ancestor_specs);
                     output.push((authority, block_refs));
                 }
                 output
@@ -1093,12 +1081,6 @@ impl<'a> LayerBuilder<'a> {
     }
 }
 
-pub enum ConnectionSpec {
-    All,
-    Only(Vec<Slot>),
-    Skip(Vec<Slot>),
-}
-
 // TODO: add more unit tests
 #[cfg(test)]
 mod tests {
@@ -1125,10 +1107,7 @@ mod tests {
     async fn test_skip_acknowledgments() {
         let context = Arc::new(Context::new_for_test(4).0);
         let mut dag_builder = DagBuilder::new(context);
-        let authorities_to_skip = vec![
-            AuthorityIndex::new_for_test(1),
-            AuthorityIndex::new_for_test(2),
-        ];
+        let authorities_to_skip = vec![1.into(), 2.into()];
         dag_builder.layers(1..=5).build();
         // Round 6 and above should skip acknowledgments from authorities to skip
         dag_builder
@@ -1155,10 +1134,7 @@ mod tests {
     async fn test_only_acknowledge() {
         let context = Arc::new(Context::new_for_test(4).0);
         let mut dag_builder = DagBuilder::new(context);
-        let only_acknowledge = vec![
-            AuthorityIndex::new_for_test(1),
-            AuthorityIndex::new_for_test(2),
-        ];
+        let only_acknowledge = vec![1.into(), 2.into()];
         dag_builder.layers(1..=5).build();
         // Round 6 and above should only acknowledge blocks from authorities to
         // acknowledge
@@ -1193,12 +1169,7 @@ mod tests {
         // Genesis  Round 0 : { 4 },
         let context = Arc::new(Context::new_for_test(4).0);
         let mut dag_builder = DagBuilder::new(context);
-        let (a, b, c, d) = (
-            AuthorityIndex::new_for_test(0),
-            AuthorityIndex::new_for_test(1),
-            AuthorityIndex::new_for_test(2),
-            AuthorityIndex::new_for_test(3),
-        );
+        let (a, b, c, d) = (0.into(), 1.into(), 2.into(), 3.into());
 
         let ancestor_specs = vec![
             // Round 1 : { * }
@@ -1226,27 +1197,27 @@ mod tests {
                     (
                         a,
                         vec![
-                            AncestorSelection::IncludeFrom(Slot::new_for_test(3, a.value() as u32)),
-                            AncestorSelection::IncludeFrom(Slot::new_for_test(3, b.value() as u32)),
-                            AncestorSelection::IncludeFrom(Slot::new_for_test(3, c.value() as u32)),
+                            AncestorSelection::IncludeFrom(Slot::new(3, a)),
+                            AncestorSelection::IncludeFrom(Slot::new(3, b)),
+                            AncestorSelection::IncludeFrom(Slot::new(3, c)),
                         ],
                     ),
                     // B -> [A3, B3, C3]
                     (
                         b,
                         vec![
-                            AncestorSelection::IncludeFrom(Slot::new_for_test(3, a.value() as u32)),
-                            AncestorSelection::IncludeFrom(Slot::new_for_test(3, b.value() as u32)),
-                            AncestorSelection::IncludeFrom(Slot::new_for_test(3, c.value() as u32)),
+                            AncestorSelection::IncludeFrom(Slot::new(3, a)),
+                            AncestorSelection::IncludeFrom(Slot::new(3, b)),
+                            AncestorSelection::IncludeFrom(Slot::new(3, c)),
                         ],
                     ),
                     // C -> [A3, B3, C3],
                     (
                         c,
                         vec![
-                            AncestorSelection::IncludeFrom(Slot::new_for_test(3, a.value() as u32)),
-                            AncestorSelection::IncludeFrom(Slot::new_for_test(3, b.value() as u32)),
-                            AncestorSelection::IncludeFrom(Slot::new_for_test(3, c.value() as u32)),
+                            AncestorSelection::IncludeFrom(Slot::new(3, a)),
+                            AncestorSelection::IncludeFrom(Slot::new(3, b)),
+                            AncestorSelection::IncludeFrom(Slot::new(3, c)),
                         ],
                     ),
                     // D -> [*]
@@ -1260,29 +1231,11 @@ mod tests {
                     // A -> [*]
                     (a, vec![AncestorSelection::UseLast]),
                     // B -> [-A4]
-                    (
-                        b,
-                        vec![AncestorSelection::ExcludeFrom(Slot::new_for_test(
-                            4,
-                            a.value() as u32,
-                        ))],
-                    ),
+                    (b, vec![AncestorSelection::ExcludeFrom(Slot::new(4, a))]),
                     // C -> [-A4],
-                    (
-                        c,
-                        vec![AncestorSelection::ExcludeFrom(Slot::new_for_test(
-                            4,
-                            a.value() as u32,
-                        ))],
-                    ),
+                    (c, vec![AncestorSelection::ExcludeFrom(Slot::new(4, a))]),
                     // D -> [-A4]
-                    (
-                        d,
-                        vec![AncestorSelection::ExcludeFrom(Slot::new_for_test(
-                            4,
-                            a.value() as u32,
-                        ))],
-                    ),
+                    (d, vec![AncestorSelection::ExcludeFrom(Slot::new(4, a))]),
                 ],
                 HashMap::new(),
             ),
@@ -1293,11 +1246,11 @@ mod tests {
                     (
                         a,
                         vec![
-                            AncestorSelection::IncludeFrom(Slot::new_for_test(3, a.value() as u32)),
-                            AncestorSelection::IncludeFrom(Slot::new_for_test(3, b.value() as u32)),
-                            AncestorSelection::IncludeFrom(Slot::new_for_test(3, c.value() as u32)),
-                            AncestorSelection::IncludeFrom(Slot::new_for_test(1, a.value() as u32)),
-                            AncestorSelection::IncludeFrom(Slot::new_for_test(1, b.value() as u32)),
+                            AncestorSelection::IncludeFrom(Slot::new(3, a)),
+                            AncestorSelection::IncludeFrom(Slot::new(3, b)),
+                            AncestorSelection::IncludeFrom(Slot::new(3, c)),
+                            AncestorSelection::IncludeFrom(Slot::new(1, a)),
+                            AncestorSelection::IncludeFrom(Slot::new(1, b)),
                         ],
                     ),
                     // B -> [*, A0]
@@ -1305,17 +1258,11 @@ mod tests {
                         b,
                         vec![
                             AncestorSelection::UseLast,
-                            AncestorSelection::IncludeFrom(Slot::new_for_test(0, a.value() as u32)),
+                            AncestorSelection::IncludeFrom(Slot::new(0, a)),
                         ],
                     ),
                     // C -> [-A5],
-                    (
-                        c,
-                        vec![AncestorSelection::ExcludeFrom(Slot::new_for_test(
-                            5,
-                            a.value() as u32,
-                        ))],
-                    ),
+                    (c, vec![AncestorSelection::ExcludeFrom(Slot::new(5, a))]),
                 ],
                 HashMap::new(),
             ),
@@ -1325,60 +1272,53 @@ mod tests {
 
         for (i, ancestor_spec) in ancestor_specs.iter().enumerate() {
             let round = (i + 1) as Round; // No transactions in this test
-            dag_builder.layer_with_ancestor_connections(ancestor_spec.clone(), round);
+            dag_builder.layer_with_connections(ancestor_spec.clone(), round);
         }
 
         assert_eq!(dag_builder.block_headers.len(), 23);
 
         // Check the blocks were correctly parsed in Round 6
-        let blocks_a6 = dag_builder
-            .get_uncommitted_blocks_at_slot(Slot::new(6, AuthorityIndex::new_for_test(0)));
+        let blocks_a6 = dag_builder.get_uncommitted_blocks_at_slot(Slot::new(6, 0));
         assert_eq!(blocks_a6.len(), 1);
         let block_a6 = blocks_a6.first().unwrap();
         assert_eq!(block_a6.round(), 6);
-        assert_eq!(block_a6.author(), AuthorityIndex::new_for_test(0));
+        assert_eq!(block_a6.author(), 0.into());
         assert_eq!(block_a6.ancestors().len(), 5);
         let expected_block_a6_ancestor_slots = [
-            Slot::new(3, AuthorityIndex::new_for_test(0)),
-            Slot::new(3, AuthorityIndex::new_for_test(1)),
-            Slot::new(3, AuthorityIndex::new_for_test(2)),
-            Slot::new(1, AuthorityIndex::new_for_test(0)),
-            Slot::new(1, AuthorityIndex::new_for_test(1)),
+            Slot::new(3, 0),
+            Slot::new(3, 1),
+            Slot::new(3, 2),
+            Slot::new(1, 0),
+            Slot::new(1, 1),
         ];
         for ancestor in block_a6.ancestors() {
             assert!(expected_block_a6_ancestor_slots.contains(&Slot::from(*ancestor)));
         }
 
-        let blocks_b6 = dag_builder
-            .get_uncommitted_blocks_at_slot(Slot::new(6, AuthorityIndex::new_for_test(1)));
+        let blocks_b6 = dag_builder.get_uncommitted_blocks_at_slot(Slot::new(6, 1));
         assert_eq!(blocks_b6.len(), 1);
         let block_b6 = blocks_b6.first().unwrap();
         assert_eq!(block_b6.round(), 6);
-        assert_eq!(block_b6.author(), AuthorityIndex::new_for_test(1));
+        assert_eq!(block_b6.author(), 1.into());
         assert_eq!(block_b6.ancestors().len(), 5);
         let expected_block_b6_ancestor_slots = [
-            Slot::new(5, AuthorityIndex::new_for_test(0)),
-            Slot::new(5, AuthorityIndex::new_for_test(1)),
-            Slot::new(5, AuthorityIndex::new_for_test(2)),
-            Slot::new(5, AuthorityIndex::new_for_test(3)),
-            Slot::new(0, AuthorityIndex::new_for_test(0)),
+            Slot::new(5, 0),
+            Slot::new(5, 1),
+            Slot::new(5, 2),
+            Slot::new(5, 3),
+            Slot::new(0, 0),
         ];
         for ancestor in block_b6.ancestors() {
             assert!(expected_block_b6_ancestor_slots.contains(&Slot::from(*ancestor)));
         }
 
-        let blocks_c6 = dag_builder
-            .get_uncommitted_blocks_at_slot(Slot::new(6, AuthorityIndex::new_for_test(2)));
+        let blocks_c6 = dag_builder.get_uncommitted_blocks_at_slot(Slot::new(6, 2));
         assert_eq!(blocks_c6.len(), 1);
         let block_c6 = blocks_c6.first().unwrap();
         assert_eq!(block_c6.round(), 6);
-        assert_eq!(block_c6.author(), AuthorityIndex::new_for_test(2));
+        assert_eq!(block_c6.author(), 2.into());
         assert_eq!(block_c6.ancestors().len(), 3);
-        let expected_block_c6_ancestor_slots = [
-            Slot::new(5, AuthorityIndex::new_for_test(1)),
-            Slot::new(5, AuthorityIndex::new_for_test(2)),
-            Slot::new(5, AuthorityIndex::new_for_test(3)),
-        ];
+        let expected_block_c6_ancestor_slots = [Slot::new(5, 1), Slot::new(5, 2), Slot::new(5, 3)];
         for ancestor in block_c6.ancestors() {
             assert!(expected_block_c6_ancestor_slots.contains(&Slot::from(*ancestor)));
         }

--- a/crates/starfish/core/src/test_dag_parser.rs
+++ b/crates/starfish/core/src/test_dag_parser.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
+    char,
     collections::{HashMap, HashSet},
     sync::Arc,
 };
@@ -11,17 +12,20 @@ use nom::{
     IResult,
     branch::alt,
     bytes::complete::{tag, take_until, take_while_m_n, take_while1},
-    character::complete::{char, digit1, multispace0, multispace1, space0, space1},
-    combinator::{map_res, opt},
-    multi::{many0, separated_list0},
-    sequence::{delimited, preceded, terminated, tuple},
+    character::complete::{
+        alpha1, anychar, char, digit1, multispace0, multispace1, space0, space1,
+    },
+    combinator::{map, map_res, opt},
+    multi::{many0, separated_list0, separated_list1},
+    sequence::{delimited, pair, preceded, terminated, tuple},
 };
+use nom::bytes::complete::take_while;
 use starfish_config::AuthorityIndex;
 
 use crate::{
     block_header::{BlockRef, Round, Slot},
     context::Context,
-    test_dag_builder::DagBuilder,
+    test_dag_builder::{ConnectionSpec, DagBuilder},
 };
 
 /// DagParser
@@ -55,15 +59,18 @@ use crate::{
 /// dag_builder.print(); // print the parsed DAG
 /// dag_builder.persist_all_blocks(dag_state.clone()); // persist all blocks to DagState
 /// ```
-pub(crate) fn parse_dag(dag_string: &str) -> IResult<&str, DagBuilder> {
+pub(crate) fn parse_dag(dag_string: &str) -> Result<DagBuilder, nom::Err<()>> {
     let (input, _) = tuple((tag("DAG"), multispace0, char('{')))(dag_string)?;
 
-    let (mut input, num_authors) = parse_genesis(input)?;
+    let (mut input, num_authors) = parse_genesis(input).expect("Failed to parse genesis round");
 
     let context = Arc::new(Context::new_for_test(num_authors as usize).0);
     let mut dag_builder = DagBuilder::new(context);
 
     // Parse subsequent rounds
+    // remove whitespace from the input
+    let cleaned: String = input.chars().filter(|c| !c.is_whitespace()).collect();
+    let mut input = cleaned.as_str();
     loop {
         match parse_round(input, &dag_builder) {
             Ok((new_input, (round, connections, transaction_acknowledgments))) => {
@@ -76,17 +83,13 @@ pub(crate) fn parse_dag(dag_string: &str) -> IResult<&str, DagBuilder> {
     }
     let (input, _) = tuple((multispace0, char('}')))(input)?;
 
-    Ok((input, dag_builder))
+    Ok(dag_builder)
 }
-fn parse_round_number<'a>(input: &'a str) -> IResult<&'a str, (&'a str, Round)> {
-    let (input, _) = tuple((multispace0, tag("Round"), space1))(input)?;
-    let (input, round_num): (&'a str, Round) = map_res(digit1, str::parse::<Round>)(input)?;
-    // Capture everything before the `{` to get the round number
-    let (input, _) = take_until("{")(input)?;
-    // Capture everything between `{` and `}`
-    let (input, content) = delimited(tag("{"), take_until("}"), tag("}"))(input)?;
-    Ok((input, (content, round_num)))
-}
+
+// Parses a round from the input string and returns a tuple containing the round
+// number, a vector of connections (authority index and their corresponding
+// block references), and a hashmap of transaction acknowledgments for each
+// authority index.
 fn parse_round<'a>(
     input: &'a str,
     dag_builder: &DagBuilder,
@@ -98,13 +101,21 @@ fn parse_round<'a>(
         HashMap<AuthorityIndex, Vec<BlockRef>>,
     ),
 > {
-    let (input, (content, round)) = parse_round_number(input)?;
-    let (_, connections) = alt((
-        |input| parse_fully_connected(input, dag_builder),
-        |input| parse_specified_connections(input, dag_builder),
-    ))(content)?;
-    // remove trailing comma if present
-    let (input, _) = opt(char(','))(input)?;
+    let (input,(round, connections)) = map(
+        tuple((
+            map_res(preceded(tag("Round"), alpha1), |s: &str| {
+                s.parse::<Round>()
+            }),
+            char(':'),
+            delimited(
+                char('{'),
+                |i| parse_connections(i, dag_builder),
+                char('}')
+            ),
+            opt(char(',')),
+        )),
+        |(round,_, connections,_)| (round, connections),
+    )(input)?;
 
     // TODO: extend DAG parser with transaction acknowledgments. For now it's
     //  assumed that transactions are available together with the block headers and
@@ -121,24 +132,7 @@ fn parse_round<'a>(
     Ok((input, (round, connections, transactions_acknowledgments)))
 }
 
-fn parse_fully_connected<'a>(
-    input: &'a str,
-    dag_builder: &DagBuilder,
-) -> IResult<&'a str, Vec<(AuthorityIndex, Vec<BlockRef>)>> {
-    let (input, _) = tuple((space0, char('*'), space0))(input)?;
-
-    let ancestors = dag_builder.last_ancestors.clone();
-    let connections = dag_builder
-        .context
-        .committee
-        .authorities()
-        .map(|authority| (authority.0, ancestors.clone()))
-        .collect::<Vec<_>>();
-
-    Ok((input, connections))
-}
-
-fn parse_specified_connections<'a>(
+fn parse_connections<'a>(
     input: &'a str,
     dag_builder: &DagBuilder,
 ) -> IResult<&'a str, Vec<(AuthorityIndex, Vec<BlockRef>)>> {
@@ -154,21 +148,29 @@ fn parse_specified_connections<'a>(
     let mut output = Vec::new();
     for (author, connections) in authors_and_connections {
         let mut block_refs = HashSet::new();
-        for connection in connections {
-            if connection == "*" {
+        match connections {
+            ConnectionSpec::All => {
+                // If the connection is "*", we take all last ancestors
                 block_refs.extend(dag_builder.last_ancestors.clone());
-            } else if connection.starts_with('-') {
-                let (input, _) = char('-')(connection)?;
-                let (_, slot) = parse_slot(input)?;
-                let stored_block_refs = get_blocks(slot, dag_builder);
+            }
+            ConnectionSpec::Skip(slots) => {
+                // If the connection is a skip list, we get the blocks at those slots
+                let stored_block_refs = slots
+                    .into_iter()
+                    .flat_map(|slot| get_blocks(slot, dag_builder))
+                    .collect::<HashSet<_>>();
                 block_refs.extend(dag_builder.last_ancestors.clone());
 
+                // Retain only those ancestors that are not in the stored block references
                 block_refs.retain(|ancestor| !stored_block_refs.contains(ancestor));
-            } else {
-                let input = connection;
-                let (_, slot) = parse_slot(input)?;
-                let stored_block_refs = get_blocks(slot, dag_builder);
-
+            }
+            ConnectionSpec::Only(slots) => {
+                // If the connection is a list of specific slots, we get the blocks at those
+                // slots
+                let stored_block_refs = slots
+                    .into_iter()
+                    .flat_map(|slot| get_blocks(slot, dag_builder))
+                    .collect::<HashSet<_>>();
                 block_refs.extend(stored_block_refs);
             }
         }
@@ -196,40 +198,44 @@ fn get_blocks(slot: Slot, dag_builder: &DagBuilder) -> Vec<BlockRef> {
     block_refs
 }
 
-fn parse_author_and_connections(input: &str) -> IResult<&str, (AuthorityIndex, Vec<&str>)> {
-    // parse author
-    let (input, author) = preceded(
-        multispace0,
-        terminated(
-            take_while1(|c: char| c.is_alphabetic()),
-            preceded(opt(space0), tag("->")),
-        ),
-    )(input)?;
-
-    // parse connections
-    let (input, connections) = delimited(
-        preceded(opt(space0), char('[')),
-        separated_list0(tag(", "), parse_block),
-        terminated(char(']'), opt(char(','))),
-    )(input)?;
-    let (input, _) = opt(multispace1)(input)?;
-    Ok((
-        input,
-        (
-            str_to_authority_index(author).expect("Invalid authority index"),
-            connections,
-        ),
-    ))
+// Parses "B1", "C3", "G44" into a Slot
+fn alpha_num(input: &str) -> IResult<&str, Slot> {
+    map(pair(anychar, digit1), |(anychar, digit): (char, &str)| {
+        Slot::new(
+            digit.parse::<Round>().unwrap(),
+            AuthorityIndex::new_for_test(anychar as u32 - 'A' as u32),
+        )
+    })(input)
 }
 
-fn parse_block(input: &str) -> IResult<&str, &str> {
+// Parses ["B1", "C3", "G44"] into vector of slots
+fn only_list(input: &str) -> IResult<&str, Vec<Slot>> {
+    separated_list1(char(','), alpha_num)(input)
+}
+
+// Parses ["-B4", "-C33", "-G44"] into vector of slots
+fn skip_list(input: &str) -> IResult<&str, Vec<Slot>> {
+    separated_list1(char(','), preceded(char('-'), alpha_num))(input)
+}
+
+// Parses ["*"],["A1", "B2", "C3"], ["-A4", "-B5"] into ConnectionSpec
+// - "*"                -> ConnectionSpec::All
+// - ["-A4", "-B5"]     -> ConnectionSpec::Skip(Vec<Slot>)
+// - ["A1", "B2", "C3"] -> ConnectionSpec::Only(Vec<Slot>)
+fn parse_connection_spec(input: &str) -> IResult<&str, ConnectionSpec> {
     alt((
-        map_res(tag("*"), |s: &str| Ok::<_, nom::error::ErrorKind>(s)),
-        map_res(
-            take_while1(|c: char| c.is_alphanumeric() || c == '-'),
-            |s: &str| Ok::<_, nom::error::ErrorKind>(s),
-        ),
+        map(tag("*"), |_| ConnectionSpec::All),
+        map(skip_list, ConnectionSpec::Skip),
+        map(only_list, ConnectionSpec::Only),
     ))(input)
+}
+fn parse_author_and_connections(input: &str) -> IResult<&str, (AuthorityIndex, ConnectionSpec)> {
+    pair(
+        map(terminated(anychar, tag("->")), |author: char| {
+            AuthorityIndex::new_for_test(author as u32 - 'A' as u32)
+        }),
+        delimited(char('['), parse_connection_spec, char(']')),
+    )(input)
 }
 
 fn parse_genesis(input: &str) -> IResult<&str, u32> {
@@ -255,42 +261,6 @@ fn parse_genesis(input: &str) -> IResult<&str, u32> {
 fn parse_authority_count(input: &str) -> IResult<&str, u32> {
     let (input, num_str) = digit1(input)?;
     Ok((input, num_str.parse().unwrap()))
-}
-
-fn parse_slot(input: &str) -> IResult<&str, Slot> {
-    let parse_authority = map_res(
-        take_while_m_n(1, 1, |c: char| c.is_alphabetic() && c.is_uppercase()),
-        |letter: &str| {
-            Ok::<_, nom::error::ErrorKind>(
-                str_to_authority_index(letter).expect("Invalid authority index"),
-            )
-        },
-    );
-
-    let parse_round = map_res(digit1, |digits: &str| digits.parse::<Round>());
-
-    let mut parser = tuple((parse_authority, parse_round));
-
-    let (input, (authority, round)) = parser(input)?;
-    Ok((input, Slot::new(round, authority)))
-}
-
-// Helper function to convert a string representation (e.g., 'A' or '[26]') to
-// an AuthorityIndex
-fn str_to_authority_index(input: &str) -> Option<AuthorityIndex> {
-    if input.starts_with('[') && input.ends_with(']') && input.len() > 2 {
-        input[1..input.len() - 1]
-            .parse::<u32>()
-            .ok()
-            .map(AuthorityIndex::new_for_test)
-    } else if input.len() == 1 && input.chars().next()?.is_ascii_uppercase() {
-        // Handle single uppercase ASCII alphabetic character
-        let alpha_char = input.chars().next().unwrap();
-        let index = alpha_char as u32 - 'A' as u32;
-        Some(AuthorityIndex::new_for_test(index))
-    } else {
-        None
-    }
 }
 
 #[cfg(test)]
@@ -334,7 +304,7 @@ mod tests {
         let result = parse_dag(dag_str);
         assert!(result.is_ok());
 
-        let (_, dag_builder) = result.unwrap();
+        let dag_builder = result.unwrap();
         assert_eq!(dag_builder.genesis.len(), 4);
         assert_eq!(dag_builder.block_headers.len(), 23);
 
@@ -403,17 +373,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_slot_parsing() {
-        let dag_str = "A0";
-        let result = parse_slot(dag_str);
-        assert!(result.is_ok());
-        let (_, slot) = result.unwrap();
-
-        assert_eq!(slot.authority, str_to_authority_index("A").unwrap());
-        assert_eq!(slot.round, 0);
-    }
-
-    #[tokio::test]
     async fn test_all_round_parsing() {
         let dag_str = "Round 1 : { * }";
         let context = Arc::new(Context::new_for_test(4).0);
@@ -475,89 +434,43 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_parse_author_and_connections() {
-        let expected_authority = str_to_authority_index("A").unwrap();
+    // #[tokio::test]
+    // async fn test_parse_author_and_connections() {
+    //     let expected_authority = str_to_authority_index("A").unwrap();
 
-        // case 1: all authorities
-        let dag_str = "A -> [*]";
-        let result = parse_author_and_connections(dag_str);
-        assert!(result.is_ok());
-        let (_, (actual_author, actual_connections)) = result.unwrap();
-        assert_eq!(actual_author, expected_authority);
-        assert_eq!(actual_connections, ["*"]);
+    //     // case 1: all authorities
+    //     let dag_str = "A -> [*]";
+    //     let result = parse_author_and_connections(dag_str);
+    //     assert!(result.is_ok());
+    //     let (_, (actual_author, actual_connections)) = result.unwrap();
+    //     assert_eq!(actual_author, expected_authority);
+    //     assert_eq!(actual_connections, ["*"]);
 
-        // case 2: specific included authorities
-        let dag_str = "A -> [A0, B0, C0]";
-        let result = parse_author_and_connections(dag_str);
-        assert!(result.is_ok());
-        let (_, (actual_author, actual_connections)) = result.unwrap();
-        assert_eq!(actual_author, expected_authority);
-        assert_eq!(actual_connections, ["A0", "B0", "C0"]);
+    //     // case 2: specific included authorities
+    //     let dag_str = "A -> [A0, B0, C0]";
+    //     let result = parse_author_and_connections(dag_str);
+    //     assert!(result.is_ok());
+    //     let (_, (actual_author, actual_connections)) = result.unwrap();
+    //     assert_eq!(actual_author, expected_authority);
+    //     assert_eq!(actual_connections, ["A0", "B0", "C0"]);
 
-        // case 3: specific excluded authorities
-        let dag_str = "A -> [-A0, -B0]";
-        let result = parse_author_and_connections(dag_str);
-        assert!(result.is_ok());
-        let (_, (actual_author, actual_connections)) = result.unwrap();
-        assert_eq!(actual_author, expected_authority);
-        assert_eq!(actual_connections, ["-A0", "-B0"]);
+    //     // case 3: specific excluded authorities
+    //     let dag_str = "A -> [-A0, -B0]";
+    //     let result = parse_author_and_connections(dag_str);
+    //     assert!(result.is_ok());
+    //     let (_, (actual_author, actual_connections)) = result.unwrap();
+    //     assert_eq!(actual_author, expected_authority);
+    //     assert_eq!(actual_connections, ["-A0", "-B0"]);
 
-        // case 4: mixed all authorities + specific included/excluded authorities
-        let dag_str = "A -> [*, A0, -B0]";
-        let result = parse_author_and_connections(dag_str);
-        assert!(result.is_ok());
-        let (_, (actual_author, actual_connections)) = result.unwrap();
-        assert_eq!(actual_author, expected_authority);
-        assert_eq!(actual_connections, ["*", "A0", "-B0"]);
+    //     // case 4: mixed all authorities + specific included/excluded authorities
+    //     let dag_str = "A -> [*, A0, -B0]";
+    //     let result = parse_author_and_connections(dag_str);
+    //     assert!(result.is_ok());
+    //     let (_, (actual_author, actual_connections)) = result.unwrap();
+    //     assert_eq!(actual_author, expected_authority);
+    //     assert_eq!(actual_connections, ["*", "A0", "-B0"]);
 
-        // TODO: case 5: byzantine case of multiple blocks per slot; [*];
-        // timestamp=1
-    }
-
-    #[tokio::test]
-    async fn test_str_to_authority_index() {
-        assert_eq!(
-            str_to_authority_index("A"),
-            Some(AuthorityIndex::new_for_test(0))
-        );
-        assert_eq!(
-            str_to_authority_index("Z"),
-            Some(AuthorityIndex::new_for_test(25))
-        );
-        assert_eq!(
-            str_to_authority_index("[26]"),
-            Some(AuthorityIndex::new_for_test(26))
-        );
-        assert_eq!(
-            str_to_authority_index("[100]"),
-            Some(AuthorityIndex::new_for_test(100))
-        );
-        assert_eq!(str_to_authority_index("a"), None);
-        assert_eq!(str_to_authority_index("0"), None);
-        assert_eq!(str_to_authority_index(" "), None);
-        assert_eq!(str_to_authority_index("!"), None);
-    }
-    #[tokio::test]
-    async fn test_parse_round_number() {
-        let dag_str = r"Round 199 : {
-    A -> [A0, B0, C0, D0],
-    B -> [*, A0],
-    C -> [-A0],
-},
-Round 200 : {";
-        let result = parse_round_number(dag_str);
-        assert!(result.is_ok());
-        let (input, (content, round)) = result.unwrap();
-        assert_eq!(round, 199);
-        assert_eq!(
-            content,
-            r"
-    A -> [A0, B0, C0, D0],
-    B -> [*, A0],
-    C -> [-A0],
-"
-        );
-        assert_eq!(input, ",\nRound 200 : {");
-    }
+    //     // TODO: case 5: byzantine case of multiple blocks per slot; [*];
+    //     // timestamp=1
+    // }
 }

--- a/crates/starfish/core/src/test_dag_parser.rs
+++ b/crates/starfish/core/src/test_dag_parser.rs
@@ -10,7 +10,7 @@ use std::{
 use nom::{
     IResult,
     branch::alt,
-    bytes::complete::{tag, take_while_m_n, take_while1},
+    bytes::complete::{tag, take_until, take_while_m_n, take_while1},
     character::complete::{char, digit1, multispace0, multispace1, space0, space1},
     combinator::{map_res, opt},
     multi::{many0, separated_list0},
@@ -78,7 +78,15 @@ pub(crate) fn parse_dag(dag_string: &str) -> IResult<&str, DagBuilder> {
 
     Ok((input, dag_builder))
 }
-
+fn parse_round_number<'a>(input: &'a str) -> IResult<&'a str, (&'a str, Round)> {
+    let (input, _) = tuple((multispace0, tag("Round"), space1))(input)?;
+    let (input, round_num): (&'a str, Round) = map_res(digit1, str::parse::<Round>)(input)?;
+    // Capture everything before the `{` to get the round number
+    let (input, _) = take_until("{")(input)?;
+    // Capture everything between `{` and `}`
+    let (input, content) = delimited(tag("{"), take_until("}"), tag("}"))(input)?;
+    Ok((input, (content, round_num)))
+}
 fn parse_round<'a>(
     input: &'a str,
     dag_builder: &DagBuilder,
@@ -90,13 +98,13 @@ fn parse_round<'a>(
         HashMap<AuthorityIndex, Vec<BlockRef>>,
     ),
 > {
-    let (input, _) = tuple((multispace0, tag("Round"), space1))(input)?;
-    let (input, round) = take_while1(|c: char| c.is_ascii_digit())(input)?;
-
-    let (input, connections) = alt((
+    let (input, (content, round)) = parse_round_number(input)?;
+    let (_, connections) = alt((
         |input| parse_fully_connected(input, dag_builder),
         |input| parse_specified_connections(input, dag_builder),
-    ))(input)?;
+    ))(content)?;
+    // remove trailing comma if present
+    let (input, _) = opt(char(','))(input)?;
 
     // TODO: extend DAG parser with transaction acknowledgments. For now it's
     //  assumed that transactions are available together with the block headers and
@@ -104,36 +112,20 @@ fn parse_round<'a>(
 
     //  If the round is "1", we assume no transactions in Round 0 (genesis) are
     // acknowledged.
-    let transactions_acknowledgments: HashMap<AuthorityIndex, Vec<BlockRef>> = if round == "1" {
-        HashMap::new()
-    } else {
-        connections.clone().into_iter().collect()
-    };
-    Ok((
-        input,
-        (
-            round.parse().unwrap(),
-            connections,
-            transactions_acknowledgments,
-        ),
-    ))
+    let transactions_acknowledgments: HashMap<AuthorityIndex, Vec<BlockRef>> =
+        if round == 1 as Round {
+            HashMap::new()
+        } else {
+            connections.clone().into_iter().collect()
+        };
+    Ok((input, (round, connections, transactions_acknowledgments)))
 }
 
 fn parse_fully_connected<'a>(
     input: &'a str,
     dag_builder: &DagBuilder,
 ) -> IResult<&'a str, Vec<(AuthorityIndex, Vec<BlockRef>)>> {
-    let (input, _) = tuple((
-        space0,
-        char(':'),
-        space0,
-        char('{'),
-        space0,
-        char('*'),
-        space0,
-        char('}'),
-        opt(char(',')),
-    ))(input)?;
+    let (input, _) = tuple((space0, char('*'), space0))(input)?;
 
     let ancestors = dag_builder.last_ancestors.clone();
     let connections = dag_builder
@@ -150,8 +142,6 @@ fn parse_specified_connections<'a>(
     input: &'a str,
     dag_builder: &DagBuilder,
 ) -> IResult<&'a str, Vec<(AuthorityIndex, Vec<BlockRef>)>> {
-    let (input, _) = tuple((space0, char(':'), space0, char('{'), multispace0))(input)?;
-
     // parse specified connections
     // case 1: all authorities; [*]
     // case 2: specific included authorities; [A0, B0, C0]
@@ -184,8 +174,6 @@ fn parse_specified_connections<'a>(
         }
         output.push((author, block_refs.into_iter().collect()));
     }
-
-    let (input, _) = tuple((multispace0, char('}'), opt(char(','))))(input)?;
 
     Ok((input, output))
 }
@@ -549,5 +537,27 @@ mod tests {
         assert_eq!(str_to_authority_index("0"), None);
         assert_eq!(str_to_authority_index(" "), None);
         assert_eq!(str_to_authority_index("!"), None);
+    }
+    #[tokio::test]
+    async fn test_parse_round_number() {
+        let dag_str = r"Round 199 : {
+    A -> [A0, B0, C0, D0],
+    B -> [*, A0],
+    C -> [-A0],
+},
+Round 200 : {";
+        let result = parse_round_number(dag_str);
+        assert!(result.is_ok());
+        let (input, (content, round)) = result.unwrap();
+        assert_eq!(round, 199);
+        assert_eq!(
+            content,
+            r"
+    A -> [A0, B0, C0, D0],
+    B -> [*, A0],
+    C -> [-A0],
+"
+        );
+        assert_eq!(input, ",\nRound 200 : {");
     }
 }

--- a/crates/starfish/core/src/test_dag_parser.rs
+++ b/crates/starfish/core/src/test_dag_parser.rs
@@ -2,37 +2,210 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    char,
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::{char, collections::HashMap, sync::Arc};
 
 use nom::{
     IResult,
     branch::alt,
-    bytes::complete::{tag, take_until, take_while_m_n, take_while1},
-    character::complete::{
-        alpha1, anychar, char, digit1, multispace0, multispace1, space0, space1,
-    },
+    bytes::complete::tag,
+    character::complete::{anychar, char, digit1},
     combinator::{map, map_res, opt},
-    multi::{many0, separated_list0, separated_list1},
+    multi::{many0, separated_list0},
     sequence::{delimited, pair, preceded, terminated, tuple},
 };
-use nom::bytes::complete::take_while;
 use starfish_config::AuthorityIndex;
 
 use crate::{
-    block_header::{BlockRef, Round, Slot},
+    block_header::{Round, Slot},
     context::Context,
-    test_dag_builder::{ConnectionSpec, DagBuilder},
+    test_dag_builder::{AncestorConnectionSpec, AncestorSelection, DagBuilder},
 };
 
+/// Parses a non-empty sequence of decimal digits into a `u32` integer.
+///
+/// # Format
+/// - One or more ASCII digits (`0-9`)
+///
+/// # Returns
+/// The parsed `u32` value on success.
+fn parse_u32(input: &str) -> IResult<&str, u32> {
+    map_res(digit1, |num_str: &str| num_str.parse::<u32>())(input)
+}
+/// Parses the genesis round definition with the number of authorities.
+///
+/// # Format
+/// - The literal string `"Round0:{"`
+/// - Followed by a non-empty sequence of digits representing the number of
+///   authorities
+/// - Followed by a closing brace `}`
+/// - Optionally followed by a comma `,`
+///
+/// # Returns
+/// The parsed `u32` number representing the number of authorities.
+fn parse_genesis(input: &str) -> IResult<&str, u32> {
+    delimited(
+        tag("Round0:{"),
+        parse_u32,
+        tuple((char('}'), opt(char(',')))),
+    )(input)
+}
+/// Parses a single uppercase ASCII character representing an authority index.
+///
+/// # Format
+/// - A single ASCII uppercase letter (`'A'` to `'Z'`)
+///
+/// # Returns
+/// - `AuthorityIndex` constructed by mapping `'A'` → 0, `'B'` → 1, etc.
+fn parse_authority_index(input: &str) -> IResult<&str, AuthorityIndex> {
+    map_res(anychar, |c: char| {
+        if c.is_ascii_uppercase() {
+            Ok((c as u32 - 'A' as u32).into())
+        } else {
+            Err(nom::Err::Error(()))
+        }
+    })(input)
+}
+/// Parses an alphanumeric slot identifier in the format `A1`, `B3`, etc.
+///
+/// # Format
+/// - A single uppercase ASCII letter representing the authority (e.g., `'A'`
+///   maps to index 0)
+/// - Followed by one or more digits representing the round number
+fn parse_slot(input: &str) -> IResult<&str, Slot> {
+    map(
+        pair(parse_authority_index, parse_u32),
+        |(authority, digit)| Slot::new(digit, authority),
+    )(input)
+}
+/// Parses a single ancestor selection syntax.
+///
+/// # Supported Formats
+/// - `"*"` → `AncestorSelection::UseLast`
+/// - `"-A1"` → `AncestorSelection::ExcludeFrom(Slot::A1)`
+/// - `"B2"` → `AncestorSelection::IncludeFrom(Slot::B2)`
+fn parse_ancestor_selection(input: &str) -> IResult<&str, AncestorSelection> {
+    alt((
+        map(tag("*"), |_| AncestorSelection::UseLast),
+        map(
+            preceded(char('-'), parse_slot),
+            AncestorSelection::ExcludeFrom,
+        ),
+        map(parse_slot, AncestorSelection::IncludeFrom),
+    ))(input)
+}
+/// Parses a comma-separated list of ancestor selections.
+///
+/// # Format
+/// - Any number of entries separated by commas, e.g.: `"*,-A2,B3"`
+fn parse_ancestor_selections(input: &str) -> IResult<&str, Vec<AncestorSelection>> {
+    separated_list0(char(','), parse_ancestor_selection)(input)
+}
+/// Parses an author identifier followed by their ancestor selections enclosed
+/// in brackets.
+///
+/// # Format
+/// - An uppercase ASCII character representing the author (e.g. `'A'`)
+/// - Followed by the literal string `"->"`
+/// - Followed by a bracketed list of ancestor selections, e.g. `[*, -B2, C3]`
+/// - Optionally terminated by a comma `,` (useful for parsing lists)
+///
+/// # Returns
+/// A tuple `(AuthorityIndex, Vec<AncestorSelection>)` where:
+/// - `AuthorityIndex` is derived from the author character (`'A'` maps to index
+///   0)
+/// - `Vec<AncestorSelection>` contains parsed ancestor selections inside the
+///   brackets
+fn parse_author_and_connections(
+    input: &str,
+) -> IResult<&str, (AuthorityIndex, Vec<AncestorSelection>)> {
+    terminated(
+        pair(
+            map(terminated(anychar, tag("->")), |author: char| {
+                (author as u32 - 'A' as u32).into()
+            }),
+            delimited(char('['), parse_ancestor_selections, char(']')),
+        ),
+        opt(char(',')),
+    )(input)
+}
+/// Parses an ancestor connection specification from input.
+///
+/// # Supported Formats
+/// - `"*"` indicating a fully connected ancestor graph
+///   (`AncestorConnectionSpec::FullyConnected`)
+/// - Or a sequence (zero or more) of author-and-connections entries, e.g.:
+///   ```text A->[*, -B1],B->[C2], ... ```
+///
+/// # Returns
+/// An `AncestorConnectionSpec` enum value:
+/// - `FullyConnected` if the input is a single `"*"` character
+/// - `AuthoritySpecific` with a vector of `(AuthorityIndex,
+///   Vec<AncestorSelection>)` parsed by `parse_author_and_connections`
+fn parse_connections(input: &str) -> IResult<&str, AncestorConnectionSpec> {
+    alt((
+        map(char('*'), |_| AncestorConnectionSpec::FullyConnected),
+        map(
+            many0(parse_author_and_connections),
+            |author_and_connections| {
+                AncestorConnectionSpec::AuthoritySpecific(author_and_connections, HashMap::new())
+            },
+        ),
+    ))(input)
+}
+/// Parses a round definition with its ancestor connection specification.
+///
+/// # Format
+/// - The literal prefix `"Round"`
+/// - Followed by one or more digits representing the round number (e.g.
+///   `"Round0"`, `"Round42"`)
+/// - Followed by a colon `:`
+/// - Followed by a block of connections enclosed in braces `{ ... }`
+/// - Optionally followed by a comma `,`
+///
+/// Example input:
+/// ```text
+/// Round3:{A->[*,-B1],B->[C2]},
+/// ```
+///
+/// # Returns
+/// A tuple `(Round, AncestorConnectionSpec)` where:
+/// - `Round` is the parsed round number as an integer type
+/// - `AncestorConnectionSpec` is parsed from the contents inside the braces
+fn parse_round(input: &str) -> IResult<&str, (Round, AncestorConnectionSpec)> {
+    map(
+        tuple((
+            map_res(preceded(tag("Round"), digit1), |s: &str| s.parse::<Round>()),
+            char(':'),
+            delimited(char('{'), |i| parse_connections(i), char('}')),
+            opt(char(',')),
+        )),
+        |(round, _, connections, _)| (round, connections),
+    )(input)
+}
+
+/// Custom error wrapper to box `nom` errors into a standard `Error` type
+#[derive(Debug)]
+pub struct ParseDagError(String);
+
+impl std::fmt::Display for ParseDagError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Parse DAG Error: {}", self.0)
+    }
+}
+
+impl std::error::Error for ParseDagError {}
+
+impl<E: std::fmt::Debug> From<nom::Err<E>> for ParseDagError {
+    fn from(err: nom::Err<E>) -> Self {
+        ParseDagError(format!("{:?}", err))
+    }
+}
 /// DagParser
 ///
 /// Usage:
 ///
-/// ```
+/// ```rust
+/// use super::test_dag_parser::parse_dag;
 /// let dag_str = "DAG {
 ///     Round 0 : { 4 },
 ///     Round 1 : { * },
@@ -55,218 +228,36 @@ use crate::{
 ///     Round 8 : { * },
 ///     }";
 ///
-/// let (_, dag_builder) = parse_dag(dag_str).expect("Invalid dag"); // parse DAG DSL
+/// let dag_builder = parse_dag(dag_str).expect("Invalid dag"); // parse DAG DSL
 /// dag_builder.print(); // print the parsed DAG
-/// dag_builder.persist_all_blocks(dag_state.clone()); // persist all blocks to DagState
 /// ```
-pub(crate) fn parse_dag(dag_string: &str) -> Result<DagBuilder, nom::Err<()>> {
-    let (input, _) = tuple((tag("DAG"), multispace0, char('{')))(dag_string)?;
+pub(crate) fn parse_dag(dag_string: &str) -> Result<DagBuilder, ParseDagError> {
+    // Parse subsequent rounds
+    // remove whitespace from the input
+    let cleaned: String = dag_string.chars().filter(|c| !c.is_whitespace()).collect();
+    let input = cleaned.as_str();
 
-    let (mut input, num_authors) = parse_genesis(input).expect("Failed to parse genesis round");
+    let (mut input, num_authors) = preceded(tag("DAG{"), parse_genesis)(input)?;
 
     let context = Arc::new(Context::new_for_test(num_authors as usize).0);
     let mut dag_builder = DagBuilder::new(context);
-
-    // Parse subsequent rounds
-    // remove whitespace from the input
-    let cleaned: String = input.chars().filter(|c| !c.is_whitespace()).collect();
-    let mut input = cleaned.as_str();
     loop {
-        match parse_round(input, &dag_builder) {
-            Ok((new_input, (round, connections, transaction_acknowledgments))) => {
-                dag_builder.layer_with_connections(connections, transaction_acknowledgments, round);
+        match parse_round(input) {
+            Ok((new_input, (round, ancestor_connection_spec))) => {
+                dag_builder.layer_with_connections(ancestor_connection_spec, round);
                 input = new_input
             }
             Err(nom::Err::Error(_)) | Err(nom::Err::Failure(_)) => break,
-            Err(nom::Err::Incomplete(needed)) => return Err(nom::Err::Incomplete(needed)),
+            Err(e) => return Err(e.into()),
         }
     }
-    let (input, _) = tuple((multispace0, char('}')))(input)?;
-
+    // Ensure the DAG ends with a closing brace
+    let _ = char::<&str, nom::error::Error<&str>>('}')(input)?;
     Ok(dag_builder)
-}
-
-// Parses a round from the input string and returns a tuple containing the round
-// number, a vector of connections (authority index and their corresponding
-// block references), and a hashmap of transaction acknowledgments for each
-// authority index.
-fn parse_round<'a>(
-    input: &'a str,
-    dag_builder: &DagBuilder,
-) -> IResult<
-    &'a str,
-    (
-        Round,
-        Vec<(AuthorityIndex, Vec<BlockRef>)>,
-        HashMap<AuthorityIndex, Vec<BlockRef>>,
-    ),
-> {
-    let (input,(round, connections)) = map(
-        tuple((
-            map_res(preceded(tag("Round"), alpha1), |s: &str| {
-                s.parse::<Round>()
-            }),
-            char(':'),
-            delimited(
-                char('{'),
-                |i| parse_connections(i, dag_builder),
-                char('}')
-            ),
-            opt(char(',')),
-        )),
-        |(round,_, connections,_)| (round, connections),
-    )(input)?;
-
-    // TODO: extend DAG parser with transaction acknowledgments. For now it's
-    //  assumed that transactions are available together with the block headers and
-    //  we acknowledge transactions of all ancestors.
-
-    //  If the round is "1", we assume no transactions in Round 0 (genesis) are
-    // acknowledged.
-    let transactions_acknowledgments: HashMap<AuthorityIndex, Vec<BlockRef>> =
-        if round == 1 as Round {
-            HashMap::new()
-        } else {
-            connections.clone().into_iter().collect()
-        };
-    Ok((input, (round, connections, transactions_acknowledgments)))
-}
-
-fn parse_connections<'a>(
-    input: &'a str,
-    dag_builder: &DagBuilder,
-) -> IResult<&'a str, Vec<(AuthorityIndex, Vec<BlockRef>)>> {
-    // parse specified connections
-    // case 1: all authorities; [*]
-    // case 2: specific included authorities; [A0, B0, C0]
-    // case 3: specific excluded authorities;  [-A0]
-    // case 4: mixed all authorities + specific included/excluded authorities; [*,
-    // A0] TODO: case 5: byzantine case of multiple blocks per slot; [*];
-    // timestamp=1
-    let (input, authors_and_connections) = many0(parse_author_and_connections)(input)?;
-
-    let mut output = Vec::new();
-    for (author, connections) in authors_and_connections {
-        let mut block_refs = HashSet::new();
-        match connections {
-            ConnectionSpec::All => {
-                // If the connection is "*", we take all last ancestors
-                block_refs.extend(dag_builder.last_ancestors.clone());
-            }
-            ConnectionSpec::Skip(slots) => {
-                // If the connection is a skip list, we get the blocks at those slots
-                let stored_block_refs = slots
-                    .into_iter()
-                    .flat_map(|slot| get_blocks(slot, dag_builder))
-                    .collect::<HashSet<_>>();
-                block_refs.extend(dag_builder.last_ancestors.clone());
-
-                // Retain only those ancestors that are not in the stored block references
-                block_refs.retain(|ancestor| !stored_block_refs.contains(ancestor));
-            }
-            ConnectionSpec::Only(slots) => {
-                // If the connection is a list of specific slots, we get the blocks at those
-                // slots
-                let stored_block_refs = slots
-                    .into_iter()
-                    .flat_map(|slot| get_blocks(slot, dag_builder))
-                    .collect::<HashSet<_>>();
-                block_refs.extend(stored_block_refs);
-            }
-        }
-        output.push((author, block_refs.into_iter().collect()));
-    }
-
-    Ok((input, output))
-}
-
-fn get_blocks(slot: Slot, dag_builder: &DagBuilder) -> Vec<BlockRef> {
-    // note: special case for genesis blocks as they are cached separately
-    let block_refs = if slot.round == 0 {
-        dag_builder
-            .genesis_block_refs()
-            .into_iter()
-            .filter(|block| Slot::from(*block) == slot)
-            .collect::<Vec<_>>()
-    } else {
-        dag_builder
-            .get_uncommitted_blocks_at_slot(slot)
-            .iter()
-            .map(|block| block.reference())
-            .collect::<Vec<_>>()
-    };
-    block_refs
-}
-
-// Parses "B1", "C3", "G44" into a Slot
-fn alpha_num(input: &str) -> IResult<&str, Slot> {
-    map(pair(anychar, digit1), |(anychar, digit): (char, &str)| {
-        Slot::new(
-            digit.parse::<Round>().unwrap(),
-            AuthorityIndex::new_for_test(anychar as u32 - 'A' as u32),
-        )
-    })(input)
-}
-
-// Parses ["B1", "C3", "G44"] into vector of slots
-fn only_list(input: &str) -> IResult<&str, Vec<Slot>> {
-    separated_list1(char(','), alpha_num)(input)
-}
-
-// Parses ["-B4", "-C33", "-G44"] into vector of slots
-fn skip_list(input: &str) -> IResult<&str, Vec<Slot>> {
-    separated_list1(char(','), preceded(char('-'), alpha_num))(input)
-}
-
-// Parses ["*"],["A1", "B2", "C3"], ["-A4", "-B5"] into ConnectionSpec
-// - "*"                -> ConnectionSpec::All
-// - ["-A4", "-B5"]     -> ConnectionSpec::Skip(Vec<Slot>)
-// - ["A1", "B2", "C3"] -> ConnectionSpec::Only(Vec<Slot>)
-fn parse_connection_spec(input: &str) -> IResult<&str, ConnectionSpec> {
-    alt((
-        map(tag("*"), |_| ConnectionSpec::All),
-        map(skip_list, ConnectionSpec::Skip),
-        map(only_list, ConnectionSpec::Only),
-    ))(input)
-}
-fn parse_author_and_connections(input: &str) -> IResult<&str, (AuthorityIndex, ConnectionSpec)> {
-    pair(
-        map(terminated(anychar, tag("->")), |author: char| {
-            AuthorityIndex::new_for_test(author as u32 - 'A' as u32)
-        }),
-        delimited(char('['), parse_connection_spec, char(']')),
-    )(input)
-}
-
-fn parse_genesis(input: &str) -> IResult<&str, u32> {
-    let (input, num_authorities) = preceded(
-        tuple((
-            multispace0,
-            tag("Round"),
-            space1,
-            char('0'),
-            space0,
-            char(':'),
-            space0,
-            char('{'),
-            space0,
-        )),
-        |i| parse_authority_count(i),
-    )(input)?;
-    let (input, _) = tuple((space0, char('}'), opt(char(','))))(input)?;
-
-    Ok((input, num_authorities))
-}
-
-fn parse_authority_count(input: &str) -> IResult<&str, u32> {
-    let (input, num_str) = digit1(input)?;
-    Ok((input, num_str.parse().unwrap()))
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use super::*;
     use crate::block_header::BlockHeaderAPI;
 
@@ -309,54 +300,47 @@ mod tests {
         assert_eq!(dag_builder.block_headers.len(), 23);
 
         // Check the blocks were correctly parsed in Round 6
-        let blocks_a6 = dag_builder
-            .get_uncommitted_blocks_at_slot(Slot::new(6, AuthorityIndex::new_for_test(0)));
+        let blocks_a6 = dag_builder.get_uncommitted_blocks_at_slot(Slot::new(6, 0));
         assert_eq!(blocks_a6.len(), 1);
         let block_a6 = blocks_a6.first().unwrap();
         assert_eq!(block_a6.round(), 6);
-        assert_eq!(block_a6.author(), AuthorityIndex::new_for_test(0));
+        assert_eq!(block_a6.author(), 0.into());
         assert_eq!(block_a6.ancestors().len(), 5);
         let expected_block_a6_ancestor_slots = [
-            Slot::new(3, AuthorityIndex::new_for_test(0)),
-            Slot::new(3, AuthorityIndex::new_for_test(1)),
-            Slot::new(3, AuthorityIndex::new_for_test(2)),
-            Slot::new(1, AuthorityIndex::new_for_test(0)),
-            Slot::new(1, AuthorityIndex::new_for_test(1)),
+            Slot::new(3, 0),
+            Slot::new(3, 1),
+            Slot::new(3, 2),
+            Slot::new(1, 0),
+            Slot::new(1, 1),
         ];
         for ancestor in block_a6.ancestors() {
             assert!(expected_block_a6_ancestor_slots.contains(&Slot::from(*ancestor)));
         }
 
-        let blocks_b6 = dag_builder
-            .get_uncommitted_blocks_at_slot(Slot::new(6, AuthorityIndex::new_for_test(1)));
+        let blocks_b6 = dag_builder.get_uncommitted_blocks_at_slot(Slot::new(6, 1));
         assert_eq!(blocks_b6.len(), 1);
         let block_b6 = blocks_b6.first().unwrap();
         assert_eq!(block_b6.round(), 6);
-        assert_eq!(block_b6.author(), AuthorityIndex::new_for_test(1));
+        assert_eq!(block_b6.author(), 1.into());
         assert_eq!(block_b6.ancestors().len(), 5);
         let expected_block_b6_ancestor_slots = [
-            Slot::new(5, AuthorityIndex::new_for_test(0)),
-            Slot::new(5, AuthorityIndex::new_for_test(1)),
-            Slot::new(5, AuthorityIndex::new_for_test(2)),
-            Slot::new(5, AuthorityIndex::new_for_test(3)),
-            Slot::new(0, AuthorityIndex::new_for_test(0)),
+            Slot::new(5, 0),
+            Slot::new(5, 1),
+            Slot::new(5, 2),
+            Slot::new(5, 3),
+            Slot::new(0, 0),
         ];
         for ancestor in block_b6.ancestors() {
             assert!(expected_block_b6_ancestor_slots.contains(&Slot::from(*ancestor)));
         }
 
-        let blocks_c6 = dag_builder
-            .get_uncommitted_blocks_at_slot(Slot::new(6, AuthorityIndex::new_for_test(2)));
+        let blocks_c6 = dag_builder.get_uncommitted_blocks_at_slot(Slot::new(6, 2));
         assert_eq!(blocks_c6.len(), 1);
         let block_c6 = blocks_c6.first().unwrap();
         assert_eq!(block_c6.round(), 6);
-        assert_eq!(block_c6.author(), AuthorityIndex::new_for_test(2));
+        assert_eq!(block_c6.author(), 2.into());
         assert_eq!(block_c6.ancestors().len(), 3);
-        let expected_block_c6_ancestor_slots = [
-            Slot::new(5, AuthorityIndex::new_for_test(1)),
-            Slot::new(5, AuthorityIndex::new_for_test(2)),
-            Slot::new(5, AuthorityIndex::new_for_test(3)),
-        ];
+        let expected_block_c6_ancestor_slots = [Slot::new(5, 1), Slot::new(5, 2), Slot::new(5, 3)];
         for ancestor in block_c6.ancestors() {
             assert!(expected_block_c6_ancestor_slots.contains(&Slot::from(*ancestor)));
         }
@@ -364,7 +348,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_genesis_round_parsing() {
-        let dag_str = "Round 0 : { 4 }";
+        let dag_str = "Round0:{4}";
         let result = parse_genesis(dag_str);
         assert!(result.is_ok());
         let (_, num_authorities) = result.unwrap();
@@ -374,103 +358,112 @@ mod tests {
 
     #[tokio::test]
     async fn test_all_round_parsing() {
-        let dag_str = "Round 1 : { * }";
-        let context = Arc::new(Context::new_for_test(4).0);
-        let dag_builder = DagBuilder::new(context);
-        let result = parse_round(dag_str, &dag_builder);
+        let dag_str = "Round1:{*}";
+        let result = parse_round(dag_str);
         assert!(result.is_ok());
-        let (_, (round, connections, transactions_acknowledgments)) = result.unwrap();
+        let (_, (round, ancestor_connection_spec)) = result.unwrap();
 
         assert_eq!(round, 1);
-        for (i, (authority, references)) in connections.into_iter().enumerate() {
-            assert_eq!(authority, AuthorityIndex::new_for_test(i as u32));
-            assert_eq!(references, dag_builder.last_ancestors);
-            assert!(
-                transactions_acknowledgments
-                    .get(&authority)
-                    .cloned()
-                    .unwrap_or_default()
-                    .is_empty(),
-                "Transactions should not be acknowledged in Round 1"
-            );
-        }
+        assert_eq!(
+            ancestor_connection_spec,
+            AncestorConnectionSpec::FullyConnected
+        );
     }
 
     #[tokio::test]
     async fn test_specific_round_parsing() {
-        let dag_str = "Round 1 : {
-            A -> [A0, B0, C0, D0],
-            B -> [*, A0],
-            C -> [-A0],
-        }";
-        let context = Arc::new(Context::new_for_test(4).0);
-        let dag_builder = DagBuilder::new(context);
-        let result = parse_round(dag_str, &dag_builder);
+        let dag_str = "Round1:{A->[A0,B0,C0,D0],B->[*,A0],C->[-A0],}";
+        let result = parse_round(dag_str);
         assert!(result.is_ok());
-        let (_, (round, connections, transactions_acknowledgments)) = result.unwrap();
-
-        let skipped_slot = Slot::new_for_test(0, 0); // A0
-        let mut expected_references = [
-            dag_builder.last_ancestors.clone(),
-            dag_builder.last_ancestors.clone(),
-            dag_builder
-                .last_ancestors
-                .into_iter()
-                .filter(|ancestor| Slot::from(*ancestor) != skipped_slot)
-                .collect(),
-        ];
-
+        let (_, (round, ancestor_connection_spec)) = result.unwrap();
         assert_eq!(round, 1);
-        for (i, (authority, mut references)) in connections.into_iter().enumerate() {
-            assert_eq!(authority, AuthorityIndex::new_for_test(i as u32));
-            references.sort();
-            expected_references[i].sort();
-            assert_eq!(references, expected_references[i]);
-
-            assert!(
-                transactions_acknowledgments.is_empty(),
-                "Transactions should not be acknowledged in Round 1"
-            );
-        }
+        assert_eq!(
+            ancestor_connection_spec,
+            AncestorConnectionSpec::AuthoritySpecific(
+                vec![
+                    (
+                        0.into(),
+                        vec![
+                            AncestorSelection::IncludeFrom(Slot::new(0, 0)),
+                            AncestorSelection::IncludeFrom(Slot::new(0, 1)),
+                            AncestorSelection::IncludeFrom(Slot::new(0, 2)),
+                            AncestorSelection::IncludeFrom(Slot::new(0, 3))
+                        ]
+                    ),
+                    (
+                        1.into(),
+                        vec![
+                            AncestorSelection::UseLast,
+                            AncestorSelection::IncludeFrom(Slot::new(0, 0))
+                        ]
+                    ),
+                    (
+                        2.into(),
+                        vec![AncestorSelection::ExcludeFrom(Slot::new(0, 0))]
+                    ),
+                ],
+                HashMap::new()
+            )
+        );
     }
 
-    // #[tokio::test]
-    // async fn test_parse_author_and_connections() {
-    //     let expected_authority = str_to_authority_index("A").unwrap();
+    #[tokio::test]
+    async fn test_parse_author_and_connections() {
+        let expected_authority = 0.into(); // 'A'
 
-    //     // case 1: all authorities
-    //     let dag_str = "A -> [*]";
-    //     let result = parse_author_and_connections(dag_str);
-    //     assert!(result.is_ok());
-    //     let (_, (actual_author, actual_connections)) = result.unwrap();
-    //     assert_eq!(actual_author, expected_authority);
-    //     assert_eq!(actual_connections, ["*"]);
+        // case 1: all authorities
+        let dag_str = "A->[*]";
+        let result = parse_author_and_connections(dag_str);
+        assert!(result.is_ok());
+        let (_, (actual_author, actual_connections)) = result.unwrap();
+        assert_eq!(actual_author, expected_authority);
+        assert_eq!(actual_connections, vec![AncestorSelection::UseLast]);
 
-    //     // case 2: specific included authorities
-    //     let dag_str = "A -> [A0, B0, C0]";
-    //     let result = parse_author_and_connections(dag_str);
-    //     assert!(result.is_ok());
-    //     let (_, (actual_author, actual_connections)) = result.unwrap();
-    //     assert_eq!(actual_author, expected_authority);
-    //     assert_eq!(actual_connections, ["A0", "B0", "C0"]);
+        // case 2: specific included authorities
+        let dag_str = "A->[A0,B0,C0]";
+        let result = parse_author_and_connections(dag_str);
+        assert!(result.is_ok());
+        let (_, (actual_author, actual_connections)) = result.unwrap();
+        assert_eq!(actual_author, expected_authority);
+        assert_eq!(
+            actual_connections,
+            vec![
+                AncestorSelection::IncludeFrom(Slot::new(0, 0)), // A0
+                AncestorSelection::IncludeFrom(Slot::new(0, 1)), // B0
+                AncestorSelection::IncludeFrom(Slot::new(0, 2)), // C0
+            ]
+        );
 
-    //     // case 3: specific excluded authorities
-    //     let dag_str = "A -> [-A0, -B0]";
-    //     let result = parse_author_and_connections(dag_str);
-    //     assert!(result.is_ok());
-    //     let (_, (actual_author, actual_connections)) = result.unwrap();
-    //     assert_eq!(actual_author, expected_authority);
-    //     assert_eq!(actual_connections, ["-A0", "-B0"]);
+        // case 3: specific excluded authorities
+        let dag_str = "A->[-A0,-B0]";
+        let result = parse_author_and_connections(dag_str);
+        assert!(result.is_ok());
+        let (_, (actual_author, actual_connections)) = result.unwrap();
+        assert_eq!(actual_author, expected_authority);
+        assert_eq!(
+            actual_connections,
+            vec![
+                AncestorSelection::ExcludeFrom(Slot::new(0, 0)), // -A0
+                AncestorSelection::ExcludeFrom(Slot::new(0, 1)), // -B0
+            ]
+        );
 
-    //     // case 4: mixed all authorities + specific included/excluded authorities
-    //     let dag_str = "A -> [*, A0, -B0]";
-    //     let result = parse_author_and_connections(dag_str);
-    //     assert!(result.is_ok());
-    //     let (_, (actual_author, actual_connections)) = result.unwrap();
-    //     assert_eq!(actual_author, expected_authority);
-    //     assert_eq!(actual_connections, ["*", "A0", "-B0"]);
+        // case 4: mixed all authorities + specific included/excluded authorities
+        let dag_str = "A->[*,A0,-B0]";
+        let result = parse_author_and_connections(dag_str);
+        assert!(result.is_ok());
+        let (_, (actual_author, actual_connections)) = result.unwrap();
+        assert_eq!(actual_author, expected_authority);
+        assert_eq!(
+            actual_connections,
+            vec![
+                AncestorSelection::UseLast,                      // *
+                AncestorSelection::IncludeFrom(Slot::new(0, 0)), // A0
+                AncestorSelection::ExcludeFrom(Slot::new(0, 1)), // -B0
+            ]
+        );
 
-    //     // TODO: case 5: byzantine case of multiple blocks per slot; [*];
-    //     // timestamp=1
-    // }
+        // TODO: case 5: byzantine case of multiple blocks per slot; [*];
+        // timestamp=1
+    }
 }

--- a/crates/starfish/core/src/tests/base_committer_declarative_tests.rs
+++ b/crates/starfish/core/src/tests/base_committer_declarative_tests.rs
@@ -46,7 +46,7 @@ async fn direct_commit() {
         },
         }";
 
-    let (_, dag_builder) = parse_dag(dag_str).expect("a DAG should be valid");
+    let dag_builder = parse_dag(dag_str).expect("a DAG should be valid");
     dag_builder.persist_all_blocks(dag_state.clone());
 
     let leader_round = committer.leader_round(1);
@@ -90,7 +90,7 @@ async fn direct_skip() {
         Round 5 : { * },
         }";
 
-    let (_, dag_builder) = parse_dag(dag_str).expect("a DAG should be valid");
+    let dag_builder = parse_dag(dag_str).expect("a DAG should be valid");
     dag_builder.persist_all_blocks(dag_state.clone());
 
     let leader_round = committer.leader_round(1);
@@ -134,7 +134,7 @@ async fn direct_undecided() {
         Round 5 : { * },
         }";
 
-    let (_, dag_builder) = parse_dag(dag_str).expect("a DAG should be valid");
+    let dag_builder = parse_dag(dag_str).expect("a DAG should be valid");
     dag_builder.persist_all_blocks(dag_state.clone());
 
     let leader_round = committer.leader_round(1);
@@ -208,7 +208,7 @@ async fn indirect_commit() {
         },
     }";
 
-    let (_, dag_builder) = parse_dag(dag_str).expect("a DAG should be valid");
+    let dag_builder = parse_dag(dag_str).expect("a DAG should be valid");
     dag_builder.persist_all_blocks(dag_state.clone());
 
     let leader_round = committer.leader_round(1);
@@ -290,7 +290,7 @@ async fn indirect_skip() {
         Round 11 : { * },
     }";
 
-    let (_, dag_builder) = parse_dag(dag_str).expect("a DAG should be valid");
+    let dag_builder = parse_dag(dag_str).expect("a DAG should be valid");
     dag_builder.persist_all_blocks(dag_state.clone());
 
     let leader_round = committer.leader_round(1);

--- a/crates/starfish/core/src/tests/pipelined_committer_tests.rs
+++ b/crates/starfish/core/src/tests/pipelined_committer_tests.rs
@@ -27,7 +27,7 @@ async fn direct_commit() {
     let decision_round_wave_0_pipeline_1 = committer.committers[1].certifying_round(0);
     build_dag(context, dag_state, None, decision_round_wave_0_pipeline_1);
 
-    let last_decided = Slot::new_for_test(0, 0);
+    let last_decided = Slot::new(0, 0);
     let sequence = committer.try_decide(last_decided);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert_eq!(sequence.len(), 1);
@@ -61,7 +61,7 @@ async fn idempotence() {
     );
 
     // Commit one leader.
-    let last_decided = Slot::new_for_test(0, 0);
+    let last_decided = Slot::new(0, 0);
     let first_sequence = committer.try_decide(last_decided);
     assert_eq!(first_sequence.len(), 1);
     tracing::info!("Commit sequence: {first_sequence:#?}");
@@ -104,7 +104,7 @@ async fn multiple_direct_commit() {
     let (context, dag_state, committer) = basic_test_setup();
     let wave_length = WAVE_LENGTH;
 
-    let mut last_decided = Slot::new_for_test(0, 0);
+    let mut last_decided = Slot::new(0, 0);
     let mut ancestors = None;
     for n in 1..=10 {
         // Build the dag up to the decision round for each pipeline's wave starting
@@ -158,7 +158,7 @@ async fn direct_commit_late_call() {
 
     build_dag(context.clone(), dag_state.clone(), None, certifying_round);
 
-    let last_decided = Slot::new_for_test(0, 0);
+    let last_decided = Slot::new(0, 0);
     let sequence = committer.try_decide(last_decided);
     tracing::info!("Commit sequence: {sequence:#?}");
 
@@ -189,7 +189,7 @@ async fn no_genesis_commit() {
     for r in 0..certifying_round_pipeline_0_wave_0 {
         ancestors = Some(build_dag(context.clone(), dag_state.clone(), ancestors, r));
 
-        let last_decided = Slot::new_for_test(0, 0);
+        let last_decided = Slot::new(0, 0);
         let sequence = committer.try_decide(last_decided);
         assert!(sequence.is_empty());
     }
@@ -233,7 +233,7 @@ async fn direct_skip_no_leader() {
 
     // Ensure no blocks are committed because there are 2f+1 blame (non-votes) for
     // the missing leader.
-    let last_decided = Slot::new_for_test(0, 0);
+    let last_decided = Slot::new(0, 0);
     let sequence = committer.try_decide(last_decided);
     tracing::info!("Commit sequence: {sequence:#?}");
 
@@ -307,7 +307,7 @@ async fn direct_skip_enough_blame() {
 
     // Ensure the leader is skipped because there are 2f+1 blame (non-votes) for
     // the wave 0 leader of pipeline 1.
-    let last_decided = Slot::new_for_test(0, 0);
+    let last_decided = Slot::new(0, 0);
     let sequence = committer.try_decide(last_decided);
     tracing::info!("Commit sequence: {sequence:#?}");
 
@@ -413,7 +413,7 @@ async fn indirect_commit() {
     );
 
     // Ensure we commit the first leaders.
-    let last_decided = Slot::new_for_test(0, 0);
+    let last_decided = Slot::new(0, 0);
     let sequence = committer.try_decide(last_decided);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert_eq!(sequence.len(), 5);
@@ -494,7 +494,7 @@ async fn indirect_skip() {
 
     // Ensure we commit the first 3 leaders, skip the 4th, and commit the last 2
     // leaders.
-    let last_decided = Slot::new_for_test(0, 0);
+    let last_decided = Slot::new(0, 0);
     let sequence = committer.try_decide(last_decided);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert_eq!(sequence.len(), 7);
@@ -572,7 +572,7 @@ async fn undecided() {
     );
 
     // Ensure no blocks are committed.
-    let last_decided = Slot::new_for_test(0, 0);
+    let last_decided = Slot::new(0, 0);
     let sequence = committer.try_decide(last_decided);
     assert!(sequence.is_empty());
 }
@@ -730,7 +730,7 @@ async fn test_byzantine_validator() {
 
     // Expect a successful direct commit of A12 and leaders at rounds 1 ~ 11 as
     // pipelining is enabled.
-    let last_decided = Slot::new_for_test(0, 0);
+    let last_decided = Slot::new(0, 0);
     let sequence = committer.try_decide(last_decided);
     tracing::info!("Commit sequence: {sequence:#?}");
 

--- a/crates/starfish/core/src/tests/randomized_tests.rs
+++ b/crates/starfish/core/src/tests/randomized_tests.rs
@@ -54,7 +54,7 @@ async fn test_randomized_dag_all_direct_commit() {
             "Running test with committee size {num_authorities} & {NUM_ROUNDS} rounds in the DAG..."
         );
 
-        let last_decided = Slot::new_for_test(0, 0);
+        let last_decided = Slot::new(0, 0);
         let sequence = authority.committer.try_decide(last_decided);
         tracing::debug!("Commit sequence: {sequence:#?}");
 
@@ -118,7 +118,7 @@ async fn test_randomized_dag_and_decision_sequence() {
         all_blocks.shuffle(&mut random_test_setup.seeded_rng);
 
         let mut sequenced_leaders_1 = vec![];
-        let mut last_decided = Slot::new_for_test(0, 0);
+        let mut last_decided = Slot::new(0, 0);
         let mut i = 0;
         while i < all_blocks.len() {
             let chunk_size = random_test_setup
@@ -153,7 +153,7 @@ async fn test_randomized_dag_and_decision_sequence() {
         all_blocks.shuffle(&mut random_test_setup.seeded_rng);
 
         let mut sequenced_leaders_2 = vec![];
-        let mut last_decided = Slot::new_for_test(0, 0);
+        let mut last_decided = Slot::new(0, 0);
         let mut i = 0;
         while i < all_blocks.len() {
             let chunk_size = random_test_setup

--- a/crates/starfish/core/src/tests/universal_committer_tests.rs
+++ b/crates/starfish/core/src/tests/universal_committer_tests.rs
@@ -43,7 +43,7 @@ async fn direct_commit() {
 
     // Genesis cert will not be included in commit sequence, marking it as last
     // decided
-    let last_decided = Slot::new_for_test(0, 0);
+    let last_decided = Slot::new(0, 0);
 
     // The universal committer should mark the potential leaders in leader round 6
     // as undecided because there is no way to get enough certificates for
@@ -80,7 +80,7 @@ async fn idempotence() {
     );
 
     // Commit one leader.
-    let last_decided = Slot::new_for_test(0, 0);
+    let last_decided = Slot::new(0, 0);
     let first_sequence = committer.try_decide(last_decided);
     assert_eq!(first_sequence.len(), 1);
 
@@ -146,7 +146,7 @@ async fn multiple_direct_commit() {
     let (context, dag_state, committer) = basic_test_setup();
 
     let mut ancestors = None;
-    let mut last_decided = Slot::new_for_test(0, 0);
+    let mut last_decided = Slot::new(0, 0);
     for n in 1..=10 {
         // Build the DAG up to the certifying round for leader blocks of authority 1,
         // i.e. full DAG is built with chunks of 3 rounds
@@ -194,7 +194,7 @@ async fn direct_commit_late_call() {
         certifying_round_wave_10,
     );
 
-    let last_decided = Slot::new_for_test(0, 0);
+    let last_decided = Slot::new(0, 0);
     let sequence = committer.try_decide(last_decided);
     tracing::info!("Commit sequence: {sequence:#?}");
 
@@ -223,7 +223,7 @@ async fn no_genesis_commit() {
     for r in 0..certifying_round {
         ancestors = Some(build_dag(context.clone(), dag_state.clone(), ancestors, r));
 
-        let last_committed = Slot::new_for_test(0, 0);
+        let last_committed = Slot::new(0, 0);
         let sequence = committer.try_decide(last_committed);
         tracing::info!("Commit sequence: {sequence:#?}");
         assert!(sequence.is_empty());
@@ -252,7 +252,7 @@ async fn direct_skip_no_leader_votes() {
     let first_leader = AuthorityIndex::new_for_test(1);
     let first_round = 1 as Round;
 
-    let (_, dag_builder) = parse_dag(dag_str).expect("Invalid dag");
+    let dag_builder = parse_dag(dag_str).expect("Invalid dag");
     let dag_state = Arc::new(RwLock::new(DagState::new(
         dag_builder.context.clone(),
         Arc::new(MemStore::new()),
@@ -276,7 +276,7 @@ async fn direct_skip_no_leader_votes() {
     // committer.
     assert_eq!(committer.committers.len(), 3);
 
-    let last_decided = Slot::new_for_test(0, 0);
+    let last_decided = Slot::new(0, 0);
     let sequence = committer.try_decide(last_decided);
     // Only leader for slot B1 should be decided, specifically, skipped
     assert_eq!(sequence.len(), 1);
@@ -323,7 +323,7 @@ async fn direct_skip_missing_leader_block() {
         .persist_all_blocks(test_setup.dag_state.clone());
 
     // Ensure that the leader of round 3 is skipped because the leader is missing.
-    let last_committed = Slot::new_for_test(0, 0);
+    let last_committed = Slot::new(0, 0);
     let sequence = test_setup.committer.try_decide(last_committed);
     tracing::info!("Commit sequence: {sequence:#?}");
 
@@ -372,7 +372,7 @@ async fn indirect_commit() {
         Round 8 : { * },
      }";
 
-    let (_, dag_builder) = parse_dag(dag_str).expect("Invalid dag");
+    let dag_builder = parse_dag(dag_str).expect("Invalid dag");
     let dag_state = Arc::new(RwLock::new(DagState::new(
         dag_builder.context.clone(),
         Arc::new(MemStore::new()),
@@ -398,7 +398,7 @@ async fn indirect_commit() {
 
     // Ensure we indirectly commit the leader of round 3 via the directly committed
     // leader of round 6.
-    let last_decided = Slot::new_for_test(0, 0);
+    let last_decided = Slot::new(0, 0);
     let sequence = committer.try_decide(last_decided);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert_eq!(sequence.len(), 6);
@@ -454,7 +454,7 @@ async fn indirect_skip() {
         Round 9 : { * },
      }";
 
-    let (_, dag_builder) = parse_dag(dag_str).expect("Invalid dag");
+    let dag_builder = parse_dag(dag_str).expect("Invalid dag");
     let dag_state = Arc::new(RwLock::new(DagState::new(
         dag_builder.context.clone(),
         Arc::new(MemStore::new()),
@@ -480,7 +480,7 @@ async fn indirect_skip() {
 
     // Ensure we indirectly skip the leader of round 4 via the directly committed
     // leader of round 7.
-    let last_decided = Slot::new_for_test(0, 0);
+    let last_decided = Slot::new(0, 0);
     let sequence = committer.try_decide(last_decided);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert_eq!(sequence.len(), 7);
@@ -540,7 +540,7 @@ async fn undecided() {
         },
      }";
 
-    let (_, dag_builder) = parse_dag(dag_str).expect("Invalid dag");
+    let dag_builder = parse_dag(dag_str).expect("Invalid dag");
     let dag_state = Arc::new(RwLock::new(DagState::new(
         dag_builder.context.clone(),
         Arc::new(MemStore::new()),
@@ -566,7 +566,7 @@ async fn undecided() {
 
     // Ensure we indirectly commit the leader of round3 via the directly committed
     // leader of round 6.
-    let last_decided = Slot::new_for_test(0, 0);
+    let last_decided = Slot::new(0, 0);
     let sequence = committer.try_decide(last_decided);
     tracing::info!("Commit sequence: {sequence:#?}");
     assert!(sequence.is_empty());
@@ -715,7 +715,7 @@ async fn test_byzantine_direct_commit() {
     // all of these blocks also have good votes for leader A12 through A, B, D.
 
     // Expect a successful direct commit of A12 and all leaders at previous rounds.
-    let last_decided = Slot::new_for_test(0, 0);
+    let last_decided = Slot::new(0, 0);
     let sequence = committer.try_decide(last_decided);
     tracing::info!("Commit sequence: {sequence:#?}");
 


### PR DESCRIPTION
# Description of change

This PR refactors the `test_dag_parser` module to separate the parsing logic from the Dag Building logic.

## Links to any relevant issues

part of #7257

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
