### PR TITLE
fix(starfish): Fix tests test_restart_authority_committee

### DIFF
--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -391,22 +391,22 @@ mod tests {
     /// with the rest of the committee.
     #[rstest]
     #[tokio::test(flavor = "current_thread")]
-    async fn test_restart_authority_committee() {
-        telemetry_subscribers::init_for_testing();
+    async fn test_restart_authority_committee(#[values(4, 6)] num_of_authorities: usize) {
+        // telemetry_subscribers::init_for_testing();
         let db_registry = Registry::new();
         DBMetrics::init(&db_registry);
 
-        const NUM_OF_AUTHORITIES: usize = 4;
-        let (committee, keypairs) = local_committee_and_keys(0, [1; NUM_OF_AUTHORITIES].to_vec());
+        let (committee, keypairs) =
+            local_committee_and_keys(0, vec![1; num_of_authorities].to_vec());
         let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
 
-        let temp_dirs = (0..NUM_OF_AUTHORITIES)
+        let temp_dirs = (0..num_of_authorities)
             .map(|_| TempDir::new().unwrap())
             .collect::<Vec<_>>();
 
         let mut output_receivers = Vec::with_capacity(committee.size());
         let mut authorities = Vec::with_capacity(committee.size());
-        let mut boot_counters = [0; NUM_OF_AUTHORITIES];
+        let mut boot_counters = vec![0; num_of_authorities];
         let mut consumer_monitors = Vec::with_capacity(committee.size());
 
         for (index, _authority_info) in committee.authorities() {
@@ -510,10 +510,10 @@ mod tests {
         let mut expected_transactions = submitted_transactions.clone();
 
         let start_time = Instant::now();
-        let mut last_committed_index = [0, 4];
-        let mut last_round_committed_blocks = [0, 4];
+        let mut last_committed_index = vec![0; num_of_authorities];
+        let mut last_round_committed_blocks = vec![0; num_of_authorities];
         loop {
-            if start_time.elapsed() > Duration::from_secs(15) {
+            if start_time.elapsed() > Duration::from_secs(30) {
                 break;
             }
             for (index, receiver) in output_receivers.iter_mut().enumerate() {

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -324,7 +324,11 @@ impl ConsensusAuthority {
 mod tests {
     #![allow(non_snake_case)]
 
-    use std::{collections::BTreeMap, sync::Arc, time::Duration};
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        sync::Arc,
+        time::Duration,
+    };
 
     use iota_metrics::monitored_mpsc::{UnboundedReceiver, unbounded_channel};
     use iota_protocol_config::ProtocolConfig;
@@ -383,7 +387,8 @@ mod tests {
         authority.stop().await;
     }
 
-    // TODO: add transactions to control how the consensus works
+    /// This test checks that an authority can be restarted and still get synced
+    /// with the rest of the committee.
     #[rstest]
     #[tokio::test(flavor = "current_thread")]
     async fn test_restart_authority_committee() {
@@ -402,9 +407,10 @@ mod tests {
         let mut output_receivers = Vec::with_capacity(committee.size());
         let mut authorities = Vec::with_capacity(committee.size());
         let mut boot_counters = [0; NUM_OF_AUTHORITIES];
+        let mut consumer_monitors = Vec::with_capacity(committee.size());
 
         for (index, _authority_info) in committee.authorities() {
-            let (authority, receiver) = make_authority(
+            let (authority, receiver, monitor) = make_authority(
                 index,
                 &temp_dirs[index.value()],
                 committee.clone(),
@@ -415,16 +421,79 @@ mod tests {
             .await;
             boot_counters[index] += 1;
             output_receivers.push(receiver);
+            consumer_monitors.push(monitor);
             authorities.push(authority);
         }
 
+        const NUM_TRANSACTIONS: u8 = 15;
+        let mut submitted_transactions = BTreeSet::<Vec<u8>>::new();
+        for i in 0..NUM_TRANSACTIONS {
+            let txn = vec![i; 16];
+            submitted_transactions.insert(txn.clone());
+            authorities[i as usize % authorities.len()]
+                .transaction_client()
+                .submit(vec![txn])
+                .await
+                .unwrap();
+        }
+
+        for (index, receiver) in output_receivers.iter_mut().enumerate() {
+            let mut expected_transactions = submitted_transactions.clone();
+            loop {
+                let committed_subdag =
+                    tokio::time::timeout(Duration::from_secs(1), receiver.recv())
+                        .await
+                        .unwrap()
+                        .unwrap();
+                let commit_index = committed_subdag.commit_ref.index;
+                consumer_monitors[index].set_highest_handled_commit(commit_index);
+                for txns in committed_subdag.transactions {
+                    for txn in txns.transactions().iter().map(|t| t.data().to_vec()) {
+                        assert!(
+                            expected_transactions.remove(&txn),
+                            "Transaction not submitted or already seen: {txn:?}"
+                        );
+                    }
+                }
+
+                if expected_transactions.is_empty() {
+                    break;
+                }
+            }
+        }
         // Stop authority 1.
         let index = committee.to_authority_index(1).unwrap();
         authorities.remove(index.value()).stop().await;
-        sleep(Duration::from_secs(10)).await;
+
+        // Add some new transactions while authority 1 is down.
+        const BIG_NUM_TRANSACTIONS: u8 = 100;
+        for i in NUM_TRANSACTIONS..BIG_NUM_TRANSACTIONS {
+            let txn = vec![i; 16];
+            submitted_transactions.insert(txn.clone());
+            authorities[i as usize % authorities.len()]
+                .transaction_client()
+                .submit(vec![txn])
+                .await
+                .unwrap();
+        }
+
+        sleep(Duration::from_secs(5)).await;
+
+        // After a long sleep, add some new transactions while authority 1 is down.
+        // We expect that the transaction synchronizer of authority 1 will kick in to
+        // download the transactions that were submitted while it was down.
+        for i in BIG_NUM_TRANSACTIONS..2 * BIG_NUM_TRANSACTIONS {
+            let txn = vec![i; 16];
+            submitted_transactions.insert(txn.clone());
+            authorities[i as usize % authorities.len()]
+                .transaction_client()
+                .submit(vec![txn])
+                .await
+                .unwrap();
+        }
 
         // Restart authority 1 and let it run.
-        let (authority, receiver) = make_authority(
+        let (authority, receiver, monitor) = make_authority(
             index,
             &temp_dirs[index.value()],
             committee.clone(),
@@ -435,12 +504,86 @@ mod tests {
         .await;
         boot_counters[index] += 1;
         output_receivers[index] = receiver;
+        consumer_monitors[index] = monitor;
         authorities.insert(index.value(), authority);
-        sleep(Duration::from_secs(10)).await;
+
+        let mut expected_transactions = submitted_transactions.clone();
+
+        let start_time = Instant::now();
+        let mut last_committed_index = [0, 4];
+        let mut last_round_committed_blocks = [0, 4];
+        loop {
+            if start_time.elapsed() > Duration::from_secs(15) {
+                break;
+            }
+            for (index, receiver) in output_receivers.iter_mut().enumerate() {
+                // Manually update the commit consumer monitor with the highest handled commit
+                let deadline = Instant::now() + Duration::from_millis(25);
+                while Instant::now() < deadline {
+                    let remaining = deadline - Instant::now();
+                    if let Ok(Some(committed_subdag)) =
+                        tokio::time::timeout(remaining, receiver.recv()).await
+                    {
+                        for block in &committed_subdag.blocks {
+                            if block.round() > GENESIS_ROUND {
+                                let author_index = block.author();
+                                last_round_committed_blocks[author_index] = block.round();
+                            }
+                        }
+
+                        if index == 1 {
+                            for txns in &committed_subdag.transactions {
+                                for txn in txns.transactions().iter().map(|t| t.data().to_vec()) {
+                                    assert!(
+                                        expected_transactions.remove(&txn),
+                                        "Transaction not submitted or already seen: {txn:?}"
+                                    );
+                                }
+                            }
+                        }
+                        let commit_index = committed_subdag.commit_ref.index;
+                        last_committed_index[index] = commit_index;
+                        consumer_monitors[index].set_highest_handled_commit(commit_index);
+                    } else {
+                        // If we time out, we assume that no new dags were committed.
+                        break;
+                    }
+                }
+            }
+        }
+
         // Stop all authorities and exit.
         for authority in authorities {
             authority.stop().await;
         }
+
+        // Expect that authorities get synced and commit indices are close enough.
+        let min_commit_index = last_committed_index.iter().min().unwrap();
+        let max_commit_index = last_committed_index.iter().max().unwrap();
+        assert!(
+            max_commit_index - min_commit_index < 5,
+            "Commit indices are not close enough: min = {}, max = {}",
+            min_commit_index,
+            max_commit_index
+        );
+
+        // Expect that all transactions were submitted and processed.
+        assert!(
+            expected_transactions.is_empty(),
+            "Not all transactions were submitted or processed: {:?}",
+            expected_transactions
+        );
+
+        // Expect that all authorities have committed blocks in rounds that are close
+        // enough.
+        let min_round = last_round_committed_blocks.iter().min().unwrap();
+        let max_round = last_round_committed_blocks.iter().max().unwrap();
+        assert!(
+            max_round - min_round < 5,
+            "Committed block rounds are not close enough: min = {}, max = {}",
+            min_round,
+            max_round
+        );
     }
 
     // TODO: add transactions to control how the consensus works
@@ -462,7 +605,7 @@ mod tests {
         let mut boot_counters = vec![0; num_authorities];
 
         for (index, _authority_info) in committee.authorities() {
-            let (authority, receiver) = make_authority(
+            let (authority, receiver, _) = make_authority(
                 index,
                 &temp_dirs[index.value()],
                 committee.clone(),
@@ -482,7 +625,7 @@ mod tests {
         sleep(Duration::from_secs(10)).await;
 
         // Restart authority 0 and let it run.
-        let (authority, receiver) = make_authority(
+        let (authority, receiver, _) = make_authority(
             index,
             &temp_dirs[index.value()],
             committee.clone(),
@@ -521,7 +664,7 @@ mod tests {
 
         for (index, _authority_info) in committee.authorities() {
             let dir = TempDir::new().unwrap();
-            let (authority, receiver) = make_authority(
+            let (authority, receiver, _) = make_authority(
                 index,
                 &dir,
                 committee.clone(),
@@ -541,8 +684,7 @@ mod tests {
         }
 
         // Now we take the receiver of authority 1 and we wait until we see at least one
-        // block committed from this authority We wait until we see at least one
-        // committed block authored from this authority. That way we'll be 100% sure
+        // block committed from this authority. That way we'll be 100% sure
         // that at least one block has been proposed and successfully received
         // by a quorum of nodes.
         let index_1 = committee.to_authority_index(1).unwrap();
@@ -561,24 +703,23 @@ mod tests {
         // Stop authority 1 & 2.
         // * Authority 1 will be used to wipe out their DB and practically "force" the
         //   amnesia recovery.
-        // * Authority 2 is stopped in order to simulate less than f+1 availability
+        // * Authority 2 is stopped in order to simulate less than 2f+1 availability
         //   which will
         // make authority 1 retry during amnesia recovery until it has finally managed
-        // to successfully get back f+1 responses. once authority 2 is up and
+        // to successfully get back 2f+1 responses. once authority 2 is up and
         // running again.
         authorities.remove(&index_1).unwrap().stop().await;
         let index_2 = committee.to_authority_index(2).unwrap();
         authorities.remove(&index_2).unwrap().stop().await;
         sleep(Duration::from_secs(5)).await;
 
-        // Authority 1: create a new directory to simulate amnesia. The node will start
-        // having participated previously to consensus but now will attempt to
-        // synchronize the last own block and recover from there. It won't be able
-        // to do that successfully as authority 2 is still down.
+        // Authority 1: create a new directory to simulate amnesia. The node will
+        // attempt to synchronize the last own block and recover from there. It
+        // won't be able to do that successfully as authority 2 is still down.
         let dir = TempDir::new().unwrap();
         // We do reset the boot counter for this one to simulate a "binary" restart
         boot_counters[index_1] = 0;
-        let (authority, mut receiver) = make_authority(
+        let (authority, mut receiver, _) = make_authority(
             index_1,
             &dir,
             committee.clone(),
@@ -599,7 +740,7 @@ mod tests {
         // Now spin up authority 2 using its earlier directly - so no amnesia recovery
         // should be forced here. Authority 1 should be able to recover from
         // amnesia successfully.
-        let (authority, _receiver) = make_authority(
+        let (authority, _receiver, _) = make_authority(
             index_2,
             &temp_dirs[&index_2],
             committee.clone(),
@@ -640,7 +781,11 @@ mod tests {
         keypairs: Vec<(NetworkKeyPair, ProtocolKeyPair)>,
         boot_counter: u64,
         protocol_config: ProtocolConfig,
-    ) -> (ConsensusAuthority, UnboundedReceiver<CommittedSubDag>) {
+    ) -> (
+        ConsensusAuthority,
+        UnboundedReceiver<CommittedSubDag>,
+        Arc<CommitConsumerMonitor>,
+    ) {
         let registry = Registry::new();
 
         // Cache less blocks to exercise commit sync.
@@ -660,6 +805,8 @@ mod tests {
         let (sender, receiver) = unbounded_channel("consensus_output");
         let commit_consumer = CommitConsumer::new(sender, 0);
 
+        let consensus_consumer_monitor = commit_consumer.monitor();
+
         let authority = ConsensusAuthority::start(
             index,
             committee,
@@ -674,6 +821,6 @@ mod tests {
         )
         .await;
 
-        (authority, receiver)
+        (authority, receiver, consensus_consumer_monitor)
     }
 }

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -225,7 +225,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let verified_block = VerifiedBlock::new(verified_block_header, verified_transactions);
 
         let block_ref = verified_block.reference();
-        debug!("Received block {} via send block.", block_ref);
+        debug!("Received block {} via stream block bundle.", block_ref);
 
         // 2. Reject block with timestamp too far in the future.
         let now = self.context.clock.timestamp_utc_ms();
@@ -529,6 +529,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 let mut dag_state_guard = dag_state.write();
                 let block_headers =
                     dag_state_guard.take_unknown_headers_for_authority(peer, block.round());
+                drop(dag_state_guard);
                 let block_bundle = BlockBundle {
                     verified_block: block,
                     verified_headers: block_headers,

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -761,6 +761,33 @@ impl VerifiedBlock {
         }
     }
 
+    #[cfg(test)]
+    pub fn new_with_transaction_for_test(block_header: BlockHeader, tx: u8) -> Self {
+        let verified_block_header = VerifiedBlockHeader::new_for_test(block_header);
+        let verified_transactions = VerifiedTransactions::new(
+            vec![],
+            BlockRef::new(
+                verified_block_header.round(),
+                verified_block_header.author(),
+                verified_block_header.digest(),
+            ),
+            verified_block_header.transactions_commitment(),
+            Bytes::from(
+                bcs::to_bytes::<Vec<Transaction>>(
+                    &vec![vec![tx; 16]]
+                        .into_iter()
+                        .map(Transaction::new)
+                        .collect(),
+                )
+                .unwrap(),
+            ),
+        );
+        Self {
+            verified_block_header,
+            verified_transactions,
+        }
+    }
+
     // This function returns a pair of serialized block header and serialized
     // transactions
     pub fn serialized(&self) -> (&Bytes, &Bytes) {
@@ -872,6 +899,28 @@ impl TestBlockHeader {
                 author: author.into(),
                 transactions_commitment: TransactionsCommitment::compute_transactions_commitment(
                     &Bytes::from(bcs::to_bytes::<Vec<Transaction>>(&vec![]).unwrap()),
+                )
+                .unwrap(),
+                ..Default::default()
+            },
+        }
+    }
+
+    pub fn new_with_transaction(round: Round, author: u32, tx: u8) -> Self {
+        Self {
+            block_header: BlockHeaderV1 {
+                round,
+                author: author.into(),
+                transactions_commitment: TransactionsCommitment::compute_transactions_commitment(
+                    &Bytes::from(
+                        bcs::to_bytes::<Vec<Transaction>>(
+                            &vec![vec![tx; 16]]
+                                .into_iter()
+                                .map(Transaction::new)
+                                .collect(),
+                        )
+                        .unwrap(),
+                    ),
                 )
                 .unwrap(),
                 ..Default::default()

--- a/crates/starfish/core/src/commit.rs
+++ b/crates/starfish/core/src/commit.rs
@@ -861,7 +861,6 @@ mod tests {
     };
 
     #[tokio::test]
-    #[ignore = "Finish implementing this test when Transaction storage is ready"]
     async fn test_new_committed_subdag_from_commit() {
         let store = Arc::new(MemStore::new());
         let context = Arc::new(Context::new_for_test(4).0);
@@ -876,8 +875,9 @@ mod tests {
             .authorities()
             .map(|index| {
                 let author_idx = index.0.value() as u32;
-                let block = TestBlockHeader::new(0, author_idx).build();
-                VerifiedBlock::new_for_test(block)
+                let tx = index.0.value() as u8;
+                let block = TestBlockHeader::new_with_transaction(0, author_idx, tx).build();
+                VerifiedBlock::new_with_transaction_for_test(block, tx)
             })
             .map(|block| {
                 (
@@ -897,7 +897,6 @@ mod tests {
             )
             .unwrap();
         blocks.append(&mut first_round_references.clone());
-        // TODO: create some data for blocks in the first round
 
         let mut ancestors = first_round_references.clone();
         let mut leader = None;
@@ -954,6 +953,13 @@ mod tests {
         assert_eq!(subdag.commit_ref, commit.reference());
         assert_eq!(subdag.committed_transaction_refs, first_round_references);
         assert_eq!(subdag.reputation_scores_desc, vec![]);
+        let transactions = store
+            .read_transactions(&subdag.committed_transaction_refs)
+            .expect("We should have the transactions referenced in the commit data")
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        assert_eq!(transactions.len(), 4);
     }
 
     #[tokio::test]

--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -364,7 +364,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
                             .inc();
                     }
                     if !missing_committed_txns.is_empty() {
-                        debug!(
+                        info!(
                             "Fetched blocks have missing committed transactions: {:?} for commit range {:?}",
                             missing_committed_txns, fetched_commit_range
                         );

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -393,10 +393,13 @@ impl Core {
         let _scope = monitored_scope("Core::add_transactions");
 
         // Add transactions to the dag state.
-        let mut dag_state = self.dag_state.write();
+        let mut dag_state_guard = self.dag_state.write();
         for transaction in transactions {
-            dag_state.add_transactions(transaction);
+            dag_state_guard.add_transactions(transaction);
         }
+        // Safe to drop the guard here as the write/read locks will be asquired in
+        // commit_observer
+        drop(dag_state_guard);
 
         // After adding transactions, some pending subdags might be committable.
         // Commit observer is called with an empty vector of new leaders to check if all
@@ -713,12 +716,14 @@ impl Core {
         assert_eq!(accepted_blocks.len(), 1);
         assert!(missing.is_empty());
         // Ensure the new block and its ancestors are persisted, before broadcasting it.
-        self.dag_state.write().flush();
-
+        let mut dag_state_guard = self.dag_state.write();
+        dag_state_guard.flush();
+        drop(dag_state_guard);
         // Now acknowledge the transactions for their inclusion to block
-        ack_transactions(verified_block.reference());
+        let block_ref = verified_block.reference();
+        ack_transactions(block_ref);
 
-        info!("Created block {verified_block:?} for round {clock_round}");
+        info!("Created block {block_ref} for round {clock_round}");
 
         self.context
             .metrics

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -526,22 +526,6 @@ impl DagState {
         transactions
     }
 
-    /// Gets blocks by reconstructing them from their headers and transactions.
-    /// Returns None for elements where the block is not found.
-    pub(crate) fn get_blocks(&self, block_refs: &[BlockRef]) -> Vec<Option<VerifiedBlock>> {
-        let headers = self.get_block_headers(block_refs);
-        let transactions = self.get_transactions(block_refs);
-
-        headers
-            .into_iter()
-            .zip(transactions)
-            .map(|(header, transaction)| match (header, transaction) {
-                (Some(header), Some(transaction)) => Some(VerifiedBlock::new(header, transaction)),
-                _ => None,
-            })
-            .collect()
-    }
-
     /// Gets a block header by checking cached recent blocks then storage.
     /// Returns None when the block is not found.
     pub(crate) fn get_block_header(&self, reference: &BlockRef) -> Option<VerifiedBlockHeader> {

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -323,17 +323,21 @@ impl DagState {
 
     pub(crate) fn add_transactions(&mut self, transactions: VerifiedTransactions) {
         let block_ref = transactions.block_ref();
-        self.recent_transactions
-            .insert(block_ref, transactions.clone());
+        if self
+            .recent_transactions
+            .insert(block_ref, transactions.clone())
+            .is_none()
+        {
+            tracing::debug!("Adding transactions for block ref: {block_ref}");
+            self.transactions_to_write.push(transactions);
+            // If a block is not very old, add it to pending acknowledgments
+            let clock_round = self.threshold_clock_round();
+            let min_round: Round = clock_round.saturating_sub(MAX_TRANSACTIONS_ACK_DEPTH);
 
-        // If a block is not very old, add it to pending acknowledgments
-        let clock_round = self.threshold_clock_round();
-        let min_round: Round = clock_round.saturating_sub(MAX_TRANSACTIONS_ACK_DEPTH);
-
-        if block_ref.round >= min_round {
-            self.add_pending_acknowledgment(block_ref);
+            if block_ref.round >= min_round {
+                self.add_pending_acknowledgment(block_ref);
+            }
         }
-        self.transactions_to_write.push(transactions);
     }
 
     pub fn update_last_available_commit_leader_round(&mut self, round: Round) {
@@ -520,6 +524,22 @@ impl DagState {
         }
 
         transactions
+    }
+
+    /// Gets blocks by reconstructing them from their headers and transactions.
+    /// Returns None for elements where the block is not found.
+    pub(crate) fn get_blocks(&self, block_refs: &[BlockRef]) -> Vec<Option<VerifiedBlock>> {
+        let headers = self.get_block_headers(block_refs);
+        let transactions = self.get_transactions(block_refs);
+
+        headers
+            .into_iter()
+            .zip(transactions)
+            .map(|(header, transaction)| match (header, transaction) {
+                (Some(header), Some(transaction)) => Some(VerifiedBlock::new(header, transaction)),
+                _ => None,
+            })
+            .collect()
     }
 
     /// Gets a block header by checking cached recent blocks then storage.

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -85,18 +85,21 @@ impl Linearizer {
             .with_label_values(&["Linearizer::collect_sub_dag_and_commit"])
             .start_timer();
         // Grab latest commit state from dag state
-        let mut dag_state = self.dag_state.write();
-        let last_commit_index = dag_state.last_commit_index();
-        let last_commit_digest = dag_state.last_commit_digest();
-        let last_commit_timestamp_ms = dag_state.last_commit_timestamp_ms();
-        let last_committed_rounds = dag_state.last_committed_rounds();
+        let mut dag_state_guard = self.dag_state.write();
+        let last_commit_index = dag_state_guard.last_commit_index();
+        let last_commit_digest = dag_state_guard.last_commit_digest();
+        let last_commit_timestamp_ms = dag_state_guard.last_commit_timestamp_ms();
+        let last_committed_rounds = dag_state_guard.last_committed_rounds();
         let timestamp_ms = leader_block.timestamp_ms().max(last_commit_timestamp_ms);
 
         // Now linearize the sub-dag starting from the leader block
-        let to_commit =
-            Self::linearize_sub_dag(leader_block.clone(), last_committed_rounds, &mut dag_state);
+        let to_commit = Self::linearize_sub_dag(
+            leader_block.clone(),
+            last_committed_rounds,
+            &mut dag_state_guard,
+        );
 
-        drop(dag_state);
+        drop(dag_state_guard);
 
         // Collect all block references for transactions that reached quorum after
         // adding acknowledgments
@@ -238,7 +241,9 @@ impl Linearizer {
 
             // Buffer commit in dag state for persistence later.
             // This also updates the last committed rounds.
-            self.dag_state.write().add_commit(commit.clone());
+            let mut dag_state_guard = self.dag_state.write();
+            dag_state_guard.add_commit(commit.clone());
+            drop(dag_state_guard);
 
             pending_sub_dags.push(sub_dag);
         }
@@ -249,7 +254,9 @@ impl Linearizer {
         // Uncommitted blocks can wait to persist too.
         // But for simplicity, all unpersisted blocks and commits are flushed to
         // storage.
-        self.dag_state.write().flush();
+        let mut dag_state_guard = self.dag_state.write();
+        dag_state_guard.flush();
+        drop(dag_state_guard);
 
         // Evict old acknowledgments from the tracker of the linearizer.
         self.evict_old_acknowledgments(max_round_committed_leader);
@@ -605,20 +612,20 @@ mod tests {
                 Round 0 : { 4 },
                 Round 1 : { * },
                 Round 2 : {
-                    A -> [-D1],
-                    B -> [-D1],
-                    C -> [-D1],
+                    A -> ([-D1],[-D1]),
+                    B -> ([-D1],[-D1]),
+                    C -> ([-D1],[-D1]),
                     D -> [*],
                 },
                 Round 3 : {
-                    A -> [-D2],
-                    B -> [-D2],
-                    C -> [-D2],
+                    A -> ([-D2],[-D2]),
+                    B -> ([-D2],[-D2]),
+                    C -> ([-D2],[-D2]),
                 },
                 Round 4 : {
-                    A -> [-D3],
-                    B -> [-D3],
-                    C -> [-D3],
+                    A -> ([-D3],[-D3]),
+                    B -> ([-D3],[-D3]),
+                    C -> ([-D3],[-D3]),
                     D -> [A3, B3, C3, D2],
                 },
                 Round 5 : { * },
@@ -628,8 +635,10 @@ mod tests {
         dag_builder.print();
         dag_builder.persist_all_blocks(dag_state.clone());
 
+        // Blocks B1, C2, A4, B5 are the leaders of rounds 1-5 (e.g. D3 is not present
+        // in DAG)
         let leaders = dag_builder
-            .leader_blocks(1..=6)
+            .leader_blocks(1..=5)
             .into_iter()
             .flatten()
             .collect::<Vec<_>>();

--- a/crates/starfish/core/src/network/test_network.rs
+++ b/crates/starfish/core/src/network/test_network.rs
@@ -20,11 +20,6 @@ pub(crate) struct TestService {
     pub(crate) handle_subscribed_block_bundle: Vec<(AuthorityIndex, SerializedBlockBundle)>,
     pub(crate) handle_subscribed_block_bundle_requests: Vec<(AuthorityIndex, Round)>,
     pub(crate) handle_fetch_block_headers: Vec<(AuthorityIndex, Vec<BlockRef>)>,
-    pub(crate) handle_fetch_blocks: Vec<(AuthorityIndex, Vec<BlockRef>)>,
-    pub(crate) handle_subscribe_blocks: Vec<(AuthorityIndex, Round)>,
-    pub(crate) handle_subscribed_block_bundle: Vec<(AuthorityIndex, SerializedBlockBundle)>,
-    pub(crate) handle_subscribed_block_bundle_requests: Vec<(AuthorityIndex, Round)>,
-    pub(crate) own_block_bundles: Vec<SerializedBlockBundle>,
     pub(crate) handle_fetch_commits: Vec<(AuthorityIndex, CommitRange)>,
     pub(crate) own_block_bundles: Vec<SerializedBlockBundle>,
 }
@@ -35,10 +30,8 @@ impl TestService {
             own_block_bundles: Vec::new(),
             handle_subscribed_block_bundle: Vec::new(),
             handle_subscribed_block_bundle_requests: Vec::new(),
-            handle_subscribed_block: Vec::new(),
             handle_fetch_block_headers: Vec::new(),
             handle_fetch_commits: Vec::new(),
-            own_block_bundles: Vec::new(),
         }
     }
 
@@ -62,38 +55,7 @@ impl NetworkService for Mutex<TestService> {
         Ok(())
     }
 
-    async fn handle_subscribed_block_bundle(
-        &self,
-        peer: AuthorityIndex,
-        serialized_block_bundle: SerializedBlockBundle,
-    ) -> ConsensusResult<()> {
-        let mut state = self.lock();
-        state
-            .handle_subscribed_block_bundle
-            .push((peer, serialized_block_bundle));
-        Ok(())
-    }
-
     async fn handle_subscribe_block_bundles_request(
-        &self,
-        peer: AuthorityIndex,
-        last_received: Round,
-    ) -> ConsensusResult<BlockBundleStream> {
-        let mut state = self.lock();
-        state
-            .handle_subscribed_block_bundle_requests
-            .push((peer, last_received));
-        let own_blocks = state
-            .own_block_bundles
-            .iter()
-            // Let index in own_blocks be the round, and skip blocks <= last_received round.
-            .skip(last_received as usize + 1)
-            .cloned()
-            .collect::<Vec<_>>();
-        Ok(Box::pin(stream::iter(own_blocks)))
-    }
-
-    async fn handle_subscribe_blocks(
         &self,
         peer: AuthorityIndex,
         last_received: Round,

--- a/crates/starfish/core/src/network/test_network.rs
+++ b/crates/starfish/core/src/network/test_network.rs
@@ -20,6 +20,11 @@ pub(crate) struct TestService {
     pub(crate) handle_subscribed_block_bundle: Vec<(AuthorityIndex, SerializedBlockBundle)>,
     pub(crate) handle_subscribed_block_bundle_requests: Vec<(AuthorityIndex, Round)>,
     pub(crate) handle_fetch_block_headers: Vec<(AuthorityIndex, Vec<BlockRef>)>,
+    pub(crate) handle_fetch_blocks: Vec<(AuthorityIndex, Vec<BlockRef>)>,
+    pub(crate) handle_subscribe_blocks: Vec<(AuthorityIndex, Round)>,
+    pub(crate) handle_subscribed_block_bundle: Vec<(AuthorityIndex, SerializedBlockBundle)>,
+    pub(crate) handle_subscribed_block_bundle_requests: Vec<(AuthorityIndex, Round)>,
+    pub(crate) own_block_bundles: Vec<SerializedBlockBundle>,
     pub(crate) handle_fetch_commits: Vec<(AuthorityIndex, CommitRange)>,
     pub(crate) own_block_bundles: Vec<SerializedBlockBundle>,
 }
@@ -27,8 +32,10 @@ pub(crate) struct TestService {
 impl TestService {
     pub(crate) fn new() -> Self {
         Self {
+            own_block_bundles: Vec::new(),
             handle_subscribed_block_bundle: Vec::new(),
             handle_subscribed_block_bundle_requests: Vec::new(),
+            handle_subscribed_block: Vec::new(),
             handle_fetch_block_headers: Vec::new(),
             handle_fetch_commits: Vec::new(),
             own_block_bundles: Vec::new(),
@@ -55,7 +62,38 @@ impl NetworkService for Mutex<TestService> {
         Ok(())
     }
 
+    async fn handle_subscribed_block_bundle(
+        &self,
+        peer: AuthorityIndex,
+        serialized_block_bundle: SerializedBlockBundle,
+    ) -> ConsensusResult<()> {
+        let mut state = self.lock();
+        state
+            .handle_subscribed_block_bundle
+            .push((peer, serialized_block_bundle));
+        Ok(())
+    }
+
     async fn handle_subscribe_block_bundles_request(
+        &self,
+        peer: AuthorityIndex,
+        last_received: Round,
+    ) -> ConsensusResult<BlockBundleStream> {
+        let mut state = self.lock();
+        state
+            .handle_subscribed_block_bundle_requests
+            .push((peer, last_received));
+        let own_blocks = state
+            .own_block_bundles
+            .iter()
+            // Let index in own_blocks be the round, and skip blocks <= last_received round.
+            .skip(last_received as usize + 1)
+            .cloned()
+            .collect::<Vec<_>>();
+        Ok(Box::pin(stream::iter(own_blocks)))
+    }
+
+    async fn handle_subscribe_blocks(
         &self,
         peer: AuthorityIndex,
         last_received: Round,

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -121,7 +121,7 @@ impl Store for RocksDBStore {
     fn write(&self, write_batch: WriteBatch) -> ConsensusResult<()> {
         fail_point!("consensus-store-before-write");
         // TODO: does it matter which CF we use here?
-        let mut batch = self.transactions.batch();
+        let mut batch = self.block_headers.batch();
 
         // Store block headers and their associated commit votes
         for block_header in write_batch.block_headers {

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -241,7 +241,10 @@ mod test {
         block_header::BlockRef,
         commit::CommitRange,
         error::ConsensusResult,
-        network::{BlockBundleStream, SerializedBlockBundle, test_network::TestService},
+        network::{
+            BlockBundleStream, BlockStream, SerializedBlock, SerializedBlockBundle,
+            SerializedHeaderAndTransactions, test_network::TestService,
+        },
         storage::mem_store::MemStore,
     };
 
@@ -271,6 +274,26 @@ mod test {
             .take(10);
             Ok(Box::pin(block_stream))
         }
+
+        async fn subscribe_block_bundles(
+            &self,
+            _peer: AuthorityIndex,
+            _last_received: Round,
+            _timeout: Duration,
+        ) -> ConsensusResult<BlockBundleStream> {
+            let block_stream = stream::unfold((), |_| async {
+                sleep(Duration::from_millis(1)).await;
+                Some((
+                    SerializedBlockBundle {
+                        serialized_block_bundle: Bytes::from(vec![1u8; 8]),
+                    },
+                    (),
+                ))
+            })
+            .take(10);
+            Ok(Box::pin(block_stream))
+        }
+
         async fn fetch_transactions(
             &self,
             _peer: AuthorityIndex,
@@ -311,6 +334,7 @@ mod test {
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn subscriber_retries() {
+        telemetry_subscribers::init_for_testing();
         let (context, _keys) = Context::new_for_test(4);
         let context = Arc::new(context);
         let authority_service = Arc::new(Mutex::new(TestService::new()));

--- a/crates/starfish/core/src/subscriber.rs
+++ b/crates/starfish/core/src/subscriber.rs
@@ -241,10 +241,7 @@ mod test {
         block_header::BlockRef,
         commit::CommitRange,
         error::ConsensusResult,
-        network::{
-            BlockBundleStream, BlockStream, SerializedBlock, SerializedBlockBundle,
-            SerializedHeaderAndTransactions, test_network::TestService,
-        },
+        network::{BlockBundleStream, SerializedBlockBundle, test_network::TestService},
         storage::mem_store::MemStore,
     };
 
@@ -270,25 +267,6 @@ mod test {
                     serialized_block_bundle: Bytes::from(vec![1u8; 8]),
                 };
                 Some((block, ()))
-            })
-            .take(10);
-            Ok(Box::pin(block_stream))
-        }
-
-        async fn subscribe_block_bundles(
-            &self,
-            _peer: AuthorityIndex,
-            _last_received: Round,
-            _timeout: Duration,
-        ) -> ConsensusResult<BlockBundleStream> {
-            let block_stream = stream::unfold((), |_| async {
-                sleep(Duration::from_millis(1)).await;
-                Some((
-                    SerializedBlockBundle {
-                        serialized_block_bundle: Bytes::from(vec![1u8; 8]),
-                    },
-                    (),
-                ))
             })
             .take(10);
             Ok(Box::pin(block_stream))

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -523,7 +523,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                 .inc();
         }
 
-        debug!(
+        info!(
             "[{sync_method}] Synced {} missing transactions from peer {peer_index} {peer_hostname}: {}",
             transactions.len(),
             transactions


### PR DESCRIPTION
# Description of change

We adapted the tests to the Starfish logic and significantly enhanced the tested scenario. Specifically, in the test `test_restart_authority_committee()` 4 validators start for some time and sequence some transactions. Then one validator restarts, while others advance the DAG and sequence new transactions. The restarted node should catch up, by making use of commit syncer and transaction syncer.

## Links to any relevant issues

Fixes #7956 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
