### PR TITLE
upstream(node): Install git in iota-tool Dockerfile to fetch move dependencies during build

### DIFF
--- a/docker/iota-tools/Dockerfile
+++ b/docker/iota-tools/Dockerfile
@@ -17,8 +17,8 @@ RUN apt update && apt install -y cmake clang lld
 RUN mkdir -p ~/.cargo && \
     echo -e "[target.x86_64-unknown-linux-gnu]\nlinker = \"clang\"\nrustflags = [\"-C\", \"link-arg=-fuse-ld=lld\"]" > ~/.cargo/config.toml
 
-# Install additional dependencies
-RUN apt install -y libpq5 libpq-dev ca-certificates
+# Install additional dependencies (git is needed when fetching move dependencies during builds)
+RUN apt install -y libpq5 libpq-dev ca-certificates git
 
 # Copy in all crates, Cargo.toml, and Cargo.lock
 COPY consensus consensus


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.40.3, v1.41.2)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/3dfcf5ad1933b981809f3ac0e13d575da7d9fafd



## Links to any relevant issues

Part of #6149   

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
