### PR TITLE
fix(move-analyzer): VSCode package fix for Windows

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "iotaledger",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "preview": true,
   "repository": {
     "url": "https://github.com/iotaledger/iota.git",

--- a/external-crates/move/crates/move-package/src/resolution/dependency_cache.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_cache.rs
@@ -2,7 +2,13 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeSet, ffi::OsStr, io::Write, path::PathBuf, process::Command};
+use std::{
+    collections::BTreeSet,
+    ffi::OsStr,
+    io::Write,
+    path::PathBuf,
+    process::{Command, Stdio},
+};
 
 use anyhow::Result;
 use colored::Colorize;
@@ -64,7 +70,7 @@ impl DependencyCache {
 
                 if Command::new("git")
                     .arg("--version")
-                    .stdin(std::process::Stdio::null())
+                    .stdin(Stdio::null())
                     .output()
                     .is_err()
                 {
@@ -86,7 +92,7 @@ impl DependencyCache {
                     // If the cached folder does not exist, download and clone accordingly
                     if let Ok(mut output) = Command::new("git")
                         .args([OsStr::new("clone"), os_git_url, git_path.as_os_str()])
-                        .stdin(std::process::Stdio::null())
+                        .stdin(Stdio::null())
                         .spawn()
                     {
                         output.wait().map_err(|_| {
@@ -112,7 +118,7 @@ impl DependencyCache {
                             OsStr::new("checkout"),
                             os_git_rev,
                         ])
-                        .stdin(std::process::Stdio::null())
+                        .stdin(Stdio::null())
                         .output()
                         .map_err(|_| {
                             anyhow::anyhow!(
@@ -133,7 +139,7 @@ impl DependencyCache {
                             OsStr::new("--verify"),
                             os_git_rev,
                         ])
-                        .stdin(std::process::Stdio::null())
+                        .stdin(Stdio::null())
                         .output()
                     {
                         if let Ok(parsable_version) = String::from_utf8(rev.stdout) {
@@ -152,7 +158,7 @@ impl DependencyCache {
                             OsStr::new("--list"),
                             os_git_rev,
                         ])
-                        .stdin(std::process::Stdio::null())
+                        .stdin(Stdio::null())
                         .output();
 
                     if let Ok(tag) = tag {
@@ -187,7 +193,7 @@ impl DependencyCache {
                             OsStr::new("fetch"),
                             OsStr::new("origin"),
                         ])
-                        .stdin(std::process::Stdio::null())
+                        .stdin(Stdio::null())
                         .spawn()
                     {
                         output.wait().map_err(|_| {
@@ -216,7 +222,9 @@ impl DependencyCache {
                             OsStr::new("--hard"),
                             OsStr::new(&format!("origin/{}", git_rev)),
                         ])
-                        .stdin(std::process::Stdio::null())
+                        .stdin(Stdio::null())
+                        .stdout(Stdio::null())
+                        .stderr(Stdio::null())
                         .status()
                         .map_err(|_| {
                             anyhow::anyhow!(

--- a/external-crates/move/crates/move-package/src/resolution/dependency_cache.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_cache.rs
@@ -2,13 +2,7 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::BTreeSet,
-    ffi::OsStr,
-    io::Write,
-    path::PathBuf,
-    process::{Command, Stdio},
-};
+use std::{collections::BTreeSet, ffi::OsStr, io::Write, path::PathBuf, process::Command};
 
 use anyhow::Result;
 use colored::Colorize;
@@ -68,7 +62,12 @@ impl DependencyCache {
                     return Ok(());
                 }
 
-                if Command::new("git").arg("--version").output().is_err() {
+                if Command::new("git")
+                    .arg("--version")
+                    .stdin(std::process::Stdio::null())
+                    .output()
+                    .is_err()
+                {
                     writeln!(progress_output, "Git is not installed or not in the PATH.")?;
                     return Err(anyhow::anyhow!("Git is not installed or not in the PATH."));
                 }
@@ -87,6 +86,7 @@ impl DependencyCache {
                     // If the cached folder does not exist, download and clone accordingly
                     if let Ok(mut output) = Command::new("git")
                         .args([OsStr::new("clone"), os_git_url, git_path.as_os_str()])
+                        .stdin(std::process::Stdio::null())
                         .spawn()
                     {
                         output.wait().map_err(|_| {
@@ -112,6 +112,7 @@ impl DependencyCache {
                             OsStr::new("checkout"),
                             os_git_rev,
                         ])
+                        .stdin(std::process::Stdio::null())
                         .output()
                         .map_err(|_| {
                             anyhow::anyhow!(
@@ -132,6 +133,7 @@ impl DependencyCache {
                             OsStr::new("--verify"),
                             os_git_rev,
                         ])
+                        .stdin(std::process::Stdio::null())
                         .output()
                     {
                         if let Ok(parsable_version) = String::from_utf8(rev.stdout) {
@@ -150,6 +152,7 @@ impl DependencyCache {
                             OsStr::new("--list"),
                             os_git_rev,
                         ])
+                        .stdin(std::process::Stdio::null())
                         .output();
 
                     if let Ok(tag) = tag {
@@ -184,6 +187,7 @@ impl DependencyCache {
                             OsStr::new("fetch"),
                             OsStr::new("origin"),
                         ])
+                        .stdin(std::process::Stdio::null())
                         .spawn()
                     {
                         output.wait().map_err(|_| {
@@ -212,9 +216,7 @@ impl DependencyCache {
                             OsStr::new("--hard"),
                             OsStr::new(&format!("origin/{}", git_rev)),
                         ])
-                        .stdin(Stdio::null())
-                        .stdout(Stdio::null())
-                        .stderr(Stdio::null())
+                        .stdin(std::process::Stdio::null())
                         .status()
                         .map_err(|_| {
                             anyhow::anyhow!(


### PR DESCRIPTION
# Description of change

This fixes a package build problem on Windows where one has to specify
input/output for OS commands explicitly.

## Links to any relevant issues

fixes #7982
