### PR TITLE
fix(iota-core): bump object execution slots only if `max_execution_duration_per_commit` is `Some`

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -3505,7 +3505,13 @@ impl AuthorityPerEpochStore {
                         }
 
                         // This certificate will be scheduled. Update object execution slots.
-                        if certificate.contains_shared_object() {
+                        // We only need to do this if `max_execution_duration_per_commit` is
+                        // `Some`, since otherwise this bumping will panic as object
+                        // execution slots are only initialized if
+                        // `max_execution_duration_per_commit` is not `None`.
+                        if certificate.contains_shared_object()
+                            && self.get_max_execution_duration_per_commit().is_some()
+                        {
                             shared_object_congestion_tracker
                                 .bump_object_execution_slots(&certificate, start_time);
                         }


### PR DESCRIPTION
# Description of change

Since object execution slots for the sequencer are only initialized if `max_execution_duration_per_commit` is `Some`, we should only bump object execution slots using the same condition. Otherwise, `bump_object_execution_slots` will panic with `object execution slot should have been initialized before.`.

## Links to any relevant issues

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
