### PR TITLE
upstream(core): Deprecate skip_to/skip_prior_to/skip_to_last/reverse methods

### DIFF
--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -246,12 +246,10 @@ impl Store for RocksDBStore {
         let mut refs = std::collections::VecDeque::new();
         for kv in self
             .digests_by_authorities
-            .safe_range_iter((
-                Included((author, Round::MIN, BlockDigest::MIN)),
-                Included((author, before_round, BlockDigest::MAX)),
-            ))
-            .skip_to_last()
-            .reverse()
+            .reversed_safe_iter_with_bounds(
+                Some((author, Round::MIN, BlockDigest::MIN)),
+                Some((author, before_round, BlockDigest::MAX)),
+            )?
             .take(num_of_rounds as usize)
         {
             let ((author, round, digest), _) = kv?;
@@ -268,7 +266,11 @@ impl Store for RocksDBStore {
     }
 
     fn read_last_commit(&self) -> ConsensusResult<Option<TrustedCommit>> {
-        let Some(result) = self.commits.safe_iter().skip_to_last().next() else {
+        let Some(result) = self
+            .commits
+            .reversed_safe_iter_with_bounds(None, None)?
+            .next()
+        else {
             return Ok(None);
         };
         let ((_index, digest), serialized) = result?;
@@ -310,7 +312,11 @@ impl Store for RocksDBStore {
     }
 
     fn read_last_commit_info(&self) -> ConsensusResult<Option<(CommitRef, CommitInfo)>> {
-        let Some(result) = self.commit_info.safe_iter().skip_to_last().next() else {
+        let Some(result) = self
+            .commit_info
+            .reversed_safe_iter_with_bounds(None, None)?
+            .next()
+        else {
             return Ok(None);
         };
         let (key, commit_info) = result.map_err(ConsensusError::RocksDBFailure)?;

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -2791,7 +2791,7 @@ impl AuthorityState {
                 Some(seq) => self
                     .checkpoint_store
                     .get_checkpoint_by_sequence_number(seq)?,
-                None => self.checkpoint_store.get_latest_certified_checkpoint(),
+                None => self.checkpoint_store.get_latest_certified_checkpoint()?,
             }
             .map(|v| v.into_inner());
             summary.map(CheckpointSummaryResponse::Certified)
@@ -2800,7 +2800,7 @@ impl AuthorityState {
                 Some(seq) => self.checkpoint_store.get_locally_computed_checkpoint(seq)?,
                 None => self
                     .checkpoint_store
-                    .get_latest_locally_computed_checkpoint(),
+                    .get_latest_locally_computed_checkpoint()?,
             };
             summary.map(CheckpointSummaryResponse::Pending)
         };

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -617,7 +617,7 @@ pub struct AuthorityEpochTables {
     /// Stores pending signatures
     /// The key in this table is checkpoint sequence number and an arbitrary
     /// integer
-    pending_checkpoint_signatures:
+    pub(crate) pending_checkpoint_signatures:
         DBMap<(CheckpointSequenceNumber, u64), CheckpointSignatureMessage>,
 
     /// When we see certificate through consensus for the first time, we record
@@ -804,22 +804,6 @@ impl AuthorityEpochTables {
         Ok(self.last_consensus_stats.get(&LAST_CONSENSUS_STATS_ADDR)?)
     }
 
-    pub fn get_pending_checkpoint_signatures_iter(
-        &self,
-        checkpoint_seq: CheckpointSequenceNumber,
-        starting_index: u64,
-    ) -> IotaResult<
-        impl Iterator<Item = ((CheckpointSequenceNumber, u64), CheckpointSignatureMessage)> + '_,
-    > {
-        let key = (checkpoint_seq, starting_index);
-        trace!("Scanning pending checkpoint signatures from {:?}", key);
-        let iter = self
-            .pending_checkpoint_signatures
-            .unbounded_iter()
-            .skip_to(&key)?;
-        Ok::<_, IotaError>(iter)
-    }
-
     pub fn get_locked_transaction(&self, obj_ref: &ObjectRef) -> IotaResult<Option<LockDetails>> {
         Ok(self
             .owned_object_locked_transactions
@@ -962,7 +946,7 @@ impl AuthorityPerEpochStore {
 
         let mut jwk_aggregator = JwkAggregator::new(committee.clone());
 
-        for ((authority, id, jwk), _) in tables.pending_jwks.unbounded_iter().seek_to_first() {
+        for ((authority, id, jwk), _) in tables.pending_jwks.unbounded_iter() {
             jwk_aggregator.insert(authority, (id, jwk));
         }
 
@@ -1179,9 +1163,9 @@ impl AuthorityPerEpochStore {
         Ok(self
             .tables()?
             .running_root_accumulators
-            .unbounded_iter()
-            .skip_to_last()
-            .next())
+            .reversed_safe_iter_with_bounds(None, None)?
+            .next()
+            .transpose()?)
     }
 
     pub fn insert_running_root_accumulator(
@@ -3044,9 +3028,11 @@ impl AuthorityPerEpochStore {
         self.tables()
             .expect("test should not cross epoch boundary")
             .pending_checkpoints
-            .unbounded_iter()
-            .skip_to_last()
+            .reversed_safe_iter_with_bounds(None, None)
+            .unwrap()
             .next()
+            .transpose()
+            .unwrap()
             .map(|(key, _)| key)
             .unwrap_or_default()
     }
@@ -3875,11 +3861,13 @@ impl AuthorityPerEpochStore {
         last: Option<CheckpointHeight>,
     ) -> IotaResult<Vec<(CheckpointHeight, PendingCheckpoint)>> {
         let tables = self.tables()?;
-        let mut iter = tables.pending_checkpoints.unbounded_iter();
-        if let Some(last_processed_height) = last {
-            iter = iter.skip_to(&(last_processed_height + 1))?;
-        }
-        Ok(iter.collect())
+
+        let db_iter = tables
+            .pending_checkpoints
+            .safe_iter_with_bounds(last.map(|height| height + 1), None);
+        db_iter
+            .collect::<Result<Vec<(CheckpointHeight, PendingCheckpoint)>, _>>()
+            .map_err(Into::into)
     }
 
     pub fn get_pending_checkpoint(
@@ -3970,9 +3958,9 @@ impl AuthorityPerEpochStore {
         Ok(self
             .tables()?
             .builder_checkpoint_summary
-            .unbounded_iter()
-            .skip_to_last()
+            .reversed_safe_iter_with_bounds(None, None)?
             .next()
+            .transpose()?
             .map(|(_, s)| s))
     }
 
@@ -3982,9 +3970,9 @@ impl AuthorityPerEpochStore {
         Ok(self
             .tables()?
             .builder_checkpoint_summary
-            .unbounded_iter()
-            .skip_to_last()
+            .reversed_safe_iter_with_bounds(None, None)?
             .next()
+            .transpose()?
             .map(|(seq, s)| (seq, s.summary)))
     }
 
@@ -4013,9 +4001,9 @@ impl AuthorityPerEpochStore {
         Ok(self
             .tables()?
             .pending_checkpoint_signatures
-            .unbounded_iter()
-            .skip_to_last()
+            .reversed_safe_iter_with_bounds(None, None)?
             .next()
+            .transpose()?
             .map(|((_, index), _)| index)
             .unwrap_or_default())
     }

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -479,8 +479,7 @@ impl AuthorityStore {
         let marker_entry = self
             .perpetual_tables
             .object_per_epoch_marker_table
-            .safe_iter_with_bounds(Some(min_key), Some(max_key))
-            .skip_prior_to(&max_key)?
+            .reversed_safe_iter_with_bounds(Some(min_key), Some(max_key))?
             .next();
         match marker_entry {
             Some(Ok(((epoch, key), marker))) => {
@@ -632,10 +631,9 @@ impl AuthorityStore {
         let marker_entry = self
             .perpetual_tables
             .object_per_epoch_marker_table
-            .unbounded_iter()
-            .skip_prior_to(&marker_key)?
+            .reversed_safe_iter_with_bounds(None, Some(marker_key))?
             .next();
-        match marker_entry {
+        match marker_entry.transpose()? {
             Some(((epoch, key), marker)) => {
                 // Make sure object id matches and version is >= `version`
                 let object_data_ok = key.0 == *object_id && key.1 >= version;
@@ -1049,11 +1047,13 @@ impl AuthorityStore {
         let mut iterator = self
             .perpetual_tables
             .live_owned_object_markers
-            .unbounded_iter()
-            // Make the max possible entry for this object ID.
-            .skip_prior_to(&(object_id, SequenceNumber::MAX_VALID_EXCL, ObjectDigest::MAX))?;
+            .reversed_safe_iter_with_bounds(
+                None,
+                Some((object_id, SequenceNumber::MAX_VALID_EXCL, ObjectDigest::MAX)),
+            )?;
         Ok(iterator
             .next()
+            .transpose()?
             .and_then(|value| {
                 if value.0.0 == object_id {
                     Some(value)
@@ -1726,8 +1726,7 @@ impl AccumulatorStore for AuthorityStore {
         Ok(self
             .perpetual_tables
             .root_state_hash_by_epoch
-            .safe_iter()
-            .skip_to_last()
+            .reversed_safe_iter_with_bounds(None, None)?
             .next()
             .transpose()?)
     }

--- a/crates/iota-core/src/authority/authority_store_tables.rs
+++ b/crates/iota-core/src/authority/authority_store_tables.rs
@@ -240,11 +240,11 @@ impl AuthorityPerpetualTables {
         object_id: ObjectID,
         version: SequenceNumber,
     ) -> IotaResult<Option<Object>> {
-        let iter = self
-            .objects
-            .safe_range_iter(ObjectKey::min_for_id(&object_id)..=ObjectKey::max_for_id(&object_id))
-            .skip_prior_to(&ObjectKey(object_id, version))?;
-        match iter.reverse().next() {
+        let mut iter = self.objects.reversed_safe_iter_with_bounds(
+            Some(ObjectKey::min_for_id(&object_id)),
+            Some(ObjectKey(object_id, version)),
+        )?;
+        match iter.next() {
             Some(Ok((key, o))) => self.object(&key, o),
             Some(Err(e)) => Err(e.into()),
             None => Ok(None),
@@ -320,12 +320,12 @@ impl AuthorityPerpetualTables {
         &self,
         object_id: ObjectID,
     ) -> Result<Option<ObjectRef>, IotaError> {
-        let mut iterator = self
-            .objects
-            .unbounded_iter()
-            .skip_prior_to(&ObjectKey::max_for_id(&object_id))?;
+        let mut iterator = self.objects.reversed_safe_iter_with_bounds(
+            Some(ObjectKey::min_for_id(&object_id)),
+            Some(ObjectKey::max_for_id(&object_id)),
+        )?;
 
-        if let Some((object_key, value)) = iterator.next() {
+        if let Some(Ok((object_key, value))) = iterator.next() {
             if object_key.0 == object_id {
                 return Ok(Some(self.object_reference(&object_key, value)?));
             }
@@ -337,12 +337,12 @@ impl AuthorityPerpetualTables {
         &self,
         object_id: ObjectID,
     ) -> Result<Option<(ObjectKey, StoreObjectWrapper)>, IotaError> {
-        let mut iterator = self
-            .objects
-            .unbounded_iter()
-            .skip_prior_to(&ObjectKey::max_for_id(&object_id))?;
+        let mut iterator = self.objects.reversed_safe_iter_with_bounds(
+            Some(ObjectKey::min_for_id(&object_id)),
+            Some(ObjectKey::max_for_id(&object_id)),
+        )?;
 
-        if let Some((object_key, value)) = iterator.next() {
+        if let Some(Ok((object_key, value))) = iterator.next() {
             if object_key.0 == object_id {
                 return Ok(Some((object_key, value)));
             }
@@ -438,12 +438,7 @@ impl AuthorityPerpetualTables {
     }
 
     pub fn database_is_empty(&self) -> IotaResult<bool> {
-        Ok(self
-            .objects
-            .unbounded_iter()
-            .skip_to(&ObjectKey::ZERO)?
-            .next()
-            .is_none())
+        Ok(self.objects.unbounded_iter().next().is_none())
     }
 
     pub fn iter_live_object_set(&self) -> LiveSetIter<'_> {
@@ -530,12 +525,11 @@ impl ObjectStore for AuthorityPerpetualTables {
     ) -> Result<Option<Object>, iota_types::storage::error::Error> {
         let obj_entry = self
             .objects
-            .unbounded_iter()
-            .skip_prior_to(&ObjectKey::max_for_id(object_id))
+            .reversed_safe_iter_with_bounds(None, Some(ObjectKey::max_for_id(object_id)))
             .map_err(iota_types::storage::error::Error::custom)?
             .next();
 
-        match obj_entry {
+        match obj_entry.transpose()? {
             Some((ObjectKey(obj_id, version), obj)) if obj_id == *object_id => Ok(self
                 .object(&ObjectKey(obj_id, version), obj)
                 .map_err(iota_types::storage::error::Error::custom)?),

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -315,22 +315,28 @@ impl CheckpointStore {
             .remove(digest)
     }
 
-    pub fn get_latest_certified_checkpoint(&self) -> Option<VerifiedCheckpoint> {
-        self.tables
+    pub fn get_latest_certified_checkpoint(
+        &self,
+    ) -> Result<Option<VerifiedCheckpoint>, TypedStoreError> {
+        Ok(self
+            .tables
             .certified_checkpoints
-            .unbounded_iter()
-            .skip_to_last()
+            .reversed_safe_iter_with_bounds(None, None)?
             .next()
-            .map(|(_, v)| v.into())
+            .transpose()?
+            .map(|(_, v)| v.into()))
     }
 
-    pub fn get_latest_locally_computed_checkpoint(&self) -> Option<CheckpointSummary> {
-        self.tables
+    pub fn get_latest_locally_computed_checkpoint(
+        &self,
+    ) -> Result<Option<CheckpointSummary>, TypedStoreError> {
+        Ok(self
+            .tables
             .locally_computed_checkpoints
-            .unbounded_iter()
-            .skip_to_last()
+            .reversed_safe_iter_with_bounds(None, None)?
             .next()
-            .map(|(_, v)| v)
+            .transpose()?
+            .map(|(_, v)| v))
     }
 
     pub fn multi_get_checkpoint_by_sequence_number(
@@ -457,9 +463,9 @@ impl CheckpointStore {
         if let Some((last_local_summary, _)) = self
             .tables
             .locally_computed_checkpoints
-            .unbounded_iter()
-            .skip_to_last()
+            .reversed_safe_iter_with_bounds(None, None)?
             .next()
+            .transpose()?
         {
             let mut batch = self.tables.locally_computed_checkpoints.batch();
             batch.schedule_delete_range(
@@ -882,7 +888,10 @@ impl CheckpointStore {
             .expect("get_highest_executed_checkpoint_seq_number should not fail")
             .unwrap_or(0);
 
-        let Some(highest_built) = self.get_latest_locally_computed_checkpoint() else {
+        let Some(highest_built) = self
+            .get_latest_locally_computed_checkpoint()
+            .expect("failed to get latest locally computed checkpoint")
+        else {
             info!("no locally built checkpoints to verify");
             return;
         };
@@ -1972,7 +1981,7 @@ impl CheckpointAggregator {
         let _scope = monitored_scope("CheckpointAggregator");
         let mut result = vec![];
         'outer: loop {
-            let next_to_certify = self.next_checkpoint_to_certify();
+            let next_to_certify = self.next_checkpoint_to_certify()?;
             let current = if let Some(current) = &mut self.current {
                 // It's possible that the checkpoint was already certified by
                 // the rest of the network and we've already received the
@@ -2009,11 +2018,14 @@ impl CheckpointAggregator {
                 .epoch_store
                 .tables()
                 .expect("should not run past end of epoch");
-            let iter = epoch_tables.get_pending_checkpoint_signatures_iter(
-                current.summary.sequence_number,
-                current.next_index,
-            )?;
-            for ((seq, index), data) in iter {
+            let iter = epoch_tables
+                .pending_checkpoint_signatures
+                .safe_iter_with_bounds(
+                    Some((current.summary.sequence_number, current.next_index)),
+                    None,
+                );
+            for item in iter {
+                let ((seq, index), data) = item?;
                 if seq != current.summary.sequence_number {
                     trace!(
                         checkpoint_seq =? current.summary.sequence_number,
@@ -2067,15 +2079,16 @@ impl CheckpointAggregator {
         Ok(result)
     }
 
-    fn next_checkpoint_to_certify(&self) -> CheckpointSequenceNumber {
-        self.store
+    fn next_checkpoint_to_certify(&self) -> IotaResult<CheckpointSequenceNumber> {
+        Ok(self
+            .store
             .tables
             .certified_checkpoints
-            .unbounded_iter()
-            .skip_to_last()
+            .reversed_safe_iter_with_bounds(None, None)?
             .next()
+            .transpose()?
             .map(|(seq, _)| seq + 1)
-            .unwrap_or_default()
+            .unwrap_or_default())
     }
 }
 

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -888,10 +888,7 @@ impl CheckpointStore {
             .expect("get_highest_executed_checkpoint_seq_number should not fail")
             .unwrap_or(0);
 
-        let Some(highest_built) = self
-            .get_latest_locally_computed_checkpoint()
-            .expect("failed to get latest locally computed checkpoint")
-        else {
+        let Ok(Some(highest_built)) = self.get_latest_locally_computed_checkpoint() else {
             info!("no locally built checkpoints to verify");
             return;
         };

--- a/crates/iota-core/src/epoch/committee_store.rs
+++ b/crates/iota-core/src/epoch/committee_store.rs
@@ -101,16 +101,17 @@ impl CommitteeStore {
     }
 
     // todo - make use of cache or remove this method
-    pub fn get_latest_committee(&self) -> Committee {
-        self.tables
+    pub fn get_latest_committee(&self) -> IotaResult<Committee> {
+        Ok(self
+            .tables
             .committee_map
-            .unbounded_iter()
-            .skip_to_last()
+            .reversed_safe_iter_with_bounds(None, None)?
             .next()
+            .transpose()?
             // unwrap safe because we guarantee there is at least a genesis epoch
             // when initializing the store.
             .unwrap()
-            .1
+            .1)
     }
     /// Return the committee specified by `epoch`. If `epoch` is `None`, return
     /// the latest committee.
@@ -121,7 +122,7 @@ impl CommitteeStore {
                 .get_committee(&epoch)?
                 .ok_or(IotaError::MissingCommitteeAtEpoch(epoch))
                 .map(|c| Committee::clone(&*c))?,
-            None => self.get_latest_committee(),
+            None => self.get_latest_committee()?,
         })
     }
 

--- a/crates/iota-core/src/jsonrpc_index.rs
+++ b/crates/iota-core/src/jsonrpc_index.rs
@@ -297,9 +297,11 @@ impl IndexStore {
         };
         let next_sequence_number = tables
             .transaction_order
-            .unbounded_iter()
-            .skip_to_last()
+            .reversed_safe_iter_with_bounds(None, None)
+            .expect("failed to initialize indexes")
             .next()
+            .transpose()
+            .expect("failed to initialize indexes")
             .map(|(seq, _)| seq + 1)
             .unwrap_or(0)
             .into();
@@ -684,22 +686,26 @@ impl IndexStore {
                 error: UserInputError::Unsupported(format!("{filter:?}")),
             }),
             None => {
-                let iter = self.tables.transaction_order.unbounded_iter();
-
                 if reverse {
-                    let iter = iter
-                        .skip_prior_to(&cursor.unwrap_or(TxSequenceNumber::MAX))?
-                        .reverse()
+                    let iter = self
+                        .tables
+                        .transaction_order
+                        .reversed_safe_iter_with_bounds(
+                            None,
+                            Some(cursor.unwrap_or(TxSequenceNumber::MAX)),
+                        )?
                         .skip(usize::from(cursor.is_some()))
-                        .map(|(_, digest)| digest);
+                        .map(|result| result.map(|(_, digest)| digest));
                     if let Some(limit) = limit {
-                        Ok(iter.take(limit).collect())
+                        Ok(iter.take(limit).collect::<Result<Vec<_>, _>>()?)
                     } else {
-                        Ok(iter.collect())
+                        Ok(iter.collect::<Result<Vec<_>, _>>()?)
                     }
                 } else {
-                    let iter = iter
-                        .skip_to(&cursor.unwrap_or(TxSequenceNumber::MIN))?
+                    let iter = self
+                        .tables
+                        .transaction_order
+                        .iter_with_bounds(Some(cursor.unwrap_or(TxSequenceNumber::MIN)), None)
                         .skip(usize::from(cursor.is_some()))
                         .map(|(_, digest)| digest);
                     if let Some(limit) = limit {
@@ -721,11 +727,14 @@ impl IndexStore {
     ) -> IotaResult<Vec<TransactionDigest>> {
         Ok(if reverse {
             let iter = index
-                .unbounded_iter()
-                .skip_prior_to(&(key.clone(), cursor.unwrap_or(TxSequenceNumber::MAX)))?
-                .reverse()
+                .reversed_safe_iter_with_bounds(
+                    None,
+                    Some((key.clone(), cursor.unwrap_or(TxSequenceNumber::MAX))),
+                )?
                 // skip one more if exclusive cursor is Some
                 .skip(usize::from(cursor.is_some()))
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter()
                 .take_while(|((id, _), _)| *id == key)
                 .map(|(_, digest)| digest);
             if let Some(limit) = limit {
@@ -735,8 +744,10 @@ impl IndexStore {
             }
         } else {
             let iter = index
-                .unbounded_iter()
-                .skip_to(&(key.clone(), cursor.unwrap_or(TxSequenceNumber::MIN)))?
+                .iter_with_bounds(
+                    Some((key.clone(), cursor.unwrap_or(TxSequenceNumber::MIN))),
+                    None,
+                )
                 // skip one more if exclusive cursor is Some
                 .skip(usize::from(cursor.is_some()))
                 .take_while(|((id, _), _)| *id == key)
@@ -851,13 +862,15 @@ impl IndexStore {
                 .unwrap_or(if reverse { max_string } else { "".to_string() });
 
         let key = (package, module_val, function_val, cursor_val);
-        let iter = self.tables.transactions_by_move_function.unbounded_iter();
         Ok(if reverse {
-            let iter = iter
-                .skip_prior_to(&key)?
-                .reverse()
+            let iter = self
+                .tables
+                .transactions_by_move_function
+                .reversed_safe_iter_with_bounds(None, Some(key))?
                 // skip one more if exclusive cursor is Some
                 .skip(usize::from(cursor.is_some()))
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter()
                 .take_while(|((id, m, f, _), _)| {
                     *id == package
                         && module.as_ref().map(|x| x == m).unwrap_or(true)
@@ -870,8 +883,10 @@ impl IndexStore {
                 iter.collect()
             }
         } else {
-            let iter = iter
-                .skip_to(&key)?
+            let iter = self
+                .tables
+                .transactions_by_move_function
+                .iter_with_bounds(Some(key), None)
                 // skip one more if exclusive cursor is Some
                 .skip(usize::from(cursor.is_some()))
                 .take_while(|((id, m, f, _), _)| {
@@ -921,19 +936,18 @@ impl IndexStore {
         Ok(if descending {
             self.tables
                 .event_order
-                .unbounded_iter()
-                .skip_prior_to(&(tx_seq, event_seq))?
-                .reverse()
+                .reversed_safe_iter_with_bounds(None, Some((tx_seq, event_seq)))?
                 .take(limit)
-                .map(|((_, event_seq), (digest, tx_digest, time))| {
-                    (digest, tx_digest, event_seq, time)
+                .map(|result| {
+                    result.map(|((_, event_seq), (digest, tx_digest, time))| {
+                        (digest, tx_digest, event_seq, time)
+                    })
                 })
-                .collect()
+                .collect::<Result<Vec<_>, _>>()?
         } else {
             self.tables
                 .event_order
-                .unbounded_iter()
-                .skip_to(&(tx_seq, event_seq))?
+                .iter_with_bounds(Some((tx_seq, event_seq)), None)
                 .take(limit)
                 .map(|((_, event_seq), (digest, tx_digest, time))| {
                     (digest, tx_digest, event_seq, time)
@@ -956,9 +970,9 @@ impl IndexStore {
         Ok(if descending {
             self.tables
                 .event_order
-                .unbounded_iter()
-                .skip_prior_to(&(min(tx_seq, seq), event_seq))?
-                .reverse()
+                .reversed_safe_iter_with_bounds(None, Some((min(tx_seq, seq), event_seq)))?
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter()
                 .take_while(|((tx, _), _)| tx == &seq)
                 .take(limit)
                 .map(|((_, event_seq), (digest, tx_digest, time))| {
@@ -968,8 +982,7 @@ impl IndexStore {
         } else {
             self.tables
                 .event_order
-                .unbounded_iter()
-                .skip_to(&(max(tx_seq, seq), event_seq))?
+                .iter_with_bounds(Some((max(tx_seq, seq), event_seq)), None)
                 .take_while(|((tx, _), _)| tx == &seq)
                 .take(limit)
                 .map(|((_, event_seq), (digest, tx_digest, time))| {
@@ -989,9 +1002,9 @@ impl IndexStore {
     ) -> IotaResult<Vec<(TransactionEventsDigest, TransactionDigest, usize, u64)>> {
         Ok(if descending {
             index
-                .unbounded_iter()
-                .skip_prior_to(&(key.clone(), (tx_seq, event_seq)))?
-                .reverse()
+                .reversed_safe_iter_with_bounds(None, Some((key.clone(), (tx_seq, event_seq))))?
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter()
                 .take_while(|((m, _), _)| m == key)
                 .take(limit)
                 .map(|((_, (_, event_seq)), (digest, tx_digest, time))| {
@@ -1000,8 +1013,7 @@ impl IndexStore {
                 .collect()
         } else {
             index
-                .unbounded_iter()
-                .skip_to(&(key.clone(), (tx_seq, event_seq)))?
+                .iter_with_bounds(Some((key.clone(), (tx_seq, event_seq))), None)
                 .take_while(|((m, _), _)| m == key)
                 .take(limit)
                 .map(|((_, (_, event_seq)), (digest, tx_digest, time))| {
@@ -1095,9 +1107,9 @@ impl IndexStore {
         Ok(if descending {
             self.tables
                 .event_by_time
-                .unbounded_iter()
-                .skip_prior_to(&(end_time, (tx_seq, event_seq)))?
-                .reverse()
+                .reversed_safe_iter_with_bounds(None, Some((end_time, (tx_seq, event_seq))))?
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter()
                 .take_while(|((m, _), _)| m >= &start_time)
                 .take(limit)
                 .map(|((_, (_, event_seq)), (digest, tx_digest, time))| {
@@ -1107,8 +1119,7 @@ impl IndexStore {
         } else {
             self.tables
                 .event_by_time
-                .unbounded_iter()
-                .skip_to(&(start_time, (tx_seq, event_seq)))?
+                .iter_with_bounds(Some((start_time, (tx_seq, event_seq))), None)
                 .take_while(|((m, _), _)| m <= &end_time)
                 .take(limit)
                 .map(|((_, (_, event_seq)), (digest, tx_digest, time))| {
@@ -1125,14 +1136,13 @@ impl IndexStore {
     ) -> IotaResult<impl Iterator<Item = Result<(ObjectID, DynamicFieldInfo), TypedStoreError>> + '_>
     {
         debug!(?object, "get_dynamic_fields");
-        let iter_lower_bound = (object, ObjectID::ZERO);
+        // The object id 0 is the smallest possible
+        let iter_lower_bound = (object, cursor.unwrap_or(ObjectID::ZERO));
         let iter_upper_bound = (object, ObjectID::MAX);
         Ok(self
             .tables
             .dynamic_field_index
             .safe_iter_with_bounds(Some(iter_lower_bound), Some(iter_upper_bound))
-            // The object id 0 is the smallest possible
-            .skip_to(&(object, cursor.unwrap_or(ObjectID::ZERO)))?
             // skip an extra b/c the cursor is exclusive
             .skip(usize::from(cursor.is_some()))
             .take_while(move |result| result.is_err() || (result.as_ref().unwrap().0.0 == object))
@@ -1217,8 +1227,10 @@ impl IndexStore {
         let starting_coin_type =
             coin_type_tag.unwrap_or_else(|| String::from_utf8([0u8].to_vec()).unwrap());
         Ok(coin_index
-            .unbounded_iter()
-            .skip_to(&(owner, starting_coin_type.clone(), ObjectID::ZERO))?
+            .iter_with_bounds(
+                Some((owner, starting_coin_type.clone(), ObjectID::ZERO)),
+                None,
+            )
             .take_while(move |((addr, coin_type, _), _)| {
                 if addr != &owner {
                     return false;
@@ -1242,8 +1254,10 @@ impl IndexStore {
         Ok(self
             .tables
             .coin_index
-            .unbounded_iter()
-            .skip_to(&(owner, starting_coin_type.clone(), starting_object_id))?
+            .iter_with_bounds(
+                Some((owner, starting_coin_type.clone(), starting_object_id)),
+                None,
+            )
             .filter(move |((_, _, obj_id), _)| obj_id != &starting_object_id)
             .enumerate()
             .take_while(move |(index, ((addr, coin_type, _), _))| {
@@ -1273,9 +1287,8 @@ impl IndexStore {
         Ok(self
             .tables
             .owner_index
-            .unbounded_iter()
             // The object id 0 is the smallest possible
-            .skip_to(&(owner, starting_object_id))?
+            .iter_with_bounds(Some((owner, starting_object_id)), None)
             .skip(usize::from(starting_object_id != ObjectID::ZERO))
             .take_while(move |((address_owner, _), _)| address_owner == &owner)
             .filter(move |(_, o)| {

--- a/crates/iota-core/src/rest_index.rs
+++ b/crates/iota-core/src/rest_index.rs
@@ -406,17 +406,11 @@ impl IndexStoreTables {
         owner: IotaAddress,
         cursor: Option<ObjectID>,
     ) -> Result<impl Iterator<Item = (OwnerIndexKey, OwnerIndexInfo)> + '_, TypedStoreError> {
-        let lower_bound = OwnerIndexKey::new(owner, ObjectID::ZERO);
+        let lower_bound = OwnerIndexKey::new(owner, cursor.unwrap_or(ObjectID::ZERO));
         let upper_bound = OwnerIndexKey::new(owner, ObjectID::MAX);
-        let mut iter = self
+        Ok(self
             .owner
-            .iter_with_bounds(Some(lower_bound), Some(upper_bound));
-
-        if let Some(cursor) = cursor {
-            iter = iter.skip_to(&OwnerIndexKey::new(owner, cursor))?;
-        }
-
-        Ok(iter)
+            .iter_with_bounds(Some(lower_bound), Some(upper_bound)))
     }
 
     fn dynamic_field_iter(
@@ -425,16 +419,11 @@ impl IndexStoreTables {
         cursor: Option<ObjectID>,
     ) -> Result<impl Iterator<Item = (DynamicFieldKey, DynamicFieldIndexInfo)> + '_, TypedStoreError>
     {
-        let lower_bound = DynamicFieldKey::new(parent, ObjectID::ZERO);
+        let lower_bound = DynamicFieldKey::new(parent, cursor.unwrap_or(ObjectID::ZERO));
         let upper_bound = DynamicFieldKey::new(parent, ObjectID::MAX);
-        let mut iter = self
+        let iter = self
             .dynamic_field
             .iter_with_bounds(Some(lower_bound), Some(upper_bound));
-
-        if let Some(cursor) = cursor {
-            iter = iter.skip_to(&DynamicFieldKey::new(parent, cursor))?;
-        }
-
         Ok(iter)
     }
 

--- a/crates/iota-single-node-benchmark/src/single_node.rs
+++ b/crates/iota-single-node-benchmark/src/single_node.rs
@@ -252,6 +252,7 @@ impl SingleValidator {
             self.get_validator()
                 .get_checkpoint_store()
                 .get_latest_certified_checkpoint()
+                .unwrap()
                 .unwrap(),
         );
         let mut checkpoints = vec![];

--- a/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/iota-transactional-test-runner/src/simulator_persisted_store.rs
@@ -186,9 +186,11 @@ impl SimulatorStore for PersistedStore {
     fn get_highest_checkpoint(&self) -> Option<VerifiedCheckpoint> {
         self.read_write
             .checkpoints
-            .unbounded_iter()
-            .skip_to_last()
+            .reversed_safe_iter_with_bounds(None, None)
+            .expect("failed to fetch highest checkpoint")
             .next()
+            .transpose()
+            .expect("failed to fetch highest checkpoint")
             .map(|(_, checkpoint)| checkpoint.into())
     }
 
@@ -558,9 +560,9 @@ impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
         self.sync();
         self.inner
             .checkpoints
-            .unbounded_iter()
-            .skip_to_last()
+            .reversed_safe_iter_with_bounds(None, None)?
             .next()
+            .transpose()?
             .map(|(_, checkpoint)| checkpoint.into())
             .ok_or(IotaError::UserInput {
                 error: UserInputError::LatestCheckpointSequenceNumberNotFound,

--- a/crates/typed-store/src/rocks/iter.rs
+++ b/crates/typed-store/src/rocks/iter.rs
@@ -7,9 +7,9 @@ use std::{marker::PhantomData, sync::Arc};
 use bincode::Options;
 use prometheus::{Histogram, HistogramTimer};
 use rocksdb::Direction;
-use serde::{Serialize, de::DeserializeOwned};
+use serde::de::DeserializeOwned;
 
-use super::{RocksDBRawIter, TypedStoreError, be_fix_int_ser};
+use super::RocksDBRawIter;
 use crate::{DBMetrics, metrics::RocksDBPerfContext};
 
 /// An iterator over all key-value pairs in a data map.
@@ -107,70 +107,5 @@ impl<K, V> Drop for Iter<'_, K, V> {
                 .read_perf_ctx_metrics
                 .report_metrics(&self.cf_name);
         }
-    }
-}
-
-impl<'a, K: Serialize, V> Iter<'a, K, V> {
-    /// Skips all the elements that are smaller than the given key,
-    /// and either lands on the key or the first one greater than
-    /// the key.
-    pub fn skip_to(mut self, key: &K) -> Result<Self, TypedStoreError> {
-        self.is_initialized = true;
-        self.db_iter.seek(be_fix_int_ser(key)?);
-        Ok(self)
-    }
-
-    /// Moves the iterator the element given or
-    /// the one prior to it if it does not exist. If there is
-    /// no element prior to it, it returns an empty iterator.
-    pub fn skip_prior_to(mut self, key: &K) -> Result<Self, TypedStoreError> {
-        self.is_initialized = true;
-        self.db_iter.seek_for_prev(be_fix_int_ser(key)?);
-        Ok(self)
-    }
-
-    /// Seeks to the last key in the database (at this column family).
-    pub fn skip_to_last(mut self) -> Self {
-        self.is_initialized = true;
-        self.db_iter.seek_to_last();
-        self
-    }
-
-    /// Seeks to the first key in the database (at this column family).
-    pub fn seek_to_first(mut self) -> Self {
-        self.is_initialized = true;
-        self.db_iter.seek_to_first();
-        self
-    }
-
-    /// Will make the direction of the iteration reverse and will
-    /// create a new `RevIter` to consume. Every call to `next` method
-    /// will give the next element from the end.
-    pub fn reverse(mut self) -> RevIter<'a, K, V> {
-        self.direction = Direction::Reverse;
-        RevIter::new(self)
-    }
-}
-
-/// An iterator with a reverted direction to the original. The `RevIter`
-/// is hosting an iteration which is consuming in the opposing direction.
-/// It's not possible to do further manipulation (ex re-reverse) to the
-/// iterator.
-pub struct RevIter<'a, K, V> {
-    iter: Iter<'a, K, V>,
-}
-
-impl<'a, K, V> RevIter<'a, K, V> {
-    fn new(iter: Iter<'a, K, V>) -> Self {
-        Self { iter }
-    }
-}
-
-impl<K: DeserializeOwned, V: DeserializeOwned> Iterator for RevIter<'_, K, V> {
-    type Item = (K, V);
-
-    /// Will give the next item backwards
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next()
     }
 }

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -43,7 +43,7 @@ use crate::{
             typed_store_err_from_bcs_err, typed_store_err_from_bincode_err,
             typed_store_err_from_rocks_err,
         },
-        safe_iter::SafeIter,
+        safe_iter::{SafeIter, SafeRevIter},
     },
     traits::{Map, TableSummary},
 };
@@ -1325,6 +1325,43 @@ impl<K, V> DBMap<K, V> {
         readopts
     }
 
+    /// Creates a safe reversed iterator with optional bounds.
+    /// Upper bound is included.
+    pub fn reversed_safe_iter_with_bounds(
+        &self,
+        lower_bound: Option<K>,
+        upper_bound: Option<K>,
+    ) -> Result<SafeRevIter<'_, K, V>, TypedStoreError>
+    where
+        K: Serialize + DeserializeOwned,
+        V: Serialize + DeserializeOwned,
+    {
+        let upper_bound_key = upper_bound.as_ref().map(|k| be_fix_int_ser(&k));
+        let readopts = self.create_read_options_with_range((
+            lower_bound
+                .as_ref()
+                .map(Bound::Included)
+                .unwrap_or(Bound::Unbounded),
+            upper_bound
+                .as_ref()
+                .map(Bound::Included)
+                .unwrap_or(Bound::Unbounded),
+        ));
+
+        let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
+        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+        let iter = SafeIter::new(
+            self.cf.clone(),
+            db_iter,
+            _timer,
+            _perf_ctx,
+            bytes_scanned,
+            keys_scanned,
+            Some(self.db_metrics.clone()),
+        );
+        Ok(SafeRevIter::new(iter, upper_bound_key.transpose()?))
+    }
+
     // Creates a RocksDB read option with lower and upper bounds set corresponding
     // to `range`.
     fn create_read_options_with_range(&self, range: impl RangeBounds<K>) -> ReadOptions
@@ -2007,9 +2044,12 @@ where
     /// overridden in the config), so please use this function with caution
     #[instrument(level = "trace", skip_all, err)]
     fn schedule_delete_all(&self) -> Result<(), TypedStoreError> {
-        let mut iter = self.unbounded_iter().seek_to_first();
-        let first_key = iter.next().map(|(k, _v)| k);
-        let last_key = iter.skip_to_last().next().map(|(k, _v)| k);
+        let first_key = self.unbounded_iter().next().map(|(k, _v)| k);
+        let last_key = self
+            .reversed_safe_iter_with_bounds(None, None)?
+            .next()
+            .transpose()?
+            .map(|(k, _v)| k);
         if let Some((first_key, last_key)) = first_key.zip(last_key) {
             let mut batch = self.batch();
             batch.schedule_delete_range(self, &first_key, &last_key)?;

--- a/crates/typed-store/src/rocks/safe_iter.rs
+++ b/crates/typed-store/src/rocks/safe_iter.rs
@@ -7,9 +7,9 @@ use std::{marker::PhantomData, sync::Arc};
 use bincode::Options;
 use prometheus::{Histogram, HistogramTimer};
 use rocksdb::Direction;
-use serde::{Serialize, de::DeserializeOwned};
+use serde::de::DeserializeOwned;
 
-use super::{RocksDBRawIter, TypedStoreError, be_fix_int_ser};
+use super::{RocksDBRawIter, TypedStoreError};
 use crate::metrics::{DBMetrics, RocksDBPerfContext};
 
 /// An iterator over all key-value pairs in a data map.
@@ -111,41 +111,6 @@ impl<K, V> Drop for SafeIter<'_, K, V> {
     }
 }
 
-impl<'a, K: Serialize, V> SafeIter<'a, K, V> {
-    /// Skips all the elements that are smaller than the given key,
-    /// and either lands on the key or the first one greater than
-    /// the key.
-    pub fn skip_to(mut self, key: &K) -> Result<Self, TypedStoreError> {
-        self.db_iter.seek(be_fix_int_ser(key)?);
-        self.is_initialized = true;
-        Ok(self)
-    }
-
-    /// Moves the iterator the element given or
-    /// the one prior to it if it does not exist. If there is
-    /// no element prior to it, it returns an empty iterator.
-    pub fn skip_prior_to(mut self, key: &K) -> Result<Self, TypedStoreError> {
-        self.db_iter.seek_for_prev(be_fix_int_ser(key)?);
-        self.is_initialized = true;
-        Ok(self)
-    }
-
-    /// Seeks to the last key in the database (at this column family).
-    pub fn skip_to_last(mut self) -> Self {
-        self.db_iter.seek_to_last();
-        self.is_initialized = true;
-        self
-    }
-
-    /// Will make the direction of the iteration reverse and will
-    /// create a new `RevIter` to consume. Every call to `next` method
-    /// will give the next element from the end.
-    pub fn reverse(mut self) -> SafeRevIter<'a, K, V> {
-        self.direction = Direction::Reverse;
-        SafeRevIter::new(self)
-    }
-}
-
 /// An iterator with a reverted direction to the original. The `RevIter`
 /// is hosting an iteration which is consuming in the opposing direction.
 /// It's not possible to do further manipulation (ex re-reverse) to the
@@ -155,7 +120,13 @@ pub struct SafeRevIter<'a, K, V> {
 }
 
 impl<'a, K, V> SafeRevIter<'a, K, V> {
-    fn new(iter: SafeIter<'a, K, V>) -> Self {
+    pub(crate) fn new(mut iter: SafeIter<'a, K, V>, upper_bound: Option<Vec<u8>>) -> Self {
+        iter.is_initialized = true;
+        iter.direction = Direction::Reverse;
+        match upper_bound {
+            None => iter.db_iter.seek_to_last(),
+            Some(key) => iter.db_iter.seek_for_prev(&key),
+        }
         Self { iter }
     }
 }

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -3,13 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use rstest::rstest;
-use serde::Deserialize;
 
 use super::*;
 use crate::{
     reopen, retry_transaction,
     rocks::{
-        iter::{Iter, RevIter},
+        iter::Iter,
         safe_iter::{SafeIter, SafeRevIter},
     },
 };
@@ -25,9 +24,7 @@ fn temp_dir() -> std::path::PathBuf {
 // tests, while varying different types of underlying Iterator.
 enum TestIteratorWrapper<'a, K, V> {
     Iter(Iter<'a, K, V>),
-    RevIter(RevIter<'a, K, V>),
     SafeIter(SafeIter<'a, K, V>),
-    SafeRevIter(SafeRevIter<'a, K, V>),
 }
 
 // Implement Iterator for TestIteratorWrapper that returns the same type result
@@ -39,9 +36,7 @@ impl<K: DeserializeOwned, V: DeserializeOwned> Iterator for TestIteratorWrapper<
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             TestIteratorWrapper::Iter(iter) => iter.next(),
-            TestIteratorWrapper::RevIter(iter) => iter.next(),
             TestIteratorWrapper::SafeIter(iter) => iter.next().map(|result| result.unwrap()),
-            TestIteratorWrapper::SafeRevIter(iter) => iter.next().map(|result| result.unwrap()),
         }
     }
 }
@@ -56,6 +51,19 @@ where
         true => TestIteratorWrapper::SafeIter(db.safe_iter()),
         false => TestIteratorWrapper::Iter(db.unbounded_iter()),
     }
+}
+
+fn get_reverse_iter<K, V>(
+    db: &DBMap<K, V>,
+    lower_bound: Option<K>,
+    upper_bound: Option<K>,
+) -> SafeRevIter<'_, K, V>
+where
+    K: Serialize + DeserializeOwned,
+    V: Serialize + DeserializeOwned,
+{
+    db.reversed_safe_iter_with_bounds(lower_bound, upper_bound)
+        .unwrap()
 }
 
 // Creates an range bounded Iterator based on `use_safe_iter` on `db`.
@@ -88,45 +96,6 @@ where
     match use_safe_iter {
         true => TestIteratorWrapper::SafeIter(db.safe_range_iter(range)),
         false => TestIteratorWrapper::Iter(db.range_iter(range)),
-    }
-}
-
-impl<K: Serialize, V> TestIteratorWrapper<'_, K, V> {
-    pub fn skip_to(self, key: &K) -> Result<Self, TypedStoreError> {
-        match self {
-            TestIteratorWrapper::Iter(iter) => Ok(TestIteratorWrapper::Iter(iter.skip_to(key)?)),
-            TestIteratorWrapper::SafeIter(iter) => {
-                Ok(TestIteratorWrapper::SafeIter(iter.skip_to(key)?))
-            }
-            _ => panic!("Not supported!"),
-        }
-    }
-    pub fn skip_prior_to(self, key: &K) -> Result<Self, TypedStoreError> {
-        match self {
-            TestIteratorWrapper::Iter(iter) => {
-                Ok(TestIteratorWrapper::Iter(iter.skip_prior_to(key)?))
-            }
-            TestIteratorWrapper::SafeIter(iter) => {
-                Ok(TestIteratorWrapper::SafeIter(iter.skip_prior_to(key)?))
-            }
-            _ => panic!("Not supported!"),
-        }
-    }
-    pub fn skip_to_last(self) -> Self {
-        match self {
-            TestIteratorWrapper::Iter(iter) => TestIteratorWrapper::Iter(iter.skip_to_last()),
-            TestIteratorWrapper::SafeIter(iter) => {
-                TestIteratorWrapper::SafeIter(iter.skip_to_last())
-            }
-            _ => panic!("Not supported!"),
-        }
-    }
-    pub fn reverse(self) -> Self {
-        match self {
-            TestIteratorWrapper::Iter(iter) => TestIteratorWrapper::RevIter(iter.reverse()),
-            TestIteratorWrapper::SafeIter(iter) => TestIteratorWrapper::SafeRevIter(iter.reverse()),
-            _ => panic!("Not supported!"),
-        }
     }
 }
 
@@ -281,54 +250,33 @@ async fn test_skip(
         .expect("Failed to insert");
 
     // Skip all smaller
-    let key_vals: Vec<_> = get_iter(&db, use_safe_iter)
-        .skip_to(&456)
-        .expect("Seek failed")
-        .collect();
+    let key_vals: Vec<_> = get_iter_with_bounds(&db, Some(456), None, use_safe_iter).collect();
     assert_eq!(key_vals.len(), 2);
     assert_eq!(key_vals[0], (456, "456".to_string()));
     assert_eq!(key_vals[1], (789, "789".to_string()));
 
     // Skip to the end
     assert_eq!(
-        get_iter(&db, use_safe_iter)
-            .skip_to(&999)
-            .expect("Seek failed")
-            .count(),
+        get_iter_with_bounds(&db, Some(999), None, use_safe_iter).count(),
         0
     );
 
     // Skip to last
     assert_eq!(
-        get_iter(&db, use_safe_iter).skip_to_last().next(),
-        Some((789, "789".to_string()))
+        get_reverse_iter(&db, None, None).next(),
+        Some(Ok((789, "789".to_string()))),
     );
 
-    // Skip to successor of first value
+    // Skip to predecessor of first value
     assert_eq!(
-        get_iter(&db, use_safe_iter)
-            .skip_to(&000)
-            .expect("Skip failed")
-            .count(),
-        3
-    );
-    assert_eq!(
-        get_iter(&db, use_safe_iter)
-            .skip_to(&000)
-            .expect("Skip failed")
-            .count(),
+        get_iter_with_bounds(&db, Some(122), None, use_safe_iter).count(),
         3
     );
 }
 
-#[rstest]
 #[tokio::test]
-async fn test_skip_to_previous_simple(
-    #[values(true, false)] is_transactional: bool,
-    #[values(true, false)] use_safe_iter: bool,
-) {
-    let db = open_map(temp_dir(), None, is_transactional);
-
+async fn test_reverse_iter_with_bounds() {
+    let db = open_map(temp_dir(), None, false);
     db.insert(&123, &"123".to_string())
         .expect("Failed to insert");
     db.insert(&456, &"456".to_string())
@@ -336,65 +284,16 @@ async fn test_skip_to_previous_simple(
     db.insert(&789, &"789".to_string())
         .expect("Failed to insert");
 
-    // Skip to the one before the end
-    let key_vals: Vec<_> = get_iter(&db, use_safe_iter)
-        .skip_prior_to(&999)
-        .expect("Seek failed")
-        .collect();
-    assert_eq!(key_vals.len(), 1);
-    assert_eq!(key_vals[0], (789, "789".to_string()));
+    let mut iter = get_reverse_iter(&db, None, Some(999));
+    assert_eq!(iter.next().unwrap(), Ok((789, "789".to_string())));
 
-    // Skip to prior of first value
-    // Note: returns an empty iterator!
-    assert_eq!(
-        get_iter(&db, use_safe_iter)
-            .skip_prior_to(&000)
-            .expect("Seek failed")
-            .count(),
-        0
-    );
-    // Same for the keys iterator
-    assert_eq!(
-        get_iter(&db, use_safe_iter)
-            .skip_prior_to(&000)
-            .expect("Seek failed")
-            .count(),
-        0
-    );
-}
+    db.insert(&999, &"999".to_string())
+        .expect("Failed to insert");
+    let mut iter = get_reverse_iter(&db, None, Some(999));
+    assert_eq!(iter.next().unwrap(), Ok((999, "999".to_string())));
 
-#[rstest]
-#[tokio::test]
-async fn test_iter_skip_to_previous_gap(
-    #[values(true, false)] is_transactional: bool,
-    #[values(true, false)] use_safe_iter: bool,
-) {
-    let db = open_map(temp_dir(), None, is_transactional);
-
-    for i in 1..100 {
-        if i != 50 {
-            db.insert(&i, &i.to_string()).unwrap();
-        }
-    }
-
-    // Skip prior to will return an iterator starting with an "unexpected" key if
-    // the sought one is not in the table
-    let db_iter = get_iter(&db, use_safe_iter).skip_prior_to(&50).unwrap();
-
-    assert_eq!(
-        (49..50)
-            .chain(51..100)
-            .map(|i| (i, i.to_string()))
-            .collect::<Vec<_>>(),
-        db_iter.collect::<Vec<_>>()
-    );
-    // Same logic in the keys iterator
-    let db_iter = get_iter(&db, true).skip_prior_to(&50).unwrap();
-
-    assert_eq!(
-        (49..50).chain(51..100).collect::<Vec<_>>(),
-        db_iter.map(|(k, _)| k).collect::<Vec<_>>()
-    );
+    let mut iter = get_reverse_iter(&db, None, None);
+    assert_eq!(iter.next().unwrap(), Ok((999, "999".to_string())));
 }
 
 #[rstest]
@@ -441,16 +340,15 @@ async fn test_iter_reverse(
     db.insert(&2, &"2".to_string()).expect("Failed to insert");
     db.insert(&3, &"3".to_string()).expect("Failed to insert");
 
-    let mut iter = get_iter(&db, use_safe_iter).skip_to_last().reverse();
-    assert_eq!(Some((3, "3".to_string())), iter.next());
-    assert_eq!(Some((2, "2".to_string())), iter.next());
-    assert_eq!(Some((1, "1".to_string())), iter.next());
+    let mut iter = get_reverse_iter(&db, None, None);
+    assert_eq!(Some(Ok((3, "3".to_string()))), iter.next());
+    assert_eq!(Some(Ok((2, "2".to_string()))), iter.next());
+    assert_eq!(Some(Ok((1, "1".to_string()))), iter.next());
     assert_eq!(None, iter.next());
 
-    let mut iter = get_iter(&db, use_safe_iter).skip_to(&2).unwrap().reverse();
-    assert_eq!(Some((2, "2".to_string())), iter.next());
+    let mut iter = get_iter_with_bounds(&db, Some(1), None, use_safe_iter);
     assert_eq!(Some((1, "1".to_string())), iter.next());
-    assert_eq!(None, iter.next());
+    assert_eq!(Some((2, "2".to_string())), iter.next());
 }
 
 #[rstest]
@@ -732,49 +630,12 @@ async fn test_iter_with_bounds(
     let db_iter = db.iter_with_bounds(Some(200), Some(300));
     assert!(db_iter.collect::<Vec<_>>().is_empty());
 
-    // Tests bounded scan with skip operation.
-    // Skip prior to will return an iterator starting with an "unexpected" key if
-    // the sought one is not in the table
-    let db_iter = get_iter_with_bounds(&db, Some(1), Some(100), use_safe_iter)
-        .skip_prior_to(&50)
-        .unwrap();
-
-    assert_eq!(
-        (49..50)
-            .chain(51..100)
-            .map(|i| (i, i.to_string()))
-            .collect::<Vec<_>>(),
-        db_iter.collect::<Vec<_>>()
-    );
-
-    // Same logic in the keys iterator
-    let db_iter = get_iter(&db, use_safe_iter).skip_prior_to(&50).unwrap();
-
-    assert_eq!(
-        (49..50).chain(51..100).collect::<Vec<_>>(),
-        db_iter.map(|(k, _)| k).collect::<Vec<_>>()
-    );
-
-    // Skip to a key which is not within the bounds (bound is [1, 50))
-    let db_iter = get_iter_with_bounds(&db, Some(1), Some(50), use_safe_iter)
-        .skip_to(&50)
-        .unwrap();
-    assert_eq!(Vec::<(i32, String)>::new(), db_iter.collect::<Vec<_>>());
-
     // Skip to first key in the bound (bound is [1, 50))
-    let db_iter = get_iter_with_bounds(&db, Some(1), Some(50), use_safe_iter)
-        .skip_to(&1)
-        .unwrap();
+    let db_iter = get_iter_with_bounds(&db, Some(1), Some(50), use_safe_iter);
     assert_eq!(
         (1..50).map(|i| (i, i.to_string())).collect::<Vec<_>>(),
         db_iter.collect::<Vec<_>>()
     );
-
-    // Skip to a key which is not within the bounds (bound is [1, 50))
-    let db_iter = get_iter_with_bounds(&db, Some(1), Some(50), use_safe_iter)
-        .skip_prior_to(&50)
-        .unwrap();
-    assert_eq!(vec![(49, "49".to_string())], db_iter.collect::<Vec<_>>());
 }
 
 #[rstest]
@@ -783,26 +644,6 @@ async fn test_range_iter(
     #[values(true, false)] is_transactional: bool,
     #[values(true, false)] use_safe_iter: bool,
 ) {
-    let db = open_map(temp_dir(), None, is_transactional);
-    let min = u64::MAX - 100;
-    let max = u64::MAX;
-    for i in min..=max {
-        if i != min + 50 {
-            db.insert(&i, &i.to_string()).unwrap();
-        }
-    }
-    let db_iter = get_range_iter(&db, min..=max, use_safe_iter)
-        .skip_prior_to(&(min + 50))
-        .unwrap();
-
-    assert_eq!(
-        (min + 49..min + 50)
-            .chain(min + 51..=max)
-            .map(|i| (i, i.to_string()))
-            .collect::<Vec<_>>(),
-        db_iter.collect::<Vec<_>>()
-    );
-
     let db = open_map(temp_dir(), None, is_transactional);
 
     // Add [1, 50) and (50, 100) in the db
@@ -833,92 +674,12 @@ async fn test_range_iter(
         db_iter.collect::<Vec<_>>()
     );
 
-    // Tests range with seek to the middle of the range.
-    // Skip prior to will return an iterator starting with an "unexpected" key if
-    // the sought one is not in the table
-    let db_iter = get_range_iter(&db, 1..=99, use_safe_iter)
-        .skip_prior_to(&50)
-        .unwrap();
-    assert_eq!(
-        (49..50)
-            .chain(51..100)
-            .map(|i| (i, i.to_string()))
-            .collect::<Vec<_>>(),
-        db_iter.collect::<Vec<_>>()
-    );
-
-    // Tests seeking to the beginning of the range.
-    let db_iter = get_range_iter(&db, 1..=99, use_safe_iter)
-        .skip_prior_to(&1)
-        .unwrap();
-    assert_eq!(
-        (1..50)
-            .chain(51..100)
-            .map(|i| (i, i.to_string()))
-            .collect::<Vec<_>>(),
-        db_iter.collect::<Vec<_>>()
-    );
-
-    let db_iter = get_range_iter(&db, 2..=99, use_safe_iter)
-        .skip_prior_to(&2)
-        .unwrap();
-    assert_eq!(
-        (2..50)
-            .chain(51..100)
-            .map(|i| (i, i.to_string()))
-            .collect::<Vec<_>>(),
-        db_iter.collect::<Vec<_>>()
-    );
-
-    // Tests seeking to the end of the range.
-    let db_iter = get_range_iter(&db, 60..70, use_safe_iter)
-        .skip_prior_to(&200)
-        .unwrap();
-    assert_eq!(
-        (69..70).map(|i| (i, i.to_string())).collect::<Vec<_>>(),
-        db_iter.collect::<Vec<_>>()
-    );
-
-    let db_iter = get_range_iter(&db, 2..99, use_safe_iter)
-        .skip_prior_to(&2)
-        .unwrap();
-    assert_eq!(
-        (2..50)
-            .chain(51..99)
-            .map(|i| (i, i.to_string()))
-            .collect::<Vec<_>>(),
-        db_iter.collect::<Vec<_>>()
-    );
-
-    // Same logic in the keys iterator
-    let db_iter = get_iter(&db, use_safe_iter).skip_prior_to(&50).unwrap();
-
-    assert_eq!(
-        (49..50).chain(51..100).collect::<Vec<_>>(),
-        db_iter.map(|(k, _)| k).collect::<Vec<_>>()
-    );
-
-    // Skip to a key which is not within the bounds (bound is [1, 50], but 50
-    // doesn't exist in DB)
-    let db_iter = get_range_iter(&db, 1..=50, use_safe_iter)
-        .skip_to(&50)
-        .unwrap();
-    assert_eq!(Vec::<(i32, String)>::new(), db_iter.collect::<Vec<_>>());
-
     // Skip to first key in the bound (bound is [1, 49))
-    let db_iter = get_range_iter(&db, 1..49, use_safe_iter)
-        .skip_to(&1)
-        .unwrap();
+    let db_iter = get_range_iter(&db, 1..49, use_safe_iter);
     assert_eq!(
         (1..49).map(|i| (i, i.to_string())).collect::<Vec<_>>(),
         db_iter.collect::<Vec<_>>()
     );
-
-    // Skip to a key which is not within the bounds (bound is [1, 50))
-    let db_iter = get_range_iter(&db, 1..=50, use_safe_iter)
-        .skip_prior_to(&50)
-        .unwrap();
-    assert_eq!(vec![(49, "49".to_string())], db_iter.collect::<Vec<_>>());
 }
 
 #[tokio::test]
@@ -1288,12 +1049,6 @@ async fn open_as_secondary_test() {
 
     // New value should be present
     assert_eq!(secondary_db.get(&0).unwrap(), Some("10".to_string()));
-}
-
-#[derive(Serialize, Deserialize, Copy, Clone)]
-struct ObjectWithRefCount {
-    value: i64,
-    ref_count: i64,
 }
 
 fn open_map<P: AsRef<Path>, K, V>(


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.43.1, v1.44.3)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/0269b42498befb8f4cf628dd16b277d2e9d250dc



## Links to any relevant issues
Part of #5727 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
