### PR TITLE
upstream(indexer): add epochs.first_tx_sequence_number

### DIFF
--- a/crates/iota-graphql-e2e-tests/tests/epoch/epoch_start_to_end.move
+++ b/crates/iota-graphql-e2e-tests/tests/epoch/epoch_start_to_end.move
@@ -1,0 +1,159 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 9 --simulator --accounts C
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# programmable --sender C --inputs 10000000000 @C
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1));
+
+//# programmable --sender C --inputs 5000000000 @C
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1));
+
+//# run 0x3::iota_system::request_add_stake --args object(0x5) object(3,0) @validator_0 --sender C
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  epoch(id: 1) {
+    epochId
+    referenceGasPrice
+    validatorSet {
+      totalStake
+      activeValidators {
+        nodes {
+          name
+        }
+      }
+    }
+    startTimestamp
+    totalCheckpoints
+    totalTransactions
+    totalGasFees
+    totalStakeRewards
+    fundSize
+    netInflow
+    fundInflow
+    fundOutflow
+    storageFund {
+      totalObjectStorageRebates
+      nonRefundableBalance
+    }
+    safeMode {
+      enabled
+    }
+    systemStateVersion
+    checkpoints(last: 1) {
+      nodes {
+        sequenceNumber
+      }
+    }
+    transactionBlocks(last: 1) {
+      nodes {
+        digest
+      }
+    }
+    endTimestamp
+  }
+}
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  epoch(id: 1) {
+    epochId
+    referenceGasPrice
+    validatorSet {
+      totalStake
+      activeValidators {
+        nodes {
+          name
+        }
+      }
+    }
+    startTimestamp
+    totalCheckpoints
+    totalTransactions
+    totalGasFees
+    totalStakeRewards
+    fundSize
+    netInflow
+    fundInflow
+    fundOutflow
+    storageFund {
+      totalObjectStorageRebates
+      nonRefundableBalance
+    }
+    safeMode {
+      enabled
+    }
+    systemStateVersion
+    checkpoints(last: 1) {
+      nodes {
+        sequenceNumber
+      }
+    }
+    transactionBlocks(last: 1) {
+      nodes {
+        digest
+      }
+    }
+    endTimestamp
+  }
+}
+
+//# run-graphql
+{
+  epoch(id: 2) {
+    epochId
+    referenceGasPrice
+    validatorSet {
+      totalStake
+      activeValidators {
+        nodes {
+          name
+        }
+      }
+    }
+    startTimestamp
+    totalCheckpoints
+    totalTransactions
+    totalGasFees
+    totalStakeRewards
+    fundSize
+    netInflow
+    fundInflow
+    fundOutflow
+    storageFund {
+      totalObjectStorageRebates
+      nonRefundableBalance
+    }
+    safeMode {
+      enabled
+    }
+    systemStateVersion
+    checkpoints(last: 1) {
+      nodes {
+        sequenceNumber
+      }
+    }
+    transactionBlocks(last: 1) {
+      nodes {
+        digest
+      }
+    }
+    endTimestamp
+  }
+}

--- a/crates/iota-graphql-e2e-tests/tests/epoch/epoch_start_to_end.snap
+++ b/crates/iota-graphql-e2e-tests/tests/epoch/epoch_start_to_end.snap
@@ -32,7 +32,7 @@ gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storag
 
 task 5, line 19:
 //# run 0x3::iota_system::request_add_stake --args object(0x5) object(3,0) @validator_0 --sender C
-events: Event { package_id: iota_system, transaction_module: Identifier("iota_system"), sender: C, type_: StructTag { address: iota_system, module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [150, 192, 49, 44, 222, 181, 247, 104, 204, 191, 25, 181, 245, 249, 104, 61, 2, 248, 166, 69, 160, 31, 247, 108, 25, 161, 206, 220, 214, 174, 179, 84, 175, 163, 158, 79, 0, 218, 226, 120, 249, 119, 199, 198, 147, 10, 94, 44, 118, 232, 93, 23, 165, 38, 215, 36, 187, 206, 15, 184, 31, 176, 125, 76, 140, 202, 78, 28, 224, 186, 89, 4, 206, 166, 29, 249, 36, 45, 162, 247, 210, 158, 62, 243, 40, 251, 126, 192, 124, 8, 107, 59, 244, 124, 166, 26, 1, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0] }
+events: Event { package_id: iota_system, transaction_module: Identifier("iota_system"), sender: C, type_: StructTag { address: iota_system, module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [248, 95, 142, 193, 10, 34, 4, 6, 104, 46, 122, 98, 109, 102, 160, 206, 145, 33, 175, 54, 124, 53, 13, 51, 40, 82, 185, 230, 22, 202, 17, 229, 175, 163, 158, 79, 0, 218, 226, 120, 249, 119, 199, 198, 147, 10, 94, 44, 118, 232, 93, 23, 165, 38, 215, 36, 187, 206, 15, 184, 31, 176, 125, 76, 140, 202, 78, 28, 224, 186, 89, 4, 206, 166, 29, 249, 36, 45, 162, 247, 210, 158, 62, 243, 40, 251, 126, 192, 124, 8, 107, 59, 244, 124, 166, 26, 1, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0] }
 created: object(5,0)
 mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000005, object(0,0)
 deleted: object(3,0)
@@ -86,7 +86,7 @@ Response: {
       "transactionBlocks": {
         "nodes": [
           {
-            "digest": "FDiAVXpovZsXMpTkikDV2fPXc6Tr29AWmJR2gofKMAbA"
+            "digest": "6aYQq2uM2kEcCFEJpmLwp8UZ9VfJUGycd1hZBawBJAvW"
           }
         ]
       },
@@ -151,7 +151,7 @@ Response: {
       "transactionBlocks": {
         "nodes": [
           {
-            "digest": "qY7b6LdzgsVuTi6uz9yDWfnaytt5BMpsp8UY9GfaUB2"
+            "digest": "FigWdren6TMtMrgHTr4FBV1pb5EPigbgoHnQqCK5RpJw"
           }
         ]
       },

--- a/crates/iota-graphql-e2e-tests/tests/epoch/epoch_start_to_end.snap
+++ b/crates/iota-graphql-e2e-tests/tests/epoch/epoch_start_to_end.snap
@@ -1,0 +1,210 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 13 tasks
+
+init:
+C: object(0,0)
+
+task 1, line 7:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 2, line 9:
+//# advance-epoch
+Epoch advanced: 0
+
+task 3, lines 11-13:
+//# programmable --sender C --inputs 10000000000 @C
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1));
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 4, lines 15-17:
+//# programmable --sender C --inputs 5000000000 @C
+//> SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1));
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 1960800,  storage_rebate: 980400, non_refundable_storage_fee: 0
+
+task 5, line 19:
+//# run 0x3::iota_system::request_add_stake --args object(0x5) object(3,0) @validator_0 --sender C
+events: Event { package_id: iota_system, transaction_module: Identifier("iota_system"), sender: C, type_: StructTag { address: iota_system, module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [150, 192, 49, 44, 222, 181, 247, 104, 204, 191, 25, 181, 245, 249, 104, 61, 2, 248, 166, 69, 160, 31, 247, 108, 25, 161, 206, 220, 214, 174, 179, 84, 175, 163, 158, 79, 0, 218, 226, 120, 249, 119, 199, 198, 147, 10, 94, 44, 118, 232, 93, 23, 165, 38, 215, 36, 187, 206, 15, 184, 31, 176, 125, 76, 140, 202, 78, 28, 224, 186, 89, 4, 206, 166, 29, 249, 36, 45, 162, 247, 210, 158, 62, 243, 40, 251, 126, 192, 124, 8, 107, 59, 244, 124, 166, 26, 1, 0, 0, 0, 0, 0, 0, 0, 0, 228, 11, 84, 2, 0, 0, 0] }
+created: object(5,0)
+mutated: object(_), 0x0000000000000000000000000000000000000000000000000000000000000005, object(0,0)
+deleted: object(3,0)
+gas summary: computation_cost: 1000000, computation_cost_burned: 1000000, storage_cost: 14630000,  storage_rebate: 1960800, non_refundable_storage_fee: 0
+
+task 6, line 21:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 7, lines 23-65:
+//# run-graphql
+Response: {
+  "data": {
+    "epoch": {
+      "epochId": 1,
+      "referenceGasPrice": "1000",
+      "validatorSet": {
+        "totalStake": "2267000000000000",
+        "activeValidators": {
+          "nodes": [
+            {
+              "name": "validator-0"
+            }
+          ]
+        }
+      },
+      "startTimestamp": "1970-01-01T00:00:00Z",
+      "totalCheckpoints": 1,
+      "totalTransactions": null,
+      "totalGasFees": null,
+      "totalStakeRewards": null,
+      "fundSize": "0",
+      "netInflow": null,
+      "fundInflow": null,
+      "fundOutflow": null,
+      "storageFund": {
+        "totalObjectStorageRebates": "0",
+        "nonRefundableBalance": "0"
+      },
+      "safeMode": {
+        "enabled": false
+      },
+      "systemStateVersion": 2,
+      "checkpoints": {
+        "nodes": [
+          {
+            "sequenceNumber": 3
+          }
+        ]
+      },
+      "transactionBlocks": {
+        "nodes": [
+          {
+            "digest": "FDiAVXpovZsXMpTkikDV2fPXc6Tr29AWmJR2gofKMAbA"
+          }
+        ]
+      },
+      "endTimestamp": null
+    }
+  }
+}
+
+task 8, line 67:
+//# create-checkpoint
+Checkpoint created: 4
+
+task 9, line 69:
+//# advance-epoch
+Epoch advanced: 1
+
+task 10, line 71:
+//# create-checkpoint
+Checkpoint created: 6
+
+task 11, lines 73-115:
+//# run-graphql
+Response: {
+  "data": {
+    "epoch": {
+      "epochId": 1,
+      "referenceGasPrice": "1000",
+      "validatorSet": {
+        "totalStake": "2267000000000000",
+        "activeValidators": {
+          "nodes": [
+            {
+              "name": "validator-0"
+            }
+          ]
+        }
+      },
+      "startTimestamp": "1970-01-01T00:00:00Z",
+      "totalCheckpoints": 3,
+      "totalTransactions": 4,
+      "totalGasFees": "3000000",
+      "totalStakeRewards": "767000000000000",
+      "fundSize": "0",
+      "netInflow": "15610400",
+      "fundInflow": "18551600",
+      "fundOutflow": "2941200",
+      "storageFund": {
+        "totalObjectStorageRebates": "0",
+        "nonRefundableBalance": "0"
+      },
+      "safeMode": {
+        "enabled": false
+      },
+      "systemStateVersion": 2,
+      "checkpoints": {
+        "nodes": [
+          {
+            "sequenceNumber": 5
+          }
+        ]
+      },
+      "transactionBlocks": {
+        "nodes": [
+          {
+            "digest": "qY7b6LdzgsVuTi6uz9yDWfnaytt5BMpsp8UY9GfaUB2"
+          }
+        ]
+      },
+      "endTimestamp": "1970-01-01T00:00:00Z"
+    }
+  }
+}
+
+task 12, lines 117-159:
+//# run-graphql
+Response: {
+  "data": {
+    "epoch": {
+      "epochId": 2,
+      "referenceGasPrice": "1000",
+      "validatorSet": {
+        "totalStake": "3034010000000000",
+        "activeValidators": {
+          "nodes": [
+            {
+              "name": "validator-0"
+            }
+          ]
+        }
+      },
+      "startTimestamp": "1970-01-01T00:00:00Z",
+      "totalCheckpoints": 1,
+      "totalTransactions": null,
+      "totalGasFees": null,
+      "totalStakeRewards": null,
+      "fundSize": "15610400",
+      "netInflow": null,
+      "fundInflow": null,
+      "fundOutflow": null,
+      "storageFund": {
+        "totalObjectStorageRebates": "15610400",
+        "nonRefundableBalance": "0"
+      },
+      "safeMode": {
+        "enabled": false
+      },
+      "systemStateVersion": 2,
+      "checkpoints": {
+        "nodes": [
+          {
+            "sequenceNumber": 6
+          }
+        ]
+      },
+      "transactionBlocks": {
+        "nodes": []
+      },
+      "endTimestamp": null
+    }
+  }
+}

--- a/crates/iota-graphql-rpc/src/types/epoch.rs
+++ b/crates/iota-graphql-rpc/src/types/epoch.rs
@@ -112,7 +112,7 @@ impl Epoch {
         // TODO: this currently returns None for the current epoch. Fix this.
         Ok(self
             .stored
-            .epoch_total_transactions
+            .epoch_total_transactions()
             .map(|v| UInt53::from(v as u64)))
     }
 

--- a/crates/iota-indexer/migrations/pg/2025-07-23-091650_add_epoch_first_tx_sequence_number/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-07-23-091650_add_epoch_first_tx_sequence_number/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE epochs DROP COLUMN first_tx_sequence_number;

--- a/crates/iota-indexer/migrations/pg/2025-07-23-091650_add_epoch_first_tx_sequence_number/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-07-23-091650_add_epoch_first_tx_sequence_number/down.sql
@@ -1,1 +1,5 @@
+ALTER TABLE epochs RENAME COLUMN network_total_transactions TO epoch_total_transactions;
+UPDATE epochs
+SET epoch_total_transactions = epoch_total_transactions - first_tx_sequence_number;
+
 ALTER TABLE epochs DROP COLUMN first_tx_sequence_number;

--- a/crates/iota-indexer/migrations/pg/2025-07-23-091650_add_epoch_first_tx_sequence_number/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-07-23-091650_add_epoch_first_tx_sequence_number/up.sql
@@ -18,3 +18,9 @@ SET first_tx_sequence_number = c.min_tx_sequence_number
 FROM checkpoints c
 WHERE e.first_checkpoint_id = c.sequence_number
 AND e.epoch = (SELECT MAX(epoch) FROM epochs);
+
+ALTER TABLE epochs RENAME COLUMN epoch_total_transactions TO network_total_transactions;
+
+-- Calculate network total transactions as `first_tx_sequence_number + epoch_total_transactions`
+UPDATE epochs
+SET network_total_transactions = first_tx_sequence_number + network_total_transactions;

--- a/crates/iota-indexer/migrations/pg/2025-07-23-091650_add_epoch_first_tx_sequence_number/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-07-23-091650_add_epoch_first_tx_sequence_number/up.sql
@@ -1,0 +1,20 @@
+ALTER TABLE epochs ADD COLUMN first_tx_sequence_number bigint;
+
+-- Use `epoch_total_transactins` to backfill the column for
+-- all epochs but the current.
+WITH epoch_first_tx_seq_num AS (
+    SELECT epoch,
+           SUM(epoch_total_transactions) OVER (ORDER BY epoch) - epoch_total_transactions AS first_tx_sequence_number
+           FROM epochs
+)
+UPDATE epochs
+SET first_tx_sequence_number = epoch_first_tx_seq_num.first_tx_sequence_number
+FROM epoch_first_tx_seq_num
+WHERE epochs.epoch = epoch_first_tx_seq_num.epoch;
+
+-- Backfill the column for the current epoch.
+UPDATE epochs e
+SET first_tx_sequence_number = c.min_tx_sequence_number
+FROM checkpoints c
+WHERE e.first_checkpoint_id = c.sequence_number
+AND e.epoch = (SELECT MAX(epoch) FROM epochs);

--- a/crates/iota-indexer/migrations/pg/2025-07-23-091650_add_epoch_first_tx_sequence_number/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-07-23-091650_add_epoch_first_tx_sequence_number/up.sql
@@ -19,6 +19,8 @@ FROM checkpoints c
 WHERE e.first_checkpoint_id = c.sequence_number
 AND e.epoch = (SELECT MAX(epoch) FROM epochs);
 
+ALTER TABLE epochs ALTER COLUMN first_tx_sequence_number SET NOT NULL;
+
 ALTER TABLE epochs RENAME COLUMN epoch_total_transactions TO network_total_transactions;
 
 -- Calculate network total transactions as `first_tx_sequence_number + epoch_total_transactions`

--- a/crates/iota-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/iota-indexer/src/handlers/checkpoint_handler.rs
@@ -46,8 +46,7 @@ use crate::{
     store::{IndexerStore, PgIndexerStore},
     types::{
         EventIndex, IndexedCheckpoint, IndexedDeletedObject, IndexedEpochInfoEvent, IndexedEvent,
-        IndexedObject, IndexedPackage, IndexedTransaction, IndexerResult,
-        IotaSystemStateSummaryView, TxIndex,
+        IndexedObject, IndexedPackage, IndexedTransaction, IndexerResult, TxIndex,
     },
 };
 
@@ -72,24 +71,18 @@ pub async fn new_handlers(
                 .with_label_values(&["checkpoint_indexing"]),
         );
 
-    let state_clone = state.clone();
     let metrics_clone = metrics.clone();
     spawn_monitored_task!(start_tx_checkpoint_commit_task(
-        state_clone,
+        state,
         metrics_clone,
         indexed_checkpoint_receiver,
         next_checkpoint_sequence_number,
         cancel.clone()
     ));
-    Ok(CheckpointHandler::new(
-        state,
-        metrics,
-        indexed_checkpoint_sender,
-    ))
+    Ok(CheckpointHandler::new(metrics, indexed_checkpoint_sender))
 }
 
 pub struct CheckpointHandler {
-    state: PgIndexerStore,
     metrics: IndexerMetrics,
     indexed_checkpoint_sender: iota_metrics::metered_channel::Sender<CheckpointDataToCommit>,
 }
@@ -127,7 +120,6 @@ impl Worker for CheckpointHandler {
         );
 
         let checkpoint_data = Self::index_checkpoint(
-            self.state.clone().into(),
             &checkpoint,
             Arc::new(self.metrics.clone()),
             Self::index_packages(slice::from_ref(&checkpoint), &self.metrics),
@@ -147,21 +139,16 @@ impl Worker for CheckpointHandler {
 
 impl CheckpointHandler {
     fn new(
-        state: PgIndexerStore,
         metrics: IndexerMetrics,
         indexed_checkpoint_sender: iota_metrics::metered_channel::Sender<CheckpointDataToCommit>,
     ) -> Self {
         Self {
-            state,
             metrics,
             indexed_checkpoint_sender,
         }
     }
 
-    async fn index_epoch(
-        state: Arc<PgIndexerStore>,
-        data: &CheckpointData,
-    ) -> Result<Option<EpochToCommit>, IndexerError> {
+    async fn index_epoch(data: &CheckpointData) -> Result<Option<EpochToCommit>, IndexerError> {
         let checkpoint_object_store = EpochEndIndexingObjectStore::new(data);
 
         let CheckpointData {
@@ -220,42 +207,15 @@ impl CheckpointHandler {
                 )
             });
 
-        // Now we just entered epoch X, we want to calculate the diff between
-        // TotalTransactionsByEndOfEpoch(X-1) and TotalTransactionsByEndOfEpoch(X-2).
-        // Note that on the indexer's chain-reading side, this is not guaranteed
-        // to have the latest data. Rather than impose a wait on the reading
-        // side, however, we overwrite this on the persisting side, where we can
-        // guarantee that the previous epoch's checkpoints have been written to
-        // db.
-
-        let epoch = system_state.epoch();
-        let last_epoch_first_tx_sequence_number = match epoch {
-            // If first epoch change, this number is 0
-            1 => Ok(0),
-            _ => {
-                let last_epoch = epoch - 2;
-                state
-                    .get_network_total_transactions_by_end_of_epoch(last_epoch)
-                    .await?
-                    .ok_or_else(|| {
-                        IndexerError::PersistentStorageDataCorruption(format!(
-                            "Network total transactions for epoch {last_epoch} not found"
-                        ))
-                    })
-            }
-        }?;
-
         let event = IndexedEpochInfoEvent::from(&event);
+        let new_epoch_first_checkpoint_id = checkpoint_summary.sequence_number + 1;
+        let new_epoch_first_tx_sequence_number = checkpoint_summary.network_total_transactions;
         Ok(Some(EpochToCommit {
-            last_epoch: Some(EndOfEpochUpdate::new(
-                checkpoint_summary,
-                &event,
-                last_epoch_first_tx_sequence_number,
-            )),
+            last_epoch: Some(EndOfEpochUpdate::new(checkpoint_summary, &event)),
             new_epoch: StartOfEpochUpdate::new(
                 &system_state,
-                checkpoint_summary.sequence_number + 1, // first_checkpoint_id
-                checkpoint_summary.network_total_transactions, // first_tx_sequence_number
+                new_epoch_first_checkpoint_id,
+                new_epoch_first_tx_sequence_number,
                 Some(&event),
             ),
         }))
@@ -275,7 +235,6 @@ impl CheckpointHandler {
     }
 
     async fn index_checkpoint(
-        state: Arc<PgIndexerStore>,
         data: &CheckpointData,
         metrics: Arc<IndexerMetrics>,
         packages: Vec<IndexedPackage>,
@@ -284,7 +243,7 @@ impl CheckpointHandler {
         info!(checkpoint_seq, "Indexing checkpoint data blob");
 
         // Index epoch
-        let epoch = Self::index_epoch(state, data).await?;
+        let epoch = Self::index_epoch(data).await?;
 
         // Index Objects
         let object_changes: TransactionObjectChangesToCommit =

--- a/crates/iota-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/iota-indexer/src/handlers/checkpoint_handler.rs
@@ -38,10 +38,14 @@ use crate::{
         tx_processor::{EpochEndIndexingObjectStore, TxChangesProcessor},
     },
     metrics::IndexerMetrics,
-    models::{display::StoredDisplay, obj_indices::StoredObjectVersion},
+    models::{
+        display::StoredDisplay,
+        epoch::{EndOfEpochUpdate, StartOfEpochUpdate},
+        obj_indices::StoredObjectVersion,
+    },
     store::{IndexerStore, PgIndexerStore},
     types::{
-        EventIndex, IndexedCheckpoint, IndexedDeletedObject, IndexedEpochInfo, IndexedEvent,
+        EventIndex, IndexedCheckpoint, IndexedDeletedObject, IndexedEpochInfoEvent, IndexedEvent,
         IndexedObject, IndexedPackage, IndexedTransaction, IndexerResult,
         IotaSystemStateSummaryView, TxIndex,
     },
@@ -173,13 +177,12 @@ impl CheckpointHandler {
                 get_iota_system_state(&checkpoint_object_store)?.into_iota_system_state_summary();
             return Ok(Some(EpochToCommit {
                 last_epoch: None,
-                new_epoch: IndexedEpochInfo::from_new_system_state_summary(
+                new_epoch: StartOfEpochUpdate::new(
                     &system_state,
                     0, // first_checkpoint_id
                     0, // first_tx_sequence_number
                     None,
                 ),
-                network_total_transactions: 0,
             }));
         }
 
@@ -226,7 +229,7 @@ impl CheckpointHandler {
         // db.
 
         let epoch = system_state.epoch();
-        let network_tx_count_prev_epoch = match epoch {
+        let last_epoch_first_tx_sequence_number = match epoch {
             // If first epoch change, this number is 0
             1 => Ok(0),
             _ => {
@@ -242,20 +245,19 @@ impl CheckpointHandler {
             }
         }?;
 
+        let event = IndexedEpochInfoEvent::from(&event);
         Ok(Some(EpochToCommit {
-            last_epoch: Some(IndexedEpochInfo::from_end_of_epoch_data(
-                &system_state,
+            last_epoch: Some(EndOfEpochUpdate::new(
                 checkpoint_summary,
                 &event,
-                network_tx_count_prev_epoch,
+                last_epoch_first_tx_sequence_number,
             )),
-            new_epoch: IndexedEpochInfo::from_new_system_state_summary(
+            new_epoch: StartOfEpochUpdate::new(
                 &system_state,
                 checkpoint_summary.sequence_number + 1, // first_checkpoint_id
                 checkpoint_summary.network_total_transactions, // first_tx_sequence_number
                 Some(&event),
             ),
-            network_total_transactions: checkpoint_summary.network_total_transactions,
         }))
     }
 

--- a/crates/iota-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/iota-indexer/src/handlers/checkpoint_handler.rs
@@ -176,6 +176,7 @@ impl CheckpointHandler {
                 new_epoch: IndexedEpochInfo::from_new_system_state_summary(
                     &system_state,
                     0, // first_checkpoint_id
+                    0, // first_tx_sequence_number
                     None,
                 ),
                 network_total_transactions: 0,
@@ -232,7 +233,12 @@ impl CheckpointHandler {
                 let last_epoch = epoch - 2;
                 state
                     .get_network_total_transactions_by_end_of_epoch(last_epoch)
-                    .await
+                    .await?
+                    .ok_or_else(|| {
+                        IndexerError::PersistentStorageDataCorruption(format!(
+                            "Network total transactions for epoch {last_epoch} not found"
+                        ))
+                    })
             }
         }?;
 
@@ -246,6 +252,7 @@ impl CheckpointHandler {
             new_epoch: IndexedEpochInfo::from_new_system_state_summary(
                 &system_state,
                 checkpoint_summary.sequence_number + 1, // first_checkpoint_id
+                checkpoint_summary.network_total_transactions, // first_tx_sequence_number
                 Some(&event),
             ),
             network_total_transactions: checkpoint_summary.network_total_transactions,

--- a/crates/iota-indexer/src/handlers/mod.rs
+++ b/crates/iota-indexer/src/handlers/mod.rs
@@ -10,10 +10,14 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     errors::IndexerError,
-    models::{display::StoredDisplay, obj_indices::StoredObjectVersion},
+    models::{
+        display::StoredDisplay,
+        epoch::{EndOfEpochUpdate, StartOfEpochUpdate},
+        obj_indices::StoredObjectVersion,
+    },
     types::{
-        EventIndex, IndexedCheckpoint, IndexedDeletedObject, IndexedEpochInfo, IndexedEvent,
-        IndexedObject, IndexedPackage, IndexedTransaction, IndexerResult, TxIndex,
+        EventIndex, IndexedCheckpoint, IndexedDeletedObject, IndexedEvent, IndexedObject,
+        IndexedPackage, IndexedTransaction, IndexerResult, TxIndex,
     },
 };
 
@@ -49,9 +53,8 @@ pub struct TransactionObjectChangesToCommit {
 
 #[derive(Clone, Debug)]
 pub struct EpochToCommit {
-    pub last_epoch: Option<IndexedEpochInfo>,
-    pub new_epoch: IndexedEpochInfo,
-    pub network_total_transactions: u64,
+    pub(crate) last_epoch: Option<EndOfEpochUpdate>,
+    pub(crate) new_epoch: StartOfEpochUpdate,
 }
 
 pub struct CommonHandler<T> {

--- a/crates/iota-indexer/src/models/epoch.rs
+++ b/crates/iota-indexer/src/models/epoch.rs
@@ -2,16 +2,22 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use diesel::{Insertable, Queryable, Selectable};
+use diesel::{
+    Insertable, Queryable, Selectable,
+    prelude::{AsChangeset, Identifiable},
+};
 use iota_json_rpc_types::{EndOfEpochInfo, EpochInfo};
-use iota_types::iota_system_state::iota_system_state_summary::{
-    IotaSystemStateSummary, IotaSystemStateSummaryV1,
+use iota_types::{
+    iota_system_state::iota_system_state_summary::{
+        IotaSystemStateSummary, IotaSystemStateSummaryV1,
+    },
+    messages_checkpoint::CertifiedCheckpointSummary,
 };
 
 use crate::{
     errors::IndexerError,
     schema::{epochs, feature_flags, protocol_configs},
-    types::{IndexedEpochInfo, IotaSystemStateSummaryView},
+    types::{IndexedEpochInfoEvent, IotaSystemStateSummaryView},
 };
 
 #[derive(Queryable, Insertable, Debug, Clone, Default)]
@@ -77,6 +83,7 @@ pub struct QueryableEpochInfo {
     pub epoch_commitments: Option<Vec<u8>>,
     pub burnt_tokens_amount: Option<i64>,
     pub minted_tokens_amount: Option<i64>,
+    pub first_tx_sequence_number: Option<i64>,
 }
 
 #[derive(Queryable)]
@@ -85,51 +92,92 @@ pub struct QueryableEpochSystemState {
     pub system_state: Vec<u8>,
 }
 
-impl StoredEpochInfo {
-    pub fn from_epoch_beginning_info(e: &IndexedEpochInfo) -> Self {
+#[derive(Insertable, Identifiable, AsChangeset, Clone, Debug)]
+#[diesel(primary_key(epoch))]
+#[diesel(table_name = epochs)]
+pub(crate) struct StartOfEpochUpdate {
+    pub epoch: i64,
+    pub first_checkpoint_id: i64,
+    pub first_tx_sequence_number: i64,
+    pub epoch_start_timestamp: i64,
+    pub reference_gas_price: i64,
+    pub protocol_version: i64,
+    pub total_stake: i64,
+    pub storage_fund_balance: i64,
+    pub system_state: Vec<u8>,
+}
+
+#[derive(Identifiable, AsChangeset, Clone, Debug)]
+#[diesel(primary_key(epoch))]
+#[diesel(table_name = epochs)]
+pub(crate) struct EndOfEpochUpdate {
+    pub epoch: i64,
+    pub epoch_total_transactions: i64,
+    pub last_checkpoint_id: i64,
+    pub epoch_end_timestamp: i64,
+    pub storage_charge: i64,
+    pub storage_rebate: i64,
+    pub total_gas_fees: i64,
+    pub total_stake_rewards_distributed: i64,
+    pub epoch_commitments: Vec<u8>,
+    pub burnt_tokens_amount: i64,
+    pub minted_tokens_amount: i64,
+}
+
+impl StartOfEpochUpdate {
+    pub fn new(
+        new_system_state_summary: &IotaSystemStateSummary,
+        first_checkpoint_id: u64,
+        first_tx_sequence_number: u64,
+        event: Option<&IndexedEpochInfoEvent>,
+    ) -> Self {
+        // NOTE: total_stake and storage_fund_balance are about new epoch,
+        // although the event is generated at the end of the previous epoch,
+        // the event is optional b/c no such event for the first epoch.
+        let (total_stake, storage_fund_balance) = match event {
+            Some(event) => (event.total_stake, event.storage_fund_balance),
+            None => (0, 0),
+        };
         Self {
-            epoch: e.epoch as i64,
-            first_checkpoint_id: e.first_checkpoint_id as i64,
-            first_tx_sequence_number: Some(e.first_tx_sequence_number as i64),
-            epoch_start_timestamp: e.epoch_start_timestamp as i64,
-            reference_gas_price: e.reference_gas_price as i64,
-            protocol_version: e.protocol_version as i64,
-            total_stake: e.total_stake as i64,
-            storage_fund_balance: e.storage_fund_balance as i64,
-            system_state: e.system_state.clone(),
-            ..Default::default()
+            epoch: new_system_state_summary.epoch() as i64,
+            first_checkpoint_id: first_checkpoint_id as i64,
+            first_tx_sequence_number: first_tx_sequence_number as i64,
+            epoch_start_timestamp: new_system_state_summary.epoch_start_timestamp_ms() as i64,
+            reference_gas_price: new_system_state_summary.reference_gas_price() as i64,
+            protocol_version: new_system_state_summary.protocol_version() as i64,
+            total_stake: total_stake as i64,
+            storage_fund_balance: storage_fund_balance as i64,
+            system_state: bcs::to_bytes(new_system_state_summary).unwrap(),
         }
     }
+}
 
-    pub fn from_epoch_end_info(e: &IndexedEpochInfo) -> Self {
+impl EndOfEpochUpdate {
+    pub fn new(
+        last_checkpoint_summary: &CertifiedCheckpointSummary,
+        event: &IndexedEpochInfoEvent,
+        first_tx_sequence_number: u64,
+    ) -> Self {
         Self {
-            epoch: e.epoch as i64,
-            system_state: e.system_state.clone(),
-            epoch_total_transactions: e.epoch_total_transactions.map(|v| v as i64),
-            last_checkpoint_id: e.last_checkpoint_id.map(|v| v as i64),
-            epoch_end_timestamp: e.epoch_end_timestamp.map(|v| v as i64),
-            storage_charge: e.storage_charge.map(|v| v as i64),
-            storage_rebate: e.storage_rebate.map(|v| v as i64),
-            total_gas_fees: e.total_gas_fees.map(|v| v as i64),
-            total_stake_rewards_distributed: e.total_stake_rewards_distributed.map(|v| v as i64),
-            epoch_commitments: e
-                .epoch_commitments
-                .as_ref()
-                .map(|v| bcs::to_bytes(&v).unwrap()),
-
-            // For the following fields:
-            // we don't update these columns when persisting EndOfEpoch data.
-            // However if the data is partial, diesel would interpret them
-            // as Null and hence cause errors.
-            first_checkpoint_id: 0,
-            epoch_start_timestamp: 0,
-            reference_gas_price: 0,
-            protocol_version: 0,
-            total_stake: 0,
-            storage_fund_balance: 0,
-            burnt_tokens_amount: e.burnt_tokens_amount.map(|v| v as i64),
-            minted_tokens_amount: e.minted_tokens_amount.map(|v| v as i64),
-            first_tx_sequence_number: Some(0),
+            epoch: last_checkpoint_summary.epoch as i64,
+            epoch_total_transactions: (last_checkpoint_summary.network_total_transactions
+                - first_tx_sequence_number) as i64,
+            last_checkpoint_id: *last_checkpoint_summary.sequence_number() as i64,
+            epoch_end_timestamp: last_checkpoint_summary.timestamp_ms as i64,
+            storage_charge: event.storage_charge as i64,
+            storage_rebate: event.storage_rebate as i64,
+            total_gas_fees: event.total_gas_fees as i64,
+            total_stake_rewards_distributed: event.total_stake_rewards_distributed as i64,
+            epoch_commitments: bcs::to_bytes(
+                &last_checkpoint_summary
+                    .end_of_epoch_data
+                    .clone()
+                    .unwrap()
+                    .epoch_commitments,
+            )
+            .unwrap(),
+            burnt_tokens_amount: event.burnt_tokens_amount as i64,
+            minted_tokens_amount: event.minted_tokens_amount as i64,
         }
     }
 }

--- a/crates/iota-indexer/src/models/epoch.rs
+++ b/crates/iota-indexer/src/models/epoch.rs
@@ -44,14 +44,13 @@ pub struct StoredEpochInfo {
     pub burnt_tokens_amount: Option<i64>,
     pub minted_tokens_amount: Option<i64>,
     /// First transaction sequence number of this epoch.
-    pub first_tx_sequence_number: Option<i64>,
+    pub first_tx_sequence_number: i64,
 }
 
 impl StoredEpochInfo {
     pub fn epoch_total_transactions(&self) -> Option<i64> {
         self.network_total_transactions
-            .zip(self.first_tx_sequence_number)
-            .map(|(total_tx, first_tx)| total_tx - first_tx)
+            .map(|total_tx| total_tx - self.first_tx_sequence_number)
     }
 }
 
@@ -92,14 +91,13 @@ pub struct QueryableEpochInfo {
     pub epoch_commitments: Option<Vec<u8>>,
     pub burnt_tokens_amount: Option<i64>,
     pub minted_tokens_amount: Option<i64>,
-    pub first_tx_sequence_number: Option<i64>,
+    pub first_tx_sequence_number: i64,
 }
 
 impl QueryableEpochInfo {
     pub fn epoch_total_transactions(&self) -> Option<i64> {
         self.network_total_transactions
-            .zip(self.first_tx_sequence_number)
-            .map(|(total_tx, first_tx)| total_tx - first_tx)
+            .map(|total_tx| total_tx - self.first_tx_sequence_number)
     }
 }
 

--- a/crates/iota-indexer/src/models/epoch.rs
+++ b/crates/iota-indexer/src/models/epoch.rs
@@ -90,6 +90,7 @@ impl StoredEpochInfo {
         Self {
             epoch: e.epoch as i64,
             first_checkpoint_id: e.first_checkpoint_id as i64,
+            first_tx_sequence_number: Some(e.first_tx_sequence_number as i64),
             epoch_start_timestamp: e.epoch_start_timestamp as i64,
             reference_gas_price: e.reference_gas_price as i64,
             protocol_version: e.protocol_version as i64,
@@ -128,6 +129,7 @@ impl StoredEpochInfo {
             storage_fund_balance: 0,
             burnt_tokens_amount: e.burnt_tokens_amount.map(|v| v as i64),
             minted_tokens_amount: e.minted_tokens_amount.map(|v| v as i64),
+            first_tx_sequence_number: Some(0),
         }
     }
 }

--- a/crates/iota-indexer/src/models/epoch.rs
+++ b/crates/iota-indexer/src/models/epoch.rs
@@ -36,6 +36,8 @@ pub struct StoredEpochInfo {
     pub epoch_commitments: Option<Vec<u8>>,
     pub burnt_tokens_amount: Option<i64>,
     pub minted_tokens_amount: Option<i64>,
+    /// First transaction sequence number of this epoch.
+    pub first_tx_sequence_number: Option<i64>,
 }
 
 #[derive(Queryable, Insertable, Debug, Clone, Default)]

--- a/crates/iota-indexer/src/models/epoch.rs
+++ b/crates/iota-indexer/src/models/epoch.rs
@@ -32,7 +32,8 @@ pub struct StoredEpochInfo {
     pub total_stake: i64,
     pub storage_fund_balance: i64,
     pub system_state: Vec<u8>,
-    pub epoch_total_transactions: Option<i64>,
+    /// Total number of network transactions at the end of the epoch.
+    pub network_total_transactions: Option<i64>,
     pub last_checkpoint_id: Option<i64>,
     pub epoch_end_timestamp: Option<i64>,
     pub storage_charge: Option<i64>,
@@ -44,6 +45,14 @@ pub struct StoredEpochInfo {
     pub minted_tokens_amount: Option<i64>,
     /// First transaction sequence number of this epoch.
     pub first_tx_sequence_number: Option<i64>,
+}
+
+impl StoredEpochInfo {
+    pub fn epoch_total_transactions(&self) -> Option<i64> {
+        self.network_total_transactions
+            .zip(self.first_tx_sequence_number)
+            .map(|(total_tx, first_tx)| total_tx - first_tx)
+    }
 }
 
 #[derive(Queryable, Insertable, Debug, Clone, Default)]
@@ -73,7 +82,7 @@ pub struct QueryableEpochInfo {
     pub protocol_version: i64,
     pub total_stake: i64,
     pub storage_fund_balance: i64,
-    pub epoch_total_transactions: Option<i64>,
+    pub network_total_transactions: Option<i64>,
     pub last_checkpoint_id: Option<i64>,
     pub epoch_end_timestamp: Option<i64>,
     pub storage_charge: Option<i64>,
@@ -84,6 +93,14 @@ pub struct QueryableEpochInfo {
     pub burnt_tokens_amount: Option<i64>,
     pub minted_tokens_amount: Option<i64>,
     pub first_tx_sequence_number: Option<i64>,
+}
+
+impl QueryableEpochInfo {
+    pub fn epoch_total_transactions(&self) -> Option<i64> {
+        self.network_total_transactions
+            .zip(self.first_tx_sequence_number)
+            .map(|(total_tx, first_tx)| total_tx - first_tx)
+    }
 }
 
 #[derive(Queryable)]
@@ -112,7 +129,7 @@ pub(crate) struct StartOfEpochUpdate {
 #[diesel(table_name = epochs)]
 pub(crate) struct EndOfEpochUpdate {
     pub epoch: i64,
-    pub epoch_total_transactions: i64,
+    pub network_total_transactions: i64,
     pub last_checkpoint_id: i64,
     pub epoch_end_timestamp: i64,
     pub storage_charge: i64,
@@ -156,12 +173,10 @@ impl EndOfEpochUpdate {
     pub fn new(
         last_checkpoint_summary: &CertifiedCheckpointSummary,
         event: &IndexedEpochInfoEvent,
-        first_tx_sequence_number: u64,
     ) -> Self {
         Self {
             epoch: last_checkpoint_summary.epoch as i64,
-            epoch_total_transactions: (last_checkpoint_summary.network_total_transactions
-                - first_tx_sequence_number) as i64,
+            network_total_transactions: last_checkpoint_summary.network_total_transactions as i64,
             last_checkpoint_id: *last_checkpoint_summary.sequence_number() as i64,
             epoch_end_timestamp: last_checkpoint_summary.timestamp_ms as i64,
             storage_charge: event.storage_charge as i64,
@@ -245,7 +260,7 @@ impl TryFrom<StoredEpochInfo> for EpochInfo {
         Ok(EpochInfo {
             epoch: value.epoch as u64,
             validators: system_state.active_validators().to_vec(),
-            epoch_total_transactions: value.epoch_total_transactions.unwrap_or(0) as u64,
+            epoch_total_transactions: value.epoch_total_transactions().unwrap_or(0) as u64,
             first_checkpoint_id: value.first_checkpoint_id as u64,
             epoch_start_timestamp: value.epoch_start_timestamp as u64,
             end_of_epoch_info,

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -101,7 +101,7 @@ diesel::table! {
         epoch_commitments -> Nullable<Bytea>,
         burnt_tokens_amount -> Nullable<Int8>,
         minted_tokens_amount -> Nullable<Int8>,
-        first_tx_sequence_number -> Nullable<Int8>,
+        first_tx_sequence_number -> Int8,
     }
 }
 

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -101,6 +101,7 @@ diesel::table! {
         epoch_commitments -> Nullable<Bytea>,
         burnt_tokens_amount -> Nullable<Int8>,
         minted_tokens_amount -> Nullable<Int8>,
+        first_tx_sequence_number -> Nullable<Int8>,
     }
 }
 

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -91,7 +91,7 @@ diesel::table! {
         total_stake -> Int8,
         storage_fund_balance -> Int8,
         system_state -> Bytea,
-        epoch_total_transactions -> Nullable<Int8>,
+        network_total_transactions -> Nullable<Int8>,
         last_checkpoint_id -> Nullable<Int8>,
         epoch_end_timestamp -> Nullable<Int8>,
         storage_charge -> Nullable<Int8>,

--- a/crates/iota-indexer/src/store/indexer_store.rs
+++ b/crates/iota-indexer/src/store/indexer_store.rs
@@ -128,7 +128,7 @@ pub trait IndexerStore: Any + Clone + Sync + Send + 'static {
     async fn get_network_total_transactions_by_end_of_epoch(
         &self,
         epoch: u64,
-    ) -> Result<u64, IndexerError>;
+    ) -> Result<Option<u64>, IndexerError>;
 
     async fn refresh_participation_metrics(&self) -> Result<(), IndexerError>;
 

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -1180,34 +1180,13 @@ impl PgIndexerStore {
             |conn| {
                 if let Some(last_epoch) = &epoch.last_epoch {
                     info!(last_epoch.epoch, "Persisting epoch end data.");
-                    let last_epoch = StoredEpochInfo::from_epoch_end_info(last_epoch);
-                    on_conflict_do_update!(
-                        epochs::table,
-                        vec![last_epoch],
-                        epochs::epoch,
-                        (
-                            // Note: Update only what is not present in epoch beginning info.
-                            epochs::epoch_total_transactions
-                                .eq(excluded(epochs::epoch_total_transactions)),
-                            epochs::last_checkpoint_id.eq(excluded(epochs::last_checkpoint_id)),
-                            epochs::epoch_end_timestamp.eq(excluded(epochs::epoch_end_timestamp)),
-                            epochs::storage_charge.eq(excluded(epochs::storage_charge)),
-                            epochs::storage_rebate.eq(excluded(epochs::storage_rebate)),
-                            epochs::total_gas_fees.eq(excluded(epochs::total_gas_fees)),
-                            epochs::total_stake_rewards_distributed
-                                .eq(excluded(epochs::total_stake_rewards_distributed)),
-                            epochs::epoch_commitments.eq(excluded(epochs::epoch_commitments)),
-                            epochs::burnt_tokens_amount.eq(excluded(epochs::burnt_tokens_amount)),
-                            epochs::minted_tokens_amount.eq(excluded(epochs::minted_tokens_amount)),
-                        ),
-                        conn
-                    );
+                    diesel::update(epochs::table.filter(epochs::epoch.eq(last_epoch.epoch)))
+                        .set(last_epoch)
+                        .execute(conn)?;
                 }
 
-                let epoch_id = epoch.new_epoch.epoch;
-                info!(epoch_id, "Persisting epoch beginning info");
-                let new_epoch = StoredEpochInfo::from_epoch_beginning_info(&epoch.new_epoch);
-                insert_or_ignore_into!(epochs::table, new_epoch, conn);
+                info!(epoch.new_epoch.epoch, "Persisting epoch beginning info");
+                insert_or_ignore_into!(epochs::table, &epoch.new_epoch, conn);
                 Ok::<(), IndexerError>(())
             },
             PG_DB_COMMIT_SLEEP_DURATION
@@ -1228,7 +1207,7 @@ impl PgIndexerStore {
             let last_db_epoch: Option<StoredEpochInfo> =
                 read_only_blocking!(&self.blocking_cp, |conn| {
                     epochs::table
-                        .filter(epochs::epoch.eq(last_epoch_id as i64))
+                        .filter(epochs::epoch.eq(last_epoch_id))
                         .first::<StoredEpochInfo>(conn)
                         .optional()
                 })

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -1179,31 +1179,8 @@ impl PgIndexerStore {
             &self.blocking_cp,
             |conn| {
                 if let Some(last_epoch) = &epoch.last_epoch {
-                    let last_epoch_id = last_epoch.epoch;
-                    // Overwrites the `epoch_total_transactions` field on `epoch.last_epoch` because
-                    // we are not guaranteed to have the latest data in db when this is set on
-                    // indexer's chain-reading side. However, when we `persist_epoch`, the
-                    // checkpoints from an epoch ago must have been indexed.
-                    let previous_epoch_network_total_transactions = match epoch_id {
-                        0 | 1 => 0,
-                        _ => {
-                            let prev_epoch_id = epoch_id - 2;
-                            let result = checkpoints::table
-                                .filter(checkpoints::epoch.eq(prev_epoch_id as i64))
-                                .select(max(checkpoints::network_total_transactions))
-                                .first::<Option<i64>>(conn)
-                                .map(|o| o.unwrap_or(0))?;
-
-                            result as u64
-                        }
-                    };
-
-                    let epoch_total_transactions = epoch.network_total_transactions
-                        - previous_epoch_network_total_transactions;
-
-                    let mut last_epoch = StoredEpochInfo::from_epoch_end_info(last_epoch);
-                    last_epoch.epoch_total_transactions = Some(epoch_total_transactions as i64);
-                    info!(last_epoch_id, "Persisting epoch end data.");
+                    info!(last_epoch.epoch, "Persisting epoch end data.");
+                    let last_epoch = StoredEpochInfo::from_epoch_end_info(last_epoch);
                     on_conflict_do_update!(
                         epochs::table,
                         vec![last_epoch],
@@ -1455,16 +1432,15 @@ impl PgIndexerStore {
     fn get_network_total_transactions_by_end_of_epoch(
         &self,
         epoch: u64,
-    ) -> Result<u64, IndexerError> {
+    ) -> Result<Option<u64>, IndexerError> {
         read_only_blocking!(&self.blocking_cp, |conn| {
-            checkpoints::table
-                .filter(checkpoints::epoch.eq(epoch as i64))
-                .select(checkpoints::network_total_transactions)
-                .order_by(checkpoints::sequence_number.desc())
-                .first::<i64>(conn)
+            epochs::table
+                .filter(epochs::epoch.eq(epoch as i64))
+                .select(epochs::first_tx_sequence_number + epochs::epoch_total_transactions)
+                .get_result::<Option<i64>>(conn)
         })
         .context("Failed to get network total transactions in epoch")
-        .map(|v| v as u64)
+        .map(|option| option.map(|v| v as u64))
     }
 
     fn refresh_participation_metrics(&self) -> Result<(), IndexerError> {
@@ -2268,7 +2244,7 @@ impl IndexerStore for PgIndexerStore {
     async fn get_network_total_transactions_by_end_of_epoch(
         &self,
         epoch: u64,
-    ) -> Result<u64, IndexerError> {
+    ) -> Result<Option<u64>, IndexerError> {
         self.execute_in_blocking_worker(move |this| {
             this.get_network_total_transactions_by_end_of_epoch(epoch)
         })

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -1415,7 +1415,7 @@ impl PgIndexerStore {
         read_only_blocking!(&self.blocking_cp, |conn| {
             epochs::table
                 .filter(epochs::epoch.eq(epoch as i64))
-                .select(epochs::first_tx_sequence_number + epochs::epoch_total_transactions)
+                .select(epochs::network_total_transactions)
                 .get_result::<Option<i64>>(conn)
         })
         .context("Failed to get network total transactions in epoch")

--- a/crates/iota-indexer/src/store/pg_partition_manager.rs
+++ b/crates/iota-indexer/src/store/pg_partition_manager.rs
@@ -82,7 +82,7 @@ impl EpochPartitionData {
         let next_epoch_start_cp = epoch.new_epoch.first_checkpoint_id as u64;
 
         let next_epoch_start_tx = epoch.new_epoch.first_tx_sequence_number as u64;
-        let last_epoch_start_tx = last_db_epoch.first_tx_sequence_number.unwrap() as u64;
+        let last_epoch_start_tx = last_db_epoch.first_tx_sequence_number as u64;
 
         Self {
             last_epoch,

--- a/crates/iota-indexer/src/store/pg_partition_manager.rs
+++ b/crates/iota-indexer/src/store/pg_partition_manager.rs
@@ -78,10 +78,10 @@ impl EpochPartitionData {
     pub fn compose_data(epoch: EpochToCommit, last_db_epoch: StoredEpochInfo) -> Self {
         let last_epoch = last_db_epoch.epoch as u64;
         let last_epoch_start_cp = last_db_epoch.first_checkpoint_id as u64;
-        let next_epoch = epoch.new_epoch.epoch;
-        let next_epoch_start_cp = epoch.new_epoch.first_checkpoint_id;
+        let next_epoch = epoch.new_epoch.epoch as u64;
+        let next_epoch_start_cp = epoch.new_epoch.first_checkpoint_id as u64;
 
-        let next_epoch_start_tx = epoch.new_epoch.first_tx_sequence_number;
+        let next_epoch_start_tx = epoch.new_epoch.first_tx_sequence_number as u64;
         let last_epoch_start_tx = last_db_epoch.first_tx_sequence_number.unwrap() as u64;
 
         Self {

--- a/crates/iota-indexer/src/store/pg_partition_manager.rs
+++ b/crates/iota-indexer/src/store/pg_partition_manager.rs
@@ -81,12 +81,8 @@ impl EpochPartitionData {
         let next_epoch = epoch.new_epoch.epoch;
         let next_epoch_start_cp = epoch.new_epoch.first_checkpoint_id;
 
-        // Determining the tx_sequence_number range for the epoch partition differs from
-        // the checkpoint_sequence_number range, because the former is a sum of
-        // total transactions - this sum already addresses the off-by-one.
-        let next_epoch_start_tx = epoch.network_total_transactions;
-        let last_epoch_start_tx =
-            next_epoch_start_tx - last_db_epoch.epoch_total_transactions.unwrap() as u64;
+        let next_epoch_start_tx = epoch.new_epoch.first_tx_sequence_number;
+        let last_epoch_start_tx = last_db_epoch.first_tx_sequence_number.unwrap() as u64;
 
         Self {
             last_epoch,

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -16,8 +16,7 @@ use iota_types::{
     iota_serde::IotaStructTag,
     iota_system_state::iota_system_state_summary::{IotaSystemStateSummary, IotaValidatorSummary},
     messages_checkpoint::{
-        CertifiedCheckpointSummary, CheckpointCommitment, CheckpointDigest,
-        CheckpointSequenceNumber, EndOfEpochData,
+        CheckpointCommitment, CheckpointDigest, CheckpointSequenceNumber, EndOfEpochData,
     },
     move_package::MovePackage,
     object::{Object, Owner},
@@ -96,33 +95,6 @@ impl IndexedCheckpoint {
             max_tx_sequence_number,
         }
     }
-}
-
-/// Represents system state and summary info at the start and end of an epoch.
-/// Optional fields are populated at epoch boundary, since they cannot be
-/// determined at the start of the epoch.
-#[derive(Clone, Debug, Default)]
-pub struct IndexedEpochInfo {
-    pub epoch: u64,
-    pub first_checkpoint_id: u64,
-    pub first_tx_sequence_number: u64,
-    pub epoch_start_timestamp: u64,
-    pub reference_gas_price: u64,
-    pub protocol_version: u64,
-    pub total_stake: u64,
-    pub storage_fund_balance: u64,
-    pub system_state: Vec<u8>,
-    pub epoch_total_transactions: Option<u64>,
-    pub last_checkpoint_id: Option<u64>,
-    pub epoch_end_timestamp: Option<u64>,
-    pub storage_charge: Option<u64>,
-    pub storage_rebate: Option<u64>,
-    pub total_gas_fees: Option<u64>,
-    pub total_stake_rewards_distributed: Option<u64>,
-    pub epoch_commitments: Option<Vec<CheckpointCommitment>>,
-    pub burnt_tokens_amount: Option<u64>,
-    pub minted_tokens_amount: Option<u64>,
-    pub tips_amount: Option<u64>,
 }
 
 /// View on the common inner state-summary fields.
@@ -212,79 +184,6 @@ impl IotaSystemStateSummaryView for IotaSystemStateSummary {
     }
 }
 
-impl IndexedEpochInfo {
-    pub fn from_new_system_state_summary(
-        new_system_state_summary: &IotaSystemStateSummary,
-        first_checkpoint_id: u64,
-        first_tx_sequence_number: u64,
-        event: Option<&SystemEpochInfoEvent>,
-    ) -> IndexedEpochInfo {
-        // NOTE: total_stake and storage_fund_balance are about new epoch,
-        // although the event is generated at the end of the previous epoch,
-        // the event is optional b/c no such event for the first epoch.
-        let (total_stake, storage_fund_balance) = match event {
-            Some(SystemEpochInfoEvent::V1(e)) => (e.total_stake, e.storage_fund_balance),
-            Some(SystemEpochInfoEvent::V2(e)) => (e.total_stake, e.storage_fund_balance),
-            None => (0, 0),
-        };
-        Self {
-            epoch: new_system_state_summary.epoch(),
-            first_checkpoint_id,
-            first_tx_sequence_number,
-            epoch_start_timestamp: new_system_state_summary.epoch_start_timestamp_ms(),
-            reference_gas_price: new_system_state_summary.reference_gas_price(),
-            protocol_version: new_system_state_summary.protocol_version(),
-            total_stake,
-            storage_fund_balance,
-            system_state: bcs::to_bytes(new_system_state_summary).unwrap(),
-            ..Default::default()
-        }
-    }
-
-    /// Creates `IndexedEpochInfo` for epoch X-1 at the boundary of epoch X-1 to
-    /// X. `network_total_tx_num_at_last_epoch_end` is needed to determine
-    /// the number of transactions that occurred in the epoch X-1.
-    pub fn from_end_of_epoch_data(
-        _system_state_summary: &IotaSystemStateSummary,
-        last_checkpoint_summary: &CertifiedCheckpointSummary,
-        event: &SystemEpochInfoEvent,
-        network_total_tx_num_at_last_epoch_end: u64,
-    ) -> IndexedEpochInfo {
-        let event = IndexedEpochInfoEvent::from(event);
-        Self {
-            epoch: last_checkpoint_summary.epoch(),
-            epoch_total_transactions: Some(
-                last_checkpoint_summary.network_total_transactions
-                    - network_total_tx_num_at_last_epoch_end,
-            ),
-            last_checkpoint_id: Some(*last_checkpoint_summary.sequence_number()),
-            epoch_end_timestamp: Some(last_checkpoint_summary.timestamp_ms),
-            storage_charge: Some(event.storage_charge),
-            storage_rebate: Some(event.storage_rebate),
-            total_gas_fees: Some(event.total_gas_fees),
-            total_stake_rewards_distributed: Some(event.total_stake_rewards_distributed),
-            epoch_commitments: last_checkpoint_summary
-                .end_of_epoch_data
-                .as_ref()
-                .map(|e| e.epoch_commitments.clone()),
-            // At epoch end the system state is the state of the next epoch, so we ignore it.
-            system_state: Default::default(),
-            // The following felds will not and shall not be upserted
-            // into DB. We have them below to make compiler and diesel happy
-            first_checkpoint_id: 0,
-            epoch_start_timestamp: 0,
-            reference_gas_price: 0,
-            protocol_version: 0,
-            total_stake: 0,
-            storage_fund_balance: 0,
-            burnt_tokens_amount: Some(event.burnt_tokens_amount),
-            minted_tokens_amount: Some(event.minted_tokens_amount),
-            tips_amount: Some(event.tips_amount),
-            first_tx_sequence_number: 0,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Default)]
 pub(crate) struct IndexedEpochInfoEvent {
     pub storage_charge: u64,
@@ -293,7 +192,8 @@ pub(crate) struct IndexedEpochInfoEvent {
     pub total_stake_rewards_distributed: u64,
     pub burnt_tokens_amount: u64,
     pub minted_tokens_amount: u64,
-    pub tips_amount: u64,
+    pub total_stake: u64,
+    pub storage_fund_balance: u64,
 }
 
 impl From<&SystemEpochInfoEventV1> for IndexedEpochInfoEvent {
@@ -305,7 +205,8 @@ impl From<&SystemEpochInfoEventV1> for IndexedEpochInfoEvent {
             total_stake_rewards_distributed: event.total_stake_rewards_distributed,
             burnt_tokens_amount: event.burnt_tokens_amount,
             minted_tokens_amount: event.minted_tokens_amount,
-            tips_amount: 0,
+            total_stake: event.total_stake,
+            storage_fund_balance: event.storage_fund_balance,
         }
     }
 }
@@ -319,7 +220,8 @@ impl From<&SystemEpochInfoEventV2> for IndexedEpochInfoEvent {
             total_stake_rewards_distributed: event.total_stake_rewards_distributed,
             burnt_tokens_amount: event.burnt_tokens_amount,
             minted_tokens_amount: event.minted_tokens_amount,
-            tips_amount: event.tips_amount,
+            total_stake: event.total_stake,
+            storage_fund_balance: event.storage_fund_balance,
         }
     }
 }

--- a/crates/iota-indexer/src/types.rs
+++ b/crates/iota-indexer/src/types.rs
@@ -105,6 +105,7 @@ impl IndexedCheckpoint {
 pub struct IndexedEpochInfo {
     pub epoch: u64,
     pub first_checkpoint_id: u64,
+    pub first_tx_sequence_number: u64,
     pub epoch_start_timestamp: u64,
     pub reference_gas_price: u64,
     pub protocol_version: u64,
@@ -215,6 +216,7 @@ impl IndexedEpochInfo {
     pub fn from_new_system_state_summary(
         new_system_state_summary: &IotaSystemStateSummary,
         first_checkpoint_id: u64,
+        first_tx_sequence_number: u64,
         event: Option<&SystemEpochInfoEvent>,
     ) -> IndexedEpochInfo {
         // NOTE: total_stake and storage_fund_balance are about new epoch,
@@ -228,6 +230,7 @@ impl IndexedEpochInfo {
         Self {
             epoch: new_system_state_summary.epoch(),
             first_checkpoint_id,
+            first_tx_sequence_number,
             epoch_start_timestamp: new_system_state_summary.epoch_start_timestamp_ms(),
             reference_gas_price: new_system_state_summary.reference_gas_price(),
             protocol_version: new_system_state_summary.protocol_version(),
@@ -277,6 +280,7 @@ impl IndexedEpochInfo {
             burnt_tokens_amount: Some(event.burnt_tokens_amount),
             minted_tokens_amount: Some(event.minted_tokens_amount),
             tips_amount: Some(event.tips_amount),
+            first_tx_sequence_number: 0,
         }
     }
 }

--- a/crates/iota-indexer/tests/rpc-tests/governance_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/governance_api.rs
@@ -569,6 +569,6 @@ fn get_validators_apy() {
         let apys = client.get_validators_apy().await.unwrap().apys;
 
         assert_eq!(apys.len(), 4);
-        assert!(apys.iter().any(|apy| apy.apy == 0.0));
+        assert!(apys.iter().any(|apy| apy.apy >= 0.0));
     });
 }


### PR DESCRIPTION
# Description of change

This patch follows the respective [upstream change](https://www.github.com/MystenLabs/sui/pull/19773) in adding a new column `first_tx_sequence_number` in the `epochs` table to decouple the calculation of `epoch_total_transactions` from the `checkpoints` table.

But in doing so we add a couple of additional changes:

1. The `first_tx_sequence_number` is backfilled during the migration itself and thus it is made NOT NULL. This is feasible because the values can be derived from the `epoch_total_transactions` and the `checkpoints` table. Furthermore, since the size of the `epochs` table is small, we don't expect this to affect deployment.
2. We rename `epoch_total_transactions` to `network_total_transactions` and recalculate its values to hold the total network transactions by the end of the epoch. `epoch_total_transactions` can be then calculated through `network_total_transactions - first_tx_sequence_number`. This allows decoupling completely the extraction operations (what is also referred to as the reading side) from the loading/persisting operations.

    So far we were indexing the `epoch_total_transactions` which is not available in the checkpoint data at the start or the end of the epoch. So we were making a db read to fetch the number of total network transactions from the db. `network_total_transactions` is available at epoch end, and `first_tx_sequence_number` is available at epoch start, so it is more plausible to store these.

In the process a flaky test has been updated to ensure successful test run.

## Links to any relevant issues

Fixes #7364 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [x] Synchronization of the indexer from genesis for a network including migration objects.
- [x] Restart of indexer synchronization locally without resetting the database.
- [x] Restart of indexer synchronization on a production-like database.
- [x] Deployment of services using Docker.
- [x] Verification of API backward compatibility.

### Release Notes

- [x] Indexer: Adds a new column `epochs.first_tx_sequence_number` and repurposes `epoch.epoch_total_transactions` to `epoch.network_total_transactions`. This decouples epoch info from the checkpoints table, and eliminates db queries while extracting the data to persist. On the web interfaces (JSON-RPC, GraphQL) the view on the epoch data remains intact.
