### PR TITLE
fix(starfish): processing batches in synchroniser

### DIFF
--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -391,7 +391,7 @@ mod tests {
     /// with the rest of the committee.
     #[rstest]
     #[tokio::test(flavor = "current_thread")]
-    async fn test_restart_authority_committee(#[values(4,6,8)] num_of_authorities: usize) {
+    async fn test_restart_authority_committee(#[values(4, 6, 8)] num_of_authorities: usize) {
         telemetry_subscribers::init_for_testing();
         let db_registry = Registry::new();
         DBMetrics::init(&db_registry);

--- a/crates/starfish/core/src/authority_node.rs
+++ b/crates/starfish/core/src/authority_node.rs
@@ -391,8 +391,8 @@ mod tests {
     /// with the rest of the committee.
     #[rstest]
     #[tokio::test(flavor = "current_thread")]
-    async fn test_restart_authority_committee(#[values(4, 6)] num_of_authorities: usize) {
-        // telemetry_subscribers::init_for_testing();
+    async fn test_restart_authority_committee(#[values(4,6,8)] num_of_authorities: usize) {
+        telemetry_subscribers::init_for_testing();
         let db_registry = Registry::new();
         DBMetrics::init(&db_registry);
 
@@ -793,7 +793,7 @@ mod tests {
             db_path: db_dir.path().to_path_buf(),
             dag_state_cached_rounds: 5,
             commit_sync_parallel_fetches: 2,
-            commit_sync_batch_size: 3,
+            commit_sync_batch_size: 10,
             sync_last_known_own_block_timeout: Duration::from_millis(2_000),
             ..Default::default()
         };

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -479,15 +479,15 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         if !missing_committed_txns.is_empty() {
             // TODO: decide whether to remove the live transaction fetcher
-            // Also, fetch missing committed transactions after adding the blocks.
-            // if let Err(err) = self
+            // Also, fetch missing committed transactions after adding the
+            // blocks. if let Err(err) = self
             //     .transactions_synchronizer
             //     .fetch_transactions(missing_committed_txns)
             //     .await
             // {
             //     warn!(
-            //         "Errored while trying to fetch missing transactions via transactions synchronizer: {err}"
-            //     );
+            //         "Errored while trying to fetch missing transactions via
+            // transactions synchronizer: {err}"     );
             // }
         }
         Ok(())

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -478,16 +478,17 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         }
 
         if !missing_committed_txns.is_empty() {
+            // TODO: decide whether to remove the live transaction fetcher
             // Also, fetch missing committed transactions after adding the blocks.
-            if let Err(err) = self
-                .transactions_synchronizer
-                .fetch_transactions(missing_committed_txns)
-                .await
-            {
-                warn!(
-                    "Errored while trying to fetch missing transactions via transactions synchronizer: {err}"
-                );
-            }
+            // if let Err(err) = self
+            //     .transactions_synchronizer
+            //     .fetch_transactions(missing_committed_txns)
+            //     .await
+            // {
+            //     warn!(
+            //         "Errored while trying to fetch missing transactions via transactions synchronizer: {err}"
+            //     );
+            // }
         }
         Ok(())
     }

--- a/crates/starfish/core/src/authority_service.rs
+++ b/crates/starfish/core/src/authority_service.rs
@@ -479,16 +479,17 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
 
         if !missing_committed_txns.is_empty() {
             // TODO: decide whether to remove the live transaction fetcher
-            // Also, fetch missing committed transactions after adding the
-            // blocks. if let Err(err) = self
-            //     .transactions_synchronizer
-            //     .fetch_transactions(missing_committed_txns)
-            //     .await
-            // {
-            //     warn!(
-            //         "Errored while trying to fetch missing transactions via
-            // transactions synchronizer: {err}"     );
-            // }
+
+            if let Err(err) = self
+                .transactions_synchronizer
+                .fetch_transactions(missing_committed_txns)
+                .await
+            {
+                warn!(
+                    "Errored while trying to fetch missing transactions via
+             transactions synchronizer: {err}"
+                );
+            }
         }
         Ok(())
     }

--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -220,12 +220,14 @@ impl<C: NetworkClient> CommitSyncer<C> {
             .max(self.highest_scheduled_index.unwrap_or(0));
         // When the node is falling behind, schedule pending fetches which will be
         // executed on later.
+        let step = self.inner.context.parameters.commit_sync_batch_size;
+
         for prev_end in (fetch_after_index..=quorum_commit_index)
-            .step_by(self.inner.context.parameters.commit_sync_batch_size as usize)
+            .step_by(step as usize)
         {
             // Create range with inclusive start and end.
             let range_start = prev_end + 1;
-            let range_end = prev_end + self.inner.context.parameters.commit_sync_batch_size;
+            let range_end = prev_end + step;
             // Commit range is not fetched when [range_start, range_end] contains less
             // number of commits than the target batch size. This is to avoid
             // the cost of processing more and smaller batches. Block broadcast,
@@ -368,16 +370,17 @@ impl<C: NetworkClient> CommitSyncer<C> {
                             "Fetched blocks have missing committed transactions: {:?} for commit range {:?}",
                             missing_committed_txns, fetched_commit_range
                         );
-                        if let Err(err) = self
-                            .inner
-                            .transactions_synchronizer
-                            .fetch_transactions(missing_committed_txns)
-                            .await
-                        {
-                            warn!(
-                                "Error while trying to fetch missing transactions via transactions synchronizer: {err}"
-                            );
-                        }
+                        // TODO: decide whether to rely on periodic transactions synchronizer or make use of live one
+                        // if let Err(err) = self
+                        //     .inner
+                        //     .transactions_synchronizer
+                        //     .fetch_transactions(missing_committed_txns)
+                        //     .await
+                        // {
+                        //     warn!(
+                        //         "Error while trying to fetch missing transactions via transactions synchronizer: {err}"
+                        //     );
+                        // }
                     }
                 }
                 Err(e) => {
@@ -425,6 +428,10 @@ impl<C: NetworkClient> CommitSyncer<C> {
         loop {
             if self.inflight_fetches.len() >= target_parallel_fetches {
                 break;
+            }
+            if !self.pending_fetches.is_empty() {
+                info!("Pending fetches: {:?}, target parallel fetches: {}, inflight fetch number: {}",
+                    self.pending_fetches, target_parallel_fetches, self.inflight_fetches.len());
             }
             let Some(commit_range) = self.pending_fetches.pop_first() else {
                 break;

--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -370,17 +370,17 @@ impl<C: NetworkClient> CommitSyncer<C> {
                         );
                         // TODO: decide whether to rely on periodic transactions
                         // synchronizer or make use of live one
-                        // if let Err(err) = self
-                        //     .inner
-                        //     .transactions_synchronizer
-                        //     .fetch_transactions(missing_committed_txns)
-                        //     .await
-                        // {
-                        //     warn!(
-                        //         "Error while trying to fetch missing
-                        // transactions via transactions synchronizer: {err}"
-                        //     );
-                        // }
+                        if let Err(err) = self
+                            .inner
+                            .transactions_synchronizer
+                            .fetch_transactions(missing_committed_txns)
+                            .await
+                        {
+                            warn!(
+                                "Error while trying to fetch missing
+                         transactions via transactions synchronizer: {err}"
+                            );
+                        }
                     }
                 }
                 Err(e) => {

--- a/crates/starfish/core/src/commit_syncer.rs
+++ b/crates/starfish/core/src/commit_syncer.rs
@@ -222,9 +222,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
         // executed on later.
         let step = self.inner.context.parameters.commit_sync_batch_size;
 
-        for prev_end in (fetch_after_index..=quorum_commit_index)
-            .step_by(step as usize)
-        {
+        for prev_end in (fetch_after_index..=quorum_commit_index).step_by(step as usize) {
             // Create range with inclusive start and end.
             let range_start = prev_end + 1;
             let range_end = prev_end + step;
@@ -370,7 +368,8 @@ impl<C: NetworkClient> CommitSyncer<C> {
                             "Fetched blocks have missing committed transactions: {:?} for commit range {:?}",
                             missing_committed_txns, fetched_commit_range
                         );
-                        // TODO: decide whether to rely on periodic transactions synchronizer or make use of live one
+                        // TODO: decide whether to rely on periodic transactions
+                        // synchronizer or make use of live one
                         // if let Err(err) = self
                         //     .inner
                         //     .transactions_synchronizer
@@ -378,7 +377,8 @@ impl<C: NetworkClient> CommitSyncer<C> {
                         //     .await
                         // {
                         //     warn!(
-                        //         "Error while trying to fetch missing transactions via transactions synchronizer: {err}"
+                        //         "Error while trying to fetch missing
+                        // transactions via transactions synchronizer: {err}"
                         //     );
                         // }
                     }
@@ -430,8 +430,12 @@ impl<C: NetworkClient> CommitSyncer<C> {
                 break;
             }
             if !self.pending_fetches.is_empty() {
-                info!("Pending fetches: {:?}, target parallel fetches: {}, inflight fetch number: {}",
-                    self.pending_fetches, target_parallel_fetches, self.inflight_fetches.len());
+                info!(
+                    "Pending fetches: {:?}, target parallel fetches: {}, inflight fetch number: {}",
+                    self.pending_fetches,
+                    target_parallel_fetches,
+                    self.inflight_fetches.len()
+                );
             }
             let Some(commit_range) = self.pending_fetches.pop_first() else {
                 break;

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -341,9 +341,14 @@ impl DagState {
     }
 
     pub fn update_last_available_commit_leader_round(&mut self, round: Round) {
-        debug!(
-            "Last commit with available transactions has leader at round {}",
-            round
+        let max_commit_round = self.last_committed_rounds
+            .iter()
+            .max()
+            .expect("There should be at least one last committed round");
+        info!(
+            "Last commit with available transactions has leader at round {}; last commit leader round was {}",
+            round,
+            max_commit_round
         );
         self.last_available_commit_leader_round = Some(round);
     }

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -341,14 +341,14 @@ impl DagState {
     }
 
     pub fn update_last_available_commit_leader_round(&mut self, round: Round) {
-        let max_commit_round = self.last_committed_rounds
+        let max_commit_round = self
+            .last_committed_rounds
             .iter()
             .max()
             .expect("There should be at least one last committed round");
         info!(
             "Last commit with available transactions has leader at round {}; last commit leader round was {}",
-            round,
-            max_commit_round
+            round, max_commit_round
         );
         self.last_available_commit_leader_round = Some(round);
     }

--- a/crates/starfish/core/src/data_manager.rs
+++ b/crates/starfish/core/src/data_manager.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use parking_lot::RwLock;
-use tracing::{debug};
+use tracing::debug;
 
 use crate::{BlockRef, CommittedSubDag, commit::PendingSubDag, dag_state::DagState};
 
@@ -135,13 +135,12 @@ impl DataManager {
         if !committed.is_empty() {
             let mut dag_state_guard = self.dag_state.write();
 
-            dag_state_guard
-                .update_last_available_commit_leader_round(
-                    committed
-                        .last()
-                        .expect("We should expect at least one committed subdag")
-                        .leader_round(),
-                );
+            dag_state_guard.update_last_available_commit_leader_round(
+                committed
+                    .last()
+                    .expect("We should expect at least one committed subdag")
+                    .leader_round(),
+            );
             drop(dag_state_guard);
         }
 
@@ -154,8 +153,8 @@ impl DataManager {
             if subdag.commit_ref.index > self.last_committed_index {
                 // Query dag_state directly for missing transactions
                 let dag_state_guard = self.dag_state.read();
-                let exists =
-                    dag_state_guard.contains_transactions(subdag.committed_transaction_refs.clone());
+                let exists = dag_state_guard
+                    .contains_transactions(subdag.committed_transaction_refs.clone());
                 drop(dag_state_guard);
                 for (i, exists) in exists.iter().enumerate() {
                     if !exists {

--- a/crates/starfish/core/src/data_manager.rs
+++ b/crates/starfish/core/src/data_manager.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use parking_lot::RwLock;
-use tracing::trace;
+use tracing::{debug};
 
 use crate::{BlockRef, CommittedSubDag, commit::PendingSubDag, dag_state::DagState};
 
@@ -120,7 +120,7 @@ impl DataManager {
                 }
                 Err(missing_refs) => {
                     // If we have missing refs, we cannot commit this subdag
-                    trace!(
+                    debug!(
                         "Cannot create CommittedSubDag at index {}. Missing refs: {:?}",
                         next_index, missing_refs
                     );
@@ -133,14 +133,16 @@ impl DataManager {
         // Update dag state with the round of the leader in the last committed subdag
         // This will allow to evict transactions from the DAG state
         if !committed.is_empty() {
-            self.dag_state
-                .write()
+            let mut dag_state_guard = self.dag_state.write();
+
+            dag_state_guard
                 .update_last_available_commit_leader_round(
                     committed
                         .last()
                         .expect("We should expect at least one committed subdag")
                         .leader_round(),
                 );
+            drop(dag_state_guard);
         }
 
         // Update last_committed_index
@@ -151,9 +153,10 @@ impl DataManager {
         for subdag in subdags {
             if subdag.commit_ref.index > self.last_committed_index {
                 // Query dag_state directly for missing transactions
-                let dag_state = self.dag_state.read();
+                let dag_state_guard = self.dag_state.read();
                 let exists =
-                    dag_state.contains_transactions(subdag.committed_transaction_refs.clone());
+                    dag_state_guard.contains_transactions(subdag.committed_transaction_refs.clone());
+                drop(dag_state_guard);
                 for (i, exists) in exists.iter().enumerate() {
                     if !exists {
                         let block_ref = subdag.committed_transaction_refs[i];

--- a/crates/starfish/core/src/error.rs
+++ b/crates/starfish/core/src/error.rs
@@ -65,12 +65,6 @@ pub(crate) enum ConsensusError {
         received_headers: usize,
     },
 
-    #[error("Unexpected block header returned while fetching missing block headers")]
-    UnexpectedFetchedHeader {
-        index: AuthorityIndex,
-        block_ref: BlockRef,
-    },
-
     #[error(
         "Unexpected block header {block_ref} returned while fetching last own header from peer {index}"
     )]

--- a/crates/starfish/core/src/synchronizer.rs
+++ b/crates/starfish/core/src/synchronizer.rs
@@ -658,14 +658,15 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 "Missing committed transactions after fetching blocks: {:?}",
                 missing_committed_txns
             );
-            if let Err(err) = transactions_synchronizer
-                .fetch_transactions(missing_committed_txns)
-                .await
-            {
-                warn!(
-                    "Error while trying to fetch missing transactions via transactions synchronizer: {err}"
-                );
-            }
+            // TODO: decide whether remove this live transactions synchronizer here or not.
+            // if let Err(err) = transactions_synchronizer
+            //     .fetch_transactions(missing_committed_txns)
+            //     .await
+            // {
+            //     warn!(
+            //         "Error while trying to fetch missing transactions via transactions synchronizer: {err}"
+            //     );
+            // }
         }
 
         Ok(())

--- a/crates/starfish/core/src/synchronizer.rs
+++ b/crates/starfish/core/src/synchronizer.rs
@@ -579,7 +579,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             return Err(ConsensusError::TooManyFetchedHeadersReturned(peer_index));
         }
 
-
         // Verify all the fetched block headers
         let block_headers = Handle::current()
             .spawn_blocking({
@@ -596,7 +595,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             })
             .await
             .expect("Spawn blocking should not fail")?;
-
 
         // Record commit votes from the verified blocks.
         for block in &block_headers {
@@ -658,14 +656,15 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 "Missing committed transactions after fetching blocks: {:?}",
                 missing_committed_txns
             );
-            // TODO: decide whether remove this live transactions synchronizer here or not.
-            // if let Err(err) = transactions_synchronizer
+            // TODO: decide whether remove this live transactions synchronizer
+            // here or not. if let Err(err) =
+            // transactions_synchronizer
             //     .fetch_transactions(missing_committed_txns)
             //     .await
             // {
             //     warn!(
-            //         "Error while trying to fetch missing transactions via transactions synchronizer: {err}"
-            //     );
+            //         "Error while trying to fetch missing transactions via
+            // transactions synchronizer: {err}"     );
             // }
         }
 

--- a/crates/starfish/core/src/synchronizer.rs
+++ b/crates/starfish/core/src/synchronizer.rs
@@ -657,15 +657,16 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 missing_committed_txns
             );
             // TODO: decide whether remove this live transactions synchronizer
-            // here or not. if let Err(err) =
-            // transactions_synchronizer
-            //     .fetch_transactions(missing_committed_txns)
-            //     .await
-            // {
-            //     warn!(
-            //         "Error while trying to fetch missing transactions via
-            // transactions synchronizer: {err}"     );
-            // }
+            // here or not.
+            if let Err(err) = transactions_synchronizer
+                .fetch_transactions(missing_committed_txns)
+                .await
+            {
+                warn!(
+                    "Error while trying to fetch missing transactions via
+             transactions synchronizer: {err}"
+                );
+            }
         }
 
         Ok(())

--- a/crates/starfish/core/src/synchronizer.rs
+++ b/crates/starfish/core/src/synchronizer.rs
@@ -579,7 +579,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             return Err(ConsensusError::TooManyFetchedHeadersReturned(peer_index));
         }
 
-        // TODO : check if header is already accepted or suspended
 
         // Verify all the fetched block headers
         let block_headers = Handle::current()
@@ -598,27 +597,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             .await
             .expect("Spawn blocking should not fail")?;
 
-        // Get all the ancestors of the requested blocks only
-        let ancestors = block_headers
-            .iter()
-            .filter(|b| requested_blocks_guard.block_refs.contains(&b.reference()))
-            .flat_map(|b| b.ancestors().to_vec())
-            .collect::<BTreeSet<BlockRef>>();
-
-        // Now confirm that the blocks are either between the ones requested, or they
-        // are parents of the requested blocks
-        for block in &block_headers {
-            if !requested_blocks_guard
-                .block_refs
-                .contains(&block.reference())
-                && !ancestors.contains(&block.reference())
-            {
-                return Err(ConsensusError::UnexpectedFetchedHeader {
-                    index: peer_index,
-                    block_ref: block.reference(),
-                });
-            }
-        }
 
         // Record commit votes from the verified blocks.
         for block in &block_headers {

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -22,6 +22,7 @@ use rand::{
     rngs::{OsRng, StdRng},
     seq::IteratorRandom,
 };
+use rand::seq::SliceRandom;
 use starfish_config::AuthorityIndex;
 use tokio::{
     runtime::Handle,
@@ -49,14 +50,9 @@ const FETCH_TRANSACTIONS_CONCURRENCY: usize = 5;
 const FETCH_REQUEST_TIMEOUT: Duration = Duration::from_millis(2_000);
 const FETCH_FROM_PEERS_TIMEOUT: Duration = Duration::from_millis(4_000);
 
-/// Max number of transactions to fetch per request.
-/// This value should be chosen so even with transactions at max size, the
-/// requests can finish on hosts with good network using the timeouts above.
-const MAX_TRANSACTIONS_PER_FETCH: usize = 32;
-
 /// TODO: this should be calculated based on the number of authorities and
-///  should be at least 2/3 of all authorities by stake
-const MAX_AUTHORITIES_TO_FETCH_PER_TRANSACTION: usize = 2;
+///  should be at least 1/3 of all authorities + 1 by stake
+const MAX_AUTHORITIES_TO_FETCH_PER_TRANSACTION: usize = 3;
 
 struct TransactionsGuard {
     map: Arc<InflightTransactionsMap>,
@@ -307,10 +303,11 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
     }
 
     // The main loop to listen for the submitted commands.
+    #[cfg_attr(test,tracing::instrument(skip_all, name ="",fields(authority = %self.context.own_index)))]
     async fn run(&mut self) {
         // We want the transactions synchronizer to run periodically every 500ms to
         // fetch any missing transactions.
-        const TRANSACTIONS_SYNCHRONIZER_TIMEOUT: Duration = Duration::from_millis(500);
+        const TRANSACTIONS_SYNCHRONIZER_TIMEOUT: Duration = Duration::from_millis(200);
         let scheduler_timeout = sleep_until(Instant::now() + TRANSACTIONS_SYNCHRONIZER_TIMEOUT);
 
         tokio::pin!(scheduler_timeout);
@@ -825,7 +822,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         let mut request_futures = FuturesUnordered::new();
 
         // For each authority, randomize and try to lock up to
-        // MAX_TRANSACTIONS_PER_FETCH acknowledged blocks.
+        // maximum amount of acknowledged blocks.
         // The logic is as follows:
         // * Iterate all authorities that have acknowledged missing transactions.
         // * Randomly select up to MAX_TRANSACTIONS_PER_FETCH missing transactions
@@ -838,7 +835,24 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         //   random selection. TODO: This part of the logic needs to be improved!
         // * If transactions are successfully locked, then send a request to the network
         //   client to fetch the transactions from the authority.
-        for (authority, authority_block_refs) in blocks_by_authority {
+
+
+        // Create an iterator over authorities with their corresponding block refs
+        // This will allow us to iterate over authorities in a stable (for test) or random order
+
+        let iter_authorities: Box<dyn Iterator<Item = (AuthorityIndex, BTreeSet<BlockRef>)>> = if cfg!(test) {
+            // Stable order for tests
+            Box::new(blocks_by_authority.into_iter())
+        } else {
+            // Random order for production
+            let mut rng = StdRng::from_rng(OsRng).expect("OsRng should be available");
+            let mut vec: Vec<_> = blocks_by_authority.into_iter().collect();
+            vec.shuffle(&mut rng);
+            Box::new(vec.into_iter())
+        };
+        
+
+        for (authority, authority_block_refs) in iter_authorities {
             let peer_hostname = &context.committee.authority(authority).hostname;
             // Remove block_refs already assigned to another peer
             let mut available_refs: BTreeSet<_> = authority_block_refs.clone();
@@ -850,7 +864,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                 //  randomly
                 let selected_block_refs = available_refs
                     .iter()
-                    .choose_multiple(&mut rng, MAX_TRANSACTIONS_PER_FETCH)
+                    .choose_multiple(&mut rng, context.parameters.max_transactions_per_fetch)
                     .into_iter()
                     .cloned()
                     .collect::<BTreeSet<_>>();
@@ -1722,8 +1736,8 @@ mod tests {
         {
             let mut all_guards = Vec::new();
 
-            // Try to acquire the transaction locks for authorities 1 & 2
-            for i in 1..=2 {
+            // Try to acquire the transaction locks for authorities 0, 1 & 2
+            for i in 0..=2 {
                 let authority = AuthorityIndex::new_for_test(i);
 
                 let guard = map.lock_transactions(missing_block_refs.clone(), authority);
@@ -1738,7 +1752,7 @@ mod tests {
             }
 
             // Trying to acquire for authority 3 it will fail - as we have maxed out the
-            // number of allowed peers (MAX_AUTHORITIES_TO_FETCH_PER_TRANSACTION = 2)
+            // number of allowed peers (MAX_AUTHORITIES_TO_FETCH_PER_TRANSACTION = 3)
             let authority_3 = AuthorityIndex::new_for_test(3);
 
             let guard = map.lock_transactions(missing_block_refs.clone(), authority_3);

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -305,7 +305,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
     // The main loop to listen for the submitted commands.
     #[cfg_attr(test,tracing::instrument(skip_all, name ="",fields(authority = %self.context.own_index)))]
     async fn run(&mut self) {
-        // We want the transactions synchronizer to run periodically every 500ms to
+        // We want the transactions synchronizer to run periodically every 200ms to
         // fetch any missing transactions.
         const TRANSACTIONS_SYNCHRONIZER_TIMEOUT: Duration = Duration::from_millis(200);
         let scheduler_timeout = sleep_until(Instant::now() + TRANSACTIONS_SYNCHRONIZER_TIMEOUT);

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -20,9 +20,8 @@ use parking_lot::{Mutex, RwLock};
 use rand::{
     SeedableRng,
     rngs::{OsRng, StdRng},
-    seq::IteratorRandom,
+    seq::{IteratorRandom, SliceRandom},
 };
-use rand::seq::SliceRandom;
 use starfish_config::AuthorityIndex;
 use tokio::{
     runtime::Handle,
@@ -818,11 +817,10 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
             }
         }
 
-        // let mut assigned_block_refs = BTreeSet::new();
         let mut request_futures = FuturesUnordered::new();
 
         // For each authority, randomize and try to lock up the
-        // maximum possible amount of acknowledged blocks.
+        // maximum possible amount of acknowledged transactions in blocks.
         // The logic is as follows:
         // * Iterate all authorities that have acknowledged missing transactions.
         // * Randomly select up to max_transactions_per_fetch missing transactions
@@ -836,21 +834,21 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         // * If transactions are successfully locked, then send a request to the network
         //   client to fetch the transactions from the authority.
 
-
         // Create an iterator over authorities with their corresponding block refs
-        // This will allow us to iterate over authorities in a stable (for test) or random order
+        // This will allow us to iterate over authorities in a stable (for test) or
+        // random order
 
-        let iter_authorities: Box<dyn Iterator<Item = (AuthorityIndex, BTreeSet<BlockRef>)>> = if cfg!(test) {
-            // Stable order for tests
-            Box::new(blocks_by_authority.into_iter())
-        } else {
-            // Random order for production
-            let mut rng = StdRng::from_rng(OsRng).expect("OsRng should be available");
-            let mut vec: Vec<_> = blocks_by_authority.into_iter().collect();
-            vec.shuffle(&mut rng);
-            Box::new(vec.into_iter())
-        };
-
+        let iter_authorities: Box<dyn Iterator<Item = (AuthorityIndex, BTreeSet<BlockRef>)>> =
+            if cfg!(test) {
+                // Stable order for tests
+                Box::new(blocks_by_authority.into_iter())
+            } else {
+                // Random order for production
+                let mut rng = StdRng::from_rng(OsRng).expect("OsRng should be available");
+                let mut vec: Vec<_> = blocks_by_authority.into_iter().collect();
+                vec.shuffle(&mut rng);
+                Box::new(vec.into_iter())
+            };
 
         for (authority, authority_block_refs) in iter_authorities {
             let peer_hostname = &context.committee.authority(authority).hostname;
@@ -938,7 +936,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                             }
                         },
                         Err(e) => {
-                            warn!("Error while trying to fetch blocks from peer {peer_index} {peer_hostname}. Error: {e}");
+                            warn!("Error while trying to fetch transactions from peer {peer_index} {peer_hostname}. Error: {e}");
                             // we don't necessarily need to do, but dropping the guard here to unlock the blocks
                             drop(transactions_guard);
 

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -821,11 +821,11 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         // let mut assigned_block_refs = BTreeSet::new();
         let mut request_futures = FuturesUnordered::new();
 
-        // For each authority, randomize and try to lock up to
-        // maximum amount of acknowledged blocks.
+        // For each authority, randomize and try to lock up the
+        // maximum possible amount of acknowledged blocks.
         // The logic is as follows:
         // * Iterate all authorities that have acknowledged missing transactions.
-        // * Randomly select up to MAX_TRANSACTIONS_PER_FETCH missing transactions
+        // * Randomly select up to max_transactions_per_fetch missing transactions
         //   acknowledged by the authority.
         // * Attempt to lock the selected transactions using the
         //   inflight_transactions_map. Some transactions may already be locked by other
@@ -850,7 +850,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
             vec.shuffle(&mut rng);
             Box::new(vec.into_iter())
         };
-        
+
 
         for (authority, authority_block_refs) in iter_authorities {
             let peer_hostname = &context.committee.authority(authority).hostname;

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -42,8 +42,8 @@ use crate::{
     network::{NetworkClient, SerializedTransactions},
 };
 
-/// The number of concurrent fetch transactions requests per authority
-const FETCH_TRANSACTIONS_CONCURRENCY: usize = 5;
+/// The number of concurrent live transaction fetch requests
+const LIVE_FETCH_TRANSACTIONS_CONCURRENCY: usize = 5;
 
 /// Timeouts when fetching transactions.
 const FETCH_REQUEST_TIMEOUT: Duration = Duration::from_millis(2_000);
@@ -258,7 +258,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         // Create a channel for live fetch requests
         let (live_fetch_sender, live_fetch_receiver) = channel(
             "consensus_transactions_synchronizer_live_fetches",
-            FETCH_TRANSACTIONS_CONCURRENCY,
+            LIVE_FETCH_TRANSACTIONS_CONCURRENCY,
         );
 
         let mut tasks = JoinSet::new();
@@ -389,7 +389,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
 
         loop {
             tokio::select! {
-                Some(missing_block_refs) = receiver.recv(), if requests.len() < FETCH_TRANSACTIONS_CONCURRENCY => {
+                Some(missing_block_refs) = receiver.recv(), if requests.len() < LIVE_FETCH_TRANSACTIONS_CONCURRENCY => {
                     requests.push(Self::fetch_transactions_from_authorities(
                         context.clone(),
                         inflight_transactions_map.clone(),
@@ -831,8 +831,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         //   locked. If no transactions can be locked and there are remaining missing
         //   transactions acknowledged by the authority, then try again with a new
         //   random selection. TODO: This part of the logic needs to be improved!
-        // * If transactions are successfully locked, then send a request to the network
-        //   client to fetch the transactions from the authority.
 
         // Create an iterator over authorities with their corresponding block refs
         // This will allow us to iterate over authorities in a stable (for test) or
@@ -843,8 +841,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                 // Stable order for tests
                 Box::new(blocks_by_authority.into_iter())
             } else {
-                // Random order for production
-                let mut rng = StdRng::from_rng(OsRng).expect("OsRng should be available");
                 let mut vec: Vec<_> = blocks_by_authority.into_iter().collect();
                 vec.shuffle(&mut rng);
                 Box::new(vec.into_iter())
@@ -871,6 +867,8 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                     break;
                 }
 
+                // * If transactions are successfully locked, then send a request to the network
+                //   client to fetch the transactions from the authority.
                 if let Some(transactions_guard) = inflight_transactions_map
                     .lock_transactions(selected_block_refs.clone(), authority)
                 {
@@ -888,7 +886,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                     // assigned_block_refs.extend(&selected_block_refs);
                     // TODO: we need to measure how many requests are sent in each run and possibly
                     //  limit that. This can be limited after we implement Starfish with shards as
-                    //  there will definitely be more requests perform.
+                    //  there will definitely be more requests performed
                     request_futures.push(Self::fetch_transactions_request(
                         network_client.clone(),
                         authority,
@@ -1101,7 +1099,7 @@ mod tests {
         );
 
         // Create block round author pairs
-        let block_round_authors = (1..FETCH_TRANSACTIONS_CONCURRENCY * 2 + 1)
+        let block_round_authors = (1..LIVE_FETCH_TRANSACTIONS_CONCURRENCY * 2 + 1)
             .map(|i| (i as Round, 1u32))
             .collect::<Vec<_>>();
 
@@ -1152,7 +1150,7 @@ mod tests {
         // WHEN
         // Send many requests to saturate the tasks
         let mut results = Vec::new();
-        for _ in 0..FETCH_TRANSACTIONS_CONCURRENCY * 3 {
+        for _ in 0..LIVE_FETCH_TRANSACTIONS_CONCURRENCY * 3 {
             results.push(
                 handle
                     .fetch_transactions(missing_transactions.clone())
@@ -1175,13 +1173,13 @@ mod tests {
 
         assert_eq!(
             successes,
-            FETCH_TRANSACTIONS_CONCURRENCY * 2,
+            LIVE_FETCH_TRANSACTIONS_CONCURRENCY * 2,
             "Expected {} requests to succeed",
-            FETCH_TRANSACTIONS_CONCURRENCY * 2
+            LIVE_FETCH_TRANSACTIONS_CONCURRENCY * 2
         );
         assert_eq!(
-            saturated, FETCH_TRANSACTIONS_CONCURRENCY,
-            "Expected {FETCH_TRANSACTIONS_CONCURRENCY} requests to be saturated"
+            saturated, LIVE_FETCH_TRANSACTIONS_CONCURRENCY,
+            "Expected {LIVE_FETCH_TRANSACTIONS_CONCURRENCY} requests to be saturated"
         );
 
         // Clean up


### PR DESCRIPTION
# Description of change

We remove a check about parents when processing received block headers in the synchronizer. 
In addition, we added a randomization in the order of requested authorities in the transaction synchronizer, which assigns transactions to be fetched.

## Links to any relevant issues

Fixes #8004
Fixes #8005  

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
