### PR TITLE
fix(execution): fix debug assertion in object store

### DIFF
--- a/iota-execution/latest/iota-move-natives/src/object_runtime/object_store.rs
+++ b/iota-execution/latest/iota-move-natives/src/object_runtime/object_store.rs
@@ -771,6 +771,7 @@ impl<'a> ChildObjectStore<'a> {
                     // This means that if the object changed, the dirty flag must have been marked.
                     // However, we can't guarantee the opposite.
                     // object changed ==> dirty flag mutated
+                    #[cfg(debug_assertions)]
                     debug_assert!(!object_changed || dirty_flag_mutated);
                     let child_effect = ChildObjectEffectV1 {
                         owner,
@@ -795,6 +796,7 @@ impl<'a> ChildObjectStore<'a> {
                     } = child_object;
                     let effect = value.into_effect()?;
                     // should be disabled if the feature is disabled
+                    #[cfg(debug_assertions)]
                     debug_assert!(_fingerprint.is_disabled());
                     let child_effect = ChildObjectEffectV0 { owner, ty, effect };
                     Some((id, child_effect))


### PR DESCRIPTION
# Description of change

Nightly [build failed](https://github.com/iotaledger/iota/actions/runs/16608465440) because of that debug assertions missing. 

## Links to any relevant issues

Fix #7067 

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
