### PR TITLE
upstream(core): Remove the direct dependency from `iota-core` to `iota-move-build`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5721,6 +5721,7 @@ dependencies = [
  "iota-json",
  "iota-json-rpc-types",
  "iota-keys",
+ "iota-move-build",
  "iota-sdk 1.4.0-alpha",
  "iota-swarm",
  "iota-swarm-config",

--- a/crates/iota-cluster-test/Cargo.toml
+++ b/crates/iota-cluster-test/Cargo.toml
@@ -34,6 +34,7 @@ iota-indexer.workspace = true
 iota-json.workspace = true
 iota-json-rpc-types.workspace = true
 iota-keys.workspace = true
+iota-move-build.workspace = true
 iota-sdk.workspace = true
 iota-swarm.workspace = true
 iota-swarm-config.workspace = true

--- a/crates/iota-cluster-test/src/test_case/coin_index_test.rs
+++ b/crates/iota-cluster-test/src/test_case/coin_index_test.rs
@@ -4,11 +4,11 @@
 
 use async_trait::async_trait;
 use futures::StreamExt;
-use iota_core::test_utils::compile_managed_coin_package;
 use iota_json::IotaJsonValue;
 use iota_json_rpc_types::{
     Balance, IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions, ObjectChange,
 };
+use iota_move_build::test_utils::compile_managed_coin_package;
 use iota_sdk::PagedFn;
 use iota_test_transaction_builder::make_staking_transaction;
 use iota_types::{

--- a/crates/iota-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
+++ b/crates/iota-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
-use iota_core::test_utils::compile_basics_package;
 use iota_json_rpc_types::IotaTransactionBlockEffectsAPI;
+use iota_move_build::test_utils::compile_basics_package;
 use iota_types::{base_types::ObjectID, object::Owner};
 use jsonrpsee::rpc_params;
 

--- a/crates/iota-core/Cargo.toml
+++ b/crates/iota-core/Cargo.toml
@@ -69,7 +69,6 @@ iota-genesis-builder.workspace = true
 iota-json-rpc-types.workspace = true
 iota-macros.workspace = true
 iota-metrics.workspace = true
-iota-move-build.workspace = true
 iota-network.workspace = true
 iota-network-stack.workspace = true
 iota-protocol-config.workspace = true
@@ -104,6 +103,7 @@ tower.workspace = true
 
 # internal dependencies
 iota-move.workspace = true
+iota-move-build.workspace = true
 iota-test-transaction-builder.workspace = true
 
 [target.'cfg(not(target_env = "msvc"))'.dev-dependencies]

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -195,6 +195,10 @@ mod batch_verification_tests;
 #[path = "unit_tests/coin_deny_list_tests.rs"]
 mod coin_deny_list_tests;
 
+#[cfg(test)]
+#[path = "unit_tests/auth_unit_test_utils.rs"]
+pub mod auth_unit_test_utils;
+
 pub mod authority_test_utils;
 
 pub mod authority_per_epoch_store;

--- a/crates/iota-core/src/authority/authority_test_utils.rs
+++ b/crates/iota-core/src/authority/authority_test_utils.rs
@@ -6,16 +6,11 @@
 use core::default::Default;
 
 use fastcrypto::{hash::MultisetHash, traits::KeyPair};
-use iota_move_build::{BuildConfig, CompiledPackage};
 use iota_types::{
-    crypto::{AccountKeyPair, AuthorityKeyPair, Signature},
+    crypto::{AccountKeyPair, AuthorityKeyPair},
     messages_consensus::ConsensusTransaction,
-    move_package::UpgradePolicy,
-    programmable_transaction_builder::ProgrammableTransactionBuilder,
     utils::to_sender_signed_transaction,
 };
-use move_core_types::account_address::AccountAddress;
-use move_symbol_pool::Symbol;
 
 use super::{test_authority_builder::TestAuthorityBuilder, *};
 use crate::{checkpoints::CheckpointServiceNoop, consensus_handler::SequencedConsensusTransaction};
@@ -465,147 +460,4 @@ pub async fn send_batch_consensus_no_execution(
         )
         .await
         .unwrap()
-}
-
-pub fn build_test_modules_with_dep_addr(
-    path: &Path,
-    dep_original_addresses: impl IntoIterator<Item = (&'static str, ObjectID)>,
-    dep_ids: impl IntoIterator<Item = (&'static str, ObjectID)>,
-) -> CompiledPackage {
-    let mut build_config = BuildConfig::new_for_testing();
-    for (addr_name, obj_id) in dep_original_addresses {
-        build_config
-            .config
-            .additional_named_addresses
-            .insert(addr_name.to_string(), AccountAddress::from(obj_id));
-    }
-    let mut package = build_config.build(path).unwrap();
-
-    let dep_id_mapping: BTreeMap<_, _> = dep_ids
-        .into_iter()
-        .map(|(dep_name, obj_id)| (Symbol::from(dep_name), obj_id))
-        .collect();
-
-    assert_eq!(
-        dep_id_mapping.len(),
-        package.dependency_ids.unpublished.len()
-    );
-    for unpublished_dep in &package.dependency_ids.unpublished {
-        let published_id = dep_id_mapping.get(unpublished_dep).unwrap();
-        // Make sure we aren't overriding a package
-        assert!(
-            package
-                .dependency_ids
-                .published
-                .insert(*unpublished_dep, *published_id)
-                .is_none()
-        )
-    }
-
-    // No unpublished deps
-    package.dependency_ids.unpublished.clear();
-    package
-}
-
-/// Returns the new package's ID and the upgrade cap object ref.
-/// `dep_original_addresses` allows us to fill out mappings in the addresses
-/// section of the package manifest. These IDs must be the original IDs of
-/// names. dep_ids are the IDs of the dependencies of the package, in the latest
-/// version (if there were upgrades).
-pub async fn publish_package_on_single_authority(
-    path: &Path,
-    sender: IotaAddress,
-    sender_key: &dyn Signer<Signature>,
-    gas_payment: ObjectRef,
-    dep_original_addresses: impl IntoIterator<Item = (&'static str, ObjectID)>,
-    dep_ids: Vec<ObjectID>,
-    state: &Arc<AuthorityState>,
-) -> IotaResult<(TransactionDigest, (ObjectID, ObjectRef))> {
-    let mut build_config = BuildConfig::new_for_testing();
-    for (addr_name, obj_id) in dep_original_addresses {
-        build_config
-            .config
-            .additional_named_addresses
-            .insert(addr_name.to_string(), AccountAddress::from(obj_id));
-    }
-    let modules = build_config.build(path).unwrap().get_package_bytes(false);
-
-    let mut builder = ProgrammableTransactionBuilder::new();
-    let cap = builder.publish_upgradeable(modules, dep_ids);
-    builder.transfer_arg(sender, cap);
-    let pt = builder.finish();
-
-    let rgp = state.epoch_store_for_testing().reference_gas_price();
-    let txn_data = TransactionData::new_programmable(
-        sender,
-        vec![gas_payment],
-        pt,
-        rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
-        rgp,
-    );
-
-    let signed = to_sender_signed_transaction(txn_data, sender_key);
-    let (_cert, effects) = send_and_confirm_transaction(state, signed).await?;
-    assert!(effects.data().status().is_ok());
-    let package_id = effects
-        .data()
-        .created()
-        .iter()
-        .find(|c| c.1 == Owner::Immutable)
-        .unwrap()
-        .0
-        .0;
-    let cap_object = effects
-        .data()
-        .created()
-        .iter()
-        .find(|c| matches!(c.1, Owner::AddressOwner(..)))
-        .unwrap()
-        .0;
-    Ok((*effects.transaction_digest(), (package_id, cap_object)))
-}
-
-pub async fn upgrade_package_on_single_authority(
-    path: &Path,
-    sender: IotaAddress,
-    sender_key: &dyn Signer<Signature>,
-    gas_payment: ObjectRef,
-    package_id: ObjectID,
-    upgrade_cap: ObjectRef,
-    dep_original_addresses: impl IntoIterator<Item = (&'static str, ObjectID)>,
-    dep_id_mapping: impl IntoIterator<Item = (&'static str, ObjectID)>,
-    state: &Arc<AuthorityState>,
-) -> IotaResult<(TransactionDigest, ObjectID)> {
-    let package = build_test_modules_with_dep_addr(path, dep_original_addresses, dep_id_mapping);
-
-    let with_unpublished_deps = false;
-    let modules = package.get_package_bytes(with_unpublished_deps);
-    let digest = package.get_package_digest(with_unpublished_deps).to_vec();
-
-    let rgp = state.epoch_store_for_testing().reference_gas_price();
-    let data = TransactionData::new_upgrade(
-        sender,
-        gas_payment,
-        package_id,
-        modules,
-        package.get_dependency_storage_package_ids(),
-        (upgrade_cap, Owner::AddressOwner(sender)),
-        UpgradePolicy::COMPATIBLE,
-        digest,
-        rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
-        rgp,
-    )
-    .unwrap();
-    let signed = to_sender_signed_transaction(data, sender_key);
-    let (_cert, effects) = send_and_confirm_transaction(state, signed).await?;
-    assert!(effects.data().status().is_ok());
-    let package_id = effects
-        .data()
-        .created()
-        .iter()
-        .find(|c| c.1 == Owner::Immutable)
-        .unwrap()
-        .0
-        .0;
-    Ok((*effects.transaction_digest(), package_id))
 }

--- a/crates/iota-core/src/lib.rs
+++ b/crates/iota-core/src/lib.rs
@@ -74,6 +74,9 @@ mod transfer_to_object_tests;
 #[cfg(test)]
 #[path = "unit_tests/type_param_tests.rs"]
 mod type_param_tests;
+#[cfg(test)]
+#[path = "unit_tests/unit_test_utils.rs"]
+mod unit_test_utils;
 
 pub mod signature_verifier;
 

--- a/crates/iota-core/src/quorum_driver/tests.rs
+++ b/crates/iota-core/src/quorum_driver/tests.rs
@@ -31,7 +31,8 @@ use crate::{
         reconfig_observer::DummyReconfigObserver,
     },
     test_authority_clients::{LocalAuthorityClient, LocalAuthorityClientFaultConfig},
-    test_utils::{init_local_authorities, make_transfer_iota_transaction},
+    test_utils::make_transfer_iota_transaction,
+    unit_test_utils::init_local_authorities,
 };
 
 async fn setup() -> (AuthorityAggregator<LocalAuthorityClient>, Transaction) {

--- a/crates/iota-core/src/test_utils.rs
+++ b/crates/iota-core/src/test_utils.rs
@@ -2,17 +2,9 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, path::PathBuf, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use fastcrypto::{hash::MultisetHash, traits::KeyPair};
-use futures::future::join_all;
-use iota_config::{genesis::Genesis, local_ip_utils, node::AuthorityOverloadConfig};
-use iota_framework::BuiltInFramework;
-use iota_genesis_builder::{
-    genesis_build_effects::GenesisBuildEffects, validator_info::ValidatorInfo,
-};
-use iota_move_build::{BuildConfig, CompiledPackage, IotaPackageHooks};
-use iota_protocol_config::ProtocolConfig;
 use iota_types::{
     base_types::{
         AuthorityName, ExecutionDigests, IotaAddress, ObjectID, ObjectRef, TransactionDigest,
@@ -21,13 +13,11 @@ use iota_types::{
     committee::Committee,
     crypto::{
         AccountKeyPair, AuthorityKeyPair, AuthorityPublicKeyBytes, AuthoritySignInfo,
-        AuthoritySignature, IotaKeyPair, NetworkKeyPair, Signer, generate_proof_of_possession,
-        get_key_pair,
+        AuthoritySignature, Signer,
     },
     effects::{SignedTransactionEffects, TestEffectsBuilder},
     error::IotaError,
     message_envelope::Message,
-    object::Object,
     signature_verification::VerifiedDigestCache,
     transaction::{
         CallArg, CertifiedTransaction, ObjectArg, SignedTransaction,
@@ -40,12 +30,7 @@ use shared_crypto::intent::{Intent, IntentScope};
 use tokio::time::timeout;
 use tracing::{info, warn};
 
-use crate::{
-    authority::{AuthorityState, test_authority_builder::TestAuthorityBuilder},
-    authority_aggregator::{AuthorityAggregator, AuthorityAggregatorBuilder, TimeoutConfig},
-    state_accumulator::StateAccumulator,
-    test_authority_clients::LocalAuthorityClient,
-};
+use crate::{authority::AuthorityState, state_accumulator::StateAccumulator};
 
 const WAIT_FOR_TX_TIMEOUT: Duration = Duration::from_secs(15);
 
@@ -94,7 +79,7 @@ pub async fn send_and_confirm_transaction(
 }
 
 #[cfg(test)]
-pub(crate) fn init_state_parameters_from_rng<R>(rng: &mut R) -> (Genesis, AuthorityKeyPair)
+pub(crate) fn init_state_parameters_from_rng<R>(rng: &mut R) -> (iota_config::genesis::Genesis, AuthorityKeyPair)
 where
     R: rand::CryptoRng + rand::RngCore,
 {
@@ -175,145 +160,6 @@ pub fn create_fake_cert_and_effect_digest<'a>(
         ExecutionDigests::new(*transaction.digest(), effects.digest()),
         cert,
     )
-}
-
-pub fn compile_basics_package() -> CompiledPackage {
-    compile_example_package("../../examples/move/basics")
-}
-
-pub fn compile_managed_coin_package() -> CompiledPackage {
-    compile_example_package("../../crates/iota-core/src/unit_tests/data/managed_coin")
-}
-
-pub fn compile_example_package(relative_path: &str) -> CompiledPackage {
-    move_package::package_hooks::register_package_hooks(Box::new(IotaPackageHooks));
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.push(relative_path);
-
-    BuildConfig::new_for_testing().build(&path).unwrap()
-}
-
-async fn init_genesis(
-    committee_size: usize,
-    mut genesis_objects: Vec<Object>,
-) -> (
-    Genesis,
-    Vec<(AuthorityPublicKeyBytes, AuthorityKeyPair)>,
-    ObjectID,
-) {
-    // add object_basics package object to genesis
-    let modules: Vec<_> = compile_basics_package().get_modules().cloned().collect();
-    let genesis_move_packages: Vec<_> = BuiltInFramework::genesis_move_packages().collect();
-    let config = ProtocolConfig::get_for_max_version_UNSAFE();
-    let pkg = Object::new_package(
-        &modules,
-        TransactionDigest::genesis_marker(),
-        config.max_move_package_size(),
-        config.move_binary_format_version(),
-        &genesis_move_packages,
-    )
-    .unwrap();
-    let pkg_id = pkg.id();
-    genesis_objects.push(pkg);
-
-    let mut builder = iota_genesis_builder::Builder::new().add_objects(genesis_objects);
-    let mut key_pairs = Vec::new();
-    for i in 0..committee_size {
-        let authority_key_pair: AuthorityKeyPair = get_key_pair().1;
-        let authority_pubkey_bytes = authority_key_pair.public().into();
-        let protocol_key_pair: NetworkKeyPair = get_key_pair().1;
-        let protocol_pubkey = protocol_key_pair.public().clone();
-        let account_key_pair: IotaKeyPair = get_key_pair::<AccountKeyPair>().1.into();
-        let network_key_pair: NetworkKeyPair = get_key_pair().1;
-        let validator_info = ValidatorInfo {
-            name: format!("validator-{i}"),
-            authority_key: authority_pubkey_bytes,
-            protocol_key: protocol_pubkey,
-            account_address: IotaAddress::from(&account_key_pair.public()),
-            network_key: network_key_pair.public().clone(),
-            gas_price: 1,
-            commission_rate: 0,
-            network_address: local_ip_utils::new_local_tcp_address_for_testing(),
-            p2p_address: local_ip_utils::new_local_udp_address_for_testing(),
-            primary_address: local_ip_utils::new_local_udp_address_for_testing(),
-            description: String::new(),
-            image_url: String::new(),
-            project_url: String::new(),
-        };
-        let pop =
-            generate_proof_of_possession(&authority_key_pair, (&account_key_pair.public()).into());
-        builder = builder.add_validator(validator_info, pop);
-        key_pairs.push((authority_pubkey_bytes, authority_key_pair));
-    }
-    for (_, key) in &key_pairs {
-        builder = builder.add_validator_signature(key);
-    }
-
-    let GenesisBuildEffects { genesis, .. } = builder.build();
-    (genesis, key_pairs, pkg_id)
-}
-
-pub async fn init_local_authorities(
-    committee_size: usize,
-    genesis_objects: Vec<Object>,
-) -> (
-    AuthorityAggregator<LocalAuthorityClient>,
-    Vec<Arc<AuthorityState>>,
-    Genesis,
-    ObjectID,
-) {
-    let (genesis, key_pairs, framework) = init_genesis(committee_size, genesis_objects).await;
-    let authorities = join_all(key_pairs.iter().map(|(_, key_pair)| {
-        TestAuthorityBuilder::new()
-            .with_genesis_and_keypair(&genesis, key_pair)
-            .build()
-    }))
-    .await;
-    let aggregator = init_local_authorities_with_genesis(&genesis, authorities.clone()).await;
-    (aggregator, authorities, genesis, framework)
-}
-
-pub async fn init_local_authorities_with_overload_thresholds(
-    committee_size: usize,
-    genesis_objects: Vec<Object>,
-    overload_thresholds: AuthorityOverloadConfig,
-) -> (
-    AuthorityAggregator<LocalAuthorityClient>,
-    Vec<Arc<AuthorityState>>,
-    Genesis,
-    ObjectID,
-) {
-    let (genesis, key_pairs, framework) = init_genesis(committee_size, genesis_objects).await;
-    let authorities = join_all(key_pairs.iter().map(|(_, key_pair)| {
-        TestAuthorityBuilder::new()
-            .with_genesis_and_keypair(&genesis, key_pair)
-            .with_authority_overload_config(overload_thresholds.clone())
-            .build()
-    }))
-    .await;
-    let aggregator = init_local_authorities_with_genesis(&genesis, authorities.clone()).await;
-    (aggregator, authorities, genesis, framework)
-}
-
-pub async fn init_local_authorities_with_genesis(
-    genesis: &Genesis,
-    authorities: Vec<Arc<AuthorityState>>,
-) -> AuthorityAggregator<LocalAuthorityClient> {
-    telemetry_subscribers::init_for_testing();
-    let mut clients = BTreeMap::new();
-    for state in authorities {
-        let name = state.name;
-        let client = LocalAuthorityClient::new_from_authority(state);
-        clients.insert(name, client);
-    }
-    let timeouts = TimeoutConfig {
-        pre_quorum_timeout: Duration::from_secs(5),
-        post_quorum_timeout: Duration::from_secs(5),
-        serial_authority_request_interval: Duration::from_secs(1),
-    };
-    AuthorityAggregatorBuilder::from_genesis(genesis)
-        .with_timeouts_config(timeouts)
-        .build_custom_clients(clients)
 }
 
 pub fn make_transfer_iota_transaction(

--- a/crates/iota-core/src/test_utils.rs
+++ b/crates/iota-core/src/test_utils.rs
@@ -79,7 +79,9 @@ pub async fn send_and_confirm_transaction(
 }
 
 #[cfg(test)]
-pub(crate) fn init_state_parameters_from_rng<R>(rng: &mut R) -> (iota_config::genesis::Genesis, AuthorityKeyPair)
+pub(crate) fn init_state_parameters_from_rng<R>(
+    rng: &mut R,
+) -> (iota_config::genesis::Genesis, AuthorityKeyPair)
 where
     R: rand::CryptoRng + rand::RngCore,
 {

--- a/crates/iota-core/src/unit_tests/auth_unit_test_utils.rs
+++ b/crates/iota-core/src/unit_tests/auth_unit_test_utils.rs
@@ -1,0 +1,157 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_move_build::{BuildConfig, CompiledPackage};
+use iota_types::{
+    crypto::Signature, move_package::UpgradePolicy,
+    programmable_transaction_builder::ProgrammableTransactionBuilder,
+    utils::to_sender_signed_transaction,
+};
+use move_core_types::account_address::AccountAddress;
+use move_symbol_pool::Symbol;
+
+use super::{authority_test_utils::*, *};
+
+pub fn build_test_modules_with_dep_addr(
+    path: &Path,
+    dep_original_addresses: impl IntoIterator<Item = (&'static str, ObjectID)>,
+    dep_ids: impl IntoIterator<Item = (&'static str, ObjectID)>,
+) -> CompiledPackage {
+    let mut build_config = BuildConfig::new_for_testing();
+    for (addr_name, obj_id) in dep_original_addresses {
+        build_config
+            .config
+            .additional_named_addresses
+            .insert(addr_name.to_string(), AccountAddress::from(obj_id));
+    }
+    let mut package = build_config.build(path).unwrap();
+
+    let dep_id_mapping: BTreeMap<_, _> = dep_ids
+        .into_iter()
+        .map(|(dep_name, obj_id)| (Symbol::from(dep_name), obj_id))
+        .collect();
+
+    assert_eq!(
+        dep_id_mapping.len(),
+        package.dependency_ids.unpublished.len()
+    );
+    for unpublished_dep in &package.dependency_ids.unpublished {
+        let published_id = dep_id_mapping.get(unpublished_dep).unwrap();
+        // Make sure we aren't overriding a package
+        assert!(
+            package
+                .dependency_ids
+                .published
+                .insert(*unpublished_dep, *published_id)
+                .is_none()
+        )
+    }
+
+    // No unpublished deps
+    package.dependency_ids.unpublished.clear();
+    package
+}
+
+/// Returns the new package's ID and the upgrade cap object ref.
+/// `dep_original_addresses` allows us to fill out mappings in the addresses
+/// section of the package manifest. These IDs must be the original IDs of
+/// names. dep_ids are the IDs of the dependencies of the package, in the latest
+/// version (if there were upgrades).
+pub async fn publish_package_on_single_authority(
+    path: &Path,
+    sender: IotaAddress,
+    sender_key: &dyn Signer<Signature>,
+    gas_payment: ObjectRef,
+    dep_original_addresses: impl IntoIterator<Item = (&'static str, ObjectID)>,
+    dep_ids: Vec<ObjectID>,
+    state: &Arc<AuthorityState>,
+) -> IotaResult<(TransactionDigest, (ObjectID, ObjectRef))> {
+    let mut build_config = BuildConfig::new_for_testing();
+    for (addr_name, obj_id) in dep_original_addresses {
+        build_config
+            .config
+            .additional_named_addresses
+            .insert(addr_name.to_string(), AccountAddress::from(obj_id));
+    }
+    let modules = build_config.build(path).unwrap().get_package_bytes(false);
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let cap = builder.publish_upgradeable(modules, dep_ids);
+    builder.transfer_arg(sender, cap);
+    let pt = builder.finish();
+
+    let rgp = state.epoch_store_for_testing().reference_gas_price();
+    let txn_data = TransactionData::new_programmable(
+        sender,
+        vec![gas_payment],
+        pt,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        rgp,
+    );
+
+    let signed = to_sender_signed_transaction(txn_data, sender_key);
+    let (_cert, effects) = send_and_confirm_transaction(state, signed).await?;
+    assert!(effects.data().status().is_ok());
+    let package_id = effects
+        .data()
+        .created()
+        .iter()
+        .find(|c| c.1 == Owner::Immutable)
+        .unwrap()
+        .0
+        .0;
+    let cap_object = effects
+        .data()
+        .created()
+        .iter()
+        .find(|c| matches!(c.1, Owner::AddressOwner(..)))
+        .unwrap()
+        .0;
+    Ok((*effects.transaction_digest(), (package_id, cap_object)))
+}
+
+pub async fn upgrade_package_on_single_authority(
+    path: &Path,
+    sender: IotaAddress,
+    sender_key: &dyn Signer<Signature>,
+    gas_payment: ObjectRef,
+    package_id: ObjectID,
+    upgrade_cap: ObjectRef,
+    dep_original_addresses: impl IntoIterator<Item = (&'static str, ObjectID)>,
+    dep_id_mapping: impl IntoIterator<Item = (&'static str, ObjectID)>,
+    state: &Arc<AuthorityState>,
+) -> IotaResult<(TransactionDigest, ObjectID)> {
+    let package = build_test_modules_with_dep_addr(path, dep_original_addresses, dep_id_mapping);
+
+    let with_unpublished_deps = false;
+    let modules = package.get_package_bytes(with_unpublished_deps);
+    let digest = package.get_package_digest(with_unpublished_deps).to_vec();
+
+    let rgp = state.epoch_store_for_testing().reference_gas_price();
+    let data = TransactionData::new_upgrade(
+        sender,
+        gas_payment,
+        package_id,
+        modules,
+        package.published_dependency_ids(),
+        (upgrade_cap, Owner::AddressOwner(sender)),
+        UpgradePolicy::COMPATIBLE,
+        digest,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        rgp,
+    )
+    .unwrap();
+    let signed = to_sender_signed_transaction(data, sender_key);
+    let (_cert, effects) = send_and_confirm_transaction(state, signed).await?;
+    assert!(effects.data().status().is_ok());
+    let package_id = effects
+        .data()
+        .created()
+        .iter()
+        .find(|c| c.1 == Owner::Immutable)
+        .unwrap()
+        .0
+        .0;
+    Ok((*effects.transaction_digest(), package_id))
+}

--- a/crates/iota-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_aggregator_tests.rs
@@ -39,9 +39,8 @@ use crate::{
         HandleTransactionTestAuthorityClient, LocalAuthorityClient,
         LocalAuthorityClientFaultConfig, MockAuthorityApi,
     },
-    test_utils::{
-        init_local_authorities, make_transfer_iota_transaction, make_transfer_object_transaction,
-    },
+    test_utils::{make_transfer_iota_transaction, make_transfer_object_transaction},
+    unit_test_utils::init_local_authorities,
 };
 
 macro_rules! assert_matches {

--- a/crates/iota-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/iota-core/src/unit_tests/execution_driver_tests.rs
@@ -45,10 +45,8 @@ use crate::{
     },
     safe_client::SafeClient,
     test_authority_clients::LocalAuthorityClient,
-    test_utils::{
-        init_local_authorities, init_local_authorities_with_overload_thresholds,
-        make_transfer_object_move_transaction, make_transfer_object_transaction,
-    },
+    test_utils::{make_transfer_object_move_transaction, make_transfer_object_transaction},
+    unit_test_utils::{init_local_authorities, init_local_authorities_with_overload_thresholds},
 };
 
 #[expect(dead_code)]

--- a/crates/iota-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/iota-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -31,7 +31,7 @@ use move_core_types::{ident_str, language_storage::StructTag};
 
 use crate::authority::{
     AuthorityState,
-    authority_test_utils::build_test_modules_with_dep_addr,
+    auth_unit_test_utils::build_test_modules_with_dep_addr,
     authority_tests::{execute_programmable_transaction, init_state_with_ids},
     move_integration_tests::{
         UpgradeData, build_and_publish_test_package_with_upgrade_cap, build_multi_publish_txns,
@@ -561,7 +561,7 @@ async fn test_upgrade_package_invalid_dep_only_upgrade_pre_v5() {
         FileOverlay::Add {
             file_name: "new_friend_module.move",
             contents: r#"
-module base_addr::new_friend_module; 
+module base_addr::new_friend_module;
 public fun friend_call(): u64 { base_addr::base::friend_fun(1) }
         "#,
         },
@@ -600,7 +600,7 @@ async fn test_invalid_dep_only_upgrades() {
         FileOverlay::Add {
             file_name: "new_friend_module.move",
             contents: r#"
-module base_addr::new_friend_module; 
+module base_addr::new_friend_module;
 public fun friend_call(): u64 { base_addr::base::friend_fun(1) }
         "#,
         },

--- a/crates/iota-core/src/unit_tests/transaction_deny_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_deny_tests.rs
@@ -34,7 +34,7 @@ use move_core_types::ident_str;
 use crate::{
     authority::{
         AuthorityState,
-        authority_test_utils::{
+        auth_unit_test_utils::{
             publish_package_on_single_authority, upgrade_package_on_single_authority,
         },
         test_authority_builder::TestAuthorityBuilder,

--- a/crates/iota-core/src/unit_tests/unit_test_utils.rs
+++ b/crates/iota-core/src/unit_tests/unit_test_utils.rs
@@ -1,0 +1,152 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
+
+use fastcrypto::traits::KeyPair;
+use futures::future::join_all;
+use iota_config::{genesis::Genesis, local_ip_utils, node::AuthorityOverloadConfig};
+use iota_framework::BuiltInFramework;
+use iota_genesis_builder::validator_info::ValidatorInfo;
+use iota_move_build::test_utils::compile_basics_package;
+use iota_protocol_config::ProtocolConfig;
+use iota_types::{
+    base_types::{IotaAddress, ObjectID, TransactionDigest},
+    crypto::{
+        AccountKeyPair, AuthorityKeyPair, AuthorityPublicKeyBytes, IotaKeyPair, NetworkKeyPair,
+        generate_proof_of_possession, get_key_pair,
+    },
+    object::Object,
+};
+
+use crate::{
+    authority::{AuthorityState, test_authority_builder::TestAuthorityBuilder},
+    authority_aggregator::{AuthorityAggregator, AuthorityAggregatorBuilder, TimeoutConfig},
+    test_authority_clients::LocalAuthorityClient,
+};
+
+async fn init_genesis(
+    committee_size: usize,
+    mut genesis_objects: Vec<Object>,
+) -> (
+    Genesis,
+    Vec<(AuthorityPublicKeyBytes, AuthorityKeyPair)>,
+    ObjectID,
+) {
+    // add object_basics package object to genesis
+    let modules: Vec<_> = compile_basics_package().get_modules().cloned().collect();
+    let genesis_move_packages: Vec<_> = BuiltInFramework::genesis_move_packages().collect();
+    let config = ProtocolConfig::get_for_max_version_UNSAFE();
+    let pkg = Object::new_package(
+        &modules,
+        TransactionDigest::genesis_marker(),
+        config.max_move_package_size(),
+        config.move_binary_format_version(),
+        &genesis_move_packages,
+    )
+    .unwrap();
+    let pkg_id = pkg.id();
+    genesis_objects.push(pkg);
+
+    let mut builder = iota_genesis_builder::Builder::new().add_objects(genesis_objects);
+    let mut key_pairs = Vec::new();
+    for i in 0..committee_size {
+        let authority_key_pair: AuthorityKeyPair = get_key_pair().1;
+        let authority_pubkey_bytes = authority_key_pair.public().into();
+        let protocol_key_pair: NetworkKeyPair = get_key_pair().1;
+        let protocol_pubkey = protocol_key_pair.public().clone();
+        let account_key_pair: IotaKeyPair = get_key_pair::<AccountKeyPair>().1.into();
+        let network_key_pair: NetworkKeyPair = get_key_pair().1;
+        let validator_info = ValidatorInfo {
+            name: format!("validator-{i}"),
+            authority_key: authority_pubkey_bytes,
+            protocol_key: protocol_pubkey,
+            account_address: IotaAddress::from(&account_key_pair.public()),
+            network_key: network_key_pair.public().clone(),
+            gas_price: 1,
+            commission_rate: 0,
+            network_address: local_ip_utils::new_local_tcp_address_for_testing(),
+            p2p_address: local_ip_utils::new_local_udp_address_for_testing(),
+            primary_address: local_ip_utils::new_local_udp_address_for_testing(),
+            description: String::new(),
+            image_url: String::new(),
+            project_url: String::new(),
+        };
+        let pop =
+            generate_proof_of_possession(&authority_key_pair, (&account_key_pair.public()).into());
+        builder = builder.add_validator(validator_info, pop);
+        key_pairs.push((authority_pubkey_bytes, authority_key_pair));
+    }
+    for (_, key) in &key_pairs {
+        builder = builder.add_validator_signature(key);
+    }
+    let genesis_build_effects = builder.build();
+    (genesis_build_effects.genesis, key_pairs, pkg_id)
+}
+
+#[cfg(test)]
+pub async fn init_local_authorities(
+    committee_size: usize,
+    genesis_objects: Vec<Object>,
+) -> (
+    AuthorityAggregator<LocalAuthorityClient>,
+    Vec<Arc<AuthorityState>>,
+    Genesis,
+    ObjectID,
+) {
+    let (genesis, key_pairs, framework) = init_genesis(committee_size, genesis_objects).await;
+    let authorities = join_all(key_pairs.iter().map(|(_, key_pair)| {
+        TestAuthorityBuilder::new()
+            .with_genesis_and_keypair(&genesis, key_pair)
+            .build()
+    }))
+    .await;
+    let aggregator = init_local_authorities_with_genesis(&genesis, authorities.clone()).await;
+    (aggregator, authorities, genesis, framework)
+}
+
+#[cfg(test)]
+pub async fn init_local_authorities_with_overload_thresholds(
+    committee_size: usize,
+    genesis_objects: Vec<Object>,
+    overload_thresholds: AuthorityOverloadConfig,
+) -> (
+    AuthorityAggregator<LocalAuthorityClient>,
+    Vec<Arc<AuthorityState>>,
+    Genesis,
+    ObjectID,
+) {
+    let (genesis, key_pairs, framework) = init_genesis(committee_size, genesis_objects).await;
+    let authorities = join_all(key_pairs.iter().map(|(_, key_pair)| {
+        TestAuthorityBuilder::new()
+            .with_genesis_and_keypair(&genesis, key_pair)
+            .with_authority_overload_config(overload_thresholds.clone())
+            .build()
+    }))
+    .await;
+    let aggregator = init_local_authorities_with_genesis(&genesis, authorities.clone()).await;
+    (aggregator, authorities, genesis, framework)
+}
+
+#[cfg(test)]
+pub async fn init_local_authorities_with_genesis(
+    genesis: &Genesis,
+    authorities: Vec<Arc<AuthorityState>>,
+) -> AuthorityAggregator<LocalAuthorityClient> {
+    telemetry_subscribers::init_for_testing();
+    let mut clients = BTreeMap::new();
+    for state in authorities {
+        let name = state.name;
+        let client = LocalAuthorityClient::new_from_authority(state);
+        clients.insert(name, client);
+    }
+    let timeouts = TimeoutConfig {
+        pre_quorum_timeout: Duration::from_secs(5),
+        post_quorum_timeout: Duration::from_secs(5),
+        serial_authority_request_interval: Duration::from_secs(1),
+    };
+    AuthorityAggregatorBuilder::from_genesis(genesis)
+        .with_timeouts_config(timeouts)
+        .build_custom_clients(clients)
+}

--- a/crates/iota-move-build/src/lib.rs
+++ b/crates/iota-move-build/src/lib.rs
@@ -53,6 +53,28 @@ use serde_reflection::Registry;
 #[path = "unit_tests/build_tests.rs"]
 mod build_tests;
 
+pub mod test_utils {
+    use std::path::PathBuf;
+
+    use crate::{BuildConfig, CompiledPackage, IotaPackageHooks};
+
+    pub fn compile_basics_package() -> CompiledPackage {
+        compile_example_package("../../examples/move/basics")
+    }
+
+    pub fn compile_managed_coin_package() -> CompiledPackage {
+        compile_example_package("../../crates/iota-core/src/unit_tests/data/managed_coin")
+    }
+
+    pub fn compile_example_package(relative_path: &str) -> CompiledPackage {
+        move_package::package_hooks::register_package_hooks(Box::new(IotaPackageHooks));
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push(relative_path);
+
+        BuildConfig::new_for_testing().build(&path).unwrap()
+    }
+}
+
 /// Wrapper around the core Move `CompiledPackage` with some IOTA-specific
 /// traits and info
 #[derive(Debug, Clone)]
@@ -589,6 +611,10 @@ impl CompiledPackage {
         Err(IotaError::ModulePublishFailure {
             error: error_message.join("\n"),
         })
+    }
+
+    pub fn published_dependency_ids(&self) -> Vec<ObjectID> {
+        self.dependency_ids.published.values().cloned().collect()
     }
 }
 


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.40.3, v1.41.2)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/e54c57db0ca21a7546ed7d14be57a35492f9fc4b
- Description:
Previously, `iota-move-build` is linked into `iota-core` as a normal
dependency. The only reason for this is that some of the `iota-core`
testing utilities depend on `iota-move-build` and some other crates
depend on the `iota-core` testing utilities. This PR cleans this up a bit
so that the testing infrastructure that depends on `iota-move-build` is
not re-exported, and therefore `iota-move-build` only needs to be a
dev-dependency of `iota-core`.

Specifically, the `iota::test_utils` code that is only used
inside of `iota-core` was split off into `iota::unit_test_utils`, and gated
this file behind `#[cfg(test)]`. The tiny bit of shared
testing code that uses `iota-move-build` was moved into
`iota_move_build::test_utils`.

Similarly,
`iota_core::authority::authority_test_utils` into
`iota_core::authority::auth_unit_test_utils`
were split.

## Links to any relevant issues

Part of #6149   

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
