### PR TITLE
upstream(node): Remove versioning of StateAccumulator

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1333,8 +1333,10 @@ impl AuthorityPerEpochStore {
         &self,
         digests: impl IntoIterator<Item = &'a TransactionDigest>,
     ) -> IotaResult<Vec<bool>> {
-        let tables = self.tables()?;
-        Ok(tables.executed_in_epoch.multi_contains_keys(digests)?)
+        Ok(self
+            .tables()?
+            .executed_in_epoch
+            .multi_contains_keys(digests)?)
     }
 
     pub fn get_effects_signature(

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -742,7 +742,6 @@ impl CheckpointExecutor {
                         .expect("Failed to accumulate running root");
                     self.accumulator
                         .accumulate_epoch(epoch_store.clone(), *checkpoint.sequence_number())
-                        .await
                         .expect("Accumulating epoch cannot fail");
 
                     self.bump_highest_executed_checkpoint(checkpoint);

--- a/crates/iota-core/src/state_accumulator.rs
+++ b/crates/iota-core/src/state_accumulator.rs
@@ -43,11 +43,7 @@ impl StateAccumulatorMetrics {
     }
 }
 
-pub enum StateAccumulator {
-    V1(StateAccumulatorV1),
-}
-
-pub struct StateAccumulatorV1 {
+pub struct StateAccumulator {
     store: Arc<dyn AccumulatorStore>,
     metrics: Arc<StateAccumulatorMetrics>,
 }
@@ -156,7 +152,7 @@ fn accumulate_effects(effects: Vec<TransactionEffects>) -> Accumulator {
 
 impl StateAccumulator {
     pub fn new(store: Arc<dyn AccumulatorStore>, metrics: Arc<StateAccumulatorMetrics>) -> Self {
-        StateAccumulator::V1(StateAccumulatorV1::new(store, metrics))
+        Self { store, metrics }
     }
 
     pub fn new_for_tests(store: Arc<dyn AccumulatorStore>) -> Self {
@@ -164,17 +160,13 @@ impl StateAccumulator {
     }
 
     pub fn metrics(&self) -> Arc<StateAccumulatorMetrics> {
-        match self {
-            StateAccumulator::V1(impl_v1) => impl_v1.metrics.clone(),
-        }
+        self.metrics.clone()
     }
 
     pub fn set_inconsistent_state(&self, is_inconsistent_state: bool) {
-        match self {
-            StateAccumulator::V1(impl_v1) => &impl_v1.metrics,
-        }
-        .inconsistent_state
-        .set(is_inconsistent_state as i64);
+        self.metrics
+            .inconsistent_state
+            .set(is_inconsistent_state as i64);
     }
 
     /// Accumulates the effects of a single checkpoint and persists the
@@ -202,57 +194,14 @@ impl StateAccumulator {
         Ok(acc)
     }
 
-    pub async fn accumulate_running_root(
-        &self,
-        epoch_store: &AuthorityPerEpochStore,
-        checkpoint_seq_num: CheckpointSequenceNumber,
-        checkpoint_acc: Option<Accumulator>,
-    ) -> IotaResult {
-        match self {
-            StateAccumulator::V1(impl_v1) => {
-                impl_v1
-                    .accumulate_running_root(epoch_store, checkpoint_seq_num, checkpoint_acc)
-                    .await
-            }
-        }
-    }
-
-    pub async fn accumulate_epoch(
-        &self,
-        epoch_store: Arc<AuthorityPerEpochStore>,
-        last_checkpoint_of_epoch: CheckpointSequenceNumber,
-    ) -> IotaResult<Accumulator> {
-        match self {
-            StateAccumulator::V1(impl_v1) => {
-                impl_v1.accumulate_epoch(epoch_store, last_checkpoint_of_epoch)
-            }
-        }
-    }
-
     pub fn accumulate_cached_live_object_set_for_testing(&self) -> Accumulator {
-        match self {
-            StateAccumulator::V1(impl_v1) => Self::accumulate_live_object_set_impl(
-                impl_v1.store.iter_cached_live_object_set_for_testing(),
-            ),
-        }
+        Self::accumulate_live_object_set_impl(self.store.iter_cached_live_object_set_for_testing())
     }
 
     /// Returns the result of accumulating the live object set, without side
     /// effects
     pub fn accumulate_live_object_set(&self) -> Accumulator {
-        match self {
-            StateAccumulator::V1(impl_v1) => {
-                Self::accumulate_live_object_set_impl(impl_v1.store.iter_live_object_set())
-            }
-        }
-    }
-
-    /// Accumulates given effects and returns the accumulator without side
-    /// effects.
-    pub fn accumulate_effects(&self, effects: Vec<TransactionEffects>) -> Accumulator {
-        match self {
-            StateAccumulator::V1(impl_v1) => impl_v1.accumulate_effects(effects),
-        }
+        Self::accumulate_live_object_set_impl(self.store.iter_live_object_set())
     }
 
     fn accumulate_live_object_set_impl(iter: impl Iterator<Item = LiveObject>) -> Accumulator {
@@ -288,16 +237,9 @@ impl StateAccumulator {
         last_checkpoint_of_epoch: CheckpointSequenceNumber,
     ) -> IotaResult<ECMHLiveObjectSetDigest> {
         Ok(self
-            .accumulate_epoch(epoch_store, last_checkpoint_of_epoch)
-            .await?
+            .accumulate_epoch(epoch_store, last_checkpoint_of_epoch)?
             .digest()
             .into())
-    }
-}
-
-impl StateAccumulatorV1 {
-    pub fn new(store: Arc<dyn AccumulatorStore>, metrics: Arc<StateAccumulatorMetrics>) -> Self {
-        Self { store, metrics }
     }
 
     pub async fn accumulate_running_root(


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.41.2, v1.42.2)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/1357d6131ffe5ecd5aae94b4d489dbfc984b6249
- Description:
Remove old Epoch Flags
  - Remove EpochFlag::ExecutedInEpochTable
  - Remove StateAccumulatorV1
  - Remove EpochFlag::WritebackCacheEnabled

NOTE: We removed the unused epoch flags before, thus, only the removal of StateAccumulator versioning is ported in this PR.

## Links to any relevant issues

Part of #6150    

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
