### PR TITLE
upstream(node): Reduce thread stall log level from ERROR to WARN

### DIFF
--- a/crates/iota-metrics/src/thread_stall_monitor.rs
+++ b/crates/iota-metrics/src/thread_stall_monitor.rs
@@ -7,7 +7,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use tracing::{error, info};
+use tracing::{info, warn};
 
 use crate::{get_metrics, spawn_logged_monitored_task};
 
@@ -41,12 +41,12 @@ const ALERT_THRESHOLD: Duration = Duration::from_millis(500);
 // is detected.
 #[inline(never)]
 extern "C" fn thread_monitor_report_stall(duration_ms: u64) {
-    error!("Thread stalled for {}ms", duration_ms);
+    warn!("Thread stalled for {}ms", duration_ms);
 }
 
 #[inline(never)]
 extern "C" fn thread_monitor_report_stall_cleared(duration_ms: u64) {
-    error!("Thread stall cleared after {}ms", duration_ms);
+    warn!("Thread stall cleared after {}ms", duration_ms);
 }
 
 /// Monitors temporary stalls in tokio scheduling every MONITOR_INTERVAL.


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.42.2, v1.43.1)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/2ecc920b215874b2739fd69eca42554417c8daee
- Description:
Thread stalls can happen spuriously. Most operators are not equipped to
debug the error and it is hard to help them debug too. So downgrading to
warn to be less distracting.

## Links to any relevant issues

Part of #6151    

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
