### PR TITLE
feat(indexer): Resolve cursor using `tx_global_order` in `query_transaction_blocks_impl`

### DIFF
--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -100,6 +100,163 @@ impl Clone for IndexerReader {
 
 pub type PackageResolver = Arc<Resolver<PackageStoreWithLruCache<IndexerStorePackageResolver>>>;
 
+#[derive(Clone, Copy)]
+enum CursorPosition {
+    BeforeGlobalOrder(i64),
+    InGlobalOrder(i64, i64),
+}
+
+struct QueryTransactionBlocksSqlQueryBuilder<'a> {
+    source_table_alias: &'a str,
+    source_table_or_query: &'a str,
+    main_filter_condition: &'a str,
+    cursor_position: Option<CursorPosition>,
+    is_descending: bool,
+    limit: usize,
+    smallest_tx_seq_with_global_order: i64,
+    order_str: String,
+}
+
+impl<'a> QueryTransactionBlocksSqlQueryBuilder<'a> {
+    fn new(
+        source_table_alias: &'a str,
+        source_table_or_query: &'a str,
+        main_filter_condition: &'a str,
+        cursor_position: Option<CursorPosition>,
+        is_descending: bool,
+        limit: usize,
+        smallest_tx_seq_with_global_order: i64,
+    ) -> Self {
+        Self {
+            cursor_position,
+            is_descending,
+            limit,
+            source_table_alias,
+            source_table_or_query,
+            main_filter_condition,
+            smallest_tx_seq_with_global_order,
+            order_str: if is_descending {
+                "DESC".into()
+            } else {
+                "ASC".into()
+            },
+        }
+    }
+
+    fn get_before_global_order_cursor_clause(&self) -> String {
+        if let Some(CursorPosition::BeforeGlobalOrder(cursor_tx_seq)) = self.cursor_position {
+            if self.is_descending {
+                format!("AND {TX_SEQUENCE_NUMBER_STR} < {cursor_tx_seq}")
+            } else {
+                format!("AND {TX_SEQUENCE_NUMBER_STR} > {cursor_tx_seq}")
+            }
+        } else {
+            "".to_string()
+        }
+    }
+
+    fn get_with_global_order_cursor_clause(&self) -> String {
+        if let Some(CursorPosition::InGlobalOrder(global_seq, optimistic_seq)) =
+            self.cursor_position
+        {
+            if self.is_descending {
+                format!(
+                    "AND (tx_global_order.global_sequence_number, tx_global_order.optimistic_sequence_number) < ({global_seq}, {optimistic_seq})"
+                )
+            } else {
+                format!(
+                    "AND (tx_global_order.global_sequence_number, tx_global_order.optimistic_sequence_number) > ({global_seq}, {optimistic_seq})"
+                )
+            }
+        } else {
+            "".to_string()
+        }
+    }
+
+    fn combine_queries(
+        query_before_global_order: String,
+        query_in_global_order: String,
+        is_descending: bool,
+        cursor_position: &Option<CursorPosition>,
+        limit: usize,
+    ) -> String {
+        if is_descending {
+            if matches!(cursor_position, Some(CursorPosition::BeforeGlobalOrder(_))) {
+                // if cursor is placed before global order bagan, and we are descending, we
+                // can safely omit global ordered entries
+                query_before_global_order
+            } else {
+                format!(
+                    "({query_in_global_order}) UNION ALL ({query_before_global_order}) LIMIT {limit}"
+                )
+            }
+        } else if matches!(cursor_position, Some(CursorPosition::InGlobalOrder(_, _))) {
+            // if cursor is placed in globally ordered area and we are ascending, we can
+            // safely omit non-global-ordered entries
+            query_in_global_order
+        } else {
+            format!(
+                "({query_before_global_order}) UNION ALL ({query_in_global_order}) LIMIT {limit}"
+            )
+        }
+    }
+
+    fn get_query_before_global_order(&self, fields_to_select: &String) -> String {
+        let source_table_alias = self.source_table_alias;
+        let source_table_or_query = self.source_table_or_query;
+        let main_filter_condition = self.main_filter_condition;
+        let smallest_tx_seq_with_global_order = self.smallest_tx_seq_with_global_order;
+        let limit = self.limit;
+        let before_global_order_cursor_clause = self.get_before_global_order_cursor_clause();
+        let order_str = &self.order_str;
+
+        format!(
+            "SELECT {fields_to_select} \
+            FROM {source_table_or_query} \
+            WHERE {main_filter_condition} \
+            {before_global_order_cursor_clause} AND {source_table_alias}.{TX_SEQUENCE_NUMBER_STR} < {smallest_tx_seq_with_global_order} \
+            ORDER BY {source_table_alias}.{TX_SEQUENCE_NUMBER_STR} {order_str} \
+            LIMIT {limit} \
+            ",
+        )
+    }
+
+    fn get_query_with_global_order(&self, fields_to_select: &String) -> String {
+        let source_table_alias = self.source_table_alias;
+        let source_table_or_query = self.source_table_or_query;
+        let main_filter_condition = self.main_filter_condition;
+        let smallest_tx_seq_with_global_order = self.smallest_tx_seq_with_global_order;
+        let limit = self.limit;
+        let global_order_cursor_clause = self.get_with_global_order_cursor_clause();
+        let order_str = &self.order_str;
+
+        format!(
+            "SELECT {fields_to_select} \
+            FROM {source_table_or_query} \
+            JOIN tx_digests on {source_table_alias}.{TX_SEQUENCE_NUMBER_STR} = tx_digests.{TX_SEQUENCE_NUMBER_STR} \
+            JOIN tx_global_order ON tx_global_order.tx_digest = tx_digests.tx_digest \
+            WHERE {main_filter_condition} \
+            {global_order_cursor_clause} AND {source_table_alias}.{TX_SEQUENCE_NUMBER_STR} >= {smallest_tx_seq_with_global_order} \
+            ORDER BY tx_global_order.global_sequence_number {order_str}, tx_global_order.optimistic_sequence_number {order_str} \
+            LIMIT {limit} \
+            ",
+        )
+    }
+
+    fn get_combined_query(&self, fields_to_select: String) -> String {
+        let query_before_global_order = self.get_query_before_global_order(&fields_to_select);
+        let query_after_global_order = self.get_query_with_global_order(&fields_to_select);
+
+        QueryTransactionBlocksSqlQueryBuilder::combine_queries(
+            query_before_global_order,
+            query_after_global_order,
+            self.is_descending,
+            &self.cursor_position,
+            self.limit,
+        )
+    }
+}
+
 // Impl for common initialization and utilities
 impl IndexerReader {
     pub fn new(pool: ConnectionPool) -> Self {
@@ -969,6 +1126,20 @@ impl IndexerReader {
             .await
     }
 
+    async fn get_smallest_tx_seq_with_global_order(&self) -> IndexerResult<i64> {
+        // TODO: consider making it cached
+        let pool = self.get_pool();
+        Ok(run_query_async!(&pool, move |conn| {
+            tx_digests::table
+                .inner_join(
+                    tx_global_order::table.on(tx_digests::tx_digest.eq(tx_global_order::tx_digest)),
+                )
+                .select(diesel::dsl::min(tx_digests::tx_sequence_number))
+                .first::<Option<i64>>(conn)
+        })?
+        .unwrap_or(i64::MAX))
+    }
+
     async fn query_transaction_blocks_impl(
         &self,
         filter: Option<TransactionFilter>,
@@ -977,7 +1148,18 @@ impl IndexerReader {
         limit: usize,
         is_descending: bool,
     ) -> IndexerResult<Vec<IotaTransactionBlockResponse>> {
-        let cursor_tx_seq = if let Some(cursor) = cursor {
+        enum FilteredDataSource {
+            SingleTable {
+                table_name: String,
+                filter_condition: String,
+            },
+            CustomQuery(String),
+        }
+
+        let smallest_tx_seq_with_global_order =
+            self.get_smallest_tx_seq_with_global_order().await?;
+
+        let (old_order_tx_seq, cursor_position) = if let Some(cursor) = cursor {
             let pool = self.get_pool();
             let tx_seq = run_query_async!(&pool, move |conn| {
                 tx_digests::table
@@ -987,28 +1169,34 @@ impl IndexerReader {
                     .filter(tx_digests::tx_digest.eq(cursor.into_inner().to_vec()))
                     .first::<i64>(conn)
             })?;
-            Some(tx_seq)
-        } else {
-            None
-        };
-        let cursor_clause = if let Some(cursor_tx_seq) = cursor_tx_seq {
-            if is_descending {
-                format!("AND {TX_SEQUENCE_NUMBER_STR} < {cursor_tx_seq}")
+            let cursor_position = if tx_seq >= smallest_tx_seq_with_global_order {
+                let pool = self.get_pool();
+                let (global_seq, optimistic_seq) = run_query_async!(&pool, move |conn| {
+                    tx_global_order::table
+                        .select((
+                            tx_global_order::global_sequence_number,
+                            tx_global_order::optimistic_sequence_number,
+                        ))
+                        .filter(tx_global_order::tx_digest.eq(cursor.into_inner().to_vec()))
+                        .first::<(i64, i64)>(conn)
+                })?;
+                CursorPosition::InGlobalOrder(global_seq, optimistic_seq)
             } else {
-                format!("AND {TX_SEQUENCE_NUMBER_STR} > {cursor_tx_seq}")
-            }
+                CursorPosition::BeforeGlobalOrder(tx_seq)
+            };
+            (Some(tx_seq), Some(cursor_position))
         } else {
-            "".to_string()
+            (None, None)
         };
-        let order_str = if is_descending { "DESC" } else { "ASC" };
-        let (table_name, main_where_clause) = match filter {
+
+        let filtered_data_source = match filter {
             // Processed above
             Some(TransactionFilter::Checkpoint(seq)) => {
                 return self
                     .query_transaction_blocks_by_checkpoint_impl(
                         seq,
                         options,
-                        cursor_tx_seq,
+                        old_order_tx_seq,
                         limit,
                         is_descending,
                     )
@@ -1022,110 +1210,160 @@ impl IndexerReader {
             }) => {
                 let package = Hex::encode(package.to_vec());
                 match (module, function) {
-                    (Some(module), Some(function)) => (
-                        "tx_calls_fun".into(),
-                        format!(
+                    (Some(module), Some(function)) => FilteredDataSource::SingleTable {
+                        table_name: "tx_calls_fun".into(),
+                        filter_condition: format!(
                             "package = '\\x{package}'::bytea AND module = '{module}' AND func = '{function}'"
                         ),
-                    ),
-                    (Some(module), None) => (
-                        "tx_calls_mod".into(),
-                        format!("package = '\\x{package}'::bytea AND module = '{module}'"),
-                    ),
+                    },
+                    (Some(module), None) => FilteredDataSource::SingleTable {
+                        table_name: "tx_calls_mod".into(),
+                        filter_condition: format!(
+                            "package = '\\x{package}'::bytea AND module = '{module}'"
+                        ),
+                    },
                     (None, Some(_)) => {
                         return Err(IndexerError::InvalidArgument(
                             "Function cannot be present without Module.".into(),
                         ));
                     }
-                    (None, None) => (
-                        "tx_calls_pkg".into(),
-                        format!("package = '\\x{package}'::bytea"),
-                    ),
+                    (None, None) => FilteredDataSource::SingleTable {
+                        table_name: "tx_calls_pkg".into(),
+                        filter_condition: format!("package = '\\x{package}'::bytea"),
+                    },
                 }
             }
             Some(TransactionFilter::InputObject(object_id)) => {
                 let object_id = Hex::encode(object_id.to_vec());
-                (
-                    "tx_input_objects".into(),
-                    format!("object_id = '\\x{object_id}'::bytea"),
-                )
+                FilteredDataSource::SingleTable {
+                    table_name: "tx_input_objects".into(),
+                    filter_condition: format!("object_id = '\\x{object_id}'::bytea"),
+                }
             }
             Some(TransactionFilter::ChangedObject(object_id)) => {
                 let object_id = Hex::encode(object_id.to_vec());
-                (
-                    "tx_changed_objects".into(),
-                    format!("object_id = '\\x{object_id}'::bytea"),
-                )
+                FilteredDataSource::SingleTable {
+                    table_name: "tx_changed_objects".into(),
+                    filter_condition: format!("object_id = '\\x{object_id}'::bytea"),
+                }
             }
             Some(TransactionFilter::FromAddress(from_address)) => {
                 let from_address = Hex::encode(from_address.to_vec());
-                (
-                    "tx_senders".into(),
-                    format!("sender = '\\x{from_address}'::bytea"),
-                )
+                FilteredDataSource::SingleTable {
+                    table_name: "tx_senders".into(),
+                    filter_condition: format!("sender = '\\x{from_address}'::bytea"),
+                }
             }
             Some(TransactionFilter::ToAddress(to_address)) => {
                 let to_address = Hex::encode(to_address.to_vec());
-                (
-                    "tx_recipients".into(),
-                    format!("recipient = '\\x{to_address}'::bytea"),
-                )
+                FilteredDataSource::SingleTable {
+                    table_name: "tx_recipients".into(),
+                    filter_condition: format!("recipient = '\\x{to_address}'::bytea"),
+                }
             }
             Some(TransactionFilter::FromAndToAddress { from, to }) => {
                 let from_address = Hex::encode(from.to_vec());
                 let to_address = Hex::encode(to.to_vec());
-                // Need to remove ambiguities for tx_sequence_number column
-                let cursor_clause = if let Some(cursor_tx_seq) = cursor_tx_seq {
-                    if is_descending {
-                        format!("AND tx_senders.{TX_SEQUENCE_NUMBER_STR} < {cursor_tx_seq}")
-                    } else {
-                        format!("AND tx_senders.{TX_SEQUENCE_NUMBER_STR} > {cursor_tx_seq}")
-                    }
-                } else {
-                    "".to_string()
-                };
-                let inner_query = format!(
-                    "(SELECT tx_senders.{TX_SEQUENCE_NUMBER_STR} \
-                    FROM tx_senders \
+
+                let data_source_query = format!(
+                    "tx_senders \
                     JOIN tx_recipients \
-                    ON tx_senders.{TX_SEQUENCE_NUMBER_STR} = tx_recipients.{TX_SEQUENCE_NUMBER_STR} \
-                    WHERE tx_senders.sender = '\\x{from_address}'::BYTEA \
-                    AND tx_recipients.recipient = '\\x{to_address}'::BYTEA \
-                    {cursor_clause} \
-                    ORDER BY {TX_SEQUENCE_NUMBER_STR} {order_str} \
-                    LIMIT {limit}) AS inner_query
-                    ",
+                    ON tx_senders.{TX_SEQUENCE_NUMBER_STR} = tx_recipients.{TX_SEQUENCE_NUMBER_STR}"
                 );
-                (inner_query, "1 = 1".into())
+                let filter_condition = format!(
+                    "tx_senders.sender = '\\x{from_address}'::BYTEA \
+                     AND tx_recipients.recipient = '\\x{to_address}'::BYTEA"
+                );
+
+                let query_builder = QueryTransactionBlocksSqlQueryBuilder::new(
+                    "tx_senders",
+                    &data_source_query,
+                    &filter_condition,
+                    cursor_position,
+                    is_descending,
+                    limit,
+                    smallest_tx_seq_with_global_order,
+                );
+
+                FilteredDataSource::CustomQuery(
+                    query_builder
+                        .get_combined_query(format!("tx_senders.{TX_SEQUENCE_NUMBER_STR}")),
+                )
             }
             Some(TransactionFilter::FromOrToAddress { addr }) => {
                 let address = Hex::encode(addr.to_vec());
-                let inner_query = format!(
-                    "( \
-                        ( \
-                            SELECT {TX_SEQUENCE_NUMBER_STR} FROM tx_senders \
-                            WHERE sender = '\\x{address}'::BYTEA {cursor_clause} \
-                            ORDER BY {TX_SEQUENCE_NUMBER_STR} {order_str} \
-                            LIMIT {limit} \
-                        ) \
-                        UNION \
-                        ( \
-                            SELECT {TX_SEQUENCE_NUMBER_STR} FROM tx_recipients \
-                            WHERE recipient = '\\x{address}'::BYTEA {cursor_clause} \
-                            ORDER BY {TX_SEQUENCE_NUMBER_STR} {order_str} \
-                            LIMIT {limit} \
-                        ) \
-                    ) AS combined",
+                let sender_address_filter = format!("sender = '\\x{address}'::BYTEA");
+                let recipient_address_filter = format!("recipient = '\\x{address}'::BYTEA");
+                let query_builder_senders = QueryTransactionBlocksSqlQueryBuilder::new(
+                    "tx_senders",
+                    "tx_senders",
+                    &sender_address_filter,
+                    cursor_position,
+                    is_descending,
+                    limit,
+                    smallest_tx_seq_with_global_order,
                 );
-                (inner_query, "1 = 1".into())
+                let query_builder_recipients = QueryTransactionBlocksSqlQueryBuilder::new(
+                    "tx_recipients",
+                    "tx_recipients",
+                    &recipient_address_filter,
+                    cursor_position,
+                    is_descending,
+                    limit,
+                    smallest_tx_seq_with_global_order,
+                );
+                let order_str = &query_builder_senders.order_str;
+
+                let inner_query_before_global_order = {
+                    let senders_before = query_builder_senders.get_query_before_global_order(
+                        &format!("tx_senders.{TX_SEQUENCE_NUMBER_STR}"),
+                    );
+                    let recipients_before = query_builder_recipients.get_query_before_global_order(
+                        &format!("tx_recipients.{TX_SEQUENCE_NUMBER_STR}"),
+                    );
+
+                    format!(
+                        "SELECT {TX_SEQUENCE_NUMBER_STR} \
+                        FROM (({senders_before}) UNION ({recipients_before})) AS combined \
+                        ORDER BY {TX_SEQUENCE_NUMBER_STR} {order_str}"
+                    ) // we need UNION to remove duplicates, but we need to restore order after that
+                };
+
+                let inner_query_with_global_order = {
+                    let senders_with = query_builder_senders
+                        .get_query_with_global_order(&format!("tx_senders.{TX_SEQUENCE_NUMBER_STR}, tx_global_order.global_sequence_number, tx_global_order.optimistic_sequence_number"));
+                    let recipients_with = query_builder_recipients
+                        .get_query_with_global_order(&format!("tx_recipients.{TX_SEQUENCE_NUMBER_STR}, tx_global_order.global_sequence_number, tx_global_order.optimistic_sequence_number"));
+
+                    format!(
+                        "SELECT {TX_SEQUENCE_NUMBER_STR} \
+                        FROM (({senders_with}) UNION ({recipients_with})) AS combined \
+                        ORDER BY global_sequence_number {order_str}, optimistic_sequence_number {order_str}"
+                    ) // we need UNION to remove duplicates, but we need to restore order after that
+                };
+
+                let inner_query = QueryTransactionBlocksSqlQueryBuilder::combine_queries(
+                    inner_query_before_global_order,
+                    inner_query_with_global_order,
+                    is_descending,
+                    &cursor_position,
+                    limit,
+                );
+                FilteredDataSource::CustomQuery(inner_query)
             }
             Some(TransactionFilter::TransactionKind(kind)) => {
                 // The `SystemTransaction` variant can be used to filter for all types of system
                 // transactions.
                 if kind == IotaTransactionKind::SystemTransaction {
-                    ("tx_kinds".into(), "tx_kind != 1".to_string())
+                    FilteredDataSource::SingleTable {
+                        table_name: "tx_kinds".into(),
+                        filter_condition: "tx_kind != 1".to_string(),
+                    }
                 } else {
-                    ("tx_kinds".into(), format!("tx_kind = {}", kind as u8))
+                    FilteredDataSource::SingleTable {
+                        table_name: "tx_kinds".into(),
+                        filter_condition: format!("tx_kind = {}", kind as u8),
+                    }
                 }
             }
             Some(TransactionFilter::TransactionKindIn(kind_vec)) => {
@@ -1183,22 +1421,44 @@ impl IndexerReader {
                     }
                 };
 
-                ("tx_kinds".into(), query)
+                FilteredDataSource::SingleTable {
+                    table_name: "tx_kinds".into(),
+                    filter_condition: query,
+                }
             }
             None => {
                 // apply no filter
-                ("transactions".into(), "1 = 1".into())
+                FilteredDataSource::SingleTable {
+                    table_name: "transactions".into(),
+                    filter_condition: "1 = 1".into(),
+                }
             }
         };
 
-        let query = format!(
-            "SELECT {TX_SEQUENCE_NUMBER_STR} FROM {table_name} WHERE {main_where_clause} {cursor_clause} ORDER BY {TX_SEQUENCE_NUMBER_STR} {order_str} LIMIT {limit}",
-        );
+        let final_query = match filtered_data_source {
+            FilteredDataSource::CustomQuery(custom_query) => custom_query,
+            FilteredDataSource::SingleTable {
+                table_name,
+                filter_condition,
+            } => {
+                let query_builder = QueryTransactionBlocksSqlQueryBuilder::new(
+                    &table_name,
+                    &table_name,
+                    &filter_condition,
+                    cursor_position,
+                    is_descending,
+                    limit,
+                    smallest_tx_seq_with_global_order,
+                );
 
-        tracing::debug!("query transaction blocks: {}", query);
+                query_builder.get_combined_query(format!("{table_name}.{TX_SEQUENCE_NUMBER_STR}"))
+            }
+        };
+
+        tracing::debug!("query transaction blocks: {}", final_query);
         let pool = self.get_pool();
         let tx_sequence_numbers = run_query_async!(&pool, move |conn| {
-            diesel::sql_query(query.clone()).load::<TxSequenceNumber>(conn)
+            diesel::sql_query(final_query.clone()).load::<TxSequenceNumber>(conn)
         })?
         .into_iter()
         .map(|tsn| tsn.tx_sequence_number)

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -1119,8 +1119,14 @@ impl IndexerReader {
         limit: usize,
         is_descending: bool,
     ) -> IndexerResult<Vec<IotaTransactionBlockResponse>> {
-        self.query_transaction_blocks_impl(filter, options, cursor, limit, is_descending)
-            .await
+        self.query_transaction_blocks_impl_with_optimistic_indexing(
+            filter,
+            options,
+            cursor,
+            limit,
+            is_descending,
+        )
+        .await
     }
 
     async fn get_smallest_tx_seq_with_global_order(&self) -> IndexerResult<i64> {
@@ -1134,7 +1140,249 @@ impl IndexerReader {
         .unwrap_or(i64::MAX))
     }
 
-    async fn query_transaction_blocks_impl(
+    async fn query_transaction_blocks_impl_with_checkpointed_data_only(
+        &self,
+        filter: Option<TransactionFilter>,
+        options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,
+        cursor: Option<TransactionDigest>,
+        limit: usize,
+        is_descending: bool,
+    ) -> IndexerResult<Vec<IotaTransactionBlockResponse>> {
+        let cursor_tx_seq = if let Some(cursor) = cursor {
+            let pool = self.get_pool();
+            let tx_seq = run_query_async!(&pool, move |conn| {
+                tx_digests::table
+                    .select(tx_digests::tx_sequence_number)
+                    // we filter the tx_digests table because it is indexed by digest,
+                    // transactions (and other tables) are not
+                    .filter(tx_digests::tx_digest.eq(cursor.into_inner().to_vec()))
+                    .first::<i64>(conn)
+            })?;
+            Some(tx_seq)
+        } else {
+            None
+        };
+        let cursor_clause = if let Some(cursor_tx_seq) = cursor_tx_seq {
+            if is_descending {
+                format!("AND {TX_SEQUENCE_NUMBER_STR} < {cursor_tx_seq}")
+            } else {
+                format!("AND {TX_SEQUENCE_NUMBER_STR} > {cursor_tx_seq}")
+            }
+        } else {
+            "".to_string()
+        };
+        let order_str = if is_descending { "DESC" } else { "ASC" };
+        let (table_name, main_where_clause) = match filter {
+            // Processed above
+            Some(TransactionFilter::Checkpoint(seq)) => {
+                return self
+                    .query_transaction_blocks_by_checkpoint_impl(
+                        seq,
+                        options,
+                        cursor_tx_seq,
+                        limit,
+                        is_descending,
+                    )
+                    .await;
+            }
+            // FIXME: sanitize module & function
+            Some(TransactionFilter::MoveFunction {
+                package,
+                module,
+                function,
+            }) => {
+                let package = Hex::encode(package.to_vec());
+                match (module, function) {
+                    (Some(module), Some(function)) => (
+                        "tx_calls_fun".into(),
+                        format!(
+                            "package = '\\x{package}'::bytea AND module = '{module}' AND func = '{function}'"
+                        ),
+                    ),
+                    (Some(module), None) => (
+                        "tx_calls_mod".into(),
+                        format!("package = '\\x{package}'::bytea AND module = '{module}'"),
+                    ),
+                    (None, Some(_)) => {
+                        return Err(IndexerError::InvalidArgument(
+                            "Function cannot be present without Module.".into(),
+                        ));
+                    }
+                    (None, None) => (
+                        "tx_calls_pkg".into(),
+                        format!("package = '\\x{package}'::bytea"),
+                    ),
+                }
+            }
+            Some(TransactionFilter::InputObject(object_id)) => {
+                let object_id = Hex::encode(object_id.to_vec());
+                (
+                    "tx_input_objects".into(),
+                    format!("object_id = '\\x{object_id}'::bytea"),
+                )
+            }
+            Some(TransactionFilter::ChangedObject(object_id)) => {
+                let object_id = Hex::encode(object_id.to_vec());
+                (
+                    "tx_changed_objects".into(),
+                    format!("object_id = '\\x{object_id}'::bytea"),
+                )
+            }
+            Some(TransactionFilter::FromAddress(from_address)) => {
+                let from_address = Hex::encode(from_address.to_vec());
+                (
+                    "tx_senders".into(),
+                    format!("sender = '\\x{from_address}'::bytea"),
+                )
+            }
+            Some(TransactionFilter::ToAddress(to_address)) => {
+                let to_address = Hex::encode(to_address.to_vec());
+                (
+                    "tx_recipients".into(),
+                    format!("recipient = '\\x{to_address}'::bytea"),
+                )
+            }
+            Some(TransactionFilter::FromAndToAddress { from, to }) => {
+                let from_address = Hex::encode(from.to_vec());
+                let to_address = Hex::encode(to.to_vec());
+                // Need to remove ambiguities for tx_sequence_number column
+                let cursor_clause = if let Some(cursor_tx_seq) = cursor_tx_seq {
+                    if is_descending {
+                        format!("AND tx_senders.{TX_SEQUENCE_NUMBER_STR} < {cursor_tx_seq}")
+                    } else {
+                        format!("AND tx_senders.{TX_SEQUENCE_NUMBER_STR} > {cursor_tx_seq}")
+                    }
+                } else {
+                    "".to_string()
+                };
+                let inner_query = format!(
+                    "(SELECT tx_senders.{TX_SEQUENCE_NUMBER_STR} \
+                    FROM tx_senders \
+                    JOIN tx_recipients \
+                    ON tx_senders.{TX_SEQUENCE_NUMBER_STR} = tx_recipients.{TX_SEQUENCE_NUMBER_STR} \
+                    WHERE tx_senders.sender = '\\x{from_address}'::BYTEA \
+                    AND tx_recipients.recipient = '\\x{to_address}'::BYTEA \
+                    {cursor_clause} \
+                    ORDER BY {TX_SEQUENCE_NUMBER_STR} {order_str} \
+                    LIMIT {limit}) AS inner_query
+                    ",
+                );
+                (inner_query, "1 = 1".into())
+            }
+            Some(TransactionFilter::FromOrToAddress { addr }) => {
+                let address = Hex::encode(addr.to_vec());
+                let inner_query = format!(
+                    "( \
+                        ( \
+                            SELECT {TX_SEQUENCE_NUMBER_STR} FROM tx_senders \
+                            WHERE sender = '\\x{address}'::BYTEA {cursor_clause} \
+                            ORDER BY {TX_SEQUENCE_NUMBER_STR} {order_str} \
+                            LIMIT {limit} \
+                        ) \
+                        UNION \
+                        ( \
+                            SELECT {TX_SEQUENCE_NUMBER_STR} FROM tx_recipients \
+                            WHERE recipient = '\\x{address}'::BYTEA {cursor_clause} \
+                            ORDER BY {TX_SEQUENCE_NUMBER_STR} {order_str} \
+                            LIMIT {limit} \
+                        ) \
+                    ) AS combined",
+                );
+                (inner_query, "1 = 1".into())
+            }
+            Some(TransactionFilter::TransactionKind(kind)) => {
+                // The `SystemTransaction` variant can be used to filter for all types of system
+                // transactions.
+                if kind == IotaTransactionKind::SystemTransaction {
+                    ("tx_kinds".into(), "tx_kind != 1".to_string())
+                } else {
+                    ("tx_kinds".into(), format!("tx_kind = {}", kind as u8))
+                }
+            }
+            Some(TransactionFilter::TransactionKindIn(kind_vec)) => {
+                if kind_vec.is_empty() {
+                    return Err(IndexerError::InvalidArgument(
+                        "no transaction kind provided".into(),
+                    ));
+                }
+
+                let mut has_system_transaction = false;
+                let mut has_programmable_transaction = false;
+                let mut other_kinds = HashSet::new();
+
+                for kind in kind_vec.iter() {
+                    match kind {
+                        IotaTransactionKind::SystemTransaction => has_system_transaction = true,
+                        IotaTransactionKind::ProgrammableTransaction => {
+                            has_programmable_transaction = true
+                        }
+                        other => {
+                            other_kinds.insert(*other as u8);
+                        }
+                    }
+                }
+
+                let query = if has_system_transaction {
+                    // Case: If `SystemTransaction` is present but `ProgrammableTransaction` is not,
+                    // we need to filter out `ProgrammableTransaction`.
+                    if !has_programmable_transaction {
+                        "tx_kind != 1".to_string()
+                    } else {
+                        // No filter applied if both exist
+                        "1 = 1".to_string()
+                    }
+                } else {
+                    // Case: `ProgrammableTransaction` is present
+                    if has_programmable_transaction {
+                        other_kinds.insert(IotaTransactionKind::ProgrammableTransaction as u8);
+                    }
+
+                    if other_kinds.is_empty() {
+                        // If there's nothing to filter on, return an empty query
+                        "1 = 1".to_string()
+                    } else {
+                        let mut query = String::from("tx_kind IN (");
+                        query.push_str(
+                            &other_kinds
+                                .iter()
+                                .map(ToString::to_string)
+                                .collect::<Vec<_>>()
+                                .join(", "),
+                        );
+                        query.push(')');
+                        query
+                    }
+                };
+
+                ("tx_kinds".into(), query)
+            }
+            None => {
+                // apply no filter
+                ("transactions".into(), "1 = 1".into())
+            }
+        };
+
+        let query = format!(
+            "SELECT {TX_SEQUENCE_NUMBER_STR} FROM {table_name} WHERE {main_where_clause} {cursor_clause} ORDER BY {TX_SEQUENCE_NUMBER_STR} {order_str} LIMIT {limit}",
+        );
+
+        tracing::debug!("query transaction blocks: {}", query);
+        let pool = self.get_pool();
+        let tx_sequence_numbers = run_query_async!(&pool, move |conn| {
+            diesel::sql_query(query.clone()).load::<TxSequenceNumber>(conn)
+        })?
+        .into_iter()
+        .map(|tsn| tsn.tx_sequence_number)
+        .collect::<Vec<i64>>();
+        self.multi_get_transaction_block_response_by_sequence_numbers_in_blocking_task(
+            tx_sequence_numbers,
+            options,
+            Some(is_descending),
+        )
+        .await
+    }
+
+    async fn query_transaction_blocks_impl_with_optimistic_indexing(
         &self,
         filter: Option<TransactionFilter>,
         options: iota_json_rpc_types::IotaTransactionBlockResponseOptions,

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -225,7 +225,6 @@ impl<'a> QueryTransactionBlocksSqlQueryBuilder<'a> {
         let source_table_alias = self.source_table_alias;
         let source_table_or_query = self.source_table_or_query;
         let main_filter_condition = self.main_filter_condition;
-        let smallest_tx_seq_with_global_order = self.smallest_tx_seq_with_global_order;
         let limit = self.limit;
         let global_order_cursor_clause = self.get_with_global_order_cursor_clause();
         let order_str = &self.order_str;
@@ -233,10 +232,8 @@ impl<'a> QueryTransactionBlocksSqlQueryBuilder<'a> {
         format!(
             "SELECT {fields_to_select} \
             FROM {source_table_or_query} \
-            JOIN tx_digests on {source_table_alias}.{TX_SEQUENCE_NUMBER_STR} = tx_digests.{TX_SEQUENCE_NUMBER_STR} \
-            JOIN tx_global_order ON tx_global_order.tx_digest = tx_digests.tx_digest \
-            WHERE {main_filter_condition} \
-            {global_order_cursor_clause} AND {source_table_alias}.{TX_SEQUENCE_NUMBER_STR} >= {smallest_tx_seq_with_global_order} \
+            JOIN tx_global_order ON tx_global_order.chk_tx_sequence_number = {source_table_alias}.{TX_SEQUENCE_NUMBER_STR} \
+            WHERE {main_filter_condition} {global_order_cursor_clause} \
             ORDER BY tx_global_order.global_sequence_number {order_str}, tx_global_order.optimistic_sequence_number {order_str} \
             LIMIT {limit} \
             ",
@@ -1130,11 +1127,8 @@ impl IndexerReader {
         // TODO: consider making it cached
         let pool = self.get_pool();
         Ok(run_query_async!(&pool, move |conn| {
-            tx_digests::table
-                .inner_join(
-                    tx_global_order::table.on(tx_digests::tx_digest.eq(tx_global_order::tx_digest)),
-                )
-                .select(diesel::dsl::min(tx_digests::tx_sequence_number))
+            tx_global_order::table
+                .select(diesel::dsl::min(tx_global_order::chk_tx_sequence_number))
                 .first::<Option<i64>>(conn)
         })?
         .unwrap_or(i64::MAX))

--- a/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
@@ -1,10 +1,27 @@
 // Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{str::FromStr, time::SystemTime};
+use std::{
+    str::FromStr,
+    time::{Duration, SystemTime},
+};
 
+use diesel::RunQueryDsl;
+use downcast::Any;
+use iota_indexer::{
+    schema::{
+        optimistic_event_emit_module, optimistic_event_emit_package, optimistic_event_senders,
+        optimistic_event_struct_instantiation, optimistic_event_struct_module,
+        optimistic_event_struct_name, optimistic_event_struct_package, optimistic_events,
+        optimistic_transactions, optimistic_tx_calls_fun, optimistic_tx_calls_mod,
+        optimistic_tx_calls_pkg, optimistic_tx_changed_objects, optimistic_tx_input_objects,
+        optimistic_tx_kinds, optimistic_tx_recipients, optimistic_tx_senders, tx_global_order,
+    },
+    store::PgIndexerStore,
+    transactional_blocking_with_retry,
+};
 use iota_json::{call_args, type_args};
-use iota_json_rpc_api::{IndexerApiClient, WriteApiClient};
+use iota_json_rpc_api::{IndexerApiClient, TransactionBuilderClient, WriteApiClient};
 use iota_json_rpc_types::{
     EventFilter, EventPage, IotaMoveValue, IotaObjectDataFilter, IotaObjectDataOptions,
     IotaObjectResponseQuery, IotaTransactionBlockData, IotaTransactionBlockKind,
@@ -31,9 +48,9 @@ use move_core_types::{
 };
 
 use crate::common::{
-    ApiTestSetup, indexer_wait_for_checkpoint, indexer_wait_for_latest_checkpoint,
-    indexer_wait_for_object, indexer_wait_for_transaction, rpc_call_error_msg_matches,
-    start_test_cluster_with_read_write_indexer,
+    ApiTestSetup, execute_tx_and_wait_for_indexer, indexer_wait_for_checkpoint,
+    indexer_wait_for_latest_checkpoint, indexer_wait_for_object, indexer_wait_for_transaction,
+    rpc_call_error_msg_matches, start_test_cluster_with_read_write_indexer,
 };
 
 #[test]
@@ -361,9 +378,8 @@ fn test_query_transaction_blocks_pagination() -> Result<(), anyhow::Error> {
             filter: Some(TransactionFilter::FromAddress(address)),
         };
 
-        let first_page = iota_client
-            .read_api()
-            .query_transaction_blocks(query.clone(), None, Some(3), true)
+        let first_page = client
+            .query_transaction_blocks(query.clone(), None, Some(3), Some(true))
             .await
             .unwrap();
         assert_eq!(3, first_page.data.len());
@@ -373,9 +389,8 @@ fn test_query_transaction_blocks_pagination() -> Result<(), anyhow::Error> {
         assert!(first_page.has_next_page);
 
         // Read the next page for the last transaction
-        let next_page = iota_client
-            .read_api()
-            .query_transaction_blocks(query, first_page.next_cursor, None, true)
+        let next_page = client
+            .query_transaction_blocks(query, first_page.next_cursor, None, Some(true))
             .await
             .unwrap();
 
@@ -384,6 +399,156 @@ fn test_query_transaction_blocks_pagination() -> Result<(), anyhow::Error> {
         assert!(next_page.data[0].effects.is_some());
         assert!(next_page.data[0].events.is_some());
         assert!(!next_page.has_next_page);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_query_transaction_blocks_pagination_with_partial_global_order() -> Result<(), anyhow::Error>
+{
+    let ApiTestSetup {
+        runtime,
+        store,
+        cluster,
+        client,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        let (address, keypair): (_, AccountKeyPair) = get_key_pair();
+
+        let gas_ref = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(500_000_000),
+                address,
+            )
+            .await;
+        indexer_wait_for_object(client, gas_ref.0, gas_ref.1).await;
+        let coin_to_split = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(500_000_000),
+                address,
+            )
+            .await;
+        indexer_wait_for_object(client, coin_to_split.0, coin_to_split.1).await;
+        let iota_client = cluster.wallet.get_client().await.unwrap();
+
+        for _ in 0..5 {
+            let tx_data = iota_client
+                .transaction_builder()
+                .split_coin_equal(address, coin_to_split.0, 2, Some(gas_ref.0), 10_000_000)
+                .await?;
+            let signed_transaction = to_sender_signed_transaction(tx_data, &keypair);
+            let (tx_bytes, signatures) = signed_transaction.to_tx_bytes_and_signatures();
+            let res = client
+                .execute_transaction_block(
+                    tx_bytes,
+                    signatures,
+                    Some(IotaTransactionBlockResponseOptions::new().with_effects()),
+                    Some(ExecuteTransactionRequestType::WaitForEffectsCert),
+                )
+                .await?;
+            indexer_wait_for_transaction(res.digest, store, client).await;
+        }
+
+        wipe_global_order_and_optimistic_tables(store); // data indexed before this point will not have global order
+
+        for _ in 0..5 {
+            let tx_data = iota_client
+                .transaction_builder()
+                .split_coin_equal(address, coin_to_split.0, 2, Some(gas_ref.0), 10_000_000)
+                .await?;
+            let signed_transaction = to_sender_signed_transaction(tx_data, &keypair);
+            let (tx_bytes, signatures) = signed_transaction.to_tx_bytes_and_signatures();
+            let res = client
+                .execute_transaction_block(
+                    tx_bytes,
+                    signatures,
+                    Some(IotaTransactionBlockResponseOptions::new().with_effects()),
+                    Some(ExecuteTransactionRequestType::WaitForEffectsCert),
+                )
+                .await?;
+            indexer_wait_for_transaction(res.digest, store, client).await;
+        }
+
+        let objects = client
+            .get_owned_objects(
+                address,
+                Some(IotaObjectResponseQuery::new_with_options(
+                    IotaObjectDataOptions::new(),
+                )),
+                None,
+                None,
+            )
+            .await?
+            .data;
+        // 2 gas coins + 5 coins without global order + 5 coins with global order
+        assert_eq!(12, objects.len());
+
+        // filter transactions by address
+        let query = IotaTransactionBlockResponseQuery {
+            options: Some(IotaTransactionBlockResponseOptions {
+                show_input: true,
+                show_effects: true,
+                show_events: true,
+                ..Default::default()
+            }),
+            filter: Some(TransactionFilter::FromAddress(address)),
+        };
+
+        // Paging in ascending order
+        {
+            let first_page = client
+                .query_transaction_blocks(query.clone(), None, Some(3), Some(false))
+                .await
+                .unwrap();
+            assert_eq!(3, first_page.data.len());
+
+            let next_page = client
+                .query_transaction_blocks(
+                    query.clone(),
+                    first_page.next_cursor,
+                    Some(4),
+                    Some(false),
+                )
+                .await
+                .unwrap();
+            assert_eq!(4, next_page.data.len());
+
+            let last_page = client
+                .query_transaction_blocks(query.clone(), next_page.next_cursor, None, Some(false))
+                .await
+                .unwrap();
+            assert_eq!(3, last_page.data.len());
+        }
+
+        // Paging in descending order
+        {
+            let first_page = client
+                .query_transaction_blocks(query.clone(), None, Some(3), Some(true))
+                .await
+                .unwrap();
+            assert_eq!(3, first_page.data.len());
+
+            let next_page = client
+                .query_transaction_blocks(
+                    query.clone(),
+                    first_page.next_cursor,
+                    Some(4),
+                    Some(true),
+                )
+                .await
+                .unwrap();
+            assert_eq!(4, next_page.data.len());
+
+            let last_page = client
+                .query_transaction_blocks(query, next_page.next_cursor, None, Some(true))
+                .await
+                .unwrap();
+            assert_eq!(3, last_page.data.len());
+        }
 
         Ok(())
     })
@@ -529,6 +694,252 @@ fn test_query_transaction_blocks() -> Result<(), anyhow::Error> {
 }
 
 #[test]
+fn test_query_transaction_blocks_from_and_to_address() -> Result<(), anyhow::Error> {
+    let ApiTestSetup {
+        runtime,
+        store,
+        cluster,
+        client,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        let (address, keypair): (_, AccountKeyPair) = get_key_pair();
+        let recipient_1 = IotaAddress::random_for_testing_only();
+        let recipient_2 = IotaAddress::random_for_testing_only();
+
+        let gas = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(500_000_000),
+                address,
+            )
+            .await;
+        indexer_wait_for_object(client, gas.0, gas.1).await;
+
+        let transfer_request = client
+            .transfer_iota(
+                address,
+                gas.0,
+                5_000_000.into(),
+                recipient_1,
+                Some(100_000_000.into()),
+            )
+            .await
+            .unwrap();
+        execute_tx_and_wait_for_indexer(client, cluster, store, transfer_request, &keypair).await;
+        let transfer_request = client
+            .transfer_iota(
+                address,
+                gas.0,
+                5_000_000.into(),
+                recipient_2,
+                Some(100_000_000.into()),
+            )
+            .await
+            .unwrap();
+        execute_tx_and_wait_for_indexer(client, cluster, store, transfer_request, &keypair).await;
+
+        let query = IotaTransactionBlockResponseQuery::new_with_filter(
+            TransactionFilter::FromAndToAddress {
+                from: address,
+                to: recipient_1,
+            },
+        );
+        let res = client
+            .query_transaction_blocks(query, None, Some(20), Some(true))
+            .await
+            .unwrap();
+
+        assert_eq!(1, res.data.len());
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_query_transaction_blocks_from_or_to_address() -> Result<(), anyhow::Error> {
+    let ApiTestSetup {
+        runtime,
+        store,
+        cluster,
+        client,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        let (address, keypair): (_, AccountKeyPair) = get_key_pair();
+        let recipient_1 = IotaAddress::random_for_testing_only();
+        let recipient_2 = IotaAddress::random_for_testing_only();
+
+        let gas = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(500_000_000),
+                address,
+            )
+            .await;
+        indexer_wait_for_object(client, gas.0, gas.1).await;
+
+        let transfer_request = client
+            .transfer_iota(
+                address,
+                gas.0,
+                5_000_000.into(),
+                recipient_1,
+                Some(100_000_000.into()),
+            )
+            .await
+            .unwrap();
+        execute_tx_and_wait_for_indexer(client, cluster, store, transfer_request, &keypair).await;
+        let transfer_request = client
+            .transfer_iota(
+                address,
+                gas.0,
+                5_000_000.into(),
+                recipient_2,
+                Some(100_000_000.into()),
+            )
+            .await
+            .unwrap();
+        execute_tx_and_wait_for_indexer(client, cluster, store, transfer_request, &keypair).await;
+
+        let query = IotaTransactionBlockResponseQuery::new_with_filter(
+            TransactionFilter::FromOrToAddress { addr: address },
+        );
+        let res = client
+            .query_transaction_blocks(query, None, None, Some(false))
+            .await
+            .unwrap();
+        assert_eq!(3, res.data.len());
+
+        let query = IotaTransactionBlockResponseQuery::new_with_filter(
+            TransactionFilter::FromOrToAddress { addr: recipient_1 },
+        );
+        let res = client
+            .query_transaction_blocks(query, None, None, Some(true))
+            .await
+            .unwrap();
+        assert_eq!(1, res.data.len());
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_query_transaction_blocks_from_or_to_address_with_incomplete_global_order()
+-> Result<(), anyhow::Error> {
+    let ApiTestSetup {
+        runtime,
+        store,
+        cluster,
+        client,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        let (address, keypair): (_, AccountKeyPair) = get_key_pair();
+        let recipient_1 = IotaAddress::random_for_testing_only();
+
+        let gas = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(500_000_000),
+                address,
+            )
+            .await;
+        indexer_wait_for_object(client, gas.0, gas.1).await;
+
+        for _ in 0..5 {
+            let transfer_request = client
+                .transfer_iota(
+                    address,
+                    gas.0,
+                    5_000_000.into(),
+                    recipient_1,
+                    Some(1_000_000.into()),
+                )
+                .await
+                .unwrap();
+            execute_tx_and_wait_for_indexer(client, cluster, store, transfer_request, &keypair)
+                .await;
+        }
+
+        wipe_global_order_and_optimistic_tables(store); // data indexed before this point will not have global order
+
+        for _ in 0..5 {
+            let transfer_request = client
+                .transfer_iota(
+                    address,
+                    gas.0,
+                    5_000_000.into(),
+                    recipient_1,
+                    Some(1_000_000.into()),
+                )
+                .await
+                .unwrap();
+            execute_tx_and_wait_for_indexer(client, cluster, store, transfer_request, &keypair)
+                .await;
+        }
+
+        let query = IotaTransactionBlockResponseQuery::new_with_filter(
+            TransactionFilter::FromOrToAddress { addr: address },
+        );
+
+        // Paging in ascending order
+        {
+            let first_page = client
+                .query_transaction_blocks(query.clone(), None, Some(3), Some(false))
+                .await
+                .unwrap();
+            assert_eq!(3, first_page.data.len());
+
+            let next_page = client
+                .query_transaction_blocks(
+                    query.clone(),
+                    first_page.next_cursor,
+                    Some(4),
+                    Some(false),
+                )
+                .await
+                .unwrap();
+            assert_eq!(4, next_page.data.len());
+
+            let last_page = client
+                .query_transaction_blocks(query.clone(), next_page.next_cursor, None, Some(false))
+                .await
+                .unwrap();
+            assert_eq!(4, last_page.data.len());
+        }
+
+        // Paging in descending order
+        {
+            let first_page = client
+                .query_transaction_blocks(query.clone(), None, Some(3), Some(true))
+                .await
+                .unwrap();
+            assert_eq!(3, first_page.data.len());
+
+            let next_page = client
+                .query_transaction_blocks(
+                    query.clone(),
+                    first_page.next_cursor,
+                    Some(4),
+                    Some(true),
+                )
+                .await
+                .unwrap();
+            assert_eq!(4, next_page.data.len());
+
+            let last_page = client
+                .query_transaction_blocks(query, next_page.next_cursor, None, Some(true))
+                .await
+                .unwrap();
+            assert_eq!(4, last_page.data.len());
+        }
+
+        Ok(())
+    })
+}
+
+#[test]
 fn test_get_dynamic_fields() -> Result<(), anyhow::Error> {
     let ApiTestSetup {
         runtime,
@@ -626,6 +1037,136 @@ fn test_get_dynamic_fields() -> Result<(), anyhow::Error> {
 
         Ok(())
     })
+}
+
+fn wipe_global_order_and_optimistic_tables(store: &PgIndexerStore) {
+    let pool = store.blocking_cp();
+
+    transactional_blocking_with_retry!(
+        &pool,
+        |conn| { diesel::dsl::delete(tx_global_order::table).execute(conn) },
+        Duration::from_secs(10)
+    )
+    .unwrap();
+
+    transactional_blocking_with_retry!(
+        &pool,
+        |conn| { diesel::dsl::delete(optimistic_event_emit_module::table).execute(conn) },
+        Duration::from_secs(10)
+    )
+    .unwrap();
+
+    transactional_blocking_with_retry!(
+        &pool,
+        |conn| { diesel::dsl::delete(optimistic_event_emit_package::table).execute(conn) },
+        Duration::from_secs(10)
+    )
+    .unwrap();
+
+    transactional_blocking_with_retry!(
+        &pool,
+        |conn| { diesel::dsl::delete(optimistic_event_senders::table).execute(conn) },
+        Duration::from_secs(10)
+    )
+    .unwrap();
+
+    transactional_blocking_with_retry!(
+        &pool,
+        |conn| { diesel::dsl::delete(optimistic_event_struct_instantiation::table).execute(conn) },
+        Duration::from_secs(10)
+    )
+    .unwrap();
+
+    transactional_blocking_with_retry!(
+        &pool,
+        |conn| { diesel::dsl::delete(optimistic_event_struct_module::table).execute(conn) },
+        Duration::from_secs(10)
+    )
+    .unwrap();
+
+    transactional_blocking_with_retry!(
+        &pool,
+        |conn| { diesel::dsl::delete(optimistic_event_struct_name::table).execute(conn) },
+        Duration::from_secs(10)
+    )
+    .unwrap();
+
+    transactional_blocking_with_retry!(
+        &pool,
+        |conn| { diesel::dsl::delete(optimistic_event_struct_package::table).execute(conn) },
+        Duration::from_secs(10)
+    )
+    .unwrap();
+
+    transactional_blocking_with_retry!(
+        &pool,
+        |conn| { diesel::dsl::delete(optimistic_events::table).execute(conn) },
+        Duration::from_secs(10)
+    )
+    .unwrap();
+
+    transactional_blocking_with_retry!(
+        &pool,
+        |conn| { diesel::dsl::delete(optimistic_transactions::table).execute(conn) },
+        Duration::from_secs(10)
+    )
+    .unwrap();
+
+    transactional_blocking_with_retry!(
+        &pool,
+        |conn| { diesel::dsl::delete(optimistic_tx_calls_fun::table).execute(conn) },
+        Duration::from_secs(10)
+    )
+    .unwrap();
+
+    transactional_blocking_with_retry!(
+        &pool,
+        |conn| { diesel::dsl::delete(optimistic_tx_calls_mod::table).execute(conn) },
+        Duration::from_secs(10)
+    )
+    .unwrap();
+
+    transactional_blocking_with_retry!(
+        &pool,
+        |conn| { diesel::dsl::delete(optimistic_tx_calls_pkg::table).execute(conn) },
+        Duration::from_secs(10)
+    )
+    .unwrap();
+
+    transactional_blocking_with_retry!(
+        &pool,
+        |conn| { diesel::dsl::delete(optimistic_tx_changed_objects::table).execute(conn) },
+        Duration::from_secs(10)
+    )
+    .unwrap();
+
+    transactional_blocking_with_retry!(
+        &pool,
+        |conn| { diesel::dsl::delete(optimistic_tx_input_objects::table).execute(conn) },
+        Duration::from_secs(10)
+    )
+    .unwrap();
+
+    transactional_blocking_with_retry!(
+        &pool,
+        |conn| { diesel::dsl::delete(optimistic_tx_kinds::table).execute(conn) },
+        Duration::from_secs(10)
+    )
+    .unwrap();
+
+    transactional_blocking_with_retry!(
+        &pool,
+        |conn| { diesel::dsl::delete(optimistic_tx_recipients::table).execute(conn) },
+        Duration::from_secs(10)
+    )
+    .unwrap();
+
+    transactional_blocking_with_retry!(
+        &pool,
+        |conn| { diesel::dsl::delete(optimistic_tx_senders::table).execute(conn) },
+        Duration::from_secs(10)
+    )
+    .unwrap();
 }
 
 #[test]


### PR DESCRIPTION
# Description of change

`query_transaction_blocks_impl` now uses `tx_global_order` when appropriate for ordering the results.
Cursor passed to `query_transaction_blocks_impl` also correctly resolves to `tx_global_order` when appropriate.  

The change does not make optimistic transactions being returned from the function yet, this will be handled in other PRs.

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/7795

## How the change has been tested

Extracted sample queries generated by the modified function:
```
(SELECT tx_kinds.tx_sequence_number FROM tx_kinds JOIN tx_global_order ON tx_global_order.chk_tx_sequence_number = tx_kinds.tx_sequence_number WHERE tx_kind = 3  ORDER BY tx_global_order.global_sequence_number DESC, tx_global_order.optimistic_sequence_number DESC LIMIT 2 ) UNION ALL (SELECT tx_kinds.tx_sequence_number FROM tx_kinds WHERE tx_kind = 3  AND tx_kinds.tx_sequence_number < 0 ORDER BY tx_kinds.tx_sequence_number DESC LIMIT 2 ) LIMIT 2
```

```
(SELECT tx_senders.tx_sequence_number FROM tx_senders JOIN tx_global_order ON tx_global_order.chk_tx_sequence_number = tx_senders.tx_sequence_number WHERE sender = '\x0000000000000000000000000000000000000000000000000000000000000000'::bytea AND (tx_global_order.global_sequence_number, tx_global_order.optimistic_sequence_number) < (641, 13) ORDER BY tx_global_order.global_sequence_number DESC, tx_global_order.optimistic_sequence_number DESC LIMIT 5 ) UNION ALL (SELECT tx_senders.tx_sequence_number FROM tx_senders WHERE sender = '\x0000000000000000000000000000000000000000000000000000000000000000'::bytea  AND tx_senders.tx_sequence_number < 614 ORDER BY tx_senders.tx_sequence_number DESC LIMIT 5 ) LIMIT 5
```

```
(SELECT tx_sequence_number FROM ((SELECT tx_senders.tx_sequence_number, tx_global_order.global_sequence_number, tx_global_order.optimistic_sequence_number FROM tx_senders JOIN tx_global_order ON tx_global_order.chk_tx_sequence_number = tx_senders.tx_sequence_number WHERE sender = '\x0000000000000000000000000000000000000000000000000000000000000000'::BYTEA AND (tx_global_order.global_sequence_number, tx_global_order.optimistic_sequence_number) < (711, -1) ORDER BY tx_global_order.global_sequence_number DESC, tx_global_order.optimistic_sequence_number DESC LIMIT 5 ) UNION (SELECT tx_recipients.tx_sequence_number, tx_global_order.global_sequence_number, tx_global_order.optimistic_sequence_number FROM tx_recipients JOIN tx_global_order ON tx_global_order.chk_tx_sequence_number = tx_recipients.tx_sequence_number WHERE recipient = '\x0000000000000000000000000000000000000000000000000000000000000000'::BYTEA AND (tx_global_order.global_sequence_number, tx_global_order.optimistic_sequence_number) < (711, -1) ORDER BY tx_global_order.global_sequence_number DESC, tx_global_order.optimistic_sequence_number DESC LIMIT 5 )) AS combined ORDER BY global_sequence_number DESC, optimistic_sequence_number DESC) UNION ALL (SELECT tx_sequence_number FROM ((SELECT tx_senders.tx_sequence_number FROM tx_senders WHERE sender = '\x0000000000000000000000000000000000000000000000000000000000000000'::BYTEA  AND tx_senders.tx_sequence_number < 614 ORDER BY tx_senders.tx_sequence_number DESC LIMIT 5 ) UNION (SELECT tx_recipients.tx_sequence_number FROM tx_recipients WHERE recipient = '\x0000000000000000000000000000000000000000000000000000000000000000'::BYTEA  AND tx_recipients.tx_sequence_number < 614 ORDER BY tx_recipients.tx_sequence_number DESC LIMIT 5 )) AS combined ORDER BY tx_sequence_number DESC) LIMIT 5
```

and checked it with sql `EXPLAIN(ANALYZE)` on the staging server to see if they are performant. (execution times took less than 1ms with 92172170 transactions in the DB)

`cargo test --profile dev-nodebug --package iota-indexer --test rpc-tests --all-features`
`cargo nextest run --release -p iota-graphql-rpc --features pg_integration --no-fail-fast --test-threads 1`
`cargo nextest run --release --features pg_integration -p iota-graphql-e2e-tests`

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
