### PR TITLE
refactor(consensus): extract `dag_state` mutation from computation

### DIFF
--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -68,7 +68,7 @@ impl Transaction {
 /// to transactions that the authority considers valid.
 /// Well behaved authorities produce at most one block header per round, but
 /// malicious authorities can equivocate.
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize, PartialOrd, PartialEq, Ord, Eq)]
 pub enum BlockHeader {
     V1(BlockHeaderV1),
 }
@@ -85,7 +85,7 @@ pub trait BlockHeaderAPI {
     fn transactions_commitment(&self) -> TransactionsCommitment;
 }
 
-#[derive(Clone, Default, Deserialize, Serialize)]
+#[derive(Clone, Default, Deserialize, Serialize, PartialOrd, PartialEq, Ord, Eq)]
 pub struct BlockHeaderV1 {
     epoch: Epoch,
     round: Round,
@@ -509,7 +509,7 @@ impl fmt::Debug for Slot {
 /// Note: `BlockDigest` is computed over this struct, so any added field
 /// (without `#[serde(skip)]`) will affect the values of `BlockDigest` and
 /// `BlockRef`.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, PartialOrd, PartialEq, Ord, Eq)]
 pub(crate) struct SignedBlockHeader {
     inner: BlockHeader,
     signature: Bytes,
@@ -631,7 +631,7 @@ impl Deref for SignedBlockHeader {
 
 /// VerifiedBlock allows full access to its content.
 /// Note: clone() is relatively cheap with most underlying data refcounted.
-#[derive(Clone)]
+#[derive(Clone, PartialOrd, Ord, Eq)]
 pub struct VerifiedBlockHeader {
     signed_block_header: Arc<SignedBlockHeader>,
 

--- a/crates/starfish/core/src/block_manager/block_suspender.rs
+++ b/crates/starfish/core/src/block_manager/block_suspender.rs
@@ -1,0 +1,507 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+use std::{
+    collections::{BTreeMap, BTreeSet, btree_map::Entry},
+    sync::Arc,
+    time::Instant,
+};
+
+use itertools::Itertools;
+use starfish_config::AuthorityIndex;
+use tracing::debug;
+
+use crate::{BlockHeaderAPI, BlockRef, VerifiedBlockHeader, context::Context};
+
+struct SuspendedBlockHeader {
+    block_header: VerifiedBlockHeader,
+    missing_ancestors: BTreeSet<BlockRef>,
+    timestamp: Instant,
+}
+
+impl SuspendedBlockHeader {
+    fn new(block: VerifiedBlockHeader, missing_ancestors: &BTreeSet<BlockRef>) -> Self {
+        let mut ma = BTreeSet::new();
+        for ancestor in missing_ancestors {
+            ma.insert(*ancestor);
+        }
+        Self {
+            block_header: block,
+            missing_ancestors: ma,
+            timestamp: Instant::now(),
+        }
+    }
+}
+
+pub(crate) struct BlockSuspender {
+    context: Arc<Context>,
+    /// Keeps all the suspended block headers. A suspended block header is a
+    /// header that is missing part of its causal history and thus can't be
+    /// immediately processed. A block header will remain in this map until
+    /// all its causal history has been successfully processed.
+    suspended_block_headers: BTreeMap<BlockRef, SuspendedBlockHeader>,
+    /// A map that keeps all the blocks that we are missing (keys) and the
+    /// corresponding blocks that reference the missing blocks as ancestors
+    /// and need them to get unsuspended. It is possible for a missing
+    /// dependency (key) to be a suspended block, so the block has been
+    /// already fetched but itself is still missing some of its ancestors to be
+    /// processed.
+    missing_ancestors: BTreeMap<BlockRef, BTreeSet<BlockRef>>,
+    /// A map of currently missing blocks to the set of authorities expected
+    /// to have them available locally. This set is approximated based on the
+    /// block's author and the authors of its direct children.
+    /// A block is considered missing if it appears in `missing_ancestors`
+    /// and has not yet been accepted or fetched. Blocks already stored or
+    /// present in `suspended_blocks` are excluded.
+    missing_blocks: BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
+}
+
+impl BlockSuspender {
+    pub(crate) fn new(context: Arc<Context>) -> Self {
+        Self {
+            context: context.clone(),
+            suspended_block_headers: BTreeMap::new(),
+            missing_ancestors: BTreeMap::new(),
+            missing_blocks: BTreeMap::new(),
+        }
+    }
+    /// Accept or suspend a batch of received block headers based on their
+    /// missing ancestors.
+    ///
+    /// Each header is either:
+    /// - Accepted immediately if all its ancestors are resolved (directly or
+    ///   through this batch),
+    /// - Or suspended if it still has missing or unresolved ancestors.
+    ///
+    /// After initially processing the batch, this function also recursively
+    /// unsuspends any other blocks that were previously suspended and are
+    /// now unblocked due to newly accepted ancestors.
+    ///
+    /// # Arguments
+    /// * `missing_ancestors` - A map of verified block headers to the set of
+    ///   their unresolved ancestor references as read from the DagState by the
+    ///   caller.
+    ///
+    /// # Returns
+    /// * `Vec<VerifiedBlockHeader>` — All headers that were accepted, either
+    ///   directly or via recursive unsuspension.
+    /// * `BTreeSet<BlockRef>` — Set of ancestor block references that are still
+    ///   missing and should be fetched.
+    ///
+    /// # Side Effects
+    /// - Updates the suspension state of blocks.
+    /// - May recursively unsuspend dependent blocks.
+    /// - Updates internal fetch statistics.
+    pub(crate) fn accept_or_suspend_received_headers(
+        &mut self,
+        missing_ancestors: BTreeMap<VerifiedBlockHeader, BTreeSet<BlockRef>>,
+    ) -> (Vec<VerifiedBlockHeader>, BTreeSet<BlockRef>) {
+        // Decide which headers are resolved now, which need to be suspended, and which
+        // ancestors must still be fetched
+        let (fully_resolved_headers, ancestors_to_fetch) =
+            self.resolve_or_suspend_headers(missing_ancestors);
+        let mut accepted_headers = vec![];
+
+        for fully_resolved_header in fully_resolved_headers {
+            let fully_resolved_header_reference = fully_resolved_header.reference();
+            // Accept the resolved header
+            accepted_headers.push(fully_resolved_header);
+            // Recursively attempt to unsuspend any blocks that were waiting on this one
+            let unsuspended =
+                self.recursively_unsuspend_dependents(fully_resolved_header_reference);
+            // Add them to the list of accepted headers
+            accepted_headers.extend(unsuspended);
+        }
+        self.update_stats(ancestors_to_fetch.len() as u64);
+        (accepted_headers, ancestors_to_fetch)
+    }
+    /// Processes a batch of verified block headers and updates their suspension
+    /// state based on missing ancestors.
+    ///
+    /// This function evaluates each incoming block to determine whether it can
+    /// be accepted immediately (i.e., all its ancestors are resolved), or
+    /// if it must be suspended due to unresolved or missing ancestors.
+    /// Suspended blocks are tracked, and any additional ancestor blocks that
+    /// need to be fetched are identified.
+    ///
+    /// # Arguments
+    /// * `missing_ancestors_map` - A map from the incoming verified block
+    ///   headers to the set of their missing ancestor references as read from
+    ///   the DagState by the calling code in BlockManager.
+    ///
+    /// # Returns
+    /// A tuple containing:
+    /// * `Vec<VerifiedBlockHeader>` - List of block headers that are fully
+    ///   resolved and ready for further processing to check if their children
+    ///   can be unsuspended.
+    /// * `BTreeSet<BlockRef>` - Set of ancestor block references that still
+    ///   need to be fetched.
+    ///
+    /// # Side Effects
+    /// This function:
+    /// - Removes incoming batch block references from `self.missing_blocks`.
+    /// - Registers suspended blocks and their missing ancestors in internal
+    ///   tracking structures.
+    /// - Triggers reporting mechanisms for suspended blocks and missing
+    ///   ancestors.
+    /// - Identifies which ancestor blocks must still be fetched externally.
+    fn resolve_or_suspend_headers(
+        &mut self,
+        missing_ancestors_map: BTreeMap<VerifiedBlockHeader, BTreeSet<BlockRef>>,
+    ) -> (Vec<VerifiedBlockHeader>, BTreeSet<BlockRef>) {
+        // Collect references of all incoming blocks in this batch
+        let incoming_block_refs: BTreeSet<BlockRef> = missing_ancestors_map
+            .keys()
+            .map(|b| b.reference())
+            .collect();
+        debug!(
+            "Trying to accept block headers: {}",
+            incoming_block_refs.iter().map(|b| b.to_string()).join(",")
+        );
+        let mut fully_resolved_headers = vec![];
+        let mut ancestors_to_fetch = BTreeSet::new();
+        for (incoming_block_header, missing_ancestors) in missing_ancestors_map {
+            let block_ref = incoming_block_header.reference();
+            let block_header_author = incoming_block_header.author();
+
+            // We're now processing this block, so remove it from the missing_blocks list
+            self.missing_blocks.remove(&block_ref);
+
+            // If all missing ancestors are resolved or incoming, and none are suspended,
+            // accept the block
+            if self.are_missing_ancestors_fully_resolved(&incoming_block_refs, &missing_ancestors) {
+                fully_resolved_headers.push(incoming_block_header);
+                continue;
+            }
+
+            // Otherwise, suspend the block and track its missing ancestors
+            self.register_suspended_block(incoming_block_header, &missing_ancestors);
+            self.report_suspended_block(&block_ref);
+            for ancestor in missing_ancestors {
+                self.register_missing_ancestor(block_ref, ancestor);
+                self.report_missing_ancestor(&ancestor);
+
+                // If this ancestor is not already suspended and is not part of the incoming
+                // batch, we may need to fetch it
+                if !self.suspended_block_headers.contains_key(&ancestor)
+                    && !incoming_block_refs.contains(&ancestor)
+                {
+                    ancestors_to_fetch.insert(ancestor);
+                    // Only report the block as missing if we’re not already fetching it
+                    if !self.missing_blocks.contains_key(&ancestor) {
+                        self.report_missing_block(ancestor.author);
+                    }
+                    self.register_missing_block(&ancestor, block_header_author);
+                }
+            }
+        }
+        (fully_resolved_headers, ancestors_to_fetch)
+    }
+    /// Determines whether all missing ancestors of a block are resolved,
+    /// allowing the block to be accepted.
+    ///
+    /// A block is considered fully resolved if:
+    /// - It has no missing ancestors, **or**
+    /// - All of its missing ancestors are among the set of incoming blocks
+    ///   (`incoming_block_refs`), **and** none of those ancestors are currently
+    ///   suspended.
+    ///
+    /// This function is used to decide whether a block can be accepted
+    /// immediately, or if it should be suspended due to unresolved
+    /// dependencies.
+    ///
+    /// # Arguments
+    /// * `incoming_block_refs` - A set of block references that are being
+    ///   processed in the current batch.
+    /// * `missing_ancestors` - The set of ancestor block references that are
+    ///   missing for a given block.
+    ///
+    /// # Returns
+    /// `true` if the block has no unresolved or suspended ancestors; otherwise,
+    /// `false`.
+    fn are_missing_ancestors_fully_resolved(
+        &self,
+        block_refs: &BTreeSet<BlockRef>,
+        missing_ancestors: &BTreeSet<BlockRef>,
+    ) -> bool {
+        missing_ancestors.is_empty()
+            || (block_refs.is_superset(missing_ancestors)
+                // Even if all missing ancestors are included in the incoming headers,
+                // we must ensure none of them are currently suspended.
+                // Suspended ancestors indicate unresolved dependencies further up the chain.
+                && !missing_ancestors
+                    .iter()
+                    .any(|a| self.suspended_block_headers.contains_key(a)))
+    }
+    /// Recursively unsuspends all blocks that were dependent on a now-accepted
+    /// block.
+    ///
+    /// Starting from `resolved_block`, this function walks the dependency graph
+    /// and attempts to unsuspend any suspended blocks that were blocked on
+    /// it. Successfully unsuspended blocks are added to the result, and
+    /// their own dependents are checked in turn.
+    ///
+    /// # Arguments
+    /// * `resolved_block` - The block that was just accepted and may unsuspend
+    ///   other blocks.
+    ///
+    /// # Returns
+    /// * A list of verified block headers that have been unsuspended.
+    fn recursively_unsuspend_dependents(
+        &mut self,
+        resolved_block_ref: BlockRef,
+    ) -> Vec<VerifiedBlockHeader> {
+        let mut ready_blocks = vec![];
+        let mut stack = vec![resolved_block_ref];
+
+        while let Some(popped_resolved_block_ref) = stack.pop() {
+            // And try to check if its direct children can be unsuspended
+            if let Some(suspended_block_refs_with_missing_deps) =
+                self.missing_ancestors.remove(&popped_resolved_block_ref)
+            {
+                for suspended_block_ref in suspended_block_refs_with_missing_deps {
+                    // For each dependency try to unsuspend it. If that's successful then we add it
+                    // to the stack so we can recursively try to unsuspend its
+                    // children.
+                    if let Some(unsuspended_block) =
+                        self.unsuspend_if_ready(&suspended_block_ref, &popped_resolved_block_ref)
+                    {
+                        self.report_unsuspended_block(&unsuspended_block);
+                        stack.push(unsuspended_block.block_header.reference());
+                        ready_blocks.push(unsuspended_block.block_header);
+                    }
+                }
+            }
+        }
+        ready_blocks
+    }
+    /// Attempts to unsuspend a block if one of its missing dependencies has
+    /// just been accepted.
+    ///
+    /// This function is called when a block that was previously suspended (due
+    /// to missing ancestors) may now be unblocked because one of its
+    /// dependencies (`accepted_dependency`) has been resolved.
+    /// The dependency is removed from the suspended block’s set of missing
+    /// ancestors. If this was the final missing dependency, the block is
+    /// removed from the suspension map and returned.
+    ///
+    /// # Arguments
+    /// * `block_ref` - Reference to the suspended block being re-evaluated.
+    /// * `accepted_dependency` - A block reference that was just accepted and
+    ///   may resolve a dependency.
+    ///
+    /// # Returns
+    /// * `Some(SuspendedBlockHeader)` if the block no longer has missing
+    ///   ancestors and is ready to be reprocessed.
+    /// * `None` if the block still has unresolved ancestors.
+    ///
+    /// # Panics
+    /// - If the block is not found in the `suspended_block_headers` map.
+    /// - If `accepted_dependency` is not in the block's `missing_ancestors`
+    ///   set.
+    ///
+    /// # Side Effects
+    /// - Mutates internal state by removing resolved dependencies and possibly
+    ///   removing the suspended block.
+    fn unsuspend_if_ready(
+        &mut self,
+        suspended_block_ref: &BlockRef,
+        resolved_dependency: &BlockRef,
+    ) -> Option<SuspendedBlockHeader> {
+        let block = self
+            .suspended_block_headers
+            .get_mut(suspended_block_ref)
+            .expect("Block should be in suspended map");
+
+        assert!(
+            block.missing_ancestors.remove(resolved_dependency),
+            "Block reference {} should be present in missing dependencies of {:?}",
+            suspended_block_ref,
+            block.block_header
+        );
+        // If there are no more missing ancestors, unsuspend and return the block
+        if block.missing_ancestors.is_empty() {
+            return self.suspended_block_headers.remove(suspended_block_ref);
+        }
+        // Otherwise, keep it suspended
+        None
+    }
+    fn register_suspended_block(
+        &mut self,
+        block_header: VerifiedBlockHeader,
+        missing_ancestors: &BTreeSet<BlockRef>,
+    ) {
+        let block_ref = block_header.reference();
+        match self.suspended_block_headers.entry(block_ref) {
+            Entry::Vacant(v) => {
+                let suspended_block = SuspendedBlockHeader::new(block_header, missing_ancestors);
+                v.insert(suspended_block);
+            }
+            Entry::Occupied(mut o) => {
+                o.get_mut().missing_ancestors.extend(missing_ancestors);
+            }
+        };
+    }
+    fn register_missing_ancestor(&mut self, block_ref: BlockRef, ancestor: BlockRef) {
+        self.missing_ancestors
+            .entry(ancestor)
+            .or_default()
+            .insert(block_ref);
+    }
+    fn report_suspended_block(&self, block_ref: &BlockRef) {
+        self.context
+            .metrics
+            .node_metrics
+            .block_suspensions
+            .with_label_values(&[self.context.authority_hostname(block_ref.author)])
+            .inc();
+    }
+    fn report_missing_ancestor(&mut self, ancestor: &BlockRef) {
+        self.context
+            .metrics
+            .node_metrics
+            .block_manager_missing_ancestors_by_authority
+            .with_label_values(&[self.context.authority_hostname(ancestor.author)])
+            .inc();
+    }
+    fn register_missing_block(
+        &mut self,
+        missing_ancestor: &BlockRef,
+        child_author: AuthorityIndex,
+    ) {
+        match self.missing_blocks.entry(*missing_ancestor) {
+            Entry::Vacant(v) => {
+                // Both the child block's author and the actual missing ancestor's author
+                // are expected to have this block available.
+                v.insert(BTreeSet::from([missing_ancestor.author, child_author]));
+            }
+            Entry::Occupied(mut o) => {
+                o.get_mut().insert(child_author);
+            }
+        }
+    }
+
+    fn report_missing_block(&mut self, missing_block_author: AuthorityIndex) {
+        self.context
+            .metrics
+            .node_metrics
+            .block_manager_missing_blocks_by_authority
+            .with_label_values(&[self.context.authority_hostname(missing_block_author)])
+            .inc();
+    }
+    fn report_unsuspended_block(&self, unsuspended_block: &SuspendedBlockHeader) {
+        let now = Instant::now();
+        self.context
+            .metrics
+            .node_metrics
+            .block_unsuspensions
+            .with_label_values(&[self
+                .context
+                .authority_hostname(unsuspended_block.block_header.author())])
+            .inc();
+        self.context
+            .metrics
+            .node_metrics
+            .suspended_block_time
+            .with_label_values(&[self
+                .context
+                .authority_hostname(unsuspended_block.block_header.author())])
+            .observe(
+                now.saturating_duration_since(unsuspended_block.timestamp)
+                    .as_secs_f64(),
+            );
+    }
+    pub(crate) fn is_block_ref_suspended(&self, block_ref: &BlockRef) -> bool {
+        self.suspended_block_headers.contains_key(block_ref)
+    }
+    pub(crate) fn missing_blocks(&self) -> BTreeMap<BlockRef, BTreeSet<AuthorityIndex>> {
+        self.missing_blocks.clone()
+    }
+    fn update_stats(&mut self, missing_blocks: u64) {
+        let metrics = &self.context.metrics.node_metrics;
+        metrics.missing_blocks_total.inc_by(missing_blocks);
+        metrics
+            .block_manager_suspended_blocks
+            .set(self.suspended_block_headers.len() as i64);
+        metrics
+            .block_manager_missing_ancestors
+            .set(self.missing_ancestors.len() as i64);
+        metrics
+            .block_manager_missing_blocks
+            .set(self.missing_blocks.len() as i64);
+    }
+    #[cfg(test)]
+    pub(crate) fn missing_blocks_len(&self) -> usize {
+        self.missing_blocks.len()
+    }
+    #[cfg(test)]
+    pub(crate) fn insert_missing_block(
+        &mut self,
+        block_ref: BlockRef,
+        set: BTreeSet<AuthorityIndex>,
+    ) -> Option<BTreeSet<AuthorityIndex>> {
+        self.missing_blocks.insert(block_ref, set)
+    }
+    #[cfg(test)]
+    pub(crate) fn set_missing_ancestors_with_no_children(&mut self, block_ref: BlockRef) {
+        self.missing_ancestors.entry(block_ref).or_default();
+    }
+    #[cfg(test)]
+    pub(crate) fn suspended_blocks_refs(&self) -> BTreeSet<BlockRef> {
+        self.suspended_block_headers.keys().cloned().collect()
+    }
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.suspended_block_headers.is_empty()
+            && self.missing_ancestors.is_empty()
+            && self.missing_blocks.is_empty()
+    }
+    #[cfg(test)]
+    pub(crate) fn missing_block_refs(&self) -> BTreeSet<BlockRef> {
+        self.missing_blocks.keys().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    /// Evaluates a set of verified block headers to determine which blocks
+    /// should be suspended and which are still missing.
+    ///
+    /// This function is called in randomized tests to verify the
+    /// suspension logic of the `BlockSuspender`.
+    /// returns:
+    /// tuple of:
+    /// - `Vec<BlockRef>`: all block references that should be suspended
+    /// - `Vec<BlockRef>`: all block references that are still missing and need
+    ///   to be fetched
+    pub(crate) fn evaluate_block_headers(
+        seen_so_far: &[VerifiedBlockHeader],
+    ) -> (BTreeSet<BlockRef>, BTreeSet<BlockRef>) {
+        let mut suspended = BTreeSet::new();
+        let mut missing = BTreeSet::new();
+        let mut seen_so_far_ordered = seen_so_far.iter().collect::<Vec<_>>();
+        let seen_so_far_refs: BTreeSet<BlockRef> =
+            seen_so_far.iter().map(|b| b.reference()).collect();
+        seen_so_far_ordered.sort_by_key(|b| b.round());
+        for block in seen_so_far_ordered {
+            if block.round() == 1 {
+                // Skip the first block as it has no ancestors.
+                continue;
+            }
+            let block_ref = block.reference();
+            for ancestor in block.ancestors() {
+                let is_missing = !seen_so_far_refs.contains(ancestor);
+                let is_suspended = suspended.contains(ancestor);
+
+                if is_missing {
+                    missing.insert(*ancestor);
+                }
+
+                if is_missing || is_suspended {
+                    suspended.insert(block_ref);
+                }
+            }
+        }
+        (suspended, missing)
+    }
+}

--- a/crates/starfish/core/src/block_manager/block_suspender.rs
+++ b/crates/starfish/core/src/block_manager/block_suspender.rs
@@ -14,7 +14,7 @@ use crate::{BlockHeaderAPI, BlockRef, VerifiedBlockHeader, context::Context};
 
 struct SuspendedBlockHeader {
     block_header: VerifiedBlockHeader,
-    unresolved_ancestors: BTreeSet<BlockRef>,
+    missing_ancestors: BTreeSet<BlockRef>,
     timestamp: Instant,
 }
 
@@ -26,7 +26,7 @@ impl SuspendedBlockHeader {
         }
         Self {
             block_header: block,
-            unresolved_ancestors: ma,
+            missing_ancestors: ma,
             timestamp: Instant::now(),
         }
     }
@@ -38,30 +38,30 @@ pub(crate) struct BlockSuspender {
     /// header that is missing part of its causal history and thus can't be
     /// immediately processed. A block header will remain in this map until
     /// all its causal history has been successfully processed.
-    suspended_block_headers: BTreeMap<BlockRef, SuspendedBlockHeader>,
+    suspended_headers: BTreeMap<BlockRef, SuspendedBlockHeader>,
     /// A map that keeps all the blocks that we are missing (keys) and the
     /// corresponding blocks that reference the missing blocks as ancestors
     /// and need them to get unsuspended. It is possible for a missing
     /// dependency (key) to be a suspended block, so the block has been
     /// already fetched but itself is still missing some of its ancestors to be
     /// processed.
-    unresolved_ancestors: BTreeMap<BlockRef, BTreeSet<BlockRef>>,
-    /// A map of currently missing blocks to the set of authorities expected
-    /// to have them available locally. This set is approximated based on the
-    /// block's author and the authors of its direct children.
+    missing_ancestors: BTreeMap<BlockRef, BTreeSet<BlockRef>>,
+    /// A map of blocks that need to be fetched to the set of authorities
+    /// expected to have them available locally. This set is approximated
+    /// based on the block's author and the authors of its direct children.
     /// A block is considered missing if it appears in `missing_ancestors`
-    /// and has not yet been accepted or fetched. Blocks already stored or
-    /// present in `suspended_blocks` are excluded.
-    missing_blocks: BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
+    /// and has not yet been fetched. Blocks already stored or present in
+    /// `suspended_headers` are excluded.
+    headers_to_fetch: BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
 }
 
 impl BlockSuspender {
     pub(crate) fn new(context: Arc<Context>) -> Self {
         Self {
             context: context.clone(),
-            suspended_block_headers: BTreeMap::new(),
-            unresolved_ancestors: BTreeMap::new(),
-            missing_blocks: BTreeMap::new(),
+            suspended_headers: BTreeMap::new(),
+            missing_ancestors: BTreeMap::new(),
+            headers_to_fetch: BTreeMap::new(),
         }
     }
     /// Accept or suspend a batch of received block headers based on their
@@ -157,18 +157,18 @@ impl BlockSuspender {
             "Trying to accept block headers: {}",
             incoming_block_refs.iter().map(|b| b.to_string()).join(",")
         );
-        let mut fully_resolved_headers = vec![];
+        let mut fully_resolved_headers: Vec<VerifiedBlockHeader> = vec![];
         let mut ancestors_to_fetch = BTreeSet::new();
         for (incoming_block_header, missing_ancestors) in missing_ancestors_map {
             let block_ref = incoming_block_header.reference();
             let block_header_author = incoming_block_header.author();
 
             // We're now processing this block, so remove it from the missing_blocks list
-            self.missing_blocks.remove(&block_ref);
+            self.headers_to_fetch.remove(&block_ref);
 
-            // If all missing ancestors are resolved or incoming, and none are suspended,
-            // accept the block
-            if self.are_missing_ancestors_fully_resolved(&incoming_block_refs, &missing_ancestors) {
+            // If there are no missing ancestors, we can mark the block header as fully
+            // resolved
+            if missing_ancestors.is_empty() {
                 fully_resolved_headers.push(incoming_block_header);
                 continue;
             }
@@ -177,60 +177,24 @@ impl BlockSuspender {
             self.register_suspended_block(incoming_block_header, &missing_ancestors);
             self.report_suspended_block(&block_ref);
             for ancestor in missing_ancestors {
-                self.register_unresolved_ancestor(block_ref, ancestor);
-                self.report_unresolved_ancestor(&ancestor);
+                self.register_missing_ancestor(block_ref, ancestor);
+                self.report_missing_ancestor(&ancestor);
 
                 // If this ancestor is not already suspended and is not part of the incoming
                 // batch, we may need to fetch it
-                if !self.suspended_block_headers.contains_key(&ancestor)
+                if !self.suspended_headers.contains_key(&ancestor)
                     && !incoming_block_refs.contains(&ancestor)
                 {
                     ancestors_to_fetch.insert(ancestor);
                     // Only report the block as missing if we’re not already fetching it
-                    if !self.missing_blocks.contains_key(&ancestor) {
-                        self.report_missing_block(ancestor.author);
+                    if !self.headers_to_fetch.contains_key(&ancestor) {
+                        self.report_block_to_fetch(ancestor.author);
                     }
-                    self.register_missing_block(&ancestor, block_header_author);
+                    self.register_block_to_fetch(&ancestor, block_header_author);
                 }
             }
         }
         (fully_resolved_headers, ancestors_to_fetch)
-    }
-    /// Determines whether all missing ancestors of a block are resolved,
-    /// allowing the block to be accepted.
-    ///
-    /// A block is considered fully resolved if:
-    /// - It has no missing ancestors, **or**
-    /// - All of its missing ancestors are among the set of incoming blocks
-    ///   (`incoming_block_refs`), **and** none of those ancestors are currently
-    ///   suspended.
-    ///
-    /// This function is used to decide whether a block can be accepted
-    /// immediately, or if it should be suspended due to unresolved
-    /// dependencies.
-    ///
-    /// # Arguments
-    /// * `incoming_block_refs` - A set of block references that are being
-    ///   processed in the current batch.
-    /// * `missing_ancestors` - The set of ancestor block references that are
-    ///   missing for a given block.
-    ///
-    /// # Returns
-    /// `true` if the block has no unresolved or suspended ancestors; otherwise,
-    /// `false`.
-    fn are_missing_ancestors_fully_resolved(
-        &self,
-        block_refs: &BTreeSet<BlockRef>,
-        missing_ancestors: &BTreeSet<BlockRef>,
-    ) -> bool {
-        missing_ancestors.is_empty()
-            || (block_refs.is_superset(missing_ancestors)
-                // Even if all missing ancestors are included in the incoming headers,
-                // we must ensure none of them are currently suspended.
-                // Suspended ancestors indicate unresolved dependencies further up the chain.
-                && !missing_ancestors
-                    .iter()
-                    .any(|a| self.suspended_block_headers.contains_key(a)))
     }
     /// Recursively unsuspends all blocks that were dependent on a now-accepted
     /// block.
@@ -256,7 +220,7 @@ impl BlockSuspender {
         while let Some(popped_resolved_block_ref) = stack.pop() {
             // And try to check if its direct children can be unsuspended
             if let Some(suspended_block_refs_with_missing_deps) =
-                self.unresolved_ancestors.remove(&popped_resolved_block_ref)
+                self.missing_ancestors.remove(&popped_resolved_block_ref)
             {
                 for suspended_block_ref in suspended_block_refs_with_missing_deps {
                     // For each dependency try to unsuspend it. If that's successful then we add it
@@ -309,19 +273,19 @@ impl BlockSuspender {
         resolved_dependency: &BlockRef,
     ) -> Option<SuspendedBlockHeader> {
         let block = self
-            .suspended_block_headers
+            .suspended_headers
             .get_mut(suspended_block_ref)
             .expect("Block should be in suspended map");
 
         assert!(
-            block.unresolved_ancestors.remove(resolved_dependency),
+            block.missing_ancestors.remove(resolved_dependency),
             "Block reference {} should be present in missing dependencies of {:?}",
             suspended_block_ref,
             block.block_header
         );
         // If there are no more missing ancestors, unsuspend and return the block
-        if block.unresolved_ancestors.is_empty() {
-            return self.suspended_block_headers.remove(suspended_block_ref);
+        if block.missing_ancestors.is_empty() {
+            return self.suspended_headers.remove(suspended_block_ref);
         }
         // Otherwise, keep it suspended
         None
@@ -332,18 +296,18 @@ impl BlockSuspender {
         missing_ancestors: &BTreeSet<BlockRef>,
     ) {
         let block_ref = block_header.reference();
-        match self.suspended_block_headers.entry(block_ref) {
+        match self.suspended_headers.entry(block_ref) {
             Entry::Vacant(v) => {
                 let suspended_block = SuspendedBlockHeader::new(block_header, missing_ancestors);
                 v.insert(suspended_block);
             }
             Entry::Occupied(mut o) => {
-                o.get_mut().unresolved_ancestors.extend(missing_ancestors);
+                o.get_mut().missing_ancestors.extend(missing_ancestors);
             }
         };
     }
-    fn register_unresolved_ancestor(&mut self, block_ref: BlockRef, ancestor: BlockRef) {
-        self.unresolved_ancestors
+    fn register_missing_ancestor(&mut self, block_ref: BlockRef, ancestor: BlockRef) {
+        self.missing_ancestors
             .entry(ancestor)
             .or_default()
             .insert(block_ref);
@@ -356,7 +320,7 @@ impl BlockSuspender {
             .with_label_values(&[self.context.authority_hostname(block_ref.author)])
             .inc();
     }
-    fn report_unresolved_ancestor(&mut self, ancestor: &BlockRef) {
+    fn report_missing_ancestor(&mut self, ancestor: &BlockRef) {
         self.context
             .metrics
             .node_metrics
@@ -364,12 +328,12 @@ impl BlockSuspender {
             .with_label_values(&[self.context.authority_hostname(ancestor.author)])
             .inc();
     }
-    fn register_missing_block(
+    fn register_block_to_fetch(
         &mut self,
         missing_ancestor: &BlockRef,
         child_author: AuthorityIndex,
     ) {
-        match self.missing_blocks.entry(*missing_ancestor) {
+        match self.headers_to_fetch.entry(*missing_ancestor) {
             Entry::Vacant(v) => {
                 // Both the child block's author and the actual missing ancestor's author
                 // are expected to have this block available.
@@ -381,12 +345,12 @@ impl BlockSuspender {
         }
     }
 
-    fn report_missing_block(&mut self, missing_block_author: AuthorityIndex) {
+    fn report_block_to_fetch(&mut self, block_to_fetch_author: AuthorityIndex) {
         self.context
             .metrics
             .node_metrics
             .block_manager_missing_blocks_by_authority
-            .with_label_values(&[self.context.authority_hostname(missing_block_author)])
+            .with_label_values(&[self.context.authority_hostname(block_to_fetch_author)])
             .inc();
     }
     fn report_unsuspended_block(&self, unsuspended_block: &SuspendedBlockHeader) {
@@ -412,53 +376,53 @@ impl BlockSuspender {
             );
     }
     pub(crate) fn is_block_ref_suspended(&self, block_ref: &BlockRef) -> bool {
-        self.suspended_block_headers.contains_key(block_ref)
+        self.suspended_headers.contains_key(block_ref)
     }
-    pub(crate) fn missing_blocks(&self) -> BTreeMap<BlockRef, BTreeSet<AuthorityIndex>> {
-        self.missing_blocks.clone()
+    pub(crate) fn headers_to_fetch(&self) -> BTreeMap<BlockRef, BTreeSet<AuthorityIndex>> {
+        self.headers_to_fetch.clone()
     }
-    fn update_stats(&mut self, missing_blocks: u64) {
+    fn update_stats(&mut self, blocks_to_fetch: u64) {
         let metrics = &self.context.metrics.node_metrics;
-        metrics.missing_blocks_total.inc_by(missing_blocks);
+        metrics.missing_blocks_total.inc_by(blocks_to_fetch);
         metrics
             .block_manager_suspended_blocks
-            .set(self.suspended_block_headers.len() as i64);
+            .set(self.suspended_headers.len() as i64);
         metrics
             .block_manager_missing_ancestors
-            .set(self.unresolved_ancestors.len() as i64);
+            .set(self.missing_ancestors.len() as i64);
         metrics
             .block_manager_missing_blocks
-            .set(self.missing_blocks.len() as i64);
+            .set(self.headers_to_fetch.len() as i64);
     }
     #[cfg(test)]
-    pub(crate) fn missing_blocks_len(&self) -> usize {
-        self.missing_blocks.len()
+    pub(crate) fn blocks_to_fetch_len(&self) -> usize {
+        self.headers_to_fetch.len()
     }
     #[cfg(test)]
-    pub(crate) fn insert_missing_block(
+    pub(crate) fn insert_block_to_fetch(
         &mut self,
         block_ref: BlockRef,
         set: BTreeSet<AuthorityIndex>,
     ) -> Option<BTreeSet<AuthorityIndex>> {
-        self.missing_blocks.insert(block_ref, set)
+        self.headers_to_fetch.insert(block_ref, set)
     }
     #[cfg(test)]
-    pub(crate) fn set_unresolved_ancestors_with_no_children(&mut self, block_ref: BlockRef) {
-        self.unresolved_ancestors.entry(block_ref).or_default();
+    pub(crate) fn set_missing_ancestors_with_no_children(&mut self, block_ref: BlockRef) {
+        self.missing_ancestors.entry(block_ref).or_default();
     }
     #[cfg(test)]
     pub(crate) fn suspended_blocks_refs(&self) -> BTreeSet<BlockRef> {
-        self.suspended_block_headers.keys().cloned().collect()
+        self.suspended_headers.keys().cloned().collect()
     }
     #[cfg(test)]
     pub(crate) fn is_empty(&self) -> bool {
-        self.suspended_block_headers.is_empty()
-            && self.unresolved_ancestors.is_empty()
-            && self.missing_blocks.is_empty()
+        self.suspended_headers.is_empty()
+            && self.missing_ancestors.is_empty()
+            && self.headers_to_fetch.is_empty()
     }
     #[cfg(test)]
-    pub(crate) fn missing_block_refs(&self) -> BTreeSet<BlockRef> {
-        self.missing_blocks.keys().cloned().collect()
+    pub(crate) fn blocks_to_fetch_refs(&self) -> BTreeSet<BlockRef> {
+        self.headers_to_fetch.keys().cloned().collect()
     }
 }
 

--- a/crates/starfish/core/src/block_manager/block_suspender.rs
+++ b/crates/starfish/core/src/block_manager/block_suspender.rs
@@ -14,7 +14,7 @@ use crate::{BlockHeaderAPI, BlockRef, VerifiedBlockHeader, context::Context};
 
 struct SuspendedBlockHeader {
     block_header: VerifiedBlockHeader,
-    missing_ancestors: BTreeSet<BlockRef>,
+    unresolved_ancestors: BTreeSet<BlockRef>,
     timestamp: Instant,
 }
 
@@ -26,7 +26,7 @@ impl SuspendedBlockHeader {
         }
         Self {
             block_header: block,
-            missing_ancestors: ma,
+            unresolved_ancestors: ma,
             timestamp: Instant::now(),
         }
     }
@@ -45,7 +45,7 @@ pub(crate) struct BlockSuspender {
     /// dependency (key) to be a suspended block, so the block has been
     /// already fetched but itself is still missing some of its ancestors to be
     /// processed.
-    missing_ancestors: BTreeMap<BlockRef, BTreeSet<BlockRef>>,
+    unresolved_ancestors: BTreeMap<BlockRef, BTreeSet<BlockRef>>,
     /// A map of currently missing blocks to the set of authorities expected
     /// to have them available locally. This set is approximated based on the
     /// block's author and the authors of its direct children.
@@ -60,7 +60,7 @@ impl BlockSuspender {
         Self {
             context: context.clone(),
             suspended_block_headers: BTreeMap::new(),
-            missing_ancestors: BTreeMap::new(),
+            unresolved_ancestors: BTreeMap::new(),
             missing_blocks: BTreeMap::new(),
         }
     }
@@ -77,9 +77,9 @@ impl BlockSuspender {
     /// now unblocked due to newly accepted ancestors.
     ///
     /// # Arguments
-    /// * `missing_ancestors` - A map of verified block headers to the set of
-    ///   their unresolved ancestor references as read from the DagState by the
-    ///   caller.
+    /// * `missing_ancestors_map` - A map of verified block headers to the set
+    ///   of their unresolved ancestor references as read from the DagState by
+    ///   the caller.
     ///
     /// # Returns
     /// * `Vec<VerifiedBlockHeader>` — All headers that were accepted, either
@@ -93,12 +93,12 @@ impl BlockSuspender {
     /// - Updates internal fetch statistics.
     pub(crate) fn accept_or_suspend_received_headers(
         &mut self,
-        missing_ancestors: BTreeMap<VerifiedBlockHeader, BTreeSet<BlockRef>>,
+        missing_ancestors_map: BTreeMap<VerifiedBlockHeader, BTreeSet<BlockRef>>,
     ) -> (Vec<VerifiedBlockHeader>, BTreeSet<BlockRef>) {
         // Decide which headers are resolved now, which need to be suspended, and which
         // ancestors must still be fetched
         let (fully_resolved_headers, ancestors_to_fetch) =
-            self.resolve_or_suspend_headers(missing_ancestors);
+            self.resolve_or_suspend_headers(missing_ancestors_map);
         let mut accepted_headers = vec![];
 
         for fully_resolved_header in fully_resolved_headers {
@@ -177,8 +177,8 @@ impl BlockSuspender {
             self.register_suspended_block(incoming_block_header, &missing_ancestors);
             self.report_suspended_block(&block_ref);
             for ancestor in missing_ancestors {
-                self.register_missing_ancestor(block_ref, ancestor);
-                self.report_missing_ancestor(&ancestor);
+                self.register_unresolved_ancestor(block_ref, ancestor);
+                self.report_unresolved_ancestor(&ancestor);
 
                 // If this ancestor is not already suspended and is not part of the incoming
                 // batch, we may need to fetch it
@@ -241,8 +241,8 @@ impl BlockSuspender {
     /// their own dependents are checked in turn.
     ///
     /// # Arguments
-    /// * `resolved_block` - The block that was just accepted and may unsuspend
-    ///   other blocks.
+    /// * `resolved_block_ref` - The block that was just accepted and may
+    ///   unsuspend other blocks.
     ///
     /// # Returns
     /// * A list of verified block headers that have been unsuspended.
@@ -256,7 +256,7 @@ impl BlockSuspender {
         while let Some(popped_resolved_block_ref) = stack.pop() {
             // And try to check if its direct children can be unsuspended
             if let Some(suspended_block_refs_with_missing_deps) =
-                self.missing_ancestors.remove(&popped_resolved_block_ref)
+                self.unresolved_ancestors.remove(&popped_resolved_block_ref)
             {
                 for suspended_block_ref in suspended_block_refs_with_missing_deps {
                     // For each dependency try to unsuspend it. If that's successful then we add it
@@ -279,14 +279,15 @@ impl BlockSuspender {
     ///
     /// This function is called when a block that was previously suspended (due
     /// to missing ancestors) may now be unblocked because one of its
-    /// dependencies (`accepted_dependency`) has been resolved.
+    /// dependencies (`resolved_dependency`) has been resolved.
     /// The dependency is removed from the suspended block’s set of missing
     /// ancestors. If this was the final missing dependency, the block is
     /// removed from the suspension map and returned.
     ///
     /// # Arguments
-    /// * `block_ref` - Reference to the suspended block being re-evaluated.
-    /// * `accepted_dependency` - A block reference that was just accepted and
+    /// * `suspended_block_ref` - Reference to the suspended block being
+    ///   re-evaluated.
+    /// * `resolved_dependency` - A block reference that was just accepted and
     ///   may resolve a dependency.
     ///
     /// # Returns
@@ -296,7 +297,7 @@ impl BlockSuspender {
     ///
     /// # Panics
     /// - If the block is not found in the `suspended_block_headers` map.
-    /// - If `accepted_dependency` is not in the block's `missing_ancestors`
+    /// - If `resolved_dependency` is not in the block's `missing_ancestors`
     ///   set.
     ///
     /// # Side Effects
@@ -313,13 +314,13 @@ impl BlockSuspender {
             .expect("Block should be in suspended map");
 
         assert!(
-            block.missing_ancestors.remove(resolved_dependency),
+            block.unresolved_ancestors.remove(resolved_dependency),
             "Block reference {} should be present in missing dependencies of {:?}",
             suspended_block_ref,
             block.block_header
         );
         // If there are no more missing ancestors, unsuspend and return the block
-        if block.missing_ancestors.is_empty() {
+        if block.unresolved_ancestors.is_empty() {
             return self.suspended_block_headers.remove(suspended_block_ref);
         }
         // Otherwise, keep it suspended
@@ -337,12 +338,12 @@ impl BlockSuspender {
                 v.insert(suspended_block);
             }
             Entry::Occupied(mut o) => {
-                o.get_mut().missing_ancestors.extend(missing_ancestors);
+                o.get_mut().unresolved_ancestors.extend(missing_ancestors);
             }
         };
     }
-    fn register_missing_ancestor(&mut self, block_ref: BlockRef, ancestor: BlockRef) {
-        self.missing_ancestors
+    fn register_unresolved_ancestor(&mut self, block_ref: BlockRef, ancestor: BlockRef) {
+        self.unresolved_ancestors
             .entry(ancestor)
             .or_default()
             .insert(block_ref);
@@ -355,7 +356,7 @@ impl BlockSuspender {
             .with_label_values(&[self.context.authority_hostname(block_ref.author)])
             .inc();
     }
-    fn report_missing_ancestor(&mut self, ancestor: &BlockRef) {
+    fn report_unresolved_ancestor(&mut self, ancestor: &BlockRef) {
         self.context
             .metrics
             .node_metrics
@@ -424,7 +425,7 @@ impl BlockSuspender {
             .set(self.suspended_block_headers.len() as i64);
         metrics
             .block_manager_missing_ancestors
-            .set(self.missing_ancestors.len() as i64);
+            .set(self.unresolved_ancestors.len() as i64);
         metrics
             .block_manager_missing_blocks
             .set(self.missing_blocks.len() as i64);
@@ -442,8 +443,8 @@ impl BlockSuspender {
         self.missing_blocks.insert(block_ref, set)
     }
     #[cfg(test)]
-    pub(crate) fn set_missing_ancestors_with_no_children(&mut self, block_ref: BlockRef) {
-        self.missing_ancestors.entry(block_ref).or_default();
+    pub(crate) fn set_unresolved_ancestors_with_no_children(&mut self, block_ref: BlockRef) {
+        self.unresolved_ancestors.entry(block_ref).or_default();
     }
     #[cfg(test)]
     pub(crate) fn suspended_blocks_refs(&self) -> BTreeSet<BlockRef> {
@@ -452,7 +453,7 @@ impl BlockSuspender {
     #[cfg(test)]
     pub(crate) fn is_empty(&self) -> bool {
         self.suspended_block_headers.is_empty()
-            && self.missing_ancestors.is_empty()
+            && self.unresolved_ancestors.is_empty()
             && self.missing_blocks.is_empty()
     }
     #[cfg(test)]

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -177,7 +177,7 @@ impl BlockManager {
             block_refs.iter().map(|b| b.to_string()).join(",")
         );
 
-        let mut missing_blocks = BTreeSet::new();
+        let mut blocks_to_fetch = BTreeSet::new();
 
         for (found, block_ref) in self
             .dag_state
@@ -190,16 +190,16 @@ impl BlockManager {
                 continue;
             }
             // Fetches the block if it is not in dag state or suspended.
-            missing_blocks.insert(*block_ref);
+            blocks_to_fetch.insert(*block_ref);
             if self
                 .block_suspender
-                .insert_missing_block(*block_ref, BTreeSet::from([block_ref.author]))
+                .insert_block_to_fetch(*block_ref, BTreeSet::from([block_ref.author]))
                 .is_none()
             {
                 // We want to report this as a missing ancestor even if there is no block that
                 // is actually references it right now.
                 self.block_suspender
-                    .set_unresolved_ancestors_with_no_children(*block_ref);
+                    .set_missing_ancestors_with_no_children(*block_ref);
 
                 self.context
                     .metrics
@@ -213,12 +213,12 @@ impl BlockManager {
         let metrics = &self.context.metrics.node_metrics;
         metrics
             .missing_blocks_total
-            .inc_by(missing_blocks.len() as u64);
+            .inc_by(blocks_to_fetch.len() as u64);
         metrics
             .block_manager_missing_blocks
-            .set(self.block_suspender.missing_blocks_len() as i64);
+            .set(self.block_suspender.blocks_to_fetch_len() as i64);
 
-        missing_blocks
+        blocks_to_fetch
     }
     /// Verifies a block w.r.t. ancestor blocks.
     /// This is called after a block has complete causal history locally,
@@ -284,8 +284,7 @@ impl BlockManager {
                     }
                     {
                         panic!(
-                            "Unsuspended block {:?} has a missing ancestor! Ancestor not found in DagState: {:?}",
-                            b, ancestor_ref
+                            "Unsuspended block {b:?} has a missing ancestor! Ancestor not found in DagState: {ancestor_ref:?}",
                         );
                     }
                 }
@@ -303,7 +302,7 @@ impl BlockManager {
             self.context
                 .metrics
                 .node_metrics
-                .invalid_blocks
+                .invalid_block_headers
                 .with_label_values(&[
                     self.context.authority_hostname(block_ref.author),
                     "accept_block",
@@ -341,14 +340,14 @@ impl BlockManager {
     /// Returns all the blocks that are currently missing and needed in order to
     /// accept suspended blocks. For each block reference it returns the set of
     /// authorities who have this block.
-    pub(crate) fn missing_blocks(&self) -> BTreeMap<BlockRef, BTreeSet<AuthorityIndex>> {
-        self.block_suspender.missing_blocks()
+    pub(crate) fn blocks_to_fetch(&self) -> BTreeMap<BlockRef, BTreeSet<AuthorityIndex>> {
+        self.block_suspender.headers_to_fetch()
     }
 
     /// Returns all the block refs that are currently missing.
     #[cfg(test)]
-    pub(crate) fn missing_block_refs(&self) -> BTreeSet<BlockRef> {
-        self.block_suspender.missing_block_refs()
+    pub(crate) fn blocks_to_fetch_refs(&self) -> BTreeSet<BlockRef> {
+        self.block_suspender.blocks_to_fetch_refs()
     }
     /// Checks if block manager is empty.
     #[cfg(test)]
@@ -486,7 +485,7 @@ mod tests {
         // AND the missing blocks are the parents of the round 2 blocks. Since this is a
         // fully connected DAG taking the ancestors of the first element
         // suffices.
-        assert_eq!(block_manager.missing_block_refs(), missing_block_refs);
+        assert_eq!(block_manager.blocks_to_fetch_refs(), missing_block_refs);
 
         // AND suspended blocks should return the round_2_blocks
         assert_eq!(
@@ -499,7 +498,7 @@ mod tests {
 
         // AND each missing block should be known to all authorities
         let known_by_manager = block_manager
-            .missing_blocks()
+            .blocks_to_fetch()
             .iter()
             .next()
             .expect("We should expect at least two elements there")
@@ -647,8 +646,7 @@ mod tests {
 
             assert_eq!(
                 all_accepted_block_headers, all_block_headers,
-                "Failed acceptance sequence for seed {}",
-                seed
+                "Failed acceptance sequence for seed {seed}"
             );
             assert!(block_manager.is_empty());
         }
@@ -694,7 +692,7 @@ mod tests {
         // Blocks from round 1 are all missing, since the DAG is fully connected
         assert_eq!(missing_blocks, blocks_round_1);
 
-        let missing_blocks_with_authorities = block_manager.missing_blocks();
+        let missing_blocks_with_authorities = block_manager.blocks_to_fetch();
 
         let block_round_1_authority_0 = all_blocks
             .iter()
@@ -723,7 +721,7 @@ mod tests {
         // Add a new block from round 2 from authority 1, which updates the set of
         // authorities that are aware of the missing blocks
         block_manager.try_accept_block_headers(vec![blocks_round_2[1].clone()]);
-        let missing_blocks_with_authorities = block_manager.missing_blocks();
+        let missing_blocks_with_authorities = block_manager.blocks_to_fetch();
         assert_eq!(
             missing_blocks_with_authorities[&block_round_1_authority_0],
             BTreeSet::from([
@@ -850,7 +848,7 @@ mod tests {
             missing_block_refs.iter().cloned().collect::<BTreeSet<_>>();
         assert_eq!(missing, missing_block_refs_from_accept);
         assert_eq!(
-            block_manager.missing_block_refs(),
+            block_manager.blocks_to_fetch_refs(),
             missing_block_refs_from_accept
         );
 
@@ -883,7 +881,7 @@ mod tests {
                 .all(|block_ref| block_ref.round == 3)
         );
         assert_eq!(
-            block_manager.missing_block_refs(),
+            block_manager.blocks_to_fetch_refs(),
             missing_block_refs_from_accept
                 .into_iter()
                 .chain(missing_block_refs_from_find.into_iter())

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -3,42 +3,35 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, BTreeSet, btree_map::Entry},
+    collections::{BTreeMap, BTreeSet},
     sync::Arc,
-    time::Instant,
 };
 
 use iota_metrics::monitored_scope;
+#[cfg(test)]
 use itertools::Itertools as _;
 use parking_lot::RwLock;
 use starfish_config::AuthorityIndex;
-use tracing::{debug, warn};
+#[cfg(test)]
+use tracing::debug;
+use tracing::warn;
+
+/// Block Suspender is a private module unless under test.
+#[cfg(not(test))]
+mod block_suspender;
+#[cfg(test)]
+pub(crate) mod block_suspender;
 
 use crate::{
     Round,
     block_header::{
         BlockHeaderAPI, BlockRef, BlockTimestampMs, VerifiedBlock, VerifiedBlockHeader,
     },
+    block_manager::block_suspender::BlockSuspender,
     context::Context,
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
 };
-
-struct SuspendedBlockHeader {
-    block_header: VerifiedBlockHeader,
-    missing_ancestors: BTreeSet<BlockRef>,
-    timestamp: Instant,
-}
-
-impl SuspendedBlockHeader {
-    fn new(block: VerifiedBlockHeader, missing_ancestors: BTreeSet<BlockRef>) -> Self {
-        Self {
-            block_header: block,
-            missing_ancestors,
-            timestamp: Instant::now(),
-        }
-    }
-}
 
 /// Block manager suspends incoming blocks until they are connected to the
 /// existing graph, returning newly connected blocks.
@@ -49,30 +42,11 @@ pub(crate) struct BlockManager {
     context: Arc<Context>,
     dag_state: Arc<RwLock<DagState>>,
 
-    /// Keeps all the suspended block headers. A suspended block header is a
-    /// header that is missing part of its causal history and thus can't be
-    /// immediately processed. A block header will remain in this map until
-    /// all its causal history has been successfully processed.
-    suspended_block_headers: BTreeMap<BlockRef, SuspendedBlockHeader>,
     /// Keeps full blocks for suspended block headers
     /// TODO: this set can grow to become too big, need to add some eviction
     /// mechanism
     suspended_blocks: BTreeMap<BlockRef, VerifiedBlock>,
-
-    /// A map that keeps all the blocks that we are missing (keys) and the
-    /// corresponding blocks that reference the missing blocks as ancestors
-    /// and need them to get unsuspended. It is possible for a missing
-    /// dependency (key) to be a suspended block, so the block has been
-    /// already fetched but it self is still missing some of its ancestors to be
-    /// processed.
-    missing_ancestors: BTreeMap<BlockRef, BTreeSet<BlockRef>>,
-    /// A map of currently missing blocks to the set of authorities expected
-    /// to have them available locally. This set is approximated based on the
-    /// block's author and the authors of its direct children.
-    /// A block is considered missing if it appears in `missing_ancestors`
-    /// and has not yet been accepted or fetched. Blocks already stored or
-    /// present in `suspended_blocks` are excluded.
-    missing_block_headers: BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
+    block_suspender: BlockSuspender,
     /// A vector that holds a tuple of (lowest_round, highest_round) of received
     /// blocks per authority. This is used for metrics reporting purposes
     /// and resets during restarts.
@@ -81,15 +55,12 @@ pub(crate) struct BlockManager {
 
 impl BlockManager {
     pub(crate) fn new(context: Arc<Context>, dag_state: Arc<RwLock<DagState>>) -> Self {
-        let committee_size = context.committee.size();
         Self {
-            context,
+            context: context.clone(),
             dag_state,
-            suspended_block_headers: BTreeMap::new(),
             suspended_blocks: BTreeMap::new(),
-            missing_ancestors: BTreeMap::new(),
-            missing_block_headers: BTreeMap::new(),
-            received_block_rounds: vec![None; committee_size],
+            block_suspender: BlockSuspender::new(context.clone()),
+            received_block_rounds: vec![None; context.committee.size()],
         }
     }
 
@@ -146,60 +117,33 @@ impl BlockManager {
     /// Attempts to accept the provided blocks.
     fn try_accept_block_headers_internal(
         &mut self,
-        mut block_headers: Vec<VerifiedBlockHeader>,
+        block_headers: Vec<VerifiedBlockHeader>,
     ) -> (Vec<VerifiedBlockHeader>, BTreeSet<BlockRef>) {
         let _s = monitored_scope("BlockManager::try_accept_block_headers_internal");
 
-        block_headers.sort_by_key(|b| b.round());
-        debug!(
-            "Trying to accept block headers: {}",
-            block_headers
-                .iter()
-                .map(|b| b.reference().to_string())
-                .join(",")
-        );
-
-        let mut accepted_block_headers = vec![];
-        let mut missing_block_headers = BTreeSet::new();
-
-        for block_header in block_headers {
-            self.update_block_received_metrics(&block_header);
-
-            // Try to accept the input block.
-            let block_ref = block_header.reference();
-
-            let mut to_verify_timestamps_and_accept = vec![];
-
-            match self.try_accept_one_block_header(block_header) {
-                TryAcceptResult::Accepted(block_header) => {
-                    to_verify_timestamps_and_accept.push(block_header);
-                }
-                TryAcceptResult::Suspended(ancestors_to_fetch) => {
-                    debug!(
-                        "Missing ancestors to fetch for block {block_ref}: {}",
-                        ancestors_to_fetch.iter().map(|b| b.to_string()).join(",")
-                    );
-                    missing_block_headers.extend(ancestors_to_fetch);
-                    continue;
-                }
-                TryAcceptResult::Processed => continue,
-            };
-
-            // If the block is accepted, try to unsuspend its children blocks if any.
-            let unsuspended_blocks = self.try_unsuspend_children_blocks(block_ref);
-            to_verify_timestamps_and_accept.extend(unsuspended_blocks);
-
-            // Verify block timestamps
-            let blocks_to_accept =
-                self.verify_block_timestamps_and_accept(to_verify_timestamps_and_accept);
-            accepted_block_headers.extend(blocks_to_accept);
+        // Filter out already processed and suspended block headers.
+        let block_headers = self.filter_out_already_processed_and_sort(block_headers);
+        // update received block rounds
+        for block_header in &block_headers {
+            self.update_block_received_metrics(block_header);
         }
+        // Find missing ancestors for the provided block headers in the DAG state.
+        let missing_ancestors = self.find_missing_ancestors(block_headers);
+        let (processed_block_headers, ancestors_to_fetch) = self
+            .block_suspender
+            .accept_or_suspend_received_headers(missing_ancestors);
+        // Verify block timestamps
+        let accepted_block_headers =
+            self.verify_block_timestamps_and_accept(processed_block_headers);
 
-        self.update_stats(missing_block_headers.len() as u64);
+        // Insert the accepted blocks into DAG state so future blocks including them as
+        // ancestors do not get suspended.
+        self.dag_state
+            .write()
+            .accept_block_headers(accepted_block_headers.clone());
 
         // check if we already have blocks for this accepted header. If yes, add them to
-        // dag
-
+        // dag_state
         for block_header in accepted_block_headers.iter() {
             if let Some(block) = self.suspended_blocks.remove(&block_header.reference()) {
                 // for this accepted header we already have a block, so we add it to dag_state
@@ -210,7 +154,7 @@ impl BlockManager {
         }
 
         // Figure out the new missing blocks
-        (accepted_block_headers, missing_block_headers)
+        (accepted_block_headers, ancestors_to_fetch)
     }
 
     /// Tries to find the provided block_refs in DagState and BlockManager,
@@ -242,19 +186,20 @@ impl BlockManager {
             .into_iter()
             .zip(block_refs.iter())
         {
-            if found || self.suspended_block_headers.contains_key(block_ref) {
+            if found || self.block_suspender.is_block_ref_suspended(block_ref) {
                 continue;
             }
             // Fetches the block if it is not in dag state or suspended.
             missing_blocks.insert(*block_ref);
             if self
-                .missing_block_headers
-                .insert(*block_ref, BTreeSet::from([block_ref.author]))
+                .block_suspender
+                .insert_missing_block(*block_ref, BTreeSet::from([block_ref.author]))
                 .is_none()
             {
                 // We want to report this as a missing ancestor even if there is no block that
                 // is actually references it right now.
-                self.missing_ancestors.entry(*block_ref).or_default();
+                self.block_suspender
+                    .set_missing_ancestors_with_no_children(*block_ref);
 
                 self.context
                     .metrics
@@ -271,7 +216,7 @@ impl BlockManager {
             .inc_by(missing_blocks.len() as u64);
         metrics
             .block_manager_missing_blocks
-            .set(self.missing_block_headers.len() as i64);
+            .set(self.block_suspender.missing_blocks_len() as i64);
 
         missing_blocks
     }
@@ -279,7 +224,7 @@ impl BlockManager {
     /// This is called after a block has complete causal history locally,
     /// and is ready to be accepted into the DAG.
     ///
-    /// Caller must make sure ancestors corresponse to block.ancestors() 1-to-1,
+    /// Caller must make sure ancestors correspond to block.ancestors() 1-to-1,
     /// in the same order.
     fn check_ancestors(
         &self,
@@ -337,10 +282,10 @@ impl BlockManager {
                         blocks_to_reject.insert(b.reference(), b);
                         continue 'block;
                     }
-
                     {
                         panic!(
-                            "Unsuspended block {b:?} has a missing ancestor! Ancestor not found in DagState: {ancestor_ref:?}"
+                            "Unsuspended block {:?} has a missing ancestor! Ancestor not found in DagState: {:?}",
+                            b, ancestor_ref
                         );
                     }
                 }
@@ -354,11 +299,11 @@ impl BlockManager {
         }
 
         // TODO: report blocks_to_reject to peers.
-        for (block_ref, block) in blocks_to_reject {
+        for (block_ref, block) in &blocks_to_reject {
             self.context
                 .metrics
                 .node_metrics
-                .invalid_block_headers
+                .invalid_blocks
                 .with_label_values(&[
                     self.context.authority_hostname(block_ref.author),
                     "accept_block",
@@ -368,224 +313,8 @@ impl BlockManager {
             warn!("Invalid block {:?} is rejected", block);
         }
 
-        let blocks_to_accept = blocks_to_accept.values().cloned().collect::<Vec<_>>();
-
-        // Insert the accepted blocks into DAG state so future blocks including them as
-        // ancestors do not get suspended.
-        self.dag_state
-            .write()
-            .accept_block_headers(blocks_to_accept.clone());
-
-        blocks_to_accept
+        blocks_to_accept.values().cloned().collect::<Vec<_>>()
     }
-
-    /// Tries to accept the provided block. To accept a block its ancestors must
-    /// have been already successfully accepted. If block is accepted then
-    /// Some result is returned. None is returned when either the block is
-    /// suspended or the block has been already accepted before.
-    fn try_accept_one_block_header(
-        &mut self,
-        block_header: VerifiedBlockHeader,
-    ) -> TryAcceptResult {
-        let block_ref = block_header.reference();
-        let mut missing_ancestors = BTreeSet::new();
-        let mut ancestors_to_fetch = BTreeSet::new();
-        let dag_state = self.dag_state.read();
-
-        // If block has been already received and suspended, or already processed and
-        // stored, or is a genesis block, then skip it.
-        if self.suspended_block_headers.contains_key(&block_ref)
-            || dag_state.contains_block_header(&block_ref)
-        {
-            self.context
-                .metrics
-                .node_metrics
-                .block_manager_filtered_processed_headers_by_authority
-                .with_label_values(&[self.context.authority_hostname(block_ref.author)])
-                .inc();
-            return TryAcceptResult::Processed;
-        }
-
-        let ancestors = block_header.ancestors().to_vec();
-
-        // make sure that we have all the required ancestors in store
-        for (found, ancestor) in dag_state
-            .contains_block_headers(ancestors.clone())
-            .into_iter()
-            .zip(ancestors.iter())
-        {
-            if !found {
-                missing_ancestors.insert(*ancestor);
-
-                // mark the block as having missing ancestors
-                self.missing_ancestors
-                    .entry(*ancestor)
-                    .or_default()
-                    .insert(block_ref);
-
-                self.context
-                    .metrics
-                    .node_metrics
-                    .block_manager_missing_ancestors_by_authority
-                    .with_label_values(&[self.context.authority_hostname(ancestor.author)])
-                    .inc();
-
-                // Add the ancestor to the missing blocks set only if it doesn't already exist
-                // in the suspended blocks - meaning that we already have its
-                // payload.
-                if !self.suspended_block_headers.contains_key(ancestor) {
-                    // Fetches the block if it is not in dag state or suspended.
-                    ancestors_to_fetch.insert(*ancestor);
-                    // We also want to keep track of the authorities that have this block.
-                    // This block could be already missing, so we just update the set  of
-                    // authorities who have it.
-                    let entry = self.missing_block_headers.entry(*ancestor);
-                    match entry {
-                        Entry::Vacant(v) => {
-                            v.insert(BTreeSet::from([ancestor.author, block_ref.author]));
-                            self.context
-                                .metrics
-                                .node_metrics
-                                .block_manager_missing_blocks_by_authority
-                                .with_label_values(&[self
-                                    .context
-                                    .authority_hostname(ancestor.author)])
-                                .inc();
-                        }
-                        Entry::Occupied(mut o) => {
-                            o.get_mut().insert(block_ref.author);
-                        }
-                    }
-                }
-            }
-        }
-
-        // Remove the block ref from the `missing_blocks` - if exists - since we now
-        // have received the block. The block might still get suspended, but we
-        // won't report it as missing in order to not re-fetch.
-        self.missing_block_headers.remove(&block_header.reference());
-
-        if !missing_ancestors.is_empty() {
-            self.context
-                .metrics
-                .node_metrics
-                .block_suspensions
-                .with_label_values(&[self.context.authority_hostname(block_header.author())])
-                .inc();
-            self.suspended_block_headers.insert(
-                block_ref,
-                SuspendedBlockHeader::new(block_header, missing_ancestors),
-            );
-            return TryAcceptResult::Suspended(ancestors_to_fetch);
-        }
-
-        TryAcceptResult::Accepted(block_header)
-    }
-
-    /// Given an accepted block `accepted_block` it attempts to accept all the
-    /// suspended children blocks assuming such exist. All the unsuspended /
-    /// accepted blocks are returned as a vector in causal order.
-    fn try_unsuspend_children_blocks(
-        &mut self,
-        accepted_block: BlockRef,
-    ) -> Vec<VerifiedBlockHeader> {
-        let mut unsuspended_blocks = vec![];
-        let mut to_process_blocks = vec![accepted_block];
-
-        while let Some(block_ref) = to_process_blocks.pop() {
-            // And try to check if its direct children can be unsuspended
-            if let Some(block_refs_with_missing_deps) = self.missing_ancestors.remove(&block_ref) {
-                for r in block_refs_with_missing_deps {
-                    // For each dependency try to unsuspend it. If that's successful then we add it
-                    // to the queue so we can recursively try to unsuspend its
-                    // children.
-                    if let Some(block) = self.try_unsuspend_block(&r, &block_ref) {
-                        to_process_blocks.push(block.block_header.reference());
-                        unsuspended_blocks.push(block);
-                    }
-                }
-            }
-        }
-
-        let now = Instant::now();
-
-        // Report the unsuspended blocks
-        for block in &unsuspended_blocks {
-            self.context
-                .metrics
-                .node_metrics
-                .block_unsuspensions
-                .with_label_values(&[self.context.authority_hostname(block.block_header.author())])
-                .inc();
-            self.context
-                .metrics
-                .node_metrics
-                .suspended_block_time
-                .with_label_values(&[self.context.authority_hostname(block.block_header.author())])
-                .observe(now.saturating_duration_since(block.timestamp).as_secs_f64());
-        }
-
-        unsuspended_blocks
-            .into_iter()
-            .map(|block| block.block_header)
-            .collect()
-    }
-
-    /// Attempts to unsuspend a block by checking its ancestors and removing the
-    /// `accepted_dependency` by its local set. If there is no missing
-    /// dependency then this block can be unsuspended immediately and is removed
-    /// from the `suspended_blocks` map.
-    fn try_unsuspend_block(
-        &mut self,
-        block_ref: &BlockRef,
-        accepted_dependency: &BlockRef,
-    ) -> Option<SuspendedBlockHeader> {
-        let block = self
-            .suspended_block_headers
-            .get_mut(block_ref)
-            .expect("Block should be in suspended map");
-
-        assert!(
-            block.missing_ancestors.remove(accepted_dependency),
-            "Block reference {} should be present in missing dependencies of {:?}",
-            block_ref,
-            block.block_header
-        );
-
-        if block.missing_ancestors.is_empty() {
-            // we have no missing dependency, so we unsuspend the block and return it
-            return self.suspended_block_headers.remove(block_ref);
-        }
-        None
-    }
-
-    /// Returns all the block headers that are currently missing and needed in
-    /// order to accept suspended block headers. For each block reference it
-    /// returns the set of authorities who have this block header.
-    pub(crate) fn missing_block_headers(&self) -> BTreeMap<BlockRef, BTreeSet<AuthorityIndex>> {
-        self.missing_block_headers.clone()
-    }
-
-    /// Returns all the block refs that are currently missing.
-    #[cfg(test)]
-    pub(crate) fn missing_block_refs(&self) -> BTreeSet<BlockRef> {
-        self.missing_block_headers.keys().cloned().collect()
-    }
-
-    fn update_stats(&mut self, missing_blocks: u64) {
-        let metrics = &self.context.metrics.node_metrics;
-        metrics.missing_blocks_total.inc_by(missing_blocks);
-        metrics
-            .block_manager_suspended_blocks
-            .set(self.suspended_block_headers.len() as i64);
-        metrics
-            .block_manager_missing_ancestors
-            .set(self.missing_ancestors.len() as i64);
-        metrics
-            .block_manager_missing_blocks
-            .set(self.missing_block_headers.len() as i64);
-    }
-
     fn update_block_received_metrics(&mut self, block: &VerifiedBlockHeader) {
         let (min_round, max_round) =
             if let Some((curr_min, curr_max)) = self.received_block_rounds[block.author()] {
@@ -609,32 +338,90 @@ impl BlockManager {
             .set(max_round.into());
     }
 
+    /// Returns all the blocks that are currently missing and needed in order to
+    /// accept suspended blocks. For each block reference it returns the set of
+    /// authorities who have this block.
+    pub(crate) fn missing_blocks(&self) -> BTreeMap<BlockRef, BTreeSet<AuthorityIndex>> {
+        self.block_suspender.missing_blocks()
+    }
+
+    /// Returns all the block refs that are currently missing.
+    #[cfg(test)]
+    pub(crate) fn missing_block_refs(&self) -> BTreeSet<BlockRef> {
+        self.block_suspender.missing_block_refs()
+    }
     /// Checks if block manager is empty.
     #[cfg(test)]
     pub(crate) fn is_empty(&self) -> bool {
-        self.suspended_block_headers.is_empty()
-            && self.missing_ancestors.is_empty()
-            && self.missing_block_headers.is_empty()
+        self.block_suspender.is_empty()
     }
 
     /// Returns all the suspended blocks refs whose causal history we miss hence
     /// we can't accept them yet.
     #[cfg(test)]
-    fn suspended_blocks_refs(&self) -> BTreeSet<BlockRef> {
-        self.suspended_block_headers.keys().cloned().collect()
+    pub(crate) fn suspended_blocks_refs(&self) -> BTreeSet<BlockRef> {
+        self.block_suspender.suspended_blocks_refs()
     }
-}
 
-// Result of trying to accept one block.
-enum TryAcceptResult {
-    // The block is accepted. Wraps the block itself.
-    Accepted(VerifiedBlockHeader),
-    // The block is suspended. Wraps ancestors to be fetched.
-    Suspended(BTreeSet<BlockRef>),
-    // The block has been processed before and already exists in BlockManager (and is suspended)
-    // or in DagState (so has been already accepted). No further processing has been done at
-    // this point.
-    Processed,
+    fn find_missing_ancestors(
+        &self,
+        incoming_headers: Vec<VerifiedBlockHeader>,
+    ) -> BTreeMap<VerifiedBlockHeader, BTreeSet<BlockRef>> {
+        let mut missing_ancestors = BTreeMap::new();
+        let dag_state = self.dag_state.read();
+        for incoming_header in incoming_headers {
+            let ancestors: &[BlockRef] = incoming_header.ancestors();
+            let mut missing_ancestors_set = BTreeSet::new();
+            for (found, ancestor) in dag_state
+                .contains_block_headers(ancestors.to_vec())
+                .into_iter()
+                .zip(ancestors.iter())
+            {
+                if !found {
+                    missing_ancestors_set.insert(*ancestor);
+                }
+            }
+            missing_ancestors.insert(incoming_header, missing_ancestors_set);
+        }
+        missing_ancestors
+    }
+    /// Filters out the block headers that have been already processed
+    /// or are currently suspended. Reports metrics for the filtered out headers
+    fn filter_out_already_processed_and_sort(
+        &self,
+        block_headers: Vec<VerifiedBlockHeader>,
+    ) -> Vec<VerifiedBlockHeader> {
+        let block_references = block_headers
+            .iter()
+            .map(|b| b.reference())
+            .collect::<Vec<_>>();
+        let dag_state = self.dag_state.read();
+        let mut processed = block_headers
+            .into_iter()
+            .zip(dag_state.contains_block_headers(block_references))
+            .filter_map(|(block_header, found)| {
+                if found
+                    || self
+                        .block_suspender
+                        .is_block_ref_suspended(&block_header.reference())
+                {
+                    self.context
+                        .metrics
+                        .node_metrics
+                        .block_manager_filtered_processed_headers_by_authority
+                        .with_label_values(&[self
+                            .context
+                            .authority_hostname(block_header.author())])
+                        .inc();
+                    None // filter out
+                } else {
+                    Some(block_header) // keep
+                }
+            })
+            .collect::<Vec<_>>();
+        processed.sort_by_key(|h| h.round());
+        processed
+    }
 }
 
 #[cfg(test)]
@@ -655,7 +442,6 @@ mod tests {
         storage::mem_store::MemStore,
         test_dag_builder::DagBuilder,
     };
-
     #[tokio::test]
     async fn suspend_blocks_with_missing_ancestors() {
         // GIVEN
@@ -713,7 +499,7 @@ mod tests {
 
         // AND each missing block should be known to all authorities
         let known_by_manager = block_manager
-            .missing_block_headers()
+            .missing_blocks()
             .iter()
             .next()
             .expect("We should expect at least two elements there")
@@ -816,7 +602,7 @@ mod tests {
         assert!(accepted_block_headers.is_empty());
     }
 
-    /// The test generate blocks for a well connected DAG and feed them to block
+    /// The test generate blocks for a well-connected DAG and feed them to block
     /// manager in random order. In the end all the blocks should be
     /// uniquely suspended and no missing blocks should exist.
     #[tokio::test]
@@ -861,7 +647,8 @@ mod tests {
 
             assert_eq!(
                 all_accepted_block_headers, all_block_headers,
-                "Failed acceptance sequence for seed {seed}",
+                "Failed acceptance sequence for seed {}",
+                seed
             );
             assert!(block_manager.is_empty());
         }
@@ -907,7 +694,7 @@ mod tests {
         // Blocks from round 1 are all missing, since the DAG is fully connected
         assert_eq!(missing_blocks, blocks_round_1);
 
-        let missing_blocks_with_authorities = block_manager.missing_block_headers();
+        let missing_blocks_with_authorities = block_manager.missing_blocks();
 
         let block_round_1_authority_0 = all_blocks
             .iter()
@@ -936,7 +723,7 @@ mod tests {
         // Add a new block from round 2 from authority 1, which updates the set of
         // authorities that are aware of the missing blocks
         block_manager.try_accept_block_headers(vec![blocks_round_2[1].clone()]);
-        let missing_blocks_with_authorities = block_manager.missing_block_headers();
+        let missing_blocks_with_authorities = block_manager.missing_blocks();
         assert_eq!(
             missing_blocks_with_authorities[&block_round_1_authority_0],
             BTreeSet::from([
@@ -972,7 +759,6 @@ mod tests {
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
         let mut block_manager = BlockManager::new(context.clone(), dag_state);
-
         // Try to accept blocks from round 2 ~ 5 into block manager. All of them should
         // be suspended.
         let (accepted_block_headers, missing_refs) = block_manager.try_accept_block_headers(
@@ -982,7 +768,6 @@ mod tests {
                 .cloned()
                 .collect(),
         );
-
         // Missing refs should all come from round 1.
         assert!(accepted_block_headers.is_empty());
         assert_eq!(missing_refs.len(), 4);
@@ -998,7 +783,6 @@ mod tests {
                 .cloned()
                 .collect(),
         );
-
         // Only round 1 and round 2 blocks should be accepted.
         assert_eq!(accepted_block_headers.len(), 8);
         accepted_block_headers.iter().for_each(|block_header| {
@@ -1006,8 +790,8 @@ mod tests {
         });
         assert!(missing_refs.is_empty());
 
-        // Other blocks should be rejected and there should be no remaining suspended
-        // block.
+        // Other blocks should be rejected and there should be no suspended block
+        // remaining.
         assert!(block_manager.suspended_blocks_refs().is_empty());
     }
 
@@ -1055,7 +839,7 @@ mod tests {
                 .all(|block_ref| block_ref.round == 2)
         );
 
-        // Try accept blocks which will cause blocks to be suspended and added to
+        // Try to accept blocks which will cause blocks to be suspended and added to
         // missing in block manager.
         let (accepted_blocks_headers, missing) =
             block_manager.try_accept_block_headers(round_2_block_headers.clone());
@@ -1072,7 +856,7 @@ mod tests {
 
         // No blocks should be accepted and block manager should have made note
         // of the missing & suspended blocks.
-        // Now we can check get the result of try find block with all of the blocks
+        // Now we can check get the result of try to find block with all the blocks
         // from newly created but not accepted round 3.
         dag_builder.layer(3).build();
 

--- a/crates/starfish/core/src/block_manager/mod.rs
+++ b/crates/starfish/core/src/block_manager/mod.rs
@@ -199,7 +199,7 @@ impl BlockManager {
                 // We want to report this as a missing ancestor even if there is no block that
                 // is actually references it right now.
                 self.block_suspender
-                    .set_missing_ancestors_with_no_children(*block_ref);
+                    .set_unresolved_ancestors_with_no_children(*block_ref);
 
                 self.context
                     .metrics
@@ -396,7 +396,7 @@ impl BlockManager {
             .map(|b| b.reference())
             .collect::<Vec<_>>();
         let dag_state = self.dag_state.read();
-        let mut processed = block_headers
+        let mut filtered = block_headers
             .into_iter()
             .zip(dag_state.contains_block_headers(block_references))
             .filter_map(|(block_header, found)| {
@@ -419,8 +419,8 @@ impl BlockManager {
                 }
             })
             .collect::<Vec<_>>();
-        processed.sort_by_key(|h| h.round());
-        processed
+        filtered.sort_by_key(|h| h.round());
+        filtered
     }
 }
 

--- a/crates/starfish/core/src/core.rs
+++ b/crates/starfish/core/src/core.rs
@@ -878,7 +878,7 @@ impl Core {
             .scope_processing_time
             .with_label_values(&["Core::get_missing_blocks"])
             .start_timer();
-        self.block_manager.missing_block_headers()
+        self.block_manager.blocks_to_fetch()
     }
     pub(crate) fn get_missing_transaction_data(
         &self,

--- a/crates/starfish/core/src/tests/randomized_tests.rs
+++ b/crates/starfish/core/src/tests/randomized_tests.rs
@@ -140,7 +140,7 @@ async fn test_randomized_dag_and_decision_sequence() {
             // Evaluate the seen blocks so far
             let (suspended, missing) = evaluate_block_headers(&seen_so_far);
             let authority1_suspended = authority_1.block_manager.suspended_blocks_refs();
-            let authority1_missing = authority_1.block_manager.missing_block_refs();
+            let authority1_missing = authority_1.block_manager.blocks_to_fetch_refs();
             assert_eq!(suspended, authority1_suspended);
             assert_eq!(missing, authority1_missing);
         }
@@ -181,7 +181,7 @@ async fn test_randomized_dag_and_decision_sequence() {
             // Evaluate the seen blocks so far
             let (suspended, missing) = evaluate_block_headers(&seen_so_far);
             let authority2_suspended = authority_2.block_manager.suspended_blocks_refs();
-            let authority2_missing = authority_2.block_manager.missing_block_refs();
+            let authority2_missing = authority_2.block_manager.blocks_to_fetch_refs();
             assert_eq!(suspended, authority2_suspended);
             assert_eq!(missing, authority2_missing);
             i += chunk_size;

--- a/crates/starfish/core/src/tests/randomized_tests.rs
+++ b/crates/starfish/core/src/tests/randomized_tests.rs
@@ -10,7 +10,7 @@ use starfish_config::AuthorityIndex;
 
 use crate::{
     block_header::{BlockHeaderAPI, Slot},
-    block_manager::BlockManager,
+    block_manager::{BlockManager, block_suspender::tests::evaluate_block_headers},
     commit::DecidedLeader,
     context::Context,
     dag_state::DagState,
@@ -73,7 +73,6 @@ async fn test_randomized_dag_all_direct_commit() {
         }
     }
 }
-
 /// Test builds a randomized dag with the following conditions:
 /// - Links to 2f+1 minimum ancestors
 /// - Links to leader of previous round 50% of the time.
@@ -119,12 +118,13 @@ async fn test_randomized_dag_and_decision_sequence() {
         let mut sequenced_leaders_1 = vec![];
         let mut last_decided = Slot::new(0, 0);
         let mut i = 0;
+        let mut seen_so_far = vec![];
         while i < all_blocks.len() {
             let chunk_size = random_test_setup
                 .seeded_rng
                 .gen_range(1..=(all_blocks.len() - i));
             let chunk = &all_blocks[i..i + chunk_size];
-
+            seen_so_far.extend(chunk.iter().cloned());
             let _ = authority_1
                 .block_manager
                 .try_accept_block_headers(chunk.to_vec());
@@ -137,6 +137,12 @@ async fn test_randomized_dag_and_decision_sequence() {
             }
 
             i += chunk_size;
+            // Evaluate the seen blocks so far
+            let (suspended, missing) = evaluate_block_headers(&seen_so_far);
+            let authority1_suspended = authority_1.block_manager.suspended_blocks_refs();
+            let authority1_missing = authority_1.block_manager.missing_block_refs();
+            assert_eq!(suspended, authority1_suspended);
+            assert_eq!(missing, authority1_missing);
         }
 
         assert!(authority_1.block_manager.is_empty());
@@ -154,11 +160,13 @@ async fn test_randomized_dag_and_decision_sequence() {
         let mut sequenced_leaders_2 = vec![];
         let mut last_decided = Slot::new(0, 0);
         let mut i = 0;
+        let mut seen_so_far = vec![];
         while i < all_blocks.len() {
             let chunk_size = random_test_setup
                 .seeded_rng
                 .gen_range(1..=(all_blocks.len() - i));
             let chunk = &all_blocks[i..i + chunk_size];
+            seen_so_far.extend(chunk.iter().cloned());
 
             let _ = authority_2
                 .block_manager
@@ -170,7 +178,12 @@ async fn test_randomized_dag_and_decision_sequence() {
                 let leader_status = sequence.last().unwrap();
                 last_decided = Slot::new(leader_status.round(), leader_status.authority());
             }
-
+            // Evaluate the seen blocks so far
+            let (suspended, missing) = evaluate_block_headers(&seen_so_far);
+            let authority2_suspended = authority_2.block_manager.suspended_blocks_refs();
+            let authority2_missing = authority_2.block_manager.missing_block_refs();
+            assert_eq!(suspended, authority2_suspended);
+            assert_eq!(missing, authority2_missing);
             i += chunk_size;
         }
 


### PR DESCRIPTION
# Description of change

This pull request refactors the `BlockManager` to improve modularity and maintainability by extracting the block suspension logic into a new `BlockSuspender` struct and module. The changes enhance code organization, reduce the complexity of `BlockManager`, and make the suspension logic more reusable and testable.

### Key Changes:
1. **New `BlockSuspender` Module/Struct**:
   - Created `src/block_manager/block_suspender.rs` to encapsulate block suspension logic, including the `SuspendedBlockHeader` struct and methods for accepting, suspending, and un-suspending headers.
   - Manages suspended block headers, missing ancestors, and missing blocks in a dedicated `BlockSuspender` struct.

2. **BlockManager Refactoring**:
   - Renamed `block_manager.rs` to `block_manager/mod.rs` to support the new module structure with `block_suspender.rs`.
   - Replaced suspension-related fields in `BlockManager` (`suspended_block_headers`, `missing_ancestors`, `missing_blocks`) with a single `block_suspender: BlockSuspender` field.
   - Simplified `try_accept_block_headers_internal` by delegating to `BlockSuspender::accept_or_suspend_received_headers`.
   - Added `find_missing_ancestors` and `filter_out_already_processed_and_sort` helper methods to handle block filtering and ancestor lookup.

3. **BlockHeader Enhancements**:
   - Added `PartialOrd`, `PartialEq`, `Ord`, and `Eq` derive macros to `BlockHeader`, `BlockHeaderV1`, `SignedBlockHeader`, and `VerifiedBlockHeader` in `block_header.rs` to ensure consistent ordering and comparison for `BTreeMap` and `BTreeSet` operations in `BlockSuspender`.

4. **Test Updates**:
   - Added `evaluate_block_headers` helper function that evaluates which blocks should be suspended, and which should be missing, based on a list of `block_headers` seen so far. Used in randomized test `test_randomized_dag_and_decision_sequence` to make sure that after each iteration of the randomized chunks the suspension logic is working as expected.

### Why:
- **Efficiancy**: Processing is now done in batches, and thus reading from the DagState is only done at the beginning, and writing the entire batch of resolved headers is done at the end, where previously DagState was accessed many times for each block header.
- **Modularity**: Separates suspension logic into `BlockSuspender`, improving code organization and maintainability.
- **Readability**: Reduces `BlockManager` complexity by delegating suspension tasks to a dedicated module.
- **Testability**: Enables independent testing of suspension logic.
- **Consistency**: Ensures predictable behavior in collections with proper ordering traits.

### Warning:
- The refactored code modifies the previous implementation such that where previously blocks were processed and stored in the dag one by one, they are now processed and stored in batches.

## Links to any relevant issues

Fixes #8060.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
