### PR TITLE
feat(node): use atomic instead of RwLock to speedup proxy cache

### DIFF
--- a/crates/iota-config/src/node.rs
+++ b/crates/iota-config/src/node.rs
@@ -273,6 +273,35 @@ pub enum ExecutionCacheType {
     PassthroughCache,
 }
 
+impl From<ExecutionCacheType> for u8 {
+    fn from(cache_type: ExecutionCacheType) -> Self {
+        match cache_type {
+            ExecutionCacheType::WritebackCache => 0,
+            ExecutionCacheType::PassthroughCache => 1,
+        }
+    }
+}
+
+impl From<&u8> for ExecutionCacheType {
+    fn from(cache_type: &u8) -> Self {
+        match cache_type {
+            0 => ExecutionCacheType::WritebackCache,
+            1 => ExecutionCacheType::PassthroughCache,
+            _ => unreachable!("Invalid value for ExecutionCacheType"),
+        }
+    }
+}
+
+/// Type alias for atomic representation of ExecutionCacheType for lock-free
+/// operations
+pub type ExecutionCacheTypeAtomicU8 = std::sync::atomic::AtomicU8;
+
+impl From<ExecutionCacheType> for ExecutionCacheTypeAtomicU8 {
+    fn from(cache_type: ExecutionCacheType) -> Self {
+        ExecutionCacheTypeAtomicU8::new(u8::from(cache_type))
+    }
+}
+
 impl ExecutionCacheType {
     pub fn cache_type(self) -> Self {
         if std::env::var("DISABLE_WRITEBACK_CACHE").is_ok() {

--- a/crates/iota-core/src/execution_cache/proxy_cache.rs
+++ b/crates/iota-core/src/execution_cache/proxy_cache.rs
@@ -5,6 +5,7 @@
 use std::{sync::Arc, time::Duration};
 
 use futures::{FutureExt, future::BoxFuture};
+use iota_config::node::ExecutionCacheTypeAtomicU8;
 use iota_types::{
     accumulator::Accumulator,
     base_types::{EpochId, ObjectID, ObjectRef, SequenceNumber, VerifiedExecutionData},
@@ -17,7 +18,6 @@ use iota_types::{
     storage::{MarkerValue, ObjectKey, ObjectOrTombstone, PackageObject},
     transaction::{VerifiedSignedTransaction, VerifiedTransaction},
 };
-use parking_lot::RwLock;
 
 use super::{
     CheckpointCache, ExecutionCacheCommit, ExecutionCacheConfig, ExecutionCacheMetrics,
@@ -37,7 +37,7 @@ use crate::{
 
 macro_rules! delegate_method {
     ($self:ident.$method:ident($($args:ident),*)) => {
-        match *$self.mode.read() {
+        match ExecutionCacheType::from(&$self.mode.load(std::sync::atomic::Ordering::Acquire)) {
             ExecutionCacheType::PassthroughCache => $self.passthrough_cache.$method($($args),*),
             ExecutionCacheType::WritebackCache => $self.writeback_cache.$method($($args),*),
         }
@@ -53,7 +53,7 @@ pub struct ProxyCache {
     // Cache implementations are entirely passive, so the unused one will have no effect.
     passthrough_cache: PassthroughCache,
     writeback_cache: WritebackCache,
-    mode: RwLock<ExecutionCacheType>,
+    mode: ExecutionCacheTypeAtomicU8,
 }
 
 impl ProxyCache {
@@ -76,7 +76,7 @@ impl ProxyCache {
         Self {
             passthrough_cache,
             writeback_cache,
-            mode: RwLock::new(cache_type),
+            mode: cache_type.into(),
         }
     }
 
@@ -101,7 +101,8 @@ impl ProxyCache {
             tokio::time::sleep(Duration::from_nanos(100)).await;
             self.writeback_cache.clear_caches_and_assert_empty();
         }
-        *self.mode.write() = cache_type;
+        self.mode
+            .store(cache_type.into(), std::sync::atomic::Ordering::Release);
     }
 }
 


### PR DESCRIPTION
# Description of change

This PR replaces the `RwLock` in the proxy cache with a simple atomic.
This approach should be much faster according to my benchmarks. (hint: it's not benchmarking with the real caches, but the difference in access to the underlying cache)

```bash
rustc -O cache_benchmark.rs && ./cache_benchmark
Cache Mode Switch Benchmark
Iterations per thread: 1000000
Number of threads: 8
Total operations: 8000000

RwLock approach:  2.366701541s
Atomic approach:  401.125µs

Speedup: 5900.16x faster
```

Benchmark code:
```rust
use std::sync::atomic::{AtomicU8, Ordering};
use std::sync::{Arc, RwLock};
use std::thread;
use std::time::{Duration, Instant};

#[derive(Debug, Clone, Copy)]
enum CacheConfigType {
    WritebackCache = 0,
    PassthroughCache = 1,
}

impl CacheConfigType {
    fn to_atomic(self) -> u8 {
        match self {
            CacheConfigType::WritebackCache => 0,
            CacheConfigType::PassthroughCache => 1,
        }
    }

    fn from_atomic(atomic: &AtomicU8) -> Self {
        match atomic.load(Ordering::Acquire) {
            0 => CacheConfigType::WritebackCache,
            1 => CacheConfigType::PassthroughCache,
            _ => unreachable!("Invalid atomic value"),
        }
    }
}

fn benchmark_rwlock_reads(iterations: usize, num_threads: usize) -> Duration {
    let mode = Arc::new(RwLock::new(CacheConfigType::WritebackCache));
    let start = Instant::now();
    
    let handles: Vec<_> = (0..num_threads)
        .map(|_| {
            let mode = mode.clone();
            thread::spawn(move || {
                for _ in 0..iterations {
                    // Simulate the delegate_method! macro usage
                    match *mode.read().unwrap() {
                        CacheConfigType::WritebackCache => {
                            // Simulate some work
                            std::hint::black_box(42);
                        }
                        CacheConfigType::PassthroughCache => {
                            // Simulate some work
                            std::hint::black_box(24);
                        }
                    }
                }
            })
        })
        .collect();
    
    for handle in handles {
        handle.join().unwrap();
    }
    
    start.elapsed()
}

fn benchmark_atomic_reads(iterations: usize, num_threads: usize) -> Duration {
    let mode = Arc::new(AtomicU8::new(CacheConfigType::WritebackCache.to_atomic()));
    let start = Instant::now();
    
    let handles: Vec<_> = (0..num_threads)
        .map(|_| {
            let mode = mode.clone();
            thread::spawn(move || {
                for _ in 0..iterations {
                    // Simulate the optimized delegate_method! macro usage
                    match CacheConfigType::from_atomic(&mode) {
                        CacheConfigType::WritebackCache => {
                            // Simulate some work
                            std::hint::black_box(42);
                        }
                        CacheConfigType::PassthroughCache => {
                            // Simulate some work
                            std::hint::black_box(24);
                        }
                    }
                }
            })
        })
        .collect();
    
    for handle in handles {
        handle.join().unwrap();
    }
    
    start.elapsed()
}

fn main() {
    let iterations = 1_000_000;
    let num_threads = 8;
    
    println!("Cache Mode Switch Benchmark");
    println!("Iterations per thread: {}", iterations);
    println!("Number of threads: {}", num_threads);
    println!("Total operations: {}", iterations * num_threads);
    println!();
    
    // Warmup
    benchmark_rwlock_reads(10_000, 1);
    benchmark_atomic_reads(10_000, 1);
    
    // Benchmark RwLock approach
    let rwlock_time = benchmark_rwlock_reads(iterations, num_threads);
    println!("RwLock approach:  {:?}", rwlock_time);
    
    // Benchmark Atomic approach
    let atomic_time = benchmark_atomic_reads(iterations, num_threads);
    println!("Atomic approach:  {:?}", atomic_time);
    
    let speedup = rwlock_time.as_nanos() as f64 / atomic_time.as_nanos() as f64;
    println!();
    println!("Speedup: {:.2}x faster", speedup);
    
    //let improvement = ((rwlock_time.as_nanos() as f64 - atomic_time.as_nanos() as f64) / rwlock_time.as_nanos() as f64) * 100.0;
    //println!("Improvement: {:.1}% faster", improvement);
}

```


## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes