### PR TITLE
refactor(iota-execution): Enable ChildObjectEffect versioning

### DIFF
--- a/iota-execution/latest/iota-move-natives/src/object_runtime/mod.rs
+++ b/iota-execution/latest/iota-move-natives/src/object_runtime/mod.rs
@@ -41,7 +41,7 @@ use move_vm_types::{
 use object_store::{ActiveChildObject, ChildObjectStore};
 use tracing::error;
 
-use self::object_store::{ChildObjectEffect, ObjectResult};
+use self::object_store::{ChildObjectEffectV0, ChildObjectEffects, ObjectResult};
 use super::get_object_id;
 
 pub enum ObjectEvent {
@@ -530,7 +530,7 @@ impl ObjectRuntimeState {
     pub(crate) fn finish(
         mut self,
         loaded_child_objects: BTreeMap<ObjectID, DynamicallyLoadedObjectMetadata>,
-        child_object_effects: BTreeMap<ObjectID, ChildObjectEffect>,
+        child_object_effects: ChildObjectEffects,
     ) -> Result<RuntimeResults, ExecutionError> {
         let mut loaded_child_objects: BTreeMap<_, _> = loaded_child_objects
             .into_iter()
@@ -544,46 +544,7 @@ impl ObjectRuntimeState {
                 )
             })
             .collect();
-        for (child, child_object_effect) in child_object_effects {
-            let ChildObjectEffect {
-                owner: parent,
-                ty,
-                effect,
-            } = child_object_effect;
-
-            if let Some(loaded_child) = loaded_child_objects.get_mut(&child) {
-                loaded_child.is_modified = true;
-            }
-
-            match effect {
-                // was modified, so mark it as mutated and transferred
-                Op::Modify(v) => {
-                    debug_assert!(!self.transfers.contains_key(&child));
-                    debug_assert!(!self.new_ids.contains(&child));
-                    debug_assert!(loaded_child_objects.contains_key(&child));
-                    self.transfers
-                        .insert(child, (Owner::ObjectOwner(parent.into()), ty, v));
-                }
-
-                Op::New(v) => {
-                    debug_assert!(!self.transfers.contains_key(&child));
-                    self.transfers
-                        .insert(child, (Owner::ObjectOwner(parent.into()), ty, v));
-                }
-
-                Op::Delete => {
-                    // was transferred so not actually deleted
-                    if self.transfers.contains_key(&child) {
-                        debug_assert!(!self.deleted_ids.contains(&child));
-                    }
-                    // ID was deleted too was deleted so mark as deleted
-                    if self.deleted_ids.contains(&child) {
-                        debug_assert!(!self.transfers.contains_key(&child));
-                        debug_assert!(!self.new_ids.contains(&child));
-                    }
-                }
-            }
-        }
+        self.apply_child_object_effects(&mut loaded_child_objects, child_object_effects);
         let ObjectRuntimeState {
             input_objects: _,
             new_ids,
@@ -654,6 +615,65 @@ impl ObjectRuntimeState {
 
     pub fn incr_total_events_size(&mut self, size: u64) {
         self.total_events_size += size;
+    }
+
+    fn apply_child_object_effects(
+        &mut self,
+        loaded_child_objects: &mut BTreeMap<ObjectID, LoadedRuntimeObject>,
+        child_object_effects: ChildObjectEffects,
+    ) {
+        match child_object_effects {
+            ChildObjectEffects::V0(child_object_effects) => {
+                self.apply_child_object_effects_v0(loaded_child_objects, child_object_effects)
+            }
+        }
+    }
+
+    fn apply_child_object_effects_v0(
+        &mut self,
+        loaded_child_objects: &mut BTreeMap<ObjectID, LoadedRuntimeObject>,
+        child_object_effects: BTreeMap<ObjectID, ChildObjectEffectV0>,
+    ) {
+        for (child, child_object_effect) in child_object_effects {
+            let ChildObjectEffectV0 {
+                owner: parent,
+                ty,
+                effect,
+            } = child_object_effect;
+
+            if let Some(loaded_child) = loaded_child_objects.get_mut(&child) {
+                loaded_child.is_modified = true;
+            }
+
+            match effect {
+                // was modified, so mark it as mutated and transferred
+                Op::Modify(v) => {
+                    debug_assert!(!self.transfers.contains_key(&child));
+                    debug_assert!(!self.new_ids.contains(&child));
+                    debug_assert!(loaded_child_objects.contains_key(&child));
+                    self.transfers
+                        .insert(child, (Owner::ObjectOwner(parent.into()), ty, v));
+                }
+
+                Op::New(v) => {
+                    debug_assert!(!self.transfers.contains_key(&child));
+                    self.transfers
+                        .insert(child, (Owner::ObjectOwner(parent.into()), ty, v));
+                }
+
+                Op::Delete => {
+                    // was transferred so not actually deleted
+                    if self.transfers.contains_key(&child) {
+                        debug_assert!(!self.deleted_ids.contains(&child));
+                    }
+                    // ID was deleted too was deleted so mark as deleted
+                    if self.deleted_ids.contains(&child) {
+                        debug_assert!(!self.transfers.contains_key(&child));
+                        debug_assert!(!self.new_ids.contains(&child));
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/iota-execution/latest/iota-move-natives/src/object_runtime/object_store.rs
+++ b/iota-execution/latest/iota-move-natives/src/object_runtime/object_store.rs
@@ -51,10 +51,16 @@ struct ConfigSetting {
 }
 
 #[derive(Debug)]
-pub(crate) struct ChildObjectEffect {
+pub(crate) struct ChildObjectEffectV0 {
     pub(super) owner: ObjectID,
     pub(super) ty: Type,
     pub(super) effect: Op<Value>,
+}
+
+pub(crate) enum ChildObjectEffects {
+    // In this version, we accurately track mutations via WriteRef to the child object, or
+    // references rooted in the child object.
+    V0(BTreeMap<ObjectID, ChildObjectEffectV0>),
 }
 
 struct Inner<'a> {
@@ -700,8 +706,8 @@ impl<'a> ChildObjectStore<'a> {
     }
 
     // retrieve the `Op` effects for the child objects
-    pub(super) fn take_effects(&mut self) -> BTreeMap<ObjectID, ChildObjectEffect> {
-        std::mem::take(&mut self.store)
+    pub(super) fn take_effects(&mut self) -> ChildObjectEffects {
+        let v0_effects = std::mem::take(&mut self.store)
             .into_iter()
             .filter_map(|(id, child_object)| {
                 let ChildObject {
@@ -711,10 +717,11 @@ impl<'a> ChildObjectStore<'a> {
                     value,
                 } = child_object;
                 let effect = value.into_effect()?;
-                let child_effect = ChildObjectEffect { owner, ty, effect };
+                let child_effect = ChildObjectEffectV0 { owner, ty, effect };
                 Some((id, child_effect))
             })
-            .collect()
+            .collect();
+        ChildObjectEffects::V0(v0_effects)
     }
 
     pub(super) fn all_active_objects(&self) -> impl Iterator<Item = ActiveChildObject<'_>> {
@@ -741,5 +748,11 @@ impl<'a> ChildObjectStore<'a> {
                 copied_value: copied_child_value,
             }
         })
+    }
+}
+
+impl ChildObjectEffects {
+    pub(crate) fn empty() -> Self {
+        ChildObjectEffects::V0(BTreeMap::new())
     }
 }

--- a/iota-execution/latest/iota-move-natives/src/test_scenario.rs
+++ b/iota-execution/latest/iota-move-natives/src/test_scenario.rs
@@ -42,7 +42,7 @@ use smallvec::smallvec;
 
 use crate::{
     get_nth_struct_field, get_tag_and_layouts, legacy_test_cost,
-    object_runtime::{ObjectRuntime, RuntimeResults},
+    object_runtime::{ObjectRuntime, RuntimeResults, object_store::ChildObjectEffects},
 };
 
 const E_COULD_NOT_GENERATE_EFFECTS: u64 = 0;
@@ -143,7 +143,7 @@ pub fn end_transaction(
     // Determine writes and deletes
     // We pass the received objects since they should be viewed as "loaded" for the
     // purposes of of calculating the effects of the transaction.
-    let results = object_runtime_state.finish(received, BTreeMap::new());
+    let results = object_runtime_state.finish(received, ChildObjectEffects::empty());
     let RuntimeResults {
         writes,
         user_events,


### PR DESCRIPTION
# Description of change

No behavior changes, just ChildObjectEffects turns into an enum to support possible future versions.

## Links to any relevant issues

fixes #7091 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
