### PR TITLE
fix(iota): add missing url dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5478,6 +5478,7 @@ dependencies = [
  "thiserror 1.0.64",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/iota/Cargo.toml
+++ b/crates/iota/Cargo.toml
@@ -48,6 +48,7 @@ tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
+url.workspace = true
 
 # internal dependencies
 bin-version.workspace = true


### PR DESCRIPTION
# Description of change

It got removed and then still used, because #7950 was not up to date
