### PR TITLE
feat(iota-indexer): Add `tx_wrapped_or_deleted_objects` backfill job

### DIFF
--- a/crates/iota-indexer/src/backfill/ingestion/adapter.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/adapter.rs
@@ -11,7 +11,7 @@ use iota_types::{
 };
 use tokio::sync::Notify;
 
-use crate::backfill::ingestion::IngestionBackfill;
+use crate::{backfill::ingestion::IngestionBackfill, errors::IndexerError};
 
 /// Bridge between the ingestion engine and the backfill task.
 #[derive(Clone)]
@@ -27,10 +27,13 @@ pub(crate) struct Adapter<T: IngestionBackfill> {
 #[async_trait::async_trait]
 impl<T: IngestionBackfill> Worker for Adapter<T> {
     type Message = ();
-    type Error = anyhow::Error;
+    type Error = IndexerError;
 
-    async fn process_checkpoint(&self, checkpoint: Arc<CheckpointData>) -> anyhow::Result<()> {
-        let processed = T::process_checkpoint(checkpoint.clone());
+    async fn process_checkpoint(
+        &self,
+        checkpoint: Arc<CheckpointData>,
+    ) -> Result<(), IndexerError> {
+        let processed = T::process_checkpoint(checkpoint.clone())?;
         self.ready_checkpoints
             .insert(checkpoint.checkpoint_summary.sequence_number, processed);
         self.notify.notify_waiters();

--- a/crates/iota-indexer/src/backfill/ingestion/jobs/mod.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/jobs/mod.rs
@@ -1,0 +1,5 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+pub(crate) mod tx_wrapped_or_deleted_objects;

--- a/crates/iota-indexer/src/backfill/ingestion/jobs/mod.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/jobs/mod.rs
@@ -1,5 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 pub(crate) mod tx_wrapped_or_deleted_objects;

--- a/crates/iota-indexer/src/backfill/ingestion/jobs/tx_wrapped_or_deleted_objects.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/jobs/tx_wrapped_or_deleted_objects.rs
@@ -20,28 +20,51 @@ pub(crate) struct TxWrappedOrDeletedObjectsBackfill;
 impl IngestionBackfill for TxWrappedOrDeletedObjectsBackfill {
     type ProcessedType = StoredTxWrappedOrDeletedObject;
 
-    fn process_checkpoint(checkpoint: Arc<CheckpointData>) -> Vec<Self::ProcessedType> {
-        let first_tx = checkpoint.checkpoint_summary.network_total_transactions as usize
-            - checkpoint.transactions.len();
+    fn process_checkpoint(
+        checkpoint: Arc<CheckpointData>,
+    ) -> Result<Vec<Self::ProcessedType>, IndexerError> {
+        let checkpoint_summary = &checkpoint.checkpoint_summary;
+        let checkpoint_contents = &checkpoint.checkpoint_contents;
+        let transactions = &checkpoint.transactions;
+        let checkpoint_seq = checkpoint_summary.sequence_number;
 
-        checkpoint
-            .transactions
-            .iter()
-            .enumerate()
-            .flat_map(|(i, tx)| {
-                let effects = &tx.effects;
+        if checkpoint_contents.size() != transactions.len() {
+            return Err(IndexerError::FullNodeReading(format!(
+                "Checkpoint content size mismatch at checkpoint {checkpoint_seq}: expected {}, found {}",
+                checkpoint_contents.size(),
+                transactions.len()
+            )));
+        }
 
-                effects
+        let tx_seq_numbers = checkpoint_contents
+            .enumerate_transactions(checkpoint_summary)
+            .map(|(seq, digest)| (digest.transaction, seq));
+
+        let mut results = Vec::new();
+
+        for (tx, (expected_digest, tx_sequence_number)) in transactions.iter().zip(tx_seq_numbers) {
+            let actual_digest = tx.transaction.digest();
+
+            if expected_digest != *actual_digest {
+                return Err(IndexerError::FullNodeReading(format!(
+                    "Digest mismatch at checkpoint {checkpoint_seq}: expected {expected_digest}, found {actual_digest}",
+                )));
+            }
+
+            results.extend(
+                tx.effects
                     .all_tombstones()
                     .into_iter()
-                    .chain(effects.created_then_wrapped_objects())
-                    .map(move |(object_id, _)| StoredTxWrappedOrDeletedObject {
-                        tx_sequence_number: (first_tx + i) as i64,
+                    .chain(tx.effects.created_then_wrapped_objects())
+                    .map(|(object_id, _)| StoredTxWrappedOrDeletedObject {
+                        tx_sequence_number: tx_sequence_number as i64,
                         object_id: object_id.to_vec(),
                         sender: tx.transaction.sender_address().to_vec(),
-                    })
-            })
-            .collect()
+                    }),
+            );
+        }
+
+        Ok(results)
     }
 
     async fn persist_chunk(

--- a/crates/iota-indexer/src/backfill/ingestion/jobs/tx_wrapped_or_deleted_objects.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/jobs/tx_wrapped_or_deleted_objects.rs
@@ -1,5 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;

--- a/crates/iota-indexer/src/backfill/ingestion/jobs/tx_wrapped_or_deleted_objects.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/jobs/tx_wrapped_or_deleted_objects.rs
@@ -1,0 +1,61 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use diesel::RunQueryDsl;
+use iota_types::full_checkpoint_content::CheckpointData;
+
+use crate::{
+    backfill::ingestion::IngestionBackfill,
+    db::{ConnectionPool, get_pool_connection},
+    errors::IndexerError,
+    models::tx_indices::StoredTxWrappedOrDeletedObject,
+    schema::tx_wrapped_or_deleted_objects,
+};
+
+pub(crate) struct TxWrappedOrDeletedObjectsBackfill;
+
+#[async_trait::async_trait]
+impl IngestionBackfill for TxWrappedOrDeletedObjectsBackfill {
+    type ProcessedType = StoredTxWrappedOrDeletedObject;
+
+    fn process_checkpoint(checkpoint: Arc<CheckpointData>) -> Vec<Self::ProcessedType> {
+        let first_tx = checkpoint.checkpoint_summary.network_total_transactions as usize
+            - checkpoint.transactions.len();
+
+        checkpoint
+            .transactions
+            .iter()
+            .enumerate()
+            .flat_map(|(i, tx)| {
+                let effects = &tx.effects;
+
+                effects
+                    .all_tombstones()
+                    .into_iter()
+                    .chain(effects.created_then_wrapped_objects())
+                    .map(move |(object_id, _)| StoredTxWrappedOrDeletedObject {
+                        tx_sequence_number: (first_tx + i) as i64,
+                        object_id: object_id.to_vec(),
+                        sender: tx.transaction.sender_address().to_vec(),
+                    })
+            })
+            .collect()
+    }
+
+    async fn persist_chunk(
+        pool: ConnectionPool,
+        processed_data: Vec<Self::ProcessedType>,
+    ) -> Result<(), IndexerError> {
+        let mut conn = get_pool_connection(&pool)?;
+
+        diesel::insert_into(tx_wrapped_or_deleted_objects::table)
+            .values(processed_data)
+            .on_conflict_do_nothing()
+            .execute(&mut conn)?;
+
+        Ok(())
+    }
+}

--- a/crates/iota-indexer/src/backfill/ingestion/mod.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/mod.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub(crate) mod adapter;
+pub(crate) mod jobs;
 pub(crate) mod task;
 
 use std::sync::Arc;

--- a/crates/iota-indexer/src/backfill/ingestion/mod.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/mod.rs
@@ -18,7 +18,9 @@ pub(crate) trait IngestionBackfill: Send + Sync {
     type ProcessedType: Send + Sync;
 
     /// Converts a `CheckpointData` into zero-or-more items (`ProcessedType`).
-    fn process_checkpoint(checkpoint: Arc<CheckpointData>) -> Vec<Self::ProcessedType>;
+    fn process_checkpoint(
+        checkpoint: Arc<CheckpointData>,
+    ) -> Result<Vec<Self::ProcessedType>, IndexerError>;
 
     /// Stores a chunk of processed items.
     async fn persist_chunk(

--- a/crates/iota-indexer/src/backfill/ingestion/task.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/task.rs
@@ -128,8 +128,10 @@ mod tests {
     impl IngestionBackfill for BackfillDummyTable {
         type ProcessedType = usize;
 
-        fn process_checkpoint(checkpoint: Arc<CheckpointData>) -> Vec<Self::ProcessedType> {
-            vec![checkpoint.checkpoint_summary.sequence_number as usize]
+        fn process_checkpoint(
+            checkpoint: Arc<CheckpointData>,
+        ) -> Result<Vec<Self::ProcessedType>, IndexerError> {
+            Ok(vec![checkpoint.checkpoint_summary.sequence_number as usize])
         }
 
         async fn persist_chunk(

--- a/crates/iota-indexer/src/backfill/ingestion/task.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/task.rs
@@ -36,7 +36,6 @@ pub struct IngestionBackfillTask<T: IngestionBackfill> {
 
 impl<T: IngestionBackfill + 'static> IngestionBackfillTask<T> {
     // Creates and starts a new ingestion‐driven backfill task using processor `T`.
-    #[expect(dead_code)]
     pub(crate) async fn new(
         remote_store_url: String,
         start_checkpoint: CheckpointSequenceNumber,

--- a/crates/iota-indexer/src/backfill/mod.rs
+++ b/crates/iota-indexer/src/backfill/mod.rs
@@ -6,8 +6,19 @@ use std::{ops::RangeInclusive, sync::Arc};
 
 use async_trait::async_trait;
 use clap::{Subcommand, ValueEnum};
+use iota_types::messages_checkpoint::CheckpointSequenceNumber;
 
-use crate::{backfill::sql::sql_backfill::SqlBackfill, db::ConnectionPool, errors::IndexerError};
+use crate::{
+    backfill::{
+        ingestion::{
+            jobs::tx_wrapped_or_deleted_objects::TxWrappedOrDeletedObjectsBackfill,
+            task::IngestionBackfillTask,
+        },
+        sql::sql_backfill::SqlBackfill,
+    },
+    db::ConnectionPool,
+    errors::IndexerError,
+};
 
 pub(crate) mod ingestion;
 pub mod runner;
@@ -63,13 +74,27 @@ pub enum BackfillKind {
 /// implements the `IngestionBackfill` trait.
 #[derive(ValueEnum, Clone, Debug)]
 #[non_exhaustive]
-pub enum IngestionBackfillKind {}
+pub enum IngestionBackfillKind {
+    TxWrappedOrDeletedObjects,
+}
 
-pub(crate) async fn get_backfill(kind: BackfillKind, _range_start: usize) -> Arc<dyn Backfill> {
+pub(crate) async fn get_backfill(
+    kind: BackfillKind,
+    range_start: usize,
+) -> Result<Arc<dyn Backfill>, IndexerError> {
     match kind {
-        BackfillKind::Sql { sql, key_column } => Arc::new(SqlBackfill::new(sql, key_column)),
-        BackfillKind::Ingestion { .. } => {
-            unimplemented!("No ingestion backfill tasks implemented yet.")
-        }
+        BackfillKind::Sql { sql, key_column } => Ok(Arc::new(SqlBackfill::new(sql, key_column))),
+        BackfillKind::Ingestion {
+            kind,
+            remote_store_url,
+        } => match kind {
+            IngestionBackfillKind::TxWrappedOrDeletedObjects => Ok(Arc::new(
+                IngestionBackfillTask::<TxWrappedOrDeletedObjectsBackfill>::new(
+                    remote_store_url,
+                    range_start as CheckpointSequenceNumber,
+                )
+                .await?,
+            )),
+        },
     }
 }

--- a/crates/iota-indexer/src/backfill/mod.rs
+++ b/crates/iota-indexer/src/backfill/mod.rs
@@ -75,6 +75,7 @@ pub enum BackfillKind {
 #[derive(ValueEnum, Clone, Debug)]
 #[non_exhaustive]
 pub enum IngestionBackfillKind {
+    /// Backfills the `tx_wrapped_or_deleted_objects` table.
     TxWrappedOrDeletedObjects,
 }
 

--- a/crates/iota-indexer/src/backfill/runner.rs
+++ b/crates/iota-indexer/src/backfill/runner.rs
@@ -38,7 +38,7 @@ impl BackfillRunner {
         backfill_config: BackfillConfig,
         total_range: RangeInclusive<usize>,
     ) -> Result<(), IndexerError> {
-        let backfill = get_backfill(runner_kind, *total_range.start()).await;
+        let backfill = get_backfill(runner_kind, *total_range.start()).await?;
         Self::run_impl(pool, backfill_config, total_range, backfill).await
     }
 


### PR DESCRIPTION
# Description of change

Adds an ingestion backfill job to backfill the new Indexer `tx_wrapped_or_deleted_objects` table.
Inspired by following upstream patch: https://github.com/MystenLabs/sui/commit/b902e8213d5ff7f62d2ad6baf4091527f21d227d

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/7631

## How the change has been tested

- [X] Basic tests (linting, compilation, formatting, unit/integration tests)
- [X] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

Tested backfilling of a local Indexer DB instance with an ingestion worker that gets data from the devnet.

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [X] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [X] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
