### PR TITLE
refactor(ci): remove all `protoc` actions from jobs

### DIFF
--- a/.github/workflows/_rust_lints.yml
+++ b/.github/workflows/_rust_lints.yml
@@ -73,7 +73,6 @@ jobs:
     runs-on: [self-hosted-x64]
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - uses: taiki-e/install-action@protoc
       # TODO(bradh): debug and re-enable this; the caching is breaking the clippy build
       # Enable caching of the 'librocksdb-sys' crate by additionally caching the
       # 'librocksdb-sys' src directory which is managed by cargo

--- a/.github/workflows/_rust_tests.yml
+++ b/.github/workflows/_rust_tests.yml
@@ -82,7 +82,6 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - uses: taiki-e/install-action@protoc
       - name: Install postgresql-client
         run: sudo apt-get install -y postgresql-client
       - name: Setup db
@@ -141,7 +140,6 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - uses: taiki-e/install-action@protoc
       - name: Install postgresql-client
         run: sudo apt-get install -y postgresql-client
       - name: Setup db
@@ -180,7 +178,6 @@ jobs:
     runs-on: [self-hosted-x64]
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - uses: taiki-e/install-action@protoc
       - name: Run Cargo Udeps
         run: cargo +nightly-2025-04-01 ci-udeps ${{ matrix.flags }}
       - name: Run Cargo Udeps (external crates)
@@ -201,7 +198,6 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - uses: taiki-e/install-action@protoc
       - name: benchmark (smoke)
         run: |
           cargo run --package iota-benchmark --bin stress -- --log-path /tmp/stress.log --num-client-threads 10 --num-server-threads 24 --num-transfer-accounts 2 bench --target-qps 100 --num-workers 10  --transfer-object 50 --shared-counter 50 --run-duration 10s --stress-stat-collection

--- a/.github/workflows/crate_docs.yml
+++ b/.github/workflows/crate_docs.yml
@@ -18,7 +18,6 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - uses: taiki-e/install-action@protoc
 
       - name: Generate documentation
         uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,14 @@ jobs:
         run: |
           brew install postgresql
 
+      - name: Install protoc (Windows)
+        if: ${{ matrix.os_type == 'windows-x86_64' }}
+        uses: taiki-e/install-action@protoc
+
+      - name: Install protoc (MacOS arm64)
+        if: ${{ matrix.os_type == 'macos-arm64' }}
+        uses: taiki-e/install-action@protoc
+
       - name: Remove unused apps (MacOS arm64)
         if: ${{ matrix.os_type == 'macos-arm64' }}
         continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,8 +156,6 @@ jobs:
           sudo rm -rf ~/Library/Developer/Xcode/iOS\ DeviceSupport/*
           df -h /
 
-      - uses: taiki-e/install-action@protoc
-
       - name: Cargo build for ${{ matrix.os_type }} platform
         shell: bash
         run: |


### PR DESCRIPTION
# Description of change

Remove `protoc` installation and configuration from CI jobs in favor of runner system-wide dependency installation.

## Links to any relevant issues

fixes #7987 .

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
