### PR TITLE
feat(iota-core,iota-types): Add AuthorityCapabilities endpoint 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2816,16 +2816,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8179,30 +8169,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13529,98 +13495,6 @@ dependencies = [
  "libc",
  "psm",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "starfish-config"
-version = "0.1.0"
-dependencies = [
- "fastcrypto",
- "insta",
- "iota-network-stack",
- "rand 0.8.5",
- "serde",
- "shared-crypto",
-]
-
-[[package]]
-name = "starfish-core"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "arc-swap",
- "async-trait",
- "base64 0.21.7",
- "bcs",
- "bytes",
- "cfg-if",
- "dashmap",
- "enum_dispatch",
- "fastcrypto",
- "futures",
- "http 1.3.1",
- "iota-common",
- "iota-http",
- "iota-macros",
- "iota-metrics",
- "iota-network-stack",
- "iota-protocol-config",
- "iota-tls",
- "itertools 0.13.0",
- "nom",
- "parking_lot 0.12.3",
- "prometheus",
- "prost",
- "quinn-proto",
- "rand 0.8.5",
- "reed-solomon-simd",
- "rstest",
- "rustls 0.23.28",
- "serde",
- "shared-crypto",
- "starfish-config",
- "strum_macros 0.26.4",
- "tap",
- "telemetry-subscribers",
- "tempfile",
- "thiserror 1.0.64",
- "tokio",
- "tokio-rustls 0.26.2",
- "tokio-stream",
- "tokio-util 0.7.12",
- "tonic 0.13.1",
- "tonic-build",
- "tonic-rustls",
- "tower 0.4.13",
- "tower-http",
- "tracing",
- "typed-store",
-]
-
-[[package]]
-name = "starfish-simtests"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "arc-swap",
- "iota-config",
- "iota-macros",
- "iota-metrics",
- "iota-network-stack",
- "iota-protocol-config",
- "iota-simulator",
- "parking_lot 0.12.3",
- "prometheus",
- "rand 0.8.5",
- "starfish-config",
- "starfish-core",
- "telemetry-subscribers",
- "tempfile",
- "tokio",
- "tokio-stream",
- "tokio-util 0.7.12",
- "tracing",
- "typed-store",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2816,6 +2816,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8166,6 +8176,30 @@ checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13498,6 +13498,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "starfish-config"
+version = "0.1.0"
+dependencies = [
+ "fastcrypto",
+ "insta",
+ "iota-network-stack",
+ "rand 0.8.5",
+ "serde",
+ "shared-crypto",
+]
+
+[[package]]
+name = "starfish-core"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "async-trait",
+ "base64 0.21.7",
+ "bcs",
+ "bytes",
+ "cfg-if",
+ "dashmap",
+ "enum_dispatch",
+ "fastcrypto",
+ "futures",
+ "http 1.3.1",
+ "iota-common",
+ "iota-http",
+ "iota-macros",
+ "iota-metrics",
+ "iota-network-stack",
+ "iota-protocol-config",
+ "iota-tls",
+ "itertools 0.13.0",
+ "nom",
+ "parking_lot 0.12.3",
+ "prometheus",
+ "prost",
+ "quinn-proto",
+ "rand 0.8.5",
+ "reed-solomon-simd",
+ "rstest",
+ "rustls 0.23.28",
+ "serde",
+ "shared-crypto",
+ "starfish-config",
+ "strum_macros 0.26.4",
+ "tap",
+ "telemetry-subscribers",
+ "tempfile",
+ "thiserror 1.0.64",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tokio-stream",
+ "tokio-util 0.7.12",
+ "tonic 0.13.1",
+ "tonic-build",
+ "tonic-rustls",
+ "tower 0.4.13",
+ "tower-http",
+ "tracing",
+ "typed-store",
+]
+
+[[package]]
+name = "starfish-simtests"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "iota-config",
+ "iota-macros",
+ "iota-metrics",
+ "iota-network-stack",
+ "iota-protocol-config",
+ "iota-simulator",
+ "parking_lot 0.12.3",
+ "prometheus",
+ "rand 0.8.5",
+ "starfish-config",
+ "starfish-core",
+ "telemetry-subscribers",
+ "tempfile",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.7.12",
+ "tracing",
+ "typed-store",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/iota-core/benches/batch_verification_bench.rs
+++ b/crates/iota-core/benches/batch_verification_bench.rs
@@ -78,7 +78,7 @@ fn async_verifier_bench(c: &mut Criterion) {
                         .unwrap();
                     let batch_verifier = Arc::new(SignatureVerifier::new_with_batch_size(
                         committee.clone(),
-                        BTreeMap::new(),
+                        BTreeSet::new(),
                         batch_size,
                         metrics.clone(),
                         ZkLoginEnv::Test,

--- a/crates/iota-core/benches/batch_verification_bench.rs
+++ b/crates/iota-core/benches/batch_verification_bench.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeSet, sync::Arc};
 
 use criterion::*;
 use fastcrypto_zkp::bn254::zk_login_api::ZkLoginEnv;

--- a/crates/iota-core/benches/batch_verification_bench.rs
+++ b/crates/iota-core/benches/batch_verification_bench.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use criterion::*;
 use fastcrypto_zkp::bn254::zk_login_api::ZkLoginEnv;
@@ -78,6 +78,7 @@ fn async_verifier_bench(c: &mut Criterion) {
                         .unwrap();
                     let batch_verifier = Arc::new(SignatureVerifier::new_with_batch_size(
                         committee.clone(),
+                        BTreeMap::new(),
                         batch_size,
                         metrics.clone(),
                         ZkLoginEnv::Test,

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1695,9 +1695,17 @@ impl AuthorityState {
     pub async fn handle_authority_capabilities(
         &self,
         verified_authority_capabilities: VerifiedAuthorityCapabilitiesV1,
-        epoch_store: Arc<AuthorityPerEpochStore>,
+        _epoch_store: Arc<AuthorityPerEpochStore>,
     ) -> Result<(), IotaError> {
-        epoch_store.record_capabilities_v1(verified_authority_capabilities.data())?;
+        info!(
+            "Received authority capabilities from non-validator authority. not doing anything with it. Received capabilities: {:?}",
+            verified_authority_capabilities.data()
+        );
+
+        // TODO: Implement the logic to handle authority capabilities from non-committee
+        //  active validators.
+
+        // epoch_store.record_capabilities_v1(verified_authority_capabilities.data())?;
 
         Ok(())
     }

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1692,7 +1692,7 @@ impl AuthorityState {
 
     /// Verifies the signature on the capability notification and updates the
     /// authority capabilities after verifying the signature
-    pub async fn handle_authority_capabilities(
+    pub fn handle_authority_capabilities(
         &self,
         verified_authority_capabilities: VerifiedAuthorityCapabilitiesV1,
         _epoch_store: Arc<AuthorityPerEpochStore>,

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -57,10 +57,7 @@ use iota_types::{
     authenticator_state::get_authenticator_state,
     base_types::*,
     committee::{Committee, EpochId, ProtocolVersion},
-    crypto::{
-        AuthoritySignInfo, AuthoritySignInfoTrait, AuthoritySignature, RandomnessRound, Signer,
-        default_hash,
-    },
+    crypto::{AuthoritySignInfo, AuthoritySignature, RandomnessRound, Signer, default_hash},
     deny_list_v1::check_coin_deny_list_v1_during_signing,
     digests::{ChainIdentifier, TransactionEventsDigest},
     dynamic_field::{DynamicFieldInfo, DynamicFieldName, visitor as DFV},
@@ -92,7 +89,7 @@ use iota_types::{
         CheckpointSequenceNumber, CheckpointSummary, CheckpointSummaryResponse,
         CheckpointTimestamp, ECMHLiveObjectSetDigest, VerifiedCheckpoint,
     },
-    messages_consensus::AuthorityCapabilitiesV1,
+    messages_consensus::{AuthorityCapabilitiesV1, VerifiedAuthorityCapabilitiesV1},
     messages_grpc::{
         HandleTransactionResponse, LayoutGenerationOption, ObjectInfoRequest,
         ObjectInfoRequestKind, ObjectInfoResponse, TransactionInfoRequest, TransactionInfoResponse,
@@ -1695,21 +1692,12 @@ impl AuthorityState {
 
     /// Verifies the signature on the capability notification and updates the
     /// authority capabilities after verifying the signature
-    pub async fn update_authority_capabilities(
+    pub async fn handle_authority_capabilities(
         &self,
-        capabilities: AuthorityCapabilitiesV1,
-        signature: &AuthoritySignInfo,
+        verified_authority_capabilities: VerifiedAuthorityCapabilitiesV1,
+        epoch_store: Arc<AuthorityPerEpochStore>,
     ) -> Result<(), IotaError> {
-        let epoch_store = self.load_epoch_store_one_call_per_task();
-
-        // Verify that the signature is from a valid authority in the current epoch
-        let authority = epoch_store.committee().authority(&signature.authority)?;
-
-        // Verify the actual signature
-        signature.verify_secure(capabilities, authority)?;
-
-        // TODO: Store the new capabilities
-        // epoch_store.update_authority_capabilities(capabilities)?;
+        epoch_store.record_capabilities_v1(verified_authority_capabilities.data())?;
 
         Ok(())
     }

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -57,7 +57,10 @@ use iota_types::{
     authenticator_state::get_authenticator_state,
     base_types::*,
     committee::{Committee, EpochId, ProtocolVersion},
-    crypto::{AuthoritySignInfo, AuthoritySignature, RandomnessRound, Signer, default_hash},
+    crypto::{
+        AuthoritySignInfo, AuthoritySignInfoTrait, AuthoritySignature, RandomnessRound, Signer,
+        default_hash,
+    },
     deny_list_v1::check_coin_deny_list_v1_during_signing,
     digests::{ChainIdentifier, TransactionEventsDigest},
     dynamic_field::{DynamicFieldInfo, DynamicFieldName, visitor as DFV},
@@ -1688,6 +1691,27 @@ impl AuthorityState {
         let execution_guard = lock.try_read().unwrap();
 
         self.prepare_certificate(&execution_guard, certificate, input_objects, epoch_store)
+    }
+
+    /// Verifies the signature on the capability notification and updates the
+    /// authority capabilities after verifying the signature
+    pub async fn update_authority_capabilities(
+        &self,
+        capabilities: AuthorityCapabilitiesV1,
+        signature: &AuthoritySignInfo,
+    ) -> Result<(), IotaError> {
+        let epoch_store = self.load_epoch_store_one_call_per_task();
+
+        // Verify that the signature is from a valid authority in the current epoch
+        let authority = epoch_store.committee().authority(&signature.authority)?;
+
+        // Verify the actual signature
+        signature.verify_secure(capabilities, authority)?;
+
+        // TODO: Store the new capabilities
+        // epoch_store.update_authority_capabilities(capabilities)?;
+
+        Ok(())
     }
 
     #[allow(clippy::type_complexity)]

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -2334,7 +2334,7 @@ impl AuthorityPerEpochStore {
 
     /// Record most recently advertised capabilities of all authorities
     pub fn record_capabilities_v1(&self, capabilities: &AuthorityCapabilitiesV1) -> IotaResult {
-        info!("received capabilities v1 {:?}", capabilities);
+        info!("received capabilities v1 {capabilities:?}");
         let authority = &capabilities.authority;
         let tables = self.tables()?;
 

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -36,9 +36,7 @@ use iota_types::{
         TransactionDigest,
     },
     committee::{Committee, CommitteeTrait},
-    crypto::{
-        AuthorityPublicKey, AuthoritySignInfo, AuthorityStrongQuorumSignInfo, RandomnessRound,
-    },
+    crypto::{AuthoritySignInfo, AuthorityStrongQuorumSignInfo, RandomnessRound},
     digests::{ChainIdentifier, TransactionEffectsDigest},
     effects::TransactionEffects,
     error::{IotaError, IotaResult},
@@ -52,7 +50,8 @@ use iota_types::{
     },
     messages_consensus::{
         AuthorityCapabilitiesV1, ConsensusTransaction, ConsensusTransactionKey,
-        ConsensusTransactionKind, TimestampMs, VersionedDkgConfirmation, check_total_jwk_size,
+        ConsensusTransactionKind, SignedAuthorityCapabilitiesV1, TimestampMs,
+        VerifiedAuthorityCapabilitiesV1, VersionedDkgConfirmation, check_total_jwk_size,
     },
     signature::GenericSignature,
     storage::{BackingPackageStore, InputKey, ObjectStore},
@@ -907,7 +906,9 @@ impl AuthorityPerEpochStore {
 
         let signature_verifier = SignatureVerifier::new(
             committee.clone(),
-            epoch_start_configuration.non_committee_validators(),
+            epoch_start_configuration
+                .epoch_start_state()
+                .get_non_committee_validators(),
             signature_verifier_metrics,
             zklogin_env,
             protocol_config.accept_zklogin_in_multisig(),
@@ -2326,7 +2327,7 @@ impl AuthorityPerEpochStore {
 
     /// Record most recently advertised capabilities of all authorities
     pub fn record_capabilities_v1(&self, capabilities: &AuthorityCapabilitiesV1) -> IotaResult {
-        info!("received capabilities v2 {:?}", capabilities);
+        info!("received capabilities v1 {:?}", capabilities);
         let authority = &capabilities.authority;
         let tables = self.tables()?;
 
@@ -2560,6 +2561,16 @@ impl AuthorityPerEpochStore {
         self.signature_verifier
             .verify_tx(tx.data())
             .map(|_| VerifiedTransaction::new_from_verified(tx))
+    }
+
+    #[instrument(level = "trace", skip_all)]
+    pub fn verify_authority_capabilities(
+        &self,
+        authority_capabilities: SignedAuthorityCapabilitiesV1,
+    ) -> IotaResult<VerifiedAuthorityCapabilitiesV1> {
+        self.signature_verifier
+            .verify_authority_capabilities(&authority_capabilities)
+            .map(|_| VerifiedAuthorityCapabilitiesV1::new_from_verified(authority_capabilities))
     }
 
     /// Verifies transaction signatures and other data

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -904,11 +904,18 @@ impl AuthorityPerEpochStore {
             _ => ZkLoginEnv::Test,
         };
 
+        // Get all active validators and filter out committee members to get
+        // non-committee validators
+        let non_committee_validators: BTreeMap<_, _> = epoch_start_configuration
+            .epoch_start_state()
+            .get_active_validators()
+            .into_iter()
+            .filter(|(authority_name, _)| !committee.authority_exists(authority_name))
+            .collect();
+
         let signature_verifier = SignatureVerifier::new(
             committee.clone(),
-            epoch_start_configuration
-                .epoch_start_state()
-                .get_non_committee_validators(),
+            non_committee_validators,
             signature_verifier_metrics,
             zklogin_env,
             protocol_config.accept_zklogin_in_multisig(),
@@ -2638,7 +2645,7 @@ impl AuthorityPerEpochStore {
                 ..
             }) => {
                 // TODO: this needs to be modified as committee validators might be different
-                // than the actual authority
+                //  than the actual authority sending the notification.
                 if transaction.sender_authority() != *authority {
                     warn!(
                         "CapabilityNotificationV1 authority {} does not match its author from consensus {}",

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1118,6 +1118,10 @@ impl AuthorityPerEpochStore {
         &self.committee
     }
 
+    pub fn committee(&self) -> &Arc<Committee> {
+        &self.committee
+    }
+
     pub fn protocol_config(&self) -> &ProtocolConfig {
         &self.protocol_config
     }
@@ -2623,6 +2627,8 @@ impl AuthorityPerEpochStore {
                     }),
                 ..
             }) => {
+                // TODO: this needs to be modified as committee validators might be different
+                // than the actual authority
                 if transaction.sender_authority() != *authority {
                     warn!(
                         "CapabilityNotificationV1 authority {} does not match its author from consensus {}",

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -36,7 +36,9 @@ use iota_types::{
         TransactionDigest,
     },
     committee::{Committee, CommitteeTrait},
-    crypto::{AuthoritySignInfo, AuthorityStrongQuorumSignInfo, RandomnessRound},
+    crypto::{
+        AuthorityPublicKey, AuthoritySignInfo, AuthorityStrongQuorumSignInfo, RandomnessRound,
+    },
     digests::{ChainIdentifier, TransactionEffectsDigest},
     effects::TransactionEffects,
     error::{IotaError, IotaResult},
@@ -905,6 +907,7 @@ impl AuthorityPerEpochStore {
 
         let signature_verifier = SignatureVerifier::new(
             committee.clone(),
+            epoch_start_configuration.non_committee_validators(),
             signature_verifier_metrics,
             zklogin_env,
             protocol_config.accept_zklogin_in_multisig(),
@@ -1112,10 +1115,6 @@ impl AuthorityPerEpochStore {
             self.chain_identifier,
             previous_epoch_last_checkpoint,
         )
-    }
-
-    pub fn committee(&self) -> &Arc<Committee> {
-        &self.committee
     }
 
     pub fn committee(&self) -> &Arc<Committee> {

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -906,11 +906,14 @@ impl AuthorityPerEpochStore {
 
         // Get all active validators and filter out committee members to get
         // non-committee validators
-        let non_committee_validators: BTreeMap<_, _> = epoch_start_configuration
+        let non_committee_validators: BTreeSet<_> = epoch_start_configuration
             .epoch_start_state()
             .get_active_validators()
             .into_iter()
-            .filter(|(authority_name, _)| !committee.authority_exists(authority_name))
+            .filter(|authority_public_key| {
+                let authority_name = AuthorityName::from(authority_public_key);
+                !committee.authority_exists(&authority_name)
+            })
             .collect();
 
         let signature_verifier = SignatureVerifier::new(

--- a/crates/iota-core/src/authority_client.rs
+++ b/crates/iota-core/src/authority_client.rs
@@ -21,6 +21,7 @@ use iota_types::{
     iota_system_state::IotaSystemState,
     messages_checkpoint::{CheckpointRequest, CheckpointResponse},
     messages_grpc::{
+        HandleCapabilityNotificationV1Request, HandleCapabilityNotificationV1Response,
         HandleCertificateRequestV1, HandleCertificateResponseV1,
         HandleSoftBundleCertificatesRequestV1, HandleSoftBundleCertificatesResponseV1,
         HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse, SystemStateRequest,
@@ -79,6 +80,12 @@ pub trait AuthorityAPI {
         &self,
         request: SystemStateRequest,
     ) -> Result<IotaSystemState, IotaError>;
+
+    /// Handle a capability notification from another authority
+    async fn handle_capability_notification_v1(
+        &self,
+        request: HandleCapabilityNotificationV1Request,
+    ) -> Result<HandleCapabilityNotificationV1Response, IotaError>;
 }
 
 /// A client for the network authority.
@@ -233,6 +240,17 @@ impl AuthorityAPI for NetworkAuthorityClient {
     ) -> Result<IotaSystemState, IotaError> {
         self.client()?
             .get_system_state_object(request)
+            .await
+            .map(tonic::Response::into_inner)
+            .map_err(Into::into)
+    }
+
+    async fn handle_capability_notification_v1(
+        &self,
+        request: HandleCapabilityNotificationV1Request,
+    ) -> Result<HandleCapabilityNotificationV1Response, IotaError> {
+        self.client()?
+            .handle_capability_notification_v1(request)
             .await
             .map(tonic::Response::into_inner)
             .map_err(Into::into)

--- a/crates/iota-core/src/authority_client.rs
+++ b/crates/iota-core/src/authority_client.rs
@@ -21,7 +21,7 @@ use iota_types::{
     iota_system_state::IotaSystemState,
     messages_checkpoint::{CheckpointRequest, CheckpointResponse},
     messages_grpc::{
-        HandleCapabilityNotificationV1Request, HandleCapabilityNotificationV1Response,
+        HandleCapabilityNotificationRequestV1, HandleCapabilityNotificationResponseV1,
         HandleCertificateRequestV1, HandleCertificateResponseV1,
         HandleSoftBundleCertificatesRequestV1, HandleSoftBundleCertificatesResponseV1,
         HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse, SystemStateRequest,
@@ -84,8 +84,8 @@ pub trait AuthorityAPI {
     /// Handle a capability notification from another authority
     async fn handle_capability_notification_v1(
         &self,
-        request: HandleCapabilityNotificationV1Request,
-    ) -> Result<HandleCapabilityNotificationV1Response, IotaError>;
+        request: HandleCapabilityNotificationRequestV1,
+    ) -> Result<HandleCapabilityNotificationResponseV1, IotaError>;
 }
 
 /// A client for the network authority.
@@ -247,8 +247,8 @@ impl AuthorityAPI for NetworkAuthorityClient {
 
     async fn handle_capability_notification_v1(
         &self,
-        request: HandleCapabilityNotificationV1Request,
-    ) -> Result<HandleCapabilityNotificationV1Response, IotaError> {
+        request: HandleCapabilityNotificationRequestV1,
+    ) -> Result<HandleCapabilityNotificationResponseV1, IotaError> {
         self.client()?
             .handle_capability_notification_v1(request)
             .await

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -1132,7 +1132,7 @@ impl ValidatorService {
         fp_ensure!(
             epoch_store
                 .protocol_config()
-                .select_committee_supporting_protocol_version(),
+                .track_non_committee_eligible_validators(),
             IotaError::UnsupportedFeature {
                 error: "capability notification endpoint is not supported in this Protocol Version"
                     .to_string()

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -1154,9 +1154,8 @@ impl ValidatorService {
         // Verify the message signature
         let verified_authority_capabilities = epoch_store
             .verify_authority_capabilities(signed_authority_capabilities)
-            .map_err(|e| {
+            .inspect_err(|_e| {
                 self.metrics.signature_errors.inc();
-                e
             })?;
 
         // Process the verified capabilities

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -202,147 +202,147 @@ impl ValidatorServiceMetrics {
                 "Number of transaction signature errors",
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
             tx_verification_latency: register_histogram_with_registry!(
                 "validator_service_tx_verification_latency",
                 "Latency of verifying a transaction",
                 iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
             cert_verification_latency: register_histogram_with_registry!(
                 "validator_service_cert_verification_latency",
                 "Latency of verifying a certificate",
                 iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
             consensus_latency: register_histogram_with_registry!(
                 "validator_service_consensus_latency",
                 "Time spent between submitting a shared obj txn to consensus and getting result",
                 iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
             handle_transaction_latency: register_histogram_with_registry!(
                 "validator_service_handle_transaction_latency",
                 "Latency of handling a transaction",
                 iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
             handle_certificate_consensus_latency: register_histogram_with_registry!(
                 "validator_service_handle_certificate_consensus_latency",
                 "Latency of handling a consensus transaction certificate",
                 iota_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
             submit_certificate_consensus_latency: register_histogram_with_registry!(
                 "validator_service_submit_certificate_consensus_latency",
                 "Latency of submit_certificate RPC handler",
                 iota_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
             handle_certificate_non_consensus_latency: register_histogram_with_registry!(
                 "validator_service_handle_certificate_non_consensus_latency",
                 "Latency of handling a non-consensus transaction certificate",
                 iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
             handle_soft_bundle_certificates_consensus_latency: register_histogram_with_registry!(
                 "validator_service_handle_soft_bundle_certificates_consensus_latency",
                 "Latency of handling a consensus soft bundle",
                 iota_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
             handle_soft_bundle_certificates_count: register_histogram_with_registry!(
                 "validator_service_handle_soft_bundle_certificates_count",
                 "The number of certificates included in a soft bundle",
                 iota_metrics::COUNT_BUCKETS.to_vec(),
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
             handle_soft_bundle_certificates_size_bytes: register_histogram_with_registry!(
                 "validator_service_handle_soft_bundle_certificates_size_bytes",
                 "The size of soft bundle in bytes",
                 iota_metrics::BYTES_BUCKETS.to_vec(),
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
             handle_capability_notification_latency: register_histogram_with_registry!(
                 "validator_service_handle_capability_notification_latency",
                 "Latency of handling a capability notification",
                 iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
             num_rejected_tx_in_epoch_boundary: register_int_counter_with_registry!(
                 "validator_service_num_rejected_tx_in_epoch_boundary",
                 "Number of rejected transaction during epoch transitioning",
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
             num_rejected_cert_in_epoch_boundary: register_int_counter_with_registry!(
                 "validator_service_num_rejected_cert_in_epoch_boundary",
                 "Number of rejected transaction certificate during epoch transitioning",
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
             num_rejected_tx_during_overload: register_int_counter_vec_with_registry!(
                 "validator_service_num_rejected_tx_during_overload",
                 "Number of rejected transaction due to system overload",
                 &["error_type"],
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
             num_rejected_cert_during_overload: register_int_counter_vec_with_registry!(
                 "validator_service_num_rejected_cert_during_overload",
                 "Number of rejected transaction certificate due to system overload",
                 &["error_type"],
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
             num_rejected_capability_notifications_during_overload: register_int_counter_vec_with_registry!(
                 "num_rejected_capability_notifications_during_overload",
                 "Number of rejected capability notifications from non-committee active validators due to system overload",
                 &["error_type"],
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
             connection_ip_not_found: register_int_counter_with_registry!(
                 "validator_service_connection_ip_not_found",
                 "Number of times connection IP was not extractable from request",
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
             forwarded_header_parse_error: register_int_counter_with_registry!(
                 "validator_service_forwarded_header_parse_error",
                 "Number of times x-forwarded-for header could not be parsed",
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
             forwarded_header_invalid: register_int_counter_with_registry!(
                 "validator_service_forwarded_header_invalid",
                 "Number of times x-forwarded-for header was invalid",
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
             forwarded_header_not_included: register_int_counter_with_registry!(
                 "validator_service_forwarded_header_not_included",
                 "Number of times x-forwarded-for header was (unexpectedly) not included in request",
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
             client_id_source_config_mismatch: register_int_counter_with_registry!(
                 "validator_service_client_id_source_config_mismatch",
                 "Number of times detected that client id source config doesn't agree with x-forwarded-for header",
                 registry,
             )
-                .unwrap(),
+            .unwrap(),
         }
     }
 

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -28,6 +28,7 @@ use iota_types::{
     messages_checkpoint::{CheckpointRequest, CheckpointResponse},
     messages_consensus::ConsensusTransaction,
     messages_grpc::{
+        HandleCapabilityNotificationV1Request, HandleCapabilityNotificationV1Response,
         HandleCertificateRequestV1, HandleCertificateResponseV1,
         HandleSoftBundleCertificatesRequestV1, HandleSoftBundleCertificatesResponseV1,
         HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse,
@@ -48,7 +49,7 @@ use tonic::{
     metadata::{Ascii, MetadataValue},
     transport::server::TcpConnectInfo,
 };
-use tracing::{Instrument, error, error_span, info};
+use tracing::{Instrument, error, error_span, info, warn};
 
 use crate::{
     authority::{AuthorityState, authority_per_epoch_store::AuthorityPerEpochStore},
@@ -178,6 +179,7 @@ pub struct ValidatorServiceMetrics {
     pub handle_soft_bundle_certificates_consensus_latency: Histogram,
     pub handle_soft_bundle_certificates_count: Histogram,
     pub handle_soft_bundle_certificates_size_bytes: Histogram,
+    pub handle_capability_notification_latency: Histogram,
 
     num_rejected_tx_in_epoch_boundary: IntCounter,
     num_rejected_cert_in_epoch_boundary: IntCounter,
@@ -267,6 +269,13 @@ impl ValidatorServiceMetrics {
                 "validator_service_handle_soft_bundle_certificates_size_bytes",
                 "The size of soft bundle in bytes",
                 iota_metrics::BYTES_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            handle_capability_notification_latency: register_histogram_with_registry!(
+                "validator_service_handle_capability_notification_latency",
+                "Latency of handling a capability notification",
+                iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),
@@ -1105,6 +1114,65 @@ impl ValidatorService {
         }
         unwrapped_response
     }
+
+    async fn handle_capability_notification_v1_impl(
+        &self,
+        request: tonic::Request<HandleCapabilityNotificationV1Request>,
+    ) -> WrappedServiceResponse<HandleCapabilityNotificationV1Response> {
+        let epoch_store = self.state.load_epoch_store_one_call_per_task();
+        let request = request.into_inner();
+
+        // Validate if cert can be executed
+        // Fullnode does not serve handle_certificate call.
+        fp_ensure!(
+            !self.state.is_fullnode(&epoch_store),
+            IotaError::FullNodeCantHandleCertificate.into()
+        );
+
+        if let Err(error) = self.consensus_adapter.check_consensus_overload() {
+            self.metrics
+                .num_rejected_capability_notifications_during_overload
+                .with_label_values(&[error.as_ref()])
+                .inc();
+            return Err(error.into());
+        }
+
+        let _handle_tx_metrics_guard = self
+            .metrics
+            .handle_capability_notification_latency
+            .start_timer();
+
+        // Verify the message signature
+        let verified_envelope = {
+            epoch_store
+                .signature_verifier
+                .verify_tx(request.message)
+                .await
+                .map_err(|e| {
+                    self.metrics.signature_errors.inc();
+                    e
+                })?
+        };
+
+        // Process the capabilities
+        info!(
+            "Received capability notification: {:?}",
+            verified_envelope.data().capabilities
+        );
+
+        // Store or process the capabilities as needed
+        self.state
+            .update_authority_capabilities(
+                verified_envelope.data().capabilities.clone(),
+                verified_envelope.auth_sig(),
+            )
+            .await?;
+
+        Ok((
+            tonic::Response::new(HandleCapabilityNotificationV1Response {}),
+            Weight::zero(),
+        ))
+    }
 }
 
 fn make_tonic_request_for_testing<T>(message: T) -> tonic::Request<T> {
@@ -1242,5 +1310,12 @@ impl Validator for ValidatorService {
         request: tonic::Request<SystemStateRequest>,
     ) -> Result<tonic::Response<IotaSystemState>, tonic::Status> {
         handle_with_decoration!(self, get_system_state_object_impl, request)
+    }
+
+    async fn handle_capability_notification_v1(
+        &self,
+        request: tonic::Request<HandleCapabilityNotificationV1Request>,
+    ) -> Result<tonic::Response<HandleCapabilityNotificationV1Response>, tonic::Status> {
+        handle_with_decoration!(self, handle_capability_notification_v1_impl, request)
     }
 }

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -49,7 +49,7 @@ use tonic::{
     metadata::{Ascii, MetadataValue},
     transport::server::TcpConnectInfo,
 };
-use tracing::{Instrument, error, error_span, info, warn};
+use tracing::{Instrument, error, error_span, info};
 
 use crate::{
     authority::{AuthorityState, authority_per_epoch_store::AuthorityPerEpochStore},
@@ -185,6 +185,7 @@ pub struct ValidatorServiceMetrics {
     num_rejected_cert_in_epoch_boundary: IntCounter,
     num_rejected_tx_during_overload: IntCounterVec,
     num_rejected_cert_during_overload: IntCounterVec,
+    num_rejected_capability_notifications_during_overload: IntCounterVec,
     connection_ip_not_found: IntCounter,
     forwarded_header_parse_error: IntCounter,
     forwarded_header_invalid: IntCounter,
@@ -201,140 +202,147 @@ impl ValidatorServiceMetrics {
                 "Number of transaction signature errors",
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             tx_verification_latency: register_histogram_with_registry!(
                 "validator_service_tx_verification_latency",
                 "Latency of verifying a transaction",
                 iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             cert_verification_latency: register_histogram_with_registry!(
                 "validator_service_cert_verification_latency",
                 "Latency of verifying a certificate",
                 iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             consensus_latency: register_histogram_with_registry!(
                 "validator_service_consensus_latency",
                 "Time spent between submitting a shared obj txn to consensus and getting result",
                 iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             handle_transaction_latency: register_histogram_with_registry!(
                 "validator_service_handle_transaction_latency",
                 "Latency of handling a transaction",
                 iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             handle_certificate_consensus_latency: register_histogram_with_registry!(
                 "validator_service_handle_certificate_consensus_latency",
                 "Latency of handling a consensus transaction certificate",
                 iota_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             submit_certificate_consensus_latency: register_histogram_with_registry!(
                 "validator_service_submit_certificate_consensus_latency",
                 "Latency of submit_certificate RPC handler",
                 iota_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             handle_certificate_non_consensus_latency: register_histogram_with_registry!(
                 "validator_service_handle_certificate_non_consensus_latency",
                 "Latency of handling a non-consensus transaction certificate",
                 iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             handle_soft_bundle_certificates_consensus_latency: register_histogram_with_registry!(
                 "validator_service_handle_soft_bundle_certificates_consensus_latency",
                 "Latency of handling a consensus soft bundle",
                 iota_metrics::COARSE_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             handle_soft_bundle_certificates_count: register_histogram_with_registry!(
                 "validator_service_handle_soft_bundle_certificates_count",
                 "The number of certificates included in a soft bundle",
                 iota_metrics::COUNT_BUCKETS.to_vec(),
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             handle_soft_bundle_certificates_size_bytes: register_histogram_with_registry!(
                 "validator_service_handle_soft_bundle_certificates_size_bytes",
                 "The size of soft bundle in bytes",
                 iota_metrics::BYTES_BUCKETS.to_vec(),
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             handle_capability_notification_latency: register_histogram_with_registry!(
                 "validator_service_handle_capability_notification_latency",
                 "Latency of handling a capability notification",
                 iota_metrics::SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             num_rejected_tx_in_epoch_boundary: register_int_counter_with_registry!(
                 "validator_service_num_rejected_tx_in_epoch_boundary",
                 "Number of rejected transaction during epoch transitioning",
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             num_rejected_cert_in_epoch_boundary: register_int_counter_with_registry!(
                 "validator_service_num_rejected_cert_in_epoch_boundary",
                 "Number of rejected transaction certificate during epoch transitioning",
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             num_rejected_tx_during_overload: register_int_counter_vec_with_registry!(
                 "validator_service_num_rejected_tx_during_overload",
                 "Number of rejected transaction due to system overload",
                 &["error_type"],
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             num_rejected_cert_during_overload: register_int_counter_vec_with_registry!(
                 "validator_service_num_rejected_cert_during_overload",
                 "Number of rejected transaction certificate due to system overload",
                 &["error_type"],
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
+            num_rejected_capability_notifications_during_overload: register_int_counter_vec_with_registry!(
+                "num_rejected_capability_notifications_during_overload",
+                "Number of rejected capability notifications from non-committee active validators due to system overload",
+                &["error_type"],
+                registry,
+            )
+                .unwrap(),
             connection_ip_not_found: register_int_counter_with_registry!(
                 "validator_service_connection_ip_not_found",
                 "Number of times connection IP was not extractable from request",
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             forwarded_header_parse_error: register_int_counter_with_registry!(
                 "validator_service_forwarded_header_parse_error",
                 "Number of times x-forwarded-for header could not be parsed",
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             forwarded_header_invalid: register_int_counter_with_registry!(
                 "validator_service_forwarded_header_invalid",
                 "Number of times x-forwarded-for header was invalid",
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             forwarded_header_not_included: register_int_counter_with_registry!(
                 "validator_service_forwarded_header_not_included",
                 "Number of times x-forwarded-for header was (unexpectedly) not included in request",
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
             client_id_source_config_mismatch: register_int_counter_with_registry!(
                 "validator_service_client_id_source_config_mismatch",
                 "Number of times detected that client id source config doesn't agree with x-forwarded-for header",
                 registry,
             )
-            .unwrap(),
+                .unwrap(),
         }
     }
 
@@ -1142,30 +1150,24 @@ impl ValidatorService {
             .handle_capability_notification_latency
             .start_timer();
 
+        let signed_authority_capabilities = request.message;
         // Verify the message signature
-        let verified_envelope = {
-            epoch_store
-                .signature_verifier
-                .verify_tx(request.message)
-                .await
-                .map_err(|e| {
-                    self.metrics.signature_errors.inc();
-                    e
-                })?
-        };
+        let verified_authority_capabilities = epoch_store
+            .verify_authority_capabilities(signed_authority_capabilities)
+            .map_err(|e| {
+                self.metrics.signature_errors.inc();
+                e
+            })?;
 
-        // Process the capabilities
+        // Process the verified capabilities
         info!(
             "Received capability notification: {:?}",
-            verified_envelope.data().capabilities
+            verified_authority_capabilities.data()
         );
 
         // Store or process the capabilities as needed
         self.state
-            .update_authority_capabilities(
-                verified_envelope.data().capabilities.clone(),
-                verified_envelope.auth_sig(),
-            )
+            .handle_authority_capabilities(verified_authority_capabilities, epoch_store.clone())
             .await?;
 
         Ok((

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -28,7 +28,7 @@ use iota_types::{
     messages_checkpoint::{CheckpointRequest, CheckpointResponse},
     messages_consensus::ConsensusTransaction,
     messages_grpc::{
-        HandleCapabilityNotificationV1Request, HandleCapabilityNotificationV1Response,
+        HandleCapabilityNotificationRequestV1, HandleCapabilityNotificationResponseV1,
         HandleCertificateRequestV1, HandleCertificateResponseV1,
         HandleSoftBundleCertificatesRequestV1, HandleSoftBundleCertificatesResponseV1,
         HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse,
@@ -1125,16 +1125,25 @@ impl ValidatorService {
 
     async fn handle_capability_notification_v1_impl(
         &self,
-        request: tonic::Request<HandleCapabilityNotificationV1Request>,
-    ) -> WrappedServiceResponse<HandleCapabilityNotificationV1Response> {
+        request: tonic::Request<HandleCapabilityNotificationRequestV1>,
+    ) -> WrappedServiceResponse<HandleCapabilityNotificationResponseV1> {
         let epoch_store = self.state.load_epoch_store_one_call_per_task();
         let request = request.into_inner();
-
+        fp_ensure!(
+            epoch_store
+                .protocol_config()
+                .select_committee_supporting_protocol_version(),
+            IotaError::UnsupportedFeature {
+                error: "capability notification endpoint is not supported in this Protocol Version"
+                    .to_string()
+            }
+            .into()
+        );
         // Validate if cert can be executed
         // Fullnode does not serve handle_certificate call.
         fp_ensure!(
             !self.state.is_fullnode(&epoch_store),
-            IotaError::FullNodeCantHandleCertificate.into()
+            IotaError::FullNodeCantHandleAuthorityCapabilities.into()
         );
 
         if let Err(error) = self.consensus_adapter.check_consensus_overload() {
@@ -1166,11 +1175,10 @@ impl ValidatorService {
 
         // Store or process the capabilities as needed
         self.state
-            .handle_authority_capabilities(verified_authority_capabilities, epoch_store.clone())
-            .await?;
+            .handle_authority_capabilities(verified_authority_capabilities, epoch_store.clone())?;
 
         Ok((
-            tonic::Response::new(HandleCapabilityNotificationV1Response {}),
+            tonic::Response::new(HandleCapabilityNotificationResponseV1 {}),
             Weight::zero(),
         ))
     }
@@ -1315,8 +1323,8 @@ impl Validator for ValidatorService {
 
     async fn handle_capability_notification_v1(
         &self,
-        request: tonic::Request<HandleCapabilityNotificationV1Request>,
-    ) -> Result<tonic::Response<HandleCapabilityNotificationV1Response>, tonic::Status> {
+        request: tonic::Request<HandleCapabilityNotificationRequestV1>,
+    ) -> Result<tonic::Response<HandleCapabilityNotificationResponseV1>, tonic::Status> {
         handle_with_decoration!(self, handle_capability_notification_v1_impl, request)
     }
 }

--- a/crates/iota-core/src/signature_verifier.rs
+++ b/crates/iota-core/src/signature_verifier.rs
@@ -2,10 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeSet, sync::Arc};
 
 use either::Either;
-use fastcrypto::traits::AggregateAuthenticator;
+use fastcrypto::traits::{AggregateAuthenticator, ToFromBytes};
 use fastcrypto_zkp::bn254::{
     zk_login::{JWK, JwkId},
     zk_login_api::ZkLoginEnv,
@@ -14,7 +14,6 @@ use futures::pin_mut;
 use im::hashmap::HashMap as ImHashMap;
 use iota_metrics::monitored_scope;
 use iota_types::{
-    base_types::AuthorityName,
     committee::Committee,
     crypto::{AuthorityPublicKey, AuthoritySignInfoTrait, VerificationObligation},
     digests::{CertificateDigest, SenderSignedDataDigest, ZKLoginInputsDigest},
@@ -98,7 +97,7 @@ impl CertBuffer {
 /// - User signed data - caching.
 pub struct SignatureVerifier {
     committee: Arc<Committee>,
-    non_committee_validators: BTreeMap<AuthorityName, AuthorityPublicKey>,
+    non_committee_validators: BTreeSet<AuthorityPublicKey>,
 
     certificate_cache: VerifiedDigestCache<CertificateDigest>,
     signed_data_cache: VerifiedDigestCache<SenderSignedDataDigest>,
@@ -140,7 +139,7 @@ struct ZkLoginParams {
 impl SignatureVerifier {
     pub fn new_with_batch_size(
         committee: Arc<Committee>,
-        non_committee_validators: BTreeMap<AuthorityName, AuthorityPublicKey>,
+        non_committee_validators: BTreeSet<AuthorityPublicKey>,
         batch_size: usize,
         metrics: Arc<SignatureVerifierMetrics>,
         env: ZkLoginEnv,
@@ -187,7 +186,7 @@ impl SignatureVerifier {
 
     pub fn new(
         committee: Arc<Committee>,
-        non_committee_validators: BTreeMap<AuthorityName, AuthorityPublicKey>,
+        non_committee_validators: BTreeSet<AuthorityPublicKey>,
         metrics: Arc<SignatureVerifierMetrics>,
         zklogin_env: ZkLoginEnv,
         accept_zklogin_in_multisig: bool,
@@ -434,12 +433,15 @@ impl SignatureVerifier {
             || {
                 // Check if authority exists in non-committee validators
                 let authority_name = signed_authority_capabilities.data().authority;
-                let authority_key = self
-                    .non_committee_validators
-                    .get(&authority_name)
-                    .ok_or_else(|| IotaError::IncorrectSigner {
-                        error: "Signer must be part of non-committee active validators".to_string(),
+                let authority_key = AuthorityPublicKey::from_bytes(authority_name.as_bytes())
+                    .map_err(|_| IotaError::IncorrectSigner {
+                        error: "Invalid authority public key bytes".to_string(),
                     })?;
+                if !self.non_committee_validators.contains(&authority_key) {
+                    return Err(IotaError::IncorrectSigner {
+                        error: "Signer must be part of non-committee active validators".to_string(),
+                    });
+                }
 
                 // Create a verification obligation
                 let mut obligation = VerificationObligation::default();
@@ -454,7 +456,7 @@ impl SignatureVerifier {
                     .public_keys
                     .get_mut(idx)
                     .ok_or(IotaError::InvalidAuthenticator)?
-                    .push(authority_key);
+                    .push(&authority_key);
 
                 obligation
                     .signatures

--- a/crates/iota-core/src/signature_verifier.rs
+++ b/crates/iota-core/src/signature_verifier.rs
@@ -2,9 +2,10 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use either::Either;
+use fastcrypto::traits::AggregateAuthenticator;
 use fastcrypto_zkp::bn254::{
     zk_login::{JWK, JwkId},
     zk_login_api::ZkLoginEnv,
@@ -13,13 +14,14 @@ use futures::pin_mut;
 use im::hashmap::HashMap as ImHashMap;
 use iota_metrics::monitored_scope;
 use iota_types::{
+    base_types::AuthorityName,
     committee::Committee,
-    crypto::{AuthoritySignInfoTrait, VerificationObligation},
+    crypto::{AuthorityPublicKey, AuthoritySignInfoTrait, VerificationObligation},
     digests::{CertificateDigest, SenderSignedDataDigest, ZKLoginInputsDigest},
     error::{IotaError, IotaResult},
     message_envelope::Message,
     messages_checkpoint::SignedCheckpointSummary,
-    messages_consensus::AuthorityCapabilitiesDigest,
+    messages_consensus::{AuthorityCapabilitiesDigest, SignedAuthorityCapabilitiesV1},
     signature::VerifyParams,
     signature_verification::{VerifiedDigestCache, verify_sender_signed_data_message_signatures},
     transaction::{CertifiedTransaction, SenderSignedData, VerifiedCertificate},
@@ -96,6 +98,8 @@ impl CertBuffer {
 /// - User signed data - caching.
 pub struct SignatureVerifier {
     committee: Arc<Committee>,
+    non_committee_validators: BTreeMap<AuthorityName, AuthorityPublicKey>,
+
     certificate_cache: VerifiedDigestCache<CertificateDigest>,
     signed_data_cache: VerifiedDigestCache<SenderSignedDataDigest>,
     authority_capability_cache: VerifiedDigestCache<AuthorityCapabilitiesDigest>,
@@ -136,6 +140,7 @@ struct ZkLoginParams {
 impl SignatureVerifier {
     pub fn new_with_batch_size(
         committee: Arc<Committee>,
+        non_committee_validators: BTreeMap<AuthorityName, AuthorityPublicKey>,
         batch_size: usize,
         metrics: Arc<SignatureVerifierMetrics>,
         env: ZkLoginEnv,
@@ -146,6 +151,7 @@ impl SignatureVerifier {
     ) -> Self {
         Self {
             committee,
+            non_committee_validators,
             certificate_cache: VerifiedDigestCache::new(
                 metrics.certificate_signatures_cache_hits.clone(),
                 metrics.certificate_signatures_cache_misses.clone(),
@@ -155,6 +161,11 @@ impl SignatureVerifier {
                 metrics.signed_data_cache_hits.clone(),
                 metrics.signed_data_cache_misses.clone(),
                 metrics.signed_data_cache_evictions.clone(),
+            ),
+            authority_capability_cache: VerifiedDigestCache::new(
+                metrics.authority_capabilities_cache_hits.clone(),
+                metrics.authority_capabilities_cache_misses.clone(),
+                metrics.authority_capabilities_cache_evictions.clone(),
             ),
             zklogin_inputs_cache: Arc::new(VerifiedDigestCache::new(
                 metrics.zklogin_inputs_cache_hits.clone(),
@@ -176,6 +187,7 @@ impl SignatureVerifier {
 
     pub fn new(
         committee: Arc<Committee>,
+        non_committee_validators: BTreeMap<AuthorityName, AuthorityPublicKey>,
         metrics: Arc<SignatureVerifierMetrics>,
         zklogin_env: ZkLoginEnv,
         accept_zklogin_in_multisig: bool,
@@ -185,6 +197,7 @@ impl SignatureVerifier {
     ) -> Self {
         Self::new_with_batch_size(
             committee,
+            non_committee_validators,
             MAX_BATCH_SIZE,
             metrics,
             zklogin_env,
@@ -412,8 +425,55 @@ impl SignatureVerifier {
         )
     }
 
+    pub fn verify_authority_capabilities(
+        &self,
+        signed_authority_capabilities: &SignedAuthorityCapabilitiesV1,
+    ) -> IotaResult {
+        self.authority_capability_cache.is_verified(
+            *signed_authority_capabilities.digest(),
+            || {
+                // Check if authority exists in non-committee validators
+                let authority_name = signed_authority_capabilities.data().authority;
+                let authority_key = self
+                    .non_committee_validators
+                    .get(&authority_name)
+                    .ok_or_else(|| IotaError::IncorrectSigner {
+                        error: "Signer must be part of non-committee active validators".to_string(),
+                    })?;
+
+                // Create a verification obligation
+                let mut obligation = VerificationObligation::default();
+                let idx = obligation.add_message(
+                    signed_authority_capabilities.data(),
+                    self.committee.epoch(), // TODO: store epoch in non-committee validators
+                    Intent::iota_app(signed_authority_capabilities.scope()),
+                );
+
+                // Add the signature and public key to the obligation
+                obligation
+                    .public_keys
+                    .get_mut(idx)
+                    .ok_or(IotaError::InvalidAuthenticator)?
+                    .push(authority_key);
+
+                obligation
+                    .signatures
+                    .get_mut(idx)
+                    .ok_or(IotaError::InvalidAuthenticator)?
+                    .add_signature(signed_authority_capabilities.auth_sig().clone())
+                    .map_err(|_| IotaError::InvalidSignature {
+                        error: "Failed to add authority signature to obligation".to_string(),
+                    })?;
+
+                obligation.verify_all()
+            },
+            || Ok(()),
+        )
+    }
+
     pub fn clear_signature_cache(&self) {
         self.certificate_cache.clear();
+        self.authority_capability_cache.clear();
         self.signed_data_cache.clear();
         self.zklogin_inputs_cache.clear();
     }
@@ -429,6 +489,9 @@ pub struct SignatureVerifierMetrics {
     pub zklogin_inputs_cache_hits: IntCounter,
     pub zklogin_inputs_cache_misses: IntCounter,
     pub zklogin_inputs_cache_evictions: IntCounter,
+    pub authority_capabilities_cache_hits: IntCounter,
+    pub authority_capabilities_cache_misses: IntCounter,
+    pub authority_capabilities_cache_evictions: IntCounter,
     timeouts: IntCounter,
     full_batches: IntCounter,
     partial_batches: IntCounter,
@@ -474,25 +537,43 @@ impl SignatureVerifierMetrics {
                 "Number of times we evict a pre-existing signed data were known to be verified because of signature cache.",
                 registry
             )
-                .unwrap(),
-                zklogin_inputs_cache_hits: register_int_counter_with_registry!(
-                    "zklogin_inputs_cache_hits",
-                    "Number of zklogin signature which were known to be partially verified because of zklogin inputs cache.",
-                    registry
-                )
-                .unwrap(),
-                zklogin_inputs_cache_misses: register_int_counter_with_registry!(
-                    "zklogin_inputs_cache_misses",
-                    "Number of zklogin signatures which missed the zklogin inputs cache.",
-                    registry
-                )
-                .unwrap(),
-                zklogin_inputs_cache_evictions: register_int_counter_with_registry!(
-                    "zklogin_inputs_cache_evictions",
-                    "Number of times we evict a pre-existing zklogin inputs digest that was known to be verified because of zklogin inputs cache.",
-                    registry
-                )
-                .unwrap(),
+            .unwrap(),
+            zklogin_inputs_cache_hits: register_int_counter_with_registry!(
+                "zklogin_inputs_cache_hits",
+                "Number of zklogin signature which were known to be partially verified because of zklogin inputs cache.",
+                registry
+            )
+            .unwrap(),
+            zklogin_inputs_cache_misses: register_int_counter_with_registry!(
+                "zklogin_inputs_cache_misses",
+                "Number of zklogin signatures which missed the zklogin inputs cache.",
+                registry
+            )
+            .unwrap(),
+            zklogin_inputs_cache_evictions: register_int_counter_with_registry!(
+                "zklogin_inputs_cache_evictions",
+                "Number of times we evict a pre-existing zklogin inputs digest that was known to be verified because of zklogin inputs cache.",
+                registry
+            )
+            .unwrap(),
+            authority_capabilities_cache_hits: register_int_counter_with_registry!(
+                "authority_capabilities_cache_hits",
+                "Number of authority capabilities which were known to be verified because of capabilities cache.",
+                registry
+            )
+            .unwrap(),
+            authority_capabilities_cache_misses: register_int_counter_with_registry!(
+                "authority_capabilities_cache_misses",
+                "Number of authority capabilities which missed the capabilities cache.",
+                registry
+            )
+            .unwrap(),
+            authority_capabilities_cache_evictions: register_int_counter_with_registry!(
+                "authority_capabilities_cache_evictions",
+                "Number of times we evict a pre-existing authority capabilities that were known to be verified.",
+                registry
+            )
+            .unwrap(),
             timeouts: register_int_counter_with_registry!(
                 "async_batch_verifier_timeouts",
                 "Number of times batch verifier times out and verifies a partial batch",

--- a/crates/iota-core/src/signature_verifier.rs
+++ b/crates/iota-core/src/signature_verifier.rs
@@ -445,7 +445,7 @@ impl SignatureVerifier {
                 let mut obligation = VerificationObligation::default();
                 let idx = obligation.add_message(
                     signed_authority_capabilities.data(),
-                    self.committee.epoch(), // TODO: store epoch in non-committee validators
+                    self.committee.epoch(),
                     Intent::iota_app(signed_authority_capabilities.scope()),
                 );
 

--- a/crates/iota-core/src/signature_verifier.rs
+++ b/crates/iota-core/src/signature_verifier.rs
@@ -19,6 +19,7 @@ use iota_types::{
     error::{IotaError, IotaResult},
     message_envelope::Message,
     messages_checkpoint::SignedCheckpointSummary,
+    messages_consensus::AuthorityCapabilitiesDigest,
     signature::VerifyParams,
     signature_verification::{VerifiedDigestCache, verify_sender_signed_data_message_signatures},
     transaction::{CertifiedTransaction, SenderSignedData, VerifiedCertificate},
@@ -34,6 +35,7 @@ use tokio::{
     time::{Duration, timeout},
 };
 use tracing::debug;
+
 // Maximum amount of time we wait for a batch to fill up before verifying a
 // partial batch.
 const BATCH_TIMEOUT_MS: Duration = Duration::from_millis(10);
@@ -96,6 +98,7 @@ pub struct SignatureVerifier {
     committee: Arc<Committee>,
     certificate_cache: VerifiedDigestCache<CertificateDigest>,
     signed_data_cache: VerifiedDigestCache<SenderSignedDataDigest>,
+    authority_capability_cache: VerifiedDigestCache<AuthorityCapabilitiesDigest>,
     zklogin_inputs_cache: Arc<VerifiedDigestCache<ZKLoginInputsDigest>>,
 
     /// Map from JwkId (iss, kid) to the fetched JWK for that key.

--- a/crates/iota-core/src/test_authority_clients.rs
+++ b/crates/iota-core/src/test_authority_clients.rs
@@ -19,7 +19,7 @@ use iota_types::{
     iota_system_state::IotaSystemState,
     messages_checkpoint::{CheckpointRequest, CheckpointResponse},
     messages_grpc::{
-        HandleCapabilityNotificationV1Request, HandleCapabilityNotificationV1Response,
+        HandleCapabilityNotificationRequestV1, HandleCapabilityNotificationResponseV1,
         HandleCertificateRequestV1, HandleCertificateResponseV1,
         HandleSoftBundleCertificatesRequestV1, HandleSoftBundleCertificatesResponseV1,
         HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse, SystemStateRequest,
@@ -140,8 +140,8 @@ impl AuthorityAPI for LocalAuthorityClient {
 
     async fn handle_capability_notification_v1(
         &self,
-        request: HandleCapabilityNotificationV1Request,
-    ) -> Result<HandleCapabilityNotificationV1Response, IotaError> {
+        request: HandleCapabilityNotificationRequestV1,
+    ) -> Result<HandleCapabilityNotificationResponseV1, IotaError> {
         let state = self.state.clone();
         let epoch_store = state.load_epoch_store_one_call_per_task();
 
@@ -156,10 +156,9 @@ impl AuthorityAPI for LocalAuthorityClient {
         );
 
         state
-            .handle_authority_capabilities(verified_authority_capabilities, epoch_store.clone())
-            .await?;
+            .handle_authority_capabilities(verified_authority_capabilities, epoch_store.clone())?;
 
-        Ok(HandleCapabilityNotificationV1Response {})
+        Ok(HandleCapabilityNotificationResponseV1 {})
     }
 }
 
@@ -346,8 +345,8 @@ impl AuthorityAPI for MockAuthorityApi {
 
     async fn handle_capability_notification_v1(
         &self,
-        _request: HandleCapabilityNotificationV1Request,
-    ) -> Result<HandleCapabilityNotificationV1Response, IotaError> {
+        _request: HandleCapabilityNotificationRequestV1,
+    ) -> Result<HandleCapabilityNotificationResponseV1, IotaError> {
         unimplemented!()
     }
 }
@@ -423,8 +422,8 @@ impl AuthorityAPI for HandleTransactionTestAuthorityClient {
 
     async fn handle_capability_notification_v1(
         &self,
-        _request: HandleCapabilityNotificationV1Request,
-    ) -> Result<HandleCapabilityNotificationV1Response, IotaError> {
+        _request: HandleCapabilityNotificationRequestV1,
+    ) -> Result<HandleCapabilityNotificationResponseV1, IotaError> {
         unimplemented!()
     }
 }

--- a/crates/iota-core/src/test_authority_clients.rs
+++ b/crates/iota-core/src/test_authority_clients.rs
@@ -27,6 +27,7 @@ use iota_types::{
     },
     transaction::{Transaction, VerifiedTransaction},
 };
+use tracing::info;
 
 use crate::{
     authority::{AuthorityState, test_authority_builder::TestAuthorityBuilder},
@@ -139,10 +140,26 @@ impl AuthorityAPI for LocalAuthorityClient {
 
     async fn handle_capability_notification_v1(
         &self,
-        _request: HandleCapabilityNotificationV1Request,
+        request: HandleCapabilityNotificationV1Request,
     ) -> Result<HandleCapabilityNotificationV1Response, IotaError> {
         let state = self.state.clone();
-        state.handle_transaction(request).await
+        let epoch_store = state.load_epoch_store_one_call_per_task();
+
+        // Verify the message signature
+        let verified_authority_capabilities =
+            epoch_store.verify_authority_capabilities(request.message)?;
+
+        // Process the verified capabilities
+        info!(
+            "Received capability notification: {:?}",
+            verified_authority_capabilities.data()
+        );
+
+        state
+            .handle_authority_capabilities(verified_authority_capabilities, epoch_store.clone())
+            .await?;
+
+        Ok(HandleCapabilityNotificationV1Response {})
     }
 }
 

--- a/crates/iota-core/src/test_authority_clients.rs
+++ b/crates/iota-core/src/test_authority_clients.rs
@@ -19,6 +19,7 @@ use iota_types::{
     iota_system_state::IotaSystemState,
     messages_checkpoint::{CheckpointRequest, CheckpointResponse},
     messages_grpc::{
+        HandleCapabilityNotificationV1Request, HandleCapabilityNotificationV1Response,
         HandleCertificateRequestV1, HandleCertificateResponseV1,
         HandleSoftBundleCertificatesRequestV1, HandleSoftBundleCertificatesResponseV1,
         HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse, SystemStateRequest,
@@ -134,6 +135,14 @@ impl AuthorityAPI for LocalAuthorityClient {
         _request: SystemStateRequest,
     ) -> Result<IotaSystemState, IotaError> {
         self.state.get_iota_system_state_object_for_testing()
+    }
+
+    async fn handle_capability_notification_v1(
+        &self,
+        _request: HandleCapabilityNotificationV1Request,
+    ) -> Result<HandleCapabilityNotificationV1Response, IotaError> {
+        let state = self.state.clone();
+        state.handle_transaction(request).await
     }
 }
 
@@ -317,6 +326,13 @@ impl AuthorityAPI for MockAuthorityApi {
     ) -> Result<IotaSystemState, IotaError> {
         unimplemented!();
     }
+
+    async fn handle_capability_notification_v1(
+        &self,
+        _request: HandleCapabilityNotificationV1Request,
+    ) -> Result<HandleCapabilityNotificationV1Response, IotaError> {
+        unimplemented!()
+    }
 }
 
 #[derive(Clone)]
@@ -385,6 +401,13 @@ impl AuthorityAPI for HandleTransactionTestAuthorityClient {
         &self,
         _request: SystemStateRequest,
     ) -> Result<IotaSystemState, IotaError> {
+        unimplemented!()
+    }
+
+    async fn handle_capability_notification_v1(
+        &self,
+        _request: HandleCapabilityNotificationV1Request,
+    ) -> Result<HandleCapabilityNotificationV1Response, IotaError> {
         unimplemented!()
     }
 }

--- a/crates/iota-core/src/unit_tests/batch_verification_tests.rs
+++ b/crates/iota-core/src/unit_tests/batch_verification_tests.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeSet, sync::Arc};
 
 use fastcrypto::traits::KeyPair;
 use futures::future::join_all;

--- a/crates/iota-core/src/unit_tests/batch_verification_tests.rs
+++ b/crates/iota-core/src/unit_tests/batch_verification_tests.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use fastcrypto::traits::KeyPair;
 use futures::future::join_all;
@@ -145,6 +145,7 @@ async fn test_async_verifier() {
     let metrics = SignatureVerifierMetrics::new(&registry);
     let verifier = Arc::new(SignatureVerifier::new(
         committee.clone(),
+        BTreeMap::new(),
         metrics,
         ZkLoginEnv::Test,
         true, // accept_zklogin_in_multisig

--- a/crates/iota-core/src/unit_tests/batch_verification_tests.rs
+++ b/crates/iota-core/src/unit_tests/batch_verification_tests.rs
@@ -145,7 +145,7 @@ async fn test_async_verifier() {
     let metrics = SignatureVerifierMetrics::new(&registry);
     let verifier = Arc::new(SignatureVerifier::new(
         committee.clone(),
-        BTreeMap::new(),
+        BTreeSet::new(),
         metrics,
         ZkLoginEnv::Test,
         true, // accept_zklogin_in_multisig

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -70,7 +70,8 @@ async fn test_authority_reject_authority_capabilities() {
     let (_sender, sender_key): (_, AuthorityKeyPair) = get_authority_key_pair();
 
     let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-    protocol_config.set_select_committee_supporting_protocol_version_for_testing(true);
+    protocol_config.set_select_committee_from_eligible_validators_for_testing(true);
+    protocol_config.set_track_non_committee_eligible_validators_for_testing(true);
 
     let authority_state = TestAuthorityBuilder::new()
         .with_protocol_config(protocol_config)
@@ -175,7 +176,8 @@ async fn test_handle_capability_notification_v1_feature_disabled() {
     let (_sender, sender_key): (_, AuthorityKeyPair) = get_authority_key_pair();
 
     let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-    protocol_config.set_select_committee_supporting_protocol_version_for_testing(false);
+    protocol_config.set_select_committee_from_eligible_validators_for_testing(false);
+    protocol_config.set_track_non_committee_eligible_validators_for_testing(false);
 
     let authority_state = TestAuthorityBuilder::new()
         .with_protocol_config(protocol_config)

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -2,15 +2,25 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use iota_protocol_config::Chain;
 use iota_types::{
-    base_types::{dbg_addr, dbg_object_id},
+    base_types::{AuthorityName, dbg_addr, dbg_object_id},
+    crypto::{
+        AuthorityKeyPair, AuthoritySignature, IotaAuthoritySignature, get_authority_key_pair,
+    },
+    messages_consensus::{AuthorityCapabilitiesV1, SignedAuthorityCapabilitiesV1},
     messages_grpc::LayoutGenerationOption,
+    supported_protocol_versions::SupportedProtocolVersions,
 };
+use shared_crypto::intent::{Intent, IntentMessage, IntentScope::AuthorityCapabilities};
 
 use super::*;
 use crate::{
-    authority::authority_tests::init_state_with_object_id,
+    authority::{
+        authority_tests::init_state_with_object_id, test_authority_builder::TestAuthorityBuilder,
+    },
     authority_client::{AuthorityAPI, NetworkAuthorityClient},
+    consensus_adapter::MockConsensusClient,
 };
 
 // This is the most basic example of how to test the server logic
@@ -43,4 +53,110 @@ async fn test_simple_request() {
         ObjectInfoRequest::latest_object_info_request(object_id, LayoutGenerationOption::Generate);
 
     client.handle_object_info_request(req).await.unwrap();
+}
+
+// TODO: Happy path tests for handling AuthorityCapabilities are not covered
+//  here as the setup is more  complex and will be handled in end-to-end tests.
+
+// This test verifies that the authority rejects capability notifications from
+// unauthorized authorities (authorities that are not part of non-committee
+// validators).
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_authority_reject_authority_capabilities() {
+    telemetry_subscribers::init_for_testing();
+
+    // Create one sender, one recipient addresses, and 2 gas objects.
+    let (_sender, sender_key): (_, AuthorityKeyPair) = get_authority_key_pair();
+
+    let authority_state = TestAuthorityBuilder::new().build().await;
+
+    // Create a validator service around the `authority_state`.
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    // Create the validator service that will handle capability notifications
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state.clone(),
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    // Create authority capabilities message containing the authority's identity and
+    // supported features
+    let capabilities = AuthorityCapabilitiesV1::new(
+        AuthorityName::new(sender_key.public().pubkey.to_bytes()), // Authority identifier
+        Chain::Mainnet,                                            // Target blockchain network
+        SupportedProtocolVersions::new_for_testing(1, 10),         // Protocol version range
+        vec![],                                                    /* Empty capabilities list
+                                                                    * for this test */
+    );
+
+    // Sign the capabilities message with the authority's private key
+    // This creates a cryptographic proof that the message came from the claimed
+    // authority
+    let signature = AuthoritySignature::new_secure(
+        &IntentMessage::new(Intent::iota_app(AuthorityCapabilities), &capabilities),
+        &authority_state.current_epoch_for_testing(),
+        &sender_key,
+    );
+
+    // Package the signed capabilities into a request message
+    let request1 = HandleCapabilityNotificationV1Request {
+        message: SignedAuthorityCapabilitiesV1::new_from_data_and_sig(capabilities, signature),
+    };
+
+    // Attempt to handle the capability notification and verify it gets rejected
+    // The request should be rejected because the signer is not a non-committee
+    // validator authorized to send capability notifications
+    assert!(
+        validator_service
+            .handle_capability_notification_v1(make_tonic_request_for_testing(request1))
+            .await
+            .is_err(),
+        "Expected capability notification from unauthorized authority to be rejected"
+    );
+
+    // Test with authority_state's own keys - this should also be rejected
+    // because the authority should not accept capability notifications from itself
+    let authority_capabilities = AuthorityCapabilitiesV1::new(
+        authority_state.name, // Use the authority's own name
+        Chain::Mainnet,
+        SupportedProtocolVersions::new_for_testing(1, 10),
+        vec![],
+    );
+
+    // Sign with the authority_state's own key pair
+    let authority_signature = AuthoritySignature::new_secure(
+        &IntentMessage::new(
+            Intent::iota_app(AuthorityCapabilities),
+            &authority_capabilities,
+        ),
+        &authority_state.current_epoch_for_testing(),
+        &*authority_state.secret,
+    );
+
+    let request2 = HandleCapabilityNotificationV1Request {
+        message: SignedAuthorityCapabilitiesV1::new_from_data_and_sig(
+            authority_capabilities,
+            authority_signature,
+        ),
+    };
+
+    // This should also be rejected - authorities should not accept capability
+    // notifications from themselves or other committee members
+    assert!(
+        validator_service
+            .handle_capability_notification_v1(make_tonic_request_for_testing(request2))
+            .await
+            .is_err(),
+        "Expected capability notification from authority itself to be rejected"
+    );
 }

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -96,8 +96,8 @@ async fn test_authority_reject_authority_capabilities() {
         Arc::new(ValidatorServiceMetrics::new_for_tests()),
     ));
 
-    // Create authority capabilities message containing the authority's identity and
-    // supported features
+    // Create an authority capabilities message containing the authority's identity
+    // and supported features
     let capabilities = AuthorityCapabilitiesV1::new(
         AuthorityName::new(sender_key.public().pubkey.to_bytes()), // Authority identifier
         Chain::Mainnet,                                            // Target blockchain network
@@ -106,7 +106,7 @@ async fn test_authority_reject_authority_capabilities() {
                                                                     * for this test */
     );
 
-    // Sign the capabilities message with the authority's private key
+    // Sign the capability message with the authority's private key
     // This creates a cryptographic proof that the message came from the claimed
     // authority
     let signature = AuthoritySignature::new_secure(
@@ -157,8 +157,8 @@ async fn test_authority_reject_authority_capabilities() {
         ),
     };
 
-    // This should also be rejected - authorities should not accept capability
-    // notifications from themselves or other committee members
+    // This should also be rejected - committee validators should not accept
+    // capability notifications from themselves or other committee members
     assert!(
         validator_service
             .handle_capability_notification_v1(make_tonic_request_for_testing(request2))

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -2,12 +2,13 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_protocol_config::Chain;
+use iota_protocol_config::{Chain, ProtocolConfig};
 use iota_types::{
     base_types::{AuthorityName, dbg_addr, dbg_object_id},
     crypto::{
         AuthorityKeyPair, AuthoritySignature, IotaAuthoritySignature, get_authority_key_pair,
     },
+    error::IotaError,
     messages_consensus::{AuthorityCapabilitiesV1, SignedAuthorityCapabilitiesV1},
     messages_grpc::LayoutGenerationOption,
     supported_protocol_versions::SupportedProtocolVersions,
@@ -68,7 +69,13 @@ async fn test_authority_reject_authority_capabilities() {
     // Create one sender, one recipient addresses, and 2 gas objects.
     let (_sender, sender_key): (_, AuthorityKeyPair) = get_authority_key_pair();
 
-    let authority_state = TestAuthorityBuilder::new().build().await;
+    let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+    protocol_config.set_select_committee_supporting_protocol_version_for_testing(true);
+
+    let authority_state = TestAuthorityBuilder::new()
+        .with_protocol_config(protocol_config)
+        .build()
+        .await;
 
     // Create a validator service around the `authority_state`.
     let consensus_adapter = Arc::new(ConsensusAdapter::new(
@@ -109,7 +116,7 @@ async fn test_authority_reject_authority_capabilities() {
     );
 
     // Package the signed capabilities into a request message
-    let request1 = HandleCapabilityNotificationV1Request {
+    let request1 = HandleCapabilityNotificationRequestV1 {
         message: SignedAuthorityCapabilitiesV1::new_from_data_and_sig(capabilities, signature),
     };
 
@@ -143,7 +150,7 @@ async fn test_authority_reject_authority_capabilities() {
         &*authority_state.secret,
     );
 
-    let request2 = HandleCapabilityNotificationV1Request {
+    let request2 = HandleCapabilityNotificationRequestV1 {
         message: SignedAuthorityCapabilitiesV1::new_from_data_and_sig(
             authority_capabilities,
             authority_signature,
@@ -158,5 +165,69 @@ async fn test_authority_reject_authority_capabilities() {
             .await
             .is_err(),
         "Expected capability notification from authority itself to be rejected"
+    );
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_handle_capability_notification_v1_feature_disabled() {
+    telemetry_subscribers::init_for_testing();
+
+    let (_sender, sender_key): (_, AuthorityKeyPair) = get_authority_key_pair();
+
+    let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+    protocol_config.set_select_committee_supporting_protocol_version_for_testing(false);
+
+    let authority_state = TestAuthorityBuilder::new()
+        .with_protocol_config(protocol_config)
+        .build()
+        .await;
+
+    let consensus_adapter = Arc::new(ConsensusAdapter::new(
+        Arc::new(MockConsensusClient::new()),
+        authority_state.name,
+        Arc::new(ConnectionMonitorStatusForTests {}),
+        100_000,
+        100_000,
+        None,
+        None,
+        ConsensusAdapterMetrics::new_test(),
+    ));
+
+    let validator_service = Arc::new(ValidatorService::new_for_tests(
+        authority_state.clone(),
+        consensus_adapter,
+        Arc::new(ValidatorServiceMetrics::new_for_tests()),
+    ));
+
+    let capabilities = AuthorityCapabilitiesV1::new(
+        AuthorityName::new(sender_key.public().pubkey.to_bytes()),
+        Chain::Mainnet,
+        SupportedProtocolVersions::new_for_testing(1, 10),
+        vec![],
+    );
+
+    let signature = AuthoritySignature::new_secure(
+        &IntentMessage::new(Intent::iota_app(AuthorityCapabilities), &capabilities),
+        &authority_state.current_epoch_for_testing(),
+        &sender_key,
+    );
+
+    let request = HandleCapabilityNotificationRequestV1 {
+        message: SignedAuthorityCapabilitiesV1::new_from_data_and_sig(capabilities, signature),
+    };
+
+    let result = validator_service
+        .handle_capability_notification_v1(make_tonic_request_for_testing(request))
+        .await;
+
+    assert!(
+        result.is_err(),
+        "Expected capability notification to be rejected due to feature being disabled"
+    );
+    let err_kind = IotaError::from(result.unwrap_err());
+    assert!(
+        matches!(err_kind, IotaError::UnsupportedFeature { .. }),
+        "Expected UnsupportedFeature error, but got {:?}",
+        err_kind
     );
 }

--- a/crates/iota-core/src/unit_tests/server_tests.rs
+++ b/crates/iota-core/src/unit_tests/server_tests.rs
@@ -227,7 +227,6 @@ async fn test_handle_capability_notification_v1_feature_disabled() {
     let err_kind = IotaError::from(result.unwrap_err());
     assert!(
         matches!(err_kind, IotaError::UnsupportedFeature { .. }),
-        "Expected UnsupportedFeature error, but got {:?}",
-        err_kind
+        "Expected UnsupportedFeature error, but got {err_kind:?}",
     );
 }

--- a/crates/iota-core/src/validator_tx_finalizer.rs
+++ b/crates/iota-core/src/validator_tx_finalizer.rs
@@ -305,6 +305,7 @@ mod tests {
         iota_system_state::IotaSystemState,
         messages_checkpoint::{CheckpointRequest, CheckpointResponse},
         messages_grpc::{
+            HandleCapabilityNotificationV1Request, HandleCapabilityNotificationV1Response,
             HandleCertificateRequestV1, HandleCertificateResponseV1,
             HandleSoftBundleCertificatesRequestV1, HandleSoftBundleCertificatesResponseV1,
             HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse, SystemStateRequest,
@@ -413,6 +414,13 @@ mod tests {
             &self,
             _request: SystemStateRequest,
         ) -> Result<IotaSystemState, IotaError> {
+            unimplemented!()
+        }
+
+        async fn handle_capability_notification_v1(
+            &self,
+            _request: HandleCapabilityNotificationV1Request,
+        ) -> Result<HandleCapabilityNotificationV1Response, IotaError> {
             unimplemented!()
         }
     }

--- a/crates/iota-core/src/validator_tx_finalizer.rs
+++ b/crates/iota-core/src/validator_tx_finalizer.rs
@@ -305,7 +305,7 @@ mod tests {
         iota_system_state::IotaSystemState,
         messages_checkpoint::{CheckpointRequest, CheckpointResponse},
         messages_grpc::{
-            HandleCapabilityNotificationV1Request, HandleCapabilityNotificationV1Response,
+            HandleCapabilityNotificationRequestV1, HandleCapabilityNotificationResponseV1,
             HandleCertificateRequestV1, HandleCertificateResponseV1,
             HandleSoftBundleCertificatesRequestV1, HandleSoftBundleCertificatesResponseV1,
             HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse, SystemStateRequest,
@@ -419,8 +419,8 @@ mod tests {
 
         async fn handle_capability_notification_v1(
             &self,
-            _request: HandleCapabilityNotificationV1Request,
-        ) -> Result<HandleCapabilityNotificationV1Response, IotaError> {
+            _request: HandleCapabilityNotificationRequestV1,
+        ) -> Result<HandleCapabilityNotificationResponseV1, IotaError> {
             unimplemented!()
         }
     }

--- a/crates/iota-json-rpc/src/authority_state.rs
+++ b/crates/iota-json-rpc/src/authority_state.rs
@@ -25,6 +25,7 @@ use iota_storage::key_value_store::{
 use iota_types::{
     base_types::{IotaAddress, MoveObjectType, ObjectID, ObjectInfo, ObjectRef, SequenceNumber},
     committee::{Committee, EpochId},
+    crypto::AuthoritySignInfoTrait,
     digests::{ChainIdentifier, TransactionDigest},
     dynamic_field::DynamicFieldInfo,
     effects::TransactionEffects,
@@ -254,16 +255,16 @@ impl StateRead for AuthorityState {
         Ok(self.get_object_read(object_id)?)
     }
 
-    async fn get_object(&self, object_id: &ObjectID) -> StateReadResult<Option<Object>> {
-        Ok(self.try_get_object(object_id).await?)
-    }
-
     fn get_past_object_read(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,
     ) -> StateReadResult<PastObjectRead> {
         Ok(self.get_past_object_read(object_id, version)?)
+    }
+
+    async fn get_object(&self, object_id: &ObjectID) -> StateReadResult<Option<Object>> {
+        Ok(self.get_object(object_id).await?)
     }
 
     fn load_epoch_store_one_call_per_task(&self) -> Guard<Arc<AuthorityPerEpochStore>> {

--- a/crates/iota-json-rpc/src/authority_state.rs
+++ b/crates/iota-json-rpc/src/authority_state.rs
@@ -25,7 +25,6 @@ use iota_storage::key_value_store::{
 use iota_types::{
     base_types::{IotaAddress, MoveObjectType, ObjectID, ObjectInfo, ObjectRef, SequenceNumber},
     committee::{Committee, EpochId},
-    crypto::AuthoritySignInfoTrait,
     digests::{ChainIdentifier, TransactionDigest},
     dynamic_field::DynamicFieldInfo,
     effects::TransactionEffects,
@@ -255,16 +254,16 @@ impl StateRead for AuthorityState {
         Ok(self.get_object_read(object_id)?)
     }
 
+    async fn get_object(&self, object_id: &ObjectID) -> StateReadResult<Option<Object>> {
+        Ok(self.try_get_object(object_id).await?)
+    }
+
     fn get_past_object_read(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,
     ) -> StateReadResult<PastObjectRead> {
         Ok(self.get_past_object_read(object_id, version)?)
-    }
-
-    async fn get_object(&self, object_id: &ObjectID) -> StateReadResult<Option<Object>> {
-        Ok(self.get_object(object_id).await?)
     }
 
     fn load_epoch_store_one_call_per_task(&self) -> Guard<Arc<AuthorityPerEpochStore>> {

--- a/crates/iota-network/build.rs
+++ b/crates/iota-network/build.rs
@@ -99,6 +99,15 @@ fn main() -> Result<()> {
                 .codec_path(codec_path)
                 .build(),
         )
+        .method(
+            Method::builder()
+                .name("handle_capability_notification_v1")
+                .route_name("CapabilityNotificationV1")
+                .input_type("iota_types::messages_grpc::HandleCapabilityNotificationV1Request")
+                .output_type("iota_types::messages_grpc::HandleCapabilityNotificationV1Response")
+                .codec_path(codec_path)
+                .build(),
+        )
         .build();
 
     Builder::new()

--- a/crates/iota-network/build.rs
+++ b/crates/iota-network/build.rs
@@ -103,8 +103,8 @@ fn main() -> Result<()> {
             Method::builder()
                 .name("handle_capability_notification_v1")
                 .route_name("CapabilityNotificationV1")
-                .input_type("iota_types::messages_grpc::HandleCapabilityNotificationV1Request")
-                .output_type("iota_types::messages_grpc::HandleCapabilityNotificationV1Response")
+                .input_type("iota_types::messages_grpc::HandleCapabilityNotificationRequestV1")
+                .output_type("iota_types::messages_grpc::HandleCapabilityNotificationResponseV1")
                 .codec_path(codec_path)
                 .build(),
         )

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -328,9 +328,10 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     select_committee_from_eligible_validators: bool,
 
-    // If true, use ChangeEpochV3 for epoch change to pass an additional eligible_active_validators
-    // parameter to IotaSystem's advance_epoch call. This should only be enabled when on-chain
-    // IotaSystem objects are updated as well.
+    // If true, non-committee active validators will sign and send AuthorityCapabilitiesV1 to the
+    // committee. The committee will track them and include them in the epoch change. If this is
+    // disabled, then all active validators are used for selecting the committee (same as previous
+    // behavior).
     #[serde(skip_serializing_if = "is_false")]
     track_non_committee_eligible_validators: bool,
 }
@@ -1339,7 +1340,7 @@ impl ProtocolConfig {
         0
     }
 
-    pub fn select_committee_supporting_protocol_version(&self) -> bool {
+    pub fn select_committee_from_eligible_validators(&self) -> bool {
         self.feature_flags.select_committee_from_eligible_validators
     }
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -72,6 +72,10 @@ pub const MAX_PROTOCOL_VERSION: u64 = 12;
 //             Add additional linkage checks
 // Version 11: Framework fix regarding candidate validator commission rate.
 // Version 12: Enable the gas price feedback mechanism in all networks.
+//             Introduce logic to allow the committee to be selected from a set
+//             of eligible active validators.
+//             Enable processing and tracking AuthorityCapabilitiesV1 from
+//             non-committee validators in the devnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -318,10 +322,17 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     additional_multisig_checks: bool,
 
-    // If true, select committee among active validators supporting a protocol version in the
-    // upcoming epoch.
+    // If true, use ChangeEpochV3 for epoch change to pass an additional eligible_active_validators
+    // parameter to IotaSystem's advance_epoch call. This should only be enabled when on-chain
+    // IotaSystem objects are updated as well.
     #[serde(skip_serializing_if = "is_false")]
-    select_committee_supporting_protocol_version: bool,
+    select_committee_from_eligible_validators: bool,
+
+    // If true, use ChangeEpochV3 for epoch change to pass an additional eligible_active_validators
+    // parameter to IotaSystem's advance_epoch call. This should only be enabled when on-chain
+    // IotaSystem objects are updated as well.
+    #[serde(skip_serializing_if = "is_false")]
+    track_non_committee_eligible_validators: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1329,8 +1340,11 @@ impl ProtocolConfig {
     }
 
     pub fn select_committee_supporting_protocol_version(&self) -> bool {
-        self.feature_flags
-            .select_committee_supporting_protocol_version
+        self.feature_flags.select_committee_from_eligible_validators
+    }
+
+    pub fn track_non_committee_eligible_validators(&self) -> bool {
+        self.feature_flags.track_non_committee_eligible_validators
     }
 }
 
@@ -2144,8 +2158,10 @@ impl ProtocolConfig {
                         .congestion_control_gas_price_feedback_mechanism = true;
                     // Enable select committee supporting protocol version in devnet.
                     if chain != Chain::Testnet && chain != Chain::Mainnet {
-                        cfg.feature_flags
-                            .select_committee_supporting_protocol_version = true;
+                        // Enable selecting committee based on eligible active validators in devnet.
+                        cfg.feature_flags.select_committee_from_eligible_validators = true;
+                        // Enable tracking non-committee eligible active validators in devnet.
+                        cfg.feature_flags.track_non_committee_eligible_validators = true;
                     }
                 }
                 // Use this template when making changes:
@@ -2308,9 +2324,12 @@ impl ProtocolConfig {
         self.feature_flags
             .congestion_control_gas_price_feedback_mechanism = val;
     }
-    pub fn set_select_committee_supporting_protocol_version_for_testing(&mut self, val: bool) {
-        self.feature_flags
-            .select_committee_supporting_protocol_version = val;
+    pub fn set_select_committee_from_eligible_validators_for_testing(&mut self, val: bool) {
+        self.feature_flags.select_committee_from_eligible_validators = val;
+    }
+
+    pub fn set_track_non_committee_eligible_validators_for_testing(&mut self, val: bool) {
+        self.feature_flags.track_non_committee_eligible_validators = val;
     }
 }
 

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -317,6 +317,11 @@ struct FeatureFlags {
     // If true enable additional multisig checks.
     #[serde(skip_serializing_if = "is_false")]
     additional_multisig_checks: bool,
+
+    // If true, select committee among active validators supporting a protocol version in the
+    // upcoming epoch.
+    #[serde(skip_serializing_if = "is_false")]
+    select_committee_supporting_protocol_version: bool,
 }
 
 fn is_true(b: &bool) -> bool {
@@ -1322,6 +1327,11 @@ impl ProtocolConfig {
         // parameters.
         0
     }
+
+    pub fn select_committee_supporting_protocol_version(&self) -> bool {
+        self.feature_flags
+            .select_committee_supporting_protocol_version
+    }
 }
 
 #[cfg(not(msim))]
@@ -2132,6 +2142,11 @@ impl ProtocolConfig {
                     // cancelled due to congestion in all networks
                     cfg.feature_flags
                         .congestion_control_gas_price_feedback_mechanism = true;
+                    // Enable select committee supporting protocol version in devnet.
+                    if chain != Chain::Testnet && chain != Chain::Mainnet {
+                        cfg.feature_flags
+                            .select_committee_supporting_protocol_version = true;
+                    }
                 }
                 // Use this template when making changes:
                 //
@@ -2292,6 +2307,10 @@ impl ProtocolConfig {
     pub fn set_congestion_control_gas_price_feedback_mechanism_for_testing(&mut self, val: bool) {
         self.feature_flags
             .congestion_control_gas_price_feedback_mechanism = val;
+    }
+    pub fn set_select_committee_supporting_protocol_version_for_testing(&mut self, val: bool) {
+        self.feature_flags
+            .select_committee_supporting_protocol_version = val;
     }
 }
 

--- a/crates/iota-types/src/error.rs
+++ b/crates/iota-types/src/error.rs
@@ -600,6 +600,8 @@ pub enum IotaError {
     // Unsupported Operations on Fullnode
     #[error("Fullnode does not support handle_certificate")]
     FullNodeCantHandleCertificate,
+    #[error("Fullnode does not support handle_authority_capabilities")]
+    FullNodeCantHandleAuthorityCapabilities,
 
     // Epoch related errors.
     #[error("Validator temporarily stopped processing transactions due to epoch change")]

--- a/crates/iota-types/src/iota_system_state/epoch_start_iota_system_state.rs
+++ b/crates/iota-types/src/iota_system_state/epoch_start_iota_system_state.rs
@@ -751,8 +751,7 @@ mod test {
             let (found_name, found_pubkey) = &active_validators[i];
             assert_eq!(
                 *found_name, expected_name,
-                "Order not preserved: expected {} at index {}",
-                expected_name, i
+                "Order not preserved: expected {expected_name} at index {i}",
             );
             assert_eq!(
                 found_pubkey.as_bytes(),

--- a/crates/iota-types/src/iota_system_state/epoch_start_iota_system_state.rs
+++ b/crates/iota-types/src/iota_system_state/epoch_start_iota_system_state.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 use anemo::{
     PeerId,
@@ -39,7 +39,7 @@ pub trait EpochStartSystemStateTrait {
     fn get_validator_as_p2p_peers(&self, excluding_self: AuthorityName) -> Vec<PeerInfo>;
     fn get_authority_names_to_peer_ids(&self) -> HashMap<AuthorityName, PeerId>;
     fn get_authority_names_to_hostnames(&self) -> HashMap<AuthorityName, String>;
-    fn get_non_committee_validators(&self) -> BTreeMap<AuthorityName, AuthorityPublicKey>;
+    fn get_active_validators(&self) -> Vec<(AuthorityName, AuthorityPublicKey)>;
 }
 
 /// This type captures the minimum amount of information from IotaSystemState
@@ -87,7 +87,7 @@ impl EpochStartSystemState {
         epoch_start_timestamp_ms: u64,
         epoch_duration_ms: u64,
         committee_validators: Vec<EpochStartValidatorInfoV1>,
-        non_committee_validators: Vec<EpochStartValidatorInfoV1>,
+        active_validators: Vec<EpochStartValidatorInfoV1>,
     ) -> Self {
         Self::V2(EpochStartSystemStateV2 {
             epoch,
@@ -97,7 +97,7 @@ impl EpochStartSystemState {
             epoch_start_timestamp_ms,
             epoch_duration_ms,
             committee_validators,
-            non_committee_validators: Some(non_committee_validators),
+            active_validators,
         })
     }
 
@@ -125,7 +125,7 @@ impl EpochStartSystemState {
                 epoch_start_timestamp_ms: state.epoch_start_timestamp_ms,
                 epoch_duration_ms: state.epoch_duration_ms,
                 committee_validators: state.committee_validators.clone(),
-                non_committee_validators: state.non_committee_validators.clone(),
+                active_validators: state.active_validators.clone(),
             }),
         }
     }
@@ -339,9 +339,18 @@ impl EpochStartSystemStateTrait for EpochStartSystemStateV1 {
             .collect()
     }
 
-    fn get_non_committee_validators(&self) -> BTreeMap<AuthorityName, AuthorityPublicKey> {
-        // V1 does not have non-committee validators, so return an empty map.
-        BTreeMap::new()
+    fn get_active_validators(&self) -> Vec<(AuthorityName, AuthorityPublicKey)> {
+        // for V1 the committee and active validators are the same as there is no
+        // additional committee selection
+        self.committee_validators
+            .iter()
+            .map(|validator| {
+                (
+                    validator.authority_name(),
+                    validator.authority_pubkey.clone(),
+                )
+            })
+            .collect()
     }
 }
 
@@ -354,7 +363,7 @@ pub struct EpochStartSystemStateV2 {
     epoch_start_timestamp_ms: u64,
     epoch_duration_ms: u64,
     committee_validators: Vec<EpochStartValidatorInfoV1>,
-    non_committee_validators: Option<Vec<EpochStartValidatorInfoV1>>,
+    active_validators: Vec<EpochStartValidatorInfoV1>,
 }
 
 impl EpochStartSystemStateV2 {
@@ -371,7 +380,7 @@ impl EpochStartSystemStateV2 {
             epoch_start_timestamp_ms: 0,
             epoch_duration_ms: 1000,
             committee_validators: vec![],
-            non_committee_validators: None,
+            active_validators: vec![],
         }
     }
 }
@@ -528,10 +537,8 @@ impl EpochStartSystemStateTrait for EpochStartSystemStateV2 {
             .collect()
     }
 
-    fn get_non_committee_validators(&self) -> BTreeMap<AuthorityName, AuthorityPublicKey> {
-        self.non_committee_validators
-            .clone()
-            .unwrap_or_default()
+    fn get_active_validators(&self) -> Vec<(AuthorityName, AuthorityPublicKey)> {
+        self.active_validators
             .iter()
             .map(|validator| {
                 (
@@ -702,6 +709,10 @@ mod test {
             });
         }
 
+        // Create active_validators list containing all validators in the desired order
+        let mut active_validators = committee_validators.clone();
+        active_validators.extend(non_committee_validators.clone());
+
         let state = EpochStartSystemState::new_v2(
             10,
             ProtocolVersion::MAX.as_u64(),
@@ -710,13 +721,13 @@ mod test {
             0,
             0,
             committee_validators.clone(),
-            non_committee_validators.clone(),
+            active_validators,
         );
 
         // WHEN
         let iota_committee = state.get_iota_committee();
         let consensus_committee = state.get_consensus_committee();
-        let non_committee = state.get_non_committee_validators();
+        let active_validators = state.get_active_validators();
 
         // THEN
         // Assert committee validators details
@@ -749,13 +760,55 @@ mod test {
             );
         }
 
-        // Verify non-committee validators
-        assert_eq!(non_committee.len(), 10);
+        // Verify active validators (should include all: committee + non-committee)
+        assert_eq!(active_validators.len(), 20); // 10 committee + 10 non-committee
+
+        // Verify order is preserved - active_validators should contain all validators
+        // in the expected order First committee validators, then non-committee
+        // validators
+        let expected_order: Vec<_> = committee_validators
+            .iter()
+            .chain(non_committee_validators.iter())
+            .collect();
+
+        for (i, expected_validator) in expected_order.iter().enumerate() {
+            let expected_name = expected_validator.authority_name();
+            let (found_name, found_pubkey) = &active_validators[i];
+            assert_eq!(
+                *found_name, expected_name,
+                "Order not preserved: expected {} at index {}",
+                expected_name, i
+            );
+            assert_eq!(
+                found_pubkey.as_bytes(),
+                expected_validator.authority_pubkey.as_bytes()
+            );
+        }
+
+        // Verify committee validators are in active_validators
+        for validator in committee_validators.iter() {
+            let authority_name = validator.authority_name();
+            let pubkey_from_vec = active_validators
+                .iter()
+                .find(|(name, _)| *name == authority_name)
+                .map(|(_, pubkey)| pubkey)
+                .unwrap();
+            assert_eq!(
+                pubkey_from_vec.as_bytes(),
+                validator.authority_pubkey.as_bytes()
+            );
+        }
+
+        // Verify non-committee validators are in active_validators
         for validator in non_committee_validators.iter() {
             let authority_name = validator.authority_name();
-            let pubkey_from_map = non_committee.get(&authority_name).unwrap();
+            let pubkey_from_vec = active_validators
+                .iter()
+                .find(|(name, _)| *name == authority_name)
+                .map(|(_, pubkey)| pubkey)
+                .unwrap();
             assert_eq!(
-                pubkey_from_map.as_bytes(),
+                pubkey_from_vec.as_bytes(),
                 validator.authority_pubkey.as_bytes()
             );
         }
@@ -819,7 +872,7 @@ mod test {
             3_000_000,
             4_000_000,
             vec![committee_validator.clone()],
-            vec![non_committee_validator.clone()],
+            vec![committee_validator.clone(), non_committee_validator.clone()],
         );
 
         // Test V1 serialization/deserialization
@@ -842,8 +895,8 @@ mod test {
         assert_eq!(v1_validators.len(), 1);
         assert_eq!(v1_validators[0], iota_address1);
 
-        let v1_non_committee = v1_deserialized.get_non_committee_validators();
-        assert_eq!(v1_non_committee.len(), 0);
+        let v1_active_validators = v1_deserialized.get_active_validators();
+        assert_eq!(v1_active_validators.len(), 1); // in V1 committee_validators and active_validators are the same as there is no additional committee selection
 
         // Test V2 serialization/deserialization
         let v2_serialized = bcs::to_bytes(&v2_state).unwrap();
@@ -865,16 +918,29 @@ mod test {
         assert_eq!(v2_validators.len(), 1);
         assert_eq!(v2_validators[0], iota_address1);
 
-        let mut v2_non_committee = v2_deserialized.get_non_committee_validators();
-        assert_eq!(v2_non_committee.len(), 1);
-        let non_committee_validator_deserialized = v2_non_committee.pop_first().unwrap();
+        let v2_active_validators = v2_deserialized.get_active_validators();
+        assert_eq!(v2_active_validators.len(), 2); // Should contain one committee member and one validator.
+
+        let non_committee_validator_pubkey = v2_active_validators
+            .iter()
+            .find(|(name, _)| *name == non_committee_validator.authority_name())
+            .map(|(_, pubkey)| pubkey)
+            .unwrap();
+
         assert_eq!(
-            non_committee_validator_deserialized.0.as_bytes(),
-            non_committee_validator.authority_name().as_bytes()
-        );
-        assert_eq!(
-            non_committee_validator_deserialized.1.as_bytes(),
+            non_committee_validator_pubkey.as_bytes(),
             non_committee_validator.authority_pubkey.as_bytes()
+        );
+
+        let committee_validator_pubkey = v2_active_validators
+            .iter()
+            .find(|(name, _)| *name == committee_validator.authority_name())
+            .map(|(_, pubkey)| pubkey)
+            .unwrap();
+
+        assert_eq!(
+            committee_validator_pubkey.as_bytes(),
+            committee_validator.authority_pubkey.as_bytes()
         );
     }
 }

--- a/crates/iota-types/src/iota_system_state/epoch_start_iota_system_state.rs
+++ b/crates/iota-types/src/iota_system_state/epoch_start_iota_system_state.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use anemo::{
     PeerId,
@@ -39,7 +39,7 @@ pub trait EpochStartSystemStateTrait {
     fn get_validator_as_p2p_peers(&self, excluding_self: AuthorityName) -> Vec<PeerInfo>;
     fn get_authority_names_to_peer_ids(&self) -> HashMap<AuthorityName, PeerId>;
     fn get_authority_names_to_hostnames(&self) -> HashMap<AuthorityName, String>;
-    fn get_non_committee_validators(&self) -> Vec<EpochStartValidatorInfoV1>;
+    fn get_non_committee_validators(&self) -> BTreeMap<AuthorityName, AuthorityPublicKey>;
 }
 
 /// This type captures the minimum amount of information from IotaSystemState
@@ -339,8 +339,9 @@ impl EpochStartSystemStateTrait for EpochStartSystemStateV1 {
             .collect()
     }
 
-    fn get_non_committee_validators(&self) -> Vec<EpochStartValidatorInfoV1> {
-        Vec::new()
+    fn get_non_committee_validators(&self) -> BTreeMap<AuthorityName, AuthorityPublicKey> {
+        // V1 does not have non-committee validators, so return an empty map.
+        BTreeMap::new()
     }
 }
 
@@ -527,8 +528,18 @@ impl EpochStartSystemStateTrait for EpochStartSystemStateV2 {
             .collect()
     }
 
-    fn get_non_committee_validators(&self) -> Vec<EpochStartValidatorInfoV1> {
-        self.non_committee_validators.clone().unwrap_or_default()
+    fn get_non_committee_validators(&self) -> BTreeMap<AuthorityName, AuthorityPublicKey> {
+        self.non_committee_validators
+            .clone()
+            .unwrap_or_default()
+            .iter()
+            .map(|validator| {
+                (
+                    validator.authority_name(),
+                    validator.authority_pubkey.clone(),
+                )
+            })
+            .collect()
     }
 }
 

--- a/crates/iota-types/src/iota_system_state/epoch_start_iota_system_state.rs
+++ b/crates/iota-types/src/iota_system_state/epoch_start_iota_system_state.rs
@@ -39,7 +39,7 @@ pub trait EpochStartSystemStateTrait {
     fn get_validator_as_p2p_peers(&self, excluding_self: AuthorityName) -> Vec<PeerInfo>;
     fn get_authority_names_to_peer_ids(&self) -> HashMap<AuthorityName, PeerId>;
     fn get_authority_names_to_hostnames(&self) -> HashMap<AuthorityName, String>;
-    fn get_active_validators(&self) -> Vec<(AuthorityName, AuthorityPublicKey)>;
+    fn get_active_validators(&self) -> Vec<AuthorityPublicKey>;
 }
 
 /// This type captures the minimum amount of information from IotaSystemState
@@ -90,13 +90,15 @@ impl EpochStartSystemState {
         active_validators: Vec<EpochStartValidatorInfoV1>,
     ) -> Self {
         Self::V2(EpochStartSystemStateV2 {
-            epoch,
-            protocol_version,
-            reference_gas_price,
-            safe_mode,
-            epoch_start_timestamp_ms,
-            epoch_duration_ms,
-            committee_validators,
+            v1: EpochStartSystemStateV1 {
+                epoch,
+                protocol_version,
+                reference_gas_price,
+                safe_mode,
+                epoch_start_timestamp_ms,
+                epoch_duration_ms,
+                committee_validators,
+            },
             active_validators,
         })
     }
@@ -118,13 +120,15 @@ impl EpochStartSystemState {
                 committee_validators: state.committee_validators.clone(),
             }),
             Self::V2(state) => Self::V2(EpochStartSystemStateV2 {
-                epoch: state.epoch + 1,
-                protocol_version: state.protocol_version,
-                reference_gas_price: state.reference_gas_price,
-                safe_mode: state.safe_mode,
-                epoch_start_timestamp_ms: state.epoch_start_timestamp_ms,
-                epoch_duration_ms: state.epoch_duration_ms,
-                committee_validators: state.committee_validators.clone(),
+                v1: EpochStartSystemStateV1 {
+                    epoch: state.v1.epoch + 1,
+                    protocol_version: state.v1.protocol_version,
+                    reference_gas_price: state.v1.reference_gas_price,
+                    safe_mode: state.v1.safe_mode,
+                    epoch_start_timestamp_ms: state.v1.epoch_start_timestamp_ms,
+                    epoch_duration_ms: state.v1.epoch_duration_ms,
+                    committee_validators: state.v1.committee_validators.clone(),
+                },
                 active_validators: state.active_validators.clone(),
             }),
         }
@@ -339,30 +343,19 @@ impl EpochStartSystemStateTrait for EpochStartSystemStateV1 {
             .collect()
     }
 
-    fn get_active_validators(&self) -> Vec<(AuthorityName, AuthorityPublicKey)> {
+    fn get_active_validators(&self) -> Vec<AuthorityPublicKey> {
         // for V1 the committee and active validators are the same as there is no
         // additional committee selection
         self.committee_validators
             .iter()
-            .map(|validator| {
-                (
-                    validator.authority_name(),
-                    validator.authority_pubkey.clone(),
-                )
-            })
+            .map(|validator| validator.authority_pubkey.clone())
             .collect()
     }
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct EpochStartSystemStateV2 {
-    epoch: EpochId,
-    protocol_version: u64,
-    reference_gas_price: u64,
-    safe_mode: bool,
-    epoch_start_timestamp_ms: u64,
-    epoch_duration_ms: u64,
-    committee_validators: Vec<EpochStartValidatorInfoV1>,
+    v1: EpochStartSystemStateV1,
     active_validators: Vec<EpochStartValidatorInfoV1>,
 }
 
@@ -373,13 +366,7 @@ impl EpochStartSystemStateV2 {
 
     pub fn new_for_testing_with_epoch(epoch: EpochId) -> Self {
         Self {
-            epoch,
-            protocol_version: ProtocolVersion::MAX.as_u64(),
-            reference_gas_price: crate::transaction::DEFAULT_VALIDATOR_GAS_PRICE,
-            safe_mode: false,
-            epoch_start_timestamp_ms: 0,
-            epoch_duration_ms: 1000,
-            committee_validators: vec![],
+            v1: EpochStartSystemStateV1::new_for_testing_with_epoch(epoch),
             active_validators: vec![],
         }
     }
@@ -387,140 +374,65 @@ impl EpochStartSystemStateV2 {
 
 impl EpochStartSystemStateTrait for EpochStartSystemStateV2 {
     fn epoch(&self) -> EpochId {
-        self.epoch
+        self.v1.epoch()
     }
 
     fn protocol_version(&self) -> ProtocolVersion {
-        ProtocolVersion::new(self.protocol_version)
+        self.v1.protocol_version()
     }
 
     fn reference_gas_price(&self) -> u64 {
-        self.reference_gas_price
+        self.v1.reference_gas_price()
     }
 
     fn safe_mode(&self) -> bool {
-        self.safe_mode
+        self.v1.safe_mode()
     }
 
     fn epoch_start_timestamp_ms(&self) -> u64 {
-        self.epoch_start_timestamp_ms
+        self.v1.epoch_start_timestamp_ms()
     }
 
     fn epoch_duration_ms(&self) -> u64 {
-        self.epoch_duration_ms
+        self.v1.epoch_duration_ms()
     }
 
     fn get_validator_addresses(&self) -> Vec<IotaAddress> {
-        self.committee_validators
-            .iter()
-            .map(|validator| validator.iota_address)
-            .collect()
+        self.v1.get_validator_addresses()
     }
 
     fn get_iota_committee_with_network_metadata(&self) -> CommitteeWithNetworkMetadata {
-        let validators = self
-            .committee_validators
-            .iter()
-            .map(|validator| {
-                (
-                    validator.authority_name(),
-                    (
-                        validator.voting_power,
-                        NetworkMetadata {
-                            network_address: validator.iota_net_address.clone(),
-                            primary_address: validator.primary_address.clone(),
-                            network_public_key: Some(validator.network_pubkey.clone()),
-                        },
-                    ),
-                )
-            })
-            .collect();
-
-        CommitteeWithNetworkMetadata::new(self.epoch, validators)
+        self.v1.get_iota_committee_with_network_metadata()
     }
 
     fn get_iota_committee(&self) -> Committee {
-        let voting_rights = self
-            .committee_validators
-            .iter()
-            .map(|validator| (validator.authority_name(), validator.voting_power))
-            .collect();
-        Committee::new(self.epoch, voting_rights)
+        self.v1.get_iota_committee()
     }
 
-    impl_get_committee!(
-        fn get_consensus_committee -> ConsensusCommittee,
-        authority = Authority,
-        cfg = consensus_config,
-        label = "Mysticeti"
-    );
+    fn get_consensus_committee(&self) -> ConsensusCommittee {
+        self.v1.get_consensus_committee()
+    }
 
-    impl_get_committee!(
-        fn get_starfish_committee -> StarfishCommittee,
-        authority = StarfishAuthority,
-        cfg = starfish_config,
-        label = "Starfish"
-    );
+    fn get_starfish_committee(&self) -> StarfishCommittee {
+        self.v1.get_starfish_committee()
+    }
 
     fn get_validator_as_p2p_peers(&self, excluding_self: AuthorityName) -> Vec<PeerInfo> {
-        self.committee_validators
-            .iter()
-            .filter(|validator| validator.authority_name() != excluding_self)
-            .map(|validator| {
-                let address = validator
-                    .p2p_address
-                    .to_anemo_address()
-                    .into_iter()
-                    .collect::<Vec<_>>();
-                let peer_id = PeerId(validator.network_pubkey.0.to_bytes());
-                if address.is_empty() {
-                    warn!(
-                        ?peer_id,
-                        "Peer has invalid p2p address: {}", &validator.p2p_address
-                    );
-                }
-                PeerInfo {
-                    peer_id,
-                    affinity: PeerAffinity::High,
-                    address,
-                }
-            })
-            .collect()
+        self.v1.get_validator_as_p2p_peers(excluding_self)
     }
 
     fn get_authority_names_to_peer_ids(&self) -> HashMap<AuthorityName, PeerId> {
-        self.committee_validators
-            .iter()
-            .map(|validator| {
-                let name = validator.authority_name();
-                let peer_id = PeerId(validator.network_pubkey.0.to_bytes());
-
-                (name, peer_id)
-            })
-            .collect()
+        self.v1.get_authority_names_to_peer_ids()
     }
 
     fn get_authority_names_to_hostnames(&self) -> HashMap<AuthorityName, String> {
-        self.committee_validators
-            .iter()
-            .map(|validator| {
-                let name = validator.authority_name();
-                let hostname = validator.hostname.clone();
-
-                (name, hostname)
-            })
-            .collect()
+        self.v1.get_authority_names_to_hostnames()
     }
 
-    fn get_active_validators(&self) -> Vec<(AuthorityName, AuthorityPublicKey)> {
+    fn get_active_validators(&self) -> Vec<AuthorityPublicKey> {
         self.active_validators
             .iter()
-            .map(|validator| {
-                (
-                    validator.authority_name(),
-                    validator.authority_pubkey.clone(),
-                )
-            })
+            .map(|validator| validator.authority_pubkey.clone())
             .collect()
     }
 }
@@ -747,44 +659,30 @@ mod test {
             .collect();
 
         for (i, expected_validator) in expected_order.iter().enumerate() {
-            let expected_name = expected_validator.authority_name();
-            let (found_name, found_pubkey) = &active_validators[i];
-            assert_eq!(
-                *found_name, expected_name,
-                "Order not preserved: expected {expected_name} at index {i}",
-            );
+            let found_pubkey = &active_validators[i];
             assert_eq!(
                 found_pubkey.as_bytes(),
-                expected_validator.authority_pubkey.as_bytes()
+                expected_validator.authority_pubkey.as_bytes(),
+                "Order not preserved: expected validator at index {i}",
             );
         }
 
         // Verify committee validators are in active_validators
         for validator in committee_validators.iter() {
-            let authority_name = validator.authority_name();
-            let pubkey_from_vec = active_validators
+            let found = active_validators
                 .iter()
-                .find(|(name, _)| *name == authority_name)
-                .map(|(_, pubkey)| pubkey)
+                .find(|pubkey| pubkey.as_bytes() == validator.authority_pubkey.as_bytes())
                 .unwrap();
-            assert_eq!(
-                pubkey_from_vec.as_bytes(),
-                validator.authority_pubkey.as_bytes()
-            );
+            assert_eq!(found.as_bytes(), validator.authority_pubkey.as_bytes());
         }
 
         // Verify non-committee validators are in active_validators
         for validator in non_committee_validators.iter() {
-            let authority_name = validator.authority_name();
-            let pubkey_from_vec = active_validators
+            let found = active_validators
                 .iter()
-                .find(|(name, _)| *name == authority_name)
-                .map(|(_, pubkey)| pubkey)
+                .find(|pubkey| pubkey.as_bytes() == validator.authority_pubkey.as_bytes())
                 .unwrap();
-            assert_eq!(
-                pubkey_from_vec.as_bytes(),
-                validator.authority_pubkey.as_bytes()
-            );
+            assert_eq!(found.as_bytes(), validator.authority_pubkey.as_bytes());
         }
     }
 
@@ -897,8 +795,7 @@ mod test {
 
         let non_committee_validator_pubkey = v2_active_validators
             .iter()
-            .find(|(name, _)| *name == non_committee_validator.authority_name())
-            .map(|(_, pubkey)| pubkey)
+            .find(|pubkey| pubkey.as_bytes() == non_committee_validator.authority_pubkey.as_bytes())
             .unwrap();
 
         assert_eq!(
@@ -908,8 +805,7 @@ mod test {
 
         let committee_validator_pubkey = v2_active_validators
             .iter()
-            .find(|(name, _)| *name == committee_validator.authority_name())
-            .map(|(_, pubkey)| pubkey)
+            .find(|pubkey| pubkey.as_bytes() == committee_validator.authority_pubkey.as_bytes())
             .unwrap();
 
         assert_eq!(

--- a/crates/iota-types/src/iota_system_state/epoch_start_iota_system_state.rs
+++ b/crates/iota-types/src/iota_system_state/epoch_start_iota_system_state.rs
@@ -19,6 +19,7 @@ use crate::{
     base_types::{AuthorityName, EpochId, IotaAddress},
     committee::{Committee, CommitteeWithNetworkMetadata, NetworkMetadata, StakeUnit},
     crypto::{AuthorityPublicKey, NetworkPublicKey},
+    iota_system_state::iota_system_state_inner_v1::ValidatorV1,
     multiaddr::Multiaddr,
 };
 
@@ -38,6 +39,7 @@ pub trait EpochStartSystemStateTrait {
     fn get_validator_as_p2p_peers(&self, excluding_self: AuthorityName) -> Vec<PeerInfo>;
     fn get_authority_names_to_peer_ids(&self) -> HashMap<AuthorityName, PeerId>;
     fn get_authority_names_to_hostnames(&self) -> HashMap<AuthorityName, String>;
+    fn get_non_committee_validators(&self) -> Vec<EpochStartValidatorInfoV1>;
 }
 
 /// This type captures the minimum amount of information from IotaSystemState
@@ -53,6 +55,7 @@ pub trait EpochStartSystemStateTrait {
 #[enum_dispatch(EpochStartSystemStateTrait)]
 pub enum EpochStartSystemState {
     V1(EpochStartSystemStateV1),
+    V2(EpochStartSystemStateV2),
 }
 
 impl EpochStartSystemState {
@@ -76,6 +79,28 @@ impl EpochStartSystemState {
         })
     }
 
+    pub fn new_v2(
+        epoch: EpochId,
+        protocol_version: u64,
+        reference_gas_price: u64,
+        safe_mode: bool,
+        epoch_start_timestamp_ms: u64,
+        epoch_duration_ms: u64,
+        committee_validators: Vec<EpochStartValidatorInfoV1>,
+        non_committee_validators: Vec<EpochStartValidatorInfoV1>,
+    ) -> Self {
+        Self::V2(EpochStartSystemStateV2 {
+            epoch,
+            protocol_version,
+            reference_gas_price,
+            safe_mode,
+            epoch_start_timestamp_ms,
+            epoch_duration_ms,
+            committee_validators,
+            non_committee_validators: Some(non_committee_validators),
+        })
+    }
+
     pub fn new_for_testing_with_epoch(epoch: EpochId) -> Self {
         Self::V1(EpochStartSystemStateV1::new_for_testing_with_epoch(epoch))
     }
@@ -91,6 +116,16 @@ impl EpochStartSystemState {
                 epoch_start_timestamp_ms: state.epoch_start_timestamp_ms,
                 epoch_duration_ms: state.epoch_duration_ms,
                 committee_validators: state.committee_validators.clone(),
+            }),
+            Self::V2(state) => Self::V2(EpochStartSystemStateV2 {
+                epoch: state.epoch + 1,
+                protocol_version: state.protocol_version,
+                reference_gas_price: state.reference_gas_price,
+                safe_mode: state.safe_mode,
+                epoch_start_timestamp_ms: state.epoch_start_timestamp_ms,
+                epoch_duration_ms: state.epoch_duration_ms,
+                committee_validators: state.committee_validators.clone(),
+                non_committee_validators: state.non_committee_validators.clone(),
             }),
         }
     }
@@ -303,6 +338,198 @@ impl EpochStartSystemStateTrait for EpochStartSystemStateV1 {
             })
             .collect()
     }
+
+    fn get_non_committee_validators(&self) -> Vec<EpochStartValidatorInfoV1> {
+        Vec::new()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub struct EpochStartSystemStateV2 {
+    epoch: EpochId,
+    protocol_version: u64,
+    reference_gas_price: u64,
+    safe_mode: bool,
+    epoch_start_timestamp_ms: u64,
+    epoch_duration_ms: u64,
+    committee_validators: Vec<EpochStartValidatorInfoV1>,
+    non_committee_validators: Option<Vec<EpochStartValidatorInfoV1>>,
+}
+
+impl EpochStartSystemStateV2 {
+    pub fn new_for_testing() -> Self {
+        Self::new_for_testing_with_epoch(0)
+    }
+
+    pub fn new_for_testing_with_epoch(epoch: EpochId) -> Self {
+        Self {
+            epoch,
+            protocol_version: ProtocolVersion::MAX.as_u64(),
+            reference_gas_price: crate::transaction::DEFAULT_VALIDATOR_GAS_PRICE,
+            safe_mode: false,
+            epoch_start_timestamp_ms: 0,
+            epoch_duration_ms: 1000,
+            committee_validators: vec![],
+            non_committee_validators: None,
+        }
+    }
+}
+
+impl EpochStartSystemStateTrait for EpochStartSystemStateV2 {
+    fn epoch(&self) -> EpochId {
+        self.epoch
+    }
+
+    fn protocol_version(&self) -> ProtocolVersion {
+        ProtocolVersion::new(self.protocol_version)
+    }
+
+    fn reference_gas_price(&self) -> u64 {
+        self.reference_gas_price
+    }
+
+    fn safe_mode(&self) -> bool {
+        self.safe_mode
+    }
+
+    fn epoch_start_timestamp_ms(&self) -> u64 {
+        self.epoch_start_timestamp_ms
+    }
+
+    fn epoch_duration_ms(&self) -> u64 {
+        self.epoch_duration_ms
+    }
+
+    fn get_validator_addresses(&self) -> Vec<IotaAddress> {
+        self.committee_validators
+            .iter()
+            .map(|validator| validator.iota_address)
+            .collect()
+    }
+
+    fn get_iota_committee_with_network_metadata(&self) -> CommitteeWithNetworkMetadata {
+        let validators = self
+            .committee_validators
+            .iter()
+            .map(|validator| {
+                (
+                    validator.authority_name(),
+                    (
+                        validator.voting_power,
+                        NetworkMetadata {
+                            network_address: validator.iota_net_address.clone(),
+                            primary_address: validator.primary_address.clone(),
+                            network_public_key: Some(validator.network_pubkey.clone()),
+                        },
+                    ),
+                )
+            })
+            .collect();
+
+        CommitteeWithNetworkMetadata::new(self.epoch, validators)
+    }
+
+    fn get_iota_committee(&self) -> Committee {
+        let voting_rights = self
+            .committee_validators
+            .iter()
+            .map(|validator| (validator.authority_name(), validator.voting_power))
+            .collect();
+        Committee::new(self.epoch, voting_rights)
+    }
+
+    fn get_consensus_committee(&self) -> ConsensusCommittee {
+        let mut authorities = vec![];
+        for validator in self.committee_validators.iter() {
+            authorities.push(Authority {
+                stake: validator.voting_power as consensus_config::Stake,
+                address: validator.primary_address.clone(),
+                hostname: validator.hostname.clone(),
+                authority_key: consensus_config::AuthorityPublicKey::new(
+                    validator.authority_pubkey.clone(),
+                ),
+                protocol_key: consensus_config::ProtocolPublicKey::new(
+                    validator.protocol_pubkey.clone(),
+                ),
+                network_key: consensus_config::NetworkPublicKey::new(
+                    validator.network_pubkey.clone(),
+                ),
+            });
+        }
+
+        // Sort the authorities by their authority (public) key in ascending order, same
+        // as the order in the IOTA committee returned from get_iota_committee().
+        authorities.sort_by(|a1, a2| a1.authority_key.cmp(&a2.authority_key));
+
+        for ((i, mysticeti_authority), iota_authority_name) in authorities
+            .iter()
+            .enumerate()
+            .zip(self.get_iota_committee().names())
+        {
+            if iota_authority_name.0 != mysticeti_authority.authority_key.to_bytes() {
+                error!(
+                    "Mismatched authority order between IOTA and Mysticeti! Index {}, Mysticeti authority {:?}\nIota authority name {}",
+                    i, mysticeti_authority, iota_authority_name
+                );
+            }
+        }
+
+        ConsensusCommittee::new(self.epoch as consensus_config::Epoch, authorities)
+    }
+
+    fn get_validator_as_p2p_peers(&self, excluding_self: AuthorityName) -> Vec<PeerInfo> {
+        self.committee_validators
+            .iter()
+            .filter(|validator| validator.authority_name() != excluding_self)
+            .map(|validator| {
+                let address = validator
+                    .p2p_address
+                    .to_anemo_address()
+                    .into_iter()
+                    .collect::<Vec<_>>();
+                let peer_id = PeerId(validator.network_pubkey.0.to_bytes());
+                if address.is_empty() {
+                    warn!(
+                        ?peer_id,
+                        "Peer has invalid p2p address: {}", &validator.p2p_address
+                    );
+                }
+                PeerInfo {
+                    peer_id,
+                    affinity: PeerAffinity::High,
+                    address,
+                }
+            })
+            .collect()
+    }
+
+    fn get_authority_names_to_peer_ids(&self) -> HashMap<AuthorityName, PeerId> {
+        self.committee_validators
+            .iter()
+            .map(|validator| {
+                let name = validator.authority_name();
+                let peer_id = PeerId(validator.network_pubkey.0.to_bytes());
+
+                (name, peer_id)
+            })
+            .collect()
+    }
+
+    fn get_authority_names_to_hostnames(&self) -> HashMap<AuthorityName, String> {
+        self.committee_validators
+            .iter()
+            .map(|validator| {
+                let name = validator.authority_name();
+                let hostname = validator.hostname.clone();
+
+                (name, hostname)
+            })
+            .collect()
+    }
+
+    fn get_non_committee_validators(&self) -> Vec<EpochStartValidatorInfoV1> {
+        self.non_committee_validators.clone().unwrap_or_default()
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
@@ -324,8 +551,25 @@ impl EpochStartValidatorInfoV1 {
     }
 }
 
+/// Converts a validator into EpochStartValidatorInfoV1
+pub fn convert_validator_to_epoch_start_info(validator: &ValidatorV1) -> EpochStartValidatorInfoV1 {
+    let metadata = validator.verified_metadata();
+    EpochStartValidatorInfoV1 {
+        iota_address: metadata.iota_address,
+        authority_pubkey: metadata.authority_pubkey.clone(),
+        network_pubkey: metadata.network_pubkey.clone(),
+        protocol_pubkey: metadata.protocol_pubkey.clone(),
+        iota_net_address: metadata.net_address.clone(),
+        p2p_address: metadata.p2p_address.clone(),
+        primary_address: metadata.primary_address.clone(),
+        voting_power: validator.voting_power,
+        hostname: metadata.name.clone(),
+    }
+}
+
 #[cfg(test)]
 mod test {
+    use bcs;
     use fastcrypto::traits::KeyPair;
     use iota_network_stack::Multiaddr;
     use iota_protocol_config::ProtocolVersion;
@@ -336,7 +580,8 @@ mod test {
         committee::CommitteeTrait,
         crypto::{AuthorityKeyPair, NetworkKeyPair, get_key_pair},
         iota_system_state::epoch_start_iota_system_state::{
-            EpochStartSystemStateTrait, EpochStartSystemStateV1, EpochStartValidatorInfoV1,
+            EpochStartSystemState, EpochStartSystemStateTrait, EpochStartSystemStateV1,
+            EpochStartValidatorInfoV1,
         },
     };
 
@@ -350,6 +595,25 @@ mod test {
             let protocol_network_key = NetworkKeyPair::generate(&mut thread_rng());
 
             committee_validators.push(EpochStartValidatorInfoV1 {
+                iota_address,
+                authority_pubkey: authority_key.public().clone(),
+                network_pubkey: protocol_network_key.public().clone(),
+                protocol_pubkey: protocol_network_key.public().clone(),
+                iota_net_address: Multiaddr::empty(),
+                p2p_address: Multiaddr::empty(),
+                primary_address: Multiaddr::empty(),
+                voting_power: 1_000,
+                hostname: format!("host-{i}").to_string(),
+            })
+        }
+
+        let mut non_committee_validators = vec![];
+
+        for i in 0..10 {
+            let (iota_address, authority_key): (IotaAddress, AuthorityKeyPair) = get_key_pair();
+            let protocol_network_key = NetworkKeyPair::generate(&mut thread_rng());
+
+            non_committee_validators.push(EpochStartValidatorInfoV1 {
                 iota_address,
                 authority_pubkey: authority_key.public().clone(),
                 network_pubkey: protocol_network_key.public().clone(),
@@ -406,5 +670,212 @@ mod test {
                 "IOTA Foundation & IOTA committee member stake differs"
             );
         }
+    }
+
+    #[test]
+    fn test_v2_iota_and_mysticeti_committee_are_same() {
+        // GIVEN
+        let mut committee_validators = vec![];
+        let mut non_committee_validators = vec![];
+
+        for i in 0..10 {
+            let (iota_address, authority_key): (IotaAddress, AuthorityKeyPair) = get_key_pair();
+            let protocol_network_key = NetworkKeyPair::generate(&mut thread_rng());
+
+            committee_validators.push(EpochStartValidatorInfoV1 {
+                iota_address,
+                authority_pubkey: authority_key.public().clone(),
+                network_pubkey: protocol_network_key.public().clone(),
+                protocol_pubkey: protocol_network_key.public().clone(),
+                iota_net_address: Multiaddr::empty(),
+                p2p_address: Multiaddr::empty(),
+                primary_address: Multiaddr::empty(),
+                voting_power: 1_000,
+                hostname: format!("committee-{i}").to_string(),
+            });
+
+            let (iota_address, authority_key): (IotaAddress, AuthorityKeyPair) = get_key_pair();
+            let protocol_network_key = NetworkKeyPair::generate(&mut thread_rng());
+
+            non_committee_validators.push(EpochStartValidatorInfoV1 {
+                iota_address,
+                authority_pubkey: authority_key.public().clone(),
+                network_pubkey: protocol_network_key.public().clone(),
+                protocol_pubkey: protocol_network_key.public().clone(),
+                iota_net_address: Multiaddr::empty(),
+                p2p_address: Multiaddr::empty(),
+                primary_address: Multiaddr::empty(),
+                voting_power: 500,
+                hostname: format!("non-committee-{i}").to_string(),
+            });
+        }
+
+        let state = EpochStartSystemState::new_v2(
+            10,
+            ProtocolVersion::MAX.as_u64(),
+            0,
+            false,
+            0,
+            0,
+            committee_validators.clone(),
+            non_committee_validators.clone(),
+        );
+
+        // WHEN
+        let iota_committee = state.get_iota_committee();
+        let consensus_committee = state.get_consensus_committee();
+        let non_committee = state.get_non_committee_validators();
+
+        // THEN
+        // Assert committee validators details
+        assert_eq!(iota_committee.num_members(), 10);
+        assert_eq!(iota_committee.num_members(), consensus_committee.size());
+        assert_eq!(
+            iota_committee.validity_threshold(),
+            consensus_committee.validity_threshold()
+        );
+        assert_eq!(
+            iota_committee.quorum_threshold(),
+            consensus_committee.quorum_threshold()
+        );
+
+        // Verify committee validators are correctly mapped
+        for (authority_index, consensus_authority) in consensus_committee.authorities() {
+            let iota_authority_name = iota_committee
+                .authority_by_index(authority_index.value() as u32)
+                .unwrap();
+
+            assert_eq!(
+                consensus_authority.authority_key.to_bytes(),
+                iota_authority_name.0,
+                "IOTA Foundation & IOTA committee member of same index correspond to different public key"
+            );
+            assert_eq!(
+                consensus_authority.stake,
+                iota_committee.weight(iota_authority_name),
+                "IOTA Foundation & IOTA committee member stake differs"
+            );
+        }
+
+        // Verify non-committee validators
+        assert_eq!(non_committee.len(), 10);
+        for (i, validator) in non_committee.iter().enumerate() {
+            assert_eq!(validator.hostname, format!("non-committee-{i}"));
+            assert_eq!(validator.voting_power, 500);
+        }
+    }
+
+    #[test]
+    fn test_epoch_start_system_state_versioning() {
+        // Create test validators
+        let (iota_address1, authority_key1): (IotaAddress, AuthorityKeyPair) = get_key_pair();
+        let protocol_network_key1 = NetworkKeyPair::generate(&mut thread_rng());
+        let net_address1 = "/ip4/127.0.0.1/tcp/1337".parse().unwrap();
+        let p2p_address1 = "/ip4/127.0.0.1/tcp/1338".parse().unwrap();
+        let primary_address1 = "/ip4/127.0.0.1/tcp/1339".parse().unwrap();
+
+        let committee_validator = EpochStartValidatorInfoV1 {
+            iota_address: iota_address1,
+            authority_pubkey: authority_key1.public().clone(),
+            network_pubkey: protocol_network_key1.public().clone(),
+            protocol_pubkey: protocol_network_key1.public().clone(),
+            iota_net_address: net_address1,
+            p2p_address: p2p_address1,
+            primary_address: primary_address1,
+            voting_power: 1_000,
+            hostname: "committee-1.example.com".to_string(),
+        };
+
+        let (iota_address2, authority_key2): (IotaAddress, AuthorityKeyPair) = get_key_pair();
+        let protocol_network_key2 = NetworkKeyPair::generate(&mut thread_rng());
+        let net_address2: Multiaddr = "/ip4/127.0.0.1/tcp/2337".parse().unwrap();
+        let p2p_address2: Multiaddr = "/ip4/127.0.0.1/tcp/2338".parse().unwrap();
+        let primary_address2: Multiaddr = "/ip4/127.0.0.1/tcp/2339".parse().unwrap();
+
+        let non_committee_validator = EpochStartValidatorInfoV1 {
+            iota_address: iota_address2,
+            authority_pubkey: authority_key2.public().clone(),
+            network_pubkey: protocol_network_key2.public().clone(),
+            protocol_pubkey: protocol_network_key2.public().clone(),
+            iota_net_address: net_address2.clone(),
+            p2p_address: p2p_address2.clone(),
+            primary_address: primary_address2.clone(),
+            voting_power: 500,
+            hostname: "non-committee-1.example.com".to_string(),
+        };
+
+        // Create test states with non-default values
+        let v1_state = EpochStartSystemState::new_v1(
+            10,
+            ProtocolVersion::MAX.as_u64(),
+            100_000,
+            true,
+            1_000_000,
+            2_000_000,
+            vec![committee_validator.clone()],
+        );
+
+        let v2_state = EpochStartSystemState::new_v2(
+            20,
+            ProtocolVersion::MAX.as_u64(),
+            200_000,
+            true,
+            3_000_000,
+            4_000_000,
+            vec![committee_validator.clone()],
+            vec![non_committee_validator.clone()],
+        );
+
+        // Test V1 serialization/deserialization
+        let v1_serialized = bcs::to_bytes(&v1_state).unwrap();
+        let v1_deserialized: EpochStartSystemState = bcs::from_bytes(&v1_serialized).unwrap();
+
+        // Verify all V1 fields
+        assert_eq!(v1_deserialized.epoch(), 10);
+        assert_eq!(v1_deserialized.protocol_version(), ProtocolVersion::MAX);
+        assert_eq!(v1_deserialized.reference_gas_price(), 100_000);
+        assert_eq!(v1_deserialized.safe_mode(), true);
+        assert_eq!(v1_deserialized.epoch_start_timestamp_ms(), 1_000_000);
+        assert_eq!(v1_deserialized.epoch_duration_ms(), 2_000_000);
+
+        let v1_committee = v1_deserialized.get_iota_committee_with_network_metadata();
+        assert_eq!(v1_committee.epoch(), 10);
+        assert_eq!(v1_committee.validators().len(), 1);
+
+        let v1_validators = v1_deserialized.get_validator_addresses();
+        assert_eq!(v1_validators.len(), 1);
+        assert_eq!(v1_validators[0], iota_address1);
+
+        let v1_non_committee = v1_deserialized.get_non_committee_validators();
+        assert_eq!(v1_non_committee.len(), 0);
+
+        // Test V2 serialization/deserialization
+        let v2_serialized = bcs::to_bytes(&v2_state).unwrap();
+        let v2_deserialized: EpochStartSystemState = bcs::from_bytes(&v2_serialized).unwrap();
+
+        // Verify all V2 fields
+        assert_eq!(v2_deserialized.epoch(), 20);
+        assert_eq!(v2_deserialized.protocol_version(), ProtocolVersion::MAX);
+        assert_eq!(v2_deserialized.reference_gas_price(), 200_000);
+        assert_eq!(v2_deserialized.safe_mode(), true);
+        assert_eq!(v2_deserialized.epoch_start_timestamp_ms(), 3_000_000);
+        assert_eq!(v2_deserialized.epoch_duration_ms(), 4_000_000);
+
+        let v2_committee = v2_deserialized.get_iota_committee_with_network_metadata();
+        assert_eq!(v2_committee.epoch(), 20);
+        assert_eq!(v2_committee.validators().len(), 1);
+
+        let v2_validators = v2_deserialized.get_validator_addresses();
+        assert_eq!(v2_validators.len(), 1);
+        assert_eq!(v2_validators[0], iota_address1);
+
+        let v2_non_committee = v2_deserialized.get_non_committee_validators();
+        assert_eq!(v2_non_committee.len(), 1);
+        assert_eq!(v2_non_committee[0].iota_address, iota_address2);
+        assert_eq!(v2_non_committee[0].voting_power, 500);
+        assert_eq!(v2_non_committee[0].hostname, "non-committee-1.example.com");
+        assert_eq!(v2_non_committee[0].iota_net_address, net_address2);
+        assert_eq!(v2_non_committee[0].p2p_address, p2p_address2);
+        assert_eq!(v2_non_committee[0].primary_address, primary_address2);
     }
 }

--- a/crates/iota-types/src/iota_system_state/epoch_start_iota_system_state.rs
+++ b/crates/iota-types/src/iota_system_state/epoch_start_iota_system_state.rs
@@ -448,44 +448,19 @@ impl EpochStartSystemStateTrait for EpochStartSystemStateV2 {
         Committee::new(self.epoch, voting_rights)
     }
 
-    fn get_consensus_committee(&self) -> ConsensusCommittee {
-        let mut authorities = vec![];
-        for validator in self.committee_validators.iter() {
-            authorities.push(Authority {
-                stake: validator.voting_power as consensus_config::Stake,
-                address: validator.primary_address.clone(),
-                hostname: validator.hostname.clone(),
-                authority_key: consensus_config::AuthorityPublicKey::new(
-                    validator.authority_pubkey.clone(),
-                ),
-                protocol_key: consensus_config::ProtocolPublicKey::new(
-                    validator.protocol_pubkey.clone(),
-                ),
-                network_key: consensus_config::NetworkPublicKey::new(
-                    validator.network_pubkey.clone(),
-                ),
-            });
-        }
+    impl_get_committee!(
+        fn get_consensus_committee -> ConsensusCommittee,
+        authority = Authority,
+        cfg = consensus_config,
+        label = "Mysticeti"
+    );
 
-        // Sort the authorities by their authority (public) key in ascending order, same
-        // as the order in the IOTA committee returned from get_iota_committee().
-        authorities.sort_by(|a1, a2| a1.authority_key.cmp(&a2.authority_key));
-
-        for ((i, mysticeti_authority), iota_authority_name) in authorities
-            .iter()
-            .enumerate()
-            .zip(self.get_iota_committee().names())
-        {
-            if iota_authority_name.0 != mysticeti_authority.authority_key.to_bytes() {
-                error!(
-                    "Mismatched authority order between IOTA and Mysticeti! Index {}, Mysticeti authority {:?}\nIota authority name {}",
-                    i, mysticeti_authority, iota_authority_name
-                );
-            }
-        }
-
-        ConsensusCommittee::new(self.epoch as consensus_config::Epoch, authorities)
-    }
+    impl_get_committee!(
+        fn get_starfish_committee -> StarfishCommittee,
+        authority = StarfishAuthority,
+        cfg = starfish_config,
+        label = "Starfish"
+    );
 
     fn get_validator_as_p2p_peers(&self, excluding_self: AuthorityName) -> Vec<PeerInfo> {
         self.committee_validators

--- a/crates/iota-types/src/iota_system_state/epoch_start_iota_system_state.rs
+++ b/crates/iota-types/src/iota_system_state/epoch_start_iota_system_state.rs
@@ -581,7 +581,7 @@ pub fn convert_validator_to_epoch_start_info(validator: &ValidatorV1) -> EpochSt
 #[cfg(test)]
 mod test {
     use bcs;
-    use fastcrypto::traits::KeyPair;
+    use fastcrypto::traits::{KeyPair, ToFromBytes};
     use iota_network_stack::Multiaddr;
     use iota_protocol_config::ProtocolVersion;
     use rand::thread_rng;
@@ -606,25 +606,6 @@ mod test {
             let protocol_network_key = NetworkKeyPair::generate(&mut thread_rng());
 
             committee_validators.push(EpochStartValidatorInfoV1 {
-                iota_address,
-                authority_pubkey: authority_key.public().clone(),
-                network_pubkey: protocol_network_key.public().clone(),
-                protocol_pubkey: protocol_network_key.public().clone(),
-                iota_net_address: Multiaddr::empty(),
-                p2p_address: Multiaddr::empty(),
-                primary_address: Multiaddr::empty(),
-                voting_power: 1_000,
-                hostname: format!("host-{i}").to_string(),
-            })
-        }
-
-        let mut non_committee_validators = vec![];
-
-        for i in 0..10 {
-            let (iota_address, authority_key): (IotaAddress, AuthorityKeyPair) = get_key_pair();
-            let protocol_network_key = NetworkKeyPair::generate(&mut thread_rng());
-
-            non_committee_validators.push(EpochStartValidatorInfoV1 {
                 iota_address,
                 authority_pubkey: authority_key.public().clone(),
                 network_pubkey: protocol_network_key.public().clone(),
@@ -770,9 +751,13 @@ mod test {
 
         // Verify non-committee validators
         assert_eq!(non_committee.len(), 10);
-        for (i, validator) in non_committee.iter().enumerate() {
-            assert_eq!(validator.hostname, format!("non-committee-{i}"));
-            assert_eq!(validator.voting_power, 500);
+        for validator in non_committee_validators.iter() {
+            let authority_name = validator.authority_name();
+            let pubkey_from_map = non_committee.get(&authority_name).unwrap();
+            assert_eq!(
+                pubkey_from_map.as_bytes(),
+                validator.authority_pubkey.as_bytes()
+            );
         }
     }
 
@@ -845,7 +830,7 @@ mod test {
         assert_eq!(v1_deserialized.epoch(), 10);
         assert_eq!(v1_deserialized.protocol_version(), ProtocolVersion::MAX);
         assert_eq!(v1_deserialized.reference_gas_price(), 100_000);
-        assert_eq!(v1_deserialized.safe_mode(), true);
+        assert!(v1_deserialized.safe_mode());
         assert_eq!(v1_deserialized.epoch_start_timestamp_ms(), 1_000_000);
         assert_eq!(v1_deserialized.epoch_duration_ms(), 2_000_000);
 
@@ -868,7 +853,7 @@ mod test {
         assert_eq!(v2_deserialized.epoch(), 20);
         assert_eq!(v2_deserialized.protocol_version(), ProtocolVersion::MAX);
         assert_eq!(v2_deserialized.reference_gas_price(), 200_000);
-        assert_eq!(v2_deserialized.safe_mode(), true);
+        assert!(v2_deserialized.safe_mode());
         assert_eq!(v2_deserialized.epoch_start_timestamp_ms(), 3_000_000);
         assert_eq!(v2_deserialized.epoch_duration_ms(), 4_000_000);
 
@@ -880,13 +865,16 @@ mod test {
         assert_eq!(v2_validators.len(), 1);
         assert_eq!(v2_validators[0], iota_address1);
 
-        let v2_non_committee = v2_deserialized.get_non_committee_validators();
+        let mut v2_non_committee = v2_deserialized.get_non_committee_validators();
         assert_eq!(v2_non_committee.len(), 1);
-        assert_eq!(v2_non_committee[0].iota_address, iota_address2);
-        assert_eq!(v2_non_committee[0].voting_power, 500);
-        assert_eq!(v2_non_committee[0].hostname, "non-committee-1.example.com");
-        assert_eq!(v2_non_committee[0].iota_net_address, net_address2);
-        assert_eq!(v2_non_committee[0].p2p_address, p2p_address2);
-        assert_eq!(v2_non_committee[0].primary_address, primary_address2);
+        let non_committee_validator_deserialized = v2_non_committee.pop_first().unwrap();
+        assert_eq!(
+            non_committee_validator_deserialized.0.as_bytes(),
+            non_committee_validator.authority_name().as_bytes()
+        );
+        assert_eq!(
+            non_committee_validator_deserialized.1.as_bytes(),
+            non_committee_validator.authority_pubkey.as_bytes()
+        );
     }
 }

--- a/crates/iota-types/src/iota_system_state/iota_system_state_inner_v1.rs
+++ b/crates/iota-types/src/iota_system_state/iota_system_state_inner_v1.rs
@@ -26,7 +26,7 @@ use crate::{
     gas_coin::IotaTreasuryCap,
     id::ID,
     iota_system_state::epoch_start_iota_system_state::{
-        EpochStartSystemState, convert_validator_to_epoch_start_info,
+        EpochStartSystemState, EpochStartValidatorInfoV1, convert_validator_to_epoch_start_info,
     },
     multiaddr::Multiaddr,
     storage::ObjectStore,
@@ -540,6 +540,13 @@ impl IotaSystemStateTrait for IotaSystemStateV1 {
     }
 
     fn into_epoch_start_state(self) -> EpochStartSystemState {
+        let committee_validators: Vec<EpochStartValidatorInfoV1> = self
+            .validators
+            .active_validators
+            .iter()
+            .map(convert_validator_to_epoch_start_info)
+            .collect();
+
         EpochStartSystemState::new_v2(
             self.epoch,
             self.protocol_version,
@@ -547,12 +554,8 @@ impl IotaSystemStateTrait for IotaSystemStateV1 {
             self.safe_mode,
             self.epoch_start_timestamp_ms,
             self.parameters.epoch_duration_ms,
-            self.validators
-                .active_validators
-                .iter()
-                .map(convert_validator_to_epoch_start_info)
-                .collect(),
-            Vec::new(), // V1 has no non-committee validators
+            committee_validators.clone(),
+            committee_validators, // V1 uses committee_validators as active_validators
         )
     }
 

--- a/crates/iota-types/src/iota_system_state/iota_system_state_inner_v1.rs
+++ b/crates/iota-types/src/iota_system_state/iota_system_state_inner_v1.rs
@@ -8,9 +8,7 @@ use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    AdvanceEpochParams, IotaSystemStateTrait,
-    epoch_start_iota_system_state::EpochStartValidatorInfoV1,
-    get_validators_from_table_vec,
+    AdvanceEpochParams, IotaSystemStateTrait, get_validators_from_table_vec,
     iota_system_state_summary::{
         IotaSystemStateSummary, IotaSystemStateSummaryV1, IotaValidatorSummary,
     },
@@ -27,7 +25,9 @@ use crate::{
     error::IotaError,
     gas_coin::IotaTreasuryCap,
     id::ID,
-    iota_system_state::epoch_start_iota_system_state::EpochStartSystemState,
+    iota_system_state::epoch_start_iota_system_state::{
+        EpochStartSystemState, convert_validator_to_epoch_start_info,
+    },
     multiaddr::Multiaddr,
     storage::ObjectStore,
     system_admin_cap::IotaSystemAdminCap,
@@ -540,7 +540,7 @@ impl IotaSystemStateTrait for IotaSystemStateV1 {
     }
 
     fn into_epoch_start_state(self) -> EpochStartSystemState {
-        EpochStartSystemState::new_v1(
+        EpochStartSystemState::new_v2(
             self.epoch,
             self.protocol_version,
             self.reference_gas_price,
@@ -550,21 +550,9 @@ impl IotaSystemStateTrait for IotaSystemStateV1 {
             self.validators
                 .active_validators
                 .iter()
-                .map(|validator| {
-                    let metadata = validator.verified_metadata();
-                    EpochStartValidatorInfoV1 {
-                        iota_address: metadata.iota_address,
-                        authority_pubkey: metadata.authority_pubkey.clone(),
-                        network_pubkey: metadata.network_pubkey.clone(),
-                        protocol_pubkey: metadata.protocol_pubkey.clone(),
-                        iota_net_address: metadata.net_address.clone(),
-                        p2p_address: metadata.p2p_address.clone(),
-                        primary_address: metadata.primary_address.clone(),
-                        voting_power: validator.voting_power,
-                        hostname: metadata.name.clone(),
-                    }
-                })
+                .map(convert_validator_to_epoch_start_info)
                 .collect(),
+            Vec::new(), // V1 has no non-committee validators
         )
     }
 

--- a/crates/iota-types/src/iota_system_state/iota_system_state_inner_v2.rs
+++ b/crates/iota-types/src/iota_system_state/iota_system_state_inner_v2.rs
@@ -175,17 +175,13 @@ impl IotaSystemStateTrait for IotaSystemStateV2 {
     }
 
     fn into_epoch_start_state(self) -> EpochStartSystemState {
-        // Convert active validators that are not in committee into non-committee
-        // validators
-        let committee_validator_set: std::collections::HashSet<_> =
-            self.validators.committee_members.iter().collect();
-        let non_committee_validators: Vec<_> = self
+        // Convert all active validators to epoch start info, maintaining the same order
+        // as in ValidatorSetV2
+        let all_active_validators: Vec<_> = self
             .validators
             .active_validators
             .iter()
-            .enumerate()
-            .filter(|(idx, _)| !committee_validator_set.contains(&(*idx as u64)))
-            .map(|(_, validator)| convert_validator_to_epoch_start_info(validator))
+            .map(convert_validator_to_epoch_start_info)
             .collect();
 
         EpochStartSystemState::new_v2(
@@ -199,7 +195,7 @@ impl IotaSystemStateTrait for IotaSystemStateV2 {
                 .iter_committee_members()
                 .map(convert_validator_to_epoch_start_info)
                 .collect(),
-            non_committee_validators,
+            all_active_validators,
         )
     }
 

--- a/crates/iota-types/src/iota_system_state/iota_system_state_inner_v2.rs
+++ b/crates/iota-types/src/iota_system_state/iota_system_state_inner_v2.rs
@@ -6,9 +6,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    AdvanceEpochParams, IotaSystemStateTrait,
-    epoch_start_iota_system_state::EpochStartValidatorInfoV1,
-    get_validators_from_table_vec,
+    AdvanceEpochParams, IotaSystemStateTrait, get_validators_from_table_vec,
     iota_system_state_inner_v1::{StorageFundV1, ValidatorV1},
     iota_system_state_summary::{
         IotaSystemStateSummary, IotaSystemStateSummaryV2, IotaValidatorSummary,
@@ -22,7 +20,9 @@ use crate::{
     error::IotaError,
     gas_coin::IotaTreasuryCap,
     iota_system_state::{
-        epoch_start_iota_system_state::EpochStartSystemState,
+        epoch_start_iota_system_state::{
+            EpochStartSystemState, convert_validator_to_epoch_start_info,
+        },
         iota_system_state_inner_v1::SystemParametersV1,
     },
     storage::ObjectStore,
@@ -175,7 +175,20 @@ impl IotaSystemStateTrait for IotaSystemStateV2 {
     }
 
     fn into_epoch_start_state(self) -> EpochStartSystemState {
-        EpochStartSystemState::new_v1(
+        // Convert active validators that are not in committee into non-committee
+        // validators
+        let committee_validator_set: std::collections::HashSet<_> =
+            self.validators.committee_members.iter().collect();
+        let non_committee_validators: Vec<_> = self
+            .validators
+            .active_validators
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| !committee_validator_set.contains(&(*idx as u64)))
+            .map(|(_, validator)| convert_validator_to_epoch_start_info(validator))
+            .collect();
+
+        EpochStartSystemState::new_v2(
             self.epoch,
             self.protocol_version,
             self.reference_gas_price,
@@ -184,21 +197,9 @@ impl IotaSystemStateTrait for IotaSystemStateV2 {
             self.parameters.epoch_duration_ms,
             self.validators
                 .iter_committee_members()
-                .map(|validator| {
-                    let metadata = validator.verified_metadata();
-                    EpochStartValidatorInfoV1 {
-                        iota_address: metadata.iota_address,
-                        authority_pubkey: metadata.authority_pubkey.clone(),
-                        network_pubkey: metadata.network_pubkey.clone(),
-                        protocol_pubkey: metadata.protocol_pubkey.clone(),
-                        iota_net_address: metadata.net_address.clone(),
-                        p2p_address: metadata.p2p_address.clone(),
-                        primary_address: metadata.primary_address.clone(),
-                        voting_power: validator.voting_power,
-                        hostname: metadata.name.clone(),
-                    }
-                })
+                .map(convert_validator_to_epoch_start_info)
                 .collect(),
+            non_committee_validators,
         )
     }
 

--- a/crates/iota-types/src/iota_system_state/simtest_iota_system_state_inner.rs
+++ b/crates/iota-types/src/iota_system_state/simtest_iota_system_state_inner.rs
@@ -194,6 +194,26 @@ impl IotaSystemStateTrait for SimTestIotaSystemStateV1 {
     }
 
     fn into_epoch_start_state(self) -> EpochStartSystemState {
+        let committee_validators: Vec<_> = self
+            .validators
+            .active_validators
+            .iter()
+            .map(|validator| {
+                let metadata = validator.verified_metadata();
+                EpochStartValidatorInfoV1 {
+                    iota_address: metadata.iota_address,
+                    authority_pubkey: metadata.authority_pubkey.clone(),
+                    network_pubkey: metadata.network_pubkey.clone(),
+                    protocol_pubkey: metadata.protocol_pubkey.clone(),
+                    iota_net_address: metadata.net_address.clone(),
+                    p2p_address: metadata.p2p_address.clone(),
+                    primary_address: metadata.primary_address.clone(),
+                    voting_power: validator.voting_power,
+                    hostname: "".to_string(),
+                }
+            })
+            .collect();
+
         EpochStartSystemState::new_v2(
             self.epoch,
             self.protocol_version,
@@ -201,26 +221,9 @@ impl IotaSystemStateTrait for SimTestIotaSystemStateV1 {
             self.safe_mode,
             self.epoch_start_timestamp_ms,
             self.parameters.epoch_duration_ms,
-            self.validators
-                .active_validators
-                .iter()
-                .map(|validator| {
-                    let metadata = validator.verified_metadata();
-                    EpochStartValidatorInfoV1 {
-                        iota_address: metadata.iota_address,
-                        authority_pubkey: metadata.authority_pubkey.clone(),
-                        network_pubkey: metadata.network_pubkey.clone(),
-                        protocol_pubkey: metadata.protocol_pubkey.clone(),
-                        iota_net_address: metadata.net_address.clone(),
-                        p2p_address: metadata.p2p_address.clone(),
-                        primary_address: metadata.primary_address.clone(),
-                        voting_power: validator.voting_power,
-                        hostname: "".to_string(),
-                    }
-                })
-                .collect(),
-            // There are no active validators that are not part of the committee.
-            Vec::new(),
+            committee_validators.clone(),
+            committee_validators, /* In simtest, committee_validators are the same as
+                                   * active_validators */
         )
     }
 
@@ -314,6 +317,26 @@ impl IotaSystemStateTrait for SimTestIotaSystemStateShallowV1 {
     }
 
     fn into_epoch_start_state(self) -> EpochStartSystemState {
+        let committee_validators: Vec<_> = self
+            .validators
+            .active_validators
+            .iter()
+            .map(|validator| {
+                let metadata = validator.verified_metadata();
+                EpochStartValidatorInfoV1 {
+                    iota_address: metadata.iota_address,
+                    authority_pubkey: metadata.authority_pubkey.clone(),
+                    network_pubkey: metadata.network_pubkey.clone(),
+                    protocol_pubkey: metadata.protocol_pubkey.clone(),
+                    iota_net_address: metadata.net_address.clone(),
+                    p2p_address: metadata.p2p_address.clone(),
+                    primary_address: metadata.primary_address.clone(),
+                    voting_power: validator.voting_power,
+                    hostname: "".to_string(),
+                }
+            })
+            .collect();
+
         EpochStartSystemState::new_v2(
             self.epoch,
             self.protocol_version,
@@ -321,26 +344,9 @@ impl IotaSystemStateTrait for SimTestIotaSystemStateShallowV1 {
             self.safe_mode,
             self.epoch_start_timestamp_ms,
             self.parameters.epoch_duration_ms,
-            self.validators
-                .active_validators
-                .iter()
-                .map(|validator| {
-                    let metadata = validator.verified_metadata();
-                    EpochStartValidatorInfoV1 {
-                        iota_address: metadata.iota_address,
-                        authority_pubkey: metadata.authority_pubkey.clone(),
-                        network_pubkey: metadata.network_pubkey.clone(),
-                        protocol_pubkey: metadata.protocol_pubkey.clone(),
-                        iota_net_address: metadata.net_address.clone(),
-                        p2p_address: metadata.p2p_address.clone(),
-                        primary_address: metadata.primary_address.clone(),
-                        voting_power: validator.voting_power,
-                        hostname: "".to_string(),
-                    }
-                })
-                .collect(),
-            // There are no active validators that are not part of the committee.
-            Vec::new(),
+            committee_validators.clone(),
+            committee_validators, /* In simtest, committee_validators are the same as
+                                   * active_validators */
         )
     }
 
@@ -463,6 +469,26 @@ impl IotaSystemStateTrait for SimTestIotaSystemStateDeepV1 {
     }
 
     fn into_epoch_start_state(self) -> EpochStartSystemState {
+        let committee_validators: Vec<_> = self
+            .validators
+            .active_validators
+            .iter()
+            .map(|validator| {
+                let metadata = validator.verified_metadata();
+                EpochStartValidatorInfoV1 {
+                    iota_address: metadata.iota_address,
+                    authority_pubkey: metadata.authority_pubkey.clone(),
+                    network_pubkey: metadata.network_pubkey.clone(),
+                    protocol_pubkey: metadata.protocol_pubkey.clone(),
+                    iota_net_address: metadata.net_address.clone(),
+                    p2p_address: metadata.p2p_address.clone(),
+                    primary_address: metadata.primary_address.clone(),
+                    voting_power: validator.voting_power,
+                    hostname: "".to_string(),
+                }
+            })
+            .collect();
+
         EpochStartSystemState::new_v2(
             self.epoch,
             self.protocol_version,
@@ -470,26 +496,9 @@ impl IotaSystemStateTrait for SimTestIotaSystemStateDeepV1 {
             self.safe_mode,
             self.epoch_start_timestamp_ms,
             self.parameters.epoch_duration_ms,
-            self.validators
-                .active_validators
-                .iter()
-                .map(|validator| {
-                    let metadata = validator.verified_metadata();
-                    EpochStartValidatorInfoV1 {
-                        iota_address: metadata.iota_address,
-                        authority_pubkey: metadata.authority_pubkey.clone(),
-                        network_pubkey: metadata.network_pubkey.clone(),
-                        protocol_pubkey: metadata.protocol_pubkey.clone(),
-                        iota_net_address: metadata.net_address.clone(),
-                        p2p_address: metadata.p2p_address.clone(),
-                        primary_address: metadata.primary_address.clone(),
-                        voting_power: validator.voting_power,
-                        hostname: "".to_string(),
-                    }
-                })
-                .collect(),
-            // There are no active validators that are not part of the committee.
-            Vec::new(),
+            committee_validators.clone(),
+            committee_validators, /* In simtest, committee_validators are the same as
+                                   * active_validators */
         )
     }
 

--- a/crates/iota-types/src/iota_system_state/simtest_iota_system_state_inner.rs
+++ b/crates/iota-types/src/iota_system_state/simtest_iota_system_state_inner.rs
@@ -194,7 +194,7 @@ impl IotaSystemStateTrait for SimTestIotaSystemStateV1 {
     }
 
     fn into_epoch_start_state(self) -> EpochStartSystemState {
-        EpochStartSystemState::new_v1(
+        EpochStartSystemState::new_v2(
             self.epoch,
             self.protocol_version,
             self.reference_gas_price,
@@ -219,6 +219,8 @@ impl IotaSystemStateTrait for SimTestIotaSystemStateV1 {
                     }
                 })
                 .collect(),
+            // There are no active validators that are not part of the committee.
+            Vec::new(),
         )
     }
 
@@ -312,7 +314,7 @@ impl IotaSystemStateTrait for SimTestIotaSystemStateShallowV1 {
     }
 
     fn into_epoch_start_state(self) -> EpochStartSystemState {
-        EpochStartSystemState::new_v1(
+        EpochStartSystemState::new_v2(
             self.epoch,
             self.protocol_version,
             self.reference_gas_price,
@@ -337,6 +339,8 @@ impl IotaSystemStateTrait for SimTestIotaSystemStateShallowV1 {
                     }
                 })
                 .collect(),
+            // There are no active validators that are not part of the committee.
+            Vec::new(),
         )
     }
 
@@ -459,7 +463,7 @@ impl IotaSystemStateTrait for SimTestIotaSystemStateDeepV1 {
     }
 
     fn into_epoch_start_state(self) -> EpochStartSystemState {
-        EpochStartSystemState::new_v1(
+        EpochStartSystemState::new_v2(
             self.epoch,
             self.protocol_version,
             self.reference_gas_price,
@@ -484,6 +488,8 @@ impl IotaSystemStateTrait for SimTestIotaSystemStateDeepV1 {
                     }
                 })
                 .collect(),
+            // There are no active validators that are not part of the committee.
+            Vec::new(),
         )
     }
 

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -11,10 +11,7 @@ use std::{
 };
 
 use byteorder::{BigEndian, ReadBytesExt};
-use fastcrypto::{
-    ed25519::Ed25519Signature, error::FastCryptoResult, groups::bls12381, hash::HashFunction,
-    traits::Signer,
-};
+use fastcrypto::{error::FastCryptoResult, groups::bls12381, hash::HashFunction};
 use fastcrypto_tbls::dkg_v1;
 use fastcrypto_zkp::bn254::zk_login::{JwkId, JWK};
 use schemars::JsonSchema;
@@ -25,8 +22,8 @@ use crate::{
     base_types::{
         AuthorityName, ConciseableName, ObjectID, ObjectRef, SequenceNumber, TransactionDigest,
     },
-    crypto::{AuthorityKeyPair, AuthoritySignature, DefaultHash, NetworkKeyPair},
-    digests::{ConsensusCommitDigest, Digest, SenderSignedDataDigest},
+    crypto::{AuthoritySignature, DefaultHash},
+    digests::{ConsensusCommitDigest, Digest},
     message_envelope::{Envelope, Message, VerifiedEnvelope},
     messages_checkpoint::{CheckpointSequenceNumber, CheckpointSignatureMessage},
     supported_protocol_versions::{
@@ -134,12 +131,20 @@ pub type SignedAuthorityCapabilitiesV1 = Envelope<AuthorityCapabilitiesV1, Autho
 pub type VerifiedAuthorityCapabilitiesV1 =
     VerifiedEnvelope<AuthorityCapabilitiesV1, AuthoritySignature>;
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AuthorityCapabilitiesDigest(Digest);
 
 impl AuthorityCapabilitiesDigest {
     pub const fn new(digest: [u8; 32]) -> Self {
         Self(Digest::new(digest))
+    }
+}
+
+impl Debug for AuthorityCapabilitiesDigest {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("AuthorityCapabilitiesDigest")
+            .field(&self.0)
+            .finish()
     }
 }
 
@@ -169,7 +174,7 @@ pub struct AuthorityCapabilitiesV1 {
 }
 
 impl Message for AuthorityCapabilitiesV1 {
-    type DigestType = SenderSignedDataDigest;
+    type DigestType = AuthorityCapabilitiesDigest;
     const SCOPE: IntentScope = IntentScope::AuthorityCapabilities;
 
     fn digest(&self) -> Self::DigestType {
@@ -177,7 +182,7 @@ impl Message for AuthorityCapabilitiesV1 {
         let mut hasher = DefaultHash::new();
         let serialized = bcs::to_bytes(&self).expect("BCS should not fail");
         hasher.update(&serialized);
-        SenderSignedDataDigest::new(<[u8; 32]>::from(hasher.finalize()))
+        AuthorityCapabilitiesDigest::new(<[u8; 32]>::from(hasher.finalize()))
     }
 }
 
@@ -218,12 +223,6 @@ impl AuthorityCapabilitiesV1 {
                 ),
             available_system_packages,
         }
-    }
-
-    fn sign(self, keypair: &AuthorityKeyPair) -> SignedAuthorityCapabilitiesV1 {
-        let msg = bcs::to_bytes(&self).expect("BCS serialization should not fail");
-        let sig = keypair.sign(&msg);
-        SignedAuthorityCapabilitiesV1::new_from_data_and_sig(self, sig)
     }
 }
 

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -11,17 +11,23 @@ use std::{
 };
 
 use byteorder::{BigEndian, ReadBytesExt};
-use fastcrypto::{error::FastCryptoResult, groups::bls12381};
+use fastcrypto::{
+    ed25519::Ed25519Signature, error::FastCryptoResult, groups::bls12381, hash::HashFunction,
+    traits::Signer,
+};
 use fastcrypto_tbls::dkg_v1;
-use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId};
+use fastcrypto_zkp::bn254::zk_login::{JwkId, JWK};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use shared_crypto::intent::IntentScope;
 
 use crate::{
     base_types::{
         AuthorityName, ConciseableName, ObjectID, ObjectRef, SequenceNumber, TransactionDigest,
     },
-    digests::ConsensusCommitDigest,
+    crypto::{AuthorityKeyPair, AuthoritySignature, DefaultHash, NetworkKeyPair},
+    digests::{ConsensusCommitDigest, Digest, SenderSignedDataDigest},
+    message_envelope::{Envelope, Message, VerifiedEnvelope},
     messages_checkpoint::{CheckpointSequenceNumber, CheckpointSignatureMessage},
     supported_protocol_versions::{
         Chain, SupportedProtocolVersions, SupportedProtocolVersionsWithHashes,
@@ -123,6 +129,20 @@ impl Debug for ConsensusTransactionKey {
     }
 }
 
+pub type SignedAuthorityCapabilitiesV1 = Envelope<AuthorityCapabilitiesV1, AuthoritySignature>;
+
+pub type VerifiedAuthorityCapabilitiesV1 =
+    VerifiedEnvelope<AuthorityCapabilitiesV1, AuthoritySignature>;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct AuthorityCapabilitiesDigest(Digest);
+
+impl AuthorityCapabilitiesDigest {
+    pub const fn new(digest: [u8; 32]) -> Self {
+        Self(Digest::new(digest))
+    }
+}
+
 /// Used to advertise capabilities of each authority via consensus. This allows
 /// validators to negotiate the creation of the ChangeEpoch transaction.
 #[derive(Serialize, Deserialize, Clone, Hash)]
@@ -146,6 +166,19 @@ pub struct AuthorityCapabilitiesV1 {
     /// possesses. Used to determine whether to do a framework/movestdlib
     /// upgrade.
     pub available_system_packages: Vec<ObjectRef>,
+}
+
+impl Message for AuthorityCapabilitiesV1 {
+    type DigestType = SenderSignedDataDigest;
+    const SCOPE: IntentScope = IntentScope::AuthorityCapabilities;
+
+    fn digest(&self) -> Self::DigestType {
+        // Ensure deterministic serialization for digest
+        let mut hasher = DefaultHash::new();
+        let serialized = bcs::to_bytes(&self).expect("BCS should not fail");
+        hasher.update(&serialized);
+        SenderSignedDataDigest::new(<[u8; 32]>::from(hasher.finalize()))
+    }
 }
 
 impl Debug for AuthorityCapabilitiesV1 {
@@ -185,6 +218,12 @@ impl AuthorityCapabilitiesV1 {
                 ),
             available_system_packages,
         }
+    }
+
+    fn sign(self, keypair: &AuthorityKeyPair) -> SignedAuthorityCapabilitiesV1 {
+        let msg = bcs::to_bytes(&self).expect("BCS serialization should not fail");
+        let sig = keypair.sign(&msg);
+        SignedAuthorityCapabilitiesV1::new_from_data_and_sig(self, sig)
     }
 }
 

--- a/crates/iota-types/src/messages_grpc.rs
+++ b/crates/iota-types/src/messages_grpc.rs
@@ -2,6 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use fastcrypto::hash::HashFunction;
 use move_core_types::annotated_value::MoveStructLayout;
 use serde::{Deserialize, Serialize};
 
@@ -9,6 +10,8 @@ use crate::{
     base_types::{ObjectID, SequenceNumber, TransactionDigest},
     crypto::{AuthoritySignInfo, AuthorityStrongQuorumSignInfo},
     effects::{SignedTransactionEffects, TransactionEvents, VerifiedSignedTransactionEffects},
+    message_envelope::Message,
+    messages_consensus::SignedAuthorityCapabilitiesV1,
     object::Object,
     transaction::{CertifiedTransaction, SenderSignedData, SignedTransaction},
 };
@@ -271,4 +274,13 @@ pub struct HandleSoftBundleCertificatesRequestV1 {
     pub include_input_objects: bool,
     pub include_output_objects: bool,
     pub include_auxiliary_data: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct HandleCapabilityNotificationV1Request {
+    pub message: SignedAuthorityCapabilitiesV1,
+}
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct HandleCapabilityNotificationV1Response {
+    // Currently empty, may be extended in the future
 }

--- a/crates/iota-types/src/messages_grpc.rs
+++ b/crates/iota-types/src/messages_grpc.rs
@@ -2,7 +2,6 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use fastcrypto::hash::HashFunction;
 use move_core_types::annotated_value::MoveStructLayout;
 use serde::{Deserialize, Serialize};
 
@@ -10,7 +9,6 @@ use crate::{
     base_types::{ObjectID, SequenceNumber, TransactionDigest},
     crypto::{AuthoritySignInfo, AuthorityStrongQuorumSignInfo},
     effects::{SignedTransactionEffects, TransactionEvents, VerifiedSignedTransactionEffects},
-    message_envelope::Message,
     messages_consensus::SignedAuthorityCapabilitiesV1,
     object::Object,
     transaction::{CertifiedTransaction, SenderSignedData, SignedTransaction},

--- a/crates/iota-types/src/messages_grpc.rs
+++ b/crates/iota-types/src/messages_grpc.rs
@@ -275,10 +275,9 @@ pub struct HandleSoftBundleCertificatesRequestV1 {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct HandleCapabilityNotificationV1Request {
+pub struct HandleCapabilityNotificationRequestV1 {
     pub message: SignedAuthorityCapabilitiesV1,
 }
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct HandleCapabilityNotificationV1Response {
-    // Currently empty, may be extended in the future
-}
+pub struct HandleCapabilityNotificationResponseV1 {}

--- a/crates/shared-crypto/src/intent.rs
+++ b/crates/shared-crypto/src/intent.rs
@@ -70,7 +70,7 @@ pub enum IntentScope {
                                 * purposes but was never included in messages. */
     ConsensusBlock = 7, // Used for consensus authority signature on block's digest.
     DiscoveryPeers = 8, // Used for reporting peer addresses in discovery
-    AuthorityCapabilities = 9, // Used for reporting peer addresses in discovery
+    AuthorityCapabilities = 9, // Used for authority capabilities from non-committee authorities.
 }
 
 impl TryFrom<u8> for IntentScope {

--- a/crates/shared-crypto/src/intent.rs
+++ b/crates/shared-crypto/src/intent.rs
@@ -70,6 +70,7 @@ pub enum IntentScope {
                                 * purposes but was never included in messages. */
     ConsensusBlock = 7, // Used for consensus authority signature on block's digest.
     DiscoveryPeers = 8, // Used for reporting peer addresses in discovery
+    AuthorityCapabilities = 9, // Used for reporting peer addresses in discovery
 }
 
 impl TryFrom<u8> for IntentScope {


### PR DESCRIPTION
# Description of change

This PR implements the authority capabilities advertisement endpoint for non-committee validators, enabling them to notify committee validators about their capabilities and supported protocol versions. This feature lays the groundwork for improved validator coordination and protocol version management across the network that will be implemented in subsequent PRs.

Key Features

- New message format for non-committee active validators to advertise their capabilities.
- Signature Verification: Enhanced signature verifier to validate capability notifications from authorized non-committee active validators
- gRPC Endpoint: New handle_capability_notification_v1 endpoint for receiving capability advertisements
- Epoch State V2: Extended epoch start state to include non-committee active validator information
- Comprehensive Testing: Added unit tests to verify proper rejection of unauthorized capability notifications

## Links to any relevant issues

Resolves #7992 

## How the change has been tested

- Unit tests verify proper rejection of capability notifications from unauthorized authorities
- Further tests will be implemented in subsequent PRs as end-to-end tests. 

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](../../CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

### Release Notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): Adds gRPC endpoint to allow non-committee active validators to forward their signed AuthorityCapabilities message to committee members. This will enable selecting new committee only among validators supporting new protocol version when advancing epoch. This endpoint is only enabled on the devnet. 
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
