### PR TITLE
upstream(node): Add option to reuse downloaded formal snapshot files

### DIFF
--- a/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -1329,7 +1329,11 @@ async fn concurrent_latest_object_cache_race_test() {
     static METRICS: once_cell::sync::Lazy<Arc<ExecutionCacheMetrics>> =
         once_cell::sync::Lazy::new(|| Arc::new(ExecutionCacheMetrics::new(default_registry())));
 
-    let cache = Arc::new(WritebackCache::new(store.clone(), (*METRICS).clone()));
+    let cache = Arc::new(WritebackCache::new(
+        &WritebackCacheConfig::default(),
+        store.clone(),
+        (*METRICS).clone(),
+    ));
 
     let object_id = ObjectID::random();
     let owner = IotaAddress::random_for_testing_only();
@@ -1422,7 +1426,11 @@ async fn concurrent_latest_object_cache_collision_test() {
     static METRICS: once_cell::sync::Lazy<Arc<ExecutionCacheMetrics>> =
         once_cell::sync::Lazy::new(|| Arc::new(ExecutionCacheMetrics::new(default_registry())));
 
-    let cache = Arc::new(WritebackCache::new(store.clone(), (*METRICS).clone()));
+    let cache = Arc::new(WritebackCache::new(
+        &WritebackCacheConfig::default(),
+        store.clone(),
+        (*METRICS).clone(),
+    ));
 
     let mk_object_id = |i: usize| -> ObjectID {
         let mut obj_id = [0_u8; 32];

--- a/crates/iota-snapshot/src/reader.rs
+++ b/crates/iota-snapshot/src/reader.rs
@@ -33,7 +33,7 @@ use iota_core::authority::{
 use iota_storage::{
     blob::{Blob, BlobEncoding},
     object_store::{
-        ObjectStoreGetExt, ObjectStorePutExt,
+        ObjectStoreGetExt, ObjectStoreListExt, ObjectStorePutExt,
         http::HttpDownloaderBuilder,
         util::{copy_file, copy_files, path_to_filesystem},
     },
@@ -79,6 +79,7 @@ impl StateSnapshotReaderV1 {
         indirect_objects_threshold: usize,
         download_concurrency: NonZeroUsize,
         multi_progress_bar: MultiProgress,
+        skip_reset_local_store: bool,
     ) -> Result<Self> {
         let epoch_dir = format!("epoch_{epoch}");
         let remote_object_store = if remote_store_config.no_sign_request {
@@ -88,16 +89,20 @@ impl StateSnapshotReaderV1 {
         };
         let local_object_store: Arc<dyn ObjectStorePutExt> =
             local_store_config.make().map(Arc::new)?;
+        let local_object_store_list: Arc<dyn ObjectStoreListExt> =
+            local_store_config.make().map(Arc::new)?;
         let local_staging_dir_root = local_store_config
             .directory
             .as_ref()
             .context("No directory specified")?
             .clone();
-        let local_epoch_dir_path = local_staging_dir_root.join(&epoch_dir);
-        if local_epoch_dir_path.exists() {
-            fs::remove_dir_all(&local_epoch_dir_path)?;
+        if !skip_reset_local_store {
+            let local_epoch_dir_path = local_staging_dir_root.join(&epoch_dir);
+            if local_epoch_dir_path.exists() {
+                fs::remove_dir_all(&local_epoch_dir_path)?;
+            }
+            fs::create_dir_all(&local_epoch_dir_path)?;
         }
-        fs::create_dir_all(&local_epoch_dir_path)?;
         // Downloads MANIFEST from remote store
         let manifest_file_path = Path::from(epoch_dir.clone()).child("MANIFEST");
         copy_file(
@@ -161,10 +166,28 @@ impl StateSnapshotReaderV1 {
             })
             .collect();
 
+        let files_to_download = if skip_reset_local_store {
+            let mut list_stream = local_object_store_list
+                .list_objects(Some(&epoch_dir_path))
+                .await;
+            let mut existing_files = std::collections::HashSet::new();
+            while let Some(Ok(meta)) = list_stream.next().await {
+                existing_files.insert(meta.location);
+            }
+            let mut missing_files = Vec::new();
+            for file in &files {
+                if !existing_files.contains(file) {
+                    missing_files.push(file.clone());
+                }
+            }
+            missing_files
+        } else {
+            files
+        };
         let progress_bar = multi_progress_bar.add(
-            ProgressBar::new(files.len() as u64).with_style(
+            ProgressBar::new(files_to_download.len() as u64).with_style(
                 ProgressStyle::with_template(
-                    "[{elapsed_precise}] {wide_bar} {pos} out of {len} .ref files done ({msg})",
+                    "[{elapsed_precise}] {wide_bar} {pos} out of {len} missing .ref files done ({msg})",
                 )
                 .unwrap(),
             ),
@@ -172,15 +195,15 @@ impl StateSnapshotReaderV1 {
         // Downloads all reference files from remote store to local store in parallel
         // and updates the progress bar accordingly
         copy_files(
-            &files,
-            &files,
+            &files_to_download,
+            &files_to_download,
             &remote_object_store,
             &local_object_store,
             download_concurrency,
             Some(progress_bar.clone()),
         )
         .await?;
-        progress_bar.finish_with_message("ref files download complete");
+        progress_bar.finish_with_message("Missing ref files download complete");
         Ok(StateSnapshotReaderV1 {
             epoch,
             local_staging_dir_root,

--- a/crates/iota-snapshot/src/tests.rs
+++ b/crates/iota-snapshot/src/tests.rs
@@ -106,6 +106,7 @@ async fn test_snapshot_basic() -> Result<(), anyhow::Error> {
         usize::MAX,
         NonZeroUsize::new(1).unwrap(),
         MultiProgress::new(),
+        false, // skip_reset_local_store
     )
     .await?;
     let restored_perpetual_db = AuthorityPerpetualTables::open(&restored_db_path, None);
@@ -159,6 +160,7 @@ async fn test_snapshot_empty_db() -> Result<(), anyhow::Error> {
         usize::MAX,
         NonZeroUsize::new(1).unwrap(),
         MultiProgress::new(),
+        false, // skip_reset_local_store
     )
     .await?;
     let restored_perpetual_db = AuthorityPerpetualTables::open(&restored_db_path, None);

--- a/crates/iota-tool/src/lib.rs
+++ b/crates/iota-tool/src/lib.rs
@@ -895,6 +895,7 @@ pub async fn download_formal_snapshot(
             usize::MAX,
             NonZeroUsize::new(num_parallel_downloads).unwrap(),
             m_clone,
+            false, // skip_reset_local_store
         )
         .await
         .unwrap_or_else(|err| panic!("Failed to create reader: {err}"));


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.39.4, v1.40.3)
- Port commit: https://github.com/MystenLabs/sui/commit/cb5dd8e4e458e315e70b0a2b43fb019148cf37e8
- Description:
This can be problematic when a file is half-downloaded but useful when all file downloading is complete, which helps to speed up iteration over restore, as each time the .ref files download would take about 30min.


## Links to any relevant issues

Part of #6148  

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes


### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes):
  - Nodes can now download only the missing formal snapshot files instead of fetching the entire snapshot.
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API: