### PR TITLE
feat(iota-core): add unit tests for the gas price feedback mechanism

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1782,7 +1782,7 @@ impl AuthorityPerEpochStore {
 
         if self
             .protocol_config
-            .congested_objects_gas_price_feedback_mechanism()
+            .congestion_control_gas_price_feedback_mechanism()
         {
             self.tables()?
                 .deferred_transactions_v2
@@ -2007,7 +2007,7 @@ impl AuthorityPerEpochStore {
     pub fn deferred_transactions_empty(&self) -> bool {
         if self
             .protocol_config
-            .congested_objects_gas_price_feedback_mechanism()
+            .congestion_control_gas_price_feedback_mechanism()
         {
             self.tables()
                 .expect("deferred transactions should not be read past end of epoch")
@@ -3006,7 +3006,7 @@ impl AuthorityPerEpochStore {
                         &mut shared_input_next_version,
                         cancelled_txns,
                         self.protocol_config
-                            .congested_objects_gas_price_feedback_mechanism(),
+                            .congestion_control_gas_price_feedback_mechanism(),
                     );
                     version_assignment.push((*txn.digest(), assigned_versions));
                 }
@@ -3616,7 +3616,7 @@ impl AuthorityPerEpochStore {
 
                                 let suggested_gas_price = if self
                                     .protocol_config
-                                    .congested_objects_gas_price_feedback_mechanism()
+                                    .congestion_control_gas_price_feedback_mechanism()
                                 {
                                     let current_commit_suggested_gas_price =
                                         suggested_gas_price_calculator
@@ -4356,7 +4356,7 @@ impl ConsensusCommitOutput {
 
         if epoch_store
             .protocol_config
-            .congested_objects_gas_price_feedback_mechanism()
+            .congestion_control_gas_price_feedback_mechanism()
         {
             batch.delete_batch(&tables.deferred_transactions_v2, self.deleted_deferred_txns)?;
             batch.insert_batch(&tables.deferred_transactions_v2, self.deferred_txns)?;

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3700,8 +3700,10 @@ impl AuthorityPerEpochStore {
                         // - shared object execution slots (for congestion tracker);
                         // - shared object congestion info (for suggested gas price calculator).
                         if certificate.contains_shared_object() {
-                            shared_object_congestion_tracker
-                                .bump_object_execution_slots(&certificate, start_time);
+                            if self.get_max_execution_duration_per_commit().is_some() {
+                                shared_object_congestion_tracker
+                                    .bump_object_execution_slots(&certificate, start_time);
+                            }
 
                             suggested_gas_price_calculator.update_congestion_info(
                                 &certificate,

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -189,6 +189,10 @@ impl DeferredTransaction {
             suggested_gas_price,
         }
     }
+
+    pub fn suggested_gas_price(&self) -> Option<u64> {
+        self.suggested_gas_price
+    }
 }
 
 /// Represents a scheduling result: a transaction can be either scheduled

--- a/crates/iota-core/src/authority/shared_object_version_manager.rs
+++ b/crates/iota-core/src/authority/shared_object_version_manager.rs
@@ -82,7 +82,7 @@ impl SharedObjVerManager {
                 cancelled_txns,
                 epoch_store
                     .protocol_config()
-                    .congested_objects_gas_price_feedback_mechanism(),
+                    .congestion_control_gas_price_feedback_mechanism(),
             );
             assigned_versions.push((cert.key(), cert_assigned_versions));
         }
@@ -188,7 +188,7 @@ impl SharedObjVerManager {
                                 )
                             } else {
                                 // WARN: do not remove this `else` branch even after
-                                // `congested_objects_gas_price_feedback_mechanism` is enabled
+                                // `congestion_control_gas_price_feedback_mechanism` is enabled
                                 // on the mainnet. It must be kept to be able to replay old
                                 // transaction data.
                                 SequenceNumber::CONGESTED_PRIOR_TO_GAS_PRICE_FEEDBACK

--- a/crates/iota-core/src/authority/suggested_gas_price_calculator.rs
+++ b/crates/iota-core/src/authority/suggested_gas_price_calculator.rs
@@ -159,16 +159,6 @@ impl SuggestedGasPriceCalculator {
         estimated_execution_duration: ExecutionTime,
     ) -> u64 {
         if let Some(max_execution_duration_per_commit) = self.max_execution_duration_per_commit {
-            debug_assert!(
-                estimated_execution_duration <= max_execution_duration_per_commit,
-                "This certificate alone has estimated execution duration of \
-                {estimated_execution_duration}, which is larger than the maximum execution \
-                duration per commit {max_execution_duration_per_commit}, so the certificate \
-                cannot be scheduled regardless of suggested gas price. It is likely that \
-                {max_execution_duration_per_commit} was set too low in the protocol config, \
-                such that a commit cannot accommodate a single certificate."
-            );
-
             let clearing_gas_price = self.find_clearing_gas_price(
                 certificate,
                 estimated_execution_duration,
@@ -177,7 +167,8 @@ impl SuggestedGasPriceCalculator {
 
             // Suggested gas price equals `clearing_gas_price + 1`. We add 1 to make this
             // transaction would be scheduled if the same commit structure was repeated.
-            let suggested_gas_price = clearing_gas_price + 1;
+            let suggested_gas_price =
+                clearing_gas_price.map_or(self.reference_gas_price, |p| p + 1);
 
             // Make sure suggested gas price is not larger than the maximum possible gas
             // price.
@@ -197,13 +188,15 @@ impl SuggestedGasPriceCalculator {
         certificate: &VerifiedExecutableTransaction,
         estimated_execution_duration: ExecutionTime,
         max_execution_duration_per_commit: ExecutionTime,
-    ) -> u64 {
+    ) -> Option<u64> {
         // Imaginary start time of the deferred/cancelled certificate. We consider
         // only the highest possible (but sufficient for scheduling) start time as
         // it is very likely that scheduled certificates with lower gas prices
-        // appear have higher start times.
+        // appear have higher start times. If a transaction with its
+        // `estimated_execution_duration` cannot fit within
+        // `max_execution_duration_per_commit`, set its imaginary start time to 0.
         let start_time_of_deferred_cert =
-            max_execution_duration_per_commit - estimated_execution_duration;
+            max_execution_duration_per_commit.saturating_sub(estimated_execution_duration);
 
         certificate
             .shared_input_objects()
@@ -217,8 +210,7 @@ impl SuggestedGasPriceCalculator {
                                 let end_time_of_scheduled_cert = execution_start_time
                                     + tx_congestion_info.estimated_execution_duration;
 
-                                if end_time_of_scheduled_cert > start_time_of_deferred_cert
-                                {
+                                if end_time_of_scheduled_cert > start_time_of_deferred_cert {
                                     // Store gas price of that scheduled certificate
                                     Some(tx_congestion_info.gas_price)
                                 } else {
@@ -240,14 +232,6 @@ impl SuggestedGasPriceCalculator {
             // was repeated again in a commit.
             .max()
             .flatten()
-            .unwrap_or_else(|| {
-                panic!(
-                    "At least one of the shared input objects should have appeared in between \
-                    execution start time of {start_time_of_deferred_cert} and execution end time of \
-                    {max_execution_duration_per_commit}; otherwise, this deferred certificate \
-                    would be scheduled by the sequencer."
-                );
-            })
     }
 }
 
@@ -296,8 +280,8 @@ pub mod suggested_gas_price_calculator_test_utils {
                         *duration,
                     )
                     .expect(
-                        "initial value should be fit within the available range of slots \
-                            in the tracker",
+                        "initial value should fit within the available range of slots in the \
+                                tracker",
                     );
 
                     shared_object_congestion_tracker
@@ -319,8 +303,8 @@ pub mod suggested_gas_price_calculator_test_utils {
                             *duration,
                         )
                         .expect(
-                            "initial value should be fit within the available range of slots \
-                            in the tracker",
+                            "initial value should fit within the available range of slots in \
+                                    the tracker",
                         );
 
                         shared_object_congestion_tracker

--- a/crates/iota-core/src/lib.rs
+++ b/crates/iota-core/src/lib.rs
@@ -52,6 +52,9 @@ pub mod verify_indexes;
 #[path = "unit_tests/congestion_control_tests.rs"]
 mod congestion_control_tests;
 #[cfg(test)]
+#[path = "unit_tests/gas_price_feedback_tests.rs"]
+mod gas_price_feedback_tests;
+#[cfg(test)]
 #[path = "unit_tests/move_package_management_tests.rs"]
 mod move_package_management_tests;
 #[cfg(test)]

--- a/crates/iota-core/src/unit_tests/congestion_control_tests.rs
+++ b/crates/iota-core/src/unit_tests/congestion_control_tests.rs
@@ -414,3 +414,6 @@ async fn test_congestion_control_execution_cancellation() {
     );
     assert_eq!(&effects, effects_2.data())
 }
+
+#[sim_test]
+async fn gas_price_feedback_mechanism() {}

--- a/crates/iota-core/src/unit_tests/congestion_control_tests.rs
+++ b/crates/iota-core/src/unit_tests/congestion_control_tests.rs
@@ -414,6 +414,3 @@ async fn test_congestion_control_execution_cancellation() {
     );
     assert_eq!(&effects, effects_2.data())
 }
-
-#[sim_test]
-async fn gas_price_feedback_mechanism() {}

--- a/crates/iota-core/src/unit_tests/data/gas_price_feedback/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/gas_price_feedback/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "gas_price_feedback"
+version = "0.0.1"
+edition = "2024.beta"
+
+[dependencies]
+Iota = { local = "../../../../../iota-framework/packages/iota-framework" }
+
+[addresses]
+gas_price_feedback = "0x0"

--- a/crates/iota-core/src/unit_tests/data/gas_price_feedback/sources/gas_price_feedback.move
+++ b/crates/iota-core/src/unit_tests/data/gas_price_feedback/sources/gas_price_feedback.move
@@ -1,0 +1,41 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+module gas_price_feedback::gas_price_feedback {
+    public struct Counter has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public entry fun create_shared_counter(ctx: &mut TxContext) {
+        transfer::public_share_object(Counter { id: object::new(ctx), value: 0 })
+    }
+
+    public entry fun increment_both(counter_1:  &mut Counter, counter_2:  &mut Counter) {
+        let value = counter_1.value + 1;
+        counter_1.value = value;
+
+        let value = counter_2.value + 1;
+        counter_2.value = value;
+    }
+
+    public entry fun increment_first_read_second(counter_1:  &mut Counter, counter_2:  &Counter) {
+        let value = counter_1.value + 1;
+        counter_1.value = value;
+
+        let value = counter_2.value;
+    }
+
+    public entry fun read_first_increment_second(counter_1:  &Counter, counter_2:  &mut Counter) {
+        let value = counter_1.value;
+
+        let value = counter_2.value + 1;
+        counter_2.value = value;
+    }
+
+    public entry fun read_both(counter_1:  &Counter, counter_2:  &Counter) {
+        let value = counter_1.value;
+
+        let value = counter_2.value;
+    }
+}

--- a/crates/iota-core/src/unit_tests/data/gas_price_feedback/sources/gas_price_feedback.move
+++ b/crates/iota-core/src/unit_tests/data/gas_price_feedback/sources/gas_price_feedback.move
@@ -38,4 +38,13 @@ module gas_price_feedback::gas_price_feedback {
 
         let value = counter_2.value;
     }
+
+    public entry fun increment_one(counter:  &mut Counter) {
+        let value = counter.value + 1;
+        counter.value = value;
+    }
+
+    public entry fun read_one(counter:  &Counter) {
+        let value = counter.value;
+    }
 }

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -9,10 +9,11 @@ use iota_protocol_config::{
 use iota_types::{
     base_types::{IotaAddress, ObjectID, ObjectRef},
     crypto::{AccountKeyPair, get_key_pair},
-    effects::TransactionEffectsAPI,
+    effects::{TransactionEffects, TransactionEffectsAPI},
+    executable_transaction::VerifiedExecutableTransaction,
     object::Object,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{ObjectArg, Transaction},
+    transaction::{ObjectArg, Transaction, VerifiedCertificate},
 };
 use move_core_types::ident_str;
 use rand::seq::SliceRandom;
@@ -159,7 +160,7 @@ impl GasPriceFeedbackTester {
         effects.created()[0].0
     }
 
-    async fn build_increment_both_counters_tx(
+    async fn build_increment_both_counters_transaction(
         &self,
         gas_object_id: &ObjectID,
         // gas_price: u64
@@ -200,6 +201,40 @@ impl GasPriceFeedbackTester {
         .await
         .unwrap()
     }
+
+    async fn certify_transaction(&self, transaction: Transaction) -> VerifiedCertificate {
+        certify_transaction(&self.authority_state, transaction)
+            .await
+            .unwrap()
+    }
+
+    async fn send_certificates_to_consensus_for_scheduling(
+        &self,
+        certificates: &[VerifiedCertificate],
+    ) -> Vec<VerifiedExecutableTransaction> {
+        send_batch_consensus_no_execution(&self.authority_state, certificates, false).await
+    }
+
+    async fn enqueue_and_execute_scheduled_transactions(
+        &self,
+        transactions: Vec<VerifiedExecutableTransaction>,
+    ) -> Vec<TransactionEffects> {
+        let transaction_digests = transactions
+            .iter()
+            .map(|tx| *tx.digest())
+            .collect::<Vec<_>>();
+
+        self.authority_state.transaction_manager().enqueue(
+            transactions,
+            &self.authority_state.epoch_store_for_testing(),
+        );
+
+        self.authority_state
+            .get_transaction_cache_reader()
+            .notify_read_executed_effects(&transaction_digests)
+            .await
+            .unwrap()
+    }
 }
 
 #[tokio::test]
@@ -207,7 +242,7 @@ async fn gas_price_feedback_mechanism() {
     let max_deferral_rounds_for_congestion_control = 1;
     let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalTxCount;
     let max_execution_duration_per_commit = 1;
-    let num_gas_objects = 20;
+    let num_gas_objects = 2;
 
     let tester = GasPriceFeedbackTester::new(
         max_deferral_rounds_for_congestion_control,
@@ -220,37 +255,30 @@ async fn gas_price_feedback_mechanism() {
     // Prepare certificates
     let mut certificates = vec![];
     for gas_object_id in tester.gas_object_ids.iter() {
-        let transaction = tester.build_increment_both_counters_tx(gas_object_id).await;
+        let transaction = tester
+            .build_increment_both_counters_transaction(gas_object_id)
+            .await;
+        let certificate = tester.certify_transaction(transaction).await;
 
-        certificates.push(
-            certify_transaction(&tester.authority_state, transaction)
-                .await
-                .unwrap(),
-        );
+        certificates.push(certificate);
     }
     certificates.shuffle(&mut rand::thread_rng());
     assert_eq!(certificates.len(), num_gas_objects);
 
-    let scheduled_certificates =
-        send_batch_consensus_no_execution(&tester.authority_state, &certificates, true).await;
+    let scheduled_transactions = tester
+        .send_certificates_to_consensus_for_scheduling(&certificates)
+        .await;
     assert_eq!(
-        scheduled_certificates.len(),
-        max_execution_duration_per_commit as usize
+        scheduled_transactions.len(),
+        // +1 because of consensus commit prologue transaction
+        max_execution_duration_per_commit as usize + 1,
     );
 
-    tester.authority_state.transaction_manager().enqueue(
-        scheduled_certificates.clone(),
-        &tester.authority_state.epoch_store_for_testing(),
-    );
+    let effects_vec = tester
+        .enqueue_and_execute_scheduled_transactions(scheduled_transactions)
+        .await;
 
-    for cert in scheduled_certificates {
-        let effects = tester
-            .authority_state
-            .get_transaction_cache_reader()
-            .notify_read_executed_effects(&[*cert.digest()])
-            .await
-            .map(|mut r| r.pop().expect("must return correct number of effects"))
-            .unwrap();
+    for effects in effects_vec {
         assert!(effects.status().is_ok());
     }
 }

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -227,12 +227,14 @@ impl GasPriceFeedbackTester {
         to_sender_signed_transaction(transaction_data, &self.sender_key)
     }
 
+    /// Certify a transaction signed by the user.
     async fn certify_transaction(&self, transaction: Transaction) -> VerifiedCertificate {
         certify_transaction(&self.authority_state, transaction)
             .await
             .unwrap()
     }
 
+    /// Send certificates to consensus for scheduling.
     async fn send_certificates_to_consensus_for_scheduling(
         &self,
         certificates: &[VerifiedCertificate],
@@ -240,6 +242,7 @@ impl GasPriceFeedbackTester {
         send_batch_consensus_no_execution(&self.authority_state, certificates, false).await
     }
 
+    /// Enqueue scheduled transactions and execute them to effects.
     async fn enqueue_and_execute_scheduled_transactions(
         &self,
         transactions: Vec<VerifiedExecutableTransaction>,
@@ -261,9 +264,14 @@ impl GasPriceFeedbackTester {
             .unwrap()
     }
 
-    async fn build_increment_both_counters_transaction(
+    /// Build and sign a programmable transaction that accesses both counters.
+    /// `counter_1_mutable` and `counter_2_mutable` flags control how the
+    /// counters are accessed: mutably or immutably.
+    async fn build_access_both_counters_transaction(
         &self,
         gas_data: GasDataForTests,
+        counter_1_mutable: bool,
+        counter_2_mutable: bool,
     ) -> Transaction {
         let mut txn_builder = ProgrammableTransactionBuilder::new();
 
@@ -271,7 +279,7 @@ impl GasPriceFeedbackTester {
             .obj(ObjectArg::SharedObject {
                 id: self.shared_counter_1.0,
                 initial_shared_version: self.shared_counter_1.1,
-                mutable: true,
+                mutable: counter_1_mutable,
             })
             .unwrap();
 
@@ -279,14 +287,31 @@ impl GasPriceFeedbackTester {
             .obj(ObjectArg::SharedObject {
                 id: self.shared_counter_2.0,
                 initial_shared_version: self.shared_counter_2.1,
-                mutable: true,
+                mutable: counter_2_mutable,
             })
             .unwrap();
 
-        move_call! {
-            txn_builder,
-            (self.package.0)::gas_price_feedback::increment_both(arg1, arg2)
-        };
+        if counter_1_mutable && counter_2_mutable {
+            move_call! {
+                txn_builder,
+                (self.package.0)::gas_price_feedback::increment_both(arg1, arg2)
+            };
+        } else if counter_1_mutable && !counter_2_mutable {
+            move_call! {
+                txn_builder,
+                (self.package.0)::gas_price_feedback::increment_first_read_second(arg1, arg2)
+            };
+        } else if !counter_1_mutable && counter_2_mutable {
+            move_call! {
+                txn_builder,
+                (self.package.0)::gas_price_feedback::read_first_increment_second(arg1, arg2)
+            };
+        } else {
+            move_call! {
+                txn_builder,
+                (self.package.0)::gas_price_feedback::read_both(arg1, arg2)
+            };
+        }
 
         let pt = txn_builder.finish();
 
@@ -320,7 +345,7 @@ async fn gas_price_feedback_mechanism() {
             DEFAULT_GAS_BUDGET_FOR_TESTS,
         );
         let transaction = tester
-            .build_increment_both_counters_transaction(gas_data)
+            .build_access_both_counters_transaction(gas_data, true, true)
             .await;
         let certificate = tester.certify_transaction(transaction).await;
 

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -320,12 +320,12 @@ impl GasPriceFeedbackTester {
 }
 
 #[sim_test]
-async fn gas_price_feedback_mechanism() {
-    let max_deferral_rounds_for_congestion_control = 1;
-    let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalTxCount;
-    let max_execution_duration_per_commit = 1;
-    let assign_min_free_execution_slot = false;
-    let num_gas_objects = 2;
+async fn congestion_control_is_turned_off() {
+    let max_deferral_rounds_for_congestion_control = 0;
+    let per_object_congestion_control_mode = PerObjectCongestionControlMode::None;
+    let max_execution_duration_per_commit = 0;
+    let assign_min_free_execution_slot = true;
+    let num_gas_objects = 10;
 
     let tester = GasPriceFeedbackTester::new(
         max_deferral_rounds_for_congestion_control,
@@ -338,10 +338,10 @@ async fn gas_price_feedback_mechanism() {
 
     // Prepare certificates
     let mut certificates = vec![];
-    for gas_object_id in tester.gas_object_ids.iter() {
+    for (i, gas_object_id) in tester.gas_object_ids.iter().enumerate() {
         let gas_data = GasDataForTests::new(
             *gas_object_id,
-            REFERENCE_GAS_PRICE_FOR_TESTS,
+            REFERENCE_GAS_PRICE_FOR_TESTS + i as u64,
             DEFAULT_GAS_BUDGET_FOR_TESTS,
         );
         let transaction = tester
@@ -351,6 +351,8 @@ async fn gas_price_feedback_mechanism() {
 
         certificates.push(certificate);
     }
+    // Shuffle certificates so that they do not have any specific order in
+    // terms of gas price.
     certificates.shuffle(&mut rand::thread_rng());
     assert_eq!(certificates.len(), num_gas_objects);
 
@@ -360,13 +362,19 @@ async fn gas_price_feedback_mechanism() {
     assert_eq!(
         scheduled_transactions.len(),
         // +1 because of consensus commit prologue transaction
-        max_execution_duration_per_commit as usize + 1,
+        certificates.len() + 1,
     );
 
     let effects_vec = tester
         .enqueue_and_execute_scheduled_transactions(scheduled_transactions)
         .await;
+    assert_eq!(
+        effects_vec.len(),
+        // +1 because of consensus commit prologue transaction
+        certificates.len() + 1,
+    );
 
+    // All transactions should be successfully executed.
     for effects in effects_vec {
         assert!(effects.status().is_ok());
     }

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -1204,7 +1204,7 @@ async fn gas_price_feedback_mechanism_for_multiple_commits() {
 
 // Test gas price feedback mechanism in `TotalTxCount` mode in non-trivial case.
 #[sim_test]
-async fn gas_price_feedback_mechanism_non_trivial_case_in_total_tx_count_mode() {
+async fn gas_price_feedback_mechanism_non_trivial_case_total_tx_count_mode() {
     let num_gas_objects = 13;
     let tester = GasPriceFeedbackTester::new(
         0,                                            // max_deferral_rounds_for_congestion_control
@@ -1455,7 +1455,7 @@ async fn gas_price_feedback_mechanism_non_trivial_case_in_total_tx_count_mode() 
             ),]
         );
     }
-    // Transactions that both shared counters:
+    // Transactions that touch both shared counters:
     for effects in effects_vec.iter().skip(9).take(5) {
         if let ExecutionStatus::Failure { error, command } = effects.status() {
             assert!(command.is_none());
@@ -1499,6 +1499,323 @@ async fn gas_price_feedback_mechanism_non_trivial_case_in_total_tx_count_mode() 
                     UnchangedSharedKind::Cancelled(
                         SequenceNumber::new_congested_with_suggested_gas_price(
                             expected_suggested_gas_price_for_both_objects
+                        )
+                    )
+                ),
+            ]
+        );
+    }
+}
+
+// Test gas price feedback mechanism in `TotalGasBudget` mode in non-trivial
+// case.
+#[sim_test]
+async fn gas_price_feedback_mechanism_non_trivial_case_total_gas_budget_mode() {
+    let num_gas_objects = 13;
+    let tester = GasPriceFeedbackTester::new(
+        0,                                              // max_deferral_rounds_for_congestion_control
+        PerObjectCongestionControlMode::TotalGasBudget, // per_object_congestion_control_mode
+        Some(9_000_000_000),                            // max_execution_duration_per_commit
+        true,                                           // assign_min_free_execution_slot
+        true,                                           // enable_gas_price_feedback_mechanism
+        num_gas_objects,
+    )
+    .await;
+
+    // Prepare certificates
+    let certificates = tester.create_certificates_for_non_trivial_case().await;
+    assert_eq!(certificates.len(), num_gas_objects);
+    // Shuffle certificates so that they do not have any specific order in
+    // terms of gas price.
+    let mut shuffled_certificates = certificates.clone();
+    shuffled_certificates.shuffle(&mut rand::thread_rng());
+
+    let scheduled_transactions = tester
+        .send_certificates_to_consensus_for_scheduling(&shuffled_certificates)
+        .await;
+    assert_eq!(
+        scheduled_transactions.len(),
+        // +1 because of consensus commit prologue transaction
+        certificates.len() + 1,
+    );
+
+    // Recall the structure of these certificates:
+    // (gas price, gas budget, counter_1_mutable, counter_2_mutable)
+    // [
+    //     (100K, 3_000_000_000, Some(true),  Some(false)), // 0
+    //     (1011, 1_000_000_000, Some(false), Some(true)),  // 1
+    //     (1010, 4_000_000_000, Some(false), Some(true)),  // 2
+    //     (1009, 2_000_000_000, None,        Some(true)),  // 3
+    //     (1008, 1_000_000_001, None,        Some(false)), // 4
+    //     (1007, 5_000_000_000, None,        Some(true)),  // 5
+    //     (1006, 5_000_000_001, Some(true),  Some(true)),  // 6
+    //     (1005, 8_000_000_000, Some(true),  Some(true)),  // 7
+    //     (1004, 4_000_000_000, Some(true),  None),        // 8
+    //     (1003, 2_000_000_000, Some(true),  None),        // 9
+    //     (1002, 1_000_000_001, Some(false), Some(false)), // 10
+    //     (1001, 5_000_000_001, Some(true),  Some(false)), // 11
+    //     (1000, 9_000_000_000, Some(false), Some(true)),  // 12
+    // ];
+
+    // Allocations of mutably accessed shared objects should look as follows:
+    // |-------------------------------------------------|------------|
+    // |        object_1        |        object_2        | start time |
+    // |________________________|________________________|____________|
+    // |------------------------|------------------------|---- 9B     |
+    // |                        |                        |            |
+    // | cert. 9 (g=5000, d=2B) |------------------------|---- 8B     |
+    // |                        |                        |            |
+    // |------------------------|                        |---- 7B     |
+    // |                        |                        |            |
+    // |                        | cert. 2 (g=8000, d=4B) |---- 6B     |
+    // |                        |                        |            |
+    // | cert. 8 (g=6000, d=4B) |                        |---- 5B     |
+    // |                        |                        |            |
+    // |                        |------------------------|---- 4B     |
+    // |                        | cert. 1 (g=9000, d=1B) |            |
+    // |------------------------|------------------------|---- 3B     |
+    // |                        |                        |            |
+    // |                        |------------------------|---- 2B     |
+    // | cert. 0 (g=100K, d=3M) |                        |            |
+    // |                        | cert. 3 (g=7000, d=2B) |---- 1B     |
+    // |                        |                        |            |
+    // |-------------------------------------------------|---- 0 -----|
+    // That is, certificates 4, 5, 6, 7, 10, 11, 12 should be cancelled.
+
+    // Checks that there are no deferred transactions
+    assert!(
+        tester
+            .authority_state
+            .epoch_store_for_testing()
+            .get_all_deferred_transactions_for_test()
+            .unwrap()
+            .is_empty()
+    );
+
+    // The first scheduled transaction should be `ConsensusCommitPrologueV1`
+    if let TransactionKind::ConsensusCommitPrologueV1(prologue_tx) =
+        scheduled_transactions[0].data().transaction_data().kind()
+    {
+        // Check if `ConsensusDeterminedVersionAssignments` are correct.
+        let cancelled_txs = vec![
+            (
+                *certificates[4].digest(),
+                vec![(
+                    tester.shared_counter_2.0,
+                    SequenceNumber::new_congested_with_suggested_gas_price(
+                        certificates[2].gas_price() + 1,
+                    ),
+                )],
+            ),
+            (
+                *certificates[5].digest(),
+                vec![(
+                    tester.shared_counter_2.0,
+                    SequenceNumber::new_congested_with_suggested_gas_price(
+                        certificates[2].gas_price() + 1,
+                    ),
+                )],
+            ),
+            (
+                *certificates[6].digest(),
+                vec![
+                    (
+                        tester.shared_counter_1.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            certificates[1].gas_price() + 1,
+                        ),
+                    ),
+                    (
+                        tester.shared_counter_2.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            certificates[1].gas_price() + 1,
+                        ),
+                    ),
+                ],
+            ),
+            (
+                *certificates[7].digest(),
+                vec![
+                    (
+                        tester.shared_counter_1.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            certificates[0].gas_price(),
+                        ),
+                    ),
+                    (
+                        tester.shared_counter_2.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            certificates[0].gas_price(),
+                        ),
+                    ),
+                ],
+            ),
+            (
+                *certificates[10].digest(),
+                vec![
+                    (
+                        tester.shared_counter_1.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            certificates[2].gas_price() + 1,
+                        ),
+                    ),
+                    (
+                        tester.shared_counter_2.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            certificates[2].gas_price() + 1,
+                        ),
+                    ),
+                ],
+            ),
+            (
+                *certificates[11].digest(),
+                vec![
+                    (
+                        tester.shared_counter_1.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            certificates[1].gas_price() + 1,
+                        ),
+                    ),
+                    (
+                        tester.shared_counter_2.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            certificates[1].gas_price() + 1,
+                        ),
+                    ),
+                ],
+            ),
+            (
+                *certificates[12].digest(),
+                vec![
+                    (
+                        tester.shared_counter_1.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            certificates[0].gas_price(),
+                        ),
+                    ),
+                    (
+                        tester.shared_counter_2.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            certificates[0].gas_price(),
+                        ),
+                    ),
+                ],
+            ),
+        ];
+        assert_eq!(
+            prologue_tx.consensus_determined_version_assignments,
+            ConsensusDeterminedVersionAssignments::CancelledTransactions(cancelled_txs)
+        );
+    } else {
+        panic!("First scheduled transaction must be a ConsensusCommitPrologueV1 transaction.");
+    }
+
+    let effects_vec = tester
+        .enqueue_and_execute_scheduled_transactions(scheduled_transactions)
+        .await;
+    assert_eq!(
+        effects_vec.len(),
+        // +1 because of consensus commit prologue transaction
+        certificates.len() + 1,
+    );
+
+    // `ConsensusCommitPrologueV1` and first 6 scheduled transactions should be
+    // successfully executed
+    for effects in effects_vec.iter().take(7) {
+        assert!(effects.status().is_ok());
+    }
+
+    // The rest of transactions should be cancelled:
+    //
+    // Transactions that touch shared counter 2:
+    let expected_suggested_gas_price = certificates[2].gas_price() + 1;
+    for effects in effects_vec.iter().skip(7).take(2) {
+        if let ExecutionStatus::Failure { error, command } = effects.status() {
+            assert!(command.is_none());
+            if let ExecutionFailureStatus::ExecutionCancelledDueToSharedObjectCongestionV2 {
+                congested_objects,
+                suggested_gas_price,
+            } = error
+            {
+                // Check is returned congested_objects and suggested_gas_price are correct.
+                assert_eq!(
+                    *congested_objects,
+                    CongestedObjects(vec![tester.shared_counter_2.0])
+                );
+                assert_eq!(*suggested_gas_price, expected_suggested_gas_price);
+            } else {
+                panic!(
+                    "ExecutionFailureStatus must be ExecutionCancelledDueToSharedObjectCongestionV2."
+                );
+            }
+        } else {
+            panic!("Transaction should have been be cancelled.")
+        }
+        // Check if unchanged_shared_objects in effects of the cancelled transaction
+        // are correct
+        assert_eq!(
+            effects.unchanged_shared_objects(),
+            vec![(
+                tester.shared_counter_2.0,
+                UnchangedSharedKind::Cancelled(
+                    SequenceNumber::new_congested_with_suggested_gas_price(
+                        expected_suggested_gas_price
+                    )
+                )
+            ),]
+        );
+    }
+    // Transactions that touch both shared counters:
+    for (i, effects) in effects_vec.iter().skip(9).take(5).enumerate() {
+        let expected_suggested_gas_price = if i == 0 || i == 3 {
+            certificates[1].gas_price() + 1
+        } else if i == 1 || i == 4 {
+            certificates[0].gas_price()
+        } else if i == 2 {
+            certificates[2].gas_price() + 1
+        } else {
+            panic!("Expected only 5 effects to iterate.")
+        };
+
+        if let ExecutionStatus::Failure { error, command } = effects.status() {
+            assert!(command.is_none());
+            if let ExecutionFailureStatus::ExecutionCancelledDueToSharedObjectCongestionV2 {
+                congested_objects,
+                suggested_gas_price,
+            } = error
+            {
+                // Check is returned congested_objects and suggested_gas_price are correct.
+                assert_eq!(
+                    *congested_objects,
+                    CongestedObjects(vec![tester.shared_counter_1.0, tester.shared_counter_2.0])
+                );
+                assert_eq!(*suggested_gas_price, expected_suggested_gas_price);
+            } else {
+                panic!(
+                    "ExecutionFailureStatus must be ExecutionCancelledDueToSharedObjectCongestionV2."
+                );
+            }
+        } else {
+            panic!("Transaction should have been be cancelled.")
+        }
+        // Check if unchanged_shared_objects in effects of the cancelled transaction
+        // are correct
+        assert_eq!(
+            effects.unchanged_shared_objects(),
+            vec![
+                (
+                    tester.shared_counter_1.0,
+                    UnchangedSharedKind::Cancelled(
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            expected_suggested_gas_price
+                        )
+                    )
+                ),
+                (
+                    tester.shared_counter_2.0,
+                    UnchangedSharedKind::Cancelled(
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            expected_suggested_gas_price
                         )
                     )
                 ),

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -572,90 +572,239 @@ async fn max_execution_duration_per_commit_is_none() {
     }
 }
 
-// Test that the suggested gas price calculator panics if
-// `max_execution_duration_per_commit` is set too low such that even
-// one transaction cannot fit in a commit.
-#[tokio::test]
-#[should_panic] // because `max_execution_duration_per_commit` is set too low.
-async fn max_execution_duration_per_commit_too_low_in_total_tx_count_mode() {
-    let num_gas_objects = 2;
+// Test that the suggested gas price calculator return the correct gas price
+// if there are transactions with estimated execution duration larger than
+// `max_execution_duration_per_commit`, that is such, transactions cannot
+// be scheduled.
+#[sim_test]
+async fn transaction_duration_exceeds_max_execution_duration_per_commit() {
+    let num_gas_objects = 3;
+    let gas_budget_of_scheduled_tx =
+        (REFERENCE_GAS_PRICE_FOR_TESTS + 2) * DEFAULT_GAS_UNITS_FOR_TESTS;
     let tester = GasPriceFeedbackTester::new(
-        10,                                           // max_deferral_rounds_for_congestion_control
-        PerObjectCongestionControlMode::TotalTxCount, // per_object_congestion_control_mode
-        Some(0),                                      // max_execution_duration_per_commit
-        true,                                         // assign_min_free_execution_slot
-        true,                                         // enable_gas_price_feedback_mechanism
-        num_gas_objects,
-    )
-    .await;
-
-    // Prepare certificates
-    let mut certificates = vec![];
-    for (i, gas_object_id) in tester.gas_object_ids.iter().enumerate() {
-        let gas_price = REFERENCE_GAS_PRICE_FOR_TESTS + i as u64;
-        let gas_data = GasDataForTests::new(
-            *gas_object_id,
-            gas_price,
-            gas_price * DEFAULT_GAS_UNITS_FOR_TESTS,
-        );
-        let transaction = tester
-            .build_access_both_counters_transaction(gas_data, true, true)
-            .await;
-        let certificate = tester.certify_transaction(transaction).await;
-
-        certificates.push(certificate);
-    }
-    // Shuffle certificates so that they do not have any specific order in
-    // terms of gas price.
-    certificates.shuffle(&mut rand::thread_rng());
-    assert_eq!(certificates.len(), num_gas_objects);
-
-    let _scheduled_transactions = tester
-        .send_certificates_to_consensus_for_scheduling(&certificates)
-        .await;
-}
-
-// Test that the suggested gas price calculator panics if
-// `max_execution_duration_per_commit` is set too low such that even
-// one transaction cannot fit in a commit.
-#[tokio::test]
-#[should_panic] // because `max_execution_duration_per_commit` is set too low.
-async fn max_execution_duration_per_commit_too_low_in_total_gas_budget_mode() {
-    let num_gas_objects = 2;
-    let tester = GasPriceFeedbackTester::new(
-        10,                                             // max_deferral_rounds_for_congestion_control
+        0,                                              // max_deferral_rounds_for_congestion_control
         PerObjectCongestionControlMode::TotalGasBudget, // per_object_congestion_control_mode
-        Some(REFERENCE_GAS_PRICE_FOR_TESTS * DEFAULT_GAS_UNITS_FOR_TESTS), // max_execution_duration_per_commit
-        true, // assign_min_free_execution_slot
-        true, // enable_gas_price_feedback_mechanism
+        Some(gas_budget_of_scheduled_tx),               // max_execution_duration_per_commit
+        true,                                           // assign_min_free_execution_slot
+        true,                                           // enable_gas_price_feedback_mechanism
         num_gas_objects,
     )
     .await;
 
     // Prepare certificates
     let mut certificates = vec![];
-    for (i, gas_object_id) in tester.gas_object_ids.iter().enumerate() {
-        let gas_price = REFERENCE_GAS_PRICE_FOR_TESTS + i as u64;
-        let gas_data = GasDataForTests::new(
-            *gas_object_id,
-            gas_price,
-            gas_price * DEFAULT_GAS_UNITS_FOR_TESTS,
-        );
-        let transaction = tester
-            .build_access_both_counters_transaction(gas_data, true, true)
-            .await;
-        let certificate = tester.certify_transaction(transaction).await;
+    // Should be cancelled as it does not fit, suggested gas price must be equal
+    // the reference gas price as there are no congested objects.
+    let gas_data = GasDataForTests::new(
+        tester.gas_object_ids[0],
+        REFERENCE_GAS_PRICE_FOR_TESTS + 2,
+        tester.protocol_config.max_tx_gas(),
+    );
+    let transaction = tester
+        .build_access_both_counters_transaction(gas_data, true, true)
+        .await;
+    certificates.push(tester.certify_transaction(transaction).await);
+    // Should be scheduled.
+    let gas_data = GasDataForTests::new(
+        tester.gas_object_ids[1],
+        REFERENCE_GAS_PRICE_FOR_TESTS + 2,
+        gas_budget_of_scheduled_tx,
+    );
+    let transaction = tester
+        .build_access_both_counters_transaction(gas_data, true, true)
+        .await;
+    certificates.push(tester.certify_transaction(transaction).await);
+    // Should be cancelled as it does not fit, suggested gas price must be equal
+    // gas price of the scheduled transaction + 1.
+    let gas_data = GasDataForTests::new(
+        tester.gas_object_ids[2],
+        REFERENCE_GAS_PRICE_FOR_TESTS + 1,
+        tester.protocol_config.max_tx_gas(),
+    );
+    let transaction = tester
+        .build_access_both_counters_transaction(gas_data, true, true)
+        .await;
+    certificates.push(tester.certify_transaction(transaction).await);
 
-        certificates.push(certificate);
-    }
-    // Shuffle certificates so that they do not have any specific order in
-    // terms of gas price.
-    certificates.shuffle(&mut rand::thread_rng());
-    assert_eq!(certificates.len(), num_gas_objects);
-
-    let _scheduled_transactions = tester
+    let scheduled_transactions = tester
         .send_certificates_to_consensus_for_scheduling(&certificates)
         .await;
+    assert_eq!(
+        scheduled_transactions.len(),
+        // +1 because of consensus commit prologue transaction
+        certificates.len() + 1,
+    );
+
+    // Checks that there are no deferred transactions
+    assert!(
+        tester
+            .authority_state
+            .epoch_store_for_testing()
+            .get_all_deferred_transactions_for_test()
+            .unwrap()
+            .is_empty()
+    );
+
+    let expected_suggested_gas_price_2 = scheduled_transactions[2]
+        .data()
+        .transaction_data()
+        .gas_price()
+        + 1;
+
+    // The first scheduled transaction should be `ConsensusCommitPrologueV1`
+    if let TransactionKind::ConsensusCommitPrologueV1(prologue_tx) =
+        scheduled_transactions[0].data().transaction_data().kind()
+    {
+        // Check if `ConsensusDeterminedVersionAssignments` are correct.
+        let cancelled_txs = vec![
+            (
+                *scheduled_transactions[1].digest(),
+                vec![
+                    (
+                        tester.shared_counter_1.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            REFERENCE_GAS_PRICE_FOR_TESTS,
+                        ),
+                    ),
+                    (
+                        tester.shared_counter_2.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            REFERENCE_GAS_PRICE_FOR_TESTS,
+                        ),
+                    ),
+                ],
+            ),
+            (
+                *scheduled_transactions[3].digest(),
+                vec![
+                    (
+                        tester.shared_counter_1.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            expected_suggested_gas_price_2,
+                        ),
+                    ),
+                    (
+                        tester.shared_counter_2.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            expected_suggested_gas_price_2,
+                        ),
+                    ),
+                ],
+            ),
+        ];
+        assert_eq!(
+            prologue_tx.consensus_determined_version_assignments,
+            ConsensusDeterminedVersionAssignments::CancelledTransactions(cancelled_txs)
+        );
+    } else {
+        panic!("First scheduled transaction must be a ConsensusCommitPrologueV1 transaction.");
+    }
+
+    let effects_vec = tester
+        .enqueue_and_execute_scheduled_transactions(scheduled_transactions)
+        .await;
+    assert_eq!(
+        effects_vec.len(),
+        // +1 because of consensus commit prologue transaction
+        certificates.len() + 1,
+    );
+
+    // `ConsensusCommitPrologueV1` should be successfully executed
+    assert!(effects_vec[0].status().is_ok());
+    // The second transaction should be scheduled.
+    assert!(effects_vec[2].status().is_ok());
+
+    // The first transaction should be cancelled
+    if let ExecutionStatus::Failure { error, command } = effects_vec[1].status() {
+        assert!(command.is_none());
+        if let ExecutionFailureStatus::ExecutionCancelledDueToSharedObjectCongestionV2 {
+            congested_objects,
+            suggested_gas_price,
+        } = error
+        {
+            // Check is returned congested_objects and suggested_gas_price are correct.
+            assert_eq!(
+                *congested_objects,
+                CongestedObjects(vec![tester.shared_counter_1.0, tester.shared_counter_2.0])
+            );
+            assert_eq!(*suggested_gas_price, REFERENCE_GAS_PRICE_FOR_TESTS);
+        } else {
+            panic!(
+                "ExecutionFailureStatus must be ExecutionCancelledDueToSharedObjectCongestionV2."
+            );
+        }
+    } else {
+        panic!("The transaction must be cancelled.")
+    }
+    // Check if unchanged_shared_objects in effects of the cancelled transaction
+    // are correct
+    assert_eq!(
+        effects_vec[1].unchanged_shared_objects(),
+        vec![
+            (
+                tester.shared_counter_1.0,
+                UnchangedSharedKind::Cancelled(
+                    SequenceNumber::new_congested_with_suggested_gas_price(
+                        REFERENCE_GAS_PRICE_FOR_TESTS
+                    )
+                )
+            ),
+            (
+                tester.shared_counter_2.0,
+                UnchangedSharedKind::Cancelled(
+                    SequenceNumber::new_congested_with_suggested_gas_price(
+                        REFERENCE_GAS_PRICE_FOR_TESTS
+                    )
+                )
+            ),
+        ]
+    );
+
+    // The third transaction should be cancelled
+    if let ExecutionStatus::Failure { error, command } = effects_vec[3].status() {
+        assert!(command.is_none());
+        if let ExecutionFailureStatus::ExecutionCancelledDueToSharedObjectCongestionV2 {
+            congested_objects,
+            suggested_gas_price,
+        } = error
+        {
+            // Check is returned congested_objects and suggested_gas_price are correct.
+            assert_eq!(
+                *congested_objects,
+                CongestedObjects(vec![tester.shared_counter_1.0, tester.shared_counter_2.0])
+            );
+            assert_eq!(*suggested_gas_price, expected_suggested_gas_price_2);
+        } else {
+            panic!(
+                "ExecutionFailureStatus must be ExecutionCancelledDueToSharedObjectCongestionV2."
+            );
+        }
+    } else {
+        panic!("The transaction must be cancelled.")
+    }
+    // Check if unchanged_shared_objects in effects of the cancelled transaction
+    // are correct
+    assert_eq!(
+        effects_vec[3].unchanged_shared_objects(),
+        vec![
+            (
+                tester.shared_counter_1.0,
+                UnchangedSharedKind::Cancelled(
+                    SequenceNumber::new_congested_with_suggested_gas_price(
+                        expected_suggested_gas_price_2
+                    )
+                )
+            ),
+            (
+                tester.shared_counter_2.0,
+                UnchangedSharedKind::Cancelled(
+                    SequenceNumber::new_congested_with_suggested_gas_price(
+                        expected_suggested_gas_price_2
+                    )
+                )
+            ),
+        ]
+    );
 }
 
 // Test that everything works well if the gas price feedback mechanism is

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -80,7 +80,7 @@ impl GasPriceFeedbackTester {
     async fn new(
         max_deferral_rounds_for_congestion_control: u64,
         per_object_congestion_control_mode: PerObjectCongestionControlMode,
-        max_execution_duration_per_commit: u64,
+        max_execution_duration_per_commit: Option<u64>,
         assign_min_free_execution_slot: bool,
         enable_gas_price_feedback_mechanism: bool,
         num_gas_objects: usize,
@@ -94,9 +94,15 @@ impl GasPriceFeedbackTester {
         );
         protocol_config
             .set_per_object_congestion_control_mode_for_testing(per_object_congestion_control_mode);
-        protocol_config.set_max_accumulated_txn_cost_per_object_in_mysticeti_commit_for_testing(
-            max_execution_duration_per_commit,
-        );
+        if let Some(max_execution_duration_per_commit) = max_execution_duration_per_commit {
+            protocol_config
+                .set_max_accumulated_txn_cost_per_object_in_mysticeti_commit_for_testing(
+                    max_execution_duration_per_commit,
+                );
+        } else {
+            protocol_config
+                .disable_max_accumulated_txn_cost_per_object_in_mysticeti_commit_for_testing();
+        }
         protocol_config.set_congestion_control_min_free_execution_slot_for_testing(
             assign_min_free_execution_slot,
         );
@@ -334,7 +340,77 @@ impl GasPriceFeedbackTester {
 async fn per_object_congestion_control_mode_is_none() {
     let max_deferral_rounds_for_congestion_control = 0;
     let per_object_congestion_control_mode = PerObjectCongestionControlMode::None;
-    let max_execution_duration_per_commit = 0;
+    let max_execution_duration_per_commit = Some(1);
+    let assign_min_free_execution_slot = true;
+    let enable_gas_price_feedback_mechanism = true;
+    let num_gas_objects = 10;
+
+    let tester = GasPriceFeedbackTester::new(
+        max_deferral_rounds_for_congestion_control,
+        per_object_congestion_control_mode,
+        max_execution_duration_per_commit,
+        assign_min_free_execution_slot,
+        enable_gas_price_feedback_mechanism,
+        num_gas_objects,
+    )
+    .await;
+
+    // Prepare certificates
+    let mut certificates = vec![];
+    for (i, gas_object_id) in tester.gas_object_ids.iter().enumerate() {
+        let gas_price = REFERENCE_GAS_PRICE_FOR_TESTS + i as u64;
+        let gas_data = GasDataForTests::new(
+            *gas_object_id,
+            gas_price,
+            gas_price * DEFAULT_GAS_UNITS_FOR_TESTS,
+        );
+        let transaction = tester
+            .build_access_both_counters_transaction(gas_data, true, true)
+            .await;
+        let certificate = tester.certify_transaction(transaction).await;
+
+        certificates.push(certificate);
+    }
+    // Shuffle certificates so that they do not have any specific order in
+    // terms of gas price.
+    certificates.shuffle(&mut rand::thread_rng());
+    assert_eq!(certificates.len(), num_gas_objects);
+
+    let scheduled_transactions = tester
+        .send_certificates_to_consensus_for_scheduling(&certificates)
+        .await;
+    assert_eq!(
+        scheduled_transactions.len(),
+        // +1 because of consensus commit prologue transaction
+        certificates.len() + 1,
+    );
+    assert!(matches!(
+        scheduled_transactions[0].data().transaction_data().kind(),
+        TransactionKind::ConsensusCommitPrologueV1(..)
+    ));
+
+    let effects_vec = tester
+        .enqueue_and_execute_scheduled_transactions(scheduled_transactions)
+        .await;
+    assert_eq!(
+        effects_vec.len(),
+        // +1 because of consensus commit prologue transaction
+        certificates.len() + 1,
+    );
+
+    // All transactions should be successfully executed.
+    for effects in effects_vec {
+        assert!(effects.status().is_ok());
+    }
+}
+
+// Test that everything goes well (i.e., no transactions are deferred or
+// cancelled) if `max_execution_duration_per_commit` is set None.
+#[sim_test]
+async fn max_execution_duration_per_commit_is_none() {
+    let max_deferral_rounds_for_congestion_control = 0;
+    let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalTxCount;
+    let max_execution_duration_per_commit = None;
     let assign_min_free_execution_slot = true;
     let enable_gas_price_feedback_mechanism = true;
     let num_gas_objects = 10;
@@ -408,7 +484,7 @@ async fn max_execution_duration_per_commit_too_low_in_total_tx_count_mode() {
     let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalTxCount;
     // Intentionally set to 0 so that even one transaction will not fit in a
     // single commit.
-    let max_execution_duration_per_commit = 0;
+    let max_execution_duration_per_commit = Some(0);
     let assign_min_free_execution_slot = true;
     let enable_gas_price_feedback_mechanism = true;
     let num_gas_objects = 2;
@@ -460,7 +536,7 @@ async fn max_execution_duration_per_commit_too_low_in_total_gas_budget_mode() {
     // Intentionally set too low so that even one transaction will not fit in a
     // single commit.
     let max_execution_duration_per_commit =
-        REFERENCE_GAS_PRICE_FOR_TESTS * DEFAULT_GAS_UNITS_FOR_TESTS;
+        Some(REFERENCE_GAS_PRICE_FOR_TESTS * DEFAULT_GAS_UNITS_FOR_TESTS);
     let assign_min_free_execution_slot = true;
     let enable_gas_price_feedback_mechanism = true;
     let num_gas_objects = 2;
@@ -509,7 +585,7 @@ async fn gas_price_feedback_mechanism_is_turned_off() {
     // All deferred transactions will be cancelled
     let max_deferral_rounds_for_congestion_control = 0;
     let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalTxCount;
-    let max_execution_duration_per_commit = 1;
+    let max_execution_duration_per_commit = Some(1);
     let assign_min_free_execution_slot = true;
     let enable_gas_price_feedback_mechanism = false;
     let num_gas_objects = 2;
@@ -661,7 +737,7 @@ async fn gas_price_feedback_mechanism_with_max_gas_price() {
     // All deferred transactions will be cancelled
     let max_deferral_rounds_for_congestion_control = 0;
     let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalGasBudget;
-    let max_execution_duration_per_commit = max_gas_price * DEFAULT_GAS_UNITS_FOR_TESTS;
+    let max_execution_duration_per_commit = Some(max_gas_price * DEFAULT_GAS_UNITS_FOR_TESTS);
     let assign_min_free_execution_slot = true;
     let enable_gas_price_feedback_mechanism = true;
     let num_gas_objects = 2;

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -3,7 +3,6 @@
 
 use std::sync::Arc;
 
-use iota_macros::sim_test;
 use iota_protocol_config::{
     Chain, PerObjectCongestionControlMode, ProtocolConfig, ProtocolVersion,
 };
@@ -319,7 +318,9 @@ impl GasPriceFeedbackTester {
     }
 }
 
-#[sim_test]
+// Test that everything goes well (i.e., no transactions are deferred or
+// cancelled) if the congestion control is turned off.
+#[tokio::test]
 async fn congestion_control_is_turned_off() {
     let max_deferral_rounds_for_congestion_control = 0;
     let per_object_congestion_control_mode = PerObjectCongestionControlMode::None;
@@ -378,4 +379,100 @@ async fn congestion_control_is_turned_off() {
     for effects in effects_vec {
         assert!(effects.status().is_ok());
     }
+}
+
+// Test that the suggested gas price calculator panics if
+// `max_execution_duration_per_commit` is set too low such that even
+// one transaction cannot fit in a commit.
+#[tokio::test]
+#[should_panic] // because `max_execution_duration_per_commit` is set too low.
+async fn max_execution_duration_per_commit_is_set_too_low_in_total_tx_count_mode() {
+    let max_deferral_rounds_for_congestion_control = 10;
+    let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalTxCount;
+    // Intentionally set to 0 so that even one transaction will not fit in a
+    // single commit.
+    let max_execution_duration_per_commit = 0;
+    let assign_min_free_execution_slot = true;
+    let num_gas_objects = 2;
+
+    let tester = GasPriceFeedbackTester::new(
+        max_deferral_rounds_for_congestion_control,
+        per_object_congestion_control_mode,
+        max_execution_duration_per_commit,
+        assign_min_free_execution_slot,
+        num_gas_objects,
+    )
+    .await;
+
+    // Prepare certificates
+    let mut certificates = vec![];
+    for (i, gas_object_id) in tester.gas_object_ids.iter().enumerate() {
+        let gas_data = GasDataForTests::new(
+            *gas_object_id,
+            REFERENCE_GAS_PRICE_FOR_TESTS + i as u64,
+            DEFAULT_GAS_BUDGET_FOR_TESTS,
+        );
+        let transaction = tester
+            .build_access_both_counters_transaction(gas_data, true, true)
+            .await;
+        let certificate = tester.certify_transaction(transaction).await;
+
+        certificates.push(certificate);
+    }
+    // Shuffle certificates so that they do not have any specific order in
+    // terms of gas price.
+    certificates.shuffle(&mut rand::thread_rng());
+    assert_eq!(certificates.len(), num_gas_objects);
+
+    let _scheduled_transactions = tester
+        .send_certificates_to_consensus_for_scheduling(&certificates)
+        .await;
+}
+
+// Test that the suggested gas price calculator panics if
+// `max_execution_duration_per_commit` is set too low such that even
+// one transaction cannot fit in a commit.
+#[tokio::test]
+#[should_panic] // because `max_execution_duration_per_commit` is set too low.
+async fn max_execution_duration_per_commit_is_set_too_low_in_total_gas_budget_mode() {
+    let max_deferral_rounds_for_congestion_control = 10;
+    let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalGasBudget;
+    // Intentionally set too low so that even one transaction will not fit in a
+    // single commit.
+    let max_execution_duration_per_commit = DEFAULT_GAS_BUDGET_FOR_TESTS - 1;
+    let assign_min_free_execution_slot = true;
+    let num_gas_objects = 2;
+
+    let tester = GasPriceFeedbackTester::new(
+        max_deferral_rounds_for_congestion_control,
+        per_object_congestion_control_mode,
+        max_execution_duration_per_commit,
+        assign_min_free_execution_slot,
+        num_gas_objects,
+    )
+    .await;
+
+    // Prepare certificates
+    let mut certificates = vec![];
+    for (i, gas_object_id) in tester.gas_object_ids.iter().enumerate() {
+        let gas_data = GasDataForTests::new(
+            *gas_object_id,
+            REFERENCE_GAS_PRICE_FOR_TESTS + i as u64,
+            DEFAULT_GAS_BUDGET_FOR_TESTS,
+        );
+        let transaction = tester
+            .build_access_both_counters_transaction(gas_data, true, true)
+            .await;
+        let certificate = tester.certify_transaction(transaction).await;
+
+        certificates.push(certificate);
+    }
+    // Shuffle certificates so that they do not have any specific order in
+    // terms of gas price.
+    certificates.shuffle(&mut rand::thread_rng());
+    assert_eq!(certificates.len(), num_gas_objects);
+
+    let _scheduled_transactions = tester
+        .send_certificates_to_consensus_for_scheduling(&certificates)
+        .await;
 }

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -77,6 +77,7 @@ impl GasPriceFeedbackTester {
         per_object_congestion_control_mode: PerObjectCongestionControlMode,
         max_execution_duration_per_commit: u64,
         assign_min_free_execution_slot: bool,
+        enable_gas_price_feedback_mechanism: bool,
         num_gas_objects: usize,
     ) -> Self {
         let (sender, sender_key): (IotaAddress, AccountKeyPair) = get_key_pair();
@@ -93,6 +94,9 @@ impl GasPriceFeedbackTester {
         );
         protocol_config.set_congestion_control_min_free_execution_slot_for_testing(
             assign_min_free_execution_slot,
+        );
+        protocol_config.set_congestion_control_gas_price_feedback_mechanism_for_testing(
+            enable_gas_price_feedback_mechanism,
         );
 
         let authority_state = TestAuthorityBuilder::new()
@@ -326,6 +330,7 @@ async fn congestion_control_is_turned_off() {
     let per_object_congestion_control_mode = PerObjectCongestionControlMode::None;
     let max_execution_duration_per_commit = 0;
     let assign_min_free_execution_slot = true;
+    let enable_gas_price_feedback_mechanism = true;
     let num_gas_objects = 10;
 
     let tester = GasPriceFeedbackTester::new(
@@ -333,6 +338,7 @@ async fn congestion_control_is_turned_off() {
         per_object_congestion_control_mode,
         max_execution_duration_per_commit,
         assign_min_free_execution_slot,
+        enable_gas_price_feedback_mechanism,
         num_gas_objects,
     )
     .await;
@@ -393,6 +399,7 @@ async fn max_execution_duration_per_commit_is_set_too_low_in_total_tx_count_mode
     // single commit.
     let max_execution_duration_per_commit = 0;
     let assign_min_free_execution_slot = true;
+    let enable_gas_price_feedback_mechanism = true;
     let num_gas_objects = 2;
 
     let tester = GasPriceFeedbackTester::new(
@@ -400,6 +407,7 @@ async fn max_execution_duration_per_commit_is_set_too_low_in_total_tx_count_mode
         per_object_congestion_control_mode,
         max_execution_duration_per_commit,
         assign_min_free_execution_slot,
+        enable_gas_price_feedback_mechanism,
         num_gas_objects,
     )
     .await;
@@ -441,6 +449,7 @@ async fn max_execution_duration_per_commit_is_set_too_low_in_total_gas_budget_mo
     // single commit.
     let max_execution_duration_per_commit = DEFAULT_GAS_BUDGET_FOR_TESTS - 1;
     let assign_min_free_execution_slot = true;
+    let enable_gas_price_feedback_mechanism = true;
     let num_gas_objects = 2;
 
     let tester = GasPriceFeedbackTester::new(
@@ -448,6 +457,7 @@ async fn max_execution_duration_per_commit_is_set_too_low_in_total_gas_budget_mo
         per_object_congestion_control_mode,
         max_execution_duration_per_commit,
         assign_min_free_execution_slot,
+        enable_gas_price_feedback_mechanism,
         num_gas_objects,
     )
     .await;

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -1,0 +1,113 @@
+// Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_macros::sim_test;
+use iota_protocol_config::{
+    Chain, PerObjectCongestionControlMode, ProtocolConfig, ProtocolVersion,
+};
+use iota_types::{
+    base_types::{IotaAddress, ObjectID, ObjectRef},
+    crypto::{AccountKeyPair, get_key_pair},
+    effects::TransactionEffectsAPI,
+    object::Object,
+    programmable_transaction_builder::ProgrammableTransactionBuilder,
+};
+use move_core_types::ident_str;
+
+use crate::{
+    authority::{
+        AuthorityState, authority_tests::execute_programmable_transaction,
+        move_integration_tests::build_and_publish_test_package,
+        test_authority_builder::TestAuthorityBuilder,
+    },
+    move_call,
+};
+
+/// Gas price used only for testing gas price feedback mechanism.
+const GAS_PRICE_FOR_TEST: u64 = 1_000;
+
+const GAS_UNITS_FOR_TEST: u64 = 10_000;
+
+async fn create_shared_counter_ptb(
+    authority_state: &AuthorityState,
+    package_id: &ObjectID,
+    gas_object_id: &ObjectID,
+    sender: &IotaAddress,
+    sender_key: &AccountKeyPair,
+) -> ObjectRef {
+    let mut builder = ProgrammableTransactionBuilder::new();
+    move_call! {
+        builder,
+        (*package_id)::gas_price_feedback::create_shared_counter()
+    };
+    let pt = builder.finish();
+
+    let effects = execute_programmable_transaction(
+        authority_state,
+        gas_object_id,
+        sender,
+        sender_key,
+        pt,
+        GAS_UNITS_FOR_TEST,
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        effects.status().is_ok(),
+        "Execution error {:?}",
+        effects.status()
+    );
+    assert_eq!(effects.created().len(), 1);
+
+    effects.created()[0].0
+}
+
+#[sim_test]
+async fn gas_price_feedback_mechanism() {
+    let (sender, sender_key): (IotaAddress, AccountKeyPair) = get_key_pair();
+
+    let mut protocol_config =
+        ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
+    protocol_config.set_per_object_congestion_control_mode_for_testing(
+        PerObjectCongestionControlMode::TotalTxCount,
+    );
+
+    let max_execution_duration_per_commit = 2;
+    protocol_config.set_max_accumulated_txn_cost_per_object_in_mysticeti_commit_for_testing(
+        max_execution_duration_per_commit,
+    );
+
+    protocol_config.set_max_deferral_rounds_for_congestion_control_for_testing(3);
+
+    let authority_state = TestAuthorityBuilder::new()
+        .with_reference_gas_price(GAS_PRICE_FOR_TEST)
+        .with_protocol_config(protocol_config.clone())
+        .build()
+        .await;
+
+    let gas_object_id = ObjectID::random();
+    let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
+    authority_state
+        .insert_genesis_object(gas_object.clone())
+        .await;
+
+    let package = build_and_publish_test_package(
+        &authority_state,
+        &sender,
+        &sender_key,
+        &gas_object_id,
+        "gas_price_feedback",
+        false,
+    )
+    .await;
+
+    create_shared_counter_ptb(
+        &authority_state,
+        &package.0,
+        &gas_object_id,
+        &sender,
+        &sender_key,
+    )
+    .await;
+}

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use iota_macros::sim_test;
 use iota_protocol_config::{
     Chain, PerObjectCongestionControlMode, ProtocolConfig, ProtocolVersion,
 };
@@ -13,7 +14,10 @@ use iota_types::{
     executable_transaction::VerifiedExecutableTransaction,
     object::Object,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{ObjectArg, Transaction, VerifiedCertificate},
+    transaction::{
+        ObjectArg, ProgrammableTransaction, Transaction, TransactionData, VerifiedCertificate,
+    },
+    utils::to_sender_signed_transaction,
 };
 use move_core_types::ident_str;
 use rand::seq::SliceRandom;
@@ -22,8 +26,7 @@ use crate::{
     authority::{
         AuthorityState,
         authority_tests::{
-            build_programmable_transaction, certify_transaction, execute_programmable_transaction,
-            send_batch_consensus_no_execution,
+            certify_transaction, send_and_confirm_transaction_, send_batch_consensus_no_execution,
         },
         move_integration_tests::build_and_publish_test_package,
         test_authority_builder::TestAuthorityBuilder,
@@ -34,7 +37,25 @@ use crate::{
 /// Reference gas price used in gas price feedback mechanism tests.
 const REFERENCE_GAS_PRICE_FOR_TESTS: u64 = 1_000;
 
-const GAS_UNITS_FOR_TEST: u64 = 10_000;
+/// Default gas budget used in gas price feedback mechanism tests.
+const DEFAULT_GAS_BUDGET_FOR_TESTS: u64 = 10_000_000;
+
+/// Container holding gas object ID, gas price, and gas budget.
+struct GasDataForTests {
+    gas_object_id: ObjectID,
+    gas_price: u64,
+    gas_budget: u64,
+}
+
+impl GasDataForTests {
+    fn new(gas_object_id: ObjectID, gas_price: u64, gas_budget: u64) -> Self {
+        Self {
+            gas_object_id,
+            gas_price,
+            gas_budget,
+        }
+    }
+}
 
 struct GasPriceFeedbackTester {
     authority_state: Arc<AuthorityState>,
@@ -47,10 +68,16 @@ struct GasPriceFeedbackTester {
 }
 
 impl GasPriceFeedbackTester {
+    /// Create a new `GasPriceFeedbackTester`. Under the hood, this builds
+    /// a new `AuthorityState` with protocol config parameters related to
+    /// shared object congestion. This will also deploy a number of gas
+    /// objects needed to send test transactions, and deploy a package with
+    /// two shared counters and simple Move calls operating on those counters.
     async fn new(
         max_deferral_rounds_for_congestion_control: u64,
         per_object_congestion_control_mode: PerObjectCongestionControlMode,
         max_execution_duration_per_commit: u64,
+        assign_min_free_execution_slot: bool,
         num_gas_objects: usize,
     ) -> Self {
         let (sender, sender_key): (IotaAddress, AccountKeyPair) = get_key_pair();
@@ -65,7 +92,9 @@ impl GasPriceFeedbackTester {
         protocol_config.set_max_accumulated_txn_cost_per_object_in_mysticeti_commit_for_testing(
             max_execution_duration_per_commit,
         );
-        protocol_config.set_min_checkpoint_interval_ms_for_testing(1000);
+        protocol_config.set_congestion_control_min_free_execution_slot_for_testing(
+            assign_min_free_execution_slot,
+        );
 
         let authority_state = TestAuthorityBuilder::new()
             .with_reference_gas_price(REFERENCE_GAS_PRICE_FOR_TESTS)
@@ -123,6 +152,7 @@ impl GasPriceFeedbackTester {
         }
     }
 
+    /// Build and execute a transaction that creates a shared counter.
     async fn create_shared_counter(
         authority_state: &AuthorityState,
         package_id: &ObjectID,
@@ -139,16 +169,28 @@ impl GasPriceFeedbackTester {
 
         let pt = builder.finish();
 
-        let effects = execute_programmable_transaction(
-            authority_state,
-            gas_object_id,
-            sender,
-            sender_key,
+        let gas_object_ref = authority_state
+            .get_object(gas_object_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .compute_object_reference();
+
+        let transaction_data = TransactionData::new_programmable(
+            *sender,
+            vec![gas_object_ref],
             pt,
-            GAS_UNITS_FOR_TEST,
-        )
-        .await
-        .unwrap();
+            DEFAULT_GAS_BUDGET_FOR_TESTS,
+            REFERENCE_GAS_PRICE_FOR_TESTS,
+        );
+
+        let transaction = to_sender_signed_transaction(transaction_data, sender_key);
+
+        let effects = send_and_confirm_transaction_(authority_state, None, transaction, false)
+            .await
+            .unwrap()
+            .1
+            .into_data();
 
         assert!(
             effects.status().is_ok(),
@@ -160,46 +202,29 @@ impl GasPriceFeedbackTester {
         effects.created()[0].0
     }
 
-    async fn build_increment_both_counters_transaction(
+    /// Build and sign a programmable transaction.
+    async fn build_programmable_transaction(
         &self,
-        gas_object_id: &ObjectID,
-        // gas_price: u64
+        pt: ProgrammableTransaction,
+        gas_data: GasDataForTests,
     ) -> Transaction {
-        let mut txn_builder = ProgrammableTransactionBuilder::new();
+        let gas_object_ref = self
+            .authority_state
+            .get_object(&gas_data.gas_object_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .compute_object_reference();
 
-        let arg1 = txn_builder
-            .obj(ObjectArg::SharedObject {
-                id: self.shared_counter_1.0,
-                initial_shared_version: self.shared_counter_1.1,
-                mutable: true,
-            })
-            .unwrap();
-
-        let arg2 = txn_builder
-            .obj(ObjectArg::SharedObject {
-                id: self.shared_counter_2.0,
-                initial_shared_version: self.shared_counter_2.1,
-                mutable: true,
-            })
-            .unwrap();
-
-        move_call! {
-            txn_builder,
-            (self.package.0)::gas_price_feedback::increment_both(arg1, arg2)
-        };
-
-        let pt = txn_builder.finish();
-
-        build_programmable_transaction(
-            &self.authority_state,
-            gas_object_id,
-            &self.sender,
-            &self.sender_key,
+        let transaction_data = TransactionData::new_programmable(
+            self.sender,
+            vec![gas_object_ref],
             pt,
-            GAS_UNITS_FOR_TEST,
-        )
-        .await
-        .unwrap()
+            gas_data.gas_budget,
+            gas_data.gas_price,
+        );
+
+        to_sender_signed_transaction(transaction_data, &self.sender_key)
     }
 
     async fn certify_transaction(&self, transaction: Transaction) -> VerifiedCertificate {
@@ -235,19 +260,53 @@ impl GasPriceFeedbackTester {
             .await
             .unwrap()
     }
+
+    async fn build_increment_both_counters_transaction(
+        &self,
+        gas_data: GasDataForTests,
+    ) -> Transaction {
+        let mut txn_builder = ProgrammableTransactionBuilder::new();
+
+        let arg1 = txn_builder
+            .obj(ObjectArg::SharedObject {
+                id: self.shared_counter_1.0,
+                initial_shared_version: self.shared_counter_1.1,
+                mutable: true,
+            })
+            .unwrap();
+
+        let arg2 = txn_builder
+            .obj(ObjectArg::SharedObject {
+                id: self.shared_counter_2.0,
+                initial_shared_version: self.shared_counter_2.1,
+                mutable: true,
+            })
+            .unwrap();
+
+        move_call! {
+            txn_builder,
+            (self.package.0)::gas_price_feedback::increment_both(arg1, arg2)
+        };
+
+        let pt = txn_builder.finish();
+
+        self.build_programmable_transaction(pt, gas_data).await
+    }
 }
 
-#[tokio::test]
+#[sim_test]
 async fn gas_price_feedback_mechanism() {
     let max_deferral_rounds_for_congestion_control = 1;
     let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalTxCount;
     let max_execution_duration_per_commit = 1;
+    let assign_min_free_execution_slot = false;
     let num_gas_objects = 2;
 
     let tester = GasPriceFeedbackTester::new(
         max_deferral_rounds_for_congestion_control,
         per_object_congestion_control_mode,
         max_execution_duration_per_commit,
+        assign_min_free_execution_slot,
         num_gas_objects,
     )
     .await;
@@ -255,8 +314,13 @@ async fn gas_price_feedback_mechanism() {
     // Prepare certificates
     let mut certificates = vec![];
     for gas_object_id in tester.gas_object_ids.iter() {
+        let gas_data = GasDataForTests::new(
+            *gas_object_id,
+            REFERENCE_GAS_PRICE_FOR_TESTS,
+            DEFAULT_GAS_BUDGET_FOR_TESTS,
+        );
         let transaction = tester
-            .build_increment_both_counters_transaction(gas_object_id)
+            .build_increment_both_counters_transaction(gas_data)
             .await;
         let certificate = tester.certify_transaction(transaction).await;
 

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -7,14 +7,17 @@ use iota_protocol_config::{
     Chain, PerObjectCongestionControlMode, ProtocolConfig, ProtocolVersion,
 };
 use iota_types::{
-    base_types::{IotaAddress, ObjectID, ObjectRef},
+    base_types::{IotaAddress, ObjectID, ObjectRef, SequenceNumber},
     crypto::{AccountKeyPair, get_key_pair},
-    effects::{TransactionEffects, TransactionEffectsAPI},
+    effects::{TransactionEffects, TransactionEffectsAPI, UnchangedSharedKind},
     executable_transaction::VerifiedExecutableTransaction,
+    execution_status::{CongestedObjects, ExecutionFailureStatus, ExecutionStatus},
+    messages_consensus::ConsensusDeterminedVersionAssignments,
     object::Object,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::{
-        ObjectArg, ProgrammableTransaction, Transaction, TransactionData, VerifiedCertificate,
+        ObjectArg, ProgrammableTransaction, Transaction, TransactionData, TransactionDataAPI,
+        TransactionKind, VerifiedCertificate,
     },
     utils::to_sender_signed_transaction,
 };
@@ -371,6 +374,10 @@ async fn congestion_control_is_turned_off() {
         // +1 because of consensus commit prologue transaction
         certificates.len() + 1,
     );
+    assert!(matches!(
+        scheduled_transactions[0].data().transaction_data().kind(),
+        TransactionKind::ConsensusCommitPrologueV1(..)
+    ));
 
     let effects_vec = tester
         .enqueue_and_execute_scheduled_transactions(scheduled_transactions)
@@ -485,4 +492,153 @@ async fn max_execution_duration_per_commit_is_set_too_low_in_total_gas_budget_mo
     let _scheduled_transactions = tester
         .send_certificates_to_consensus_for_scheduling(&certificates)
         .await;
+}
+
+// Test that everything works well if the gas price feedback mechanism is
+// turned off: specifically, old `ExecutionCancelledDueToSharedObjectCongestion`
+// and `SequenceNumber::CONGESTED_PRIOR_TO_GAS_PRICE_FEEDBACK` should appear.
+#[tokio::test]
+async fn gas_price_feedback_mechanism_is_turned_off() {
+    let max_deferral_rounds_for_congestion_control = 0;
+    let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalTxCount;
+    let max_execution_duration_per_commit = 1;
+    let assign_min_free_execution_slot = true;
+    let enable_gas_price_feedback_mechanism = false;
+    let num_gas_objects = 2;
+
+    let tester = GasPriceFeedbackTester::new(
+        max_deferral_rounds_for_congestion_control,
+        per_object_congestion_control_mode,
+        max_execution_duration_per_commit,
+        assign_min_free_execution_slot,
+        enable_gas_price_feedback_mechanism,
+        num_gas_objects,
+    )
+    .await;
+
+    // Prepare certificates
+    let mut certificates = vec![];
+    for (i, gas_object_id) in tester.gas_object_ids.iter().enumerate() {
+        let gas_data = GasDataForTests::new(
+            *gas_object_id,
+            REFERENCE_GAS_PRICE_FOR_TESTS + i as u64,
+            DEFAULT_GAS_BUDGET_FOR_TESTS,
+        );
+        let transaction = tester
+            .build_access_both_counters_transaction(gas_data, true, true)
+            .await;
+        let certificate = tester.certify_transaction(transaction).await;
+
+        certificates.push(certificate);
+    }
+    // Shuffle certificates so that they do not have any specific order in
+    // terms of gas price.
+    certificates.shuffle(&mut rand::thread_rng());
+    assert_eq!(certificates.len(), num_gas_objects);
+
+    let scheduled_transactions = tester
+        .send_certificates_to_consensus_for_scheduling(&certificates)
+        .await;
+    assert_eq!(
+        scheduled_transactions.len(),
+        // +1 because of consensus commit prologue transaction
+        certificates.len() + 1,
+    );
+
+    // The first executed transaction should be `ConsensusCommitPrologueV1`
+    if let TransactionKind::ConsensusCommitPrologueV1(prologue_tx) =
+        scheduled_transactions[0].data().transaction_data().kind()
+    {
+        // Check if `ConsensusDeterminedVersionAssignments` are correct.
+        let cancelled_txs = vec![(
+            *scheduled_transactions[2].digest(),
+            vec![
+                (
+                    tester.shared_counter_1.0,
+                    SequenceNumber::CONGESTED_PRIOR_TO_GAS_PRICE_FEEDBACK,
+                ),
+                (
+                    tester.shared_counter_2.0,
+                    SequenceNumber::CONGESTED_PRIOR_TO_GAS_PRICE_FEEDBACK,
+                ),
+            ],
+        )];
+        assert_eq!(
+            prologue_tx.consensus_determined_version_assignments,
+            ConsensusDeterminedVersionAssignments::CancelledTransactions(cancelled_txs)
+        );
+    } else {
+        panic!("First scheduled transaction must be a `ConsensusCommitPrologueV1` transaction.");
+    }
+
+    // Confirm that gas price order of scheduled transactions is descending
+    assert_eq!(
+        scheduled_transactions[1]
+            .data()
+            .transaction_data()
+            .gas_price(),
+        REFERENCE_GAS_PRICE_FOR_TESTS + 1
+    );
+    assert_eq!(
+        scheduled_transactions[2]
+            .data()
+            .transaction_data()
+            .gas_price(),
+        REFERENCE_GAS_PRICE_FOR_TESTS
+    );
+
+    let effects_vec = tester
+        .enqueue_and_execute_scheduled_transactions(scheduled_transactions)
+        .await;
+    assert_eq!(
+        effects_vec.len(),
+        // +1 because of consensus commit prologue transaction
+        certificates.len() + 1,
+    );
+
+    // `ConsensusCommitPrologueV1` should be successfully executed
+    assert!(effects_vec[0].status().is_ok());
+    // The first transaction should be successfully executed
+    assert!(effects_vec[1].status().is_ok());
+
+    // The second transaction should be cancelled
+    if let ExecutionStatus::Failure { error, command } = effects_vec[2].status() {
+        assert!(command.is_none());
+        if let ExecutionFailureStatus::ExecutionCancelledDueToSharedObjectCongestion {
+            congested_objects,
+        } = error
+        {
+            // Check is returned congested_objects are correct.
+            assert_eq!(
+                *congested_objects,
+                CongestedObjects(vec![tester.shared_counter_1.0, tester.shared_counter_2.0])
+            );
+        } else {
+            panic!(
+                "`ExecutionFailureStatus` must be `ExecutionCancelledDueToSharedObjectCongestion`."
+            );
+        }
+    } else {
+        panic!("The second transaction must be cancelled.")
+    }
+
+    // Check if unchanged_shared_objects in effects of the cancelled transaction
+    // are correct
+    assert_eq!(
+        effects_vec[2].unchanged_shared_objects(),
+        vec![
+            (
+                tester.shared_counter_1.0,
+                UnchangedSharedKind::Cancelled(
+                    SequenceNumber::CONGESTED_PRIOR_TO_GAS_PRICE_FEEDBACK
+                )
+            ),
+            (
+                tester.shared_counter_2.0,
+                UnchangedSharedKind::Cancelled(
+                    SequenceNumber::CONGESTED_PRIOR_TO_GAS_PRICE_FEEDBACK
+                )
+            ),
+        ]
+    );
 }

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use iota_macros::sim_test;
 use iota_protocol_config::{
     Chain, PerObjectCongestionControlMode, ProtocolConfig, ProtocolVersion,
 };
@@ -39,8 +40,8 @@ use crate::{
 /// Reference gas price used in gas price feedback mechanism tests.
 const REFERENCE_GAS_PRICE_FOR_TESTS: u64 = 1_000;
 
-/// Default gas budget used in gas price feedback mechanism tests.
-const DEFAULT_GAS_BUDGET_FOR_TESTS: u64 = 10_000_000;
+/// Default gas units used in gas price feedback mechanism tests.
+const DEFAULT_GAS_UNITS_FOR_TESTS: u64 = 10_000;
 
 /// Container holding gas object ID, gas price, and gas budget.
 struct GasDataForTests {
@@ -61,6 +62,7 @@ impl GasDataForTests {
 
 struct GasPriceFeedbackTester {
     authority_state: Arc<AuthorityState>,
+    protocol_config: ProtocolConfig,
     sender: IotaAddress,
     sender_key: AccountKeyPair,
     gas_object_ids: Vec<ObjectID>,
@@ -149,6 +151,7 @@ impl GasPriceFeedbackTester {
 
         Self {
             authority_state,
+            protocol_config,
             sender,
             sender_key,
             gas_object_ids,
@@ -186,7 +189,7 @@ impl GasPriceFeedbackTester {
             *sender,
             vec![gas_object_ref],
             pt,
-            DEFAULT_GAS_BUDGET_FOR_TESTS,
+            REFERENCE_GAS_PRICE_FOR_TESTS * DEFAULT_GAS_UNITS_FOR_TESTS,
             REFERENCE_GAS_PRICE_FOR_TESTS,
         );
 
@@ -326,9 +329,9 @@ impl GasPriceFeedbackTester {
 }
 
 // Test that everything goes well (i.e., no transactions are deferred or
-// cancelled) if the congestion control is turned off.
-#[tokio::test]
-async fn congestion_control_is_turned_off() {
+// cancelled) if per-object congestion control mode is None.
+#[sim_test]
+async fn per_object_congestion_control_mode_is_none() {
     let max_deferral_rounds_for_congestion_control = 0;
     let per_object_congestion_control_mode = PerObjectCongestionControlMode::None;
     let max_execution_duration_per_commit = 0;
@@ -349,10 +352,11 @@ async fn congestion_control_is_turned_off() {
     // Prepare certificates
     let mut certificates = vec![];
     for (i, gas_object_id) in tester.gas_object_ids.iter().enumerate() {
+        let gas_price = REFERENCE_GAS_PRICE_FOR_TESTS + i as u64;
         let gas_data = GasDataForTests::new(
             *gas_object_id,
-            REFERENCE_GAS_PRICE_FOR_TESTS + i as u64,
-            DEFAULT_GAS_BUDGET_FOR_TESTS,
+            gas_price,
+            gas_price * DEFAULT_GAS_UNITS_FOR_TESTS,
         );
         let transaction = tester
             .build_access_both_counters_transaction(gas_data, true, true)
@@ -399,7 +403,7 @@ async fn congestion_control_is_turned_off() {
 // one transaction cannot fit in a commit.
 #[tokio::test]
 #[should_panic] // because `max_execution_duration_per_commit` is set too low.
-async fn max_execution_duration_per_commit_is_set_too_low_in_total_tx_count_mode() {
+async fn max_execution_duration_per_commit_too_low_in_total_tx_count_mode() {
     let max_deferral_rounds_for_congestion_control = 10;
     let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalTxCount;
     // Intentionally set to 0 so that even one transaction will not fit in a
@@ -422,10 +426,11 @@ async fn max_execution_duration_per_commit_is_set_too_low_in_total_tx_count_mode
     // Prepare certificates
     let mut certificates = vec![];
     for (i, gas_object_id) in tester.gas_object_ids.iter().enumerate() {
+        let gas_price = REFERENCE_GAS_PRICE_FOR_TESTS + i as u64;
         let gas_data = GasDataForTests::new(
             *gas_object_id,
-            REFERENCE_GAS_PRICE_FOR_TESTS + i as u64,
-            DEFAULT_GAS_BUDGET_FOR_TESTS,
+            gas_price,
+            gas_price * DEFAULT_GAS_UNITS_FOR_TESTS,
         );
         let transaction = tester
             .build_access_both_counters_transaction(gas_data, true, true)
@@ -449,12 +454,13 @@ async fn max_execution_duration_per_commit_is_set_too_low_in_total_tx_count_mode
 // one transaction cannot fit in a commit.
 #[tokio::test]
 #[should_panic] // because `max_execution_duration_per_commit` is set too low.
-async fn max_execution_duration_per_commit_is_set_too_low_in_total_gas_budget_mode() {
+async fn max_execution_duration_per_commit_too_low_in_total_gas_budget_mode() {
     let max_deferral_rounds_for_congestion_control = 10;
     let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalGasBudget;
     // Intentionally set too low so that even one transaction will not fit in a
     // single commit.
-    let max_execution_duration_per_commit = DEFAULT_GAS_BUDGET_FOR_TESTS - 1;
+    let max_execution_duration_per_commit =
+        REFERENCE_GAS_PRICE_FOR_TESTS * DEFAULT_GAS_UNITS_FOR_TESTS;
     let assign_min_free_execution_slot = true;
     let enable_gas_price_feedback_mechanism = true;
     let num_gas_objects = 2;
@@ -472,10 +478,11 @@ async fn max_execution_duration_per_commit_is_set_too_low_in_total_gas_budget_mo
     // Prepare certificates
     let mut certificates = vec![];
     for (i, gas_object_id) in tester.gas_object_ids.iter().enumerate() {
+        let gas_price = REFERENCE_GAS_PRICE_FOR_TESTS + i as u64;
         let gas_data = GasDataForTests::new(
             *gas_object_id,
-            REFERENCE_GAS_PRICE_FOR_TESTS + i as u64,
-            DEFAULT_GAS_BUDGET_FOR_TESTS,
+            gas_price,
+            gas_price * DEFAULT_GAS_UNITS_FOR_TESTS,
         );
         let transaction = tester
             .build_access_both_counters_transaction(gas_data, true, true)
@@ -497,8 +504,9 @@ async fn max_execution_duration_per_commit_is_set_too_low_in_total_gas_budget_mo
 // Test that everything works well if the gas price feedback mechanism is
 // turned off: specifically, old `ExecutionCancelledDueToSharedObjectCongestion`
 // and `SequenceNumber::CONGESTED_PRIOR_TO_GAS_PRICE_FEEDBACK` should appear.
-#[tokio::test]
+#[sim_test]
 async fn gas_price_feedback_mechanism_is_turned_off() {
+    // All deferred transactions will be cancelled
     let max_deferral_rounds_for_congestion_control = 0;
     let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalTxCount;
     let max_execution_duration_per_commit = 1;
@@ -519,10 +527,11 @@ async fn gas_price_feedback_mechanism_is_turned_off() {
     // Prepare certificates
     let mut certificates = vec![];
     for (i, gas_object_id) in tester.gas_object_ids.iter().enumerate() {
+        let gas_price = REFERENCE_GAS_PRICE_FOR_TESTS + i as u64;
         let gas_data = GasDataForTests::new(
             *gas_object_id,
-            REFERENCE_GAS_PRICE_FOR_TESTS + i as u64,
-            DEFAULT_GAS_BUDGET_FOR_TESTS,
+            gas_price,
+            gas_price * DEFAULT_GAS_UNITS_FOR_TESTS,
         );
         let transaction = tester
             .build_access_both_counters_transaction(gas_data, true, true)
@@ -637,6 +646,146 @@ async fn gas_price_feedback_mechanism_is_turned_off() {
                 tester.shared_counter_2.0,
                 UnchangedSharedKind::Cancelled(
                     SequenceNumber::CONGESTED_PRIOR_TO_GAS_PRICE_FEEDBACK
+                )
+            ),
+        ]
+    );
+}
+
+// Test that suggested gas price does not exceed the max gas price set in
+// the protocol.
+#[sim_test]
+async fn gas_price_feedback_mechanism_with_max_gas_price() {
+    let max_gas_price = 100_000;
+
+    // All deferred transactions will be cancelled
+    let max_deferral_rounds_for_congestion_control = 0;
+    let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalGasBudget;
+    let max_execution_duration_per_commit = max_gas_price * DEFAULT_GAS_UNITS_FOR_TESTS;
+    let assign_min_free_execution_slot = true;
+    let enable_gas_price_feedback_mechanism = true;
+    let num_gas_objects = 2;
+
+    let tester = GasPriceFeedbackTester::new(
+        max_deferral_rounds_for_congestion_control,
+        per_object_congestion_control_mode,
+        max_execution_duration_per_commit,
+        assign_min_free_execution_slot,
+        enable_gas_price_feedback_mechanism,
+        num_gas_objects,
+    )
+    .await;
+    assert_eq!(max_gas_price, tester.protocol_config.max_gas_price());
+
+    // Prepare certificates
+    let mut certificates = vec![];
+    for gas_object_id in tester.gas_object_ids.iter() {
+        let gas_data = GasDataForTests::new(
+            *gas_object_id,
+            max_gas_price,
+            max_gas_price * DEFAULT_GAS_UNITS_FOR_TESTS,
+        );
+        let transaction = tester
+            .build_access_both_counters_transaction(gas_data, true, false)
+            .await;
+        let certificate = tester.certify_transaction(transaction).await;
+
+        certificates.push(certificate);
+    }
+    // Shuffle certificates so that they do not have any specific order in
+    // terms of gas price.
+    certificates.shuffle(&mut rand::thread_rng());
+    assert_eq!(certificates.len(), num_gas_objects);
+
+    let scheduled_transactions = tester
+        .send_certificates_to_consensus_for_scheduling(&certificates)
+        .await;
+    assert_eq!(
+        scheduled_transactions.len(),
+        // +1 because of consensus commit prologue transaction
+        certificates.len() + 1,
+    );
+
+    let suggested_gas_price = tester.protocol_config.max_gas_price();
+
+    // The first executed transaction should be `ConsensusCommitPrologueV1`
+    if let TransactionKind::ConsensusCommitPrologueV1(prologue_tx) =
+        scheduled_transactions[0].data().transaction_data().kind()
+    {
+        // Check if `ConsensusDeterminedVersionAssignments` are correct.
+        let cancelled_txs = vec![(
+            *scheduled_transactions[2].digest(),
+            vec![
+                (
+                    tester.shared_counter_1.0,
+                    SequenceNumber::new_congested_with_suggested_gas_price(suggested_gas_price),
+                ),
+                (
+                    tester.shared_counter_2.0,
+                    SequenceNumber::new_congested_with_suggested_gas_price(suggested_gas_price),
+                ),
+            ],
+        )];
+        assert_eq!(
+            prologue_tx.consensus_determined_version_assignments,
+            ConsensusDeterminedVersionAssignments::CancelledTransactions(cancelled_txs)
+        );
+    } else {
+        panic!("First scheduled transaction must be a `ConsensusCommitPrologueV1` transaction.");
+    }
+
+    let effects_vec = tester
+        .enqueue_and_execute_scheduled_transactions(scheduled_transactions)
+        .await;
+    assert_eq!(
+        effects_vec.len(),
+        // +1 because of consensus commit prologue transaction
+        certificates.len() + 1,
+    );
+
+    // `ConsensusCommitPrologueV1` should be successfully executed
+    assert!(effects_vec[0].status().is_ok());
+    // The first transaction should be successfully executed
+    assert!(effects_vec[1].status().is_ok());
+
+    // The second transaction should be cancelled
+    if let ExecutionStatus::Failure { error, command } = effects_vec[2].status() {
+        assert!(command.is_none());
+        if let ExecutionFailureStatus::ExecutionCancelledDueToSharedObjectCongestionV2 {
+            congested_objects,
+            suggested_gas_price,
+        } = error
+        {
+            // Check is returned congested_objects and suggested_gas_price are correct.
+            assert_eq!(
+                *congested_objects,
+                CongestedObjects(vec![tester.shared_counter_1.0, tester.shared_counter_2.0])
+            );
+            assert_eq!(*suggested_gas_price, tester.protocol_config.max_gas_price());
+        } else {
+            panic!(
+                "`ExecutionFailureStatus` must be `ExecutionCancelledDueToSharedObjectCongestion`."
+            );
+        }
+    } else {
+        panic!("The second transaction must be cancelled.")
+    }
+
+    // Check if unchanged_shared_objects in effects of the cancelled transaction
+    // are correct
+    assert_eq!(
+        effects_vec[2].unchanged_shared_objects(),
+        vec![
+            (
+                tester.shared_counter_1.0,
+                UnchangedSharedKind::Cancelled(
+                    SequenceNumber::new_congested_with_suggested_gas_price(suggested_gas_price)
+                )
+            ),
+            (
+                tester.shared_counter_2.0,
+                UnchangedSharedKind::Cancelled(
+                    SequenceNumber::new_congested_with_suggested_gas_price(suggested_gas_price)
                 )
             ),
         ]

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -339,19 +339,13 @@ impl GasPriceFeedbackTester {
 // cancelled) if per-object congestion control mode is None.
 #[sim_test]
 async fn per_object_congestion_control_mode_is_none() {
-    let max_deferral_rounds_for_congestion_control = 0;
-    let per_object_congestion_control_mode = PerObjectCongestionControlMode::None;
-    let max_execution_duration_per_commit = Some(1);
-    let assign_min_free_execution_slot = true;
-    let enable_gas_price_feedback_mechanism = true;
     let num_gas_objects = 10;
-
     let tester = GasPriceFeedbackTester::new(
-        max_deferral_rounds_for_congestion_control,
-        per_object_congestion_control_mode,
-        max_execution_duration_per_commit,
-        assign_min_free_execution_slot,
-        enable_gas_price_feedback_mechanism,
+        0,                                    // max_deferral_rounds_for_congestion_control
+        PerObjectCongestionControlMode::None, // per_object_congestion_control_mode
+        Some(1),                              // max_execution_duration_per_commit
+        true,                                 // assign_min_free_execution_slot
+        true,                                 // enable_gas_price_feedback_mechanism
         num_gas_objects,
     )
     .await;
@@ -389,6 +383,16 @@ async fn per_object_congestion_control_mode_is_none() {
         scheduled_transactions[0].data().transaction_data().kind(),
         TransactionKind::ConsensusCommitPrologueV1(..)
     ));
+
+    // Checks that there are no deferred transactions
+    assert!(
+        tester
+            .authority_state
+            .epoch_store_for_testing()
+            .get_all_deferred_transactions_for_test()
+            .unwrap()
+            .is_empty()
+    );
 
     let effects_vec = tester
         .enqueue_and_execute_scheduled_transactions(scheduled_transactions)
@@ -409,19 +413,13 @@ async fn per_object_congestion_control_mode_is_none() {
 // cancelled) if `max_execution_duration_per_commit` is set None.
 #[sim_test]
 async fn max_execution_duration_per_commit_is_none() {
-    let max_deferral_rounds_for_congestion_control = 0;
-    let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalTxCount;
-    let max_execution_duration_per_commit = None;
-    let assign_min_free_execution_slot = true;
-    let enable_gas_price_feedback_mechanism = true;
     let num_gas_objects = 10;
-
     let tester = GasPriceFeedbackTester::new(
-        max_deferral_rounds_for_congestion_control,
-        per_object_congestion_control_mode,
-        max_execution_duration_per_commit,
-        assign_min_free_execution_slot,
-        enable_gas_price_feedback_mechanism,
+        0,                                            // max_deferral_rounds_for_congestion_control
+        PerObjectCongestionControlMode::TotalTxCount, // per_object_congestion_control_mode
+        None,                                         // max_execution_duration_per_commit
+        true,                                         // assign_min_free_execution_slot
+        true,                                         // enable_gas_price_feedback_mechanism
         num_gas_objects,
     )
     .await;
@@ -459,6 +457,16 @@ async fn max_execution_duration_per_commit_is_none() {
         scheduled_transactions[0].data().transaction_data().kind(),
         TransactionKind::ConsensusCommitPrologueV1(..)
     ));
+
+    // Checks that there are no deferred transactions
+    assert!(
+        tester
+            .authority_state
+            .epoch_store_for_testing()
+            .get_all_deferred_transactions_for_test()
+            .unwrap()
+            .is_empty()
+    );
 
     let effects_vec = tester
         .enqueue_and_execute_scheduled_transactions(scheduled_transactions)
@@ -481,21 +489,13 @@ async fn max_execution_duration_per_commit_is_none() {
 #[tokio::test]
 #[should_panic] // because `max_execution_duration_per_commit` is set too low.
 async fn max_execution_duration_per_commit_too_low_in_total_tx_count_mode() {
-    let max_deferral_rounds_for_congestion_control = 10;
-    let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalTxCount;
-    // Intentionally set to 0 so that even one transaction will not fit in a
-    // single commit.
-    let max_execution_duration_per_commit = Some(0);
-    let assign_min_free_execution_slot = true;
-    let enable_gas_price_feedback_mechanism = true;
     let num_gas_objects = 2;
-
     let tester = GasPriceFeedbackTester::new(
-        max_deferral_rounds_for_congestion_control,
-        per_object_congestion_control_mode,
-        max_execution_duration_per_commit,
-        assign_min_free_execution_slot,
-        enable_gas_price_feedback_mechanism,
+        10,                                           // max_deferral_rounds_for_congestion_control
+        PerObjectCongestionControlMode::TotalTxCount, // per_object_congestion_control_mode
+        Some(0),                                      // max_execution_duration_per_commit
+        true,                                         // assign_min_free_execution_slot
+        true,                                         // enable_gas_price_feedback_mechanism
         num_gas_objects,
     )
     .await;
@@ -532,22 +532,13 @@ async fn max_execution_duration_per_commit_too_low_in_total_tx_count_mode() {
 #[tokio::test]
 #[should_panic] // because `max_execution_duration_per_commit` is set too low.
 async fn max_execution_duration_per_commit_too_low_in_total_gas_budget_mode() {
-    let max_deferral_rounds_for_congestion_control = 10;
-    let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalGasBudget;
-    // Intentionally set too low so that even one transaction will not fit in a
-    // single commit.
-    let max_execution_duration_per_commit =
-        Some(REFERENCE_GAS_PRICE_FOR_TESTS * DEFAULT_GAS_UNITS_FOR_TESTS);
-    let assign_min_free_execution_slot = true;
-    let enable_gas_price_feedback_mechanism = true;
     let num_gas_objects = 2;
-
     let tester = GasPriceFeedbackTester::new(
-        max_deferral_rounds_for_congestion_control,
-        per_object_congestion_control_mode,
-        max_execution_duration_per_commit,
-        assign_min_free_execution_slot,
-        enable_gas_price_feedback_mechanism,
+        10,                                             // max_deferral_rounds_for_congestion_control
+        PerObjectCongestionControlMode::TotalGasBudget, // per_object_congestion_control_mode
+        Some(REFERENCE_GAS_PRICE_FOR_TESTS * DEFAULT_GAS_UNITS_FOR_TESTS), // max_execution_duration_per_commit
+        true, // assign_min_free_execution_slot
+        true, // enable_gas_price_feedback_mechanism
         num_gas_objects,
     )
     .await;
@@ -583,20 +574,13 @@ async fn max_execution_duration_per_commit_too_low_in_total_gas_budget_mode() {
 // and `SequenceNumber::CONGESTED_PRIOR_TO_GAS_PRICE_FEEDBACK` should appear.
 #[sim_test]
 async fn gas_price_feedback_mechanism_is_turned_off() {
-    // All deferred transactions will be cancelled
-    let max_deferral_rounds_for_congestion_control = 0;
-    let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalTxCount;
-    let max_execution_duration_per_commit = Some(1);
-    let assign_min_free_execution_slot = true;
-    let enable_gas_price_feedback_mechanism = false;
     let num_gas_objects = 2;
-
     let tester = GasPriceFeedbackTester::new(
-        max_deferral_rounds_for_congestion_control,
-        per_object_congestion_control_mode,
-        max_execution_duration_per_commit,
-        assign_min_free_execution_slot,
-        enable_gas_price_feedback_mechanism,
+        0,                                            // max_deferral_rounds_for_congestion_control
+        PerObjectCongestionControlMode::TotalTxCount, // per_object_congestion_control_mode
+        Some(1),                                      // max_execution_duration_per_commit
+        true,                                         // assign_min_free_execution_slot
+        false,                                        // enable_gas_price_feedback_mechanism
         num_gas_objects,
     )
     .await;
@@ -631,6 +615,16 @@ async fn gas_price_feedback_mechanism_is_turned_off() {
         certificates.len() + 1,
     );
 
+    // Checks that there are no deferred transactions
+    assert!(
+        tester
+            .authority_state
+            .epoch_store_for_testing()
+            .get_all_deferred_transactions_for_test()
+            .unwrap()
+            .is_empty()
+    );
+
     // The first scheduled transaction should be `ConsensusCommitPrologueV1`
     if let TransactionKind::ConsensusCommitPrologueV1(prologue_tx) =
         scheduled_transactions[0].data().transaction_data().kind()
@@ -654,7 +648,7 @@ async fn gas_price_feedback_mechanism_is_turned_off() {
             ConsensusDeterminedVersionAssignments::CancelledTransactions(cancelled_txs)
         );
     } else {
-        panic!("First scheduled transaction must be a `ConsensusCommitPrologueV1` transaction.");
+        panic!("First scheduled transaction must be a ConsensusCommitPrologueV1 transaction.");
     }
 
     // Confirm that gas price order of scheduled transactions is descending
@@ -700,9 +694,7 @@ async fn gas_price_feedback_mechanism_is_turned_off() {
                 CongestedObjects(vec![tester.shared_counter_1.0, tester.shared_counter_2.0])
             );
         } else {
-            panic!(
-                "`ExecutionFailureStatus` must be `ExecutionCancelledDueToSharedObjectCongestion`."
-            );
+            panic!("ExecutionFailureStatus must be ExecutionCancelledDueToSharedObjectCongestion.");
         }
     } else {
         panic!("The second transaction must be cancelled.")
@@ -734,21 +726,13 @@ async fn gas_price_feedback_mechanism_is_turned_off() {
 #[sim_test]
 async fn gas_price_feedback_mechanism_with_max_gas_price() {
     let max_gas_price = 100_000;
-
-    // All deferred transactions will be cancelled
-    let max_deferral_rounds_for_congestion_control = 0;
-    let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalGasBudget;
-    let max_execution_duration_per_commit = Some(max_gas_price * DEFAULT_GAS_UNITS_FOR_TESTS);
-    let assign_min_free_execution_slot = true;
-    let enable_gas_price_feedback_mechanism = true;
     let num_gas_objects = 2;
-
     let tester = GasPriceFeedbackTester::new(
-        max_deferral_rounds_for_congestion_control,
-        per_object_congestion_control_mode,
-        max_execution_duration_per_commit,
-        assign_min_free_execution_slot,
-        enable_gas_price_feedback_mechanism,
+        0,                                                 // max_deferral_rounds_for_congestion_control
+        PerObjectCongestionControlMode::TotalGasBudget,    // per_object_congestion_control_mode
+        Some(max_gas_price * DEFAULT_GAS_UNITS_FOR_TESTS), // max_execution_duration_per_commit
+        true,                                              // assign_min_free_execution_slot
+        true,                                              // enable_gas_price_feedback_mechanism
         num_gas_objects,
     )
     .await;
@@ -783,7 +767,17 @@ async fn gas_price_feedback_mechanism_with_max_gas_price() {
         certificates.len() + 1,
     );
 
-    let suggested_gas_price = tester.protocol_config.max_gas_price();
+    // Checks that there are no deferred transactions
+    assert!(
+        tester
+            .authority_state
+            .epoch_store_for_testing()
+            .get_all_deferred_transactions_for_test()
+            .unwrap()
+            .is_empty()
+    );
+
+    let expected_suggested_gas_price = tester.protocol_config.max_gas_price();
 
     // The first scheduled transaction should be `ConsensusCommitPrologueV1`
     if let TransactionKind::ConsensusCommitPrologueV1(prologue_tx) =
@@ -795,11 +789,15 @@ async fn gas_price_feedback_mechanism_with_max_gas_price() {
             vec![
                 (
                     tester.shared_counter_1.0,
-                    SequenceNumber::new_congested_with_suggested_gas_price(suggested_gas_price),
+                    SequenceNumber::new_congested_with_suggested_gas_price(
+                        expected_suggested_gas_price,
+                    ),
                 ),
                 (
                     tester.shared_counter_2.0,
-                    SequenceNumber::new_congested_with_suggested_gas_price(suggested_gas_price),
+                    SequenceNumber::new_congested_with_suggested_gas_price(
+                        expected_suggested_gas_price,
+                    ),
                 ),
             ],
         )];
@@ -808,7 +806,7 @@ async fn gas_price_feedback_mechanism_with_max_gas_price() {
             ConsensusDeterminedVersionAssignments::CancelledTransactions(cancelled_txs)
         );
     } else {
-        panic!("First scheduled transaction must be a `ConsensusCommitPrologueV1` transaction.");
+        panic!("First scheduled transaction must be a ConsensusCommitPrologueV1 transaction.");
     }
 
     let effects_vec = tester
@@ -838,10 +836,10 @@ async fn gas_price_feedback_mechanism_with_max_gas_price() {
                 *congested_objects,
                 CongestedObjects(vec![tester.shared_counter_1.0, tester.shared_counter_2.0])
             );
-            assert_eq!(*suggested_gas_price, tester.protocol_config.max_gas_price());
+            assert_eq!(*suggested_gas_price, expected_suggested_gas_price);
         } else {
             panic!(
-                "`ExecutionFailureStatus` must be `ExecutionCancelledDueToSharedObjectCongestionV2`."
+                "ExecutionFailureStatus must be ExecutionCancelledDueToSharedObjectCongestionV2."
             );
         }
     } else {
@@ -856,13 +854,17 @@ async fn gas_price_feedback_mechanism_with_max_gas_price() {
             (
                 tester.shared_counter_1.0,
                 UnchangedSharedKind::Cancelled(
-                    SequenceNumber::new_congested_with_suggested_gas_price(suggested_gas_price)
+                    SequenceNumber::new_congested_with_suggested_gas_price(
+                        expected_suggested_gas_price
+                    )
                 )
             ),
             (
                 tester.shared_counter_2.0,
                 UnchangedSharedKind::Cancelled(
-                    SequenceNumber::new_congested_with_suggested_gas_price(suggested_gas_price)
+                    SequenceNumber::new_congested_with_suggested_gas_price(
+                        expected_suggested_gas_price
+                    )
                 )
             ),
         ]
@@ -874,19 +876,14 @@ async fn gas_price_feedback_mechanism_with_max_gas_price() {
 // transaction was deferred.
 #[sim_test]
 async fn gas_price_feedback_mechanism_for_multiple_commits() {
-    let max_deferral_rounds_for_congestion_control = 1;
-    let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalTxCount;
     let max_execution_duration_per_commit = 1;
-    let assign_min_free_execution_slot = true;
-    let enable_gas_price_feedback_mechanism = true;
     let num_gas_objects = 2;
-
     let tester = GasPriceFeedbackTester::new(
-        max_deferral_rounds_for_congestion_control,
-        per_object_congestion_control_mode,
+        1,                                            // max_deferral_rounds_for_congestion_control
+        PerObjectCongestionControlMode::TotalTxCount, // per_object_congestion_control_mode
         Some(max_execution_duration_per_commit),
-        assign_min_free_execution_slot,
-        enable_gas_price_feedback_mechanism,
+        true, // assign_min_free_execution_slot
+        true, // enable_gas_price_feedback_mechanism
         num_gas_objects,
     )
     .await;
@@ -942,7 +939,7 @@ async fn gas_price_feedback_mechanism_for_multiple_commits() {
             ConsensusDeterminedVersionAssignments::CancelledTransactions(vec![])
         );
     } else {
-        panic!("First scheduled transaction must be a `ConsensusCommitPrologueV1` transaction.");
+        panic!("First scheduled transaction must be a ConsensusCommitPrologueV1 transaction.");
     }
     // The second scheduled transaction should be one paying higher gas price
     assert_eq!(
@@ -1041,7 +1038,7 @@ async fn gas_price_feedback_mechanism_for_multiple_commits() {
             ConsensusDeterminedVersionAssignments::CancelledTransactions(cancelled_txs)
         );
     } else {
-        panic!("First scheduled transaction must be a `ConsensusCommitPrologueV1` transaction.");
+        panic!("First scheduled transaction must be a ConsensusCommitPrologueV1 transaction.");
     }
     // The second scheduled transaction should be one paying higher gas price
     assert_eq!(
@@ -1084,7 +1081,7 @@ async fn gas_price_feedback_mechanism_for_multiple_commits() {
             assert_eq!(*suggested_gas_price, expected_suggested_gas_price);
         } else {
             panic!(
-                "`ExecutionFailureStatus` must be `ExecutionCancelledDueToSharedObjectCongestionV2`."
+                "ExecutionFailureStatus must be ExecutionCancelledDueToSharedObjectCongestionV2."
             );
         }
     } else {

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{panic, sync::Arc};
 
 use iota_macros::sim_test;
 use iota_protocol_config::{
@@ -332,6 +332,95 @@ impl GasPriceFeedbackTester {
         let pt = txn_builder.finish();
 
         self.build_programmable_transaction(pt, gas_data).await
+    }
+
+    /// Build and sign a programmable transaction that accesses one counter.
+    /// The `mutable` flag control how the counter is accessed: mutably or
+    /// immutably. The `first` flag control whether the first or the second
+    /// counter is accessed.
+    async fn build_access_one_counter_transaction(
+        &self,
+        gas_data: GasDataForTests,
+        mutable: bool,
+        first: bool,
+    ) -> Transaction {
+        let mut txn_builder = ProgrammableTransactionBuilder::new();
+
+        let counter = if first {
+            self.shared_counter_1
+        } else {
+            self.shared_counter_2
+        };
+
+        let arg = txn_builder
+            .obj(ObjectArg::SharedObject {
+                id: counter.0,
+                initial_shared_version: counter.1,
+                mutable,
+            })
+            .unwrap();
+
+        if mutable {
+            move_call! {
+                txn_builder,
+                (self.package.0)::gas_price_feedback::increment_one(arg)
+            };
+        } else {
+            move_call! {
+                txn_builder,
+                (self.package.0)::gas_price_feedback::read_one(arg)
+            };
+        }
+
+        let pt = txn_builder.finish();
+
+        self.build_programmable_transaction(pt, gas_data).await
+    }
+
+    async fn create_certificates_for_non_trivial_case(&self) -> Vec<VerifiedCertificate> {
+        let max_gp = self.protocol_config.max_gas_price();
+        // (gas price, gas budget, counter_1_mutable, counter_2_mutable)
+        let data = [
+            (max_gp, 3_000_000_000, Some(true), Some(false)), // 0
+            (1_011, 1_000_000_000, Some(false), Some(true)),  // 1
+            (1_010, 4_000_000_000, Some(false), Some(true)),  // 2
+            (1_009, 2_000_000_000, None, Some(true)),         // 3
+            (1_008, 1_000_000_001, None, Some(false)),        // 4
+            (1_007, 5_000_000_000, None, Some(true)),         // 5
+            (1_006, 5_000_000_001, Some(true), Some(true)),   // 6
+            (1_005, 8_000_000_000, Some(true), Some(true)),   // 7
+            (1_004, 4_000_000_000, Some(true), None),         // 8
+            (1_003, 2_000_000_000, Some(true), None),         // 9
+            (1_002, 1_000_000_001, Some(false), Some(false)), // 10
+            (1_001, 5_000_000_001, Some(true), Some(false)),  // 11
+            (1_000, 9_000_000_000, Some(false), Some(true)),  // 12
+        ];
+
+        let mut certificates = vec![];
+        for (index, data) in data.into_iter().enumerate() {
+            let gas_data = GasDataForTests::new(self.gas_object_ids[index], data.0, data.1);
+
+            let transaction = if data.2.is_some() && data.3.is_some() {
+                self.build_access_both_counters_transaction(
+                    gas_data,
+                    data.2.unwrap(),
+                    data.3.unwrap(),
+                )
+                .await
+            } else if data.2.is_some() && data.3.is_none() {
+                self.build_access_one_counter_transaction(gas_data, data.2.unwrap(), true)
+                    .await
+            } else if data.2.is_none() && data.3.is_some() {
+                self.build_access_one_counter_transaction(gas_data, data.3.unwrap(), false)
+                    .await
+            } else {
+                panic!("At least one counter must be accessed in transactions.");
+            };
+
+            certificates.push(self.certify_transaction(transaction).await);
+        }
+
+        certificates
     }
 }
 
@@ -1111,4 +1200,309 @@ async fn gas_price_feedback_mechanism_for_multiple_commits() {
             ),
         ]
     );
+}
+
+// Test gas price feedback mechanism in `TotalTxCount` mode in non-trivial case.
+#[sim_test]
+async fn gas_price_feedback_mechanism_non_trivial_case_in_total_tx_count_mode() {
+    let num_gas_objects = 13;
+    let tester = GasPriceFeedbackTester::new(
+        0,                                            // max_deferral_rounds_for_congestion_control
+        PerObjectCongestionControlMode::TotalTxCount, // per_object_congestion_control_mode
+        Some(3),                                      // max_execution_duration_per_commit
+        true,                                         // assign_min_free_execution_slot
+        true,                                         // enable_gas_price_feedback_mechanism
+        num_gas_objects,
+    )
+    .await;
+
+    // Prepare certificates
+    let certificates = tester.create_certificates_for_non_trivial_case().await;
+    assert_eq!(certificates.len(), num_gas_objects);
+    // Shuffle certificates so that they do not have any specific order in
+    // terms of gas price.
+    let mut shuffled_certificates = certificates.clone();
+    shuffled_certificates.shuffle(&mut rand::thread_rng());
+
+    let scheduled_transactions = tester
+        .send_certificates_to_consensus_for_scheduling(&shuffled_certificates)
+        .await;
+    assert_eq!(
+        scheduled_transactions.len(),
+        // +1 because of consensus commit prologue transaction
+        certificates.len() + 1,
+    );
+
+    // Recall the structure of these certificates:
+    // (gas price, gas budget, counter_1_mutable, counter_2_mutable)
+    // [
+    //     (100K, 3_000_000_000, Some(true),  Some(false)), // 0
+    //     (1011, 1_000_000_000, Some(false), Some(true)),  // 1
+    //     (1010, 4_000_000_000, Some(false), Some(true)),  // 2
+    //     (1009, 2_000_000_000, None,        Some(true)),  // 3
+    //     (1008, 1_000_000_001, None,        Some(false)), // 4
+    //     (1007, 5_000_000_000, None,        Some(true)),  // 5
+    //     (1006, 5_000_000_001, Some(true),  Some(true)),  // 6
+    //     (1005, 8_000_000_000, Some(true),  Some(true)),  // 7
+    //     (1004, 4_000_000_000, Some(true),  None),        // 8
+    //     (1003, 2_000_000_000, Some(true),  None),        // 9
+    //     (1002, 1_000_000_001, Some(false), Some(false)), // 10
+    //     (1001, 5_000_000_001, Some(true),  Some(false)), // 11
+    //     (1000, 9_000_000_000, Some(false), Some(true)),  // 12
+    // ];
+
+    // Allocations of mutably accessed shared objects should look as follows:
+    // |-------------------------------------|------------|
+    // |     object_1     |     object_2     | start time |
+    // |__________________|__________________|____________|
+    // |------------------|------------------|---- 3      |
+    // | cert. 9 (g=1003) | cert. 2 (g=1010) |            |
+    // |------------------|------------------|---- 2      |
+    // | cert. 8 (g=1004) | cert. 1 (g=1011) |            |
+    // |------------------|------------------|---- 1      |
+    // | cert. 0 (g=100K) | cert. 3 (g=1009) |            |
+    // |-------------------------------------|---- 0 -----|
+    // That is, certificates 4, 5, 6, 7, 10, 11, 12 should be cancelled.
+
+    // Checks that there are no deferred transactions
+    assert!(
+        tester
+            .authority_state
+            .epoch_store_for_testing()
+            .get_all_deferred_transactions_for_test()
+            .unwrap()
+            .is_empty()
+    );
+
+    // As can be seen from the illustration above:
+    let expected_suggested_gas_price_for_object_1 = certificates[9].gas_price() + 1;
+    let expected_suggested_gas_price_for_object_2 = certificates[2].gas_price() + 1;
+    let expected_suggested_gas_price_for_both_objects =
+        expected_suggested_gas_price_for_object_1.max(expected_suggested_gas_price_for_object_2);
+
+    // The first scheduled transaction should be `ConsensusCommitPrologueV1`
+    if let TransactionKind::ConsensusCommitPrologueV1(prologue_tx) =
+        scheduled_transactions[0].data().transaction_data().kind()
+    {
+        // Check if `ConsensusDeterminedVersionAssignments` are correct.
+        let cancelled_txs = vec![
+            (
+                *certificates[4].digest(),
+                vec![(
+                    tester.shared_counter_2.0,
+                    SequenceNumber::new_congested_with_suggested_gas_price(
+                        expected_suggested_gas_price_for_object_2,
+                    ),
+                )],
+            ),
+            (
+                *certificates[5].digest(),
+                vec![(
+                    tester.shared_counter_2.0,
+                    SequenceNumber::new_congested_with_suggested_gas_price(
+                        expected_suggested_gas_price_for_object_2,
+                    ),
+                )],
+            ),
+            (
+                *certificates[6].digest(),
+                vec![
+                    (
+                        tester.shared_counter_1.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            expected_suggested_gas_price_for_both_objects,
+                        ),
+                    ),
+                    (
+                        tester.shared_counter_2.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            expected_suggested_gas_price_for_both_objects,
+                        ),
+                    ),
+                ],
+            ),
+            (
+                *certificates[7].digest(),
+                vec![
+                    (
+                        tester.shared_counter_1.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            expected_suggested_gas_price_for_both_objects,
+                        ),
+                    ),
+                    (
+                        tester.shared_counter_2.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            expected_suggested_gas_price_for_both_objects,
+                        ),
+                    ),
+                ],
+            ),
+            (
+                *certificates[10].digest(),
+                vec![
+                    (
+                        tester.shared_counter_1.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            expected_suggested_gas_price_for_both_objects,
+                        ),
+                    ),
+                    (
+                        tester.shared_counter_2.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            expected_suggested_gas_price_for_both_objects,
+                        ),
+                    ),
+                ],
+            ),
+            (
+                *certificates[11].digest(),
+                vec![
+                    (
+                        tester.shared_counter_1.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            expected_suggested_gas_price_for_both_objects,
+                        ),
+                    ),
+                    (
+                        tester.shared_counter_2.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            expected_suggested_gas_price_for_both_objects,
+                        ),
+                    ),
+                ],
+            ),
+            (
+                *certificates[12].digest(),
+                vec![
+                    (
+                        tester.shared_counter_1.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            expected_suggested_gas_price_for_both_objects,
+                        ),
+                    ),
+                    (
+                        tester.shared_counter_2.0,
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            expected_suggested_gas_price_for_both_objects,
+                        ),
+                    ),
+                ],
+            ),
+        ];
+        assert_eq!(
+            prologue_tx.consensus_determined_version_assignments,
+            ConsensusDeterminedVersionAssignments::CancelledTransactions(cancelled_txs)
+        );
+    } else {
+        panic!("First scheduled transaction must be a ConsensusCommitPrologueV1 transaction.");
+    }
+
+    let effects_vec = tester
+        .enqueue_and_execute_scheduled_transactions(scheduled_transactions)
+        .await;
+    assert_eq!(
+        effects_vec.len(),
+        // +1 because of consensus commit prologue transaction
+        certificates.len() + 1,
+    );
+
+    // `ConsensusCommitPrologueV1` and first 6 scheduled transactions should be
+    // successfully executed
+    for effects in effects_vec.iter().take(7) {
+        assert!(effects.status().is_ok());
+    }
+
+    // The rest of transactions should be cancelled:
+    //
+    // Transactions that touch shared counter 2:
+    for effects in effects_vec.iter().skip(7).take(2) {
+        if let ExecutionStatus::Failure { error, command } = effects.status() {
+            assert!(command.is_none());
+            if let ExecutionFailureStatus::ExecutionCancelledDueToSharedObjectCongestionV2 {
+                congested_objects,
+                suggested_gas_price,
+            } = error
+            {
+                // Check is returned congested_objects and suggested_gas_price are correct.
+                assert_eq!(
+                    *congested_objects,
+                    CongestedObjects(vec![tester.shared_counter_2.0])
+                );
+                assert_eq!(
+                    *suggested_gas_price,
+                    expected_suggested_gas_price_for_object_2
+                );
+            } else {
+                panic!(
+                    "ExecutionFailureStatus must be ExecutionCancelledDueToSharedObjectCongestionV2."
+                );
+            }
+        } else {
+            panic!("Transaction should have been be cancelled.")
+        }
+        // Check if unchanged_shared_objects in effects of the cancelled transaction
+        // are correct
+        assert_eq!(
+            effects.unchanged_shared_objects(),
+            vec![(
+                tester.shared_counter_2.0,
+                UnchangedSharedKind::Cancelled(
+                    SequenceNumber::new_congested_with_suggested_gas_price(
+                        expected_suggested_gas_price_for_object_2
+                    )
+                )
+            ),]
+        );
+    }
+    // Transactions that both shared counters:
+    for effects in effects_vec.iter().skip(9).take(5) {
+        if let ExecutionStatus::Failure { error, command } = effects.status() {
+            assert!(command.is_none());
+            if let ExecutionFailureStatus::ExecutionCancelledDueToSharedObjectCongestionV2 {
+                congested_objects,
+                suggested_gas_price,
+            } = error
+            {
+                // Check is returned congested_objects and suggested_gas_price are correct.
+                assert_eq!(
+                    *congested_objects,
+                    CongestedObjects(vec![tester.shared_counter_1.0, tester.shared_counter_2.0])
+                );
+                assert_eq!(
+                    *suggested_gas_price,
+                    expected_suggested_gas_price_for_both_objects
+                );
+            } else {
+                panic!(
+                    "ExecutionFailureStatus must be ExecutionCancelledDueToSharedObjectCongestionV2."
+                );
+            }
+        } else {
+            panic!("Transaction should have been be cancelled.")
+        }
+        // Check if unchanged_shared_objects in effects of the cancelled transaction
+        // are correct
+        assert_eq!(
+            effects.unchanged_shared_objects(),
+            vec![
+                (
+                    tester.shared_counter_1.0,
+                    UnchangedSharedKind::Cancelled(
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            expected_suggested_gas_price_for_both_objects
+                        )
+                    )
+                ),
+                (
+                    tester.shared_counter_2.0,
+                    UnchangedSharedKind::Cancelled(
+                        SequenceNumber::new_congested_with_suggested_gas_price(
+                            expected_suggested_gas_price_for_both_objects
+                        )
+                    )
+                ),
+            ]
+        );
+    }
 }

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -1,7 +1,8 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_macros::sim_test;
+use std::sync::Arc;
+
 use iota_protocol_config::{
     Chain, PerObjectCongestionControlMode, ProtocolConfig, ProtocolVersion,
 };
@@ -11,103 +12,245 @@ use iota_types::{
     effects::TransactionEffectsAPI,
     object::Object,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
+    transaction::{ObjectArg, Transaction},
 };
 use move_core_types::ident_str;
+use rand::seq::SliceRandom;
 
 use crate::{
     authority::{
-        AuthorityState, authority_tests::execute_programmable_transaction,
+        AuthorityState,
+        authority_tests::{
+            build_programmable_transaction, certify_transaction, execute_programmable_transaction,
+            send_batch_consensus_no_execution,
+        },
         move_integration_tests::build_and_publish_test_package,
         test_authority_builder::TestAuthorityBuilder,
     },
     move_call,
 };
 
-/// Gas price used only for testing gas price feedback mechanism.
-const GAS_PRICE_FOR_TEST: u64 = 1_000;
+/// Reference gas price used in gas price feedback mechanism tests.
+const REFERENCE_GAS_PRICE_FOR_TESTS: u64 = 1_000;
 
 const GAS_UNITS_FOR_TEST: u64 = 10_000;
 
-async fn create_shared_counter_ptb(
-    authority_state: &AuthorityState,
-    package_id: &ObjectID,
-    gas_object_id: &ObjectID,
-    sender: &IotaAddress,
-    sender_key: &AccountKeyPair,
-) -> ObjectRef {
-    let mut builder = ProgrammableTransactionBuilder::new();
-    move_call! {
-        builder,
-        (*package_id)::gas_price_feedback::create_shared_counter()
-    };
-    let pt = builder.finish();
-
-    let effects = execute_programmable_transaction(
-        authority_state,
-        gas_object_id,
-        sender,
-        sender_key,
-        pt,
-        GAS_UNITS_FOR_TEST,
-    )
-    .await
-    .unwrap();
-
-    assert!(
-        effects.status().is_ok(),
-        "Execution error {:?}",
-        effects.status()
-    );
-    assert_eq!(effects.created().len(), 1);
-
-    effects.created()[0].0
+struct GasPriceFeedbackTester {
+    authority_state: Arc<AuthorityState>,
+    sender: IotaAddress,
+    sender_key: AccountKeyPair,
+    gas_object_ids: Vec<ObjectID>,
+    package: ObjectRef,
+    shared_counter_1: ObjectRef,
+    shared_counter_2: ObjectRef,
 }
 
-#[sim_test]
+impl GasPriceFeedbackTester {
+    async fn new(
+        max_deferral_rounds_for_congestion_control: u64,
+        per_object_congestion_control_mode: PerObjectCongestionControlMode,
+        max_execution_duration_per_commit: u64,
+        num_gas_objects: usize,
+    ) -> Self {
+        let (sender, sender_key): (IotaAddress, AccountKeyPair) = get_key_pair();
+
+        let mut protocol_config =
+            ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
+        protocol_config.set_max_deferral_rounds_for_congestion_control_for_testing(
+            max_deferral_rounds_for_congestion_control,
+        );
+        protocol_config
+            .set_per_object_congestion_control_mode_for_testing(per_object_congestion_control_mode);
+        protocol_config.set_max_accumulated_txn_cost_per_object_in_mysticeti_commit_for_testing(
+            max_execution_duration_per_commit,
+        );
+        protocol_config.set_min_checkpoint_interval_ms_for_testing(1000);
+
+        let authority_state = TestAuthorityBuilder::new()
+            .with_reference_gas_price(REFERENCE_GAS_PRICE_FOR_TESTS)
+            .with_protocol_config(protocol_config.clone())
+            .build()
+            .await;
+
+        let gas_object_ids = (0..num_gas_objects)
+            .map(|_| ObjectID::random())
+            .collect::<Vec<_>>();
+        let gas_objects = gas_object_ids
+            .iter()
+            .map(|gas_object_id| Object::with_id_owner_for_testing(*gas_object_id, sender))
+            .collect::<Vec<_>>();
+        authority_state.insert_genesis_objects(&gas_objects).await;
+
+        let gas_object_id = gas_object_ids.first().unwrap();
+
+        let package = build_and_publish_test_package(
+            &authority_state,
+            &sender,
+            &sender_key,
+            gas_object_id,
+            "gas_price_feedback",
+            false,
+        )
+        .await;
+
+        let shared_counter_1 = Self::create_shared_counter(
+            &authority_state,
+            &package.0,
+            gas_object_id,
+            &sender,
+            &sender_key,
+        )
+        .await;
+
+        let shared_counter_2 = Self::create_shared_counter(
+            &authority_state,
+            &package.0,
+            gas_object_id,
+            &sender,
+            &sender_key,
+        )
+        .await;
+
+        Self {
+            authority_state,
+            sender,
+            sender_key,
+            gas_object_ids,
+            package,
+            shared_counter_1,
+            shared_counter_2,
+        }
+    }
+
+    async fn create_shared_counter(
+        authority_state: &AuthorityState,
+        package_id: &ObjectID,
+        gas_object_id: &ObjectID,
+        sender: &IotaAddress,
+        sender_key: &AccountKeyPair,
+    ) -> ObjectRef {
+        let mut builder = ProgrammableTransactionBuilder::new();
+
+        move_call! {
+            builder,
+            (*package_id)::gas_price_feedback::create_shared_counter()
+        };
+
+        let pt = builder.finish();
+
+        let effects = execute_programmable_transaction(
+            authority_state,
+            gas_object_id,
+            sender,
+            sender_key,
+            pt,
+            GAS_UNITS_FOR_TEST,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            effects.status().is_ok(),
+            "Execution error {:?}",
+            effects.status()
+        );
+        assert_eq!(effects.created().len(), 1);
+
+        effects.created()[0].0
+    }
+
+    async fn build_increment_both_counters_tx(
+        &self,
+        gas_object_id: &ObjectID,
+        // gas_price: u64
+    ) -> Transaction {
+        let mut txn_builder = ProgrammableTransactionBuilder::new();
+
+        let arg1 = txn_builder
+            .obj(ObjectArg::SharedObject {
+                id: self.shared_counter_1.0,
+                initial_shared_version: self.shared_counter_1.1,
+                mutable: true,
+            })
+            .unwrap();
+
+        let arg2 = txn_builder
+            .obj(ObjectArg::SharedObject {
+                id: self.shared_counter_2.0,
+                initial_shared_version: self.shared_counter_2.1,
+                mutable: true,
+            })
+            .unwrap();
+
+        move_call! {
+            txn_builder,
+            (self.package.0)::gas_price_feedback::increment_both(arg1, arg2)
+        };
+
+        let pt = txn_builder.finish();
+
+        build_programmable_transaction(
+            &self.authority_state,
+            gas_object_id,
+            &self.sender,
+            &self.sender_key,
+            pt,
+            GAS_UNITS_FOR_TEST,
+        )
+        .await
+        .unwrap()
+    }
+}
+
+#[tokio::test]
 async fn gas_price_feedback_mechanism() {
-    let (sender, sender_key): (IotaAddress, AccountKeyPair) = get_key_pair();
+    let max_deferral_rounds_for_congestion_control = 1;
+    let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalTxCount;
+    let max_execution_duration_per_commit = 1;
+    let num_gas_objects = 20;
 
-    let mut protocol_config =
-        ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
-    protocol_config.set_per_object_congestion_control_mode_for_testing(
-        PerObjectCongestionControlMode::TotalTxCount,
-    );
-
-    let max_execution_duration_per_commit = 2;
-    protocol_config.set_max_accumulated_txn_cost_per_object_in_mysticeti_commit_for_testing(
+    let tester = GasPriceFeedbackTester::new(
+        max_deferral_rounds_for_congestion_control,
+        per_object_congestion_control_mode,
         max_execution_duration_per_commit,
+        num_gas_objects,
+    )
+    .await;
+
+    // Prepare certificates
+    let mut certificates = vec![];
+    for gas_object_id in tester.gas_object_ids.iter() {
+        let transaction = tester.build_increment_both_counters_tx(gas_object_id).await;
+
+        certificates.push(
+            certify_transaction(&tester.authority_state, transaction)
+                .await
+                .unwrap(),
+        );
+    }
+    certificates.shuffle(&mut rand::thread_rng());
+    assert_eq!(certificates.len(), num_gas_objects);
+
+    let scheduled_certificates =
+        send_batch_consensus_no_execution(&tester.authority_state, &certificates, true).await;
+    assert_eq!(
+        scheduled_certificates.len(),
+        max_execution_duration_per_commit as usize
     );
 
-    protocol_config.set_max_deferral_rounds_for_congestion_control_for_testing(3);
+    tester.authority_state.transaction_manager().enqueue(
+        scheduled_certificates.clone(),
+        &tester.authority_state.epoch_store_for_testing(),
+    );
 
-    let authority_state = TestAuthorityBuilder::new()
-        .with_reference_gas_price(GAS_PRICE_FOR_TEST)
-        .with_protocol_config(protocol_config.clone())
-        .build()
-        .await;
-
-    let gas_object_id = ObjectID::random();
-    let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
-    authority_state
-        .insert_genesis_object(gas_object.clone())
-        .await;
-
-    let package = build_and_publish_test_package(
-        &authority_state,
-        &sender,
-        &sender_key,
-        &gas_object_id,
-        "gas_price_feedback",
-        false,
-    )
-    .await;
-
-    create_shared_counter_ptb(
-        &authority_state,
-        &package.0,
-        &gas_object_id,
-        &sender,
-        &sender_key,
-    )
-    .await;
+    for cert in scheduled_certificates {
+        let effects = tester
+            .authority_state
+            .get_transaction_cache_reader()
+            .notify_read_executed_effects(&[*cert.digest()])
+            .await
+            .map(|mut r| r.pop().expect("must return correct number of effects"))
+            .unwrap();
+        assert!(effects.status().is_ok());
+    }
 }

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -33,6 +33,7 @@ use crate::{
         },
         move_integration_tests::build_and_publish_test_package,
         test_authority_builder::TestAuthorityBuilder,
+        transaction_deferral::DeferralKey,
     },
     move_call,
 };
@@ -630,7 +631,7 @@ async fn gas_price_feedback_mechanism_is_turned_off() {
         certificates.len() + 1,
     );
 
-    // The first executed transaction should be `ConsensusCommitPrologueV1`
+    // The first scheduled transaction should be `ConsensusCommitPrologueV1`
     if let TransactionKind::ConsensusCommitPrologueV1(prologue_tx) =
         scheduled_transactions[0].data().transaction_data().kind()
     {
@@ -784,7 +785,7 @@ async fn gas_price_feedback_mechanism_with_max_gas_price() {
 
     let suggested_gas_price = tester.protocol_config.max_gas_price();
 
-    // The first executed transaction should be `ConsensusCommitPrologueV1`
+    // The first scheduled transaction should be `ConsensusCommitPrologueV1`
     if let TransactionKind::ConsensusCommitPrologueV1(prologue_tx) =
         scheduled_transactions[0].data().transaction_data().kind()
     {
@@ -840,7 +841,7 @@ async fn gas_price_feedback_mechanism_with_max_gas_price() {
             assert_eq!(*suggested_gas_price, tester.protocol_config.max_gas_price());
         } else {
             panic!(
-                "`ExecutionFailureStatus` must be `ExecutionCancelledDueToSharedObjectCongestion`."
+                "`ExecutionFailureStatus` must be `ExecutionCancelledDueToSharedObjectCongestionV2`."
             );
         }
     } else {
@@ -862,6 +863,253 @@ async fn gas_price_feedback_mechanism_with_max_gas_price() {
                 tester.shared_counter_2.0,
                 UnchangedSharedKind::Cancelled(
                     SequenceNumber::new_congested_with_suggested_gas_price(suggested_gas_price)
+                )
+            ),
+        ]
+    );
+}
+
+// Test that suggested gas price for a cancelled transactions is the
+// lowest suggested gas price over multiple commits in which the
+// transaction was deferred.
+#[sim_test]
+async fn gas_price_feedback_mechanism_for_multiple_commits() {
+    let max_deferral_rounds_for_congestion_control = 1;
+    let per_object_congestion_control_mode = PerObjectCongestionControlMode::TotalTxCount;
+    let max_execution_duration_per_commit = 1;
+    let assign_min_free_execution_slot = true;
+    let enable_gas_price_feedback_mechanism = true;
+    let num_gas_objects = 2;
+
+    let tester = GasPriceFeedbackTester::new(
+        max_deferral_rounds_for_congestion_control,
+        per_object_congestion_control_mode,
+        Some(max_execution_duration_per_commit),
+        assign_min_free_execution_slot,
+        enable_gas_price_feedback_mechanism,
+        num_gas_objects,
+    )
+    .await;
+
+    // Prepare certificates for consensus commit round 1
+    let mut certificates = vec![];
+    // Create a certificate that should be deferred
+    let gas_price = REFERENCE_GAS_PRICE_FOR_TESTS;
+    let gas_data = GasDataForTests::new(
+        tester.gas_object_ids[0],
+        gas_price,
+        gas_price * DEFAULT_GAS_UNITS_FOR_TESTS,
+    );
+    let transaction = tester
+        .build_access_both_counters_transaction(gas_data, true, true)
+        .await;
+    let should_defer_certificate = tester.certify_transaction(transaction).await;
+    certificates.push(should_defer_certificate.clone());
+    // Create a certificate that should be scheduled
+    let gas_price = REFERENCE_GAS_PRICE_FOR_TESTS + 5;
+    let gas_data = GasDataForTests::new(
+        tester.gas_object_ids[1],
+        gas_price,
+        gas_price * DEFAULT_GAS_UNITS_FOR_TESTS,
+    );
+    let transaction = tester
+        .build_access_both_counters_transaction(gas_data, false, true)
+        .await;
+    let should_schedule_certificate_1 = tester.certify_transaction(transaction).await;
+    certificates.push(should_schedule_certificate_1.clone());
+
+    // Shuffle certificates so that they do not have any specific order in
+    // terms of gas price.
+    certificates.shuffle(&mut rand::thread_rng());
+    assert_eq!(certificates.len(), num_gas_objects);
+
+    let scheduled_transactions = tester
+        .send_certificates_to_consensus_for_scheduling(&certificates)
+        .await;
+    assert_eq!(
+        scheduled_transactions.len() as u64,
+        // +1 because of consensus commit prologue transaction
+        max_execution_duration_per_commit + 1,
+    );
+
+    // The first scheduled transaction should be `ConsensusCommitPrologueV1`
+    if let TransactionKind::ConsensusCommitPrologueV1(prologue_tx) =
+        scheduled_transactions[0].data().transaction_data().kind()
+    {
+        // Check if `ConsensusDeterminedVersionAssignments` are correct.
+        assert_eq!(
+            prologue_tx.consensus_determined_version_assignments,
+            ConsensusDeterminedVersionAssignments::CancelledTransactions(vec![])
+        );
+    } else {
+        panic!("First scheduled transaction must be a `ConsensusCommitPrologueV1` transaction.");
+    }
+    // The second scheduled transaction should be one paying higher gas price
+    assert_eq!(
+        scheduled_transactions[1].digest(),
+        should_schedule_certificate_1.digest()
+    );
+
+    // Checks that deferred transactions are formed correctly
+    let deferred_transactions = tester
+        .authority_state
+        .epoch_store_for_testing()
+        .get_all_deferred_transactions_for_test()
+        .unwrap();
+    assert_eq!(deferred_transactions.len(), 1);
+    assert_eq!(deferred_transactions[0].1.len(), 1);
+    assert!(matches!(
+        deferred_transactions[0].0,
+        DeferralKey::ConsensusRound { .. }
+    ));
+    assert_eq!(
+        deferred_transactions[0].1[0].suggested_gas_price(),
+        Some(should_schedule_certificate_1.gas_price() + 1)
+    );
+
+    let effects_vec = tester
+        .enqueue_and_execute_scheduled_transactions(scheduled_transactions)
+        .await;
+    assert_eq!(
+        effects_vec.len() as u64,
+        // +1 because of consensus commit prologue transaction
+        max_execution_duration_per_commit + 1,
+    );
+
+    // Both scheduled transactions should be successfully executed
+    for effects in effects_vec {
+        assert!(effects.status().is_ok());
+    }
+
+    // Prepare certificates for consensus commit round 2
+    let mut certificates = vec![];
+    // Create a certificate that should be scheduled
+    let gas_price = REFERENCE_GAS_PRICE_FOR_TESTS + 10;
+    let gas_data = GasDataForTests::new(
+        tester.gas_object_ids[1],
+        gas_price,
+        gas_price * DEFAULT_GAS_UNITS_FOR_TESTS,
+    );
+    let transaction = tester
+        .build_access_both_counters_transaction(gas_data, false, true)
+        .await;
+    let should_schedule_certificate_2 = tester.certify_transaction(transaction).await;
+    certificates.push(should_schedule_certificate_2.clone());
+
+    // Shuffle certificates so that they do not have any specific order in
+    // terms of gas price.
+    certificates.shuffle(&mut rand::thread_rng());
+    assert_eq!(certificates.len(), 1);
+
+    let scheduled_transactions = tester
+        .send_certificates_to_consensus_for_scheduling(&certificates)
+        .await;
+    assert_eq!(
+        scheduled_transactions.len(),
+        // +2 because one consensus commit prologue transaction and one cancelled transaction
+        certificates.len() + 2,
+    );
+
+    // Suggested gas price must be gas price of the scheduled certificate in the
+    // first commit round (not the current commit round) plus one
+    let expected_suggested_gas_price = should_schedule_certificate_1.gas_price() + 1;
+
+    // The first scheduled transaction should be `ConsensusCommitPrologueV1`
+    if let TransactionKind::ConsensusCommitPrologueV1(prologue_tx) =
+        scheduled_transactions[0].data().transaction_data().kind()
+    {
+        // Check if `ConsensusDeterminedVersionAssignments` are correct.
+        let cancelled_txs = vec![(
+            *scheduled_transactions[2].digest(),
+            vec![
+                (
+                    tester.shared_counter_1.0,
+                    SequenceNumber::new_congested_with_suggested_gas_price(
+                        expected_suggested_gas_price,
+                    ),
+                ),
+                (
+                    tester.shared_counter_2.0,
+                    SequenceNumber::new_congested_with_suggested_gas_price(
+                        expected_suggested_gas_price,
+                    ),
+                ),
+            ],
+        )];
+        assert_eq!(
+            prologue_tx.consensus_determined_version_assignments,
+            ConsensusDeterminedVersionAssignments::CancelledTransactions(cancelled_txs)
+        );
+    } else {
+        panic!("First scheduled transaction must be a `ConsensusCommitPrologueV1` transaction.");
+    }
+    // The second scheduled transaction should be one paying higher gas price
+    assert_eq!(
+        scheduled_transactions[1].digest(),
+        should_schedule_certificate_2.digest()
+    );
+    // The third scheduled transaction should be the canceled transaction
+    assert_eq!(
+        scheduled_transactions[2].digest(),
+        should_defer_certificate.digest()
+    );
+
+    let effects_vec = tester
+        .enqueue_and_execute_scheduled_transactions(scheduled_transactions)
+        .await;
+    assert_eq!(
+        effects_vec.len(),
+        // +2 because one consensus commit prologue transaction and one cancelled transaction
+        certificates.len() + 2,
+    );
+
+    // `ConsensusCommitPrologueV1` should be successfully executed
+    assert!(effects_vec[0].status().is_ok());
+    // The first scheduled transaction should be successfully executed
+    assert!(effects_vec[1].status().is_ok());
+
+    // The second scheduled transaction should be cancelled
+    if let ExecutionStatus::Failure { error, command } = effects_vec[2].status() {
+        assert!(command.is_none());
+        if let ExecutionFailureStatus::ExecutionCancelledDueToSharedObjectCongestionV2 {
+            congested_objects,
+            suggested_gas_price,
+        } = error
+        {
+            // Check is returned congested_objects and suggested_gas_price are correct.
+            assert_eq!(
+                *congested_objects,
+                CongestedObjects(vec![tester.shared_counter_1.0, tester.shared_counter_2.0])
+            );
+            assert_eq!(*suggested_gas_price, expected_suggested_gas_price);
+        } else {
+            panic!(
+                "`ExecutionFailureStatus` must be `ExecutionCancelledDueToSharedObjectCongestionV2`."
+            );
+        }
+    } else {
+        panic!("The second transaction must be cancelled.")
+    }
+
+    // Check if unchanged_shared_objects in effects of the cancelled transaction
+    // are correct
+    assert_eq!(
+        effects_vec[2].unchanged_shared_objects(),
+        vec![
+            (
+                tester.shared_counter_1.0,
+                UnchangedSharedKind::Cancelled(
+                    SequenceNumber::new_congested_with_suggested_gas_price(
+                        expected_suggested_gas_price
+                    )
+                )
+            ),
+            (
+                tester.shared_counter_2.0,
+                UnchangedSharedKind::Cancelled(
+                    SequenceNumber::new_congested_with_suggested_gas_price(
+                        expected_suggested_gas_price
+                    )
                 )
             ),
         ]

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1306,7 +1306,7 @@
               "featureFlags": {
                 "accept_passkey_in_multisig": false,
                 "accept_zklogin_in_multisig": false,
-                "congested_objects_gas_price_feedback_mechanism": false,
+                "congestion_control_gas_price_feedback_mechanism": false,
                 "congestion_control_min_free_execution_slot": false,
                 "consensus_distributed_vote_scoring_strategy": false,
                 "consensus_linearize_subdag_v2": false,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -279,7 +279,7 @@ struct FeatureFlags {
     // To enable/disable the gas price feedback mechanism used for transactions
     // cancelled due to shared object congestion
     #[serde(skip_serializing_if = "is_false")]
-    congested_objects_gas_price_feedback_mechanism: bool,
+    congestion_control_gas_price_feedback_mechanism: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1249,9 +1249,9 @@ impl ProtocolConfig {
 
     /// Check if the gas price feedback mechanism (which is used for
     /// transactions cancelled due to shared object congestion) is enabled
-    pub fn congested_objects_gas_price_feedback_mechanism(&self) -> bool {
+    pub fn congestion_control_gas_price_feedback_mechanism(&self) -> bool {
         self.feature_flags
-            .congested_objects_gas_price_feedback_mechanism
+            .congestion_control_gas_price_feedback_mechanism
     }
 }
 
@@ -2013,7 +2013,7 @@ impl ProtocolConfig {
                         // Enable the gas price feedback mechanism (which is used for
                         // transactions cancelled due to shared object congestion) in devnet
                         cfg.feature_flags
-                            .congested_objects_gas_price_feedback_mechanism = true;
+                            .congestion_control_gas_price_feedback_mechanism = true;
                     }
                 }
                 // Use this template when making changes:
@@ -2166,6 +2166,11 @@ impl ProtocolConfig {
     pub fn set_congestion_control_min_free_execution_slot_for_testing(&mut self, val: bool) {
         self.feature_flags
             .congestion_control_min_free_execution_slot = val;
+    }
+
+    pub fn set_congestion_control_gas_price_feedback_mechanism_for_testing(&mut self, val: bool) {
+        self.feature_flags
+            .congestion_control_gas_price_feedback_mechanism = val;
     }
 }
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -2162,6 +2162,11 @@ impl ProtocolConfig {
     pub fn set_consensus_smart_ancestor_selection_for_testing(&mut self, val: bool) {
         self.feature_flags.consensus_smart_ancestor_selection = val;
     }
+
+    pub fn set_congestion_control_min_free_execution_slot_for_testing(&mut self, val: bool) {
+        self.feature_flags
+            .congestion_control_min_free_execution_slot = val;
+    }
 }
 
 type OverrideFn = dyn Fn(ProtocolVersion, ProtocolConfig) -> ProtocolConfig + Send + Sync;

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_10.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_10.snap
@@ -25,7 +25,7 @@ feature_flags:
   consensus_zstd_compression: true
   congestion_control_min_free_execution_slot: true
   accept_passkey_in_multisig: true
-  congested_objects_gas_price_feedback_mechanism: true
+  congestion_control_gas_price_feedback_mechanism: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -335,7 +335,7 @@ mod checked {
             } else if let Some((cancelled_objects, reason)) = cancelled_objects {
                 match reason {
                     version if version.is_congested() => Err(ExecutionError::new(
-                        if protocol_config.congested_objects_gas_price_feedback_mechanism() {
+                        if protocol_config.congestion_control_gas_price_feedback_mechanism() {
                             ExecutionErrorKind::ExecutionCancelledDueToSharedObjectCongestionV2 {
                                 congested_objects: CongestedObjects(cancelled_objects),
                                 suggested_gas_price: version
@@ -343,7 +343,7 @@ mod checked {
                             }
                         } else {
                             // WARN: do not remove this `else` branch even after
-                            // `congested_objects_gas_price_feedback_mechanism` is enabled
+                            // `congestion_control_gas_price_feedback_mechanism` is enabled
                             // on the mainnet. It must be kept to be able to replay old
                             // transaction data.
                             ExecutionErrorKind::ExecutionCancelledDueToSharedObjectCongestion {


### PR DESCRIPTION
# Description of change

- This PR adds unit tests to test the gas price feedback mechanism. The aim is to test all the components: the mechanism itself, calculations of suggested gas price and its propagation across multiple commits.
- Instead of panic, the calculator will now suggest reference gas price (or max clearing gas price) if transaction duration exceeds `max_execution_duration_per_commit`.
- Renamed `congested_objects_gas_price_feedback_mechanism` feature flag to `congestion_control_gas_price_feedback_mechanism`.

## Links to any relevant issues

## How the change has been tested

```console
cargo simtest -p iota-core unit_tests gas_price_feedback_tests
```

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
