### PR TITLE
feat(consensus): add authority index to traces

### DIFF
--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -152,7 +152,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
             tx_shutdown,
         }
     }
-
+    #[cfg_attr(test,tracing::instrument(skip_all, name ="",fields(authority = %self.inner.context.own_index)))]
     async fn schedule_loop(mut self, mut rx_shutdown: oneshot::Receiver<()>) {
         let mut interval = tokio::time::interval(Duration::from_secs(2));
         interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
@@ -449,6 +449,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
     // a request succeeds where at least a prefix of the commit range is
     // fetched. Returns the fetched commits and block headers referenced by the
     // commits.
+    #[cfg_attr(test,tracing::instrument(skip_all, name ="",fields(authority = %inner.context.own_index)))]
     async fn fetch_loop(
         inner: Arc<Inner<C>>,
         commit_range: CommitRange,

--- a/crates/starfish/core/src/core_thread.rs
+++ b/crates/starfish/core/src/core_thread.rs
@@ -175,6 +175,7 @@ struct CoreThread {
 }
 
 impl CoreThread {
+    #[cfg_attr(test,tracing::instrument(skip_all, name ="",fields(authority = %self.context.own_index)))]
     pub async fn run(mut self) -> ConsensusResult<()> {
         tracing::debug!("Started core thread");
 

--- a/crates/starfish/core/src/synchronizer.rs
+++ b/crates/starfish/core/src/synchronizer.rs
@@ -350,6 +350,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
     }
 
     // The main loop to listen for the submitted commands.
+    #[cfg_attr(test,tracing::instrument(skip_all, name ="",fields(authority = %self.context.own_index)))]
     async fn run(&mut self) {
         // We want the synchronizer to run periodically every 500ms to fetch any missing
         // blocks.
@@ -460,7 +461,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             }
         }
     }
-
     async fn fetch_block_headers_from_authority(
         peer_index: AuthorityIndex,
         network_client: Arc<C>,
@@ -802,7 +802,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         };
         (resp, blocks_guard, retries, peer, highest_rounds)
     }
-
+    #[cfg_attr(test,tracing::instrument(skip_all, name ="",fields(authority = %self.context.own_index)))]
     fn start_fetch_own_last_block_task(&mut self) {
         const FETCH_OWN_BLOCK_RETRY_DELAY: Duration = Duration::from_millis(1_000);
         const MAX_RETRY_DELAY_STEP: Duration = Duration::from_millis(4_000);
@@ -1084,6 +1084,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
     /// successfully responded and any corresponding additional ancestor blocks.
     /// Each element of the vector is a tuple which contains the requested
     /// missing block refs, the returned blocks and the peer authority index.
+    #[cfg_attr(test,tracing::instrument(skip_all, name ="",fields(authority = %context.own_index)))]
     async fn fetch_block_headers_from_authorities(
         context: Arc<Context>,
         inflight_block_headers: Arc<InflightBlockHeadersMap>,


### PR DESCRIPTION
# Description of change

Adds `{authority:[n]}:` in front of logs, where `n` is the `AuhtorityIndex`.
e.g:
```shell
2025-07-23T09:33:56.609802Z DEBUG {authority=[0]}: starfish_core::core: crates/starfish/core/src/core.rs:625: 0 transaction are consumed by a block
```


fixes #7944

Be sure to reference any related issues by adding `fixes #(issue)`.

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
