### PR TITLE
refactor(docs): showcase historical checkpoint stream in custom indexer 

### DIFF
--- a/crates/iota-rest-kv/src/extractors.rs
+++ b/crates/iota-rest-kv/src/extractors.rs
@@ -28,7 +28,7 @@ struct RequestParams {
 /// We define our own extractor that includes validation and custom error
 /// message.
 ///
-/// This custom extractor matches [`Path`] segments and deserilize them
+/// This custom extractor matches [`Path`] segments and deserialize them
 /// internally into [`RequestParams`] and constructs a [`Key`].
 pub struct ExtractPath(pub Key);
 

--- a/docs/content/developer/advanced/custom-indexer.mdx
+++ b/docs/content/developer/advanced/custom-indexer.mdx
@@ -86,7 +86,7 @@ flowchart LR
   B-->External
 ```
 
-In this example we'll explore a simple custom indexer that ingests data from a `historical` & `live` endpoints.
+In this example, we'll explore a simple custom indexer that can ingest data from multiple sources: the `historical` and `live` endpoints, or directly from a local fullnode REST API. The [`RemoteUrl`](https://iotaledger.github.io/iota/iota_data_ingestion_core/reader/v2/enum.RemoteUrl.html) enum provides flexible configuration options for these different data sources, including hybrid configurations that combine multiple sources.
 
 ```rust file=<rootDir>/examples/custom-indexer/rust/remote_reader.rs
 ```

--- a/docs/content/developer/advanced/custom-indexer.mdx
+++ b/docs/content/developer/advanced/custom-indexer.mdx
@@ -22,11 +22,14 @@ To use the framework, implement a basic interface:
 ```rust
 #[async_trait]
 trait Worker: Send + Sync {
-    async fn process_checkpoint(&self, checkpoint: CheckpointData) -> Result<()>;
+    type Error: Debug + Display;
+    type Message: Send + Sync;
+
+    async fn process_checkpoint(&self, checkpoint: Arc<CheckpointData>) -> Result<Self::Message, Self::Error>;
 }
 ```
 
-In this example, the `CheckpointData` struct represents full checkpoint content. The struct contains checkpoint summary and contents, as well as detailed information about each individual transaction. The individual transaction data includes events and input/output objects. The full definition for this content is in the [full_checkpoint_content.rs](https://github.com/iotaledger/iota/blob/releases/iota-graphql-rpc-v2024.1.0-release/crates/iota-types/src/full_checkpoint_content.rs) file of the `iota-types` crate.
+In this example, the `CheckpointData` struct represents full checkpoint content. The struct contains checkpoint summary and contents, as well as detailed information about each individual transaction. The individual transaction data includes events and input/output objects. The full definition for this content is in the [full_checkpoint_content.rs](https://github.com/iotaledger/iota/blob/v1.2.3/crates/iota-types/src/full_checkpoint_content.rs) file of the `iota-types` crate.
 
 ## Checkpoint Stream Sources
 
@@ -34,19 +37,50 @@ Data ingestion for your indexer supports several checkpoint stream sources.
 
 ### Remote Reader
 
-The most straightforward stream source is to subscribe to a remote store of checkpoint contents.
+The most straightforward stream source is to subscribe to a remote store of checkpoint contents. The IOTA Foundation provides the following endpoints for downloading checkpoint data:
 
-:::info Unavailable
+#### Historical Checkpoint Data
 
-The IOTA Foundation does not provide this service at the moment. It's possible to start a fullnode locally and use the REST API to sync.
+For syncing historical data up to the tip of the network:
+
+- Devnet: `https://checkpoints.devnet.iota.cafe/ingestion/historical`
+- Testnet: `https://checkpoints.testnet.iota.cafe/ingestion/historical`
+- Mainnet: `https://checkpoints.mainnet.iota.cafe/ingestion/historical`
+
+#### Live Checkpoint Streaming (Optional)
+
+For real-time streaming of current epoch checkpoints only:
+
+- Devnet: `https://checkpoints.devnet.iota.cafe/ingestion/live`
+- Testnet: `https://checkpoints.testnet.iota.cafe/ingestion/live`
+- Mainnet: `https://checkpoints.mainnet.iota.cafe/ingestion/live`
+
+:::info Historical vs Live Endpoints
+
+**Historical Endpoint:**
+
+- **Format:** Batches multiple checkpoints into single files
+- **Best for:** Initial sync from genesis to near network tip
+- **Latency behavior:**
+  - Near zero latency during historical sync (processes batches as fast as possible)
+  - Variable latency at network tip (waits for batch completion, typically ~1000 checkpoints or epoch change)
+- **Guarantees:** Complete data coverage from genesis
+- **Optimization:** Throughput-focused for bulk ingestion
+
+**Live Endpoint:**
+
+- **Format:** Individual checkpoint files
+- **Best for:** Real-time ingestion at network tip
+- **Latency behavior:** Minimal latency (published immediately)
+- **Data scope:** Current epoch only (older checkpoints automatically purged)
+- **Optimization:** Low-latency processing
+
+**How They Work Together:**
+
+1. **Historical endpoint** should always be used as the primary source to guarantee complete data coverage from genesis
+2. **Live endpoint** is optional for applications needing real-time access to the very latest checkpoints
 
 :::
-
-If you are running a local fullnode, checkpoints are available for download via HTTP GET requests to a URL similar to the following:
-
-```
-http://127.0.0.1:9000/api/v1/checkpoints/<checkpoint_id>/full
-```
 
 ```mermaid
 flowchart LR
@@ -54,7 +88,7 @@ flowchart LR
   B[("fa:fa-gears
   Indexer
   daemon")];
-  B-->A;
+  A -- checkppint stream -->B;
   B<-->C("fa:fa-floppy-disk Progress store");
   subgraph External
     D("fa:fa-database Postgres");
@@ -64,12 +98,20 @@ flowchart LR
   B-->External
 ```
 
-The IOTA data ingestion framework provides a helper function to quickly bootstrap an indexer workflow.
+In this example we'll explore a simple custom indexer that ingests data from a `historical` & `live` endpoints.
 
 ```rust file=<rootDir>/examples/custom-indexer/rust/remote_reader.rs
 ```
 
-This is suitable for setups with a single ingestion pipeline where progress tracking is managed outside of the framework.
+It's also possible to start a fullnode locally and use the REST API to sync checkpoints data:
+
+```rust
+let config = CheckpointReaderConfig {
+    remote_store_url: Some(RemoteUrl::Fullnode("http://127.0.0.1:9000/api/v1".to_string())),
+    reader_options: ReaderOptions::default(),
+    ..Default::default()
+};
+```
 
 ### Local Reader
 
@@ -119,16 +161,18 @@ The concurrency parameter specifies how many threads the workflow uses. Having a
 ### Hybrid Mode
 
 Specify both a local and remote store as a fallback to ensure constant data flow. The framework always prioritizes locally available checkpoint data over remote data. It's useful when you want to start utilizing your own full node for data ingestion but need to partially backfill historical data or just have a failover.
-```rust
-executor.run(
-    PathBuf::from("./chk".to_string()), // path to a local directory
-    Some("http://127.0.0.1:9000/api/v1".to_string()), // fullnode REST API
-    vec![], // optional remote store access options
-    ReaderOptions::default(),
-    exit_receiver,
-    ).await?;
-```
 
+```rust
+let config = CheckpointReaderConfig {
+    ingestion_path: Some(PathBuf::from("./chk")),
+    remote_store_url: Some(RemoteUrl::HybridHistoricalStore {
+        historical_url: "https://checkpoints.mainnet.iota.cafe/ingestion/historical".into(),
+        live_url: Some("https://checkpoints.mainnet.iota.cafe/ingestion/live".into()),
+    }),
+    reader_options: ReaderOptions::default(),
+};
+executor.run_with_config(config).await?;
+```
 
 ### Manifest
 

--- a/docs/content/developer/advanced/custom-indexer.mdx
+++ b/docs/content/developer/advanced/custom-indexer.mdx
@@ -29,7 +29,7 @@ trait Worker: Send + Sync {
 }
 ```
 
-In this example, the `CheckpointData` struct represents full checkpoint content. The struct contains checkpoint summary and contents, as well as detailed information about each individual transaction. The individual transaction data includes events and input/output objects. The full definition for this content is in the [full_checkpoint_content.rs](https://github.com/iotaledger/iota/blob/v1.2.3/crates/iota-types/src/full_checkpoint_content.rs) file of the `iota-types` crate.
+In this example, the [`CheckpointData`](https://iotaledger.github.io/iota/iota_types/full_checkpoint_content/struct.CheckpointData.html) struct represents full checkpoint content. The struct contains checkpoint summary and contents, as well as detailed information about each individual transaction.
 
 ## Checkpoint Stream Sources
 

--- a/docs/content/developer/advanced/custom-indexer.mdx
+++ b/docs/content/developer/advanced/custom-indexer.mdx
@@ -57,25 +57,13 @@ For real-time streaming of current epoch checkpoints only:
 
 :::info Historical vs Live Endpoints
 
-**Historical Endpoint:**
-
-- **Format:** Batches multiple checkpoints into single files
-- **Best for:** Initial sync from genesis to near network tip
-- **Latency behavior:**
-  - Near zero latency during historical sync (processes batches as fast as possible)
-  - Variable latency at network tip (waits for batch completion, typically ~1000 checkpoints or epoch change)
-- **Guarantees:** Complete data coverage from genesis
-- **Optimization:** Throughput-focused for bulk ingestion
-
-**Live Endpoint:**
-
-- **Format:** Individual checkpoint files
-- **Best for:** Real-time ingestion at network tip
-- **Latency behavior:** Minimal latency (published immediately)
-- **Data scope:** Current epoch only (older checkpoints automatically purged)
-- **Optimization:** Low-latency processing
-
-**How They Work Together:**
+| Feature              | Historical Endpoint                                                                                                                                                                                | Live Endpoint                                               |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| **Format**           | Batches multiple checkpoints into single files                                                                                                                                                     | Individual checkpoint files                                 |
+| **Best for**         | Initial sync from genesis to near network tip                                                                                                                                                      | Real-time ingestion at network tip                          |
+| **Latency behavior** | • Near zero latency during historical sync (processes batches as fast as possible)<br/>• Variable latency at network tip (waits for batch completion, typically ~1000 checkpoints or epoch change) | Minimal latency (published immediately)                     |
+| **Data coverage**    | Complete data coverage from genesis                                                                                                                                                                | Current epoch only (older checkpoints automatically purged) |
+| **Optimization**     | Throughput-focused for bulk ingestion                                                                                                                                                              | Low-latency processing                                      |
 
 1. **Historical endpoint** should always be used as the primary source to guarantee complete data coverage from genesis
 2. **Live endpoint** is optional for applications needing real-time access to the very latest checkpoints
@@ -88,7 +76,7 @@ flowchart LR
   B[("fa:fa-gears
   Indexer
   daemon")];
-  A -- checkppint stream -->B;
+  A -- checkpoint stream -->B;
   B<-->C("fa:fa-floppy-disk Progress store");
   subgraph External
     D("fa:fa-database Postgres");
@@ -101,16 +89,6 @@ flowchart LR
 In this example we'll explore a simple custom indexer that ingests data from a `historical` & `live` endpoints.
 
 ```rust file=<rootDir>/examples/custom-indexer/rust/remote_reader.rs
-```
-
-It's also possible to start a fullnode locally and use the REST API to sync checkpoints data:
-
-```rust
-let config = CheckpointReaderConfig {
-    remote_store_url: Some(RemoteUrl::Fullnode("http://127.0.0.1:9000/api/v1".to_string())),
-    reader_options: ReaderOptions::default(),
-    ..Default::default()
-};
 ```
 
 ### Local Reader
@@ -162,16 +140,7 @@ The concurrency parameter specifies how many threads the workflow uses. Having a
 
 Specify both a local and remote store as a fallback to ensure constant data flow. The framework always prioritizes locally available checkpoint data over remote data. It's useful when you want to start utilizing your own full node for data ingestion but need to partially backfill historical data or just have a failover.
 
-```rust
-let config = CheckpointReaderConfig {
-    ingestion_path: Some(PathBuf::from("./chk")),
-    remote_store_url: Some(RemoteUrl::HybridHistoricalStore {
-        historical_url: "https://checkpoints.mainnet.iota.cafe/ingestion/historical".into(),
-        live_url: Some("https://checkpoints.mainnet.iota.cafe/ingestion/live".into()),
-    }),
-    reader_options: ReaderOptions::default(),
-};
-executor.run_with_config(config).await?;
+```rust file=<rootDir>/examples/custom-indexer/rust/hybrid_reader.rs
 ```
 
 ### Manifest

--- a/examples/custom-indexer/rust/Cargo.toml
+++ b/examples/custom-indexer/rust/Cargo.toml
@@ -13,8 +13,8 @@ tokio = "1.46.1"
 tokio-util = "0.7"
 
 # internal dependencies
-iota-data-ingestion-core = { path = "../../../crates/iota-data-ingestion-core" }
-iota-types = { path = "../../../crates/iota-types" }
+iota-data-ingestion-core = { git = "https://github.com/iotaledger/iota", package = "iota-data-ingestion-core" }
+iota-types = { git = "https://github.com/iotaledger/iota", package = "iota-types" }
 
 [[bin]]
 name = "local_reader"
@@ -23,3 +23,7 @@ path = "local_reader.rs"
 [[bin]]
 name = "remote_reader"
 path = "remote_reader.rs"
+
+[[bin]]
+name = "hybrid_reader"
+path = "hybrid_reader.rs"

--- a/examples/custom-indexer/rust/hybrid_reader.rs
+++ b/examples/custom-indexer/rust/hybrid_reader.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<()> {
     );
     let worker_pool = WorkerPool::new(
         CustomWorker,
-        "remote_reader".to_string(),
+        "hybrid_reader".to_string(),
         concurrency,
         Default::default(),
     );
@@ -56,16 +56,12 @@ async fn main() -> Result<()> {
     executor.register(worker_pool).await?;
 
     let config = CheckpointReaderConfig {
-        // It's also possible to start a fullnode locally and use the REST API to sync checkpoints
-        // data.
-        //
-        // remote_store_url: Some(RemoteUrl::Fullnode("http://127.0.0.1:9000/api/v1".to_string())),
+        ingestion_path: Some(PathBuf::from("./chk")),
         remote_store_url: Some(RemoteUrl::HybridHistoricalStore {
             historical_url: "https://checkpoints.mainnet.iota.cafe/ingestion/historical".into(),
             live_url: Some("https://checkpoints.mainnet.iota.cafe/ingestion/live".into()),
         }),
         reader_options: ReaderOptions::default(),
-        ..Default::default()
     };
     executor.run_with_config(config).await?;
     Ok(())

--- a/examples/custom-indexer/rust/hybrid_reader.rs
+++ b/examples/custom-indexer/rust/hybrid_reader.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env, sync::Arc};
+use std::{env, path::PathBuf, sync::Arc};
 
 use anyhow::Result;
 use async_trait::async_trait;

--- a/examples/custom-indexer/rust/local_reader.rs
+++ b/examples/custom-indexer/rust/local_reader.rs
@@ -8,10 +8,10 @@ use anyhow::Result;
 use async_trait::async_trait;
 use iota_data_ingestion_core::{
     DataIngestionMetrics, FileProgressStore, IndexerExecutor, ReaderOptions, Worker, WorkerPool,
+    reader::v2::CheckpointReaderConfig,
 };
 use iota_types::full_checkpoint_content::CheckpointData;
 use prometheus::Registry;
-use tokio_util::sync::CancellationToken;
 
 struct CustomWorker;
 
@@ -32,16 +32,18 @@ impl Worker for CustomWorker {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Number of Workers to process checkpoints in parallel.
     let concurrency = 5;
     let metrics = DataIngestionMetrics::new(&Registry::new());
-    let backfill_progress_file_path =
-        env::var("BACKFILL_PROGRESS_FILE_PATH").unwrap_or("/tmp/local_reader_progress".to_string());
-    let progress_store = FileProgressStore::new(backfill_progress_file_path).await?;
+    let progress_file_path =
+        env::var("PROGRESS_FILE_PATH").unwrap_or("/tmp/local_reader_progress".to_string());
+    // Save last processed checkpoint to a file.
+    let progress_store = FileProgressStore::new(progress_file_path).await?;
     let mut executor = IndexerExecutor::new(
         progress_store,
-        1, // number of workflow types
+        1, // should match the total number of registered workers.
         metrics,
-        CancellationToken::new(),
+        Default::default(),
     );
     let worker_pool = WorkerPool::new(
         CustomWorker,
@@ -51,13 +53,13 @@ async fn main() -> Result<()> {
     );
 
     executor.register(worker_pool).await?;
-    executor
-        .run(
-            PathBuf::from("./chk".to_string()), // path to a local directory
-            None,
-            vec![],                   // optional remote store access options
-            ReaderOptions::default(), // remote_read_batch_size
-        )
-        .await?;
+
+    let config = CheckpointReaderConfig {
+        ingestion_path: Some(PathBuf::from("./chk")),
+        reader_options: ReaderOptions::default(),
+        ..Default::default()
+    };
+
+    executor.run_with_config(config).await?;
     Ok(())
 }

--- a/examples/custom-indexer/rust/remote_reader.rs
+++ b/examples/custom-indexer/rust/remote_reader.rs
@@ -2,12 +2,16 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{env, sync::Arc};
 
 use anyhow::Result;
 use async_trait::async_trait;
-use iota_data_ingestion_core::{Worker, setup_single_workflow};
+use iota_data_ingestion_core::{
+    DataIngestionMetrics, FileProgressStore, IndexerExecutor, ReaderOptions, Worker, WorkerPool,
+    reader::v2::{CheckpointReaderConfig, RemoteUrl},
+};
 use iota_types::full_checkpoint_content::CheckpointData;
+use prometheus::Registry;
 
 struct CustomWorker;
 
@@ -18,7 +22,6 @@ impl Worker for CustomWorker {
 
     async fn process_checkpoint(&self, checkpoint: Arc<CheckpointData>) -> Result<Self::Message> {
         // custom processing logic
-        // print out the checkpoint number
         println!(
             "Processing checkpoint: {}",
             checkpoint.checkpoint_summary.to_string()
@@ -29,14 +32,37 @@ impl Worker for CustomWorker {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let (executor, _) = setup_single_workflow(
+    // Number of Workers to process checkpoints in parallel.
+    let concurrency = 5;
+    let metrics = DataIngestionMetrics::new(&Registry::new());
+    let progress_file_path =
+        env::var("PROGRESS_FILE_PATH").unwrap_or("/tmp/remote_reader_progress".to_string());
+    // Save last processed checkpoint to a file.
+    let progress_store = FileProgressStore::new(progress_file_path).await?;
+
+    let mut executor = IndexerExecutor::new(
+        progress_store,
+        1, // should match the total number of registered workers.
+        metrics,
+        Default::default(),
+    );
+    let worker_pool = WorkerPool::new(
         CustomWorker,
-        "http://127.0.0.1:9000/api/v1".to_string(), // fullnode REST API
-        0,                                          // initial checkpoint number
-        5,                                          // concurrency
-        None,                                       // extra reader options
-    )
-    .await?;
-    executor.await?;
+        "remote_reader".to_string(),
+        concurrency,
+        Default::default(),
+    );
+
+    executor.register(worker_pool).await?;
+
+    let config = CheckpointReaderConfig {
+        remote_store_url: Some(RemoteUrl::HybridHistoricalStore {
+            historical_url: "https://checkpoints.mainnet.iota.cafe/ingestion/historical".into(),
+            live_url: Some("https://checkpoints.mainnet.iota.cafe/ingestion/live".into()),
+        }),
+        reader_options: ReaderOptions::default(),
+        ..Default::default()
+    };
+    executor.run_with_config(config).await?;
     Ok(())
 }


### PR DESCRIPTION
# Description of change

This PR updates the custom indexer documentation to include the `historical` and `live` checkpoint stream endpoints. It also applies general fixes to align the documentation with recent framework changes.**

**Key Changes:**
- **Added endpoint documentation** for historical and live checkpoint streams across all networks (Devnet, Mainnet, Testnet)
- **Detailed explanation** of the differences between historical and live endpoints
- **Updated code examples** in `examples/custom-indexer/rust` to demonstrate the new `HybridHistoricalStore` configuration

## Links to any relevant issues

fixes #7533 

## How the change has been tested

- made sure that examples worked as expected & ingested the data from the remote endpoint.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

> [!NOTE]
> This PR does not affect the normal operation for the `iota-indexer`, thus no QA tests were perfomed.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer: update docs custom indexer section showcasing hybrid historical checkpoint storage
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
