### PR TITLE
fix(core): use gas_owner() instead of sender() for gas object creation

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1772,7 +1772,7 @@ impl AuthorityState {
         let mut gas_object_refs = transaction.gas().to_vec();
         let reference_gas_price = epoch_store.reference_gas_price();
         let ((gas_status, checked_input_objects), mock_gas) = if transaction.gas().is_empty() {
-            let sender = transaction.sender();
+            let sender = transaction.gas_owner();
             // use a 1B iota coin
             const NANOS_TO_IOTA: u64 = 1_000_000_000;
             const DRY_RUN_IOTA: u64 = 1_000_000_000;
@@ -1957,7 +1957,7 @@ impl AuthorityState {
         // make a gas object if one was not provided
         let mut gas_object_refs = transaction.gas().to_vec();
         let ((gas_status, checked_input_objects), mock_gas) = if transaction.gas().is_empty() {
-            let sender = transaction.sender();
+            let sender = transaction.gas_owner();
             // use a 1B iota coin
             const NANOS_TO_IOTA: u64 = 1_000_000_000;
             const DRY_RUN_IOTA: u64 = 1_000_000_000;

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1769,6 +1769,7 @@ impl AuthorityState {
         )?;
 
         // make a gas object if one was not provided
+        let mut transaction = transaction;
         let mut gas_object_refs = transaction.gas().to_vec();
         let reference_gas_price = epoch_store.reference_gas_price();
         let ((gas_status, checked_input_objects), mock_gas) = if transaction.gas().is_empty() {
@@ -1785,6 +1786,8 @@ impl AuthorityState {
             );
             let gas_object_ref = gas_object.compute_object_reference();
             gas_object_refs = vec![gas_object_ref];
+            // Add gas object to transaction gas payment
+            transaction.gas_data_mut().payment = gas_object_refs.clone();
             (
                 iota_transaction_checks::check_transaction_input_with_given_gas(
                     epoch_store.protocol_config(),
@@ -1953,8 +1956,8 @@ impl AuthorityState {
             &receiving_object_refs,
             epoch_store.epoch(),
         )?;
-
         // make a gas object if one was not provided
+        let mut transaction = transaction;
         let mut gas_object_refs = transaction.gas().to_vec();
         let ((gas_status, checked_input_objects), mock_gas) = if transaction.gas().is_empty() {
             let sender = transaction.gas_owner();
@@ -1970,6 +1973,9 @@ impl AuthorityState {
             );
             let gas_object_ref = gas_object.compute_object_reference();
             gas_object_refs = vec![gas_object_ref];
+
+            // Add the gas object to the transaction payment.
+            transaction.gas_data_mut().payment = gas_object_refs.clone();
             (
                 iota_transaction_checks::check_transaction_input_with_given_gas(
                     epoch_store.protocol_config(),


### PR DESCRIPTION
# Description of change

1. Replace `transaction.sender()` with `transaction.gas_owner()` when creating mock gas objects in `dry_exec_transaction_impl()` and `simulate_transaction_impl()`.
This ensures that gas objects are properly owned by the gas sponsor in sponsored transactions, rather than the transaction sender.

2. Include the mock gas object in the transaction's gas payment for both `dry_exec_transaction_impl()` and `simulate_transaction_impl()`. Previously, it wasn't added, causing misalignment of `transaction.gas()` in `check_objects()`.

## Links to any relevant issues

Fixes #7892 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

