### PR TITLE
fix(iota-data-ingestion-core): add timeout to historical reader

### DIFF
--- a/crates/iota-data-ingestion-core/src/reader/fetch.rs
+++ b/crates/iota-data-ingestion-core/src/reader/fetch.rs
@@ -191,6 +191,7 @@ pub async fn fetch_from_object_store(
     checkpoint_number: CheckpointSequenceNumber,
 ) -> CheckpointResult {
     let path = ObjectStorePath::from(format!("{checkpoint_number}.{CHECKPOINT_FILE_SUFFIX}"));
+    debug!("Fetch {path} from live");
     let response = store.get(&path).await?;
     let bytes = response.bytes().await?;
     Ok((

--- a/crates/iota-data-ingestion-core/src/reader/v2.rs
+++ b/crates/iota-data-ingestion-core/src/reader/v2.rs
@@ -117,7 +117,6 @@ impl RemoteStore {
                 };
                 let historical = HistoricalReader::new(config)
                     .inspect_err(|e| error!("Unable to instantiate historical reader: {e}"))?;
-                historical.sync_manifest_once().await?;
 
                 let live = live_url
                     .map(|url| create_remote_store_client(url, Default::default(), timeout_secs))
@@ -225,7 +224,14 @@ impl CheckpointReaderActor {
         // If the requested checkpoint is beyond what's currently available in our
         // cached manifest, we need to refresh it to check for newer checkpoints.
         if self.current_checkpoint_number > historical_reader.latest_available_checkpoint().await? {
-            historical_reader.sync_manifest_once().await?;
+            timeout(
+                Duration::from_secs(self.reader_options.timeout_secs),
+                historical_reader.sync_manifest_once(),
+            )
+            .await
+            .map_err(|_| {
+                IngestionError::HistoryRead("Reading Manifest exceeded the timeout".into())
+            })??;
 
             // Verify the requested checkpoint is now available after the manifest refresh.
             // If it's still not available, the checkpoint hasn't been published yet.
@@ -252,11 +258,19 @@ impl CheckpointReaderActor {
             .enumerate()
             .filter_map(|(index, metadata)| (index >= start_index).then_some(metadata))
         {
-            let checkpoints = historical_reader
-                .iter_for_file(metadata.file_path())
-                .await?
-                .filter(|c| c.checkpoint_summary.sequence_number >= self.current_checkpoint_number)
-                .collect::<Vec<CheckpointData>>();
+            let checkpoints = timeout(
+                Duration::from_secs(self.reader_options.timeout_secs),
+                historical_reader.iter_for_file(metadata.file_path()),
+            )
+            .await
+            .map_err(|_| {
+                IngestionError::HistoryRead(format!(
+                    "Reading checkpoint {} exceeded the timeout",
+                    metadata.file_path()
+                ))
+            })??
+            .filter(|c| c.checkpoint_summary.sequence_number >= self.current_checkpoint_number)
+            .collect::<Vec<CheckpointData>>();
 
             for checkpoint in checkpoints {
                 let size = bcs::serialized_size(&checkpoint)?;


### PR DESCRIPTION
# Description of change

This PR fixes a corner case where the GET requests from the `HisotricalReader` to the `S3 ObjectStore` could hang for around 2 hours. This was because the `ObjectStore client` the `HisotricalReader` relies does disable all timeouts (this change was inherited from upstream). 

The fix applies a `tokio::time::timeout`, the duration can be configured as it reads the `ReaderOptions.timeout_secs` field.

## Links to any relevant issues

fixes #8072 

## How the change has been tested

- Ran a custom indexer and manitored it's logs for some hours to assert the fix works. in this amount of time it happened 2 times, once the timeout was reached, it exited the loop and once entered again it was able to successfully fetched the requested file.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

> [!NOTE]
> The indexer does not use the `CheckpointReader V2` so this path does not affect the normal operation of the indexer. QA tests were skipped.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [x] Indexer: the `iota-data-ingestion-core` `CheckpointReader` applies the `ReaderOptions.timeout_secs` also for historical checkpoint reads, previously only live checkpoint reads were respecting the provided timeout value.
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
