### PR TITLE
upstream(benchmark): Remove unneeded timeout

### DIFF
--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -896,12 +896,7 @@ mod test {
             .await
             .into();
 
-        tokio::time::timeout(
-            Duration::from_secs(120),
-            test_simulated_load(test_cluster, 60),
-        )
-        .await
-        .expect("test_backpressure timed out");
+        test_simulated_load(test_cluster, 60).await;
     }
 
     fn handle_bool_failpoint(


### PR DESCRIPTION
# Description of change

Removes an unneeded timeout that causes the nightlies to fail.
Ports https://github.com/MystenLabs/sui/commit/332ef78426cdf0d7b6a9e4b03195339c119747c3 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes