### PR TITLE
feat(core): Move static OnceCell ChainIdentifier into AuthorityState

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -111,7 +111,6 @@ use iota_types::{
 use itertools::Itertools;
 use move_binary_format::{CompiledModule, binary_config::BinaryConfig};
 use move_core_types::{annotated_value::MoveStructLayout, language_storage::ModuleId};
-use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use prometheus::{
     Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Registry,
@@ -121,7 +120,7 @@ use prometheus::{
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use shared_crypto::intent::{AppId, Intent, IntentMessage, IntentScope, IntentVersion};
-use tap::{TapFallible, TapOptional};
+use tap::TapFallible;
 use tokio::{
     sync::{RwLock, mpsc, mpsc::unbounded_channel, oneshot},
     task::JoinHandle,
@@ -212,8 +211,6 @@ pub mod test_authority_builder;
 pub mod transaction_deferral;
 
 pub(crate) mod authority_store;
-
-pub static CHAIN_IDENTIFIER: OnceCell<ChainIdentifier> = OnceCell::new();
 
 /// Prometheus metrics which can be displayed in Grafana, queried and alerted on
 pub struct AuthorityMetrics {
@@ -806,6 +803,10 @@ pub struct AuthorityState {
     pub overload_info: AuthorityOverloadInfo,
 
     pub validator_tx_finalizer: Option<Arc<ValidatorTxFinalizer<NetworkAuthorityClient>>>,
+
+    /// The chain identifier is derived from the digest of the genesis
+    /// checkpoint.
+    chain_identifier: ChainIdentifier,
 }
 
 /// The authority state encapsulates all state, drives execution, and ensures
@@ -2836,6 +2837,7 @@ impl AuthorityState {
         indirect_objects_threshold: usize,
         archive_readers: ArchiveReaderBalancer,
         validator_tx_finalizer: Option<Arc<ValidatorTxFinalizer<NetworkAuthorityClient>>>,
+        chain_identifier: ChainIdentifier,
     ) -> Arc<Self> {
         Self::check_protocol_version(supported_protocol_versions, epoch_store.protocol_version());
 
@@ -2892,6 +2894,7 @@ impl AuthorityState {
             config,
             overload_info: AuthorityOverloadInfo::default(),
             validator_tx_finalizer,
+            chain_identifier,
         });
 
         // Start a task to execute ready certificates.
@@ -3431,19 +3434,8 @@ impl AuthorityState {
     }
 
     /// Chain Identifier is the digest of the genesis checkpoint.
-    pub fn get_chain_identifier(&self) -> Option<ChainIdentifier> {
-        if let Some(digest) = CHAIN_IDENTIFIER.get() {
-            return Some(*digest);
-        }
-
-        let checkpoint = self
-            .get_checkpoint_by_sequence_number(0)
-            .tap_err(|e| error!("Failed to get genesis checkpoint: {:?}", e))
-            .ok()?
-            .tap_none(|| error!("Genesis checkpoint is missing from DB"))?;
-        // It's ok if the value is already set due to data races.
-        let _ = CHAIN_IDENTIFIER.set(ChainIdentifier::from(*checkpoint.digest()));
-        Some(ChainIdentifier::from(*checkpoint.digest()))
+    pub fn get_chain_identifier(&self) -> ChainIdentifier {
+        self.chain_identifier
     }
 
     #[instrument(level = "trace", skip_all)]

--- a/crates/iota-core/src/authority/test_authority_builder.rs
+++ b/crates/iota-core/src/authority/test_authority_builder.rs
@@ -324,6 +324,8 @@ impl<'a> TestAuthorityBuilder<'a> {
         config.authority_overload_config = authority_overload_config;
         config.authority_store_pruning_config = pruning_config;
 
+        let chain_identifier = ChainIdentifier::from(*genesis.checkpoint().digest());
+
         let state = AuthorityState::new(
             name,
             secret,
@@ -342,6 +344,7 @@ impl<'a> TestAuthorityBuilder<'a> {
             usize::MAX,
             ArchiveReaderBalancer::default(),
             None,
+            chain_identifier,
         )
         .await;
 

--- a/crates/iota-core/src/execution_driver.rs
+++ b/crates/iota-core/src/execution_driver.rs
@@ -51,10 +51,7 @@ pub async fn execution_process(
             return;
         };
 
-        state
-            .get_chain_identifier()
-            .map(|chain_id| chain_id.chain())
-            == Some(Chain::Mainnet)
+        state.get_chain_identifier().chain() == Chain::Mainnet
     };
 
     // Loop whenever there is a signal that a new transactions is ready to process.

--- a/crates/iota-core/src/storage.rs
+++ b/crates/iota-core/src/storage.rs
@@ -515,12 +515,8 @@ impl RestStateReader for RestReadStore {
         }
     }
 
-    fn get_chain_identifier(
-        &self,
-    ) -> iota_types::storage::error::Result<iota_types::digests::ChainIdentifier> {
-        self.state
-            .get_chain_identifier()
-            .ok_or_else(|| StorageError::missing("unable to query chain identifier"))
+    fn get_chain_identifier(&self) -> Result<iota_types::digests::ChainIdentifier> {
+        Ok(self.state.get_chain_identifier())
     }
 
     fn get_epoch_last_checkpoint(

--- a/crates/iota-json-rpc-tests/tests/read_api.rs
+++ b/crates/iota-json-rpc-tests/tests/read_api.rs
@@ -1273,8 +1273,7 @@ async fn get_chain_identifier() {
     let fullnode_chain_identifier = cluster
         .fullnode_handle
         .iota_node
-        .with(|node| node.state().get_chain_identifier())
-        .unwrap();
+        .with(|node| node.state().get_chain_identifier());
 
     let rpc_chain_identifier = http_client.get_chain_identifier().await.unwrap();
 

--- a/crates/iota-json-rpc/src/authority_state.rs
+++ b/crates/iota-json-rpc/src/authority_state.rs
@@ -7,7 +7,6 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::anyhow;
 use arc_swap::Guard;
 use async_trait::async_trait;
 use iota_core::{
@@ -541,9 +540,7 @@ impl StateRead for AuthorityState {
     }
 
     fn get_chain_identifier(&self) -> StateReadResult<ChainIdentifier> {
-        Ok(self
-            .get_chain_identifier()
-            .ok_or(anyhow!("Chain identifier not found"))?)
+        Ok(self.get_chain_identifier())
     }
 }
 

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -35,7 +35,7 @@ use iota_config::{
 };
 use iota_core::{
     authority::{
-        AuthorityState, AuthorityStore, CHAIN_IDENTIFIER, RandomnessRoundReceiver,
+        AuthorityState, AuthorityStore, RandomnessRoundReceiver,
         authority_per_epoch_store::AuthorityPerEpochStore,
         authority_store_tables::{AuthorityPerpetualTables, AuthorityPerpetualTablesOptions},
         epoch_start_configuration::{EpochFlag, EpochStartConfigTrait, EpochStartConfiguration},
@@ -443,8 +443,6 @@ impl IotaNode {
         let genesis = config.genesis()?.clone();
 
         let chain_identifier = ChainIdentifier::from(*genesis.checkpoint().digest());
-        // It's ok if the value is already set due to data races.
-        let _ = CHAIN_IDENTIFIER.set(chain_identifier);
         info!("IOTA chain identifier: {chain_identifier}");
 
         // Check and set the db_corrupted flag
@@ -729,6 +727,7 @@ impl IotaNode {
             config.indirect_objects_threshold,
             archive_readers,
             validator_tx_finalizer,
+            chain_identifier,
         )
         .await;
 


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.39.4, v1.40.3)
- Port commit: https://github.com/MystenLabs/sui/commit/0ae930ce73f2cf5a6e34d410069ff8e594cd74f4
- Description from upstream:

As part of fixing flakey graphql tests, I observed an inconsistency in
how the fullnode rpc in TestCluster was reporting chain_identifier. The
nodes wrote `0.chk` to file with a particular checkpoint
digest->chain_id, but the rpc would report a different chain_id.
Conspicuously, the chain_id was the same across tests.

The issue stemmed from using a global static OnceCell<ChainIdentifier>.
This global state meant that if the
`test_simple_client_validator_cluster` test did not set the `chain_id`,
then it would fail. I suppose there might be some production issues as
well, for example if someone were to run multiple nodes in the same
process to different networks.

To address, I moved chain_identifier into AuthorityState, and modified
SuiNode to explicitly pass the chain_identifier to components that need
it, which is basically just StateSnapshotUploader today.

By eagerly setting `chain_identifier`, we can also simplify some logic
around existing callsites
## Links to any relevant issues

Part of #6148  

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes