### PR TITLE
feat(ci): reduce amount of benchmark processes running in parallel in the nightlies

### DIFF
--- a/crates/iota-core/src/epoch/consensus_store_pruner.rs
+++ b/crates/iota-core/src/epoch/consensus_store_pruner.rs
@@ -14,7 +14,7 @@ use tokio::{
     sync::mpsc,
     time::{Instant, sleep},
 };
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use typed_store::rocks::safe_drop_db;
 
 struct Metrics {
@@ -165,7 +165,7 @@ impl ConsensusStorePruner {
 
             if file_epoch < drop_boundary {
                 if let Err(e) = safe_drop_db(f.path()) {
-                    error!(
+                    warn!(
                         "Could not prune old consensus storage \"{:?}\" directory with safe approach. Will fallback to force delete: {:?}",
                         f.path(),
                         e

--- a/scripts/simtest/simtest-run.sh
+++ b/scripts/simtest/simtest-run.sh
@@ -77,16 +77,19 @@ scripts/simtest/cargo-simtest simtest \
   --profile simtestnightly \
   -E "$FINAL_TEST_FILTER" 2>&1 | tee "$LOG_FILE"
 
+# define the worker count, it's max of NUM_CPUS or 8
+WORKERS_COUNT=$(($NUM_CPUS > 8 ? 8 : $NUM_CPUS))
+
 echo ""
 echo "============================================="
-echo "Running $NUM_CPUS stress simtests in parallel"
+echo "Running $WORKERS_COUNT stress simtests in parallel"
 echo "============================================="
 date
 
-for CPU_NUMBER in `seq 1 $NUM_CPUS`; do
-  SUB_SEED="$CPU_NUMBER$DATE"
+for WORKER_NUMBER in `seq 1 $WORKERS_COUNT`; do
+  SUB_SEED="$WORKER_NUMBER$DATE"
   LOG_FILE="$LOG_DIR/log-$SUB_SEED"
-  echo "Iteration $CPU_NUMBER using MSIM_TEST_SEED=${SUB_SEED}, MSIM_TEST_NUM=1, SIM_STRESS_TEST_DURATION_SECS=300, TEST_FILTER=${FINAL_TEST_FILTER}, logging to $LOG_FILE"
+  echo "Iteration $WORKER_NUMBER using MSIM_TEST_SEED=${SUB_SEED}, MSIM_TEST_NUM=1, SIM_STRESS_TEST_DURATION_SECS=300, TEST_FILTER=${FINAL_TEST_FILTER}, logging to $LOG_FILE"
 
   # --test-threads 1 is important: parallelism is achieved via the for loop
   MSIM_TEST_SEED="$SUB_SEED" \


### PR DESCRIPTION
# Description of change

This PR reduces the amount of benchmark processes running in parallel in the nightlies. Before they were only limited by "NUM_CPU", which is 32 in our backend. I guess we can create more load in those tests, if we actually run less workers.

Also I fixed a confusing log level, in case the safe approach for epoch database deletion did fail. It was changed from "error" to "warn", because there is a fallback mechanism in place in case this happens.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes