### PR TITLE
upstream(node): Add backpressure to WritebackCache

### DIFF
--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -871,11 +871,11 @@ mod test {
         // To validate this, change
         // backpressure::Watermarks::is_backpressure_suppressed() to
         // always return false and verify the test fails.
-        cache_config.backpressure_threshold = Some(1);
+        cache_config.writeback_cache.backpressure_threshold = Some(1);
 
         // for the tests to pass we still need to be able to submit transactions
         // during backpressure.
-        cache_config.backpressure_threshold_for_rpc = Some(10000);
+        cache_config.writeback_cache.backpressure_threshold_for_rpc = Some(10000);
 
         let test_cluster = init_test_cluster_builder(4, 10000)
             .with_authority_overload_config(AuthorityOverloadConfig {
@@ -884,6 +884,9 @@ mod test {
                 // having queued certs which are missing dependencies.
                 check_system_overload_at_execution: false,
                 check_system_overload_at_signing: false,
+                max_txn_age_in_queue: Duration::from_secs(10000),
+                max_transaction_manager_queue_length: 10000,
+                max_transaction_manager_per_object_queue_length: 10000,
                 ..Default::default()
             })
             .with_execution_cache_type(ExecutionCacheType::WritebackCache)

--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -29,7 +29,10 @@ mod test {
             workload_configuration::{WorkloadConfig, WorkloadConfiguration, WorkloadWeights},
         },
     };
-    use iota_config::{AUTHORITIES_DB_NAME, IOTA_KEYSTORE_FILENAME, node::AuthorityOverloadConfig};
+    use iota_config::{
+        AUTHORITIES_DB_NAME, ExecutionCacheConfig, IOTA_KEYSTORE_FILENAME,
+        node::AuthorityOverloadConfig,
+    };
     use iota_core::{
         authority::{
             AuthorityState, authority_store_tables::AuthorityPerpetualTables, framework_injection,
@@ -857,6 +860,52 @@ mod test {
         });
 
         test_simulated_load(test_cluster, 60).await
+    }
+
+    #[sim_test(config = "test_config()")]
+    async fn test_backpressure() {
+        iota_protocol_config::ProtocolConfig::poison_get_for_min_version();
+
+        let mut cache_config: ExecutionCacheConfig = Default::default();
+        // make sure we don't halt even with absurdly low backpressure threshold
+        // To validate this, change
+        // backpressure::Watermarks::is_backpressure_suppressed() to
+        // always return false and verify the test fails.
+        match &mut cache_config {
+            ExecutionCacheConfig::WritebackCache {
+                backpressure_threshold,
+                backpressure_threshold_for_rpc,
+                ..
+            } => {
+                *backpressure_threshold = Some(1);
+                // for the tests to pass we still need to be able to submit transactions
+                // during backpressure.
+                *backpressure_threshold_for_rpc = Some(10000);
+            }
+            _ => panic!(),
+        }
+
+        let test_cluster = init_test_cluster_builder(4, 10000)
+            .with_authority_overload_config(AuthorityOverloadConfig {
+                // Disable system overload checks for the test - during tests with crashes,
+                // it is possible for overload protection to trigger due to validators
+                // having queued certs which are missing dependencies.
+                check_system_overload_at_execution: false,
+                check_system_overload_at_signing: false,
+                ..Default::default()
+            })
+            .with_execution_cache_config(cache_config)
+            .with_submit_delay_step_override_millis(3000)
+            .build()
+            .await
+            .into();
+
+        tokio::time::timeout(
+            Duration::from_secs(120),
+            test_simulated_load(test_cluster, 60),
+        )
+        .await
+        .expect("test_backpressure timed out");
     }
 
     fn handle_bool_failpoint(

--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -30,7 +30,7 @@ mod test {
         },
     };
     use iota_config::{
-        AUTHORITIES_DB_NAME, ExecutionCacheConfig, IOTA_KEYSTORE_FILENAME,
+        AUTHORITIES_DB_NAME, ExecutionCacheConfig, ExecutionCacheType, IOTA_KEYSTORE_FILENAME,
         node::AuthorityOverloadConfig,
     };
     use iota_core::{
@@ -871,19 +871,11 @@ mod test {
         // To validate this, change
         // backpressure::Watermarks::is_backpressure_suppressed() to
         // always return false and verify the test fails.
-        match &mut cache_config {
-            ExecutionCacheConfig::WritebackCache {
-                backpressure_threshold,
-                backpressure_threshold_for_rpc,
-                ..
-            } => {
-                *backpressure_threshold = Some(1);
-                // for the tests to pass we still need to be able to submit transactions
-                // during backpressure.
-                *backpressure_threshold_for_rpc = Some(10000);
-            }
-            _ => panic!(),
-        }
+        cache_config.backpressure_threshold = Some(1);
+
+        // for the tests to pass we still need to be able to submit transactions
+        // during backpressure.
+        cache_config.backpressure_threshold_for_rpc = Some(10000);
 
         let test_cluster = init_test_cluster_builder(4, 10000)
             .with_authority_overload_config(AuthorityOverloadConfig {
@@ -894,6 +886,7 @@ mod test {
                 check_system_overload_at_signing: false,
                 ..Default::default()
             })
+            .with_execution_cache_type(ExecutionCacheType::WritebackCache)
             .with_execution_cache_config(cache_config)
             .with_submit_delay_step_override_millis(3000)
             .build()

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -324,7 +324,7 @@ pub struct WritebackCacheConfig {
     /// Number of uncommitted transactions at which to pause consensus
     /// handler.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub backpressure_threshold: Option<u64>, // defaults to 10000
+    pub backpressure_threshold: Option<u64>, // defaults to 100_000
 
     /// Number of uncommitted transactions at which to refuse new
     /// transaction submissions. Defaults to backpressure_threshold
@@ -419,7 +419,7 @@ impl WritebackCacheConfig {
             .ok()
             .and_then(|s| s.parse().ok())
             .or(self.backpressure_threshold)
-            .unwrap_or(10000)
+            .unwrap_or(100_000)
     }
 
     pub fn backpressure_threshold_for_rpc(&self) -> u64 {

--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -294,9 +294,9 @@ pub struct ExecutionCacheConfig {
 #[serde(rename_all = "kebab-case")]
 pub struct WritebackCacheConfig {
     /// Maximum number of entries in each cache. (There are several
-    /// different caches). If None, the default of 10000 is used.
+    /// different caches).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_cache_size: Option<u64>,
+    pub max_cache_size: Option<u64>, // defaults to 100000
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub package_cache_size: Option<u64>, // defaults to 1000
@@ -320,6 +320,17 @@ pub struct WritebackCacheConfig {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub transaction_objects_cache_size: Option<u64>, // defaults to 1000
+
+    /// Number of uncommitted transactions at which to pause consensus
+    /// handler.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backpressure_threshold: Option<u64>, // defaults to 10000
+
+    /// Number of uncommitted transactions at which to refuse new
+    /// transaction submissions. Defaults to backpressure_threshold
+    /// if unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backpressure_threshold_for_rpc: Option<u64>, // defaults to backpressure_threshold
 }
 
 impl WritebackCacheConfig {
@@ -401,6 +412,22 @@ impl WritebackCacheConfig {
             .and_then(|s| s.parse().ok())
             .or(self.transaction_objects_cache_size)
             .unwrap_or(1000)
+    }
+
+    pub fn backpressure_threshold(&self) -> u64 {
+        std::env::var("IOTA_CACHE_WRITEBACK_BACKPRESSURE_THRESHOLD")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .or(self.backpressure_threshold)
+            .unwrap_or(10000)
+    }
+
+    pub fn backpressure_threshold_for_rpc(&self) -> u64 {
+        std::env::var("IOTA_CACHE_WRITEBACK_BACKPRESSURE_THRESHOLD_FOR_RPC")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .or(self.backpressure_threshold_for_rpc)
+            .unwrap_or(self.backpressure_threshold())
     }
 }
 

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -211,6 +211,7 @@ pub mod test_authority_builder;
 pub mod transaction_deferral;
 
 pub(crate) mod authority_store;
+pub mod backpressure;
 
 /// Prometheus metrics which can be displayed in Grafana, queried and alerted on
 pub struct AuthorityMetrics {
@@ -1002,6 +1003,22 @@ impl AuthorityState {
         consensus_adapter.check_consensus_overload().tap_err(|_| {
             self.update_overload_metrics("consensus");
         })?;
+
+        let pending_tx_count = self
+            .get_cache_commit()
+            .approximate_pending_transaction_count();
+        if pending_tx_count
+            > self
+                .config
+                .execution_cache_config
+                .writeback_cache
+                .backpressure_threshold_for_rpc()
+        {
+            return Err(IotaError::ValidatorOverloadedRetryAfter {
+                retry_after_secs: 10,
+            });
+        }
+
         Ok(())
     }
 

--- a/crates/iota-core/src/authority/backpressure.rs
+++ b/crates/iota-core/src/authority/backpressure.rs
@@ -1,0 +1,319 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use iota_metrics::monitored_scope;
+use iota_types::messages_checkpoint::CheckpointSequenceNumber;
+use tokio::sync::watch;
+use tracing::{debug, info};
+
+use crate::checkpoints::CheckpointStore;
+
+#[derive(Debug, Default, Copy, Clone)]
+struct Watermarks {
+    executed: CheckpointSequenceNumber,
+    certified: CheckpointSequenceNumber,
+}
+
+impl Watermarks {
+    // we can only permit backpressure if the certified checkpoint is ahead of the
+    // executed checkpoint. Otherwise, backpressure might prevent construction
+    // of the next checkpoint, because it could stop consensus commits from
+    // being processed.
+    fn should_suppress_backpressure(&self) -> bool {
+        self.certified <= self.executed
+    }
+}
+
+pub struct BackpressureManager {
+    // Holds the executed and certified checkpoint watermarks.
+    // Because we never execute an uncertified checkpoint, the executed watermark is always
+    // less than or equal to the certified watermark.
+    //
+    // If the watermarks are equal, we must not apply backpressure to consensus handler,
+    // because we could be waiting on the next consensus commit in order to build and eventually
+    // certify the next checkpoint.
+    watermarks_sender: watch::Sender<Watermarks>,
+
+    // used by the WritebackCache to notify us when it has too many pending transactions in memory.
+    backpressure_sender: watch::Sender<bool>,
+}
+
+pub struct BackpressureSubscriber {
+    mgr: Arc<BackpressureManager>,
+}
+
+impl BackpressureManager {
+    pub fn new_for_tests() -> Arc<Self> {
+        Self::new_from_watermarks(Default::default())
+    }
+
+    fn new_from_watermarks(watermarks: Watermarks) -> Arc<Self> {
+        let (watermarks_sender, _) = watch::channel(watermarks);
+        let (backpressure_sender, _) = watch::channel(false);
+        Arc::new(Self {
+            watermarks_sender,
+            backpressure_sender,
+        })
+    }
+
+    pub fn new_from_checkpoint_store(store: &CheckpointStore) -> Arc<Self> {
+        let executed = store
+            .get_highest_executed_checkpoint_seq_number()
+            .expect("read cannot fail")
+            .unwrap_or_default();
+        let certified = store
+            .get_highest_synced_checkpoint_seq_number()
+            .expect("read cannot fail")
+            .unwrap_or_default();
+        info!(
+            ?executed,
+            ?certified,
+            "initializing backpressure manager from checkpoint store"
+        );
+        Self::new_from_watermarks(Watermarks {
+            executed,
+            certified,
+        })
+    }
+
+    pub fn update_highest_certified_checkpoint(&self, seq: CheckpointSequenceNumber) {
+        self.watermarks_sender.send_if_modified(|watermarks| {
+            if seq > watermarks.certified {
+                watermarks.certified = seq;
+                debug!(?watermarks, "updating highest certified checkpoint");
+                true
+            } else {
+                false
+            }
+        });
+    }
+
+    pub fn update_highest_executed_checkpoint(&self, seq: CheckpointSequenceNumber) {
+        self.watermarks_sender.send_if_modified(|watermarks| {
+            if seq > watermarks.executed {
+                debug_assert_eq!(seq, watermarks.executed + 1);
+                watermarks.executed = seq;
+                debug!(?watermarks, "updating highest executed checkpoint");
+                true
+            } else {
+                false
+            }
+        });
+    }
+
+    // Returns true if the backpressure state was changed.
+    pub fn set_backpressure(&self, backpressure: bool) -> bool {
+        self.backpressure_sender.send_if_modified(|bp| {
+            if *bp != backpressure {
+                debug!(?backpressure, "setting backpressure");
+                *bp = backpressure;
+                true
+            } else {
+                false
+            }
+        })
+    }
+
+    pub fn subscribe(self: &Arc<Self>) -> BackpressureSubscriber {
+        BackpressureSubscriber { mgr: self.clone() }
+    }
+}
+
+impl BackpressureSubscriber {
+    pub fn is_backpressure_active(&self) -> bool {
+        *self.mgr.backpressure_sender.borrow()
+    }
+
+    /// If there is no backpressure returns immediately.
+    /// Otherwise, wait until backpressure is lifted or suppressed.
+    pub async fn await_no_backpressure(&self) {
+        let mut watermarks_rx = self.mgr.watermarks_sender.subscribe();
+        if watermarks_rx
+            .borrow_and_update()
+            .should_suppress_backpressure()
+        {
+            return;
+        }
+
+        let mut backpressure_rx = self.mgr.backpressure_sender.subscribe();
+        if !*backpressure_rx.borrow_and_update() {
+            return;
+        }
+
+        info!("waiting for backpressure to be lifted");
+        let _scope = monitored_scope("await_backpressure");
+
+        loop {
+            tokio::select! {
+                _ = backpressure_rx.changed() => {
+                    let backpressure = *backpressure_rx.borrow_and_update();
+                    debug!(?backpressure, "backpressure updated");
+                    if !backpressure {
+                        info!("backpressure lifted");
+                        return;
+                    }
+                }
+                _ = watermarks_rx.changed() => {
+                    let watermarks = watermarks_rx.borrow_and_update();
+                    debug!(?watermarks, "watermarks updated");
+                    if watermarks.should_suppress_backpressure() {
+                        info!("backpressure suppressed");
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use futures::FutureExt;
+    use parking_lot::Mutex;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_no_backpressure() {
+        let manager = Arc::new(BackpressureManager::new_for_tests());
+
+        manager.update_highest_certified_checkpoint(1);
+        manager.set_backpressure(false);
+
+        let subscriber = manager.subscribe();
+
+        subscriber.await_no_backpressure().now_or_never().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_backpressure_suppressed() {
+        let manager = Arc::new(BackpressureManager::new_for_tests());
+
+        // watermarks start at 0, 0
+        manager.set_backpressure(true);
+
+        let subscriber = manager.subscribe();
+
+        // backpressure should be suppressed because of watermarks.
+        subscriber.await_no_backpressure().now_or_never().unwrap();
+    }
+
+    async fn await_with_timeout<R>(f: impl std::future::Future<Output = R>) {
+        tokio::time::timeout(Duration::from_secs(1), f)
+            .await
+            .unwrap();
+    }
+
+    #[derive(Clone)]
+    struct Log {
+        log: Arc<Mutex<Vec<String>>>,
+        manager: Arc<BackpressureManager>,
+    }
+
+    impl Log {
+        fn new(manager: Arc<BackpressureManager>) -> Self {
+            Self {
+                log: Arc::new(Mutex::new(Vec::new())),
+                manager,
+            }
+        }
+
+        fn set_backpressure(&self, backpressure: bool) {
+            self.log
+                .lock()
+                .push(format!("set backpressure {}", backpressure));
+            self.manager.set_backpressure(backpressure);
+        }
+
+        fn update_executed(&self, executed: u64) {
+            self.log
+                .lock()
+                .push(format!("update executed {}", executed));
+            self.manager.update_highest_executed_checkpoint(executed);
+        }
+
+        fn push<S: Into<String>>(&self, msg: S) {
+            self.log.lock().push(msg.into());
+        }
+
+        fn get(&self) -> Vec<String> {
+            self.log.lock().clone()
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_clear_backpressure() {
+        let manager = BackpressureManager::new_for_tests();
+
+        // backpressure is in effect, and not suppressed by watermarks.
+        manager.update_highest_certified_checkpoint(1);
+        manager.set_backpressure(true);
+
+        let log = Log::new(manager.clone());
+
+        let waiter = tokio::spawn({
+            let subscriber = manager.subscribe();
+            let log = log.clone();
+            log.push("await");
+            async move {
+                subscriber.await_no_backpressure().await;
+                log.push("await_finished");
+            }
+        });
+
+        // clear the backpressure
+        log.set_backpressure(false);
+
+        await_with_timeout(waiter).await;
+
+        assert_eq!(
+            log.get(),
+            vec![
+                "await".to_string(),
+                "set backpressure false".to_string(),
+                "await_finished".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_backpressure_becomes_suppressed() {
+        let manager = BackpressureManager::new_for_tests();
+
+        // backpressure is in effect, and not suppressed by watermarks.
+        manager.update_highest_certified_checkpoint(1);
+        manager.set_backpressure(true);
+
+        let log = Log::new(manager.clone());
+
+        let waiter = tokio::spawn({
+            let subscriber = manager.subscribe();
+            let log = log.clone();
+            log.push("await");
+            async move {
+                subscriber.await_no_backpressure().await;
+                log.push("await_finished");
+            }
+        });
+
+        // once executed checkpoint catches up to certified checkpoint,
+        // backpressure should be suppressed.
+        log.update_executed(1);
+
+        await_with_timeout(waiter).await;
+
+        assert_eq!(
+            log.get(),
+            vec![
+                "await".to_string(),
+                "update executed 1".to_string(),
+                "await_finished".to_string(),
+            ]
+        );
+    }
+}

--- a/crates/iota-core/src/authority/test_authority_builder.rs
+++ b/crates/iota-core/src/authority/test_authority_builder.rs
@@ -32,7 +32,7 @@ use iota_types::{
 };
 use prometheus::Registry;
 
-use super::epoch_start_configuration::EpochFlag;
+use super::{backpressure::BackpressureManager, epoch_start_configuration::EpochFlag};
 use crate::{
     authority::{
         AuthorityState, AuthorityStore, authority_per_epoch_store::AuthorityPerEpochStore,
@@ -255,11 +255,16 @@ impl<'a> TestAuthorityBuilder<'a> {
         .unwrap();
         let expensive_safety_checks = self.expensive_safety_checks.unwrap_or_default();
 
+        let checkpoint_store = CheckpointStore::new(&path.join("checkpoints"));
+        let backpressure_manager =
+            BackpressureManager::new_from_checkpoint_store(&checkpoint_store);
+
         let cache_traits = build_execution_cache(
             &config.execution_cache_config,
             &epoch_start_configuration,
             &registry,
             &authority_store,
+            backpressure_manager.clone(),
         );
 
         let epoch_store = AuthorityPerEpochStore::new(
@@ -282,7 +287,6 @@ impl<'a> TestAuthorityBuilder<'a> {
             None,
         ));
 
-        let checkpoint_store = CheckpointStore::new(&path.join("checkpoints"));
         if self.insert_genesis_checkpoint {
             checkpoint_store.insert_genesis_checkpoint(
                 genesis.checkpoint(),

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -190,10 +190,10 @@ impl CheckpointExecutor {
     ) -> Self {
         Self::new(
             mailbox,
-            checkpoint_store,
+            checkpoint_store.clone(),
             state,
             accumulator,
-            BackpressureManager::new_for_tests(),
+            BackpressureManager::new_from_checkpoint_store(&checkpoint_store),
             Default::default(),
             CheckpointExecutorMetrics::new_for_tests(),
         )

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -58,7 +58,10 @@ use tracing::{debug, error, info, instrument, trace, warn};
 
 use self::metrics::CheckpointExecutorMetrics;
 use crate::{
-    authority::{AuthorityState, authority_per_epoch_store::AuthorityPerEpochStore},
+    authority::{
+        AuthorityState, authority_per_epoch_store::AuthorityPerEpochStore,
+        backpressure::BackpressureManager,
+    },
     checkpoints::{
         CheckpointStore,
         checkpoint_executor::data_ingestion_handler::{
@@ -150,6 +153,7 @@ pub struct CheckpointExecutor {
     transaction_cache_reader: Arc<dyn TransactionCacheRead>,
     tx_manager: Arc<TransactionManager>,
     accumulator: Arc<StateAccumulator>,
+    backpressure_manager: Arc<BackpressureManager>,
     config: CheckpointExecutorConfig,
     metrics: Arc<CheckpointExecutorMetrics>,
 }
@@ -160,6 +164,7 @@ impl CheckpointExecutor {
         checkpoint_store: Arc<CheckpointStore>,
         state: Arc<AuthorityState>,
         accumulator: Arc<StateAccumulator>,
+        backpressure_manager: Arc<BackpressureManager>,
         config: CheckpointExecutorConfig,
         metrics: Arc<CheckpointExecutorMetrics>,
     ) -> Self {
@@ -171,6 +176,7 @@ impl CheckpointExecutor {
             transaction_cache_reader: state.get_transaction_cache_reader().clone(),
             tx_manager: state.transaction_manager().clone(),
             accumulator,
+            backpressure_manager,
             config,
             metrics,
         }
@@ -187,6 +193,7 @@ impl CheckpointExecutor {
             checkpoint_store,
             state,
             accumulator,
+            BackpressureManager::new_for_tests(),
             Default::default(),
             CheckpointExecutorMetrics::new_for_tests(),
         )
@@ -310,6 +317,7 @@ impl CheckpointExecutor {
                     let _process_scope = iota_metrics::monitored_scope("ProcessExecutedCheckpoint");
 
                     self.process_executed_checkpoint(&epoch_store, &checkpoint, checkpoint_acc, checkpoint_data, &tx_digests).await;
+                    self.backpressure_manager.update_highest_executed_checkpoint(*checkpoint.sequence_number());
                     highest_executed = Some(checkpoint.clone());
 
                     // Estimate TPS every 10k transactions or 30 sec
@@ -338,6 +346,9 @@ impl CheckpointExecutor {
                             "Received checkpoint summary from state sync"
                         );
                         checkpoint.report_checkpoint_age(&self.metrics.checkpoint_contents_age);
+                        // Note: checkpoints arrive in increasing order by sequence number, but they are not
+                        // necessarily consecutive.
+                        self.backpressure_manager.update_highest_certified_checkpoint(*checkpoint.sequence_number());
                     },
                     Err(RecvError::Lagged(num_skipped)) => {
                         debug!(

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -342,6 +342,16 @@ impl CheckpointStore {
         self.get_checkpoint_by_digest(&highest_synced.1)
     }
 
+    pub fn get_highest_synced_checkpoint_seq_number(
+        &self,
+    ) -> Result<Option<CheckpointSequenceNumber>, TypedStoreError> {
+        if let Some(highest_synced) = self.watermarks.get(&CheckpointWatermark::HighestSynced)? {
+            Ok(Some(highest_synced.0))
+        } else {
+            Ok(None)
+        }
+    }
+
     pub fn get_highest_executed_checkpoint_seq_number(
         &self,
     ) -> Result<Option<CheckpointSequenceNumber>, TypedStoreError> {

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -34,6 +34,7 @@ use crate::{
             AuthorityPerEpochStore, ConsensusStats, ConsensusStatsAPI, ExecutionIndices,
             ExecutionIndicesWithStats,
         },
+        backpressure::{BackpressureManager, BackpressureSubscriber},
         epoch_start_configuration::EpochStartConfigTrait,
     },
     checkpoints::{CheckpointService, CheckpointServiceNotify},
@@ -48,6 +49,7 @@ pub struct ConsensusHandlerInitializer {
     checkpoint_service: Arc<CheckpointService>,
     epoch_store: Arc<AuthorityPerEpochStore>,
     low_scoring_authorities: Arc<ArcSwap<HashMap<AuthorityName, u64>>>,
+    backpressure_manager: Arc<BackpressureManager>,
 }
 
 impl ConsensusHandlerInitializer {
@@ -56,12 +58,14 @@ impl ConsensusHandlerInitializer {
         checkpoint_service: Arc<CheckpointService>,
         epoch_store: Arc<AuthorityPerEpochStore>,
         low_scoring_authorities: Arc<ArcSwap<HashMap<AuthorityName, u64>>>,
+        backpressure_manager: Arc<BackpressureManager>,
     ) -> Self {
         Self {
             state,
             checkpoint_service,
             epoch_store,
             low_scoring_authorities,
+            backpressure_manager,
         }
     }
 
@@ -69,11 +73,13 @@ impl ConsensusHandlerInitializer {
         state: Arc<AuthorityState>,
         checkpoint_service: Arc<CheckpointService>,
     ) -> Self {
+        let backpressure_manager = BackpressureManager::new_for_tests();
         Self {
             state: state.clone(),
             checkpoint_service,
             epoch_store: state.epoch_store_for_testing().clone(),
             low_scoring_authorities: Arc::new(Default::default()),
+            backpressure_manager,
         }
     }
 
@@ -89,6 +95,7 @@ impl ConsensusHandlerInitializer {
             self.low_scoring_authorities.clone(),
             consensus_committee,
             self.state.metrics.clone(),
+            self.backpressure_manager.subscribe(),
         )
     }
 }
@@ -119,6 +126,8 @@ pub struct ConsensusHandler<C> {
     /// Lru cache to quickly discard transactions processed by consensus
     processed_cache: LruCache<SequencedConsensusTransactionKey, ()>,
     transaction_scheduler: AsyncTransactionScheduler,
+
+    backpressure_subscriber: BackpressureSubscriber,
 }
 
 const PROCESSED_CACHE_CAP: usize = 1024 * 1024;
@@ -132,6 +141,7 @@ impl<C> ConsensusHandler<C> {
         low_scoring_authorities: Arc<ArcSwap<HashMap<AuthorityName, u64>>>,
         committee: ConsensusCommittee,
         metrics: Arc<AuthorityMetrics>,
+        backpressure_subscriber: BackpressureSubscriber,
     ) -> Self {
         // Recover last_consensus_stats so it is consistent across validators.
         let mut last_consensus_stats = epoch_store
@@ -153,6 +163,7 @@ impl<C> ConsensusHandler<C> {
             metrics,
             processed_cache: LruCache::new(NonZeroUsize::new(PROCESSED_CACHE_CAP).unwrap()),
             transaction_scheduler,
+            backpressure_subscriber,
         }
     }
 
@@ -165,6 +176,13 @@ impl<C> ConsensusHandler<C> {
 impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
     #[instrument(level = "debug", skip_all)]
     async fn handle_consensus_output(&mut self, consensus_output: impl ConsensusOutputAPI) {
+        // This may block until one of two conditions happens:
+        // - Number of uncommitted transactions in the writeback cache goes below the
+        //   backpressure threshold.
+        // - The highest executed checkpoint catches up to the highest certified
+        //   checkpoint.
+        self.backpressure_subscriber.await_no_backpressure().await;
+
         let _scope = monitored_scope("HandleConsensusOutput");
 
         let last_committed_round = self.last_consensus_stats.index.last_committed_round;
@@ -762,6 +780,7 @@ mod tests {
     use consensus_core::{
         BlockAPI, CommitDigest, CommitRef, CommittedSubDag, TestBlock, Transaction, VerifiedBlock,
     };
+    use futures::pin_mut;
     use iota_protocol_config::{Chain, ConsensusTransactionOrdering};
     use iota_types::{
         base_types::{AuthorityName, IotaAddress, random_object_ref},
@@ -790,7 +809,7 @@ mod tests {
         post_consensus_tx_reorder::PostConsensusTxReorder,
     };
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     pub async fn test_consensus_handler() {
         // GIVEN
         let mut objects = test_gas_objects();
@@ -813,6 +832,8 @@ mod tests {
 
         let metrics = Arc::new(AuthorityMetrics::new(&Registry::new()));
 
+        let backpressure_manager = BackpressureManager::new_for_tests();
+
         let mut consensus_handler = ConsensusHandler::new(
             epoch_store,
             Arc::new(CheckpointServiceNoop {}),
@@ -821,6 +842,7 @@ mod tests {
             Arc::new(ArcSwap::default()),
             consensus_committee.clone(),
             metrics,
+            backpressure_manager.subscribe(),
         );
 
         // AND
@@ -854,10 +876,29 @@ mod tests {
             vec![],
         );
 
+        // Test that the consensus handler respects backpressure.
+        backpressure_manager.set_backpressure(true);
+        // Default watermarks are 0,0 which will suppress the backpressure.
+        backpressure_manager.update_highest_certified_checkpoint(1);
+
         // AND processing the consensus output once
-        consensus_handler
-            .handle_consensus_output(committed_sub_dag.clone())
-            .await;
+        {
+            let waiter = consensus_handler.handle_consensus_output(committed_sub_dag.clone());
+            pin_mut!(waiter);
+
+            // waiter should not complete within 5 seconds
+            tokio::time::timeout(std::time::Duration::from_secs(5), &mut waiter)
+                .await
+                .unwrap_err();
+
+            // lift backpressure
+            backpressure_manager.set_backpressure(false);
+
+            // waiter completes now.
+            tokio::time::timeout(std::time::Duration::from_secs(100), waiter)
+                .await
+                .unwrap();
+        }
 
         // AND capturing the consensus stats
         let num_blocks = blocks.len();

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -30,6 +30,7 @@ use crate::{
         AuthorityStore,
         authority_per_epoch_store::AuthorityPerEpochStore,
         authority_store::{ExecutionLockWriteGuard, IotaLockResult, ObjectLockStatus},
+        backpressure::BackpressureManager,
         epoch_start_configuration::{EpochFlag, EpochStartConfiguration},
     },
     state_accumulator::AccumulatorStore,
@@ -108,6 +109,7 @@ pub fn build_execution_cache(
     epoch_start_config: &EpochStartConfiguration,
     prometheus_registry: &Registry,
     store: &Arc<AuthorityStore>,
+    backpressure_manager: Arc<BackpressureManager>,
 ) -> ExecutionCacheTraitPointers {
     let execution_cache_metrics = Arc::new(ExecutionCacheMetrics::new(prometheus_registry));
 
@@ -117,6 +119,7 @@ pub fn build_execution_cache(
             epoch_start_config,
             store.clone(),
             execution_cache_metrics,
+            backpressure_manager,
         )
         .into(),
     )
@@ -143,6 +146,7 @@ pub fn build_execution_cache_from_env(
                 &config.writeback_cache,
                 store.clone(),
                 execution_cache_metrics,
+                BackpressureManager::new_for_tests(),
             )
             .into(),
         ),
@@ -196,6 +200,9 @@ pub trait ExecutionCacheCommit: Send + Sync {
                 .expect("storage access failed")
         })
     }
+
+    // Number of pending uncommitted transactions
+    fn approximate_pending_transaction_count(&self) -> u64;
 }
 
 pub trait ObjectCacheRead: Send + Sync {

--- a/crates/iota-core/src/execution_cache/metrics.rs
+++ b/crates/iota-core/src/execution_cache/metrics.rs
@@ -16,6 +16,8 @@ pub struct ExecutionCacheMetrics {
     pub(crate) cache_misses: IntCounterVec,
     pub(crate) cache_writes: IntCounterVec,
     pub(crate) expired_tickets: IntCounter,
+    pub(crate) backpressure_status: IntGauge,
+    pub(crate) backpressure_toggles: IntCounter,
 }
 
 impl ExecutionCacheMetrics {
@@ -70,6 +72,20 @@ impl ExecutionCacheMetrics {
             expired_tickets: register_int_counter_with_registry!(
                 "execution_cache_expired_tickets",
                 "Failed inserts to monotonic caches because of expired tickets",
+                registry,
+            )
+            .unwrap(),
+
+            backpressure_status: register_int_gauge_with_registry!(
+                "execution_cache_backpressure_status",
+                "Backpressure status (1 = on, 0 = off)",
+                registry,
+            )
+            .unwrap(),
+
+            backpressure_toggles: register_int_counter_with_registry!(
+                "execution_cache_backpressure_toggles",
+                "Number of times backpressure was turned on or off",
                 registry,
             )
             .unwrap(),

--- a/crates/iota-core/src/execution_cache/passthrough_cache.rs
+++ b/crates/iota-core/src/execution_cache/passthrough_cache.rs
@@ -345,6 +345,10 @@ impl ExecutionCacheCommit for PassthroughCache {
         // write_transaction_outputs
         async { Ok(()) }.boxed()
     }
+
+    fn approximate_pending_transaction_count(&self) -> u64 {
+        0
+    }
 }
 
 impl StateSyncAPI for PassthroughCache {

--- a/crates/iota-core/src/execution_cache/proxy_cache.rs
+++ b/crates/iota-core/src/execution_cache/proxy_cache.rs
@@ -29,6 +29,7 @@ use crate::{
         AuthorityStore,
         authority_per_epoch_store::AuthorityPerEpochStore,
         authority_store::{ExecutionLockWriteGuard, IotaLockResult},
+        backpressure::BackpressureManager,
         epoch_start_configuration::{EpochFlag, EpochStartConfigTrait, EpochStartConfiguration},
     },
     state_accumulator::AccumulatorStore,
@@ -62,6 +63,7 @@ impl ProxyCache {
         epoch_start_config: &EpochStartConfiguration,
         store: Arc<AuthorityStore>,
         metrics: Arc<ExecutionCacheMetrics>,
+        backpressure_manager: Arc<BackpressureManager>,
     ) -> Self {
         let cache_type = epoch_start_config.execution_cache_type();
         tracing::info!("using cache impl {:?}", cache_type);
@@ -71,6 +73,7 @@ impl ProxyCache {
             &cache_config.writeback_cache,
             store.clone(),
             metrics.clone(),
+            backpressure_manager,
         );
 
         Self {
@@ -319,6 +322,10 @@ impl ExecutionCacheCommit for ProxyCache {
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, IotaResult> {
         delegate_method!(self.try_persist_transactions(digests))
+    }
+
+    fn approximate_pending_transaction_count(&self) -> u64 {
+        delegate_method!(self.approximate_pending_transaction_count())
     }
 }
 

--- a/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -81,6 +81,7 @@ impl Scenario {
             &WritebackCacheConfig::default(),
             store.clone(),
             (*METRICS).clone(),
+            BackpressureManager::new_for_tests(),
         ));
         Self {
             authority,
@@ -378,6 +379,7 @@ impl Scenario {
             &WritebackCacheConfig::default(),
             self.store.clone(),
             self.cache.metrics.clone(),
+            BackpressureManager::new_for_tests(),
         ));
 
         // reset the scenario state to match the db
@@ -1210,6 +1212,7 @@ async fn latest_object_cache_race_test() {
         &WritebackCacheConfig::default(),
         store.clone(),
         (*METRICS).clone(),
+        BackpressureManager::new_for_tests(),
     ));
 
     let object_id = ObjectID::random();
@@ -1333,6 +1336,7 @@ async fn concurrent_latest_object_cache_race_test() {
         &WritebackCacheConfig::default(),
         store.clone(),
         (*METRICS).clone(),
+        BackpressureManager::new_for_tests(),
     ));
 
     let object_id = ObjectID::random();
@@ -1430,6 +1434,7 @@ async fn concurrent_latest_object_cache_collision_test() {
         &WritebackCacheConfig::default(),
         store.clone(),
         (*METRICS).clone(),
+        BackpressureManager::new_for_tests(),
     ));
 
     let mk_object_id = |i: usize| -> ObjectID {

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -50,7 +50,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     hash::Hash,
-    sync::Arc,
+    sync::{Arc, atomic::AtomicU64},
 };
 
 use dashmap::{DashMap, mapref::entry::Entry as DashMapEntry};
@@ -91,6 +91,7 @@ use crate::{
         authority_per_epoch_store::AuthorityPerEpochStore,
         authority_store::{ExecutionLockWriteGuard, IotaLockResult, ObjectLockStatus},
         authority_store_tables::LiveObject,
+        backpressure::BackpressureManager,
         epoch_start_configuration::{EpochFlag, EpochStartConfiguration},
     },
     state_accumulator::AccumulatorStore,
@@ -240,6 +241,9 @@ struct UncommittedData {
     // Transaction outputs that have not yet been written to the DB. Items are removed from this
     // table as they are flushed to the db.
     pending_transaction_writes: DashMap<TransactionDigest, Arc<TransactionOutputs>>,
+
+    total_transaction_inserts: AtomicU64,
+    total_transaction_commits: AtomicU64,
 }
 
 impl UncommittedData {
@@ -251,6 +255,8 @@ impl UncommittedData {
             executed_effects_digests: DashMap::new(),
             pending_transaction_writes: DashMap::new(),
             transaction_events: DashMap::new(),
+            total_transaction_inserts: AtomicU64::new(0),
+            total_transaction_commits: AtomicU64::new(0),
         }
     }
 
@@ -261,6 +267,10 @@ impl UncommittedData {
         self.executed_effects_digests.clear();
         self.pending_transaction_writes.clear();
         self.transaction_events.clear();
+        self.total_transaction_inserts
+            .store(0, std::sync::atomic::Ordering::Relaxed);
+        self.total_transaction_commits
+            .store(0, std::sync::atomic::Ordering::Relaxed);
     }
 
     fn is_empty(&self) -> bool {
@@ -272,6 +282,12 @@ impl UncommittedData {
                     && self.transaction_effects.is_empty()
                     && self.executed_effects_digests.is_empty()
                     && self.transaction_events.is_empty()
+                    && self
+                        .total_transaction_inserts
+                        .load(std::sync::atomic::Ordering::Relaxed)
+                        == self
+                            .total_transaction_commits
+                            .load(std::sync::atomic::Ordering::Relaxed),
             );
         }
         empty
@@ -413,6 +429,8 @@ pub struct WritebackCache {
 
     executed_effects_digests_notify_read: NotifyRead<TransactionDigest, TransactionEffectsDigest>,
     store: Arc<AuthorityStore>,
+    backpressure_threshold: u64,
+    backpressure_manager: Arc<BackpressureManager>,
     metrics: Arc<ExecutionCacheMetrics>,
 }
 
@@ -458,6 +476,7 @@ impl WritebackCache {
         config: &WritebackCacheConfig,
         store: Arc<AuthorityStore>,
         metrics: Arc<ExecutionCacheMetrics>,
+        backpressure_manager: Arc<BackpressureManager>,
     ) -> Self {
         let packages = MokaCache::builder()
             .max_capacity(config.package_cache_size())
@@ -469,6 +488,8 @@ impl WritebackCache {
             object_locks: ObjectLocks::new(),
             executed_effects_digests_notify_read: NotifyRead::new(),
             store,
+            backpressure_manager,
+            backpressure_threshold: config.backpressure_threshold(),
             metrics,
         }
     }
@@ -478,6 +499,7 @@ impl WritebackCache {
             &Default::default(),
             store,
             ExecutionCacheMetrics::new(registry).into(),
+            BackpressureManager::new_for_tests(),
         )
     }
 
@@ -487,6 +509,7 @@ impl WritebackCache {
             &Default::default(),
             self.store.clone(),
             self.metrics.clone(),
+            self.backpressure_manager.clone(),
         );
         std::mem::swap(self, &mut new);
     }
@@ -915,6 +938,19 @@ impl WritebackCache {
             .pending_notify_read
             .set(self.executed_effects_digests_notify_read.num_pending() as i64);
 
+        let prev = self
+            .dirty
+            .total_transaction_inserts
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let pending_count = (prev + 1).saturating_sub(
+            self.dirty
+                .total_transaction_commits
+                .load(std::sync::atomic::Ordering::Relaxed),
+        );
+
+        self.set_backpressure(pending_count);
+
         Ok(())
     }
 
@@ -967,7 +1003,45 @@ impl WritebackCache {
             self.flush_transactions_from_dirty_to_cached(epoch, *tx_digest, outputs);
         }
 
+        let num_outputs = all_outputs.len() as u64;
+        let num_commits = self
+            .dirty
+            .total_transaction_commits
+            .fetch_add(num_outputs, std::sync::atomic::Ordering::Relaxed)
+            + num_outputs;
+
+        let pending_count = self
+            .dirty
+            .total_transaction_inserts
+            .load(std::sync::atomic::Ordering::Relaxed)
+            .saturating_sub(num_commits);
+
+        self.set_backpressure(pending_count);
+
         Ok(())
+    }
+
+    fn approximate_pending_transaction_count(&self) -> u64 {
+        let num_commits = self
+            .dirty
+            .total_transaction_commits
+            .load(std::sync::atomic::Ordering::Relaxed);
+
+        self.dirty
+            .total_transaction_inserts
+            .load(std::sync::atomic::Ordering::Relaxed)
+            .saturating_sub(num_commits)
+    }
+
+    fn set_backpressure(&self, pending_count: u64) {
+        let backpressure = pending_count > self.backpressure_threshold;
+        let backpressure_changed = self.backpressure_manager.set_backpressure(backpressure);
+        if backpressure_changed {
+            self.metrics.backpressure_toggles.inc();
+        }
+        self.metrics
+            .backpressure_status
+            .set(if backpressure { 1 } else { 0 });
     }
 
     fn flush_transactions_from_dirty_to_cached(
@@ -1272,6 +1346,10 @@ impl ExecutionCacheCommit for WritebackCache {
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, IotaResult> {
         WritebackCache::persist_transactions(self, digests).boxed()
+    }
+
+    fn approximate_pending_transaction_count(&self) -> u64 {
+        WritebackCache::approximate_pending_transaction_count(self)
     }
 }
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -38,6 +38,7 @@ use iota_core::{
         AuthorityState, AuthorityStore, RandomnessRoundReceiver,
         authority_per_epoch_store::AuthorityPerEpochStore,
         authority_store_tables::{AuthorityPerpetualTables, AuthorityPerpetualTablesOptions},
+        backpressure::BackpressureManager,
         epoch_start_configuration::{EpochFlag, EpochStartConfigTrait, EpochStartConfiguration},
     },
     authority_aggregator::{AuthAggMetrics, AuthorityAggregator},
@@ -237,6 +238,8 @@ pub struct IotaNode {
     /// Broadcast channel to notify [`DiscoveryEventLoop`] for new validator
     /// peers.
     trusted_peer_change_tx: watch::Sender<TrustedPeerChangeEvent>,
+
+    backpressure_manager: Arc<BackpressureManager>,
 
     _db_checkpoint_handle: Option<tokio::sync::broadcast::Sender<()>>,
 
@@ -505,6 +508,10 @@ impl IotaNode {
         let is_genesis = perpetual_tables
             .database_is_empty()
             .expect("Database read should not fail at init.");
+        let checkpoint_store = CheckpointStore::new(&config.db_path().join("checkpoints"));
+        let backpressure_manager =
+            BackpressureManager::new_from_checkpoint_store(&checkpoint_store);
+
         let store = AuthorityStore::open(
             perpetual_tables,
             &genesis,
@@ -529,6 +536,7 @@ impl IotaNode {
             &epoch_start_configuration,
             &prometheus_registry,
             &store,
+            backpressure_manager.clone(),
         );
 
         let auth_agg = {
@@ -595,7 +603,6 @@ impl IotaNode {
 
         info!("creating checkpoint store");
 
-        let checkpoint_store = CheckpointStore::new(&config.db_path().join("checkpoints"));
         checkpoint_store.insert_genesis_checkpoint(
             genesis.checkpoint(),
             genesis.checkpoint_contents().clone(),
@@ -847,6 +854,7 @@ impl IotaNode {
                     state_sync_handle.clone(),
                     randomness_handle.clone(),
                     Arc::downgrade(&accumulator),
+                    backpressure_manager.clone(),
                     connection_monitor_status.clone(),
                     &registry_service,
                     iota_node_metrics.clone(),
@@ -885,6 +893,7 @@ impl IotaNode {
             end_of_epoch_channel,
             connection_monitor_status,
             trusted_peer_change_tx,
+            backpressure_manager,
 
             _db_checkpoint_handle: db_checkpoint_handle,
 
@@ -1221,6 +1230,7 @@ impl IotaNode {
         state_sync_handle: state_sync::Handle,
         randomness_handle: randomness::Handle,
         accumulator: Weak<StateAccumulator>,
+        backpressure_manager: Arc<BackpressureManager>,
         connection_monitor_status: Arc<ConnectionMonitorStatus>,
         registry_service: &RegistryService,
         iota_node_metrics: Arc<IotaNodeMetrics>,
@@ -1300,6 +1310,7 @@ impl IotaNode {
             consensus_manager,
             consensus_store_pruner,
             accumulator,
+            backpressure_manager,
             validator_server_handle,
             validator_server_cancel_handle,
             validator_overload_monitor_handle,
@@ -1324,6 +1335,7 @@ impl IotaNode {
         consensus_manager: ConsensusManager,
         consensus_store_pruner: ConsensusStorePruner,
         accumulator: Weak<StateAccumulator>,
+        backpressure_manager: Arc<BackpressureManager>,
         validator_server_handle: SpawnOnce,
         validator_server_cancel_handle: tokio::sync::oneshot::Sender<()>,
         validator_overload_monitor_handle: Option<JoinHandle<()>>,
@@ -1369,6 +1381,7 @@ impl IotaNode {
             checkpoint_service.clone(),
             epoch_store.clone(),
             low_scoring_authorities,
+            backpressure_manager,
         );
 
         consensus_manager
@@ -1704,6 +1717,7 @@ impl IotaNode {
                 self.checkpoint_store.clone(),
                 self.state.clone(),
                 accumulator.clone(),
+                self.backpressure_manager.clone(),
                 self.config.checkpoint_executor_config.clone(),
                 checkpoint_executor_metrics.clone(),
             );
@@ -1892,6 +1906,7 @@ impl IotaNode {
                             consensus_manager,
                             consensus_store_pruner,
                             weak_accumulator,
+                            self.backpressure_manager.clone(),
                             validator_server_handle,
                             validator_server_cancel_handle,
                             validator_overload_monitor_handle,
@@ -1952,6 +1967,7 @@ impl IotaNode {
                         self.state_sync_handle.clone(),
                         self.randomness_handle.clone(),
                         weak_accumulator,
+                        self.backpressure_manager.clone(),
                         self.connection_monitor_status.clone(),
                         &self.registry_service,
                         self.metrics.clone(),

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -11,7 +11,7 @@ use std::{
 
 use fastcrypto::traits::KeyPair;
 use iota_config::{
-    ExecutionCacheConfig, IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME,
+    ExecutionCacheConfig, ExecutionCacheType, IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME,
     genesis::{TokenAllocation, TokenDistributionScheduleBuilder},
     node::AuthorityOverloadConfig,
 };
@@ -86,6 +86,7 @@ pub struct ConfigBuilder<R = OsRng> {
     jwk_fetch_interval: Option<Duration>,
     num_unpruned_validators: Option<usize>,
     authority_overload_config: Option<AuthorityOverloadConfig>,
+    execution_cache_type: Option<ExecutionCacheType>,
     execution_cache_config: Option<ExecutionCacheConfig>,
     data_ingestion_dir: Option<PathBuf>,
     policy_config: Option<PolicyConfig>,
@@ -109,6 +110,7 @@ impl ConfigBuilder {
             jwk_fetch_interval: None,
             num_unpruned_validators: None,
             authority_overload_config: None,
+            execution_cache_type: None,
             execution_cache_config: None,
             data_ingestion_dir: None,
             policy_config: None,
@@ -252,6 +254,11 @@ impl<R> ConfigBuilder<R> {
         self
     }
 
+    pub fn with_execution_cache_type(mut self, c: ExecutionCacheType) -> Self {
+        self.execution_cache_type = Some(c);
+        self
+    }
+
     pub fn with_execution_cache_config(mut self, c: ExecutionCacheConfig) -> Self {
         self.execution_cache_config = Some(c);
         self
@@ -292,6 +299,7 @@ impl<R> ConfigBuilder<R> {
             num_unpruned_validators: self.num_unpruned_validators,
             jwk_fetch_interval: self.jwk_fetch_interval,
             authority_overload_config: self.authority_overload_config,
+            execution_cache_type: self.execution_cache_type,
             execution_cache_config: self.execution_cache_config,
             data_ingestion_dir: self.data_ingestion_dir,
             policy_config: self.policy_config,
@@ -494,6 +502,10 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                 if let Some(authority_overload_config) = &self.authority_overload_config {
                     builder =
                         builder.with_authority_overload_config(authority_overload_config.clone());
+                }
+
+                if let Some(execution_cache_type) = &self.execution_cache_type {
+                    builder = builder.with_execution_cache_type(*execution_cache_type);
                 }
 
                 if let Some(execution_cache_config) = &self.execution_cache_config {

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -45,7 +45,7 @@ pub struct ValidatorConfigBuilder {
     force_unpruned_checkpoints: bool,
     jwk_fetch_interval: Option<Duration>,
     authority_overload_config: Option<AuthorityOverloadConfig>,
-    execution_cache: Option<ExecutionCacheType>,
+    execution_cache_type: Option<ExecutionCacheType>,
     execution_cache_config: Option<ExecutionCacheConfig>,
     data_ingestion_dir: Option<PathBuf>,
     policy_config: Option<PolicyConfig>,
@@ -88,6 +88,11 @@ impl ValidatorConfigBuilder {
 
     pub fn with_authority_overload_config(mut self, config: AuthorityOverloadConfig) -> Self {
         self.authority_overload_config = Some(config);
+        self
+    }
+
+    pub fn with_execution_cache_type(mut self, execution_cache_type: ExecutionCacheType) -> Self {
+        self.execution_cache_type = Some(execution_cache_type);
         self
     }
 
@@ -231,7 +236,7 @@ impl ValidatorConfigBuilder {
                 .unwrap_or(3600),
             zklogin_oauth_providers: default_zklogin_oauth_providers(),
             authority_overload_config: self.authority_overload_config.unwrap_or_default(),
-            execution_cache: self.execution_cache.unwrap_or_default(),
+            execution_cache: self.execution_cache_type.unwrap_or_default(),
             execution_cache_config: self.execution_cache_config.unwrap_or_default(),
             run_with_range: None,
             jsonrpc_server_type: None,

--- a/crates/iota-swarm/src/memory/swarm.rs
+++ b/crates/iota-swarm/src/memory/swarm.rs
@@ -14,7 +14,7 @@ use std::{
 use anyhow::Result;
 use futures::future::try_join_all;
 use iota_config::{
-    ExecutionCacheConfig, IOTA_GENESIS_FILENAME, NodeConfig,
+    ExecutionCacheConfig, ExecutionCacheType, IOTA_GENESIS_FILENAME, NodeConfig,
     node::{AuthorityOverloadConfig, DBCheckpointConfig, RunWithRange},
 };
 use iota_macros::nondeterministic;
@@ -60,6 +60,7 @@ pub struct SwarmBuilder<R = OsRng> {
     jwk_fetch_interval: Option<Duration>,
     num_unpruned_validators: Option<usize>,
     authority_overload_config: Option<AuthorityOverloadConfig>,
+    execution_cache_type: Option<ExecutionCacheType>,
     execution_cache_config: Option<ExecutionCacheConfig>,
     data_ingestion_dir: Option<PathBuf>,
     fullnode_run_with_range: Option<RunWithRange>,
@@ -91,6 +92,7 @@ impl SwarmBuilder {
             jwk_fetch_interval: None,
             num_unpruned_validators: None,
             authority_overload_config: None,
+            execution_cache_type: None,
             execution_cache_config: None,
             data_ingestion_dir: None,
             fullnode_run_with_range: None,
@@ -124,6 +126,7 @@ impl<R> SwarmBuilder<R> {
             jwk_fetch_interval: self.jwk_fetch_interval,
             num_unpruned_validators: self.num_unpruned_validators,
             authority_overload_config: self.authority_overload_config,
+            execution_cache_type: self.execution_cache_type,
             execution_cache_config: self.execution_cache_config,
             data_ingestion_dir: self.data_ingestion_dir,
             fullnode_run_with_range: self.fullnode_run_with_range,
@@ -271,6 +274,12 @@ impl<R> SwarmBuilder<R> {
         self
     }
 
+    pub fn with_execution_cache_type(mut self, execution_cache_type: ExecutionCacheType) -> Self {
+        assert!(self.execution_cache_type.is_none());
+        self.execution_cache_type = Some(execution_cache_type);
+        self
+    }
+
     pub fn with_execution_cache_config(
         mut self,
         execution_cache_config: ExecutionCacheConfig,
@@ -363,6 +372,10 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
             if let Some(authority_overload_config) = self.authority_overload_config {
                 config_builder =
                     config_builder.with_authority_overload_config(authority_overload_config);
+            }
+
+            if let Some(execution_cache_type) = self.execution_cache_type {
+                config_builder = config_builder.with_execution_cache_type(execution_cache_type);
             }
 
             if let Some(execution_cache_config) = self.execution_cache_config {

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -13,8 +13,8 @@ use std::{
 
 use futures::{StreamExt, future::join_all};
 use iota_config::{
-    Config, ExecutionCacheConfig, IOTA_CLIENT_CONFIG, IOTA_KEYSTORE_FILENAME, IOTA_NETWORK_CONFIG,
-    NodeConfig, PersistedConfig,
+    Config, ExecutionCacheConfig, ExecutionCacheType, IOTA_CLIENT_CONFIG, IOTA_KEYSTORE_FILENAME,
+    IOTA_NETWORK_CONFIG, NodeConfig, PersistedConfig,
     genesis::Genesis,
     node::{AuthorityOverloadConfig, DBCheckpointConfig, RunWithRange},
 };
@@ -990,6 +990,7 @@ pub struct TestClusterBuilder {
     config_dir: Option<PathBuf>,
     default_jwks: bool,
     authority_overload_config: Option<AuthorityOverloadConfig>,
+    execution_cache_type: Option<ExecutionCacheType>,
     execution_cache_config: Option<ExecutionCacheConfig>,
     data_ingestion_dir: Option<PathBuf>,
     fullnode_run_with_range: Option<RunWithRange>,
@@ -1021,6 +1022,7 @@ impl TestClusterBuilder {
             config_dir: None,
             default_jwks: false,
             authority_overload_config: None,
+            execution_cache_type: None,
             execution_cache_config: None,
             data_ingestion_dir: None,
             fullnode_run_with_range: None,
@@ -1217,6 +1219,12 @@ impl TestClusterBuilder {
         self
     }
 
+    pub fn with_execution_cache_type(mut self, config: ExecutionCacheType) -> Self {
+        assert!(self.network_config.is_none());
+        self.execution_cache_type = Some(config);
+        self
+    }
+
     pub fn with_execution_cache_config(mut self, config: ExecutionCacheConfig) -> Self {
         assert!(self.network_config.is_none());
         self.execution_cache_config = Some(config);
@@ -1352,6 +1360,10 @@ impl TestClusterBuilder {
 
         if let Some(authority_overload_config) = self.authority_overload_config.take() {
             builder = builder.with_authority_overload_config(authority_overload_config);
+        }
+
+        if let Some(execution_cache_type) = self.execution_cache_type.take() {
+            builder = builder.with_execution_cache_type(execution_cache_type);
         }
 
         if let Some(execution_cache_config) = self.execution_cache_config.take() {


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.39.4, v1.40.3)
- Port commits:
  - https://github.com/MystenLabs/sui/commit/769f14529c115eb4c26120186bdc4978f4c74abd
  - https://github.com/MystenLabs/sui/commit/f18b17d94d0aa16978f3dd637bbd0b132cad680b
  - https://github.com/MystenLabs/sui/commit/4b59afd90e5d9067f792d20d83a959489bff1dbf

- Description:
Implement back pressure for writeback cache

Backpressure is initiated when:
- There are too many pending transaction writes in memory, and
- The certified checkpoint watermark is ahead of the executed watermark.

The second condition is necessary to ensure that backpressure cannot halt a validator by making it unable to process consensus transactions that might be needed to construct the next checkpoint.

When backpressure is in effect, the consensus handler will pause.


## Links to any relevant issues

Part of #6148  

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): - Add backpressure to the WritebackCache
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API: