### PR TITLE
upstream(iota): Allow 0x0 in Move.toml on upgrade

### DIFF
--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/address_change_v1/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/address_change_v1/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "upgrades"
+edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+
+[addresses]
+# represents the "deployed" package with non-zero address
+upgrades = "0x1"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/address_change_v1/sources/UpgradeErrors.move
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/address_change_v1/sources/UpgradeErrors.move
@@ -1,0 +1,27 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+module upgrades::upgrades {
+    // enum
+    public struct MyStruct has drop {
+        a: u32,
+    }
+
+    public enum MyEnum {
+        A(MyStruct),
+    }
+
+    // struct
+    public struct MyNestedStruct has drop {
+        a: MyStruct,
+    }
+
+    public struct MyStructWithGeneric<T> has drop {
+        f: T,
+    }
+
+    public fun func_with_generic_struct_param(a: MyStructWithGeneric<MyStruct>): u64 {
+        0
+    }
+}

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/address_change_v2/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/address_change_v2/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "upgrades"
+edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+
+[addresses]
+upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/address_change_v2/sources/UpgradeErrors.move
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/address_change_v2/sources/UpgradeErrors.move
@@ -1,0 +1,32 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+module upgrades::upgrades {
+    // enum
+    public struct MyStruct has drop {
+        a: u32,
+    }
+
+    public enum MyEnum {
+        A(MyStruct),
+    }
+
+    // struct
+    public struct MyNestedStruct has drop {
+        a: MyStruct,
+    }
+
+    public struct MyStructWithGeneric<T> has drop {
+        f: T,
+    }
+
+    public fun func_with_generic_struct_param(a: MyStructWithGeneric<MyStruct>): u64 {
+        0
+    }
+    
+    // add a new struct to simulate upgrade
+    public struct MyNewStruct has drop {
+        b: u64,
+    }
+}

--- a/crates/iota/src/unit_tests/snapshots/iota__upgrade_compatibility__upgrade_compatibility_tests__address_change.snap
+++ b/crates/iota/src/unit_tests/snapshots/iota__upgrade_compatibility__upgrade_compatibility_tests__address_change.snap
@@ -1,0 +1,37 @@
+---
+source: crates/iota/src/upgrade_compatibility/../unit_tests/upgrade_compatibility_tests.rs
+expression: normalize_path(err.to_string())
+---
+error[Compatibility E01002]: type mismatch
+   ┌─ /fixtures/upgrade_errors/address_change_v2/sources/UpgradeErrors.move:12:9
+   │
+11 │     public enum MyEnum {
+   │                 ------ Enum definition
+12 │         A(MyStruct),
+   │         ^^^^^^^^^^^ Mismatched field type '0x2::upgrades::MyStruct', expected '0x1::upgrades::MyStruct'.
+   │
+   = Enums are part of a module's public interface and cannot be removed or changed during an upgrade.
+   = Restore the original enum's variant for enum 'MyEnum' including the ordering.
+
+error[Compatibility E01002]: type mismatch
+   ┌─ /fixtures/upgrade_errors/address_change_v2/sources/UpgradeErrors.move:17:9
+   │
+16 │     public struct MyNestedStruct has drop {
+   │                   -------------- Struct definition
+17 │         a: MyStruct,
+   │         ^ Mismatched field type '0x2::upgrades::MyStruct', expected '0x1::upgrades::MyStruct'.
+   │
+   = Structs are part of a module's public interface and cannot be removed or changed during an upgrade.
+   = Restore the original struct's field for struct 'MyNestedStruct' including the ordering.
+
+error[Compatibility E03001]: function signature mismatch
+   ┌─ /fixtures/upgrade_errors/address_change_v2/sources/UpgradeErrors.move:24:47
+   │
+24 │     public fun func_with_generic_struct_param(a: MyStructWithGeneric<MyStruct>): u64 {
+   │                                               ^ Unexpected parameter '0x2::upgrades::MyStructWithGeneric<0x2::upgrades::MyStruct>', expected '0x1::upgrades::MyStructWithGeneric<0x1::upgrades::MyStruct>'
+   │
+   = Functions are part of a module's public interface and cannot be removed or changed during a 'compatible' upgrade.
+   = Restore the original function's parameter for function 'func_with_generic_struct_param'.
+
+
+Upgrade failed, this package requires changes to be compatible with the existing package. Its upgrade policy is set to 'compatible'.

--- a/crates/iota/src/unit_tests/upgrade_compatibility_tests.rs
+++ b/crates/iota/src/unit_tests/upgrade_compatibility_tests.rs
@@ -16,14 +16,20 @@ use move_compiler::{
     diagnostics::report_diagnostics_to_buffer,
     shared::files::{FileName, FilesSourceText},
 };
-use move_core_types::identifier::Identifier;
+use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 
 use crate::upgrade_compatibility::{FormattedField, compare_packages, missing_module_diag};
 
 #[test]
 fn test_all() {
     let (mods_v1, pkg_v2, path) = get_packages("all");
-    let result = compare_packages(mods_v1, pkg_v2, path, UpgradePolicy::Compatible);
+    let result = compare_packages(
+        AccountAddress::ZERO,
+        mods_v1,
+        pkg_v2,
+        path,
+        UpgradePolicy::Compatible,
+    );
 
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -33,7 +39,13 @@ fn test_all() {
 #[test]
 fn test_declarations_missing() {
     let (pkg_v1, pkg_v2, path) = get_packages("declaration_errors");
-    let result = compare_packages(pkg_v1, pkg_v2, path, UpgradePolicy::Compatible);
+    let result = compare_packages(
+        AccountAddress::ZERO,
+        pkg_v1,
+        pkg_v2,
+        path,
+        UpgradePolicy::Compatible,
+    );
 
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -43,7 +55,13 @@ fn test_declarations_missing() {
 #[test]
 fn test_function() {
     let (pkg_v1, pkg_v2, path) = get_packages("function_errors");
-    let result = compare_packages(pkg_v1, pkg_v2, path, UpgradePolicy::Compatible);
+    let result = compare_packages(
+        AccountAddress::ZERO,
+        pkg_v1,
+        pkg_v2,
+        path,
+        UpgradePolicy::Compatible,
+    );
 
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -53,7 +71,13 @@ fn test_function() {
 #[test]
 fn test_struct() {
     let (pkg_v1, pkg_v2, path) = get_packages("struct_errors");
-    let result = compare_packages(pkg_v1, pkg_v2, path, UpgradePolicy::Compatible);
+    let result = compare_packages(
+        AccountAddress::ZERO,
+        pkg_v1,
+        pkg_v2,
+        path,
+        UpgradePolicy::Compatible,
+    );
 
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -63,7 +87,13 @@ fn test_struct() {
 #[test]
 fn test_enum() {
     let (pkg_v1, pkg_v2, path) = get_packages("enum_errors");
-    let result = compare_packages(pkg_v1, pkg_v2, path, UpgradePolicy::Compatible);
+    let result = compare_packages(
+        AccountAddress::ZERO,
+        pkg_v1,
+        pkg_v2,
+        path,
+        UpgradePolicy::Compatible,
+    );
 
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -73,7 +103,13 @@ fn test_enum() {
 #[test]
 fn test_type_param() {
     let (pkg_v1, pkg_v2, path) = get_packages("type_param_errors");
-    let result = compare_packages(pkg_v1, pkg_v2, path, UpgradePolicy::Compatible);
+    let result = compare_packages(
+        AccountAddress::ZERO,
+        pkg_v1,
+        pkg_v2,
+        path,
+        UpgradePolicy::Compatible,
+    );
 
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -83,7 +119,13 @@ fn test_type_param() {
 #[test]
 fn test_additive() {
     let (pkg_v1, pkg_v2, p) = get_packages("additive_errors");
-    let result = compare_packages(pkg_v1, pkg_v2, p, UpgradePolicy::Additive);
+    let result = compare_packages(
+        AccountAddress::ZERO,
+        pkg_v1,
+        pkg_v2,
+        p,
+        UpgradePolicy::Additive,
+    );
 
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -93,7 +135,13 @@ fn test_additive() {
 #[test]
 fn test_deponly() {
     let (pkg_v1, pkg_v2, p) = get_packages("deponly_errors");
-    let result = compare_packages(pkg_v1, pkg_v2, p, UpgradePolicy::DepOnly);
+    let result = compare_packages(
+        AccountAddress::ZERO,
+        pkg_v1,
+        pkg_v2,
+        p,
+        UpgradePolicy::DepOnly,
+    );
 
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -107,7 +155,13 @@ fn test_version_mismatch() {
     pkg_v1[0].version = 1; // previous version was 1
     pkg_v2.package.root_compiled_units[0].unit.module.version = 0; // downgraded to version 0
 
-    let result = compare_packages(pkg_v1, pkg_v2, p, UpgradePolicy::Additive);
+    let result = compare_packages(
+        AccountAddress::ZERO,
+        pkg_v1,
+        pkg_v2,
+        p,
+        UpgradePolicy::Additive,
+    );
     assert!(result.is_err());
     assert_snapshot!(normalize_path(result.unwrap_err().to_string()));
 }
@@ -116,14 +170,32 @@ fn test_version_mismatch() {
 fn test_friend_link_ok() {
     let (pkg_v1, pkg_v2, path) = get_packages("friend_linking");
     // upgrade compatibility ignores friend linking
-    assert!(compare_packages(pkg_v1, pkg_v2, path, UpgradePolicy::Compatible).is_ok());
+    assert!(
+        compare_packages(
+            AccountAddress::ZERO,
+            pkg_v1,
+            pkg_v2,
+            path,
+            UpgradePolicy::Compatible
+        )
+        .is_ok()
+    );
 }
 
 #[test]
 fn test_entry_linking_ok() {
     let (pkg_v1, pkg_v2, path) = get_packages("entry_linking");
     // upgrade compatibility ignores entry linking
-    assert!(compare_packages(pkg_v1, pkg_v2, path, UpgradePolicy::Compatible).is_ok());
+    assert!(
+        compare_packages(
+            AccountAddress::ZERO,
+            pkg_v1,
+            pkg_v2,
+            path,
+            UpgradePolicy::Compatible
+        )
+        .is_ok()
+    );
 }
 
 #[test]
@@ -169,6 +241,36 @@ fn test_missing_module_toml() {
         .unwrap();
         assert_snapshot!(malformed_pkg, normalize_path(output));
     }
+}
+
+#[test]
+fn test_address_change() {
+    // mismatched address on upgrade should fail
+    let (pkg_v1, pkg_v2, path) = get_packages("address_change");
+    let result = compare_packages(
+        AccountAddress::from_str("0x2").unwrap(), // mismatched "on-chain" address
+        pkg_v1,
+        pkg_v2,
+        path,
+        UpgradePolicy::Compatible,
+    );
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_snapshot!(normalize_path(err.to_string()));
+
+    // with correct address, should not error
+    let (pkg_v1, pkg_v2, path) = get_packages("address_change");
+    let result = compare_packages(
+        AccountAddress::from_str("0x1").unwrap(), /* correct "on-chain" address, matches address
+                                                   * set in v1 package */
+        pkg_v1,
+        pkg_v2,
+        path,
+        UpgradePolicy::Compatible,
+    );
+
+    assert!(result.is_ok());
 }
 
 #[test]

--- a/crates/iota/src/upgrade_compatibility/mod.rs
+++ b/crates/iota/src/upgrade_compatibility/mod.rs
@@ -699,18 +699,27 @@ pub(crate) async fn check_compatibility(
     let policy =
         UpgradePolicy::try_from(upgrade_policy).map_err(|_| anyhow!("Invalid upgrade policy"))?;
 
-    compare_packages(existing_modules, new_package, package_path, policy)
+    compare_packages(
+        *existing_package
+            .to_move_package(u64::MAX /* safe as this pkg comes from the network */)?
+            .original_package_id(),
+        existing_modules,
+        new_package,
+        package_path,
+        policy,
+    )
 }
 
 /// Collect all the errors into a single error message.
 fn compare_packages(
+    package_id: AccountAddress,
     existing_modules: Vec<CompiledModule>,
     mut new_package: CompiledPackage,
     package_path: PathBuf,
     policy: UpgradePolicy,
 ) -> Result<(), Error> {
     // create a map from the new modules
-    let new_modules_map: HashMap<Identifier, CompiledModule> = new_package
+    let mut new_modules_map: HashMap<Identifier, CompiledModule> = new_package
         .get_modules()
         .map(|m| (m.self_id().name().to_owned(), m.clone()))
         .collect();
@@ -739,8 +748,17 @@ fn compare_packages(
 
     for existing_module in existing_modules {
         let name = existing_module.self_id().name().to_owned();
-        match new_modules_map.get(&name) {
+        match new_modules_map.get_mut(&name) {
             Some(new_module) => {
+                let new_module_address_idx = new_module.self_handle().address;
+                let addrs = &mut new_module.address_identifiers;
+                if let Some(address_mut) = addrs.get_mut(new_module_address_idx.0 as usize) {
+                    if *address_mut == AccountAddress::ZERO {
+                        // if the new module address is zero, set it to the on-chain address
+                        *address_mut = package_id;
+                    }
+                }
+
                 let compiled_unit_with_source = new_package
                     .package
                     .get_module_by_name_from_root(name.as_str())


### PR DESCRIPTION
## Description 

Upstream changes from https://github.com/MystenLabs/sui/pull/22426

Closes #7835

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Allow 0x0 address in Move.toml for package upgrades.
- [ ] Rust SDK:

