### PR TITLE
feat(starfish): batching in synchronizer

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -41,9 +41,13 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_max_forward_time_drift")]
     pub max_forward_time_drift: Duration,
 
-    /// Number of blocks to fetch per request.
-    #[serde(default = "Parameters::default_max_block_headers_per_fetch")]
-    pub max_block_headers_per_fetch: usize,
+    /// Number of block headers to fetch per commit sync request.
+    #[serde(default = "Parameters::default_max_headers_per_commit_sync_fetch")]
+    pub max_headers_per_commit_sync_fetch: usize,
+
+    /// Number of block headers to fetch per periodic or live sync request
+    #[serde(default = "Parameters::default_max_headers_per_regular_sync_fetch")]
+    pub max_headers_per_regular_sync_fetch: usize,
 
     /// Number of transactions to fetch per request.
     #[serde(default = "Parameters::default_max_transactions_per_fetch")]
@@ -124,8 +128,8 @@ impl Parameters {
         Duration::from_millis(500)
     }
 
-    pub(crate) fn default_max_block_headers_per_fetch() -> usize {
-        // TODO: set some sensible value adjusted for Starfish
+    // Maximum number of block headers to fetch per commit sync request.
+    pub(crate) fn default_max_headers_per_commit_sync_fetch() -> usize {
         if cfg!(msim) {
             // Exercise hitting blocks per fetch limit.
             10
@@ -134,14 +138,20 @@ impl Parameters {
         }
     }
 
-    pub(crate) fn default_max_transactions_per_fetch() -> usize {
-        // TODO: set some sensible value adjusted for Starfish
+    // Maximum number of block headers to fetch per periodic or live sync request.
+    pub(crate) fn default_max_headers_per_regular_sync_fetch() -> usize {
         if cfg!(msim) {
             // Exercise hitting blocks per fetch limit.
             10
         } else {
-            1000
+            // TODO: This might should match the value of block headers in the bundle.
+            100
         }
+    }
+
+    // Maximum number of block headers to fetch per periodic or live sync request.
+    pub(crate) fn default_max_transactions_per_fetch() -> usize {
+        if cfg!(msim) { 10 } else { 1000 }
     }
 
     pub(crate) fn default_sync_last_known_own_block_timeout() -> Duration {
@@ -205,7 +215,10 @@ impl Default for Parameters {
             leader_timeout: Parameters::default_leader_timeout(),
             min_round_delay: Parameters::default_min_round_delay(),
             max_forward_time_drift: Parameters::default_max_forward_time_drift(),
-            max_block_headers_per_fetch: Parameters::default_max_block_headers_per_fetch(),
+            max_headers_per_commit_sync_fetch:
+                Parameters::default_max_headers_per_commit_sync_fetch(),
+            max_headers_per_regular_sync_fetch:
+                Parameters::default_max_headers_per_regular_sync_fetch(),
             max_transactions_per_fetch: Parameters::default_max_transactions_per_fetch(),
             sync_last_known_own_block_timeout:
                 Parameters::default_sync_last_known_own_block_timeout(),

--- a/crates/starfish/core/build.rs
+++ b/crates/starfish/core/build.rs
@@ -28,17 +28,6 @@ fn build_tonic_services(out_dir: &Path) {
         .comment("Consensus authority interface")
         .method(
             tonic_build::manual::Method::builder()
-                .name("subscribe_blocks")
-                .route_name("SubscribeBlocks")
-                .input_type("crate::network::tonic_network::SubscribeBlocksRequest")
-                .output_type("crate::network::tonic_network::SubscribeBlocksResponse")
-                .codec_path(codec_path)
-                .server_streaming()
-                .client_streaming()
-                .build(),
-        )
-        .method(
-            tonic_build::manual::Method::builder()
                 .name("subscribe_block_bundles")
                 .route_name("SubscribeBlockBundles")
                 .input_type("crate::network::tonic_network::SubscribeBlockBundlesRequest")
@@ -54,16 +43,6 @@ fn build_tonic_services(out_dir: &Path) {
                 .route_name("FetchBlockHeaders")
                 .input_type("crate::network::tonic_network::FetchBlockHeadersRequest")
                 .output_type("crate::network::tonic_network::FetchBlockHeadersResponse")
-                .codec_path(codec_path)
-                .server_streaming()
-                .build(),
-        )
-        .method(
-            tonic_build::manual::Method::builder()
-                .name("fetch_blocks")
-                .route_name("FetchBlocks")
-                .input_type("crate::network::tonic_network::FetchBlocksRequest")
-                .output_type("crate::network::tonic_network::FetchBlocksResponse")
                 .codec_path(codec_path)
                 .server_streaming()
                 .build(),

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -386,7 +386,8 @@ mod tests {
     // TODO: add transactions to control how the consensus works
     #[rstest]
     #[tokio::test(flavor = "current_thread")]
-    async fn test_authority_committee() {
+    async fn test_restart_authority_committee() {
+        telemetry_subscribers::init_for_testing();
         let db_registry = Registry::new();
         DBMetrics::init(&db_registry);
 
@@ -436,7 +437,6 @@ mod tests {
         output_receivers[index] = receiver;
         authorities.insert(index.value(), authority);
         sleep(Duration::from_secs(10)).await;
-
         // Stop all authorities and exit.
         for authority in authorities {
             authority.stop().await;

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -2,7 +2,12 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::VecDeque, pin::Pin, sync::Arc, time::Duration};
+use std::{
+    collections::{BTreeMap, VecDeque},
+    pin::Pin,
+    sync::Arc,
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -32,9 +37,8 @@ use crate::{
     dag_state::{DagState, MAX_HEADERS_PER_BUNDLE},
     error::{ConsensusError, ConsensusResult},
     network::{
-        BlockBundle, BlockBundleStream, BlockStream, NetworkService, SerializedBlock,
-        SerializedBlockAndHeaders, SerializedBlockBundle, SerializedHeaderAndTransactions,
-        SerializedTransactions,
+        BlockBundle, BlockBundleStream, NetworkService, SerializedBlock, SerializedBlockAndHeaders,
+        SerializedBlockBundle, SerializedHeaderAndTransactions, SerializedTransactions,
     },
     stake_aggregator::{QuorumThreshold, StakeAggregator},
     storage::Store,
@@ -140,205 +144,6 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
 
 #[async_trait]
 impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
-    #[cfg(test)]
-    async fn handle_subscribed_block(
-        &self,
-        peer: AuthorityIndex,
-        serialized_block: SerializedBlock,
-    ) -> ConsensusResult<()> {
-        fail_point_async!("consensus-rpc-response");
-
-        let peer_hostname = &self.context.committee.authority(peer).hostname;
-        let SerializedHeaderAndTransactions {
-            serialized_block_header,
-            serialized_transactions,
-        } = SerializedHeaderAndTransactions::try_from(serialized_block)?;
-        let signed_block_header: SignedBlockHeader = bcs::from_bytes(&serialized_block_header)
-            .map_err(ConsensusError::MalformedBlockHeader)?;
-
-        // Reject blocks not produced by the peer.
-        if peer != signed_block_header.author() {
-            self.context
-                .metrics
-                .node_metrics
-                .invalid_blocks
-                .with_label_values(&[
-                    peer_hostname.as_str(),
-                    "handle_subscribed_block",
-                    "UnexpectedAuthority",
-                ])
-                .inc();
-            let e = ConsensusError::UnexpectedAuthority(signed_block_header.author(), peer);
-            info!("Block with wrong authority from {}: {}", peer, e);
-            return Err(e);
-        }
-
-        if let Err(e) = self.block_verifier.verify(&signed_block_header) {
-            self.context
-                .metrics
-                .node_metrics
-                .invalid_blocks
-                .with_label_values(&[
-                    peer_hostname.as_str(),
-                    "handle_subscribed_block",
-                    e.clone().name(),
-                ])
-                .inc();
-            info!("Invalid block from {}: {}", peer, e);
-            return Err(e);
-        }
-
-        if signed_block_header.transactions_commitment()
-            != TransactionsCommitment::compute_transactions_commitment(&serialized_transactions)
-                .expect("we should expect correct computation of the transactions commitment")
-        {
-            return Err(ConsensusError::TransactionCommitmentFailure {
-                round: signed_block_header.round(),
-                author: signed_block_header.author(),
-                peer,
-            });
-        }
-
-        let verified_block_header =
-            VerifiedBlockHeader::new_verified(signed_block_header, serialized_block_header);
-        let transactions: Vec<Transaction> = bcs::from_bytes(&serialized_transactions)
-            .map_err(ConsensusError::MalformedTransactions)?;
-        self.block_verifier
-            .check_and_verify_transactions(&transactions)?;
-        let verified_transactions = VerifiedTransactions::new(
-            transactions,
-            verified_block_header.reference(),
-            verified_block_header.transactions_commitment(),
-            serialized_transactions,
-        );
-        let verified_block = VerifiedBlock::new(verified_block_header, verified_transactions);
-
-        let block_ref = verified_block.reference();
-        debug!("Received block {} via subscribed block.", block_ref);
-
-        // Reject block with timestamp too far in the future.
-        let now = self.context.clock.timestamp_utc_ms();
-        let forward_time_drift =
-            Duration::from_millis(verified_block.timestamp_ms().saturating_sub(now));
-        if forward_time_drift > self.context.parameters.max_forward_time_drift {
-            self.context
-                .metrics
-                .node_metrics
-                .rejected_future_blocks
-                .with_label_values(&[peer_hostname])
-                .inc();
-            debug!(
-                "Block {:?} timestamp ({} > {}) is too far in the future, rejected.",
-                block_ref,
-                verified_block.timestamp_ms(),
-                now,
-            );
-            return Err(ConsensusError::BlockRejected {
-                block_ref,
-                reason: format!(
-                    "Block timestamp is too far in the future: {} > {}",
-                    verified_block.timestamp_ms(),
-                    now
-                ),
-            });
-        }
-
-        // Wait until the block's timestamp is current.
-        if forward_time_drift > Duration::ZERO {
-            self.context
-                .metrics
-                .node_metrics
-                .block_timestamp_drift_wait_ms
-                .with_label_values(&[peer_hostname.as_str(), "handle_subscribed_block"])
-                .inc_by(forward_time_drift.as_millis() as u64);
-            debug!(
-                "Block {:?} timestamp ({} > {}) is in the future, waiting for {}ms",
-                block_ref,
-                verified_block.timestamp_ms(),
-                now,
-                forward_time_drift.as_millis(),
-            );
-            sleep(forward_time_drift).await;
-        }
-
-        // Observe the block for the commit votes. When local commit is lagging too
-        // much, commit sync loop will trigger fetching.
-        self.commit_vote_monitor.observe_block(&verified_block);
-
-        // Reject blocks when local commit index is lagging too far from quorum commit
-        // index.
-        //
-        // IMPORTANT: this must be done after observing votes from the block, otherwise
-        // observed quorum commit will no longer progress.
-        //
-        // Since the main issue with too many suspended blocks is memory usage not CPU,
-        // it is ok to reject after block verifications instead of before.
-        let last_commit_index = self.dag_state.read().last_commit_index();
-        let quorum_commit_index = self.commit_vote_monitor.quorum_commit_index();
-        // The threshold to ignore block should be larger than commit_sync_batch_size,
-        // to avoid excessive block rejections and synchronizations.
-        if last_commit_index
-            + self.context.parameters.commit_sync_batch_size * COMMIT_LAG_MULTIPLIER
-            < quorum_commit_index
-        {
-            self.context
-                .metrics
-                .node_metrics
-                .rejected_blocks
-                .with_label_values(&["commit_lagging"])
-                .inc();
-            debug!(
-                "Block {:?} is rejected because last commit index is lagging quorum commit index too much ({} < {})",
-                block_ref, last_commit_index, quorum_commit_index,
-            );
-            return Err(ConsensusError::BlockRejected {
-                block_ref,
-                reason: format!(
-                    "Last commit index is lagging quorum commit index too much ({} < {})",
-                    last_commit_index, quorum_commit_index,
-                ),
-            });
-        }
-
-        self.context
-            .metrics
-            .node_metrics
-            .verified_blocks
-            .with_label_values(&[peer_hostname])
-            .inc();
-
-        let (missing_ancestors, missing_committed_txns) = self
-            .core_dispatcher
-            .add_blocks(vec![verified_block])
-            .await
-            .map_err(|_| ConsensusError::Shutdown)?;
-
-        if !missing_ancestors.is_empty() {
-            // schedule the fetching of them from this peer
-            if let Err(err) = self
-                .synchronizer
-                .fetch_block_headers(missing_ancestors, peer)
-                .await
-            {
-                warn!("Errored while trying to fetch missing ancestors via synchronizer: {err}");
-            }
-        }
-        if !missing_committed_txns.is_empty() {
-            // Also fetch missing transactions for these blocks
-            if let Err(err) = self
-                .transactions_synchronizer
-                .fetch_transactions(missing_committed_txns)
-                .await
-            {
-                warn!(
-                    "Errored while trying to fetch missing transactions via transactions synchronizer: {err}"
-                );
-            }
-        }
-
-        Ok(())
-    }
-
     async fn handle_subscribed_block_bundle(
         &self,
         peer: AuthorityIndex,
@@ -357,8 +162,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             serialized_block: serialized_block_and_headers.serialized_block,
         })?;
 
-        let signed_block_header: SignedBlockHeader = bcs::from_bytes(&serialized_block_header)
-            .map_err(ConsensusError::MalformedBlockHeader)?;
+        let signed_block_header: SignedBlockHeader =
+            bcs::from_bytes(&serialized_block_header).map_err(ConsensusError::MalformedHeader)?;
 
         // Reject blocks not produced by the peer.
         if peer != signed_block_header.author() {
@@ -489,8 +294,8 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 continue;
             }
 
-            let signed_block_header: SignedBlockHeader = bcs::from_bytes(&serialized_header)
-                .map_err(ConsensusError::MalformedBlockHeader)?;
+            let signed_block_header: SignedBlockHeader =
+                bcs::from_bytes(&serialized_header).map_err(ConsensusError::MalformedHeader)?;
 
             let header_round = signed_block_header.round();
             if header_round >= verified_block.round() {
@@ -665,7 +470,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             // 10. schedule the fetching of missing ancestors from this peer
             if let Err(err) = self
                 .synchronizer
-                .fetch_block_headers(missing_ancestors, peer)
+                .fetch_headers(missing_ancestors, peer)
                 .await
             {
                 warn!("Errored while trying to fetch missing ancestors via synchronizer: {err}");
@@ -685,40 +490,6 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             }
         }
         Ok(())
-    }
-
-    async fn handle_subscribe_blocks(
-        &self,
-        peer: AuthorityIndex,
-        last_received: Round,
-    ) -> ConsensusResult<BlockStream> {
-        fail_point_async!("consensus-rpc-response");
-
-        let dag_state = self.dag_state.read();
-        // Find recent own blocks that have not been received by the peer.
-        // If last_received is a valid and more blocks have been proposed since then,
-        // this call is guaranteed to return at least some recent blocks, which
-        // will help with liveness.
-        let missed_blocks = stream::iter(
-            dag_state
-                .get_cached_blocks(self.context.own_index, last_received + 1)
-                .into_iter()
-                // TODO::deal with possible error in try_from
-                .map(|block| SerializedBlock::try_from(block).unwrap()),
-        );
-
-        let broadcasted_blocks = BroadcastedBlockStream::new(
-            peer,
-            self.rx_block_broadcaster.resubscribe(),
-            self.subscription_counter.clone(),
-        );
-
-        // Return a stream of blocks that first yields missed blocks as requested, then
-        // new blocks.
-        // TODO::deal with possible error in try_from
-        Ok(Box::pin(missed_blocks.chain(
-            broadcasted_blocks.map(|block| SerializedBlock::try_from(block).unwrap()),
-        )))
     }
 
     async fn handle_subscribe_block_bundles_request(
@@ -767,17 +538,32 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         })))
     }
 
-    async fn handle_fetch_block_headers(
+    // Handles two types of fetch headers requests:
+    // 1. Missing block headers for regular sync:
+    //    - uses highest_accepted_rounds.
+    //    - at most max_blocks_per_regular_sync blocks should be returned.
+    // 2. Committed block headers for commit sync:
+    //    - does not use highest_accepted_rounds.
+    //    - at most max_blocks_per_commit_sync blocks should be returned.
+    async fn handle_fetch_headers(
         &self,
         peer: AuthorityIndex,
-        block_refs: Vec<BlockRef>,
+        mut block_refs: Vec<BlockRef>,
         highest_accepted_rounds: Vec<Round>,
     ) -> ConsensusResult<Vec<Bytes>> {
         fail_point_async!("consensus-rpc-response");
 
-        const MAX_ADDITIONAL_BLOCKS: usize = 10;
-        if block_refs.len() > self.context.parameters.max_block_headers_per_fetch {
-            return Err(ConsensusError::TooManyFetchBlockHeadersRequested(peer));
+        // Some quick validation of the requested block refs
+        for block in &block_refs {
+            if !self.context.committee.is_valid_index(block.author) {
+                return Err(ConsensusError::InvalidAuthorityIndex {
+                    index: block.author,
+                    max: self.context.committee.size(),
+                });
+            }
+            if block.round == GENESIS_ROUND {
+                return Err(ConsensusError::UnexpectedGenesisHeaderRequested);
+            }
         }
 
         if !highest_accepted_rounds.is_empty()
@@ -789,118 +575,97 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             ));
         }
 
-        // Some quick validation of the requested block refs
-        for block in &block_refs {
-            if !self.context.committee.is_valid_index(block.author) {
-                return Err(ConsensusError::InvalidAuthorityIndex {
-                    index: block.author,
-                    max: self.context.committee.size(),
-                });
-            }
-            if block.round == GENESIS_ROUND {
-                return Err(ConsensusError::UnexpectedGenesisBlockHeaderRequested);
-            }
+        // This method is used for both commit sync and periodic/live synchronizer.
+        // For commit sync, we do not use highest_accepted_rounds and the fetch size is
+        // larger.
+        let commit_sync_handle = highest_accepted_rounds.is_empty();
+
+        // For commit sync, the fetch size is larger. For periodic/live synchronizer,
+        // the fetch size is smaller.else { Instead of rejecting the request, we
+        // truncate the size to allow an easy update of this parameter in the future.
+        let max_fetch_size = if commit_sync_handle {
+            self.context.parameters.max_headers_per_commit_sync_fetch
+        } else {
+            self.context.parameters.max_headers_per_regular_sync_fetch
+        };
+
+        if block_refs.len() > max_fetch_size {
+            // TODO: we might need to reevaluate whether we want to reject such a request
+            // or just truncate the size. Simple truncating with warning allows for easier
+            // upgradability in future until the size of requests is settled
+            return Err(ConsensusError::TooManyFetchHeadersRequested(peer));
         }
 
-        // For now ask dag state directly
-        let block_headers = self.dag_state.read().get_block_headers(&block_refs);
-
-        // Now check if an ancestor's round is higher than the one that the peer has. If
-        // yes, then serve that ancestor blocks up to `MAX_ADDITIONAL_BLOCKS`.
-        let mut ancestor_block_headers = vec![];
-        if !highest_accepted_rounds.is_empty() {
-            let all_ancestors = block_headers
-                .iter()
+        // Get requested blocks from store.
+        let blocks = if commit_sync_handle {
+            // For commit sync, we respond with all blocks from the store
+            self.dag_state
+                .read()
+                .get_block_headers(&block_refs)
+                .into_iter()
                 .flatten()
-                .flat_map(|block| block.ancestors().to_vec())
-                .filter(|block_ref| highest_accepted_rounds[block_ref.author] < block_ref.round)
-                .take(MAX_ADDITIONAL_BLOCKS)
+                .collect()
+        } else {
+            // For periodic or live synchronizer, we respond with requested blocks from the
+            // store and with additional blocks from the cache
+            block_refs.sort();
+            block_refs.dedup();
+            let dag_state = self.dag_state.read();
+            let mut blocks = dag_state
+                .get_block_headers(&block_refs)
+                .into_iter()
+                .flatten()
                 .collect::<Vec<_>>();
 
-            if !all_ancestors.is_empty() {
-                ancestor_block_headers = self.dag_state.read().get_block_headers(&all_ancestors);
+            // Get additional blocks for authorities with missing block, if they are
+            // available in cache. Compute the lowest missing round per
+            // requested authority.
+            let mut lowest_missing_rounds = BTreeMap::<AuthorityIndex, Round>::new();
+            for block_ref in blocks.iter().map(|b| b.reference()) {
+                let entry = lowest_missing_rounds
+                    .entry(block_ref.author)
+                    .or_insert(block_ref.round);
+                *entry = (*entry).min(block_ref.round);
             }
-        }
+            // Retrieve additional blocks per authority, from peer's highest accepted round
+            // + 1 to lowest missing round (exclusive) per requested authority. Start with
+            //   own blocks.
+            let own_index = self.context.own_index;
 
-        // Return the serialised blocks & the ancestor blocks
-        let result = block_headers
+            // Collect and sort so own_index comes first
+            let mut ordered_missing_rounds: Vec<_> = lowest_missing_rounds.into_iter().collect();
+            ordered_missing_rounds.sort_by_key(|(auth, _)| if *auth == own_index { 0 } else { 1 });
+
+            for (authority, lowest_missing_round) in ordered_missing_rounds {
+                let highest_accepted_round = highest_accepted_rounds[authority];
+                if highest_accepted_round >= lowest_missing_round {
+                    continue;
+                }
+
+                let missing_blocks = dag_state.get_cached_block_headers_in_range(
+                    authority,
+                    highest_accepted_round + 1,
+                    lowest_missing_round,
+                    self.context
+                        .parameters
+                        .max_headers_per_regular_sync_fetch
+                        .saturating_sub(blocks.len()),
+                );
+                blocks.extend(missing_blocks);
+                if blocks.len() >= self.context.parameters.max_headers_per_regular_sync_fetch {
+                    blocks.truncate(self.context.parameters.max_headers_per_regular_sync_fetch);
+                    break;
+                }
+            }
+
+            blocks
+        };
+        // Return the serialized blocks
+        let bytes = blocks
             .into_iter()
-            .chain(ancestor_block_headers)
-            .flatten()
-            .map(|block_header| block_header.serialized().clone())
-            .collect();
-
-        Ok(result)
-    }
-
-    async fn handle_fetch_blocks(
-        &self,
-        peer: AuthorityIndex,
-        block_refs: Vec<BlockRef>,
-        highest_accepted_rounds: Vec<Round>,
-    ) -> ConsensusResult<Vec<Bytes>> {
-        fail_point_async!("consensus-rpc-response");
-
-        const MAX_ADDITIONAL_BLOCKS: usize = 10;
-        if block_refs.len() > self.context.parameters.max_block_headers_per_fetch {
-            return Err(ConsensusError::TooManyFetchBlocksRequested(peer));
-        }
-
-        if !highest_accepted_rounds.is_empty()
-            && highest_accepted_rounds.len() != self.context.committee.size()
-        {
-            return Err(ConsensusError::InvalidSizeOfHighestAcceptedRounds(
-                highest_accepted_rounds.len(),
-                self.context.committee.size(),
-            ));
-        }
-
-        // Some quick validation of the requested block refs
-        for block in &block_refs {
-            if !self.context.committee.is_valid_index(block.author) {
-                return Err(ConsensusError::InvalidAuthorityIndex {
-                    index: block.author,
-                    max: self.context.committee.size(),
-                });
-            }
-            if block.round == GENESIS_ROUND {
-                return Err(ConsensusError::UnexpectedGenesisBlockRequested);
-            }
-        }
-
-        // For now ask dag state directly
-        let blocks = self.dag_state.read().get_blocks(&block_refs);
-
-        // Now check if an ancestor's round is higher than the one that the peer has. If
-        // yes, then serve that ancestor blocks up to `MAX_ADDITIONAL_BLOCKS`.
-        let mut ancestor_blocks = vec![];
-        // TODO: remove additional blocks and highest_accepted_rounds
-        if !highest_accepted_rounds.is_empty() {
-            let all_ancestors = blocks
-                .iter()
-                .flatten()
-                .flat_map(|block| block.ancestors().to_vec())
-                .filter(|block_ref| highest_accepted_rounds[block_ref.author] < block_ref.round)
-                .take(MAX_ADDITIONAL_BLOCKS)
-                .collect::<Vec<_>>();
-
-            if !all_ancestors.is_empty() {
-                ancestor_blocks = self.dag_state.read().get_blocks(&all_ancestors);
-            }
-        }
-
-        // Return the serialised headers and transactions for blocks & their ancestors
-        let result = blocks
-            .into_iter()
-            .chain(ancestor_blocks)
-            .flatten()
-            .map(|block| {
-                // TODO::propagate error correctly
-                SerializedBlock::try_from(block).unwrap().serialized_block
-            })
-            .collect();
-
-        Ok(result)
+            .map(|block| block.serialized().clone())
+            .collect::<Vec<_>>();
+        Ok(bytes)
     }
 
     async fn handle_fetch_commits(
@@ -1051,7 +816,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 });
             }
             if block.round == GENESIS_ROUND {
-                return Err(ConsensusError::UnexpectedGenesisBlockRequested);
+                return Err(ConsensusError::UnexpectedGenesisTransactionsRequested);
             }
         }
 
@@ -1328,8 +1093,8 @@ mod tests {
         error::ConsensusResult,
         leader_schedule::LeaderSchedule,
         network::{
-            BlockBundle, BlockBundleStream, BlockStream, NetworkClient, NetworkService,
-            SerializedBlock, SerializedBlockAndHeaders, SerializedBlockBundle,
+            BlockBundle, BlockBundleStream, NetworkClient, NetworkService,
+            SerializedBlockAndHeaders, SerializedBlockBundle,
         },
         storage::mem_store::MemStore,
         synchronizer::Synchronizer,
@@ -1343,31 +1108,12 @@ mod tests {
 
     #[async_trait]
     impl NetworkClient for FakeNetworkClient {
-        async fn subscribe_blocks(
-            &self,
-            _peer: AuthorityIndex,
-            _last_received: Round,
-            _timeout: Duration,
-        ) -> ConsensusResult<BlockStream> {
-            unimplemented!("Unimplemented")
-        }
-
         async fn subscribe_block_bundles(
             &self,
             _peer: AuthorityIndex,
             _last_received: Round,
             _timeout: Duration,
         ) -> ConsensusResult<BlockBundleStream> {
-            unimplemented!("Unimplemented")
-        }
-
-        async fn fetch_blocks(
-            &self,
-            _peer: AuthorityIndex,
-            _block_refs: Vec<BlockRef>,
-            _highest_accepted_rounds: Vec<Round>,
-            _timeout: Duration,
-        ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Unimplemented")
         }
 
@@ -1411,7 +1157,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_handle_subscribed_block() {
+    async fn test_handle_subscribed_block_bundle() {
         let (context, _keys) = Context::new_for_test(4);
         let context = Arc::new(context);
         let block_verifier = Arc::new(crate::block_verifier::NoopBlockVerifier {});
@@ -1462,13 +1208,12 @@ mod tests {
         );
 
         let service = authority_service.clone();
-        let serialized_block = SerializedBlock::try_from(input_block.clone()).unwrap();
-
+        let serialized_block_bundle = SerializedBlockBundle::try_from(input_block.clone()).unwrap();
         tokio::spawn(async move {
             service
-                .handle_subscribed_block(
+                .handle_subscribed_block_bundle(
                     context.committee.to_authority_index(0).unwrap(),
-                    serialized_block,
+                    serialized_block_bundle,
                 )
                 .await
                 .unwrap();

--- a/crates/starfish/core/src/base_committer.rs
+++ b/crates/starfish/core/src/base_committer.rs
@@ -197,7 +197,7 @@ impl BaseCommitter {
             let ancestor = self
                 .dag_state
                 .read()
-                .get_block(ancestor)
+                .get_block_header(ancestor)
                 .unwrap_or_else(|| panic!("Block not found in storage: {:?}", ancestor));
             if let Some(support) = self.find_supported_block(leader_slot, &ancestor) {
                 return Some(support);

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -554,8 +554,8 @@ impl VerifiedBlockHeader {
     }
 
     pub(crate) fn new_from_bytes(serialized_block_header: Bytes) -> ConsensusResult<Self> {
-        let signed_block_header: SignedBlockHeader = bcs::from_bytes(&serialized_block_header)
-            .map_err(ConsensusError::MalformedBlockHeader)?;
+        let signed_block_header: SignedBlockHeader =
+            bcs::from_bytes(&serialized_block_header).map_err(ConsensusError::MalformedHeader)?;
 
         // Only accepted blocks should have been written to storage.
         Ok(VerifiedBlockHeader::new_verified(
@@ -787,7 +787,7 @@ impl TryFrom<SerializedHeaderAndTransactions> for VerifiedBlock {
     fn try_from(serialized_block: SerializedHeaderAndTransactions) -> ConsensusResult<Self> {
         let signed_block_header: SignedBlockHeader =
             bcs::from_bytes(&serialized_block.serialized_block_header)
-                .map_err(ConsensusError::MalformedBlockHeader)?;
+                .map_err(ConsensusError::MalformedHeader)?;
         let transactions: Vec<Transaction> =
             bcs::from_bytes(&serialized_block.serialized_transactions)
                 .map_err(ConsensusError::MalformedTransactions)?;

--- a/crates/starfish/core/src/block_verifier.rs
+++ b/crates/starfish/core/src/block_verifier.rs
@@ -110,7 +110,7 @@ impl BlockVerifier for SignedBlockVerifier {
             });
         }
         if block.round() == 0 {
-            return Err(ConsensusError::UnexpectedGenesisBlock);
+            return Err(ConsensusError::UnexpectedGenesisHeader);
         }
         if !committee.is_valid_index(block.author()) {
             return Err(ConsensusError::InvalidAuthorityIndex {
@@ -310,7 +310,7 @@ pub(crate) mod test {
             let signed_block = SignedBlockHeader::new(block, authority_2_protocol_keypair).unwrap();
             assert!(matches!(
                 verifier.verify(&signed_block),
-                Err(ConsensusError::UnexpectedGenesisBlock)
+                Err(ConsensusError::UnexpectedGenesisHeader)
             ));
         }
 

--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -599,10 +599,10 @@ impl<C: NetworkClient> CommitSyncer<C> {
         let block_refs: Vec<_> = commits.iter().flat_map(|c| c.blocks()).cloned().collect();
         let num_chunks = block_refs
             .len()
-            .div_ceil(inner.context.parameters.max_block_headers_per_fetch)
+            .div_ceil(inner.context.parameters.max_headers_per_commit_sync_fetch)
             as u32;
         let mut requests: FuturesOrdered<_> = block_refs
-            .chunks(inner.context.parameters.max_block_headers_per_fetch)
+            .chunks(inner.context.parameters.max_headers_per_commit_sync_fetch)
             .enumerate()
             .map(|(i, request_block_refs)| {
                 let inner = inner.clone();
@@ -622,10 +622,10 @@ impl<C: NetworkClient> CommitSyncer<C> {
                         .await?;
                     // 5. Verify the same number of block headers is returned as requested.
                     if request_block_refs.len() != serialized_block_headers.len() {
-                        return Err(ConsensusError::UnexpectedNumberOfBlockHeadersFetched {
+                        return Err(ConsensusError::UnexpectedNumberOfHeadersFetched {
                             authority: target_authority,
                             requested: request_block_refs.len(),
-                            received_block_headers: serialized_block_headers.len(),
+                            received_headers: serialized_block_headers.len(),
                         });
                     }
                     // 6. Verify returned block headers have valid formats.
@@ -815,7 +815,7 @@ impl<C: NetworkClient> Inner<C> {
         let mut vote_block_headers = Vec::new();
         for serialized_block_header in serialized_vote_blocks_headers.into_iter() {
             let signed_block_header: SignedBlockHeader = bcs::from_bytes(&serialized_block_header)
-                .map_err(ConsensusError::MalformedBlock)?;
+                .map_err(ConsensusError::MalformedHeader)?;
             // The block signature needs to be verified.
             self.block_verifier.verify(&signed_block_header)?;
             for vote in signed_block_header.commit_votes() {
@@ -866,7 +866,7 @@ mod tests {
         core_thread::tests::MockCoreThreadDispatcher,
         dag_state::DagState,
         error::ConsensusResult,
-        network::{BlockBundleStream, BlockStream, NetworkClient},
+        network::{BlockBundleStream, NetworkClient},
         storage::mem_store::MemStore,
         transactions_synchronizer::TransactionsSynchronizer,
     };
@@ -876,15 +876,6 @@ mod tests {
 
     #[async_trait::async_trait]
     impl NetworkClient for FakeNetworkClient {
-        async fn subscribe_blocks(
-            &self,
-            _peer: AuthorityIndex,
-            _last_received: Round,
-            _timeout: Duration,
-        ) -> ConsensusResult<BlockStream> {
-            unimplemented!("Unimplemented")
-        }
-
         async fn subscribe_block_bundles(
             &self,
             _peer: AuthorityIndex,
@@ -898,16 +889,6 @@ mod tests {
             &self,
             _peer: AuthorityIndex,
             _block_refs: Vec<BlockRef>,
-            _timeout: Duration,
-        ) -> ConsensusResult<Vec<Bytes>> {
-            unimplemented!("Unimplemented")
-        }
-
-        async fn fetch_blocks(
-            &self,
-            _peer: AuthorityIndex,
-            _block_refs: Vec<BlockRef>,
-            _highest_accepted_rounds: Vec<Round>,
             _timeout: Duration,
         ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Unimplemented")
@@ -954,7 +935,7 @@ mod tests {
                 commit_sync_batch_size: 5,
                 commit_sync_batches_ahead: 5,
                 commit_sync_parallel_fetches: 5,
-                max_block_headers_per_fetch: 5,
+                max_headers_per_commit_sync_fetch: 5,
                 ..context.parameters
             },
             ..context

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -718,7 +718,7 @@ impl Core {
         // Now acknowledge the transactions for their inclusion to block
         ack_transactions(verified_block.reference());
 
-        debug!("Created block {verified_block:?} for round {clock_round}");
+        info!("Created block {verified_block:?} for round {clock_round}");
 
         self.context
             .metrics

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -51,89 +51,98 @@ pub(crate) const MAX_HEADERS_PER_BUNDLE: usize = 150;
 pub(crate) struct DagState {
     context: Arc<Context>,
 
-    // The genesis blocks
+    /// The genesis blocks
     genesis: BTreeMap<BlockRef, VerifiedBlock>,
 
-    // Contains recent block headers within CACHED_ROUNDS from the last traversed round per
-    // authority. Note: all uncommitted block headers are kept in memory.
+    /// Contains recent block headers within CACHED_ROUNDS from the last
+    /// traversed round per authority. Note: all uncommitted block headers
+    /// are kept in memory.
     recent_block_headers: BTreeMap<BlockRef, VerifiedBlockHeader>,
 
-    // Contains recent transactions. It contains MAX_TRANSACTIONS_ACK_DEPTH+MAX_LINEARIZER_DEPTH
-    // from the round of the last consumed commit. Note: all transactions in blocks below that
-    // round are evicted from memory.
+    /// Contains recent transactions. It contains
+    /// MAX_TRANSACTIONS_ACK_DEPTH+MAX_LINEARIZER_DEPTH from the round of
+    /// the last consumed commit. Note: all transactions in blocks below that
+    /// round are evicted from memory.
     recent_transactions: BTreeMap<BlockRef, VerifiedTransactions>,
 
-    // Indexes recent block headers refs by their authorities.
-    // Vec position corresponds to the authority index.
+    /// Indexes recent block headers refs by their authorities.
+    /// Vec position corresponds to the authority index.
     recent_headers_refs_by_authority: Vec<BTreeSet<BlockRef>>,
 
-    // Keeps track of the threshold clock for proposing blocks.
+    /// Keeps track of the threshold clock for proposing blocks.
     threshold_clock: ThresholdClock,
 
-    // Keeps track of the highest round that has been evicted for each authority. Any block header
-    // that are of round <= evict_round should be considered evicted, and if any exist we
-    // should not consider the causally complete in the order they appear. The `evicted_rounds`
-    // size should be the same as the committee size.
+    /// Keeps track of the highest round that has been evicted for each
+    /// authority. Any block header that are of round <= evict_round should
+    /// be considered evicted, and if any exist we should not consider the
+    /// causally complete in the order they appear. The `evicted_rounds`
+    /// size should be the same as the committee size.
     evicted_rounds: Vec<Round>,
 
-    // Highest round of blocks accepted.
+    /// Highest round of blocks accepted.
     highest_accepted_round: Round,
 
-    // Last consensus commit of the dag.
+    /// Last consensus commit of the dag.
     last_commit: Option<TrustedCommit>,
 
-    // Last wall time when commit round advanced. Does not persist across restarts.
+    /// Last wall time when commit round advanced. Does not persist across
+    /// restarts.
     last_commit_round_advancement_time: Option<std::time::Instant>,
 
-    // Round of the last committed leader which created a commit with available transactions. Does
-    // not persist across restarts and after recovery. All transactions below this round minus
-    // MAX_TRANSACTIONS_ACK_DEPTH minus MAX_LINEARIZER_DEPTH are evicted from memory.
+    /// Round of the last committed leader which created a commit with available
+    /// transactions. Does not persist across restarts and after recovery.
+    /// All transactions below this round minus MAX_TRANSACTIONS_ACK_DEPTH
+    /// minus MAX_LINEARIZER_DEPTH are evicted from memory.
     last_available_commit_leader_round: Option<Round>,
 
-    // Rounds for latest blocks traversed by linearizer per authority.
+    /// Rounds for latest blocks traversed by linearizer per authority.
     last_committed_rounds: Vec<Round>,
 
     /// The committed subdags that have been scored but scores have not been
     /// used for leader schedule yet.
     scoring_subdag: ScoringSubdag,
 
-    // Commit votes pending to be included in new blocks.
+    /// Commit votes pending to be included in new blocks.
     // TODO: limit to 1st commit per round with multi-leader.
     pending_commit_votes: VecDeque<CommitVote>,
 
-    // Acknowledgments pending to be included in new blocks. These represent votes indicating
-    // availability of transaction data from the corresponding blocks
+    /// Acknowledgments pending to be included in new blocks. These represent
+    /// votes indicating availability of transaction data from the
+    /// corresponding blocks
     pending_acknowledgments: BTreeSet<BlockRef>,
 
     // TODO: add metrics for recent_dag_cordial_knowledge and block_headers_not_known_by_authority
-    // and pending_acknowledgments Keeps track of the most recent BlockHeaderDAG cordial
-    // knowledge (who knows which blocks) for each authority. This is a helper structure that
-    // is used primarily for traversing the recent DAG. This struct is evicted after flushing
-    // the dag state to storage and is not persisted.
-    // To access the cordial knowledge of a given block_ref, one shall retrieve it from
-    // `recent_dag_cordial_knowledge[block_ref.author][(block_ref.round, block_ref.digest)]`.
-    // The value is a tuple of (parents, who knows the block header).
+    // and pending_acknowledgments
+    /// Keeps track of the most recent BlockHeaderDAG cordial
+    /// knowledge (who knows which blocks) for each authority. This is a helper
+    /// structure that is used primarily for traversing the recent DAG. This
+    /// struct is evicted after flushing the dag state to storage and is not
+    /// persisted. To access the cordial knowledge of a given block_ref, one
+    /// shall retrieve it from `recent_dag_cordial_knowledge[block_ref.
+    /// author][(block_ref.round, block_ref.digest)]`. The value is a tuple
+    /// of (parents, who knows the block header).
     recent_dag_cordial_knowledge:
         Vec<BTreeMap<(Round, BlockHeaderDigest), (Vec<BlockRef>, HashSet<AuthorityIndex>)>>,
-    // Keeps tracks of block headers that are not known by the authority.
-    // Is used to ensure that we send block headers that are really needed
-    // to the authority, and not the ones that they already know.
+    /// Keeps tracks of block headers that are not known by the authority.
+    /// Is used to ensure that we send block headers that are really needed
+    /// to the authority, and not the ones that they already know.
     block_headers_not_known_by_authority: Vec<BTreeSet<BlockRef>>,
 
-    // Transactions to be flushed to storage.
+    /// Transactions to be flushed to storage.
     transactions_to_write: Vec<VerifiedTransactions>,
     block_headers_to_write: Vec<VerifiedBlockHeader>,
     commits_to_write: Vec<TrustedCommit>,
 
-    // Buffer the reputation scores & last_committed_rounds to be flushed with the
-    // next dag state flush. This is okay because we can recover reputation scores
-    // & last_committed_rounds from the commits as needed.
+    /// Buffer the reputation scores & last_committed_rounds to be flushed with
+    /// the next dag state flush. This is okay because we can recover
+    /// reputation scores & last_committed_rounds from the commits as
+    /// needed.
     commit_info_to_write: Vec<(CommitRef, CommitInfo)>,
 
-    // Persistent storage for blocks, commits and other consensus data.
+    /// Persistent storage for blocks, commits and other consensus data.
     store: Arc<dyn Store>,
 
-    // The number of cached rounds
+    /// The number of cached rounds
     cached_rounds: Round,
 }
 
@@ -458,14 +467,6 @@ impl DagState {
         }
     }
 
-    /// Gets a transaction by checking cached recent transactions then storage.
-    /// Returns None when the transaction is not found.
-    pub(crate) fn get_transaction(&self, reference: &BlockRef) -> Option<VerifiedTransactions> {
-        self.get_transactions(&[*reference])
-            .pop()
-            .expect("Exactly one element should be returned")
-    }
-
     /// Gets transactions by checking cached recent transactions in memory, then
     /// storage. An element is None when the corresponding transaction is not
     /// found.
@@ -519,30 +520,6 @@ impl DagState {
         }
 
         transactions
-    }
-
-    /// Gets a block by reconstructing it from its header and transactions.
-    /// Returns None when the block is not found.
-    pub(crate) fn get_block(&self, reference: &BlockRef) -> Option<VerifiedBlock> {
-        let header = self.get_block_header(reference)?;
-        let transactions = self.get_transaction(reference)?;
-        Some(VerifiedBlock::new(header, transactions))
-    }
-
-    /// Gets blocks by reconstructing them from their headers and transactions.
-    /// Returns None for elements where the block is not found.
-    pub(crate) fn get_blocks(&self, block_refs: &[BlockRef]) -> Vec<Option<VerifiedBlock>> {
-        let headers = self.get_block_headers(block_refs);
-        let transactions = self.get_transactions(block_refs);
-
-        headers
-            .into_iter()
-            .zip(transactions)
-            .map(|(header, transaction)| match (header, transaction) {
-                (Some(header), Some(transaction)) => Some(VerifiedBlock::new(header, transaction)),
-                _ => None,
-            })
-            .collect()
     }
 
     /// Gets a block header by checking cached recent blocks then storage.
@@ -785,16 +762,40 @@ impl DagState {
         authority: AuthorityIndex,
         start: Round,
     ) -> Vec<VerifiedBlockHeader> {
+        self.get_cached_block_headers_in_range(authority, start, Round::MAX, usize::MAX)
+    }
+    pub(crate) fn get_cached_block_headers_in_range(
+        &self,
+        authority: AuthorityIndex,
+        start_round: Round,
+        end_round: Round,
+        limit: usize,
+    ) -> Vec<VerifiedBlockHeader> {
+        if start_round >= end_round || limit == 0 {
+            return vec![];
+        }
+
         let mut block_headers = vec![];
         for block_ref in self.recent_headers_refs_by_authority[authority].range((
-            Included(BlockRef::new(start, authority, BlockHeaderDigest::MIN)),
-            Unbounded,
+            Included(BlockRef::new(
+                start_round,
+                authority,
+                BlockHeaderDigest::MIN,
+            )),
+            Excluded(BlockRef::new(
+                end_round,
+                AuthorityIndex::MIN,
+                BlockHeaderDigest::MIN,
+            )),
         )) {
             let block_header = self
                 .recent_block_headers
                 .get(block_ref)
-                .expect("Block Header should exist in recent blocks headers");
+                .expect("Block should exist in recent blocks");
             block_headers.push(block_header.clone());
+            if block_headers.len() >= limit {
+                break;
+            }
         }
         block_headers
     }
@@ -809,10 +810,8 @@ impl DagState {
         start_round: Round,
         end_round: Round,
     ) -> Option<VerifiedBlockHeader> {
-        if end_round == GENESIS_ROUND {
-            panic!(
-                "Attempted to retrieve blocks earlier than the genesis round which is impossible"
-            );
+        if start_round >= end_round {
+            return None;
         }
 
         let block_ref = self.recent_headers_refs_by_authority[authority]
@@ -1149,23 +1148,6 @@ impl DagState {
             .push((last_commit.reference(), commit_info));
     }
 
-    /// Returns the set of block headers up to a given round that are not known
-    /// by the given authority
-    #[expect(unused)]
-    pub(crate) fn get_past_block_headers_not_known_by_authority(
-        &self,
-        authority_index: AuthorityIndex,
-        round: Round,
-    ) -> Vec<BlockRef> {
-        let set = &self.block_headers_not_known_by_authority[authority_index.value()];
-
-        // Construct an upper bound (exclusive)
-        let upper_bound = BlockRef::new(round, AuthorityIndex::MAX, BlockHeaderDigest::MAX);
-
-        // Take all BlockRefs strictly less than the upper bound
-        set.range(..upper_bound).cloned().collect()
-    }
-
     /// Takes a batch of at most MAX_HEADERS_PER_BUNDLE unknown headers for the
     /// given authority, but only from round smaller than
     /// round_upper_bound_exclusive. Marks these headers as known to the
@@ -1196,10 +1178,20 @@ impl DagState {
         let mut block_refs: Vec<BlockRef> = vec![];
         for block_ref in set.into_iter() {
             block_refs.push(block_ref);
-            let (_, who_knows_given_block) = self.recent_dag_cordial_knowledge
-                [block_ref.author.value()]
-            .get_mut(&(block_ref.round, block_ref.digest))
-            .expect("We expect block ref to be in recent dag cordial knowledge");
+            let opt_block_knowledge = self.recent_dag_cordial_knowledge[block_ref.author.value()]
+                .get_mut(&(block_ref.round, block_ref.digest));
+            if opt_block_knowledge.is_none() {
+                println!(
+                    "WARNING: Block knowledge for {:?} not found in recent dag cordial knowledge",
+                    block_ref
+                );
+                println!(
+                    "Current block headers not known by authority: {:?}",
+                    self.block_headers_not_known_by_authority
+                );
+            }
+            let (_, who_knows_given_block) = opt_block_knowledge
+                .expect("We expect block ref to be in recent dag cordial knowledge");
             who_knows_given_block.insert(authority_index);
         }
         self.get_block_headers(&block_refs)
@@ -1619,7 +1611,7 @@ mod test {
         let last_ref = blocks.keys().last().unwrap();
         assert!(
             dag_state
-                .get_block(&BlockRef::new(
+                .get_block_header(&BlockRef::new(
                     last_ref.round,
                     last_ref.author,
                     BlockHeaderDigest::MIN
@@ -2246,6 +2238,77 @@ mod test {
             .get_cached_block_headers(context.committee.to_authority_index(3).unwrap(), 12);
         assert_eq!(cached_block_headers.len(), 1);
         assert_eq!(cached_block_headers[0].round(), 12);
+
+        // Test get_cached_block_headers_in_range()
+
+        // Start == end
+        let cached_block_headers = dag_state.get_cached_block_headers_in_range(
+            context.committee.to_authority_index(3).unwrap(),
+            10,
+            10,
+            1,
+        );
+        assert!(cached_block_headers.is_empty());
+
+        // Start > end
+        let cached_block_headers = dag_state.get_cached_block_headers_in_range(
+            context.committee.to_authority_index(3).unwrap(),
+            11,
+            10,
+            1,
+        );
+        assert!(cached_block_headers.is_empty());
+
+        // Empty result.
+        let cached_blocks = dag_state.get_cached_block_headers_in_range(
+            context.committee.to_authority_index(0).unwrap(),
+            9,
+            10,
+            1,
+        );
+        assert!(cached_blocks.is_empty());
+
+        // Single block, one round before the end.
+        let cached_block_headers = dag_state.get_cached_block_headers_in_range(
+            context.committee.to_authority_index(1).unwrap(),
+            9,
+            11,
+            1,
+        );
+        assert_eq!(cached_block_headers.len(), 1);
+        assert_eq!(cached_block_headers[0].round(), 10);
+
+        // Respect end round.
+        let cached_block_headers = dag_state.get_cached_block_headers_in_range(
+            context.committee.to_authority_index(2).unwrap(),
+            9,
+            12,
+            5,
+        );
+        assert_eq!(cached_block_headers.len(), 2);
+        assert_eq!(cached_block_headers[0].round(), 10);
+        assert_eq!(cached_block_headers[1].round(), 11);
+
+        // Respect start round.
+        let cached_block_headers = dag_state.get_cached_block_headers_in_range(
+            context.committee.to_authority_index(3).unwrap(),
+            11,
+            20,
+            5,
+        );
+        assert_eq!(cached_block_headers.len(), 2);
+        assert_eq!(cached_block_headers[0].round(), 11);
+        assert_eq!(cached_block_headers[1].round(), 12);
+
+        // Respect limit
+        let cached_block_headers = dag_state.get_cached_block_headers_in_range(
+            context.committee.to_authority_index(3).unwrap(),
+            10,
+            20,
+            1,
+        );
+        assert_eq!(cached_block_headers.len(), 1);
+        assert_eq!(cached_block_headers[0].round(), 10);
     }
 
     #[rstest]

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -17,11 +17,8 @@ use crate::{
 /// encountering shutdown.
 #[derive(Clone, Debug, Error, IntoStaticStr)]
 pub(crate) enum ConsensusError {
-    #[error("Error deserializing block: {0}")]
-    MalformedBlock(bcs::Error),
-
     #[error("Error deserializing block header: {0}")]
-    MalformedBlockHeader(bcs::Error),
+    MalformedHeader(bcs::Error),
 
     #[error("Error deserializing block transactions: {0}")]
     MalformedTransactions(bcs::Error),
@@ -50,53 +47,48 @@ pub(crate) enum ConsensusError {
     #[error("Block has wrong epoch: expected {expected}, actual {actual}")]
     WrongEpoch { expected: Epoch, actual: Epoch },
 
-    #[error("Genesis blocks should only be generated from Committee!")]
-    UnexpectedGenesisBlock,
+    #[error("Genesis block headers should only be generated from Committee!")]
+    UnexpectedGenesisHeader,
 
-    #[error("Genesis blocks should not be queried!")]
-    UnexpectedGenesisBlockRequested,
+    #[error("Genesis transactions should not be queried!")]
+    UnexpectedGenesisTransactionsRequested,
 
     #[error("Genesis block headers should not be queried!")]
-    UnexpectedGenesisBlockHeaderRequested,
+    UnexpectedGenesisHeaderRequested,
 
     #[error(
-        "Expected {requested} but received {received_block_headers} block headers from authority {authority}"
+        "Expected {requested} but received {received_headers} block headers from authority {authority}"
     )]
-    UnexpectedNumberOfBlockHeadersFetched {
+    UnexpectedNumberOfHeadersFetched {
         authority: AuthorityIndex,
         requested: usize,
-        received_block_headers: usize,
+        received_headers: usize,
     },
 
-    #[error("Unexpected block returned while fetching missing blocks")]
-    UnexpectedFetchedBlock {
+    #[error("Unexpected block header returned while fetching missing block headers")]
+    UnexpectedFetchedHeader {
         index: AuthorityIndex,
         block_ref: BlockRef,
     },
 
     #[error(
-        "Unexpected block {block_ref} returned while fetching last own block from peer {index}"
+        "Unexpected block header {block_ref} returned while fetching last own header from peer {index}"
     )]
-    UnexpectedLastOwnBlock {
+    UnexpectedLastOwnHeader {
         index: AuthorityIndex,
         block_ref: BlockRef,
     },
-
-    #[error(
-        "Too many blocks have been returned from authority {0} when requesting to fetch missing blocks"
-    )]
-    TooManyFetchedBlocksReturned(AuthorityIndex),
 
     #[error(
         "Too many transactions have been returned from authority {0} when requesting to fetch missing transactions"
     )]
     TooManyFetchedTransactionsReturned(AuthorityIndex),
 
-    #[error("Too many blocks have been requested from authority {0}")]
-    TooManyFetchBlocksRequested(AuthorityIndex),
-
     #[error("Too many block headers have been requested from authority {0}")]
-    TooManyFetchBlockHeadersRequested(AuthorityIndex),
+    TooManyFetchHeadersRequested(AuthorityIndex),
+
+    #[error("Too many block headers have been rteurned from authority {0}")]
+    TooManyFetchedHeadersReturned(AuthorityIndex),
 
     #[error("Too many transaction bundles have been requested from authority {0}")]
     TooManyFetchTransactionsRequested(AuthorityIndex),

--- a/crates/starfish/core/src/leader_timeout.rs
+++ b/crates/starfish/core/src/leader_timeout.rs
@@ -191,7 +191,7 @@ mod tests {
         dag_state::DagState,
         error::ConsensusResult,
         leader_timeout::LeaderTimeoutTask,
-        network::{BlockBundleStream, BlockStream, NetworkClient},
+        network::{BlockBundleStream, NetworkClient},
         storage::mem_store::MemStore,
         transactions_synchronizer::TransactionsSynchronizer,
     };
@@ -201,15 +201,6 @@ mod tests {
 
     #[async_trait::async_trait]
     impl NetworkClient for FakeNetworkClient {
-        async fn subscribe_blocks(
-            &self,
-            _peer: AuthorityIndex,
-            _last_received: Round,
-            _timeout: Duration,
-        ) -> ConsensusResult<BlockStream> {
-            unimplemented!("Unimplemented")
-        }
-
         async fn subscribe_block_bundles(
             &self,
             _peer: AuthorityIndex,
@@ -223,16 +214,6 @@ mod tests {
             &self,
             _peer: AuthorityIndex,
             _block_refs: Vec<BlockRef>,
-            _timeout: Duration,
-        ) -> ConsensusResult<Vec<Bytes>> {
-            unimplemented!("Unimplemented")
-        }
-
-        async fn fetch_blocks(
-            &self,
-            _peer: AuthorityIndex,
-            _block_refs: Vec<BlockRef>,
-            _highest_accepted_rounds: Vec<Round>,
             _timeout: Duration,
         ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Unimplemented")

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -131,6 +131,8 @@ pub(crate) struct NodeMetrics {
     pub(crate) synchronizer_current_missing_blocks_by_authority: IntGaugeVec,
     pub(crate) synchronizer_fetched_blocks_by_authority: IntCounterVec,
     pub(crate) synchronizer_requested_blocks_by_authority: IntCounterVec,
+    pub(crate) synchronizer_fetch_failures_by_peer: IntCounterVec,
+    pub(crate) synchronizer_process_fetched_failures_by_peer: IntCounterVec,
     pub(crate) invalid_blocks: IntCounterVec,
     pub(crate) invalid_transactions: IntCounterVec,
     pub(crate) invalid_headers_in_bundles: IntCounterVec,
@@ -379,6 +381,18 @@ impl NodeMetrics {
                 "synchronizer_current_missing_blocks_by_authority",
                 "Current number of missing blocks per block author, as observed by the synchronizer during periodic sync.",
                 &["authority"],
+                registry,
+            ).unwrap(),
+            synchronizer_fetch_failures_by_peer: register_int_counter_vec_with_registry!(
+                "synchronizer_fetch_failures",
+                "Number of fetch failures against each peer",
+                &["peer", "type"],
+                registry,
+            ).unwrap(),
+            synchronizer_process_fetched_failures_by_peer: register_int_counter_vec_with_registry!(
+                "synchronizer_process_fetched_failures",
+                "Number of failures for processing fetched blocks against each peer",
+                &["peer", "type"],
                 registry,
             ).unwrap(),
             synchronizer_fetched_blocks_by_authority: register_int_counter_vec_with_registry!(

--- a/crates/starfish/core/src/network/mod.rs
+++ b/crates/starfish/core/src/network/mod.rs
@@ -54,8 +54,6 @@ pub(crate) mod tonic_network;
 pub mod tonic_network;
 mod tonic_tls;
 
-/// A stream of serialized filtered blocks returned over the network.
-pub(crate) type BlockStream = Pin<Box<dyn Stream<Item = SerializedBlock> + Send>>;
 /// A stream of serialized blocks with additional information such as headers or
 /// shards.
 pub(crate) type BlockBundleStream = Pin<Box<dyn Stream<Item = SerializedBlockBundle> + Send>>;
@@ -68,16 +66,6 @@ pub(crate) type BlockBundleStream = Pin<Box<dyn Stream<Item = SerializedBlockBun
 ///   incoming requests.
 #[async_trait]
 pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
-    /// Subscribes to blocks from a peer after last_received round.
-    // TODO:: remove when block bundles logic is finalized
-    #[allow(dead_code)]
-    async fn subscribe_blocks(
-        &self,
-        peer: AuthorityIndex,
-        last_received: Round,
-        timeout: Duration,
-    ) -> ConsensusResult<BlockStream>;
-
     /// Subscribes to blocks from a peer after last_received round.
     #[allow(dead_code)]
     async fn subscribe_block_bundles(
@@ -92,21 +80,6 @@ pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
         &self,
         peer: AuthorityIndex,
         block_refs: Vec<BlockRef>,
-        timeout: Duration,
-    ) -> ConsensusResult<Vec<Bytes>>;
-
-    /// Fetches serialized `SerializedBlocks` from a peer. It also might
-    /// return additional ancestor blocks of the requested blocks according
-    /// to the provided `highest_accepted_rounds`. The
-    /// `highest_accepted_rounds` length should be equal to the committee
-    /// size. If `highest_accepted_rounds` is empty then it will be simply
-    /// ignored.
-    #[expect(dead_code)]
-    async fn fetch_blocks(
-        &self,
-        peer: AuthorityIndex,
-        block_refs: Vec<BlockRef>,
-        highest_accepted_rounds: Vec<Round>,
         timeout: Duration,
     ) -> ConsensusResult<Vec<Bytes>>;
 
@@ -150,17 +123,6 @@ pub(crate) trait NetworkClient: Send + Sync + Sized + 'static {
 /// Network service for handling requests from peers.
 #[async_trait]
 pub(crate) trait NetworkService: Send + Sync + 'static {
-    /// Handles the block sent from the peer via subscription stream. Peer value
-    /// can be trusted to be a valid authority index. But serialized_block
-    /// must be verified before its contents are trusted.
-    // TODO:: remove when block bundles logic is finalized
-    #[cfg(test)]
-    async fn handle_subscribed_block(
-        &self,
-        peer: AuthorityIndex,
-        serialized_block: SerializedBlock,
-    ) -> ConsensusResult<()>;
-
     /// Handles the block and headers sent from the peer via subscription
     /// stream. Peer value can be trusted to be a valid authority index. But
     /// serialized_block must be verified before its contents are trusted.
@@ -169,16 +131,6 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
         peer: AuthorityIndex,
         serialized_block_bundle: SerializedBlockBundle,
     ) -> ConsensusResult<()>;
-
-    /// Handles the subscription request from the peer.
-    /// A stream of newly proposed blocks is returned to the peer.
-    /// The stream continues until the end of epoch, peer unsubscribes, or a
-    /// network error / crash occurs.
-    async fn handle_subscribe_blocks(
-        &self,
-        peer: AuthorityIndex,
-        last_received: Round,
-    ) -> ConsensusResult<BlockStream>;
 
     /// Handles the subscription request from the peer.
     /// A stream of newly proposed blocks with additional data (headers or
@@ -191,17 +143,7 @@ pub(crate) trait NetworkService: Send + Sync + 'static {
     ) -> ConsensusResult<BlockBundleStream>;
 
     /// Handles the request to fetch block headers by references from the peer.
-    async fn handle_fetch_block_headers(
-        &self,
-        peer: AuthorityIndex,
-        block_refs: Vec<BlockRef>,
-        highest_accepted_rounds: Vec<Round>,
-    ) -> ConsensusResult<Vec<Bytes>>;
-
-    /// Handles the request to fetch blocks by references from the peer.
-    /// The function returns Vec<Bytes>. Each element is a serialization of
-    /// header and transactions of a block. Used only in commit syncer.
-    async fn handle_fetch_blocks(
+    async fn handle_fetch_headers(
         &self,
         peer: AuthorityIndex,
         block_refs: Vec<BlockRef>,
@@ -279,16 +221,6 @@ pub(crate) struct SerializedHeaderAndTransactions {
     pub(crate) serialized_transactions: Bytes,
 }
 
-impl SerializedHeaderAndTransactions {
-    #[cfg(test)]
-    pub(crate) fn new_for_test(bytes: Bytes) -> Self {
-        Self {
-            serialized_block_header: bytes.clone(),
-            serialized_transactions: bytes,
-        }
-    }
-}
-
 impl From<VerifiedBlock> for SerializedHeaderAndTransactions {
     fn from(verified_block: VerifiedBlock) -> Self {
         let (serialized_block_header, serialized_transactions) = verified_block.serialized();
@@ -303,7 +235,7 @@ impl TryFrom<SerializedBlock> for SerializedHeaderAndTransactions {
     type Error = ConsensusError;
 
     fn try_from(serialized_block: SerializedBlock) -> ConsensusResult<Self> {
-        bcs::from_bytes(&serialized_block.serialized_block).map_err(ConsensusError::MalformedBlock)
+        bcs::from_bytes(&serialized_block.serialized_block).map_err(ConsensusError::MalformedHeader)
     }
 }
 

--- a/crates/starfish/core/src/network/network_tests.rs
+++ b/crates/starfish/core/src/network/network_tests.rs
@@ -10,25 +10,22 @@ use parking_lot::Mutex;
 use rstest::rstest;
 
 use super::{
-    NetworkClient, SerializedBlock, SerializedHeaderAndTransactions, test_network::TestService,
-    tonic_network::TonicManager,
+    NetworkClient, SerializedBlockBundle, test_network::TestService, tonic_network::TonicManager,
 };
 use crate::{Round, context::Context};
 
-fn serialized_block_for_round(round: Round) -> SerializedBlock {
-    SerializedBlock::try_from(SerializedHeaderAndTransactions {
-        serialized_block_header: Bytes::from(vec![round as u8; 16]),
-        serialized_transactions: Bytes::from(vec![round as u8; 16]),
-    })
-    .unwrap()
+fn serialized_block_bundle_for_round(round: Round) -> SerializedBlockBundle {
+    SerializedBlockBundle {
+        serialized_block_bundle: Bytes::from(vec![round as u8; 16]),
+    }
 }
 
-fn service_with_own_blocks() -> Arc<Mutex<TestService>> {
+fn service_with_own_block_bundles() -> Arc<Mutex<TestService>> {
     let service = Arc::new(Mutex::new(TestService::new()));
     {
         let mut service = service.lock();
         let own_blocks = (0..=100u8)
-            .map(|i| serialized_block_for_round(i as Round))
+            .map(|i| serialized_block_bundle_for_round(i as Round))
             .collect::<Vec<_>>();
         service.add_own_blocks(own_blocks);
     }
@@ -37,7 +34,7 @@ fn service_with_own_blocks() -> Arc<Mutex<TestService>> {
 
 #[rstest]
 #[tokio::test]
-async fn subscribe_and_receive_blocks() {
+async fn subscribe_and_receive_block_bundles() {
     let (context, keys) = Context::new_for_test(4);
 
     let context_0 = Arc::new(
@@ -47,7 +44,7 @@ async fn subscribe_and_receive_blocks() {
     );
     let mut manager_0 = TonicManager::new(context_0.clone(), keys[0].0.clone());
     let client_0 = manager_0.client();
-    let service_0 = service_with_own_blocks();
+    let service_0 = service_with_own_block_bundles();
     manager_0.install_service(service_0.clone()).await;
 
     let context_1 = Arc::new(
@@ -57,12 +54,12 @@ async fn subscribe_and_receive_blocks() {
     );
     let mut manager_1 = TonicManager::new(context_1.clone(), keys[1].0.clone());
     let client_1 = manager_1.client();
-    let service_1 = service_with_own_blocks();
+    let service_1 = service_with_own_block_bundles();
     manager_1.install_service(service_1.clone()).await;
 
     let client_0_round = 50;
     let receive_stream_0 = client_0
-        .subscribe_blocks(
+        .subscribe_block_bundles(
             context_0.committee.to_authority_index(1).unwrap(),
             client_0_round,
             Duration::from_secs(5),
@@ -75,7 +72,7 @@ async fn subscribe_and_receive_blocks() {
         .then(|(i, item)| async move {
             assert_eq!(
                 item,
-                serialized_block_for_round(client_0_round + i as Round + 1)
+                serialized_block_bundle_for_round(client_0_round + i as Round + 1)
             );
             1
         })
@@ -86,7 +83,7 @@ async fn subscribe_and_receive_blocks() {
 
     let client_1_round = 100;
     let mut receive_stream_1 = client_1
-        .subscribe_blocks(
+        .subscribe_block_bundles(
             context_1.committee.to_authority_index(0).unwrap(),
             client_1_round,
             Duration::from_secs(5),

--- a/crates/starfish/core/src/network/test_network.rs
+++ b/crates/starfish/core/src/network/test_network.rs
@@ -13,67 +13,59 @@ use crate::{
     block_header::{BlockRef, VerifiedBlockHeader},
     commit::{CommitRange, TrustedCommit},
     error::ConsensusResult,
-    network::{
-        BlockBundleStream, BlockStream, NetworkService, SerializedBlock, SerializedBlockBundle,
-    },
+    network::{BlockBundleStream, NetworkService, SerializedBlockBundle},
 };
 
 pub(crate) struct TestService {
-    pub(crate) handle_subscribed_block: Vec<(AuthorityIndex, SerializedBlock)>,
+    pub(crate) handle_subscribed_block_bundle: Vec<(AuthorityIndex, SerializedBlockBundle)>,
+    pub(crate) handle_subscribed_block_bundle_requests: Vec<(AuthorityIndex, Round)>,
     pub(crate) handle_fetch_block_headers: Vec<(AuthorityIndex, Vec<BlockRef>)>,
-    pub(crate) handle_fetch_blocks: Vec<(AuthorityIndex, Vec<BlockRef>)>,
-    pub(crate) handle_subscribe_blocks: Vec<(AuthorityIndex, Round)>,
     pub(crate) handle_fetch_commits: Vec<(AuthorityIndex, CommitRange)>,
-    pub(crate) own_blocks: Vec<SerializedBlock>,
+    pub(crate) own_block_bundles: Vec<SerializedBlockBundle>,
 }
 
 impl TestService {
     pub(crate) fn new() -> Self {
         Self {
-            handle_subscribed_block: Vec::new(),
+            handle_subscribed_block_bundle: Vec::new(),
+            handle_subscribed_block_bundle_requests: Vec::new(),
             handle_fetch_block_headers: Vec::new(),
-            handle_fetch_blocks: Vec::new(),
-            handle_subscribe_blocks: Vec::new(),
             handle_fetch_commits: Vec::new(),
-            own_blocks: Vec::new(),
+            own_block_bundles: Vec::new(),
         }
     }
 
     #[cfg_attr(msim, allow(dead_code))]
-    pub(crate) fn add_own_blocks(&mut self, blocks: Vec<SerializedBlock>) {
-        self.own_blocks.extend(blocks);
+    pub(crate) fn add_own_blocks(&mut self, blocks: Vec<SerializedBlockBundle>) {
+        self.own_block_bundles.extend(blocks);
     }
 }
 
 #[async_trait]
 impl NetworkService for Mutex<TestService> {
-    async fn handle_subscribed_block(
+    async fn handle_subscribed_block_bundle(
         &self,
         peer: AuthorityIndex,
-        serialized_block: SerializedBlock,
+        serialized_block_bundle: SerializedBlockBundle,
     ) -> ConsensusResult<()> {
         let mut state = self.lock();
-        state.handle_subscribed_block.push((peer, serialized_block));
+        state
+            .handle_subscribed_block_bundle
+            .push((peer, serialized_block_bundle));
         Ok(())
     }
 
-    async fn handle_subscribed_block_bundle(
-        &self,
-        _peer: AuthorityIndex,
-        _serialized_block_bundle: SerializedBlockBundle,
-    ) -> ConsensusResult<()> {
-        unimplemented!("Unimplemented")
-    }
-
-    async fn handle_subscribe_blocks(
+    async fn handle_subscribe_block_bundles_request(
         &self,
         peer: AuthorityIndex,
         last_received: Round,
-    ) -> ConsensusResult<BlockStream> {
+    ) -> ConsensusResult<BlockBundleStream> {
         let mut state = self.lock();
-        state.handle_subscribe_blocks.push((peer, last_received));
+        state
+            .handle_subscribed_block_bundle_requests
+            .push((peer, last_received));
         let own_blocks = state
-            .own_blocks
+            .own_block_bundles
             .iter()
             // Let index in own_blocks be the round, and skip blocks <= last_received round.
             .skip(last_received as usize + 1)
@@ -82,15 +74,7 @@ impl NetworkService for Mutex<TestService> {
         Ok(Box::pin(stream::iter(own_blocks)))
     }
 
-    async fn handle_subscribe_block_bundles_request(
-        &self,
-        _peer: AuthorityIndex,
-        _last_received: Round,
-    ) -> ConsensusResult<BlockBundleStream> {
-        unimplemented!("Unimplemented");
-    }
-
-    async fn handle_fetch_block_headers(
+    async fn handle_fetch_headers(
         &self,
         peer: AuthorityIndex,
         block_refs: Vec<BlockRef>,
@@ -99,16 +83,6 @@ impl NetworkService for Mutex<TestService> {
         self.lock()
             .handle_fetch_block_headers
             .push((peer, block_refs));
-        Ok(vec![])
-    }
-
-    async fn handle_fetch_blocks(
-        &self,
-        peer: AuthorityIndex,
-        block_refs: Vec<BlockRef>,
-        _highest_accepted_rounds: Vec<Round>,
-    ) -> ConsensusResult<Vec<Bytes>> {
-        self.lock().handle_fetch_blocks.push((peer, block_refs));
         Ok(vec![])
     }
 

--- a/crates/starfish/core/src/network/tonic_network.rs
+++ b/crates/starfish/core/src/network/tonic_network.rs
@@ -28,8 +28,7 @@ use tower_http::trace::{DefaultMakeSpan, DefaultOnFailure, TraceLayer};
 use tracing::{debug, error, info, trace, warn};
 
 use super::{
-    BlockBundleStream, BlockStream, NetworkClient, NetworkService, SerializedBlock,
-    SerializedBlockBundle,
+    BlockBundleStream, NetworkClient, NetworkService, SerializedBlockBundle,
     metrics_layer::{MetricsCallbackMaker, MetricsResponseCallback, SizedRequest, SizedResponse},
     tonic_gen::{
         consensus_service_client::ConsensusServiceClient,
@@ -99,42 +98,6 @@ impl TonicClient {
 // otherwise.
 #[async_trait]
 impl NetworkClient for TonicClient {
-    async fn subscribe_blocks(
-        &self,
-        peer: AuthorityIndex,
-        last_received: Round,
-        timeout: Duration,
-    ) -> ConsensusResult<BlockStream> {
-        let mut client = self.get_client(peer, timeout).await?;
-        // TODO: add sampled block acknowledgments for latency measurements.
-        let request = Request::new(stream::once(async move {
-            SubscribeBlocksRequest {
-                last_received_round: last_received,
-            }
-        }));
-        let response = client.subscribe_blocks(request).await.map_err(|e| {
-            ConsensusError::NetworkRequest(format!("subscribe_blocks failed: {e:?}"))
-        })?;
-        let stream = response
-            .into_inner()
-            .take_while(|b| futures::future::ready(b.is_ok()))
-            .filter_map(move |b| async move {
-                match b {
-                    Ok(response) => Some(SerializedBlock {
-                        serialized_block: response.vec_serialized_blocks,
-                    }),
-                    Err(e) => {
-                        debug!("Network error received from {}: {e:?}", peer);
-                        None
-                    }
-                }
-            });
-        let rate_limited_stream =
-            tokio_stream::StreamExt::throttle(stream, self.context.parameters.min_round_delay / 2)
-                .boxed();
-        Ok(rate_limited_stream)
-    }
-
     async fn subscribe_block_bundles(
         &self,
         peer: AuthorityIndex,
@@ -169,80 +132,6 @@ impl NetworkClient for TonicClient {
             tokio_stream::StreamExt::throttle(stream, self.context.parameters.min_round_delay / 2)
                 .boxed();
         Ok(rate_limited_stream)
-    }
-
-    // Returns a vector of serialized blocks. Used by commit synchronizer
-    async fn fetch_blocks(
-        &self,
-        peer: AuthorityIndex,
-        block_refs: Vec<BlockRef>,
-        highest_accepted_rounds: Vec<Round>,
-        timeout: Duration,
-    ) -> ConsensusResult<Vec<Bytes>> {
-        let mut client = self.get_client(peer, timeout).await?;
-        let mut request = Request::new(FetchBlocksRequest {
-            block_refs: block_refs
-                .iter()
-                .filter_map(|r| match bcs::to_bytes(r) {
-                    Ok(serialized) => Some(serialized),
-                    Err(e) => {
-                        debug!("Failed to serialize block ref {:?}: {e:?}", r);
-                        None
-                    }
-                })
-                .collect(),
-            highest_accepted_rounds,
-        });
-        request.set_timeout(timeout);
-        let mut stream = client
-            .fetch_blocks(request)
-            .await
-            .map_err(|e| {
-                if e.code() == tonic::Code::DeadlineExceeded {
-                    ConsensusError::NetworkRequestTimeout(format!("fetch_blocks failed: {e:?}"))
-                } else {
-                    ConsensusError::NetworkRequest(format!("fetch_blocks failed: {e:?}"))
-                }
-            })?
-            .into_inner();
-        let mut total_fetched_bytes = 0;
-        let mut vec_serialized_blocks = vec![];
-        loop {
-            match stream.message().await {
-                Ok(Some(response)) => {
-                    for b in &response.vec_serialized_blocks {
-                        total_fetched_bytes += b.len();
-                    }
-                    if total_fetched_bytes > MAX_TOTAL_FETCHED_BYTES {
-                        info!(
-                            "fetch_blocks() fetched bytes exceeded limit: {} > {}, terminating stream.",
-                            total_fetched_bytes, MAX_TOTAL_FETCHED_BYTES,
-                        );
-                        break;
-                    }
-                    vec_serialized_blocks.extend(response.vec_serialized_blocks);
-                }
-                Ok(None) => {
-                    break;
-                }
-                Err(e) => {
-                    if total_fetched_bytes == 0 {
-                        if e.code() == tonic::Code::DeadlineExceeded {
-                            return Err(ConsensusError::NetworkRequestTimeout(format!(
-                                "fetch_blocks failed mid-stream: {e:?}"
-                            )));
-                        }
-                        return Err(ConsensusError::NetworkRequest(format!(
-                            "fetch_blocks failed mid-stream: {e:?}"
-                        )));
-                    } else {
-                        warn!("fetch_blocks failed mid-stream: {e:?}");
-                        break;
-                    }
-                }
-            }
-        }
-        Ok(vec_serialized_blocks)
     }
 
     // Returns a vector of serialized block headers
@@ -604,50 +493,6 @@ impl<S: NetworkService> TonicServiceProxy<S> {
 
 #[async_trait]
 impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
-    type SubscribeBlocksStream =
-        Pin<Box<dyn Stream<Item = Result<SubscribeBlocksResponse, tonic::Status>> + Send>>;
-
-    async fn subscribe_blocks(
-        &self,
-        request: Request<Streaming<SubscribeBlocksRequest>>,
-    ) -> Result<Response<Self::SubscribeBlocksStream>, tonic::Status> {
-        let Some(peer_index) = request
-            .extensions()
-            .get::<PeerInfo>()
-            .map(|p| p.authority_index)
-        else {
-            return Err(tonic::Status::internal("PeerInfo not found"));
-        };
-        let mut request_stream = request.into_inner();
-        let first_request = match request_stream.next().await {
-            Some(Ok(r)) => r,
-            Some(Err(e)) => {
-                debug!(
-                    "subscribe_blocks() request from {} failed: {e:?}",
-                    peer_index
-                );
-                return Err(tonic::Status::invalid_argument("Request error"));
-            }
-            None => {
-                return Err(tonic::Status::invalid_argument("Missing request"));
-            }
-        };
-        let stream = self
-            .service
-            .handle_subscribe_blocks(peer_index, first_request.last_received_round)
-            .await
-            .map_err(|e| tonic::Status::internal(format!("{e:?}")))?
-            .map(|serialized_block| {
-                Ok(SubscribeBlocksResponse {
-                    vec_serialized_blocks: serialized_block.serialized_block,
-                })
-            });
-        let rate_limited_stream =
-            tokio_stream::StreamExt::throttle(stream, self.context.parameters.min_round_delay / 2)
-                .boxed();
-        Ok(Response::new(rate_limited_stream))
-    }
-
     type SubscribeBlockBundlesStream =
         Pin<Box<dyn Stream<Item = Result<SubscribeBlockBundlesResponse, tonic::Status>> + Send>>;
 
@@ -721,7 +566,7 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
         let highest_accepted_rounds = inner.highest_accepted_rounds;
         let blocks = self
             .service
-            .handle_fetch_block_headers(peer_index, block_refs, highest_accepted_rounds)
+            .handle_fetch_headers(peer_index, block_refs, highest_accepted_rounds)
             .await
             .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;
         let responses: std::vec::IntoIter<Result<FetchBlockHeadersResponse, tonic::Status>> =
@@ -730,51 +575,6 @@ impl<S: NetworkService> ConsensusService for TonicServiceProxy<S> {
                 .map(|block_headers| {
                     Ok(FetchBlockHeadersResponse {
                         vec_serialized_block_header: block_headers,
-                    })
-                })
-                .collect::<Vec<_>>()
-                .into_iter();
-        let stream = iter(responses);
-        Ok(Response::new(stream))
-    }
-
-    type FetchBlocksStream = Iter<std::vec::IntoIter<Result<FetchBlocksResponse, tonic::Status>>>;
-
-    async fn fetch_blocks(
-        &self,
-        request: Request<FetchBlocksRequest>,
-    ) -> Result<Response<Self::FetchBlocksStream>, tonic::Status> {
-        let Some(peer_index) = request
-            .extensions()
-            .get::<PeerInfo>()
-            .map(|p| p.authority_index)
-        else {
-            return Err(tonic::Status::internal("PeerInfo not found"));
-        };
-        let inner = request.into_inner();
-        let block_refs = inner
-            .block_refs
-            .into_iter()
-            .filter_map(|serialized| match bcs::from_bytes(&serialized) {
-                Ok(r) => Some(r),
-                Err(e) => {
-                    debug!("Failed to deserialize block ref {:?}: {e:?}", serialized);
-                    None
-                }
-            })
-            .collect();
-        let highest_accepted_rounds = inner.highest_accepted_rounds;
-        let blocks = self
-            .service
-            .handle_fetch_blocks(peer_index, block_refs, highest_accepted_rounds)
-            .await
-            .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;
-        let responses: std::vec::IntoIter<Result<FetchBlocksResponse, tonic::Status>> =
-            chunk_data(blocks, MAX_FETCH_RESPONSE_BYTES)
-                .into_iter()
-                .map(|serialized_block| {
-                    Ok(FetchBlocksResponse {
-                        vec_serialized_blocks: serialized_block,
                     })
                 })
                 .collect::<Vec<_>>()

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -241,10 +241,7 @@ mod test {
         block_header::BlockRef,
         commit::CommitRange,
         error::ConsensusResult,
-        network::{
-            BlockBundleStream, BlockStream, SerializedBlock, SerializedHeaderAndTransactions,
-            test_network::TestService,
-        },
+        network::{BlockBundleStream, SerializedBlockBundle, test_network::TestService},
         storage::mem_store::MemStore,
     };
 
@@ -258,49 +255,26 @@ mod test {
 
     #[async_trait]
     impl NetworkClient for SubscriberTestClient {
-        async fn subscribe_blocks(
-            &self,
-            _peer: AuthorityIndex,
-            _last_received: Round,
-            _timeout: Duration,
-        ) -> ConsensusResult<BlockStream> {
-            let block_stream = stream::unfold((), |_| async {
-                sleep(Duration::from_millis(1)).await;
-                Some((
-                    SerializedBlock::try_from(SerializedHeaderAndTransactions::new_for_test(
-                        Bytes::from(vec![1u8; 8]),
-                    ))
-                    .unwrap(),
-                    (),
-                ))
-            })
-            .take(10);
-            Ok(Box::pin(block_stream))
-        }
-
         async fn subscribe_block_bundles(
             &self,
             _peer: AuthorityIndex,
             _last_received: Round,
             _timeout: Duration,
         ) -> ConsensusResult<BlockBundleStream> {
-            unimplemented!("Unimplemented")
+            let block_stream = stream::unfold((), |_| async {
+                sleep(Duration::from_millis(1)).await;
+                let block = SerializedBlockBundle {
+                    serialized_block_bundle: Bytes::from(vec![1u8; 8]),
+                };
+                Some((block, ()))
+            })
+            .take(10);
+            Ok(Box::pin(block_stream))
         }
-
         async fn fetch_transactions(
             &self,
             _peer: AuthorityIndex,
             _block_refs: Vec<BlockRef>,
-            _timeout: Duration,
-        ) -> ConsensusResult<Vec<Bytes>> {
-            unimplemented!("Unimplemented")
-        }
-
-        async fn fetch_blocks(
-            &self,
-            _peer: AuthorityIndex,
-            _block_refs: Vec<BlockRef>,
-            _highest_accepted_rounds: Vec<Round>,
             _timeout: Duration,
         ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Unimplemented")
@@ -353,11 +327,11 @@ mod test {
         let peer = context.committee.to_authority_index(2).unwrap();
         subscriber.subscribe(peer);
 
-        // Wait for enough blocks received.
+        // Wait for enough block bundles received.
         for _ in 0..10 {
-            tokio::time::sleep(Duration::from_secs(1)).await;
+            sleep(Duration::from_secs(1)).await;
             let service = authority_service.lock();
-            if service.handle_subscribed_block.len() >= 100 {
+            if service.handle_subscribed_block_bundle.len() >= 100 {
                 break;
             }
         }
@@ -365,15 +339,14 @@ mod test {
         // Even if the stream ends after 10 blocks, the subscriber should retry and get
         // enough blocks eventually.
         let service = authority_service.lock();
-        assert!(service.handle_subscribed_block.len() >= 100);
-        for (p, block) in service.handle_subscribed_block.iter() {
+        assert!(service.handle_subscribed_block_bundle.len() >= 100);
+        for (p, block) in service.handle_subscribed_block_bundle.iter() {
             assert_eq!(*p, peer);
             assert_eq!(
                 *block,
-                SerializedBlock::try_from(SerializedHeaderAndTransactions::new_for_test(
-                    Bytes::from(vec![1u8; 8])
-                ))
-                .unwrap()
+                SerializedBlockBundle {
+                    serialized_block_bundle: Bytes::from(vec![1u8; 8]),
+                }
             );
         }
     }

--- a/crates/starfish/core/src/synchronizer.rs
+++ b/crates/starfish/core/src/synchronizer.rs
@@ -49,29 +49,29 @@ use crate::{
     transactions_synchronizer::TransactionsSynchronizerHandle,
 };
 
-/// The number of concurrent fetch blocks requests per authority
-const FETCH_BLOCKS_CONCURRENCY: usize = 5;
+/// The number of concurrent fetch block headers requests per authority
+const FETCH_BLOCK_HEADERS_CONCURRENCY: usize = 5;
 
-/// Timeouts when fetching blocks.
+/// /// The timeout for synchronizer to fetch blocks from a given peer
+/// authority.
 const FETCH_REQUEST_TIMEOUT: Duration = Duration::from_millis(2_000);
+
+/// The timeout for periodic synchronizer to fetch blocks from the peers.
 const FETCH_FROM_PEERS_TIMEOUT: Duration = Duration::from_millis(4_000);
 
-/// Max number of blocks to fetch per request.
-/// This value should be chosen so even with blocks at max size, the requests
-/// can finish on hosts with good network using the timeouts above.
-// TODO: this can be increased as we're only syncing headers which have almost
-// constant size
-const MAX_BLOCKS_PER_FETCH: usize = 32;
+/// The maximum number of authorities from which we will try to fetch block
+/// header at the same moment. The guard will protect that we will not ask from
+/// more than this number of authorities at the same time.
+const MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER: usize = 3;
 
-const MAX_AUTHORITIES_TO_FETCH_PER_BLOCK: usize = 3;
+/// The maximum number of peers from which the periodic synchronizer will
+/// request block headers.
+const MAX_PERIODIC_SYNC_PEERS: usize = 4;
 
-/// The number of rounds above the highest accepted round that still willing to
-/// fetch missing blocks via the periodic synchronizer. Any missing blocks of
-/// higher rounds are considered too far in the future to fetch. This property
-/// is taken into account only when it's detected that the node has fallen
-/// behind on its commit compared to the rest of the network, otherwise
-/// scheduler will attempt to fetch any missing block.
-const SYNC_MISSING_BLOCK_ROUND_THRESHOLD: u32 = 50;
+/// The maximum number of peers in the periodic synchronizer which are chosen
+/// totally random to fetch block headers from. The other peers will be chosen
+/// based on their knowledge of the DAG.
+const MAX_PERIODIC_SYNC_RANDOM_PEERS: usize = 2;
 
 struct BlocksGuard {
     map: Arc<InflightBlockHeadersMap>,
@@ -85,7 +85,7 @@ impl Drop for BlocksGuard {
     }
 }
 
-// Keeps a mapping between the missing blocks that have been instructed to be
+// Keeps a mapping between the missing headers that have been instructed to be
 // fetched and the authorities that are currently fetching them. For a block ref
 // there is a maximum number of authorities that can concurrently fetch it. The
 // authority ids that are currently fetching a block are set on the
@@ -121,7 +121,7 @@ impl InflightBlockHeadersMap {
             // block is not higher than the allowed and the `peer_index` has not
             // already been instructed to do that.
             let authorities = inner.entry(block_ref).or_default();
-            if authorities.len() < MAX_AUTHORITIES_TO_FETCH_PER_BLOCK
+            if authorities.len() < MAX_AUTHORITIES_TO_FETCH_PER_BLOCK_HEADER
                 && authorities.get(&peer).is_none()
             {
                 assert!(authorities.insert(peer));
@@ -202,9 +202,9 @@ pub(crate) struct SynchronizerHandle {
 }
 
 impl SynchronizerHandle {
-    /// Explicitly asks from the synchronizer to fetch the blocks - provided the
-    /// block_refs set - from the peer authority.
-    pub(crate) async fn fetch_block_headers(
+    /// Explicitly asks from the synchronizer to fetch block headers - provided
+    /// the block_refs set - from the peer authority.
+    pub(crate) async fn fetch_headers(
         &self,
         missing_block_refs: BTreeSet<BlockRef>,
         peer_index: AuthorityIndex,
@@ -235,27 +235,30 @@ impl SynchronizerHandle {
 /// progress. Live synchronization refers to the process of retrieving missing
 /// blocks, particularly those essential for advancing a node when data from
 /// only a few rounds is absent. If a node significantly lags behind the
-/// network, `commit_syncer` handles fetching missing blocks via a more
-/// efficient approach. `Synchronizer` aims for swift catch-up employing two
+/// network, `commit_syncer` handles fetching missing headers via a more
+/// efficient approach. Transactions that are sequenced and included in commit
+/// are fetched through the transaction synchronizer once block headers are
+/// processed. `Synchronizer` aims for swift catch-up employing two
 /// mechanisms:
 ///
-/// 1. Explicitly requesting missing blocks from designated authorities via the
-///    "block send" path. This includes attempting to fetch any missing
-///    ancestors necessary for processing a received block. Such requests
-///    prioritize the block author, maximizing the chance of prompt retrieval. A
-///    locking mechanism allows concurrent requests for missing blocks from up
-///    to two authorities simultaneously, enhancing the chances of timely
-///    retrieval. Notably, if additional missing blocks arise during block
-///    processing, requests to the same authority are deferred to the scheduler.
+/// 1. Explicitly requesting missing headers from designated authorities via the
+///    bundle streaming path. This includes attempting to fetch any missing
+///    ancestors necessary for processing a received bundle of block and
+///    headers. Such requests prioritize the block author, maximizing the chance
+///    of prompt retrieval. A locking mechanism allows concurrent requests for
+///    missing blocks from up to three authorities simultaneously, enhancing the
+///    chances of timely retrieval. Notably, if additional missing blocks arise
+///    during block processing, requests are deferred to the scheduler.
 ///
-/// 2. Periodically requesting missing blocks via a scheduler. This primarily
-///    serves to retrieve missing blocks that were not ancestors of a received
-///    block via the "block send" path. The scheduler operates on either a fixed
-///    periodic basis or is triggered immediately after explicit fetches
-///    described in (1), ensuring continued block retrieval if gaps persist.
+/// 2. Periodically requesting missing block headers via a scheduler. This
+///    primarily serves to retrieve missing headers that were not ancestors of a
+///    received block bundle via the bundle streaming path. The scheduler
+///    operates on either a fixed periodic basis or is triggered immediately
+///    after explicit fetches described in (1), ensuring continued block
+///    retrieval if gaps persist.
 ///
 /// Additionally to the above, the synchronizer can synchronize and fetch the
-/// last own proposed block from the network peers as best effort approach to
+/// last own proposed header from the network peers as best effort approach to
 /// recover node from amnesia and avoid making the node equivocate.
 pub(crate) struct Synchronizer<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> {
     context: Arc<Context>,
@@ -266,7 +269,7 @@ pub(crate) struct Synchronizer<C: NetworkClient, V: BlockVerifier, D: CoreThread
     dag_state: Arc<RwLock<DagState>>,
     transactions_synchronizer: Arc<TransactionsSynchronizerHandle>,
     fetch_blocks_scheduler_task: JoinSet<()>,
-    fetch_own_last_block_task: JoinSet<()>,
+    fetch_own_last_header_task: JoinSet<()>,
     network_client: Arc<C>,
     block_verifier: Arc<V>,
     inflight_block_headers_map: Arc<InflightBlockHeadersMap>,
@@ -297,9 +300,11 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             if index == context.own_index {
                 continue;
             }
-            let (sender, receiver) =
-                channel("consensus_synchronizer_fetches", FETCH_BLOCKS_CONCURRENCY);
-            let fetch_blocks_from_authority_async = Self::fetch_block_headers_from_authority(
+            let (sender, receiver) = channel(
+                "consensus_synchronizer_fetches",
+                FETCH_BLOCK_HEADERS_CONCURRENCY,
+            );
+            let fetch_blocks_from_authority_async = Self::fetch_headers_from_authority(
                 index,
                 network_client.clone(),
                 block_verifier.clone(),
@@ -332,7 +337,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 core_dispatcher,
                 commit_vote_monitor,
                 fetch_blocks_scheduler_task: JoinSet::new(),
-                fetch_own_last_block_task: JoinSet::new(),
+                fetch_own_last_header_task: JoinSet::new(),
                 transactions_synchronizer,
                 network_client,
                 block_verifier,
@@ -351,10 +356,10 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
     // The main loop to listen for the submitted commands.
     async fn run(&mut self) {
-        // We want the synchronizer to run periodically every 500ms to fetch any missing
+        // We want the synchronizer to run periodically every 200ms to fetch any missing
         // blocks.
-        const SYNCHRONIZER_TIMEOUT: Duration = Duration::from_millis(500);
-        let scheduler_timeout = sleep_until(Instant::now() + SYNCHRONIZER_TIMEOUT);
+        const PERIODIC_SYNCHRONIZER_TIMEOUT: Duration = Duration::from_millis(200);
+        let scheduler_timeout = sleep_until(Instant::now() + PERIODIC_SYNCHRONIZER_TIMEOUT);
 
         tokio::pin!(scheduler_timeout);
 
@@ -372,7 +377,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                             // task will take care syncing whatever is leftover.
                             let missing_block_refs = missing_block_refs
                                 .into_iter()
-                                .take(MAX_BLOCKS_PER_FETCH)
+                                .take(self.context.parameters.max_headers_per_regular_sync_fetch)
                                 .collect();
 
                             let blocks_guard = self.inflight_block_headers_map.lock_blocks(missing_block_refs, peer_index);
@@ -398,7 +403,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                             result.send(r).ok();
                         }
                         Command::FetchOwnLastBlockHeader => {
-                            if self.fetch_own_last_block_task.is_empty() {
+                            if self.fetch_own_last_header_task.is_empty() {
                                 self.start_fetch_own_last_block_task();
                             }
                         }
@@ -408,7 +413,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                             let timeout = if self.fetch_blocks_scheduler_task.is_empty() {
                                 Instant::now()
                             } else {
-                                Instant::now() + SYNCHRONIZER_TIMEOUT.checked_div(2).unwrap()
+                                Instant::now() + PERIODIC_SYNCHRONIZER_TIMEOUT.checked_div(2).unwrap()
                             };
 
                             // only reset if it is earlier than the next deadline
@@ -418,7 +423,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                         }
                     }
                 },
-                Some(result) = self.fetch_own_last_block_task.join_next(), if !self.fetch_own_last_block_task.is_empty() => {
+                Some(result) = self.fetch_own_last_header_task.join_next(), if !self.fetch_own_last_header_task.is_empty() => {
                     match result {
                         Ok(()) => {},
                         Err(e) => {
@@ -447,7 +452,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 () = &mut scheduler_timeout => {
                     // we want to start a new task only if the previous one has already finished.
                     if self.fetch_blocks_scheduler_task.is_empty() {
-                        if let Err(err) = self.start_fetch_missing_blocks_task().await {
+                        if let Err(err) = self.start_periodic_sync_task().await {
                             debug!("Core is shutting down, synchronizer is shutting down: {err:?}");
                             return;
                         };
@@ -455,13 +460,13 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
                     scheduler_timeout
                         .as_mut()
-                        .reset(Instant::now() + SYNCHRONIZER_TIMEOUT);
+                        .reset(Instant::now() + PERIODIC_SYNCHRONIZER_TIMEOUT);
                 }
             }
         }
     }
 
-    async fn fetch_block_headers_from_authority(
+    async fn fetch_headers_from_authority(
         peer_index: AuthorityIndex,
         network_client: Arc<C>,
         block_verifier: Arc<V>,
@@ -473,14 +478,14 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         mut receiver: Receiver<BlocksGuard>,
         commands_sender: Sender<Command>,
     ) {
-        const MAX_RETRIES: u32 = 5;
+        const MAX_RETRIES: u32 = 3;
         let peer_hostname = &context.committee.authority(peer_index).hostname;
 
         let mut requests = FuturesUnordered::new();
 
         loop {
             tokio::select! {
-                Some(blocks_guard) = receiver.recv(), if requests.len() < FETCH_BLOCKS_CONCURRENCY => {
+                Some(headers_guard) = receiver.recv(), if requests.len() < FETCH_BLOCK_HEADERS_CONCURRENCY => {
                     // get the highest accepted rounds
                     let highest_rounds = Self::get_highest_accepted_rounds(dag_state.clone(), &context);
 
@@ -489,10 +494,10 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                     metrics
                         .synchronizer_requested_blocks_by_peer
                         .with_label_values(&[peer_hostname.as_str(), "live"])
-                        .inc_by(blocks_guard.block_refs.len() as u64);
+                        .inc_by(headers_guard.block_refs.len() as u64);
                     // Count requested blocks per authority and increment metric by one per authority
                     let mut authors = HashSet::new();
-                    for block_ref in &blocks_guard.block_refs {
+                    for block_ref in &headers_guard.block_refs {
                         authors.insert(block_ref.author);
                     }
                     for author in authors {
@@ -506,7 +511,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                     requests.push(Self::fetch_block_headers_request(
                         network_client.clone(),
                         peer_index,
-                        blocks_guard,
+                        headers_guard,
                         highest_rounds,
                         FETCH_REQUEST_TIMEOUT,
                         1,
@@ -516,7 +521,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 Some((response, blocks_guard, retries, _peer, highest_rounds)) = requests.next() => {
                     match response {
                         Ok(blocks) => {
-                            if let Err(err) = Self::process_fetched_block_headers(blocks,
+                            if let Err(err) = Self::process_fetched_headers_from_authority(blocks,
                                 peer_index,
                                 blocks_guard,
                                 core_dispatcher.clone(),
@@ -528,9 +533,11 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                                 "live"
                             ).await {
                                 warn!("Error while processing fetched blocks from peer {peer_index} {peer_hostname}: {err}");
+                                context.metrics.node_metrics.synchronizer_process_fetched_failures_by_peer.with_label_values(&[peer_hostname.as_str(), "live"]).inc();
                             }
                         },
                         Err(_) => {
+                            context.metrics.node_metrics.synchronizer_fetch_failures_by_peer.with_label_values(&[peer_hostname.as_str(), "live"]).inc();
                             if retries <= MAX_RETRIES {
                                 requests.push(Self::fetch_block_headers_request(network_client.clone(), peer_index, blocks_guard, highest_rounds, FETCH_REQUEST_TIMEOUT, retries))
                             } else {
@@ -549,10 +556,10 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         }
     }
 
-    /// Processes the requested raw fetched blocks from peer `peer_index`. If no
-    /// error is returned then the verified blocks are immediately sent to
-    /// Core for processing.
-    async fn process_fetched_block_headers(
+    /// Processes the requested raw fetched headers from peer `peer_index`. If
+    /// no error is returned then the verified blocks are immediately sent
+    /// to Core for processing.
+    async fn process_fetched_headers_from_authority(
         serialized_headers: Vec<Bytes>,
         peer_index: AuthorityIndex,
         requested_blocks_guard: BlocksGuard,
@@ -564,22 +571,17 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         commands_sender: Sender<Command>,
         sync_method: &str,
     ) -> ConsensusResult<()> {
-        // The maximum number of blocks that can be additionally fetched from the one
-        // requested - those are potentially missing ancestors.
-        const MAX_ADDITIONAL_BLOCKS: usize = 10;
-
-        // Ensure that all the returned blocks do not go over the total max allowed
-        // returned blocks
-        if serialized_headers.len()
-            > requested_blocks_guard.block_refs.len() + MAX_ADDITIONAL_BLOCKS
-        {
-            return Err(ConsensusError::TooManyFetchedBlocksReturned(peer_index));
+        if serialized_headers.is_empty() {
+            return Ok(());
+        }
+        if serialized_headers.len() > context.parameters.max_headers_per_regular_sync_fetch {
+            return Err(ConsensusError::TooManyFetchedHeadersReturned(peer_index));
         }
 
         // TODO : check if header is already accepted or suspended
 
-        // Verify all the fetched blocks
-        let blocks = Handle::current()
+        // Verify all the fetched block headers
+        let block_headers = Handle::current()
             .spawn_blocking({
                 let block_verifier = block_verifier.clone();
                 let context = context.clone();
@@ -596,7 +598,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             .expect("Spawn blocking should not fail")?;
 
         // Get all the ancestors of the requested blocks only
-        let ancestors = blocks
+        let ancestors = block_headers
             .iter()
             .filter(|b| requested_blocks_guard.block_refs.contains(&b.reference()))
             .flat_map(|b| b.ancestors().to_vec())
@@ -604,13 +606,13 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
         // Now confirm that the blocks are either between the ones requested, or they
         // are parents of the requested blocks
-        for block in &blocks {
+        for block in &block_headers {
             if !requested_blocks_guard
                 .block_refs
                 .contains(&block.reference())
                 && !ancestors.contains(&block.reference())
             {
-                return Err(ConsensusError::UnexpectedFetchedBlock {
+                return Err(ConsensusError::UnexpectedFetchedHeader {
                     index: peer_index,
                     block_ref: block.reference(),
                 });
@@ -618,7 +620,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         }
 
         // Record commit votes from the verified blocks.
-        for block in &blocks {
+        for block in &block_headers {
             commit_vote_monitor.observe_block(block);
         }
 
@@ -627,8 +629,8 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         metrics
             .synchronizer_fetched_blocks_by_peer
             .with_label_values(&[peer_hostname.as_str(), sync_method])
-            .inc_by(blocks.len() as u64);
-        for block in &blocks {
+            .inc_by(block_headers.len() as u64);
+        for block in &block_headers {
             let block_hostname = &context.committee.authority(block.author()).hostname;
             metrics
                 .synchronizer_fetched_blocks_by_authority
@@ -638,15 +640,18 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
         debug!(
             "Synced {} missing blocks from peer {peer_index} {peer_hostname}: {}",
-            blocks.len(),
-            blocks.iter().map(|b| b.reference().to_string()).join(", "),
+            block_headers.len(),
+            block_headers
+                .iter()
+                .map(|b| b.reference().to_string())
+                .join(", "),
         );
 
         // Now send them to core for processing. Ignore the returned missing blocks as
         // we don't want this mechanism to keep feedback looping on fetching
         // more blocks. The periodic synchronization will take care of that.
         let (missing_blocks, missing_committed_txns) = core_dispatcher
-            .add_block_headers(blocks)
+            .add_block_headers(block_headers)
             .await
             .map_err(|_| ConsensusError::Shutdown)?;
 
@@ -712,7 +717,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
         for serialized_block_header in serialized_block_headers.clone().into_iter() {
             let signed_block_header: SignedBlockHeader = bcs::from_bytes(&serialized_block_header)
-                .map_err(ConsensusError::MalformedBlockHeader)?;
+                .map_err(ConsensusError::MalformedHeader)?;
             // TODO: dedup block verifications, here and with fetched blocks??
             if let Err(e) = block_verifier.verify(&signed_block_header) {
                 // TODO: we might want to use a different metric to track the invalid "served"
@@ -813,7 +818,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         let block_verifier = self.block_verifier.clone();
         let core_dispatcher = self.core_dispatcher.clone();
 
-        self.fetch_own_last_block_task
+        self.fetch_own_last_header_task
             .spawn(monitored_future!(async move {
                 let _scope = monitored_scope("FetchOwnLastBlockTask");
 
@@ -830,7 +835,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 let process_blocks = |blocks: Vec<Bytes>, authority_index: AuthorityIndex| -> ConsensusResult<Vec<VerifiedBlockHeader >> {
                                     let mut result = Vec::new();
                                     for serialized_block in blocks {
-                                        let signed_block = bcs::from_bytes(&serialized_block).map_err(ConsensusError::MalformedBlock)?;
+                                        let signed_block = bcs::from_bytes(&serialized_block).map_err(ConsensusError::MalformedHeader)?;
                                         block_verifier.verify(&signed_block).tap_err(|err|{
                                             let hostname = context.committee.authority(authority_index).hostname.clone();
                                             context
@@ -844,7 +849,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
 
                                         let verified_block = VerifiedBlockHeader::new_verified(signed_block, serialized_block);
                                         if verified_block.author() != context.own_index {
-                                            return Err(ConsensusError::UnexpectedLastOwnBlock { index: authority_index, block_ref: verified_block.reference()});
+                                            return Err(ConsensusError::UnexpectedLastOwnHeader { index: authority_index, block_ref: verified_block.reference()});
                                         }
                                         result.push(verified_block);
                                     }
@@ -942,7 +947,10 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             }));
     }
 
-    async fn start_fetch_missing_blocks_task(&mut self) -> ConsensusResult<()> {
+    /// Starts the periodic synchronization task to fetch missing blocks from
+    /// peers. This task runs periodically to ensure that the missing blocks are
+    /// synced.
+    async fn start_periodic_sync_task(&mut self) -> ConsensusResult<()> {
         let mut missing_blocks = self
             .core_dispatcher
             .get_missing_blocks()
@@ -965,6 +973,9 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         let transactions_synchronizer = self.transactions_synchronizer.clone();
 
         let (commit_lagging, last_commit_index, quorum_commit_index) = self.is_commit_lagging();
+        trace!(
+            "Commit lagging: {commit_lagging}, last commit index: {last_commit_index}, quorum commit index: {quorum_commit_index}"
+        );
         if commit_lagging {
             // As node is commit lagging try to sync only the missing blocks that are within
             // the acceptable round thresholds to sync. The rest we don't attempt to
@@ -973,7 +984,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             missing_blocks = missing_blocks
                 .into_iter()
                 .take_while(|(block_ref, _)| {
-                    block_ref.round <= highest_accepted_round + SYNC_MISSING_BLOCK_ROUND_THRESHOLD
+                    block_ref.round <= highest_accepted_round + self.missing_block_round_threshold()
                 })
                 .collect::<BTreeMap<_, _>>();
 
@@ -1030,7 +1041,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 for (blocks_guard, fetched_blocks, peer) in results {
                     total_fetched += fetched_blocks.len();
 
-                    if let Err(err) = Self::process_fetched_block_headers(
+                    if let Err(err) = Self::process_fetched_headers_from_authority(
                         fetched_blocks,
                         peer,
                         blocks_guard,
@@ -1070,6 +1081,16 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         )
     }
 
+    /// The number of rounds above the highest accepted round to allow fetching
+    /// missing blocks via the periodic synchronization. Any missing blocks
+    /// of higher rounds are considered too far in the future to fetch. This
+    /// property is used only when it's detected that the node has fallen
+    /// behind on its commit compared to the rest of the network,
+    /// otherwise scheduler will attempt to fetch any missing block.
+    fn missing_block_round_threshold(&self) -> Round {
+        self.context.parameters.commit_sync_batch_size
+    }
+
     /// Fetches the given `missing_blocks` from up to `MAX_PEERS` authorities in
     /// parallel:
     ///
@@ -1091,12 +1112,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         missing_blocks: BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
         dag_state: Arc<RwLock<DagState>>,
     ) -> Vec<(BlocksGuard, Vec<Bytes>, AuthorityIndex)> {
-        // The maximum number of peers which will be requested in periodic synchronizer
-        const MAX_PEERS: usize = 4;
-        // The maximum number of peers which are chosen totally random to fetch blocks
-        // from
-        const MAX_RANDOM_PEERS: usize = 2;
-
         // Step 1: Map authorities to missing blocks that they are aware of
         let mut authority_to_blocks: HashMap<AuthorityIndex, Vec<BlockRef>> = HashMap::new();
         for (missing_block_ref, authorities) in &missing_blocks {
@@ -1124,11 +1139,17 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         let mut chosen_peers_with_blocks: Vec<(AuthorityIndex, Vec<BlockRef>, &str)> =
             authority_to_blocks
                 .iter()
-                .choose_multiple(&mut rng, MAX_PEERS - MAX_RANDOM_PEERS)
+                .choose_multiple(
+                    &mut rng,
+                    MAX_PERIODIC_SYNC_PEERS - MAX_PERIODIC_SYNC_RANDOM_PEERS,
+                )
                 .into_iter()
                 .map(|(&peer, blocks)| {
-                    let limited_blocks =
-                        blocks.iter().copied().take(MAX_BLOCKS_PER_FETCH).collect();
+                    let limited_blocks = blocks
+                        .iter()
+                        .copied()
+                        .take(context.parameters.max_headers_per_regular_sync_fetch)
+                        .collect();
                     (peer, limited_blocks, "periodic_known")
                 })
                 .collect();
@@ -1138,8 +1159,11 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             let mut items: Vec<(AuthorityIndex, Vec<BlockRef>, &str)> = authority_to_blocks
                 .iter()
                 .map(|(&peer, blocks)| {
-                    let limited_blocks =
-                        blocks.iter().copied().take(MAX_BLOCKS_PER_FETCH).collect();
+                    let limited_blocks = blocks
+                        .iter()
+                        .copied()
+                        .take(context.parameters.max_headers_per_regular_sync_fetch)
+                        .collect();
                     (peer, limited_blocks, "periodic_known")
                 })
                 .collect();
@@ -1148,7 +1172,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             items.sort_by_key(|(peer, _, _)| *peer);
             items
                 .into_iter()
-                .take(MAX_PEERS - MAX_RANDOM_PEERS)
+                .take(MAX_PERIODIC_SYNC_PEERS - MAX_PERIODIC_SYNC_RANDOM_PEERS)
                 .collect()
         };
 
@@ -1170,19 +1194,20 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         #[cfg(test)]
         let random_peers: Vec<AuthorityIndex> = random_candidates
             .into_iter()
-            .take(MAX_RANDOM_PEERS)
+            .take(MAX_PERIODIC_SYNC_RANDOM_PEERS)
             .collect();
         #[cfg(not(test))]
         let random_peers: Vec<AuthorityIndex> = random_candidates
             .into_iter()
-            .choose_multiple(&mut rng, MAX_RANDOM_PEERS);
+            .choose_multiple(&mut rng, MAX_PERIODIC_SYNC_RANDOM_PEERS);
 
         #[cfg_attr(test, allow(unused_mut))]
         let mut all_missing_blocks: Vec<BlockRef> = missing_blocks.keys().cloned().collect();
         #[cfg(not(test))]
         all_missing_blocks.shuffle(&mut rng);
 
-        let mut block_chunks = all_missing_blocks.chunks(MAX_BLOCKS_PER_FETCH);
+        let mut block_chunks =
+            all_missing_blocks.chunks(context.parameters.max_headers_per_regular_sync_fetch);
 
         for peer in random_peers {
             if let Some(chunk) = block_chunks.next() {
@@ -1306,6 +1331,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                             }
                         },
                         Err(_) => {
+                            context.metrics.node_metrics.synchronizer_fetch_failures_by_peer.with_label_values(&[peer_hostname.as_str(), "periodic"]).inc();
                             // try again if there is any peer left
                             if let Some(next_peer) = remaining_peers.next() {
                                 // do best effort to lock guards. If we can't lock then don't bother at this run.
@@ -1391,11 +1417,11 @@ mod tests {
         core_thread::{CoreError, CoreThreadDispatcher, tests::MockCoreThreadDispatcher},
         dag_state::DagState,
         error::{ConsensusError, ConsensusResult},
-        network::{BlockBundleStream, BlockStream, NetworkClient, SerializedBlock},
+        network::{BlockBundleStream, NetworkClient},
         storage::mem_store::MemStore,
         synchronizer::{
-            FETCH_BLOCKS_CONCURRENCY, FETCH_REQUEST_TIMEOUT, InflightBlockHeadersMap,
-            MAX_BLOCKS_PER_FETCH, SYNC_MISSING_BLOCK_ROUND_THRESHOLD, Synchronizer,
+            FETCH_BLOCK_HEADERS_CONCURRENCY, FETCH_REQUEST_TIMEOUT, InflightBlockHeadersMap,
+            Synchronizer,
         },
         transactions_synchronizer::TransactionsSynchronizer,
     };
@@ -1416,7 +1442,7 @@ mod tests {
     }
 
     impl MockNetworkClient {
-        async fn stub_fetch_block_headers(
+        async fn stub_fetch_headers(
             &self,
             block_headers: Vec<VerifiedBlockHeader>,
             peer: AuthorityIndex,
@@ -1451,15 +1477,6 @@ mod tests {
 
     #[async_trait]
     impl NetworkClient for MockNetworkClient {
-        async fn subscribe_blocks(
-            &self,
-            _peer: AuthorityIndex,
-            _last_received: Round,
-            _timeout: Duration,
-        ) -> ConsensusResult<BlockStream> {
-            unimplemented!("Unimplemented")
-        }
-
         async fn subscribe_block_bundles(
             &self,
             _peer: AuthorityIndex,
@@ -1476,32 +1493,6 @@ mod tests {
             _timeout: Duration,
         ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Unimplemented")
-        }
-
-        async fn fetch_blocks(
-            &self,
-            peer: AuthorityIndex,
-            block_refs: Vec<BlockRef>,
-            _highest_accepted_rounds: Vec<Round>,
-            _timeout: Duration,
-        ) -> ConsensusResult<Vec<Bytes>> {
-            let mut lock = self.fetch_blocks_requests.lock().await;
-            let response = lock
-                .remove(&(block_refs, peer))
-                .expect("Unexpected fetch blocks request made");
-
-            let mut serialized_blocks = vec![];
-            for block in response.0.into_iter() {
-                serialized_blocks.push(SerializedBlock::try_from(block).unwrap().serialized_block);
-            }
-
-            drop(lock);
-
-            if let Some(latency) = response.1 {
-                sleep(latency).await;
-            }
-
-            Ok(serialized_blocks)
         }
 
         async fn fetch_block_headers(
@@ -1684,16 +1675,11 @@ mod tests {
         // AND stub the fetch_blocks request from peer 1
         let peer = AuthorityIndex::new_for_test(1);
         network_client
-            .stub_fetch_block_headers(expected_blocks.clone(), peer, None)
+            .stub_fetch_headers(expected_blocks.clone(), peer, None)
             .await;
 
         // WHEN request missing blocks from peer 1
-        assert!(
-            handle
-                .fetch_block_headers(missing_blocks, peer)
-                .await
-                .is_ok()
-        );
+        assert!(handle.fetch_headers(missing_blocks, peer).await.is_ok());
 
         // Wait a little bit until those have been added in core
         sleep(Duration::from_millis(1_000)).await;
@@ -1735,7 +1721,7 @@ mod tests {
         );
 
         // Create some test blocks
-        let expected_blocks = (0..=2 * FETCH_BLOCKS_CONCURRENCY)
+        let expected_blocks = (0..=2 * FETCH_BLOCK_HEADERS_CONCURRENCY)
             .map(|round| {
                 VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round as Round, 0).build())
             })
@@ -1748,7 +1734,7 @@ mod tests {
             // stub the fetch_blocks request from peer 1 and give some high response latency
             // so requests can start blocking the peer task.
             network_client
-                .stub_fetch_block_headers(
+                .stub_fetch_headers(
                     vec![block.clone()],
                     peer,
                     Some(Duration::from_millis(5_000)),
@@ -1761,19 +1747,14 @@ mod tests {
             // WHEN requesting to fetch the blocks, it should not succeed for the last
             // request and get an error with "saturated" synchronizer
             if iter.peek().is_none() {
-                match handle.fetch_block_headers(missing_blocks, peer).await {
+                match handle.fetch_headers(missing_blocks, peer).await {
                     Err(ConsensusError::SynchronizerSaturated(index)) => {
                         assert_eq!(index, peer);
                     }
                     _ => panic!("A saturated synchronizer error was expected"),
                 }
             } else {
-                assert!(
-                    handle
-                        .fetch_block_headers(missing_blocks, peer)
-                        .await
-                        .is_ok()
-                );
+                assert!(handle.fetch_headers(missing_blocks, peer).await.is_ok());
             }
         }
     }
@@ -1814,14 +1795,14 @@ mod tests {
         // Make the first authority timeout, so the second will be called. "We" are
         // authority = 0, so we are skipped anyways.
         network_client
-            .stub_fetch_block_headers(
+            .stub_fetch_headers(
                 expected_blocks.clone(),
                 AuthorityIndex::new_for_test(1),
                 Some(FETCH_REQUEST_TIMEOUT),
             )
             .await;
         network_client
-            .stub_fetch_block_headers(
+            .stub_fetch_headers(
                 expected_blocks.clone(),
                 AuthorityIndex::new_for_test(2),
                 None,
@@ -1855,7 +1836,6 @@ mod tests {
                 .is_empty()
         );
     }
-
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn synchronizer_periodic_task_when_commit_lagging_with_missing_blocks_in_acceptable_thresholds()
      {
@@ -1876,10 +1856,18 @@ mod tests {
             block_verifier.clone(),
             dag_state.clone(),
         );
-        // AND stub some missing blocks. The highest accepted round is 0. Create some
-        // blocks that are below and above the threshold sync.
-        let expected_blocks = (0..SYNC_MISSING_BLOCK_ROUND_THRESHOLD * 2)
-            .map(|round| VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, 0).build()))
+        // AND stub some missing blocks. The highest accepted round is 0.
+        // Create some blocks that are below and above the threshold sync.
+        let sync_missing_block_round_threshold = context.parameters.commit_sync_batch_size;
+        let expected_blocks = (1..=sync_missing_block_round_threshold * 2)
+            .flat_map(|round| {
+                vec![
+                    VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, 1).build()),
+                    VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, 2).build()),
+                    VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, 3).build()),
+                ]
+                .into_iter()
+            })
             .collect::<Vec<_>>();
 
         let missing_blocks = expected_blocks
@@ -1888,27 +1876,48 @@ mod tests {
             .collect::<BTreeSet<_>>();
         core_dispatcher.stub_missing_blocks(missing_blocks).await;
 
-        // AND stub the requests for authority 1 & 2
-        // Make the first authority timeout, so the second will be called. "We" are
-        // authority = 0, so we are skipped anyways.
-        let mut expected_blocks = expected_blocks
-            .into_iter()
-            .filter(|block| block.reference().round <= SYNC_MISSING_BLOCK_ROUND_THRESHOLD)
+        // Stub the requests for authority 1 & 2 & 3
+        let stub_blocks = expected_blocks
+            .iter()
+            .map(|block| (block.reference(), block.clone()))
+            .collect::<BTreeMap<_, _>>();
+
+        // Authority 1 and 2 will be requested about their blocks
+        let stub_block_author_1 = stub_blocks
+            .iter()
+            .filter(|(block, _)| block.author == AuthorityIndex::new_for_test(1))
+            .take(context.parameters.max_headers_per_regular_sync_fetch)
+            .map(|(_, block)| block.clone())
             .collect::<Vec<_>>();
 
-        for chunk in expected_blocks.chunks(MAX_BLOCKS_PER_FETCH) {
-            network_client
-                .stub_fetch_block_headers(
-                    chunk.to_vec(),
-                    AuthorityIndex::new_for_test(1),
-                    Some(FETCH_REQUEST_TIMEOUT),
-                )
-                .await;
+        let stub_block_author_2 = stub_blocks
+            .iter()
+            .filter(|(block, _)| block.author == AuthorityIndex::new_for_test(2))
+            .take(context.parameters.max_headers_per_regular_sync_fetch)
+            .map(|(_, block)| block.clone())
+            .collect::<Vec<_>>();
 
-            network_client
-                .stub_fetch_block_headers(chunk.to_vec(), AuthorityIndex::new_for_test(2), None)
-                .await;
-        }
+        // Authority 3 will be requested about first blocks in the missing blocks
+        let stub_block_author_3 = stub_blocks
+            .iter()
+            .take(context.parameters.max_headers_per_regular_sync_fetch)
+            .map(|(_, block)| block.clone())
+            .collect::<Vec<_>>();
+
+        let mut expected_blocks: Vec<_> = Vec::new();
+        expected_blocks.extend(stub_block_author_1.clone());
+        expected_blocks.extend(stub_block_author_2.clone());
+        expected_blocks.extend(stub_block_author_3.clone());
+
+        network_client
+            .stub_fetch_headers(stub_block_author_1, AuthorityIndex::new_for_test(1), None)
+            .await;
+        network_client
+            .stub_fetch_headers(stub_block_author_2, AuthorityIndex::new_for_test(2), None)
+            .await;
+        network_client
+            .stub_fetch_headers(stub_block_author_3, AuthorityIndex::new_for_test(3), None)
+            .await;
 
         // Now create some blocks to simulate a commit lag
         let round = context.parameters.commit_sync_batch_size * COMMIT_LAG_MULTIPLIER * 2;
@@ -1975,11 +1984,13 @@ mod tests {
         );
         // AND stub some missing blocks. The highest accepted round is 0. Create blocks
         // that are above the threshold sync.
-        let mut expected_blocks = (SYNC_MISSING_BLOCK_ROUND_THRESHOLD * 2
-            ..SYNC_MISSING_BLOCK_ROUND_THRESHOLD * 3)
+        let sync_missing_block_round_threshold = context.parameters.commit_sync_batch_size;
+        let stub_headers = (sync_missing_block_round_threshold * 2
+            ..sync_missing_block_round_threshold * 2
+                + context.parameters.max_headers_per_regular_sync_fetch as u32)
             .map(|round| VerifiedBlockHeader::new_for_test(TestBlockHeader::new(round, 0).build()))
             .collect::<Vec<_>>();
-        let missing_blocks = expected_blocks
+        let missing_blocks = stub_headers
             .iter()
             .map(|block| block.reference())
             .collect::<BTreeSet<_>>();
@@ -1990,18 +2001,25 @@ mod tests {
         // AND stub the requests for authority 1 & 2
         // Make the first authority timeout, so the second will be called. "We" are
         // authority = 0, so we are skipped anyways.
-        for chunk in expected_blocks.chunks(MAX_BLOCKS_PER_FETCH) {
-            network_client
-                .stub_fetch_block_headers(
-                    chunk.to_vec(),
-                    AuthorityIndex::new_for_test(1),
-                    Some(FETCH_REQUEST_TIMEOUT),
-                )
-                .await;
-            network_client
-                .stub_fetch_block_headers(chunk.to_vec(), AuthorityIndex::new_for_test(2), None)
-                .await;
-        }
+        let mut expected_headers = stub_headers
+            .iter()
+            .take(context.parameters.max_headers_per_regular_sync_fetch)
+            .cloned()
+            .collect::<Vec<_>>();
+        network_client
+            .stub_fetch_headers(
+                expected_headers.clone(),
+                AuthorityIndex::new_for_test(1),
+                Some(FETCH_REQUEST_TIMEOUT),
+            )
+            .await;
+        network_client
+            .stub_fetch_headers(
+                expected_headers.clone(),
+                AuthorityIndex::new_for_test(2),
+                None,
+            )
+            .await;
 
         // Now create some blocks to simulate a commit lag
         let round = context.parameters.commit_sync_batch_size * COMMIT_LAG_MULTIPLIER * 2;
@@ -2077,9 +2095,9 @@ mod tests {
         let mut added_blocks = core_dispatcher.get_and_drain_block_headers().await;
 
         added_blocks.sort_by_key(|block| block.reference());
-        expected_blocks.sort_by_key(|block| block.reference());
+        expected_headers.sort_by_key(|block| block.reference());
 
-        assert_eq!(added_blocks, expected_blocks);
+        assert_eq!(added_blocks, expected_headers);
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
@@ -2336,7 +2354,7 @@ mod tests {
                 let peer = AuthorityIndex::new_for_test(i);
                 if i == 1 || i == 4 {
                     network_client
-                        .stub_fetch_block_headers(
+                        .stub_fetch_headers(
                             vec![missing_vb.clone()],
                             peer,
                             Some(2 * FETCH_REQUEST_TIMEOUT),
@@ -2345,7 +2363,7 @@ mod tests {
                     continue;
                 }
                 network_client
-                    .stub_fetch_block_headers(vec![missing_vb.clone()], peer, None)
+                    .stub_fetch_headers(vec![missing_vb.clone()], peer, None)
                     .await;
             }
 
@@ -2446,7 +2464,7 @@ mod tests {
                             .unwrap()
                             .contains(&peer)
                     })
-                    .take(MAX_BLOCKS_PER_FETCH)
+                    .take(context.parameters.max_headers_per_regular_sync_fetch)
                     .cloned()
                     .collect::<Vec<_>>();
                 (peer, verified_block_headers)
@@ -2457,14 +2475,14 @@ mod tests {
             if peer == AuthorityIndex::new_for_test(2) {
                 // Simulate timeout for peer 2, then fallback to peer 5
                 network_client
-                    .stub_fetch_block_headers(
+                    .stub_fetch_headers(
                         verified_block_headers.clone(),
                         peer,
                         Some(2 * FETCH_REQUEST_TIMEOUT),
                     )
                     .await;
                 network_client
-                    .stub_fetch_block_headers(
+                    .stub_fetch_headers(
                         verified_block_headers.clone(),
                         AuthorityIndex::new_for_test(5),
                         None,
@@ -2472,23 +2490,25 @@ mod tests {
                     .await;
             } else {
                 network_client
-                    .stub_fetch_block_headers(verified_block_headers.clone(), peer, None)
+                    .stub_fetch_headers(verified_block_headers.clone(), peer, None)
                     .await;
             }
         }
 
         // 4) Stub fetches from periodic path peers (1 and 4)
         network_client
-            .stub_fetch_block_headers(
-                missing_verified_block_headers[0..MAX_BLOCKS_PER_FETCH].to_vec(),
+            .stub_fetch_headers(
+                missing_verified_block_headers
+                    [0..context.parameters.max_headers_per_regular_sync_fetch]
+                    .to_vec(),
                 AuthorityIndex::new_for_test(1),
                 None,
             )
             .await;
 
         network_client
-            .stub_fetch_block_headers(
-                missing_verified_block_headers[MAX_BLOCKS_PER_FETCH..2 * MAX_BLOCKS_PER_FETCH]
+            .stub_fetch_headers(
+                missing_verified_block_headers[context.parameters.max_headers_per_regular_sync_fetch..2 * context.parameters.max_headers_per_regular_sync_fetch]
                     .to_vec(),
                 AuthorityIndex::new_for_test(4),
                 None,
@@ -2526,7 +2546,8 @@ mod tests {
         // 8) Second fetch from peer 1 (periodic)
         let (_guard1, bytes1, peer1) = &results[1];
         assert_eq!(*peer1, AuthorityIndex::new_for_test(1));
-        let expected1 = missing_verified_block_headers[0..MAX_BLOCKS_PER_FETCH]
+        let expected1 = missing_verified_block_headers
+            [0..context.parameters.max_headers_per_regular_sync_fetch]
             .iter()
             .map(|vb| vb.serialized().clone())
             .collect::<Vec<_>>();
@@ -2535,11 +2556,12 @@ mod tests {
         // 9) Third fetch from peer 4 (periodic)
         let (_guard4, bytes4, peer4) = &results[2];
         assert_eq!(*peer4, AuthorityIndex::new_for_test(4));
-        let expected4 = missing_verified_block_headers
-            [MAX_BLOCKS_PER_FETCH..2 * MAX_BLOCKS_PER_FETCH]
-            .iter()
-            .map(|vb| vb.serialized().clone())
-            .collect::<Vec<_>>();
+        let expected4 =
+            missing_verified_block_headers[context.parameters.max_headers_per_regular_sync_fetch
+                ..2 * context.parameters.max_headers_per_regular_sync_fetch]
+                .iter()
+                .map(|vb| vb.serialized().clone())
+                .collect::<Vec<_>>();
         assert_eq!(bytes4, &expected4);
 
         // 10) Fourth fetch from peer 5 (fallback after peer 2 timeout)

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -966,7 +966,7 @@ mod tests {
         context::Context,
         core_thread::CoreError,
         dag_state::DagState,
-        network::{BlockBundleStream, BlockStream, NetworkClient, SerializedTransactions},
+        network::{BlockBundleStream, NetworkClient, SerializedTransactions},
         storage::mem_store::MemStore,
     };
 
@@ -1968,16 +1968,6 @@ mod tests {
 
     #[async_trait]
     impl NetworkClient for MockNetworkClient {
-        async fn subscribe_blocks(
-            &self,
-            _peer: AuthorityIndex,
-            _last_received: Round,
-            _timeout: Duration,
-        ) -> ConsensusResult<BlockStream> {
-            // Not needed for transactions synchronizer tests
-            unimplemented!("subscribe_blocks not implemented in mock")
-        }
-
         async fn subscribe_block_bundles(
             &self,
             _peer: AuthorityIndex,
@@ -2035,17 +2025,6 @@ mod tests {
                 }
             }
             Ok(result)
-        }
-
-        async fn fetch_blocks(
-            &self,
-            _peer: AuthorityIndex,
-            _block_refs: Vec<BlockRef>,
-            _highest_accepted_rounds: Vec<Round>,
-            _timeout: Duration,
-        ) -> ConsensusResult<Vec<Bytes>> {
-            // Not needed for transactions synchronizer tests
-            unimplemented!("fetch_blocks not implemented in mock")
         }
 
         async fn fetch_block_headers(

--- a/crates/starfish/simtests/src/node.rs
+++ b/crates/starfish/simtests/src/node.rs
@@ -67,7 +67,7 @@ impl AuthorityNode {
             let commit_consumer_monitor = inner.commit_consumer_monitor();
             let _handle = tokio::spawn(async move {
                 while let Some(subdag) = commit_receiver.recv().await {
-                    info!(index =% authority_index, "received committed subdag");
+                    info!(authority =% authority_index, commit_index =% subdag.commit_ref.index, "received committed subdag");
                     commit_consumer_monitor.set_highest_handled_commit(subdag.commit_ref.index);
                 }
             });


### PR DESCRIPTION
# Description of change

This PR introduces batching in the synchronizer. Adapted [PR7811](https://github.com/iotaledger/iota/pull/7811) from Mysticeti to Starfish.

In addition, we cleaned up `subscribe_block` method and modified related tests.

## Links to any relevant issues

Closes #7895 and #7873 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
