### PR TITLE
upstream(core): Add metrics for policy config settings

### DIFF
--- a/crates/iota-core/src/traffic_controller/metrics.rs
+++ b/crates/iota-core/src/traffic_controller/metrics.rs
@@ -25,6 +25,10 @@ pub struct TrafficControllerMetrics {
     pub highest_proxied_spam_rate: IntGauge,
     pub highest_direct_error_rate: IntGauge,
     pub highest_proxied_error_rate: IntGauge,
+    pub spam_client_threshold: IntGauge,
+    pub error_client_threshold: IntGauge,
+    pub spam_proxied_client_threshold: IntGauge,
+    pub error_proxied_client_threshold: IntGauge,
 }
 
 impl TrafficControllerMetrics {
@@ -127,6 +131,30 @@ impl TrafficControllerMetrics {
             highest_proxied_error_rate: register_int_gauge_with_registry!(
                 "highest_proxied_error_rate",
                 "Highest proxied error rate seen recently",
+                registry
+            )
+            .unwrap(),
+            spam_client_threshold: register_int_gauge_with_registry!(
+                "spam_client_threshold",
+                "Spam client threshold",
+                registry
+            )
+            .unwrap(),
+            error_client_threshold: register_int_gauge_with_registry!(
+                "error_client_threshold",
+                "Error client threshold",
+                registry
+            )
+            .unwrap(),
+            spam_proxied_client_threshold: register_int_gauge_with_registry!(
+                "spam_proxied_client_threshold",
+                "Spam proxied client threshold",
+                registry
+            )
+            .unwrap(),
+            error_proxied_client_threshold: register_int_gauge_with_registry!(
+                "error_proxied_client_threshold",
+                "Error proxied client threshold",
                 registry
             )
             .unwrap(),

--- a/crates/iota-core/src/traffic_controller/mod.rs
+++ b/crates/iota-core/src/traffic_controller/mod.rs
@@ -19,7 +19,7 @@ use std::{
 use dashmap::DashMap;
 use fs::File;
 use iota_metrics::spawn_monitored_task;
-use iota_types::traffic_control::{PolicyConfig, RemoteFirewallConfig, Weight};
+use iota_types::traffic_control::{PolicyConfig, PolicyType, RemoteFirewallConfig, Weight};
 use prometheus::IntGauge;
 use rand::Rng;
 use tokio::{
@@ -116,6 +116,7 @@ impl TrafficController {
         fw_config: Option<RemoteFirewallConfig>,
     ) -> Self {
         let metrics = Arc::new(metrics);
+        Self::set_policy_config_metrics(&policy_config, metrics.clone());
         let (tx, rx) = mpsc::channel(policy_config.channel_capacity);
         // Memoized drainfile existence state. This is passed into delegation
         // functions to prevent them from continuing to populate blocklists
@@ -154,6 +155,28 @@ impl TrafficController {
             acl: Acl::Blocklists(blocklists),
             metrics: metrics.clone(),
             dry_run_mode,
+        }
+    }
+
+    fn set_policy_config_metrics(
+        policy_config: &PolicyConfig,
+        metrics: Arc<TrafficControllerMetrics>,
+    ) {
+        if let PolicyType::FreqThreshold(config) = &policy_config.spam_policy_type {
+            metrics
+                .spam_client_threshold
+                .set(config.client_threshold as i64);
+            metrics
+                .spam_proxied_client_threshold
+                .set(config.proxied_client_threshold as i64);
+        }
+        if let PolicyType::FreqThreshold(config) = &policy_config.error_policy_type {
+            metrics
+                .error_client_threshold
+                .set(config.client_threshold as i64);
+            metrics
+                .error_proxied_client_threshold
+                .set(config.proxied_client_threshold as i64);
         }
     }
 


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.40.3, v1.41.2)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/338a4ddaa319ca156731745096b246d33c981a6a
- Description:
This will allow us to contextualize blocked request metrics from
community nodes given that they control their own configuration.


## Links to any relevant issues

Part of #6149   

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes):
  -  Add metrics:
     - spam_client_threshold
     - error_client_threshold
     - spam_proxied_client_threshold
     - error_proxied_client_threshold
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
