### PR TITLE
chore(*): Unpin tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -348,7 +348,7 @@ test-fuzz = "3.0.4"
 thiserror = "1.0.40"
 # tokio is defined at a specific version to support patching with iota-sim
 # Do not upgrade without updating https://github.com/iotaledger/iota-sim first
-tokio = "=1.46.1"
+tokio = "1.46.1"
 tokio-rustls = { version = "0.26", default-features = false, features = ["tls12", "ring"] }
 tokio-stream = { version = "0.1.14", features = ["sync", "net"] }
 tokio-util = "0.7.10"


### PR DESCRIPTION
## Description 

Unpins the `tokio` version.

NOTE: This means that simtests will be broken if the lock file tokio version is ever updated because of a new patch version.
