### PR TITLE
feat(starfish): add transaction latency metrics

### DIFF
--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -53,6 +53,9 @@ pub(crate) struct CommitObserver {
     sender: UnboundedSender<CommittedSubDag>,
     /// Persistent storage for blocks, commits and other consensus data.
     store: Arc<dyn Store>,
+    /// Dag state for direct access to block headers
+    dag_state: Arc<RwLock<DagState>>,
+
     leader_schedule: Arc<LeaderSchedule>,
 }
 
@@ -74,6 +77,7 @@ impl CommitObserver {
             context,
             sender: commit_consumer.sender,
             store,
+            dag_state,
             leader_schedule,
         };
 
@@ -123,7 +127,7 @@ impl CommitObserver {
             .get_transaction_ack_authors(missing_transactions);
 
         let mut sent_sub_dags = Vec::with_capacity(solid_sub_dags.len());
-        for solid_sub_dag in solid_sub_dags.into_iter() {
+        for solid_sub_dag in solid_sub_dags.iter() {
             // Failures in sender.send() are assumed to be permanent
             if let Err(err) = self.sender.send(solid_sub_dag.clone()) {
                 tracing::error!(
@@ -138,7 +142,7 @@ impl CommitObserver {
             );
             sent_sub_dags.push(solid_sub_dag);
         }
-        self.report_metrics(&pending_sub_dags);
+        self.report_metrics(&pending_sub_dags, &solid_sub_dags);
         tracing::trace!("Committed & sent {sent_sub_dags:#?}");
 
         Ok((pending_sub_dags, missing_transaction_acknowledgers))
@@ -279,13 +283,18 @@ impl CommitObserver {
             .get_transaction_ack_authors(missing_refs.into_iter().collect())
     }
 
-    fn report_metrics(&self, committed: &[PendingSubDag]) {
+    fn report_metrics(
+        &self,
+        pending_sub_dags: &[PendingSubDag],
+        committed_sub_dags: &[CommittedSubDag],
+    ) {
         let metrics = &self.context.metrics.node_metrics;
         let utc_now = self.context.clock.timestamp_utc_ms();
 
-        for commit in committed {
+        // First report block_header-related metrics for pending subdags
+        for commit in pending_sub_dags {
             debug!(
-                "Consensus commit {} with leader {} has {} blocks",
+                "Consensus pending subdag {} with leader {} has {} blocks",
                 commit.commit_ref,
                 commit.leader,
                 commit.blocks.len()
@@ -315,7 +324,60 @@ impl CommitObserver {
             .metrics
             .node_metrics
             .sub_dags_per_commit_count
-            .observe(committed.len() as f64);
+            .observe(pending_sub_dags.len() as f64);
+
+        // Now report transaction-related metrics for committed subdags
+        for commit in committed_sub_dags {
+            info!(
+                "Consensus available subdag {} with leader {} has transactions from {} blocks",
+                commit.commit_ref,
+                commit.leader,
+                commit.transactions.len()
+            );
+
+            // Report the actual number of committed transactions
+            metrics.transactions_per_commit_count.observe(
+                commit
+                    .transactions
+                    .iter()
+                    .map(|x| x.transactions().len())
+                    .sum::<usize>() as f64,
+            );
+
+            let block_refs_for_committed_txs = commit
+                .transactions
+                .iter()
+                .map(|tx| tx.block_ref())
+                .collect::<Vec<_>>();
+
+            // TODO: decide whether we want to read from storage here or not as it could
+            // create an overhead in cases when available committed subdags are
+            // lagging behind the pending subdags.
+
+            // Read block headers from storage for the transactions in the commit.
+            // This is necessary to calculate the latency of the transactions.
+            let headers_for_committed_txs = self
+                .dag_state
+                .read()
+                .get_block_headers(&block_refs_for_committed_txs)
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>();
+            assert_eq!(
+                headers_for_committed_txs.len(),
+                commit.transactions.len(),
+                "All transactions should have corresponding block headers in storage"
+            );
+
+            for block_header in headers_for_committed_txs {
+                let latency_ms = utc_now
+                    .checked_sub(block_header.timestamp_ms())
+                    .unwrap_or_default();
+                metrics
+                    .transaction_commit_latency
+                    .observe(Duration::from_millis(latency_ms).as_secs_f64());
+            }
+        }
     }
 }
 

--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -350,24 +350,17 @@ impl CommitObserver {
                 .map(|tx| tx.block_ref())
                 .collect::<Vec<_>>();
 
-            // TODO: decide whether we want to read from storage here or not as it could
-            // create an overhead in cases when available committed subdags are
-            // lagging behind the pending subdags.
-
-            // Read block headers from storage for the transactions in the commit.
-            // This is necessary to calculate the latency of the transactions.
+            // Read only cached block headers from storage for the transactions in the
+            // commit. Headers are needed to calculate the latency of the
+            // transactions. The metrics reflects only the latency for cached
+            // block headers
             let headers_for_committed_txs = self
                 .dag_state
                 .read()
-                .get_block_headers(&block_refs_for_committed_txs)
+                .get_cached_block_headers(&block_refs_for_committed_txs)
                 .into_iter()
                 .flatten()
                 .collect::<Vec<_>>();
-            assert_eq!(
-                headers_for_committed_txs.len(),
-                commit.transactions.len(),
-                "All transactions should have corresponding block headers in storage"
-            );
 
             for block_header in headers_for_committed_txs {
                 let latency_ms = utc_now

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -590,6 +590,31 @@ impl DagState {
         block_headers
     }
 
+    /// Gets block headers by checking genesis and then cached recent block
+    /// headers in memory. Storage is not checked in this method. An element
+    /// is None when the corresponding block header is not found.
+    pub(crate) fn get_cached_block_headers(
+        &self,
+        block_refs: &[BlockRef],
+    ) -> Vec<Option<VerifiedBlockHeader>> {
+        let mut block_headers: Vec<Option<VerifiedBlockHeader>> = vec![None; block_refs.len()];
+        for (index, block_ref) in block_refs.iter().enumerate() {
+            if block_ref.round == GENESIS_ROUND {
+                // Allow the caller to handle the invalid genesis ancestor error.
+                if let Some(block) = self.genesis.get(block_ref) {
+                    block_headers[index] = Some((**block).clone());
+                }
+                continue;
+            }
+            if let Some(block) = self.recent_block_headers.get(block_ref) {
+                block_headers[index] = Some(block.clone());
+                continue;
+            }
+        }
+
+        block_headers
+    }
+
     /// Gets all uncommitted blocks in a slot.
     /// Uncommitted blocks must exist in memory, so only in-memory blocks are
     /// checked.
@@ -766,7 +791,7 @@ impl DagState {
     /// byzantine block headers, or when received block headers are not
     /// deduped.
     #[cfg_attr(not(test), expect(dead_code))]
-    pub(crate) fn get_cached_block_headers(
+    pub(crate) fn get_cached_block_headers_since_round(
         &self,
         authority: AuthorityIndex,
         start: Round,
@@ -2216,35 +2241,47 @@ mod test {
             }
         }
 
-        let cached_block_headers =
-            dag_state.get_cached_block_headers(context.committee.to_authority_index(0).unwrap(), 0);
+        let cached_block_headers = dag_state.get_cached_block_headers_since_round(
+            context.committee.to_authority_index(0).unwrap(),
+            0,
+        );
         assert!(cached_block_headers.is_empty());
 
-        let cached_block_headers = dag_state
-            .get_cached_block_headers(context.committee.to_authority_index(1).unwrap(), 10);
+        let cached_block_headers = dag_state.get_cached_block_headers_since_round(
+            context.committee.to_authority_index(1).unwrap(),
+            10,
+        );
         assert_eq!(cached_block_headers.len(), 1);
         assert_eq!(cached_block_headers[0].round(), 10);
 
-        let cached_block_headers = dag_state
-            .get_cached_block_headers(context.committee.to_authority_index(2).unwrap(), 10);
+        let cached_block_headers = dag_state.get_cached_block_headers_since_round(
+            context.committee.to_authority_index(2).unwrap(),
+            10,
+        );
         assert_eq!(cached_block_headers.len(), 2);
         assert_eq!(cached_block_headers[0].round(), 10);
         assert_eq!(cached_block_headers[1].round(), 11);
 
-        let cached_block_headers = dag_state
-            .get_cached_block_headers(context.committee.to_authority_index(2).unwrap(), 11);
+        let cached_block_headers = dag_state.get_cached_block_headers_since_round(
+            context.committee.to_authority_index(2).unwrap(),
+            11,
+        );
         assert_eq!(cached_block_headers.len(), 1);
         assert_eq!(cached_block_headers[0].round(), 11);
 
-        let cached_block_headers = dag_state
-            .get_cached_block_headers(context.committee.to_authority_index(3).unwrap(), 10);
+        let cached_block_headers = dag_state.get_cached_block_headers_since_round(
+            context.committee.to_authority_index(3).unwrap(),
+            10,
+        );
         assert_eq!(cached_block_headers.len(), 3);
         assert_eq!(cached_block_headers[0].round(), 10);
         assert_eq!(cached_block_headers[1].round(), 11);
         assert_eq!(cached_block_headers[2].round(), 12);
 
-        let cached_block_headers = dag_state
-            .get_cached_block_headers(context.committee.to_authority_index(3).unwrap(), 12);
+        let cached_block_headers = dag_state.get_cached_block_headers_since_round(
+            context.committee.to_authority_index(3).unwrap(),
+            12,
+        );
         assert_eq!(cached_block_headers.len(), 1);
         assert_eq!(cached_block_headers[0].round(), 12);
 

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -158,6 +158,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) missing_blocks_after_fetch_total: IntCounter,
     pub(crate) num_of_bad_nodes: IntGauge,
     pub(crate) quorum_receive_latency: Histogram,
+    pub(crate) transactions_per_commit_count: Histogram,
     pub(crate) transactions_synchronizer_fetched_transactions_by_peer: IntCounterVec,
     pub(crate) transactions_synchronizer_fetched_transactions_by_authority: IntCounterVec,
     pub(crate) transactions_synchronizer_missing_transactions_by_authority: IntCounterVec,
@@ -170,6 +171,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) reputation_scores: IntGaugeVec,
     pub(crate) scope_processing_time: HistogramVec,
     pub(crate) sub_dags_per_commit_count: Histogram,
+    pub(crate) transaction_commit_latency: Histogram,
     pub(crate) block_suspensions: IntCounterVec,
     pub(crate) block_unsuspensions: IntCounterVec,
     pub(crate) suspended_block_time: HistogramVec,
@@ -207,6 +209,12 @@ impl NodeMetrics {
             block_commit_latency: register_histogram_with_registry!(
                 "block_commit_latency",
                 "The time taken between block creation and block commit.",
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            ).unwrap(),
+            transaction_commit_latency: register_histogram_with_registry!(
+                "transaction_commit_latency",
+                "The time taken between inclusion transactions in a block and transactions are sequenced.",
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             ).unwrap(),
@@ -415,6 +423,12 @@ impl NodeMetrics {
             sync_last_known_own_block_retries: register_int_counter_with_registry!(
                 "sync_last_known_own_block_retries",
                 "Number of times this node tried to fetch the last own block from peers",
+                registry,
+            ).unwrap(),
+            transactions_per_commit_count: register_histogram_with_registry!(
+                "transactions_per_commit_count",
+                "The number of transactions per commit.",
+                NUM_BUCKETS.to_vec(),
                 registry,
             ).unwrap(),
             // TODO: add a short status label.


### PR DESCRIPTION
# Description of change

We introduce the transaction latency which is larger than the block latency. We report the transaction latency (only for block headers in memory) and the actual number of committed transactions

## Links to any relevant issues

#8054 
## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: new transaction latency metric
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
