### PR TITLE
fix(core): Enhance `TestAuthorityBuilder` and fix `test_authority_store_init`

### DIFF
--- a/crates/iota-core/src/authority/test_authority_builder.rs
+++ b/crates/iota-core/src/authority/test_authority_builder.rs
@@ -71,6 +71,7 @@ pub struct TestAuthorityBuilder<'a> {
     authority_overload_config: Option<AuthorityOverloadConfig>,
     cache_type: Option<ExecutionCacheType>,
     cache_config: Option<ExecutionCacheConfig>,
+    disable_execute_genesis_transactions: bool,
 }
 
 impl<'a> TestAuthorityBuilder<'a> {
@@ -176,6 +177,11 @@ impl<'a> TestAuthorityBuilder<'a> {
 
     pub fn with_cache_config(mut self, config: ExecutionCacheConfig) -> Self {
         self.cache_config = Some(config);
+        self
+    }
+
+    pub fn disable_execute_genesis_transactions(mut self) -> Self {
+        self.disable_execute_genesis_transactions = true;
         self
     }
 
@@ -360,28 +366,30 @@ impl<'a> TestAuthorityBuilder<'a> {
                 .unwrap();
         }
 
-        // For any type of local testing that does not actually spawn a node, the
-        // checkpoint executor won't be started, which means we won't actually
-        // execute the genesis transaction. In that case, the genesis objects
-        // (e.g. all the genesis test coins) won't be accessible. Executing it
-        // explicitly makes sure all genesis objects are ready for use.
-        state
-            .try_execute_immediately(
-                &VerifiedExecutableTransaction::new_from_checkpoint(
-                    VerifiedTransaction::new_unchecked(genesis.transaction().clone()),
-                    genesis.epoch(),
-                    genesis.checkpoint().sequence_number,
-                ),
-                None,
-                &state.epoch_store_for_testing(),
-            )
-            .await
-            .unwrap();
+        if !self.disable_execute_genesis_transactions {
+            // For any type of local testing that does not actually spawn a node, the
+            // checkpoint executor won't be started, which means we won't actually
+            // execute the genesis transaction. In that case, the genesis objects
+            // (e.g. all the genesis test coins) won't be accessible. Executing it
+            // explicitly makes sure all genesis objects are ready for use.
+            state
+                .try_execute_immediately(
+                    &VerifiedExecutableTransaction::new_from_checkpoint(
+                        VerifiedTransaction::new_unchecked(genesis.transaction().clone()),
+                        genesis.epoch(),
+                        genesis.checkpoint().sequence_number,
+                    ),
+                    None,
+                    &state.epoch_store_for_testing(),
+                )
+                .await
+                .unwrap();
 
-        state
-            .get_cache_commit()
-            .commit_transaction_outputs(epoch_store.epoch(), &[*genesis.transaction().digest()])
-            .await;
+            state
+                .get_cache_commit()
+                .commit_transaction_outputs(epoch_store.epoch(), &[*genesis.transaction().digest()])
+                .await;
+        }
 
         // We want to insert these objects directly instead of relying on genesis
         // because genesis process would set the previous transaction field for

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -2882,31 +2882,47 @@ async fn test_authority_store_init() {
     drop(authority);
 
     // Just in case, let rocksdb time to sync or something.
-    tokio::time::sleep(std::time::Duration::from_secs(20)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
     // Create the test authority.
-    let _ = {
-        let network_config = iota_swarm_config::network_config_builder::ConfigBuilder::new(&dir)
-            .rng(&mut StdRng::from_seed(authority_seed))
-            // Add the relevant and target objects to the genesis.
-            // The object version will reset to 1 when genesis is created.
-            .with_objects([gas_obj, package_obj, parent_obj, child_obj, field_obj])
-            .build();
-        let genesis = network_config.genesis;
-        let authority_key = network_config.validator_configs[0]
-            .authority_key_pair()
-            .copy();
+    let network_config = iota_swarm_config::network_config_builder::ConfigBuilder::new(&dir)
+        .rng(&mut StdRng::from_seed(authority_seed))
+        // Add the relevant and target objects to the genesis.
+        // The object version will reset to 1 when genesis is created.
+        .with_objects([
+            gas_obj.clone(),
+            package_obj.clone(),
+            parent_obj.clone(),
+            child_obj.clone(),
+            field_obj.clone(),
+        ])
+        .build();
+    let genesis = network_config.genesis;
+    let authority_key = network_config.validator_configs[0]
+        .authority_key_pair()
+        .copy();
 
-        TestAuthorityBuilder::new()
-            // Reuse the object store, there's no index store at this point.
-            .with_store_base_path(store_base_path)
-            .with_genesis_and_keypair(&genesis, &authority_key)
-            // Index is enabled by default and empty.
-            // We don't care about writeback cache now.
-            // Build invokes AuthorityState::new down to try_create_dynamic_field_info.
-            .build()
+    let authority_state = TestAuthorityBuilder::new()
+        // Reuse the object store, there's no index store at this point.
+        .with_store_base_path(store_base_path)
+        .with_genesis_and_keypair(&genesis, &authority_key)
+        // Do not execute genesis transactions again,
+        // otherwise we try to insert objects that are older than the ones that already exist in
+        // the cache, which will then panic.
+        .disable_execute_genesis_transactions()
+        // Index is enabled by default and empty.
+        // We don't care about writeback cache now.
+        // Build invokes AuthorityState::new down to try_create_dynamic_field_info.
+        .build()
+        .await;
+
+    // Check that the objects are present in the store.
+    for obj in [gas_obj, package_obj, parent_obj, child_obj, field_obj] {
+        authority_state
+            .get_object(&obj.id())
             .await
-    };
+            .expect("failed to get object");
+    }
 
     // The test is passed if the build didn't panic and authority is created.
 }


### PR DESCRIPTION
# Description of change

In the `test_authority_store_init` we recreate the genesis file and pass it twice to the `TestAuthorityBuilder`.
This causes the genesis objects to be applied twice. In the second run, the caches are already filled with the newer versions of the objects, because they were loaded for index rebuilding. Since they are then directly overwritten with an older version, this causes a panic in the writeback cache. We added a flag to be able to not overwrite the objects in the tests.

## Links to any relevant issues

Close #7891

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

