### PR TITLE
fix(consensus): `test_core_set_min_propose_round`

### DIFF
--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -1859,11 +1859,10 @@ mod test {
         let mut builder = DagBuilder::new(context.clone());
         builder.layers(1..=10).build();
 
-        let block_headers = builder.block_headers.values().cloned().collect::<Vec<_>>();
-
         // Process all the blocks
         let (missing_ancestors, missing_committed_txns) =
-            core.add_block_headers(block_headers).unwrap();
+            core.add_blocks(builder.blocks(1..=10)).unwrap();
+
         assert!(missing_ancestors.is_empty());
         assert!(missing_committed_txns.is_empty());
 

--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -16,7 +16,7 @@ use crate::{
     CommitRef, CommittedSubDag,
     block_header::{
         BlockHeaderAPI, BlockHeaderDigest, BlockRef, BlockTimestampMs, Round, Slot,
-        TestBlockHeader, Transaction, TransactionsCommitment, VerifiedBlockHeader,
+        TestBlockHeader, Transaction, TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader,
         VerifiedTransactions, genesis_block_headers,
     },
     commit::{CertifiedCommit, CommitDigest, TrustedCommit, WAVE_LENGTH},
@@ -199,6 +199,21 @@ impl DagBuilder {
             })
             .cloned()
             .collect::<Vec<VerifiedTransactions>>()
+    }
+    pub(crate) fn blocks(&self, rounds: RangeInclusive<Round>) -> Vec<VerifiedBlock> {
+        assert!(
+            !self.block_headers.is_empty(),
+            "No blocks have been created, please make sure that you have called build method"
+        );
+        self.block_headers
+            .iter()
+            .filter_map(|(block_ref, block_header)| {
+                rounds.contains(&block_ref.round).then_some(VerifiedBlock {
+                    verified_block_header: block_header.clone(),
+                    verified_transactions: self.transactions.get(block_ref).cloned()?,
+                })
+            })
+            .collect::<Vec<VerifiedBlock>>()
     }
 
     pub(crate) fn all_block_headers(&self) -> Vec<VerifiedBlockHeader> {


### PR DESCRIPTION
# Description of change

Since we separated `blocks` into `block_headers` and `transactions`, the `test_core_set_min_propose_round` started failing because we were only adding `block_headers` instead of `blocks`, and then asserting that no transactions were missing. 

## Fix
- add `pub(crate) fn blocks(&self, rounds: RangeInclusive<Round>) -> Vec<VerifiedBlock>` method on `DagBuilder` which returns a vector of `VerifiedBlock`
- pass `DagBuilder::blocks(1..==10)` result to `Core::add_blocks` instead of using `Core::add_block_headers`.

closes #7930 

Be sure to reference any related issues by adding `fixes #(issue)`.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
