### PR TITLE
upstream(core): Make transaction execution synchronous

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,7 +303,7 @@ num_enum = "0.7"
 object_store = { version = "0.10", features = ["aws", "gcp", "azure", "http"] }
 once_cell = "1.18.0"
 p256 = { version = "0.13.2", features = ["ecdsa"] }
-parking_lot = "0.12.1"
+parking_lot = { version = "0.12.3", features = ["arc_lock"] }
 passkey-authenticator = "0.4.0"
 passkey-client = "0.4.0"
 passkey-types = "0.4.0"

--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -41,8 +41,8 @@ mod test {
     };
     use iota_framework::BuiltInFramework;
     use iota_macros::{
-        clear_fail_point, nondeterministic, register_fail_point_arg, register_fail_point_async,
-        register_fail_point_if, register_fail_points, sim_test,
+        clear_fail_point, nondeterministic, register_fail_point, register_fail_point_arg,
+        register_fail_point_async, register_fail_point_if, register_fail_points, sim_test,
     };
     use iota_protocol_config::{PerObjectCongestionControlMode, ProtocolConfig, ProtocolVersion};
     use iota_simulator::{SimConfig, configs::*, tempfile::TempDir};
@@ -378,18 +378,13 @@ mod test {
         let dead_validator = dead_validator_orig.clone();
         let keep_alive_nodes_clone = keep_alive_nodes.clone();
         let grace_period_clone = grace_period.clone();
-        register_fail_point_async("crash", move || {
-            let dead_validator = dead_validator.clone();
-            let keep_alive_nodes_clone = keep_alive_nodes_clone.clone();
-            let grace_period_clone = grace_period_clone.clone();
-            async move {
-                handle_failpoint(
-                    dead_validator.clone(),
-                    keep_alive_nodes_clone.clone(),
-                    grace_period_clone.clone(),
-                    0.01,
-                );
-            }
+        register_fail_point("crash", move || {
+            handle_failpoint(
+                dead_validator.clone(),
+                keep_alive_nodes_clone.clone(),
+                grace_period_clone.clone(),
+                0.01,
+            );
         });
 
         // Consensus fail points.
@@ -430,7 +425,6 @@ mod test {
             }
         });
         register_fail_point_async("consensus-delay", || delay_failpoint(10..20, 0.001));
-        register_fail_point_async("write_object_entry", || delay_failpoint(10..20, 0.001));
 
         register_fail_point_async("writeback-cache-commit", || delay_failpoint(10..20, 0.001));
 

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1178,7 +1178,7 @@ impl AuthorityState {
     ///
     /// Should only be called within iota-core.
     #[instrument(level = "trace", skip_all)]
-    pub async fn try_execute_immediately(
+    pub fn try_execute_immediately(
         &self,
         certificate: &VerifiedExecutableTransaction,
         expected_effects_digest: Option<TransactionEffectsDigest>,
@@ -1262,13 +1262,11 @@ impl AuthorityState {
         certificate: &VerifiedCertificate,
     ) -> IotaResult<(VerifiedSignedTransactionEffects, Option<ExecutionError>)> {
         let epoch_store = self.epoch_store_for_testing();
-        let (effects, execution_error_opt) = self
-            .try_execute_immediately(
-                &VerifiedExecutableTransaction::new_from_certificate(certificate.clone()),
-                None,
-                &epoch_store,
-            )
-            .await?;
+        let (effects, execution_error_opt) = self.try_execute_immediately(
+            &VerifiedExecutableTransaction::new_from_certificate(certificate.clone()),
+            None,
+            &epoch_store,
+        )?;
         let signed_effects = self.sign_effects(effects, &epoch_store)?;
         Ok((signed_effects, execution_error_opt))
     }
@@ -1693,7 +1691,7 @@ impl AuthorityState {
         self.prepare_certificate(&execution_guard, certificate, input_objects, epoch_store)
     }
 
-    pub async fn dry_exec_transaction(
+    pub fn dry_exec_transaction(
         &self,
         transaction: TransactionData,
         transaction_digest: TransactionDigest,

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1257,7 +1257,7 @@ impl AuthorityState {
     /// Test only wrapper for `try_execute_immediately()` above, useful for
     /// checking errors if the pre-conditions are not satisfied, and
     /// executing change epoch transactions.
-    pub async fn try_execute_for_test(
+    pub fn try_execute_for_test(
         &self,
         certificate: &VerifiedCertificate,
     ) -> IotaResult<(VerifiedSignedTransactionEffects, Option<ExecutionError>)> {
@@ -1272,12 +1272,11 @@ impl AuthorityState {
     }
 
     /// Non-fallible version of `try_execute_for_test()`.
-    pub async fn execute_for_test(
+    pub fn execute_for_test(
         &self,
         certificate: &VerifiedCertificate,
     ) -> (VerifiedSignedTransactionEffects, Option<ExecutionError>) {
         self.try_execute_for_test(certificate)
-            .await
             .expect("try_execute_for_test should not fail")
     }
 

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -861,7 +861,7 @@ impl AuthorityState {
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> IotaResult<VerifiedSignedTransaction> {
         // Ensure that validator cannot reconfigure while we are signing the tx
-        let _execution_lock = self.execution_lock_for_signing().await;
+        let _execution_lock = self.execution_lock_for_signing();
 
         let tx_digest = transaction.digest();
         let tx_data = transaction.data().transaction_data();
@@ -919,9 +919,11 @@ impl AuthorityState {
         // The call to self.set_transaction_lock checks the lock is not conflicting,
         // and returns ConflictingTransaction error in case there is a lock on a
         // different existing transaction.
-        self.get_cache_writer()
-            .try_acquire_transaction_locks(epoch_store, &owned_objects, signed_transaction.clone())
-            .await?;
+        self.get_cache_writer().try_acquire_transaction_locks(
+            epoch_store,
+            &owned_objects,
+            signed_transaction.clone(),
+        )?;
 
         Ok(signed_transaction)
     }
@@ -1188,7 +1190,7 @@ impl AuthorityState {
         let tx_digest = certificate.digest();
 
         // Acquire a lock to prevent concurrent executions of the same transaction.
-        let tx_guard = epoch_store.acquire_tx_guard(certificate).await?;
+        let tx_guard = epoch_store.acquire_tx_guard(certificate)?;
 
         // The cert could have been processed by a concurrent attempt of the same cert,
         // so check if the effects have already been written.
@@ -1225,7 +1227,6 @@ impl AuthorityState {
             expected_effects_digest,
             epoch_store,
         )
-        .await
         .tap_err(|e| info!(?tx_digest, "process_certificate failed: {e}"))
         .tap_ok(
             |(fx, _)| debug!(?tx_digest, fx_digest=?fx.digest(), "process_certificate succeeded"),
@@ -1331,7 +1332,7 @@ impl AuthorityState {
     }
 
     #[instrument(level = "trace", skip_all)]
-    pub(crate) async fn process_certificate(
+    pub(crate) fn process_certificate(
         &self,
         tx_guard: CertTxGuard,
         certificate: &VerifiedExecutableTransaction,
@@ -1348,9 +1349,7 @@ impl AuthorityState {
             }
         });
 
-        let execution_guard = self
-            .execution_lock_for_executable_transaction(certificate)
-            .await;
+        let execution_guard = self.execution_lock_for_executable_transaction(certificate);
         // Any caller that verifies the signatures on the certificate will have already
         // checked the epoch. But paths that don't verify sigs (e.g. execution
         // from checkpoint, reading from db) present the possibility of an epoch
@@ -1431,7 +1430,7 @@ impl AuthorityState {
             }
         }
 
-        fail_point_async!("crash");
+        fail_point!("crash");
 
         self.commit_certificate(
             certificate,
@@ -1440,8 +1439,7 @@ impl AuthorityState {
             tx_guard,
             execution_guard,
             epoch_store,
-        )
-        .await?;
+        )?;
 
         if let TransactionKind::AuthenticatorStateUpdateV1(auth_state) =
             certificate.data().transaction_data().kind()
@@ -1485,7 +1483,7 @@ impl AuthorityState {
     }
 
     #[instrument(level = "trace", skip_all)]
-    async fn commit_certificate(
+    fn commit_certificate(
         &self,
         certificate: &VerifiedExecutableTransaction,
         inner_temporary_store: InnerTemporaryStore,
@@ -1508,7 +1506,6 @@ impl AuthorityState {
         // index certificate
         let _ = self
             .post_process_one_tx(certificate, effects, &inner_temporary_store, epoch_store)
-            .await
             .tap_err(|e| {
                 self.metrics.post_processing_total_failures.inc();
                 error!(?tx_digest, "tx post processing failed: {e}");
@@ -1520,7 +1517,7 @@ impl AuthorityState {
         epoch_store.insert_tx_key_and_digest(&tx_key, tx_digest)?;
 
         // Allow testing what happens if we crash here.
-        fail_point_async!("crash");
+        fail_point!("crash");
 
         let transaction_outputs = TransactionOutputs::build_transaction_outputs(
             certificate.clone().into_unsigned(),
@@ -1528,8 +1525,7 @@ impl AuthorityState {
             inner_temporary_store,
         );
         self.get_cache_writer()
-            .try_write_transaction_outputs(epoch_store.epoch(), transaction_outputs.into())
-            .await?;
+            .try_write_transaction_outputs(epoch_store.epoch(), transaction_outputs.into())?;
 
         if certificate.transaction_data().is_end_of_epoch_tx() {
             // At the end of epoch, since system packages may have been upgraded, force
@@ -1691,7 +1687,7 @@ impl AuthorityState {
         TransactionEffects,
         Option<ExecutionError>,
     )> {
-        let lock: RwLock<EpochId> = RwLock::new(epoch_store.epoch());
+        let lock = RwLock::new(epoch_store.epoch());
         let execution_guard = lock.try_read().unwrap();
 
         self.prepare_certificate(&execution_guard, certificate, input_objects, epoch_store)
@@ -1721,10 +1717,10 @@ impl AuthorityState {
         }
 
         self.dry_exec_transaction_impl(&epoch_store, transaction, transaction_digest)
-            .await
     }
 
-    pub async fn dry_exec_transaction_for_benchmark(
+    #[allow(clippy::type_complexity)]
+    pub fn dry_exec_transaction_for_benchmark(
         &self,
         transaction: TransactionData,
         transaction_digest: TransactionDigest,
@@ -1736,10 +1732,10 @@ impl AuthorityState {
     )> {
         let epoch_store = self.load_epoch_store_one_call_per_task();
         self.dry_exec_transaction_impl(&epoch_store, transaction, transaction_digest)
-            .await
     }
 
-    async fn dry_exec_transaction_impl(
+    #[allow(clippy::type_complexity)]
+    fn dry_exec_transaction_impl(
         &self,
         epoch_store: &AuthorityPerEpochStore,
         transaction: TransactionData,
@@ -2270,7 +2266,7 @@ impl AuthorityState {
 
     /// Indexes a transaction by updating various indexes in the `IndexStore`.
     #[instrument(level = "debug", skip_all, err)]
-    async fn index_tx(
+    fn index_tx(
         &self,
         indexes: &IndexStore,
         digest: &TransactionDigest,
@@ -2287,34 +2283,32 @@ impl AuthorityState {
             .process_object_index(effects, written, inner_temporary_store)
             .tap_err(|e| warn!(tx_digest=?digest, "Failed to process object index, index_tx is skipped: {e}"))?;
 
-        indexes
-            .index_tx(
-                cert.data().intent_message().value.sender(),
-                cert.data()
-                    .intent_message()
-                    .value
-                    .input_objects()?
-                    .iter()
-                    .map(|o| o.object_id()),
-                effects
-                    .all_changed_objects()
-                    .into_iter()
-                    .map(|(obj_ref, owner, _kind)| (obj_ref, owner)),
-                cert.data()
-                    .intent_message()
-                    .value
-                    .move_calls()
-                    .into_iter()
-                    .map(|(package, module, function)| {
-                        (*package, module.to_owned(), function.to_owned())
-                    }),
-                events,
-                changes,
-                digest,
-                timestamp_ms,
-                tx_coins,
-            )
-            .await
+        indexes.index_tx(
+            cert.data().intent_message().value.sender(),
+            cert.data()
+                .intent_message()
+                .value
+                .input_objects()?
+                .iter()
+                .map(|o| o.object_id()),
+            effects
+                .all_changed_objects()
+                .into_iter()
+                .map(|(obj_ref, owner, _kind)| (obj_ref, owner)),
+            cert.data()
+                .intent_message()
+                .value
+                .move_calls()
+                .into_iter()
+                .map(|(package, module, function)| {
+                    (*package, module.to_owned(), function.to_owned())
+                }),
+            events,
+            changes,
+            digest,
+            timestamp_ms,
+            tx_coins,
+        )
     }
 
     #[cfg(msim)]
@@ -2615,7 +2609,7 @@ impl AuthorityState {
     }
 
     #[instrument(level = "trace", skip_all, err)]
-    async fn post_process_one_tx(
+    fn post_process_one_tx(
         &self,
         certificate: &VerifiedExecutableTransaction,
         effects: &TransactionEffects,
@@ -2647,7 +2641,6 @@ impl AuthorityState {
                     written,
                     inner_temporary_store,
                 )
-                .await
                 .tap_ok(|_| self.metrics.post_processing_total_tx_indexed.inc())
                 .tap_err(|e| error!(?tx_digest, "Post processing - Couldn't index tx: {e}"))
                 .expect("Indexing tx should not fail");
@@ -3103,11 +3096,14 @@ impl AuthorityState {
     /// Attempts to acquire execution lock for an executable transaction.
     /// Returns the lock if the transaction is matching current executed epoch
     /// Returns None otherwise
-    pub async fn execution_lock_for_executable_transaction(
+    pub fn execution_lock_for_executable_transaction(
         &self,
         transaction: &VerifiedExecutableTransaction,
     ) -> IotaResult<ExecutionLockReadGuard> {
-        let lock = self.execution_lock.read().await;
+        let lock = self
+            .execution_lock
+            .try_read()
+            .map_err(|_| IotaError::ValidatorHaltedAtEpochEnd)?;
         if *lock == transaction.auth_sig().epoch() {
             Ok(lock)
         } else {
@@ -3123,8 +3119,10 @@ impl AuthorityState {
     /// finished handling the signing request. Otherwise, in-memory lock
     /// state could be cleared (by `ObjectLocks::clear_cached_locks`)
     /// while we are attempting to acquire locks for the transaction.
-    pub async fn execution_lock_for_signing(&self) -> ExecutionLockReadGuard {
-        self.execution_lock.read().await
+    pub fn execution_lock_for_signing(&self) -> IotaResult<ExecutionLockReadGuard> {
+        self.execution_lock
+            .try_read()
+            .map_err(|_| IotaError::ValidatorHaltedAtEpochEnd)
     }
 
     pub async fn execution_lock_for_reconfiguration(&self) -> ExecutionLockWriteGuard {
@@ -4841,7 +4839,7 @@ impl AuthorityState {
         );
 
         fail_point_async!("change_epoch_tx_delay");
-        let tx_lock = epoch_store.acquire_tx_lock(tx_digest).await;
+        let tx_lock = epoch_store.acquire_tx_lock(tx_digest);
 
         // The tx could have been executed by state sync already - if so simply return
         // an error. The checkpoint builder will shortly be terminated by
@@ -4854,19 +4852,15 @@ impl AuthorityState {
             bail!("change epoch tx has already been executed via state sync",);
         }
 
-        let execution_guard = self
-            .execution_lock_for_executable_transaction(&executable_tx)
-            .await?;
+        let execution_guard = self.execution_lock_for_executable_transaction(&executable_tx)?;
 
         // We must manually assign the shared object versions to the transaction before
         // executing it. This is because we do not sequence end-of-epoch
         // transactions through consensus.
-        epoch_store
-            .assign_shared_object_versions_idempotent(
-                self.get_object_cache_reader().as_ref(),
-                &[executable_tx.clone()],
-            )
-            .await?;
+        epoch_store.assign_shared_object_versions_idempotent(
+            self.get_object_cache_reader().as_ref(),
+            &[executable_tx.clone()],
+        )?;
 
         let input_objects =
             self.read_objects_for_execution(&tx_lock, &executable_tx, epoch_store)?;

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1691,6 +1691,7 @@ impl AuthorityState {
         self.prepare_certificate(&execution_guard, certificate, input_objects, epoch_store)
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn dry_exec_transaction(
         &self,
         transaction: TransactionData,

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -153,8 +153,8 @@ impl CertTxGuard {
 
 impl CertLockGuard {
     pub fn guard_for_tests() -> Self {
-        let lock = Arc::new(tokio::sync::Mutex::new(()));
-        Self(lock.try_lock_owned().unwrap())
+        let lock = Arc::new(parking_lot::Mutex::new(()));
+        Self(lock.try_lock_arc().unwrap())
     }
 }
 
@@ -1217,17 +1217,17 @@ impl AuthorityPerEpochStore {
         &self.execution_component.executor
     }
 
-    pub async fn acquire_tx_guard(
+    pub fn acquire_tx_guard(
         &self,
         cert: &VerifiedExecutableTransaction,
     ) -> IotaResult<CertTxGuard> {
         let digest = cert.digest();
-        Ok(CertTxGuard(self.acquire_tx_lock(digest).await))
+        Ok(CertTxGuard(self.acquire_tx_lock(digest)))
     }
 
     /// Acquire the lock for a tx without writing to the WAL.
-    pub async fn acquire_tx_lock(&self, digest: &TransactionDigest) -> CertLockGuard {
-        CertLockGuard(self.mutex_table.acquire_lock(*digest).await)
+    pub fn acquire_tx_lock(&self, digest: &TransactionDigest) -> CertLockGuard {
+        CertLockGuard(self.mutex_table.acquire_lock(*digest))
     }
 
     pub fn store_reconfig_state(&self, new_state: &ReconfigState) -> IotaResult {
@@ -1612,7 +1612,7 @@ impl AuthorityPerEpochStore {
     // Because all paths that assign shared versions for a shared object transaction
     // call this function, it is impossible for parent_sync to be updated before
     // this function completes successfully for each affected object id.
-    pub(crate) async fn get_or_init_next_object_versions(
+    pub(crate) fn get_or_init_next_object_versions(
         &self,
         objects_to_init: &[(ObjectID, SequenceNumber)],
         cache_reader: &dyn ObjectCacheRead,
@@ -1691,7 +1691,7 @@ impl AuthorityPerEpochStore {
         Ok(self.tables()?.assigned_shared_object_versions.get(key)?)
     }
 
-    async fn set_assigned_shared_object_versions_with_db_batch(
+    fn set_assigned_shared_object_versions_with_db_batch(
         &self,
         versions: AssignedTxAndVersions,
         db_batch: &mut DBBatch,
@@ -1709,7 +1709,7 @@ impl AuthorityPerEpochStore {
     /// idempotent. We should call this function when we are assigning shared
     /// object versions outside of consensus and do not want to taint the
     /// next_shared_object_versions table.
-    pub async fn assign_shared_object_versions_idempotent(
+    pub fn assign_shared_object_versions_idempotent(
         &self,
         cache_reader: &dyn ObjectCacheRead,
         certificates: &[VerifiedExecutableTransaction],
@@ -1721,11 +1721,9 @@ impl AuthorityPerEpochStore {
             certificates,
             None,
             &BTreeMap::new(),
-        )
-        .await?
+        )?
         .assigned_versions;
-        self.set_assigned_shared_object_versions_with_db_batch(assigned_versions, &mut db_batch)
-            .await?;
+        self.set_assigned_shared_object_versions_with_db_batch(assigned_versions, &mut db_batch)?;
         db_batch.write()?;
         Ok(())
     }
@@ -1944,11 +1942,9 @@ impl AuthorityPerEpochStore {
             &[(certificate, effects)],
             self,
             cache_reader,
-        )
-        .await?;
+        )?;
         let mut db_batch = self.tables()?.assigned_shared_object_versions.batch();
-        self.set_assigned_shared_object_versions_with_db_batch(versions, &mut db_batch)
-            .await?;
+        self.set_assigned_shared_object_versions_with_db_batch(versions, &mut db_batch)?;
         db_batch.write()?;
         Ok(())
     }
@@ -3051,7 +3047,7 @@ impl AuthorityPerEpochStore {
     // version state. Shared object versions in cancelled transactions are
     // assigned to special versions that will cause the transactions to be
     // cancelled in execution engine.
-    async fn process_consensus_transaction_shared_object_versions(
+    fn process_consensus_transaction_shared_object_versions(
         &self,
         cache_reader: &dyn ObjectCacheRead,
         transactions: &[VerifiedExecutableTransaction],
@@ -3068,8 +3064,7 @@ impl AuthorityPerEpochStore {
             transactions,
             randomness_round,
             cancelled_txns,
-        )
-        .await?;
+        )?;
         output.set_assigned_shared_object_versions(assigned_versions, shared_input_next_versions);
         Ok(())
     }
@@ -3112,7 +3107,7 @@ impl AuthorityPerEpochStore {
         .await
     }
 
-    pub async fn assign_shared_object_versions_for_tests(
+    pub fn assign_shared_object_versions_for_tests(
         self: &Arc<Self>,
         cache_reader: &dyn ObjectCacheRead,
         transactions: &[VerifiedExecutableTransaction],
@@ -3124,8 +3119,7 @@ impl AuthorityPerEpochStore {
             None,
             &BTreeMap::new(),
             &mut output,
-        )
-        .await?;
+        )?;
         let mut batch = self.db_batch()?;
         output.write_to_batch(self, &mut batch)?;
         batch.write()?;
@@ -3373,8 +3367,7 @@ impl AuthorityPerEpochStore {
             randomness_round,
             &cancelled_txns,
             output,
-        )
-        .await?;
+        )?;
 
         let (lock, final_round) = self.process_end_of_publish_transactions_and_reconfig(
             output,

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -29,10 +29,7 @@ use iota_types::{
 };
 use itertools::izip;
 use move_core_types::resolver::ModuleResolver;
-use tokio::{
-    sync::{RwLockReadGuard, RwLockWriteGuard},
-    time::Instant,
-};
+use tokio::time::Instant;
 use tracing::{debug, info, trace};
 use typed_store::{
     TypedStoreError,
@@ -144,8 +141,8 @@ pub struct AuthorityStore {
     metrics: AuthorityStoreMetrics,
 }
 
-pub type ExecutionLockReadGuard<'a> = RwLockReadGuard<'a, EpochId>;
-pub type ExecutionLockWriteGuard<'a> = RwLockWriteGuard<'a, EpochId>;
+pub type ExecutionLockReadGuard<'a> = tokio::sync::RwLockReadGuard<'a, EpochId>;
+pub type ExecutionLockWriteGuard<'a> = tokio::sync::RwLockWriteGuard<'a, EpochId>;
 
 impl AuthorityStore {
     /// Open an authority store by directory path.
@@ -592,10 +589,9 @@ impl AuthorityStore {
 
     /// A function that acquires all locks associated with the objects (in order
     /// to avoid deadlocks).
-    async fn acquire_locks(&self, input_objects: &[ObjectRef]) -> Vec<MutexGuard> {
+    fn acquire_locks(&self, input_objects: &[ObjectRef]) -> Vec<MutexGuard> {
         self.mutex_table
             .acquire_locks(input_objects.iter().map(|(_, _, digest)| *digest))
-            .await
     }
 
     pub fn object_exists_by_key(
@@ -859,7 +855,7 @@ impl AuthorityStore {
                 indirect_object.map(|obj| obj.inner().digest())
             })
             .collect();
-        self.objects_lock_table.acquire_read_locks(digests).await
+        self.objects_lock_table.acquire_read_locks(digests)
     }
 
     /// Updates the state resulting from the execution of a certificate.
@@ -868,7 +864,7 @@ impl AuthorityStore {
     /// version, and then writes objects, certificates, parents and clean up
     /// locks atomically.
     #[instrument(level = "debug", skip_all)]
-    pub async fn write_transaction_outputs(
+    pub fn write_transaction_outputs(
         &self,
         epoch_id: EpochId,
         tx_outputs: &[Arc<TransactionOutputs>],
@@ -878,14 +874,14 @@ impl AuthorityStore {
             written.extend(outputs.written.values().cloned());
         }
 
-        let _locks = self.acquire_read_locks_for_indirect_objects(&written).await;
+        let _locks = self.acquire_read_locks_for_indirect_objects(&written);
 
         let mut write_batch = self.perpetual_tables.transactions.batch();
         for outputs in tx_outputs {
             self.write_one_transaction_outputs(&mut write_batch, epoch_id, outputs)?;
         }
         // test crashing before writing the batch
-        fail_point_async!("crash");
+        fail_point!("crash");
 
         write_batch.write()?;
         trace!(
@@ -897,7 +893,7 @@ impl AuthorityStore {
         );
 
         // test crashing before notifying
-        fail_point_async!("crash");
+        fail_point!("crash");
 
         Ok(())
     }
@@ -1069,7 +1065,7 @@ impl AuthorityStore {
         // Other writers may be attempting to acquire locks on the same objects, so a
         // mutex is required.
         // TODO: replace with optimistic db_transactions (i.e. set lock to tx if none)
-        let _mutexes = self.acquire_locks(owned_input_objects).await;
+        let _mutexes = self.acquire_locks(owned_input_objects);
 
         trace!(?owned_input_objects, "acquire_transaction_locks");
         let mut locks_to_write = Vec::new();

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -1055,7 +1055,7 @@ impl AuthorityStore {
         Ok(())
     }
 
-    pub async fn acquire_transaction_locks(
+    pub fn acquire_transaction_locks(
         &self,
         epoch_store: &AuthorityPerEpochStore,
         owned_input_objects: &[ObjectRef],

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -255,9 +255,7 @@ impl AuthorityStorePruner {
         perpetual_db.set_highest_pruned_checkpoint(&mut wb, checkpoint_number)?;
         metrics.last_pruned_checkpoint.set(checkpoint_number as i64);
 
-        let _locks = objects_lock_table
-            .acquire_locks(indirect_objects.into_keys())
-            .await;
+        let _locks = objects_lock_table.acquire_locks(indirect_objects.into_keys());
         if let Some(batch) = pruner_db_wb {
             batch.write()?;
         }

--- a/crates/iota-core/src/authority/authority_test_utils.rs
+++ b/crates/iota-core/src/authority/authority_test_utils.rs
@@ -119,7 +119,7 @@ pub async fn execute_certificate_with_execution_error(
     // when we try to look up our dummy module. we unfortunately don't get a
     // very descriptive error message, but we can at least see that something went
     // wrong inside the VM
-    let (result, execution_error_opt) = authority.try_execute_for_test(&certificate).await?;
+    let (result, execution_error_opt) = authority.try_execute_for_test(&certificate)?;
     let state_after = state_acc.accumulate_cached_live_object_set_for_testing();
     let effects_acc = state_acc.accumulate_effects(vec![result.inner().data().clone()]);
     state.union(&effects_acc);
@@ -127,7 +127,7 @@ pub async fn execute_certificate_with_execution_error(
     assert_eq!(state_after.digest(), state.digest());
 
     if let Some(fullnode) = fullnode {
-        fullnode.try_execute_for_test(&certificate).await?;
+        fullnode.try_execute_for_test(&certificate)?;
     }
     Ok((
         certificate.into_inner(),
@@ -381,7 +381,7 @@ pub async fn execute_sequenced_certificate_to_effects(
         &authority.epoch_store_for_testing(),
     );
 
-    let (result, execution_error_opt) = authority.try_execute_for_test(&certificate).await?;
+    let (result, execution_error_opt) = authority.try_execute_for_test(&certificate)?;
     let effects = result.inner().data().clone();
     Ok((effects, execution_error_opt))
 }

--- a/crates/iota-core/src/authority/authority_test_utils.rs
+++ b/crates/iota-core/src/authority/authority_test_utils.rs
@@ -101,8 +101,7 @@ pub async fn execute_certificate_with_execution_error(
                     &vec![VerifiedExecutableTransaction::new_from_certificate(
                         certificate.clone(),
                     )],
-                )
-                .await?;
+                )?;
         }
         if let Some(fullnode) = fullnode {
             fullnode
@@ -112,8 +111,7 @@ pub async fn execute_certificate_with_execution_error(
                     &vec![VerifiedExecutableTransaction::new_from_certificate(
                         certificate.clone(),
                     )],
-                )
-                .await?;
+                )?;
         }
     }
 

--- a/crates/iota-core/src/authority/shared_object_version_manager.rs
+++ b/crates/iota-core/src/authority/shared_object_version_manager.rs
@@ -38,7 +38,7 @@ pub struct ConsensusSharedObjVerAssignment {
 }
 
 impl SharedObjVerManager {
-    pub async fn assign_versions_from_consensus(
+    pub fn assign_versions_from_consensus(
         epoch_store: &AuthorityPerEpochStore,
         cache_reader: &dyn ObjectCacheRead,
         certificates: &[VerifiedExecutableTransaction],
@@ -50,8 +50,7 @@ impl SharedObjVerManager {
             epoch_store,
             cache_reader,
             randomness_round.is_some(),
-        )
-        .await?;
+        )?;
         let mut assigned_versions = Vec::new();
         // We must update randomness object version first before processing any
         // transaction, so that all reads are using the next version.
@@ -93,7 +92,7 @@ impl SharedObjVerManager {
         })
     }
 
-    pub async fn assign_versions_from_effects(
+    pub fn assign_versions_from_effects(
         certs_and_effects: &[(&VerifiedExecutableTransaction, &TransactionEffects)],
         epoch_store: &AuthorityPerEpochStore,
         cache_reader: &dyn ObjectCacheRead,
@@ -111,8 +110,7 @@ impl SharedObjVerManager {
             epoch_store,
             cache_reader,
             false,
-        )
-        .await?;
+        )?;
         let mut assigned_versions = Vec::new();
         for (cert, effects) in certs_and_effects {
             let cert_assigned_versions: Vec<_> = effects
@@ -262,8 +260,8 @@ impl SharedObjVerManager {
     }
 }
 
-async fn get_or_init_versions(
-    transactions: impl Iterator<Item = &SenderSignedData>,
+fn get_or_init_versions<'a>(
+    transactions: impl Iterator<Item = &'a SenderSignedData>,
     epoch_store: &AuthorityPerEpochStore,
     cache_reader: &dyn ObjectCacheRead,
     generate_randomness: bool,
@@ -289,9 +287,7 @@ async fn get_or_init_versions(
     shared_input_objects.sort();
     shared_input_objects.dedup();
 
-    epoch_store
-        .get_or_init_next_object_versions(&shared_input_objects, cache_reader)
-        .await
+    epoch_store.get_or_init_next_object_versions(&shared_input_objects, cache_reader)
 }
 
 #[cfg(test)]
@@ -352,7 +348,6 @@ mod tests {
             None,
             &BTreeMap::new(),
         )
-        .await
         .unwrap();
         // Check that the shared object's next version is always initialized in the
         // epoch store.
@@ -419,7 +414,6 @@ mod tests {
             Some(RandomnessRound::new(1)),
             &BTreeMap::new(),
         )
-        .await
         .unwrap();
         // Check that the randomness object's next version is initialized.
         assert_eq!(
@@ -576,7 +570,6 @@ mod tests {
             None,
             &cancelled_txns,
         )
-        .await
         .unwrap();
 
         // Check that the final version of the shared object is the lamport version of
@@ -680,7 +673,6 @@ mod tests {
             &epoch_store,
             authority.get_object_cache_reader().as_ref(),
         )
-        .await
         .unwrap();
         // Check that the shared object's next version is always initialized in the
         // epoch store.

--- a/crates/iota-core/src/authority/test_authority_builder.rs
+++ b/crates/iota-core/src/authority/test_authority_builder.rs
@@ -411,7 +411,6 @@ impl<'a> TestAuthorityBuilder<'a> {
                     None,
                     &state.epoch_store_for_testing(),
                 )
-                .await
                 .unwrap();
 
             state

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -287,7 +287,7 @@ impl CheckpointExecutor {
                     pending.is_empty(),
                     "Pending checkpoint execution buffer should be empty after processing last checkpoint of epoch",
                 );
-                fail_point_async!("crash");
+                fail_point!("crash");
                 debug!(epoch = epoch_store.epoch(), "finished epoch");
                 return StopReason::EpochComplete;
             }

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -12,7 +12,7 @@ use std::{
 use arc_swap::ArcSwap;
 use consensus_config::Committee as ConsensusCommittee;
 use consensus_core::CommitConsumerMonitor;
-use iota_macros::{fail_point_async, fail_point_if};
+use iota_macros::{fail_point, fail_point_if};
 use iota_metrics::{monitored_mpsc::UnboundedReceiver, monitored_scope, spawn_monitored_task};
 use iota_types::{
     authenticator_state::ActiveJwk,
@@ -393,7 +393,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             }
         });
 
-        fail_point_async!("crash"); // for tests that produce random crashes
+        fail_point!("crash"); // for tests that produce random crashes
 
         self.transaction_scheduler
             .schedule(transactions_to_schedule)

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -968,41 +968,31 @@ pub trait ExecutionCacheWrite: Send + Sync {
         &self,
         epoch_id: EpochId,
         tx_outputs: Arc<TransactionOutputs>,
-    ) -> BoxFuture<'_, IotaResult>;
+    ) -> IotaResult;
 
     /// Non-fallible version of `try_write_transaction_outputs`.
-    fn write_transaction_outputs(
-        &self,
-        epoch_id: EpochId,
-        tx_outputs: Arc<TransactionOutputs>,
-    ) -> BoxFuture<'_, ()> {
-        Box::pin(async move {
-            self.try_write_transaction_outputs(epoch_id, tx_outputs)
-                .await
-                .expect("storage access failed")
-        })
+    fn write_transaction_outputs(&self, epoch_id: EpochId, tx_outputs: Arc<TransactionOutputs>) {
+        self.try_write_transaction_outputs(epoch_id, tx_outputs)
+            .expect("storage access failed")
     }
 
     /// Attempt to acquire object locks for all of the owned input locks.
-    fn try_acquire_transaction_locks<'a>(
-        &'a self,
-        epoch_store: &'a AuthorityPerEpochStore,
-        owned_input_objects: &'a [ObjectRef],
+    fn try_acquire_transaction_locks(
+        &self,
+        epoch_store: &AuthorityPerEpochStore,
+        owned_input_objects: &[ObjectRef],
         transaction: VerifiedSignedTransaction,
-    ) -> BoxFuture<'a, IotaResult>;
+    ) -> IotaResult;
 
     /// Non-fallible version of `try_acquire_transaction_locks`.
-    fn acquire_transaction_locks<'a>(
-        &'a self,
-        epoch_store: &'a AuthorityPerEpochStore,
-        owned_input_objects: &'a [ObjectRef],
+    fn acquire_transaction_locks(
+        &self,
+        epoch_store: &AuthorityPerEpochStore,
+        owned_input_objects: &[ObjectRef],
         transaction: VerifiedSignedTransaction,
-    ) -> BoxFuture<'a, ()> {
-        Box::pin(async move {
-            self.try_acquire_transaction_locks(epoch_store, owned_input_objects, transaction)
-                .await
-                .expect("storage access failed")
-        })
+    ) {
+        self.try_acquire_transaction_locks(epoch_store, owned_input_objects, transaction)
+            .expect("storage access failed")
     }
 }
 

--- a/crates/iota-core/src/execution_cache/object_locks.rs
+++ b/crates/iota-core/src/execution_cache/object_locks.rs
@@ -195,7 +195,7 @@ impl ObjectLocks {
     }
 
     #[instrument(level = "debug", skip_all)]
-    pub(crate) async fn acquire_transaction_locks(
+    pub(crate) fn acquire_transaction_locks(
         &self,
         cache: &WritebackCache,
         epoch_store: &AuthorityPerEpochStore,
@@ -266,8 +266,6 @@ impl ObjectLocks {
 
 #[cfg(test)]
 mod tests {
-    use futures::FutureExt;
-
     use crate::execution_cache::{
         ExecutionCacheWrite, writeback_cache::writeback_cache_tests::Scenario,
     };
@@ -293,7 +291,6 @@ mod tests {
 
             s.cache
                 .try_acquire_transaction_locks(&s.epoch_store, &[new1, new2], tx1)
-                .await
                 .expect("locks should be available");
 
             // this tx doesn't use the actual objects in question, but we just need
@@ -305,19 +302,16 @@ mod tests {
             // both locks are held by tx1, so this should fail
             s.cache
                 .try_acquire_transaction_locks(&s.epoch_store, &[new1, new2], tx2.clone())
-                .await
                 .unwrap_err();
 
             // new3 is lockable, but new2 is not, so this should fail
             s.cache
                 .try_acquire_transaction_locks(&s.epoch_store, &[new3, new2], tx2.clone())
-                .await
                 .unwrap_err();
 
             // new3 is unlocked
             s.cache
                 .try_acquire_transaction_locks(&s.epoch_store, &[new3], tx2)
-                .await
                 .expect("new3 should be unlocked");
         })
         .await;
@@ -346,14 +340,12 @@ mod tests {
             // fails because we are referring to an old object
             s.cache
                 .try_acquire_transaction_locks(&s.epoch_store, &[new1, old2], tx.clone())
-                .await
                 .unwrap_err();
 
             // succeeds because the above call releases the lock on new1 after failing
             // to get the lock on old2
             s.cache
                 .try_acquire_transaction_locks(&s.epoch_store, &[new1, new2], tx)
-                .await
                 .expect("new1 should be unlocked after revert");
         })
         .await;
@@ -382,7 +374,6 @@ mod tests {
             // fails because we are referring to an old object
             s.cache
                 .try_acquire_transaction_locks(&s.epoch_store, &[new1, old2], tx)
-                .await
                 .unwrap_err();
 
             // this tx doesn't use the actual objects in question, but we just need
@@ -395,7 +386,6 @@ mod tests {
             // to get the lock on old2
             s.cache
                 .try_acquire_transaction_locks(&s.epoch_store, &[new1, new2], tx2)
-                .await
                 .expect("new1 should be unlocked after revert");
         })
         .await;
@@ -421,8 +411,6 @@ mod tests {
             // the fail_point_async! macros above to be elided
             s.cache
                 .try_acquire_transaction_locks(&s.epoch_store, &objects, tx2)
-                .now_or_never()
-                .unwrap()
                 .unwrap();
         })
         .await;

--- a/crates/iota-core/src/execution_cache/passthrough_cache.rs
+++ b/crates/iota-core/src/execution_cache/passthrough_cache.rs
@@ -247,40 +247,36 @@ impl ExecutionCacheWrite for PassthroughCache {
         &'a self,
         epoch_id: EpochId,
         tx_outputs: Arc<TransactionOutputs>,
-    ) -> BoxFuture<'a, IotaResult> {
-        async move {
-            let tx_digest = *tx_outputs.transaction.digest();
-            let effects_digest = tx_outputs.effects.digest();
+    ) -> IotaResult {
+        let tx_digest = *tx_outputs.transaction.digest();
+        let effects_digest = tx_outputs.effects.digest();
 
-            // NOTE: We just check here that live markers exist, not that they are locked to
-            // a specific TX. Why?
-            // 1. Live markers existence prevents re-execution of old certs when objects
-            //    have been upgraded
-            // 2. Not all validators lock, just 2f+1, so transaction should proceed
-            //    regardless (But the live markers should exist which means previous
-            //    transactions finished)
-            // 3. Equivocation possible (different TX) but as long as 2f+1 approves current
-            //    TX its fine
-            // 4. Live markers may have existed when we started processing this tx, but
-            //    could have since been deleted by a concurrent tx that finished first. In
-            //    that case, check if the tx effects exist.
-            self.store
-                .check_owned_objects_are_live(&tx_outputs.live_object_markers_to_delete)?;
+        // NOTE: We just check here that live markers exist, not that they are locked to
+        // a specific TX. Why?
+        // 1. Live markers existence prevents re-execution of old certs when objects
+        //    have been upgraded
+        // 2. Not all validators lock, just 2f+1, so transaction should proceed
+        //    regardless (But the live markers should exist which means previous
+        //    transactions finished)
+        // 3. Equivocation possible (different TX) but as long as 2f+1 approves current
+        //    TX its fine
+        // 4. Live markers may have existed when we started processing this tx, but
+        //    could have since been deleted by a concurrent tx that finished first. In
+        //    that case, check if the tx effects exist.
+        self.store
+            .check_owned_objects_are_live(&tx_outputs.live_object_markers_to_delete)?;
 
-            self.store
-                .write_transaction_outputs(epoch_id, &[tx_outputs])
-                .await?;
+        self.store
+            .write_transaction_outputs(epoch_id, &[tx_outputs])?;
 
-            self.executed_effects_digests_notify_read
-                .notify(&tx_digest, &effects_digest);
+        self.executed_effects_digests_notify_read
+            .notify(&tx_digest, &effects_digest);
 
-            self.metrics
-                .pending_notify_read
-                .set(self.executed_effects_digests_notify_read.num_pending() as i64);
+        self.metrics
+            .pending_notify_read
+            .set(self.executed_effects_digests_notify_read.num_pending() as i64);
 
-            Ok(())
-        }
-        .boxed()
+        Ok(())
     }
 
     fn try_acquire_transaction_locks<'a>(
@@ -288,10 +284,9 @@ impl ExecutionCacheWrite for PassthroughCache {
         epoch_store: &'a AuthorityPerEpochStore,
         owned_input_objects: &'a [ObjectRef],
         transaction: VerifiedSignedTransaction,
-    ) -> BoxFuture<'a, IotaResult> {
+    ) -> IotaResult {
         self.store
             .acquire_transaction_locks(epoch_store, owned_input_objects, transaction)
-            .boxed()
     }
 }
 

--- a/crates/iota-core/src/execution_cache/proxy_cache.rs
+++ b/crates/iota-core/src/execution_cache/proxy_cache.rs
@@ -255,7 +255,7 @@ impl ExecutionCacheWrite for ProxyCache {
         &self,
         epoch_id: EpochId,
         tx_outputs: Arc<TransactionOutputs>,
-    ) -> BoxFuture<'_, IotaResult> {
+    ) -> IotaResult {
         delegate_method!(self.try_write_transaction_outputs(epoch_id, tx_outputs))
     }
 
@@ -264,7 +264,7 @@ impl ExecutionCacheWrite for ProxyCache {
         epoch_store: &'a AuthorityPerEpochStore,
         owned_input_objects: &'a [ObjectRef],
         transaction: VerifiedSignedTransaction,
-    ) -> BoxFuture<'a, IotaResult> {
+    ) -> IotaResult {
         delegate_method!(self.try_acquire_transaction_locks(
             epoch_store,
             owned_input_objects,

--- a/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -15,7 +15,6 @@ use std::{
 
 use iota_config::WritebackCacheConfig;
 use iota_framework::BuiltInFramework;
-use iota_macros::{register_fail_point_async, sim_test};
 use iota_test_transaction_builder::TestTransactionBuilder;
 use iota_types::{
     base_types::{IotaAddress, random_object_ref},
@@ -27,6 +26,7 @@ use iota_types::{
 };
 use prometheus::default_registry;
 use rand::{Rng, SeedableRng, rngs::StdRng};
+use tokio::sync::RwLock;
 
 use super::*;
 use crate::{
@@ -351,8 +351,7 @@ impl Scenario {
         assert!(self.transactions.insert(tx), "transaction is not unique");
 
         self.cache()
-            .write_transaction_outputs(1 /* epoch */, outputs.clone())
-            .await;
+            .write_transaction_outputs(1 /* epoch */, outputs.clone());
 
         self.count_action();
         tx
@@ -364,9 +363,9 @@ impl Scenario {
         self.count_action();
     }
 
-    pub async fn clear_state_end_of_epoch(&self) {
-        let execution_guard = tokio::sync::RwLock::new(1u64);
-        let lock = execution_guard.write().await;
+    pub fn clear_state_end_of_epoch(&self) {
+        let execution_guard = RwLock::new(1u64);
+        let lock = execution_guard.try_write().unwrap();
         self.cache().clear_state_end_of_epoch(&lock);
     }
 
@@ -852,11 +851,7 @@ async fn test_write_transaction_outputs_is_sync() {
         let outputs = s.take_outputs();
         // assert that write_transaction_outputs is sync in non-simtest, which causes
         // the fail_point_async! macros above to be elided
-        s.cache
-            .write_transaction_outputs(1, outputs)
-            .now_or_never()
-            .unwrap()
-            .unwrap();
+        s.cache.write_transaction_outputs(1, outputs).unwrap();
     })
     .await;
 }
@@ -868,7 +863,7 @@ async fn test_missing_reverts_panic() {
     Scenario::iterate(|mut s| async move {
         s.with_created(&[1]);
         s.do_tx().await;
-        s.clear_state_end_of_epoch().await;
+        s.clear_state_end_of_epoch();
     })
     .await;
 }
@@ -911,7 +906,7 @@ async fn test_revert_state_update_created() {
         s.assert_live(&[1]);
 
         s.cache().revert_state_update(&tx1);
-        s.clear_state_end_of_epoch().await;
+        s.clear_state_end_of_epoch();
 
         s.assert_not_exists(&[1]);
     })
@@ -933,7 +928,7 @@ async fn test_revert_state_update_mutated() {
         let tx = s.do_tx().await;
 
         s.cache().revert_state_update(&tx);
-        s.clear_state_end_of_epoch().await;
+        s.clear_state_end_of_epoch();
 
         let version_after_revert = s.cache().get_object(&s.obj_id(1)).unwrap().version();
         assert_eq!(v1, version_after_revert);
@@ -953,23 +948,16 @@ async fn test_invalidate_package_cache_on_revert() {
         s.assert_packages(&[2]);
 
         s.cache().revert_state_update(&tx1);
-        s.clear_state_end_of_epoch().await;
+        s.clear_state_end_of_epoch();
 
         assert!(s.cache().get_package_object(&s.obj_id(2)).is_none());
     })
     .await;
 }
 
-#[sim_test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn test_concurrent_readers() {
     telemetry_subscribers::init_for_testing();
-
-    register_fail_point_async("write_object_entry", || async {
-        tokio::task::yield_now().await;
-    });
-    register_fail_point_async("write_marker_entry", || async {
-        tokio::task::yield_now().await;
-    });
 
     let mut s = Scenario::new(None, Arc::new(AtomicU32::new(0))).await;
     let cache = s.cache.clone();
@@ -1004,11 +992,11 @@ async fn test_concurrent_readers() {
         tokio::task::spawn(async move {
             for (tx1, tx2, _, _) in txns {
                 println!("writing tx1");
-                cache.write_transaction_outputs(1, tx1).await.unwrap();
+                cache.write_transaction_outputs(1, tx1).unwrap();
 
                 barrier.wait().await;
                 println!("writing tx2");
-                cache.write_transaction_outputs(1, tx2).await.unwrap();
+                cache.write_transaction_outputs(1, tx2).unwrap();
             }
         })
     };
@@ -1086,11 +1074,11 @@ async fn test_concurrent_lockers() {
         tokio::task::spawn(async move {
             let mut results = Vec::new();
             for (tx1, _, a_ref, b_ref) in txns {
-                results.push(
-                    cache
-                        .try_acquire_transaction_locks(&epoch_store, &[a_ref, b_ref], tx1)
-                        .await,
-                );
+                results.push(cache.try_acquire_transaction_locks(
+                    &epoch_store,
+                    &[a_ref, b_ref],
+                    tx1,
+                ));
                 barrier.wait().await;
             }
             results
@@ -1105,11 +1093,11 @@ async fn test_concurrent_lockers() {
         tokio::task::spawn(async move {
             let mut results = Vec::new();
             for (_, tx2, a_ref, b_ref) in txns {
-                results.push(
-                    cache
-                        .try_acquire_transaction_locks(&epoch_store, &[a_ref, b_ref], tx2)
-                        .await,
-                );
+                results.push(cache.try_acquire_transaction_locks(
+                    &epoch_store,
+                    &[a_ref, b_ref],
+                    tx2,
+                ));
                 barrier.wait().await;
             }
             results
@@ -1159,11 +1147,11 @@ async fn test_concurrent_lockers_same_tx() {
         tokio::task::spawn(async move {
             let mut results = Vec::new();
             for (tx1, a_ref, b_ref) in txns {
-                results.push(
-                    cache
-                        .try_acquire_transaction_locks(&epoch_store, &[a_ref, b_ref], tx1)
-                        .await,
-                );
+                results.push(cache.try_acquire_transaction_locks(
+                    &epoch_store,
+                    &[a_ref, b_ref],
+                    tx1,
+                ));
                 barrier.wait().await;
             }
             results
@@ -1178,11 +1166,11 @@ async fn test_concurrent_lockers_same_tx() {
         tokio::task::spawn(async move {
             let mut results = Vec::new();
             for (tx1, a_ref, b_ref) in txns {
-                results.push(
-                    cache
-                        .try_acquire_transaction_locks(&epoch_store, &[a_ref, b_ref], tx1)
-                        .await,
-                );
+                results.push(cache.try_acquire_transaction_locks(
+                    &epoch_store,
+                    &[a_ref, b_ref],
+                    tx1,
+                ));
                 barrier.wait().await;
             }
             results
@@ -1231,10 +1219,7 @@ async fn latest_object_cache_race_test() {
                     Owner::AddressOwner(owner),
                 );
 
-                cache
-                    .write_object_entry(&object_id, version, object.into())
-                    .now_or_never()
-                    .unwrap();
+                cache.write_object_entry(&object_id, version, object.into());
 
                 version = version.next();
             }
@@ -1417,10 +1402,7 @@ async fn concurrent_latest_object_cache_race_test() {
             Owner::AddressOwner(owner),
         );
 
-        cache
-            .write_object_entry(&object_id, write_version, object.into())
-            .now_or_never()
-            .unwrap();
+        cache.write_object_entry(&object_id, write_version, object.into());
 
         write_version = write_version.next();
     };
@@ -1542,10 +1524,7 @@ async fn concurrent_latest_object_cache_collision_test() {
             Owner::AddressOwner(owner),
         );
 
-        cache
-            .write_object_entry(&object_id, *write_version, object.into())
-            .now_or_never()
-            .unwrap();
+        cache.write_object_entry(&object_id, *write_version, object.into());
 
         *write_version = write_version.next();
     };

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -57,7 +57,7 @@ use dashmap::{DashMap, mapref::entry::Entry as DashMapEntry};
 use futures::{FutureExt, future::BoxFuture};
 use iota_common::sync::notify_read::NotifyRead;
 use iota_config::WritebackCacheConfig;
-use iota_macros::fail_point_async;
+use iota_macros::{fail_point, fail_point_async};
 use iota_types::{
     accumulator::Accumulator,
     base_types::{EpochId, ObjectID, ObjectRef, SequenceNumber, VerifiedExecutionData},
@@ -514,14 +514,13 @@ impl WritebackCache {
         std::mem::swap(self, &mut new);
     }
 
-    async fn write_object_entry(
+    fn write_object_entry(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,
         object: ObjectEntry,
     ) {
         trace!(?object_id, ?version, ?object, "inserting object entry");
-        fail_point_async!("write_object_entry");
         self.metrics.record_cache_write("object");
 
         // We must hold the lock for the object entry while inserting to the
@@ -563,7 +562,7 @@ impl WritebackCache {
         entry.insert(version, object);
     }
 
-    async fn write_marker_value(
+    fn write_marker_value(
         &self,
         epoch_id: EpochId,
         object_key: &ObjectKey,
@@ -574,7 +573,7 @@ impl WritebackCache {
             object_key,
             marker_value
         );
-        fail_point_async!("write_marker_entry");
+        fail_point!("write_marker_entry");
         self.metrics.record_cache_write("marker");
         self.dirty
             .markers
@@ -836,7 +835,7 @@ impl WritebackCache {
     }
 
     #[instrument(level = "debug", skip_all)]
-    async fn write_transaction_outputs(
+    fn write_transaction_outputs(
         &self,
         epoch_id: EpochId,
         tx_outputs: Arc<TransactionOutputs>,
@@ -860,33 +859,28 @@ impl WritebackCache {
         // object, instead of the deleted/wrapped tombstone, which would cause
         // an execution fork
         for ObjectKey(id, version) in deleted.iter() {
-            self.write_object_entry(id, *version, ObjectEntry::Deleted)
-                .await;
+            self.write_object_entry(id, *version, ObjectEntry::Deleted);
         }
 
         for ObjectKey(id, version) in wrapped.iter() {
-            self.write_object_entry(id, *version, ObjectEntry::Wrapped)
-                .await;
+            self.write_object_entry(id, *version, ObjectEntry::Wrapped);
         }
 
         // Update all markers
         for (object_key, marker_value) in markers.iter() {
-            self.write_marker_value(epoch_id, object_key, *marker_value)
-                .await;
+            self.write_marker_value(epoch_id, object_key, *marker_value);
         }
 
         // Write children before parents to ensure that readers do not observe a parent
         // object before its most recent children are visible.
         for (object_id, object) in written.iter() {
             if object.is_child_object() {
-                self.write_object_entry(object_id, object.version(), object.clone().into())
-                    .await;
+                self.write_object_entry(object_id, object.version(), object.clone().into());
             }
         }
         for (object_id, object) in written.iter() {
             if !object.is_child_object() {
-                self.write_object_entry(object_id, object.version(), object.clone().into())
-                    .await;
+                self.write_object_entry(object_id, object.version(), object.clone().into());
                 if object.is_package() {
                     debug!("caching package: {:?}", object.compute_object_reference());
                     self.packages
@@ -988,9 +982,7 @@ impl WritebackCache {
         // Flush writes to disk before removing anything from dirty set. otherwise,
         // a cache eviction could cause a value to disappear briefly, even if we insert
         // to the cache before removing from the dirty set.
-        self.store
-            .write_transaction_outputs(epoch, &all_outputs)
-            .await?;
+        self.store.write_transaction_outputs(epoch, &all_outputs)?;
 
         for outputs in all_outputs.iter() {
             let tx_digest = outputs.transaction.digest();
@@ -2124,23 +2116,26 @@ impl TransactionCacheRead for WritebackCache {
 }
 
 impl ExecutionCacheWrite for WritebackCache {
-    fn try_acquire_transaction_locks<'a>(
-        &'a self,
-        epoch_store: &'a AuthorityPerEpochStore,
-        owned_input_objects: &'a [ObjectRef],
+    fn try_acquire_transaction_locks(
+        &self,
+        epoch_store: &AuthorityPerEpochStore,
+        owned_input_objects: &[ObjectRef],
         transaction: VerifiedSignedTransaction,
-    ) -> BoxFuture<'a, IotaResult> {
-        self.object_locks
-            .acquire_transaction_locks(self, epoch_store, owned_input_objects, transaction)
-            .boxed()
+    ) -> IotaResult {
+        self.object_locks.acquire_transaction_locks(
+            self,
+            epoch_store,
+            owned_input_objects,
+            transaction,
+        )
     }
 
     fn try_write_transaction_outputs(
         &self,
         epoch_id: EpochId,
         tx_outputs: Arc<TransactionOutputs>,
-    ) -> BoxFuture<'_, IotaResult> {
-        WritebackCache::write_transaction_outputs(self, epoch_id, tx_outputs).boxed()
+    ) -> IotaResult {
+        WritebackCache::write_transaction_outputs(self, epoch_id, tx_outputs)
     }
 }
 

--- a/crates/iota-core/src/execution_driver.rs
+++ b/crates/iota-core/src/execution_driver.rs
@@ -141,8 +141,7 @@ pub async fn execution_process(
                 fail_point_async!("transaction_execution_delay");
                 attempts += 1;
                 let res = authority
-                    .try_execute_immediately(&certificate, expected_effects_digest, &epoch_store_clone)
-                    .await;
+                    .try_execute_immediately(&certificate, expected_effects_digest, &epoch_store_clone);
                 if let Err(e) = res {
                     // Tighten this check everywhere except mainnet - if we don't see an increase in
                     // these crashes we will remove the retries.

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -103,7 +103,7 @@ impl IndexStoreMetrics {
         Self {
             balance_lookup_from_db: register_int_counter_with_registry!(
                 "balance_lookup_from_db",
-                "Total number of balance requests served from cache",
+                "Total number of balance requests served from database",
                 registry,
             )
             .unwrap(),
@@ -115,7 +115,7 @@ impl IndexStoreMetrics {
             .unwrap(),
             all_balance_lookup_from_db: register_int_counter_with_registry!(
                 "all_balance_lookup_from_db",
-                "Total number of all balance requests served from cache",
+                "Total number of all balance requests served from database",
                 registry,
             )
             .unwrap(),
@@ -1320,6 +1320,7 @@ impl IndexStore {
     /// database (expensive) and update the cache. Notice that db read is
     /// done with `spawn_blocking` as that is expected to block
     pub fn get_balance(&self, owner: IotaAddress, coin_type: TypeTag) -> IotaResult<TotalBalance> {
+        self.metrics.balance_lookup_from_total.inc();
         let force_disable_cache = read_size_from_env(ENV_VAR_DISABLE_INDEX_CACHE).unwrap_or(0) > 0;
         let cloned_coin_type = coin_type.clone();
         let metrics_cloned = self.metrics.clone();
@@ -1333,8 +1334,6 @@ impl IndexStore {
             )
             .map_err(|e| IotaError::Execution(format!("Failed to read balance frm DB: {e:?}")));
         }
-
-        self.metrics.balance_lookup_from_total.inc();
 
         let balance = self
             .caches
@@ -1376,6 +1375,7 @@ impl IndexStore {
         &self,
         owner: IotaAddress,
     ) -> IotaResult<Arc<HashMap<TypeTag, TotalBalance>>> {
+        self.metrics.all_balance_lookup_from_total.inc();
         let force_disable_cache = read_size_from_env(ENV_VAR_DISABLE_INDEX_CACHE).unwrap_or(0) > 0;
         let metrics_cloned = self.metrics.clone();
         let coin_index_cloned = self.tables.coin_index.clone();
@@ -1385,7 +1385,6 @@ impl IndexStore {
                 |e| IotaError::Execution(format!("Failed to read all balance from DB: {:?}", e)),
             )?
         } else {
-            self.metrics.all_balance_lookup_from_total.inc();
             self.caches.all_balances.get_with(owner, move || {
                 Self::get_all_balances_from_db(metrics_cloned, coin_index_cloned, owner).map_err(
                     |e| {

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -1374,29 +1374,28 @@ impl IndexStore {
         let force_disable_cache = read_size_from_env(ENV_VAR_DISABLE_INDEX_CACHE).unwrap_or(0) > 0;
         let metrics_cloned = self.metrics.clone();
         let coin_index_cloned = self.tables.coin_index.clone();
+        
+        let balances: Arc<HashMap<TypeTag, TotalBalance>>;
         if force_disable_cache {
-            Self::get_all_balances_from_db(metrics_cloned, coin_index_cloned, owner).map_err(
-                |e| IotaError::Execution(format!("Failed to read all balance from DB: {:?}", e)),
-            )?;
-        }
-
-        self.metrics.all_balance_lookup_from_total.inc();
-        let metrics_cloned = self.metrics.clone();
-        let coin_index_cloned = self.tables.coin_index.clone();
-        self.caches
-            .all_balances
-            .get_with(owner, move || {
-                Self::get_all_balances_from_db(metrics_cloned, coin_index_cloned, owner).map_err(
-                    |e| {
-                        IotaError::Execution(format!("Failed to read all balance from DB: {:?}", e))
-                    },
-                )
-            })
-            .map(|mut balances_map| {
-                Arc::make_mut(&mut balances_map)
-                    .retain(|_, TotalBalance { num_coins, .. }| *num_coins > 0);
-                balances_map
-            })
+            balances = Self::get_all_balances_from_db(metrics_cloned, coin_index_cloned, owner)
+                .map_err(|e| IotaError::Execution(format!("Failed to read all balance from DB: {:?}", e)))?;
+        } else {
+            self.metrics.all_balance_lookup_from_total.inc();        
+            balances = self.caches
+                .all_balances
+                .get_with(owner, move || {
+                    Self::get_all_balances_from_db(metrics_cloned, coin_index_cloned, owner).map_err(
+                        |e| {
+                            IotaError::Execution(format!("Failed to read all balance from DB: {:?}", e))
+                        },
+                    )
+                })?;
+        }        
+        
+        let mut filtered_map = (*balances).clone();
+        filtered_map.retain(|_, TotalBalance { num_coins, .. }| *num_coins > 0);
+        
+        Ok(Arc::new(filtered_map))
     }
 
     /// Read balance for a `IotaAddress` and `CoinType` from the backend

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -32,15 +32,17 @@ use iota_types::{
 };
 use itertools::Itertools;
 use move_core_types::language_storage::{ModuleId, StructTag, TypeTag};
+use parking_lot::ArcMutexGuard;
 use prometheus::{IntCounter, Registry, register_int_counter_with_registry};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use tokio::{sync::OwnedMutexGuard, task::spawn_blocking};
 use tracing::{debug, trace};
 use typed_store::{
     DBMapUtils, TypedStoreError,
     rocks::{DBBatch, DBMap, DBOptions, MetricConf, default_db_options, read_size_from_env},
     traits::{Map, TableSummary, TypedStoreDebug},
 };
+
+type OwnedMutexGuard<T> = ArcMutexGuard<parking_lot::RawMutex, T>;
 
 type OwnerIndexKey = (IotaAddress, ObjectID);
 type CoinIndexKey = (IotaAddress, String, ObjectID);
@@ -316,7 +318,7 @@ impl IndexStore {
         &self.tables
     }
 
-    pub async fn index_coin(
+    pub fn index_coin(
         &self,
         digest: &TransactionDigest,
         batch: &mut DBBatch,
@@ -343,7 +345,7 @@ impl IndexStore {
                 .iter()
                 .map(|((owner, _), _)| *owner),
         );
-        let _locks = self.caches.locks.acquire_locks(addresses.into_iter()).await;
+        let _locks = self.caches.locks.acquire_locks(addresses.into_iter());
         let mut balance_changes: HashMap<IotaAddress, HashMap<TypeTag, TotalBalance>> =
             HashMap::new();
         // Index coin info
@@ -457,7 +459,7 @@ impl IndexStore {
 
     /// Indexes a transaction by updating various indices in the `IndexStore`
     /// with the provided transaction details.
-    pub async fn index_tx(
+    pub fn index_tx(
         &self,
         sender: IotaAddress,
         active_inputs: impl Iterator<Item = ObjectID>,
@@ -519,9 +521,7 @@ impl IndexStore {
         )?;
 
         // Coin Index
-        let cache_updates = self
-            .index_coin(digest, &mut batch, &object_index_changes, tx_coins)
-            .await?;
+        let cache_updates = self.index_coin(digest, &mut batch, &object_index_changes, tx_coins)?;
 
         // Owner index
         batch.delete_batch(
@@ -619,26 +619,21 @@ impl IndexStore {
                     .per_coin_type_balance_changes
                     .iter()
                     .map(|x| x.0.clone()),
-            )
-            .await?;
+            )?;
             self.invalidate_all_balance_cache(
                 cache_updates.all_balance_changes.iter().map(|x| x.0),
-            )
-            .await?;
+            )?;
         }
 
         batch.write()?;
 
         if !invalidate_caches {
             // We cannot update the cache before updating the db or else on failing to write
-            // to db we will update the cache (when we retry to index this
-            // transaction again we would have updated the cache twice).
-            // However, this only means cache is eventually consistent with
-            // the db (within a very short delay)
-            self.update_per_coin_type_cache(cache_updates.per_coin_type_balance_changes)
-                .await?;
-            self.update_all_balance_cache(cache_updates.all_balance_changes)
-                .await?;
+            // to db we will update the cache twice). However, this only means
+            // cache is eventually consistent with the db (within a very short
+            // delay)
+            self.update_per_coin_type_cache(cache_updates.per_coin_type_balance_changes)?;
+            self.update_all_balance_cache(cache_updates.all_balance_changes)?;
         }
         Ok(sequence)
     }
@@ -1324,27 +1319,14 @@ impl IndexStore {
     /// the `all_balance` cache. Only on the second cache miss, we go to the
     /// database (expensive) and update the cache. Notice that db read is
     /// done with `spawn_blocking` as that is expected to block
-    pub async fn get_balance(
-        &self,
-        owner: IotaAddress,
-        coin_type: TypeTag,
-    ) -> IotaResult<TotalBalance> {
+    pub fn get_balance(&self, owner: IotaAddress, coin_type: TypeTag) -> IotaResult<TotalBalance> {
         let force_disable_cache = read_size_from_env(ENV_VAR_DISABLE_INDEX_CACHE).unwrap_or(0) > 0;
         let cloned_coin_type = coin_type.clone();
         let metrics_cloned = self.metrics.clone();
         let coin_index_cloned = self.tables.coin_index.clone();
         if force_disable_cache {
-            return spawn_blocking(move || {
-                Self::get_balance_from_db(
-                    metrics_cloned,
-                    coin_index_cloned,
-                    owner,
-                    cloned_coin_type,
-                )
-            })
-            .await
-            .unwrap()
-            .map_err(|e| IotaError::Execution(format!("Failed to read balance frm DB: {e:?}")));
+            Self::get_balance_from_db(metrics_cloned, coin_index_cloned, owner, cloned_coin_type)
+                .map_err(|e| IotaError::Execution(format!("Failed to read balance frm DB: {e:?}")))?;
         }
 
         self.metrics.balance_lookup_from_total.inc();
@@ -1352,13 +1334,12 @@ impl IndexStore {
         let balance = self
             .caches
             .per_coin_type_balance
-            .get(&(owner, coin_type.clone()))
-            .await;
+            .get(&(owner, coin_type.clone()));
         if let Some(balance) = balance {
             return balance;
         }
         // cache miss, lookup in all balance cache
-        let all_balance = self.caches.all_balances.get(&owner.clone()).await;
+        let all_balance = self.caches.all_balances.get(&owner.clone());
         if let Some(Ok(all_balance)) = all_balance {
             if let Some(balance) = all_balance.get(&coin_type) {
                 return Ok(*balance);
@@ -1369,20 +1350,15 @@ impl IndexStore {
         let coin_index_cloned = self.tables.coin_index.clone();
         self.caches
             .per_coin_type_balance
-            .get_with((owner, coin_type), async move {
-                spawn_blocking(move || {
-                    Self::get_balance_from_db(
-                        metrics_cloned,
-                        coin_index_cloned,
-                        owner,
-                        cloned_coin_type,
-                    )
-                })
-                .await
-                .unwrap()
+            .get_with((owner, coin_type), move || {
+                Self::get_balance_from_db(
+                    metrics_cloned,
+                    coin_index_cloned,
+                    owner,
+                    cloned_coin_type,
+                )
                 .map_err(|e| IotaError::Execution(format!("Failed to read balance frm DB: {e:?}")))
             })
-            .await
     }
 
     /// This method gets the balance for all coin types from the `all_balance`
@@ -1391,7 +1367,7 @@ impl IndexStore {
     /// serves `get_AllBalance()` calls but is also used for serving
     /// `get_Balance()` queries. Notice that db read is performed with
     /// `spawn_blocking` as that is expected to block
-    pub async fn get_all_balance(
+    pub fn get_all_balance(
         &self,
         owner: IotaAddress,
     ) -> IotaResult<Arc<HashMap<TypeTag, TotalBalance>>> {
@@ -1399,37 +1375,19 @@ impl IndexStore {
         let metrics_cloned = self.metrics.clone();
         let coin_index_cloned = self.tables.coin_index.clone();
         if force_disable_cache {
-            return spawn_blocking(move || {
-                Self::get_all_balances_from_db(metrics_cloned, coin_index_cloned, owner)
-            })
-            .await
-            .unwrap()
-            .map_err(|e| {
-                IotaError::Execution(format!("Failed to read all balance from DB: {e:?}"))
-            });
+            Self::get_all_balances_from_db(metrics_cloned, coin_index_cloned, owner).map_err(
+                |e| IotaError::Execution(format!("Failed to read all balance from DB: {:?}", e)),
+            )?;
         }
 
         self.metrics.all_balance_lookup_from_total.inc();
         let metrics_cloned = self.metrics.clone();
         let coin_index_cloned = self.tables.coin_index.clone();
-        self.caches
-            .all_balances
-            .get_with(owner, async move {
-                spawn_blocking(move || {
-                    Self::get_all_balances_from_db(metrics_cloned, coin_index_cloned, owner)
-                })
-                .await
-                .unwrap()
-                .map_err(|e| {
-                    IotaError::Execution(format!("Failed to read all balance from DB: {e:?}"))
-                })
+        self.caches.all_balances.get_with(owner, move || {
+            Self::get_all_balances_from_db(metrics_cloned, coin_index_cloned, owner).map_err(|e| {
+                IotaError::Execution(format!("Failed to read all balance from DB: {:?}", e))
             })
-            .await
-            .map(|mut balances_map| {
-                Arc::make_mut(&mut balances_map)
-                    .retain(|_, TotalBalance { num_coins, .. }| *num_coins > 0);
-                balances_map
-            })
+        })
     }
 
     /// Read balance for a `IotaAddress` and `CoinType` from the backend
@@ -1486,33 +1444,29 @@ impl IndexStore {
         Ok(Arc::new(balances))
     }
 
-    async fn invalidate_per_coin_type_cache(
+    fn invalidate_per_coin_type_cache(
         &self,
         keys: impl IntoIterator<Item = (IotaAddress, TypeTag)>,
     ) -> IotaResult {
-        self.caches
-            .per_coin_type_balance
-            .batch_invalidate(keys)
-            .await;
+        self.caches.per_coin_type_balance.batch_invalidate(keys);
         Ok(())
     }
 
-    async fn invalidate_all_balance_cache(
+    fn invalidate_all_balance_cache(
         &self,
         addresses: impl IntoIterator<Item = IotaAddress>,
     ) -> IotaResult {
-        self.caches.all_balances.batch_invalidate(addresses).await;
+        self.caches.all_balances.batch_invalidate(addresses);
         Ok(())
     }
 
-    async fn update_per_coin_type_cache(
+    fn update_per_coin_type_cache(
         &self,
         keys: impl IntoIterator<Item = ((IotaAddress, TypeTag), IotaResult<TotalBalance>)>,
     ) -> IotaResult {
         self.caches
             .per_coin_type_balance
-            .batch_merge(keys, Self::merge_balance)
-            .await;
+            .batch_merge(keys, Self::merge_balance);
         Ok(())
     }
 
@@ -1534,14 +1488,13 @@ impl IndexStore {
         }
     }
 
-    async fn update_all_balance_cache(
+    fn update_all_balance_cache(
         &self,
         keys: impl IntoIterator<Item = (IotaAddress, IotaResult<Arc<HashMap<TypeTag, TotalBalance>>>)>,
     ) -> IotaResult {
         self.caches
             .all_balances
-            .batch_merge(keys, Self::merge_all_balance)
-            .await;
+            .batch_merge(keys, Self::merge_all_balance);
         Ok(())
     }
 
@@ -1632,19 +1585,17 @@ mod tests {
         };
 
         let tx_coins = (object_map.clone(), written_objects.clone());
-        index_store
-            .index_tx(
-                address,
-                vec![].into_iter(),
-                vec![].into_iter(),
-                vec![].into_iter(),
-                &TransactionEvents { data: vec![] },
-                object_index_changes,
-                &TransactionDigest::random(),
-                1234,
-                Some(tx_coins),
-            )
-            .await?;
+        index_store.index_tx(
+            address,
+            vec![].into_iter(),
+            vec![].into_iter(),
+            vec![].into_iter(),
+            &TransactionEvents { data: vec![] },
+            object_index_changes,
+            &TransactionDigest::random(),
+            1234,
+            Some(tx_coins),
+        )?;
 
         let balance_from_db = IndexStore::get_balance_from_db(
             index_store.metrics.clone(),
@@ -1652,12 +1603,12 @@ mod tests {
             address,
             GAS::type_tag(),
         )?;
-        let balance = index_store.get_balance(address, GAS::type_tag()).await?;
+        let balance = index_store.get_balance(address, GAS::type_tag())?;
         assert_eq!(balance, balance_from_db);
         assert_eq!(balance.balance, 1000);
         assert_eq!(balance.num_coins, 10);
 
-        let all_balance = index_store.get_all_balance(address).await?;
+        let all_balance = index_store.get_all_balance(address)?;
         let balance = all_balance.get(&GAS::type_tag()).unwrap();
         assert_eq!(*balance, balance_from_db);
         assert_eq!(balance.balance, 1000);
@@ -1676,26 +1627,24 @@ mod tests {
             new_dynamic_fields: vec![],
         };
         let tx_coins = (object_map, written_objects);
-        index_store
-            .index_tx(
-                address,
-                vec![].into_iter(),
-                vec![].into_iter(),
-                vec![].into_iter(),
-                &TransactionEvents { data: vec![] },
-                object_index_changes,
-                &TransactionDigest::random(),
-                1234,
-                Some(tx_coins),
-            )
-            .await?;
+        index_store.index_tx(
+            address,
+            vec![].into_iter(),
+            vec![].into_iter(),
+            vec![].into_iter(),
+            &TransactionEvents { data: vec![] },
+            object_index_changes,
+            &TransactionDigest::random(),
+            1234,
+            Some(tx_coins),
+        )?;
         let balance_from_db = IndexStore::get_balance_from_db(
             index_store.metrics.clone(),
             index_store.tables.coin_index.clone(),
             address,
             GAS::type_tag(),
         )?;
-        let balance = index_store.get_balance(address, GAS::type_tag()).await?;
+        let balance = index_store.get_balance(address, GAS::type_tag())?;
         assert_eq!(balance, balance_from_db);
         assert_eq!(balance.balance, 700);
         assert_eq!(balance.num_coins, 7);
@@ -1704,13 +1653,11 @@ mod tests {
         index_store
             .caches
             .per_coin_type_balance
-            .invalidate(&(address, GAS::type_tag()))
-            .await;
-        let all_balance = index_store.get_all_balance(address).await;
-        let all_balance = all_balance?;
+            .invalidate(&(address, GAS::type_tag()));
+        let all_balance = index_store.get_all_balance(address)?;
         assert_eq!(all_balance.get(&GAS::type_tag()).unwrap().balance, 700);
         assert_eq!(all_balance.get(&GAS::type_tag()).unwrap().num_coins, 7);
-        let balance = index_store.get_balance(address, GAS::type_tag()).await?;
+        let balance = index_store.get_balance(address, GAS::type_tag())?;
         assert_eq!(balance, balance_from_db);
         assert_eq!(balance.balance, 700);
         assert_eq!(balance.num_coins, 7);

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -1434,6 +1434,12 @@ impl IndexStore {
                 total_balance += coin_info.balance as i128;
                 coin_object_count += 1;
             }
+
+            if coin_object_count == 0 {
+                // we do not want to return coins with 0 balance
+                continue;
+            }
+
             let coin_type = TypeTag::Struct(Box::new(parse_iota_struct_tag(&coin_type).map_err(
                 |e| IotaError::Execution(format!("Failed to parse event sender address: {e:?}")),
             )?));
@@ -1445,9 +1451,6 @@ impl IndexStore {
                 },
             );
         }
-
-        // We do not want to return coins with 0 balance
-        balances.retain(|_, TotalBalance { num_coins, .. }| *num_coins > 0);
 
         Ok(Arc::new(balances))
     }

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -1515,12 +1515,10 @@ impl IndexStore {
     ) -> IotaResult<Arc<HashMap<TypeTag, TotalBalance>>> {
         if let Ok(old_balance) = old_balance {
             if let Ok(balance_delta) = balance_delta {
-                let mut new_balance = HashMap::new();
-                for (key, value) in old_balance.iter() {
-                    new_balance.insert(key.clone(), *value);
-                }
+                // create a deep copy of the old balance hashmap
+                let mut new_balance = old_balance.as_ref().clone();
                 for (key, delta) in balance_delta.iter() {
-                    let old = new_balance.entry(key.clone()).or_insert(TotalBalance {
+                    let old = new_balance.get(key).unwrap_or(&TotalBalance {
                         balance: 0,
                         num_coins: 0,
                     });
@@ -1528,7 +1526,13 @@ impl IndexStore {
                         balance: old.balance + delta.balance,
                         num_coins: old.num_coins + delta.num_coins,
                     };
-                    new_balance.insert(key.clone(), new_total);
+
+                    // Remove entries where num_coins becomes zero to prevent cache bloat
+                    if new_total.num_coins == 0 {
+                        new_balance.remove(key);
+                    } else {
+                        new_balance.insert(key.clone(), new_total);
+                    }
                 }
                 Ok(Arc::new(new_balance))
             } else {

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -1380,24 +1380,18 @@ impl IndexStore {
         let metrics_cloned = self.metrics.clone();
         let coin_index_cloned = self.tables.coin_index.clone();
 
-        let balances: Arc<HashMap<TypeTag, TotalBalance>> = if force_disable_cache {
-            Self::get_all_balances_from_db(metrics_cloned, coin_index_cloned, owner).map_err(
-                |e| IotaError::Execution(format!("Failed to read all balance from DB: {:?}", e)),
-            )?
-        } else {
-            self.caches.all_balances.get_with(owner, move || {
-                Self::get_all_balances_from_db(metrics_cloned, coin_index_cloned, owner).map_err(
-                    |e| {
-                        IotaError::Execution(format!("Failed to read all balance from DB: {:?}", e))
-                    },
-                )
-            })?
-        };
+        if force_disable_cache {
+            return Self::get_all_balances_from_db(metrics_cloned, coin_index_cloned, owner)
+                .map_err(|e| {
+                    IotaError::Execution(format!("Failed to read all balance from DB: {:?}", e))
+                });
+        }
 
-        let mut filtered_map = (*balances).clone();
-        filtered_map.retain(|_, TotalBalance { num_coins, .. }| *num_coins > 0);
-
-        Ok(Arc::new(filtered_map))
+        self.caches.all_balances.get_with(owner, move || {
+            Self::get_all_balances_from_db(metrics_cloned, coin_index_cloned, owner).map_err(|e| {
+                IotaError::Execution(format!("Failed to read all balance from DB: {:?}", e))
+            })
+        })
     }
 
     /// Read balance for a `IotaAddress` and `CoinType` from the backend
@@ -1451,6 +1445,10 @@ impl IndexStore {
                 },
             );
         }
+
+        // We do not want to return coins with 0 balance
+        balances.retain(|_, TotalBalance { num_coins, .. }| *num_coins > 0);
+
         Ok(Arc::new(balances))
     }
 

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -1383,11 +1383,20 @@ impl IndexStore {
         self.metrics.all_balance_lookup_from_total.inc();
         let metrics_cloned = self.metrics.clone();
         let coin_index_cloned = self.tables.coin_index.clone();
-        self.caches.all_balances.get_with(owner, move || {
-            Self::get_all_balances_from_db(metrics_cloned, coin_index_cloned, owner).map_err(|e| {
-                IotaError::Execution(format!("Failed to read all balance from DB: {:?}", e))
+        self.caches
+            .all_balances
+            .get_with(owner, move || {
+                Self::get_all_balances_from_db(metrics_cloned, coin_index_cloned, owner).map_err(
+                    |e| {
+                        IotaError::Execution(format!("Failed to read all balance from DB: {:?}", e))
+                    },
+                )
             })
-        })
+            .map(|mut balances_map| {
+                Arc::make_mut(&mut balances_map)
+                    .retain(|_, TotalBalance { num_coins, .. }| *num_coins > 0);
+                balances_map
+            })
     }
 
     /// Read balance for a `IotaAddress` and `CoinType` from the backend

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -1325,8 +1325,13 @@ impl IndexStore {
         let metrics_cloned = self.metrics.clone();
         let coin_index_cloned = self.tables.coin_index.clone();
         if force_disable_cache {
-            Self::get_balance_from_db(metrics_cloned, coin_index_cloned, owner, cloned_coin_type)
-                .map_err(|e| IotaError::Execution(format!("Failed to read balance frm DB: {e:?}")))?;
+            return Self::get_balance_from_db(
+                metrics_cloned,
+                coin_index_cloned,
+                owner,
+                cloned_coin_type,
+            )
+            .map_err(|e| IotaError::Execution(format!("Failed to read balance frm DB: {e:?}")));
         }
 
         self.metrics.balance_lookup_from_total.inc();

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -1374,27 +1374,25 @@ impl IndexStore {
         let force_disable_cache = read_size_from_env(ENV_VAR_DISABLE_INDEX_CACHE).unwrap_or(0) > 0;
         let metrics_cloned = self.metrics.clone();
         let coin_index_cloned = self.tables.coin_index.clone();
-        
-        let balances: Arc<HashMap<TypeTag, TotalBalance>>;
-        if force_disable_cache {
-            balances = Self::get_all_balances_from_db(metrics_cloned, coin_index_cloned, owner)
-                .map_err(|e| IotaError::Execution(format!("Failed to read all balance from DB: {:?}", e)))?;
+
+        let balances: Arc<HashMap<TypeTag, TotalBalance>> = if force_disable_cache {
+            Self::get_all_balances_from_db(metrics_cloned, coin_index_cloned, owner).map_err(
+                |e| IotaError::Execution(format!("Failed to read all balance from DB: {:?}", e)),
+            )?
         } else {
-            self.metrics.all_balance_lookup_from_total.inc();        
-            balances = self.caches
-                .all_balances
-                .get_with(owner, move || {
-                    Self::get_all_balances_from_db(metrics_cloned, coin_index_cloned, owner).map_err(
-                        |e| {
-                            IotaError::Execution(format!("Failed to read all balance from DB: {:?}", e))
-                        },
-                    )
-                })?;
-        }        
-        
+            self.metrics.all_balance_lookup_from_total.inc();
+            self.caches.all_balances.get_with(owner, move || {
+                Self::get_all_balances_from_db(metrics_cloned, coin_index_cloned, owner).map_err(
+                    |e| {
+                        IotaError::Execution(format!("Failed to read all balance from DB: {:?}", e))
+                    },
+                )
+            })?
+        };
+
         let mut filtered_map = (*balances).clone();
         filtered_map.retain(|_, TotalBalance { num_coins, .. }| *num_coins > 0);
-        
+
         Ok(Arc::new(filtered_map))
     }
 

--- a/crates/iota-core/src/test_utils.rs
+++ b/crates/iota-core/src/test_utils.rs
@@ -65,7 +65,7 @@ pub async fn send_and_confirm_transaction(
     // set against StateAccumulator for testing and regression detection
     let state_acc = StateAccumulator::new_for_tests(authority.get_accumulator_store().clone());
     let mut state = state_acc.accumulate_cached_live_object_set_for_testing();
-    let (result, _execution_error_opt) = authority.try_execute_for_test(&certificate).await?;
+    let (result, _execution_error_opt) = authority.try_execute_for_test(&certificate)?;
     let state_after = state_acc.accumulate_cached_live_object_set_for_testing();
     let effects_acc = state_acc.accumulate_effects(vec![result.inner().data().clone()]);
     state.union(&effects_acc);
@@ -73,7 +73,7 @@ pub async fn send_and_confirm_transaction(
     assert_eq!(state_after.digest(), state.digest());
 
     if let Some(fullnode) = fullnode {
-        fullnode.try_execute_for_test(&certificate).await?;
+        fullnode.try_execute_for_test(&certificate)?;
     }
     Ok((certificate.into_inner(), result.into_inner()))
 }

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -221,7 +221,6 @@ async fn test_dry_run_transaction_block() {
             transaction.data().intent_message().value.clone(),
             transaction_digest,
         )
-        .await
         .unwrap();
     assert_eq!(*response.effects.status(), IotaExecutionStatus::Success);
     let gas_usage = response.effects.gas_cost_summary();
@@ -246,7 +245,6 @@ async fn test_dry_run_transaction_block() {
     );
     let (response, _, _, _) = fullnode
         .dry_exec_transaction(txn_data, transaction_digest)
-        .await
         .unwrap();
     let gas_usage_no_gas = response.effects.gas_cost_summary();
     assert_eq!(*response.effects.status(), IotaExecutionStatus::Success);
@@ -280,7 +278,6 @@ async fn test_dry_run_no_gas_big_transfer() {
             signed.data().intent_message().value.clone(),
             *signed.digest(),
         )
-        .await
         .unwrap();
     assert_eq!(*dry_run_res.effects.status(), IotaExecutionStatus::Success);
 }
@@ -953,12 +950,10 @@ async fn test_dry_run_on_validator() {
     let (validator, _fullnode, transaction, _gas_object_id, _shared_object_id) =
         construct_shared_object_transaction_with_sequence_number(None).await;
     let transaction_digest = *transaction.digest();
-    let response = validator
-        .dry_exec_transaction(
-            transaction.data().intent_message().value.clone(),
-            transaction_digest,
-        )
-        .await;
+    let response = validator.dry_exec_transaction(
+        transaction.data().intent_message().value.clone(),
+        transaction_digest,
+    );
     assert!(response.is_err());
 }
 
@@ -1075,7 +1070,7 @@ async fn test_dry_run_dev_inspect_dynamic_field_too_new() {
     let transaction = to_sender_signed_transaction(data.clone(), &sender_key);
     let digest = *transaction.digest();
     let DryRunTransactionBlockResponse { effects, .. } =
-        fullnode.dry_exec_transaction(data, digest).await.unwrap().0;
+        fullnode.dry_exec_transaction(data, digest).unwrap().0;
     assert_eq!(effects.deleted().len(), 0);
 }
 
@@ -1128,7 +1123,7 @@ async fn test_dry_run_dev_inspect_max_gas_version() {
     let transaction = to_sender_signed_transaction(data.clone(), &sender_key);
     let digest = *transaction.digest();
     let DryRunTransactionBlockResponse { effects, .. } =
-        fullnode.dry_exec_transaction(data, digest).await.unwrap().0;
+        fullnode.dry_exec_transaction(data, digest).unwrap().0;
     assert_eq!(effects.status(), &IotaExecutionStatus::Success);
 }
 
@@ -5523,7 +5518,6 @@ async fn test_for_inc_201_dry_run() {
             signed.data().intent_message().value.clone(),
             *signed.digest(),
         )
-        .await
         .unwrap();
     assert_eq!(effects.status(), &IotaExecutionStatus::Success);
 

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -3701,11 +3701,7 @@ async fn create_and_retrieve_df_info(function: &IdentStr) -> (IotaAddress, Vec<D
 
     let add_cert = init_certified_transaction(add_txn, &authority_state);
 
-    let add_effects = authority_state
-        .execute_for_test(&add_cert)
-        .await
-        .0
-        .into_message();
+    let add_effects = authority_state.execute_for_test(&add_cert).0.into_message();
 
     assert!(add_effects.status().is_ok(), "{:?}", add_effects.status());
     assert_eq!(add_effects.created().len(), 1);
@@ -4790,7 +4786,7 @@ async fn test_shared_object_transaction_shared_locks_not_set() {
 
     // Executing the certificate now panics since it was not sequenced and shared
     // locks are not set
-    let _ = authority.execute_for_test(&certificate).await;
+    let _ = authority.execute_for_test(&certificate);
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
@@ -4819,7 +4815,7 @@ async fn test_shared_object_transaction_ok() {
     assert_eq!(shared_object_version, OBJECT_START_VERSION);
 
     // Finally (Re-)execute the contract should succeed.
-    authority.execute_for_test(&certificate).await;
+    authority.execute_for_test(&certificate);
 
     // Ensure transaction effects are available.
     authority.notify_read_effects(&certificate).await.unwrap();
@@ -5001,7 +4997,7 @@ async fn test_consensus_message_processed() {
 
         // on authority1, we always sequence via consensus
         send_consensus(&authority1, &certificate).await;
-        let (effects1, _execution_error_opt) = authority1.execute_for_test(&certificate).await;
+        let (effects1, _execution_error_opt) = authority1.execute_for_test(&certificate);
 
         // now, on authority2, we send 0 or 1 consensus messages, then we either
         // sequence and execute via effects or via handle_certificate_v1, then
@@ -5012,11 +5008,7 @@ async fn test_consensus_message_processed() {
         }
 
         let effects2 = if send_first && rng.gen_bool(0.5) {
-            authority2
-                .execute_for_test(&certificate)
-                .await
-                .0
-                .into_message()
+            authority2.execute_for_test(&certificate).0.into_message()
         } else {
             let epoch_store = authority2.epoch_store_for_testing();
             epoch_store
@@ -5027,7 +5019,7 @@ async fn test_consensus_message_processed() {
                 )
                 .await
                 .unwrap();
-            authority2.execute_for_test(&certificate).await;
+            authority2.execute_for_test(&certificate);
             authority2
                 .get_transaction_cache_reader()
                 .get_executed_effects(transaction_digest)

--- a/crates/iota-core/src/unit_tests/congestion_control_tests.rs
+++ b/crates/iota-core/src/unit_tests/congestion_control_tests.rs
@@ -395,7 +395,7 @@ async fn test_congestion_control_execution_cancellation() {
         )
         .await
         .unwrap();
-    let (effects_2, execution_error) = authority_state_2.execute_for_test(&cert).await;
+    let (effects_2, execution_error) = authority_state_2.execute_for_test(&cert);
 
     // Should result in the same cancellation.
     assert_eq!(

--- a/crates/iota-core/src/unit_tests/transaction_deny_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_deny_tests.rs
@@ -491,7 +491,7 @@ async fn test_certificate_deny() {
         CertifiedTransaction::new(tx.into_message(), vec![signature], epoch_store.committee())
             .unwrap(),
     );
-    let (effects, _) = state.execute_for_test(&cert).await;
+    let (effects, _) = state.execute_for_test(&cert);
     assert!(matches!(
         effects.status(),
         &ExecutionStatus::Failure {

--- a/crates/iota-core/src/validator_tx_finalizer.rs
+++ b/crates/iota-core/src/validator_tx_finalizer.rs
@@ -356,16 +356,13 @@ mod tests {
             _client_addr: Option<SocketAddr>,
         ) -> Result<HandleCertificateResponseV1, IotaError> {
             let epoch_store = self.authority.epoch_store_for_testing();
-            let (effects, _) = self
-                .authority
-                .try_execute_immediately(
-                    &VerifiedExecutableTransaction::new_from_certificate(
-                        VerifiedCertificate::new_unchecked(request.certificate),
-                    ),
-                    None,
-                    &epoch_store,
-                )
-                .await?;
+            let (effects, _) = self.authority.try_execute_immediately(
+                &VerifiedExecutableTransaction::new_from_certificate(
+                    VerifiedCertificate::new_unchecked(request.certificate),
+                ),
+                None,
+                &epoch_store,
+            )?;
             let events = match effects.events_digest() {
                 None => TransactionEvents::default(),
                 Some(digest) => self.authority.get_transaction_events(digest)?,

--- a/crates/iota-json-rpc/src/authority_state.rs
+++ b/crates/iota-json-rpc/src/authority_state.rs
@@ -106,7 +106,7 @@ pub trait StateRead: Send + Sync {
 
     // transaction_execution_api
     #[allow(clippy::type_complexity)]
-    async fn dry_exec_transaction(
+    fn dry_exec_transaction(
         &self,
         transaction: TransactionData,
         transaction_digest: TransactionDigest,
@@ -316,7 +316,7 @@ impl StateRead for AuthorityState {
             .await?)
     }
 
-    async fn dry_exec_transaction(
+    fn dry_exec_transaction(
         &self,
         transaction: TransactionData,
         transaction_digest: TransactionDigest,

--- a/crates/iota-json-rpc/src/authority_state.rs
+++ b/crates/iota-json-rpc/src/authority_state.rs
@@ -458,24 +458,30 @@ impl StateRead for AuthorityState {
         owner: IotaAddress,
         coin_type: TypeTag,
     ) -> StateReadResult<TotalBalance> {
-        Ok(self
-            .indexes
-            .as_ref()
-            .ok_or(IotaError::IndexStoreNotAvailable)?
-            .get_balance(owner, coin_type)
-            .await?)
+        let indexes = self.indexes.clone();
+        Ok(tokio::task::spawn_blocking(move || {
+            indexes
+                .as_ref()
+                .ok_or(IotaError::IndexStoreNotAvailable)?
+                .get_balance(owner, coin_type)
+        })
+        .await
+        .map_err(|e: JoinError| IotaError::Execution(e.to_string()))??)
     }
 
     async fn get_all_balance(
         &self,
         owner: IotaAddress,
     ) -> StateReadResult<Arc<HashMap<TypeTag, TotalBalance>>> {
-        Ok(self
-            .indexes
-            .as_ref()
-            .ok_or(IotaError::IndexStoreNotAvailable)?
-            .get_all_balance(owner)
-            .await?)
+        let indexes = self.indexes.clone();
+        Ok(tokio::task::spawn_blocking(move || {
+            indexes
+                .as_ref()
+                .ok_or(IotaError::IndexStoreNotAvailable)?
+                .get_all_balance(owner)
+        })
+        .await
+        .map_err(|e: JoinError| IotaError::Execution(e.to_string()))??)
     }
 
     fn get_verified_checkpoint_by_sequence_number(

--- a/crates/iota-json-rpc/src/authority_state.rs
+++ b/crates/iota-json-rpc/src/authority_state.rs
@@ -326,9 +326,7 @@ impl StateRead for AuthorityState {
         TransactionEffects,
         Option<ObjectID>,
     )> {
-        Ok(self
-            .dry_exec_transaction(transaction, transaction_digest)
-            .await?)
+        Ok(self.dry_exec_transaction(transaction, transaction_digest)?)
     }
 
     async fn dev_inspect_transaction_block(

--- a/crates/iota-json-rpc/src/transaction_execution_api.rs
+++ b/crates/iota-json-rpc/src/transaction_execution_api.rs
@@ -285,10 +285,17 @@ impl TransactionExecutionApi {
         let (txn_data, txn_digest, input_objs) =
             self.prepare_dry_run_transaction_block(tx_bytes)?;
         let sender = txn_data.sender();
-        let (resp, written_objects, transaction_effects, mock_gas) = self
-            .state
-            .dry_exec_transaction(txn_data.clone(), txn_digest)
-            .await?;
+
+        // Use spawn_blocking since dry_exec_transaction is a long-running synchronous
+        // operation
+        let state = self.state.clone();
+        let (resp, written_objects, transaction_effects, mock_gas) =
+            tokio::task::spawn_blocking(move || {
+                state.dry_exec_transaction(txn_data.clone(), txn_digest)
+            })
+            .await
+            .map_err(Error::from)??;
+
         let object_cache = ObjectProviderCache::new_with_cache(self.state.clone(), written_objects);
         let balance_changes = get_balance_changes_from_effect(
             &object_cache,

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -2098,6 +2098,7 @@ impl IotaNode {
         tx: &Transaction,
         span: tracing::Span,
     ) {
+        let _guard = span.enter();
         let transaction =
             iota_types::executable_transaction::VerifiedExecutableTransaction::new_unchecked(
                 iota_types::executable_transaction::ExecutableTransaction::new_from_data_and_sig(
@@ -2107,8 +2108,6 @@ impl IotaNode {
             );
         state
             .try_execute_immediately(&transaction, None, epoch_store)
-            .instrument(span)
-            .await
             .unwrap();
     }
 

--- a/crates/iota-single-node-benchmark/src/single_node.rs
+++ b/crates/iota-single-node-benchmark/src/single_node.rs
@@ -140,7 +140,6 @@ impl SingleValidator {
                 transaction.data().intent_message().value.clone(),
                 *transaction.digest(),
             )
-            .await
             .unwrap()
             .2;
         assert!(effects.status().is_ok());
@@ -322,7 +321,6 @@ impl SingleValidator {
                 self.get_validator().get_object_cache_reader().as_ref(),
                 &transactions,
             )
-            .await
             .unwrap();
     }
 }

--- a/crates/iota-single-node-benchmark/src/single_node.rs
+++ b/crates/iota-single-node-benchmark/src/single_node.rs
@@ -126,7 +126,6 @@ impl SingleValidator {
         let effects = self
             .get_validator()
             .try_execute_immediately(&executable, None, &self.epoch_store)
-            .await
             .unwrap()
             .0;
         assert!(effects.status().is_ok());
@@ -158,7 +157,6 @@ impl SingleValidator {
                 );
                 self.get_validator()
                     .try_execute_immediately(&cert, None, &self.epoch_store)
-                    .await
                     .unwrap()
                     .0
             }

--- a/crates/iota-storage/Cargo.toml
+++ b/crates/iota-storage/Cargo.toml
@@ -31,7 +31,7 @@ lru.workspace = true
 moka.workspace = true
 num_enum.workspace = true
 object_store.workspace = true
-parking_lot.workspace = true
+parking_lot = { workspace = true, features = ["arc_lock"] }
 percent-encoding = "2.3"
 prometheus.workspace = true
 reqwest.workspace = true

--- a/crates/iota-storage/src/mutex_table.rs
+++ b/crates/iota-storage/src/mutex_table.rs
@@ -17,59 +17,54 @@ use std::{
     time::Duration,
 };
 
-use async_trait::async_trait;
 use iota_metrics::spawn_monitored_task;
-use tokio::{
-    sync::{
-        Mutex, OwnedMutexGuard, OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock, TryLockError,
-    },
-    task::JoinHandle,
-    time::Instant,
-};
+use parking_lot::{ArcMutexGuard, ArcRwLockReadGuard, ArcRwLockWriteGuard, Mutex, RwLock};
+use tokio::{task::JoinHandle, time::Instant};
 use tracing::info;
 
-#[async_trait]
+type OwnedMutexGuard<T> = ArcMutexGuard<parking_lot::RawMutex, T>;
+type OwnedRwLockReadGuard<T> = ArcRwLockReadGuard<parking_lot::RawRwLock, T>;
+type OwnedRwLockWriteGuard<T> = ArcRwLockWriteGuard<parking_lot::RawRwLock, T>;
+
 pub trait Lock: Send + Sync + Default {
     type Guard;
     type ReadGuard;
-    async fn lock_owned(self: Arc<Self>) -> Self::Guard;
-    fn try_lock_owned(self: Arc<Self>) -> Result<Self::Guard, TryLockError>;
-    async fn read_lock_owned(self: Arc<Self>) -> Self::ReadGuard;
+    fn lock_owned(self: Arc<Self>) -> Self::Guard;
+    fn try_lock_owned(self: Arc<Self>) -> Option<Self::Guard>;
+    fn read_lock_owned(self: Arc<Self>) -> Self::ReadGuard;
 }
 
-#[async_trait::async_trait]
 impl Lock for Mutex<()> {
     type Guard = OwnedMutexGuard<()>;
     type ReadGuard = Self::Guard;
 
-    async fn lock_owned(self: Arc<Self>) -> Self::Guard {
-        self.lock_owned().await
+    fn lock_owned(self: Arc<Self>) -> Self::Guard {
+        self.lock_arc()
     }
 
-    fn try_lock_owned(self: Arc<Self>) -> Result<Self::Guard, TryLockError> {
-        self.try_lock_owned()
+    fn try_lock_owned(self: Arc<Self>) -> Option<Self::Guard> {
+        self.try_lock_arc()
     }
 
-    async fn read_lock_owned(self: Arc<Self>) -> Self::ReadGuard {
-        self.lock_owned().await
+    fn read_lock_owned(self: Arc<Self>) -> Self::ReadGuard {
+        self.lock_arc()
     }
 }
 
-#[async_trait::async_trait]
 impl Lock for RwLock<()> {
     type Guard = OwnedRwLockWriteGuard<()>;
     type ReadGuard = OwnedRwLockReadGuard<()>;
 
-    async fn lock_owned(self: Arc<Self>) -> Self::Guard {
-        self.write_owned().await
+    fn lock_owned(self: Arc<Self>) -> Self::Guard {
+        self.write_arc()
     }
 
-    fn try_lock_owned(self: Arc<Self>) -> Result<Self::Guard, TryLockError> {
-        self.try_write_owned()
+    fn try_lock_owned(self: Arc<Self>) -> Option<Self::Guard> {
+        self.try_write_arc()
     }
 
-    async fn read_lock_owned(self: Arc<Self>) -> Self::ReadGuard {
-        self.read_owned().await
+    fn read_lock_owned(self: Arc<Self>) -> Self::ReadGuard {
+        self.read_arc()
     }
 }
 
@@ -101,8 +96,8 @@ impl fmt::Display for TryAcquireLockError {
 }
 
 impl Error for TryAcquireLockError {}
-pub type MutexGuard = tokio::sync::OwnedMutexGuard<()>;
-pub type RwLockGuard = tokio::sync::OwnedRwLockReadGuard<()>;
+pub type MutexGuard = OwnedMutexGuard<()>;
+pub type RwLockGuard = OwnedRwLockReadGuard<()>;
 
 impl<K: Hash + Eq + Send + Sync + 'static, L: Lock + 'static> LockTable<K, L> {
     pub fn new_with_cleanup(
@@ -164,7 +159,7 @@ impl<K: Hash + Eq + Send + Sync + 'static, L: Lock + 'static> LockTable<K, L> {
         let mut num_removed: usize = 0;
         for shard in lock_table.iter() {
             let map = shard.try_write();
-            if map.is_err() {
+            if map.is_none() {
                 continue;
             }
             map.unwrap().retain(|_k, v| {
@@ -198,7 +193,7 @@ impl<K: Hash + Eq + Send + Sync + 'static, L: Lock + 'static> LockTable<K, L> {
         hash % self.lock_table.len()
     }
 
-    pub async fn acquire_locks<I>(&self, object_iter: I) -> Vec<L::Guard>
+    pub fn acquire_locks<I>(&self, object_iter: I) -> Vec<L::Guard>
     where
         I: Iterator<Item = K>,
         K: Ord,
@@ -209,12 +204,12 @@ impl<K: Hash + Eq + Send + Sync + 'static, L: Lock + 'static> LockTable<K, L> {
 
         let mut guards = Vec::with_capacity(objects.len());
         for object in objects.into_iter() {
-            guards.push(self.acquire_lock(object).await);
+            guards.push(self.acquire_lock(object));
         }
         guards
     }
 
-    pub async fn acquire_read_locks(&self, mut objects: Vec<K>) -> Vec<L::ReadGuard>
+    pub fn acquire_read_locks(&self, mut objects: Vec<K>) -> Vec<L::ReadGuard>
     where
         K: Ord,
     {
@@ -222,15 +217,15 @@ impl<K: Hash + Eq + Send + Sync + 'static, L: Lock + 'static> LockTable<K, L> {
         objects.dedup();
         let mut guards = Vec::with_capacity(objects.len());
         for object in objects.into_iter() {
-            guards.push(self.get_lock(object).await.read_lock_owned().await);
+            guards.push(self.get_lock(object).read_lock_owned());
         }
         guards
     }
 
-    pub async fn get_lock(&self, k: K) -> Arc<L> {
+    pub fn get_lock(&self, k: K) -> Arc<L> {
         let lock_idx = self.get_lock_idx(&k);
         let element = {
-            let map = self.lock_table[lock_idx].read().await;
+            let map = self.lock_table[lock_idx].read();
             map.get(&k).cloned()
         };
         if let Some(element) = element {
@@ -238,7 +233,7 @@ impl<K: Hash + Eq + Send + Sync + 'static, L: Lock + 'static> LockTable<K, L> {
         } else {
             // element doesn't exist
             let element = {
-                let mut map = self.lock_table[lock_idx].write().await;
+                let mut map = self.lock_table[lock_idx].write();
                 map.entry(k)
                     .or_insert_with(|| {
                         self.size.fetch_add(1, Ordering::SeqCst);
@@ -250,8 +245,8 @@ impl<K: Hash + Eq + Send + Sync + 'static, L: Lock + 'static> LockTable<K, L> {
         }
     }
 
-    pub async fn acquire_lock(&self, k: K) -> L::Guard {
-        self.get_lock(k).await.lock_owned().await
+    pub fn acquire_lock(&self, k: K) -> L::Guard {
+        self.get_lock(k).lock_owned()
     }
 
     pub fn try_acquire_lock(&self, k: K) -> Result<L::Guard, TryAcquireLockError> {
@@ -259,18 +254,18 @@ impl<K: Hash + Eq + Send + Sync + 'static, L: Lock + 'static> LockTable<K, L> {
         let element = {
             let map = self.lock_table[lock_idx]
                 .try_read()
-                .map_err(|_| TryAcquireLockError::LockTableLocked)?;
+                .ok_or(TryAcquireLockError::LockTableLocked)?;
             map.get(&k).cloned()
         };
         if let Some(element) = element {
             let lock = element.try_lock_owned();
-            Ok(lock.map_err(|_| TryAcquireLockError::LockEntryLocked)?)
+            lock.ok_or(TryAcquireLockError::LockEntryLocked)
         } else {
             // element doesn't exist
             let element = {
                 let mut map = self.lock_table[lock_idx]
                     .try_write()
-                    .map_err(|_| TryAcquireLockError::LockTableLocked)?;
+                    .ok_or(TryAcquireLockError::LockTableLocked)?;
                 map.entry(k)
                     .or_insert_with(|| {
                         self.size.fetch_add(1, Ordering::SeqCst);
@@ -279,7 +274,7 @@ impl<K: Hash + Eq + Send + Sync + 'static, L: Lock + 'static> LockTable<K, L> {
                     .clone()
             };
             let lock = element.try_lock_owned();
-            lock.map_err(|_| TryAcquireLockError::LockEntryLocked)
+            lock.ok_or(TryAcquireLockError::LockEntryLocked)
         }
     }
 }
@@ -298,32 +293,34 @@ async fn test_mutex_table_concurrent_in_same_bucket() {
     use tokio::time::{sleep, timeout};
     let mutex_table = Arc::new(MutexTable::<String>::new(1));
     let john = mutex_table.try_acquire_lock("john".to_string());
-    john.unwrap();
+    let _ = john.unwrap();
     {
         let mutex_table = mutex_table.clone();
-        spawn_monitored_task!(async move {
-            mutex_table.acquire_lock("john".to_string()).await;
+        std::thread::spawn(move || {
+            let _ = mutex_table.acquire_lock("john".to_string());
         });
     }
     sleep(Duration::from_millis(50)).await;
     let jane = mutex_table.try_acquire_lock("jane".to_string());
-    jane.unwrap();
+    let _ = jane.unwrap();
 
     let mutex_table = Arc::new(MutexTable::<String>::new(1));
-    let _john = mutex_table.acquire_lock("john".to_string()).await;
+    let _john = mutex_table.acquire_lock("john".to_string());
     {
         let mutex_table = mutex_table.clone();
-        spawn_monitored_task!(async move {
-            mutex_table.acquire_lock("john".to_string()).await;
+        std::thread::spawn(move || {
+            let _ = mutex_table.acquire_lock("john".to_string());
         });
     }
     sleep(Duration::from_millis(50)).await;
     let jane = timeout(
         Duration::from_secs(1),
-        mutex_table.acquire_lock("jane".to_string()),
+        tokio::task::spawn_blocking(move || {
+            let _ = mutex_table.acquire_lock("jane".to_string());
+        }),
     )
     .await;
-    jane.unwrap();
+    let _ = jane.unwrap();
 }
 
 #[tokio::test]
@@ -342,17 +339,17 @@ async fn test_mutex_table() {
     assert!(jane.is_ok());
     MutexTable::cleanup(mutex_table.lock_table.clone());
     let map = mutex_table.lock_table.first().as_ref().unwrap().try_read();
-    assert!(map.is_ok());
+    assert!(map.is_some());
     assert_eq!(map.unwrap().len(), 2);
     drop(john2);
     MutexTable::cleanup(mutex_table.lock_table.clone());
     let map = mutex_table.lock_table.first().as_ref().unwrap().try_read();
-    assert!(map.is_ok());
+    assert!(map.is_some());
     assert_eq!(map.unwrap().len(), 1);
     drop(jane);
     MutexTable::cleanup(mutex_table.lock_table.clone());
     let map = mutex_table.lock_table.first().as_ref().unwrap().try_read();
-    assert!(map.is_ok());
+    assert!(map.is_some());
     assert!(map.unwrap().is_empty());
 }
 
@@ -374,7 +371,7 @@ async fn test_acquire_locks() {
         object_1,
     ];
 
-    let locks = mutex_table.acquire_locks(objects.clone().into_iter()).await;
+    let locks = mutex_table.acquire_locks(objects.clone().into_iter());
     assert_eq!(locks.len(), 3);
 
     for object in objects.clone() {
@@ -382,7 +379,7 @@ async fn test_acquire_locks() {
     }
 
     drop(locks);
-    let locks = mutex_table.acquire_locks(objects.into_iter()).await;
+    let locks = mutex_table.acquire_locks(objects.into_iter());
     assert_eq!(locks.len(), 3);
 }
 
@@ -391,9 +388,9 @@ async fn test_read_locks() {
     let mutex_table =
         RwLockTable::<String>::new_with_cleanup(1, Duration::from_secs(10), Duration::MAX, 1000);
     let lock = "lock".to_string();
-    let locks1 = mutex_table.acquire_read_locks(vec![lock.clone()]).await;
+    let locks1 = mutex_table.acquire_read_locks(vec![lock.clone()]);
     assert!(mutex_table.try_acquire_lock(lock.clone()).is_err());
-    let locks2 = mutex_table.acquire_read_locks(vec![lock.clone()]).await;
+    let locks2 = mutex_table.acquire_read_locks(vec![lock.clone()]);
     drop(locks1);
     drop(locks2);
     assert!(mutex_table.try_acquire_lock(lock.clone()).is_ok());
@@ -440,7 +437,7 @@ async fn test_mutex_table_bg_cleanup() {
     // Wait for bg cleanup to be triggered
     tokio::time::sleep(Duration::from_secs(10)).await;
     for entry in mutex_table.lock_table.iter() {
-        let locked = entry.read().await;
+        let locked = entry.read();
         assert!(locked.is_empty());
     }
 }
@@ -488,7 +485,7 @@ async fn test_mutex_table_bg_cleanup_with_size_threshold() {
     tokio::task::yield_now().await;
     assert_eq!(mutex_table.size(), 0);
     for entry in mutex_table.lock_table.iter() {
-        let locked = entry.read().await;
+        let locked = entry.read();
         assert!(locked.is_empty());
     }
 }

--- a/crates/iota-storage/src/sharded_lru.rs
+++ b/crates/iota-storage/src/sharded_lru.rs
@@ -5,13 +5,12 @@
 use std::{
     collections::{HashMap, hash_map::RandomState},
     fmt::Debug,
-    future::Future,
     hash::{BuildHasher, Hash},
     num::NonZeroUsize,
 };
 
 use lru::LruCache;
-use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 pub struct ShardedLruCache<K, V, S = RandomState> {
     shards: Vec<RwLock<LruCache<K, V>>>,
@@ -53,36 +52,36 @@ where
         h % self.shards.len()
     }
 
-    async fn read_shard(&self, key: &K) -> RwLockReadGuard<'_, LruCache<K, V>> {
+    fn read_shard(&self, key: &K) -> RwLockReadGuard<'_, LruCache<K, V>> {
         let shard_idx = self.shard_id(key);
-        self.shards[shard_idx].read().await
+        self.shards[shard_idx].read()
     }
 
-    async fn write_shard(&self, key: &K) -> RwLockWriteGuard<'_, LruCache<K, V>> {
+    fn write_shard(&self, key: &K) -> RwLockWriteGuard<'_, LruCache<K, V>> {
         let shard_idx = self.shard_id(key);
-        self.shards[shard_idx].write().await
+        self.shards[shard_idx].write()
     }
 
-    pub async fn invalidate(&self, key: &K) -> Option<V> {
-        self.write_shard(key).await.pop(key)
+    pub fn invalidate(&self, key: &K) -> Option<V> {
+        self.write_shard(key).pop(key)
     }
 
-    pub async fn batch_invalidate(&self, keys: impl IntoIterator<Item = K>) {
+    pub fn batch_invalidate(&self, keys: impl IntoIterator<Item = K>) {
         let mut grouped = HashMap::new();
         for key in keys.into_iter() {
             let shard_idx = self.shard_id(&key);
             grouped.entry(shard_idx).or_insert(vec![]).push(key);
         }
         for (shard_idx, keys) in grouped.into_iter() {
-            let mut lock = self.shards[shard_idx].write().await;
+            let mut lock = self.shards[shard_idx].write();
             for key in keys {
                 lock.pop(&key);
             }
         }
     }
 
-    pub async fn merge(&self, key: K, value: &V, f: fn(&V, &V) -> V) {
-        let mut shard = self.write_shard(&key).await;
+    pub fn merge(&self, key: K, value: &V, f: fn(&V, &V) -> V) {
+        let mut shard = self.write_shard(&key);
         let old_value = shard.get(&key);
         if let Some(old_value) = old_value {
             let new_value = f(old_value, value);
@@ -90,11 +89,7 @@ where
         }
     }
 
-    pub async fn batch_merge(
-        &self,
-        key_values: impl IntoIterator<Item = (K, V)>,
-        f: fn(&V, &V) -> V,
-    ) {
+    pub fn batch_merge(&self, key_values: impl IntoIterator<Item = (K, V)>, f: fn(&V, &V) -> V) {
         let mut grouped = HashMap::new();
         for (key, value) in key_values.into_iter() {
             let shard_idx = self.shard_id(&key);
@@ -104,7 +99,7 @@ where
                 .push((key, value));
         }
         for (shard_idx, keys) in grouped.into_iter() {
-            let mut shard = self.shards[shard_idx].write().await;
+            let mut shard = self.shards[shard_idx].write();
             for (key, value) in keys.into_iter() {
                 let old_value = shard.get(&key);
                 if let Some(old_value) = old_value {
@@ -115,23 +110,23 @@ where
         }
     }
 
-    pub async fn get(&self, key: &K) -> Option<V> {
-        self.read_shard(key).await.peek(key).cloned()
+    pub fn get(&self, key: &K) -> Option<V> {
+        self.read_shard(key).peek(key).cloned()
     }
 
-    pub async fn get_with(&self, key: K, init: impl Future<Output = V>) -> V {
-        let shard = self.read_shard(&key).await;
+    pub fn get_with(&self, key: K, init: impl FnOnce() -> V) -> V {
+        let shard = self.read_shard(&key);
         let value = shard.peek(&key);
         if let Some(value) = value {
             return value.clone();
         }
         drop(shard);
-        let mut shard = self.write_shard(&key).await;
+        let mut shard = self.write_shard(&key);
         let value = shard.get(&key);
         if let Some(value) = value {
             return value.clone();
         }
-        let value = init.await;
+        let value = init();
         let cloned_value = value.clone();
         shard.push(key, value);
         cloned_value

--- a/crates/iota-transactional-test-runner/src/lib.rs
+++ b/crates/iota-transactional-test-runner/src/lib.rs
@@ -180,7 +180,6 @@ impl TransactionalAdapter for ValidatorWithFullnode {
     ) -> IotaResult<DryRunTransactionBlockResponse> {
         self.fullnode
             .dry_exec_transaction(transaction_block, transaction_digest)
-            .await
             .map(|result| result.0)
     }
 

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -152,11 +152,12 @@ macro_rules! retry_transaction {
         $(,)?
 
     ) => {{
+        use std::time::Duration;
+
         use rand::{
             distributions::{Distribution, Uniform},
             rngs::ThreadRng,
         };
-        use tokio::time::{Duration, sleep};
         use tracing::{error, info};
 
         let mut retries = 0;
@@ -187,7 +188,7 @@ macro_rules! retry_transaction {
                             "transaction write conflict detected, sleeping"
                         );
                     }
-                    sleep(delay).await;
+                    std::thread::sleep(delay);
                 }
                 _ => break status,
             }

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 
 use super::*;
 use crate::{
-    reopen, retry_transaction, retry_transaction_forever,
+    reopen, retry_transaction,
     rocks::{
         iter::{Iter, RevIter},
         safe_iter::{SafeIter, SafeRevIter},
@@ -1267,26 +1267,6 @@ async fn test_retry_transaction() {
         tx1.commit()
     })
     // fails after hitting maximum number of retries
-    .unwrap_err();
-
-    // obviously we cannot verify that this never times out, this is more just a
-    // test to make sure the macro compiles as expected.
-    tokio::time::timeout(Duration::from_secs(1), async move {
-        retry_transaction_forever!({
-            let mut tx1 = db
-                .transaction_without_snapshot()
-                .expect("failed to initiate transaction");
-            tx1.insert_batch(&db, vec![(key.to_string(), "2".to_string())])
-                .unwrap();
-            db.insert(&key, &"1".to_string()).unwrap();
-            tx1.commit()
-        })
-        // fails after hitting maximum number of retries
-        .unwrap_err();
-        panic!("should never finish");
-    })
-    .await
-    // must timeout
     .unwrap_err();
 }
 


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.42.2, v1.43.1)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/0c7c26ed8907fea4f88f010eda0348adc212fbb1
- Description:

Transaction execution doesn't need to be async, so this PR removes that.
This won't have any significant performance impacts, because most of the
previous await points were probably "fake" in that they were unlikely to actually yield execution.

We made some more functions than upstream "sync", because we were touching them anyways.
Also, in the json-rpc, we made the code a bit more efficient and fixed some wrong metrics and different behavior if the cache was force disabled (filter was not applied).

## Links to any relevant issues

Part of #6151    

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
