### PR TITLE
chore(iota-core): improve importing Sui's congestion tracker

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1823,7 +1823,7 @@ impl AuthorityState {
         let module_cache =
             TemporaryModuleResolver::new(&inner_temp_store, epoch_store.module_cache().clone());
 
-         let mut layout_resolver =
+        let mut layout_resolver =
             epoch_store
                 .executor()
                 .type_layout_resolver(Box::new(PackageStoreWithFallback::new(

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -1341,11 +1341,10 @@ async fn finalize_checkpoint(
     epoch_store.insert_finalized_transactions(tx_digests, checkpoint.sequence_number)?;
 
     if state.is_fullnode(epoch_store) {
-        state.congestion_tracker.process_checkpoint_effects(
-            transaction_cache_reader,
-            &checkpoint,
-            &effects,
-        ).await;
+        state
+            .congestion_tracker
+            .process_checkpoint_effects(transaction_cache_reader, &checkpoint, &effects)
+            .await;
     }
 
     // TODO remove once we no longer need to support this table for read RPC

--- a/crates/iota-core/src/congestion_tracker.rs
+++ b/crates/iota-core/src/congestion_tracker.rs
@@ -361,7 +361,7 @@ mod tests {
         );
     }
 
-   #[tokio::test]
+    #[tokio::test]
     async fn test_get_suggested_gas_price_multiple_objects() {
         let tracker = CongestionTracker::new();
         let obj1 = ObjectID::random();


### PR DESCRIPTION
# Description of change

This PR is based on #7559, and it aims to improve importing Sui's congestion tracker.

## Links to any relevant issues

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
