### PR TITLE
feat(indexer): Include optimistic transactions in the results of query_transaction_blocks

### DIFF
--- a/crates/iota-indexer/migrations/pg/2025-05-29-072412_insertion-order-revisited/down.sql
+++ b/crates/iota-indexer/migrations/pg/2025-05-29-072412_insertion-order-revisited/down.sql
@@ -17,6 +17,7 @@ DROP TABLE IF EXISTS optimistic_tx_calls_pkg;
 DROP TABLE IF EXISTS optimistic_tx_calls_mod;
 DROP TABLE IF EXISTS optimistic_tx_calls_fun;
 DROP TABLE IF EXISTS optimistic_tx_kinds;
+DROP TABLE IF EXISTS optimistic_tx_wrapped_or_deleted_objects;
 
 DROP TABLE IF EXISTS optimistic_event_emit_package;
 DROP TABLE IF EXISTS optimistic_event_emit_module;

--- a/crates/iota-indexer/migrations/pg/2025-05-29-072412_insertion-order-revisited/up.sql
+++ b/crates/iota-indexer/migrations/pg/2025-05-29-072412_insertion-order-revisited/up.sql
@@ -187,6 +187,18 @@ CREATE TABLE optimistic_tx_kinds (
     ON DELETE CASCADE
 );
 
+CREATE TABLE optimistic_tx_wrapped_or_deleted_objects (
+    global_sequence_number BIGINT NOT NULL,
+    optimistic_sequence_number          BIGINT       NOT NULL,
+    object_id                   BYTEA        NOT NULL,
+    sender                      BYTEA        NOT NULL,
+    PRIMARY KEY(object_id, global_sequence_number, optimistic_sequence_number),
+    FOREIGN KEY (global_sequence_number, optimistic_sequence_number)
+    REFERENCES optimistic_transactions(global_sequence_number, optimistic_sequence_number)
+    ON DELETE CASCADE
+);
+CREATE INDEX optimistic_tx_wrapped_or_deleted_objects_sequence_number_index ON optimistic_tx_wrapped_or_deleted_objects (global_sequence_number, optimistic_sequence_number);
+CREATE INDEX optimistic_tx_wrapped_or_deleted_objects_sender ON optimistic_tx_wrapped_or_deleted_objects (sender, object_id, global_sequence_number, optimistic_sequence_number);
 
 
 -- EVENTS

--- a/crates/iota-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/iota-indexer/src/handlers/checkpoint_handler.rs
@@ -99,6 +99,14 @@ pub type IndexedTransactionComponents = (
     BTreeMap<String, StoredDisplay>,
 );
 
+pub(crate) type IndexedTransactionComponentsV2 = (
+    IndexedTransaction,
+    TxIndexV2,
+    Vec<IndexedEvent>,
+    Vec<EventIndex>,
+    BTreeMap<String, StoredDisplay>,
+);
+
 #[async_trait]
 impl Worker for CheckpointHandler {
     type Message = ();
@@ -529,19 +537,13 @@ impl CheckpointHandler {
         ))
     }
 
-    async fn index_transaction_v2(
+    pub(crate) async fn index_transaction_v2(
         tx: &CheckpointTransaction,
         tx_sequence_number: u64,
         checkpoint_seq: CheckpointSequenceNumber,
         checkpoint_timestamp_ms: u64,
         metrics: &IndexerMetrics,
-    ) -> IndexerResult<(
-        IndexedTransaction,
-        TxIndexV2,
-        Vec<IndexedEvent>,
-        Vec<EventIndex>,
-        BTreeMap<String, StoredDisplay>,
-    )> {
+    ) -> IndexerResult<IndexedTransactionComponentsV2> {
         let CheckpointTransaction {
             transaction: sender_signed_data,
             effects: fx,

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -79,6 +79,8 @@ use crate::{
 };
 
 pub const TX_SEQUENCE_NUMBER_STR: &str = "tx_sequence_number";
+pub const GLOBAL_SEQUENCE_NUMBER_STR: &str = "global_sequence_number";
+pub const OPTIMISTIC_SEQUENCE_NUMBER_STR: &str = "optimistic_sequence_number";
 pub const TX_DIGEST_STR: &str = "tx_digest";
 pub const EVENT_SEQUENCE_NUMBER_STR: &str = "event_sequence_number";
 
@@ -100,7 +102,7 @@ impl Clone for IndexerReader {
 
 pub type PackageResolver = Arc<Resolver<PackageStoreWithLruCache<IndexerStorePackageResolver>>>;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 enum CursorPosition {
     BeforeGlobalOrder(i64),
     InGlobalOrder(i64, i64),
@@ -109,6 +111,7 @@ enum CursorPosition {
 struct QueryTransactionBlocksSqlQueryBuilder<'a> {
     source_table_alias: &'a str,
     source_table_or_query: &'a str,
+    optimistic_source_table_or_query: &'a str,
     main_filter_condition: &'a str,
     cursor_position: Option<CursorPosition>,
     is_descending: bool,
@@ -121,6 +124,7 @@ impl<'a> QueryTransactionBlocksSqlQueryBuilder<'a> {
     fn new(
         source_table_alias: &'a str,
         source_table_or_query: &'a str,
+        optimistic_source_table_or_query: &'a str,
         main_filter_condition: &'a str,
         cursor_position: Option<CursorPosition>,
         is_descending: bool,
@@ -133,6 +137,7 @@ impl<'a> QueryTransactionBlocksSqlQueryBuilder<'a> {
             limit,
             source_table_alias,
             source_table_or_query,
+            optimistic_source_table_or_query,
             main_filter_condition,
             smallest_tx_seq_with_global_order,
             order_str: if is_descending {
@@ -202,7 +207,7 @@ impl<'a> QueryTransactionBlocksSqlQueryBuilder<'a> {
         }
     }
 
-    fn get_query_before_global_order(&self, fields_to_select: &str) -> String {
+    fn get_query_before_global_order(&self, return_order_columns: bool) -> String {
         let source_table_alias = self.source_table_alias;
         let source_table_or_query = self.source_table_or_query;
         let main_filter_condition = self.main_filter_condition;
@@ -210,6 +215,11 @@ impl<'a> QueryTransactionBlocksSqlQueryBuilder<'a> {
         let limit = self.limit;
         let before_global_order_cursor_clause = self.get_before_global_order_cursor_clause();
         let order_str = &self.order_str;
+        let fields_to_select = if return_order_columns {
+            format!("{TX_DIGEST_STR}, tx_digests.{TX_SEQUENCE_NUMBER_STR}")
+        } else {
+            TX_DIGEST_STR.into()
+        };
 
         format!(
             "SELECT {fields_to_select} \
@@ -223,28 +233,55 @@ impl<'a> QueryTransactionBlocksSqlQueryBuilder<'a> {
         )
     }
 
-    fn get_query_with_global_order(&self, fields_to_select: &str) -> String {
+    fn get_query_with_global_order(&self, return_order_columns: bool) -> String {
         let source_table_alias = self.source_table_alias;
         let source_table_or_query = self.source_table_or_query;
+        let optimistic_source_table_or_query = self.optimistic_source_table_or_query;
         let main_filter_condition = self.main_filter_condition;
         let limit = self.limit;
         let global_order_cursor_clause = self.get_with_global_order_cursor_clause();
         let order_str = &self.order_str;
+        let fields_to_select = if return_order_columns {
+            format!(
+                "{TX_DIGEST_STR}, {GLOBAL_SEQUENCE_NUMBER_STR}, {OPTIMISTIC_SEQUENCE_NUMBER_STR}"
+            )
+        } else {
+            TX_DIGEST_STR.into()
+        };
 
-        format!(
-            "SELECT {fields_to_select} \
+        let checkpointed_data_qry = format!(
+            "SELECT {TX_DIGEST_STR}, tx_global_order.{GLOBAL_SEQUENCE_NUMBER_STR}, tx_global_order.{OPTIMISTIC_SEQUENCE_NUMBER_STR} \
             FROM {source_table_or_query} \
             JOIN tx_global_order ON tx_global_order.chk_tx_sequence_number = {source_table_alias}.{TX_SEQUENCE_NUMBER_STR} \
             WHERE {main_filter_condition} {global_order_cursor_clause} \
-            ORDER BY tx_global_order.global_sequence_number {order_str}, tx_global_order.optimistic_sequence_number {order_str} \
+            ORDER BY tx_global_order.{GLOBAL_SEQUENCE_NUMBER_STR} {order_str}, tx_global_order.{OPTIMISTIC_SEQUENCE_NUMBER_STR} {order_str} \
             LIMIT {limit} \
             ",
-        )
+        );
+
+        let optimistic_data_qry = format!(
+            "SELECT {TX_DIGEST_STR}, tx_global_order.{GLOBAL_SEQUENCE_NUMBER_STR}, tx_global_order.{OPTIMISTIC_SEQUENCE_NUMBER_STR} \
+            FROM {optimistic_source_table_or_query} \
+            JOIN tx_global_order \
+                ON tx_global_order.{GLOBAL_SEQUENCE_NUMBER_STR} = {source_table_alias}.{GLOBAL_SEQUENCE_NUMBER_STR} \
+                AND tx_global_order.{OPTIMISTIC_SEQUENCE_NUMBER_STR} = {source_table_alias}.{OPTIMISTIC_SEQUENCE_NUMBER_STR} \
+            WHERE {main_filter_condition} {global_order_cursor_clause} \
+            ORDER BY tx_global_order.{GLOBAL_SEQUENCE_NUMBER_STR} {order_str}, tx_global_order.{OPTIMISTIC_SEQUENCE_NUMBER_STR} {order_str} \
+            LIMIT {limit} \
+            ",
+        );
+
+        format!(
+            "SELECT {fields_to_select} \
+            FROM (({checkpointed_data_qry}) UNION ({optimistic_data_qry})) AS combined \
+            ORDER BY {GLOBAL_SEQUENCE_NUMBER_STR} {order_str}, {OPTIMISTIC_SEQUENCE_NUMBER_STR} {order_str} \
+            LIMIT {limit}"
+        ) // we need UNION to remove duplicates, but we need to restore order after that
     }
 
-    fn get_combined_query(&self, fields_to_select: &str) -> String {
-        let query_before_global_order = self.get_query_before_global_order(fields_to_select);
-        let query_after_global_order = self.get_query_with_global_order(fields_to_select);
+    fn get_combined_query(&self) -> String {
+        let query_before_global_order = self.get_query_before_global_order(false);
+        let query_after_global_order = self.get_query_with_global_order(false);
 
         QueryTransactionBlocksSqlQueryBuilder::combine_queries(
             query_before_global_order,
@@ -1460,23 +1497,27 @@ impl IndexerReader {
                     // transactions (and other tables) are not
                     .filter(tx_digests::tx_digest.eq(cursor.into_inner().to_vec()))
                     .first::<i64>(conn)
+                    .optional()
             })?;
-            let cursor_position = if tx_seq >= smallest_tx_seq_with_global_order {
-                let pool = self.get_pool();
-                let (global_seq, optimistic_seq) = run_query_async!(&pool, move |conn| {
-                    tx_global_order::table
-                        .select((
-                            tx_global_order::global_sequence_number,
-                            tx_global_order::optimistic_sequence_number,
-                        ))
-                        .filter(tx_global_order::tx_digest.eq(cursor.into_inner().to_vec()))
-                        .first::<(i64, i64)>(conn)
-                })?;
-                CursorPosition::InGlobalOrder(global_seq, optimistic_seq)
-            } else {
-                CursorPosition::BeforeGlobalOrder(tx_seq)
+            let cursor_position = match tx_seq {
+                Some(seq) if seq < smallest_tx_seq_with_global_order => {
+                    CursorPosition::BeforeGlobalOrder(seq)
+                }
+                _ => {
+                    let pool = self.get_pool();
+                    let (global_seq, optimistic_seq) = run_query_async!(&pool, move |conn| {
+                        tx_global_order::table
+                            .select((
+                                tx_global_order::global_sequence_number,
+                                tx_global_order::optimistic_sequence_number,
+                            ))
+                            .filter(tx_global_order::tx_digest.eq(cursor.into_inner().to_vec()))
+                            .first::<(i64, i64)>(conn)
+                    })?;
+                    CursorPosition::InGlobalOrder(global_seq, optimistic_seq)
+                }
             };
-            (Some(tx_seq), Some(cursor_position))
+            (tx_seq, Some(cursor_position))
         } else {
             (None, None)
         };
@@ -1485,6 +1526,11 @@ impl IndexerReader {
             // Processed above
             Some(TransactionFilterKind::V1(TransactionFilter::Checkpoint(seq)))
             | Some(TransactionFilterKind::V2(TransactionFilterV2::Checkpoint(seq))) => {
+                if old_order_tx_seq.is_none()
+                    && matches!(cursor_position, Some(CursorPosition::InGlobalOrder(_, _)))
+                {
+                    return Err(IndexerError::InvalidArgument("Checkpoint filter cannot be used with cursor that is outside of a checkpoint".into()));
+                }
                 return self
                     .query_transaction_blocks_by_checkpoint_impl(
                         seq,
@@ -1579,18 +1625,25 @@ impl IndexerReader {
                 let to_address = Hex::encode(to.to_vec());
 
                 let data_source_query = format!(
-                    "tx_senders \
-                    JOIN tx_recipients \
-                    ON tx_senders.{TX_SEQUENCE_NUMBER_STR} = tx_recipients.{TX_SEQUENCE_NUMBER_STR}"
+                    "tx_senders AS senders_table \
+                    JOIN tx_recipients AS recipients_table \
+                    ON senders_table.{TX_SEQUENCE_NUMBER_STR} = recipients_table.{TX_SEQUENCE_NUMBER_STR}"
+                );
+                let optimistic_data_source_query = format!(
+                    "optimistic_tx_senders AS senders_table \
+                    JOIN optimistic_tx_recipients AS recipients_table \
+                    ON senders_table.{GLOBAL_SEQUENCE_NUMBER_STR} = recipients_table.{GLOBAL_SEQUENCE_NUMBER_STR} \
+                    AND senders_table.{OPTIMISTIC_SEQUENCE_NUMBER_STR} = recipients_table.{OPTIMISTIC_SEQUENCE_NUMBER_STR}"
                 );
                 let filter_condition = format!(
-                    "tx_senders.sender = '\\x{from_address}'::BYTEA \
-                     AND tx_recipients.recipient = '\\x{to_address}'::BYTEA"
+                    "senders_table.sender = '\\x{from_address}'::BYTEA \
+                     AND recipients_table.recipient = '\\x{to_address}'::BYTEA"
                 );
 
                 let query_builder = QueryTransactionBlocksSqlQueryBuilder::new(
-                    "tx_senders",
+                    "senders_table",
                     &data_source_query,
+                    &optimistic_data_source_query,
                     &filter_condition,
                     cursor_position,
                     is_descending,
@@ -1598,7 +1651,7 @@ impl IndexerReader {
                     smallest_tx_seq_with_global_order,
                 );
 
-                FilteredDataSource::CustomQuery(query_builder.get_combined_query(TX_DIGEST_STR))
+                FilteredDataSource::CustomQuery(query_builder.get_combined_query())
             }
             Some(TransactionFilterKind::V1(TransactionFilter::FromOrToAddress { addr }))
             | Some(TransactionFilterKind::V2(TransactionFilterV2::FromOrToAddress { addr })) => {
@@ -1606,8 +1659,9 @@ impl IndexerReader {
                 let sender_address_filter = format!("sender = '\\x{address}'::BYTEA");
                 let recipient_address_filter = format!("recipient = '\\x{address}'::BYTEA");
                 let query_builder_senders = QueryTransactionBlocksSqlQueryBuilder::new(
-                    "tx_senders",
-                    "tx_senders",
+                    "senders_table",
+                    "tx_senders AS senders_table",
+                    "optimistic_tx_senders AS senders_table",
                     &sender_address_filter,
                     cursor_position,
                     is_descending,
@@ -1615,8 +1669,9 @@ impl IndexerReader {
                     smallest_tx_seq_with_global_order,
                 );
                 let query_builder_recipients = QueryTransactionBlocksSqlQueryBuilder::new(
-                    "tx_recipients",
-                    "tx_recipients",
+                    "recipients_table",
+                    "tx_recipients AS recipients_table",
+                    "optimistic_tx_recipients AS recipients_table",
                     &recipient_address_filter,
                     cursor_position,
                     is_descending,
@@ -1626,12 +1681,9 @@ impl IndexerReader {
                 let order_str = &query_builder_senders.order_str;
 
                 let inner_query_before_global_order = {
-                    let senders_before = query_builder_senders.get_query_before_global_order(
-                        &format!("{TX_DIGEST_STR}, tx_senders.{TX_SEQUENCE_NUMBER_STR}"),
-                    );
-                    let recipients_before = query_builder_recipients.get_query_before_global_order(
-                        &format!("{TX_DIGEST_STR}, tx_recipients.{TX_SEQUENCE_NUMBER_STR}"),
-                    );
+                    let senders_before = query_builder_senders.get_query_before_global_order(true);
+                    let recipients_before =
+                        query_builder_recipients.get_query_before_global_order(true);
 
                     format!(
                         "SELECT {TX_DIGEST_STR} \
@@ -1641,10 +1693,9 @@ impl IndexerReader {
                 };
 
                 let inner_query_with_global_order = {
-                    let senders_with = query_builder_senders
-                        .get_query_with_global_order(&format!("{TX_DIGEST_STR}, tx_global_order.global_sequence_number, tx_global_order.optimistic_sequence_number"));
-                    let recipients_with = query_builder_recipients
-                        .get_query_with_global_order(&format!("{TX_DIGEST_STR}, tx_global_order.global_sequence_number, tx_global_order.optimistic_sequence_number"));
+                    let senders_with = query_builder_senders.get_query_with_global_order(true);
+                    let recipients_with =
+                        query_builder_recipients.get_query_with_global_order(true);
 
                     format!(
                         "SELECT {TX_DIGEST_STR} \
@@ -1759,9 +1810,11 @@ impl IndexerReader {
                 table_name,
                 filter_condition,
             } => {
+                let optimistic_table = format!("optimistic_{table_name} AS {table_name}");
                 let query_builder = QueryTransactionBlocksSqlQueryBuilder::new(
                     &table_name,
                     &table_name,
+                    &optimistic_table,
                     &filter_condition,
                     cursor_position,
                     is_descending,
@@ -1769,7 +1822,7 @@ impl IndexerReader {
                     smallest_tx_seq_with_global_order,
                 );
 
-                query_builder.get_combined_query(TX_DIGEST_STR)
+                query_builder.get_combined_query()
             }
         };
 
@@ -1787,6 +1840,7 @@ impl IndexerReader {
                 .expect("Digest read from DB should be valid")
         })
         .collect::<Vec<TransactionDigest>>();
+
         self.multi_get_transaction_block_response_in_blocking_task_with_preserved_order(
             ordered_digests,
             options,

--- a/crates/iota-indexer/src/models/tx_indices.rs
+++ b/crates/iota-indexer/src/models/tx_indices.rs
@@ -8,9 +8,9 @@ use crate::{
     schema::{
         optimistic_tx_calls_fun, optimistic_tx_calls_mod, optimistic_tx_calls_pkg,
         optimistic_tx_changed_objects, optimistic_tx_input_objects, optimistic_tx_kinds,
-        optimistic_tx_recipients, optimistic_tx_senders, tx_calls_fun, tx_calls_mod, tx_calls_pkg,
-        tx_changed_objects, tx_digests, tx_input_objects, tx_kinds, tx_recipients, tx_senders,
-        tx_wrapped_or_deleted_objects,
+        optimistic_tx_recipients, optimistic_tx_senders, optimistic_tx_wrapped_or_deleted_objects,
+        tx_calls_fun, tx_calls_mod, tx_calls_pkg, tx_changed_objects, tx_digests, tx_input_objects,
+        tx_kinds, tx_recipients, tx_senders, tx_wrapped_or_deleted_objects,
     },
     types::{TxIndex, TxIndexV2},
 };
@@ -349,6 +349,15 @@ pub struct OptimisticTxKind {
     pub global_sequence_number: i64,
 }
 
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Default)]
+#[diesel(table_name = optimistic_tx_wrapped_or_deleted_objects)]
+pub struct OptimisticTxWrappedOrDeletedObject {
+    pub optimistic_sequence_number: i64,
+    pub global_sequence_number: i64,
+    pub object_id: Vec<u8>,
+    pub sender: Vec<u8>,
+}
+
 optimistic_from_into_checkpoint!(OptimisticTxSenders, StoredTxSenders, { sender });
 optimistic_from_into_checkpoint!(OptimisticTxRecipients, StoredTxRecipients, { recipient, sender });
 optimistic_from_into_checkpoint!(OptimisticTxInputObject, StoredTxInputObject, { object_id, sender });
@@ -357,6 +366,9 @@ optimistic_from_into_checkpoint!(OptimisticTxPkg, StoredTxPkg, { package, sender
 optimistic_from_into_checkpoint!(OptimisticTxMod, StoredTxMod, { package, module, sender });
 optimistic_from_into_checkpoint!(OptimisticTxFun, StoredTxFun, { package, module, func, sender });
 optimistic_from_into_checkpoint!(OptimisticTxKind, StoredTxKind, { tx_kind });
+optimistic_from_into_checkpoint!(OptimisticTxWrappedOrDeletedObject, StoredTxWrappedOrDeletedObject, {
+    object_id, sender
+});
 
 #[derive(Clone)]
 pub struct OptimisticTxIndices {
@@ -368,4 +380,5 @@ pub struct OptimisticTxIndices {
     pub optimistic_tx_mods: Vec<OptimisticTxMod>,
     pub optimistic_tx_funs: Vec<OptimisticTxFun>,
     pub optimistic_tx_kinds: Vec<OptimisticTxKind>,
+    pub optimistic_tx_wrapped_or_deleted_objects: Vec<OptimisticTxWrappedOrDeletedObject>,
 }

--- a/crates/iota-indexer/src/optimistic_indexing.rs
+++ b/crates/iota-indexer/src/optimistic_indexing.rs
@@ -23,7 +23,7 @@ use crate::{
     handlers::{
         TransactionObjectChangesToCommit,
         checkpoint_handler::{
-            CheckpointHandler, IndexedTransactionComponents, try_extract_df_kind,
+            CheckpointHandler, IndexedTransactionComponentsV2, try_extract_df_kind,
         },
     },
     indexer_reader::IndexerReader,
@@ -40,14 +40,15 @@ use crate::{
         tx_indices::{
             OptimisticTxChangedObject, OptimisticTxFun, OptimisticTxIndices,
             OptimisticTxInputObject, OptimisticTxKind, OptimisticTxMod, OptimisticTxPkg,
-            OptimisticTxRecipients, OptimisticTxSenders,
+            OptimisticTxRecipients, OptimisticTxSenders, OptimisticTxWrappedOrDeletedObject,
+            TxIndexV2Split,
         },
     },
     store::{IndexerStore, PgIndexerStore},
     transactional_blocking_with_retry_with_conditional_abort,
     types::{
         EventIndex, IndexedDeletedObject, IndexedObject, IndexerResult,
-        IotaTransactionBlockResponseWithOptions, TxIndex,
+        IotaTransactionBlockResponseWithOptions, TxIndexV2,
     },
 };
 
@@ -442,10 +443,10 @@ impl<'a> TransactionExtractor<'a> {
 
     fn get_indexed_transactions_events_and_displays(
         &self,
-    ) -> IndexerResult<IndexedTransactionComponents> {
+    ) -> IndexerResult<IndexedTransactionComponentsV2> {
         let handle = tokio::runtime::Handle::current();
         handle.block_on(async move {
-            CheckpointHandler::index_transaction(
+            CheckpointHandler::index_transaction_v2(
                 self.full_tx_data,
                 self.optimistic_sequence_number,
                 0, // checkpoint sequence number - unknown
@@ -539,46 +540,62 @@ impl<'a> TransactionExtractor<'a> {
     }
 
     fn optimistic_tx_indices(
-        tx_index: TxIndex,
+        tx_index: TxIndexV2,
         global_sequence_number: i64,
     ) -> OptimisticTxIndices {
-        let (senders, recipients, input_objects, changed_objects, pkgs, mods, funs, _, kinds) =
-            tx_index.split();
+        let TxIndexV2Split {
+            tx_senders,
+            tx_recipients,
+            tx_input_objects,
+            tx_changed_objects,
+            tx_pkgs,
+            tx_mods,
+            tx_funs,
+            tx_wrapped_or_deleted_objects,
+            tx_kinds,
+            ..
+        } = tx_index.split();
 
         OptimisticTxIndices {
-            optimistic_tx_senders: senders
+            optimistic_tx_senders: tx_senders
                 .into_iter()
                 .map(|stored| OptimisticTxSenders::from_stored(global_sequence_number, stored))
                 .collect(),
-            optimistic_tx_recipients: recipients
+            optimistic_tx_recipients: tx_recipients
                 .into_iter()
                 .map(|stored| OptimisticTxRecipients::from_stored(global_sequence_number, stored))
                 .collect(),
-            optimistic_tx_input_objects: input_objects
+            optimistic_tx_input_objects: tx_input_objects
                 .into_iter()
                 .map(|stored| OptimisticTxInputObject::from_stored(global_sequence_number, stored))
                 .collect(),
-            optimistic_tx_changed_objects: changed_objects
+            optimistic_tx_changed_objects: tx_changed_objects
                 .into_iter()
                 .map(|stored| {
                     OptimisticTxChangedObject::from_stored(global_sequence_number, stored)
                 })
                 .collect(),
-            optimistic_tx_pkgs: pkgs
+            optimistic_tx_pkgs: tx_pkgs
                 .into_iter()
                 .map(|stored| OptimisticTxPkg::from_stored(global_sequence_number, stored))
                 .collect(),
-            optimistic_tx_mods: mods
+            optimistic_tx_mods: tx_mods
                 .into_iter()
                 .map(|stored| OptimisticTxMod::from_stored(global_sequence_number, stored))
                 .collect(),
-            optimistic_tx_funs: funs
+            optimistic_tx_funs: tx_funs
                 .into_iter()
                 .map(|stored| OptimisticTxFun::from_stored(global_sequence_number, stored))
                 .collect(),
-            optimistic_tx_kinds: kinds
+            optimistic_tx_kinds: tx_kinds
                 .into_iter()
                 .map(|stored| OptimisticTxKind::from_stored(global_sequence_number, stored))
+                .collect(),
+            optimistic_tx_wrapped_or_deleted_objects: tx_wrapped_or_deleted_objects
+                .into_iter()
+                .map(|stored| {
+                    OptimisticTxWrappedOrDeletedObject::from_stored(global_sequence_number, stored)
+                })
                 .collect(),
         }
     }

--- a/crates/iota-indexer/src/schema.rs
+++ b/crates/iota-indexer/src/schema.rs
@@ -462,6 +462,15 @@ diesel::table! {
 }
 
 diesel::table! {
+    optimistic_tx_wrapped_or_deleted_objects (object_id, global_sequence_number, optimistic_sequence_number) {
+        global_sequence_number -> Int8,
+        optimistic_sequence_number -> Int8,
+        object_id -> Bytea,
+        sender -> Bytea,
+    }
+}
+
+diesel::table! {
     packages (package_id, original_id, package_version) {
         package_id -> Bytea,
         original_id -> Bytea,
@@ -594,6 +603,7 @@ diesel::table! {
         sender -> Bytea,
     }
 }
+
 diesel::table! {
     tx_wrapped_or_deleted_objects (object_id, tx_sequence_number) {
         tx_sequence_number -> Int8,
@@ -646,6 +656,7 @@ macro_rules! for_all_tables {
             optimistic_tx_kinds,
             optimistic_tx_recipients,
             optimistic_tx_senders,
+            optimistic_tx_wrapped_or_deleted_objects,
             packages,
             protocol_configs,
             pruner_cp_watermark,

--- a/crates/iota-indexer/src/store/pg_indexer_store.rs
+++ b/crates/iota-indexer/src/store/pg_indexer_store.rs
@@ -62,10 +62,10 @@ use crate::{
         optimistic_event_struct_package, optimistic_events, optimistic_transactions,
         optimistic_tx_calls_fun, optimistic_tx_calls_mod, optimistic_tx_calls_pkg,
         optimistic_tx_changed_objects, optimistic_tx_input_objects, optimistic_tx_kinds,
-        optimistic_tx_recipients, optimistic_tx_senders, packages, protocol_configs,
-        pruner_cp_watermark, transactions, tx_calls_fun, tx_calls_mod, tx_calls_pkg,
-        tx_changed_objects, tx_digests, tx_global_order, tx_input_objects, tx_kinds, tx_recipients,
-        tx_senders, tx_wrapped_or_deleted_objects,
+        optimistic_tx_recipients, optimistic_tx_senders, optimistic_tx_wrapped_or_deleted_objects,
+        packages, protocol_configs, pruner_cp_watermark, transactions, tx_calls_fun, tx_calls_mod,
+        tx_calls_pkg, tx_changed_objects, tx_digests, tx_global_order, tx_input_objects, tx_kinds,
+        tx_recipients, tx_senders, tx_wrapped_or_deleted_objects,
     },
     store::{IndexerStore, IndexerStoreExt},
     transactional_blocking_with_retry,
@@ -2188,6 +2188,7 @@ impl IndexerStore for PgIndexerStore {
             optimistic_tx_mods: mods,
             optimistic_tx_funs: funs,
             optimistic_tx_kinds: kinds,
+            optimistic_tx_wrapped_or_deleted_objects: wrapped_or_deleted,
         } = indices;
 
         persist_chunk_into_table_in_existing_connection!(
@@ -2233,6 +2234,12 @@ impl IndexerStore for PgIndexerStore {
         );
 
         persist_chunk_into_table_in_existing_connection!(optimistic_tx_kinds::table, kinds, conn);
+
+        persist_chunk_into_table_in_existing_connection!(
+            optimistic_tx_wrapped_or_deleted_objects::table,
+            wrapped_or_deleted,
+            conn
+        );
 
         Ok(())
     }

--- a/crates/iota-indexer/tests/common/mod.rs
+++ b/crates/iota-indexer/tests/common/mod.rs
@@ -19,7 +19,7 @@ use iota_indexer::{
     store::{PgIndexerStore, indexer_store::IndexerStore},
     test_utils::{DBInitHook, IndexerTypeConfig, create_pg_store, db_url, start_test_indexer},
 };
-use iota_json_rpc_api::ReadApiClient;
+use iota_json_rpc_api::{ReadApiClient, WriteApiClient};
 use iota_json_rpc_types::{IotaTransactionBlockResponseOptions, TransactionBlockBytes};
 use iota_metrics::init_metrics;
 use iota_types::{
@@ -270,6 +270,30 @@ pub async fn execute_tx_and_wait_for_indexer(
     let txn = to_sender_signed_transaction(tx_bytes.to_data().unwrap(), keypair);
     let res = cluster.wallet.execute_transaction_must_succeed(txn).await;
     indexer_wait_for_transaction(res.digest, store, indexer_client).await;
+}
+
+pub async fn execute_tx_must_succeed(
+    indexer_client: &HttpClient,
+    tx_bytes: TransactionBlockBytes,
+    keypair: &dyn Signer<Signature>,
+) -> TransactionDigest {
+    let txn = to_sender_signed_transaction(tx_bytes.to_data().unwrap(), keypair);
+    let (tx_bytes, signatures) = txn.to_tx_bytes_and_signatures();
+    let indexer_tx_response = indexer_client
+        .execute_transaction_block(
+            tx_bytes,
+            signatures,
+            Some(IotaTransactionBlockResponseOptions::new().with_effects()),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        indexer_tx_response.status_ok(),
+        Some(true),
+        "Transaction failed: {indexer_tx_response:?}"
+    );
+    *txn.digest()
 }
 
 /// Start an Indexer instance in `Read` mode

--- a/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
@@ -9,6 +9,7 @@ use std::{
 use diesel::RunQueryDsl;
 use downcast::Any;
 use iota_indexer::{
+    errors::IndexerError,
     schema::{
         optimistic_event_emit_module, optimistic_event_emit_package, optimistic_event_senders,
         optimistic_event_struct_instantiation, optimistic_event_struct_module,
@@ -42,6 +43,7 @@ use iota_types::{
     transaction::{CallArg, Command, ObjectArg, TransactionData},
     utils::to_sender_signed_transaction,
 };
+use jsonrpsee::http_client::HttpClient;
 use move_core_types::{
     annotated_value::MoveValue,
     identifier::Identifier,
@@ -49,7 +51,7 @@ use move_core_types::{
 };
 
 use crate::common::{
-    ApiTestSetup, execute_tx_and_wait_for_indexer, indexer_wait_for_checkpoint,
+    ApiTestSetup, execute_tx_must_succeed, indexer_wait_for_checkpoint,
     indexer_wait_for_latest_checkpoint, indexer_wait_for_object, indexer_wait_for_transaction,
     rpc_call_error_msg_matches, start_test_cluster_with_read_write_indexer,
 };
@@ -405,154 +407,89 @@ fn test_query_transaction_blocks_pagination() -> Result<(), anyhow::Error> {
     })
 }
 
-#[test]
-fn test_query_transaction_blocks_pagination_with_partial_global_order() -> Result<(), anyhow::Error>
-{
-    let ApiTestSetup {
-        runtime,
-        store,
-        cluster,
-        client,
-    } = ApiTestSetup::get_or_init();
+#[tokio::test]
+async fn test_query_transaction_blocks_pagination_with_partial_global_order()
+-> Result<(), anyhow::Error> {
+    // separate test environment needed because DB is wiped during test
+    let (cluster, store, client) = &start_test_cluster_with_read_write_indexer(
+        Some("test_query_transaction_blocks_pagination_with_partial_global_order"),
+        None,
+        None,
+    )
+    .await;
+    indexer_wait_for_checkpoint(store, 1).await;
 
-    runtime.block_on(async move {
-        let (address, keypair): (_, AccountKeyPair) = get_key_pair();
+    let (address, keypair): (_, AccountKeyPair) = get_key_pair();
 
-        let gas_ref = cluster
-            .fund_address_and_return_gas(
-                cluster.get_reference_gas_price().await,
-                Some(500_000_000),
-                address,
+    let gas_ref = cluster
+        .fund_address_and_return_gas(
+            cluster.get_reference_gas_price().await,
+            Some(500_000_000),
+            address,
+        )
+        .await;
+    indexer_wait_for_object(client, gas_ref.0, gas_ref.1).await;
+    let coin_to_split = cluster
+        .fund_address_and_return_gas(
+            cluster.get_reference_gas_price().await,
+            Some(500_000_000),
+            address,
+        )
+        .await;
+    indexer_wait_for_object(client, coin_to_split.0, coin_to_split.1).await;
+    let iota_client = cluster.wallet.get_client().await.unwrap();
+    let mut expected_tx_digests = vec![];
+
+    for _ in 0..5 {
+        let tx_data = iota_client
+            .transaction_builder()
+            .split_coin_equal(address, coin_to_split.0, 2, Some(gas_ref.0), 10_000_000)
+            .await?;
+        let signed_transaction = to_sender_signed_transaction(tx_data, &keypair);
+        let (tx_bytes, signatures) = signed_transaction.to_tx_bytes_and_signatures();
+        let res = client
+            .execute_transaction_block(
+                tx_bytes,
+                signatures,
+                Some(IotaTransactionBlockResponseOptions::new().with_effects()),
+                Some(ExecuteTransactionRequestType::WaitForEffectsCert),
             )
-            .await;
-        indexer_wait_for_object(client, gas_ref.0, gas_ref.1).await;
-        let coin_to_split = cluster
-            .fund_address_and_return_gas(
-                cluster.get_reference_gas_price().await,
-                Some(500_000_000),
-                address,
+            .await?;
+        indexer_wait_for_transaction(res.digest, store, client).await;
+        expected_tx_digests.push(res.digest);
+    }
+
+    wipe_global_order_and_optimistic_tables(store); // data indexed before this point will not have global order
+
+    for _ in 0..5 {
+        let tx_data = iota_client
+            .transaction_builder()
+            .split_coin_equal(address, coin_to_split.0, 2, Some(gas_ref.0), 10_000_000)
+            .await?;
+        let signed_transaction = to_sender_signed_transaction(tx_data, &keypair);
+        let (tx_bytes, signatures) = signed_transaction.to_tx_bytes_and_signatures();
+        let res = client
+            .execute_transaction_block(
+                tx_bytes,
+                signatures,
+                Some(IotaTransactionBlockResponseOptions::new().with_effects()),
+                Some(ExecuteTransactionRequestType::WaitForEffectsCert),
             )
-            .await;
-        indexer_wait_for_object(client, coin_to_split.0, coin_to_split.1).await;
-        let iota_client = cluster.wallet.get_client().await.unwrap();
+            .await?;
+        indexer_wait_for_transaction(res.digest, store, client).await;
+        expected_tx_digests.push(res.digest);
+    }
 
-        for _ in 0..5 {
-            let tx_data = iota_client
-                .transaction_builder()
-                .split_coin_equal(address, coin_to_split.0, 2, Some(gas_ref.0), 10_000_000)
-                .await?;
-            let signed_transaction = to_sender_signed_transaction(tx_data, &keypair);
-            let (tx_bytes, signatures) = signed_transaction.to_tx_bytes_and_signatures();
-            let res = client
-                .execute_transaction_block(
-                    tx_bytes,
-                    signatures,
-                    Some(IotaTransactionBlockResponseOptions::new().with_effects()),
-                    Some(ExecuteTransactionRequestType::WaitForEffectsCert),
-                )
-                .await?;
-            indexer_wait_for_transaction(res.digest, store, client).await;
-        }
+    let filter = TransactionFilter::FromAddress(address);
 
-        wipe_global_order_and_optimistic_tables(store); // data indexed before this point will not have global order
+    assert_paginated_filtered_transactions(client, &expected_tx_digests, filter.clone(), 2).await?;
 
-        for _ in 0..5 {
-            let tx_data = iota_client
-                .transaction_builder()
-                .split_coin_equal(address, coin_to_split.0, 2, Some(gas_ref.0), 10_000_000)
-                .await?;
-            let signed_transaction = to_sender_signed_transaction(tx_data, &keypair);
-            let (tx_bytes, signatures) = signed_transaction.to_tx_bytes_and_signatures();
-            let res = client
-                .execute_transaction_block(
-                    tx_bytes,
-                    signatures,
-                    Some(IotaTransactionBlockResponseOptions::new().with_effects()),
-                    Some(ExecuteTransactionRequestType::WaitForEffectsCert),
-                )
-                .await?;
-            indexer_wait_for_transaction(res.digest, store, client).await;
-        }
+    // wait for data to be checkpointed
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
-        let objects = client
-            .get_owned_objects(
-                address,
-                Some(IotaObjectResponseQuery::new_with_options(
-                    IotaObjectDataOptions::new(),
-                )),
-                None,
-                None,
-            )
-            .await?
-            .data;
-        // 2 gas coins + 5 coins without global order + 5 coins with global order
-        assert_eq!(12, objects.len());
+    assert_paginated_filtered_transactions(client, &expected_tx_digests, filter, 2).await?;
 
-        // filter transactions by address
-        let query = IotaTransactionBlockResponseQuery {
-            options: Some(IotaTransactionBlockResponseOptions {
-                show_input: true,
-                show_effects: true,
-                show_events: true,
-                ..Default::default()
-            }),
-            filter: Some(TransactionFilter::FromAddress(address)),
-        };
-
-        // Paging in ascending order
-        {
-            let first_page = client
-                .query_transaction_blocks(query.clone(), None, Some(3), Some(false))
-                .await
-                .unwrap();
-            assert_eq!(3, first_page.data.len());
-
-            let next_page = client
-                .query_transaction_blocks(
-                    query.clone(),
-                    first_page.next_cursor,
-                    Some(4),
-                    Some(false),
-                )
-                .await
-                .unwrap();
-            assert_eq!(4, next_page.data.len());
-
-            let last_page = client
-                .query_transaction_blocks(query.clone(), next_page.next_cursor, None, Some(false))
-                .await
-                .unwrap();
-            assert_eq!(3, last_page.data.len());
-        }
-
-        // Paging in descending order
-        {
-            let first_page = client
-                .query_transaction_blocks(query.clone(), None, Some(3), Some(true))
-                .await
-                .unwrap();
-            assert_eq!(3, first_page.data.len());
-
-            let next_page = client
-                .query_transaction_blocks(
-                    query.clone(),
-                    first_page.next_cursor,
-                    Some(4),
-                    Some(true),
-                )
-                .await
-                .unwrap();
-            assert_eq!(4, next_page.data.len());
-
-            let last_page = client
-                .query_transaction_blocks(query, next_page.next_cursor, None, Some(true))
-                .await
-                .unwrap();
-            assert_eq!(3, last_page.data.len());
-        }
-
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]
@@ -698,9 +635,9 @@ fn test_query_transaction_blocks() -> Result<(), anyhow::Error> {
 fn test_query_transaction_blocks_from_and_to_address() -> Result<(), anyhow::Error> {
     let ApiTestSetup {
         runtime,
-        store,
         cluster,
         client,
+        ..
     } = ApiTestSetup::get_or_init();
 
     runtime.block_on(async move {
@@ -727,7 +664,7 @@ fn test_query_transaction_blocks_from_and_to_address() -> Result<(), anyhow::Err
             )
             .await
             .unwrap();
-        execute_tx_and_wait_for_indexer(client, cluster, store, transfer_request, &keypair).await;
+        execute_tx_must_succeed(client, transfer_request, &keypair).await;
         let transfer_request = client
             .transfer_iota(
                 address,
@@ -738,7 +675,7 @@ fn test_query_transaction_blocks_from_and_to_address() -> Result<(), anyhow::Err
             )
             .await
             .unwrap();
-        execute_tx_and_wait_for_indexer(client, cluster, store, transfer_request, &keypair).await;
+        execute_tx_must_succeed(client, transfer_request, &keypair).await;
 
         let query = IotaTransactionBlockResponseQuery::new_with_filter(
             TransactionFilter::FromAndToAddress {
@@ -758,12 +695,89 @@ fn test_query_transaction_blocks_from_and_to_address() -> Result<(), anyhow::Err
 }
 
 #[test]
+fn test_query_by_recently_executed_tx_cursor() -> Result<(), anyhow::Error> {
+    let ApiTestSetup {
+        runtime,
+        cluster,
+        client,
+        ..
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        let (address, keypair): (_, AccountKeyPair) = get_key_pair();
+        let recipient = IotaAddress::random_for_testing_only();
+        let gas = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(500_000_000),
+                address,
+            )
+            .await;
+        indexer_wait_for_object(client, gas.0, gas.1).await;
+
+        let filter = TransactionFilter::FromOrToAddress { addr: recipient };
+
+        let transfer_request = client
+            .transfer_iota(
+                address,
+                gas.0,
+                5_000_000.into(),
+                recipient,
+                Some(100_000_000.into()),
+            )
+            .await
+            .unwrap();
+        let digest_1 = execute_tx_must_succeed(client, transfer_request, &keypair).await;
+
+        let transfer_request = client
+            .transfer_iota(
+                address,
+                gas.0,
+                5_000_000.into(),
+                recipient,
+                Some(150_000_000.into()),
+            )
+            .await
+            .unwrap();
+        let digest_2 = execute_tx_must_succeed(client, transfer_request, &keypair).await;
+
+        let transfer_request = client
+            .transfer_iota(
+                address,
+                gas.0,
+                5_000_000.into(),
+                recipient,
+                Some(160_000_000.into()),
+            )
+            .await
+            .unwrap();
+        let digest_3 = execute_tx_must_succeed(client, transfer_request, &keypair).await;
+
+        assert_paginated_filtered_transactions(
+            client,
+            &[digest_1, digest_2, digest_3],
+            filter.clone(),
+            2,
+        )
+        .await?;
+
+        // wait for data to be checkpointed
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        assert_paginated_filtered_transactions(client, &[digest_1, digest_2, digest_3], filter, 2)
+            .await?;
+
+        Ok(())
+    })
+}
+
+#[test]
 fn test_query_transaction_blocks_from_or_to_address() -> Result<(), anyhow::Error> {
     let ApiTestSetup {
         runtime,
-        store,
         cluster,
         client,
+        ..
     } = ApiTestSetup::get_or_init();
 
     runtime.block_on(async move {
@@ -790,7 +804,7 @@ fn test_query_transaction_blocks_from_or_to_address() -> Result<(), anyhow::Erro
             )
             .await
             .unwrap();
-        execute_tx_and_wait_for_indexer(client, cluster, store, transfer_request, &keypair).await;
+        execute_tx_must_succeed(client, transfer_request, &keypair).await;
         let transfer_request = client
             .transfer_iota(
                 address,
@@ -801,7 +815,7 @@ fn test_query_transaction_blocks_from_or_to_address() -> Result<(), anyhow::Erro
             )
             .await
             .unwrap();
-        execute_tx_and_wait_for_indexer(client, cluster, store, transfer_request, &keypair).await;
+        execute_tx_must_succeed(client, transfer_request, &keypair).await;
 
         let query = IotaTransactionBlockResponseQuery::new_with_filter(
             TransactionFilter::FromOrToAddress { addr: address },
@@ -824,120 +838,209 @@ fn test_query_transaction_blocks_from_or_to_address() -> Result<(), anyhow::Erro
         Ok(())
     })
 }
-
-#[test]
-fn test_query_transaction_blocks_from_or_to_address_with_incomplete_global_order()
+#[tokio::test]
+async fn test_query_transaction_blocks_from_or_to_address_with_incomplete_global_order()
 -> Result<(), anyhow::Error> {
-    let ApiTestSetup {
-        runtime,
-        store,
-        cluster,
-        client,
-    } = ApiTestSetup::get_or_init();
+    // separate test environment needed because DB is wiped during test
+    let (cluster, store, client) = &start_test_cluster_with_read_write_indexer(
+        Some("test_query_transaction_blocks_from_or_to_address_with_incomplete_global_order"),
+        None,
+        None,
+    )
+    .await;
+    indexer_wait_for_checkpoint(store, 1).await;
 
-    runtime.block_on(async move {
-        let (address, keypair): (_, AccountKeyPair) = get_key_pair();
-        let recipient_1 = IotaAddress::random_for_testing_only();
+    let (address, keypair): (_, AccountKeyPair) = get_key_pair();
+    let recipient_1 = IotaAddress::random_for_testing_only();
 
-        let gas = cluster
-            .fund_address_and_return_gas(
-                cluster.get_reference_gas_price().await,
-                Some(500_000_000),
+    let gas = cluster
+        .fund_address_and_return_gas(
+            cluster.get_reference_gas_price().await,
+            Some(500_000_000),
+            address,
+        )
+        .await;
+    indexer_wait_for_object(client, gas.0, gas.1).await;
+
+    let filter = TransactionFilter::FromOrToAddress { addr: address };
+    let query = IotaTransactionBlockResponseQuery::new_with_filter(filter.clone());
+
+    let first_tx_page = client
+        .query_transaction_blocks(query.clone(), None, Some(3), None)
+        .await
+        .unwrap();
+    assert_eq!(1, first_tx_page.data.len());
+    let mut expected_tx_digests = vec![first_tx_page.data[0].digest];
+
+    // Collect digests from first batch of transactions (before wiping global order)
+    for _ in 0..5 {
+        let transfer_request = client
+            .transfer_iota(
                 address,
+                gas.0,
+                5_000_000.into(),
+                recipient_1,
+                Some(1_000_000.into()),
             )
-            .await;
-        indexer_wait_for_object(client, gas.0, gas.1).await;
+            .await
+            .unwrap();
+        let digest = execute_tx_must_succeed(client, transfer_request, &keypair).await;
+        expected_tx_digests.push(digest);
+    }
 
-        for _ in 0..5 {
-            let transfer_request = client
-                .transfer_iota(
-                    address,
-                    gas.0,
-                    5_000_000.into(),
-                    recipient_1,
-                    Some(1_000_000.into()),
-                )
-                .await
-                .unwrap();
-            execute_tx_and_wait_for_indexer(client, cluster, store, transfer_request, &keypair)
-                .await;
+    indexer_wait_for_transaction(*expected_tx_digests.last().unwrap(), store, client).await;
+    wipe_global_order_and_optimistic_tables(store); // data indexed before this point will not have global order
+
+    // Collect digests from second batch of transactions (after wiping global order)
+    for _ in 0..5 {
+        let transfer_request = client
+            .transfer_iota(
+                address,
+                gas.0,
+                5_000_000.into(),
+                recipient_1,
+                Some(1_000_000.into()),
+            )
+            .await
+            .unwrap();
+        let digest = execute_tx_must_succeed(client, transfer_request, &keypair).await;
+        expected_tx_digests.push(digest);
+    }
+
+    assert_paginated_filtered_transactions(client, &expected_tx_digests, filter, 3).await?;
+
+    Ok(())
+}
+
+async fn assert_paginated_filtered_transactions(
+    client: &HttpClient,
+    expected_transactions_digests: &[iota_types::digests::TransactionDigest],
+    filter: TransactionFilter,
+    page_size: usize,
+) -> Result<(), IndexerError> {
+    // Test querying all transactions (ascending order - default)
+    let all_transactions = client
+        .query_transaction_blocks(
+            IotaTransactionBlockResponseQuery::new_with_filter(filter.clone()),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Verify transactions are returned in ascending order
+    let returned_transactions_digests: Vec<_> =
+        all_transactions.data.iter().map(|e| e.digest).collect();
+    assert_eq!(returned_transactions_digests, expected_transactions_digests);
+
+    assert_paginated_transactions_ascending(
+        client,
+        expected_transactions_digests,
+        &filter,
+        page_size,
+    )
+    .await?;
+    assert_paginated_transactions_descending(
+        client,
+        expected_transactions_digests,
+        &filter,
+        page_size,
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn assert_paginated_transactions_ascending(
+    client: &HttpClient,
+    expected_transactions_digests: &[iota_types::digests::TransactionDigest],
+    filter: &TransactionFilter,
+    page_size: usize,
+) -> Result<(), IndexerError> {
+    let mut cursor = None;
+    let mut transactions_processed = 0;
+    let total_transactions = expected_transactions_digests.len();
+
+    loop {
+        let page = client
+            .query_transaction_blocks(
+                IotaTransactionBlockResponseQuery::new_with_filter(filter.clone()),
+                cursor,
+                Some(page_size),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let transactions_remaining = total_transactions - transactions_processed;
+        let expected_page_size = std::cmp::min(page_size, transactions_remaining);
+        let is_last_page = transactions_processed + expected_page_size >= total_transactions;
+
+        let actual_transactions_ids: Vec<_> = page.data.iter().map(|e| e.digest).collect();
+        let expected_transactions_digests_slice = &expected_transactions_digests
+            [transactions_processed..transactions_processed + expected_page_size];
+
+        assert_eq!(actual_transactions_ids, expected_transactions_digests_slice);
+        assert_eq!(page.has_next_page, !is_last_page);
+
+        if is_last_page {
+            break;
         }
+        cursor = page.next_cursor;
+        transactions_processed += expected_page_size;
+    }
 
-        wipe_global_order_and_optimistic_tables(store); // data indexed before this point will not have global order
+    Ok(())
+}
 
-        for _ in 0..5 {
-            let transfer_request = client
-                .transfer_iota(
-                    address,
-                    gas.0,
-                    5_000_000.into(),
-                    recipient_1,
-                    Some(1_000_000.into()),
-                )
-                .await
-                .unwrap();
-            execute_tx_and_wait_for_indexer(client, cluster, store, transfer_request, &keypair)
-                .await;
+async fn assert_paginated_transactions_descending(
+    client: &HttpClient,
+    expected_transactions_digests: &[iota_types::digests::TransactionDigest],
+    filter: &TransactionFilter,
+    page_size: usize,
+) -> Result<(), IndexerError> {
+    let mut cursor = None;
+    let mut transactions_processed = 0;
+    let total_transactions = expected_transactions_digests.len();
+
+    // In descending order, we expect transactions in reverse chronological order
+    let expected_desc_transactions: Vec<_> = expected_transactions_digests
+        .iter()
+        .rev()
+        .cloned()
+        .collect();
+
+    loop {
+        let page = client
+            .query_transaction_blocks(
+                IotaTransactionBlockResponseQuery::new_with_filter(filter.clone()),
+                cursor,
+                Some(page_size),
+                Some(true),
+            )
+            .await
+            .unwrap();
+
+        let transactions_remaining = total_transactions - transactions_processed;
+        let expected_page_size = std::cmp::min(page_size, transactions_remaining);
+        let is_last_page = transactions_processed + expected_page_size >= total_transactions;
+
+        let actual_transactions_ids: Vec<_> = page.data.iter().map(|e| e.digest).collect();
+        let expected_transactions_digests_slice = &expected_desc_transactions
+            [transactions_processed..transactions_processed + expected_page_size];
+
+        assert_eq!(actual_transactions_ids, expected_transactions_digests_slice);
+        assert_eq!(page.has_next_page, !is_last_page);
+
+        if is_last_page {
+            break;
         }
+        cursor = page.next_cursor;
+        transactions_processed += expected_page_size;
+    }
 
-        let query = IotaTransactionBlockResponseQuery::new_with_filter(
-            TransactionFilter::FromOrToAddress { addr: address },
-        );
-
-        // Paging in ascending order
-        {
-            let first_page = client
-                .query_transaction_blocks(query.clone(), None, Some(3), Some(false))
-                .await
-                .unwrap();
-            assert_eq!(3, first_page.data.len());
-
-            let next_page = client
-                .query_transaction_blocks(
-                    query.clone(),
-                    first_page.next_cursor,
-                    Some(4),
-                    Some(false),
-                )
-                .await
-                .unwrap();
-            assert_eq!(4, next_page.data.len());
-
-            let last_page = client
-                .query_transaction_blocks(query.clone(), next_page.next_cursor, None, Some(false))
-                .await
-                .unwrap();
-            assert_eq!(4, last_page.data.len());
-        }
-
-        // Paging in descending order
-        {
-            let first_page = client
-                .query_transaction_blocks(query.clone(), None, Some(3), Some(true))
-                .await
-                .unwrap();
-            assert_eq!(3, first_page.data.len());
-
-            let next_page = client
-                .query_transaction_blocks(
-                    query.clone(),
-                    first_page.next_cursor,
-                    Some(4),
-                    Some(true),
-                )
-                .await
-                .unwrap();
-            assert_eq!(4, next_page.data.len());
-
-            let last_page = client
-                .query_transaction_blocks(query, next_page.next_cursor, None, Some(true))
-                .await
-                .unwrap();
-            assert_eq!(4, last_page.data.len());
-        }
-
-        Ok(())
-    })
+    Ok(())
 }
 
 #[test]

--- a/crates/iota-indexer/tests/rpc-tests/transaction_builder.rs
+++ b/crates/iota-indexer/tests/rpc-tests/transaction_builder.rs
@@ -33,8 +33,8 @@ use jsonrpsee::http_client::HttpClient;
 use test_cluster::TestCluster;
 
 use crate::common::{
-    ApiTestSetup, execute_tx_and_wait_for_indexer, indexer_wait_for_checkpoint,
-    indexer_wait_for_latest_checkpoint, indexer_wait_for_object,
+    ApiTestSetup, execute_tx_and_wait_for_indexer, execute_tx_must_succeed,
+    indexer_wait_for_checkpoint, indexer_wait_for_latest_checkpoint, indexer_wait_for_object,
     start_test_cluster_with_read_write_indexer,
 };
 const FUNDED_BALANCE_PER_COIN: u64 = 10_000_000_000;
@@ -43,7 +43,7 @@ const FUNDED_BALANCE_PER_COIN: u64 = 10_000_000_000;
 fn transfer_object() {
     let ApiTestSetup {
         runtime,
-        store,
+        store: _,
         client,
         cluster,
     } = ApiTestSetup::get_or_init();
@@ -66,7 +66,7 @@ fn transfer_object() {
             )
             .await
             .unwrap();
-        execute_tx_and_wait_for_indexer(client, cluster, store, tx_bytes, &keypair).await;
+        execute_tx_must_succeed(client, tx_bytes, &keypair).await;
 
         let transferred_object = client
             .get_object(object_to_send, Some(IotaObjectDataOptions::full_content()))
@@ -84,7 +84,7 @@ fn transfer_object() {
 fn transfer_iota() {
     let ApiTestSetup {
         runtime,
-        store,
+        store: _,
         client,
         cluster,
     } = ApiTestSetup::get_or_init();
@@ -107,7 +107,7 @@ fn transfer_iota() {
             )
             .await
             .unwrap();
-        execute_tx_and_wait_for_indexer(client, cluster, store, tx_bytes, &keypair).await;
+        execute_tx_must_succeed(client, tx_bytes, &keypair).await;
 
         let receiver_balances = get_address_balances(client, receiver).await;
 
@@ -119,7 +119,7 @@ fn transfer_iota() {
 fn pay() {
     let ApiTestSetup {
         runtime,
-        store,
+        store: _,
         client,
         cluster,
     } = ApiTestSetup::get_or_init();
@@ -148,7 +148,7 @@ fn pay() {
             )
             .await
             .unwrap();
-        execute_tx_and_wait_for_indexer(client, cluster, store, tx_bytes, &keypair).await;
+        execute_tx_must_succeed(client, tx_bytes, &keypair).await;
 
         let receiver_1_balances = get_address_balances(client, receiver_1).await;
         let receiver_2_balances = get_address_balances(client, receiver_2).await;
@@ -162,7 +162,7 @@ fn pay() {
 fn pay_iota() {
     let ApiTestSetup {
         runtime,
-        store,
+        store: _,
         client,
         cluster,
     } = ApiTestSetup::get_or_init();
@@ -191,7 +191,7 @@ fn pay_iota() {
             )
             .await
             .unwrap();
-        execute_tx_and_wait_for_indexer(client, cluster, store, tx_bytes, &keypair).await;
+        execute_tx_must_succeed(client, tx_bytes, &keypair).await;
 
         let receiver_1_balances = get_address_balances(client, receiver_1).await;
         let receiver_2_balances = get_address_balances(client, receiver_2).await;
@@ -205,7 +205,7 @@ fn pay_iota() {
 fn pay_all_iota() {
     let ApiTestSetup {
         runtime,
-        store,
+        store: _,
         client,
         cluster,
     } = ApiTestSetup::get_or_init();
@@ -223,7 +223,7 @@ fn pay_all_iota() {
             .pay_all_iota(sender, sender_coins, receiver, gas_budget.into())
             .await
             .unwrap();
-        execute_tx_and_wait_for_indexer(client, cluster, store, tx_bytes, &keypair).await;
+        execute_tx_must_succeed(client, tx_bytes, &keypair).await;
 
         let receiver_balances = get_address_balances(client, receiver).await;
         let expected_minimum_receiver_balance = FUNDED_BALANCE_PER_COIN * input_coins - gas_budget;
@@ -237,7 +237,7 @@ fn pay_all_iota() {
 fn move_call() {
     let ApiTestSetup {
         runtime,
-        store,
+        store: _,
         client,
         cluster,
     } = ApiTestSetup::get_or_init();
@@ -263,7 +263,7 @@ fn move_call() {
                 )
                 .await
                 .unwrap();
-            execute_tx_and_wait_for_indexer(client, cluster, store, tx_bytes, &keypair).await;
+            execute_tx_must_succeed(client, tx_bytes, &keypair).await;
 
             let mut sender_balances = get_address_balances(client, sender).await;
             sender_balances.sort();
@@ -279,7 +279,7 @@ fn move_call() {
 fn split_coin() {
     let ApiTestSetup {
         runtime,
-        store,
+        store: _,
         client,
         cluster,
     } = ApiTestSetup::get_or_init();
@@ -307,7 +307,7 @@ fn split_coin() {
             )
             .await
             .unwrap();
-        execute_tx_and_wait_for_indexer(client, cluster, store, tx_bytes, &keypair).await;
+        execute_tx_must_succeed(client, tx_bytes, &keypair).await;
 
         let mut sender_balances = get_address_balances(client, sender).await;
         sender_balances.sort();
@@ -323,7 +323,7 @@ fn split_coin() {
 fn split_coin_equal() {
     let ApiTestSetup {
         runtime,
-        store,
+        store: _,
         client,
         cluster,
     } = ApiTestSetup::get_or_init();
@@ -338,7 +338,7 @@ fn split_coin_equal() {
             .split_coin_equal(sender, sender_coins[0], 3.into(), None, gas_budget.into())
             .await
             .unwrap();
-        execute_tx_and_wait_for_indexer(client, cluster, store, tx_bytes, &keypair).await;
+        execute_tx_must_succeed(client, tx_bytes, &keypair).await;
 
         let mut sender_balances = get_address_balances(client, sender).await;
         sender_balances.sort();
@@ -354,7 +354,7 @@ fn split_coin_equal() {
 fn merge_coin() {
     let ApiTestSetup {
         runtime,
-        store,
+        store: _,
         client,
         cluster,
     } = ApiTestSetup::get_or_init();
@@ -375,7 +375,7 @@ fn merge_coin() {
             )
             .await
             .unwrap();
-        execute_tx_and_wait_for_indexer(client, cluster, store, tx_bytes, &keypair).await;
+        execute_tx_must_succeed(client, tx_bytes, &keypair).await;
 
         let mut sender_balances = get_address_balances(client, sender).await;
         sender_balances.sort();
@@ -389,7 +389,7 @@ fn merge_coin() {
 fn batch_transaction() {
     let ApiTestSetup {
         runtime,
-        store,
+        store: _,
         client,
         cluster,
     } = ApiTestSetup::get_or_init();
@@ -429,7 +429,7 @@ fn batch_transaction() {
                     None,
                 )
                 .await?;
-            execute_tx_and_wait_for_indexer(client, cluster, store, tx_bytes, &keypair).await;
+            execute_tx_must_succeed(client, tx_bytes, &keypair).await;
 
             let mut sender_balances = get_address_balances(client, sender).await;
             let receiver_balances = get_address_balances(client, receiver).await;
@@ -476,7 +476,7 @@ fn request_add_stake() {
                 )
                 .await
                 .unwrap();
-            execute_tx_and_wait_for_indexer(client, cluster, store, tx_bytes, &keypair).await;
+            execute_tx_must_succeed(client, tx_bytes, &keypair).await;
 
             let staked_iota = client.get_stakes(address).await.unwrap();
 
@@ -504,7 +504,7 @@ fn request_add_stake() {
 fn request_withdraw_stake_from_pending() {
     let ApiTestSetup {
         runtime,
-        store,
+        store: _,
         client,
         cluster,
     } = ApiTestSetup::get_or_init();
@@ -531,7 +531,7 @@ fn request_withdraw_stake_from_pending() {
                 )
                 .await
                 .unwrap();
-            execute_tx_and_wait_for_indexer(client, cluster, store, tx_bytes, &keypair).await;
+            execute_tx_must_succeed(client, tx_bytes, &keypair).await;
 
             let staked_iota = client.get_stakes(address).await.unwrap();
             let stake = &staked_iota[0].stakes[0];
@@ -546,7 +546,7 @@ fn request_withdraw_stake_from_pending() {
                 )
                 .await
                 .unwrap();
-            execute_tx_and_wait_for_indexer(client, cluster, store, tx_bytes, &keypair).await;
+            execute_tx_must_succeed(client, tx_bytes, &keypair).await;
 
             let staked_iota = client.get_stakes(address).await.unwrap();
             assert!(staked_iota.is_empty());
@@ -588,7 +588,7 @@ fn request_withdraw_stake_from_active() {
                 )
                 .await
                 .unwrap();
-            execute_tx_and_wait_for_indexer(client, cluster, store, tx_bytes, &keypair).await;
+            execute_tx_must_succeed(client, tx_bytes, &keypair).await;
 
             cluster.force_new_epoch().await;
             indexer_wait_for_latest_checkpoint(store, cluster).await;
@@ -605,7 +605,7 @@ fn request_withdraw_stake_from_active() {
                 )
                 .await
                 .unwrap();
-            execute_tx_and_wait_for_indexer(client, cluster, store, tx_bytes, &keypair).await;
+            execute_tx_must_succeed(client, tx_bytes, &keypair).await;
 
             let staked_iota = client.get_stakes(address).await.unwrap();
             assert!(staked_iota.is_empty());
@@ -642,7 +642,7 @@ fn request_add_timelocked_stake() {
                 )
                 .await
                 .unwrap();
-            execute_tx_and_wait_for_indexer(&client, &cluster, &store, tx_bytes, &keypair).await;
+            execute_tx_must_succeed(&client, tx_bytes, &keypair).await;
 
             let staked_iota = client.get_timelocked_stakes(address).await.unwrap();
 
@@ -692,7 +692,7 @@ fn request_withdraw_timelocked_stake_from_pending() {
                 )
                 .await
                 .unwrap();
-            execute_tx_and_wait_for_indexer(&client, &cluster, &store, tx_bytes, &keypair).await;
+            execute_tx_must_succeed(&client, tx_bytes, &keypair).await;
 
             let staked_iota = client.get_timelocked_stakes(address).await.unwrap();
             let stake = &staked_iota[0].stakes[0];
@@ -744,7 +744,7 @@ fn request_withdraw_timelocked_stake_from_active() {
                 )
                 .await
                 .unwrap();
-            execute_tx_and_wait_for_indexer(&client, &cluster, &store, tx_bytes, &keypair).await;
+            execute_tx_must_succeed(&client, tx_bytes, &keypair).await;
 
             cluster.force_new_epoch().await;
             indexer_wait_for_latest_checkpoint(&store, &cluster).await;
@@ -761,7 +761,7 @@ fn request_withdraw_timelocked_stake_from_active() {
                 )
                 .await
                 .unwrap();
-            execute_tx_and_wait_for_indexer(&client, &cluster, &store, tx_bytes, &keypair).await;
+            execute_tx_must_succeed(&client, tx_bytes, &keypair).await;
 
             let staked_iota = client.get_timelocked_stakes(address).await.unwrap();
             assert!(staked_iota.is_empty());


### PR DESCRIPTION
# Description of change

Include optimistic transactions in the results of query_transaction_blocks
This allows to query for both checkpointed and optimistic transactions using paginated and filtered queries.

Support tx wrapped or deleted filter for optimistic indexing

## Links to any relevant issues

fixes https://github.com/iotaledger/iota/issues/7800
fixes https://github.com/iotaledger/iota/issues/7799
fixes https://github.com/iotaledger/iota/issues/7798
fixes https://github.com/iotaledger/iota/issues/7796

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
