### PR TITLE
fix(iota-indexer): Make backfill data ingestion worker configurable

### DIFF
--- a/crates/iota-indexer/README.md
+++ b/crates/iota-indexer/README.md
@@ -110,7 +110,10 @@ Options:
 It supports following backfill options:
 
 - `sql`: Executes a SQL statement directly against the database in chunks, filtering on a specified column (typically a sequence number). Conflict resolution is handled automatically with `ON CONFLICT DO NOTHING`.
-- `ingestion`: Fetches and buffers checkpoint data from a remote store, then slices the buffered checkpoint data into chunks to backfill the database.
+- `ingestion`: Fetches and buffers checkpoint data from a provided ingestion source, then slices the buffered checkpoint data into chunks to backfill the database. Supported ingestion sources:
+  - `--data-ingestion-path <DIR>`: Path to a directory containing checkpoint (`.chk`) files.
+  - `--remote-store-url <REMOTE_STORE_URL>`: Remote store URL to fetch checkpoint data from, e.g., `http://0.0.0.0:9000/api/v1`.
+  - `--rpc-client-url <RPC_CLIENT_URL>`: RPC client URL to fetch checkpoint data from, e.g., `http://0.0.0.0:9000`.
 
 #### Backfill job: `tx-wrapped-or-deleted-objects`
 
@@ -118,7 +121,7 @@ This job backfills the `tx_wrapped_or_deleted_objects` table, which indexes tran
 Replace `<START>` and `<END>` with the desired checkpoint range to backfill (e.g., `0` `10000`, both inclusive), and `<REMOTE_STORE_URL>` with the fullnode REST API URL used to fetch checkpoint data.
 
 ```sh
-cargo run --bin iota-indexer -- --database-url <DATABASE_URL> run-backfill <START> <END> ingestion tx-wrapped-or-deleted-objects <REMOTE_STORE_URL>
+cargo run --bin iota-indexer -- --database-url <DATABASE_URL> run-backfill <START> <END> ingestion tx-wrapped-or-deleted-objects --remote-store-url <REMOTE_STORE_URL>
 ```
 
 #### Error Handling

--- a/crates/iota-indexer/src/backfill/ingestion/task.rs
+++ b/crates/iota-indexer/src/backfill/ingestion/task.rs
@@ -5,17 +5,23 @@
 use std::{ops::RangeInclusive, sync::Arc};
 
 use dashmap::DashMap;
-use iota_data_ingestion_core::{ReaderOptions, setup_single_workflow};
+use iota_data_ingestion_core::{
+    DataIngestionMetrics, IndexerExecutor, IngestionError, ReaderOptions, ShimProgressStore,
+    WorkerPool,
+};
 use iota_types::messages_checkpoint::CheckpointSequenceNumber;
+use prometheus::Registry;
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
+use url::Url;
 
 use crate::{
     backfill::{
         Backfill,
         ingestion::{IngestionBackfill, adapter::Adapter},
     },
+    config::IngestionConfig,
     db::ConnectionPool,
     errors::IndexerError,
 };
@@ -40,7 +46,7 @@ pub struct IngestionBackfillTask<T: IngestionBackfill> {
 impl<T: IngestionBackfill + 'static> IngestionBackfillTask<T> {
     // Creates and starts a new ingestion‐driven backfill task using processor `T`.
     pub(crate) async fn new(
-        remote_store_url: String,
+        config: IngestionConfig,
         start_checkpoint: CheckpointSequenceNumber,
     ) -> Result<Self, IndexerError> {
         let ready_checkpoints = Arc::new(DashMap::new());
@@ -49,18 +55,51 @@ impl<T: IngestionBackfill + 'static> IngestionBackfillTask<T> {
             ready_checkpoints: ready_checkpoints.clone(),
             notify: notify.clone(),
         };
+
         let reader_options = ReaderOptions {
-            batch_size: 200,
+            batch_size: config.checkpoint_download_queue_size,
+            timeout_secs: config.checkpoint_download_timeout,
+            data_limit: config.checkpoint_download_queue_size_bytes,
             ..Default::default()
         };
-        let (executor, _cancel_token) = setup_single_workflow(
+
+        let metrics = DataIngestionMetrics::new(&Registry::new());
+        let progress_store = ShimProgressStore(start_checkpoint);
+        let cancel_token = CancellationToken::new();
+
+        let mut executor =
+            IndexerExecutor::new(progress_store, 1, metrics, cancel_token.child_token());
+
+        let worker_pool = WorkerPool::new(
             adapter,
+            "workflow".to_string(),
+            config.checkpoint_download_queue_size,
+            Default::default(),
+        );
+        executor.register(worker_pool).await?;
+
+        let remote_store_url: Option<String> = config
+            .sources
+            .remote_store_url
+            .as_ref()
+            .map(Url::to_string)
+            .or_else(|| {
+                config
+                    .sources
+                    .rpc_client_url
+                    .map(|rpc_url| format!("{rpc_url}/api/v1"))
+            });
+
+        let executor = executor.run(
+            config
+                .sources
+                .data_ingestion_path
+                .clone()
+                .unwrap_or(tempfile::tempdir().map_err(IngestionError::Io)?.keep()),
             remote_store_url,
-            start_checkpoint,
-            200,
-            Some(reader_options),
-        )
-        .await?;
+            vec![],
+            reader_options,
+        );
 
         tokio::spawn(async move {
             if let Err(join_err) = executor.await {
@@ -71,7 +110,7 @@ impl<T: IngestionBackfill + 'static> IngestionBackfillTask<T> {
         Ok(Self {
             ready_checkpoints,
             notify,
-            _cancel_token,
+            _cancel_token: cancel_token,
         })
     }
 }

--- a/crates/iota-indexer/src/backfill/mod.rs
+++ b/crates/iota-indexer/src/backfill/mod.rs
@@ -16,6 +16,7 @@ use crate::{
         },
         sql::sql_backfill::SqlBackfill,
     },
+    config::IngestionConfig,
     db::ConnectionPool,
     errors::IndexerError,
 };
@@ -57,15 +58,15 @@ pub enum BackfillKind {
     /// Run a backfill driven by the ingestion engine.
     ///
     /// - `kind`: defines the specific ingestion backfill implementation to use.
-    /// - `remote_store_url`: the endpoint or path of the remote checkpoint
-    ///   store to ingest from.
+    /// - `config`: configuration options for the data ingestion worker.
     ///
     /// The runner will spawn the data ingestion workflow, continuously buffer
     /// processed checkpoint data, and then slice the requested checkpoint
     /// range into chunks for database backfill.
     Ingestion {
         kind: IngestionBackfillKind,
-        remote_store_url: String,
+        #[command(flatten)]
+        config: IngestionConfig,
     },
 }
 
@@ -85,13 +86,10 @@ pub(crate) async fn get_backfill(
 ) -> Result<Arc<dyn Backfill>, IndexerError> {
     match kind {
         BackfillKind::Sql { sql, key_column } => Ok(Arc::new(SqlBackfill::new(sql, key_column))),
-        BackfillKind::Ingestion {
-            kind,
-            remote_store_url,
-        } => match kind {
+        BackfillKind::Ingestion { kind, config } => match kind {
             IngestionBackfillKind::TxWrappedOrDeletedObjects => Ok(Arc::new(
                 IngestionBackfillTask::<TxWrappedOrDeletedObjectsBackfill>::new(
-                    remote_store_url,
+                    config,
                     range_start as CheckpointSequenceNumber,
                 )
                 .await?,


### PR DESCRIPTION
# Description of change

This patch makes the ingestion worker for the backfill application configurable and allows to provide ingestion sources similarly as for the Indexer application.

To better support configuring ingestion sources (local, remote store, RPC client URL) within the application, it's reasonable to update the CLI API from:

`cargo run --bin iota-indexer -- --database-url <DATABASE_URL> run-backfill <START> <END> ingestion tx-wrapped-or-deleted-objects <REMOTE_STORE_URL>`

to

`cargo run --bin iota-indexer -- --database-url <DATABASE_URL> run-backfill <START> <END> ingestion tx-wrapped-or-deleted-objects --remote-store-url <REMOTE_STORE_URL>`

Explicitly specifying parameters here (e.g., --remote-store-url) improves clarity and maintainability of the CLI interface. 

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/8052

## How the change has been tested

- [X] Basic tests (linting, compilation, formatting, unit/integration tests)
- [X] Patch-specific tests (correctness, functionality coverage)

Tested the patch by providing CLI options, specially for file based data ingestion (checkpoints created with the help of the `iota-synthetic-ingestion` crate):

`cargo run --bin iota-indexer -- --database-url postgres://postgres:postgrespw@localhost/iota_indexer_local run-backfill 0 1000000 ingestion tx-wrapped-or-deleted-objects --data-ingestion-path path/to/checkpoints `

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

Unchecked test classes are not required for this patch. Migration objects and synchronization pipelines were not touched.

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [X] Indexer: Adjusted the Indexer backfill CLI to make the data ingestion worker configurable.
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
