### PR TITLE
feat(iota-indexer): use gRPC-API for the checkpoint fetching of indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5968,6 +5968,7 @@ dependencies = [
  "iota-archival",
  "iota-config",
  "iota-data-ingestion-core",
+ "iota-grpc-api",
  "iota-kvstore",
  "iota-metrics",
  "iota-rest-api",
@@ -5979,8 +5980,11 @@ dependencies = [
  "serde_yaml",
  "telemetry-subscribers",
  "tempfile",
+ "test-cluster",
  "tokio",
+ "tokio-stream",
  "tokio-util 0.7.12",
+ "tonic 0.13.1",
  "tracing",
 ]
 
@@ -5997,6 +6001,8 @@ dependencies = [
  "fastcrypto",
  "futures",
  "iota-config",
+ "iota-grpc-api",
+ "iota-grpc-types",
  "iota-metrics",
  "iota-protocol-config",
  "iota-rest-api",
@@ -6464,6 +6470,8 @@ dependencies = [
  "hex",
  "iota-config",
  "iota-data-ingestion-core",
+ "iota-grpc-api",
+ "iota-grpc-types",
  "iota-json",
  "iota-json-rpc",
  "iota-json-rpc-api",
@@ -6477,6 +6485,7 @@ dependencies = [
  "iota-package-resolver",
  "iota-protocol-config",
  "iota-rest-api",
+ "iota-storage",
  "iota-swarm-config",
  "iota-test-transaction-builder",
  "iota-transaction-builder",
@@ -6504,6 +6513,7 @@ dependencies = [
  "tokio-util 0.7.12",
  "toml 0.7.8",
  "tracing",
+ "tracing-subscriber",
  "url",
 ]
 

--- a/crates/iota-data-ingestion-core/Cargo.toml
+++ b/crates/iota-data-ingestion-core/Cargo.toml
@@ -32,6 +32,8 @@ url.workspace = true
 
 # internal dependencies
 iota-config.workspace = true
+iota-grpc-api.workspace = true
+iota-grpc-types.workspace = true
 iota-metrics.workspace = true
 iota-protocol-config.workspace = true
 iota-rest-api.workspace = true

--- a/crates/iota-data-ingestion-core/src/data_source.rs
+++ b/crates/iota-data-ingestion-core/src/data_source.rs
@@ -1,0 +1,65 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Data source abstractions for checkpoint ingestion.
+use std::path::PathBuf;
+
+/// Represents different sources of checkpoint data for ingestion.
+#[derive(Debug, Clone)]
+pub enum DataSource {
+    /// Local directory containing checkpoint files.
+    Local(PathBuf),
+    /// Remote source via REST API or object store.
+    Remote {
+        store_url: String,
+        store_options: Vec<(String, String)>,
+    },
+    /// gRPC endpoint for streaming.
+    Grpc { url: String },
+}
+
+impl DataSource {
+    /// Creates a local data source.
+    pub fn local<P: Into<PathBuf>>(path: P) -> Self {
+        Self::Local(path.into())
+    }
+
+    /// Creates a remote data source with store URL.
+    pub fn remote<S: Into<String>>(store_url: S) -> Self {
+        Self::Remote {
+            store_url: store_url.into(),
+            store_options: vec![],
+        }
+    }
+
+    /// Creates a remote data source with store URL and options.
+    pub fn remote_with_options<S: Into<String>>(
+        store_url: S,
+        store_options: Vec<(String, String)>,
+    ) -> Self {
+        Self::Remote {
+            store_url: store_url.into(),
+            store_options,
+        }
+    }
+
+    /// Creates a gRPC data source.
+    pub fn grpc<S: Into<String>>(url: S) -> Self {
+        Self::Grpc { url: url.into() }
+    }
+
+    /// Returns true if this is a gRPC data source.
+    pub fn is_grpc(&self) -> bool {
+        matches!(self, Self::Grpc { .. })
+    }
+
+    /// Returns true if this is a local data source.
+    pub fn is_local(&self) -> bool {
+        matches!(self, Self::Local(_))
+    }
+
+    /// Returns true if this is a remote data source.
+    pub fn is_remote(&self) -> bool {
+        matches!(self, Self::Remote { .. })
+    }
+}

--- a/crates/iota-data-ingestion-core/src/executor.rs
+++ b/crates/iota-data-ingestion-core/src/executor.rs
@@ -16,7 +16,8 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 
 use crate::{
-    DataIngestionMetrics, IngestionError, IngestionResult, ReaderOptions, Worker,
+    DataIngestionMetrics, DataSource, GrpcCheckpointReader, IngestionError, IngestionResult,
+    ReaderOptions, Worker,
     progress_store::{ExecutorProgress, ProgressStore, ProgressStoreWrapper, ShimProgressStore},
     reader::{
         v1::CheckpointReader as CheckpointReaderV1,
@@ -35,6 +36,11 @@ enum CheckpointReader {
         handle: JoinHandle<IngestionResult<()>>,
     },
     V2(CheckpointReaderV2),
+    Grpc {
+        checkpoint_recv: mpsc::Receiver<Arc<CheckpointData>>,
+        exit_sender: oneshot::Sender<()>,
+        handle: JoinHandle<IngestionResult<()>>,
+    },
 }
 
 impl CheckpointReader {
@@ -44,6 +50,9 @@ impl CheckpointReader {
                 checkpoint_recv, ..
             } => checkpoint_recv.recv().await,
             Self::V2(reader) => reader.checkpoint().await,
+            Self::Grpc {
+                checkpoint_recv, ..
+            } => checkpoint_recv.recv().await,
         }
     }
 
@@ -58,6 +67,10 @@ impl CheckpointReader {
                 )
             }),
             Self::V2(reader) => reader.send_gc_signal(seq_number).await,
+            Self::Grpc { .. } => {
+                // gRPC reader doesn't need GC signals
+                Ok(())
+            }
         }
     }
 
@@ -75,6 +88,17 @@ impl CheckpointReader {
                 })?
             }
             Self::V2(reader) => reader.shutdown().await,
+            Self::Grpc {
+                exit_sender,
+                handle,
+                ..
+            } => {
+                _ = exit_sender.send(());
+                handle.await.map_err(|err| IngestionError::Shutdown {
+                    component: "gRPC Checkpoint Reader".into(),
+                    msg: err.to_string(),
+                })?
+            }
         }
     }
 }
@@ -203,6 +227,61 @@ impl<P: ProgressStore> IndexerExecutor<P> {
         task_name: String,
     ) -> IngestionResult<CheckpointSequenceNumber> {
         self.progress_store.load(task_name).await
+    }
+
+    /// Run executor with a specified data source.
+    ///
+    /// # Error
+    ///
+    /// Returns an [`IngestionError::EmptyWorkerPool`] if no worker pool was
+    /// registered.
+    pub async fn run_with_data_source(
+        self,
+        data_source: DataSource,
+        reader_options: ReaderOptions,
+    ) -> IngestionResult<ExecutorProgress> {
+        match data_source {
+            DataSource::Local(path) => self.run(path, None, vec![], reader_options).await,
+            DataSource::Remote {
+                store_url,
+                store_options,
+            } => {
+                self.run(
+                    tempfile::tempdir()?.into_path(),
+                    Some(store_url),
+                    store_options,
+                    reader_options,
+                )
+                .await
+            }
+            DataSource::Grpc { url } => self.run_with_grpc(url, reader_options).await,
+        }
+    }
+
+    /// Run executor with gRPC data source.
+    async fn run_with_grpc(
+        mut self,
+        grpc_url: String,
+        _reader_options: ReaderOptions,
+    ) -> IngestionResult<ExecutorProgress> {
+        let reader_checkpoint_number = self.progress_store.min_watermark()?;
+        let (grpc_reader, checkpoint_recv, exit_sender) = GrpcCheckpointReader::initialize(
+            grpc_url,
+            reader_checkpoint_number,
+            self.token.child_token(),
+        );
+
+        let grpc_reader_handle = spawn_monitored_task!(grpc_reader.run());
+
+        self.run_executor_loop(
+            reader_checkpoint_number,
+            CheckpointReader::Grpc {
+                checkpoint_recv,
+                exit_sender,
+                handle: grpc_reader_handle,
+            },
+        )
+        .await
     }
 
     /// Main executor loop.

--- a/crates/iota-data-ingestion-core/src/grpc_reader.rs
+++ b/crates/iota-data-ingestion-core/src/grpc_reader.rs
@@ -1,0 +1,232 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use iota_grpc_api::{CheckpointContent, NodeClient};
+use iota_rest_api::CheckpointData;
+use iota_types::messages_checkpoint::CheckpointSequenceNumber;
+use tokio::sync::{mpsc, oneshot};
+use tokio_stream::StreamExt;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, instrument, warn};
+
+use crate::{IngestionError, IngestionResult};
+
+/// gRPC checkpoint reader that streams checkpoints from a gRPC endpoint.
+pub struct GrpcCheckpointReader {
+    grpc_url: String,
+    starting_checkpoint_number: CheckpointSequenceNumber,
+    checkpoint_sender: mpsc::Sender<Arc<CheckpointData>>,
+    exit_receiver: oneshot::Receiver<()>,
+    cancel: CancellationToken,
+    watermark_provider: Option<Box<dyn WatermarkProvider + Send + Sync>>,
+}
+pub const CHECKPOINT_BUFFER_SIZE: usize = 1000;
+/// Trait for providing the current watermark dynamically.
+#[async_trait::async_trait]
+pub trait WatermarkProvider {
+    /// Get the current watermark (starting checkpoint number).
+    async fn get_current_watermark(&self) -> CheckpointSequenceNumber;
+}
+
+impl GrpcCheckpointReader {
+    pub fn initialize(
+        grpc_url: String,
+        starting_checkpoint_number: CheckpointSequenceNumber,
+        cancel: CancellationToken,
+    ) -> (
+        Self,
+        mpsc::Receiver<Arc<CheckpointData>>,
+        oneshot::Sender<()>,
+    ) {
+        let (checkpoint_sender, checkpoint_receiver) = mpsc::channel(CHECKPOINT_BUFFER_SIZE);
+        let (exit_sender, exit_receiver) = oneshot::channel();
+
+        let reader = Self {
+            grpc_url,
+            starting_checkpoint_number,
+            checkpoint_sender,
+            exit_receiver,
+            cancel,
+            watermark_provider: None,
+        };
+
+        (reader, checkpoint_receiver, exit_sender)
+    }
+
+    pub fn initialize_with_watermark_provider(
+        grpc_url: String,
+        starting_checkpoint_number: CheckpointSequenceNumber,
+        cancel: CancellationToken,
+        watermark_provider: Box<dyn WatermarkProvider + Send + Sync>,
+    ) -> (
+        Self,
+        mpsc::Receiver<Arc<CheckpointData>>,
+        oneshot::Sender<()>,
+    ) {
+        let (checkpoint_sender, checkpoint_receiver) = mpsc::channel(CHECKPOINT_BUFFER_SIZE);
+        let (exit_sender, exit_receiver) = oneshot::channel();
+
+        let reader = Self {
+            grpc_url,
+            starting_checkpoint_number,
+            checkpoint_sender,
+            exit_receiver,
+            cancel,
+            watermark_provider: Some(watermark_provider),
+        };
+
+        (reader, checkpoint_receiver, exit_sender)
+    }
+
+    #[instrument(
+        skip(self),
+        fields(
+            grpc_url = %self.grpc_url,
+            starting_checkpoint = %self.starting_checkpoint_number
+        ),
+        name = "grpc_checkpoint_reader"
+    )]
+    pub async fn run(mut self) -> IngestionResult<()> {
+        debug!(
+            "Starting checkpoint reader from watermark {}",
+            self.starting_checkpoint_number
+        );
+
+        const MAX_RETRIES: usize = 10;
+        const INITIAL_BACKOFF_SECS: u64 = 1;
+        const MAX_BACKOFF_SECS: u64 = 60;
+
+        let mut retry_count = 0;
+        let mut backoff_secs = INITIAL_BACKOFF_SECS;
+
+        loop {
+            // Check for exit signal first
+            if let Ok(()) = self.exit_receiver.try_recv() {
+                debug!("Received exit signal, shutting down reader");
+                return Ok(());
+            }
+
+            // Try streaming
+            match self.stream_with_retry().await {
+                Ok(()) => {
+                    debug!("Stream completed normally");
+                    break;
+                }
+                Err(e) => {
+                    if self.cancel.is_cancelled() {
+                        debug!("Cancelled, stopping reader");
+                        break;
+                    }
+
+                    retry_count += 1;
+                    if retry_count > MAX_RETRIES {
+                        return Err(IngestionError::Upstream(anyhow::anyhow!(
+                            "Max retries ({}) exceeded. Last error: {}",
+                            MAX_RETRIES,
+                            e
+                        )));
+                    }
+
+                    warn!(
+                        "Stream failed (attempt {}/{}): {}, retrying in {} seconds...",
+                        retry_count, MAX_RETRIES, e, backoff_secs
+                    );
+
+                    tokio::time::sleep(tokio::time::Duration::from_secs(backoff_secs)).await;
+
+                    // Exponential backoff with cap
+                    backoff_secs = std::cmp::min(backoff_secs * 2, MAX_BACKOFF_SECS);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    #[instrument(skip(self), name = "stream_with_retry")]
+    async fn stream_with_retry(&self) -> IngestionResult<()> {
+        let client = NodeClient::connect(&self.grpc_url).await.map_err(|e| {
+            IngestionError::Upstream(anyhow::anyhow!("Failed to connect to gRPC: {e}"))
+        })?;
+
+        // Get current watermark, either from provider or use starting checkpoint
+        let current_watermark = if let Some(provider) = &self.watermark_provider {
+            provider.get_current_watermark().await
+        } else {
+            self.starting_checkpoint_number
+        };
+
+        debug!(
+            "Starting stream from watermark {} (WorkerPool mode)",
+            current_watermark
+        );
+
+        let mut checkpoint_client = client.checkpoint_client().ok_or_else(|| {
+            IngestionError::Upstream(anyhow::anyhow!("Failed to get checkpoint client"))
+        })?;
+
+        let mut stream = checkpoint_client
+            .stream_checkpoints(Some(current_watermark), None, true)
+            .await
+            .map_err(|e| {
+                IngestionError::Upstream(anyhow::anyhow!("Failed to stream checkpoints: {e}"))
+            })?;
+
+        let mut channel_closed = false;
+        while let Some(result) = stream.next().await {
+            if self.cancel.is_cancelled() {
+                warn!("Cancelled, stopping stream");
+                break;
+            }
+
+            let checkpoint_data: CheckpointData = match result {
+                Ok(CheckpointContent::Data(grpc_data)) => {
+                    // Convert from gRPC CheckpointData to iota_types CheckpointData
+                    // This requires proper conversion logic
+                    match grpc_data {
+                        iota_grpc_types::CheckpointData::V1(v1_data) => {
+                            iota_types::full_checkpoint_content::CheckpointData {
+                                checkpoint_summary: v1_data.checkpoint_summary,
+                                checkpoint_contents: v1_data.checkpoint_contents,
+                                transactions: v1_data.transactions,
+                            }
+                        }
+                    }
+                }
+                Ok(CheckpointContent::Summary(_)) => {
+                    error!("Expected checkpoint data but got summary");
+                    return Err(IngestionError::Upstream(anyhow::anyhow!(
+                        "Expected checkpoint data but received summary"
+                    )));
+                }
+                Err(e) => {
+                    warn!("Stream error: {e}");
+                    return Err(IngestionError::Upstream(anyhow::anyhow!(
+                        "gRPC stream error: {e}"
+                    )));
+                }
+            };
+
+            if let Err(_e) = self.checkpoint_sender.send(Arc::new(checkpoint_data)).await {
+                warn!("WorkerPool channel closed, stopping stream");
+                channel_closed = true;
+                break;
+            }
+        }
+
+        if channel_closed {
+            debug!("Stream stopped due to channel closure (receiver gone)");
+            return Ok(());
+        }
+
+        warn!("Stream ended - this should only happen on cancellation or error");
+        if !self.cancel.is_cancelled() {
+            return Err(IngestionError::Upstream(anyhow::anyhow!(
+                "gRPC stream ended unexpectedly"
+            )));
+        }
+        Ok(())
+    }
+}

--- a/crates/iota-data-ingestion-core/src/lib.rs
+++ b/crates/iota-data-ingestion-core/src/lib.rs
@@ -24,8 +24,10 @@
 //! 3. [`IndexerExecutor`]: Orchestrates the shutdown of all worker pools and
 //!    and finalizes system termination.
 
+mod data_source;
 mod errors;
 mod executor;
+mod grpc_reader;
 pub mod history;
 mod metrics;
 mod progress_store;
@@ -42,8 +44,10 @@ use std::{
 };
 
 use async_trait::async_trait;
+pub use data_source::DataSource;
 pub use errors::{IngestionError, IngestionResult};
 pub use executor::{IndexerExecutor, MAX_CHECKPOINTS_IN_PROGRESS, setup_single_workflow};
+pub use grpc_reader::GrpcCheckpointReader;
 use iota_types::full_checkpoint_content::CheckpointData;
 pub use metrics::DataIngestionMetrics;
 pub use progress_store::{FileProgressStore, ProgressStore, ShimProgressStore};

--- a/crates/iota-data-ingestion/Cargo.toml
+++ b/crates/iota-data-ingestion/Cargo.toml
@@ -24,19 +24,23 @@ serde.workspace = true
 serde_yaml.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tokio-stream.workspace = true
 tokio-util.workspace = true
+tonic.workspace = true
 tracing.workspace = true
 
 # internal dependencies
 iota-archival.workspace = true
 iota-config.workspace = true
 iota-data-ingestion-core.workspace = true
+iota-grpc-api.workspace = true
 iota-kvstore.workspace = true
 iota-metrics.workspace = true
 iota-rest-api.workspace = true
 iota-storage.workspace = true
 iota-types.workspace = true
 telemetry-subscribers.workspace = true
+test-cluster.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/iota-data-ingestion/src/lib.rs
+++ b/crates/iota-data-ingestion/src/lib.rs
@@ -8,6 +8,6 @@ mod workers;
 
 pub use progress_store::DynamoDBProgressStore;
 pub use workers::{
-    ArchivalConfig, ArchivalReducer, BlobTaskConfig, BlobWorker, HistoricalReducer,
+    ArchivalConfig, ArchivalReducer, BlobTaskConfig, BlobWorker, GrpcBlobWorker, HistoricalReducer,
     HistoricalWriterConfig, KVStoreTaskConfig, KVStoreWorker, RelayWorker,
 };

--- a/crates/iota-data-ingestion/src/main.rs
+++ b/crates/iota-data-ingestion/src/main.rs
@@ -6,16 +6,18 @@ use std::{env, path::PathBuf, time::Duration};
 
 use anyhow::Result;
 use iota_data_ingestion::{
-    ArchivalConfig, ArchivalReducer, BlobTaskConfig, BlobWorker, HistoricalReducer,
+    ArchivalConfig, ArchivalReducer, BlobTaskConfig, BlobWorker, GrpcBlobWorker, HistoricalReducer,
     HistoricalWriterConfig, KVStoreTaskConfig, KVStoreWorker, RelayWorker, common,
 };
 use iota_data_ingestion_core::{
     DataIngestionMetrics, FileProgressStore, IndexerExecutor, ReaderOptions, WorkerPool,
 };
+use iota_grpc_api::NodeClient;
 use iota_kvstore::{BigTableClient, KvWorker};
 use iota_rest_api::Client;
 use prometheus::Registry;
 use serde::{Deserialize, Serialize};
+use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -145,44 +147,113 @@ async fn main() -> Result<()> {
                 executor.register(worker_pool).await?;
             }
             Task::Blob(blob_config) => {
-                let rest_client = Client::new(&blob_config.node_rest_api_url);
-                let watermark = executor.read_watermark(task_config.name.clone()).await?;
-                let current_epoch = common::current_epoch(&rest_client).await?;
-                let current_epoch_first_checkpoint_seq_num =
-                    common::epoch_first_checkpoint_sequence_number(&rest_client, current_epoch)
+                if let Some(grpc_url) = blob_config.node_grpc_api_url.clone() {
+                    let remote_store = blob_config.object_store_config.make()?;
+                    let task_name = task_config.name.clone();
+                    let mut watermark = executor.read_watermark(task_name.clone()).await?;
+
+                    let node_client = NodeClient::connect(&grpc_url)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("Failed to connect to gRPC client: {}", e))?;
+                    let mut checkpoint_client = node_client
+                        .checkpoint_client()
+                        .ok_or_else(|| anyhow::anyhow!("Checkpoint client not available"))?;
+                    let mut stream = checkpoint_client
+                        .stream_checkpoints(None, Some(watermark), true)
                         .await?;
-                // if watermark is less than the first checkpoint of current epoch
-                // is safe to assume that an epoch was changed.
-                let worker = if watermark < current_epoch_first_checkpoint_seq_num {
-                    // updating the watermark ensures that the worker will start synchronization
-                    // from that point onward.
-                    executor
-                        .update_watermark(
-                            task_config.name.clone(),
-                            current_epoch_first_checkpoint_seq_num,
+                    let mut current_epoch = 0u64;
+                    if let Some(Ok(first_checkpoint)) = stream.next().await {
+                        // The stream now returns CheckpointContent directly
+                        match &first_checkpoint {
+                            iota_grpc_api::CheckpointContent::Data(checkpoint_data) => {
+                                let sequence_number = checkpoint_data.sequence_number();
+                                if sequence_number > watermark {
+                                    tracing::warn!(
+                                        "Watermark {} is behind node's first available checkpoint {}. Resetting.",
+                                        watermark,
+                                        sequence_number
+                                    );
+                                    watermark = sequence_number;
+                                    executor
+                                        .update_watermark(task_name.clone(), watermark)
+                                        .await?;
+                                }
+
+                                // Extract the current epoch from the checkpoint data
+                                if let Some(checkpoint_v1) = checkpoint_data.as_v1() {
+                                    current_epoch = checkpoint_v1.checkpoint_summary.epoch;
+                                    tracing::debug!(
+                                        "Extracted current epoch {} from checkpoint {}",
+                                        current_epoch,
+                                        sequence_number
+                                    );
+                                } else {
+                                    tracing::warn!(
+                                        "Unknown checkpoint data version, using epoch 0 as fallback"
+                                    );
+                                }
+                            }
+                            iota_grpc_api::CheckpointContent::Summary(_) => {
+                                tracing::error!(
+                                    "Checkpoint contains summary instead of data, using epoch 0 as fallback"
+                                );
+                            }
+                        }
+                    } else {
+                        tracing::warn!("No checkpoint data available from stream");
+                    }
+                    let worker = GrpcBlobWorker::new(
+                        remote_store,
+                        grpc_url,
+                        blob_config.checkpoint_chunk_size_mb,
+                        current_epoch,
+                    );
+                    let worker_pool = WorkerPool::new(
+                        worker,
+                        task_config.name,
+                        task_config.concurrency,
+                        Default::default(),
+                    );
+                    executor.register(worker_pool).await?;
+                } else {
+                    let rest_client = Client::new(&blob_config.node_rest_api_url);
+                    let watermark = executor.read_watermark(task_config.name.clone()).await?;
+                    let current_epoch = common::current_epoch(&rest_client).await?;
+                    let current_epoch_first_checkpoint_seq_num =
+                        common::epoch_first_checkpoint_sequence_number(&rest_client, current_epoch)
+                            .await?;
+                    // if watermark is less than the first checkpoint of current epoch
+                    // is safe to assume that an epoch was changed.
+                    let worker = if watermark < current_epoch_first_checkpoint_seq_num {
+                        // updating the watermark ensures that the worker will start synchronization
+                        // from that point onward.
+                        executor
+                            .update_watermark(
+                                task_config.name.clone(),
+                                current_epoch_first_checkpoint_seq_num,
+                            )
+                            .await?;
+                        // get the range from the first checkpoint of the watermark's epoch to the
+                        // watermark
+                        let reset_range = common::checkpoint_sequence_number_range_to_watermark(
+                            &rest_client,
+                            watermark,
                         )
                         .await?;
-                    // get the range from the first checkpoint of the watermark's epoch to the
-                    // watermark
-                    let reset_range = common::checkpoint_sequence_number_range_to_watermark(
-                        &rest_client,
-                        watermark,
-                    )
-                    .await?;
-                    let worker = BlobWorker::new(blob_config, rest_client, current_epoch)?;
-                    worker.reset_remote_store(reset_range).await?;
-                    worker
-                } else {
-                    BlobWorker::new(blob_config, rest_client, current_epoch)?
-                };
-
-                let worker_pool = WorkerPool::new(
-                    worker,
-                    task_config.name,
-                    task_config.concurrency,
-                    Default::default(),
-                );
-                executor.register(worker_pool).await?;
+                        let worker = BlobWorker::new(blob_config, rest_client, current_epoch)?;
+                        worker.reset_remote_store(reset_range).await?;
+                        worker
+                    } else {
+                        BlobWorker::new(blob_config, rest_client, current_epoch)?
+                    };
+                    let worker_pool = WorkerPool::new(
+                        worker,
+                        task_config.name,
+                        task_config.concurrency,
+                        Default::default(),
+                    );
+                    executor.register(worker_pool).await?;
+                }
             }
             Task::BigTableKv(kv_config) => {
                 let client = BigTableClient::new_remote(

--- a/crates/iota-data-ingestion/src/workers/blob.rs
+++ b/crates/iota-data-ingestion/src/workers/blob.rs
@@ -29,9 +29,9 @@ const MIN_CHUNK_SIZE_MB: u64 = 5 * 1024 * 1024; // 5 MB
 const MAX_CONCURRENT_PARTS_UPLOAD: usize = 50;
 const MAX_CONCURRENT_DELETE_REQUESTS: usize = 10;
 
-const CHECKPOINT_FILE_SUFFIX: &str = "chk";
-const LIVE_DIR_NAME: &str = "live";
-const INGESTION_DIR_NAME: &str = "ingestion";
+pub(crate) const CHECKPOINT_FILE_SUFFIX: &str = "chk";
+pub(crate) const LIVE_DIR_NAME: &str = "live";
+pub(crate) const INGESTION_DIR_NAME: &str = "ingestion";
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "kebab-case")]
@@ -40,6 +40,7 @@ pub struct BlobTaskConfig {
     #[serde(deserialize_with = "deserialize_chunk")]
     pub checkpoint_chunk_size_mb: u64,
     pub node_rest_api_url: String,
+    pub node_grpc_api_url: Option<String>,
 }
 
 fn deserialize_chunk<'de, D>(deserializer: D) -> Result<u64, D::Error>

--- a/crates/iota-data-ingestion/src/workers/grpc_blob.rs
+++ b/crates/iota-data-ingestion/src/workers/grpc_blob.rs
@@ -1,0 +1,115 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::StreamExt;
+use iota_data_ingestion_core::Worker;
+use iota_grpc_api::NodeClient;
+use iota_storage::blob::{Blob, BlobEncoding};
+use iota_types::{
+    full_checkpoint_content::CheckpointData, messages_checkpoint::CheckpointSequenceNumber,
+};
+use object_store::{DynObjectStore, path::Path};
+use tokio::sync::Mutex;
+
+use crate::workers::blob::{CHECKPOINT_FILE_SUFFIX, INGESTION_DIR_NAME, LIVE_DIR_NAME};
+
+pub struct GrpcBlobWorker {
+    remote_store: Arc<DynObjectStore>,
+    grpc_url: String,
+    // TODO: Note that we need to define a reasonable chunk size in the future, as BlobTaskConfig
+    // and BlobWorker. Now we don't have this size limitation for ease of our testing and try
+    // run.
+    #[allow(dead_code)]
+    checkpoint_chunk_size_mb: u64,
+    current_epoch: Arc<Mutex<u64>>,
+}
+
+impl GrpcBlobWorker {
+    pub fn new(
+        remote_store: Arc<DynObjectStore>,
+        grpc_url: String,
+        checkpoint_chunk_size_mb: u64,
+        current_epoch: u64,
+    ) -> Self {
+        Self {
+            remote_store,
+            grpc_url,
+            checkpoint_chunk_size_mb,
+            current_epoch: Arc::new(Mutex::new(current_epoch)),
+        }
+    }
+
+    pub fn file_path(chk_seq_num: CheckpointSequenceNumber) -> Path {
+        Path::from(INGESTION_DIR_NAME)
+            .child(LIVE_DIR_NAME)
+            .child(format!("{chk_seq_num}.{CHECKPOINT_FILE_SUFFIX}"))
+    }
+
+    async fn upload_blob(&self, bytes: Vec<u8>, _chk_seq_num: u64, location: Path) -> Result<()> {
+        self.remote_store
+            .put(&location, Bytes::from(bytes).into())
+            .await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Worker for GrpcBlobWorker {
+    type Message = ();
+    type Error = anyhow::Error;
+
+    async fn process_checkpoint(
+        &self,
+        checkpoint: Arc<CheckpointData>,
+    ) -> Result<Self::Message, Self::Error> {
+        let chk_seq_num = checkpoint.checkpoint_summary.sequence_number;
+        let epoch = checkpoint.checkpoint_summary.epoch;
+        {
+            let mut current_epoch = self.current_epoch.lock().await;
+            if epoch > *current_epoch {
+                // Epoch transition detected. Fetch first checkpoint of previous epoch and reset
+                // remote store.
+                tracing::debug!(
+                    "Epoch transition: {} -> {}. Performing remote store reset.",
+                    *current_epoch,
+                    epoch
+                );
+                let node_client = NodeClient::connect(&self.grpc_url)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to connect to gRPC client: {}", e))?;
+                let mut checkpoint_client = node_client
+                    .checkpoint_client()
+                    .ok_or_else(|| anyhow::anyhow!("Checkpoint client not available"))?;
+                let delete_start = checkpoint_client
+                    .get_epoch_first_checkpoint_sequence_number(*current_epoch)
+                    .await?;
+                if delete_start < chk_seq_num {
+                    // Only reset if there is something to delete
+                    let paths = (delete_start..chk_seq_num)
+                        .map(|chk_seq_num| Ok(Self::file_path(chk_seq_num)))
+                        .collect::<Vec<_>>();
+                    let paths_stream = futures::stream::iter(paths).boxed();
+                    self.remote_store
+                        .delete_stream(paths_stream)
+                        .for_each_concurrent(10, |delete_result| async {
+                            if let Err(err) = delete_result {
+                                tracing::warn!("deletion failed with: {err}");
+                            }
+                        })
+                        .await;
+                }
+                // Update epoch after reset
+                *current_epoch = epoch;
+            }
+        }
+        let bytes = Blob::encode(&checkpoint, BlobEncoding::Bcs)?.to_bytes();
+        self.upload_blob(bytes, chk_seq_num, Self::file_path(chk_seq_num))
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/iota-data-ingestion/src/workers/mod.rs
+++ b/crates/iota-data-ingestion/src/workers/mod.rs
@@ -4,12 +4,14 @@
 
 mod archival;
 mod blob;
+mod grpc_blob;
 mod historical;
 mod kv_store;
 mod relay;
 
 pub use archival::{ArchivalConfig, ArchivalReducer};
 pub use blob::{BlobTaskConfig, BlobWorker};
+pub use grpc_blob::GrpcBlobWorker;
 pub use historical::{HistoricalReducer, HistoricalWriterConfig};
 pub use kv_store::{KVStoreTaskConfig, KVStoreWorker};
 pub use relay::RelayWorker;

--- a/crates/iota-data-ingestion/tests/grpc_blob_ingestion.rs
+++ b/crates/iota-data-ingestion/tests/grpc_blob_ingestion.rs
@@ -1,0 +1,85 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_config::local_ip_utils;
+use iota_data_ingestion::GrpcBlobWorker;
+use iota_data_ingestion_core::Worker;
+use iota_grpc_api::NodeClient;
+use iota_types::full_checkpoint_content::CheckpointData;
+use object_store::memory::InMemory;
+use test_cluster::TestClusterBuilder;
+use tokio_stream::StreamExt;
+
+/// Integration test: Streams the full CheckpointData for a single checkpoint
+/// (using full=true, start_sequence_number=None,
+/// end_sequence_number=Some(idx)), decodes it, and passes it to the
+/// GrpcBlobWorker to verify ingestion logic.
+#[tokio::test]
+async fn test_grpc_blob_worker_logic() {
+    // Start a test cluster with gRPC enabled
+    let localhost = local_ip_utils::localhost_for_testing();
+    let grpc_port = local_ip_utils::get_available_port(&localhost);
+    let grpc_addr = format!("{localhost}:{grpc_port}");
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .with_fullnode_grpc_api_address(grpc_addr.parse().expect("Invalid gRPC address"))
+        .build()
+        .await;
+
+    // Wait for several checkpoints to be created
+    cluster.wait_for_checkpoint(4, None).await;
+
+    // Simulate a stale local watermark (behind the node's first available
+    // checkpoint)
+    let stale_epoch = 0u64; // Start with epoch 0, but node may be at a later epoch
+    let grpc_url = format!("http://{grpc_addr}");
+    let remote_store: std::sync::Arc<object_store::DynObjectStore> =
+        std::sync::Arc::new(InMemory::new());
+    let worker = GrpcBlobWorker::new(
+        remote_store.clone(),
+        grpc_url.clone(),
+        5 * 1024 * 1024,
+        stale_epoch,
+    );
+
+    // Connect to the gRPC endpoint and get the first available checkpoint
+    let node_client = NodeClient::connect(&grpc_url)
+        .await
+        .expect("failed to connect grpc client");
+    let mut checkpoint_client = node_client
+        .checkpoint_client()
+        .expect("Checkpoint client not available");
+    let mut stream = checkpoint_client
+        .stream_checkpoints(None, Some(4), true)
+        .await
+        .expect("failed to stream checkpoints");
+    if let Some(Ok(checkpoint_content)) = stream.next().await {
+        let checkpoint_data: CheckpointData = match checkpoint_content {
+            iota_grpc_api::CheckpointContent::Data(grpc_data) => {
+                grpc_data.into_v1().expect("Expected v1 checkpoint data")
+            }
+            iota_grpc_api::CheckpointContent::Summary(_) => {
+                panic!("Expected data, got summary")
+            }
+        };
+
+        println!(
+            "Streamed full CheckpointData for checkpoint {}",
+            checkpoint_data.checkpoint_summary.sequence_number
+        );
+
+        // Assert the checkpoint sequence number is 4 before processing
+        assert_eq!(
+            checkpoint_data.checkpoint_summary.sequence_number, 4,
+            "Should have streamed checkpoint 4"
+        );
+
+        println!("Checkpoint data: {checkpoint_data:?}");
+
+        let checkpoint_data_arc = std::sync::Arc::new(checkpoint_data.clone());
+        worker
+            .process_checkpoint(checkpoint_data_arc)
+            .await
+            .expect("worker should process checkpoint without error");
+    }
+}

--- a/crates/iota-indexer/Cargo.toml
+++ b/crates/iota-indexer/Cargo.toml
@@ -70,11 +70,15 @@ shared_test_runtime = []
 hex.workspace = true
 rand.workspace = true
 serde_json.workspace = true
+tracing-subscriber.workspace = true
 
 # internal dependencies
 iota-config.workspace = true
+iota-grpc-api.workspace = true
+iota-grpc-types.workspace = true
 iota-keys.workspace = true
 iota-move-build.workspace = true
+iota-storage.workspace = true
 iota-swarm-config.workspace = true
 iota-test-transaction-builder.workspace = true
 simulacrum.workspace = true

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -127,6 +127,9 @@ pub struct IngestionSources {
 
     #[arg(long)]
     pub rpc_client_url: Option<Url>,
+
+    #[arg(long)]
+    pub grpc_client_url: Option<Url>,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -609,6 +612,7 @@ pub mod deprecated {
                                 url.parse().expect("Remote Store URL should be correct")
                             }),
                             rpc_client_url: Some(rpc_client_url_parsed),
+                            grpc_client_url: None,
                         },
                         checkpoint_download_queue_size: download_queue_size,
                         checkpoint_download_timeout: ingestion_reader_timeout_secs,

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -7,7 +7,7 @@ use std::{collections::HashMap, env};
 use anyhow::Result;
 use async_trait::async_trait;
 use iota_data_ingestion_core::{
-    DataIngestionMetrics, IndexerExecutor, ProgressStore, ReaderOptions, WorkerPool,
+    DataIngestionMetrics, DataSource, IndexerExecutor, ProgressStore, ReaderOptions, WorkerPool,
 };
 use iota_metrics::spawn_monitored_task;
 use iota_types::messages_checkpoint::CheckpointSequenceNumber;
@@ -85,6 +85,31 @@ impl Indexer {
             store.persist_protocol_configs_and_feature_flags(chain_id)?;
         }
 
+        // Determine data source based on configuration priority: gRPC > Local > Remote
+        let data_source = if let Some(grpc_url) = &config.sources.grpc_client_url {
+            info!("Using gRPC checkpoint ingestion from {}", grpc_url);
+            DataSource::Grpc {
+                url: grpc_url.to_string(),
+            }
+        } else if let Some(local_path) = &config.sources.data_ingestion_path {
+            info!(
+                "Using local file checkpoint ingestion from {:?}",
+                local_path
+            );
+            DataSource::Local(local_path.clone())
+        } else {
+            let source_url = config
+                .sources
+                .remote_store_url
+                .as_ref()
+                .unwrap_or(config.sources.rpc_client_url.as_ref().unwrap());
+            info!("Using REST checkpoint ingestion from {}", source_url);
+            DataSource::Remote {
+                store_url: source_url.to_string(),
+                store_options: vec![],
+            }
+        };
+
         let mut executor = IndexerExecutor::new(
             ShimIndexerProgressStore::new(vec![
                 ("primary".to_string(), primary_watermark),
@@ -94,6 +119,7 @@ impl Indexer {
             DataIngestionMetrics::new(&Registry::new()),
             cancel.child_token(),
         );
+
         let worker = new_handlers(store, metrics, primary_watermark, cancel.clone()).await?;
         let worker_pool = WorkerPool::new(
             worker,
@@ -111,22 +137,10 @@ impl Indexer {
             Default::default(),
         );
         executor.register(worker_pool).await?;
+
         info!("Starting data ingestion executor...");
         executor
-            .run(
-                config
-                    .sources
-                    .data_ingestion_path
-                    .clone()
-                    .unwrap_or(tempfile::tempdir().unwrap().keep()),
-                config
-                    .sources
-                    .remote_store_url
-                    .as_ref()
-                    .map(|url| url.as_str().to_owned()),
-                vec![],
-                extra_reader_options,
-            )
+            .run_with_data_source(data_source, extra_reader_options)
             .await?;
         Ok(())
     }

--- a/crates/iota-indexer/src/test_utils.rs
+++ b/crates/iota-indexer/src/test_utils.rs
@@ -12,7 +12,10 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     IndexerMetrics,
-    config::{IngestionConfig, IotaNamesOptions, RetentionConfig, SnapshotLagConfig},
+    config::{
+        IngestionConfig, IngestionSources, IotaNamesOptions, PruningOptions, RetentionConfig,
+        SnapshotLagConfig,
+    },
     db::{ConnectionPool, ConnectionPoolConfig, PoolConnection, new_connection_pool},
     errors::IndexerError,
     indexer::Indexer,
@@ -184,6 +187,53 @@ pub async fn start_test_indexer_impl(
         }
     };
 
+    (store, handle)
+}
+
+/// Starts an indexer writer for testing using gRPC ingestion.
+pub async fn start_test_indexer_grpc(
+    db_url: String,
+    reset_db: bool,
+    db_init_hook: Option<DBInitHook>,
+    grpc_url: String,
+    data_ingestion_path: Option<PathBuf>,
+    cancel: CancellationToken,
+) -> (PgIndexerStore, JoinHandle<Result<(), IndexerError>>) {
+    let config = IngestionConfig {
+        sources: IngestionSources {
+            data_ingestion_path,
+            remote_store_url: None,
+            rpc_client_url: None,
+            grpc_client_url: Some(grpc_url.parse().expect("Invalid gRPC URL")),
+        },
+        ..Default::default()
+    };
+
+    let store = create_pg_store(&db_url, reset_db);
+    if reset_db {
+        crate::db::reset_database(&mut store.blocking_cp().get().unwrap()).unwrap();
+    }
+    if let Some(db_init_hook) = db_init_hook {
+        db_init_hook(&store);
+    }
+    let store_clone = store.clone();
+    let registry = prometheus::Registry::default();
+    let indexer_metrics = IndexerMetrics::new(&registry);
+    let handle = tokio::spawn(async move {
+        Indexer::start_writer_with_config(
+            &config,
+            store_clone,
+            indexer_metrics,
+            SnapshotLagConfig::default(),
+            PruningOptions {
+                epochs_to_keep: std::env::var("EPOCHS_TO_KEEP")
+                    .map(|s| s.parse::<u64>().ok())
+                    .unwrap_or_else(|_e| None),
+            },
+            cancel,
+        )
+        .await
+    });
     (store, handle)
 }
 

--- a/crates/iota-indexer/tests/grpc_ingestion.rs
+++ b/crates/iota-indexer/tests/grpc_ingestion.rs
@@ -1,0 +1,91 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use iota_config::local_ip_utils;
+use iota_grpc_api::client::{CheckpointClient, NodeClient};
+use iota_indexer::{store::indexer_store::IndexerStore, test_utils::start_test_indexer_grpc};
+use test_cluster::{TestCluster, TestClusterBuilder};
+use tokio_util::sync::CancellationToken;
+
+async fn setup_test_cluster_and_client() -> (TestCluster, CheckpointClient, String) {
+    let localhost = local_ip_utils::localhost_for_testing();
+    let grpc_port = local_ip_utils::get_available_port(&localhost);
+    let grpc_addr = format!("{localhost}:{grpc_port}");
+
+    // Start a test cluster with gRPC enabled and pruning disabled
+    let cluster = TestClusterBuilder::new()
+        .with_fullnode_grpc_api_address(grpc_addr.parse().expect("Invalid gRPC address"))
+        .disable_fullnode_pruning()
+        .with_num_validators(1)
+        .build()
+        .await;
+
+    let node_client = NodeClient::connect(&format!("http://{grpc_addr}"))
+        .await
+        .expect("connect gRPC");
+
+    let checkpoint_client = node_client
+        .checkpoint_client()
+        .expect("Checkpoint client should be available");
+
+    (cluster, checkpoint_client, grpc_addr)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_grpc_checkpoint_ingestion() {
+    // Start a test cluster with gRPC enabled
+    let (cluster, _checkpoint_client, grpc_addr) = setup_test_cluster_and_client().await;
+
+    // Wait for checkpoint 3 to be available
+    cluster.wait_for_checkpoint(3, None).await;
+
+    // Prepare DB and indexer
+    let db_url = "postgres://postgres:postgrespw@localhost:5432/iota_indexer_test_grpc".to_string();
+    let cancel = CancellationToken::new();
+    let (store, handle) = start_test_indexer_grpc(
+        db_url.clone(),
+        true,
+        None,
+        format!("http://{grpc_addr}"),
+        None,
+        cancel.clone(),
+    )
+    .await;
+
+    // Wait for checkpoints 0, 1, and 2 to exist in the store
+    tokio::time::timeout(Duration::from_secs(3), async {
+        loop {
+            if let Ok((min_cp, max_cp)) = store.get_available_checkpoint_range().await {
+                if min_cp == 0 && max_cp >= 3 {
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("Checkpoints 0, 1, 2 did not appear in time");
+
+    // Wait for the indexer to process at least 6 checkpoint
+    tokio::time::timeout(Duration::from_secs(3), async {
+        let mut count = 0;
+        loop {
+            let latest_cp = store.get_latest_checkpoint_sequence_number().await.unwrap();
+            if let Some(_seq) = latest_cp {
+                count += 1;
+                if count > 6 {
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    })
+    .await
+    .expect("Indexer did not process a checkpoint in time");
+
+    // Clean up
+    cancel.cancel();
+    let _ = handle.await;
+}

--- a/crates/iota-indexer/tests/ingestion_performance_test.rs
+++ b/crates/iota-indexer/tests/ingestion_performance_test.rs
@@ -1,0 +1,238 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::{Duration, Instant};
+
+use iota_config::local_ip_utils;
+use iota_grpc_api::client::{CheckpointClient, NodeClient};
+use iota_indexer::{
+    store::indexer_store::IndexerStore,
+    test_utils::{IndexerTypeConfig, start_test_indexer, start_test_indexer_grpc},
+};
+use test_cluster::{TestCluster, TestClusterBuilder};
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+const START_CP: u64 = 0;
+const MAX_CP: u64 = 19;
+
+fn init_tracing() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+
+    INIT.call_once(|| {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .try_init();
+    });
+}
+
+async fn setup_test_cluster_and_client() -> (TestCluster, CheckpointClient, String) {
+    let localhost = local_ip_utils::localhost_for_testing();
+    let grpc_port = local_ip_utils::get_available_port(&localhost);
+    let grpc_addr = format!("{localhost}:{grpc_port}");
+
+    // Start a test cluster with gRPC enabled and pruning disabled
+    let cluster = TestClusterBuilder::new()
+        .with_fullnode_grpc_api_address(grpc_addr.parse().expect("Invalid gRPC address"))
+        .disable_fullnode_pruning()
+        .with_num_validators(1)
+        .build()
+        .await;
+
+    let node_client = NodeClient::connect(&format!("http://{grpc_addr}"))
+        .await
+        .expect("connect gRPC");
+
+    let checkpoint_client = node_client
+        .checkpoint_client()
+        .expect("Checkpoint client should be available");
+
+    (cluster, checkpoint_client, grpc_addr)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_checkpoint_sync_performance_rest() {
+    init_tracing();
+
+    // Start a test cluster
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
+
+    // Wait for a range of checkpoints to be available
+    cluster.wait_for_checkpoint(MAX_CP, None).await;
+
+    // Prepare DB and indexer
+    let db_url = "postgres://postgres:postgrespw@localhost:5432/iota_indexer_perf_rest".to_string();
+    let rpc_url = cluster.rpc_url().to_string();
+    let (store, handle, _cancel) = start_test_indexer(
+        db_url.clone(),
+        true,
+        None,
+        rpc_url,
+        IndexerTypeConfig::writer_mode(None, None),
+        None,
+    )
+    .await;
+
+    // Wait for the indexer to process up to MAX_CP
+    let t0 = Instant::now();
+    tokio::time::timeout(Duration::from_secs(3600), async {
+        loop {
+            if let Ok((_min_cp, max_cp)) = store.get_available_checkpoint_range().await {
+                if max_cp >= MAX_CP {
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("Indexer did not process checkpoints in time");
+    let elapsed = t0.elapsed();
+    info!("[REST] Synced checkpoints {START_CP}-{MAX_CP} in {elapsed:?}");
+
+    // Clean up
+    handle.abort();
+    let _ = handle.await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_checkpoint_sync_performance_grpc() {
+    init_tracing();
+
+    // Start a test cluster with gRPC enabled
+    let (cluster, _checkpoint_client, grpc_addr) = setup_test_cluster_and_client().await;
+
+    // Wait for a range of checkpoints to be available
+    cluster.wait_for_checkpoint(MAX_CP, None).await;
+
+    // Prepare DB and indexer
+    let db_url = "postgres://postgres:postgrespw@localhost:5432/iota_indexer_perf_grpc".to_string();
+    let cancel = CancellationToken::new();
+    let (store, handle) = start_test_indexer_grpc(
+        db_url.clone(),
+        true,
+        None,
+        format!("http://{grpc_addr}"),
+        None,
+        cancel.clone(),
+    )
+    .await;
+
+    // Wait for the indexer to process up to MAX_CP
+    let t0 = Instant::now();
+    tokio::time::timeout(Duration::from_secs(3600), async {
+        loop {
+            if let Ok((_min_cp, max_cp)) = store.get_available_checkpoint_range().await {
+                if max_cp >= MAX_CP {
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("Indexer did not process checkpoints in time");
+    let elapsed = t0.elapsed();
+    info!("[gRPC] Synced checkpoints {START_CP}-{MAX_CP} in {elapsed:?}");
+
+    // Clean up
+    cancel.cancel();
+    let _ = handle.await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_checkpoint_sync_performance_file() {
+    init_tracing();
+
+    use tempfile::tempdir;
+
+    // Start a test cluster with gRPC enabled (needed for checkpoint export)
+    let (cluster, mut checkpoint_client, _grpc_addr) = setup_test_cluster_and_client().await;
+
+    // Wait for a range of checkpoints to be available
+    cluster.wait_for_checkpoint(MAX_CP, None).await;
+
+    // Export checkpoints to a temp directory
+    let temp_dir = tempdir().unwrap();
+    let checkpoint_dir = temp_dir.path().to_path_buf();
+
+    // --- Generate and export checkpoints via gRPC FIRST ---
+    {
+        use futures::StreamExt;
+        use iota_grpc_api::CheckpointContent;
+        use iota_storage::blob::{Blob, BlobEncoding};
+
+        let mut stream = checkpoint_client
+            .stream_checkpoints(Some(START_CP), Some(MAX_CP), true)
+            .await
+            .expect("gRPC stream");
+
+        let mut sequence_number = START_CP;
+        while let Some(Ok(checkpoint_content)) = stream.next().await {
+            // Handle the CheckpointContent
+            let checkpoint_data = match checkpoint_content {
+                CheckpointContent::Data(grpc_data) => {
+                    // Convert from gRPC CheckpointData to iota_types CheckpointData
+                    match grpc_data {
+                        iota_grpc_types::CheckpointData::V1(v1_data) => {
+                            iota_types::full_checkpoint_content::CheckpointData {
+                                checkpoint_summary: v1_data.checkpoint_summary,
+                                checkpoint_contents: v1_data.checkpoint_contents,
+                                transactions: v1_data.transactions,
+                            }
+                        }
+                    }
+                }
+                CheckpointContent::Summary(_) => {
+                    panic!("Expected data, got summary")
+                }
+            };
+
+            // Re-encode using Blob format (which is what the file reader expects)
+            let blob = Blob::encode(&checkpoint_data, BlobEncoding::Bcs)
+                .expect("encode checkpoint as blob");
+
+            let file_path = checkpoint_dir.join(format!("{}.chk", sequence_number));
+            std::fs::write(file_path, blob.to_bytes()).expect("write checkpoint file");
+            sequence_number += 1;
+        }
+    }
+    // --- End export ---
+
+    // Now start the indexer with the populated checkpoint directory
+    let db_url = "postgres://postgres:postgrespw@localhost:5432/iota_indexer_perf_file".to_string();
+    let (store, handle, _cancel) = iota_indexer::test_utils::start_test_indexer(
+        db_url.clone(),
+        true,
+        None,
+        cluster.rpc_url().to_string(),
+        IndexerTypeConfig::writer_mode(None, None),
+        Some(checkpoint_dir.clone()),
+    )
+    .await;
+
+    // Wait for the indexer to process up to MAX_CP
+    let t0 = Instant::now();
+    tokio::time::timeout(Duration::from_secs(3600), async {
+        loop {
+            if let Ok((_min_cp, max_cp)) = store.get_available_checkpoint_range().await {
+                if max_cp >= MAX_CP {
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("Indexer did not process checkpoints in time");
+    let elapsed = t0.elapsed();
+    info!("[File] Synced checkpoints {START_CP}-{MAX_CP} in {elapsed:?}");
+
+    // Clean up
+    handle.abort();
+    let _ = handle.await;
+}


### PR DESCRIPTION
# Description of change

The gRPC-indexer by using the gRPC-API.

[run-ci]

## Links to any relevant issues

Part of #8001 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [x] Indexer: add gRPC streaming for checkpoint data and checkpoint summary
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
