### PR TITLE
upstream(iota-types): extend `CheckpointBuilder` and improve `debug_fatal`

### DIFF
--- a/crates/iota-common/src/logging.rs
+++ b/crates/iota-common/src/logging.rs
@@ -16,7 +16,8 @@ macro_rules! debug_fatal {
         if cfg!(debug_assertions) {
             $crate::fatal!($($arg)*);
         } else {
-            tracing::error!(debug_fatal = true, $($arg)*);
+            let stacktrace = std::backtrace::Backtrace::capture();
+            tracing::error!(debug_fatal = true, stacktrace = ?stacktrace, $($arg)*);
             let location = concat!(file!(), ':', line!());
             if let Some(metrics) = iota_metrics::get_metrics() {
                 metrics.system_invariant_violations.with_label_values(&[location]).inc();

--- a/crates/iota-types/src/event.rs
+++ b/crates/iota-types/src/event.rs
@@ -207,7 +207,7 @@ impl From<Event> for SystemEpochInfoEvent {
 }
 
 /// Event emitted in move code `fun advance_epoch` in protocol versions 1 to 3
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct SystemEpochInfoEventV1 {
     pub epoch: u64,
     pub protocol_version: u64,
@@ -227,7 +227,7 @@ pub struct SystemEpochInfoEventV1 {
 /// This second version of the event includes the tips amount to show how much
 /// of the gas fees go to the validators when protocol_defined_base_fee is
 /// enabled in the protocol config.
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct SystemEpochInfoEventV2 {
     pub epoch: u64,
     pub protocol_version: u64,

--- a/crates/iota-types/src/test_checkpoint_data_builder.rs
+++ b/crates/iota-types/src/test_checkpoint_data_builder.rs
@@ -56,6 +56,8 @@ struct CheckpointBuilder {
     checkpoint: u64,
     /// Epoch number for the current checkpoint we are building.
     epoch: u64,
+    /// Counter for the total number of transactions added to the builder.
+    network_total_transactions: u64,
     /// Transactions that have been added to the current checkpoint.
     transactions: Vec<CheckpointTransaction>,
     /// The current transaction being built.
@@ -99,6 +101,7 @@ impl TestCheckpointDataBuilder {
             checkpoint_builder: CheckpointBuilder {
                 checkpoint,
                 epoch: 0,
+                network_total_transactions: 0,
                 transactions: vec![],
                 next_transaction: None,
             },
@@ -461,11 +464,14 @@ impl TestCheckpointDataBuilder {
                 .iter()
                 .map(|tx| ExecutionDigests::new(*tx.transaction.digest(), tx.effects.digest())),
         );
+
+        self.checkpoint_builder.network_total_transactions += transactions.len() as u64;
+
         let checkpoint_summary = CheckpointSummary::new(
             &ProtocolConfig::get_for_max_version_UNSAFE(),
             self.checkpoint_builder.epoch,
             self.checkpoint_builder.checkpoint,
-            transactions.len() as u64,
+            self.checkpoint_builder.network_total_transactions,
             &contents,
             None,
             Default::default(),
@@ -473,12 +479,15 @@ impl TestCheckpointDataBuilder {
             0,
             vec![],
         );
+
         let (committee, keys) = Committee::new_simple_test_committee();
+
         let checkpoint_cert = CertifiedCheckpointSummary::new_from_keypairs_for_testing(
             checkpoint_summary,
             &keys,
             &committee,
         );
+
         self.checkpoint_builder.checkpoint += 1;
         CheckpointData {
             checkpoint_summary: checkpoint_cert,

--- a/crates/iota-types/src/test_checkpoint_data_builder.rs
+++ b/crates/iota-types/src/test_checkpoint_data_builder.rs
@@ -5,21 +5,33 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use iota_protocol_config::ProtocolConfig;
-use move_core_types::{ident_str, language_storage::TypeTag};
+use move_core_types::{
+    ident_str,
+    language_storage::{StructTag, TypeTag},
+};
+use tap::Pipe;
 
 use crate::{
-    base_types::{ExecutionDigests, IotaAddress, ObjectID, ObjectRef, SequenceNumber, dbg_addr},
+    IOTA_SYSTEM_ADDRESS,
+    base_types::{
+        ExecutionDigests, IotaAddress, ObjectID, ObjectRef, SequenceNumber, dbg_addr,
+        random_object_ref,
+    },
     committee::Committee,
     digests::TransactionDigest,
     effects::{TestEffectsBuilder, TransactionEffectsAPI, TransactionEvents},
-    event::Event,
+    event::{Event, SystemEpochInfoEventV2},
     full_checkpoint_content::{CheckpointData, CheckpointTransaction},
     gas_coin::GAS,
     message_envelope::Message,
-    messages_checkpoint::{CertifiedCheckpointSummary, CheckpointContents, CheckpointSummary},
+    messages_checkpoint::{
+        CertifiedCheckpointSummary, CheckpointContents, CheckpointSummary, EndOfEpochData,
+    },
     object::{GAS_VALUE_FOR_TESTING, MoveObject, Object, Owner},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{SenderSignedData, Transaction, TransactionData, TransactionKind},
+    transaction::{
+        EndOfEpochTransactionKind, SenderSignedData, Transaction, TransactionData, TransactionKind,
+    },
 };
 
 /// A builder for creating test checkpoint data.
@@ -451,6 +463,88 @@ impl TestCheckpointDataBuilder {
                 output_objects,
             });
         self
+    }
+
+    /// Creates a transaction that advances the epoch, adds it to the
+    /// checkpoint, and then builds the checkpoint. This increments the
+    /// stored checkpoint sequence number and epoch. If `safe_mode` is true,
+    /// the epoch end transaction will not include the `SystemEpochInfoEvent`.
+    pub fn advance_epoch(&mut self, safe_mode: bool) -> CheckpointData {
+        let (committee, _) = Committee::new_simple_test_committee();
+        let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+        let tx_kind = EndOfEpochTransactionKind::new_change_epoch(
+            self.checkpoint_builder.epoch + 1,
+            protocol_config.version,
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        );
+
+        // TODO: need the system state object wrapper and dynamic field object to
+        // "correctly" mock advancing epoch, at least to satisfy kv_epoch_starts
+        // pipeline.
+        let end_of_epoch_tx = TransactionData::new(
+            TransactionKind::EndOfEpochTransaction(vec![tx_kind]),
+            IotaAddress::default(),
+            random_object_ref(),
+            1,
+            1,
+        )
+        .pipe(|data| SenderSignedData::new(data, vec![]))
+        .pipe(Transaction::new);
+
+        let events = if !safe_mode {
+            let system_epoch_info_event = SystemEpochInfoEventV2 {
+                epoch: self.checkpoint_builder.epoch,
+                protocol_version: protocol_config.version.as_u64(),
+                ..Default::default()
+            };
+            let struct_tag = StructTag {
+                address: IOTA_SYSTEM_ADDRESS,
+                module: ident_str!("iota_system_state_inner").to_owned(),
+                name: ident_str!("SystemEpochInfoEvent").to_owned(),
+                type_params: vec![],
+            };
+            Some(vec![Event::new(
+                &IOTA_SYSTEM_ADDRESS,
+                ident_str!("iota_system_state_inner"),
+                TestCheckpointDataBuilder::derive_address(0),
+                struct_tag,
+                bcs::to_bytes(&system_epoch_info_event).unwrap(),
+            )])
+        } else {
+            None
+        };
+
+        let transaction_events = events.map(|events| TransactionEvents { data: events });
+
+        // Similar to calling self.finish_transaction()
+        self.checkpoint_builder
+            .transactions
+            .push(CheckpointTransaction {
+                transaction: end_of_epoch_tx,
+                effects: Default::default(),
+                events: transaction_events,
+                input_objects: vec![],
+                output_objects: vec![],
+            });
+
+        // Call build_checkpoint() to finalize the checkpoint and then populate the
+        // checkpoint with additional end of epoch data.
+        let mut checkpoint = self.build_checkpoint();
+        let end_of_epoch_data = EndOfEpochData {
+            next_epoch_committee: committee.voting_rights.clone(),
+            next_epoch_protocol_version: protocol_config.version,
+            epoch_commitments: vec![],
+            // Do not simulate supply changes in tests.
+            epoch_supply_change: 0,
+        };
+        checkpoint.checkpoint_summary.end_of_epoch_data = Some(end_of_epoch_data);
+        self.checkpoint_builder.epoch += 1;
+        checkpoint
     }
 
     /// Build the checkpoint data using all the transactions added to the


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.41.2, v1.42.2)
- Ports commits: 
  - https://github.com/MystenLabs/sui/commit/be9a0eed759cec5013905fe823906480574ff7f9 (partly)
  - https://github.com/MystenLabs/sui/commit/688d28402142c53ac8315e9c8134da9c311807b2
  - https://github.com/MystenLabs/sui/commit/c769fa5a3e9f1a4e5907f71c86cf340421633794 (partly)

- Description:
Collection of some small upstream changes from this range that are not worth their own PR.

## Links to any relevant issues

Part of #6150

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes