### PR TITLE
fix(iota-move): Add the missing test case to iota tests

### DIFF
--- a/crates/iota/tests/shell_tests/new_tests/new_uppercase_name.sh
+++ b/crates/iota/tests/shell_tests/new_tests/new_uppercase_name.sh
@@ -1,0 +1,12 @@
+# Copyright (c) Mysten Labs, Inc.
+# Modifications Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+# test that `iota move new` works as expected with `<NAME>` containing uppercase letter(s)
+iota move new _Example_A
+echo ==== files in project ====
+ls -A _Example_A
+echo ==== files in sources ====
+ls -A _Example_A/sources
+echo ==== files in tests =====
+ls -A _Example_A/tests

--- a/crates/iota/tests/snapshots/shell_tests__new_tests__new_uppercase_name.sh.snap
+++ b/crates/iota/tests/snapshots/shell_tests__new_tests__new_uppercase_name.sh.snap
@@ -1,0 +1,33 @@
+---
+source: crates/iota/tests/shell_tests.rs
+description: tests/shell_tests/new_tests/new_uppercase_name.sh
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# Modifications Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+# test that `iota move new` works as expected with `<NAME>` containing uppercase letter(s)
+iota move new _Example_A
+echo ==== files in project ====
+ls -A _Example_A
+echo ==== files in sources ====
+ls -A _Example_A/sources
+echo ==== files in tests =====
+ls -A _Example_A/tests
+
+----- results -----
+success: true
+exit_code: 0
+----- stdout -----
+==== files in project ====
+.gitignore
+Move.toml
+sources
+tests
+==== files in sources ====
+_example_a.move
+==== files in tests =====
+_example_a_tests.move
+
+----- stderr -----


### PR DESCRIPTION
# Description of change

Commit iotaledger/iota@a2a18ac missed the tests case, now it has been restored.

## Links to any relevant issues

fixes #7068 

## How the change has been tested

```rust
cargo nextest run -p iota -- new_uppercase_name
```

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
