### PR TITLE
upstream(core): Receive N previously-processed consensus commits at startup

### DIFF
--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -11,7 +11,7 @@ use std::{
 
 use arc_swap::ArcSwap;
 use consensus_config::Committee as ConsensusCommittee;
-use consensus_core::CommitConsumerMonitor;
+use consensus_core::{CommitConsumerMonitor, CommitIndex};
 use iota_macros::{fail_point, fail_point_if};
 use iota_metrics::{monitored_mpsc::UnboundedReceiver, monitored_scope, spawn_monitored_task};
 use iota_types::{
@@ -174,6 +174,17 @@ impl<C> ConsensusHandler<C> {
 }
 
 impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
+    /// Called during startup to allow us to observe commits we previously
+    /// processed, for crash recovery. Any state computed here must be a
+    /// pure function of the commits observed, it cannot depend on any state
+    /// recorded in the epoch db.
+    fn handle_prior_consensus_commit(&mut self, consensus_commit: impl ConsensusOutputAPI) {
+        // TODO: this will be used to recover state computed from previous commits at
+        // startup.
+        let round = consensus_commit.leader_round();
+        info!("Ignoring prior consensus commit for round {:?}", round);
+    }
+
     #[instrument(level = "debug", skip_all)]
     async fn handle_consensus_output(&mut self, consensus_output: impl ConsensusOutputAPI) {
         // This may block until one of two conditions happens:
@@ -441,6 +452,7 @@ pub struct MysticetiConsensusHandler {
 
 impl MysticetiConsensusHandler {
     pub fn new(
+        last_processed_commit_at_startup: CommitIndex,
         mut consensus_handler: ConsensusHandler<CheckpointService>,
         mut receiver: UnboundedReceiver<consensus_core::CommittedSubDag>,
         commit_consumer_monitor: Arc<CommitConsumerMonitor>,
@@ -450,10 +462,14 @@ impl MysticetiConsensusHandler {
             // backpressure.
             while let Some(consensus_output) = receiver.recv().await {
                 let commit_index = consensus_output.commit_ref.index;
-                consensus_handler
-                    .handle_consensus_output(consensus_output)
-                    .await;
-                commit_consumer_monitor.set_highest_handled_commit(commit_index);
+                if commit_index <= last_processed_commit_at_startup {
+                    consensus_handler.handle_prior_consensus_commit(consensus_output);
+                } else {
+                    consensus_handler
+                        .handle_consensus_output(consensus_output)
+                        .await;
+                    commit_consumer_monitor.set_highest_handled_commit(commit_index);
+                }
             }
         });
         Self {

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -178,7 +178,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
     /// processed, for crash recovery. Any state computed here must be a
     /// pure function of the commits observed, it cannot depend on any state
     /// recorded in the epoch db.
-    fn handle_prior_consensus_commit(&mut self, consensus_commit: impl ConsensusOutputAPI) {
+    fn handle_prior_consensus_output(&mut self, consensus_commit: impl ConsensusOutputAPI) {
         // TODO: this will be used to recover state computed from previous commits at
         // startup.
         let round = consensus_commit.leader_round();
@@ -463,7 +463,7 @@ impl MysticetiConsensusHandler {
             while let Some(consensus_output) = receiver.recv().await {
                 let commit_index = consensus_output.commit_ref.index;
                 if commit_index <= last_processed_commit_at_startup {
-                    consensus_handler.handle_prior_consensus_commit(consensus_output);
+                    consensus_handler.handle_prior_consensus_output(consensus_output);
                 } else {
                     consensus_handler
                         .handle_consensus_output(consensus_output)

--- a/crates/iota-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/iota-core/src/consensus_manager/mysticeti_manager.rs
@@ -149,10 +149,10 @@ impl ConsensusManagerTrait for MysticetiManager {
         let (commit_sender, commit_receiver) = unbounded_channel("consensus_output");
 
         let consensus_handler = consensus_handler_initializer.new_consensus_handler();
-        let consumer = CommitConsumer::new(
-            commit_sender,
-            consensus_handler.last_processed_subdag_index() as CommitIndex,
-        );
+        let num_prior_commits = protocol_config.consensus_num_requested_prior_commits_at_startup();
+        let last_processed_commit = consensus_handler.last_processed_subdag_index() as CommitIndex;
+        let starting_commit = last_processed_commit.saturating_sub(num_prior_commits);
+        let consumer = CommitConsumer::new(commit_sender, starting_commit);
         let monitor = consumer.monitor();
 
         // If there is a previous consumer monitor, it indicates that the consensus
@@ -210,7 +210,12 @@ impl ConsensusManagerTrait for MysticetiManager {
         self.client.set(client);
 
         // spin up the new mysticeti consensus handler to listen for committed sub dags
-        let handler = MysticetiConsensusHandler::new(consensus_handler, commit_receiver, monitor);
+        let handler = MysticetiConsensusHandler::new(
+            last_processed_commit,
+            consensus_handler,
+            commit_receiver,
+            monitor,
+        );
 
         let mut consensus_handler = self.consensus_handler.lock().await;
         *consensus_handler = Some(handler);

--- a/crates/iota-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/iota-core/src/consensus_manager/mysticeti_manager.rs
@@ -149,6 +149,7 @@ impl ConsensusManagerTrait for MysticetiManager {
         let (commit_sender, commit_receiver) = unbounded_channel("consensus_output");
 
         let consensus_handler = consensus_handler_initializer.new_consensus_handler();
+
         let num_prior_commits = protocol_config.consensus_num_requested_prior_commits_at_startup();
         let last_processed_commit = consensus_handler.last_processed_subdag_index() as CommitIndex;
         let starting_commit = last_processed_commit.saturating_sub(num_prior_commits);

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -1315,6 +1315,12 @@ impl ProtocolConfig {
     pub fn additional_multisig_checks(&self) -> bool {
         self.feature_flags.additional_multisig_checks
     }
+
+    pub fn consensus_num_requested_prior_commits_at_startup(&self) -> u32 {
+        // TODO: this will eventually be the max of some number of other
+        // parameters.
+        0
+    }
 }
 
 #[cfg(not(msim))]


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.43.1, v1.44.3)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/efd3e7e374947460cb423a219d832d8a041b15b8

NOTE: The upstream commit is based on changes of fastpath that we didn't port. So the changes are a bit different from upstream.


## Links to any relevant issues
Close #6586 
Part of #5727 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
