### PR TITLE
upstream(core): persist all transactions and effects during checkpoint construction

### DIFF
--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -1038,6 +1038,27 @@ impl AuthorityStore {
         Ok(())
     }
 
+    pub(crate) fn persist_transactions_and_effects(
+        &self,
+        transactions_and_effects: &[(VerifiedTransaction, TransactionEffects)],
+    ) -> IotaResult {
+        let mut batch = self.perpetual_tables.transactions.batch();
+        batch.insert_batch(
+            &self.perpetual_tables.transactions,
+            transactions_and_effects
+                .iter()
+                .map(|(tx, _)| (*tx.digest(), tx.serializable_ref())),
+        )?;
+        batch.insert_batch(
+            &self.perpetual_tables.effects,
+            transactions_and_effects
+                .iter()
+                .map(|(_, fx)| (fx.digest(), fx.clone())),
+        )?;
+        batch.write()?;
+        Ok(())
+    }
+
     pub async fn acquire_transaction_locks(
         &self,
         epoch_store: &AuthorityPerEpochStore,

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1189,6 +1189,24 @@ impl CheckpointBuilder {
         let mut all_tx_digests =
             Vec::with_capacity(new_checkpoints.iter().map(|(_, c)| c.size()).sum());
 
+        // When upgrading to a data-quarantining build, we need to persist the
+        // transactions and effects to the database for crash recovery. After
+        // the upgrade this is no longer needed, because recovery is driven by
+        // replay of consensus commits. This only updates the content-addressed
+        // stores (similar to state sync), it does not mark any transactions as
+        // executed.
+        self.state
+            .get_cache_commit()
+            .persist_transactions_and_effects(
+                &new_checkpoints
+                    .iter()
+                    .flat_map(|(_, c)| {
+                        c.iter()
+                            .map(|digests| (digests.transaction, digests.effects))
+                    })
+                    .collect::<Vec<_>>(),
+            );
+
         for (summary, contents) in &new_checkpoints {
             debug!(
                 checkpoint_commit_height = height,

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -201,6 +201,16 @@ pub trait ExecutionCacheCommit: Send + Sync {
         })
     }
 
+    /// Persist transactions and their effects to the database, but no other
+    /// outputs. Additionally this stores the content-addressed effects in
+    /// the database but does not add an executed_effects. This is required
+    /// for recovery from a crash when upgrading to data-quarantining.
+    /// TODO: remove this once all nodes have upgraded to data-quarantining.
+    fn persist_transactions_and_effects(
+        &self,
+        digests: &[(TransactionDigest, TransactionEffectsDigest)],
+    );
+
     // Number of pending uncommitted transactions
     fn approximate_pending_transaction_count(&self) -> u64;
 }

--- a/crates/iota-core/src/execution_cache/passthrough_cache.rs
+++ b/crates/iota-core/src/execution_cache/passthrough_cache.rs
@@ -346,6 +346,25 @@ impl ExecutionCacheCommit for PassthroughCache {
         async { Ok(()) }.boxed()
     }
 
+    fn persist_transactions_and_effects(
+        &self,
+        _digests: &[(TransactionDigest, TransactionEffectsDigest)],
+    ) {
+        // Nothing needs to be done since all the data was already written.
+
+        // Explanation:
+        // In the WritebackCache, the `persist_transactions_and_effects`
+        // function is responsible for writing the pending transaction
+        // outputs and effects from `dirty.pending_transaction_writes` to the
+        // store (`perpetual_tables.transactions`, `perpetual_tables.
+        // events`). The only function that adds entries to the dirty set
+        // is `try_write_transaction_outputs`.
+        //
+        // In the PassthroughCache, exactly this function
+        // `try_write_transaction_outputs` already writes the data to the store,
+        // via `write_transaction_outputs` => `write_one_transaction_outputs`.
+    }
+
     fn approximate_pending_transaction_count(&self) -> u64 {
         0
     }

--- a/crates/iota-core/src/execution_cache/proxy_cache.rs
+++ b/crates/iota-core/src/execution_cache/proxy_cache.rs
@@ -325,6 +325,13 @@ impl ExecutionCacheCommit for ProxyCache {
         delegate_method!(self.try_persist_transactions(digests))
     }
 
+    fn persist_transactions_and_effects(
+        &self,
+        digests: &[(TransactionDigest, TransactionEffectsDigest)],
+    ) {
+        delegate_method!(self.persist_transactions_and_effects(digests))
+    }
+
     fn approximate_pending_transaction_count(&self) -> u64 {
         delegate_method!(self.approximate_pending_transaction_count())
     }

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -1021,6 +1021,37 @@ impl WritebackCache {
         Ok(())
     }
 
+    fn persist_transactions_and_effects(
+        &self,
+        digests: &[(TransactionDigest, TransactionEffectsDigest)],
+    ) {
+        let mut transactions_and_effects = Vec::with_capacity(digests.len());
+        for (tx_digest, fx_digest) in digests {
+            let Some(outputs) = self
+                .dirty
+                .pending_transaction_writes
+                .get(tx_digest)
+                .map(|o| o.clone())
+            else {
+                debug!("transaction {:?} was already committed", tx_digest);
+                continue;
+            };
+
+            assert_eq!(
+                outputs.effects.digest(),
+                *fx_digest,
+                "effects digest mismatch"
+            );
+
+            transactions_and_effects
+                .push(((*outputs.transaction).clone(), outputs.effects.clone()));
+        }
+
+        self.store
+            .persist_transactions_and_effects(&transactions_and_effects)
+            .expect("db error");
+    }
+
     fn approximate_pending_transaction_count(&self) -> u64 {
         let num_commits = self
             .dirty
@@ -1350,6 +1381,13 @@ impl ExecutionCacheCommit for WritebackCache {
 
     fn approximate_pending_transaction_count(&self) -> u64 {
         WritebackCache::approximate_pending_transaction_count(self)
+    }
+
+    fn persist_transactions_and_effects(
+        &self,
+        digests: &[(TransactionDigest, TransactionEffectsDigest)],
+    ) {
+        WritebackCache::persist_transactions_and_effects(self, digests);
     }
 }
 


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.41.2, v1.42.2)
- Ports commit: 
  - https://github.com/MystenLabs/sui/commit/d487c2ceb7366ec7b5e59db54b5aa9a48df34797

- Description:
This PR adds a flush of the dirty set in the writeback cache to disk. This is needed for upcoming data quarantine.

## Links to any relevant issues

Part of #6150

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes