### PR TITLE
fix(consensus): transactions missing in 'dag_state`

### DIFF
--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -223,14 +223,18 @@ impl DagState {
 
         for (i, round) in last_committed_rounds.into_iter().enumerate() {
             let authority_index = state.context.committee.to_authority_index(i).unwrap();
-            let (block_headers, eviction_round) = {
+            let (block_headers, transactions_by_author, eviction_round) = {
                 let eviction_round = Self::eviction_round(round, cached_rounds);
                 // TODO: scan for blocks?
                 let block_headers = state
                     .store
                     .scan_block_headers_by_author(authority_index, eviction_round + 1)
                     .expect("Database error");
-                (block_headers, eviction_round)
+                let transactions_by_author = state
+                    .store
+                    .scan_transactions_by_author(authority_index, eviction_round + 1)
+                    .expect("Database error");
+                (block_headers, transactions_by_author, eviction_round)
             };
 
             state.evicted_rounds[authority_index] = eviction_round;
@@ -238,6 +242,9 @@ impl DagState {
             // Update the block metadata for the authority.
             for block_header in &block_headers {
                 state.update_block_metadata(block_header);
+            }
+            for transactions in &transactions_by_author {
+                state.update_transaction_metadata(transactions);
             }
 
             info!(
@@ -355,6 +362,11 @@ impl DagState {
             .with_label_values(&[hostname])
             .set(highest_accepted_round_for_author as i64);
         self.update_cordial_knowledge(block_header);
+    }
+
+    fn update_transaction_metadata(&mut self, transaction: &VerifiedTransactions) {
+        self.recent_transactions
+            .insert(transaction.block_ref(), transaction.clone());
     }
 
     // Function updates who knows which BlockHeaders what after receiving a new
@@ -1154,39 +1166,6 @@ impl DagState {
         set.range(..upper_bound).cloned().collect()
     }
 
-    /// Updates the set of known block headers for a given authority assuming it
-    /// knows everything below certain round. Make use of BTree nature of
-    /// structure to efficiently prune the sets
-    pub(crate) fn update_known_block_headers_for_authority_by_round(
-        &mut self,
-        authority_index: usize,
-        target_round: Round,
-    ) {
-        // Construct an exclusive upper bound
-        let upper_bound = BlockRef::new(target_round, AuthorityIndex::MAX, BlockHeaderDigest::MAX);
-
-        // Split off entries greater than or equal to upper_bound
-        let old_set = &mut self.block_headers_not_known_by_authority[authority_index];
-        let new_set = old_set.split_off(&upper_bound);
-
-        // Replace with pruned set
-        *old_set = new_set;
-
-        let map = self
-            .recent_dag_cordial_knowledge
-            .get_mut(authority_index)
-            .expect("We expect authority index should be valid");
-
-        // Split off all entries with Round > target_round
-        let new_map = map.split_off(&(target_round + 1, BlockHeaderDigest::MIN));
-
-        // Replace the old map with the new one
-        *self
-            .recent_dag_cordial_knowledge
-            .get_mut(authority_index)
-            .expect("We expect authority index should be valid") = new_map;
-    }
-
     /// Takes a batch of at most MAX_HEADERS_PER_BUNDLE unknown headers for the
     /// given authority, but only from round smaller than
     /// round_upper_bound_exclusive. Marks these headers as known to the
@@ -1282,14 +1261,10 @@ impl DagState {
             let keep_from = (evict_round + 1, BlockHeaderDigest::MIN);
             *map = map.split_off(&keep_from);
         }
-
         // === 2. Evict from block_headers_not_known_by_authority ===
         for authority_index in 0..self.context.committee.size() {
-            let evict_round = self.evicted_rounds[authority_index];
-            self.update_known_block_headers_for_authority_by_round(
-                authority_index,
-                evict_round + 1,
-            );
+            let old_set = &mut self.block_headers_not_known_by_authority[authority_index];
+            old_set.retain(|block_ref| block_ref.round > self.evicted_rounds[block_ref.author]);
         }
     }
 

--- a/crates/starfish/core/src/storage/mem_store.rs
+++ b/crates/starfish/core/src/storage/mem_store.rs
@@ -241,27 +241,21 @@ impl Store for MemStore {
         Ok(found)
     }
 
-    fn scan_block_headers_by_author(
+    fn scan_references_by_author(
         &self,
         author: AuthorityIndex,
         start_round: Round,
-    ) -> ConsensusResult<Vec<VerifiedBlockHeader>> {
+    ) -> ConsensusResult<Vec<BlockRef>> {
         let inner = self.inner.read();
-        let mut refs = vec![];
-        for &(author, round, digest) in inner.digests_by_authorities.range((
-            Included((author, start_round, BlockHeaderDigest::MIN)),
-            Included((author, Round::MAX, BlockHeaderDigest::MAX)),
-        )) {
-            refs.push(BlockRef::new(round, author, digest));
-        }
-        let results = self.read_block_headers(refs.as_slice())?;
-        let mut block_headers = Vec::with_capacity(refs.len());
-        for (r, block_header) in refs.into_iter().zip(results.into_iter()) {
-            block_headers.push(block_header.unwrap_or_else(|| {
-                panic!("Storage inconsistency: block header {:?} not found!", r)
-            }));
-        }
-        Ok(block_headers)
+        let res = inner
+            .digests_by_authorities
+            .range((
+                Included((author, start_round, BlockHeaderDigest::MIN)),
+                Included((author, Round::MAX, BlockHeaderDigest::MAX)),
+            ))
+            .map(|(author, round, digest)| BlockRef::new(*round, *author, *digest))
+            .collect();
+        Ok(res)
     }
 
     fn read_last_commit(&self) -> ConsensusResult<Option<TrustedCommit>> {

--- a/crates/starfish/core/src/storage/mod.rs
+++ b/crates/starfish/core/src/storage/mod.rs
@@ -70,11 +70,40 @@ pub(crate) trait Store: Send + Sync {
         before_round: Option<Round>,
     ) -> ConsensusResult<Vec<VerifiedBlock>>;
 
+    fn scan_references_by_author(
+        &self,
+        author: AuthorityIndex,
+        start_round: Round,
+    ) -> ConsensusResult<Vec<BlockRef>>;
+
+    fn scan_transactions_by_author(
+        &self,
+        author: AuthorityIndex,
+        start_round: Round,
+    ) -> ConsensusResult<Vec<VerifiedTransactions>> {
+        let refs = self.scan_references_by_author(author, start_round)?;
+        let results = self
+            .read_transactions(refs.as_slice())?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        Ok(results)
+    }
     fn scan_block_headers_by_author(
         &self,
         author: AuthorityIndex,
         start_round: Round,
-    ) -> ConsensusResult<Vec<VerifiedBlockHeader>>;
+    ) -> ConsensusResult<Vec<VerifiedBlockHeader>> {
+        let refs = self.scan_references_by_author(author, start_round)?;
+        let results = self.read_block_headers(refs.as_slice())?;
+        let mut block_headers = Vec::with_capacity(refs.len());
+        for (r, block) in refs.into_iter().zip(results.into_iter()) {
+            block_headers.push(
+                block.unwrap_or_else(|| panic!("Storage inconsistency: block {:?} not found!", r)),
+            );
+        }
+        Ok(block_headers)
+    }
 
     /// Reads the last commit.
     fn read_last_commit(&self) -> ConsensusResult<Option<TrustedCommit>>;

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -31,7 +31,7 @@ use crate::{
 pub(crate) struct RocksDBStore {
     /// Stores SignedBlockHeader by refs.
     block_headers: DBMap<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
-    /// Stores SignedBlock by refs.
+    /// Stores Transactions by refs.
     transactions: DBMap<(Round, AuthorityIndex, BlockHeaderDigest), Bytes>,
     /// A secondary index that orders refs first by authors.
     digests_by_authorities: DBMap<(AuthorityIndex, Round, BlockHeaderDigest), ()>,
@@ -306,28 +306,21 @@ impl Store for RocksDBStore {
             .is_some();
         Ok(found)
     }
-
-    fn scan_block_headers_by_author(
+    fn scan_references_by_author(
         &self,
         author: AuthorityIndex,
         start_round: Round,
-    ) -> ConsensusResult<Vec<VerifiedBlockHeader>> {
-        let mut refs = vec![];
-        for kv in self.digests_by_authorities.safe_range_iter((
-            Included((author, start_round, BlockHeaderDigest::MIN)),
-            Included((author, Round::MAX, BlockHeaderDigest::MAX)),
-        )) {
-            let ((author, round, digest), _) = kv?;
-            refs.push(BlockRef::new(round, author, digest));
-        }
-        let results = self.read_block_headers(refs.as_slice())?;
-        let mut block_headers = Vec::with_capacity(refs.len());
-        for (r, block) in refs.into_iter().zip(results.into_iter()) {
-            block_headers.push(
-                block.unwrap_or_else(|| panic!("Storage inconsistency: block {:?} not found!", r)),
-            );
-        }
-        Ok(block_headers)
+    ) -> ConsensusResult<Vec<BlockRef>> {
+        self.digests_by_authorities
+            .safe_range_iter((
+                Included((author, start_round, BlockHeaderDigest::MIN)),
+                Included((author, Round::MAX, BlockHeaderDigest::MAX)),
+            ))
+            .map(|res| {
+                let ((author, round, digest), _) = res?;
+                Ok(BlockRef::new(round, author, digest))
+            })
+            .collect()
     }
 
     fn scan_blocks_by_author(


### PR DESCRIPTION
# Description of change

In `DagState::new` block headers were updated but transactions were not. This fix add an instruction to update the transactions as well

## Fix
- added `update_transaction_metadata` method to `DagState` and called it from `new`
- added `scan_transactions_by_author` method to `Store` which is used to collect the transactions from the store
- added `scan_references_by_author` as a `required` method to the  `Store` trait that is internally used by `scan_transactions_by_author` and `scan_block_headers_by_author` methods
- moved `scan_transactions_by_author` and `scan_block_headers_by_author` implementations to the `Store` trait making them `provided` methods.

## Links to any relevant issues
fixes #7940 .

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
