### PR TITLE
upstream(core): Add test checkpoint data builder

### DIFF
--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -630,7 +630,7 @@ mod test {
     async fn test_data_ingestion_pipeline() {
         let path = nondeterministic!(TempDir::new().unwrap()).into_path();
         let test_cluster = Arc::new(
-            init_test_cluster_builder(4, 1000)
+            init_test_cluster_builder(4, 5000)
                 .with_data_ingestion_dir(path.clone())
                 .build()
                 .await,

--- a/crates/iota-core/src/authority/authority_test_utils.rs
+++ b/crates/iota-core/src/authority/authority_test_utils.rs
@@ -209,7 +209,11 @@ pub async fn init_state_with_ids_and_versions<
 ) -> Arc<AuthorityState> {
     let state = TestAuthorityBuilder::new().build().await;
     for (address, object_id, version) in objects {
-        let obj = Object::with_id_owner_version_for_testing(object_id, version, address);
+        let obj = Object::with_id_owner_version_for_testing(
+            object_id,
+            version,
+            Owner::AddressOwner(address),
+        );
         state.insert_genesis_object(obj).await;
     }
     state

--- a/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -1352,7 +1352,11 @@ async fn concurrent_latest_object_cache_race_test() {
     // write a new version on request
     let mut write_version = OBJECT_START_VERSION;
     let mut writer = || {
-        let object = Object::with_id_owner_version_for_testing(object_id, write_version, owner);
+        let object = Object::with_id_owner_version_for_testing(
+            object_id,
+            write_version,
+            Owner::AddressOwner(owner),
+        );
 
         cache
             .write_object_entry(&object_id, write_version, object.into())
@@ -1400,7 +1404,11 @@ async fn concurrent_latest_object_cache_race_test() {
             .and_then(|e| e.value().get_highest().map(|v| v.0))
             .unwrap();
 
-        let object = Object::with_id_owner_version_for_testing(object_id, latest_version, owner);
+        let object = Object::with_id_owner_version_for_testing(
+            object_id,
+            latest_version,
+            Owner::AddressOwner(owner),
+        );
 
         // preempt the reader to update the latest version and invalidate the cache
         {
@@ -1469,7 +1477,11 @@ async fn concurrent_latest_object_cache_collision_test() {
         } else {
             (&mut write2_version, owner2)
         };
-        let object = Object::with_id_owner_version_for_testing(object_id, *write_version, owner);
+        let object = Object::with_id_owner_version_for_testing(
+            object_id,
+            *write_version,
+            Owner::AddressOwner(owner),
+        );
 
         cache
             .write_object_entry(&object_id, *write_version, object.into())
@@ -1504,8 +1516,11 @@ async fn concurrent_latest_object_cache_collision_test() {
             .and_then(|e| e.value().get_highest().map(|v| v.0))
             .unwrap();
 
-        let object2 =
-            Object::with_id_owner_version_for_testing(object2_id, latest2_version, owner2);
+        let object2 = Object::with_id_owner_version_for_testing(
+            object2_id,
+            latest2_version,
+            Owner::AddressOwner(owner2),
+        );
 
         // preempt the reader
         {

--- a/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -1225,7 +1225,11 @@ async fn latest_object_cache_race_test() {
         std::thread::spawn(move || {
             let mut version = OBJECT_START_VERSION;
             while start.elapsed() < Duration::from_secs(2) {
-                let object = Object::with_id_owner_version_for_testing(object_id, version, owner);
+                let object = Object::with_id_owner_version_for_testing(
+                    object_id,
+                    version,
+                    Owner::AddressOwner(owner),
+                );
 
                 cache
                     .write_object_entry(&object_id, version, object.into())
@@ -1265,8 +1269,11 @@ async fn latest_object_cache_race_test() {
                     std::thread::sleep(Duration::from_micros(1));
                 }
 
-                let object =
-                    Object::with_id_owner_version_for_testing(object_id, latest_version, owner);
+                let object = Object::with_id_owner_version_for_testing(
+                    object_id,
+                    latest_version,
+                    Owner::AddressOwner(owner),
+                );
 
                 // because we obtained the ticket before reading the object, we will not write a
                 // stale version to the cache.

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -1090,7 +1090,7 @@ async fn test_dry_run_dev_inspect_max_gas_version() {
     let gas_object = Object::with_id_owner_version_for_testing(
         gas_object_id,
         SequenceNumber::from_u64(SequenceNumber::MAX.value() - 1),
-        sender,
+        Owner::AddressOwner(sender),
     );
     let gas_object_ref = gas_object.compute_object_reference();
     validator.insert_genesis_object(gas_object.clone()).await;
@@ -6129,8 +6129,16 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
     let gas_objects = create_gas_objects(3, sender);
     let gas_objects_cancelled_txn = create_gas_objects(1, sender);
     let owned_objects_cancelled_txn = vec![
-        Object::with_id_owner_version_for_testing(ObjectID::random(), 1.into(), sender),
-        Object::with_id_owner_version_for_testing(ObjectID::random(), 2.into(), sender),
+        Object::with_id_owner_version_for_testing(
+            ObjectID::random(),
+            1.into(),
+            Owner::AddressOwner(sender),
+        ),
+        Object::with_id_owner_version_for_testing(
+            ObjectID::random(),
+            2.into(),
+            Owner::AddressOwner(sender),
+        ),
     ];
 
     // Create the cluster with controlled per object congestion control and

--- a/crates/iota-core/src/unit_tests/transaction_manager_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_manager_tests.rs
@@ -10,7 +10,7 @@ use iota_types::{
     base_types::{ObjectID, SequenceNumber},
     crypto::deterministic_random_account_key,
     executable_transaction::VerifiedExecutableTransaction,
-    object::Object,
+    object::{Object, Owner},
     storage::InputKey,
     transaction::{CallArg, ObjectArg, VerifiedTransaction},
 };
@@ -123,8 +123,11 @@ async fn transaction_manager_basics() {
     transaction_manager.check_empty_for_testing();
 
     // Enqueue a transaction with a new gas object, empty input.
-    let gas_object_new =
-        Object::with_id_owner_version_for_testing(ObjectID::random(), 0.into(), owner);
+    let gas_object_new = Object::with_id_owner_version_for_testing(
+        ObjectID::random(),
+        0.into(),
+        Owner::AddressOwner(owner),
+    );
     let transaction = make_transaction(gas_object_new.clone(), vec![]);
     let tx_start_time = Instant::now();
     transaction_manager.enqueue(vec![transaction.clone()], &state.epoch_store_for_testing());
@@ -396,7 +399,11 @@ async fn transaction_manager_receiving_notify_commit() {
     let obj_id = ObjectID::random();
     let object_arguments: Vec<_> = (0..10)
         .map(|i| {
-            let object = Object::with_id_owner_version_for_testing(obj_id, i.into(), owner);
+            let object = Object::with_id_owner_version_for_testing(
+                obj_id,
+                i.into(),
+                Owner::AddressOwner(owner),
+            );
             // Every other transaction receives the object, and we create a run of multiple
             // receives in a row at the beginning to test that the TM doesn't
             // get stuck in either configuration of: ImmOrOwnedObject =>
@@ -486,8 +493,10 @@ async fn transaction_manager_receiving_object_ready_notifications() {
     transaction_manager.check_empty_for_testing();
 
     let obj_id = ObjectID::random();
-    let receiving_object_new0 = Object::with_id_owner_version_for_testing(obj_id, 0.into(), owner);
-    let receiving_object_new1 = Object::with_id_owner_version_for_testing(obj_id, 1.into(), owner);
+    let receiving_object_new0 =
+        Object::with_id_owner_version_for_testing(obj_id, 0.into(), Owner::AddressOwner(owner));
+    let receiving_object_new1 =
+        Object::with_id_owner_version_for_testing(obj_id, 1.into(), Owner::AddressOwner(owner));
     let receiving_object_arg0 =
         ObjectArg::Receiving(receiving_object_new0.compute_object_reference());
     let receive_object_transaction0 = make_transaction(
@@ -572,8 +581,10 @@ async fn transaction_manager_receiving_object_ready_notifications_multiple_of_sa
     transaction_manager.check_empty_for_testing();
 
     let obj_id = ObjectID::random();
-    let receiving_object_new0 = Object::with_id_owner_version_for_testing(obj_id, 0.into(), owner);
-    let receiving_object_new1 = Object::with_id_owner_version_for_testing(obj_id, 1.into(), owner);
+    let receiving_object_new0 =
+        Object::with_id_owner_version_for_testing(obj_id, 0.into(), Owner::AddressOwner(owner));
+    let receiving_object_new1 =
+        Object::with_id_owner_version_for_testing(obj_id, 1.into(), Owner::AddressOwner(owner));
     let receiving_object_arg0 =
         ObjectArg::Receiving(receiving_object_new0.compute_object_reference());
     let receive_object_transaction0 = make_transaction(
@@ -673,8 +684,11 @@ async fn transaction_manager_receiving_object_ready_if_current_version_greater()
             Object::with_id_owner_for_testing(gas_object_id, owner)
         })
         .collect();
-    let receiving_object =
-        Object::with_id_owner_version_for_testing(ObjectID::random(), 10.into(), owner);
+    let receiving_object = Object::with_id_owner_version_for_testing(
+        ObjectID::random(),
+        10.into(),
+        Owner::AddressOwner(owner),
+    );
     gas_objects.push(receiving_object.clone());
     let state = init_state_with_objects(gas_objects.clone()).await;
 
@@ -686,10 +700,16 @@ async fn transaction_manager_receiving_object_ready_if_current_version_greater()
     // TM should be empty at the beginning.
     transaction_manager.check_empty_for_testing();
 
-    let receiving_object_new0 =
-        Object::with_id_owner_version_for_testing(receiving_object.id(), 0.into(), owner);
-    let receiving_object_new1 =
-        Object::with_id_owner_version_for_testing(receiving_object.id(), 1.into(), owner);
+    let receiving_object_new0 = Object::with_id_owner_version_for_testing(
+        receiving_object.id(),
+        0.into(),
+        Owner::AddressOwner(owner),
+    );
+    let receiving_object_new1 = Object::with_id_owner_version_for_testing(
+        receiving_object.id(),
+        1.into(),
+        Owner::AddressOwner(owner),
+    );
     let receiving_object_arg0 =
         ObjectArg::Receiving(receiving_object_new0.compute_object_reference());
     let receive_object_transaction0 = make_transaction(

--- a/crates/iota-types/src/effects/test_effects_builder.rs
+++ b/crates/iota-types/src/effects/test_effects_builder.rs
@@ -23,6 +23,15 @@ pub struct TestEffectsBuilder {
     /// Provide the assigned versions for all shared objects.
     shared_input_versions: BTreeMap<ObjectID, SequenceNumber>,
     events_digest: Option<TransactionEventsDigest>,
+    created_objects: Vec<(ObjectID, Owner)>,
+    /// Objects that are mutated: (ID, old version, new owner).
+    mutated_objects: Vec<(ObjectID, SequenceNumber, Owner)>,
+    /// Objects that are deleted: (ID, old version).
+    deleted_objects: Vec<(ObjectID, SequenceNumber)>,
+    /// Objects that are wrapped: (ID, old version).
+    wrapped_objects: Vec<(ObjectID, SequenceNumber)>,
+    /// Objects that are unwrapped: (ID, new owner).
+    unwrapped_objects: Vec<(ObjectID, Owner)>,
 }
 
 impl TestEffectsBuilder {
@@ -32,6 +41,11 @@ impl TestEffectsBuilder {
             status: None,
             shared_input_versions: BTreeMap::new(),
             events_digest: None,
+            created_objects: vec![],
+            mutated_objects: vec![],
+            deleted_objects: vec![],
+            wrapped_objects: vec![],
+            unwrapped_objects: vec![],
         }
     }
 
@@ -54,7 +68,49 @@ impl TestEffectsBuilder {
         self
     }
 
+    pub fn with_created_objects(
+        mut self,
+        objects: impl IntoIterator<Item = (ObjectID, Owner)>,
+    ) -> Self {
+        self.created_objects.extend(objects);
+        self
+    }
+
+    pub fn with_mutated_objects(
+        mut self,
+        // Object ID, old version, and new owner.
+        objects: impl IntoIterator<Item = (ObjectID, SequenceNumber, Owner)>,
+    ) -> Self {
+        self.mutated_objects.extend(objects);
+        self
+    }
+
+    pub fn with_wrapped_objects(
+        mut self,
+        objects: impl IntoIterator<Item = (ObjectID, SequenceNumber)>,
+    ) -> Self {
+        self.wrapped_objects.extend(objects);
+        self
+    }
+
+    pub fn with_unwrapped_objects(
+        mut self,
+        objects: impl IntoIterator<Item = (ObjectID, Owner)>,
+    ) -> Self {
+        self.unwrapped_objects.extend(objects);
+        self
+    }
+
+    pub fn with_deleted_objects(
+        mut self,
+        objects: impl IntoIterator<Item = (ObjectID, SequenceNumber)>,
+    ) -> Self {
+        self.deleted_objects.extend(objects);
+        self
+    }
+
     pub fn build(self) -> TransactionEffects {
+        let lamport_version = self.get_lamport_version();
         let status = self.status.unwrap_or(ExecutionStatus::Success);
         // TODO: This does not yet support deleted shared objects.
         let shared_objects = self
@@ -63,22 +119,6 @@ impl TestEffectsBuilder {
             .map(|(id, version)| SharedInput::Existing((*id, *version, ObjectDigest::MIN)))
             .collect();
         let executed_epoch = 0;
-        let lamport_version = SequenceNumber::lamport_increment(
-            self.transaction
-                .transaction_data()
-                .input_objects()
-                .unwrap()
-                .iter()
-                .filter_map(|kind| kind.version())
-                .chain(
-                    self.transaction
-                        .transaction_data()
-                        .receiving_objects()
-                        .iter()
-                        .map(|oref| oref.1),
-                )
-                .chain(self.shared_input_versions.values().copied()),
-        );
         let sender = self.transaction.transaction_data().sender();
         // TODO: Include receiving objects in the object changes as well.
         let changed_objects = self
@@ -136,6 +176,72 @@ impl TestEffectsBuilder {
                     },
                 )),
             })
+            .chain(self.created_objects.into_iter().map(|(id, owner)| {
+                (
+                    id,
+                    EffectsObjectChange {
+                        input_state: ObjectIn::NotExist,
+                        output_state: ObjectOut::ObjectWrite((ObjectDigest::random(), owner)),
+                        id_operation: IDOperation::Created,
+                    },
+                )
+            }))
+            .chain(
+                self.mutated_objects
+                    .into_iter()
+                    .map(|(id, version, owner)| {
+                        (
+                            id,
+                            EffectsObjectChange {
+                                input_state: ObjectIn::Exist((
+                                    (version, ObjectDigest::random()),
+                                    Owner::AddressOwner(sender),
+                                )),
+                                output_state: ObjectOut::ObjectWrite((
+                                    ObjectDigest::random(),
+                                    owner,
+                                )),
+                                id_operation: IDOperation::None,
+                            },
+                        )
+                    }),
+            )
+            .chain(self.deleted_objects.into_iter().map(|(id, version)| {
+                (
+                    id,
+                    EffectsObjectChange {
+                        input_state: ObjectIn::Exist((
+                            (version, ObjectDigest::random()),
+                            Owner::AddressOwner(sender),
+                        )),
+                        output_state: ObjectOut::NotExist,
+                        id_operation: IDOperation::Deleted,
+                    },
+                )
+            }))
+            .chain(self.wrapped_objects.into_iter().map(|(id, version)| {
+                (
+                    id,
+                    EffectsObjectChange {
+                        input_state: ObjectIn::Exist((
+                            (version, ObjectDigest::random()),
+                            Owner::AddressOwner(sender),
+                        )),
+                        output_state: ObjectOut::NotExist,
+                        id_operation: IDOperation::None,
+                    },
+                )
+            }))
+            .chain(self.unwrapped_objects.into_iter().map(|(id, owner)| {
+                (
+                    id,
+                    EffectsObjectChange {
+                        input_state: ObjectIn::NotExist,
+                        output_state: ObjectOut::ObjectWrite((ObjectDigest::random(), owner)),
+                        id_operation: IDOperation::None,
+                    },
+                )
+            }))
             .collect();
         let gas_object_id = self.transaction.transaction_data().gas()[0].0;
         let event_digest = self.events_digest;
@@ -152,6 +258,28 @@ impl TestEffectsBuilder {
             Some(gas_object_id),
             event_digest,
             dependencies,
+        )
+    }
+
+    fn get_lamport_version(&self) -> SequenceNumber {
+        SequenceNumber::lamport_increment(
+            self.transaction
+                .transaction_data()
+                .input_objects()
+                .unwrap()
+                .iter()
+                .filter_map(|kind| kind.version())
+                .chain(
+                    self.transaction
+                        .transaction_data()
+                        .receiving_objects()
+                        .iter()
+                        .map(|oref| oref.1),
+                )
+                .chain(self.shared_input_versions.values().copied())
+                .chain(self.mutated_objects.iter().map(|(_, v, _)| *v))
+                .chain(self.deleted_objects.iter().map(|(_, v)| *v))
+                .chain(self.wrapped_objects.iter().map(|(_, v)| *v)),
         )
     }
 }

--- a/crates/iota-types/src/lib.rs
+++ b/crates/iota-types/src/lib.rs
@@ -85,6 +85,7 @@ pub mod stardust;
 pub mod storage;
 pub mod supported_protocol_versions;
 pub mod system_admin_cap;
+pub mod test_checkpoint_data_builder;
 pub mod timelock;
 pub mod traffic_control;
 pub mod transaction;

--- a/crates/iota-types/src/object.rs
+++ b/crates/iota-types/src/object.rs
@@ -1007,7 +1007,7 @@ impl Object {
     pub fn with_id_owner_version_for_testing(
         id: ObjectID,
         version: SequenceNumber,
-        owner: IotaAddress,
+        owner: Owner,
     ) -> Self {
         let data = Data::Move(MoveObject {
             type_: GasCoin::type_().into(),
@@ -1015,7 +1015,7 @@ impl Object {
             contents: GasCoin::new(id, GAS_VALUE_FOR_TESTING).to_bcs_bytes(),
         });
         ObjectInner {
-            owner: Owner::AddressOwner(owner),
+            owner,
             data,
             previous_transaction: TransactionDigest::genesis_marker(),
             storage_rebate: 0,

--- a/crates/iota-types/src/test_checkpoint_data_builder.rs
+++ b/crates/iota-types/src/test_checkpoint_data_builder.rs
@@ -831,6 +831,8 @@ mod tests {
 
     #[test]
     fn test_move_call() {
+        use move_core_types::identifier::Identifier;
+
         let checkpoint = TestCheckpointDataBuilder::new(1)
             .start_transaction(0)
             .add_move_call(ObjectID::ZERO, "test", "test")
@@ -847,8 +849,8 @@ mod tests {
                 .any(|cmd| {
                     cmd == &Command::MoveCall(Box::new(ProgrammableMoveCall {
                         package: ObjectID::ZERO,
-                        module: "test".to_string(),
-                        function: "test".to_string(),
+                        module: Identifier::new("test").unwrap(),
+                        function: Identifier::new("test").unwrap(),
                         type_arguments: vec![],
                         arguments: vec![],
                     }))

--- a/crates/iota-types/src/test_checkpoint_data_builder.rs
+++ b/crates/iota-types/src/test_checkpoint_data_builder.rs
@@ -1,0 +1,882 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use iota_protocol_config::ProtocolConfig;
+use move_core_types::{ident_str, language_storage::TypeTag};
+
+use crate::{
+    base_types::{ExecutionDigests, IotaAddress, ObjectID, ObjectRef, SequenceNumber, dbg_addr},
+    coin::Coin,
+    committee::Committee,
+    digests::TransactionDigest,
+    effects::{TestEffectsBuilder, TransactionEffectsAPI, TransactionEvents},
+    event::Event,
+    full_checkpoint_content::{CheckpointData, CheckpointTransaction},
+    gas_coin::GAS,
+    message_envelope::Message,
+    messages_checkpoint::{CertifiedCheckpointSummary, CheckpointContents, CheckpointSummary},
+    object::{GAS_VALUE_FOR_TESTING, MoveObject, Object, Owner},
+    programmable_transaction_builder::ProgrammableTransactionBuilder,
+    transaction::{SenderSignedData, Transaction, TransactionData, TransactionKind},
+};
+
+/// A builder for creating test checkpoint data.
+/// Once initialized, the builder can be used to build multiple checkpoints.
+/// Call `start_transaction` to begin creating a new transaction.
+/// Call `finish_transaction` to complete the current transaction and add it to
+/// the current checkpoint. After all transactions are added, call
+/// `build_checkpoint` to get the final checkpoint data. This will also
+/// increment the stored checkpoint sequence number. Start the above process
+/// again to build the next checkpoint. NOTE: The generated checkpoint data is
+/// not guaranteed to be semantically valid or consistent. For instance, all
+/// object digests will be randomly set. It focuses on providing a way to
+/// generate various shaped test data for testing purposes.
+/// If you need to test the validity of the checkpoint data, you should use
+/// Simulacrum instead.
+pub struct TestCheckpointDataBuilder {
+    /// Map of all live objects in the state.
+    live_objects: HashMap<ObjectID, Object>,
+    /// Map of all wrapped objects in the state.
+    wrapped_objects: HashMap<ObjectID, Object>,
+    /// A map from sender addresses to gas objects they own.
+    /// These are created automatically when a transaction is started.
+    /// Users of this builder should not need to worry about them.
+    gas_map: HashMap<IotaAddress, ObjectID>,
+
+    /// The current checkpoint builder.
+    /// It is initialized when the builder is created, and is reset when
+    /// `build_checkpoint` is called.
+    checkpoint_builder: CheckpointBuilder,
+}
+
+struct CheckpointBuilder {
+    /// Checkpoint number for the current checkpoint we are building.
+    checkpoint: u64,
+    /// Epoch number for the current checkpoint we are building.
+    epoch: u64,
+    /// Transactions that have been added to the current checkpoint.
+    transactions: Vec<CheckpointTransaction>,
+    /// The current transaction being built.
+    next_transaction: Option<TransactionBuilder>,
+}
+
+struct TransactionBuilder {
+    sender_idx: u8,
+    gas: ObjectRef,
+    move_calls: Vec<(ObjectID, &'static str, &'static str)>,
+    created_objects: BTreeMap<ObjectID, Object>,
+    mutated_objects: BTreeMap<ObjectID, Object>,
+    unwrapped_objects: BTreeSet<ObjectID>,
+    wrapped_objects: BTreeSet<ObjectID>,
+    deleted_objects: BTreeSet<ObjectID>,
+    events: Option<Vec<Event>>,
+}
+
+impl TransactionBuilder {
+    pub fn new(sender_idx: u8, gas: ObjectRef) -> Self {
+        Self {
+            sender_idx,
+            gas,
+            move_calls: vec![],
+            created_objects: BTreeMap::new(),
+            mutated_objects: BTreeMap::new(),
+            unwrapped_objects: BTreeSet::new(),
+            wrapped_objects: BTreeSet::new(),
+            deleted_objects: BTreeSet::new(),
+            events: None,
+        }
+    }
+}
+
+impl TestCheckpointDataBuilder {
+    pub fn new(checkpoint: u64) -> Self {
+        Self {
+            live_objects: HashMap::new(),
+            wrapped_objects: HashMap::new(),
+            gas_map: HashMap::new(),
+            checkpoint_builder: CheckpointBuilder {
+                checkpoint,
+                epoch: 0,
+                transactions: vec![],
+                next_transaction: None,
+            },
+        }
+    }
+
+    /// Set the epoch for the checkpoint.
+    pub fn with_epoch(mut self, epoch: u64) -> Self {
+        self.checkpoint_builder.epoch = epoch;
+        self
+    }
+
+    /// Start creating a new transaction.
+    /// `sender_idx` is a convenient representation of the sender's address.
+    /// A proper IotaAddress will be derived from it.
+    /// It will also create a gas object for the sender if it doesn't already
+    /// exist in the live object map. You do not need to create the gas
+    /// object yourself.
+    pub fn start_transaction(mut self, sender_idx: u8) -> Self {
+        assert!(self.checkpoint_builder.next_transaction.is_none());
+        let sender = Self::derive_address(sender_idx);
+        let gas_id = self.gas_map.entry(sender).or_insert_with(|| {
+            let gas = Object::with_owner_for_testing(sender);
+            let id = gas.id();
+            self.live_objects.insert(id, gas);
+            id
+        });
+        let gas_ref = self
+            .live_objects
+            .get(gas_id)
+            .cloned()
+            .unwrap()
+            .compute_object_reference();
+        self.checkpoint_builder.next_transaction =
+            Some(TransactionBuilder::new(sender_idx, gas_ref));
+        self
+    }
+
+    /// Create a new object in the transaction.
+    /// `object_idx` is a convenient representation of the object's ID.
+    /// The object will be created as a IOTA coin object, with default balance,
+    /// and the transaction sender as its owner.
+    pub fn create_owned_object(self, object_idx: u64) -> Self {
+        self.create_iota_object(object_idx, GAS_VALUE_FOR_TESTING)
+    }
+
+    /// Create a new shared object in the transaction.
+    /// `object_idx` is a convenient representation of the object's ID.
+    /// The object will be created as a IOTA coin object, with default balance,
+    /// and it is a shared object.
+    pub fn create_shared_object(self, object_idx: u64) -> Self {
+        self.create_coin_object_with_owner(
+            object_idx,
+            Owner::Shared {
+                initial_shared_version: SequenceNumber::MIN,
+            },
+            GAS_VALUE_FOR_TESTING,
+            GAS::type_tag(),
+        )
+    }
+
+    /// Create a new IOTA coin object in the transaction.
+    /// `object_idx` is a convenient representation of the object's ID.
+    /// `balance` is the amount of IOTA to be created.
+    pub fn create_iota_object(self, object_idx: u64, balance: u64) -> Self {
+        let sender_idx = self
+            .checkpoint_builder
+            .next_transaction
+            .as_ref()
+            .unwrap()
+            .sender_idx;
+        self.create_coin_object(object_idx, sender_idx, balance, GAS::type_tag())
+    }
+
+    /// Create a new coin object in the transaction.
+    /// `object_idx` is a convenient representation of the object's ID.
+    /// `owner_idx` is a convenient representation of the object's owner's
+    /// address. `balance` is the amount of IOTA to be created.
+    /// `coin_type` is the type of the coin to be created.
+    pub fn create_coin_object(
+        self,
+        object_idx: u64,
+        owner_idx: u8,
+        balance: u64,
+        coin_type: TypeTag,
+    ) -> Self {
+        self.create_coin_object_with_owner(
+            object_idx,
+            Owner::AddressOwner(Self::derive_address(owner_idx)),
+            balance,
+            coin_type,
+        )
+    }
+
+    fn create_coin_object_with_owner(
+        mut self,
+        object_idx: u64,
+        owner: Owner,
+        balance: u64,
+        coin_type: TypeTag,
+    ) -> Self {
+        let tx_builder = self.checkpoint_builder.next_transaction.as_mut().unwrap();
+        let object_id = Self::derive_object_id(object_idx);
+        assert!(!self.live_objects.contains_key(&object_id));
+        let move_object = MoveObject::new_coin(
+            Coin::type_(coin_type).into(),
+            // version doesn't matter since we will set it to the lamport version when we finalize
+            // the transaction
+            SequenceNumber::MIN,
+            object_id,
+            balance,
+        );
+        let object = Object::new_move(move_object, owner, TransactionDigest::ZERO);
+        tx_builder.created_objects.insert(object_id, object);
+        self
+    }
+
+    /// Mutate an existing object in the transaction.
+    /// `object_idx` is a convenient representation of the object's ID.
+    pub fn mutate_object(mut self, object_idx: u64) -> Self {
+        let tx_builder = self.checkpoint_builder.next_transaction.as_mut().unwrap();
+        let object_id = Self::derive_object_id(object_idx);
+        let object = self
+            .live_objects
+            .get(&object_id)
+            .cloned()
+            .expect("Mutating an object that doesn't exist");
+        tx_builder.mutated_objects.insert(object_id, object);
+        self
+    }
+
+    /// Transfer an existing object to a new owner.
+    /// `object_idx` is a convenient representation of the object's ID.
+    /// `recipient_idx` is a convenient representation of the recipient's
+    /// address.
+    pub fn transfer_object(self, object_idx: u64, recipient_idx: u8) -> Self {
+        self.change_object_owner(
+            object_idx,
+            Owner::AddressOwner(Self::derive_address(recipient_idx)),
+        )
+    }
+
+    /// Change the owner of an existing object.
+    /// `object_idx` is a convenient representation of the object's ID.
+    /// `owner` is the new owner of the object.
+    pub fn change_object_owner(mut self, object_idx: u64, owner: Owner) -> Self {
+        let tx_builder = self.checkpoint_builder.next_transaction.as_mut().unwrap();
+        let object_id = Self::derive_object_id(object_idx);
+        let mut object = self.live_objects.get(&object_id).unwrap().clone();
+        object.owner = owner;
+        tx_builder.mutated_objects.insert(object_id, object);
+        self
+    }
+
+    /// Transfer part of an existing coin object's balance to a new owner.
+    /// `object_idx` is a convenient representation of the object's ID.
+    /// `new_object_idx` is a convenient representation of the new object's ID.
+    /// `recipient_idx` is a convenient representation of the recipient's
+    /// address. `amount` is the amount of balance to be transferred.
+    pub fn transfer_coin_balance(
+        mut self,
+        object_idx: u64,
+        new_object_idx: u64,
+        recipient_idx: u8,
+        amount: u64,
+    ) -> Self {
+        let tx_builder = self.checkpoint_builder.next_transaction.as_mut().unwrap();
+        let object_id = Self::derive_object_id(object_idx);
+        let mut object = self
+            .live_objects
+            .get(&object_id)
+            .cloned()
+            .expect("Mutating an object that does not exist");
+        let coin_type = object.coin_type_maybe().unwrap();
+        // Withdraw balance from coin object.
+        let move_object = object.data.try_as_move_mut().unwrap();
+        let old_balance = move_object.get_coin_value_unsafe();
+        let new_balance = old_balance - amount;
+        move_object.set_coin_value_unsafe(new_balance);
+        tx_builder.mutated_objects.insert(object_id, object);
+
+        // Deposit balance into new coin object.
+        self.create_coin_object(new_object_idx, recipient_idx, amount, coin_type)
+    }
+
+    /// Wrap an existing object in the transaction.
+    /// `object_idx` is a convenient representation of the object's ID.
+    pub fn wrap_object(mut self, object_idx: u64) -> Self {
+        let tx_builder = self.checkpoint_builder.next_transaction.as_mut().unwrap();
+        let object_id = Self::derive_object_id(object_idx);
+        assert!(self.live_objects.contains_key(&object_id));
+        tx_builder.wrapped_objects.insert(object_id);
+        self
+    }
+
+    /// Unwrap an existing object from the transaction.
+    /// `object_idx` is a convenient representation of the object's ID.
+    pub fn unwrap_object(mut self, object_idx: u64) -> Self {
+        let tx_builder = self.checkpoint_builder.next_transaction.as_mut().unwrap();
+        let object_id = Self::derive_object_id(object_idx);
+        assert!(self.wrapped_objects.contains_key(&object_id));
+        tx_builder.unwrapped_objects.insert(object_id);
+        self
+    }
+
+    /// Delete an existing object from the transaction.
+    /// `object_idx` is a convenient representation of the object's ID.
+    pub fn delete_object(mut self, object_idx: u64) -> Self {
+        let tx_builder = self.checkpoint_builder.next_transaction.as_mut().unwrap();
+        let object_id = Self::derive_object_id(object_idx);
+        assert!(self.live_objects.contains_key(&object_id));
+        tx_builder.deleted_objects.insert(object_id);
+        self
+    }
+
+    /// Add events to the transaction.
+    /// `events` is a vector of events to be added to the transaction.
+    pub fn with_events(mut self, events: Vec<Event>) -> Self {
+        self.checkpoint_builder
+            .next_transaction
+            .as_mut()
+            .unwrap()
+            .events = Some(events);
+        self
+    }
+
+    /// Add a move call PTB command to the transaction.
+    /// `package` is the ID of the package to be called.
+    /// `module` is the name of the module to be called.
+    /// `function` is the name of the function to be called.
+    pub fn add_move_call(
+        mut self,
+        package: ObjectID,
+        module: &'static str,
+        function: &'static str,
+    ) -> Self {
+        let tx_builder = self.checkpoint_builder.next_transaction.as_mut().unwrap();
+        tx_builder.move_calls.push((package, module, function));
+        self
+    }
+
+    /// Complete the current transaction and add it to the checkpoint.
+    /// This will also finalize all the object changes, and reflect them in the
+    /// live object map.
+    pub fn finish_transaction(mut self) -> Self {
+        let TransactionBuilder {
+            sender_idx,
+            gas,
+            move_calls,
+            created_objects,
+            mutated_objects,
+            unwrapped_objects,
+            wrapped_objects,
+            deleted_objects,
+            events,
+        } = self.checkpoint_builder.next_transaction.take().unwrap();
+        let sender = Self::derive_address(sender_idx);
+        let events = events.map(|events| TransactionEvents { data: events });
+        let events_digest = events.as_ref().map(|events| events.digest());
+        let mut pt_builder = ProgrammableTransactionBuilder::new();
+        for (package, module, function) in move_calls {
+            pt_builder
+                .move_call(
+                    package,
+                    ident_str!(module).to_owned(),
+                    ident_str!(function).to_owned(),
+                    vec![],
+                    vec![],
+                )
+                .unwrap();
+        }
+        let pt = pt_builder.finish();
+        let tx_data = TransactionData::new(
+            TransactionKind::ProgrammableTransaction(pt),
+            sender,
+            gas,
+            1,
+            1,
+        );
+        let tx = Transaction::new(SenderSignedData::new(tx_data, vec![]));
+        let wrapped_objects: Vec<_> = wrapped_objects
+            .into_iter()
+            .map(|id| self.live_objects.remove(&id).unwrap())
+            .collect();
+        let deleted_objects: Vec<_> = deleted_objects
+            .into_iter()
+            .map(|id| self.live_objects.remove(&id).unwrap())
+            .collect();
+        let unwrapped_objects: Vec<_> = unwrapped_objects
+            .into_iter()
+            .map(|id| self.wrapped_objects.remove(&id).unwrap())
+            .collect();
+        let mut effects_builder = TestEffectsBuilder::new(tx.data())
+            .with_created_objects(created_objects.iter().map(|(id, o)| (*id, *o.owner())))
+            .with_mutated_objects(
+                mutated_objects
+                    .iter()
+                    .map(|(id, o)| (*id, o.version(), *o.owner())),
+            )
+            .with_wrapped_objects(wrapped_objects.iter().map(|o| (o.id(), o.version())))
+            .with_unwrapped_objects(unwrapped_objects.iter().map(|o| (o.id(), *o.owner())))
+            .with_deleted_objects(deleted_objects.iter().map(|o| (o.id(), o.version())));
+        if let Some(events_digest) = &events_digest {
+            effects_builder = effects_builder.with_events_digest(*events_digest);
+        }
+        let effects = effects_builder.build();
+        let lamport_version = effects.lamport_version();
+        let input_objects: Vec<_> = mutated_objects
+            .keys()
+            .map(|id| self.live_objects.get(id).unwrap().clone())
+            .chain(deleted_objects.clone())
+            .chain(wrapped_objects.clone())
+            .chain(std::iter::once(
+                self.live_objects.get(&gas.0).unwrap().clone(),
+            ))
+            .collect();
+        let output_objects: Vec<_> = created_objects
+            .values()
+            .cloned()
+            .chain(mutated_objects.values().cloned())
+            .chain(unwrapped_objects.clone())
+            .chain(std::iter::once(
+                self.live_objects.get(&gas.0).cloned().unwrap(),
+            ))
+            .map(|mut o| {
+                o.data
+                    .try_as_move_mut()
+                    .unwrap()
+                    .increment_version_to(lamport_version);
+                o
+            })
+            .collect();
+        self.live_objects
+            .extend(output_objects.iter().map(|o| (o.id(), o.clone())));
+        self.wrapped_objects
+            .extend(wrapped_objects.iter().map(|o| (o.id(), o.clone())));
+        self.checkpoint_builder
+            .transactions
+            .push(CheckpointTransaction {
+                transaction: tx,
+                effects,
+                events,
+                input_objects,
+                output_objects,
+            });
+        self
+    }
+
+    /// Build the checkpoint data using all the transactions added to the
+    /// builder so far. This will also increment the stored checkpoint
+    /// sequence number.
+    pub fn build_checkpoint(&mut self) -> CheckpointData {
+        assert!(self.checkpoint_builder.next_transaction.is_none());
+        let transactions = std::mem::take(&mut self.checkpoint_builder.transactions);
+        let contents = CheckpointContents::new_with_digests_only_for_tests(
+            transactions
+                .iter()
+                .map(|tx| ExecutionDigests::new(*tx.transaction.digest(), tx.effects.digest())),
+        );
+        let checkpoint_summary = CheckpointSummary::new(
+            &ProtocolConfig::get_for_max_version_UNSAFE(),
+            self.checkpoint_builder.epoch,
+            self.checkpoint_builder.checkpoint,
+            transactions.len() as u64,
+            &contents,
+            None,
+            Default::default(),
+            None,
+            0,
+            vec![],
+        );
+        let (committee, keys) = Committee::new_simple_test_committee();
+        let checkpoint_cert = CertifiedCheckpointSummary::new_from_keypairs_for_testing(
+            checkpoint_summary,
+            &keys,
+            &committee,
+        );
+        self.checkpoint_builder.checkpoint += 1;
+        CheckpointData {
+            checkpoint_summary: checkpoint_cert,
+            checkpoint_contents: contents,
+            transactions,
+        }
+    }
+
+    /// Derive an object ID from an index. This is used to conveniently
+    /// represent an object's ID.
+    pub fn derive_object_id(object_idx: u64) -> ObjectID {
+        ObjectID::derive_id(TransactionDigest::ZERO, object_idx)
+    }
+
+    /// Derive an address from an index.
+    pub fn derive_address(address_idx: u8) -> IotaAddress {
+        dbg_addr(address_idx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use move_core_types::ident_str;
+
+    use super::*;
+    use crate::transaction::{Command, ProgrammableMoveCall, TransactionDataAPI};
+    #[test]
+    fn test_basic_checkpoint_builder() {
+        // Create a checkpoint with a single transaction that does nothing.
+        let checkpoint = TestCheckpointDataBuilder::new(1)
+            .with_epoch(5)
+            .start_transaction(0)
+            .finish_transaction()
+            .build_checkpoint();
+
+        assert_eq!(*checkpoint.checkpoint_summary.sequence_number(), 1);
+        assert_eq!(checkpoint.checkpoint_summary.epoch, 5);
+        assert_eq!(checkpoint.transactions.len(), 1);
+        let tx = &checkpoint.transactions[0];
+        assert_eq!(
+            tx.transaction.sender_address(),
+            TestCheckpointDataBuilder::derive_address(0)
+        );
+        assert_eq!(tx.effects.mutated().len(), 1); // gas object
+        assert_eq!(tx.effects.deleted().len(), 0);
+        assert_eq!(tx.effects.created().len(), 0);
+        assert_eq!(tx.input_objects.len(), 1);
+        assert_eq!(tx.output_objects.len(), 1);
+    }
+
+    #[test]
+    fn test_multiple_transactions() {
+        let checkpoint = TestCheckpointDataBuilder::new(1)
+            .start_transaction(0)
+            .finish_transaction()
+            .start_transaction(1)
+            .finish_transaction()
+            .start_transaction(2)
+            .finish_transaction()
+            .build_checkpoint();
+
+        assert_eq!(checkpoint.transactions.len(), 3);
+
+        // Verify transactions have different senders (since we used 0, 1, 2 as sender
+        // indices above).
+        let senders: Vec<_> = checkpoint
+            .transactions
+            .iter()
+            .map(|tx| tx.transaction.transaction_data().sender())
+            .collect();
+        assert_eq!(
+            senders,
+            vec![
+                TestCheckpointDataBuilder::derive_address(0),
+                TestCheckpointDataBuilder::derive_address(1),
+                TestCheckpointDataBuilder::derive_address(2)
+            ]
+        );
+    }
+
+    #[test]
+    fn test_object_creation() {
+        let checkpoint = TestCheckpointDataBuilder::new(1)
+            .start_transaction(0)
+            .create_owned_object(0)
+            .finish_transaction()
+            .build_checkpoint();
+
+        let tx = &checkpoint.transactions[0];
+        let created_obj_id = TestCheckpointDataBuilder::derive_object_id(0);
+
+        // Verify the newly created object appears in output objects
+        assert!(
+            tx.output_objects
+                .iter()
+                .any(|obj| obj.id() == created_obj_id)
+        );
+
+        // Verify effects show object creation
+        assert!(
+            tx.effects
+                .created()
+                .iter()
+                .any(|((id, ..), owner)| *id == created_obj_id
+                    && owner.get_owner_address().unwrap()
+                        == TestCheckpointDataBuilder::derive_address(0))
+        );
+    }
+
+    #[test]
+    fn test_object_mutation() {
+        let checkpoint = TestCheckpointDataBuilder::new(1)
+            .start_transaction(0)
+            .create_owned_object(0)
+            .finish_transaction()
+            .start_transaction(0)
+            .mutate_object(0)
+            .finish_transaction()
+            .build_checkpoint();
+
+        let tx = &checkpoint.transactions[1];
+        let obj_id = TestCheckpointDataBuilder::derive_object_id(0);
+
+        // Verify object appears in both input and output objects
+        assert!(tx.input_objects.iter().any(|obj| obj.id() == obj_id));
+        assert!(tx.output_objects.iter().any(|obj| obj.id() == obj_id));
+
+        // Verify effects show object mutation
+        assert!(
+            tx.effects
+                .mutated()
+                .iter()
+                .any(|((id, ..), _)| *id == obj_id)
+        );
+    }
+
+    #[test]
+    fn test_object_deletion() {
+        let checkpoint = TestCheckpointDataBuilder::new(1)
+            .start_transaction(0)
+            .create_owned_object(0)
+            .finish_transaction()
+            .start_transaction(0)
+            .delete_object(0)
+            .finish_transaction()
+            .build_checkpoint();
+
+        let tx = &checkpoint.transactions[1];
+        let obj_id = TestCheckpointDataBuilder::derive_object_id(0);
+
+        // Verify object appears in input objects but not output
+        assert!(tx.input_objects.iter().any(|obj| obj.id() == obj_id));
+        assert!(!tx.output_objects.iter().any(|obj| obj.id() == obj_id));
+
+        // Verify effects show object deletion
+        assert!(tx.effects.deleted().iter().any(|(id, ..)| *id == obj_id));
+    }
+
+    #[test]
+    fn test_object_wrapping() {
+        let checkpoint = TestCheckpointDataBuilder::new(1)
+            .start_transaction(0)
+            .create_owned_object(0)
+            .finish_transaction()
+            .start_transaction(0)
+            .wrap_object(0)
+            .finish_transaction()
+            .start_transaction(0)
+            .unwrap_object(0)
+            .finish_transaction()
+            .build_checkpoint();
+
+        let tx = &checkpoint.transactions[1];
+        let obj_id = TestCheckpointDataBuilder::derive_object_id(0);
+
+        // Verify object appears in input objects but not output
+        assert!(tx.input_objects.iter().any(|obj| obj.id() == obj_id));
+        assert!(!tx.output_objects.iter().any(|obj| obj.id() == obj_id));
+
+        // Verify effects show object wrapping
+        assert!(tx.effects.wrapped().iter().any(|(id, ..)| *id == obj_id));
+
+        let tx = &checkpoint.transactions[2];
+
+        // Verify object appears in output objects but not input
+        assert!(!tx.input_objects.iter().any(|obj| obj.id() == obj_id));
+        assert!(tx.output_objects.iter().any(|obj| obj.id() == obj_id));
+
+        // Verify effects show object unwrapping
+        assert!(
+            tx.effects
+                .unwrapped()
+                .iter()
+                .any(|((id, ..), _)| *id == obj_id)
+        );
+    }
+
+    #[test]
+    fn test_object_transfer() {
+        let checkpoint = TestCheckpointDataBuilder::new(1)
+            .start_transaction(0)
+            .create_owned_object(0)
+            .finish_transaction()
+            .start_transaction(1)
+            .transfer_object(0, 1)
+            .finish_transaction()
+            .build_checkpoint();
+
+        let tx = &checkpoint.transactions[1];
+        let obj_id = TestCheckpointDataBuilder::derive_object_id(0);
+
+        // Verify object appears in input and output objects
+        assert!(tx.input_objects.iter().any(|obj| obj.id() == obj_id));
+        assert!(tx.output_objects.iter().any(|obj| obj.id() == obj_id));
+
+        // Verify effects show object transfer
+        assert!(
+            tx.effects
+                .mutated()
+                .iter()
+                .any(|((id, ..), owner)| *id == obj_id
+                    && owner.get_owner_address().unwrap()
+                        == TestCheckpointDataBuilder::derive_address(1))
+        );
+    }
+
+    #[test]
+    fn test_shared_object() {
+        let checkpoint = TestCheckpointDataBuilder::new(1)
+            .start_transaction(0)
+            .create_shared_object(0)
+            .finish_transaction()
+            .build_checkpoint();
+
+        let tx = &checkpoint.transactions[0];
+        let obj_id = TestCheckpointDataBuilder::derive_object_id(0);
+
+        // Verify object appears in output objects and is shared
+        assert!(
+            tx.output_objects
+                .iter()
+                .any(|obj| obj.id() == obj_id && obj.owner().is_shared())
+        );
+    }
+
+    #[test]
+    fn test_freeze_object() {
+        let checkpoint = TestCheckpointDataBuilder::new(1)
+            .start_transaction(0)
+            .create_owned_object(0)
+            .finish_transaction()
+            .start_transaction(0)
+            .change_object_owner(0, Owner::Immutable)
+            .finish_transaction()
+            .build_checkpoint();
+
+        let tx = &checkpoint.transactions[1];
+        let obj_id = TestCheckpointDataBuilder::derive_object_id(0);
+
+        // Verify object appears in output objects and is immutable
+        assert!(
+            tx.output_objects
+                .iter()
+                .any(|obj| obj.id() == obj_id && obj.owner().is_immutable())
+        );
+    }
+
+    #[test]
+    fn test_iota_balance_transfer() {
+        let checkpoint = TestCheckpointDataBuilder::new(1)
+            .start_transaction(0)
+            .create_iota_object(0, 100)
+            .finish_transaction()
+            .start_transaction(1)
+            .transfer_coin_balance(0, 1, 1, 10)
+            .finish_transaction()
+            .build_checkpoint();
+
+        let tx = &checkpoint.transactions[0];
+        let obj_id0 = TestCheckpointDataBuilder::derive_object_id(0);
+
+        // Verify the newly created object appears in output objects and is a gas coin
+        // with 100 NANOS.
+        assert!(tx.output_objects.iter().any(|obj| obj.id() == obj_id0
+            && obj.is_gas_coin()
+            && obj.data.try_as_move().unwrap().get_coin_value_unsafe() == 100));
+
+        let tx = &checkpoint.transactions[1];
+        let obj_id1 = TestCheckpointDataBuilder::derive_object_id(1);
+
+        // Verify the original IOTA coin now has 90 NANOS after the transfer.
+        assert!(tx.output_objects.iter().any(|obj| obj.id() == obj_id0
+            && obj.is_gas_coin()
+            && obj.data.try_as_move().unwrap().get_coin_value_unsafe() == 90));
+
+        // Verify the split out IOTA coin has 10 NANOS.
+        assert!(tx.output_objects.iter().any(|obj| obj.id() == obj_id1
+            && obj.is_gas_coin()
+            && obj.data.try_as_move().unwrap().get_coin_value_unsafe() == 10));
+    }
+
+    #[test]
+    fn test_coin_balance_transfer() {
+        let type_tag = TypeTag::from_str("0x100::a::b").unwrap();
+        let checkpoint = TestCheckpointDataBuilder::new(1)
+            .start_transaction(0)
+            .create_coin_object(0, 0, 100, type_tag.clone())
+            .finish_transaction()
+            .start_transaction(1)
+            .transfer_coin_balance(0, 1, 1, 10)
+            .finish_transaction()
+            .build_checkpoint();
+
+        let tx = &checkpoint.transactions[1];
+        let obj_id0 = TestCheckpointDataBuilder::derive_object_id(0);
+        let obj_id1 = TestCheckpointDataBuilder::derive_object_id(1);
+
+        // Verify the original coin now has 90 balance after the transfer.
+        assert!(tx.output_objects.iter().any(|obj| obj.id() == obj_id0
+            && obj.coin_type_maybe().unwrap() == type_tag
+            && obj.data.try_as_move().unwrap().get_coin_value_unsafe() == 90));
+
+        // Verify the split out coin has 10 balance, with the same type tag.
+        assert!(tx.output_objects.iter().any(|obj| obj.id() == obj_id1
+            && obj.coin_type_maybe().unwrap() == type_tag
+            && obj.data.try_as_move().unwrap().get_coin_value_unsafe() == 10));
+    }
+
+    #[test]
+    fn test_events() {
+        let checkpoint = TestCheckpointDataBuilder::new(1)
+            .start_transaction(0)
+            .with_events(vec![Event::new(
+                &ObjectID::ZERO,
+                ident_str!("test"),
+                TestCheckpointDataBuilder::derive_address(0),
+                GAS::type_(),
+                vec![],
+            )])
+            .finish_transaction()
+            .build_checkpoint();
+        let tx = &checkpoint.transactions[0];
+
+        // Verify the transaction has an events digest
+        assert!(tx.effects.events_digest().is_some());
+
+        // Verify the transaction has a single event
+        assert_eq!(tx.events.as_ref().unwrap().data.len(), 1);
+    }
+
+    #[test]
+    fn test_move_call() {
+        let checkpoint = TestCheckpointDataBuilder::new(1)
+            .start_transaction(0)
+            .add_move_call(ObjectID::ZERO, "test", "test")
+            .finish_transaction()
+            .build_checkpoint();
+        let tx = &checkpoint.transactions[0];
+
+        // Verify the transaction has a move call matching the arguments provided.
+        assert!(
+            tx.transaction
+                .transaction_data()
+                .kind()
+                .iter_commands()
+                .any(|cmd| {
+                    cmd == &Command::MoveCall(Box::new(ProgrammableMoveCall {
+                        package: ObjectID::ZERO,
+                        module: "test".to_string(),
+                        function: "test".to_string(),
+                        type_arguments: vec![],
+                        arguments: vec![],
+                    }))
+                })
+        );
+    }
+
+    #[test]
+    fn test_multiple_checkpoints() {
+        let mut builder = TestCheckpointDataBuilder::new(1)
+            .start_transaction(0)
+            .create_owned_object(0)
+            .finish_transaction();
+        let checkpoint1 = builder.build_checkpoint();
+        builder = builder
+            .start_transaction(0)
+            .mutate_object(0)
+            .finish_transaction();
+        let checkpoint2 = builder.build_checkpoint();
+        builder = builder
+            .start_transaction(0)
+            .delete_object(0)
+            .finish_transaction();
+        let checkpoint3 = builder.build_checkpoint();
+
+        // Verify the sequence numbers are consecutive.
+        assert_eq!(checkpoint1.checkpoint_summary.sequence_number, 1);
+        assert_eq!(checkpoint2.checkpoint_summary.sequence_number, 2);
+        assert_eq!(checkpoint3.checkpoint_summary.sequence_number, 3);
+    }
+}


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.40.3, v1.41.2)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/525f26fa7265f1e20c11461bb6bb5b14a8b67373
- Description:
This PR adds a builder that could generate arbitrary checkpoint data.
It will make it easy to test the indexer. 

## Links to any relevant issues

Part of #6149   

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
