### PR TITLE
feat(protocol): Add minimize_child_object_mutations protocol config

### DIFF
--- a/crates/iota-adapter-transactional-tests/tests/child_count/count_decremented_v9.move
+++ b/crates/iota-adapter-transactional-tests/tests/child_count/count_decremented_v9.move
@@ -1,0 +1,92 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// DEPRECATED child count no longer tracked
+// tests various ways of "removing" a child decrements the count
+// After protocol version 9, some of the child object mutations will not appear since they do not
+// modify the Move value.
+
+//# init --addresses test=0x0 --accounts A B --protocol-version 9
+
+//# publish
+
+module test::m {
+    use iota::dynamic_object_field as ofield;
+
+    public struct S has key, store {
+        id: iota::object::UID,
+    }
+
+    public struct R has key, store {
+        id: iota::object::UID,
+        s: S,
+    }
+
+    public entry fun mint(ctx: &mut TxContext) {
+        let id = iota::object::new(ctx);
+        iota::transfer::public_transfer(S { id }, tx_context::sender(ctx))
+    }
+
+    public entry fun add(parent: &mut S, idx: u64, ctx: &mut TxContext) {
+        let child = S { id: iota::object::new(ctx) };
+        ofield::add(&mut parent.id, idx, child);
+    }
+
+    public entry fun remove(parent: &mut S, idx: u64) {
+        let S { id } = ofield::remove(&mut parent.id, idx);
+        iota::object::delete(id)
+    }
+
+    public entry fun remove_and_add(parent: &mut S, idx: u64) {
+        let child: S = ofield::remove(&mut parent.id, idx);
+        ofield::add(&mut parent.id, idx, child)
+    }
+
+    public entry fun remove_and_wrap(parent: &mut S, idx: u64, ctx: &mut TxContext) {
+        let child: S = ofield::remove(&mut parent.id, idx);
+        ofield::add(&mut parent.id, idx, R { id: iota::object::new(ctx), s: child })
+    }
+}
+
+//
+// Test remove
+//
+
+//# run test::m::mint --sender A
+
+//# view-object 2,0
+
+//# run test::m::add --sender A --args object(2,0) 1
+
+//# run test::m::remove --sender A --args object(2,0) 1
+
+//# view-object 2,0
+
+//
+// Test remove and add
+//
+
+//# run test::m::mint --sender A
+
+//# view-object 7,0
+
+//# run test::m::add --sender A --args object(7,0) 1
+
+//# run test::m::remove_and_add --sender A --args object(7,0) 1
+
+//# view-object 7,0
+
+//
+// Test remove and wrap
+//
+
+//# run test::m::mint --sender A
+
+//# view-object 12,0
+
+//# run test::m::add --sender A --args object(12,0) 1
+
+//# run test::m::remove_and_wrap --sender A --args object(12,0) 1
+
+//# view-object 12,0

--- a/crates/iota-adapter-transactional-tests/tests/child_count/count_decremented_v9.snap
+++ b/crates/iota-adapter-transactional-tests/tests/child_count/count_decremented_v9.snap
@@ -6,19 +6,19 @@ processed 17 tasks
 init:
 A: object(0,0), B: object(0,1)
 
-task 1, lines 10-52:
+task 1, lines 12-54:
 //# publish
 created: object(1,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 7508800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, line 54:
+task 2, line 56:
 //# run test::m::mint --sender A
 created: object(2,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2181200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 56:
+task 3, line 58:
 //# view-object 2,0
 Owner: Account Address ( A )
 Version: 2
@@ -30,19 +30,19 @@ Contents: test::m::S {
     },
 }
 
-task 4, line 58:
+task 4, line 60:
 //# run test::m::add --sender A --args object(2,0) 1
 created: object(4,0), object(4,1)
 mutated: object(0,0), object(2,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5829200,  storage_rebate: 2181200, non_refundable_storage_fee: 0
 
-task 5, line 60:
+task 5, line 62:
 //# run test::m::remove --sender A --args object(2,0) 1
 mutated: object(0,0), object(2,0)
 deleted: object(4,0), object(4,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2181200,  storage_rebate: 5829200, non_refundable_storage_fee: 0
 
-task 6, lines 62-66:
+task 6, lines 64-68:
 //# view-object 2,0
 Owner: Account Address ( A )
 Version: 4
@@ -54,13 +54,13 @@ Contents: test::m::S {
     },
 }
 
-task 7, line 68:
+task 7, line 70:
 //# run test::m::mint --sender A
 created: object(7,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2181200,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 8, line 70:
+task 8, line 72:
 //# view-object 7,0
 Owner: Account Address ( A )
 Version: 5
@@ -72,18 +72,18 @@ Contents: test::m::S {
     },
 }
 
-task 9, line 72:
+task 9, line 74:
 //# run test::m::add --sender A --args object(7,0) 1
 created: object(9,0), object(9,1)
 mutated: object(0,0), object(7,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5829200,  storage_rebate: 2181200, non_refundable_storage_fee: 0
 
-task 10, line 74:
+task 10, line 76:
 //# run test::m::remove_and_add --sender A --args object(7,0) 1
-mutated: object(0,0), object(7,0)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2181200,  storage_rebate: 2181200, non_refundable_storage_fee: 0
+mutated: object(0,0), object(7,0), object(9,0), object(9,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5829200,  storage_rebate: 5829200, non_refundable_storage_fee: 0
 
-task 11, lines 76-80:
+task 11, lines 78-82:
 //# view-object 7,0
 Owner: Account Address ( A )
 Version: 7
@@ -95,13 +95,13 @@ Contents: test::m::S {
     },
 }
 
-task 12, line 82:
+task 12, line 84:
 //# run test::m::mint --sender A
 created: object(12,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2181200,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 13, line 84:
+task 13, line 86:
 //# view-object 12,0
 Owner: Account Address ( A )
 Version: 8
@@ -113,20 +113,20 @@ Contents: test::m::S {
     },
 }
 
-task 14, line 86:
+task 14, line 88:
 //# run test::m::add --sender A --args object(12,0) 1
 created: object(14,0), object(14,1)
 mutated: object(0,0), object(12,0)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 5829200,  storage_rebate: 2181200, non_refundable_storage_fee: 0
 
-task 15, line 88:
+task 15, line 90:
 //# run test::m::remove_and_wrap --sender A --args object(12,0) 1
 created: object(15,0)
 mutated: object(0,0), object(12,0), object(14,0)
 wrapped: object(14,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6072400,  storage_rebate: 5829200, non_refundable_storage_fee: 0
 
-task 16, line 90:
+task 16, line 92:
 //# view-object 12,0
 Owner: Account Address ( A )
 Version: 10

--- a/crates/iota-adapter-transactional-tests/tests/deny_list_v1/double_add_v9.move
+++ b/crates/iota-adapter-transactional-tests/tests/deny_list_v1/double_add_v9.move
@@ -1,0 +1,72 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// This test verifies double adding an address to the deny list does not panic and still
+// ensures the correct behavior when removing
+// After protocol version 9, some of the child object mutations will not appear since they do not
+// modify the Move value
+
+//# init --accounts A B --addresses test=0x0 --protocol-version 9
+
+//# publish --sender A
+module test::regulated_coin {
+    use iota::coin;
+    use iota::deny_list::DenyList;
+
+    public struct REGULATED_COIN has drop {}
+
+    fun init(otw: REGULATED_COIN, ctx: &mut TxContext) {
+        let (mut treasury_cap, deny_cap, metadata) = coin::create_regulated_currency_v1(
+            otw,
+            9,
+            b"RC",
+            b"REGULATED_COIN",
+            b"A new regulated coin",
+            option::none(),
+            false,
+            ctx
+        );
+        let coin = coin::mint(&mut treasury_cap, 10000, ctx);
+        transfer::public_transfer(coin, tx_context::sender(ctx));
+        transfer::public_transfer(deny_cap, tx_context::sender(ctx));
+        transfer::public_freeze_object(treasury_cap);
+        transfer::public_freeze_object(metadata);
+    }
+
+    entry fun assert_address_deny_status(
+        deny_list: &DenyList,
+        addr: address,
+        expected: bool,
+    ) {
+        let status = coin::deny_list_v1_contains_next_epoch<REGULATED_COIN>(deny_list, addr);
+        assert!(status == expected, 0);
+    }
+}
+
+// Transfer away the newly minted coin works normally.
+//# run iota::pay::split_and_transfer --args object(1,0) 1 @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+
+// Deny account B.
+//# run iota::coin::deny_list_v1_add --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+
+// Deny account B a second time. This should not change anything.
+//# run iota::coin::deny_list_v1_add --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+
+// Assert that the address is denied.
+//# run test::regulated_coin::assert_address_deny_status --args immshared(0x403) @B true --sender A
+
+// Try transfer the coin from B. This should now be denied.
+//# transfer-object 2,0 --sender B --recipient A
+
+// Try using the coin in a Move call. This should also be denied.
+//# run iota::pay::split_and_transfer --args object(2,0) 1 @A --type-args test::regulated_coin::REGULATED_COIN --sender B
+
+// Undeny account B.
+//# run iota::coin::deny_list_v1_remove --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
+
+// Assert that the address is no longer denied.
+//# run test::regulated_coin::assert_address_deny_status --args immshared(0x403) @B false --sender A
+
+// This time the transfer should work.
+//# transfer-object 2,0 --sender B --recipient A

--- a/crates/iota-adapter-transactional-tests/tests/deny_list_v1/double_add_v9.snap
+++ b/crates/iota-adapter-transactional-tests/tests/deny_list_v1/double_add_v9.snap
@@ -6,59 +6,59 @@ processed 11 tasks
 init:
 A: object(0,0), B: object(0,1)
 
-task 1, lines 10-45:
+task 1, lines 12-47:
 //# publish --sender A
 created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5)
 mutated: object(0,0)
 unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 19425600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 46-48:
+task 2, lines 48-50:
 //# run iota::pay::split_and_transfer --args object(1,0) 1 @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 created: object(2,0)
 mutated: object(0,0), object(1,0)
 unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 3914000,  storage_rebate: 2447200, non_refundable_storage_fee: 0
 
-task 3, lines 49-51:
+task 3, lines 51-53:
 //# run iota::coin::deny_list_v1_add --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 events: Event { package_id: iota, transaction_module: Identifier("coin"), sender: A, type_: StructTag { address: iota, module: Identifier("deny_list"), name: Identifier("PerTypeConfigCreated"), type_params: [] }, contents: [0, 0, 0, 0, 0, 0, 0, 0, 96, 49, 99, 57, 56, 57, 49, 57, 50, 99, 98, 55, 56, 53, 49, 102, 50, 54, 49, 99, 97, 51, 53, 55, 99, 99, 100, 55, 49, 48, 102, 51, 101, 57, 55, 50, 57, 54, 99, 101, 55, 51, 102, 53, 102, 48, 55, 48, 99, 100, 54, 97, 48, 52, 57, 102, 49, 49, 50, 52, 102, 101, 54, 49, 99, 58, 58, 114, 101, 103, 117, 108, 97, 116, 101, 100, 95, 99, 111, 105, 110, 58, 58, 82, 69, 71, 85, 76, 65, 84, 69, 68, 95, 67, 79, 73, 78, 227, 5, 87, 243, 17, 67, 48, 78, 223, 164, 121, 136, 98, 174, 80, 210, 249, 81, 188, 233, 5, 28, 211, 145, 148, 4, 203, 247, 202, 138, 227, 32] }
 created: object(3,0), object(3,1), object(3,2)
 mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,2)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 12144800,  storage_rebate: 2758800, non_refundable_storage_fee: 0
 
-task 4, lines 52-54:
+task 4, lines 54-56:
 //# run iota::coin::deny_list_v1_add --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
-mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,2)
-gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 4377600,  storage_rebate: 4377600, non_refundable_storage_fee: 0
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,2), object(3,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6832400,  storage_rebate: 6832400, non_refundable_storage_fee: 0
 
-task 5, lines 55-57:
+task 5, lines 57-59:
 //# run test::regulated_coin::assert_address_deny_status --args immshared(0x403) @B true --sender A
 mutated: object(0,0)
 unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 980400,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 6, lines 58-60:
+task 6, lines 60-62:
 //# transfer-object 2,0 --sender B --recipient A
 Error: Error checking transaction input objects: AddressDeniedForCoin { address: @B, coin_type: "object(1,5)::regulated_coin::REGULATED_COIN" }
 
-task 7, lines 61-63:
+task 7, lines 63-65:
 //# run iota::pay::split_and_transfer --args object(2,0) 1 @A --type-args test::regulated_coin::REGULATED_COIN --sender B
 Error: Error checking transaction input objects: AddressDeniedForCoin { address: @B, coin_type: "object(1,5)::regulated_coin::REGULATED_COIN" }
 
-task 8, lines 64-66:
+task 8, lines 66-68:
 //# run iota::coin::deny_list_v1_remove --args object(0x403) object(1,2) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
 mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,2)
 deleted: object(3,1)
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 4377600,  storage_rebate: 6832400, non_refundable_storage_fee: 0
 
-task 9, lines 67-69:
+task 9, lines 69-71:
 //# run test::regulated_coin::assert_address_deny_status --args immshared(0x403) @B false --sender A
 mutated: object(0,0)
 unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 980400,  storage_rebate: 980400, non_refundable_storage_fee: 0
 
-task 10, line 70:
+task 10, line 72:
 //# transfer-object 2,0 --sender B --recipient A
 mutated: object(0,1), object(2,0)
 unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged.move
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged.move
@@ -1,0 +1,84 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// This test tests that objects that are borrowed mutably or added/removed, but not modified, do not
+// need to be marked as mutated
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+
+module test::m1;
+
+use iota::dynamic_field;
+
+public struct Object has key, store {
+    id: UID,
+}
+
+public struct Value has copy, drop, store {
+    data: vector<u8>,
+}
+
+public struct ObjValue has key, store {
+    id: UID,
+    data: vector<u8>,
+}
+
+public fun create(ctx: &mut TxContext) {
+    let data = iota::address::to_bytes(ctx.sender());
+    let mut o1 = Object { id: object::new(ctx) };
+    let mut o2 = Object { id: object::new(ctx) };
+    dynamic_field::add(&mut o1.id, b"value", Value { data });
+    dynamic_field::add(&mut o1.id, b"obj", ObjValue { id: object::new(ctx), data });
+    dynamic_field::add(&mut o2.id, b"value", Value { data });
+    dynamic_field::add(&mut o2.id, b"obj", ObjValue { id: object::new(ctx), data });
+    transfer::public_transfer(o1, ctx.sender());
+    transfer::public_share_object(o2);
+}
+
+// mutably borrow but do nothing
+public fun borrow_mut(obj: &mut Object) {
+    let _: &mut Value = dynamic_field::borrow_mut(&mut obj.id, b"value");
+    let _: &mut ObjValue = dynamic_field::borrow_mut(&mut obj.id, b"obj");
+}
+
+// add remove the dynamic field but no change
+public fun add_remove(obj: &mut Object) {
+    let v: Value = dynamic_field::remove(&mut obj.id, b"value");
+    dynamic_field::add(&mut obj.id, b"value", v);
+    let o: ObjValue = dynamic_field::remove(&mut obj.id, b"obj");
+    dynamic_field::add(&mut obj.id, b"obj", o);
+}
+
+// write the same data back at the end
+public fun write_back(obj: &mut Object, ctx: &mut TxContext) {
+    let v: &mut Value = dynamic_field::borrow_mut(&mut obj.id, b"value");
+    v.data = vector[];
+    v.data = iota::address::to_bytes(ctx.sender());
+
+    let o: &mut ObjValue = dynamic_field::borrow_mut(&mut obj.id, b"obj");
+    o.data = vector[];
+    o.data = iota::address::to_bytes(ctx.sender());
+}
+
+//# run test::m1::create --sender A
+
+//# view-object 2,4
+
+//# view-object 2,5
+
+// for all of these, only the inputs are mutated
+
+//# run test::m1::borrow_mut --sender A --args object(2,4)
+
+//# run test::m1::borrow_mut --sender A --args object(2,5)
+
+//# run test::m1::add_remove --sender A --args object(2,4)
+
+//# run test::m1::add_remove --sender A --args object(2,5)
+
+//# run test::m1::write_back --sender A --args object(2,4)
+
+//# run test::m1::write_back --sender A --args object(2,5)

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged.snap
@@ -1,0 +1,73 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 11 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 10-64:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9811600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 66:
+//# run test::m1::create --sender A
+created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 11818000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 68:
+//# view-object 2,4
+Owner: Shared( 2 )
+Version: 2
+Contents: test::m1::Object {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(2,4),
+        },
+    },
+}
+
+task 4, lines 70-72:
+//# view-object 2,5
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m1::Object {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(2,5),
+        },
+    },
+}
+
+task 5, line 74:
+//# run test::m1::borrow_mut --sender A --args object(2,4)
+mutated: object(0,0), object(2,4)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2226800,  storage_rebate: 2226800, non_refundable_storage_fee: 0
+
+task 6, line 76:
+//# run test::m1::borrow_mut --sender A --args object(2,5)
+mutated: object(0,0), object(2,5)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2226800,  storage_rebate: 2226800, non_refundable_storage_fee: 0
+
+task 7, line 78:
+//# run test::m1::add_remove --sender A --args object(2,4)
+mutated: object(0,0), object(2,4)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2226800,  storage_rebate: 2226800, non_refundable_storage_fee: 0
+
+task 8, line 80:
+//# run test::m1::add_remove --sender A --args object(2,5)
+mutated: object(0,0), object(2,5)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2226800,  storage_rebate: 2226800, non_refundable_storage_fee: 0
+
+task 9, line 82:
+//# run test::m1::write_back --sender A --args object(2,4)
+mutated: object(0,0), object(2,4)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2226800,  storage_rebate: 2226800, non_refundable_storage_fee: 0
+
+task 10, line 84:
+//# run test::m1::write_back --sender A --args object(2,5)
+mutated: object(0,0), object(2,5)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2226800,  storage_rebate: 2226800, non_refundable_storage_fee: 0

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain.move
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain.move
@@ -1,0 +1,107 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// This test tests that objects that are borrowed mutably or added/removed, but not modified, do not
+// need to be marked as mutated.
+// Operates through a long chain of dynamic fields
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+
+module test::m1;
+
+use iota::dynamic_field;
+
+public struct GreatGrandParent has key, store {
+    id: UID,
+}
+
+public struct GrandParent has key, store {
+    id: UID,
+}
+
+public struct Parent has key, store {
+    id: UID,
+}
+
+public struct Value has copy, drop, store {
+    data: vector<u8>,
+}
+
+public struct ObjValue has key, store {
+    id: UID,
+    data: vector<u8>,
+}
+
+public fun create(ctx: &mut TxContext) {
+    transfer::public_transfer(create_ggp(ctx), ctx.sender());
+    transfer::public_share_object(create_ggp(ctx));
+}
+
+fun create_ggp(ctx: &mut TxContext): GreatGrandParent {
+    let data = iota::address::to_bytes(ctx.sender());
+    let mut gpp = GreatGrandParent { id: object::new(ctx) };
+    let mut gp = GrandParent { id: object::new(ctx) };
+    let mut p = Parent { id: object::new(ctx) };
+    dynamic_field::add(&mut p.id, b"value", Value { data });
+    dynamic_field::add(&mut p.id, b"obj", ObjValue { id: object::new(ctx), data });
+    dynamic_field::add(&mut gp.id, b"p", p);
+    dynamic_field::add(&mut gpp.id, b"gp", gp);
+    gpp
+}
+
+// mutably borrow but do nothing
+public fun borrow_mut(gpp: &mut GreatGrandParent) {
+    let gp: &mut GrandParent = dynamic_field::borrow_mut(&mut gpp.id, b"gp");
+    let p: &mut Parent = dynamic_field::borrow_mut(&mut gp.id, b"p");
+    let _: &mut Value = dynamic_field::borrow_mut(&mut p.id, b"value");
+    let _: &mut ObjValue = dynamic_field::borrow_mut(&mut p.id, b"obj");
+}
+
+// add remove the dynamic field but no change
+public fun add_remove(gpp: &mut GreatGrandParent) {
+    let mut gp: GrandParent = dynamic_field::remove(&mut gpp.id, b"gp");
+    let mut p: Parent = dynamic_field::remove(&mut gp.id, b"p");
+    let v: Value = dynamic_field::remove(&mut p.id, b"value");
+    let o: ObjValue = dynamic_field::remove(&mut p.id, b"obj");
+    dynamic_field::add(&mut p.id, b"obj", o);
+    dynamic_field::add(&mut p.id, b"value", v);
+    dynamic_field::add(&mut gp.id, b"p", p);
+    dynamic_field::add(&mut gpp.id, b"gp", gp);
+}
+
+// write the same data back at the end
+public fun write_back(gpp: &mut GreatGrandParent, ctx: &mut TxContext) {
+    let gp: &mut GrandParent = dynamic_field::borrow_mut(&mut gpp.id, b"gp");
+    let p: &mut Parent = dynamic_field::borrow_mut(&mut gp.id, b"p");
+
+    let v: &mut Value = dynamic_field::borrow_mut(&mut p.id, b"value");
+    v.data = vector[];
+    v.data = iota::address::to_bytes(ctx.sender());
+
+    let o: &mut ObjValue = dynamic_field::borrow_mut(&mut p.id, b"obj");
+    o.data = vector[];
+    o.data = iota::address::to_bytes(ctx.sender());
+}
+
+//# run test::m1::create --sender A
+
+//# view-object 2,8
+
+//# view-object 2,9
+
+// for all of these, only the inputs are mutated
+
+//# run test::m1::borrow_mut --sender A --args object(2,8)
+
+//# run test::m1::borrow_mut --sender A --args object(2,9)
+
+//# run test::m1::add_remove --sender A --args object(2,8)
+
+//# run test::m1::add_remove --sender A --args object(2,9)
+
+//# run test::m1::write_back --sender A --args object(2,8)
+
+//# run test::m1::write_back --sender A --args object(2,9)

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain.snap
@@ -1,0 +1,73 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 11 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 11-87:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 12061200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 89:
+//# run test::m1::create --sender A
+created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8), object(2,9)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 19782800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 91:
+//# view-object 2,8
+Owner: Shared( 2 )
+Version: 2
+Contents: test::m1::GreatGrandParent {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(2,8),
+        },
+    },
+}
+
+task 4, lines 93-95:
+//# view-object 2,9
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m1::GreatGrandParent {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(2,9),
+        },
+    },
+}
+
+task 5, line 97:
+//# run test::m1::borrow_mut --sender A --args object(2,8)
+mutated: object(0,0), object(2,8)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2302800,  storage_rebate: 2302800, non_refundable_storage_fee: 0
+
+task 6, line 99:
+//# run test::m1::borrow_mut --sender A --args object(2,9)
+mutated: object(0,0), object(2,9)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2302800,  storage_rebate: 2302800, non_refundable_storage_fee: 0
+
+task 7, line 101:
+//# run test::m1::add_remove --sender A --args object(2,8)
+mutated: object(0,0), object(2,8)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2302800,  storage_rebate: 2302800, non_refundable_storage_fee: 0
+
+task 8, line 103:
+//# run test::m1::add_remove --sender A --args object(2,9)
+mutated: object(0,0), object(2,9)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2302800,  storage_rebate: 2302800, non_refundable_storage_fee: 0
+
+task 9, line 105:
+//# run test::m1::write_back --sender A --args object(2,8)
+mutated: object(0,0), object(2,8)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2302800,  storage_rebate: 2302800, non_refundable_storage_fee: 0
+
+task 10, line 107:
+//# run test::m1::write_back --sender A --args object(2,9)
+mutated: object(0,0), object(2,9)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2302800,  storage_rebate: 2302800, non_refundable_storage_fee: 0

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_dof.move
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_dof.move
@@ -1,0 +1,95 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// This test tests that objects that are borrowed mutably or added/removed, but not modified, do not
+// need to be marked as mutated.
+// Operates through a long chain of dynamic fields
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+
+module test::m1;
+
+use iota::dynamic_object_field;
+
+public struct GreatGrandParent has key, store {
+    id: UID,
+}
+
+public struct GrandParent has key, store {
+    id: UID,
+}
+
+public struct Parent has key, store {
+    id: UID,
+}
+
+public struct ObjValue has key, store {
+    id: UID,
+    data: vector<u8>,
+}
+
+public fun create(ctx: &mut TxContext) {
+    transfer::public_transfer(create_ggp(ctx), ctx.sender());
+    transfer::public_share_object(create_ggp(ctx));
+}
+
+fun create_ggp(ctx: &mut TxContext): GreatGrandParent {
+    let data = iota::address::to_bytes(ctx.sender());
+    let mut gpp = GreatGrandParent { id: object::new(ctx) };
+    let mut gp = GrandParent { id: object::new(ctx) };
+    let mut p = Parent { id: object::new(ctx) };
+    dynamic_object_field::add(&mut p.id, b"obj", ObjValue { id: object::new(ctx), data });
+    dynamic_object_field::add(&mut gp.id, b"p", p);
+    dynamic_object_field::add(&mut gpp.id, b"gp", gp);
+    gpp
+}
+
+// mutably borrow but do nothing
+public fun borrow_mut(gpp: &mut GreatGrandParent) {
+    let gp: &mut GrandParent = dynamic_object_field::borrow_mut(&mut gpp.id, b"gp");
+    let p: &mut Parent = dynamic_object_field::borrow_mut(&mut gp.id, b"p");
+    let _: &mut ObjValue = dynamic_object_field::borrow_mut(&mut p.id, b"obj");
+}
+
+// add remove the dynamic field but no change
+public fun add_remove(gpp: &mut GreatGrandParent) {
+    let mut gp: GrandParent = dynamic_object_field::remove(&mut gpp.id, b"gp");
+    let mut p: Parent = dynamic_object_field::remove(&mut gp.id, b"p");
+    let o: ObjValue = dynamic_object_field::remove(&mut p.id, b"obj");
+    dynamic_object_field::add(&mut p.id, b"obj", o);
+    dynamic_object_field::add(&mut gp.id, b"p", p);
+    dynamic_object_field::add(&mut gpp.id, b"gp", gp);
+}
+
+// write the same data back at the end
+public fun write_back(gpp: &mut GreatGrandParent, ctx: &mut TxContext) {
+    let gp: &mut GrandParent = dynamic_object_field::borrow_mut(&mut gpp.id, b"gp");
+    let p: &mut Parent = dynamic_object_field::borrow_mut(&mut gp.id, b"p");
+
+    let o: &mut ObjValue = dynamic_object_field::borrow_mut(&mut p.id, b"obj");
+    o.data = vector[];
+    o.data = iota::address::to_bytes(ctx.sender());
+}
+
+//# run test::m1::create --sender A
+
+//# view-object 2,8
+
+//# view-object 2,9
+
+// for all of these, only the inputs are mutated
+
+//# run test::m1::borrow_mut --sender A --args object(2,8)
+
+//# run test::m1::borrow_mut --sender A --args object(2,9)
+
+//# run test::m1::add_remove --sender A --args object(2,8)
+
+//# run test::m1::add_remove --sender A --args object(2,9)
+
+//# run test::m1::write_back --sender A --args object(2,8)
+
+//# run test::m1::write_back --sender A --args object(2,9)

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_dof.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_dof.snap
@@ -1,0 +1,73 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 11 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 11-75:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 10845200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 77:
+//# run test::m1::create --sender A
+created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8), object(2,9), object(2,10), object(2,11), object(2,12), object(2,13)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 26212400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 79:
+//# view-object 2,8
+Owner: Shared( 2 )
+Version: 2
+Contents: test::m1::GreatGrandParent {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(2,8),
+        },
+    },
+}
+
+task 4, lines 81-83:
+//# view-object 2,9
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m1::GreatGrandParent {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(2,9),
+        },
+    },
+}
+
+task 5, line 85:
+//# run test::m1::borrow_mut --sender A --args object(2,8)
+mutated: object(0,0), object(2,8)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2302800,  storage_rebate: 2302800, non_refundable_storage_fee: 0
+
+task 6, line 87:
+//# run test::m1::borrow_mut --sender A --args object(2,9)
+mutated: object(0,0), object(2,9)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2302800,  storage_rebate: 2302800, non_refundable_storage_fee: 0
+
+task 7, line 89:
+//# run test::m1::add_remove --sender A --args object(2,8)
+mutated: object(0,0), object(2,8)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2302800,  storage_rebate: 2302800, non_refundable_storage_fee: 0
+
+task 8, line 91:
+//# run test::m1::add_remove --sender A --args object(2,9)
+mutated: object(0,0), object(2,9)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2302800,  storage_rebate: 2302800, non_refundable_storage_fee: 0
+
+task 9, line 93:
+//# run test::m1::write_back --sender A --args object(2,8)
+mutated: object(0,0), object(2,8)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2302800,  storage_rebate: 2302800, non_refundable_storage_fee: 0
+
+task 10, line 95:
+//# run test::m1::write_back --sender A --args object(2,9)
+mutated: object(0,0), object(2,9)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2302800,  storage_rebate: 2302800, non_refundable_storage_fee: 0

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_dof_v9.move
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_dof_v9.move
@@ -1,0 +1,97 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// This test tests that objects that are borrowed mutably or added/removed, but not modified, do not
+// need to be marked as mutated.
+// Operates through a long chain of dynamic fields
+// After protocol version 9, some of the child object mutations will not appear since they do not
+// modify the Move value.
+
+//# init --addresses test=0x0 --accounts A --protocol-version 9
+
+//# publish
+
+module test::m1;
+
+use iota::dynamic_object_field;
+
+public struct GreatGrandParent has key, store {
+    id: UID,
+}
+
+public struct GrandParent has key, store {
+    id: UID,
+}
+
+public struct Parent has key, store {
+    id: UID,
+}
+
+public struct ObjValue has key, store {
+    id: UID,
+    data: vector<u8>,
+}
+
+public fun create(ctx: &mut TxContext) {
+    transfer::public_transfer(create_ggp(ctx), ctx.sender());
+    transfer::public_share_object(create_ggp(ctx));
+}
+
+fun create_ggp(ctx: &mut TxContext): GreatGrandParent {
+    let data = iota::address::to_bytes(ctx.sender());
+    let mut gpp = GreatGrandParent { id: object::new(ctx) };
+    let mut gp = GrandParent { id: object::new(ctx) };
+    let mut p = Parent { id: object::new(ctx) };
+    dynamic_object_field::add(&mut p.id, b"obj", ObjValue { id: object::new(ctx), data });
+    dynamic_object_field::add(&mut gp.id, b"p", p);
+    dynamic_object_field::add(&mut gpp.id, b"gp", gp);
+    gpp
+}
+
+// mutably borrow but do nothing
+public fun borrow_mut(gpp: &mut GreatGrandParent) {
+    let gp: &mut GrandParent = dynamic_object_field::borrow_mut(&mut gpp.id, b"gp");
+    let p: &mut Parent = dynamic_object_field::borrow_mut(&mut gp.id, b"p");
+    let _: &mut ObjValue = dynamic_object_field::borrow_mut(&mut p.id, b"obj");
+}
+
+// add remove the dynamic field but no change
+public fun add_remove(gpp: &mut GreatGrandParent) {
+    let mut gp: GrandParent = dynamic_object_field::remove(&mut gpp.id, b"gp");
+    let mut p: Parent = dynamic_object_field::remove(&mut gp.id, b"p");
+    let o: ObjValue = dynamic_object_field::remove(&mut p.id, b"obj");
+    dynamic_object_field::add(&mut p.id, b"obj", o);
+    dynamic_object_field::add(&mut gp.id, b"p", p);
+    dynamic_object_field::add(&mut gpp.id, b"gp", gp);
+}
+
+// write the same data back at the end
+public fun write_back(gpp: &mut GreatGrandParent, ctx: &mut TxContext) {
+    let gp: &mut GrandParent = dynamic_object_field::borrow_mut(&mut gpp.id, b"gp");
+    let p: &mut Parent = dynamic_object_field::borrow_mut(&mut gp.id, b"p");
+
+    let o: &mut ObjValue = dynamic_object_field::borrow_mut(&mut p.id, b"obj");
+    o.data = vector[];
+    o.data = iota::address::to_bytes(ctx.sender());
+}
+
+//# run test::m1::create --sender A
+
+//# view-object 2,8
+
+//# view-object 2,9
+
+// for all of these, only the inputs are mutated
+
+//# run test::m1::borrow_mut --sender A --args object(2,8)
+
+//# run test::m1::borrow_mut --sender A --args object(2,9)
+
+//# run test::m1::add_remove --sender A --args object(2,8)
+
+//# run test::m1::add_remove --sender A --args object(2,9)
+
+//# run test::m1::write_back --sender A --args object(2,8)
+
+//# run test::m1::write_back --sender A --args object(2,9)

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_dof_v9.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_dof_v9.snap
@@ -1,0 +1,73 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 11 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 13-77:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 10845200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 79:
+//# run test::m1::create --sender A
+created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8), object(2,9), object(2,10), object(2,11), object(2,12), object(2,13)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 26212400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 81:
+//# view-object 2,8
+Owner: Shared( 2 )
+Version: 2
+Contents: test::m1::GreatGrandParent {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(2,8),
+        },
+    },
+}
+
+task 4, lines 83-85:
+//# view-object 2,9
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m1::GreatGrandParent {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(2,9),
+        },
+    },
+}
+
+task 5, line 87:
+//# run test::m1::borrow_mut --sender A --args object(2,8)
+mutated: object(0,0), object(2,8)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2302800,  storage_rebate: 2302800, non_refundable_storage_fee: 0
+
+task 6, line 89:
+//# run test::m1::borrow_mut --sender A --args object(2,9)
+mutated: object(0,0), object(2,9)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2302800,  storage_rebate: 2302800, non_refundable_storage_fee: 0
+
+task 7, line 91:
+//# run test::m1::add_remove --sender A --args object(2,8)
+mutated: object(0,0), object(2,3), object(2,4), object(2,5), object(2,7), object(2,8), object(2,11), object(2,13)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 13596400,  storage_rebate: 13596400, non_refundable_storage_fee: 0
+
+task 8, line 93:
+//# run test::m1::add_remove --sender A --args object(2,9)
+mutated: object(0,0), object(2,0), object(2,1), object(2,2), object(2,6), object(2,9), object(2,10), object(2,12)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 13596400,  storage_rebate: 13596400, non_refundable_storage_fee: 0
+
+task 9, line 95:
+//# run test::m1::write_back --sender A --args object(2,8)
+mutated: object(0,0), object(2,8), object(2,11)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 3815200,  storage_rebate: 3815200, non_refundable_storage_fee: 0
+
+task 10, line 97:
+//# run test::m1::write_back --sender A --args object(2,9)
+mutated: object(0,0), object(2,9), object(2,10)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 3815200,  storage_rebate: 3815200, non_refundable_storage_fee: 0

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_v9.move
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_v9.move
@@ -1,0 +1,109 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// This test tests that objects that are borrowed mutably or added/removed, but not modified, do not
+// need to be marked as mutated.
+// Operates through a long chain of dynamic fields
+// After protocol version 9, some of the child object mutations will not appear since they do not
+// modify the Move value.
+
+//# init --addresses test=0x0 --accounts A --protocol-version 9
+
+//# publish
+
+module test::m1;
+
+use iota::dynamic_field;
+
+public struct GreatGrandParent has key, store {
+    id: UID,
+}
+
+public struct GrandParent has key, store {
+    id: UID,
+}
+
+public struct Parent has key, store {
+    id: UID,
+}
+
+public struct Value has copy, drop, store {
+    data: vector<u8>,
+}
+
+public struct ObjValue has key, store {
+    id: UID,
+    data: vector<u8>,
+}
+
+public fun create(ctx: &mut TxContext) {
+    transfer::public_transfer(create_ggp(ctx), ctx.sender());
+    transfer::public_share_object(create_ggp(ctx));
+}
+
+fun create_ggp(ctx: &mut TxContext): GreatGrandParent {
+    let data = iota::address::to_bytes(ctx.sender());
+    let mut gpp = GreatGrandParent { id: object::new(ctx) };
+    let mut gp = GrandParent { id: object::new(ctx) };
+    let mut p = Parent { id: object::new(ctx) };
+    dynamic_field::add(&mut p.id, b"value", Value { data });
+    dynamic_field::add(&mut p.id, b"obj", ObjValue { id: object::new(ctx), data });
+    dynamic_field::add(&mut gp.id, b"p", p);
+    dynamic_field::add(&mut gpp.id, b"gp", gp);
+    gpp
+}
+
+// mutably borrow but do nothing
+public fun borrow_mut(gpp: &mut GreatGrandParent) {
+    let gp: &mut GrandParent = dynamic_field::borrow_mut(&mut gpp.id, b"gp");
+    let p: &mut Parent = dynamic_field::borrow_mut(&mut gp.id, b"p");
+    let _: &mut Value = dynamic_field::borrow_mut(&mut p.id, b"value");
+    let _: &mut ObjValue = dynamic_field::borrow_mut(&mut p.id, b"obj");
+}
+
+// add remove the dynamic field but no change
+public fun add_remove(gpp: &mut GreatGrandParent) {
+    let mut gp: GrandParent = dynamic_field::remove(&mut gpp.id, b"gp");
+    let mut p: Parent = dynamic_field::remove(&mut gp.id, b"p");
+    let v: Value = dynamic_field::remove(&mut p.id, b"value");
+    let o: ObjValue = dynamic_field::remove(&mut p.id, b"obj");
+    dynamic_field::add(&mut p.id, b"obj", o);
+    dynamic_field::add(&mut p.id, b"value", v);
+    dynamic_field::add(&mut gp.id, b"p", p);
+    dynamic_field::add(&mut gpp.id, b"gp", gp);
+}
+
+// write the same data back at the end
+public fun write_back(gpp: &mut GreatGrandParent, ctx: &mut TxContext) {
+    let gp: &mut GrandParent = dynamic_field::borrow_mut(&mut gpp.id, b"gp");
+    let p: &mut Parent = dynamic_field::borrow_mut(&mut gp.id, b"p");
+
+    let v: &mut Value = dynamic_field::borrow_mut(&mut p.id, b"value");
+    v.data = vector[];
+    v.data = iota::address::to_bytes(ctx.sender());
+
+    let o: &mut ObjValue = dynamic_field::borrow_mut(&mut p.id, b"obj");
+    o.data = vector[];
+    o.data = iota::address::to_bytes(ctx.sender());
+}
+
+//# run test::m1::create --sender A
+
+//# view-object 2,8
+
+//# view-object 2,9
+
+// for all of these, only the inputs are mutated
+
+//# run test::m1::borrow_mut --sender A --args object(2,8)
+
+//# run test::m1::borrow_mut --sender A --args object(2,9)
+
+//# run test::m1::add_remove --sender A --args object(2,8)
+
+//# run test::m1::add_remove --sender A --args object(2,9)
+
+//# run test::m1::write_back --sender A --args object(2,8)
+
+//# run test::m1::write_back --sender A --args object(2,9)

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_v9.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_v9.snap
@@ -1,0 +1,73 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 11 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 13-89:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 12061200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 91:
+//# run test::m1::create --sender A
+created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8), object(2,9)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 19782800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 93:
+//# view-object 2,8
+Owner: Shared( 2 )
+Version: 2
+Contents: test::m1::GreatGrandParent {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(2,8),
+        },
+    },
+}
+
+task 4, lines 95-97:
+//# view-object 2,9
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m1::GreatGrandParent {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(2,9),
+        },
+    },
+}
+
+task 5, line 99:
+//# run test::m1::borrow_mut --sender A --args object(2,8)
+mutated: object(0,0), object(2,8)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2302800,  storage_rebate: 2302800, non_refundable_storage_fee: 0
+
+task 6, line 101:
+//# run test::m1::borrow_mut --sender A --args object(2,9)
+mutated: object(0,0), object(2,9)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2302800,  storage_rebate: 2302800, non_refundable_storage_fee: 0
+
+task 7, line 103:
+//# run test::m1::add_remove --sender A --args object(2,8)
+mutated: object(0,0), object(2,1), object(2,2), object(2,5), object(2,7), object(2,8)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 10381600,  storage_rebate: 10381600, non_refundable_storage_fee: 0
+
+task 8, line 105:
+//# run test::m1::add_remove --sender A --args object(2,9)
+mutated: object(0,0), object(2,0), object(2,3), object(2,4), object(2,6), object(2,9)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 10381600,  storage_rebate: 10381600, non_refundable_storage_fee: 0
+
+task 9, line 107:
+//# run test::m1::write_back --sender A --args object(2,8)
+mutated: object(0,0), object(2,2), object(2,7), object(2,8)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6475200,  storage_rebate: 6475200, non_refundable_storage_fee: 0
+
+task 10, line 109:
+//# run test::m1::write_back --sender A --args object(2,9)
+mutated: object(0,0), object(2,3), object(2,6), object(2,9)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6475200,  storage_rebate: 6475200, non_refundable_storage_fee: 0

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_dof.move
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_dof.move
@@ -1,0 +1,71 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// This test tests that objects that are borrowed mutably or added/removed, but not modified, do not
+// need to be marked as mutated. Uses dynamic object fields
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+
+module test::m1;
+
+use iota::dynamic_object_field;
+
+public struct Object has key, store {
+    id: UID,
+}
+
+public struct ObjValue has key, store {
+    id: UID,
+    data: vector<u8>,
+}
+
+public fun create(ctx: &mut TxContext) {
+    let data = iota::address::to_bytes(ctx.sender());
+    let mut o1 = Object { id: object::new(ctx) };
+    let mut o2 = Object { id: object::new(ctx) };
+    dynamic_object_field::add(&mut o1.id, b"obj", ObjValue { id: object::new(ctx), data });
+    dynamic_object_field::add(&mut o2.id, b"obj", ObjValue { id: object::new(ctx), data });
+    transfer::public_transfer(o1, ctx.sender());
+    transfer::public_share_object(o2);
+}
+
+// mutably borrow but do nothing
+public fun borrow_mut(obj: &mut Object) {
+    let _: &mut ObjValue = dynamic_object_field::borrow_mut(&mut obj.id, b"obj");
+}
+
+// add remove the dynamic field but no change
+public fun add_remove(obj: &mut Object) {
+    let o: ObjValue = dynamic_object_field::remove(&mut obj.id, b"obj");
+    dynamic_object_field::add(&mut obj.id, b"obj", o);
+}
+
+// write the same data back at the end
+public fun write_back(obj: &mut Object, ctx: &mut TxContext) {
+    let o: &mut ObjValue = dynamic_object_field::borrow_mut(&mut obj.id, b"obj");
+    o.data = vector[];
+    o.data = iota::address::to_bytes(ctx.sender());
+}
+
+//# run test::m1::create --sender A
+
+//# view-object 2,4
+
+//# view-object 2,5
+
+// for all of these, only the inputs are mutated
+
+//# run test::m1::borrow_mut --sender A --args object(2,4)
+
+//# run test::m1::borrow_mut --sender A --args object(2,5)
+
+//# run test::m1::add_remove --sender A --args object(2,4)
+
+//# run test::m1::add_remove --sender A --args object(2,5)
+
+//# run test::m1::write_back --sender A --args object(2,4)
+
+//# run test::m1::write_back --sender A --args object(2,5)

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_dof.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_dof.snap
@@ -1,0 +1,73 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 11 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 10-51:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 8618400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 53:
+//# run test::m1::create --sender A
+created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 11346800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 55:
+//# view-object 2,4
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m1::Object {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(2,4),
+        },
+    },
+}
+
+task 4, lines 57-59:
+//# view-object 2,5
+Owner: Shared( 2 )
+Version: 2
+Contents: test::m1::Object {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(2,5),
+        },
+    },
+}
+
+task 5, line 61:
+//# run test::m1::borrow_mut --sender A --args object(2,4)
+mutated: object(0,0), object(2,4)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2226800,  storage_rebate: 2226800, non_refundable_storage_fee: 0
+
+task 6, line 63:
+//# run test::m1::borrow_mut --sender A --args object(2,5)
+mutated: object(0,0), object(2,5)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2226800,  storage_rebate: 2226800, non_refundable_storage_fee: 0
+
+task 7, line 65:
+//# run test::m1::add_remove --sender A --args object(2,4)
+mutated: object(0,0), object(2,4)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2226800,  storage_rebate: 2226800, non_refundable_storage_fee: 0
+
+task 8, line 67:
+//# run test::m1::add_remove --sender A --args object(2,5)
+mutated: object(0,0), object(2,5)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2226800,  storage_rebate: 2226800, non_refundable_storage_fee: 0
+
+task 9, line 69:
+//# run test::m1::write_back --sender A --args object(2,4)
+mutated: object(0,0), object(2,4)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2226800,  storage_rebate: 2226800, non_refundable_storage_fee: 0
+
+task 10, line 71:
+//# run test::m1::write_back --sender A --args object(2,5)
+mutated: object(0,0), object(2,5)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2226800,  storage_rebate: 2226800, non_refundable_storage_fee: 0

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_dof_v9.move
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_dof_v9.move
@@ -1,0 +1,73 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// This test tests that objects that are borrowed mutably or added/removed, but not modified, do not
+// need to be marked as mutated. Uses dynamic object fields
+// After protocol version 9, some of the child object mutations will not appear since they do not
+// modify the Move value.
+
+//# init --addresses test=0x0 --accounts A --protocol-version 9
+
+//# publish
+
+module test::m1;
+
+use iota::dynamic_object_field;
+
+public struct Object has key, store {
+    id: UID,
+}
+
+public struct ObjValue has key, store {
+    id: UID,
+    data: vector<u8>,
+}
+
+public fun create(ctx: &mut TxContext) {
+    let data = iota::address::to_bytes(ctx.sender());
+    let mut o1 = Object { id: object::new(ctx) };
+    let mut o2 = Object { id: object::new(ctx) };
+    dynamic_object_field::add(&mut o1.id, b"obj", ObjValue { id: object::new(ctx), data });
+    dynamic_object_field::add(&mut o2.id, b"obj", ObjValue { id: object::new(ctx), data });
+    transfer::public_transfer(o1, ctx.sender());
+    transfer::public_share_object(o2);
+}
+
+// mutably borrow but do nothing
+public fun borrow_mut(obj: &mut Object) {
+    let _: &mut ObjValue = dynamic_object_field::borrow_mut(&mut obj.id, b"obj");
+}
+
+// add remove the dynamic field but no change
+public fun add_remove(obj: &mut Object) {
+    let o: ObjValue = dynamic_object_field::remove(&mut obj.id, b"obj");
+    dynamic_object_field::add(&mut obj.id, b"obj", o);
+}
+
+// write the same data back at the end
+public fun write_back(obj: &mut Object, ctx: &mut TxContext) {
+    let o: &mut ObjValue = dynamic_object_field::borrow_mut(&mut obj.id, b"obj");
+    o.data = vector[];
+    o.data = iota::address::to_bytes(ctx.sender());
+}
+
+//# run test::m1::create --sender A
+
+//# view-object 2,4
+
+//# view-object 2,5
+
+// for all of these, only the inputs are mutated
+
+//# run test::m1::borrow_mut --sender A --args object(2,4)
+
+//# run test::m1::borrow_mut --sender A --args object(2,5)
+
+//# run test::m1::add_remove --sender A --args object(2,4)
+
+//# run test::m1::add_remove --sender A --args object(2,5)
+
+//# run test::m1::write_back --sender A --args object(2,4)
+
+//# run test::m1::write_back --sender A --args object(2,5)

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_dof_v9.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_dof_v9.snap
@@ -1,0 +1,73 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 11 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 12-53:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 8618400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 55:
+//# run test::m1::create --sender A
+created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 11346800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 57:
+//# view-object 2,4
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m1::Object {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(2,4),
+        },
+    },
+}
+
+task 4, lines 59-61:
+//# view-object 2,5
+Owner: Shared( 2 )
+Version: 2
+Contents: test::m1::Object {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(2,5),
+        },
+    },
+}
+
+task 5, line 63:
+//# run test::m1::borrow_mut --sender A --args object(2,4)
+mutated: object(0,0), object(2,4)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2226800,  storage_rebate: 2226800, non_refundable_storage_fee: 0
+
+task 6, line 65:
+//# run test::m1::borrow_mut --sender A --args object(2,5)
+mutated: object(0,0), object(2,5)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2226800,  storage_rebate: 2226800, non_refundable_storage_fee: 0
+
+task 7, line 67:
+//# run test::m1::add_remove --sender A --args object(2,4)
+mutated: object(0,0), object(2,0), object(2,3), object(2,4)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6163600,  storage_rebate: 6163600, non_refundable_storage_fee: 0
+
+task 8, line 69:
+//# run test::m1::add_remove --sender A --args object(2,5)
+mutated: object(0,0), object(2,1), object(2,2), object(2,5)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6163600,  storage_rebate: 6163600, non_refundable_storage_fee: 0
+
+task 9, line 71:
+//# run test::m1::write_back --sender A --args object(2,4)
+mutated: object(0,0), object(2,3), object(2,4)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 3739200,  storage_rebate: 3739200, non_refundable_storage_fee: 0
+
+task 10, line 73:
+//# run test::m1::write_back --sender A --args object(2,5)
+mutated: object(0,0), object(2,2), object(2,5)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 3739200,  storage_rebate: 3739200, non_refundable_storage_fee: 0

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_v9.move
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_v9.move
@@ -1,0 +1,86 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// This test tests that objects that are borrowed mutably or added/removed, but not modified, do not
+// need to be marked as mutated
+// After protocol version 9, some of the child object mutations will not appear since they do not
+// modify the Move value.
+
+//# init --addresses test=0x0 --accounts A --protocol-version 9
+
+//# publish
+
+module test::m1;
+
+use iota::dynamic_field;
+
+public struct Object has key, store {
+    id: UID,
+}
+
+public struct Value has copy, drop, store {
+    data: vector<u8>,
+}
+
+public struct ObjValue has key, store {
+    id: UID,
+    data: vector<u8>,
+}
+
+public fun create(ctx: &mut TxContext) {
+    let data = iota::address::to_bytes(ctx.sender());
+    let mut o1 = Object { id: object::new(ctx) };
+    let mut o2 = Object { id: object::new(ctx) };
+    dynamic_field::add(&mut o1.id, b"value", Value { data });
+    dynamic_field::add(&mut o1.id, b"obj", ObjValue { id: object::new(ctx), data });
+    dynamic_field::add(&mut o2.id, b"value", Value { data });
+    dynamic_field::add(&mut o2.id, b"obj", ObjValue { id: object::new(ctx), data });
+    transfer::public_transfer(o1, ctx.sender());
+    transfer::public_share_object(o2);
+}
+
+// mutably borrow but do nothing
+public fun borrow_mut(obj: &mut Object) {
+    let _: &mut Value = dynamic_field::borrow_mut(&mut obj.id, b"value");
+    let _: &mut ObjValue = dynamic_field::borrow_mut(&mut obj.id, b"obj");
+}
+
+// add remove the dynamic field but no change
+public fun add_remove(obj: &mut Object) {
+    let v: Value = dynamic_field::remove(&mut obj.id, b"value");
+    dynamic_field::add(&mut obj.id, b"value", v);
+    let o: ObjValue = dynamic_field::remove(&mut obj.id, b"obj");
+    dynamic_field::add(&mut obj.id, b"obj", o);
+}
+
+// write the same data back at the end
+public fun write_back(obj: &mut Object, ctx: &mut TxContext) {
+    let v: &mut Value = dynamic_field::borrow_mut(&mut obj.id, b"value");
+    v.data = vector[];
+    v.data = iota::address::to_bytes(ctx.sender());
+
+    let o: &mut ObjValue = dynamic_field::borrow_mut(&mut obj.id, b"obj");
+    o.data = vector[];
+    o.data = iota::address::to_bytes(ctx.sender());
+}
+
+//# run test::m1::create --sender A
+
+//# view-object 2,4
+
+//# view-object 2,5
+
+// for all of these, only the inputs are mutated
+
+//# run test::m1::borrow_mut --sender A --args object(2,4)
+
+//# run test::m1::borrow_mut --sender A --args object(2,5)
+
+//# run test::m1::add_remove --sender A --args object(2,4)
+
+//# run test::m1::add_remove --sender A --args object(2,5)
+
+//# run test::m1::write_back --sender A --args object(2,4)
+
+//# run test::m1::write_back --sender A --args object(2,5)

--- a/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_v9.snap
+++ b/crates/iota-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_v9.snap
@@ -1,0 +1,73 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 11 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 12-66:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 9811600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 68:
+//# run test::m1::create --sender A
+created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 11818000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 70:
+//# view-object 2,4
+Owner: Shared( 2 )
+Version: 2
+Contents: test::m1::Object {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(2,4),
+        },
+    },
+}
+
+task 4, lines 72-74:
+//# view-object 2,5
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m1::Object {
+    id: iota::object::UID {
+        id: iota::object::ID {
+            bytes: fake(2,5),
+        },
+    },
+}
+
+task 5, line 76:
+//# run test::m1::borrow_mut --sender A --args object(2,4)
+mutated: object(0,0), object(2,4)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2226800,  storage_rebate: 2226800, non_refundable_storage_fee: 0
+
+task 6, line 78:
+//# run test::m1::borrow_mut --sender A --args object(2,5)
+mutated: object(0,0), object(2,5)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 2226800,  storage_rebate: 2226800, non_refundable_storage_fee: 0
+
+task 7, line 80:
+//# run test::m1::add_remove --sender A --args object(2,4)
+mutated: object(0,0), object(2,1), object(2,3), object(2,4)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6399200,  storage_rebate: 6399200, non_refundable_storage_fee: 0
+
+task 8, line 82:
+//# run test::m1::add_remove --sender A --args object(2,5)
+mutated: object(0,0), object(2,0), object(2,2), object(2,5)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6399200,  storage_rebate: 6399200, non_refundable_storage_fee: 0
+
+task 9, line 84:
+//# run test::m1::write_back --sender A --args object(2,4)
+mutated: object(0,0), object(2,1), object(2,3), object(2,4)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6399200,  storage_rebate: 6399200, non_refundable_storage_fee: 0
+
+task 10, line 86:
+//# run test::m1::write_back --sender A --args object(2,5)
+mutated: object(0,0), object(2,0), object(2,2), object(2,5)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 6399200,  storage_rebate: 6399200, non_refundable_storage_fee: 0

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/find_all_uids_dof_enum.move
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/find_all_uids_dof_enum.move
@@ -13,7 +13,7 @@ module test::m {
 
     public struct S has key, store {
         id: UID,
-        other: EnumWrapper, 
+        other: EnumWrapper,
         wrapped: Wrapped,
         many: vector<Wrapped>,
     }
@@ -207,4 +207,3 @@ module test::m {
 // Should fail since at the version of the object we're passing in the field exists still
 //# programmable --sender A --inputs object(2,8)@2 vector[] --dev-inspect
 //> test::m::check(Input(0), Input(1))
-

--- a/crates/iota-adapter-transactional-tests/tests/mvcc/find_all_uids_enums.move
+++ b/crates/iota-adapter-transactional-tests/tests/mvcc/find_all_uids_enums.move
@@ -13,7 +13,7 @@ module test::m {
 
     public struct S has key, store {
         id: UID,
-        other: EnumWrapper, 
+        other: EnumWrapper,
         wrapped: Wrapped,
         many: vector<Wrapped>,
     }

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1322,6 +1322,7 @@
                 "enable_poseidon": true,
                 "enable_vdf": true,
                 "hardened_otw_check": true,
+                "minimize_child_object_mutations": false,
                 "native_charging_v2": true,
                 "no_extraneous_module_bytes": true,
                 "passkey_auth": true,

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -66,6 +66,7 @@ pub const MAX_PROTOCOL_VERSION: u64 = 10;
 //             to 60 rounds.
 //             Enable batching in synchronizer for testnet
 //             Enable Identifier input validation.
+//             Removes unnecessary child object mutations
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -293,6 +294,11 @@ struct FeatureFlags {
     // Validate identifier inputs separately
     #[serde(skip_serializing_if = "is_false")]
     validate_identifier_inputs: bool,
+
+    // If true, enables the optimizations for child object mutations, removing unnecessary
+    // mutations
+    #[serde(skip_serializing_if = "is_false")]
+    minimize_child_object_mutations: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1273,6 +1279,10 @@ impl ProtocolConfig {
     pub fn validate_identifier_inputs(&self) -> bool {
         self.feature_flags.validate_identifier_inputs
     }
+
+    pub fn minimize_child_object_mutations(&self) -> bool {
+        self.feature_flags.minimize_child_object_mutations
+    }
 }
 
 #[cfg(not(msim))]
@@ -2051,6 +2061,9 @@ impl ProtocolConfig {
                     // blocks within a window of ~4 seconds
                     // to be included before be considered garbage collected.
                     cfg.consensus_gc_depth = Some(60);
+
+                    // Enable minimized child object mutation counting.
+                    cfg.feature_flags.minimize_child_object_mutations = true;
 
                     if chain != Chain::Mainnet {
                         // Enable batched block sync in devnet and testnet.

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_10.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Mainnet_version_10.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/iota-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
-snapshot_kind: text
 ---
 version: 10
 feature_flags:
@@ -21,6 +20,7 @@ feature_flags:
   consensus_zstd_compression: true
   congestion_control_min_free_execution_slot: true
   validate_identifier_inputs: true
+  minimize_child_object_mutations: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_10.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__Testnet_version_10.snap
@@ -21,6 +21,7 @@ feature_flags:
   congestion_control_min_free_execution_slot: true
   consensus_batched_block_sync: true
   validate_identifier_inputs: true
+  minimize_child_object_mutations: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_10.snap
+++ b/crates/iota-protocol-config/src/snapshots/iota_protocol_config__test__version_10.snap
@@ -27,6 +27,7 @@ feature_flags:
   accept_passkey_in_multisig: true
   consensus_batched_block_sync: true
   validate_identifier_inputs: true
+  minimize_child_object_mutations: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/iota-execution/latest/iota-move-natives/src/object_runtime/fingerprint.rs
+++ b/iota-execution/latest/iota-move-natives/src/object_runtime/fingerprint.rs
@@ -1,0 +1,105 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_protocol_config::ProtocolConfig;
+use iota_types::base_types::{MoveObjectType, ObjectID};
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::vm_status::StatusCode;
+use move_vm_types::values::Value;
+
+/// This type is used to track if an object has changed since it was read from
+/// storage. Ideally, this would just store the owner ID+type+BCS bytes of the
+/// object; however, due to pending rewrites in the adapter, that would be too
+/// much code churn. Instead, we use the `Value` since the `RuntimeResults`
+/// operate over `Value` and not BCS bytes.
+pub struct ObjectFingerprint(Option<ObjectFingerprint_>);
+
+enum ObjectFingerprint_ {
+    /// The object did not exist (as a child object) in storage at the start of
+    /// the transaction.
+    Empty,
+    // The object was loaded as a child object from storage.
+    Preexisting {
+        owner: ObjectID,
+        ty: MoveObjectType,
+        value: Value,
+    },
+}
+
+impl ObjectFingerprint {
+    #[cfg(debug_assertions)]
+    pub fn is_disabled(&self) -> bool {
+        self.0.is_none()
+    }
+
+    /// Creates a new object fingerprint for a child object not found in
+    /// storage. Will be internally disabled if the feature is not enabled
+    /// in the protocol config.
+    pub fn none(protocol_config: &ProtocolConfig) -> Self {
+        if !protocol_config.minimize_child_object_mutations() {
+            Self(None)
+        } else {
+            Self(Some(ObjectFingerprint_::Empty))
+        }
+    }
+
+    /// Creates a new object fingerprint for a child found in storage.
+    /// Will be internally disabled if the feature is not enabled in the
+    /// protocol config.
+    pub fn preexisting(
+        protocol_config: &ProtocolConfig,
+        preexisting_owner: &ObjectID,
+        preexisting_type: &MoveObjectType,
+        preexisting_value: &Value,
+    ) -> PartialVMResult<Self> {
+        Ok(if !protocol_config.minimize_child_object_mutations() {
+            Self(None)
+        } else {
+            Self(Some(ObjectFingerprint_::Preexisting {
+                owner: *preexisting_owner,
+                ty: preexisting_type.clone(),
+                value: preexisting_value.copy_value()?,
+            }))
+        })
+    }
+
+    /// Checks if the object has changed since it was read from storage.
+    /// Gives an invariant violation if the fingerprint is disabled.
+    /// Gives an invariant violation if the values do not have the same layout,
+    /// but the owner and type are thesame.
+    pub fn object_has_changed(
+        &self,
+        final_owner: &ObjectID,
+        final_type: &MoveObjectType,
+        final_value: &Option<Value>,
+    ) -> PartialVMResult<bool> {
+        use ObjectFingerprint_ as F;
+        let Some(inner) = &self.0 else {
+            return Err(
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(
+                    "Object fingerprint not enabled, yet we were asked for the changes".to_string(),
+                ),
+            );
+        };
+        Ok(match (inner, final_value) {
+            (F::Empty, None) => false,
+            (F::Empty, Some(_)) | (F::Preexisting { .. }, None) => true,
+            (
+                F::Preexisting {
+                    owner: preexisting_owner,
+                    ty: preexisting_type,
+                    value: preexisting_value,
+                },
+                Some(final_value),
+            ) => {
+                // owner changed or value changed.
+                // For the value, we must first check if the types are the same before comparing
+                // the values
+                !(preexisting_owner == final_owner
+                    && preexisting_type == final_type
+                    && preexisting_value.equals(final_value)?)
+            }
+        })
+    }
+}

--- a/iota-execution/latest/iota-move-natives/src/object_runtime/mod.rs
+++ b/iota-execution/latest/iota-move-natives/src/object_runtime/mod.rs
@@ -43,6 +43,8 @@ use tracing::error;
 
 use self::object_store::{ChildObjectEffectV0, ChildObjectEffects, ObjectResult};
 use super::get_object_id;
+use crate::object_runtime::object_store::ChildObjectEffectV1;
+mod fingerprint;
 
 pub enum ObjectEvent {
     /// Transfer to a new address or object. Or make it shared or immutable.
@@ -458,7 +460,9 @@ impl<'a> ObjectRuntime<'a> {
 
     pub fn finish(mut self) -> Result<RuntimeResults, ExecutionError> {
         let loaded_child_objects = self.loaded_runtime_objects();
-        let child_effects = self.child_object_store.take_effects();
+        let child_effects = self.child_object_store.take_effects().map_err(|e| {
+            ExecutionError::invariant_violation(format!("Failed to take child object effects: {e}"))
+        })?;
         self.state.finish(loaded_child_objects, child_effects)
     }
 
@@ -626,6 +630,9 @@ impl ObjectRuntimeState {
             ChildObjectEffects::V0(child_object_effects) => {
                 self.apply_child_object_effects_v0(loaded_child_objects, child_object_effects)
             }
+            ChildObjectEffects::V1(child_object_effects) => {
+                self.apply_child_object_effects_v1(loaded_child_objects, child_object_effects)
+            }
         }
     }
 
@@ -672,6 +679,99 @@ impl ObjectRuntimeState {
                         debug_assert!(!self.new_ids.contains(&child));
                     }
                 }
+            }
+        }
+    }
+
+    fn apply_child_object_effects_v1(
+        &mut self,
+        loaded_child_objects: &mut BTreeMap<ObjectID, LoadedRuntimeObject>,
+        child_object_effects: BTreeMap<ObjectID, ChildObjectEffectV1>,
+    ) {
+        for (child, child_object_effect) in child_object_effects {
+            let ChildObjectEffectV1 {
+                owner: parent,
+                ty,
+                final_value,
+                object_changed,
+            } = child_object_effect;
+
+            if object_changed {
+                if let Some(loaded_child) = loaded_child_objects.get_mut(&child) {
+                    loaded_child.is_modified = true;
+                }
+
+                match final_value {
+                    None => {
+                        // Value was changed and is no longer present, it may have been wrapped,
+                        // transferred, or deleted.
+
+                        // If it was transferred, it should not have been deleted
+                        // transferred ==> !deleted
+                        debug_assert!(
+                            !self.transfers.contains_key(&child)
+                                || !self.deleted_ids.contains(&child)
+                        );
+                        // If it was deleted, it should not have been transferred. Additionally,
+                        // if it was deleted, it should no longer be marked as new.
+                        // deleted ==> !transferred and !new
+                        debug_assert!(
+                            !self.deleted_ids.contains(&child)
+                                || (!self.transfers.contains_key(&child)
+                                    && !self.new_ids.contains(&child))
+                        );
+                    }
+                    Some(v) => {
+                        // Value was changed (or the owner was changed)
+
+                        // It is still a dynamic field so it should not be transferred or deleted
+                        debug_assert!(
+                            !self.transfers.contains_key(&child)
+                                && !self.deleted_ids.contains(&child)
+                        );
+                        // If it was loaded, it must have been new. But keep in mind if it was not
+                        // loaded, it is not necessarily new since it could have been
+                        // input/wrapped/received
+                        // loaded ==> !new
+                        debug_assert!(
+                            !loaded_child_objects.contains_key(&child)
+                                || !self.new_ids.contains(&child)
+                        );
+                        // Mark the mutation of the new value and/or parent.
+                        self.transfers
+                            .insert(child, (Owner::ObjectOwner(parent.into()), ty, v));
+                    }
+                }
+            } else {
+                // The object was not changed.
+                // If it was created,
+                //   it must now have been moved elsewhere (wrapped or transferred).
+                // If it was deleted or transferred,
+                //   it must have been an input/received/wrapped object.
+                // In either case, the value must now have been moved elsewhere, giving us:
+                // (new or deleted or transferred or received) ==> no value
+                // which is equivalent to:
+                // has value ==> (!deleted and !transferred and !input)
+                // If the value is still there, it must have been loaded.
+                // Combining these to give us the check:
+                // has value ==> (loaded and !deleted and !transferred and !input and !received)
+                // which is equivalent to:
+                // !(no value) ==> (loaded and !deleted and !transferred and !input and
+                // !received)
+                debug_assert!(
+                    final_value.is_none()
+                        || (loaded_child_objects.contains_key(&child)
+                            && !self.deleted_ids.contains(&child)
+                            && !self.transfers.contains_key(&child)
+                            && !self.input_objects.contains_key(&child)
+                            && !self.received.contains_key(&child))
+                );
+                // In any case, if it was not changed, it should not be marked as modified
+                debug_assert!(
+                    loaded_child_objects
+                        .get(&child)
+                        .is_none_or(|loaded_child| !loaded_child.is_modified)
+                );
             }
         }
     }

--- a/iota-execution/latest/iota-move-natives/src/object_runtime/object_store.rs
+++ b/iota-execution/latest/iota-move-natives/src/object_runtime/object_store.rs
@@ -26,13 +26,14 @@ use move_vm_types::{
     values::{GlobalValue, StructRef, Value},
 };
 
-use crate::object_runtime::get_all_uids;
+use crate::object_runtime::{fingerprint::ObjectFingerprint, get_all_uids};
 
 pub(super) struct ChildObject {
     pub(super) owner: ObjectID,
     pub(super) ty: Type,
     pub(super) move_type: MoveObjectType,
     pub(super) value: GlobalValue,
+    pub(super) fingerprint: ObjectFingerprint,
 }
 
 pub(crate) struct ActiveChildObject<'a> {
@@ -57,10 +58,22 @@ pub(crate) struct ChildObjectEffectV0 {
     pub(super) effect: Op<Value>,
 }
 
+#[derive(Debug)]
+pub(crate) struct ChildObjectEffectV1 {
+    pub(super) owner: ObjectID,
+    pub(super) ty: Type,
+    pub(super) final_value: Option<Value>,
+    // True if the value or the owner has changed
+    pub(super) object_changed: bool,
+}
+
+#[derive(Debug)]
 pub(crate) enum ChildObjectEffects {
     // In this version, we accurately track mutations via WriteRef to the child object, or
     // references rooted in the child object.
     V0(BTreeMap<ObjectID, ChildObjectEffectV0>),
+    // In this version, we instead check always return the value, and report if it changed.
+    V1(BTreeMap<ObjectID, ChildObjectEffectV1>),
 }
 
 struct Inner<'a> {
@@ -152,7 +165,7 @@ macro_rules! fetch_child_object_unbounded {
                     ));
                 }
             };
-            match object.data {
+            match &object.data {
                 Data::Package(_) => {
                     return Err(PartialVMError::new(StatusCode::STORAGE_ERROR).with_message(
                         format!(
@@ -296,12 +309,17 @@ impl Inner<'_> {
         child_ty_layout: &R::MoveTypeLayout,
         child_ty_fully_annotated_layout: &A::MoveTypeLayout,
         child_move_type: &MoveObjectType,
-    ) -> PartialVMResult<ObjectResult<(Type, GlobalValue)>> {
+    ) -> PartialVMResult<ObjectResult<(Type, GlobalValue, ObjectFingerprint)>> {
+        // we copy the reference to the protocol config ahead of time for lifetime
+        // reasons
+        let protocol_config = self.protocol_config;
+        // retrieve the object from storage if it exists
         let obj = match self.get_or_fetch_object_from_store(parent, child)? {
             None => {
                 return Ok(ObjectResult::Loaded((
                     child_ty.clone(),
                     GlobalValue::none(),
+                    ObjectFingerprint::none(protocol_config),
                 )));
             }
             Some(obj) => obj,
@@ -310,7 +328,7 @@ impl Inner<'_> {
         if obj.type_() != child_move_type {
             return Ok(ObjectResult::MismatchedType);
         }
-        // generate a GlobalValue
+        // deserialize the value
         let obj_contents = obj.contents();
         let v = match Value::simple_deserialize(obj_contents, child_ty_layout) {
             Some(v) => v,
@@ -320,6 +338,16 @@ impl Inner<'_> {
                 ),
             ),
         };
+        // save a fingerprint
+        let fingerprint =
+            ObjectFingerprint::preexisting(protocol_config, &parent, child_move_type, &v).map_err(
+                |e| {
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(
+                        format!("Failed to fingerprint value for object {child}. Error: {e}"),
+                    )
+                },
+            )?;
+        // generate a global value
         let global_value =
             match GlobalValue::cached(v) {
                 Ok(gv) => gv,
@@ -346,7 +374,11 @@ impl Inner<'_> {
                 }
             }
         }
-        Ok(ObjectResult::Loaded((child_ty.clone(), global_value)))
+        Ok(ObjectResult::Loaded((
+            child_ty.clone(),
+            global_value,
+            fingerprint,
+        )))
     }
 }
 
@@ -493,7 +525,7 @@ impl<'a> ChildObjectStore<'a> {
         let store_entries_count = self.store.len() as u64;
         let child_object = match self.store.entry(child) {
             btree_map::Entry::Vacant(e) => {
-                let (ty, value) = match self.inner.fetch_object_impl(
+                let (ty, value, fingerprint) = match self.inner.fetch_object_impl(
                     parent,
                     child,
                     child_ty,
@@ -531,6 +563,7 @@ impl<'a> ChildObjectStore<'a> {
                     ty,
                     move_type: child_move_type,
                     value,
+                    fingerprint,
                 })
             }
             btree_map::Entry::Occupied(e) => {
@@ -572,7 +605,10 @@ impl<'a> ChildObjectStore<'a> {
                 ));
         };
 
-        let mut value = if let Some(ChildObject { value, .. }) = self.store.remove(&child) {
+        let (mut value, fingerprint) = if let Some(ChildObject {
+            value, fingerprint, ..
+        }) = self.store.remove(&child)
+        {
             if value.exists()? {
                 return Err(
                     PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
@@ -585,9 +621,10 @@ impl<'a> ChildObjectStore<'a> {
                         ),
                 );
             }
-            value
+            (value, fingerprint)
         } else {
-            GlobalValue::none()
+            let fingerprint = ObjectFingerprint::none(self.inner.protocol_config);
+            (GlobalValue::none(), fingerprint)
         };
         if let Err((e, _)) = value.move_to(child_value) {
             return Err(
@@ -601,6 +638,7 @@ impl<'a> ChildObjectStore<'a> {
             ty: child_ty.clone(),
             move_type: child_move_type,
             value,
+            fingerprint,
         };
         self.store.insert(child, child_object);
         Ok(())
@@ -706,22 +744,59 @@ impl<'a> ChildObjectStore<'a> {
     }
 
     // retrieve the `Op` effects for the child objects
-    pub(super) fn take_effects(&mut self) -> ChildObjectEffects {
-        let v0_effects = std::mem::take(&mut self.store)
-            .into_iter()
-            .filter_map(|(id, child_object)| {
-                let ChildObject {
-                    owner,
-                    ty,
-                    move_type: _,
-                    value,
-                } = child_object;
-                let effect = value.into_effect()?;
-                let child_effect = ChildObjectEffectV0 { owner, ty, effect };
-                Some((id, child_effect))
-            })
-            .collect();
-        ChildObjectEffects::V0(v0_effects)
+    pub(super) fn take_effects(&mut self) -> PartialVMResult<ChildObjectEffects> {
+        if self.inner.protocol_config.minimize_child_object_mutations() {
+            let v1_effects = std::mem::take(&mut self.store)
+                .into_iter()
+                .map(|(id, child_object)| {
+                    let ChildObject {
+                        owner,
+                        ty,
+                        move_type,
+                        value,
+                        fingerprint,
+                    } = child_object;
+                    #[cfg(debug_assertions)]
+                    let dirty_flag_mutated = value.is_mutated();
+                    let final_value = value.into_value();
+                    let object_changed =
+                        fingerprint.object_has_changed(&owner, &move_type, &final_value)?;
+                    // The old dirty flag was pessimistic in its tracking of mutations, meaning
+                    // it would mark mutations even if the value remained the same.
+                    // This means that if the object changed, the dirty flag must have been marked.
+                    // However, we can't guarantee the opposite.
+                    // object changed ==> dirty flag mutated
+                    debug_assert!(!object_changed || dirty_flag_mutated);
+                    let child_effect = ChildObjectEffectV1 {
+                        owner,
+                        ty,
+                        final_value,
+                        object_changed,
+                    };
+                    Ok((id, child_effect))
+                })
+                .collect::<PartialVMResult<_>>()?;
+            Ok(ChildObjectEffects::V1(v1_effects))
+        } else {
+            let v0_effects = std::mem::take(&mut self.store)
+                .into_iter()
+                .filter_map(|(id, child_object)| {
+                    let ChildObject {
+                        owner,
+                        ty,
+                        move_type: _,
+                        value,
+                        fingerprint: _fingerprint,
+                    } = child_object;
+                    let effect = value.into_effect()?;
+                    // should be disabled if the feature is disabled
+                    debug_assert!(_fingerprint.is_disabled());
+                    let child_effect = ChildObjectEffectV0 { owner, ty, effect };
+                    Some((id, child_effect))
+                })
+                .collect();
+            Ok(ChildObjectEffects::V0(v0_effects))
+        }
     }
 
     pub(super) fn all_active_objects(&self) -> impl Iterator<Item = ActiveChildObject<'_>> {


### PR DESCRIPTION
# Description of change

This option subtly changes which child object changes get billed for. Now child object changes where the object changes in such a way that between it's start and end state in the given transaction it's value, type and owner doesn't change it will be deemed unchanged.

The result is that for child objects that get
modified - changed back
get deleted - get readded
won't be counted as modified if their value, type and owner stays the same. Resulting in lower overall gas usage.

For us the above will only reduce the number of modified objects that need to be handled while processing the effects.
Otherwise no gas usage change will occur as, contrary to Sui, gas rebates for us are always 100%.
Example from `count_decremented.snap` for Sui:
```
mutated: object(0,0), object(7,0), object(9,0), object(9,1)
storage_cost: 5859600,  storage_rebate: 5801004, non_refundable_storage_fee: 58596
went to
mutated: object(0,0), object(7,0)
storage_cost: 2196400,  storage_rebate: 2174436, non_refundable_storage_fee: 21964
```
while for us
```
mutated: object(0,0), object(7,0), object(9,0), object(9,1)
storage_cost: 5829200, storage_rebate: 5829200, non_refundable_storage_fee: 0
went to
mutated: object(0,0), object(7,0)
storage_cost: 2181200, storage_rebate: 2181200, non_refundable_storage_fee: 0
```

## Links to any relevant issues

fixes #7065 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol:  Child objects mutations will not be counted as modified if the owner, value and type of the child objects stays the same between the start and end of a transaction.
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
