### PR TITLE
fix(Consensus): transactions missing if parsed

### DIFF
--- a/crates/starfish/core/src/test_dag_builder.rs
+++ b/crates/starfish/core/src/test_dag_builder.rs
@@ -572,6 +572,32 @@ impl DagBuilder {
             references.push(block.reference());
             self.block_headers.insert(block.reference(), block.clone());
         }
+        let mut rng = StdRng::from_entropy();
+        let unique_transaction_acks: Vec<BlockRef> = transaction_acks
+            .values()
+            .flatten()
+            .cloned()
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        for block_ref in unique_transaction_acks {
+            // Create random transactions and their commitment.
+            let mut tx_bytes = [0u8; 32];
+            rng.fill(&mut tx_bytes[..]);
+            let transactions = vec![Transaction::new(tx_bytes.to_vec())];
+            let serialized_transactions = Transaction::serialize(&transactions).unwrap();
+            let commitment =
+                TransactionsCommitment::compute_transactions_commitment(&serialized_transactions)
+                    .unwrap();
+
+            let verified_transactions = VerifiedTransactions::new(
+                transactions,
+                block_ref,
+                commitment,
+                serialized_transactions,
+            );
+            self.transactions.insert(block_ref, verified_transactions);
+        }
         self.last_ancestors = references;
     }
 }


### PR DESCRIPTION
# Description of change

adds logic in `layer_with_connections` method of `DagBuilder`, that is used by the `test_dag_parser`, that creates and adds `VerifiedTransactions` to `DagBuilder`.


## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
