### PR TITLE
fix(iota-indexer): replace `common::get_indexer_db_url` with `test_utils::db_url`

### DIFF
--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -16,7 +16,7 @@ use iota_indexer::{
     errors::IndexerError,
     indexer::Indexer,
     store::{PgIndexerStore, indexer_store::IndexerStore},
-    test_utils::{DBInitHook, IndexerTypeConfig, start_test_indexer},
+    test_utils::{DBInitHook, IndexerTypeConfig, db_url, start_test_indexer},
 };
 use iota_json_rpc_api::ReadApiClient;
 use iota_json_rpc_types::{IotaTransactionBlockResponseOptions, TransactionBlockBytes};
@@ -36,7 +36,6 @@ use tempfile::tempdir;
 use test_cluster::{TestCluster, TestClusterBuilder};
 use tokio::{runtime::Runtime, task::JoinHandle};
 
-const POSTGRES_URL: &str = "postgres://postgres:postgrespw@localhost:5432";
 const DEFAULT_DB: &str = "iota_indexer";
 const DEFAULT_INDEXER_IP: &str = "127.0.0.1";
 const DEFAULT_INDEXER_PORT: u16 = 9005;
@@ -131,7 +130,7 @@ pub async fn start_test_cluster_with_read_write_indexer(
 
     // start indexer in write mode
     let (pg_store, _pg_store_handle, _) = start_test_indexer(
-        get_indexer_db_url(database_name),
+        db_url(database_name.unwrap_or(DEFAULT_DB)),
         // reset the existing db
         true,
         None,
@@ -150,13 +149,6 @@ pub async fn start_test_cluster_with_read_write_indexer(
         .unwrap();
 
     (cluster, pg_store, rpc_client)
-}
-
-pub fn get_indexer_db_url(database_name: Option<&str>) -> String {
-    database_name.map_or_else(
-        || format!("{POSTGRES_URL}/{DEFAULT_DB}"),
-        |db_name| format!("{POSTGRES_URL}/{db_name}"),
-    )
 }
 
 /// Wait for the indexer to catch up to the given checkpoint sequence number
@@ -281,7 +273,7 @@ pub async fn execute_tx_and_wait_for_indexer(
 
 /// Start an Indexer instance in `Read` mode
 fn start_indexer_reader(fullnode_rpc_url: impl Into<String>, database_name: Option<&str>) -> u16 {
-    let db_url = get_indexer_db_url(database_name);
+    let db_url = db_url(database_name.unwrap_or(DEFAULT_DB));
     let port = get_available_port(DEFAULT_INDEXER_IP);
 
     let config = JsonRpcConfig {
@@ -343,7 +335,7 @@ pub async fn start_simulacrum_rest_api_with_write_indexer(
     });
     // Starts indexer
     let (pg_store, pg_handle, _) = start_test_indexer(
-        get_indexer_db_url(database_name),
+        db_url(database_name.unwrap_or(DEFAULT_DB)),
         true,
         db_init_hook,
         format!("http://{server_url}"),

--- a/crates/iota-indexer/tests/rpc-tests/read_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/read_api.rs
@@ -5,8 +5,9 @@ use std::{fs::File, path::Path, str::FromStr, sync::Arc};
 
 use hex::FromHex;
 use iota_indexer::{
-    models::transactions::StoredTransaction, store::package_resolver::IndexerStorePackageResolver,
-    test_utils::TestDatabase,
+    models::transactions::StoredTransaction,
+    store::package_resolver::IndexerStorePackageResolver,
+    test_utils::{TestDatabase, db_url},
 };
 use iota_json_rpc_api::{IndexerApiClient, ReadApiClient, TransactionBuilderClient};
 use iota_json_rpc_types::{
@@ -34,10 +35,9 @@ use move_core_types::identifier::Identifier;
 use serde_json::Value;
 
 use crate::common::{
-    ApiTestSetup, FIXTURES_DIR, execute_tx_and_wait_for_indexer, get_indexer_db_url,
-    indexer_wait_for_checkpoint, indexer_wait_for_checkpoint_pruned, indexer_wait_for_object,
-    indexer_wait_for_transaction, rpc_call_error_msg_matches,
-    start_test_cluster_with_read_write_indexer,
+    ApiTestSetup, FIXTURES_DIR, execute_tx_and_wait_for_indexer, indexer_wait_for_checkpoint,
+    indexer_wait_for_checkpoint_pruned, indexer_wait_for_object, indexer_wait_for_transaction,
+    rpc_call_error_msg_matches, start_test_cluster_with_read_write_indexer,
 };
 
 /// Utility function to convert hex strings in JSON values to byte arrays.
@@ -1719,8 +1719,7 @@ fn try_get_object_before_version() {
 
 #[tokio::test]
 async fn failed_stored_tx_into_transaction_block() {
-    let db_url = get_indexer_db_url(Some("test_failed_stored_tx_into_transaction_block"));
-    let mut test_db = TestDatabase::new(db_url);
+    let mut test_db = TestDatabase::new(db_url("test_failed_stored_tx_into_transaction_block"));
     test_db.recreate();
     test_db.reset_db();
     let pool = test_db.to_connection_pool();


### PR DESCRIPTION
# Description of change

This PR aims to remove redundant function `common::get_indexer_db_url`  implementation of getting the database url during local testing in favor of already implemented `test_utils::db_url`.

## Links to any relevant issues

fixes #7224 

## How the change has been tested

- ran all indexer tests
```shell
cargo test -p iota-indexer --features pg_integration -- --test-threads 1
cargo test -p iota-indexer --profile simulator --features shared_test_runtime
```

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

> [!NOTE]
> QA tests were not performed since the patch doe snot affect the normal operation of the `iota-indexer`


### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
