### PR TITLE
feat(starfish): garbage collection

### DIFF
--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -62,7 +62,7 @@ pub struct Parameters {
 
     /// Proposing new block is stopped when the propagation delay is greater
     /// than this threshold. Propagation delay is the difference between the
-    /// round of the last proposed block and the the highest round from this
+    /// round of the last proposed block and the highest round from this
     /// authority that is received by all validators in a quorum.
     #[serde(default = "Parameters::default_propagation_delay_stop_proposal_threshold")]
     pub propagation_delay_stop_proposal_threshold: u32,

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -14,7 +14,6 @@ use std::{
 };
 
 use arc_swap::ArcSwap;
-use consensus_core::BlockStatus;
 use dashmap::{DashMap, try_result::TryResult};
 use futures::{
     FutureExt, StreamExt,
@@ -197,7 +196,35 @@ impl ConsensusAdapterMetrics {
     }
 }
 
-pub type BlockStatusReceiver = oneshot::Receiver<BlockStatus>;
+/// Block status for internal use in the consensus adapter that serves for both
+/// Mysticeti and Starfish.
+pub enum BlockStatusInternal {
+    Sequenced,
+    GarbageCollected,
+}
+
+impl From<consensus_core::BlockStatus> for BlockStatusInternal {
+    fn from(status: consensus_core::BlockStatus) -> Self {
+        match status {
+            consensus_core::BlockStatus::Sequenced(_) => BlockStatusInternal::Sequenced,
+            consensus_core::BlockStatus::GarbageCollected(_) => {
+                BlockStatusInternal::GarbageCollected
+            }
+        }
+    }
+}
+impl From<starfish_core::BlockStatus> for BlockStatusInternal {
+    fn from(status: starfish_core::BlockStatus) -> Self {
+        match status {
+            starfish_core::BlockStatus::Sequenced(_) => BlockStatusInternal::Sequenced,
+            starfish_core::BlockStatus::GarbageCollected(_) => {
+                BlockStatusInternal::GarbageCollected
+            }
+        }
+    }
+}
+
+pub type BlockStatusReceiver = oneshot::Receiver<BlockStatusInternal>;
 
 #[mockall::automock]
 pub trait SubmitToConsensus: Sync + Send + 'static {
@@ -751,7 +778,7 @@ impl ConsensusAdapter {
                         .await;
 
                     match status_waiter.await {
-                        Ok(BlockStatus::Sequenced(_)) => {
+                        Ok(BlockStatusInternal::Sequenced) => {
                             self.metrics
                                 .sequencing_certificate_status
                                 .with_label_values(&[tx_type, "sequenced"])
@@ -763,7 +790,7 @@ impl ConsensusAdapter {
                             );
                             break;
                         }
-                        Ok(BlockStatus::GarbageCollected(_)) => {
+                        Ok(BlockStatusInternal::GarbageCollected) => {
                             self.metrics
                                 .sequencing_certificate_status
                                 .with_label_values(&[tx_type, "garbage_collected"])

--- a/crates/iota-core/src/mock_consensus.rs
+++ b/crates/iota-core/src/mock_consensus.rs
@@ -133,6 +133,6 @@ impl ConsensusClient for MockConsensusClient {
 
 pub(crate) fn with_block_status(status: consensus_core::BlockStatus) -> BlockStatusReceiver {
     let (tx, rx) = oneshot::channel();
-    tx.send(status).ok();
+    tx.send(status.into()).ok();
     rx
 }

--- a/crates/iota-core/src/mysticeti_adapter.rs
+++ b/crates/iota-core/src/mysticeti_adapter.rs
@@ -16,6 +16,7 @@ use tracing::{error, info, warn};
 
 use crate::{
     authority::authority_per_epoch_store::AuthorityPerEpochStore,
+    consensus_adapter,
     consensus_adapter::{BlockStatusReceiver, ConsensusClient},
     consensus_handler::SequencedConsensusTransactionKey,
 };
@@ -128,6 +129,19 @@ impl ConsensusClient for LazyMysticetiClient {
             let transaction_key = SequencedConsensusTransactionKey::External(transactions[0].key());
             tracing::info!("Transaction {transaction_key:?} was included in {block_ref}",)
         };
-        Ok(status_waiter)
+
+        // Transform the status waiter into a receiver that can be used by the consensus
+        // adapter.
+
+        let (tx_internal, rx_internal) =
+            tokio::sync::oneshot::channel::<consensus_adapter::BlockStatusInternal>();
+
+        tokio::spawn(async move {
+            if let Ok(status) = status_waiter.await {
+                let _ = tx_internal.send(status.into());
+            }
+        });
+
+        Ok(rx_internal)
     }
 }

--- a/crates/iota-core/src/starfish_adapter.rs
+++ b/crates/iota-core/src/starfish_adapter.rs
@@ -10,14 +10,12 @@ use iota_types::{
 };
 use starfish_core::{ClientError, TransactionClient};
 use tap::prelude::*;
-use tokio::{
-    sync::oneshot,
-    time::{Instant, sleep},
-};
+use tokio::time::{Instant, sleep};
 use tracing::{error, info, warn};
 
 use crate::{
     authority::authority_per_epoch_store::AuthorityPerEpochStore,
+    consensus_adapter,
     consensus_adapter::{BlockStatusReceiver, ConsensusClient},
     consensus_handler::SequencedConsensusTransactionKey,
 };
@@ -92,8 +90,7 @@ impl ConsensusClient for LazyStarfishClient {
             .map(|t| bcs::to_bytes(t).expect("Serializing consensus transaction cannot fail"))
             .collect::<Vec<_>>();
 
-        // TODO: remove the block status waiter from the submit function in Starfish
-        let (block_ref, _) = client
+        let (block_ref, status_waiter) = client
             .as_ref()
             .expect("Client should always be returned")
             .submit(transactions_bytes)
@@ -133,16 +130,18 @@ impl ConsensusClient for LazyStarfishClient {
             tracing::info!("Transaction {transaction_key:?} was included in {block_ref}",)
         };
 
-        // Starfish does not support GC at this point, but to be compatible with
-        // Mysticeti adapter, we always notify the status waiter that the block has been
-        // sequenced. The value is currently ignored, so for simplicity we just send
-        //  the default BlockRef value, but it should be checked that it won't cause
-        // problems in the future when the logic that handles the status is
-        // changed.
-        let (tx, status_waiter) = oneshot::channel();
-        let _ = tx.send(consensus_core::BlockStatus::Sequenced(
-            consensus_core::BlockRef::default(),
-        )); // immediately send
-        Ok(status_waiter)
+        // Transform the status waiter into a receiver that can be used by the consensus
+        // adapter.
+
+        let (tx_internal, rx_internal) =
+            tokio::sync::oneshot::channel::<consensus_adapter::BlockStatusInternal>();
+
+        tokio::spawn(async move {
+            if let Ok(status) = status_waiter.await {
+                let _ = tx_internal.send(status.into());
+            }
+        });
+
+        Ok(rx_internal)
     }
 }

--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -70,7 +70,7 @@ pub struct Parameters {
 
     /// Proposing new block is stopped when the propagation delay is greater
     /// than this threshold. Propagation delay is the difference between the
-    /// round of the last proposed block and the the highest round from this
+    /// round of the last proposed block and the highest round from this
     /// authority that is received by all validators in a quorum.
     #[serde(default = "Parameters::default_propagation_delay_stop_proposal_threshold")]
     pub propagation_delay_stop_proposal_threshold: u32,

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -852,16 +852,19 @@ impl Core {
             fail_point!("consensus-after-handle-commit");
         }
 
-        // Notify about our own committed blocks
-        let committed_block_refs = committed_sub_dags
+        // Notify about our own committed transactions
+        let committed_transaction_refs = committed_sub_dags
             .iter()
-            .flat_map(|sub_dag| sub_dag.blocks.iter())
-            .filter_map(|block| {
-                (block.author() == self.context.own_index).then_some(block.reference())
+            .flat_map(|sub_dag| sub_dag.committed_transaction_refs.iter())
+            .filter_map(|block_ref| {
+                (block_ref.author == self.context.own_index).then_some(*block_ref)
             })
             .collect::<Vec<_>>();
-        self.transaction_consumer
-            .notify_own_blocks_status(committed_block_refs);
+
+        self.transaction_consumer.notify_own_transactions_status(
+            committed_transaction_refs,
+            self.dag_state.read().gc_round(),
+        );
 
         Ok((committed_sub_dags, all_missing_committed_txns))
     }
@@ -1273,7 +1276,6 @@ mod test {
         leader_scoring::ReputationScores,
         storage::{Store, WriteBatch, mem_store::MemStore},
         test_dag_builder::DagBuilder,
-        test_dag_parser::parse_dag,
         transaction::{BlockStatus, TransactionClient},
     };
 
@@ -1289,44 +1291,30 @@ mod test {
         let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
         let mut block_status_subscriptions = FuturesUnordered::new();
 
-        // Create test blocks for all the authorities for 4 rounds and populate them in
-        // store
-        let mut last_round_blocks = genesis_blocks(context.clone());
-        let mut all_blocks: Vec<VerifiedBlock> = last_round_blocks.clone();
-        for round in 1..=4 {
-            let mut this_round_blocks = Vec::new();
-            for (index, _authority) in context.committee.authorities() {
-                let block = VerifiedBlock::new_for_test(
-                    TestBlockHeader::new(round, index.value() as u32)
-                        .set_ancestors(last_round_blocks.iter().map(|b| b.reference()).collect())
-                        .build(),
-                );
+        // Create a fully connected DAG with 6 rounds.
+        let num_rounds = 6;
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=num_rounds).build();
+        dag_builder.print();
 
-                // If it's round 1, that one will be committed later on, and it's our "own"
-                // block, then subscribe to listen for the block status.
-                if round == 1 && index == context.own_index {
-                    let subscription =
-                        transaction_consumer.subscribe_for_block_status_testing(block.reference());
-                    block_status_subscriptions.push(subscription);
-                }
-
-                this_round_blocks.push(block);
+        // Subscribe to all created "own" blocks. We know that for our node (A) we'll be
+        // able to commit transactions up to round 2.
+        for block in dag_builder.block_headers(1..=2) {
+            if block.author() == context.own_index {
+                let subscription =
+                    transaction_consumer.subscribe_for_block_status_testing(block.reference());
+                block_status_subscriptions.push(subscription);
             }
-            all_blocks.extend(this_round_blocks.clone());
-            last_round_blocks = this_round_blocks;
         }
-        // write them in store
-        let (block_headers, block_transactions) = all_blocks
-            .into_iter()
-            .map(|b| (b.verified_block_header, b.verified_transactions))
-            .unzip();
+
+        // write headers and transactions in store
         store
             .write(
                 WriteBatch::default()
-                    .block_headers(block_headers)
-                    .transactions(block_transactions),
+                    .block_headers(dag_builder.block_headers(1..=num_rounds))
+                    .transactions(dag_builder.transactions(1..=num_rounds)),
             )
-            .expect("Storage error");
+            .expect("We should expect a successful storing of headers");
 
         // create dag state after all blocks have been written to store
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
@@ -1367,38 +1355,38 @@ mod test {
             false,
         );
 
-        // New round should be 5
+        // New round should be num_round + 1
         let mut new_round = signal_receivers.new_round_receiver();
-        assert_eq!(*new_round.borrow_and_update(), 5);
+        assert_eq!(*new_round.borrow_and_update(), num_rounds + 1);
 
-        // Block for round 5 should have been proposed.
+        // Block for round 6 should have been proposed.
         let proposed_block = block_receiver
             .recv()
             .await
             .expect("A block should have been created");
-        assert_eq!(proposed_block.round(), 5);
+        assert_eq!(proposed_block.round(), num_rounds + 1);
         let ancestors = proposed_block.ancestors();
 
         // Only ancestors of round 4 should be included.
         assert_eq!(ancestors.len(), 4);
         for ancestor in ancestors {
-            assert_eq!(ancestor.round, 4);
+            assert_eq!(ancestor.round, num_rounds);
         }
 
         let last_commit = store
             .read_last_commit()
             .unwrap()
-            .expect("last commit should be set");
+            .expect("We expect that the last commit is properly defined");
 
-        // There were no commits prior to the core starting up but there was completed
-        // rounds up to and including round 4. So we should commit leaders in round 1 &
-        // 2 as soon as the new block for round 5 is proposed.
-        assert_eq!(last_commit.index(), 2);
-        assert_eq!(dag_state.read().last_commit_index(), 2);
+        // We should commit leaders in round 1 & 2 & 3 & 4 as the new block for round 7
+        // is proposed.
+        assert_eq!(last_commit.index(), num_rounds - 2);
+        assert_eq!(dag_state.read().last_commit_index(), num_rounds - 2);
         let all_stored_commits = store.scan_commits((0..=CommitIndex::MAX).into()).unwrap();
-        assert_eq!(all_stored_commits.len(), 2);
+        assert_eq!(all_stored_commits.len(), num_rounds as usize - 2);
 
-        // And ensure that our "own" block 1 sent to TransactionConsumer as notification
+        // And ensure that our "own" transaction data of blocks from rounds 1 & 2 sent
+        // to TransactionConsumer as notification
         while let Some(result) = block_status_subscriptions.next().await {
             let status = result.unwrap();
             assert!(matches!(status, BlockStatus::Sequenced(_)));
@@ -2594,38 +2582,14 @@ mod test {
         let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
         let mut block_status_subscriptions = FuturesUnordered::new();
 
-        let dag_str = "DAG {
-            Round 0 : { 4 },
-            Round 1 : { * },
-            Round 2 : { * },
-            Round 3 : {
-                A -> [*],
-                B -> [-A2],
-                C -> [-A2],
-                D -> [-A2],
-            },
-            Round 4 : {
-                B -> [-A3],
-                C -> [-A3],
-                D -> [-A3],
-            },
-            Round 5 : {
-                A -> [A3, B4, C4, D4]
-                B -> [*],
-                C -> [*],
-                D -> [*],
-            },
-            Round 6 : { * },
-            Round 7 : { * },
-            Round 8 : { * },
-        }";
-
-        let dag_builder = parse_dag(dag_str).expect("Invalid dag");
+        // Create a fully connected DAG with 8 rounds.
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=8).build();
         dag_builder.print();
 
         // Subscribe to all created "own" blocks. We know that for our node (A) we'll be
-        // able to commit up to round 5.
-        for block in dag_builder.block_headers(1..=5) {
+        // able to commit transactions up to round 4.
+        for block in dag_builder.block_headers(1..=4) {
             if block.author() == context.own_index {
                 let subscription =
                     transaction_consumer.subscribe_for_block_status_testing(block.reference());
@@ -2633,10 +2597,15 @@ mod test {
             }
         }
 
-        // write them in store
+        // write headers in store
         store
             .write(WriteBatch::default().block_headers(dag_builder.block_headers(1..=8)))
-            .expect("Storage error");
+            .expect("We should expect a successful storing of headers");
+
+        // write transactions in store
+        store
+            .write(WriteBatch::default().transactions(dag_builder.transactions(1..=8)))
+            .expect("We should expect a successful storing of transactions");
 
         // create dag state after all blocks have been written to store
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
@@ -2683,7 +2652,8 @@ mod test {
             .unwrap()
             .expect("last commit should be set");
 
-        assert_eq!(last_commit.index(), 5);
+        // The latest committed leader is from round 6 as the DAG is fully connected
+        assert_eq!(last_commit.index(), 6);
 
         while let Some(result) = block_status_subscriptions.next().await {
             let status = result.unwrap();

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -1073,6 +1073,15 @@ impl DagState {
         self.highest_accepted_round
     }
 
+    /// Highest round where a block is committed, which is last commit's leader
+    /// round.
+    pub(crate) fn last_commit_round(&self) -> Round {
+        match &self.last_commit {
+            Some(commit) => commit.leader().round,
+            None => 0,
+        }
+    }
+
     // Buffers a new commit in memory and updates last committed rounds.
     // REQUIRED: must not skip over any commit index.
     pub(crate) fn add_commit(&mut self, commit: TrustedCommit) {
@@ -1335,13 +1344,11 @@ impl DagState {
         }
     }
 
-    /// Highest round where a block is committed, which is last commit's leader
-    /// round.
-    pub(crate) fn last_commit_round(&self) -> Round {
-        match &self.last_commit {
-            Some(commit) => commit.leader().round,
-            None => 0,
-        }
+    /// Return the garbage collection round. Transactions of blocks at or below
+    /// this round which are not yet sequenced will never be sequenced.
+    pub(crate) fn gc_round(&self) -> Round {
+        let last_commit_round = self.last_commit_round();
+        last_commit_round.saturating_sub(MAX_LINEARIZER_DEPTH + MAX_TRANSACTIONS_ACK_DEPTH)
     }
 
     /// Last committed round per authority.

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -24,7 +24,7 @@ use crate::{
 /// The maximum depth of the linearizer, i.e. how many rounds back it will
 /// traverse the DAG from a committed leader block
 // TODO: make it derivable from the protocol parameters
-pub(crate) const MAX_LINEARIZER_DEPTH: Round = 10;
+pub(crate) const MAX_LINEARIZER_DEPTH: Round = 60;
 
 /// The `StorageAPI` trait provides an interface for the block store and has
 /// been mostly introduced for allowing to inject the test store in

--- a/crates/starfish/core/src/transaction.rs
+++ b/crates/starfish/core/src/transaction.rs
@@ -13,6 +13,7 @@ use tokio::sync::oneshot;
 use tracing::{error, warn};
 
 use crate::{
+    Round,
     block_header::{BlockRef, Transaction},
     context::Context,
 };
@@ -49,10 +50,13 @@ pub(crate) struct TransactionConsumer {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum BlockStatus {
-    /// The block has been sequenced as part of a committed sub dag. That means
-    /// that any transaction that has been included in the block
-    /// has been committed as well.
+    /// The transaction data associated with this block ref has been sequenced
+    /// as part of a committed sub dag.
     Sequenced(BlockRef),
+    /// The block or transaction data corresponding to this block ref has been
+    /// garbage collected and will never be committed. The transaction data
+    /// must be attempted to be resent by the client
+    GarbageCollected(BlockRef),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -135,16 +139,20 @@ impl TransactionConsumer {
                 break;
             }
         }
+        let block_status_subscribers = self.block_status_subscribers.clone();
 
         (
             transactions,
             Box::new(move |block_ref: BlockRef| {
+                let mut block_status_subscribers = block_status_subscribers.lock();
+
                 for ack in acks {
                     let (status_tx, status_rx) = oneshot::channel();
 
-                    // Report directly the block as sequenced while
-                    // tx is acknowledged for inclusion.
-                    status_tx.send(BlockStatus::Sequenced(block_ref)).ok();
+                    block_status_subscribers
+                        .entry(block_ref)
+                        .or_default()
+                        .push(status_tx);
 
                     let _ = ack.send((block_ref, status_rx));
                 }
@@ -154,17 +162,34 @@ impl TransactionConsumer {
     }
 
     /// Notifies all the transaction submitters who are waiting to receive an
-    /// update on the status of the block. The `committed_blocks` are the
-    /// blocks that have been committed. We'll notify for
-    /// all the committed blocks.
-    pub(crate) fn notify_own_blocks_status(&self, committed_blocks: Vec<BlockRef>) {
-        // Notify for all the committed blocks first
+    /// update on the status of the block. The `committed_transaction_refs` are
+    /// the the transaction data that have been committed. We'll notify for
+    /// all own committed transaction data.
+    pub(crate) fn notify_own_transactions_status(
+        &self,
+        committed_transaction_refs: Vec<BlockRef>,
+        gc_round: Round,
+    ) {
+        // Notify for all own committed transaction data first
         let mut block_status_subscribers = self.block_status_subscribers.lock();
-        for block_ref in committed_blocks {
+        for block_ref in committed_transaction_refs {
             if let Some(subscribers) = block_status_subscribers.remove(&block_ref) {
                 subscribers.into_iter().for_each(|s| {
                     let _ = s.send(BlockStatus::Sequenced(block_ref));
                 });
+            }
+        }
+
+        // Now notify everyone <= gc_round that their block has been garbage collected
+        // and clean up the entries
+        while let Some((block_ref, subscribers)) = block_status_subscribers.pop_first() {
+            if block_ref.round <= gc_round {
+                subscribers.into_iter().for_each(|s| {
+                    let _ = s.send(BlockStatus::GarbageCollected(block_ref));
+                });
+            } else {
+                block_status_subscribers.insert(block_ref, subscribers);
+                break;
             }
         }
     }
@@ -409,7 +434,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn block_status_update() {
+    async fn block_status_update_sequenced_or_garbage_collected() {
         let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
             config.set_consensus_max_transaction_size_bytes_for_testing(2_000); // 2KB
             config.set_consensus_max_transactions_in_block_bytes_for_testing(2_000);
@@ -452,11 +477,28 @@ mod tests {
             block_status_waiters.push((block_ref, block_status_waiter));
         }
 
+        // Now acknowledge the commit of the blocks 6, 8, 10 and set gc_round = 5, which
+        // should trigger the garbage collection of blocks 1..=5
+        let gc_round = 5;
+        consumer.notify_own_transactions_status(
+            vec![
+                BlockRef::new(6, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN),
+                BlockRef::new(8, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN),
+                BlockRef::new(10, AuthorityIndex::new_for_test(0), BlockHeaderDigest::MIN),
+            ],
+            gc_round,
+        );
+
         // Now iterate over all the block status waiters. Everyone should have been
-        // notified and everyone should be considered sequenced.
-        for (_block_ref, waiter) in block_status_waiters {
+        // notified.
+        for (block_ref, waiter) in block_status_waiters {
             let block_status = waiter.await.expect("Block status waiter shouldn't fail");
-            assert!(matches!(block_status, BlockStatus::Sequenced(_)));
+
+            if block_ref.round <= gc_round {
+                assert!(matches!(block_status, BlockStatus::GarbageCollected(_)))
+            } else {
+                assert!(matches!(block_status, BlockStatus::Sequenced(_)));
+            }
         }
 
         // Ensure internal structure is clear

--- a/crates/starfish/core/src/transaction.rs
+++ b/crates/starfish/core/src/transaction.rs
@@ -163,7 +163,7 @@ impl TransactionConsumer {
 
     /// Notifies all the transaction submitters who are waiting to receive an
     /// update on the status of the block. The `committed_transaction_refs` are
-    /// the the transaction data that have been committed. We'll notify for
+    /// the transaction data that have been committed. We'll notify for
     /// all own committed transaction data.
     pub(crate) fn notify_own_transactions_status(
         &self,


### PR DESCRIPTION
# Description of change

Starfish garbage collects transaction data that is below MAX_TRANSACTIONS_ACK_DEPTH+MAX_LINEARIZER_DEPTH. However, the transaction data was not resent back to the consensus. With this PR, we introduce a logic similar to Mysticeti. If the transaction data is garbage collected, the consensus adapter resends the data through the consensus client after a timeout.

## Links to any relevant issues

Fixes #8043 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: garbage collection for Starfish
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
