### PR TITLE
feat: bump iota to v1.4.1-rc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1835,7 +1835,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "const-str",
  "git-version",
@@ -5390,7 +5390,7 @@ dependencies = [
 
 [[package]]
 name = "iota"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5439,7 +5439,7 @@ dependencies = [
  "iota-package-management",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.4.1-beta",
+ "iota-sdk 1.4.1-rc",
  "iota-simulator",
  "iota-source-validation",
  "iota-swarm",
@@ -5512,7 +5512,7 @@ dependencies = [
 
 [[package]]
 name = "iota-adapter-transactional-tests"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -5520,7 +5520,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "arrow-array 53.1.0",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer-derive"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5571,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "iota-archival"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -5602,7 +5602,7 @@ dependencies = [
 
 [[package]]
 name = "iota-authority-aggregation"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "futures",
  "iota-metrics",
@@ -5613,7 +5613,7 @@ dependencies = [
 
 [[package]]
 name = "iota-aws-orchestrator"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -5643,7 +5643,7 @@ dependencies = [
 
 [[package]]
 name = "iota-benchmark"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5664,7 +5664,7 @@ dependencies = [
  "iota-metrics",
  "iota-network",
  "iota-protocol-config",
- "iota-sdk 1.4.1-beta",
+ "iota-sdk 1.4.1-rc",
  "iota-simulator",
  "iota-storage",
  "iota-surfer",
@@ -5707,7 +5707,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cluster-test"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5725,7 +5725,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-keys",
  "iota-move-build",
- "iota-sdk 1.4.1-beta",
+ "iota-sdk 1.4.1-rc",
  "iota-swarm",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5793,7 +5793,7 @@ dependencies = [
 
 [[package]]
 name = "iota-core"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5890,7 +5890,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cost"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5945,7 +5945,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5978,7 +5978,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion-core"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6012,7 +6012,7 @@ dependencies = [
 
 [[package]]
 name = "iota-e2e-tests"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6041,7 +6041,7 @@ dependencies = [
  "iota-protocol-config",
  "iota-rest-api",
  "iota-rust-sdk",
- "iota-sdk 1.4.1-beta",
+ "iota-sdk 1.4.1-rc",
  "iota-simulator",
  "iota-storage",
  "iota-swarm",
@@ -6072,7 +6072,7 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "serde_yaml",
 ]
@@ -6111,7 +6111,7 @@ dependencies = [
 
 [[package]]
 name = "iota-faucet"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6127,7 +6127,7 @@ dependencies = [
  "iota-keys",
  "iota-metrics",
  "iota-network-stack",
- "iota-sdk 1.4.1-beta",
+ "iota-sdk 1.4.1-rc",
  "iota-types",
  "parking_lot 0.12.3",
  "prometheus",
@@ -6151,7 +6151,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6171,7 +6171,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6189,7 +6189,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-tests"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "datatest-stable",
  "iota-adapter-latest",
@@ -6210,7 +6210,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-builder"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6260,7 +6260,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -6270,7 +6270,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-config"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6278,7 +6278,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-e2e-tests"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6291,7 +6291,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6329,7 +6329,7 @@ dependencies = [
  "iota-network-stack",
  "iota-package-resolver",
  "iota-rest-api",
- "iota-sdk 1.4.1-beta",
+ "iota-sdk 1.4.1-rc",
  "iota-swarm-config",
  "iota-test-transaction-builder",
  "iota-types",
@@ -6362,7 +6362,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-client"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6375,14 +6375,14 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-headers"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "axum 0.8.4",
 ]
 
 [[package]]
 name = "iota-http"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "axum 0.8.4",
  "bytes",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6465,7 +6465,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer-builder"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6481,7 +6481,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6500,7 +6500,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6555,7 +6555,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -6574,7 +6574,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-tests"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6593,7 +6593,7 @@ dependencies = [
  "iota-open-rpc",
  "iota-open-rpc-macros",
  "iota-protocol-config",
- "iota-sdk 1.4.1-beta",
+ "iota-sdk 1.4.1-rc",
  "iota-simulator",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -6612,7 +6612,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6645,7 +6645,7 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "bip32",
@@ -6666,7 +6666,7 @@ dependencies = [
 
 [[package]]
 name = "iota-kvstore"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "iota-ledger"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6705,7 +6705,7 @@ dependencies = [
 
 [[package]]
 name = "iota-ledger-signer"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6713,7 +6713,7 @@ dependencies = [
  "bip32",
  "clap",
  "iota-ledger",
- "iota-sdk 1.4.1-beta",
+ "iota-sdk 1.4.1-rc",
  "shared-crypto",
  "thiserror 1.0.64",
  "tokio",
@@ -6722,7 +6722,7 @@ dependencies = [
 
 [[package]]
 name = "iota-light-client"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6736,7 +6736,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-package-resolver",
  "iota-rest-api",
- "iota-sdk 1.4.1-beta",
+ "iota-sdk 1.4.1-rc",
  "iota-types",
  "move-core-types",
  "object_store 0.10.2",
@@ -6755,7 +6755,7 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -6765,7 +6765,7 @@ dependencies = [
 
 [[package]]
 name = "iota-mainnet-unlocks"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6777,7 +6777,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metric-checker"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "backoff",
@@ -6798,7 +6798,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6823,7 +6823,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "bin-version",
@@ -6862,7 +6862,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -6883,7 +6883,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-lsp"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "bin-version",
  "clap",
@@ -6916,7 +6916,7 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6928,7 +6928,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -6968,7 +6968,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anemo",
  "bcs",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "iota-node"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7044,7 +7044,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -7080,7 +7080,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-dump"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7096,13 +7096,13 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.4.1-beta",
+ "iota-sdk 1.4.1-rc",
  "iota-types",
  "move-core-types",
  "move-package",
@@ -7112,7 +7112,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7133,7 +7133,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "clap",
  "insta",
@@ -7158,7 +7158,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7167,7 +7167,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proxy"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7182,7 +7182,7 @@ dependencies = [
  "hex",
  "hyper 1.4.1",
  "iota-metrics",
- "iota-sdk 1.4.1-beta",
+ "iota-sdk 1.4.1-rc",
  "iota-tls",
  "iota-types",
  "itertools 0.13.0",
@@ -7210,7 +7210,7 @@ dependencies = [
 
 [[package]]
 name = "iota-replay"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7226,7 +7226,7 @@ dependencies = [
  "iota-json-rpc-api",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.4.1-beta",
+ "iota-sdk 1.4.1-rc",
  "iota-transaction-checks",
  "iota-types",
  "jsonrpsee",
@@ -7255,7 +7255,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7284,7 +7284,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-kv"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -7311,7 +7311,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rosetta"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7328,7 +7328,7 @@ dependencies = [
  "iota-metrics",
  "iota-move-build",
  "iota-node",
- "iota-sdk 1.4.1-beta",
+ "iota-sdk 1.4.1-rc",
  "iota-swarm-config",
  "iota-types",
  "move-core-types",
@@ -7352,7 +7352,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rpc-loadgen"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7362,7 +7362,7 @@ dependencies = [
  "futures",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 1.4.1-beta",
+ "iota-sdk 1.4.1-rc",
  "iota-types",
  "itertools 0.13.0",
  "serde",
@@ -7437,7 +7437,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7476,7 +7476,7 @@ dependencies = [
 
 [[package]]
 name = "iota-simulator"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7498,7 +7498,7 @@ dependencies = [
 
 [[package]]
 name = "iota-single-node-benchmark"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7532,7 +7532,7 @@ dependencies = [
 
 [[package]]
 name = "iota-snapshot"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7559,7 +7559,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "colored",
@@ -7569,7 +7569,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 1.4.1-beta",
+ "iota-sdk 1.4.1-rc",
  "iota-test-transaction-builder",
  "iota-types",
  "move-binary-format",
@@ -7591,7 +7591,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation-service"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7606,7 +7606,7 @@ dependencies = [
  "iota-move",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 1.4.1-beta",
+ "iota-sdk 1.4.1-rc",
  "iota-source-validation",
  "move-core-types",
  "move-package",
@@ -7627,7 +7627,7 @@ dependencies = [
 
 [[package]]
 name = "iota-storage"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7678,7 +7678,7 @@ dependencies = [
 
 [[package]]
 name = "iota-surfer"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "bcs",
  "clap",
@@ -7706,7 +7706,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "futures",
@@ -7733,7 +7733,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm-config"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -7761,7 +7761,7 @@ dependencies = [
 
 [[package]]
 name = "iota-synthetic-ingestion"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7778,12 +7778,12 @@ dependencies = [
 
 [[package]]
 name = "iota-test-transaction-builder"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "bcs",
  "iota-genesis-builder",
  "iota-move-build",
- "iota-sdk 1.4.1-beta",
+ "iota-sdk 1.4.1-rc",
  "iota-types",
  "move-core-types",
  "shared-crypto",
@@ -7791,7 +7791,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7813,7 +7813,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tool"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -7835,7 +7835,7 @@ dependencies = [
  "iota-package-dump",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.4.1-beta",
+ "iota-sdk 1.4.1-rc",
  "iota-snapshot",
  "iota-storage",
  "iota-types",
@@ -7858,7 +7858,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7874,7 +7874,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-checks"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "fastcrypto-zkp",
  "iota-config",
@@ -7887,7 +7887,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transactional-test-runner"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7932,7 +7932,7 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8006,7 +8006,7 @@ dependencies = [
 
 [[package]]
 name = "iota-upgrade-compatibility-transactional-tests"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "datatest-stable",
@@ -8034,7 +8034,7 @@ dependencies = [
 
 [[package]]
 name = "iota-verifier-transactional-tests"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -11299,7 +11299,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -13068,7 +13068,7 @@ dependencies = [
 
 [[package]]
 name = "shared-crypto"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "bcs",
  "eyre",
@@ -13193,7 +13193,7 @@ dependencies = [
 
 [[package]]
 name = "simulacrum"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -13846,7 +13846,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry-subscribers"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -13933,7 +13933,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-cluster"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "anyhow",
  "fastcrypto-zkp",
@@ -13949,7 +13949,7 @@ dependencies = [
  "iota-metrics",
  "iota-node",
  "iota-protocol-config",
- "iota-sdk 1.4.1-beta",
+ "iota-sdk 1.4.1-rc",
  "iota-simulator",
  "iota-swarm",
  "iota-swarm-config",
@@ -14766,7 +14766,7 @@ dependencies = [
 
 [[package]]
 name = "transaction-fuzzer"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "iota-core",
  "iota-move-build",
@@ -14838,7 +14838,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "async-trait",
  "bcs",
@@ -14869,7 +14869,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-derive"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -14879,7 +14879,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "serde",
  "thiserror 1.0.64",
@@ -14887,7 +14887,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-workspace-hack"
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 dependencies = [
  "libc",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by iota-core, iota-faucet, iota-node, iota-tools, iota-sdk, iota-move-build, and iota crates.
-version = "1.4.1-beta"
+version = "1.4.1-rc"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/iotaledger/iota/main/LICENSE"
     },
-    "version": "1.4.1-beta"
+    "version": "1.4.1-rc"
   },
   "methods": [
     {


### PR DESCRIPTION
Bump `iota` to `v1.4.1-rc` in preparation for `testnet` release.
