### PR TITLE
chore: update `tempfile` and replace `into_path` with `keep`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3022,7 +3022,7 @@ dependencies = [
  "crossterm_winapi",
  "mio 1.0.2",
  "parking_lot 0.12.3",
- "rustix",
+ "rustix 0.38.37",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -3860,12 +3860,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8697,6 +8697,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12371,8 +12377,21 @@ dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.14",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13855,14 +13874,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom 0.3.3",
  "once_cell",
- "rustix",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -13892,7 +13911,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix",
+ "rustix 0.38.37",
  "windows-sys 0.48.0",
 ]
 
@@ -13902,7 +13921,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
 dependencies = [
- "rustix",
+ "rustix 0.38.37",
  "windows-sys 0.59.0",
 ]
 
@@ -15349,7 +15368,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.37",
 ]
 
 [[package]]
@@ -15873,8 +15892,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
 dependencies = [
  "libc",
- "linux-raw-sys",
- "rustix",
+ "linux-raw-sys 0.4.14",
+ "rustix 0.38.37",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -344,7 +344,7 @@ syn = { version = "1.0.104", features = ["full", "derive", "extra-traits"] }
 sysinfo = "^0.33"
 tabled = { version = "0.12" }
 tap = "1.0.1"
-tempfile = "3.3.0"
+tempfile = "3.20.0"
 test-fuzz = "3.0.4"
 thiserror = "1.0.40"
 # tokio is defined at a specific version to support patching with iota-sim

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -447,7 +447,7 @@ mod tests {
 
         let temp_dir = TempDir::new().unwrap();
         let parameters = Parameters {
-            db_path: temp_dir.into_path(),
+            db_path: temp_dir.keep(),
             ..Default::default()
         };
         let txn_verifier = NoopTransactionVerifier {};

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -67,7 +67,7 @@ impl Context {
             AuthorityIndex::new_for_test(0),
             committee,
             Parameters {
-                db_path: temp_dir.into_path(),
+                db_path: temp_dir.keep(),
                 ..Default::default()
             },
             ProtocolConfig::get_for_max_version_UNSAFE(),

--- a/crates/iota-archival/src/tests.rs
+++ b/crates/iota-archival/src/tests.rs
@@ -50,7 +50,7 @@ struct TestState {
 fn temp_dir() -> std::path::PathBuf {
     tempdir()
         .expect("Failed to open temporary directory")
-        .into_path()
+        .keep()
 }
 
 async fn write_new_checkpoints_to_store(

--- a/crates/iota-aws-orchestrator/src/settings.rs
+++ b/crates/iota-aws-orchestrator/src/settings.rs
@@ -179,7 +179,7 @@ impl Settings {
     #[cfg(test)]
     pub fn new_for_test() -> Self {
         // Create a temporary public key file.
-        let mut path = tempfile::tempdir().unwrap().into_path();
+        let mut path = tempfile::tempdir().unwrap().keep();
         path.push("test_public_key.pub");
         let public_key = "This is a fake public key for tests";
         fs::write(&path, public_key).unwrap();

--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -628,7 +628,7 @@ mod test {
 
     #[sim_test(config = "test_config()")]
     async fn test_data_ingestion_pipeline() {
-        let path = nondeterministic!(TempDir::new().unwrap()).into_path();
+        let path = nondeterministic!(TempDir::new().unwrap()).keep();
         let test_cluster = Arc::new(
             init_test_cluster_builder(4, 5000)
                 .with_data_ingestion_dir(path.clone())

--- a/crates/iota-cluster-test/src/cluster.rs
+++ b/crates/iota-cluster-test/src/cluster.rs
@@ -158,7 +158,7 @@ impl LocalNewCluster {
 #[async_trait]
 impl Cluster for LocalNewCluster {
     async fn start(options: &ClusterTestOpt) -> Result<Self, anyhow::Error> {
-        let data_ingestion_path = tempdir()?.into_path();
+        let data_ingestion_path = tempdir()?.keep();
         // TODO: options should contain port instead of address
         let fullnode_rpc_addr = options.fullnode_address.as_ref().map(|addr| {
             addr.parse::<SocketAddr>()

--- a/crates/iota-core/src/authority/authority_per_epoch_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store_pruner.rs
@@ -94,7 +94,7 @@ mod tests {
 
     #[test]
     fn test_basic_epoch_pruner() {
-        let parent_directory = tempfile::tempdir().unwrap().into_path();
+        let parent_directory = tempfile::tempdir().unwrap().keep();
         let directories: Vec<_> = vec!["epoch_0", "epoch_1", "epoch_3", "epoch_4"]
             .into_iter()
             .map(|name| parent_directory.join(name))

--- a/crates/iota-core/src/authority/authority_store_pruner.rs
+++ b/crates/iota-core/src/authority/authority_store_pruner.rs
@@ -981,24 +981,24 @@ mod tests {
     // Tests pruning old version of live objects.
     #[tokio::test]
     async fn test_pruning_objects() {
-        let path = tempfile::tempdir().unwrap().into_path();
+        let path = tempfile::tempdir().unwrap().keep();
         let to_keep = run_pruner(&path, 3, 2, 1000, 0).await;
         assert_eq!(
             HashSet::from_iter(to_keep),
             get_keys_after_pruning(&path).unwrap()
         );
-        run_pruner(&tempfile::tempdir().unwrap().into_path(), 3, 2, 1000, 0).await;
+        run_pruner(&tempfile::tempdir().unwrap().keep(), 3, 2, 1000, 0).await;
     }
 
     // Tests pruning deleted objects (object tombstones).
     #[tokio::test]
     async fn test_pruning_tombstones() {
-        let path = tempfile::tempdir().unwrap().into_path();
+        let path = tempfile::tempdir().unwrap().keep();
         let to_keep = run_pruner(&path, 0, 0, 1000, 0).await;
         assert_eq!(to_keep.len(), 0);
         assert_eq!(get_keys_after_pruning(&path).unwrap().len(), 0);
 
-        let path = tempfile::tempdir().unwrap().into_path();
+        let path = tempfile::tempdir().unwrap().keep();
         let to_keep = run_pruner(&path, 3, 0, 1000, 0).await;
         assert_eq!(to_keep.len(), 0);
         assert_eq!(get_keys_after_pruning(&path).unwrap().len(), 0);
@@ -1006,7 +1006,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_ref_count_pruning() {
-        let path = tempfile::tempdir().unwrap().into_path();
+        let path = tempfile::tempdir().unwrap().keep();
         run_pruner(&path, 3, 2, 1000, 1).await;
         {
             let perpetual_db = AuthorityPerpetualTables::open(&path, None);
@@ -1015,7 +1015,7 @@ mod tests {
             assert_eq!(count, 1000);
         }
 
-        let path = tempfile::tempdir().unwrap().into_path();
+        let path = tempfile::tempdir().unwrap().keep();
         run_pruner(&path, 3, 0, 1000, 1).await;
         {
             let perpetual_db = AuthorityPerpetualTables::open(&path, None);
@@ -1036,7 +1036,7 @@ mod tests {
     #[cfg(not(target_env = "msvc"))]
     #[tokio::test]
     async fn test_db_size_after_compaction() -> Result<(), anyhow::Error> {
-        let primary_path = tempfile::tempdir()?.into_path();
+        let primary_path = tempfile::tempdir()?.keep();
         let perpetual_db = Arc::new(AuthorityPerpetualTables::open(&primary_path, None));
         let total_unique_object_ids = 10_000;
         let num_versions_per_object = 10;
@@ -1202,7 +1202,7 @@ mod pprof_tests {
         // stack frame in it.
         let registry = Registry::default();
         let metrics = AuthorityStorePruningMetrics::new(&registry);
-        let primary_path = tempfile::tempdir()?.into_path();
+        let primary_path = tempfile::tempdir()?.keep();
         let perpetual_db = Arc::new(AuthorityPerpetualTables::open(&primary_path, None));
         let effects = insert_keys(&perpetual_db.objects)?;
         AuthorityStorePruner::prune_objects(
@@ -1237,7 +1237,7 @@ mod pprof_tests {
         // `ignore_range_delete` set to true (default mode). We then record a
         // cpu profile of the `get()` calls and do not find any range fragmentation
         // stack frame in it.
-        let primary_path = tempfile::tempdir()?.into_path();
+        let primary_path = tempfile::tempdir()?.keep();
         let perpetual_db = Arc::new(AuthorityPerpetualTables::open(&primary_path, None));
         let effects = insert_keys(&perpetual_db.objects)?;
         let registry = Registry::default();

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -2203,7 +2203,7 @@ async fn diagnose_split_brain(
     let fork_logs_text = format!("{header}\n\n{diff_patches}\n\n");
     let path = tempfile::tempdir()
         .expect("Failed to create tempdir")
-        .into_path()
+        .keep()
         .join(Path::new("checkpoint_fork_dump.txt"));
     let mut file = File::create(path).unwrap();
     write!(file, "{fork_logs_text}").unwrap();

--- a/crates/iota-core/src/epoch/consensus_store_pruner.rs
+++ b/crates/iota-core/src/epoch/consensus_store_pruner.rs
@@ -240,7 +240,7 @@ mod tests {
             let epoch_retention = 0;
             let current_epoch = 0;
 
-            let base_directory = tempfile::tempdir().unwrap().into_path();
+            let base_directory = tempfile::tempdir().unwrap().keep();
 
             create_epoch_directories(&base_directory, vec!["0", "other"]);
 
@@ -264,7 +264,7 @@ mod tests {
             let epoch_retention = 1;
             let current_epoch = 100;
 
-            let base_directory = tempfile::tempdir().unwrap().into_path();
+            let base_directory = tempfile::tempdir().unwrap().keep();
 
             create_epoch_directories(&base_directory, vec!["97", "98", "99", "100", "other"]);
 
@@ -290,7 +290,7 @@ mod tests {
             let epoch_retention = 0;
             let current_epoch = 100;
 
-            let base_directory = tempfile::tempdir().unwrap().into_path();
+            let base_directory = tempfile::tempdir().unwrap().keep();
 
             create_epoch_directories(&base_directory, vec!["97", "98", "99", "100", "other"]);
 
@@ -314,7 +314,7 @@ mod tests {
         let epoch_retention = 1;
         let epoch_prune_period = std::time::Duration::from_millis(500);
 
-        let base_directory = tempfile::tempdir().unwrap().into_path();
+        let base_directory = tempfile::tempdir().unwrap().keep();
 
         // We create some directories up to epoch 100
         create_epoch_directories(&base_directory, vec!["97", "98", "99", "100", "other"]);

--- a/crates/iota-data-ingestion-core/src/executor.rs
+++ b/crates/iota-data-ingestion-core/src/executor.rs
@@ -403,7 +403,7 @@ pub async fn setup_single_workflow<W: Worker + 'static>(
     executor.register(worker_pool).await?;
     Ok((
         executor.run(
-            tempfile::tempdir()?.into_path(),
+            tempfile::tempdir()?.keep(),
             Some(remote_store_url),
             vec![],
             reader_options.unwrap_or_default(),

--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -494,7 +494,7 @@ impl CheckpointReader {
 
         let path = match config.ingestion_path {
             Some(p) => p,
-            None => tempfile::tempdir()?.into_path(),
+            None => tempfile::tempdir()?.keep(),
         };
 
         let reader = CheckpointReaderActor {

--- a/crates/iota-data-ingestion-core/src/tests.rs
+++ b/crates/iota-data-ingestion-core/src/tests.rs
@@ -400,7 +400,7 @@ async fn file_progress_store() {
 fn temp_dir() -> std::path::PathBuf {
     tempfile::tempdir()
         .expect("Failed to open temporary directory")
-        .into_path()
+        .keep()
 }
 
 async fn create_executor_bundle() -> ExecutorBundle {

--- a/crates/iota-data-ingestion/src/bin/archival_ingestion.rs
+++ b/crates/iota-data-ingestion/src/bin/archival_ingestion.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<()> {
     executor.register(worker_pool).await?;
     executor
         .run(
-            tempfile::tempdir()?.into_path(),
+            tempfile::tempdir()?.keep(),
             Some(config.remote_store_url),
             vec![],
             ReaderOptions::default(),

--- a/crates/iota-e2e-tests/tests/traffic_control_tests.rs
+++ b/crates/iota-e2e-tests/tests/traffic_control_tests.rs
@@ -423,7 +423,7 @@ async fn test_validator_traffic_control_error_delegated() -> Result<(), anyhow::
         delegate_spam_blocking: true,
         delegate_error_blocking: false,
         destination_port: 8080,
-        drain_path: tempfile::tempdir().unwrap().into_path().join("drain"),
+        drain_path: tempfile::tempdir().unwrap().keep().join("drain"),
         drain_timeout_secs: 10,
     };
     let network_config = ConfigBuilder::new_with_temp_dir()
@@ -494,7 +494,7 @@ async fn test_fullnode_traffic_control_spam_delegated() -> Result<(), anyhow::Er
         delegate_spam_blocking: true,
         delegate_error_blocking: false,
         destination_port: 9000,
-        drain_path: tempfile::tempdir().unwrap().into_path().join("drain"),
+        drain_path: tempfile::tempdir().unwrap().keep().join("drain"),
         drain_timeout_secs: 10,
     };
     let test_cluster = TestClusterBuilder::new()
@@ -566,7 +566,7 @@ async fn test_traffic_control_dead_mans_switch() -> Result<(), anyhow::Error> {
     };
 
     // sink all traffic to trigger dead mans switch
-    let drain_path = tempfile::tempdir().unwrap().into_path().join("drain");
+    let drain_path = tempfile::tempdir().unwrap().keep().join("drain");
     assert!(!drain_path.exists(), "Expected drain file to not yet exist",);
 
     let firewall_config = RemoteFirewallConfig {
@@ -615,7 +615,7 @@ async fn test_traffic_control_dead_mans_switch() -> Result<(), anyhow::Error> {
 #[tokio::test]
 async fn test_traffic_control_manual_set_dead_mans_switch() -> Result<(), anyhow::Error> {
     telemetry_subscribers::init_for_testing();
-    let drain_path = tempfile::tempdir().unwrap().into_path().join("drain");
+    let drain_path = tempfile::tempdir().unwrap().keep().join("drain");
     assert!(!drain_path.exists(), "Expected drain file to not yet exist",);
     File::create(&drain_path).expect("Failed to touch nodefw drain file");
     assert!(drain_path.exists(), "Expected drain file to exist",);

--- a/crates/iota-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/iota-graphql-rpc/src/test_infra/cluster.rs
@@ -56,7 +56,7 @@ pub async fn start_cluster(
     graphql_connection_config: ConnectionConfig,
     internal_data_source_rpc_port: Option<u16>,
 ) -> Cluster {
-    let data_ingestion_path = tempfile::tempdir().unwrap().into_path();
+    let data_ingestion_path = tempfile::tempdir().unwrap().keep();
     let db_url = graphql_connection_config.db_url.clone();
     let cancellation_token = CancellationToken::new();
     // Starts validator+fullnode

--- a/crates/iota-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/iota-graphql-rpc/tests/e2e_tests.rs
@@ -27,7 +27,7 @@ mod tests {
 
     async fn prep_executor_cluster() -> (ConnectionConfig, ExecutorCluster) {
         let rng = StdRng::from_seed([12; 32]);
-        let data_ingestion_path = tempdir().unwrap().into_path();
+        let data_ingestion_path = tempdir().unwrap().keep();
         let mut sim = Simulacrum::new_with_rng(rng);
         sim.set_data_ingestion_path(data_ingestion_path.clone());
 
@@ -97,7 +97,7 @@ mod tests {
     async fn test_simple_client_simulator_cluster() {
         let rng = StdRng::from_seed([12; 32]);
         let mut sim = Simulacrum::new_with_rng(rng);
-        let data_ingestion_path = tempdir().unwrap().into_path();
+        let data_ingestion_path = tempdir().unwrap().keep();
         sim.set_data_ingestion_path(data_ingestion_path.clone());
 
         sim.create_checkpoint();

--- a/crates/iota-graphql-rpc/tests/examples_validation_tests.rs
+++ b/crates/iota-graphql-rpc/tests/examples_validation_tests.rs
@@ -143,7 +143,7 @@ mod tests {
     #[serial]
     async fn good_examples_within_limits() {
         let rng = StdRng::from_seed([12; 32]);
-        let data_ingestion_path = tempdir().unwrap().into_path();
+        let data_ingestion_path = tempdir().unwrap().keep();
         let mut sim = Simulacrum::new_with_rng(rng);
         let (mut max_nodes, mut max_output_nodes, mut max_depth, mut max_payload) = (0, 0, 0, 0);
 
@@ -210,7 +210,7 @@ mod tests {
     #[serial]
     async fn bad_examples_fail() {
         let rng = StdRng::from_seed([12; 32]);
-        let data_ingestion_path = tempdir().unwrap().into_path();
+        let data_ingestion_path = tempdir().unwrap().keep();
         let mut sim = Simulacrum::new_with_rng(rng);
         let (mut max_nodes, mut max_output_nodes, mut max_depth, mut max_payload) = (0, 0, 0, 0);
         sim.set_data_ingestion_path(data_ingestion_path.clone());

--- a/crates/iota-indexer/src/indexer.rs
+++ b/crates/iota-indexer/src/indexer.rs
@@ -139,7 +139,7 @@ impl Indexer {
                     .sources
                     .data_ingestion_path
                     .clone()
-                    .unwrap_or(tempfile::tempdir().unwrap().into_path()),
+                    .unwrap_or(tempfile::tempdir().unwrap().keep()),
                 config
                     .sources
                     .remote_store_url

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -91,7 +91,7 @@ impl SimulacrumTestSetup {
     ) -> &'a SimulacrumTestSetup {
         initialized_env_container.get_or_init(|| {
             let runtime = tokio::runtime::Runtime::new().unwrap();
-            let data_ingestion_path = tempdir().unwrap().into_path();
+            let data_ingestion_path = tempdir().unwrap().keep();
 
             let sim = env_initializer(data_ingestion_path.clone());
             let sim = Arc::new(sim);

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -49,7 +49,7 @@ mod ingestion_tests {
     #[tokio::test]
     pub async fn test_transaction_table() -> Result<(), IndexerError> {
         let mut sim = Simulacrum::new();
-        let data_ingestion_path = tempdir().unwrap().into_path();
+        let data_ingestion_path = tempdir().unwrap().keep();
         sim.set_data_ingestion_path(data_ingestion_path.clone());
 
         // Execute a simple transaction.
@@ -100,7 +100,7 @@ mod ingestion_tests {
     #[tokio::test]
     pub async fn test_object_type() -> Result<(), IndexerError> {
         let mut sim = Simulacrum::new();
-        let data_ingestion_path = tempdir().unwrap().into_path();
+        let data_ingestion_path = tempdir().unwrap().keep();
         sim.set_data_ingestion_path(data_ingestion_path.clone());
 
         // Execute a simple transaction.
@@ -230,7 +230,7 @@ mod ingestion_tests {
     #[ignore = "https://github.com/iotaledger/iota/issues/6668"]
     pub async fn test_tx_insertion_order_table() -> Result<(), IndexerError> {
         let mut sim = Simulacrum::new();
-        let data_ingestion_path = tempdir().unwrap().into_path();
+        let data_ingestion_path = tempdir().unwrap().keep();
         sim.set_data_ingestion_path(data_ingestion_path.clone());
 
         // Execute a simple transaction.
@@ -272,7 +272,7 @@ mod ingestion_tests {
     #[ignore = "https://github.com/iotaledger/iota/issues/6668"]
     pub async fn test_tx_insertion_order_table_for_existing_digest() -> Result<(), IndexerError> {
         let mut sim = Simulacrum::new();
-        let data_ingestion_path = tempdir().unwrap().into_path();
+        let data_ingestion_path = tempdir().unwrap().keep();
         sim.set_data_ingestion_path(data_ingestion_path.clone());
 
         // Execute a simple transaction.

--- a/crates/iota-move-build/src/lib.rs
+++ b/crates/iota-move-build/src/lib.rs
@@ -116,7 +116,7 @@ impl BuildConfig {
     pub fn new_for_testing() -> Self {
         move_package::package_hooks::register_package_hooks(Box::new(IotaPackageHooks));
 
-        let install_dir = tempfile::tempdir().unwrap().into_path();
+        let install_dir = tempfile::tempdir().unwrap().keep();
         let config = MoveBuildConfig {
             default_flavor: Some(move_compiler::editions::Flavor::Iota),
             lock_file: Some(install_dir.join("Move.lock")),

--- a/crates/iota-network/src/state_sync/tests.rs
+++ b/crates/iota-network/src/state_sync/tests.rs
@@ -277,7 +277,7 @@ async fn test_state_sync_using_archive() -> anyhow::Result<()> {
     let (ordered_checkpoints, _, sequence_number_to_digest, checkpoints) =
         committee.make_empty_checkpoints(100, None);
     // Initialize archive store with all checkpoints
-    let temp_dir = tempdir()?.into_path();
+    let temp_dir = tempdir()?.keep();
     let local_path = temp_dir.join("local_dir");
     let remote_path = temp_dir.join("remote_dir");
     let local_store_config = ObjectStoreConfig {

--- a/crates/iota-proc-macros/src/lib.rs
+++ b/crates/iota-proc-macros/src/lib.rs
@@ -61,7 +61,7 @@ pub fn init_static_initializers(_args: TokenStream, item: TokenStream) -> TokenS
                     let mut path = PathBuf::from(env!("SIMTEST_STATIC_INIT_MOVE"));
                     let mut build_config = BuildConfig::new_for_testing();
 
-                    build_config.config.install_dir = Some(TempDir::new().unwrap().into_path());
+                    build_config.config.install_dir = Some(TempDir::new().unwrap().keep());
                     let _all_module_bytes = build_config
                         .build(&path)
                         .unwrap()

--- a/crates/iota-snapshot/src/tests.rs
+++ b/crates/iota-snapshot/src/tests.rs
@@ -23,7 +23,7 @@ use crate::{FileCompression, reader::StateSnapshotReaderV1, writer::StateSnapsho
 fn temp_dir() -> std::path::PathBuf {
     tempdir()
         .expect("Failed to open temporary directory")
-        .into_path()
+        .keep()
 }
 
 pub fn insert_keys(

--- a/crates/iota-source-validation-service/tests/tests.rs
+++ b/crates/iota-source-validation-service/tests/tests.rs
@@ -306,7 +306,7 @@ async fn test_api_route() -> anyhow::Result<()> {
     let address = "0x2";
     let module = "address";
     let source_path = fixtures
-        .into_path()
+        .keep()
         .join("iota/move-stdlib/sources/address.move");
 
     let mut source_lookup = SourceLookup::new();

--- a/crates/iota-swarm-config/src/network_config_builder.rs
+++ b/crates/iota-swarm-config/src/network_config_builder.rs
@@ -125,7 +125,7 @@ impl ConfigBuilder {
     }
 
     pub fn new_with_temp_dir() -> Self {
-        Self::new(nondeterministic!(tempfile::tempdir().unwrap()).into_path())
+        Self::new(nondeterministic!(tempfile::tempdir().unwrap()).keep())
     }
 }
 

--- a/crates/iota-swarm-config/src/node_config_builder.rs
+++ b/crates/iota-swarm-config/src/node_config_builder.rs
@@ -133,7 +133,7 @@ impl ValidatorConfigBuilder {
         let key_path = get_key_path(&validator.authority_key_pair);
         let config_directory = self
             .config_directory
-            .unwrap_or_else(|| tempfile::tempdir().unwrap().into_path());
+            .unwrap_or_else(|| tempfile::tempdir().unwrap().keep());
         let migration_tx_data_path =
             Some(config_directory.join(IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME));
         let db_path = config_directory
@@ -437,7 +437,7 @@ impl FullnodeConfigBuilder {
         let key_path = get_key_path(&validator_config.authority_key_pair);
         let config_directory = self
             .config_directory
-            .unwrap_or_else(|| tempfile::tempdir().unwrap().into_path());
+            .unwrap_or_else(|| tempfile::tempdir().unwrap().keep());
 
         let migration_tx_data_path =
             Some(config_directory.join(IOTA_GENESIS_MIGRATION_TX_DATA_FILENAME));

--- a/crates/iota-tool/src/db_tool/db_dump.rs
+++ b/crates/iota-tool/src/db_tool/db_dump.rs
@@ -329,7 +329,7 @@ mod test {
 
     #[tokio::test]
     async fn db_dump_population() -> Result<(), anyhow::Error> {
-        let primary_path = tempfile::tempdir()?.into_path();
+        let primary_path = tempfile::tempdir()?.keep();
 
         // Open the DB for writing
         let _: AuthorityEpochTables = AuthorityEpochTables::open(0, &primary_path, None);

--- a/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
@@ -112,7 +112,7 @@ impl PersistedStore {
     where
         R: rand::RngCore + rand::CryptoRng,
     {
-        let path: PathBuf = path.unwrap_or(tempdir().unwrap().into_path());
+        let path: PathBuf = path.unwrap_or(tempdir().unwrap().keep());
 
         let mut builder = ConfigBuilder::new_with_temp_dir()
             .rng(&mut rng)

--- a/crates/iota-transactional-test-runner/src/test_adapter.rs
+++ b/crates/iota-transactional-test-runner/src/test_adapter.rs
@@ -238,7 +238,7 @@ impl AdapterInitConfig {
             Some(OffChainConfig {
                 snapshot_config,
                 epochs_to_keep,
-                data_ingestion_path: data_ingestion_path.unwrap_or(tempdir().unwrap().into_path()),
+                data_ingestion_path: data_ingestion_path.unwrap_or(tempdir().unwrap().keep()),
                 rest_api_url,
             })
         } else {

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -777,7 +777,7 @@ async fn start(
     // the genesis command, which sets data_ingestion_dir to None.
     #[cfg(feature = "indexer")]
     if with_indexer.is_some() && data_ingestion_dir.is_none() {
-        data_ingestion_dir = Some(tempdir()?.into_path())
+        data_ingestion_dir = Some(tempdir()?.keep())
     }
 
     #[cfg(feature = "indexer")]
@@ -879,7 +879,7 @@ async fn start(
         tracing::info!("Starting the faucet service at {faucet_address}");
         let faucet_config_dir = if force_regenesis {
             // tempdir is used so the faucet file is cleaned up afterwards
-            tempdir()?.into_path()
+            tempdir()?.keep()
         } else {
             config_path
         };

--- a/crates/iota/src/unit_tests/profiler_tests.rs
+++ b/crates/iota/src/unit_tests/profiler_tests.rs
@@ -64,7 +64,7 @@ async fn test_profiler() {
 
     // check that the profile was written
     let mut found = false;
-    for entry in fs::read_dir(output_dir.into_path()).unwrap().flatten() {
+    for entry in fs::read_dir(output_dir.keep()).unwrap().flatten() {
         if entry
             .file_name()
             .into_string()

--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -457,7 +457,7 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                     None => {
                         let p: std::path::PathBuf = tempfile::tempdir()
                         .expect("Failed to open temporary directory")
-                        .into_path();
+                        .keep();
                         #intermediate_db_map_struct_name::open_tables_impl(primary_path, Some(p), false, metric_conf, global_db_options_override, None, false)
                     }
                 };

--- a/crates/typed-store/src/lib.rs
+++ b/crates/typed-store/src/lib.rs
@@ -93,7 +93,7 @@ pub type StoreError = typed_store_error::TypedStoreError;
 ///             "Failed to open temporary
 /// directory",
 ///         )
-///         .into_path();
+///         .keep();
 ///
 ///     // We can then open the DB with the configs
 ///     let _ = Tables::open_tables_read_write(
@@ -151,7 +151,7 @@ pub type StoreError = typed_store_error::TypedStoreError;
 ///     use typed_store::rocks::MetricConf;
 ///     let primary_path = tempfile::tempdir()
 ///         .expect("Failed to open temporary directory")
-///         .into_path();
+///         .keep();
 ///     let _ = Tables::open_tables_read_write(
 ///         primary_path.clone(),
 ///         typed_store::rocks::MetricConf::default(),

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -18,7 +18,7 @@ use crate::{
 fn temp_dir() -> std::path::PathBuf {
     tempfile::tempdir()
         .expect("Failed to open temporary directory")
-        .into_path()
+        .keep()
 }
 
 // A wrapper that holds different type of iterators for testing purpose. We use

--- a/crates/typed-store/tests/macro_tests.rs
+++ b/crates/typed-store/tests/macro_tests.rs
@@ -18,7 +18,7 @@ use typed_store::{
 fn temp_dir() -> std::path::PathBuf {
     tempfile::tempdir()
         .expect("Failed to open temporary directory")
-        .into_path()
+        .keep()
 }
 /// This struct is used to illustrate how the utility works
 #[derive(DBMapUtils)]


### PR DESCRIPTION
# Description of change

This PR fixes a clippy warning by updating tempfile and replacing the `into_path` usages with `keep`.


## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes