### PR TITLE
upstream(iota-indexer): chunk to avoid PG parameter limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6443,6 +6443,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "prometheus",
+ "rand 0.8.5",
  "secrecy",
  "serde",
  "serde_json",

--- a/crates/iota-indexer/Cargo.toml
+++ b/crates/iota-indexer/Cargo.toml
@@ -65,6 +65,7 @@ shared_test_runtime = []
 [dev-dependencies]
 # external dependencies
 hex.workspace = true
+rand.workspace = true
 serde_json.workspace = true
 
 # internal dependencies

--- a/crates/iota-indexer/Cargo.toml
+++ b/crates/iota-indexer/Cargo.toml
@@ -25,6 +25,7 @@ futures.workspace = true
 itertools.workspace = true
 jsonrpsee.workspace = true
 prometheus.workspace = true
+rand = { workspace = true, optional = true }
 secrecy = "0.8.0"
 serde.workspace = true
 serde_with.workspace = true
@@ -58,7 +59,7 @@ move-core-types.workspace = true
 telemetry-subscribers.workspace = true
 
 [features]
-pg_integration = []
+pg_integration = ["dep:rand"]
 shared_test_runtime = []
 
 [dev-dependencies]

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -205,7 +205,7 @@ pub enum Command {
     /// Backfill DB tables for some ID range [start, end].
     /// The tool will automatically slice it into smaller ranges and for each
     /// range, it first makes a read query to the DB to get data needed for
-    /// backfil if needed, which then can be processed and written back to
+    /// backfill if needed, which then can be processed and written back to
     /// the DB. To add a new backfill, add a new module and implement the
     /// `BackfillTask` trait.
     RunBackfill {

--- a/crates/iota-indexer/src/store/mod.rs
+++ b/crates/iota-indexer/src/store/mod.rs
@@ -216,6 +216,53 @@ pub mod diesel_macro {
         }};
     }
 
+    /// This macro provides a standardized way to bulk insert data into database
+    /// tables with built-in performance monitoring, error handling, and
+    /// retry logic. It automatically subdivides large chunks into smaller
+    /// batches to optimize database performance and avoid overwhelming
+    /// individual transactions.
+    ///
+    /// # Parameters
+    ///
+    /// * `$table` - The target database table (e.g., `events::table`,
+    ///   `transactions::table`)
+    /// * `$chunk` - Collection of data to persist (must implement `.len()` and
+    ///   `.chunks()`)
+    /// * `$pool` - Database connection pool reference
+    ///
+    /// # Behavior
+    ///
+    /// 1. **Performance Timing**: Records operation duration for monitoring
+    /// 2. **Automatic Batching**: Splits data into chunks of
+    ///    `PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX` rows
+    /// 3. **Transaction Safety**: Uses `transactional_blocking_with_retry!` for
+    ///    atomic operations
+    /// 4. **Conflict Resolution**: Employs `INSERT ... ON CONFLICT DO NOTHING`
+    ///    strategy
+    /// 5. **Retry Logic**: Automatically retries failed operations with timeout
+    ///    of `PG_DB_COMMIT_SLEEP_DURATION`
+    /// 6. **Comprehensive Logging**: Logs success/failure with timing and row
+    ///    count information
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let event_batch = vec![/* event data */];
+    /// // Persist event data
+    /// persist_chunk_into_table!(
+    ///     events::table,
+    ///     event_batch,
+    ///     &connection_pool
+    /// ).unwrap();
+    ///
+    /// let sender_data = vec![/* sender data */];
+    /// // Persist transaction senders
+    /// persist_chunk_into_table!(
+    ///     tx_senders::table,
+    ///     sender_data,
+    ///     &blocking_pool
+    /// ).unwrap();
+    /// ```
     #[macro_export]
     macro_rules! persist_chunk_into_table {
         ($table:expr, $chunk:expr, $pool:expr) => {{

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -6,7 +6,7 @@ use core::result::Result::Ok;
 use std::{
     any::Any as StdAny,
     collections::{BTreeMap, HashMap},
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use async_trait::async_trait;
@@ -952,203 +952,39 @@ impl PgIndexerStore {
                 },
             );
 
-        let mut futures = vec![];
-        futures.push(self.spawn_blocking_task(move |this| {
-            let now = Instant::now();
-            let senders_len = senders.len();
-            let recipients_len = recipients.len();
-            transactional_blocking_with_retry!(
-                &this.blocking_cp,
-                |conn| {
-                    for chunk in senders.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
-                        insert_or_ignore_into!(tx_senders::table, chunk, conn);
-                    }
-                    for chunk in recipients.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
-                        insert_or_ignore_into!(tx_recipients::table, chunk, conn);
-                    }
-                    Ok::<(), IndexerError>(())
-                },
-                PG_DB_COMMIT_SLEEP_DURATION
-            )
-            .tap_ok(|_| {
-                let elapsed = now.elapsed().as_secs_f64();
-                info!(
-                    elapsed,
-                    "Persisted {} rows to tx_senders and {} rows to tx_recipients",
-                    senders_len,
-                    recipients_len,
-                );
-            })
-            .tap_err(|e| {
-                tracing::error!(
-                    "Failed to persist tx_senders and tx_recipients with error: {}",
-                    e
-                );
-            })
-        }));
-
-        futures.push(self.spawn_blocking_task(move |this| {
-            let now = Instant::now();
-            let input_objects_len = input_objects.len();
-            transactional_blocking_with_retry!(
-                &this.blocking_cp,
-                |conn| {
-                    for chunk in input_objects.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
-                        insert_or_ignore_into!(tx_input_objects::table, chunk, conn);
-                    }
-                    Ok::<(), IndexerError>(())
-                },
-                PG_DB_COMMIT_SLEEP_DURATION
-            )
-            .tap_ok(|_| {
-                let elapsed = now.elapsed().as_secs_f64();
-                info!(
-                    elapsed,
-                    "Persisted {} rows to tx_input_objects", input_objects_len,
-                );
-            })
-            .tap_err(|e| {
-                tracing::error!("Failed to persist tx_input_objects with error: {}", e);
-            })
-        }));
-
-        futures.push(self.spawn_blocking_task(move |this| {
-            let now = Instant::now();
-            let changed_objects_len = changed_objects.len();
-            transactional_blocking_with_retry!(
-                &this.blocking_cp,
-                |conn| {
-                    for chunk in changed_objects.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
-                        insert_or_ignore_into!(tx_changed_objects::table, chunk, conn);
-                    }
-                    Ok::<(), IndexerError>(())
-                },
-                PG_DB_COMMIT_SLEEP_DURATION
-            )
-            .tap_ok(|_| {
-                let elapsed = now.elapsed().as_secs_f64();
-                info!(
-                    elapsed,
-                    "Persisted {} rows to tx_changed_objects table", changed_objects_len,
-                );
-            })
-            .tap_err(|e| {
-                tracing::error!("Failed to persist tx_changed_objects with error: {}", e);
-            })
-        }));
-
-        futures.push(self.spawn_blocking_task(move |this| {
-            let now = Instant::now();
-            let rows_len = pkgs.len();
-            transactional_blocking_with_retry!(
-                &this.blocking_cp,
-                |conn| {
-                    for chunk in pkgs.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
-                        insert_or_ignore_into!(tx_calls_pkg::table, chunk, conn);
-                    }
-                    Ok::<(), IndexerError>(())
-                },
-                PG_DB_COMMIT_SLEEP_DURATION
-            )
-            .tap_ok(|_| {
-                let elapsed = now.elapsed().as_secs_f64();
-                info!(
-                    elapsed,
-                    "Persisted {} rows to tx_calls_pkg tables", rows_len
-                );
-            })
-            .tap_err(|e| {
-                tracing::error!("Failed to persist tx_calls_pkg with error: {}", e);
-            })
-        }));
-
-        futures.push(self.spawn_blocking_task(move |this| {
-            let now = Instant::now();
-            let rows_len = mods.len();
-            transactional_blocking_with_retry!(
-                &this.blocking_cp,
-                |conn| {
-                    for chunk in mods.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
-                        insert_or_ignore_into!(tx_calls_mod::table, chunk, conn);
-                    }
-                    Ok::<(), IndexerError>(())
-                },
-                PG_DB_COMMIT_SLEEP_DURATION
-            )
-            .tap_ok(|_| {
-                let elapsed = now.elapsed().as_secs_f64();
-                info!(elapsed, "Persisted {} rows to tx_calls_mod table", rows_len);
-            })
-            .tap_err(|e| {
-                tracing::error!("Failed to persist tx_calls_mod with error: {}", e);
-            })
-        }));
-
-        futures.push(self.spawn_blocking_task(move |this| {
-            let now = Instant::now();
-            let rows_len = funs.len();
-            transactional_blocking_with_retry!(
-                &this.blocking_cp,
-                |conn| {
-                    for chunk in funs.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
-                        insert_or_ignore_into!(tx_calls_fun::table, chunk, conn);
-                    }
-                    Ok::<(), IndexerError>(())
-                },
-                PG_DB_COMMIT_SLEEP_DURATION
-            )
-            .tap_ok(|_| {
-                let elapsed = now.elapsed().as_secs_f64();
-                info!(elapsed, "Persisted {} rows to tx_calls_fun table", rows_len);
-            })
-            .tap_err(|e| {
-                tracing::error!("Failed to persist tx_calls_fun with error: {}", e);
-            })
-        }));
-
-        futures.push(self.spawn_blocking_task(move |this| {
-            let now = Instant::now();
-            let calls_len = digests.len();
-            transactional_blocking_with_retry!(
-                &this.blocking_cp,
-                |conn| {
-                    for chunk in digests.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
-                        insert_or_ignore_into!(tx_digests::table, chunk, conn);
-                    }
-                    Ok::<(), IndexerError>(())
-                },
-                Duration::from_secs(60)
-            )
-            .tap_ok(|_| {
-                let elapsed = now.elapsed().as_secs_f64();
-                info!(elapsed, "Persisted {} rows to tx_digests tables", calls_len);
-            })
-            .tap_err(|e| {
-                tracing::error!("Failed to persist tx_digests with error: {}", e);
-            })
-        }));
-
-        futures.push(self.spawn_blocking_task(move |this| {
-            let now = Instant::now();
-            let rows_len = kinds.len();
-            transactional_blocking_with_retry!(
-                &this.blocking_cp,
-                |conn| {
-                    for chunk in kinds.chunks(PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX) {
-                        insert_or_ignore_into!(tx_kinds::table, chunk, conn);
-                    }
-                    Ok::<(), IndexerError>(())
-                },
-                Duration::from_secs(60)
-            )
-            .tap_ok(|_| {
-                let elapsed = now.elapsed().as_secs_f64();
-                info!(elapsed, "Persisted {} rows to tx_kinds tables", rows_len);
-            })
-            .tap_err(|e| {
-                tracing::error!("Failed to persist tx_kinds with error: {}", e);
-            })
-        }));
+        let futures = [
+            self.spawn_blocking_task(move |this| {
+                persist_chunk_into_table!(tx_senders::table, senders, &this.blocking_cp)
+            }),
+            self.spawn_blocking_task(move |this| {
+                persist_chunk_into_table!(tx_recipients::table, recipients, &this.blocking_cp)
+            }),
+            self.spawn_blocking_task(move |this| {
+                persist_chunk_into_table!(tx_input_objects::table, input_objects, &this.blocking_cp)
+            }),
+            self.spawn_blocking_task(move |this| {
+                persist_chunk_into_table!(
+                    tx_changed_objects::table,
+                    changed_objects,
+                    &this.blocking_cp
+                )
+            }),
+            self.spawn_blocking_task(move |this| {
+                persist_chunk_into_table!(tx_calls_pkg::table, pkgs, &this.blocking_cp)
+            }),
+            self.spawn_blocking_task(move |this| {
+                persist_chunk_into_table!(tx_calls_mod::table, mods, &this.blocking_cp)
+            }),
+            self.spawn_blocking_task(move |this| {
+                persist_chunk_into_table!(tx_calls_fun::table, funs, &this.blocking_cp)
+            }),
+            self.spawn_blocking_task(move |this| {
+                persist_chunk_into_table!(tx_digests::table, digests, &this.blocking_cp)
+            }),
+            self.spawn_blocking_task(move |this| {
+                persist_chunk_into_table!(tx_kinds::table, kinds, &this.blocking_cp)
+            }),
+        ];
 
         futures::future::try_join_all(futures)
             .await

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -416,6 +416,27 @@ impl EventIndex {
     }
 }
 
+#[cfg(feature = "pg_integration")]
+impl EventIndex {
+    /// Generate a random event index for testing purposes.
+    pub fn random() -> Self {
+        use rand::Rng;
+
+        let mut rng = rand::thread_rng();
+        EventIndex {
+            tx_sequence_number: rng.gen(),
+            event_sequence_number: rng.gen(),
+            sender: IotaAddress::random_for_testing_only(),
+            emit_package: ObjectID::random(),
+            emit_module: rng.gen::<u64>().to_string(),
+            type_package: ObjectID::random(),
+            type_module: rng.gen::<u64>().to_string(),
+            type_name: rng.gen::<u64>().to_string(),
+            type_instantiation: rng.gen::<u64>().to_string(),
+        }
+    }
+}
+
 #[derive(Debug, Copy, Clone)]
 pub enum OwnerType {
     Immutable = 0,
@@ -541,6 +562,64 @@ pub struct TxIndex {
     pub sender: IotaAddress,
     pub recipients: Vec<IotaAddress>,
     pub move_calls: Vec<(ObjectID, String, String)>,
+}
+
+#[cfg(feature = "pg_integration")]
+impl TxIndex {
+    const MAX_OBJECTS: usize = 1000;
+    const MAX_PAYERS: usize = 100;
+    const MAX_RECIPIENTS: usize = 1000;
+    const MAX_MOVE_CALLS: usize = 1000;
+
+    /// Generate a random TxIndex for testing purposes.
+    pub fn random() -> Self {
+        use std::iter::repeat_with;
+
+        use rand::Rng;
+
+        let mut rng = rand::thread_rng();
+
+        let tx_kind = if rng.gen_bool(0.5) {
+            IotaTransactionKind::SystemTransaction
+        } else {
+            IotaTransactionKind::ProgrammableTransaction
+        };
+
+        let input_objects = repeat_with(ObjectID::random)
+            .take(Self::MAX_OBJECTS)
+            .collect();
+        let changed_objects = repeat_with(ObjectID::random)
+            .take(Self::MAX_OBJECTS)
+            .collect();
+        let payers = repeat_with(IotaAddress::random_for_testing_only)
+            .take(rng.gen_range(0..Self::MAX_PAYERS))
+            .collect();
+        let recipients = repeat_with(IotaAddress::random_for_testing_only)
+            .take(rng.gen_range(0..Self::MAX_RECIPIENTS))
+            .collect();
+        let move_calls = std::iter::repeat_with(|| {
+            (
+                ObjectID::random(),
+                rand::random::<u64>().to_string(),
+                rand::random::<u64>().to_string(),
+            )
+        })
+        .take(rng.gen_range(0..Self::MAX_MOVE_CALLS))
+        .collect();
+
+        TxIndex {
+            tx_sequence_number: rng.gen(),
+            tx_kind,
+            transaction_digest: TransactionDigest::random(),
+            checkpoint_sequence_number: rng.gen(),
+            input_objects,
+            changed_objects,
+            payers,
+            sender: IotaAddress::random_for_testing_only(),
+            recipients,
+            move_calls,
+        }
+    }
 }
 
 // ObjectChange is not bcs deserializable, IndexedObjectChange is.

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -416,7 +416,7 @@ impl EventIndex {
     }
 }
 
-#[cfg(feature = "pg_integration")]
+#[cfg(any(test, feature = "pg_integration"))]
 impl EventIndex {
     /// Generate a random event index for testing purposes.
     pub fn random() -> Self {
@@ -564,7 +564,7 @@ pub struct TxIndex {
     pub move_calls: Vec<(ObjectID, String, String)>,
 }
 
-#[cfg(feature = "pg_integration")]
+#[cfg(any(test, feature = "pg_integration"))]
 impl TxIndex {
     /// Generate a random TxIndex for testing purposes.
     pub fn random() -> Self {

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -566,16 +566,16 @@ pub struct TxIndex {
 
 #[cfg(feature = "pg_integration")]
 impl TxIndex {
-    const MAX_OBJECTS: usize = 1000;
-    const MAX_PAYERS: usize = 100;
-    const MAX_RECIPIENTS: usize = 1000;
-    const MAX_MOVE_CALLS: usize = 1000;
-
     /// Generate a random TxIndex for testing purposes.
     pub fn random() -> Self {
         use std::iter::repeat_with;
 
         use rand::Rng;
+
+        const MAX_OBJECTS: usize = 1000;
+        const MAX_PAYERS: usize = 100;
+        const MAX_RECIPIENTS: usize = 1000;
+        const MAX_MOVE_CALLS: usize = 1000;
 
         let mut rng = rand::thread_rng();
 
@@ -585,17 +585,13 @@ impl TxIndex {
             IotaTransactionKind::ProgrammableTransaction
         };
 
-        let input_objects = repeat_with(ObjectID::random)
-            .take(Self::MAX_OBJECTS)
-            .collect();
-        let changed_objects = repeat_with(ObjectID::random)
-            .take(Self::MAX_OBJECTS)
-            .collect();
+        let input_objects = repeat_with(ObjectID::random).take(MAX_OBJECTS).collect();
+        let changed_objects = repeat_with(ObjectID::random).take(MAX_OBJECTS).collect();
         let payers = repeat_with(IotaAddress::random_for_testing_only)
-            .take(rng.gen_range(0..Self::MAX_PAYERS))
+            .take(rng.gen_range(0..MAX_PAYERS))
             .collect();
         let recipients = repeat_with(IotaAddress::random_for_testing_only)
-            .take(rng.gen_range(0..Self::MAX_RECIPIENTS))
+            .take(rng.gen_range(0..MAX_RECIPIENTS))
             .collect();
         let move_calls = std::iter::repeat_with(|| {
             (
@@ -604,7 +600,7 @@ impl TxIndex {
                 rand::random::<u64>().to_string(),
             )
         })
-        .take(rng.gen_range(0..Self::MAX_MOVE_CALLS))
+        .take(rng.gen_range(0..MAX_MOVE_CALLS))
         .collect();
 
         TxIndex {

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -19,8 +19,9 @@ mod ingestion_tests {
             transactions::StoredTransaction,
         },
         schema::{objects, objects_snapshot, transactions, tx_insertion_order},
-        store::PgIndexerStore,
+        store::{PgIndexerStore, indexer_store::IndexerStore},
         transactional_blocking_with_retry,
+        types::{EventIndex, TxIndex},
     };
     use iota_types::{
         IOTA_FRAMEWORK_PACKAGE_ID, base_types::IotaAddress, effects::TransactionEffectsAPI,
@@ -327,6 +328,81 @@ mod ingestion_tests {
         .context("Failed reading tx insertion order from PostgresDB")?;
 
         assert_eq!(actual_insertion_order, pre_existing_insertion_order);
+        Ok(())
+    }
+
+    /// This test case verifies that pg_store.persist_tx_indices correctly
+    /// splits large vectors of TxIndex into smaller chunks of size
+    /// PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX.
+    ///
+    /// This prevents the Postgres error:
+    /// ```text
+    /// "error encoding message to server: value too large to transmit"
+    /// ```
+    #[tokio::test]
+    pub async fn test_insert_large_batch_tx_indices() -> Result<(), IndexerError> {
+        let tempdir = tempdir().unwrap();
+        let mut sim = Simulacrum::new();
+        let data_ingestion_path = tempdir.path().to_path_buf();
+        sim.set_data_ingestion_path(data_ingestion_path.clone());
+
+        let (_, pg_store, _) = start_simulacrum_rest_api_with_write_indexer(
+            Arc::new(sim),
+            data_ingestion_path,
+            None,
+            Some("indexer_ingestion_tx_indices_db"),
+            None,
+        )
+        .await;
+
+        // By creating 1000 random tx indices we ensure that the
+        // persist_event_indices function will flatten each TxIndex by
+        // extracting all field data and collecting each field type
+        // into its own separate vector (each field has one element or more
+        // elements). This will result in having n vectors with length
+        // greater than PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX, which will
+        // trigger the large vectors to be split into chunks of
+        // PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX.
+        let tx_indices = std::iter::repeat_with(TxIndex::random).take(1000).collect();
+        pg_store.persist_tx_indices(tx_indices).await?;
+        Ok(())
+    }
+
+    /// This test case verifies that pg_store.persist_tx_indices correctly
+    /// splits large vectors of EventIndex into smaller chunks of size
+    /// PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX.
+    ///
+    /// This prevents the Postgres error:
+    /// ```text
+    /// "error encoding message to server: value too large to transmit"
+    /// ```
+    #[tokio::test]
+    pub async fn test_insert_large_batch_event_indices() -> Result<(), IndexerError> {
+        let tempdir = tempdir().unwrap();
+        let mut sim = Simulacrum::new();
+        let data_ingestion_path = tempdir.path().to_path_buf();
+        sim.set_data_ingestion_path(data_ingestion_path.clone());
+
+        let (_, pg_store, _) = start_simulacrum_rest_api_with_write_indexer(
+            Arc::new(sim),
+            data_ingestion_path,
+            None,
+            Some("indexer_ingestion_event_indices_db"),
+            None,
+        )
+        .await;
+
+        // By creating 2000 random event indices we ensure that the
+        // persist_event_indices function will flatten each EventIndex by
+        // extracting all field data and collecting each field type
+        // into its own separate vector (each field has one element). This will
+        // result in having n vectors with length of 2000, which will
+        // trigger the large vectors to be split into chunks of
+        // PG_COMMIT_CHUNK_SIZE_INTRA_DB_TX.
+        let event_indices = std::iter::repeat_with(EventIndex::random)
+            .take(2000)
+            .collect();
+        pg_store.persist_event_indices(event_indices).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
# Description of change

This PR adds changes from upstream, the actual interested code is already present in latest `develop`, for a detailed  explanation on why we have already this change please see the issue comment:
- https://github.com/iotaledger/iota/issues/7889#issuecomment-3112528449

- Nevertheless int this PR we add the two missing test cases which verifies that events and tx indices does not hit the Postgres limit.
- The `persist_tx_indices_chunk` was refactored to use the already present `persist_chunk_into_table!` macro to store chunked data to db, as `persist_event_indices_chunk` already does, this refactor removes duplicated code making it more readable and maintainable.

## Links to any relevant issues

fixes #7889

## How the change has been tested

- run new added tests
```shell
cargo test -p iota-indexer --features pg_integration -- --test-threads 1
```
- synced iota-indexer with `devnet` data to check if genesis checkpoint was synced correctly and also checked that reliability requirements  were not exceeded. No regressions found during testing.
- synced iota-indexer with `testnet` data and also restarted it without resetting the database.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [x] Synchronization of the indexer from genesis for a network including migration objects.
- [x] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [x] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
