### PR TITLE
refactor(iota-data-ingestion-core): do not enforce a path in historical reader

### DIFF
--- a/crates/iota-data-ingestion-core/src/history/manifest.rs
+++ b/crates/iota-data-ingestion-core/src/history/manifest.rs
@@ -42,8 +42,8 @@ use crate::{
     IngestionError,
     errors::IngestionResult as Result,
     history::{
-        CHECKPOINT_FILE_SUFFIX, HISTORICAL_DIR_NAME, INGESTION_DIR_NAME, MAGIC_BYTES,
-        MANIFEST_FILE_MAGIC, MANIFEST_FILENAME, reader::HistoricalReader,
+        CHECKPOINT_FILE_SUFFIX, MAGIC_BYTES, MANIFEST_FILE_MAGIC, MANIFEST_FILENAME,
+        reader::HistoricalReader,
     },
 };
 
@@ -55,12 +55,10 @@ pub struct FileMetadata {
 
 impl FileMetadata {
     pub fn file_path(&self) -> Path {
-        Path::from(INGESTION_DIR_NAME)
-            .child(HISTORICAL_DIR_NAME)
-            .child(format!(
-                "{}.{CHECKPOINT_FILE_SUFFIX}",
-                self.checkpoint_seq_range.start
-            ))
+        Path::from(format!(
+            "{}.{CHECKPOINT_FILE_SUFFIX}",
+            self.checkpoint_seq_range.start
+        ))
     }
 }
 
@@ -108,9 +106,7 @@ impl Manifest {
     }
 
     pub fn file_path() -> Path {
-        Path::from(INGESTION_DIR_NAME)
-            .child(HISTORICAL_DIR_NAME)
-            .child(MANIFEST_FILENAME)
+        Path::from(MANIFEST_FILENAME)
     }
 }
 

--- a/crates/iota-data-ingestion-core/src/history/mod.rs
+++ b/crates/iota-data-ingestion-core/src/history/mod.rs
@@ -59,8 +59,6 @@ pub mod reader;
 
 pub const CHECKPOINT_FILE_MAGIC: u32 = 0x0000BEEF;
 pub const CHECKPOINT_FILE_SUFFIX: &str = "chk";
-const HISTORICAL_DIR_NAME: &str = "historical";
-const INGESTION_DIR_NAME: &str = "ingestion";
 pub const MAGIC_BYTES: usize = 4;
 pub const MANIFEST_FILE_MAGIC: u32 = 0x0000FACE;
 pub const MANIFEST_FILENAME: &str = "MANIFEST";

--- a/crates/iota-data-ingestion-core/src/reader/fetch.rs
+++ b/crates/iota-data-ingestion-core/src/reader/fetch.rs
@@ -18,7 +18,9 @@ use object_store::{ObjectStore, path::Path as ObjectStorePath};
 use tokio::sync::mpsc;
 use tracing::{debug, info};
 
-use crate::{IngestionError, IngestionResult, MAX_CHECKPOINTS_IN_PROGRESS};
+use crate::{
+    IngestionError, IngestionResult, MAX_CHECKPOINTS_IN_PROGRESS, history::CHECKPOINT_FILE_SUFFIX,
+};
 
 pub type CheckpointResult = IngestionResult<(Arc<CheckpointData>, usize)>;
 
@@ -188,7 +190,7 @@ pub async fn fetch_from_object_store(
     store: &dyn ObjectStore,
     checkpoint_number: CheckpointSequenceNumber,
 ) -> CheckpointResult {
-    let path = ObjectStorePath::from(format!("{checkpoint_number}.chk"));
+    let path = ObjectStorePath::from(format!("{checkpoint_number}.{CHECKPOINT_FILE_SUFFIX}"));
     let response = store.get(&path).await?;
     let bytes = response.bytes().await?;
     Ok((

--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -56,11 +56,12 @@ pub enum RemoteUrl {
     /// A hybrid source combining historical object store and optional live
     /// object store.
     HybridHistoricalStore {
-        /// The URL of the historical object store.
+        /// The URL path to the historical object store that contains `*.chk`,
+        /// `*.sum` & `MANIFEST` files.
         ///
         /// # Example
         /// ```text
-        /// "https://checkpoints.mainnet.iota.cafe"
+        /// "https://checkpoints.mainnet.iota.cafe/ingestion/historical"
         /// ```
         historical_url: String,
         /// The URL path to the live object store that contains `*.chk`

--- a/crates/iota-light-client/README.md
+++ b/crates/iota-light-client/README.md
@@ -29,7 +29,7 @@ rpc_url: "https://api.mainnet.iota.cafe"
 # A full node GraphQL RPC endpoint to query end-of-epoch checkpoints (optional if archive store config is provided)
 graphql_url: "https://graphql.mainnet.iota.cafe"
 
-# Local directory to store checkpoint summaries and other synchronization data (mandatory) 
+# Local directory to store checkpoint summaries and other synchronization data (mandatory)
 checkpoints_dir: "checkpoints_mainnet"
 
 # A URL to download or copy the genesis blob file from (optional if genesis blob is already present in checkpoints_dir)
@@ -41,7 +41,7 @@ sync_before_check: true
 # A config for an object store that gets populated by a historical checkpoint writer (optional)
 checkpoint_store_config:
   object-store: "S3"
-  aws-endpoint: "https://checkpoints.mainnet.iota.cafe"
+  aws-endpoint: "https://checkpoints.mainnet.iota.cafe/ingestion/historical"
   aws-virtual-hosted-style-request: true
   no-sign-request: true
   aws-region: "weur"

--- a/crates/iota-light-client/devnet.yaml
+++ b/crates/iota-light-client/devnet.yaml
@@ -5,7 +5,7 @@ genesis_blob_download_url: "https://dbfiles.devnet.iota.cafe/genesis.blob"
 sync_before_check: true
 checkpoint_store_config:
   object-store: "S3"
-  aws-endpoint: "https://checkpoints.devnet.iota.cafe"
+  aws-endpoint: "https://checkpoints.devnet.iota.cafe/ingestion/historical"
   aws-virtual-hosted-style-request: true
   no-sign-request: true
   aws-region: "weur"

--- a/crates/iota-light-client/mainnet.yaml
+++ b/crates/iota-light-client/mainnet.yaml
@@ -5,7 +5,7 @@ genesis_blob_download_url: "https://dbfiles.mainnet.iota.cafe/genesis.blob"
 sync_before_check: true
 checkpoint_store_config:
   object-store: "S3"
-  aws-endpoint: "https://checkpoints.mainnet.iota.cafe"
+  aws-endpoint: "https://checkpoints.mainnet.iota.cafe/ingestion/historical"
   aws-virtual-hosted-style-request: true
   no-sign-request: true
   aws-region: "weur"

--- a/crates/iota-light-client/src/config.rs
+++ b/crates/iota-light-client/src/config.rs
@@ -119,7 +119,9 @@ impl Config {
             checkpoint_store_config: Some(ObjectStoreConfig {
                 object_store: Some(ObjectStoreType::S3),
                 object_store_connection_limit: 20,
-                aws_endpoint: Some(format!("https://checkpoints.{network}.iota.cafe")),
+                aws_endpoint: Some(format!(
+                    "https://checkpoints.{network}.iota.cafe/ingestion/historical"
+                )),
                 aws_virtual_hosted_style_request: true,
                 aws_region: Some("weur".to_string()),
                 no_sign_request: true,

--- a/crates/iota-light-client/testnet.yaml
+++ b/crates/iota-light-client/testnet.yaml
@@ -5,7 +5,7 @@ genesis_blob_download_url: "https://dbfiles.testnet.iota.cafe/genesis.blob"
 sync_before_check: true
 checkpoint_store_config:
   object-store: "S3"
-  aws-endpoint: "https://checkpoints.testnet.iota.cafe"
+  aws-endpoint: "https://checkpoints.testnet.iota.cafe/ingestion/historical"
   aws-virtual-hosted-style-request: true
   no-sign-request: true
   aws-region: "weur"


### PR DESCRIPTION
# Description of change

This PR aims to fix the hardcoded path `ingestion/historical` which the `HisotricalReader` used to read historical checkpoints.

This was rather suboptimal since it enforced a certain path to be followed (e.g. in local deployment of an S3 bucket). Instead it's more flexible to provide the the complete url path during configuration as we did for the `live` part.

## Links to any relevant issues

fixes #7498 

## How the change has been tested

- Tested that the CheckpointReader using historical & live data downloaded the checkpoints.
- Ran the sync operation in the `iota-light-client` to assert that all works as expected.
```shell
$ cargo r -p iota-light-client  --bin iota-light-client -- --config crates/iota-light-client/testnet.yaml sync
```

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

> [!NOTE]
> This PR does not affect the Indexer and it's normal operation since it does not use the new `CheckpointReader`.
### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
