### PR TITLE
fix(iota-move): Allow coverage gathering in release testing

### DIFF
--- a/crates/iota-move/Cargo.toml
+++ b/crates/iota-move/Cargo.toml
@@ -65,3 +65,6 @@ harness = false
 
 [lints]
 workspace = true
+
+[features]
+tracing = []

--- a/crates/iota-move/src/unit_test.rs
+++ b/crates/iota-move/src/unit_test.rs
@@ -42,9 +42,10 @@ impl Test {
         build_config: BuildConfig,
     ) -> anyhow::Result<UnitTestResult> {
         let compute_coverage = self.test.compute_coverage;
-        if !cfg!(debug_assertions) && compute_coverage {
+        if !cfg!(feature = "tracing") && compute_coverage {
             bail!(
-                "The --coverage flag is currently supported only in debug builds. Please build the IOTA CLI from source in debug mode."
+                "The --coverage flag is currently supported only in builds built with the `tracing` feature enabled. \
++                Please build the IOTA CLI from source with `--features tracing` to use this flag."
             );
         }
         // save disassembly if trace execution is enabled

--- a/crates/iota/Cargo.toml
+++ b/crates/iota/Cargo.toml
@@ -147,4 +147,4 @@ iota-names = [
   "dep:iota-names",
   "iota-sdk/iota-names",
 ]
-tracing = ["iota-types/tracing", "iota-execution/tracing"]
+tracing = ["iota-types/tracing", "iota-execution/tracing", "iota-move/tracing"]

--- a/external-crates/move/crates/move-cli/src/base/test.rs
+++ b/external-crates/move/crates/move-cli/src/base/test.rs
@@ -63,7 +63,8 @@ pub struct Test {
     #[clap(long = "verbose")]
     pub verbose_mode: bool,
     /// Collect coverage information for later use with the various `move
-    /// coverage` subcommands. Currently supported only in debug builds.
+    /// coverage` subcommands. Currently supported only in builds with `tracing`
+    /// feature enabled.
     #[clap(long = "coverage")]
     pub compute_coverage: bool,
 


### PR DESCRIPTION
# Description of change

Previously `iota move test --coverage` would only fail to execute in release builds.
Now the command can be executed, if `iota move` was built using `--features tracing` flag enabled.

This was the last change necessary to be able to run move coverage in release builds.

Contrary to the original change the `coverage` command message has been updated as well.

## Links to any relevant issues

fixes #7077 

## How the change has been tested

Run command, it should pass:
```
cargo run --release -p iota --features tracing -- move test --coverage -p crates/iota-framework/packages/iota-system
```

While running command, should fail:
```
cargo run --release -p iota  -- move test --coverage -p crates/iota-framework/packages/iota-system
```
with the expected error message:
```
The --coverage flag is currently supported only in builds built with the `tracing` feature enabled. +                Please build the IOTA CLI from source with `--features tracing` to use this flag.
```

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
