### PR TITLE
upstream(node): Add a workload that randomly generates different transaction shapes

### DIFF
--- a/crates/iota-benchmark/src/drivers/bench_driver.rs
+++ b/crates/iota-benchmark/src/drivers/bench_driver.rs
@@ -51,7 +51,7 @@ use crate::{
     ExecutionEffects, ValidatorProxy,
     drivers::{HistogramWrapper, driver::Driver},
     system_state_observer::SystemStateObserver,
-    workloads::{GroupID, WorkloadInfo, payload::Payload},
+    workloads::{GroupID, WorkloadInfo, payload::Payload, workload::ExpectedFailureType},
 };
 pub struct BenchMetrics {
     pub benchmark_duration: IntGauge,
@@ -751,7 +751,10 @@ async fn run_bench_worker(
      -> NextOp {
         match result {
             Ok(effects) => {
-                assert!(payload.get_failure_type().is_none());
+                assert!(
+                    payload.get_failure_type().is_none()
+                        || payload.get_failure_type() == Some(ExpectedFailureType::NoFailure)
+                );
                 let latency = start.elapsed();
                 let time_from_start = total_benchmark_start_time.elapsed();
 
@@ -810,8 +813,15 @@ async fn run_bench_worker(
                 }
             }
             Err(err) => {
-                error!("{}", err);
+                tracing::error!(
+                    "Transaction execution got error: {}. Transaction digest: {:?}",
+                    err,
+                    transaction.digest()
+                );
                 match payload.get_failure_type() {
+                    Some(ExpectedFailureType::NoFailure) => {
+                        panic!("Transaction failed unexpectedly");
+                    }
                     Some(_) => {
                         metrics_cloned
                             .num_expected_error
@@ -932,10 +942,10 @@ async fn run_bench_worker(
                 if let Some(b) = retry_queue.pop_front() {
                     let tx = b.0;
                     let payload = b.1;
-                    if payload.get_failure_type().is_some() {
-                        num_expected_error_txes += 1;
-                    } else {
-                        num_error_txes += 1;
+                    match payload.get_failure_type() {
+                        Some(ExpectedFailureType::NoFailure) => num_error_txes += 1,
+                        Some(_) => num_expected_error_txes += 1,
+                        None => num_error_txes += 1,
                     }
                     num_submitted += 1;
                     metrics_cloned.num_submitted.with_label_values(&[&payload.to_string()]).inc();

--- a/crates/iota-benchmark/src/options.rs
+++ b/crates/iota-benchmark/src/options.rs
@@ -190,6 +190,9 @@ pub enum RunSpec {
         // relative weight of expected failure transactions in the benchmark workload
         #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0])]
         expected_failure: Vec<u32>,
+        // relative weight of randomized transaction in the benchmark workload
+        #[clap(long, num_args(1..), value_delimiter = ',', default_values_t = [0])]
+        randomized_transaction: Vec<u32>,
 
         // --- workload-specific options --- (TODO: use subcommands or similar)
         // 100 for max hotness i.e all requests target

--- a/crates/iota-benchmark/src/workloads/adversarial.rs
+++ b/crates/iota-benchmark/src/workloads/adversarial.rs
@@ -419,7 +419,7 @@ impl AdversarialWorkloadBuilder {
         duration: Interval,
         group: u32,
     ) -> Option<WorkloadBuilderInfo> {
-        let target_qps = (workload_weight * target_qps as f32) as u64;
+        let target_qps = (workload_weight * target_qps as f32).ceil() as u64;
         let num_workers = (workload_weight * num_workers as f32).ceil() as u64;
         let max_ops = target_qps * in_flight_ratio;
         if max_ops == 0 || num_workers == 0 {

--- a/crates/iota-benchmark/src/workloads/batch_payment.rs
+++ b/crates/iota-benchmark/src/workloads/batch_payment.rs
@@ -150,7 +150,7 @@ impl BatchPaymentWorkloadBuilder {
         duration: Interval,
         group: u32,
     ) -> Option<WorkloadBuilderInfo> {
-        let target_qps = (workload_weight * target_qps as f32) as u64;
+        let target_qps = (workload_weight * target_qps as f32).ceil() as u64;
         let num_workers = (workload_weight * num_workers as f32).ceil() as u64;
         let max_ops = target_qps * in_flight_ratio;
         if max_ops == 0 || num_workers == 0 {

--- a/crates/iota-benchmark/src/workloads/delegation.rs
+++ b/crates/iota-benchmark/src/workloads/delegation.rs
@@ -109,7 +109,7 @@ impl DelegationWorkloadBuilder {
         duration: Interval,
         group: u32,
     ) -> Option<WorkloadBuilderInfo> {
-        let target_qps = (workload_weight * target_qps as f32) as u64;
+        let target_qps = (workload_weight * target_qps as f32).ceil() as u64;
         let num_workers = (workload_weight * num_workers as f32).ceil() as u64;
         let max_ops = target_qps * in_flight_ratio;
         if max_ops == 0 || num_workers == 0 {

--- a/crates/iota-benchmark/src/workloads/expected_failure.rs
+++ b/crates/iota-benchmark/src/workloads/expected_failure.rs
@@ -60,6 +60,7 @@ impl ExpectedFailurePayload {
                 tx
             }
             ExpectedFailureType::Random => unreachable!(),
+            ExpectedFailureType::NoFailure => unreachable!(),
         }
     }
 }
@@ -118,7 +119,7 @@ impl ExpectedFailureWorkloadBuilder {
         duration: Interval,
         group: u32,
     ) -> Option<WorkloadBuilderInfo> {
-        let target_qps = (workload_weight * target_qps as f32) as u64;
+        let target_qps = (workload_weight * target_qps as f32).ceil() as u64;
         let num_workers = (workload_weight * num_workers as f32).ceil() as u64;
         let max_ops = target_qps * in_flight_ratio;
         if max_ops == 0 || num_workers == 0 {

--- a/crates/iota-benchmark/src/workloads/mod.rs
+++ b/crates/iota-benchmark/src/workloads/mod.rs
@@ -7,6 +7,7 @@ pub mod batch_payment;
 pub mod delegation;
 pub mod expected_failure;
 pub mod payload;
+pub mod randomized_transaction;
 pub mod randomness;
 pub mod shared_counter;
 pub mod shared_object_deletion;

--- a/crates/iota-benchmark/src/workloads/randomized_transaction.rs
+++ b/crates/iota-benchmark/src/workloads/randomized_transaction.rs
@@ -1,0 +1,542 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::future::join_all;
+use iota_test_transaction_builder::TestTransactionBuilder;
+use iota_types::{
+    IOTA_RANDOMNESS_STATE_OBJECT_ID, Identifier,
+    base_types::{IotaAddress, ObjectID, ObjectRef, SequenceNumber},
+    crypto::{AccountKeyPair, get_key_pair},
+    object::Owner,
+    programmable_transaction_builder::ProgrammableTransactionBuilder,
+    transaction::{CallArg, ObjectArg, Transaction},
+};
+use rand::Rng;
+use tracing::{error, info};
+
+use super::STORAGE_COST_PER_COUNTER;
+use crate::{
+    ExecutionEffects, ValidatorProxy,
+    drivers::Interval,
+    system_state_observer::SystemStateObserver,
+    util::publish_basics_package,
+    workloads::{
+        Gas, GasCoinConfig, WorkloadBuilderInfo, WorkloadParams,
+        payload::Payload,
+        workload::{
+            ESTIMATED_COMPUTATION_COST, ExpectedFailureType, MAX_GAS_FOR_TESTING, Workload,
+            WorkloadBuilder,
+        },
+    },
+};
+
+pub const MAX_GAS_IN_UNIT: u64 = 1_000_000_000;
+
+/// A workload that generates random transactions to test the system under
+/// different transaction patterns. The workload can:
+/// - Create shared counter objects
+/// - Make random move calls to increment/read/delete counters
+/// - Make calls to the randomness module
+/// - Make native transfers
+/// - Mix different numbers of pure and shared object inputs
+/// - Generate multiple move calls per transaction
+///
+/// The exact mix of operations is controlled by random selection within
+/// configured bounds.
+///
+/// Different from adversarial workload, this workload is not designed to test
+/// the system under malicious behaviors, but to test the system under different
+/// transaction patterns.
+#[derive(Debug)]
+pub struct RandomizedTransactionPayload {
+    package_id: ObjectID,
+    shared_objects: Vec<ObjectRef>,
+    owned_object: ObjectRef,
+    randomness_initial_shared_version: SequenceNumber,
+    transfer_to: IotaAddress,
+    gas: Gas,
+    system_state_observer: Arc<SystemStateObserver>,
+}
+
+impl std::fmt::Display for RandomizedTransactionPayload {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "randomized_transaction")
+    }
+}
+
+/// Config for a randomized transaction
+#[derive(Debug)]
+struct RandomizedTransactionConfig {
+    // Whether the transaction contains the owned object
+    contain_owned_object: bool,
+    // Number of pure inputs
+    num_pure_input: u64,
+    // Number of shared inputs
+    num_shared_inputs: u64,
+    // Number of move calls
+    num_move_calls: u64,
+}
+
+fn generate_random_transaction_config(
+    num_shared_objects_exist: u64,
+) -> RandomizedTransactionConfig {
+    let num_shared_inputs = rand::thread_rng().gen_range(0..=num_shared_objects_exist);
+    RandomizedTransactionConfig {
+        contain_owned_object: rand::thread_rng().gen_bool(0.5),
+        num_pure_input: rand::thread_rng().gen_range(0..=5),
+        num_shared_inputs,
+        num_move_calls: std::cmp::min(rand::thread_rng().gen_range(0..=3), num_shared_inputs),
+    }
+}
+
+/// Type of move call to generate.
+enum MoveCallType {
+    ContractCall,
+    Randomness,
+    NativeCall,
+}
+
+/// Choose a random move call type.
+fn choose_move_call_type(next_shared_input_index: usize, num_shared_inputs: u64) -> MoveCallType {
+    if next_shared_input_index < num_shared_inputs as usize {
+        match rand::thread_rng().gen_range(0..=2) {
+            0 => MoveCallType::ContractCall,
+            1 => MoveCallType::Randomness,
+            _ => MoveCallType::NativeCall,
+        }
+    } else {
+        match rand::thread_rng().gen_range(0..=1) {
+            0 => MoveCallType::Randomness,
+            _ => MoveCallType::NativeCall,
+        }
+    }
+}
+
+impl RandomizedTransactionPayload {
+    fn make_counter_move_call(
+        &mut self,
+        builder: &mut ProgrammableTransactionBuilder,
+        next_shared_input_index: usize,
+    ) {
+        // 33% chance to increment, 33% chance to set value, 33% chance to read value.
+        match rand::thread_rng().gen_range(0..=2) {
+            0 => {
+                builder
+                    .move_call(
+                        self.package_id,
+                        Identifier::new("counter").unwrap(),
+                        Identifier::new("increment").unwrap(),
+                        vec![],
+                        vec![CallArg::Object(ObjectArg::SharedObject {
+                            id: self.shared_objects[next_shared_input_index].0,
+                            initial_shared_version: self.shared_objects[next_shared_input_index].1,
+                            mutable: true,
+                        })],
+                    )
+                    .unwrap();
+            }
+            1 => {
+                builder
+                    .move_call(
+                        self.package_id,
+                        Identifier::new("counter").unwrap(),
+                        Identifier::new("set_value").unwrap(),
+                        vec![],
+                        vec![
+                            CallArg::Object(ObjectArg::SharedObject {
+                                id: self.shared_objects[next_shared_input_index].0,
+                                initial_shared_version: self.shared_objects
+                                    [next_shared_input_index]
+                                    .1,
+                                mutable: true,
+                            }),
+                            CallArg::Pure((10_u64).to_le_bytes().to_vec()),
+                        ],
+                    )
+                    .unwrap();
+            }
+            _ => {
+                builder
+                    .move_call(
+                        self.package_id,
+                        Identifier::new("counter").unwrap(),
+                        Identifier::new("value").unwrap(),
+                        vec![],
+                        vec![CallArg::Object(ObjectArg::SharedObject {
+                            id: self.shared_objects[next_shared_input_index].0,
+                            initial_shared_version: self.shared_objects[next_shared_input_index].1,
+                            mutable: false,
+                        })],
+                    )
+                    .unwrap();
+            }
+        }
+    }
+
+    fn make_randomness_move_call(&mut self, builder: &mut ProgrammableTransactionBuilder) {
+        builder
+            .move_call(
+                self.package_id,
+                Identifier::new("random").unwrap(),
+                Identifier::new("new").unwrap(),
+                vec![],
+                vec![CallArg::Object(ObjectArg::SharedObject {
+                    id: IOTA_RANDOMNESS_STATE_OBJECT_ID,
+                    initial_shared_version: self.randomness_initial_shared_version,
+                    mutable: false,
+                })],
+            )
+            .unwrap();
+    }
+
+    fn make_native_move_call(&mut self, builder: &mut ProgrammableTransactionBuilder) {
+        builder
+            .pay_iota(
+                vec![self.transfer_to],
+                vec![rand::thread_rng().gen_range(0..=1)],
+            )
+            .unwrap();
+    }
+}
+
+impl Payload for RandomizedTransactionPayload {
+    fn make_new_payload(&mut self, effects: &ExecutionEffects) {
+        if !effects.is_ok() {
+            effects.print_gas_summary();
+            error!(
+                "Randomized transaction failed... Status: {:?}",
+                effects.status()
+            );
+        }
+        self.gas.0 = effects.gas_object().0;
+
+        // Update owned object if it's mutated in this transaction
+        if let Some(owned_in_effects) = effects
+            .mutated()
+            .iter()
+            .find(|(object_ref, _)| object_ref.0 == self.owned_object.0)
+            .map(|x| x.0)
+        {
+            tracing::debug!("Owned object mutated: {:?}", owned_in_effects);
+            self.owned_object = owned_in_effects;
+        }
+    }
+
+    fn make_transaction(&mut self) -> Transaction {
+        let rgp = self
+            .system_state_observer
+            .state
+            .borrow()
+            .reference_gas_price;
+
+        let config = generate_random_transaction_config(self.shared_objects.len() as u64);
+
+        let mut builder = ProgrammableTransactionBuilder::new();
+
+        // Generate inputs in addition to move calls.
+        if config.contain_owned_object {
+            builder
+                .obj(ObjectArg::ImmOrOwnedObject(self.owned_object))
+                .unwrap();
+        }
+        for i in 0..config.num_shared_inputs {
+            builder
+                .obj(ObjectArg::SharedObject {
+                    id: self.shared_objects[i as usize].0,
+                    initial_shared_version: self.shared_objects[i as usize].1,
+                    mutable: rand::thread_rng().gen_bool(0.5),
+                })
+                .unwrap();
+        }
+        for _i in 0..config.num_pure_input {
+            let len = rand::thread_rng().gen_range(0..=3);
+            let mut bytes = vec![0u8; len];
+            rand::thread_rng().fill(&mut bytes[..]);
+            builder.pure_bytes(bytes, false);
+        }
+
+        // Generate move calls.
+        let mut next_shared_input_index: usize = 0;
+        for _i in 0..config.num_move_calls {
+            match choose_move_call_type(next_shared_input_index, config.num_shared_inputs) {
+                MoveCallType::ContractCall => {
+                    self.make_counter_move_call(&mut builder, next_shared_input_index);
+                    next_shared_input_index += 1;
+                }
+                MoveCallType::Randomness => {
+                    self.make_randomness_move_call(&mut builder);
+                    // TODO: add TransferObject move call after randomness command.
+                    break;
+                }
+                MoveCallType::NativeCall => {
+                    self.make_native_move_call(&mut builder);
+                }
+            }
+        }
+        let tx = builder.finish();
+
+        tracing::info!("Randomized transaction: {:?}", tx);
+
+        let signed_tx = TestTransactionBuilder::new(self.gas.1, self.gas.0, rgp)
+            .programmable(tx)
+            .build_and_sign(self.gas.2.as_ref());
+
+        tracing::debug!("Signed transaction digest: {:?}", signed_tx.digest());
+        signed_tx
+    }
+
+    fn get_failure_type(&self) -> Option<ExpectedFailureType> {
+        // We do not expect randomized transaction to fail
+        Some(ExpectedFailureType::NoFailure)
+    }
+}
+
+#[derive(Debug)]
+pub struct RandomizedTransactionWorkloadBuilder {
+    num_payloads: u64,
+    rgp: u64,
+}
+
+impl RandomizedTransactionWorkloadBuilder {
+    pub fn from(
+        workload_weight: f32,
+        target_qps: u64,
+        num_workers: u64,
+        in_flight_ratio: u64,
+        reference_gas_price: u64,
+        duration: Interval,
+        group: u32,
+    ) -> Option<WorkloadBuilderInfo> {
+        let target_qps = (workload_weight * target_qps as f32).ceil() as u64;
+        let num_workers = (workload_weight * num_workers as f32).ceil() as u64;
+        let max_ops = target_qps * in_flight_ratio;
+
+        if max_ops == 0 || num_workers == 0 {
+            None
+        } else {
+            let workload_params = WorkloadParams {
+                group,
+                target_qps,
+                num_workers,
+                max_ops,
+                duration,
+            };
+            let workload_builder = Box::<dyn WorkloadBuilder<dyn Payload>>::from(Box::new(
+                RandomizedTransactionWorkloadBuilder {
+                    num_payloads: max_ops,
+                    rgp: reference_gas_price,
+                },
+            ));
+            Some(WorkloadBuilderInfo {
+                workload_params,
+                workload_builder,
+            })
+        }
+    }
+}
+
+#[async_trait]
+impl WorkloadBuilder<dyn Payload> for RandomizedTransactionWorkloadBuilder {
+    async fn generate_coin_config_for_init(&self) -> Vec<GasCoinConfig> {
+        let mut configs = vec![];
+
+        // Gas coin for publishing package
+        let (address, keypair) = get_key_pair();
+        configs.push(GasCoinConfig {
+            amount: MAX_GAS_FOR_TESTING,
+            address,
+            keypair: Arc::new(keypair),
+        });
+
+        // Gas coins for creating counters
+        for _i in 0..self.num_payloads {
+            let (address, keypair) = get_key_pair();
+            configs.push(GasCoinConfig {
+                amount: MAX_GAS_FOR_TESTING,
+                address,
+                keypair: Arc::new(keypair),
+            });
+        }
+        configs
+    }
+
+    async fn generate_coin_config_for_payloads(&self) -> Vec<GasCoinConfig> {
+        let mut configs = vec![];
+        let amount = MAX_GAS_IN_UNIT * (self.rgp)
+            + ESTIMATED_COMPUTATION_COST
+            + STORAGE_COST_PER_COUNTER * self.num_payloads
+            + MAX_GAS_FOR_TESTING;
+        // Gas coins for running workload
+        for _i in 0..self.num_payloads {
+            let (address, keypair) = get_key_pair();
+            configs.push(GasCoinConfig {
+                amount,
+                address,
+                keypair: Arc::new(keypair),
+            });
+        }
+        configs
+    }
+
+    async fn build(
+        &self,
+        init_gas: Vec<Gas>,
+        payload_gas: Vec<Gas>,
+    ) -> Box<dyn Workload<dyn Payload>> {
+        Box::<dyn Workload<dyn Payload>>::from(Box::new(RandomizedTransactionWorkload {
+            basics_package_id: None,
+            shared_objects: vec![],
+            owned_objects: vec![],
+            transfer_to: None,
+            init_gas,
+            payload_gas,
+            randomness_initial_shared_version: None,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct RandomizedTransactionWorkload {
+    pub basics_package_id: Option<ObjectID>,
+    pub shared_objects: Vec<ObjectRef>,
+    pub owned_objects: Vec<ObjectRef>,
+    pub transfer_to: Option<IotaAddress>,
+    pub init_gas: Vec<Gas>,
+    pub payload_gas: Vec<Gas>,
+    pub randomness_initial_shared_version: Option<SequenceNumber>,
+}
+
+#[async_trait]
+impl Workload<dyn Payload> for RandomizedTransactionWorkload {
+    async fn init(
+        &mut self,
+        proxy: Arc<dyn ValidatorProxy + Sync + Send>,
+        system_state_observer: Arc<SystemStateObserver>,
+    ) {
+        if self.basics_package_id.is_some() {
+            return;
+        }
+        let gas_price = system_state_observer.state.borrow().reference_gas_price;
+        let (head, tail) = self
+            .init_gas
+            .split_first()
+            .expect("Not enough gas to initialize randomized transaction workload");
+
+        // Publish basics package
+        info!("Publishing basics package");
+        self.basics_package_id = Some(
+            publish_basics_package(head.0, proxy.clone(), head.1, &head.2, gas_price)
+                .await
+                .0,
+        );
+
+        // Create a transfer address
+        self.transfer_to = Some(get_key_pair::<AccountKeyPair>().0);
+
+        // Create shared objects
+        {
+            let mut futures = vec![];
+            for (gas, sender, keypair) in tail.iter() {
+                let transaction = TestTransactionBuilder::new(*sender, *gas, gas_price)
+                    .call_counter_create(self.basics_package_id.unwrap())
+                    .build_and_sign(keypair.as_ref());
+                let proxy_ref = proxy.clone();
+                futures.push(async move {
+                    proxy_ref
+                        .execute_transaction_block(transaction)
+                        .await
+                        .unwrap()
+                        .created()[0]
+                        .0
+                });
+            }
+            self.shared_objects = join_all(futures).await;
+        }
+
+        // create owned objects
+        {
+            let mut futures = vec![];
+            for (gas, sender, keypair) in self.payload_gas.iter() {
+                let transaction = TestTransactionBuilder::new(*sender, *gas, gas_price)
+                    .move_call(
+                        self.basics_package_id.unwrap(),
+                        "object_basics",
+                        "create",
+                        vec![
+                            CallArg::Pure(bcs::to_bytes(&(16_u64)).unwrap()),
+                            CallArg::Pure(bcs::to_bytes(&sender).unwrap()),
+                        ],
+                    )
+                    .build_and_sign(keypair.as_ref());
+                let proxy_ref = proxy.clone();
+                futures.push(async move {
+                    let execution_result = proxy_ref
+                        .execute_transaction_block(transaction)
+                        .await
+                        .unwrap();
+                    let created_owned = execution_result.created()[0].0;
+                    let updated_gas = execution_result.gas_object().0;
+                    (created_owned, updated_gas)
+                });
+            }
+            let results = join_all(futures).await;
+            self.owned_objects = results.iter().map(|x| x.0).collect();
+
+            // Update gas object in payload gas
+            for (payload_gas, result) in self.payload_gas.iter_mut().zip(results.iter()) {
+                payload_gas.0 = result.1;
+            }
+        }
+
+        // Get randomness shared object initial version
+        if self.randomness_initial_shared_version.is_none() {
+            let obj = proxy
+                .get_object(IOTA_RANDOMNESS_STATE_OBJECT_ID)
+                .await
+                .expect("Failed to get randomness object");
+            let Owner::Shared {
+                initial_shared_version,
+            } = obj.owner()
+            else {
+                panic!("randomness object must be shared");
+            };
+            self.randomness_initial_shared_version = Some(*initial_shared_version);
+        }
+
+        info!(
+            "Basics package id {:?}. Total shared objects created {:?}",
+            self.basics_package_id,
+            self.shared_objects.len()
+        );
+    }
+
+    async fn make_test_payloads(
+        &self,
+        _proxy: Arc<dyn ValidatorProxy + Sync + Send>,
+        system_state_observer: Arc<SystemStateObserver>,
+    ) -> Vec<Box<dyn Payload>> {
+        info!("Creating randomized transaction payloads...");
+        let mut payloads = vec![];
+
+        for (i, g) in self.payload_gas.iter().enumerate() {
+            payloads.push(Box::new(RandomizedTransactionPayload {
+                package_id: self.basics_package_id.unwrap(),
+                shared_objects: self.shared_objects.clone(),
+                owned_object: self.owned_objects[i],
+                randomness_initial_shared_version: self.randomness_initial_shared_version.unwrap(),
+                transfer_to: self.transfer_to.unwrap(),
+                gas: g.clone(),
+                system_state_observer: system_state_observer.clone(),
+            }));
+        }
+
+        payloads
+            .into_iter()
+            .map(|b| Box::<dyn Payload>::from(b))
+            .collect()
+    }
+}

--- a/crates/iota-benchmark/src/workloads/randomized_transaction.rs
+++ b/crates/iota-benchmark/src/workloads/randomized_transaction.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use futures::future::join_all;
@@ -417,6 +417,11 @@ impl Workload<dyn Payload> for RandomizedTransactionWorkload {
         proxy: Arc<dyn ValidatorProxy + Sync + Send>,
         system_state_observer: Arc<SystemStateObserver>,
     ) {
+        // We observed that randomness may need a few seconds until DKG completion, and
+        // this may causing randomness transaction fail with
+        // `TooOldTransactionPendingOnObject` error. Therefore, wait a few
+        // seconds at the beginning to give DKG some time.
+        tokio::time::sleep(Duration::from_secs(5)).await;
         if self.basics_package_id.is_some() {
             return;
         }

--- a/crates/iota-benchmark/src/workloads/randomness.rs
+++ b/crates/iota-benchmark/src/workloads/randomness.rs
@@ -86,7 +86,7 @@ impl RandomnessWorkloadBuilder {
         duration: Interval,
         group: u32,
     ) -> Option<WorkloadBuilderInfo> {
-        let target_qps = (workload_weight * target_qps as f32) as u64;
+        let target_qps = (workload_weight * target_qps as f32).ceil() as u64;
         let num_workers = (workload_weight * num_workers as f32).ceil() as u64;
         let max_ops = target_qps * in_flight_ratio;
         if max_ops == 0 || num_workers == 0 {

--- a/crates/iota-benchmark/src/workloads/shared_counter.rs
+++ b/crates/iota-benchmark/src/workloads/shared_counter.rs
@@ -103,7 +103,7 @@ impl SharedCounterWorkloadBuilder {
         duration: Interval,
         group: u32,
     ) -> Option<WorkloadBuilderInfo> {
-        let target_qps = (workload_weight * target_qps as f32) as u64;
+        let target_qps = (workload_weight * target_qps as f32).ceil() as u64;
         let num_workers = (workload_weight * num_workers as f32).ceil() as u64;
         let max_ops = target_qps * in_flight_ratio;
         let shared_counter_ratio =

--- a/crates/iota-benchmark/src/workloads/shared_object_deletion.rs
+++ b/crates/iota-benchmark/src/workloads/shared_object_deletion.rs
@@ -148,7 +148,7 @@ impl SharedCounterDeletionWorkloadBuilder {
         duration: Interval,
         group: u32,
     ) -> Option<WorkloadBuilderInfo> {
-        let target_qps = (workload_weight * target_qps as f32) as u64;
+        let target_qps = (workload_weight * target_qps as f32).ceil() as u64;
         let num_workers = (workload_weight * num_workers as f32).ceil() as u64;
         let max_ops = target_qps * in_flight_ratio;
         let shared_counter_ratio =

--- a/crates/iota-benchmark/src/workloads/transfer_object.rs
+++ b/crates/iota-benchmark/src/workloads/transfer_object.rs
@@ -111,7 +111,7 @@ impl TransferObjectWorkloadBuilder {
         duration: Interval,
         group: u32,
     ) -> Option<WorkloadBuilderInfo> {
-        let target_qps = (workload_weight * target_qps as f32) as u64;
+        let target_qps = (workload_weight * target_qps as f32).ceil() as u64;
         let num_workers = (workload_weight * num_workers as f32).ceil() as u64;
         let max_ops = target_qps * in_flight_ratio;
         if max_ops == 0 || num_workers == 0 {

--- a/crates/iota-benchmark/src/workloads/workload.rs
+++ b/crates/iota-benchmark/src/workloads/workload.rs
@@ -52,7 +52,7 @@ impl TryFrom<u32> for ExpectedFailureType {
         match value {
             0 => {
                 let mut rng = rand::thread_rng();
-                let n = rng.gen_range(0..ExpectedFailureType::COUNT - 1);
+                let n = rng.gen_range(1..ExpectedFailureType::COUNT - 1);
                 Ok(ExpectedFailureType::iter().nth(n).unwrap())
             }
             _ => ExpectedFailureType::iter()

--- a/crates/iota-benchmark/src/workloads/workload.rs
+++ b/crates/iota-benchmark/src/workloads/workload.rs
@@ -34,11 +34,15 @@ pub const STORAGE_COST_PER_COUNTER: u64 = 341 * 76 * 100;
 /// Used to estimate the budget required for each transaction.
 pub const ESTIMATED_COMPUTATION_COST: u64 = 1_000_000;
 
-#[derive(Debug, EnumCountMacro, EnumIter, Clone, Copy)]
+#[derive(Debug, EnumCountMacro, EnumIter, Clone, Copy, PartialEq)]
 pub enum ExpectedFailureType {
     Random = 0,
     InvalidSignature,
     // TODO: Add other failure types
+
+    // This is not a failure type, but a placeholder for no failure. Marking no failure asserts
+    // that the transaction must succeed.
+    NoFailure,
 }
 
 impl TryFrom<u32> for ExpectedFailureType {
@@ -46,7 +50,11 @@ impl TryFrom<u32> for ExpectedFailureType {
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(rand::random()),
+            0 => {
+                let mut rng = rand::thread_rng();
+                let n = rng.gen_range(0..ExpectedFailureType::COUNT - 1);
+                Ok(ExpectedFailureType::iter().nth(n).unwrap())
+            }
             _ => ExpectedFailureType::iter()
                 .nth(value as usize)
                 .ok_or_else(|| {

--- a/crates/iota-benchmark/src/workloads/workload_configuration.rs
+++ b/crates/iota-benchmark/src/workloads/workload_configuration.rs
@@ -10,6 +10,7 @@ use tracing::info;
 use super::{
     adversarial::{AdversarialPayloadCfg, AdversarialWorkloadBuilder},
     expected_failure::{ExpectedFailurePayloadCfg, ExpectedFailureWorkloadBuilder},
+    randomized_transaction::RandomizedTransactionWorkloadBuilder,
     randomness::RandomnessWorkloadBuilder,
     shared_object_deletion::SharedCounterDeletionWorkloadBuilder,
 };
@@ -26,6 +27,7 @@ use crate::{
     },
 };
 
+#[derive(Debug)]
 pub struct WorkloadWeights {
     pub shared_counter: u32,
     pub transfer_object: u32,
@@ -35,6 +37,7 @@ pub struct WorkloadWeights {
     pub adversarial: u32,
     pub expected_failure: u32,
     pub randomness: u32,
+    pub randomized_transaction: u32,
 }
 
 pub struct WorkloadConfig {
@@ -74,6 +77,7 @@ impl WorkloadConfiguration {
                 adversarial,
                 expected_failure,
                 randomness,
+                randomized_transaction,
                 shared_counter_hotness_factor,
                 num_shared_counters,
                 shared_counter_max_tip,
@@ -108,6 +112,7 @@ impl WorkloadConfiguration {
                             adversarial: adversarial[i],
                             expected_failure: expected_failure[i],
                             randomness: randomness[i],
+                            randomized_transaction: randomized_transaction[i],
                         },
                         adversarial_cfg: AdversarialPayloadCfg::from_str(&adversarial_cfg[i])
                             .unwrap(),
@@ -199,6 +204,13 @@ impl WorkloadConfiguration {
         }: WorkloadConfig,
         system_state_observer: Arc<SystemStateObserver>,
     ) -> Vec<Option<WorkloadBuilderInfo>> {
+        tracing::info!(
+            "Workload Configuration weights {:?} target_qps: {:?} num_workers: {:?} duration: {:?}",
+            weights,
+            target_qps,
+            num_workers,
+            duration
+        );
         let total_weight = weights.shared_counter
             + weights.shared_deletion
             + weights.transfer_object
@@ -206,7 +218,8 @@ impl WorkloadConfiguration {
             + weights.batch_payment
             + weights.adversarial
             + weights.randomness
-            + weights.expected_failure;
+            + weights.expected_failure
+            + weights.randomized_transaction;
         let reference_gas_price = system_state_observer.state.borrow().reference_gas_price;
         let mut workload_builders = vec![];
         let shared_workload = SharedCounterWorkloadBuilder::from(
@@ -294,6 +307,16 @@ impl WorkloadConfiguration {
             group,
         );
         workload_builders.push(expected_failure_workload);
+        let randomized_transaction_workload = RandomizedTransactionWorkloadBuilder::from(
+            weights.randomized_transaction as f32 / total_weight as f32,
+            target_qps,
+            num_workers,
+            in_flight_ratio,
+            reference_gas_price,
+            duration,
+            group,
+        );
+        workload_builders.push(randomized_transaction_workload);
 
         workload_builders
     }

--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -545,6 +545,9 @@ mod test {
             // Use shared_counter_max_tip to make transactions to have different gas prices.
             simulated_load_config.use_shared_counter_max_tip = rng.gen_bool(0.25);
             simulated_load_config.shared_counter_max_tip = rng.gen_range(1..=1000);
+
+            // Always enable the randomized tx workload in this test.
+            simulated_load_config.randomized_transaction_weight = 1;
             info!("Simulated load config: {:?}", simulated_load_config);
         }
 

--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -548,7 +548,7 @@ mod test {
             info!("Simulated load config: {:?}", simulated_load_config);
         }
 
-        test_simulated_load_with_test_config(test_cluster, 50, simulated_load_config, None, None)
+        test_simulated_load_with_test_config(test_cluster, 180, simulated_load_config, None, None)
             .await;
     }
 
@@ -918,6 +918,7 @@ mod test {
         shared_deletion_weight: u32,
         shared_counter_hotness_factor: u32,
         randomness_weight: u32,
+        randomized_transaction_weight: u32,
         num_shared_counters: Option<u64>,
         use_shared_counter_max_tip: bool,
         shared_counter_max_tip: u64,
@@ -936,6 +937,7 @@ mod test {
                 shared_deletion_weight: 1,
                 shared_counter_hotness_factor: 50,
                 randomness_weight: 1,
+                randomized_transaction_weight: 1,
                 num_shared_counters: Some(1),
                 use_shared_counter_max_tip: false,
                 shared_counter_max_tip: 0,
@@ -996,7 +998,7 @@ mod test {
 
         // The default test parameters are somewhat conservative in order to keep the
         // running time of the test reasonable in CI.
-        let target_qps = target_qps.unwrap_or(get_var("SIM_STRESS_TEST_QPS", 10));
+        let target_qps = target_qps.unwrap_or(get_var("SIM_STRESS_TEST_QPS", 20));
         let num_workers = num_workers.unwrap_or(get_var("SIM_STRESS_TEST_WORKERS", 10));
         let in_flight_ratio = get_var("SIM_STRESS_TEST_IFR", 2);
         let batch_payment_size = get_var("SIM_BATCH_PAYMENT_SIZE", 15);
@@ -1026,6 +1028,7 @@ mod test {
             randomness: config.randomness_weight,
             adversarial: adversarial_weight,
             expected_failure: config.expected_failure_weight,
+            randomized_transaction: config.randomized_transaction_weight,
         };
 
         let workload_config = WorkloadConfig {

--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -937,7 +937,7 @@ mod test {
                 shared_deletion_weight: 1,
                 shared_counter_hotness_factor: 50,
                 randomness_weight: 1,
-                randomized_transaction_weight: 1,
+                randomized_transaction_weight: 0,
                 num_shared_counters: Some(1),
                 use_shared_counter_max_tip: false,
                 shared_counter_max_tip: 0,


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.39.4, v1.40.3)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/c3cda5656b1d4c2bc41240e0cf1883aff1b8113c
  - https://github.com/MystenLabs/sui/commit/2e1773081fddb14b1abbc4352bf880f2ee9f443d
  - https://github.com/MystenLabs/sui/commit/b7595ebd2f9b224632a5922d0ee8bd085554ce6c
  - https://github.com/MystenLabs/sui/commit/4fdaf64d8a370cf641abf21cf8bc175b282d4999
  - https://github.com/MystenLabs/sui/commit/a1c79df65c92db7abcf802580d0af8465b94cfaf


## Links to any relevant issues

Part of #6148  

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
