### PR TITLE
upstream(iota-sdk): Add custom header support in the `IotaClientBuilder` struct

### DIFF
--- a/crates/iota-sdk/src/error.rs
+++ b/crates/iota-sdk/src/error.rs
@@ -33,5 +33,5 @@ pub enum Error {
     #[error(transparent)]
     Json(#[from] serde_json::Error),
     #[error("Invalid Header key-value pair: {0}")]
-    CustomHeadersError(String),
+    CustomHeaders(String),
 }

--- a/crates/iota-sdk/src/error.rs
+++ b/crates/iota-sdk/src/error.rs
@@ -32,4 +32,6 @@ pub enum Error {
     InsufficientFunds { address: IotaAddress, amount: u128 },
     #[error(transparent)]
     Json(#[from] serde_json::Error),
+    #[error("Invalid Header key-value pair: {0}")]
+    CustomHeadersError(String),
 }

--- a/crates/iota-sdk/src/lib.rs
+++ b/crates/iota-sdk/src/lib.rs
@@ -85,10 +85,11 @@ pub mod json_rpc_error;
 pub mod wallet_context;
 
 use std::{
-    collections::VecDeque,
+    collections::{HashMap, VecDeque},
     fmt::{Debug, Formatter},
     marker::PhantomData,
     pin::Pin,
+    str::FromStr,
     sync::Arc,
     task::Poll,
     time::Duration,
@@ -115,6 +116,7 @@ use jsonrpsee::{
     ws_client::{PingConfig, WsClient, WsClientBuilder},
 };
 use move_core_types::language_storage::StructTag;
+use reqwest::header::HeaderName;
 use rustls::crypto::{CryptoProvider, ring};
 use serde_json::Value;
 
@@ -167,6 +169,7 @@ pub struct IotaClientBuilder {
     ws_ping_interval: Option<Duration>,
     basic_auth: Option<(String, String)>,
     tls_config: Option<rustls::ClientConfig>,
+    headers: Option<HashMap<String, String>>,
 }
 
 impl Default for IotaClientBuilder {
@@ -178,6 +181,7 @@ impl Default for IotaClientBuilder {
             ws_ping_interval: None,
             basic_auth: None,
             tls_config: None,
+            headers: None,
         }
     }
 }
@@ -210,6 +214,12 @@ impl IotaClientBuilder {
     /// Set the basic auth credentials for the HTTP client.
     pub fn basic_auth(mut self, username: impl AsRef<str>, password: impl AsRef<str>) -> Self {
         self.basic_auth = Some((username.as_ref().to_string(), password.as_ref().to_string()));
+        self
+    }
+
+    /// Set custom headers for the HTTP client
+    pub fn custom_headers(mut self, headers: HashMap<String, String>) -> Self {
+        self.headers = Some(headers);
         self
     }
 
@@ -263,6 +273,17 @@ impl IotaClientBuilder {
                 // reqwest::header::AUTHORIZATION,
                 HeaderValue::from_str(&format!("Basic {auth}")).unwrap(),
             );
+        }
+
+        if let Some(custom_headers) = self.headers {
+            for (key, value) in custom_headers {
+                let header_name = HeaderName::from_str(&key)
+                    .map_err(|e| Error::CustomHeadersError(e.to_string()))?;
+
+                let header_value = HeaderValue::from_str(&value)
+                    .map_err(|e| Error::CustomHeadersError(e.to_string()))?;
+                headers.insert(header_name, header_value);
+            }
         }
 
         let ws = if let Some(url) = self.ws_url {

--- a/crates/iota-sdk/src/lib.rs
+++ b/crates/iota-sdk/src/lib.rs
@@ -279,7 +279,6 @@ impl IotaClientBuilder {
             for (key, value) in custom_headers {
                 let header_name =
                     HeaderName::from_str(&key).map_err(|e| Error::CustomHeaders(e.to_string()))?;
-
                 let header_value = HeaderValue::from_str(&value)
                     .map_err(|e| Error::CustomHeaders(e.to_string()))?;
                 headers.insert(header_name, header_value);

--- a/crates/iota-sdk/src/lib.rs
+++ b/crates/iota-sdk/src/lib.rs
@@ -277,11 +277,11 @@ impl IotaClientBuilder {
 
         if let Some(custom_headers) = self.headers {
             for (key, value) in custom_headers {
-                let header_name = HeaderName::from_str(&key)
-                    .map_err(|e| Error::CustomHeadersError(e.to_string()))?;
+                let header_name =
+                    HeaderName::from_str(&key).map_err(|e| Error::CustomHeaders(e.to_string()))?;
 
                 let header_value = HeaderValue::from_str(&value)
-                    .map_err(|e| Error::CustomHeadersError(e.to_string()))?;
+                    .map_err(|e| Error::CustomHeaders(e.to_string()))?;
                 headers.insert(header_name, header_value);
             }
         }


### PR DESCRIPTION
## Description 

Upstream changes from https://github.com/MystenLabs/sui/pull/22595

Closes #7837

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [x] Rust SDK: Adds support for custom user defined headers in `IotaClientBuilder`. You can define custom headers through the `IotaClientBuilder::custom_headers` function to be added right before building.
