### PR TITLE
feat(iota-execution): add `move-vm-types` to execution version cuts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7943,7 +7943,6 @@ dependencies = [
  "move-ir-types",
  "move-vm-profiler",
  "move-vm-test-utils",
- "move-vm-types",
  "nonempty",
  "num-bigint 0.4.6",
  "num-rational",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6075,6 +6075,7 @@ dependencies = [
  "move-trace-format",
  "move-vm-config",
  "move-vm-runtime",
+ "move-vm-types",
  "petgraph 0.6.5",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -468,7 +468,6 @@ move-unit-test = { path = "external-crates/move/crates/move-unit-test" }
 move-vm-config = { path = "external-crates/move/crates/move-vm-config" }
 move-vm-profiler = { path = "external-crates/move/crates/move-vm-profiler" }
 move-vm-test-utils = { path = "external-crates/move/crates/move-vm-test-utils/", features = ["tiered-gas"] }
-move-vm-types = { path = "external-crates/move/crates/move-vm-types" }
 prometheus-closure-metric = { path = "crates/prometheus-closure-metric" }
 shared-crypto = { path = "crates/shared-crypto" }
 simulacrum = { path = "crates/simulacrum" }

--- a/crates/iota-types/Cargo.toml
+++ b/crates/iota-types/Cargo.toml
@@ -73,7 +73,6 @@ move-disassembler.workspace = true
 move-ir-types.workspace = true
 move-vm-profiler.workspace = true
 move-vm-test-utils.workspace = true
-move-vm-types.workspace = true
 shared-crypto.workspace = true
 typed-store-error.workspace = true
 

--- a/crates/iota-types/src/gas_model/tables.rs
+++ b/crates/iota-types/src/gas_model/tables.rs
@@ -6,19 +6,12 @@ use std::collections::BTreeMap;
 
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
-    gas_algebra::{AbstractMemorySize, InternalGas, NumArgs, NumBytes},
-    language_storage::ModuleId,
+    gas_algebra::{AbstractMemorySize, InternalGas},
     vm_status::StatusCode,
 };
 use move_vm_profiler::GasProfiler;
-use move_vm_types::{
-    gas::{GasMeter, SimpleInstruction},
-    loaded_data::runtime_types::Type,
-    views::{TypeView, ValueView},
-};
 use once_cell::sync::Lazy;
 
-use super::gas_predicates::native_function_threshold_exceeded;
 use crate::gas_model::units_types::{CostTable, Gas, GasCost};
 
 /// VM flat fee
@@ -54,10 +47,10 @@ pub static INITIAL_COST_SCHEDULE: Lazy<CostTable> = Lazy::new(initial_cost_sched
 pub struct GasStatus {
     pub gas_model_version: u64,
     cost_table: CostTable,
-    gas_left: InternalGas,
+    pub gas_left: InternalGas,
     gas_price: u64,
     initial_budget: InternalGas,
-    charge: bool,
+    pub charge: bool,
 
     // The current height of the operand stack, and the maximal height that it has reached.
     stack_height_high_water_mark: u64,
@@ -76,8 +69,8 @@ pub struct GasStatus {
     instructions_next_tier_start: Option<u64>,
     instructions_current_tier_mult: u64,
 
-    profiler: Option<GasProfiler>,
-    num_native_calls: u64,
+    pub profiler: Option<GasProfiler>,
+    pub num_native_calls: u64,
 }
 
 impl GasStatus {
@@ -300,6 +293,10 @@ impl GasStatus {
         }
     }
 
+    pub fn record_native_call(&mut self) {
+        self.num_native_calls = self.num_native_calls.saturating_add(1);
+    }
+
     // Deduct the amount provided with no conversion, as if it was InternalGasUnit
     fn deduct_units(&mut self, amount: u64) -> PartialVMResult<()> {
         self.deduct_gas(InternalGas::new(amount))
@@ -327,10 +324,6 @@ impl GasStatus {
         self.deduct_units(computation_cost)
     }
 
-    fn abstract_memory_size(&self, val: impl ValueView) -> AbstractMemorySize {
-        val.abstract_memory_size(false)
-    }
-
     pub fn gas_price(&self) -> u64 {
         self.gas_price
     }
@@ -345,358 +338,6 @@ impl GasStatus {
 
     pub fn instructions_executed(&self) -> u64 {
         self.instructions_executed
-    }
-}
-
-/// Returns a tuple of (<pops>, <pushes>, <stack_size_decrease>,
-/// <stack_size_increase>)
-fn get_simple_instruction_stack_change(
-    instr: SimpleInstruction,
-) -> (u64, u64, AbstractMemorySize, AbstractMemorySize) {
-    use SimpleInstruction::*;
-
-    match instr {
-        // NB: The `Ret` pops are accounted for in `Call` instructions, so we say `Ret` has no pops.
-        Nop | Ret => (0, 0, 0.into(), 0.into()),
-        BrTrue | BrFalse => (1, 0, Type::Bool.size(), 0.into()),
-        Branch => (0, 0, 0.into(), 0.into()),
-        LdU8 => (0, 1, 0.into(), Type::U8.size()),
-        LdU16 => (0, 1, 0.into(), Type::U16.size()),
-        LdU32 => (0, 1, 0.into(), Type::U32.size()),
-        LdU64 => (0, 1, 0.into(), Type::U64.size()),
-        LdU128 => (0, 1, 0.into(), Type::U128.size()),
-        LdU256 => (0, 1, 0.into(), Type::U256.size()),
-        LdTrue | LdFalse => (0, 1, 0.into(), Type::Bool.size()),
-        FreezeRef => (1, 1, REFERENCE_SIZE, REFERENCE_SIZE),
-        ImmBorrowLoc | MutBorrowLoc => (0, 1, 0.into(), REFERENCE_SIZE),
-        ImmBorrowField | MutBorrowField | ImmBorrowFieldGeneric | MutBorrowFieldGeneric => {
-            (1, 1, REFERENCE_SIZE, REFERENCE_SIZE)
-        }
-        // Since we don't have the size of the value being cast here we take a conservative
-        // over-approximation: it is _always_ getting cast from the smallest integer type.
-        CastU8 => (1, 1, Type::U8.size(), Type::U8.size()),
-        CastU16 => (1, 1, Type::U8.size(), Type::U16.size()),
-        CastU32 => (1, 1, Type::U8.size(), Type::U32.size()),
-        CastU64 => (1, 1, Type::U8.size(), Type::U64.size()),
-        CastU128 => (1, 1, Type::U8.size(), Type::U128.size()),
-        CastU256 => (1, 1, Type::U8.size(), Type::U256.size()),
-        // NB: We don't know the size of what integers we're dealing with, so we conservatively
-        // over-approximate by popping the smallest integers, and push the largest.
-        Add | Sub | Mul | Mod | Div => (2, 1, Type::U8.size() + Type::U8.size(), Type::U256.size()),
-        BitOr | BitAnd | Xor => (2, 1, Type::U8.size() + Type::U8.size(), Type::U256.size()),
-        Shl | Shr => (2, 1, Type::U8.size() + Type::U8.size(), Type::U256.size()),
-        Or | And => (
-            2,
-            1,
-            Type::Bool.size() + Type::Bool.size(),
-            Type::Bool.size(),
-        ),
-        Lt | Gt | Le | Ge => (2, 1, Type::U8.size() + Type::U8.size(), Type::Bool.size()),
-        Not => (1, 1, Type::Bool.size(), Type::Bool.size()),
-        Abort => (1, 0, Type::U64.size(), 0.into()),
-    }
-}
-
-impl GasMeter for GasStatus {
-    /// Charge an instruction and fail if not enough gas units are left.
-    fn charge_simple_instr(&mut self, instr: SimpleInstruction) -> PartialVMResult<()> {
-        let (pops, pushes, pop_size, push_size) = get_simple_instruction_stack_change(instr);
-        self.charge(1, pushes, pops, push_size.into(), pop_size.into())
-    }
-
-    fn charge_pop(&mut self, popped_val: impl ValueView) -> PartialVMResult<()> {
-        self.charge(1, 0, 1, 0, self.abstract_memory_size(popped_val).into())
-    }
-
-    fn charge_native_function(
-        &mut self,
-        amount: InternalGas,
-        ret_vals: Option<impl ExactSizeIterator<Item = impl ValueView>>,
-    ) -> PartialVMResult<()> {
-        // Charge for the number of pushes on to the stack that the return of this
-        // function is going to cause.
-        let pushes = ret_vals
-            .as_ref()
-            .map(|ret_vals| ret_vals.len())
-            .unwrap_or(0) as u64;
-        // Calculate the number of bytes that are getting pushed onto the stack.
-        let size_increase = ret_vals
-            .map(|ret_vals| {
-                ret_vals.fold(AbstractMemorySize::zero(), |acc, elem| {
-                    acc + self.abstract_memory_size(elem)
-                })
-            })
-            .unwrap_or_else(AbstractMemorySize::zero);
-        self.num_native_calls = self.num_native_calls.saturating_add(1);
-        if native_function_threshold_exceeded(self.gas_model_version, self.num_native_calls) {
-            // Charge for the stack operations. We don't count this as an "instruction"
-            // since we already accounted for the `Call` instruction in the
-            // `charge_native_function_before_execution` call.
-            // The amount returned by the native function is viewed as the "virtual"
-            // instruction cost for the native function, and will be charged and
-            // contribute to the overall cost tier of the transaction
-            // accordingly.
-            self.charge(amount.into(), pushes, 0, size_increase.into(), 0)
-        } else {
-            // Charge for the stack operations. We don't count this as an "instruction"
-            // since we already accounted for the `Call` instruction in the
-            // `charge_native_function_before_execution` call.
-            self.charge(0, pushes, 0, size_increase.into(), 0)?;
-            // Now charge the gas that the native function told us to charge.
-            self.deduct_gas(amount)
-        }
-    }
-
-    fn charge_native_function_before_execution(
-        &mut self,
-        _ty_args: impl ExactSizeIterator<Item = impl TypeView>,
-        args: impl ExactSizeIterator<Item = impl ValueView>,
-    ) -> PartialVMResult<()> {
-        // Determine the number of pops that are going to be needed for this function
-        // call, and charge for them.
-        let pops = args.len() as u64;
-        // Calculate the size decrease of the stack from the above pops.
-        let stack_reduction_size = args.fold(AbstractMemorySize::new(pops), |acc, elem| {
-            acc + self.abstract_memory_size(elem)
-        });
-        // Track that this is going to be popping from the operand stack. We also
-        // increment the instruction count as we need to account for the `Call`
-        // bytecode that initiated this native call.
-        self.charge(1, 0, pops, 0, stack_reduction_size.into())
-    }
-
-    fn charge_call(
-        &mut self,
-        _module_id: &ModuleId,
-        _func_name: &str,
-        args: impl ExactSizeIterator<Item = impl ValueView>,
-        _num_locals: NumArgs,
-    ) -> PartialVMResult<()> {
-        // We will have to perform this many pops for the call.
-        let pops = args.len() as u64;
-        // Size stays the same -- we're just moving it from the operand stack to the
-        // locals. But the size on the operand stack is reduced by sum_{args}
-        // arg.size().
-        let stack_reduction_size = args.fold(AbstractMemorySize::new(0), |acc, elem| {
-            acc + self.abstract_memory_size(elem)
-        });
-        self.charge(1, 0, pops, 0, stack_reduction_size.into())
-    }
-
-    fn charge_call_generic(
-        &mut self,
-        _module_id: &ModuleId,
-        _func_name: &str,
-        _ty_args: impl ExactSizeIterator<Item = impl TypeView>,
-        args: impl ExactSizeIterator<Item = impl ValueView>,
-        _num_locals: NumArgs,
-    ) -> PartialVMResult<()> {
-        // We have to perform this many pops from the operand stack for this function
-        // call.
-        let pops = args.len() as u64;
-        // Calculate the size reduction on the operand stack.
-        let stack_reduction_size = args.fold(AbstractMemorySize::new(0), |acc, elem| {
-            acc + self.abstract_memory_size(elem)
-        });
-        // Charge for the pops, no pushes, and account for the stack size decrease. Also
-        // track the `CallGeneric` instruction we must have encountered for
-        // this.
-        self.charge(1, 0, pops, 0, stack_reduction_size.into())
-    }
-
-    fn charge_ld_const(&mut self, size: NumBytes) -> PartialVMResult<()> {
-        // Charge for the load from the locals onto the stack.
-        self.charge(1, 1, 0, u64::from(size), 0)
-    }
-
-    fn charge_ld_const_after_deserialization(
-        &mut self,
-        _val: impl ValueView,
-    ) -> PartialVMResult<()> {
-        // We already charged for this based on the bytes that we're loading so don't
-        // charge again.
-        Ok(())
-    }
-
-    fn charge_copy_loc(&mut self, val: impl ValueView) -> PartialVMResult<()> {
-        // Charge for the copy of the local onto the stack.
-        self.charge(1, 1, 0, self.abstract_memory_size(val).into(), 0)
-    }
-
-    fn charge_move_loc(&mut self, val: impl ValueView) -> PartialVMResult<()> {
-        // Charge for the move of the local on to the stack. Note that we charge here
-        // since we aren't tracking the local size (at least not yet). If we
-        // were, this should be a net-zero operation in terms of memory usage.
-        self.charge(1, 1, 0, self.abstract_memory_size(val).into(), 0)
-    }
-
-    fn charge_store_loc(&mut self, val: impl ValueView) -> PartialVMResult<()> {
-        // Charge for the storing of the value on the stack into a local. Note here that
-        // if we were also accounting for the size of the locals that this would
-        // be a net-zero operation in terms of memory.
-        self.charge(1, 0, 1, 0, self.abstract_memory_size(val).into())
-    }
-
-    fn charge_pack(
-        &mut self,
-        _is_generic: bool,
-        args: impl ExactSizeIterator<Item = impl ValueView>,
-    ) -> PartialVMResult<()> {
-        // We perform `num_fields` number of pops.
-        let num_fields = args.len() as u64;
-        // The actual amount of memory on the stack is staying the same with the
-        // addition of some extra size for the struct, so the size doesn't
-        // really change much.
-        self.charge(1, 1, num_fields, STRUCT_SIZE.into(), 0)
-    }
-
-    fn charge_unpack(
-        &mut self,
-        _is_generic: bool,
-        args: impl ExactSizeIterator<Item = impl ValueView>,
-    ) -> PartialVMResult<()> {
-        // We perform `num_fields` number of pushes.
-        let num_fields = args.len() as u64;
-        self.charge(1, num_fields, 1, 0, STRUCT_SIZE.into())
-    }
-
-    fn charge_variant_switch(&mut self, val: impl ValueView) -> PartialVMResult<()> {
-        // We perform a single pop of a value from the stack.
-        self.charge(1, 0, 1, 0, self.abstract_memory_size(val).into())
-    }
-
-    fn charge_read_ref(&mut self, ref_val: impl ValueView) -> PartialVMResult<()> {
-        // We read the reference so we are decreasing the size of the stack by the size
-        // of the reference, and adding to it the size of the value that has
-        // been read from that reference.
-        self.charge(
-            1,
-            1,
-            1,
-            self.abstract_memory_size(ref_val).into(),
-            REFERENCE_SIZE.into(),
-        )
-    }
-
-    fn charge_write_ref(
-        &mut self,
-        new_val: impl ValueView,
-        old_val: impl ValueView,
-    ) -> PartialVMResult<()> {
-        // TODO(tzakian): We should account for this elsewhere as the owner of data the
-        // the reference points to won't be on the stack. For now though, we
-        // treat it as adding to the stack size.
-        self.charge(
-            1,
-            1,
-            2,
-            self.abstract_memory_size(new_val).into(),
-            self.abstract_memory_size(old_val).into(),
-        )
-    }
-
-    fn charge_eq(&mut self, lhs: impl ValueView, rhs: impl ValueView) -> PartialVMResult<()> {
-        let size_reduction = self.abstract_memory_size(lhs) + self.abstract_memory_size(rhs);
-        self.charge(
-            1,
-            1,
-            2,
-            (Type::Bool.size() + size_reduction).into(),
-            size_reduction.into(),
-        )
-    }
-
-    fn charge_neq(&mut self, lhs: impl ValueView, rhs: impl ValueView) -> PartialVMResult<()> {
-        let size_reduction = self.abstract_memory_size(lhs) + self.abstract_memory_size(rhs);
-        self.charge(1, 1, 2, Type::Bool.size().into(), size_reduction.into())
-    }
-
-    fn charge_vec_pack<'a>(
-        &mut self,
-        _ty: impl TypeView + 'a,
-        args: impl ExactSizeIterator<Item = impl ValueView>,
-    ) -> PartialVMResult<()> {
-        // We will perform `num_args` number of pops.
-        let num_args = args.len() as u64;
-        // The amount of data on the stack stays constant except we have some extra
-        // metadata for the vector to hold the length of the vector.
-        self.charge(1, 1, num_args, VEC_SIZE.into(), 0)
-    }
-
-    fn charge_vec_len(&mut self, _ty: impl TypeView) -> PartialVMResult<()> {
-        self.charge(1, 1, 1, Type::U64.size().into(), REFERENCE_SIZE.into())
-    }
-
-    fn charge_vec_borrow(
-        &mut self,
-        _is_mut: bool,
-        _ty: impl TypeView,
-        _is_success: bool,
-    ) -> PartialVMResult<()> {
-        self.charge(
-            1,
-            1,
-            2,
-            REFERENCE_SIZE.into(),
-            (REFERENCE_SIZE + Type::U64.size()).into(),
-        )
-    }
-
-    fn charge_vec_push_back(
-        &mut self,
-        _ty: impl TypeView,
-        _val: impl ValueView,
-    ) -> PartialVMResult<()> {
-        // The value was already on the stack, so we aren't increasing the number of
-        // bytes on the stack.
-        self.charge(1, 0, 2, 0, REFERENCE_SIZE.into())
-    }
-
-    fn charge_vec_pop_back(
-        &mut self,
-        _ty: impl TypeView,
-        _val: Option<impl ValueView>,
-    ) -> PartialVMResult<()> {
-        self.charge(1, 1, 1, 0, REFERENCE_SIZE.into())
-    }
-
-    fn charge_vec_unpack(
-        &mut self,
-        _ty: impl TypeView,
-        expect_num_elements: NumArgs,
-        _elems: impl ExactSizeIterator<Item = impl ValueView>,
-    ) -> PartialVMResult<()> {
-        // Charge for the pushes
-        let pushes = u64::from(expect_num_elements);
-        // The stack size stays pretty much the same modulo the additional vector size
-        self.charge(1, pushes, 1, 0, VEC_SIZE.into())
-    }
-
-    fn charge_vec_swap(&mut self, _ty: impl TypeView) -> PartialVMResult<()> {
-        let size_decrease = REFERENCE_SIZE + Type::U64.size() + Type::U64.size();
-        self.charge(1, 1, 1, 0, size_decrease.into())
-    }
-
-    fn charge_drop_frame(
-        &mut self,
-        _locals: impl Iterator<Item = impl ValueView>,
-    ) -> PartialVMResult<()> {
-        Ok(())
-    }
-
-    fn remaining_gas(&self) -> InternalGas {
-        if !self.charge {
-            return InternalGas::new(u64::MAX);
-        }
-        self.gas_left
-    }
-
-    fn get_profiler_mut(&mut self) -> Option<&mut GasProfiler> {
-        self.profiler.as_mut()
-    }
-
-    fn set_profiler(&mut self, profiler: GasProfiler) {
-        self.profiler = Some(profiler);
     }
 }
 

--- a/external-crates/move/crates/move-stdlib-natives/Cargo.toml
+++ b/external-crates/move/crates/move-stdlib-natives/Cargo.toml
@@ -14,7 +14,8 @@ move-binary-format.workspace = true
 move-core-types.workspace = true
 # referred to via path for execution versioning
 move-vm-runtime = { path = "../move-vm-runtime" }
-move-vm-types.workspace = true
+# referred to via path for execution versioning
+move-vm-types = { path = "../move-vm-types" }
 sha2.workspace = true
 sha3.workspace = true
 smallvec.workspace = true

--- a/external-crates/move/crates/move-vm-runtime/Cargo.toml
+++ b/external-crates/move/crates/move-vm-runtime/Cargo.toml
@@ -24,7 +24,8 @@ move-core-types.workspace = true
 move-trace-format.workspace = true
 move-vm-config.workspace = true
 move-vm-profiler.workspace = true
-move-vm-types.workspace = true
+# referred to via path for execution versioning
+move-vm-types = { path = "../move-vm-types" }
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/iota-execution/Cargo.toml
+++ b/iota-execution/Cargo.toml
@@ -24,6 +24,8 @@ move-vm-config.workspace = true
 # move-bytecode-verifier-$CUT = { path = "../external-crates/move/move-execution/$CUT/crates/move-bytecode-verifier" }
 move-vm-runtime-latest = { path = "../external-crates/move/crates/move-vm-runtime", package = "move-vm-runtime" }
 # move-vm-runtime-$CUT = { path = "../external-crates/move/move-execution/$CUT/crates/move-vm-runtime" }
+move-vm-types-latest = { path = "../external-crates/move/crates/move-vm-types", package = "move-vm-types" }
+# move-vm-types-$CUT = { path = "../external-crates/move/move-execution/$CUT/crates/move-vm-types" }
 
 [dev-dependencies]
 cargo_metadata = "0.15"

--- a/iota-execution/cut/src/plan.rs
+++ b/iota-execution/cut/src/plan.rs
@@ -733,7 +733,7 @@ mod tests {
         let root = discover_root(cut.clone()).unwrap();
 
         let iota_execution = root.join("iota-execution");
-        let move_vm_types = root.join("external-crates/move/crates/move-vm-types");
+        let move_core_types = root.join("external-crates/move/crates/move-core-types");
 
         let ws = Workspace::read(&root).unwrap();
 
@@ -742,7 +742,7 @@ mod tests {
 
         // Other examples
         assert!(ws.members.contains(&iota_execution));
-        assert!(ws.exclude.contains(&move_vm_types));
+        assert!(ws.exclude.contains(&move_core_types));
     }
 
     #[test]

--- a/iota-execution/latest/iota-adapter/Cargo.toml
+++ b/iota-execution/latest/iota-adapter/Cargo.toml
@@ -35,7 +35,7 @@ move-trace-format.workspace = true
 move-vm-config.workspace = true
 move-vm-profiler = { path = "../../../external-crates/move/crates/move-vm-profiler" }
 move-vm-runtime = { path = "../../../external-crates/move/crates/move-vm-runtime" }
-move-vm-types.workspace = true
+move-vm-types = { path = "../../../external-crates/move/crates/move-vm-types" }
 
 [features]
 tracing = [

--- a/iota-execution/latest/iota-adapter/src/gas_meter.rs
+++ b/iota-execution/latest/iota-adapter/src/gas_meter.rs
@@ -1,3 +1,7 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
 use iota_types::gas_model::{
     gas_predicates::native_function_threshold_exceeded,
     tables::{GasStatus, REFERENCE_SIZE, STRUCT_SIZE, VEC_SIZE},

--- a/iota-execution/latest/iota-adapter/src/gas_meter.rs
+++ b/iota-execution/latest/iota-adapter/src/gas_meter.rs
@@ -1,0 +1,378 @@
+use iota_types::gas_model::{
+    gas_predicates::native_function_threshold_exceeded,
+    tables::{GasStatus, REFERENCE_SIZE, STRUCT_SIZE, VEC_SIZE},
+};
+use move_binary_format::errors::PartialVMResult;
+use move_core_types::{
+    gas_algebra::{AbstractMemorySize, InternalGas, NumArgs, NumBytes},
+    language_storage::ModuleId,
+};
+use move_vm_profiler::GasProfiler;
+use move_vm_types::{
+    gas::{GasMeter, SimpleInstruction},
+    loaded_data::runtime_types::Type,
+    views::{TypeView, ValueView},
+};
+
+pub struct IotaGasMeter<'g>(pub &'g mut GasStatus);
+
+/// Returns a tuple of (<pops>, <pushes>, <stack_size_decrease>,
+/// <stack_size_increase>)
+fn get_simple_instruction_stack_change(
+    instr: SimpleInstruction,
+) -> (u64, u64, AbstractMemorySize, AbstractMemorySize) {
+    use SimpleInstruction::*;
+
+    match instr {
+        // NB: The `Ret` pops are accounted for in `Call` instructions, so we say `Ret` has no pops.
+        Nop | Ret => (0, 0, 0.into(), 0.into()),
+        BrTrue | BrFalse => (1, 0, Type::Bool.size(), 0.into()),
+        Branch => (0, 0, 0.into(), 0.into()),
+        LdU8 => (0, 1, 0.into(), Type::U8.size()),
+        LdU16 => (0, 1, 0.into(), Type::U16.size()),
+        LdU32 => (0, 1, 0.into(), Type::U32.size()),
+        LdU64 => (0, 1, 0.into(), Type::U64.size()),
+        LdU128 => (0, 1, 0.into(), Type::U128.size()),
+        LdU256 => (0, 1, 0.into(), Type::U256.size()),
+        LdTrue | LdFalse => (0, 1, 0.into(), Type::Bool.size()),
+        FreezeRef => (1, 1, REFERENCE_SIZE, REFERENCE_SIZE),
+        ImmBorrowLoc | MutBorrowLoc => (0, 1, 0.into(), REFERENCE_SIZE),
+        ImmBorrowField | MutBorrowField | ImmBorrowFieldGeneric | MutBorrowFieldGeneric => {
+            (1, 1, REFERENCE_SIZE, REFERENCE_SIZE)
+        }
+        // Since we don't have the size of the value being cast here we take a conservative
+        // over-approximation: it is _always_ getting cast from the smallest integer type.
+        CastU8 => (1, 1, Type::U8.size(), Type::U8.size()),
+        CastU16 => (1, 1, Type::U8.size(), Type::U16.size()),
+        CastU32 => (1, 1, Type::U8.size(), Type::U32.size()),
+        CastU64 => (1, 1, Type::U8.size(), Type::U64.size()),
+        CastU128 => (1, 1, Type::U8.size(), Type::U128.size()),
+        CastU256 => (1, 1, Type::U8.size(), Type::U256.size()),
+        // NB: We don't know the size of what integers we're dealing with, so we conservatively
+        // over-approximate by popping the smallest integers, and push the largest.
+        Add | Sub | Mul | Mod | Div => (2, 1, Type::U8.size() + Type::U8.size(), Type::U256.size()),
+        BitOr | BitAnd | Xor => (2, 1, Type::U8.size() + Type::U8.size(), Type::U256.size()),
+        Shl | Shr => (2, 1, Type::U8.size() + Type::U8.size(), Type::U256.size()),
+        Or | And => (
+            2,
+            1,
+            Type::Bool.size() + Type::Bool.size(),
+            Type::Bool.size(),
+        ),
+        Lt | Gt | Le | Ge => (2, 1, Type::U8.size() + Type::U8.size(), Type::Bool.size()),
+        Not => (1, 1, Type::Bool.size(), Type::Bool.size()),
+        Abort => (1, 0, Type::U64.size(), 0.into()),
+    }
+}
+
+impl GasMeter for IotaGasMeter<'_> {
+    /// Charge an instruction and fail if not enough gas units are left.
+    fn charge_simple_instr(&mut self, instr: SimpleInstruction) -> PartialVMResult<()> {
+        let (pops, pushes, pop_size, push_size) = get_simple_instruction_stack_change(instr);
+        self.0
+            .charge(1, pushes, pops, push_size.into(), pop_size.into())
+    }
+
+    fn charge_pop(&mut self, popped_val: impl ValueView) -> PartialVMResult<()> {
+        self.0
+            .charge(1, 0, 1, 0, abstract_memory_size(popped_val).into())
+    }
+
+    fn charge_native_function(
+        &mut self,
+        amount: InternalGas,
+        ret_vals: Option<impl ExactSizeIterator<Item = impl ValueView>>,
+    ) -> PartialVMResult<()> {
+        // Charge for the number of pushes on to the stack that the return of this
+        // function is going to cause.
+        let pushes = ret_vals
+            .as_ref()
+            .map(|ret_vals| ret_vals.len())
+            .unwrap_or(0) as u64;
+        // Calculate the number of bytes that are getting pushed onto the stack.
+        let size_increase = ret_vals
+            .map(|ret_vals| {
+                ret_vals.fold(AbstractMemorySize::zero(), |acc, elem| {
+                    acc + abstract_memory_size(elem)
+                })
+            })
+            .unwrap_or_else(AbstractMemorySize::zero);
+        self.0.record_native_call();
+        if native_function_threshold_exceeded(self.0.gas_model_version, self.0.num_native_calls) {
+            // Charge for the stack operations. We don't count this as an "instruction"
+            // since we already accounted for the `Call` instruction in the
+            // `charge_native_function_before_execution` call.
+            // The amount returned by the native function is viewed as the "virtual"
+            // instruction cost for the native function, and will be charged and
+            // contribute to the overall cost tier of the transaction
+            // accordingly.
+            self.0
+                .charge(amount.into(), pushes, 0, size_increase.into(), 0)
+        } else {
+            // Charge for the stack operations. We don't count this as an "instruction"
+            // since we already accounted for the `Call` instruction in the
+            // `charge_native_function_before_execution` call.
+            self.0.charge(0, pushes, 0, size_increase.into(), 0)?;
+            // Now charge the gas that the native function told us to charge.
+            self.0.deduct_gas(amount)
+        }
+    }
+
+    fn charge_native_function_before_execution(
+        &mut self,
+        _ty_args: impl ExactSizeIterator<Item = impl TypeView>,
+        args: impl ExactSizeIterator<Item = impl ValueView>,
+    ) -> PartialVMResult<()> {
+        // Determine the number of pops that are going to be needed for this function
+        // call, and charge for them.
+        let pops = args.len() as u64;
+        // Calculate the size decrease of the stack from the above pops.
+        let stack_reduction_size = args.fold(AbstractMemorySize::new(pops), |acc, elem| {
+            acc + abstract_memory_size(elem)
+        });
+        // Track that this is going to be popping from the operand stack. We also
+        // increment the instruction count as we need to account for the `Call`
+        // bytecode that initiated this native call.
+        self.0.charge(1, 0, pops, 0, stack_reduction_size.into())
+    }
+
+    fn charge_call(
+        &mut self,
+        _module_id: &ModuleId,
+        _func_name: &str,
+        args: impl ExactSizeIterator<Item = impl ValueView>,
+        _num_locals: NumArgs,
+    ) -> PartialVMResult<()> {
+        // We will have to perform this many pops for the call.
+        let pops = args.len() as u64;
+        // Size stays the same -- we're just moving it from the operand stack to the
+        // locals. But the size on the operand stack is reduced by sum_{args}
+        // arg.size().
+        let stack_reduction_size = args.fold(AbstractMemorySize::new(0), |acc, elem| {
+            acc + abstract_memory_size(elem)
+        });
+        self.0.charge(1, 0, pops, 0, stack_reduction_size.into())
+    }
+
+    fn charge_call_generic(
+        &mut self,
+        _module_id: &ModuleId,
+        _func_name: &str,
+        _ty_args: impl ExactSizeIterator<Item = impl TypeView>,
+        args: impl ExactSizeIterator<Item = impl ValueView>,
+        _num_locals: NumArgs,
+    ) -> PartialVMResult<()> {
+        // We have to perform this many pops from the operand stack for this function
+        // call.
+        let pops = args.len() as u64;
+        // Calculate the size reduction on the operand stack.
+        let stack_reduction_size = args.fold(AbstractMemorySize::new(0), |acc, elem| {
+            acc + abstract_memory_size(elem)
+        });
+        // Charge for the pops, no pushes, and account for the stack size decrease. Also
+        // track the `CallGeneric` instruction we must have encountered for
+        // this.
+        self.0.charge(1, 0, pops, 0, stack_reduction_size.into())
+    }
+
+    fn charge_ld_const(&mut self, size: NumBytes) -> PartialVMResult<()> {
+        // Charge for the load from the locals onto the stack.
+        self.0.charge(1, 1, 0, u64::from(size), 0)
+    }
+
+    fn charge_ld_const_after_deserialization(
+        &mut self,
+        _val: impl ValueView,
+    ) -> PartialVMResult<()> {
+        // We already charged for this based on the bytes that we're loading so don't
+        // charge again.
+        Ok(())
+    }
+
+    fn charge_copy_loc(&mut self, val: impl ValueView) -> PartialVMResult<()> {
+        // Charge for the copy of the local onto the stack.
+        self.0.charge(1, 1, 0, abstract_memory_size(val).into(), 0)
+    }
+
+    fn charge_move_loc(&mut self, val: impl ValueView) -> PartialVMResult<()> {
+        // Charge for the move of the local on to the stack. Note that we charge here
+        // since we aren't tracking the local size (at least not yet). If we
+        // were, this should be a net-zero operation in terms of memory usage.
+        self.0.charge(1, 1, 0, abstract_memory_size(val).into(), 0)
+    }
+
+    fn charge_store_loc(&mut self, val: impl ValueView) -> PartialVMResult<()> {
+        // Charge for the storing of the value on the stack into a local. Note here that
+        // if we were also accounting for the size of the locals that this would
+        // be a net-zero operation in terms of memory.
+        self.0.charge(1, 0, 1, 0, abstract_memory_size(val).into())
+    }
+
+    fn charge_pack(
+        &mut self,
+        _is_generic: bool,
+        args: impl ExactSizeIterator<Item = impl ValueView>,
+    ) -> PartialVMResult<()> {
+        // We perform `num_fields` number of pops.
+        let num_fields = args.len() as u64;
+        // The actual amount of memory on the stack is staying the same with the
+        // addition of some extra size for the struct, so the size doesn't
+        // really change much.
+        self.0.charge(1, 1, num_fields, STRUCT_SIZE.into(), 0)
+    }
+
+    fn charge_unpack(
+        &mut self,
+        _is_generic: bool,
+        args: impl ExactSizeIterator<Item = impl ValueView>,
+    ) -> PartialVMResult<()> {
+        // We perform `num_fields` number of pushes.
+        let num_fields = args.len() as u64;
+        self.0.charge(1, num_fields, 1, 0, STRUCT_SIZE.into())
+    }
+
+    fn charge_variant_switch(&mut self, val: impl ValueView) -> PartialVMResult<()> {
+        // We perform a single pop of a value from the stack.
+        self.0.charge(1, 0, 1, 0, abstract_memory_size(val).into())
+    }
+
+    fn charge_read_ref(&mut self, ref_val: impl ValueView) -> PartialVMResult<()> {
+        // We read the reference so we are decreasing the size of the stack by the size
+        // of the reference, and adding to it the size of the value that has
+        // been read from that reference.
+        self.0.charge(
+            1,
+            1,
+            1,
+            abstract_memory_size(ref_val).into(),
+            REFERENCE_SIZE.into(),
+        )
+    }
+
+    fn charge_write_ref(
+        &mut self,
+        new_val: impl ValueView,
+        old_val: impl ValueView,
+    ) -> PartialVMResult<()> {
+        // TODO(tzakian): We should account for this elsewhere as the owner of data the
+        // the reference points to won't be on the stack. For now though, we
+        // treat it as adding to the stack size.
+        self.0.charge(
+            1,
+            1,
+            2,
+            abstract_memory_size(new_val).into(),
+            abstract_memory_size(old_val).into(),
+        )
+    }
+
+    fn charge_eq(&mut self, lhs: impl ValueView, rhs: impl ValueView) -> PartialVMResult<()> {
+        let size_reduction = abstract_memory_size(lhs) + abstract_memory_size(rhs);
+        self.0.charge(
+            1,
+            1,
+            2,
+            (Type::Bool.size() + size_reduction).into(),
+            size_reduction.into(),
+        )
+    }
+
+    fn charge_neq(&mut self, lhs: impl ValueView, rhs: impl ValueView) -> PartialVMResult<()> {
+        let size_reduction = abstract_memory_size(lhs) + abstract_memory_size(rhs);
+        self.0
+            .charge(1, 1, 2, Type::Bool.size().into(), size_reduction.into())
+    }
+
+    fn charge_vec_pack<'a>(
+        &mut self,
+        _ty: impl TypeView + 'a,
+        args: impl ExactSizeIterator<Item = impl ValueView>,
+    ) -> PartialVMResult<()> {
+        // We will perform `num_args` number of pops.
+        let num_args = args.len() as u64;
+        // The amount of data on the stack stays constant except we have some extra
+        // metadata for the vector to hold the length of the vector.
+        self.0.charge(1, 1, num_args, VEC_SIZE.into(), 0)
+    }
+
+    fn charge_vec_len(&mut self, _ty: impl TypeView) -> PartialVMResult<()> {
+        self.0
+            .charge(1, 1, 1, Type::U64.size().into(), REFERENCE_SIZE.into())
+    }
+
+    fn charge_vec_borrow(
+        &mut self,
+        _is_mut: bool,
+        _ty: impl TypeView,
+        _is_success: bool,
+    ) -> PartialVMResult<()> {
+        self.0.charge(
+            1,
+            1,
+            2,
+            REFERENCE_SIZE.into(),
+            (REFERENCE_SIZE + Type::U64.size()).into(),
+        )
+    }
+
+    fn charge_vec_push_back(
+        &mut self,
+        _ty: impl TypeView,
+        _val: impl ValueView,
+    ) -> PartialVMResult<()> {
+        // The value was already on the stack, so we aren't increasing the number of
+        // bytes on the stack.
+        self.0.charge(1, 0, 2, 0, REFERENCE_SIZE.into())
+    }
+
+    fn charge_vec_pop_back(
+        &mut self,
+        _ty: impl TypeView,
+        _val: Option<impl ValueView>,
+    ) -> PartialVMResult<()> {
+        self.0.charge(1, 1, 1, 0, REFERENCE_SIZE.into())
+    }
+
+    fn charge_vec_unpack(
+        &mut self,
+        _ty: impl TypeView,
+        expect_num_elements: NumArgs,
+        _elems: impl ExactSizeIterator<Item = impl ValueView>,
+    ) -> PartialVMResult<()> {
+        // Charge for the pushes
+        let pushes = u64::from(expect_num_elements);
+        // The stack size stays pretty much the same modulo the additional vector size
+        self.0.charge(1, pushes, 1, 0, VEC_SIZE.into())
+    }
+
+    fn charge_vec_swap(&mut self, _ty: impl TypeView) -> PartialVMResult<()> {
+        let size_decrease = REFERENCE_SIZE + Type::U64.size() + Type::U64.size();
+        self.0.charge(1, 1, 1, 0, size_decrease.into())
+    }
+
+    fn charge_drop_frame(
+        &mut self,
+        _locals: impl Iterator<Item = impl ValueView>,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn remaining_gas(&self) -> InternalGas {
+        if !self.0.charge {
+            return InternalGas::new(u64::MAX);
+        }
+        self.0.gas_left
+    }
+
+    fn get_profiler_mut(&mut self) -> Option<&mut GasProfiler> {
+        self.0.profiler.as_mut()
+    }
+
+    fn set_profiler(&mut self, profiler: GasProfiler) {
+        self.0.profiler = Some(profiler);
+    }
+}
+
+fn abstract_memory_size(val: impl ValueView) -> AbstractMemorySize {
+    val.abstract_memory_size(false)
+}

--- a/iota-execution/latest/iota-adapter/src/lib.rs
+++ b/iota-execution/latest/iota-adapter/src/lib.rs
@@ -11,6 +11,7 @@ pub mod execution_engine;
 pub mod execution_mode;
 pub mod execution_value;
 pub mod gas_charger;
+pub mod gas_meter;
 pub mod programmable_transactions;
 pub mod temporary_store;
 pub mod type_layout_resolver;

--- a/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
+++ b/iota-execution/latest/iota-adapter/src/programmable_transactions/context.rs
@@ -60,6 +60,7 @@ mod checked {
             ObjectValue, RawValueType, ResultValue, TryFromValue, UsageKind, Value,
         },
         gas_charger::GasCharger,
+        gas_meter::IotaGasMeter,
         programmable_transactions::linkage_view::LinkageView,
         type_resolver::TypeTagResolver,
     };
@@ -207,10 +208,9 @@ mod checked {
 
                 let tx_digest = tx_context.digest();
                 let remaining_gas: u64 =
-                    move_vm_types::gas::GasMeter::remaining_gas(gas_charger.move_gas_status())
+                    move_vm_types::gas::GasMeter::remaining_gas(&IotaGasMeter(gas_charger.move_gas_status_mut()))
                         .into();
-                gas_charger
-                    .move_gas_status_mut()
+                IotaGasMeter(gas_charger.move_gas_status_mut())
                     .set_profiler(GasProfiler::init(
                         &vm.config().profiler_config,
                         format!("{tx_digest}"),
@@ -958,7 +958,7 @@ mod checked {
                 ty_args,
                 args,
                 &mut data_store,
-                gas_status,
+                &mut IotaGasMeter(gas_status),
                 &mut self.native_extensions,
                 tracer.as_mut(),
             )
@@ -1019,7 +1019,7 @@ mod checked {
                 modules,
                 sender,
                 &mut data_store,
-                self.gas_charger.move_gas_status_mut(),
+                &mut IotaGasMeter(self.gas_charger.move_gas_status_mut()),
             )
         }
     }

--- a/iota-execution/latest/iota-move-natives/Cargo.toml
+++ b/iota-execution/latest/iota-move-natives/Cargo.toml
@@ -26,4 +26,4 @@ move-binary-format.workspace = true
 move-core-types.workspace = true
 move-stdlib-natives = { path = "../../../external-crates/move/crates/move-stdlib-natives" }
 move-vm-runtime = { path = "../../../external-crates/move/crates/move-vm-runtime" }
-move-vm-types.workspace = true
+move-vm-types = { path = "../../../external-crates/move/crates/move-vm-types" }

--- a/scripts/execution_layer.py
+++ b/scripts/execution_layer.py
@@ -371,6 +371,7 @@ def cut_command(f):
     """Arguments for creating the cut for 'feature'."""
     return [
         *["./target/debug/cut", "--feature", f],
+        *[repo_root()],
         *["-d", f"iota-execution/latest:iota-execution/{f}:-latest"],
         *["-d", f"external-crates/move:external-crates/move/move-execution/{f}"],
         *["-p", "iota-adapter-latest"],
@@ -381,6 +382,7 @@ def cut_command(f):
         *["-p", "move-stdlib-natives"],
         *["-p", "move-vm-runtime"],
         *["-p", "bytecode-verifier-tests"],
+        *["-p", "move-vm-types"],
     ]
 
 
@@ -403,6 +405,7 @@ def cut_directories(f):
                 external / "move" / "crates" / "move-stdlib-natives",
                 external / "move" / "crates" / "move-vm-runtime",
                 external / "move" / "crates" / "bytecode-verifier-tests",
+                external / "move" / "crates" / "move-vm-types",
             ]
         )
     else:
@@ -413,6 +416,7 @@ def cut_directories(f):
                 external / "move" / "move-execution" / f / "crates" / "move-stdlib-natives",
                 external / "move" / "move-execution" / f / "crates" / "move-vm-runtime",
                 external / "move" / "move-execution" / f / "crates" / "bytecode-verifier-tests",
+                external / "move" / "move-execution" / f / "crates" / "move-vm-types",
             ]
         )
 


### PR DESCRIPTION
# Description of change

Since we don't need to pull a new gas model version, this PR contains only the changes related to `move-vm-types`, which is added as a part of the execution version cuts.

## Links to any relevant issues

fixes #7860
