### PR TITLE
refactor(indexer): optimize indexes on optimistic tables

### DIFF
--- a/crates/iota-indexer/migrations/pg/2025-05-29-072412_insertion-order-revisited/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-05-29-072412_insertion-order-revisited/down.sql
@@ -9,21 +9,242 @@ ALTER SEQUENCE tx_insertion_order_seq OWNED BY tx_insertion_order.insertion_orde
 SELECT setval('tx_insertion_order_seq', (SELECT MAX(tx_sequence_number) FROM tx_digests));
 CREATE UNIQUE INDEX tx_insertion_order_insertion_order ON tx_insertion_order (insertion_order);
 
-ALTER TABLE optimistic_transactions                 RENAME sequence_number TO insertion_order;
-ALTER TABLE optimistic_tx_senders                   RENAME sequence_number TO tx_insertion_order;
-ALTER TABLE optimistic_tx_recipients                RENAME sequence_number TO tx_insertion_order;
-ALTER TABLE optimistic_tx_input_objects             RENAME sequence_number TO tx_insertion_order;
-ALTER TABLE optimistic_tx_changed_objects           RENAME sequence_number TO tx_insertion_order;
-ALTER TABLE optimistic_tx_calls_pkg                 RENAME sequence_number TO tx_insertion_order;
-ALTER TABLE optimistic_tx_calls_mod                 RENAME sequence_number TO tx_insertion_order;
-ALTER TABLE optimistic_tx_calls_fun                 RENAME sequence_number TO tx_insertion_order;
-ALTER TABLE optimistic_tx_kinds                     RENAME sequence_number TO tx_insertion_order;
+DROP TABLE IF EXISTS optimistic_tx_senders;
+DROP TABLE IF EXISTS optimistic_tx_recipients;
+DROP TABLE IF EXISTS optimistic_tx_input_objects;
+DROP TABLE IF EXISTS optimistic_tx_changed_objects;
+DROP TABLE IF EXISTS optimistic_tx_calls_pkg;
+DROP TABLE IF EXISTS optimistic_tx_calls_mod;
+DROP TABLE IF EXISTS optimistic_tx_calls_fun;
+DROP TABLE IF EXISTS optimistic_tx_kinds;
 
-ALTER TABLE optimistic_events                       RENAME sequence_number TO tx_insertion_order;
-ALTER TABLE optimistic_event_emit_package           RENAME sequence_number TO tx_insertion_order;
-ALTER TABLE optimistic_event_emit_module            RENAME sequence_number TO tx_insertion_order;
-ALTER TABLE optimistic_event_struct_package         RENAME sequence_number TO tx_insertion_order;
-ALTER TABLE optimistic_event_struct_module          RENAME sequence_number TO tx_insertion_order;
-ALTER TABLE optimistic_event_struct_name            RENAME sequence_number TO tx_insertion_order;
-ALTER TABLE optimistic_event_struct_instantiation   RENAME sequence_number TO tx_insertion_order;
-ALTER TABLE optimistic_event_senders                RENAME sequence_number TO tx_insertion_order;
+DROP TABLE IF EXISTS optimistic_event_emit_package;
+DROP TABLE IF EXISTS optimistic_event_emit_module;
+DROP TABLE IF EXISTS optimistic_event_struct_package;
+DROP TABLE IF EXISTS optimistic_event_struct_module;
+DROP TABLE IF EXISTS optimistic_event_struct_name;
+DROP TABLE IF EXISTS optimistic_event_struct_instantiation;
+DROP TABLE IF EXISTS optimistic_event_senders;
+DROP TABLE IF EXISTS optimistic_events;
+
+DROP TABLE IF EXISTS optimistic_transactions;
+
+-- Main table storing data about optimistically indexed transactions
+-- (transactions that were executed by the indexer, and indexed without waiting for them to be checkpointed).
+-- Equivalent of `transactions` table.
+CREATE TABLE optimistic_transactions (
+    insertion_order             BIGINT       PRIMARY KEY,
+    transaction_digest          bytea        NOT NULL,
+    -- bcs serialized SenderSignedData bytes
+    raw_transaction             bytea        NOT NULL,
+    -- bcs serialized TransactionEffects bytes
+    raw_effects                 bytea        NOT NULL,
+    -- array of bcs serialized IndexedObjectChange bytes
+    object_changes              bytea[]      NOT NULL,
+    -- array of bcs serialized BalanceChange bytes
+    balance_changes             bytea[]      NOT NULL,
+    -- array of bcs serialized StoredEvent bytes
+    events                      bytea[]      NOT NULL,
+    -- SystemTransaction/ProgrammableTransaction. See types.rs
+    transaction_kind            smallint     NOT NULL,
+    -- number of successful commands in this transaction, bound by number of command
+    -- in a programmable transaction.
+    success_command_count       smallint     NOT NULL
+);
+
+-- Lookup table to search for optimistic transactions by sender address.
+-- Equivalent of `tx_senders` table.
+CREATE TABLE optimistic_tx_senders (
+    tx_insertion_order          BIGINT       REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    sender                      BYTEA        NOT NULL,
+    PRIMARY KEY(sender, tx_insertion_order)
+);
+
+-- Lookup table to search for optimistic transactions by recipient address.
+-- Equivalent of `tx_recipients` table.
+CREATE TABLE optimistic_tx_recipients (
+    tx_insertion_order          BIGINT       REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    recipient                   BYTEA        NOT NULL,
+    sender                      BYTEA        NOT NULL,
+    PRIMARY KEY(recipient, tx_insertion_order)
+);
+CREATE INDEX optimistic_tx_recipients_sender ON optimistic_tx_recipients (sender, recipient, tx_insertion_order);
+
+-- Lookup table to search for optimistic transactions by transaction input.
+-- Equivalent of `tx_input_objects` table.
+CREATE TABLE optimistic_tx_input_objects (
+    tx_insertion_order          BIGINT       REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    object_id                   BYTEA        NOT NULL,
+    sender                      BYTEA        NOT NULL,
+    PRIMARY KEY(object_id, tx_insertion_order)
+);
+CREATE INDEX optimistic_tx_input_objects_tx_insertion_order_index ON optimistic_tx_input_objects (tx_insertion_order);
+CREATE INDEX optimistic_tx_input_objects_sender ON optimistic_tx_input_objects (sender, object_id, tx_insertion_order);
+
+-- Lookup table to search for optimistic transactions by objects modified by transaction.
+-- Equivalent of `tx_changed_objects` table.
+CREATE TABLE optimistic_tx_changed_objects (
+    tx_insertion_order          BIGINT       REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    object_id                   BYTEA        NOT NULL,
+    sender                      BYTEA        NOT NULL,
+    PRIMARY KEY(object_id, tx_insertion_order)
+);
+CREATE INDEX optimistic_tx_changed_objects_tx_insertion_order_index ON optimistic_tx_changed_objects (tx_insertion_order);
+CREATE INDEX optimistic_tx_changed_objects_sender ON optimistic_tx_changed_objects (sender, object_id, tx_insertion_order);
+
+-- Lookup table to search for optimistic transactions by packages (that contain functions called in given tx).
+-- Equivalent of `tx_calls_pkg` table.
+CREATE TABLE optimistic_tx_calls_pkg (
+    tx_insertion_order          BIGINT       REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    package                     BYTEA        NOT NULL,
+    sender                      BYTEA        NOT NULL,
+    PRIMARY KEY(package, tx_insertion_order)
+);
+CREATE INDEX optimistic_tx_calls_pkg_sender ON optimistic_tx_calls_pkg (sender, package, tx_insertion_order);
+
+-- Lookup table to search for optimistic transactions by modules (that contain functions called in given tx).
+-- Equivalent of `tx_calls_mod` table.
+CREATE TABLE optimistic_tx_calls_mod (
+    tx_insertion_order          BIGINT       REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    package                     BYTEA        NOT NULL,
+    module                      TEXT         NOT NULL,
+    sender                      BYTEA        NOT NULL,
+    PRIMARY KEY(package, module, tx_insertion_order)
+);
+CREATE INDEX optimistic_tx_calls_mod_sender ON optimistic_tx_calls_mod (sender, package, module, tx_insertion_order);
+
+-- Lookup table to search for optimistic transactions by called functions.
+-- Equivalent of `tx_calls_fun` table.
+CREATE TABLE optimistic_tx_calls_fun (
+    tx_insertion_order          BIGINT       REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    package                     BYTEA        NOT NULL,
+    module                      TEXT         NOT NULL,
+    func                        TEXT         NOT NULL,
+    sender                      BYTEA        NOT NULL,
+    PRIMARY KEY(package, module, func, tx_insertion_order)
+);
+CREATE INDEX optimistic_tx_calls_fun_sender ON optimistic_tx_calls_fun (sender, package, module, func, tx_insertion_order);
+
+-- Lookup table to search for optimistic transactions by transaction kind (ptb or system)
+-- Equivalent of `tx_kinds` table.
+CREATE TABLE optimistic_tx_kinds (
+    tx_insertion_order          BIGINT       REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    tx_kind                     SMALLINT     NOT NULL,
+    PRIMARY KEY(tx_kind, tx_insertion_order)
+);
+
+
+-- Main table storing data about optimistically indexed events
+-- (events produced by transactions that were executed by the indexer,
+-- and indexed without waiting for the transaction to be checkpointed).
+-- Equivalent of `events` table.
+CREATE TABLE optimistic_events
+(
+    tx_insertion_order          BIGINT       REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    event_sequence_number       BIGINT       NOT NULL,
+    transaction_digest          bytea        NOT NULL,
+    -- array of IotaAddress in bytes. All signers of the transaction.
+    senders                     bytea[]      NOT NULL,
+    -- bytes of the entry package ID. Notice that the package and module here
+    -- are the package and module of the function that emitted the event, different
+    -- from the package and module of the event type.
+    package                     bytea        NOT NULL,
+    -- entry module name
+    module                      text         NOT NULL,
+    -- StructTag in Display format, fully qualified including type parameters
+    event_type                  text         NOT NULL,
+    -- bcs of the Event contents (Event.contents)
+    bcs                         BYTEA        NOT NULL,
+    PRIMARY KEY(tx_insertion_order, event_sequence_number)
+);
+CREATE INDEX optimistic_events_package ON optimistic_events (package, tx_insertion_order, event_sequence_number);
+CREATE INDEX optimistic_events_package_module ON optimistic_events (package, module, tx_insertion_order, event_sequence_number);
+CREATE INDEX optimistic_events_event_type ON optimistic_events (event_type text_pattern_ops, tx_insertion_order, event_sequence_number);
+
+-- Lookup table to search for optimistic events by emitting package address.
+-- Equivalent of `event_emit_package` table.
+CREATE TABLE optimistic_event_emit_package
+(
+    package                     BYTEA   NOT NULL,
+    tx_insertion_order          BIGINT  REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    event_sequence_number       BIGINT  NOT NULL,
+    sender                      BYTEA   NOT NULL,
+    PRIMARY KEY(package, tx_insertion_order, event_sequence_number)
+);
+CREATE INDEX optimistic_event_emit_package_sender ON optimistic_event_emit_package (sender, package, tx_insertion_order, event_sequence_number);
+
+-- Lookup table to search for optimistic events by emitting module name.
+-- Equivalent of `event_emit_module` table.
+CREATE TABLE optimistic_event_emit_module
+(
+    package                     BYTEA   NOT NULL,
+    module                      TEXT    NOT NULL,
+    tx_insertion_order          BIGINT  REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    event_sequence_number       BIGINT  NOT NULL,
+    sender                      BYTEA   NOT NULL,
+    PRIMARY KEY(package, module, tx_insertion_order, event_sequence_number)
+);
+CREATE INDEX optimistic_event_emit_module_sender ON optimistic_event_emit_module (sender, package, module, tx_insertion_order, event_sequence_number);
+
+-- Lookup table to search for optimistic events by package address of emitted type.
+-- Equivalent of `event_struct_package` table.
+CREATE TABLE optimistic_event_struct_package
+(
+    package                     BYTEA   NOT NULL,
+    tx_insertion_order          BIGINT  REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    event_sequence_number       BIGINT  NOT NULL,
+    sender                      BYTEA   NOT NULL,
+    PRIMARY KEY(package, tx_insertion_order, event_sequence_number)
+);
+CREATE INDEX optimistic_event_struct_package_sender ON optimistic_event_struct_package (sender, package, tx_insertion_order, event_sequence_number);
+
+-- Lookup table to search for optimistic events by module name of emitted type.
+-- Equivalent of `event_struct_module` table.
+CREATE TABLE optimistic_event_struct_module
+(
+    package                     BYTEA   NOT NULL,
+    module                      TEXT    NOT NULL,
+    tx_insertion_order          BIGINT  REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    event_sequence_number       BIGINT  NOT NULL,
+    sender                      BYTEA   NOT NULL,
+    PRIMARY KEY(package, module, tx_insertion_order, event_sequence_number)
+);
+CREATE INDEX optimistic_event_struct_module_sender ON optimistic_event_struct_module (sender, package, module, tx_insertion_order, event_sequence_number);
+
+-- Lookup table to search for optimistic events by emitted type name.
+-- Equivalent of `event_struct_name` table.
+CREATE TABLE optimistic_event_struct_name
+(
+    package                     BYTEA   NOT NULL,
+    module                      TEXT    NOT NULL,
+    type_name                   TEXT    NOT NULL,
+    tx_insertion_order          BIGINT  REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    event_sequence_number       BIGINT  NOT NULL,
+    sender                      BYTEA   NOT NULL,
+    PRIMARY KEY(package, module, type_name, tx_insertion_order, event_sequence_number)
+);
+CREATE INDEX optimistic_event_struct_name_sender ON optimistic_event_struct_name (sender, package, module, type_name, tx_insertion_order, event_sequence_number);
+
+-- Lookup table to search for optimistic events by emitted type name with type parameters.
+-- Equivalent of `event_struct_instantiation` table.
+CREATE TABLE optimistic_event_struct_instantiation
+(
+    package                     BYTEA   NOT NULL,
+    module                      TEXT    NOT NULL,
+    type_instantiation          TEXT    NOT NULL,
+    tx_insertion_order          BIGINT  REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    event_sequence_number       BIGINT  NOT NULL,
+    sender                      BYTEA   NOT NULL,
+    PRIMARY KEY(package, module, type_instantiation, tx_insertion_order, event_sequence_number)
+);
+CREATE INDEX optimistic_event_struct_instantiation_sender ON optimistic_event_struct_instantiation (sender, package, module, type_instantiation, tx_insertion_order, event_sequence_number);
+
+-- Lookup table to search for optimistic events by event sender address
+-- Equivalent of `event_senders` table.
+CREATE TABLE optimistic_event_senders
+(
+    sender                      BYTEA   NOT NULL,
+    tx_insertion_order          BIGINT  REFERENCES optimistic_transactions(insertion_order) ON DELETE CASCADE,
+    event_sequence_number       BIGINT  NOT NULL,
+    PRIMARY KEY(sender, tx_insertion_order, event_sequence_number)
+);

--- a/crates/iota-indexer/migrations/pg/2025-05-29-072412_insertion-order-revisited/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-05-29-072412_insertion-order-revisited/up.sql
@@ -25,21 +25,146 @@ CREATE TABLE tx_global_order (
 CREATE UNIQUE INDEX tx_global_order_seq_digest ON tx_global_order (global_sequence_number, optimistic_sequence_number);
 CREATE UNIQUE INDEX tx_global_order_chk_tx_seq_num ON tx_global_order (chk_tx_sequence_number);
 
-ALTER TABLE optimistic_transactions                 RENAME insertion_order TO sequence_number;
-ALTER TABLE optimistic_tx_senders                   RENAME tx_insertion_order TO sequence_number;
-ALTER TABLE optimistic_tx_recipients                RENAME tx_insertion_order TO sequence_number;
-ALTER TABLE optimistic_tx_input_objects             RENAME tx_insertion_order TO sequence_number;
-ALTER TABLE optimistic_tx_changed_objects           RENAME tx_insertion_order TO sequence_number;
-ALTER TABLE optimistic_tx_calls_pkg                 RENAME tx_insertion_order TO sequence_number;
-ALTER TABLE optimistic_tx_calls_mod                 RENAME tx_insertion_order TO sequence_number;
-ALTER TABLE optimistic_tx_calls_fun                 RENAME tx_insertion_order TO sequence_number;
-ALTER TABLE optimistic_tx_kinds                     RENAME tx_insertion_order TO sequence_number;
+ALTER TABLE optimistic_transactions                 RENAME insertion_order TO optimistic_sequence_number;
+ALTER TABLE optimistic_tx_senders                   RENAME tx_insertion_order TO optimistic_sequence_number;
+ALTER TABLE optimistic_tx_recipients                RENAME tx_insertion_order TO optimistic_sequence_number;
+ALTER TABLE optimistic_tx_input_objects             RENAME tx_insertion_order TO optimistic_sequence_number;
+ALTER TABLE optimistic_tx_changed_objects           RENAME tx_insertion_order TO optimistic_sequence_number;
+ALTER TABLE optimistic_tx_calls_pkg                 RENAME tx_insertion_order TO optimistic_sequence_number;
+ALTER TABLE optimistic_tx_calls_mod                 RENAME tx_insertion_order TO optimistic_sequence_number;
+ALTER TABLE optimistic_tx_calls_fun                 RENAME tx_insertion_order TO optimistic_sequence_number;
+ALTER TABLE optimistic_tx_kinds                     RENAME tx_insertion_order TO optimistic_sequence_number;
 
-ALTER TABLE optimistic_events                       RENAME tx_insertion_order TO sequence_number;
-ALTER TABLE optimistic_event_emit_package           RENAME tx_insertion_order TO sequence_number;
-ALTER TABLE optimistic_event_emit_module            RENAME tx_insertion_order TO sequence_number;
-ALTER TABLE optimistic_event_struct_package         RENAME tx_insertion_order TO sequence_number;
-ALTER TABLE optimistic_event_struct_module          RENAME tx_insertion_order TO sequence_number;
-ALTER TABLE optimistic_event_struct_name            RENAME tx_insertion_order TO sequence_number;
-ALTER TABLE optimistic_event_struct_instantiation   RENAME tx_insertion_order TO sequence_number;
-ALTER TABLE optimistic_event_senders                RENAME tx_insertion_order TO sequence_number;
+ALTER TABLE optimistic_events                       RENAME tx_insertion_order TO optimistic_sequence_number;
+ALTER TABLE optimistic_event_emit_package           RENAME tx_insertion_order TO optimistic_sequence_number;
+ALTER TABLE optimistic_event_emit_module            RENAME tx_insertion_order TO optimistic_sequence_number;
+ALTER TABLE optimistic_event_struct_package         RENAME tx_insertion_order TO optimistic_sequence_number;
+ALTER TABLE optimistic_event_struct_module          RENAME tx_insertion_order TO optimistic_sequence_number;
+ALTER TABLE optimistic_event_struct_name            RENAME tx_insertion_order TO optimistic_sequence_number;
+ALTER TABLE optimistic_event_struct_instantiation   RENAME tx_insertion_order TO optimistic_sequence_number;
+ALTER TABLE optimistic_event_senders                RENAME tx_insertion_order TO optimistic_sequence_number;
+
+ALTER TABLE optimistic_transactions                 ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
+ALTER TABLE optimistic_tx_senders                   ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
+ALTER TABLE optimistic_tx_recipients                ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
+ALTER TABLE optimistic_tx_input_objects             ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
+ALTER TABLE optimistic_tx_changed_objects           ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
+ALTER TABLE optimistic_tx_calls_pkg                 ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
+ALTER TABLE optimistic_tx_calls_mod                 ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
+ALTER TABLE optimistic_tx_calls_fun                 ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
+ALTER TABLE optimistic_tx_kinds                     ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
+
+ALTER TABLE optimistic_events                       ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
+ALTER TABLE optimistic_event_emit_package           ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
+ALTER TABLE optimistic_event_emit_module            ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
+ALTER TABLE optimistic_event_struct_package         ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
+ALTER TABLE optimistic_event_struct_module          ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
+ALTER TABLE optimistic_event_struct_name            ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
+ALTER TABLE optimistic_event_struct_instantiation   ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
+ALTER TABLE optimistic_event_senders                ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
+
+ALTER TABLE optimistic_tx_senders                  DROP CONSTRAINT optimistic_tx_senders_pkey;
+ALTER TABLE optimistic_tx_recipients               DROP CONSTRAINT optimistic_tx_recipients_pkey;
+ALTER TABLE optimistic_tx_input_objects            DROP CONSTRAINT optimistic_tx_input_objects_pkey;
+ALTER TABLE optimistic_tx_changed_objects          DROP CONSTRAINT optimistic_tx_changed_objects_pkey;
+ALTER TABLE optimistic_tx_calls_pkg                DROP CONSTRAINT optimistic_tx_calls_pkg_pkey;
+ALTER TABLE optimistic_tx_calls_mod                DROP CONSTRAINT optimistic_tx_calls_mod_pkey;
+ALTER TABLE optimistic_tx_calls_fun                DROP CONSTRAINT optimistic_tx_calls_fun_pkey;
+ALTER TABLE optimistic_tx_kinds                    DROP CONSTRAINT optimistic_tx_kinds_pkey;
+
+ALTER TABLE optimistic_events                      DROP CONSTRAINT optimistic_events_pkey;
+ALTER TABLE optimistic_event_emit_package          DROP CONSTRAINT optimistic_event_emit_package_pkey;
+ALTER TABLE optimistic_event_emit_module           DROP CONSTRAINT optimistic_event_emit_module_pkey;
+ALTER TABLE optimistic_event_struct_package        DROP CONSTRAINT optimistic_event_struct_package_pkey;
+ALTER TABLE optimistic_event_struct_module         DROP CONSTRAINT optimistic_event_struct_module_pkey;
+ALTER TABLE optimistic_event_struct_name           DROP CONSTRAINT optimistic_event_struct_name_pkey;
+ALTER TABLE optimistic_event_struct_instantiation  DROP CONSTRAINT optimistic_event_struct_instantiation_pkey;
+ALTER TABLE optimistic_event_senders               DROP CONSTRAINT optimistic_event_senders_pkey;
+
+ALTER TABLE optimistic_tx_senders                  DROP CONSTRAINT optimistic_tx_senders_tx_insertion_order_fkey;
+ALTER TABLE optimistic_tx_recipients               DROP CONSTRAINT optimistic_tx_recipients_tx_insertion_order_fkey;
+ALTER TABLE optimistic_tx_input_objects            DROP CONSTRAINT optimistic_tx_input_objects_tx_insertion_order_fkey;
+ALTER TABLE optimistic_tx_changed_objects          DROP CONSTRAINT optimistic_tx_changed_objects_tx_insertion_order_fkey;
+ALTER TABLE optimistic_tx_calls_pkg                DROP CONSTRAINT optimistic_tx_calls_pkg_tx_insertion_order_fkey;
+ALTER TABLE optimistic_tx_calls_mod                DROP CONSTRAINT optimistic_tx_calls_mod_tx_insertion_order_fkey;
+ALTER TABLE optimistic_tx_calls_fun                DROP CONSTRAINT optimistic_tx_calls_fun_tx_insertion_order_fkey;
+ALTER TABLE optimistic_tx_kinds                    DROP CONSTRAINT optimistic_tx_kinds_tx_insertion_order_fkey;
+
+ALTER TABLE optimistic_events                      DROP CONSTRAINT optimistic_events_tx_insertion_order_fkey;
+ALTER TABLE optimistic_event_emit_package          DROP CONSTRAINT optimistic_event_emit_package_tx_insertion_order_fkey;
+ALTER TABLE optimistic_event_emit_module           DROP CONSTRAINT optimistic_event_emit_module_tx_insertion_order_fkey;
+ALTER TABLE optimistic_event_struct_package        DROP CONSTRAINT optimistic_event_struct_package_tx_insertion_order_fkey;
+ALTER TABLE optimistic_event_struct_module         DROP CONSTRAINT optimistic_event_struct_module_tx_insertion_order_fkey;
+ALTER TABLE optimistic_event_struct_name           DROP CONSTRAINT optimistic_event_struct_name_tx_insertion_order_fkey;
+ALTER TABLE optimistic_event_struct_instantiation  DROP CONSTRAINT optimistic_event_struct_instantiation_tx_insertion_order_fkey;
+ALTER TABLE optimistic_event_senders               DROP CONSTRAINT optimistic_event_senders_tx_insertion_order_fkey;
+
+ALTER TABLE optimistic_transactions                DROP CONSTRAINT optimistic_transactions_pkey;
+
+ALTER TABLE optimistic_transactions                ADD PRIMARY KEY (global_sequence_number, optimistic_sequence_number);
+ALTER TABLE optimistic_tx_senders                  ADD PRIMARY KEY (sender, global_sequence_number, optimistic_sequence_number);
+ALTER TABLE optimistic_tx_recipients               ADD PRIMARY KEY (recipient, global_sequence_number, optimistic_sequence_number);
+ALTER TABLE optimistic_tx_input_objects            ADD PRIMARY KEY (object_id, global_sequence_number, optimistic_sequence_number);
+ALTER TABLE optimistic_tx_changed_objects          ADD PRIMARY KEY (object_id, global_sequence_number, optimistic_sequence_number);
+ALTER TABLE optimistic_tx_calls_pkg                ADD PRIMARY KEY (package, global_sequence_number, optimistic_sequence_number);
+ALTER TABLE optimistic_tx_calls_mod                ADD PRIMARY KEY (package, module, global_sequence_number, optimistic_sequence_number);
+ALTER TABLE optimistic_tx_calls_fun                ADD PRIMARY KEY (package, module, func, global_sequence_number, optimistic_sequence_number);
+ALTER TABLE optimistic_tx_kinds                    ADD PRIMARY KEY (tx_kind, global_sequence_number, optimistic_sequence_number);
+
+ALTER TABLE optimistic_events                      ADD PRIMARY KEY (global_sequence_number, optimistic_sequence_number, event_sequence_number);
+ALTER TABLE optimistic_event_emit_package          ADD PRIMARY KEY (package, global_sequence_number, optimistic_sequence_number, event_sequence_number);
+ALTER TABLE optimistic_event_emit_module           ADD PRIMARY KEY (package, module, global_sequence_number, optimistic_sequence_number, event_sequence_number);
+ALTER TABLE optimistic_event_struct_package        ADD PRIMARY KEY (package, global_sequence_number, optimistic_sequence_number, event_sequence_number);
+ALTER TABLE optimistic_event_struct_module         ADD PRIMARY KEY (package, module, global_sequence_number, optimistic_sequence_number, event_sequence_number);
+ALTER TABLE optimistic_event_struct_name           ADD PRIMARY KEY (package, module, type_name, global_sequence_number, optimistic_sequence_number, event_sequence_number);
+ALTER TABLE optimistic_event_struct_instantiation  ADD PRIMARY KEY (package, module, type_instantiation, global_sequence_number, optimistic_sequence_number, event_sequence_number);
+ALTER TABLE optimistic_event_senders               ADD PRIMARY KEY (sender, global_sequence_number, optimistic_sequence_number, event_sequence_number);
+
+-- optimistic_event_emit_package
+ALTER TABLE optimistic_event_emit_package
+ADD CONSTRAINT optimistic_event_emit_package_fk
+FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+ON DELETE CASCADE;
+
+-- optimistic_event_emit_module
+ALTER TABLE optimistic_event_emit_module
+ADD CONSTRAINT optimistic_event_emit_module_fk
+FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+ON DELETE CASCADE;
+
+-- optimistic_event_sender
+ALTER TABLE optimistic_event_senders
+ADD CONSTRAINT optimistic_event_senders_fk
+FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+ON DELETE CASCADE;
+
+-- optimistic_event_struct_package
+ALTER TABLE optimistic_event_struct_package
+ADD CONSTRAINT optimistic_event_struct_package_fk
+FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+ON DELETE CASCADE;
+
+-- optimistic_event_struct_module
+ALTER TABLE optimistic_event_struct_module
+ADD CONSTRAINT optimistic_event_struct_module_fk
+FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+ON DELETE CASCADE;
+
+-- optimistic_event_struct_name
+ALTER TABLE optimistic_event_struct_name
+ADD CONSTRAINT optimistic_event_struct_name_fk
+FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+ON DELETE CASCADE;
+
+-- optimistic_event_struct_instantiation
+ALTER TABLE optimistic_event_struct_instantiation
+ADD CONSTRAINT optimistic_event_struct_instantiation_fk
+FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+ON DELETE CASCADE;

--- a/crates/iota-indexer/migrations/pg/2025-05-29-072412_insertion-order-revisited/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-05-29-072412_insertion-order-revisited/up.sql
@@ -25,146 +25,315 @@ CREATE TABLE tx_global_order (
 CREATE UNIQUE INDEX tx_global_order_seq_digest ON tx_global_order (global_sequence_number, optimistic_sequence_number);
 CREATE UNIQUE INDEX tx_global_order_chk_tx_seq_num ON tx_global_order (chk_tx_sequence_number);
 
-ALTER TABLE optimistic_transactions                 RENAME insertion_order TO optimistic_sequence_number;
-ALTER TABLE optimistic_tx_senders                   RENAME tx_insertion_order TO optimistic_sequence_number;
-ALTER TABLE optimistic_tx_recipients                RENAME tx_insertion_order TO optimistic_sequence_number;
-ALTER TABLE optimistic_tx_input_objects             RENAME tx_insertion_order TO optimistic_sequence_number;
-ALTER TABLE optimistic_tx_changed_objects           RENAME tx_insertion_order TO optimistic_sequence_number;
-ALTER TABLE optimistic_tx_calls_pkg                 RENAME tx_insertion_order TO optimistic_sequence_number;
-ALTER TABLE optimistic_tx_calls_mod                 RENAME tx_insertion_order TO optimistic_sequence_number;
-ALTER TABLE optimistic_tx_calls_fun                 RENAME tx_insertion_order TO optimistic_sequence_number;
-ALTER TABLE optimistic_tx_kinds                     RENAME tx_insertion_order TO optimistic_sequence_number;
+DROP TABLE IF EXISTS optimistic_tx_senders;
+DROP TABLE IF EXISTS optimistic_tx_recipients;
+DROP TABLE IF EXISTS optimistic_tx_input_objects;
+DROP TABLE IF EXISTS optimistic_tx_changed_objects;
+DROP TABLE IF EXISTS optimistic_tx_calls_pkg;
+DROP TABLE IF EXISTS optimistic_tx_calls_mod;
+DROP TABLE IF EXISTS optimistic_tx_calls_fun;
+DROP TABLE IF EXISTS optimistic_tx_kinds;
 
-ALTER TABLE optimistic_events                       RENAME tx_insertion_order TO optimistic_sequence_number;
-ALTER TABLE optimistic_event_emit_package           RENAME tx_insertion_order TO optimistic_sequence_number;
-ALTER TABLE optimistic_event_emit_module            RENAME tx_insertion_order TO optimistic_sequence_number;
-ALTER TABLE optimistic_event_struct_package         RENAME tx_insertion_order TO optimistic_sequence_number;
-ALTER TABLE optimistic_event_struct_module          RENAME tx_insertion_order TO optimistic_sequence_number;
-ALTER TABLE optimistic_event_struct_name            RENAME tx_insertion_order TO optimistic_sequence_number;
-ALTER TABLE optimistic_event_struct_instantiation   RENAME tx_insertion_order TO optimistic_sequence_number;
-ALTER TABLE optimistic_event_senders                RENAME tx_insertion_order TO optimistic_sequence_number;
+DROP TABLE IF EXISTS optimistic_event_emit_package;
+DROP TABLE IF EXISTS optimistic_event_emit_module;
+DROP TABLE IF EXISTS optimistic_event_struct_package;
+DROP TABLE IF EXISTS optimistic_event_struct_module;
+DROP TABLE IF EXISTS optimistic_event_struct_name;
+DROP TABLE IF EXISTS optimistic_event_struct_instantiation;
+DROP TABLE IF EXISTS optimistic_event_senders;
+DROP TABLE IF EXISTS optimistic_events;
 
-ALTER TABLE optimistic_transactions                 ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
-ALTER TABLE optimistic_tx_senders                   ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
-ALTER TABLE optimistic_tx_recipients                ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
-ALTER TABLE optimistic_tx_input_objects             ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
-ALTER TABLE optimistic_tx_changed_objects           ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
-ALTER TABLE optimistic_tx_calls_pkg                 ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
-ALTER TABLE optimistic_tx_calls_mod                 ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
-ALTER TABLE optimistic_tx_calls_fun                 ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
-ALTER TABLE optimistic_tx_kinds                     ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
+DROP TABLE IF EXISTS optimistic_transactions;
 
-ALTER TABLE optimistic_events                       ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
-ALTER TABLE optimistic_event_emit_package           ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
-ALTER TABLE optimistic_event_emit_module            ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
-ALTER TABLE optimistic_event_struct_package         ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
-ALTER TABLE optimistic_event_struct_module          ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
-ALTER TABLE optimistic_event_struct_name            ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
-ALTER TABLE optimistic_event_struct_instantiation   ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
-ALTER TABLE optimistic_event_senders                ADD COLUMN IF NOT EXISTS global_sequence_number BIGINT NOT NULL;
 
-ALTER TABLE optimistic_tx_senders                  DROP CONSTRAINT optimistic_tx_senders_pkey;
-ALTER TABLE optimistic_tx_recipients               DROP CONSTRAINT optimistic_tx_recipients_pkey;
-ALTER TABLE optimistic_tx_input_objects            DROP CONSTRAINT optimistic_tx_input_objects_pkey;
-ALTER TABLE optimistic_tx_changed_objects          DROP CONSTRAINT optimistic_tx_changed_objects_pkey;
-ALTER TABLE optimistic_tx_calls_pkg                DROP CONSTRAINT optimistic_tx_calls_pkg_pkey;
-ALTER TABLE optimistic_tx_calls_mod                DROP CONSTRAINT optimistic_tx_calls_mod_pkey;
-ALTER TABLE optimistic_tx_calls_fun                DROP CONSTRAINT optimistic_tx_calls_fun_pkey;
-ALTER TABLE optimistic_tx_kinds                    DROP CONSTRAINT optimistic_tx_kinds_pkey;
 
-ALTER TABLE optimistic_events                      DROP CONSTRAINT optimistic_events_pkey;
-ALTER TABLE optimistic_event_emit_package          DROP CONSTRAINT optimistic_event_emit_package_pkey;
-ALTER TABLE optimistic_event_emit_module           DROP CONSTRAINT optimistic_event_emit_module_pkey;
-ALTER TABLE optimistic_event_struct_package        DROP CONSTRAINT optimistic_event_struct_package_pkey;
-ALTER TABLE optimistic_event_struct_module         DROP CONSTRAINT optimistic_event_struct_module_pkey;
-ALTER TABLE optimistic_event_struct_name           DROP CONSTRAINT optimistic_event_struct_name_pkey;
-ALTER TABLE optimistic_event_struct_instantiation  DROP CONSTRAINT optimistic_event_struct_instantiation_pkey;
-ALTER TABLE optimistic_event_senders               DROP CONSTRAINT optimistic_event_senders_pkey;
+-- TRANSACTIONS
 
-ALTER TABLE optimistic_tx_senders                  DROP CONSTRAINT optimistic_tx_senders_tx_insertion_order_fkey;
-ALTER TABLE optimistic_tx_recipients               DROP CONSTRAINT optimistic_tx_recipients_tx_insertion_order_fkey;
-ALTER TABLE optimistic_tx_input_objects            DROP CONSTRAINT optimistic_tx_input_objects_tx_insertion_order_fkey;
-ALTER TABLE optimistic_tx_changed_objects          DROP CONSTRAINT optimistic_tx_changed_objects_tx_insertion_order_fkey;
-ALTER TABLE optimistic_tx_calls_pkg                DROP CONSTRAINT optimistic_tx_calls_pkg_tx_insertion_order_fkey;
-ALTER TABLE optimistic_tx_calls_mod                DROP CONSTRAINT optimistic_tx_calls_mod_tx_insertion_order_fkey;
-ALTER TABLE optimistic_tx_calls_fun                DROP CONSTRAINT optimistic_tx_calls_fun_tx_insertion_order_fkey;
-ALTER TABLE optimistic_tx_kinds                    DROP CONSTRAINT optimistic_tx_kinds_tx_insertion_order_fkey;
+-- Main table storing data about optimistically indexed transactions
+-- (transactions that were executed by the indexer, and indexed without waiting for them to be checkpointed).
+-- Equivalent of `transactions` table.
+CREATE TABLE optimistic_transactions (
+    global_sequence_number BIGINT NOT NULL,
+    optimistic_sequence_number             BIGINT NOT NULL,
+    transaction_digest          bytea        NOT NULL,
+    -- bcs serialized SenderSignedData bytes
+    raw_transaction             bytea        NOT NULL,
+    -- bcs serialized TransactionEffects bytes
+    raw_effects                 bytea        NOT NULL,
+    -- array of bcs serialized IndexedObjectChange bytes
+    object_changes              bytea[]      NOT NULL,
+    -- array of bcs serialized BalanceChange bytes
+    balance_changes             bytea[]      NOT NULL,
+    -- array of bcs serialized StoredEvent bytes
+    events                      bytea[]      NOT NULL,
+    -- SystemTransaction/ProgrammableTransaction. See types.rs
+    transaction_kind            smallint     NOT NULL,
+    -- number of successful commands in this transaction, bound by number of command
+    -- in a programmable transaction.
+    success_command_count       smallint     NOT NULL,
+    PRIMARY KEY(global_sequence_number, optimistic_sequence_number)
+);
 
-ALTER TABLE optimistic_events                      DROP CONSTRAINT optimistic_events_tx_insertion_order_fkey;
-ALTER TABLE optimistic_event_emit_package          DROP CONSTRAINT optimistic_event_emit_package_tx_insertion_order_fkey;
-ALTER TABLE optimistic_event_emit_module           DROP CONSTRAINT optimistic_event_emit_module_tx_insertion_order_fkey;
-ALTER TABLE optimistic_event_struct_package        DROP CONSTRAINT optimistic_event_struct_package_tx_insertion_order_fkey;
-ALTER TABLE optimistic_event_struct_module         DROP CONSTRAINT optimistic_event_struct_module_tx_insertion_order_fkey;
-ALTER TABLE optimistic_event_struct_name           DROP CONSTRAINT optimistic_event_struct_name_tx_insertion_order_fkey;
-ALTER TABLE optimistic_event_struct_instantiation  DROP CONSTRAINT optimistic_event_struct_instantiation_tx_insertion_order_fkey;
-ALTER TABLE optimistic_event_senders               DROP CONSTRAINT optimistic_event_senders_tx_insertion_order_fkey;
+-- Lookup table to search for optimistic transactions by sender address.
+-- Equivalent of `tx_senders` table.
+CREATE TABLE optimistic_tx_senders (
+    global_sequence_number BIGINT NOT NULL,
+    optimistic_sequence_number          BIGINT       NOT NULL,
+    sender                      BYTEA        NOT NULL,
+    PRIMARY KEY(sender, global_sequence_number, optimistic_sequence_number),
+    FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+    REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+    ON DELETE CASCADE
+);
 
-ALTER TABLE optimistic_transactions                DROP CONSTRAINT optimistic_transactions_pkey;
+-- Lookup table to search for optimistic transactions by recipient address.
+-- Equivalent of `tx_recipients` table.
+CREATE TABLE optimistic_tx_recipients (
+    global_sequence_number BIGINT NOT NULL,
+    optimistic_sequence_number          BIGINT       NOT NULL,
+    recipient                   BYTEA        NOT NULL,
+    sender                      BYTEA        NOT NULL,
+    PRIMARY KEY(recipient, global_sequence_number, optimistic_sequence_number),
+    FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+    REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+    ON DELETE CASCADE
+);
+CREATE INDEX optimistic_tx_recipients_sender ON optimistic_tx_recipients (sender, recipient, global_sequence_number, optimistic_sequence_number);
 
-ALTER TABLE optimistic_transactions                ADD PRIMARY KEY (global_sequence_number, optimistic_sequence_number);
-ALTER TABLE optimistic_tx_senders                  ADD PRIMARY KEY (sender, global_sequence_number, optimistic_sequence_number);
-ALTER TABLE optimistic_tx_recipients               ADD PRIMARY KEY (recipient, global_sequence_number, optimistic_sequence_number);
-ALTER TABLE optimistic_tx_input_objects            ADD PRIMARY KEY (object_id, global_sequence_number, optimistic_sequence_number);
-ALTER TABLE optimistic_tx_changed_objects          ADD PRIMARY KEY (object_id, global_sequence_number, optimistic_sequence_number);
-ALTER TABLE optimistic_tx_calls_pkg                ADD PRIMARY KEY (package, global_sequence_number, optimistic_sequence_number);
-ALTER TABLE optimistic_tx_calls_mod                ADD PRIMARY KEY (package, module, global_sequence_number, optimistic_sequence_number);
-ALTER TABLE optimistic_tx_calls_fun                ADD PRIMARY KEY (package, module, func, global_sequence_number, optimistic_sequence_number);
-ALTER TABLE optimistic_tx_kinds                    ADD PRIMARY KEY (tx_kind, global_sequence_number, optimistic_sequence_number);
+-- Lookup table to search for optimistic transactions by transaction input.
+-- Equivalent of `tx_input_objects` table.
+CREATE TABLE optimistic_tx_input_objects (
+    global_sequence_number BIGINT NOT NULL,
+    optimistic_sequence_number          BIGINT       NOT NULL,
+    object_id                   BYTEA        NOT NULL,
+    sender                      BYTEA        NOT NULL,
+    PRIMARY KEY(object_id, global_sequence_number, optimistic_sequence_number),
+    FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+    REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+    ON DELETE CASCADE
+);
+CREATE INDEX optimistic_tx_input_objects_optimistic_sequence_number_index ON optimistic_tx_input_objects (global_sequence_number, optimistic_sequence_number);
+CREATE INDEX optimistic_tx_input_objects_sender ON optimistic_tx_input_objects (sender, object_id, global_sequence_number, optimistic_sequence_number);
 
-ALTER TABLE optimistic_events                      ADD PRIMARY KEY (global_sequence_number, optimistic_sequence_number, event_sequence_number);
-ALTER TABLE optimistic_event_emit_package          ADD PRIMARY KEY (package, global_sequence_number, optimistic_sequence_number, event_sequence_number);
-ALTER TABLE optimistic_event_emit_module           ADD PRIMARY KEY (package, module, global_sequence_number, optimistic_sequence_number, event_sequence_number);
-ALTER TABLE optimistic_event_struct_package        ADD PRIMARY KEY (package, global_sequence_number, optimistic_sequence_number, event_sequence_number);
-ALTER TABLE optimistic_event_struct_module         ADD PRIMARY KEY (package, module, global_sequence_number, optimistic_sequence_number, event_sequence_number);
-ALTER TABLE optimistic_event_struct_name           ADD PRIMARY KEY (package, module, type_name, global_sequence_number, optimistic_sequence_number, event_sequence_number);
-ALTER TABLE optimistic_event_struct_instantiation  ADD PRIMARY KEY (package, module, type_instantiation, global_sequence_number, optimistic_sequence_number, event_sequence_number);
-ALTER TABLE optimistic_event_senders               ADD PRIMARY KEY (sender, global_sequence_number, optimistic_sequence_number, event_sequence_number);
+-- Lookup table to search for optimistic transactions by objects modified by transaction.
+-- Equivalent of `tx_changed_objects` table.
+CREATE TABLE optimistic_tx_changed_objects (
+    global_sequence_number BIGINT NOT NULL,
+    optimistic_sequence_number          BIGINT       NOT NULL,
+    object_id                   BYTEA        NOT NULL,
+    sender                      BYTEA        NOT NULL,
+    PRIMARY KEY(object_id, global_sequence_number, optimistic_sequence_number),
+    FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+    REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+    ON DELETE CASCADE
+);
+CREATE INDEX optimistic_tx_changed_objects_optimistic_sequence_number_index ON optimistic_tx_changed_objects (global_sequence_number, optimistic_sequence_number);
+CREATE INDEX optimistic_tx_changed_objects_sender ON optimistic_tx_changed_objects (sender, object_id, global_sequence_number, optimistic_sequence_number);
 
--- optimistic_event_emit_package
-ALTER TABLE optimistic_event_emit_package
-ADD CONSTRAINT optimistic_event_emit_package_fk
-FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
-REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
-ON DELETE CASCADE;
+-- Lookup table to search for optimistic transactions by packages (that contain functions called in given tx).
+-- Equivalent of `tx_calls_pkg` table.
+CREATE TABLE optimistic_tx_calls_pkg (
+    global_sequence_number BIGINT NOT NULL,
+    optimistic_sequence_number          BIGINT       NOT NULL,
+    package                     BYTEA        NOT NULL,
+    sender                      BYTEA        NOT NULL,
+    PRIMARY KEY(package, global_sequence_number, optimistic_sequence_number),
+    FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+    REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+    ON DELETE CASCADE
+);
+CREATE INDEX optimistic_tx_calls_pkg_sender ON optimistic_tx_calls_pkg (sender, package, global_sequence_number, optimistic_sequence_number);
 
--- optimistic_event_emit_module
-ALTER TABLE optimistic_event_emit_module
-ADD CONSTRAINT optimistic_event_emit_module_fk
-FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
-REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
-ON DELETE CASCADE;
+-- Lookup table to search for optimistic transactions by modules (that contain functions called in given tx).
+-- Equivalent of `tx_calls_mod` table.
+CREATE TABLE optimistic_tx_calls_mod (
+    global_sequence_number BIGINT NOT NULL,
+    optimistic_sequence_number          BIGINT       NOT NULL,
+    package                     BYTEA        NOT NULL,
+    module                      TEXT         NOT NULL,
+    sender                      BYTEA        NOT NULL,
+    PRIMARY KEY(package, module, global_sequence_number, optimistic_sequence_number),
+    FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+    REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+    ON DELETE CASCADE
+);
+CREATE INDEX optimistic_tx_calls_mod_sender ON optimistic_tx_calls_mod (sender, package, module, global_sequence_number, optimistic_sequence_number);
 
--- optimistic_event_sender
-ALTER TABLE optimistic_event_senders
-ADD CONSTRAINT optimistic_event_senders_fk
-FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
-REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
-ON DELETE CASCADE;
+-- Lookup table to search for optimistic transactions by called functions.
+-- Equivalent of `tx_calls_fun` table.
+CREATE TABLE optimistic_tx_calls_fun (
+    global_sequence_number BIGINT NOT NULL,
+    optimistic_sequence_number          BIGINT       NOT NULL,
+    package                     BYTEA        NOT NULL,
+    module                      TEXT         NOT NULL,
+    func                        TEXT         NOT NULL,
+    sender                      BYTEA        NOT NULL,
+    PRIMARY KEY(package, module, func, global_sequence_number, optimistic_sequence_number),
+    FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+    REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+    ON DELETE CASCADE
+);
+CREATE INDEX optimistic_tx_calls_fun_sender ON optimistic_tx_calls_fun (sender, package, module, func, global_sequence_number, optimistic_sequence_number);
 
--- optimistic_event_struct_package
-ALTER TABLE optimistic_event_struct_package
-ADD CONSTRAINT optimistic_event_struct_package_fk
-FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
-REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
-ON DELETE CASCADE;
+-- Lookup table to search for optimistic transactions by transaction kind (ptb or system)
+-- Equivalent of `tx_kinds` table.
+CREATE TABLE optimistic_tx_kinds (
+    global_sequence_number BIGINT NOT NULL,
+    optimistic_sequence_number          BIGINT       NOT NULL,
+    tx_kind                     SMALLINT     NOT NULL,
+    PRIMARY KEY(tx_kind, global_sequence_number, optimistic_sequence_number),
+    FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+    REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+    ON DELETE CASCADE
+);
 
--- optimistic_event_struct_module
-ALTER TABLE optimistic_event_struct_module
-ADD CONSTRAINT optimistic_event_struct_module_fk
-FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
-REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
-ON DELETE CASCADE;
 
--- optimistic_event_struct_name
-ALTER TABLE optimistic_event_struct_name
-ADD CONSTRAINT optimistic_event_struct_name_fk
-FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
-REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
-ON DELETE CASCADE;
 
--- optimistic_event_struct_instantiation
-ALTER TABLE optimistic_event_struct_instantiation
-ADD CONSTRAINT optimistic_event_struct_instantiation_fk
-FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
-REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
-ON DELETE CASCADE;
+-- EVENTS
+
+-- Main table storing data about optimistically indexed events
+-- (events produced by transactions that were executed by the indexer,
+-- and indexed without waiting for the transaction to be checkpointed).
+-- Equivalent of `events` table.
+CREATE TABLE optimistic_events
+(
+    global_sequence_number BIGINT NOT NULL,
+    optimistic_sequence_number          BIGINT       NOT NULL,
+    event_sequence_number       BIGINT       NOT NULL,
+    transaction_digest          bytea        NOT NULL,
+    -- array of IotaAddress in bytes. All signers of the transaction.
+    senders                     bytea[]      NOT NULL,
+    -- bytes of the entry package ID. Notice that the package and module here
+    -- are the package and module of the function that emitted the event, different
+    -- from the package and module of the event type.
+    package                     bytea        NOT NULL,
+    -- entry module name
+    module                      text         NOT NULL,
+    -- StructTag in Display format, fully qualified including type parameters
+    event_type                  text         NOT NULL,
+    -- bcs of the Event contents (Event.contents)
+    bcs                         BYTEA        NOT NULL,
+    PRIMARY KEY(global_sequence_number, optimistic_sequence_number, event_sequence_number),
+    FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+    REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+    ON DELETE CASCADE
+);
+CREATE INDEX optimistic_events_package ON optimistic_events (package, global_sequence_number, optimistic_sequence_number, event_sequence_number);
+CREATE INDEX optimistic_events_package_module ON optimistic_events (package, module, global_sequence_number, optimistic_sequence_number, event_sequence_number);
+CREATE INDEX optimistic_events_event_type ON optimistic_events (event_type text_pattern_ops, global_sequence_number, optimistic_sequence_number, event_sequence_number);
+
+-- Lookup table to search for optimistic events by emitting package address.
+-- Equivalent of `event_emit_package` table.
+CREATE TABLE optimistic_event_emit_package
+(
+    package                     BYTEA   NOT NULL,
+    global_sequence_number BIGINT NOT NULL,
+    optimistic_sequence_number          BIGINT  NOT NULL,
+    event_sequence_number       BIGINT  NOT NULL,
+    sender                      BYTEA   NOT NULL,
+    PRIMARY KEY(package, global_sequence_number, optimistic_sequence_number, event_sequence_number),
+    FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+    REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+    ON DELETE CASCADE
+);
+CREATE INDEX optimistic_event_emit_package_sender ON optimistic_event_emit_package (sender, package, global_sequence_number, optimistic_sequence_number, event_sequence_number);
+
+-- Lookup table to search for optimistic events by emitting module name.
+-- Equivalent of `event_emit_module` table.
+CREATE TABLE optimistic_event_emit_module
+(
+    package                     BYTEA   NOT NULL,
+    module                      TEXT    NOT NULL,
+    global_sequence_number BIGINT NOT NULL,
+    optimistic_sequence_number          BIGINT  NOT NULL,
+    event_sequence_number       BIGINT  NOT NULL,
+    sender                      BYTEA   NOT NULL,
+    PRIMARY KEY(package, module, global_sequence_number, optimistic_sequence_number, event_sequence_number),
+    FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+    REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+    ON DELETE CASCADE
+);
+CREATE INDEX optimistic_event_emit_module_sender ON optimistic_event_emit_module (sender, package, module, global_sequence_number, optimistic_sequence_number, event_sequence_number);
+
+-- Lookup table to search for optimistic events by package address of emitted type.
+-- Equivalent of `event_struct_package` table.
+CREATE TABLE optimistic_event_struct_package
+(
+    package                     BYTEA   NOT NULL,
+    global_sequence_number BIGINT NOT NULL,
+    optimistic_sequence_number          BIGINT  NOT NULL,
+    event_sequence_number       BIGINT  NOT NULL,
+    sender                      BYTEA   NOT NULL,
+    PRIMARY KEY(package, global_sequence_number, optimistic_sequence_number, event_sequence_number),
+    FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+    REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+    ON DELETE CASCADE
+);
+CREATE INDEX optimistic_event_struct_package_sender ON optimistic_event_struct_package (sender, package, global_sequence_number, optimistic_sequence_number, event_sequence_number);
+
+-- Lookup table to search for optimistic events by module name of emitted type.
+-- Equivalent of `event_struct_module` table.
+CREATE TABLE optimistic_event_struct_module
+(
+    package                     BYTEA   NOT NULL,
+    module                      TEXT    NOT NULL,
+    global_sequence_number BIGINT NOT NULL,
+    optimistic_sequence_number          BIGINT  NOT NULL,
+    event_sequence_number       BIGINT  NOT NULL,
+    sender                      BYTEA   NOT NULL,
+    PRIMARY KEY(package, module, global_sequence_number, optimistic_sequence_number, event_sequence_number),
+    FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+    REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+    ON DELETE CASCADE
+);
+CREATE INDEX optimistic_event_struct_module_sender ON optimistic_event_struct_module (sender, package, module, global_sequence_number, optimistic_sequence_number, event_sequence_number);
+
+-- Lookup table to search for optimistic events by emitted type name.
+-- Equivalent of `event_struct_name` table.
+CREATE TABLE optimistic_event_struct_name
+(
+    package                     BYTEA   NOT NULL,
+    module                      TEXT    NOT NULL,
+    type_name                   TEXT    NOT NULL,
+    global_sequence_number BIGINT NOT NULL,
+    optimistic_sequence_number          BIGINT  NOT NULL,
+    event_sequence_number       BIGINT  NOT NULL,
+    sender                      BYTEA   NOT NULL,
+    PRIMARY KEY(package, module, type_name, global_sequence_number, optimistic_sequence_number, event_sequence_number),
+    FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+    REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+    ON DELETE CASCADE
+);
+CREATE INDEX optimistic_event_struct_name_sender ON optimistic_event_struct_name (sender, package, module, type_name, global_sequence_number, optimistic_sequence_number, event_sequence_number);
+
+-- Lookup table to search for optimistic events by emitted type name with type parameters.
+-- Equivalent of `event_struct_instantiation` table.
+CREATE TABLE optimistic_event_struct_instantiation
+(
+    package                     BYTEA   NOT NULL,
+    module                      TEXT    NOT NULL,
+    type_instantiation          TEXT    NOT NULL,
+    global_sequence_number BIGINT NOT NULL,
+    optimistic_sequence_number          BIGINT  NOT NULL,
+    event_sequence_number       BIGINT  NOT NULL,
+    sender                      BYTEA   NOT NULL,
+    PRIMARY KEY(package, module, type_instantiation, global_sequence_number, optimistic_sequence_number, event_sequence_number),
+    FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+    REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+    ON DELETE CASCADE
+);
+CREATE INDEX optimistic_event_struct_instantiation_sender ON optimistic_event_struct_instantiation (sender, package, module, type_instantiation, global_sequence_number, optimistic_sequence_number, event_sequence_number);
+
+-- Lookup table to search for optimistic events by event sender address
+-- Equivalent of `event_senders` table.
+CREATE TABLE optimistic_event_senders
+(
+    sender                      BYTEA   NOT NULL,
+    global_sequence_number BIGINT NOT NULL,
+    optimistic_sequence_number          BIGINT  NOT NULL,
+    event_sequence_number       BIGINT  NOT NULL,
+    PRIMARY KEY(sender, global_sequence_number, optimistic_sequence_number, event_sequence_number),
+    FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+    REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+    ON DELETE CASCADE
+);

--- a/crates/iota-indexer/migrations/pg/2025-05-29-072412_insertion-order-revisited/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-05-29-072412_insertion-order-revisited/up.sql
@@ -19,9 +19,11 @@ DROP TABLE IF EXISTS tx_insertion_order;
 CREATE TABLE tx_global_order (
     tx_digest               BYTEA        PRIMARY KEY,
     global_sequence_number  BIGINT       NOT NULL,
-    optimistic_sequence_number     BIGSERIAL
+    optimistic_sequence_number     BIGSERIAL,
+    chk_tx_sequence_number      BIGINT
 );
 CREATE UNIQUE INDEX tx_global_order_seq_digest ON tx_global_order (global_sequence_number, optimistic_sequence_number);
+CREATE UNIQUE INDEX tx_global_order_chk_tx_seq_num ON tx_global_order (chk_tx_sequence_number);
 
 ALTER TABLE optimistic_transactions                 RENAME insertion_order TO sequence_number;
 ALTER TABLE optimistic_tx_senders                   RENAME tx_insertion_order TO sequence_number;

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -10,8 +10,9 @@ use std::{
 use anyhow::{Result, anyhow};
 use cached::{Cached, SizedCache};
 use diesel::{
-    ExpressionMethods, JoinOnDsl, NullableExpressionMethods, OptionalExtension, PgConnection,
-    QueryDsl, RunQueryDsl, SelectableHelper, TextExpressionMethods,
+    BoolExpressionMethods, ExpressionMethods, JoinOnDsl, NullableExpressionMethods,
+    OptionalExtension, PgConnection, QueryDsl, RunQueryDsl, SelectableHelper,
+    TextExpressionMethods,
     dsl::sql,
     r2d2::ConnectionManager,
     sql_query,
@@ -701,8 +702,12 @@ impl IndexerReader {
         let optimistic_txs = run_query!(&self.pool, |conn| {
             optimistic_transactions::table
                 .inner_join(
-                    tx_global_order::table.on(optimistic_transactions::sequence_number
-                        .eq(tx_global_order::optimistic_sequence_number)),
+                    tx_global_order::table.on(optimistic_transactions::global_sequence_number
+                        .eq(tx_global_order::global_sequence_number)
+                        .and(
+                            optimistic_transactions::optimistic_sequence_number
+                                .eq(tx_global_order::optimistic_sequence_number),
+                        )),
                 )
                 // we filter the `tx_global_order` table because it is indexed by digest,
                 // optimistic_transactions table is not
@@ -1301,8 +1306,12 @@ impl IndexerReader {
         run_query_async!(&pool, move |conn| {
             optimistic_transactions::table
                 .inner_join(
-                    tx_global_order::table.on(optimistic_transactions::sequence_number
-                        .eq(tx_global_order::optimistic_sequence_number)),
+                    tx_global_order::table.on(optimistic_transactions::global_sequence_number
+                        .eq(tx_global_order::global_sequence_number)
+                        .and(
+                            optimistic_transactions::optimistic_sequence_number
+                                .eq(tx_global_order::optimistic_sequence_number),
+                        )),
                 )
                 // we filter the `tx_global_order` table because it is indexed by digest,
                 // optimistic_transactions table is not

--- a/crates/iota-indexer/src/models/event_indices.rs
+++ b/crates/iota-indexer/src/models/event_indices.rs
@@ -152,7 +152,8 @@ impl EventIndex {
 #[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = optimistic_event_emit_package)]
 pub struct OptimisticEventEmitPackage {
-    pub sequence_number: i64,
+    pub global_sequence_number: i64,
+    pub optimistic_sequence_number: i64,
     pub event_sequence_number: i64,
     pub package: Vec<u8>,
     pub sender: Vec<u8>,
@@ -161,7 +162,8 @@ pub struct OptimisticEventEmitPackage {
 #[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = optimistic_event_emit_module)]
 pub struct OptimisticEventEmitModule {
-    pub sequence_number: i64,
+    pub global_sequence_number: i64,
+    pub optimistic_sequence_number: i64,
     pub event_sequence_number: i64,
     pub package: Vec<u8>,
     pub module: String,
@@ -171,7 +173,8 @@ pub struct OptimisticEventEmitModule {
 #[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = optimistic_event_senders)]
 pub struct OptimisticEventSenders {
-    pub sequence_number: i64,
+    pub global_sequence_number: i64,
+    pub optimistic_sequence_number: i64,
     pub event_sequence_number: i64,
     pub sender: Vec<u8>,
 }
@@ -179,7 +182,8 @@ pub struct OptimisticEventSenders {
 #[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = optimistic_event_struct_package)]
 pub struct OptimisticEventStructPackage {
-    pub sequence_number: i64,
+    pub global_sequence_number: i64,
+    pub optimistic_sequence_number: i64,
     pub event_sequence_number: i64,
     pub package: Vec<u8>,
     pub sender: Vec<u8>,
@@ -188,7 +192,8 @@ pub struct OptimisticEventStructPackage {
 #[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = optimistic_event_struct_module)]
 pub struct OptimisticEventStructModule {
-    pub sequence_number: i64,
+    pub global_sequence_number: i64,
+    pub optimistic_sequence_number: i64,
     pub event_sequence_number: i64,
     pub package: Vec<u8>,
     pub module: String,
@@ -198,7 +203,8 @@ pub struct OptimisticEventStructModule {
 #[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = optimistic_event_struct_name)]
 pub struct OptimisticEventStructName {
-    pub sequence_number: i64,
+    pub global_sequence_number: i64,
+    pub optimistic_sequence_number: i64,
     pub event_sequence_number: i64,
     pub package: Vec<u8>,
     pub module: String,
@@ -209,7 +215,8 @@ pub struct OptimisticEventStructName {
 #[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = optimistic_event_struct_instantiation)]
 pub struct OptimisticEventStructInstantiation {
-    pub sequence_number: i64,
+    pub global_sequence_number: i64,
+    pub optimistic_sequence_number: i64,
     pub event_sequence_number: i64,
     pub package: Vec<u8>,
     pub module: String,

--- a/crates/iota-indexer/src/models/events.rs
+++ b/crates/iota-indexer/src/models/events.rs
@@ -57,7 +57,10 @@ pub struct StoredEvent {
 #[diesel(table_name = optimistic_events)]
 pub struct OptimisticEvent {
     #[diesel(sql_type = diesel::sql_types::BigInt)]
-    pub sequence_number: i64,
+    pub optimistic_sequence_number: i64,
+
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    pub global_sequence_number: i64,
 
     #[diesel(sql_type = diesel::sql_types::BigInt)]
     pub event_sequence_number: i64,
@@ -106,7 +109,7 @@ impl From<IndexedEvent> for StoredEvent {
 impl From<OptimisticEvent> for StoredEvent {
     fn from(event: OptimisticEvent) -> Self {
         Self {
-            tx_sequence_number: event.sequence_number,
+            tx_sequence_number: event.global_sequence_number,
             event_sequence_number: event.event_sequence_number,
             transaction_digest: event.transaction_digest,
             senders: event.senders,
@@ -119,10 +122,11 @@ impl From<OptimisticEvent> for StoredEvent {
     }
 }
 
-impl From<StoredEvent> for OptimisticEvent {
-    fn from(event: StoredEvent) -> Self {
+impl OptimisticEvent {
+    pub fn from_stored(global_sequence_number: i64, event: StoredEvent) -> Self {
         Self {
-            sequence_number: event.tx_sequence_number,
+            global_sequence_number,
+            optimistic_sequence_number: event.tx_sequence_number,
             event_sequence_number: event.event_sequence_number,
             transaction_digest: event.transaction_digest,
             senders: event.senders,

--- a/crates/iota-indexer/src/models/events.rs
+++ b/crates/iota-indexer/src/models/events.rs
@@ -109,7 +109,7 @@ impl From<IndexedEvent> for StoredEvent {
 impl From<OptimisticEvent> for StoredEvent {
     fn from(event: OptimisticEvent) -> Self {
         Self {
-            tx_sequence_number: event.global_sequence_number,
+            tx_sequence_number: event.optimistic_sequence_number,
             event_sequence_number: event.event_sequence_number,
             transaction_digest: event.transaction_digest,
             senders: event.senders,

--- a/crates/iota-indexer/src/models/macros.rs
+++ b/crates/iota-indexer/src/models/macros.rs
@@ -18,7 +18,7 @@ macro_rules! optimistic_from_into_checkpoint {
         impl From<$optimistic_record> for $checkpoint_record {
             fn from(item: $optimistic_record) -> Self {
                 Self {
-                    tx_sequence_number: item.global_sequence_number,
+                    tx_sequence_number: item.optimistic_sequence_number,
                     $($field: item.$field),*
                 }
             }

--- a/crates/iota-indexer/src/models/macros.rs
+++ b/crates/iota-indexer/src/models/macros.rs
@@ -18,17 +18,18 @@ macro_rules! optimistic_from_into_checkpoint {
         impl From<$optimistic_record> for $checkpoint_record {
             fn from(item: $optimistic_record) -> Self {
                 Self {
-                    tx_sequence_number: item.sequence_number,
+                    tx_sequence_number: item.global_sequence_number,
                     $($field: item.$field),*
                 }
             }
         }
 
-        impl From<$checkpoint_record> for $optimistic_record {
-            fn from(item: $checkpoint_record) -> Self {
+        impl $optimistic_record {
+            pub fn from_stored(global_sequence_number: i64, stored: $checkpoint_record) -> Self {
                 Self {
-                    sequence_number: item.tx_sequence_number,
-                    $($field: item.$field),*
+                    global_sequence_number,
+                    optimistic_sequence_number: stored.tx_sequence_number,
+                    $($field: stored.$field),*
                 }
             }
         }

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -56,7 +56,7 @@ pub struct TxGlobalOrder {
     /// To maintain these semantics the value should be non-positive for
     /// checkpointed transactions. More specifically we allow values
     /// in the set `[0, -1]` to represent the index status of checkpointed
-    /// transactions. See also [`CheckpointTxGlobalOrder`].
+    /// transactions.
     ///
     /// Optimistic transactions should set this value to `None`,
     /// so that it is auto-generated on the database.

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -40,6 +40,8 @@ use crate::{
 #[derive(Clone, Debug, Queryable, Insertable, QueryableByName, Selectable)]
 #[diesel(table_name = tx_global_order)]
 pub struct TxGlobalOrder {
+    /// Sequence number of transaction according to checkpoint ordering.
+    /// Set after transaction is checkpoint-indexed.
     pub chk_tx_sequence_number: Option<i64>,
     /// Number that represents the global ordering between optimistic and
     /// checkpointed transactions.
@@ -168,29 +170,12 @@ pub struct OptimisticTransaction {
 impl From<OptimisticTransaction> for StoredTransaction {
     fn from(tx: OptimisticTransaction) -> Self {
         StoredTransaction {
-            tx_sequence_number: tx.global_sequence_number,
+            tx_sequence_number: tx.optimistic_sequence_number,
             transaction_digest: tx.transaction_digest,
             raw_transaction: tx.raw_transaction,
             raw_effects: tx.raw_effects,
             checkpoint_sequence_number: -1,
             timestamp_ms: -1,
-            object_changes: tx.object_changes,
-            balance_changes: tx.balance_changes,
-            events: tx.events,
-            transaction_kind: tx.transaction_kind,
-            success_command_count: tx.success_command_count,
-        }
-    }
-}
-
-impl From<StoredTransaction> for OptimisticTransaction {
-    fn from(tx: StoredTransaction) -> Self {
-        OptimisticTransaction {
-            global_sequence_number: 0,
-            optimistic_sequence_number: tx.tx_sequence_number,
-            transaction_digest: tx.transaction_digest,
-            raw_transaction: tx.raw_transaction,
-            raw_effects: tx.raw_effects,
             object_changes: tx.object_changes,
             balance_changes: tx.balance_changes,
             events: tx.events,

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -153,7 +153,8 @@ pub struct StoredTransaction {
 #[derive(Clone, Debug, Queryable, Insertable, QueryableByName, Selectable)]
 #[diesel(table_name = optimistic_transactions)]
 pub struct OptimisticTransaction {
-    pub sequence_number: i64,
+    pub global_sequence_number: i64,
+    pub optimistic_sequence_number: i64,
     pub transaction_digest: Vec<u8>,
     pub raw_transaction: Vec<u8>,
     pub raw_effects: Vec<u8>,
@@ -167,7 +168,7 @@ pub struct OptimisticTransaction {
 impl From<OptimisticTransaction> for StoredTransaction {
     fn from(tx: OptimisticTransaction) -> Self {
         StoredTransaction {
-            tx_sequence_number: tx.sequence_number,
+            tx_sequence_number: tx.global_sequence_number,
             transaction_digest: tx.transaction_digest,
             raw_transaction: tx.raw_transaction,
             raw_effects: tx.raw_effects,
@@ -185,7 +186,8 @@ impl From<OptimisticTransaction> for StoredTransaction {
 impl From<StoredTransaction> for OptimisticTransaction {
     fn from(tx: StoredTransaction) -> Self {
         OptimisticTransaction {
-            sequence_number: tx.tx_sequence_number,
+            global_sequence_number: 0,
+            optimistic_sequence_number: tx.tx_sequence_number,
             transaction_digest: tx.transaction_digest,
             raw_transaction: tx.raw_transaction,
             raw_effects: tx.raw_effects,
@@ -194,6 +196,23 @@ impl From<StoredTransaction> for OptimisticTransaction {
             events: tx.events,
             transaction_kind: tx.transaction_kind,
             success_command_count: tx.success_command_count,
+        }
+    }
+}
+
+impl OptimisticTransaction {
+    pub fn from_stored(global_sequence_number: i64, stored: StoredTransaction) -> Self {
+        OptimisticTransaction {
+            global_sequence_number,
+            optimistic_sequence_number: stored.tx_sequence_number,
+            transaction_digest: stored.transaction_digest,
+            raw_transaction: stored.raw_transaction,
+            raw_effects: stored.raw_effects,
+            object_changes: stored.object_changes,
+            balance_changes: stored.balance_changes,
+            events: stored.events,
+            transaction_kind: stored.transaction_kind,
+            success_command_count: stored.success_command_count,
         }
     }
 }

--- a/crates/iota-indexer/src/models/transactions.rs
+++ b/crates/iota-indexer/src/models/transactions.rs
@@ -40,6 +40,7 @@ use crate::{
 #[derive(Clone, Debug, Queryable, Insertable, QueryableByName, Selectable)]
 #[diesel(table_name = tx_global_order)]
 pub struct TxGlobalOrder {
+    pub chk_tx_sequence_number: Option<i64>,
     /// Number that represents the global ordering between optimistic and
     /// checkpointed transactions.
     ///
@@ -66,6 +67,7 @@ pub struct TxGlobalOrder {
 impl From<&IndexedTransaction> for CheckpointTxGlobalOrder {
     fn from(tx: &IndexedTransaction) -> Self {
         Self {
+            chk_tx_sequence_number: Some(tx.tx_sequence_number as i64),
             global_sequence_number: tx.tx_sequence_number as i64,
             tx_digest: tx.tx_digest.into_inner().to_vec(),
             index_status: Some(IndexStatus::Started),
@@ -81,6 +83,7 @@ impl From<&IndexedTransaction> for CheckpointTxGlobalOrder {
 #[derive(Clone, Debug, Queryable, Insertable, QueryableByName, Selectable)]
 #[diesel(table_name = tx_global_order)]
 pub(crate) struct CheckpointTxGlobalOrder {
+    pub(crate) chk_tx_sequence_number: Option<i64>,
     pub(crate) global_sequence_number: i64,
     pub(crate) tx_digest: Vec<u8>,
     /// The index status of checkpointed transactions.

--- a/crates/iota-indexer/src/models/tx_indices.rs
+++ b/crates/iota-indexer/src/models/tx_indices.rs
@@ -217,14 +217,16 @@ impl TxIndex {
 #[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = optimistic_tx_senders)]
 pub struct OptimisticTxSenders {
-    pub sequence_number: i64,
+    pub global_sequence_number: i64,
+    pub optimistic_sequence_number: i64,
     pub sender: Vec<u8>,
 }
 
 #[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = optimistic_tx_recipients)]
 pub struct OptimisticTxRecipients {
-    pub sequence_number: i64,
+    pub global_sequence_number: i64,
+    pub optimistic_sequence_number: i64,
     pub recipient: Vec<u8>,
     pub sender: Vec<u8>,
 }
@@ -232,7 +234,8 @@ pub struct OptimisticTxRecipients {
 #[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = optimistic_tx_input_objects)]
 pub struct OptimisticTxInputObject {
-    pub sequence_number: i64,
+    pub global_sequence_number: i64,
+    pub optimistic_sequence_number: i64,
     pub object_id: Vec<u8>,
     pub sender: Vec<u8>,
 }
@@ -240,7 +243,8 @@ pub struct OptimisticTxInputObject {
 #[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = optimistic_tx_changed_objects)]
 pub struct OptimisticTxChangedObject {
-    pub sequence_number: i64,
+    pub global_sequence_number: i64,
+    pub optimistic_sequence_number: i64,
     pub object_id: Vec<u8>,
     pub sender: Vec<u8>,
 }
@@ -248,7 +252,8 @@ pub struct OptimisticTxChangedObject {
 #[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = optimistic_tx_calls_pkg)]
 pub struct OptimisticTxPkg {
-    pub sequence_number: i64,
+    pub global_sequence_number: i64,
+    pub optimistic_sequence_number: i64,
     pub package: Vec<u8>,
     pub sender: Vec<u8>,
 }
@@ -256,7 +261,8 @@ pub struct OptimisticTxPkg {
 #[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = optimistic_tx_calls_mod)]
 pub struct OptimisticTxMod {
-    pub sequence_number: i64,
+    pub global_sequence_number: i64,
+    pub optimistic_sequence_number: i64,
     pub package: Vec<u8>,
     pub module: String,
     pub sender: Vec<u8>,
@@ -265,7 +271,8 @@ pub struct OptimisticTxMod {
 #[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
 #[diesel(table_name = optimistic_tx_calls_fun)]
 pub struct OptimisticTxFun {
-    pub sequence_number: i64,
+    pub global_sequence_number: i64,
+    pub optimistic_sequence_number: i64,
     pub package: Vec<u8>,
     pub module: String,
     pub func: String,
@@ -276,7 +283,8 @@ pub struct OptimisticTxFun {
 #[diesel(table_name = optimistic_tx_kinds)]
 pub struct OptimisticTxKind {
     pub tx_kind: i16,
-    pub sequence_number: i64,
+    pub optimistic_sequence_number: i64,
+    pub global_sequence_number: i64,
 }
 
 optimistic_from_into_checkpoint!(OptimisticTxSenders, StoredTxSenders, { sender });

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -30,10 +30,18 @@ use crate::{
     metrics::IndexerMetrics,
     models::{
         display::StoredDisplay,
-        event_indices::OptimisticEventIndices,
+        event_indices::{
+            OptimisticEventEmitModule, OptimisticEventEmitPackage, OptimisticEventIndices,
+            OptimisticEventSenders, OptimisticEventStructInstantiation,
+            OptimisticEventStructModule, OptimisticEventStructName, OptimisticEventStructPackage,
+        },
         events::{OptimisticEvent, StoredEvent},
-        transactions::{OptimisticTransaction, StoredTransaction, TxGlobalOrder},
-        tx_indices::OptimisticTxIndices,
+        transactions::{OptimisticTransaction, TxGlobalOrder},
+        tx_indices::{
+            OptimisticTxChangedObject, OptimisticTxFun, OptimisticTxIndices,
+            OptimisticTxInputObject, OptimisticTxKind, OptimisticTxMod, OptimisticTxPkg,
+            OptimisticTxRecipients, OptimisticTxSenders,
+        },
     },
     store::{IndexerStore, PgIndexerStore},
     transactional_blocking_with_retry_with_conditional_abort,
@@ -310,7 +318,8 @@ impl OptimisticTransactionExecutor {
                     &self.metrics,
                 );
 
-                let tx_data_to_commit = extractor.to_transaction_data_to_commit()?;
+                let tx_data_to_commit = extractor
+                    .to_transaction_data_to_commit(assigned_global_order.global_sequence_number)?;
 
                 self.persist_optimistic_tx(conn, tx_data_to_commit)
             },
@@ -447,19 +456,24 @@ impl<'a> TransactionExtractor<'a> {
         })
     }
 
-    fn to_transaction_data_to_commit(&self) -> IndexerResult<TransactionDataToCommit> {
+    fn to_transaction_data_to_commit(
+        &self,
+        global_sequence_number: i64,
+    ) -> IndexerResult<TransactionDataToCommit> {
         let object_changes = self.get_object_changes()?;
         let (indexed_tx, tx_indices, indexed_events, events_indices, indexed_displays) =
             self.get_indexed_transactions_events_and_displays()?;
 
-        let optimistic_tx = StoredTransaction::from(&indexed_tx).into();
-        let optimistic_tx_indices = Self::optimistic_tx_indices(tx_indices);
+        let optimistic_tx =
+            OptimisticTransaction::from_stored(global_sequence_number, (&indexed_tx).into());
+        let optimistic_tx_indices = Self::optimistic_tx_indices(tx_indices, global_sequence_number);
         let optimistic_events = indexed_events
             .into_iter()
             .map(StoredEvent::from)
-            .map(Into::into)
+            .map(|stored| OptimisticEvent::from_stored(global_sequence_number, stored))
             .collect();
-        let optimistic_event_indices = Self::optimistic_event_indices(events_indices);
+        let optimistic_event_indices =
+            Self::optimistic_event_indices(events_indices, global_sequence_number);
 
         Ok((
             optimistic_tx,
@@ -471,36 +485,101 @@ impl<'a> TransactionExtractor<'a> {
         ))
     }
 
-    fn optimistic_event_indices(event_indices: Vec<EventIndex>) -> OptimisticEventIndices {
+    fn optimistic_event_indices(
+        event_indices: Vec<EventIndex>,
+        global_sequence_number: i64,
+    ) -> OptimisticEventIndices {
         let splits: Vec<_> = event_indices.into_iter().map(|i| i.split()).collect();
 
         OptimisticEventIndices {
-            optimistic_event_emit_packages: splits.iter().map(|t| t.0.clone().into()).collect(),
-            optimistic_event_emit_modules: splits.iter().map(|t| t.1.clone().into()).collect(),
-            optimistic_event_senders: splits.iter().map(|t| t.2.clone().into()).collect(),
-            optimistic_event_struct_packages: splits.iter().map(|t| t.3.clone().into()).collect(),
-            optimistic_event_struct_modules: splits.iter().map(|t| t.4.clone().into()).collect(),
-            optimistic_event_struct_names: splits.iter().map(|t| t.5.clone().into()).collect(),
+            optimistic_event_emit_packages: splits
+                .iter()
+                .map(|t| {
+                    OptimisticEventEmitPackage::from_stored(global_sequence_number, t.0.clone())
+                })
+                .collect(),
+            optimistic_event_emit_modules: splits
+                .iter()
+                .map(|t| {
+                    OptimisticEventEmitModule::from_stored(global_sequence_number, t.1.clone())
+                })
+                .collect(),
+            optimistic_event_senders: splits
+                .iter()
+                .map(|t| OptimisticEventSenders::from_stored(global_sequence_number, t.2.clone()))
+                .collect(),
+            optimistic_event_struct_packages: splits
+                .iter()
+                .map(|t| {
+                    OptimisticEventStructPackage::from_stored(global_sequence_number, t.3.clone())
+                })
+                .collect(),
+            optimistic_event_struct_modules: splits
+                .iter()
+                .map(|t| {
+                    OptimisticEventStructModule::from_stored(global_sequence_number, t.4.clone())
+                })
+                .collect(),
+            optimistic_event_struct_names: splits
+                .iter()
+                .map(|t| {
+                    OptimisticEventStructName::from_stored(global_sequence_number, t.5.clone())
+                })
+                .collect(),
             optimistic_event_struct_instantiations: splits
                 .iter()
-                .map(|t| t.6.clone().into())
+                .map(|t| {
+                    OptimisticEventStructInstantiation::from_stored(
+                        global_sequence_number,
+                        t.6.clone(),
+                    )
+                })
                 .collect(),
         }
     }
 
-    fn optimistic_tx_indices(tx_index: TxIndex) -> OptimisticTxIndices {
+    fn optimistic_tx_indices(
+        tx_index: TxIndex,
+        global_sequence_number: i64,
+    ) -> OptimisticTxIndices {
         let (senders, recipients, input_objects, changed_objects, pkgs, mods, funs, _, kinds) =
             tx_index.split();
 
         OptimisticTxIndices {
-            optimistic_tx_senders: senders.into_iter().map(Into::into).collect(),
-            optimistic_tx_recipients: recipients.into_iter().map(Into::into).collect(),
-            optimistic_tx_input_objects: input_objects.into_iter().map(Into::into).collect(),
-            optimistic_tx_changed_objects: changed_objects.into_iter().map(Into::into).collect(),
-            optimistic_tx_pkgs: pkgs.into_iter().map(Into::into).collect(),
-            optimistic_tx_mods: mods.into_iter().map(Into::into).collect(),
-            optimistic_tx_funs: funs.into_iter().map(Into::into).collect(),
-            optimistic_tx_kinds: kinds.into_iter().map(Into::into).collect(),
+            optimistic_tx_senders: senders
+                .into_iter()
+                .map(|stored| OptimisticTxSenders::from_stored(global_sequence_number, stored))
+                .collect(),
+            optimistic_tx_recipients: recipients
+                .into_iter()
+                .map(|stored| OptimisticTxRecipients::from_stored(global_sequence_number, stored))
+                .collect(),
+            optimistic_tx_input_objects: input_objects
+                .into_iter()
+                .map(|stored| OptimisticTxInputObject::from_stored(global_sequence_number, stored))
+                .collect(),
+            optimistic_tx_changed_objects: changed_objects
+                .into_iter()
+                .map(|stored| {
+                    OptimisticTxChangedObject::from_stored(global_sequence_number, stored)
+                })
+                .collect(),
+            optimistic_tx_pkgs: pkgs
+                .into_iter()
+                .map(|stored| OptimisticTxPkg::from_stored(global_sequence_number, stored))
+                .collect(),
+            optimistic_tx_mods: mods
+                .into_iter()
+                .map(|stored| OptimisticTxMod::from_stored(global_sequence_number, stored))
+                .collect(),
+            optimistic_tx_funs: funs
+                .into_iter()
+                .map(|stored| OptimisticTxFun::from_stored(global_sequence_number, stored))
+                .collect(),
+            optimistic_tx_kinds: kinds
+                .into_iter()
+                .map(|stored| OptimisticTxKind::from_stored(global_sequence_number, stored))
+                .collect(),
         }
     }
 }

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -327,8 +327,8 @@ impl OptimisticTransactionExecutor {
 
         sql_query(
             r#"
-                INSERT INTO tx_global_order (tx_digest, global_sequence_number)
-                SELECT $1, MAX(tx_sequence_number) FROM tx_digests
+                INSERT INTO tx_global_order (tx_digest, global_sequence_number, chk_tx_sequence_number)
+                SELECT $1, MAX(tx_sequence_number), NULL FROM tx_digests
                 RETURNING *;
             "#,
         )

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -288,29 +288,29 @@ diesel::table! {
     optimistic_event_emit_module (package, module, global_sequence_number, optimistic_sequence_number, event_sequence_number) {
         package -> Bytea,
         module -> Text,
+        global_sequence_number -> Int8,
         optimistic_sequence_number -> Int8,
         event_sequence_number -> Int8,
         sender -> Bytea,
-        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
     optimistic_event_emit_package (package, global_sequence_number, optimistic_sequence_number, event_sequence_number) {
         package -> Bytea,
+        global_sequence_number -> Int8,
         optimistic_sequence_number -> Int8,
         event_sequence_number -> Int8,
         sender -> Bytea,
-        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
     optimistic_event_senders (sender, global_sequence_number, optimistic_sequence_number, event_sequence_number) {
         sender -> Bytea,
+        global_sequence_number -> Int8,
         optimistic_sequence_number -> Int8,
         event_sequence_number -> Int8,
-        global_sequence_number -> Int8,
     }
 }
 
@@ -319,10 +319,10 @@ diesel::table! {
         package -> Bytea,
         module -> Text,
         type_instantiation -> Text,
+        global_sequence_number -> Int8,
         optimistic_sequence_number -> Int8,
         event_sequence_number -> Int8,
         sender -> Bytea,
-        global_sequence_number -> Int8,
     }
 }
 
@@ -330,10 +330,10 @@ diesel::table! {
     optimistic_event_struct_module (package, module, global_sequence_number, optimistic_sequence_number, event_sequence_number) {
         package -> Bytea,
         module -> Text,
+        global_sequence_number -> Int8,
         optimistic_sequence_number -> Int8,
         event_sequence_number -> Int8,
         sender -> Bytea,
-        global_sequence_number -> Int8,
     }
 }
 
@@ -342,25 +342,26 @@ diesel::table! {
         package -> Bytea,
         module -> Text,
         type_name -> Text,
+        global_sequence_number -> Int8,
         optimistic_sequence_number -> Int8,
         event_sequence_number -> Int8,
         sender -> Bytea,
-        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
     optimistic_event_struct_package (package, global_sequence_number, optimistic_sequence_number, event_sequence_number) {
         package -> Bytea,
+        global_sequence_number -> Int8,
         optimistic_sequence_number -> Int8,
         event_sequence_number -> Int8,
         sender -> Bytea,
-        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
     optimistic_events (global_sequence_number, optimistic_sequence_number, event_sequence_number) {
+        global_sequence_number -> Int8,
         optimistic_sequence_number -> Int8,
         event_sequence_number -> Int8,
         transaction_digest -> Bytea,
@@ -369,12 +370,12 @@ diesel::table! {
         module -> Text,
         event_type -> Text,
         bcs -> Bytea,
-        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
     optimistic_transactions (global_sequence_number, optimistic_sequence_number) {
+        global_sequence_number -> Int8,
         optimistic_sequence_number -> Int8,
         transaction_digest -> Bytea,
         raw_transaction -> Bytea,
@@ -384,80 +385,79 @@ diesel::table! {
         events -> Array<Nullable<Bytea>>,
         transaction_kind -> Int2,
         success_command_count -> Int2,
-        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
     optimistic_tx_calls_fun (package, module, func, global_sequence_number, optimistic_sequence_number) {
+        global_sequence_number -> Int8,
         optimistic_sequence_number -> Int8,
         package -> Bytea,
         module -> Text,
         func -> Text,
         sender -> Bytea,
-        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
     optimistic_tx_calls_mod (package, module, global_sequence_number, optimistic_sequence_number) {
+        global_sequence_number -> Int8,
         optimistic_sequence_number -> Int8,
         package -> Bytea,
         module -> Text,
         sender -> Bytea,
-        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
     optimistic_tx_calls_pkg (package, global_sequence_number, optimistic_sequence_number) {
+        global_sequence_number -> Int8,
         optimistic_sequence_number -> Int8,
         package -> Bytea,
         sender -> Bytea,
-        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
     optimistic_tx_changed_objects (object_id, global_sequence_number, optimistic_sequence_number) {
+        global_sequence_number -> Int8,
         optimistic_sequence_number -> Int8,
         object_id -> Bytea,
         sender -> Bytea,
-        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
     optimistic_tx_input_objects (object_id, global_sequence_number, optimistic_sequence_number) {
+        global_sequence_number -> Int8,
         optimistic_sequence_number -> Int8,
         object_id -> Bytea,
         sender -> Bytea,
-        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
     optimistic_tx_kinds (tx_kind, global_sequence_number, optimistic_sequence_number) {
+        global_sequence_number -> Int8,
         optimistic_sequence_number -> Int8,
         tx_kind -> Int2,
-        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
     optimistic_tx_recipients (recipient, global_sequence_number, optimistic_sequence_number) {
+        global_sequence_number -> Int8,
         optimistic_sequence_number -> Int8,
         recipient -> Bytea,
         sender -> Bytea,
-        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
     optimistic_tx_senders (sender, global_sequence_number, optimistic_sequence_number) {
+        global_sequence_number -> Int8,
         optimistic_sequence_number -> Int8,
         sender -> Bytea,
-        global_sequence_number -> Int8,
     }
 }
 

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -285,76 +285,83 @@ diesel::table! {
 }
 
 diesel::table! {
-    optimistic_event_emit_module (package, module, sequence_number, event_sequence_number) {
+    optimistic_event_emit_module (package, module, global_sequence_number, optimistic_sequence_number, event_sequence_number) {
         package -> Bytea,
         module -> Text,
-        sequence_number -> Int8,
+        optimistic_sequence_number -> Int8,
         event_sequence_number -> Int8,
         sender -> Bytea,
+        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
-    optimistic_event_emit_package (package, sequence_number, event_sequence_number) {
+    optimistic_event_emit_package (package, global_sequence_number, optimistic_sequence_number, event_sequence_number) {
         package -> Bytea,
-        sequence_number -> Int8,
+        optimistic_sequence_number -> Int8,
         event_sequence_number -> Int8,
         sender -> Bytea,
+        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
-    optimistic_event_senders (sender, sequence_number, event_sequence_number) {
+    optimistic_event_senders (sender, global_sequence_number, optimistic_sequence_number, event_sequence_number) {
         sender -> Bytea,
-        sequence_number -> Int8,
+        optimistic_sequence_number -> Int8,
         event_sequence_number -> Int8,
+        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
-    optimistic_event_struct_instantiation (package, module, type_instantiation, sequence_number, event_sequence_number) {
+    optimistic_event_struct_instantiation (package, module, type_instantiation, global_sequence_number, optimistic_sequence_number, event_sequence_number) {
         package -> Bytea,
         module -> Text,
         type_instantiation -> Text,
-        sequence_number -> Int8,
+        optimistic_sequence_number -> Int8,
         event_sequence_number -> Int8,
         sender -> Bytea,
+        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
-    optimistic_event_struct_module (package, module, sequence_number, event_sequence_number) {
+    optimistic_event_struct_module (package, module, global_sequence_number, optimistic_sequence_number, event_sequence_number) {
         package -> Bytea,
         module -> Text,
-        sequence_number -> Int8,
+        optimistic_sequence_number -> Int8,
         event_sequence_number -> Int8,
         sender -> Bytea,
+        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
-    optimistic_event_struct_name (package, module, type_name, sequence_number, event_sequence_number) {
+    optimistic_event_struct_name (package, module, type_name, global_sequence_number, optimistic_sequence_number, event_sequence_number) {
         package -> Bytea,
         module -> Text,
         type_name -> Text,
-        sequence_number -> Int8,
+        optimistic_sequence_number -> Int8,
         event_sequence_number -> Int8,
         sender -> Bytea,
+        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
-    optimistic_event_struct_package (package, sequence_number, event_sequence_number) {
+    optimistic_event_struct_package (package, global_sequence_number, optimistic_sequence_number, event_sequence_number) {
         package -> Bytea,
-        sequence_number -> Int8,
+        optimistic_sequence_number -> Int8,
         event_sequence_number -> Int8,
         sender -> Bytea,
+        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
-    optimistic_events (sequence_number, event_sequence_number) {
-        sequence_number -> Int8,
+    optimistic_events (global_sequence_number, optimistic_sequence_number, event_sequence_number) {
+        optimistic_sequence_number -> Int8,
         event_sequence_number -> Int8,
         transaction_digest -> Bytea,
         senders -> Array<Nullable<Bytea>>,
@@ -362,12 +369,13 @@ diesel::table! {
         module -> Text,
         event_type -> Text,
         bcs -> Bytea,
+        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
-    optimistic_transactions (sequence_number) {
-        sequence_number -> Int8,
+    optimistic_transactions (global_sequence_number, optimistic_sequence_number) {
+        optimistic_sequence_number -> Int8,
         transaction_digest -> Bytea,
         raw_transaction -> Bytea,
         raw_effects -> Bytea,
@@ -376,71 +384,80 @@ diesel::table! {
         events -> Array<Nullable<Bytea>>,
         transaction_kind -> Int2,
         success_command_count -> Int2,
+        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
-    optimistic_tx_calls_fun (package, module, func, sequence_number) {
-        sequence_number -> Int8,
+    optimistic_tx_calls_fun (package, module, func, global_sequence_number, optimistic_sequence_number) {
+        optimistic_sequence_number -> Int8,
         package -> Bytea,
         module -> Text,
         func -> Text,
         sender -> Bytea,
+        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
-    optimistic_tx_calls_mod (package, module, sequence_number) {
-        sequence_number -> Int8,
+    optimistic_tx_calls_mod (package, module, global_sequence_number, optimistic_sequence_number) {
+        optimistic_sequence_number -> Int8,
         package -> Bytea,
         module -> Text,
         sender -> Bytea,
+        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
-    optimistic_tx_calls_pkg (package, sequence_number) {
-        sequence_number -> Int8,
+    optimistic_tx_calls_pkg (package, global_sequence_number, optimistic_sequence_number) {
+        optimistic_sequence_number -> Int8,
         package -> Bytea,
         sender -> Bytea,
+        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
-    optimistic_tx_changed_objects (object_id, sequence_number) {
-        sequence_number -> Int8,
+    optimistic_tx_changed_objects (object_id, global_sequence_number, optimistic_sequence_number) {
+        optimistic_sequence_number -> Int8,
         object_id -> Bytea,
         sender -> Bytea,
+        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
-    optimistic_tx_input_objects (object_id, sequence_number) {
-        sequence_number -> Int8,
+    optimistic_tx_input_objects (object_id, global_sequence_number, optimistic_sequence_number) {
+        optimistic_sequence_number -> Int8,
         object_id -> Bytea,
         sender -> Bytea,
+        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
-    optimistic_tx_kinds (tx_kind, sequence_number) {
-        sequence_number -> Int8,
+    optimistic_tx_kinds (tx_kind, global_sequence_number, optimistic_sequence_number) {
+        optimistic_sequence_number -> Int8,
         tx_kind -> Int2,
+        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
-    optimistic_tx_recipients (recipient, sequence_number) {
-        sequence_number -> Int8,
+    optimistic_tx_recipients (recipient, global_sequence_number, optimistic_sequence_number) {
+        optimistic_sequence_number -> Int8,
         recipient -> Bytea,
         sender -> Bytea,
+        global_sequence_number -> Int8,
     }
 }
 
 diesel::table! {
-    optimistic_tx_senders (sender, sequence_number) {
-        sequence_number -> Int8,
+    optimistic_tx_senders (sender, global_sequence_number, optimistic_sequence_number) {
+        optimistic_sequence_number -> Int8,
         sender -> Bytea,
+        global_sequence_number -> Int8,
     }
 }
 
@@ -577,23 +594,6 @@ diesel::table! {
         sender -> Bytea,
     }
 }
-
-diesel::joinable!(optimistic_event_emit_module -> optimistic_transactions (sequence_number));
-diesel::joinable!(optimistic_event_emit_package -> optimistic_transactions (sequence_number));
-diesel::joinable!(optimistic_event_senders -> optimistic_transactions (sequence_number));
-diesel::joinable!(optimistic_event_struct_instantiation -> optimistic_transactions (sequence_number));
-diesel::joinable!(optimistic_event_struct_module -> optimistic_transactions (sequence_number));
-diesel::joinable!(optimistic_event_struct_name -> optimistic_transactions (sequence_number));
-diesel::joinable!(optimistic_event_struct_package -> optimistic_transactions (sequence_number));
-diesel::joinable!(optimistic_events -> optimistic_transactions (sequence_number));
-diesel::joinable!(optimistic_tx_calls_fun -> optimistic_transactions (sequence_number));
-diesel::joinable!(optimistic_tx_calls_mod -> optimistic_transactions (sequence_number));
-diesel::joinable!(optimistic_tx_calls_pkg -> optimistic_transactions (sequence_number));
-diesel::joinable!(optimistic_tx_changed_objects -> optimistic_transactions (sequence_number));
-diesel::joinable!(optimistic_tx_input_objects -> optimistic_transactions (sequence_number));
-diesel::joinable!(optimistic_tx_kinds -> optimistic_transactions (sequence_number));
-diesel::joinable!(optimistic_tx_recipients -> optimistic_transactions (sequence_number));
-diesel::joinable!(optimistic_tx_senders -> optimistic_transactions (sequence_number));
 
 #[macro_export]
 macro_rules! for_all_tables {

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -544,6 +544,7 @@ diesel::table! {
         tx_digest -> Bytea,
         global_sequence_number -> Int8,
         optimistic_sequence_number -> Int8,
+        chk_tx_sequence_number -> Nullable<Int8>,
     }
 }
 

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -3,11 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::result::Result::Ok;
-use std::{
-    any::Any as StdAny,
-    collections::BTreeMap,
-    time::Duration,
-};
+use std::{any::Any as StdAny, collections::BTreeMap, time::Duration};
 
 use async_trait::async_trait;
 use diesel::{
@@ -905,6 +901,15 @@ impl PgIndexerStore {
                     tx_global_order::tx_digest,
                     tx_global_order::optimistic_sequence_number.eq(IndexStatus::Completed),
                     tx_global_order::optimistic_sequence_number.eq(IndexStatus::Started),
+                    conn
+                );
+                on_conflict_do_update_with_condition!(
+                    tx_global_order::table,
+                    tx_order.clone(),
+                    tx_global_order::tx_digest,
+                    tx_global_order::chk_tx_sequence_number
+                        .eq(excluded(tx_global_order::chk_tx_sequence_number)),
+                    tx_global_order::chk_tx_sequence_number.is_null(),
                     conn
                 );
                 Ok::<(), IndexerError>(())

--- a/crates/iota-indexer/tests/ingestion_tests.rs
+++ b/crates/iota-indexer/tests/ingestion_tests.rs
@@ -310,6 +310,7 @@ mod ingestion_tests {
                             tx_digest: digest.inner().to_vec(),
                             global_sequence_number,
                             optimistic_sequence_number: None,
+                            chk_tx_sequence_number: None,
                         };
                         insert_or_ignore_into!(tx_global_order::table, insertable, conn);
                         Ok::<(), IndexerError>(())


### PR DESCRIPTION
# Description of change

This patch does the following changes:

* Extends the `tx_global_order` table to include the `tx_sequence_number` assigned to transactions when checkpointed. This is to allow for more efficient pagination queries, as we observed 20-fold decrease in performance.
* It also adds the composite key `(global_sequence_number, optimistic_sequence_number)` to `optimistic_{tx,event}_indices` to allow for more efficient joins with `tx_global_order`

## Links to any relevant issues

Part of #5871 

## How the change has been tested


- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [x] Synchronization of the indexer from genesis for a network including migration objects.
- [x] Restart of indexer synchronization locally without resetting the database.
- [x] Restart of indexer synchronization on a production-like database.
- [x] Deployment of services using Docker.
- [x] Verification of API backward compatibility.


