### PR TITLE
chore(iota-indexer): Add backfill section to `README.md`

### DIFF
--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -110,10 +110,10 @@ Options:                                                                        
           Print help
 ```
 
-It supports two kinds of backfills:
+It supports following backfill options:
 
-- **SQL Backfill**: Executes a SQL statement directly against the database in chunks, filtering on a specified column (typically a sequence number). Conflict resolution is handled automatically with `ON CONFLICT DO NOTHING`.
-- **Ingestion Backfill**: Fetches and buffers checkpoint data from a remote store, then slices the buffered checkpoint data into chunks to backfill the database.
+- `sql`: Executes a SQL statement directly against the database in chunks, filtering on a specified column (typically a sequence number). Conflict resolution is handled automatically with `ON CONFLICT DO NOTHING`.
+- `ingestion`: Fetches and buffers checkpoint data from a remote store, then slices the buffered checkpoint data into chunks to backfill the database.
 
 #### Backfill job: `tx-wrapped-or-deleted-objects`
 
@@ -134,11 +134,11 @@ You can use the following parameters to optimize performance:
 
 #### Error Handling
 
-If any errors occur during the backfill, the error log will indicate the exact chunk (`{start}`-`{end}`) where the failure occurred. To avoid any data gaps, restart the backfill from the calculated restart point:
+If any errors occur during the backfill, the error log will indicate the exact chunk (`{start}`-`{end}`) where the failure occurred. To prevent data gaps, you can restart the backfill from the calculated restart point:
 
 `restart_from = failed_chunk_start - (max_concurrency * chunk_size)`
 
-This ensures any unprocessed chunks are covered, preventing data gaps.
+This ensures any unprocessed chunks are covered also in the worst-case, preventing data gaps.
 
 ### DB reset
 

--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -107,11 +107,11 @@ You can use the following parameters to optimize performance:
 
 #### Error Handling
 
-If any errors occur during the backfill, the error log will specify the checkpoint sequence number where the failure happened. To ensure no data gaps remain, restart the backfill from:
+If any errors occur during the backfill, the error log will indicate the exact chunk (`{start}`-`{end}`) where the failure occurred. To avoid any data gaps, restart the backfill from the calculated restart point:
 
-`checkpoint_seq_num = failing_checkpoint_seq_num - (concurrency * chunk_size)`
+`restart_from = failed_chunk_start - (concurrency * chunk_size)`
 
-This approach covers potential edge cases and ensures data integrity.
+This ensures any unprocessed chunks are covered, preventing data gaps.
 
 ### DB reset
 

--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -105,7 +105,7 @@ Options:                                                                        
       --max-concurrency <MAX_CONCURRENCY>                                                      │
           Maximum number of concurrent tasks to run [default: 10]                              │
       --chunk-size <CHUNK_SIZE>                                                                │
-          Number of checkpoints to backfill in a single SQL command [default: 1000]            │
+          Size of the data chunks processed per task [default: 1000]            │
   -h, --help                                                                                   │
           Print help
 ```

--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -118,7 +118,7 @@ This job backfills the `tx_wrapped_or_deleted_objects` table, which indexes tran
 Replace `<START>` and `<END>` with the desired checkpoint range to backfill (e.g., `0` `10000`, both inclusive), and `<REMOTE_STORE_URL>` with the fullnode REST API URL used to fetch checkpoint data.
 
 ```sh
-cargo run --bin iota-indexer -- --database-url "postgres://postgres:postgrespw@localhost/iota_indexer" run-backfill <START> <END> ingestion tx-wrapped-or-deleted-objects <REMOTE_STORE_URL>
+cargo run --bin iota-indexer -- --database-url <DATABASE_URL> run-backfill <START> <END> ingestion tx-wrapped-or-deleted-objects <REMOTE_STORE_URL>
 ```
 
 #### Configuring concurrency and chunk size

--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -85,7 +85,7 @@ More available flags can be found in this [file](https://github.com/iotaledger/i
 
 ### Backfilling of data
 
-When a new database table is introduced, backfilling may be required to populate historical data.
+Sometimes when the schema changes (e.g. adding a new table or column), backfilling may be required to populate historical data.
 The CLI provides a `run-backfill` command to facilitate this process.
 
 #### Backfill job: `tx-wrapped-or-deleted-objects`

--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -89,25 +89,22 @@ Sometimes when the schema changes (e.g. adding a new table or column), backfilli
 The CLI provides a `run-backfill` command to facilitate this process:
 
 ```sh
-Usage: iota-indexer run-backfill [OPTIONS] <START> <END> <COMMAND>                             │
-                                                                                               │
-Commands:                                                                                      │
-  sql        Run a SQL backfill                                                                │
-  ingestion  Run a backfill driven by the ingestion engine                                     │
-  help       Print this message or the help of the given subcommand(s)                         │
-                                                                                               │
-Arguments:                                                                                     │
-  <START>  Start of the range to backfill, inclusive. It can be a checkpoint number or an epoch│
-           or any other identifier that can be used to slice the backfill range                │
-  <END>    End of the range to backfill, inclusive                                             │
-                                                                                               │
-Options:                                                                                       │
-      --max-concurrency <MAX_CONCURRENCY>                                                      │
-          Maximum number of concurrent tasks to run [default: 10]                              │
-      --chunk-size <CHUNK_SIZE>                                                                │
-          Size of the data chunks processed per task [default: 1000]            │
-  -h, --help                                                                                   │
-          Print help
+Usage: iota-indexer run-backfill [OPTIONS] <START> <END> <COMMAND>
+
+Commands:
+  sql        Run a SQL backfill
+  ingestion  Run a backfill driven by the ingestion engine
+  help       Print this message or the help of the given subcommand(s)
+
+Arguments:
+  <START>  Start of the range to backfill, inclusive. It can be a checkpoint number or an epoch or any other identifier that
+           can be used to slice the backfill range
+  <END>    End of the range to backfill, inclusive
+
+Options:
+      --max-concurrency <MAX_CONCURRENCY>  Maximum number of concurrent tasks to run [default: 10]
+      --chunk-size <CHUNK_SIZE>            Size of the data chunks processed per task [default: 1000]
+  -h, --help                               Print help
 ```
 
 It supports following backfill options:

--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -83,6 +83,36 @@ cargo run --bin iota-indexer -- --db-url "postgres://postgres:postgrespw@localho
 
 More available flags can be found in this [file](https://github.com/iotaledger/iota/blob/develop/crates/iota-indexer/src/lib.rs).
 
+### Backfilling of data
+
+When a new database table is introduced, backfilling may be required to populate historical data.
+The CLI provides a `run-backfill` command to facilitate this process.
+
+#### Backfill job: `tx-wrapped-or-deleted-objects`
+
+This job backfills the `tx_wrapped_or_deleted_objects` table, which indexes transactions that either wrapped or deleted given objects.
+Replace `<START>` and `<END>` with the desired checkpoint range to backfill (e.g., `0` `10000`, both inclusive), and `<REMOTE_STORE_URL>` with the fullnode REST API URL used to fetch checkpoint data.
+
+```sh
+cargo run --bin iota-indexer -- --database-url "postgres://postgres:postgrespw@localhost/iota_indexer" run-backfill <START> <END> ingestion tx-wrapped-or-deleted-objects <REMOTE_STORE_URL>
+```
+
+#### Configuring concurrency and chunk size
+
+You can use the following parameters to optimize performance:
+
+`--max-concurrency`: Maximum number of concurrent tasks to run (default: `10`).
+
+`--chunk-size`: Size of the data chunks processed per task (default: `1000`).
+
+#### Error Handling
+
+If any errors occur during the backfill, the error log will specify the checkpoint sequence number where the failure happened. To ensure no data gaps remain, restart the backfill from:
+
+`checkpoint_seq_num = failing_checkpoint_seq_num - (concurrency * chunk_size)`
+
+This approach covers potential edge cases and ensures data integrity.
+
 ### DB reset
 
 To wipe the database, make sure you are in the `iota/crates/iota-indexer` directory and run following command. In case of schema changes in `.sql` files, this will also update corresponding `schema.rs` file:

--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -109,7 +109,7 @@ You can use the following parameters to optimize performance:
 
 If any errors occur during the backfill, the error log will indicate the exact chunk (`{start}`-`{end}`) where the failure occurred. To avoid any data gaps, restart the backfill from the calculated restart point:
 
-`restart_from = failed_chunk_start - (concurrency * chunk_size)`
+`restart_from = failed_chunk_start - (max_concurrency * chunk_size)`
 
 This ensures any unprocessed chunks are covered, preventing data gaps.
 

--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -121,14 +121,6 @@ Replace `<START>` and `<END>` with the desired checkpoint range to backfill (e.g
 cargo run --bin iota-indexer -- --database-url <DATABASE_URL> run-backfill <START> <END> ingestion tx-wrapped-or-deleted-objects <REMOTE_STORE_URL>
 ```
 
-#### Configuring concurrency and chunk size
-
-You can use the following parameters to optimize performance:
-
-`--max-concurrency`: Maximum number of concurrent tasks to run (default: `10`).
-
-`--chunk-size`: Size of the data chunks processed per task (default: `1000`).
-
 #### Error Handling
 
 If any errors occur during the backfill, the error log will indicate the exact chunk (`{start}`-`{end}`) where the failure occurred. To prevent data gaps, you can restart the backfill from the calculated restart point:

--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -86,7 +86,34 @@ More available flags can be found in this [file](https://github.com/iotaledger/i
 ### Backfilling of data
 
 Sometimes when the schema changes (e.g. adding a new table or column), backfilling may be required to populate historical data.
-The CLI provides a `run-backfill` command to facilitate this process.
+The CLI provides a `run-backfill` command to facilitate this process:
+
+```sh
+Usage: iota-indexer run-backfill [OPTIONS] <START> <END> <COMMAND>                             │
+                                                                                               │
+Commands:                                                                                      │
+  sql        Run a SQL backfill                                                                │
+  ingestion  Run a backfill driven by the ingestion engine                                     │
+  help       Print this message or the help of the given subcommand(s)                         │
+                                                                                               │
+Arguments:                                                                                     │
+  <START>  Start of the range to backfill, inclusive. It can be a checkpoint number or an epoch│
+           or any other identifier that can be used to slice the backfill range                │
+  <END>    End of the range to backfill, inclusive                                             │
+                                                                                               │
+Options:                                                                                       │
+      --max-concurrency <MAX_CONCURRENCY>                                                      │
+          Maximum number of concurrent tasks to run [default: 10]                              │
+      --chunk-size <CHUNK_SIZE>                                                                │
+          Number of checkpoints to backfill in a single SQL command [default: 1000]            │
+  -h, --help                                                                                   │
+          Print help
+```
+
+It supports two kinds of backfills:
+
+- **SQL Backfill**: Executes a SQL statement directly against the database in chunks, filtering on a specified column (typically a sequence number). Conflict resolution is handled automatically with `ON CONFLICT DO NOTHING`.
+- **Ingestion Backfill**: Fetches and buffers checkpoint data from a remote store, then slices the buffered checkpoint data into chunks to backfill the database.
 
 #### Backfill job: `tx-wrapped-or-deleted-objects`
 

--- a/crates/iota-indexer/src/config.rs
+++ b/crates/iota-indexer/src/config.rs
@@ -173,7 +173,7 @@ pub struct BackfillConfig {
     default_value_t = Self::DEFAULT_MAX_CONCURRENCY,
     )]
     pub max_concurrency: usize,
-    /// Number of checkpoints to backfill in a single SQL command.
+    /// Size of the data chunks processed per task.
     #[arg(
     long,
     default_value_t = Self::DEFAULT_CHUNK_SIZE,


### PR DESCRIPTION
# Description of change

Adds a new section about "backfilling" to the Indexer `README.md` to facilitate the backfilling of newly introduced `tx_wrapped_or_deleted_objects` database table.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/8066

## How the change has been tested

- [X] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

Not relevant for this PR.

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
