### PR TITLE
chore(iota-types): add reminder to introduce `CancelledTransactionsV2` when adding `ConsensusCommitPrologueV2`

### DIFF
--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -335,6 +335,10 @@ pub enum TransactionKind {
 
     RandomnessStateUpdate(RandomnessStateUpdate),
     // .. more transaction types go here
+    // TODO: When introducing `ConsensusCommitPrologueV2`, please add
+    // and use a new variant for `ConsensusDeterminedVersionAssignments`.
+    // See https://github.com/iotaledger/iota/issues/7692 and
+    // https://github.com/iotaledger/iota/pull/7697 for detail.
 }
 
 /// EndOfEpochTransactionKind


### PR DESCRIPTION
# Description of change

Just added a to-do comment to remind about introducing `CancelledTransactionsV2` whenever we add `ConsensusCommitPrologueV2`.

## Links to any relevant issues

Related issue #7692 and PR #7697.

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
