### PR TITLE
fix(iota-indexer): Batch insert backfilled data to respect PostgreSQL's parameter limit (#8084)

### DIFF
--- a/crates/iota-indexer/src/backfill/ingestion/task.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/task.rs
@@ -20,6 +20,9 @@ use crate::{
     errors::IndexerError,
 };
 
+// The amount of rows to update in one DB transaction
+const PG_COMMIT_CHUNK_SIZE: usize = 100;
+
 /// Orchestrates ingestion-driven backfill by buffering processed checkpoints
 /// and coordinating range-based commits.
 ///
@@ -104,10 +107,18 @@ impl<T: IngestionBackfill> Backfill for IngestionBackfillTask<T> {
             processed_data.len()
         );
 
-        // TODO: Limit the size of each chunk.
+        // Limit the size of each chunk.
         // postgres has a parameter limit of 65535, meaning that row_count * col_count
-        // <= 65536.
-        T::persist_chunk(pool.clone(), processed_data).await
+        // <= 65535.
+        while !processed_data.is_empty() {
+            let batch: Vec<_> = processed_data
+                .drain(..processed_data.len().min(PG_COMMIT_CHUNK_SIZE))
+                .collect();
+
+            T::persist_chunk(pool.clone(), batch).await?;
+        }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Cherry-picking #8084 for `v1.4.1-beta` release.

# Description of change

This PR fixes an issue where backfill tasks fail due to exceeding PostgreSQL's limit of 65,535 parameters per query.

Previously, the insertion logic didn't batch inserts, causing failures when a checkpoint produced too many rows. The fix introduces batching logic that splits inserts into smaller chunks, ensuring the total parameters per query remain within the postgres limit.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/8083

## How the change has been tested

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [X] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

I was testing backfilling of the table with the failing checkpoint (alphanet) and it can proceed as expected.

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

Not relevant for this patch. This PR doesn't touch migration objects or synchronization of the indexer.

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [X] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:


