### PR TITLE
backport: fix the `test_json_rpc_spec` failure (#8076)

### DIFF
--- a/crates/iota-json-rpc-api/src/transaction_builder.rs
+++ b/crates/iota-json-rpc-api/src/transaction_builder.rs
@@ -146,7 +146,7 @@ pub trait TransactionBuilder {
         function: String,
         /// the type arguments of the Move function
         type_arguments: Vec<IotaTypeTag>,
-        /// the arguments to be passed into the Move function, in [IotaJson](https://docs.iota.org/references/iota-api) format
+        /// the arguments to be passed into the Move function, in [IotaJson](https://docs.iota.org/developer/references/iota-api) format
         arguments: Vec<IotaJsonValue>,
         /// gas object to be used in this transaction, node will pick one from the signer's possession if not provided
         gas: Option<ObjectID>,

--- a/sdk/typescript/src/client/types/params.ts
+++ b/sdk/typescript/src/client/types/params.ts
@@ -460,7 +460,7 @@ export interface UnsafeMoveCallParams {
     typeArguments: string[];
     /**
      * the arguments to be passed into the Move function, in
-     * [IotaJson](https://docs.iota.org/references/iota-api) format
+     * [IotaJson](https://docs.iota.org/developer/references/iota-api) format
      */
     arguments: unknown[];
     /**


### PR DESCRIPTION
# Description of change

This is a backport of PR #8076 

This fixes the failing test on develop.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes