### PR TITLE
feat(ci): upload split cluster logs as artifacts on failure

### DIFF
--- a/.github/workflows/_split_cluster.yml
+++ b/.github/workflows/_split_cluster.yml
@@ -1,6 +1,7 @@
 name: Split Cluster Check
 
 on:
+  workflow_dispatch:
   workflow_call:
 
 concurrency:
@@ -25,8 +26,17 @@ jobs:
       - name: Run split cluster check script
         id: mn-split-cluster-check
         run: |
+          WORKING_DIR=/tmp/mainnet-split-cluster-${{ github.run_id }} \
           IOTA_PROTOCOL_CONFIG_CHAIN_OVERRIDE=mainnet \
           scripts/compatibility/split-cluster-check.sh origin/mainnet ${{ github.sha }}
+      - name: Upload mainnet split cluster logs on failure
+        if: failure()
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: mainnet-split-cluster-logs-${{ github.run_id }}
+          path: /tmp/mainnet-split-cluster-${{ github.run_id }}/logs/
+          retention-days: 5
+          if-no-files-found: warn
   validate-testnet:
     runs-on: self-hosted-x64
     if: (!cancelled() && !failure())
@@ -38,5 +48,14 @@ jobs:
       - name: Run split cluster check script
         id: tn-split-cluster-check
         run: |
+          WORKING_DIR=/tmp/testnet-split-cluster-${{ github.run_id }} \
           IOTA_PROTOCOL_CONFIG_CHAIN_OVERRIDE=testnet \
           scripts/compatibility/split-cluster-check.sh origin/testnet ${{ github.sha }}
+      - name: Upload testnet split cluster logs on failure
+        if: failure()
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: testnet-split-cluster-logs-${{ github.run_id }}
+          path: /tmp/testnet-split-cluster-${{ github.run_id }}/logs/
+          retention-days: 5
+          if-no-files-found: warn

--- a/scripts/compatibility/split-cluster-check.sh
+++ b/scripts/compatibility/split-cluster-check.sh
@@ -28,6 +28,9 @@ fi
 # if WORKING_DIR is not set, create a temp dir
 if [ -z "$WORKING_DIR" ]; then
   WORKING_DIR=$(mktemp -d)
+else
+  # if WORKING_DIR is set but doesn't exist, create it
+  mkdir -p "$WORKING_DIR"
 fi
 
 echo "Using working dir $WORKING_DIR"


### PR DESCRIPTION
# Description of change

We need a way to check why the split cluster tests fail, so the logs files of the nodes will be uploaded as artifacts on failure.