### PR TITLE
fix(docker): add libudev-dev dependency for iota-tools Docker image build

### DIFF
--- a/docker/iota-tools/Dockerfile
+++ b/docker/iota-tools/Dockerfile
@@ -11,7 +11,8 @@ ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "/iota"
 
 # Install build dependencies, including clang and lld for faster linking
-RUN apt update && apt install -y cmake clang lld
+# libudev for Ledger hardware wallets
+RUN apt update && apt install -y cmake clang lld libudev-dev
 
 # Configure Rust to use clang and lld as the linker
 RUN mkdir -p ~/.cargo && \


### PR DESCRIPTION
This PR adds a missing dependency for the iota-tool docker container. 
The dependency is needed for ledger hardware wallet support.