### PR TITLE
upstream(node): Remove console-subscriber feature flag

### DIFF
--- a/crates/telemetry-subscribers/Cargo.toml
+++ b/crates/telemetry-subscribers/Cargo.toml
@@ -12,7 +12,7 @@ atomic_float = "1.0"
 bytes.workspace = true
 bytes-varint = "1.1.0"
 clap.workspace = true
-console-subscriber = { version = "0.4", optional = true }
+console-subscriber = "0.4"
 crossterm.workspace = true
 futures.workspace = true
 once_cell.workspace = true
@@ -29,10 +29,6 @@ tracing.workspace = true
 tracing-appender = "0.2.2"
 tracing-opentelemetry = "0.28.0"
 tracing-subscriber.workspace = true
-
-[features]
-default = []
-tokio-console = ["console-subscriber"]
 
 [dev-dependencies]
 camino.workspace = true

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -383,7 +383,6 @@ impl TelemetryConfig {
         // tokio-console layer
         // Please see https://docs.rs/console-subscriber/latest/console_subscriber/struct.Builder.html#configuration
         // for environment vars/config options
-        #[cfg(feature = "tokio-console")]
         if config.tokio_console {
             layers.push(console_subscriber::spawn().boxed());
         }


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.40.3, v1.41.2)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/80955a537c2c2309bc14db49ee625991f3be61d5
- Description:
Remove the feature flags from the `telemetry-subscribers` crate. The
existing flags were not being properly handled which could have lead to
broken compilation if features were enabled/disabled and given we don't
make use of feature flags in the iota repo it makes things easier to
maintain with these removed.


## Links to any relevant issues

Part of #6149   

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
