### PR TITLE
fix(iota-core): remove inexistent required feature

### DIFF
--- a/crates/iota-core/Cargo.toml
+++ b/crates/iota-core/Cargo.toml
@@ -123,7 +123,10 @@ iota-protocol-config.workspace = true
 
 # moka uses `quanta` by default for timing, which is not compatible with the simulator
 [target.'cfg(msim)'.dependencies]
-moka = { version = "0.12", default-features = false, features = ["sync", "atomic64"] }
+moka = { version = "0.12", default-features = false, features = [
+    "sync",
+    "atomic64",
+] }
 
 [target.'cfg(msim)'.dev-dependencies]
 test-cluster.workspace = true
@@ -143,7 +146,6 @@ harness = false
 [[bench]]
 name = "batch_verification_bench"
 harness = false
-required-features = ["test-utils"]
 
 [package.metadata.cargo-udeps.ignore]
 development = ["pprof", "test-fuzz"]

--- a/crates/iota-core/Cargo.toml
+++ b/crates/iota-core/Cargo.toml
@@ -123,10 +123,7 @@ iota-protocol-config.workspace = true
 
 # moka uses `quanta` by default for timing, which is not compatible with the simulator
 [target.'cfg(msim)'.dependencies]
-moka = { version = "0.12", default-features = false, features = [
-    "sync",
-    "atomic64",
-] }
+moka = { version = "0.12", default-features = false, features = ["sync", "atomic64"] }
 
 [target.'cfg(msim)'.dev-dependencies]
 test-cluster.workspace = true


### PR DESCRIPTION
It was causing a warning
```sh
thibault@Mac ~/i/iota (develop)> cargo check --all-targets --all-features
warning: invalid feature `test-utils` in required-features of target `batch_verification_bench`: `test-utils` is not present in [features] section
```