### PR TITLE
feat(consensus): add support for transaction acknowledgements to `test_dag_parser`

### DIFF
--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -31,7 +31,7 @@ use crate::{
 /// Usage:
 ///
 /// DAG Building
-/// ```rust
+/// ```ignore
 /// use std::sync::Arc;
 /// use super::context::Context;
 /// use super::test_dag_builder::DagBuilder;
@@ -49,7 +49,7 @@ use crate::{
 /// ```
 ///
 /// Persisting to DagState by Layer
-/// ```rust
+/// ```ignore
 /// use std::sync::{Arc, RwLock};
 ///
 /// use super::{
@@ -68,7 +68,7 @@ use crate::{
 /// ```
 ///
 /// Persisting entire DAG to DagState
-/// ```rust
+/// ```ignore
 /// use std::sync::{Arc, RwLock};
 ///
 /// use super::{
@@ -87,7 +87,7 @@ use crate::{
 /// ```
 ///
 /// Printing DAG
-/// ```rust
+/// ```ignore
 /// use std::sync::Arc;
 ///
 /// use super::{context::Context, test_dag_builder::DagBuilder};
@@ -399,7 +399,7 @@ impl DagBuilder {
         tracing::info!("{dag_str}");
     }
 
-    /// Gets all uncommitted blocks in a slot.
+    // Gets all uncommitted blocks in a slot.
     pub(crate) fn get_uncommitted_blocks_at_slot(&self, slot: Slot) -> Vec<VerifiedBlockHeader> {
         let mut blocks = vec![];
         for (_block_ref, block) in self.block_headers.range((
@@ -419,15 +419,30 @@ impl DagBuilder {
         blocks
     }
 
+    // Gets transactions in a slot.
+    pub(crate) fn get_transaction_block_refs_at_slot(&self, slot: Slot) -> Vec<BlockRef> {
+        let mut acks = Vec::new();
+        for verified_transaction in self.transactions.range((
+            Included(BlockRef::new(
+                slot.round,
+                slot.authority,
+                BlockHeaderDigest::MIN,
+            )),
+            Included(BlockRef::new(
+                slot.round,
+                slot.authority,
+                BlockHeaderDigest::MAX,
+            )),
+        )) {
+            acks.push(*verified_transaction.0);
+        }
+        acks
+    }
+
     pub(crate) fn genesis_block_refs(&self) -> Vec<BlockRef> {
         self.genesis.keys().cloned().collect()
     }
 
-    // Refactor of the `get_blocks` function from the `test_dag_parser` into a
-    // method of the `DagBuilder` struct. Converts the slot into a block
-    // reference and retrieves the corresponding blocks from the `DagBuilder`
-    // state. Special case for genesis blocks as they are cached separately in
-    // the `genesis` field.
     fn get_blocks(&self, slot: Slot) -> Vec<BlockRef> {
         // note: special case for genesis blocks as they are cached separately
         let block_refs = if slot.round == 0 {
@@ -443,18 +458,16 @@ impl DagBuilder {
         };
         block_refs
     }
-    // Refactor of the `parse_specified_connections` and 'parse_fully_connected'
-    // functions from the `test_dag_parser` into a single method of the
-    // `DagBuilder` struct using ancestor_selections instead of text. Converts
-    // the ancestor selections into block references from the DagBuilder's
+
+    // Converts the ancestor selections into block references from the DagBuilder's
     // last ancestors or from the blocks in the specified slots.
-    fn get_references_from_ancestor_specs(
+    fn get_references_from_ancestor_selections(
         &self,
         ancestor_selections: Vec<AncestorSelection>,
     ) -> Vec<BlockRef> {
         let mut block_refs = vec![];
-        for ancestor_spec in ancestor_selections {
-            match ancestor_spec {
+        for ancestor_selection in ancestor_selections {
+            match ancestor_selection {
                 AncestorSelection::UseLast => {
                     block_refs.extend(self.last_ancestors.clone());
                 }
@@ -473,6 +486,31 @@ impl DagBuilder {
         block_refs
     }
 
+    fn get_transaction_acks_from_ancestor_selections(
+        &self,
+        ancestor_selections: Vec<AncestorSelection>,
+    ) -> Vec<BlockRef> {
+        let mut block_refs = vec![];
+        for ancestor_selection in ancestor_selections {
+            match ancestor_selection {
+                AncestorSelection::UseLast => {
+                    block_refs.extend(self.last_ancestors.clone());
+                }
+                AncestorSelection::ExcludeFrom(slot) => {
+                    let stored_block_refs = self.get_transaction_block_refs_at_slot(slot);
+                    block_refs.extend(self.last_ancestors.clone());
+
+                    block_refs.retain(|ancestor| !stored_block_refs.contains(ancestor));
+                }
+                AncestorSelection::IncludeFrom(slot) => {
+                    let stored_block_refs = self.get_transaction_block_refs_at_slot(slot);
+                    block_refs.extend(stored_block_refs);
+                }
+            }
+        }
+        block_refs
+    }
+
     // TODO: merge into layer builder?
     // This method allows the user to specify specific links to ancestors. The
     // layer is written to dag state and the blocks are cached in [`DagBuilder`]
@@ -482,7 +520,7 @@ impl DagBuilder {
         ancestor_connection_spec: AncestorConnectionSpec,
         round: Round,
     ) {
-        let connections = match ancestor_connection_spec {
+        let (transaction_acks, connections) = match ancestor_connection_spec {
             AncestorConnectionSpec::FullyConnected => {
                 let ancestors = self.last_ancestors.clone();
                 let connections = self
@@ -491,21 +529,31 @@ impl DagBuilder {
                     .authorities()
                     .map(|authority| (authority.0, ancestors.clone()))
                     .collect::<Vec<_>>();
-                connections
+                let transaction_acks = if round == 1 {
+                    HashMap::new()
+                } else {
+                    connections.clone().into_iter().collect()
+                };
+                (transaction_acks, connections)
             }
-            AncestorConnectionSpec::AuthoritySpecific(ancestor_connections, _transaction_acks) => {
-                let mut output = vec![];
+            AncestorConnectionSpec::AuthoritySpecific(ancestor_connections, transaction_acks) => {
+                let mut connections = vec![];
                 for (authority, ancestor_specs) in ancestor_connections {
-                    let block_refs = self.get_references_from_ancestor_specs(ancestor_specs);
-                    output.push((authority, block_refs));
+                    let block_refs = self.get_references_from_ancestor_selections(ancestor_specs);
+                    connections.push((authority, block_refs));
                 }
-                output
+                let mut transaction_acks_map: HashMap<AuthorityIndex, Vec<BlockRef>> =
+                    HashMap::new();
+                if round > 1 {
+                    for (authority, transactions_ancestor_specs) in transaction_acks {
+                        let transaction_acks = self.get_transaction_acks_from_ancestor_selections(
+                            transactions_ancestor_specs,
+                        );
+                        transaction_acks_map.insert(authority, transaction_acks);
+                    }
+                }
+                (transaction_acks_map, connections)
             }
-        };
-        let transactions_acks: HashMap<AuthorityIndex, Vec<BlockRef>> = if round == 1 {
-            HashMap::new()
-        } else {
-            connections.clone().into_iter().collect()
         };
 
         let mut references = Vec::new();
@@ -517,7 +565,7 @@ impl DagBuilder {
                 TestBlockHeader::new(round, author)
                     .set_ancestors(ancestors)
                     .set_acknowledgments(
-                        transactions_acks
+                        transaction_acks
                             .get(&authority)
                             .cloned()
                             .unwrap_or_default(),
@@ -1081,7 +1129,6 @@ impl<'a> LayerBuilder<'a> {
     }
 }
 
-// TODO: add more unit tests
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -1156,171 +1203,6 @@ mod tests {
                     assert!(only_acknowledge.contains(&ack.author));
                 }
             }
-        }
-    }
-
-    // Recreating the test from the test_dag_parser::test_dag_parsing
-    // to ensure that the layer_with_ancestor_connections method works as expected.
-    // and that the AncestorSpecConnections enum can be used as an interim
-    // representation of the dag string.
-    #[tokio::test]
-    async fn test_layer_with_ancestor_connections() {
-        telemetry_subscribers::init_for_testing();
-        // Genesis  Round 0 : { 4 },
-        let context = Arc::new(Context::new_for_test(4).0);
-        let mut dag_builder = DagBuilder::new(context);
-        let (a, b, c, d) = (0.into(), 1.into(), 2.into(), 3.into());
-
-        let ancestor_specs = vec![
-            // Round 1 : { * }
-            AncestorConnectionSpec::FullyConnected,
-            // Round 2 : { * },
-            AncestorConnectionSpec::FullyConnected,
-            // Round 3 :
-            AncestorConnectionSpec::AuthoritySpecific(
-                vec![
-                    // A -> [*]
-                    (a, vec![AncestorSelection::UseLast]),
-                    // B -> [*]
-                    (b, vec![AncestorSelection::UseLast]),
-                    // C -> [*]
-                    (c, vec![AncestorSelection::UseLast]),
-                    // D -> [*]
-                    (d, vec![AncestorSelection::UseLast]),
-                ],
-                HashMap::new(),
-            ),
-            // Round 4 :
-            AncestorConnectionSpec::AuthoritySpecific(
-                vec![
-                    // A -> [A3, B3, C3]
-                    (
-                        a,
-                        vec![
-                            AncestorSelection::IncludeFrom(Slot::new(3, a)),
-                            AncestorSelection::IncludeFrom(Slot::new(3, b)),
-                            AncestorSelection::IncludeFrom(Slot::new(3, c)),
-                        ],
-                    ),
-                    // B -> [A3, B3, C3]
-                    (
-                        b,
-                        vec![
-                            AncestorSelection::IncludeFrom(Slot::new(3, a)),
-                            AncestorSelection::IncludeFrom(Slot::new(3, b)),
-                            AncestorSelection::IncludeFrom(Slot::new(3, c)),
-                        ],
-                    ),
-                    // C -> [A3, B3, C3],
-                    (
-                        c,
-                        vec![
-                            AncestorSelection::IncludeFrom(Slot::new(3, a)),
-                            AncestorSelection::IncludeFrom(Slot::new(3, b)),
-                            AncestorSelection::IncludeFrom(Slot::new(3, c)),
-                        ],
-                    ),
-                    // D -> [*]
-                    (d, vec![AncestorSelection::UseLast]),
-                ],
-                HashMap::new(),
-            ),
-            // Round 5 :
-            AncestorConnectionSpec::AuthoritySpecific(
-                vec![
-                    // A -> [*]
-                    (a, vec![AncestorSelection::UseLast]),
-                    // B -> [-A4]
-                    (b, vec![AncestorSelection::ExcludeFrom(Slot::new(4, a))]),
-                    // C -> [-A4],
-                    (c, vec![AncestorSelection::ExcludeFrom(Slot::new(4, a))]),
-                    // D -> [-A4]
-                    (d, vec![AncestorSelection::ExcludeFrom(Slot::new(4, a))]),
-                ],
-                HashMap::new(),
-            ),
-            // Round 6 :
-            AncestorConnectionSpec::AuthoritySpecific(
-                vec![
-                    // A -> [A3, B3, C3, A1, B1]
-                    (
-                        a,
-                        vec![
-                            AncestorSelection::IncludeFrom(Slot::new(3, a)),
-                            AncestorSelection::IncludeFrom(Slot::new(3, b)),
-                            AncestorSelection::IncludeFrom(Slot::new(3, c)),
-                            AncestorSelection::IncludeFrom(Slot::new(1, a)),
-                            AncestorSelection::IncludeFrom(Slot::new(1, b)),
-                        ],
-                    ),
-                    // B -> [*, A0]
-                    (
-                        b,
-                        vec![
-                            AncestorSelection::UseLast,
-                            AncestorSelection::IncludeFrom(Slot::new(0, a)),
-                        ],
-                    ),
-                    // C -> [-A5],
-                    (c, vec![AncestorSelection::ExcludeFrom(Slot::new(5, a))]),
-                ],
-                HashMap::new(),
-            ),
-        ];
-
-        assert_eq!(dag_builder.genesis.len(), 4);
-
-        for (i, ancestor_spec) in ancestor_specs.iter().enumerate() {
-            let round = (i + 1) as Round; // No transactions in this test
-            dag_builder.layer_with_connections(ancestor_spec.clone(), round);
-        }
-
-        assert_eq!(dag_builder.block_headers.len(), 23);
-
-        // Check the blocks were correctly parsed in Round 6
-        let blocks_a6 = dag_builder.get_uncommitted_blocks_at_slot(Slot::new(6, 0));
-        assert_eq!(blocks_a6.len(), 1);
-        let block_a6 = blocks_a6.first().unwrap();
-        assert_eq!(block_a6.round(), 6);
-        assert_eq!(block_a6.author(), 0.into());
-        assert_eq!(block_a6.ancestors().len(), 5);
-        let expected_block_a6_ancestor_slots = [
-            Slot::new(3, 0),
-            Slot::new(3, 1),
-            Slot::new(3, 2),
-            Slot::new(1, 0),
-            Slot::new(1, 1),
-        ];
-        for ancestor in block_a6.ancestors() {
-            assert!(expected_block_a6_ancestor_slots.contains(&Slot::from(*ancestor)));
-        }
-
-        let blocks_b6 = dag_builder.get_uncommitted_blocks_at_slot(Slot::new(6, 1));
-        assert_eq!(blocks_b6.len(), 1);
-        let block_b6 = blocks_b6.first().unwrap();
-        assert_eq!(block_b6.round(), 6);
-        assert_eq!(block_b6.author(), 1.into());
-        assert_eq!(block_b6.ancestors().len(), 5);
-        let expected_block_b6_ancestor_slots = [
-            Slot::new(5, 0),
-            Slot::new(5, 1),
-            Slot::new(5, 2),
-            Slot::new(5, 3),
-            Slot::new(0, 0),
-        ];
-        for ancestor in block_b6.ancestors() {
-            assert!(expected_block_b6_ancestor_slots.contains(&Slot::from(*ancestor)));
-        }
-
-        let blocks_c6 = dag_builder.get_uncommitted_blocks_at_slot(Slot::new(6, 2));
-        assert_eq!(blocks_c6.len(), 1);
-        let block_c6 = blocks_c6.first().unwrap();
-        assert_eq!(block_c6.round(), 6);
-        assert_eq!(block_c6.author(), 2.into());
-        assert_eq!(block_c6.ancestors().len(), 3);
-        let expected_block_c6_ancestor_slots = [Slot::new(5, 1), Slot::new(5, 2), Slot::new(5, 3)];
-        for ancestor in block_c6.ancestors() {
-            assert!(expected_block_c6_ancestor_slots.contains(&Slot::from(*ancestor)));
         }
     }
 }

--- a/crates/starfish/core/src/test_dag_parser.rs
+++ b/crates/starfish/core/src/test_dag_parser.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{char, collections::HashMap, sync::Arc};
+use std::{char, sync::Arc};
 
 use nom::{
     IResult,
@@ -11,7 +11,7 @@ use nom::{
     character::complete::{anychar, char, digit1},
     combinator::{map, map_res, opt},
     multi::{many0, separated_list0},
-    sequence::{delimited, pair, preceded, terminated, tuple},
+    sequence::{delimited, pair, preceded, separated_pair, terminated, tuple},
 };
 use starfish_config::AuthorityIndex;
 
@@ -96,9 +96,45 @@ fn parse_ancestor_selection(input: &str) -> IResult<&str, AncestorSelection> {
 /// Parses a comma-separated list of ancestor selections.
 ///
 /// # Format
-/// - Any number of entries separated by commas, e.g.: `"*,-A2,B3"`
+/// - a bracketed list of ancestor selections, e.g. `[*, -B2, C3]`
 fn parse_ancestor_selections(input: &str) -> IResult<&str, Vec<AncestorSelection>> {
-    separated_list0(char(','), parse_ancestor_selection)(input)
+    delimited(
+        char('['),
+        separated_list0(char(','), parse_ancestor_selection),
+        char(']'),
+    )(input)
+}
+/// Parses a pair of ancestor connections or a single one.
+///
+/// # Supported Formats
+/// - a comma(',') separated pair of ancestor selections delimited by '()'
+///   brackets, e.g.: `([A1,B2],[C3,-D4])`
+/// - a single list of ancestor connections, e.g.: ```text [*,-B1]```
+///
+/// # Returns
+/// A tuple of two `Vec<AncestorSelection>` where:
+/// - the first vector contains block ancestors
+/// - the second vector contains transaction acknowledgements
+///
+/// # Note:
+/// If only one selection is provided, it is duplicated for both
+fn parse_pair_of_ancestor_selections(
+    input: &str,
+) -> IResult<&str, (Vec<AncestorSelection>, Vec<AncestorSelection>)> {
+    alt((
+        delimited(
+            char('('),
+            separated_pair(
+                parse_ancestor_selections,
+                char(','),
+                parse_ancestor_selections,
+            ),
+            char(')'),
+        ),
+        map(parse_ancestor_selections, |selections| {
+            (selections.clone(), selections)
+        }),
+    ))(input)
 }
 /// Parses an author identifier followed by their ancestor selections enclosed
 /// in brackets.
@@ -106,7 +142,7 @@ fn parse_ancestor_selections(input: &str) -> IResult<&str, Vec<AncestorSelection
 /// # Format
 /// - An uppercase ASCII character representing the author (e.g. `'A'`)
 /// - Followed by the literal string `"->"`
-/// - Followed by a bracketed list of ancestor selections, e.g. `[*, -B2, C3]`
+/// - Followed by
 /// - Optionally terminated by a comma `,` (useful for parsing lists)
 ///
 /// # Returns
@@ -117,15 +153,26 @@ fn parse_ancestor_selections(input: &str) -> IResult<&str, Vec<AncestorSelection
 ///   brackets
 fn parse_author_and_connections(
     input: &str,
-) -> IResult<&str, (AuthorityIndex, Vec<AncestorSelection>)> {
-    terminated(
-        pair(
-            map(terminated(anychar, tag("->")), |author: char| {
-                (author as u32 - 'A' as u32).into()
-            }),
-            delimited(char('['), parse_ancestor_selections, char(']')),
+) -> IResult<
+    &str,
+    (
+        (AuthorityIndex, Vec<AncestorSelection>),
+        (AuthorityIndex, Vec<AncestorSelection>),
+    ),
+> {
+    map(
+        terminated(
+            pair(
+                map(terminated(anychar, tag("->")), |author: char| {
+                    AuthorityIndex::from(author as u32 - 'A' as u32)
+                }),
+                parse_pair_of_ancestor_selections,
+            ),
+            opt(char(',')),
         ),
-        opt(char(',')),
+        |(authority, (ancestors, transactions))| {
+            ((authority, ancestors), (authority, transactions))
+        },
     )(input)
 }
 /// Parses an ancestor connection specification from input.
@@ -147,7 +194,12 @@ fn parse_connections(input: &str) -> IResult<&str, AncestorConnectionSpec> {
         map(
             many0(parse_author_and_connections),
             |author_and_connections| {
-                AncestorConnectionSpec::AuthoritySpecific(author_and_connections, HashMap::new())
+                let (ancestors, transactions): (Vec<_>, Vec<_>) =
+                    author_and_connections.into_iter().unzip();
+                AncestorConnectionSpec::AuthoritySpecific(
+                    ancestors,
+                    transactions.into_iter().collect(),
+                )
             },
         ),
     ))(input)
@@ -204,7 +256,7 @@ impl<E: std::fmt::Debug> From<nom::Err<E>> for ParseDagError {
 ///
 /// Usage:
 ///
-/// ```rust
+/// ```ignore
 /// use super::test_dag_parser::parse_dag;
 /// let dag_str = "DAG {
 ///     Round 0 : { 4 },
@@ -288,8 +340,8 @@ mod tests {
             },
             Round 6 : {
                 A -> [A3, B3, C3, A1, B1],
-                B -> [*, A0],
-                C -> [-A5],
+                B -> ([*, A0],[B1, C1]),
+                C -> ([-A5],[]),
             }
          }";
         let result = parse_dag(dag_str);
@@ -316,6 +368,11 @@ mod tests {
         for ancestor in block_a6.ancestors() {
             assert!(expected_block_a6_ancestor_slots.contains(&Slot::from(*ancestor)));
         }
+        // all ancestors have corresponding acknowledgments
+        // A -> [A3, B3, C3, A1, B1]
+        for transaction_ack in block_a6.acknowledgments() {
+            assert!(expected_block_a6_ancestor_slots.contains(&Slot::from(*transaction_ack)));
+        }
 
         let blocks_b6 = dag_builder.get_uncommitted_blocks_at_slot(Slot::new(6, 1));
         assert_eq!(blocks_b6.len(), 1);
@@ -330,8 +387,15 @@ mod tests {
             Slot::new(5, 3),
             Slot::new(0, 0),
         ];
+        let expected_block_b6_acknowledgments_slots = [Slot::new(1, 1), Slot::new(1, 2)];
         for ancestor in block_b6.ancestors() {
             assert!(expected_block_b6_ancestor_slots.contains(&Slot::from(*ancestor)));
+        }
+        // B -> ([*, A0],[B1, C1]),
+        for transaction_ack in block_a6.acknowledgments() {
+            assert!(
+                expected_block_b6_acknowledgments_slots.contains(&Slot::from(*transaction_ack))
+            );
         }
 
         let blocks_c6 = dag_builder.get_uncommitted_blocks_at_slot(Slot::new(6, 2));
@@ -344,6 +408,8 @@ mod tests {
         for ancestor in block_c6.ancestors() {
             assert!(expected_block_c6_ancestor_slots.contains(&Slot::from(*ancestor)));
         }
+        // C -> ([-A5],[]),
+        assert_eq!(block_c6.acknowledgments().len(), 0);
     }
 
     #[tokio::test]
@@ -354,6 +420,23 @@ mod tests {
         let (_, num_authorities) = result.unwrap();
 
         assert_eq!(num_authorities, 4);
+    }
+
+    #[tokio::test]
+    async fn test_parse_pair_of_ancestor_selections() {
+        let dag_str = "([A1,B2],[C3,-D4])";
+        let expected_block_ancestors = parse_ancestor_selections("[A1,B2]").unwrap().1;
+        let expected_transaction_acknowledgements =
+            parse_ancestor_selections("[C3,-D4]").unwrap().1;
+        let result = parse_pair_of_ancestor_selections(dag_str);
+        assert!(result.is_ok());
+        let (_, (block_ancestors, transaction_acknowledgements)) = result.unwrap();
+
+        assert_eq!(block_ancestors, expected_block_ancestors,);
+        assert_eq!(
+            transaction_acknowledgements,
+            expected_transaction_acknowledgements,
+        );
     }
 
     #[tokio::test]
@@ -373,6 +456,14 @@ mod tests {
     #[tokio::test]
     async fn test_specific_round_parsing() {
         let dag_str = "Round1:{A->[A0,B0,C0,D0],B->[*,A0],C->[-A0],}";
+        let expected_ancestors_for_a = parse_ancestor_selections("[A0,B0,C0,D0]").unwrap().1;
+        let expected_ancestors_for_b = parse_ancestor_selections("[*,A0]").unwrap().1;
+        let expected_ancestors_for_c = parse_ancestor_selections("[-A0]").unwrap().1;
+        let expected_vector = vec![
+            (0.into(), expected_ancestors_for_a),
+            (1.into(), expected_ancestors_for_b),
+            (2.into(), expected_ancestors_for_c),
+        ];
         let result = parse_round(dag_str);
         assert!(result.is_ok());
         let (_, (round, ancestor_connection_spec)) = result.unwrap();
@@ -380,29 +471,8 @@ mod tests {
         assert_eq!(
             ancestor_connection_spec,
             AncestorConnectionSpec::AuthoritySpecific(
-                vec![
-                    (
-                        0.into(),
-                        vec![
-                            AncestorSelection::IncludeFrom(Slot::new(0, 0)),
-                            AncestorSelection::IncludeFrom(Slot::new(0, 1)),
-                            AncestorSelection::IncludeFrom(Slot::new(0, 2)),
-                            AncestorSelection::IncludeFrom(Slot::new(0, 3))
-                        ]
-                    ),
-                    (
-                        1.into(),
-                        vec![
-                            AncestorSelection::UseLast,
-                            AncestorSelection::IncludeFrom(Slot::new(0, 0))
-                        ]
-                    ),
-                    (
-                        2.into(),
-                        vec![AncestorSelection::ExcludeFrom(Slot::new(0, 0))]
-                    ),
-                ],
-                HashMap::new()
+                expected_vector.clone(),
+                expected_vector.into_iter().collect()
             )
         );
     }
@@ -415,7 +485,7 @@ mod tests {
         let dag_str = "A->[*]";
         let result = parse_author_and_connections(dag_str);
         assert!(result.is_ok());
-        let (_, (actual_author, actual_connections)) = result.unwrap();
+        let (_, ((actual_author, actual_connections), _)) = result.unwrap();
         assert_eq!(actual_author, expected_authority);
         assert_eq!(actual_connections, vec![AncestorSelection::UseLast]);
 
@@ -423,7 +493,7 @@ mod tests {
         let dag_str = "A->[A0,B0,C0]";
         let result = parse_author_and_connections(dag_str);
         assert!(result.is_ok());
-        let (_, (actual_author, actual_connections)) = result.unwrap();
+        let (_, ((actual_author, actual_connections), _)) = result.unwrap();
         assert_eq!(actual_author, expected_authority);
         assert_eq!(
             actual_connections,
@@ -438,7 +508,7 @@ mod tests {
         let dag_str = "A->[-A0,-B0]";
         let result = parse_author_and_connections(dag_str);
         assert!(result.is_ok());
-        let (_, (actual_author, actual_connections)) = result.unwrap();
+        let (_, ((actual_author, actual_connections), _)) = result.unwrap();
         assert_eq!(actual_author, expected_authority);
         assert_eq!(
             actual_connections,
@@ -452,7 +522,7 @@ mod tests {
         let dag_str = "A->[*,A0,-B0]";
         let result = parse_author_and_connections(dag_str);
         assert!(result.is_ok());
-        let (_, (actual_author, actual_connections)) = result.unwrap();
+        let (_, ((actual_author, actual_connections), _)) = result.unwrap();
         assert_eq!(actual_author, expected_authority);
         assert_eq!(
             actual_connections,


### PR DESCRIPTION
# Description of change

Adds support for transaction acknowledgements in `test_dag_parser`.

## Implementation
- `parse_pair_of_ancestor_selections` - was added to handle a tuple of ancestor selections
- other parsed in the stack were modified to accommodate this
- `test_parse_pair_of_ancestor_selections` was added
-  `test_dag_parsing` was modified to include transaction_acknowledgment tuples
- `test_dag_builder` was modified to now support transaction_acknowledgments being passed via `layer_with_connections` from `test_dag_parser`.

## Usage
Similarly to how specifying ancestors works in the DAG string, the transaction acknowledgements are added as an optional tuple. ```A -> ( [A1, B3 ], [C4, D5] )```.
- When no tuple is given, e.g: ``` B -> [*, A0]``` -  transactions acknowledgements are copied from the ancestors
- Wildcard is used, e.g: ```A -> ( [A1, B3 ], [*] )``` - transaction acknowledgements from `last_ancestors` are added
- Specific slot is used, e.g: ```A -> ( [A1, B3 ], [C5] )``` - transaction acknowledgements from the specified slot are added
- Specific slot with `-` prefix, e.g: ```A -> ( [A1, B3 ], [-C5] )``` - transaction acknowledgements from 'last_ancestors' except those in slot `C5` are added.
- empty array, e.g.: ```A -> ( [A1, B3 ], [-C5] )``` - no transaction acknowledgements are added

## Links to any relevant issues
fixes  #7257
## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
