### PR TITLE
upstream(node): Clean up various APIs

### DIFF
--- a/crates/iota-benchmark/tests/simtest.rs
+++ b/crates/iota-benchmark/tests/simtest.rs
@@ -426,8 +426,6 @@ mod test {
         });
         register_fail_point_async("consensus-delay", || delay_failpoint(10..20, 0.001));
 
-        register_fail_point_async("writeback-cache-commit", || delay_failpoint(10..20, 0.001));
-
         test_simulated_load(test_cluster, 120).await;
     }
 

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -1088,13 +1088,11 @@ impl AuthorityState {
         );
 
         if transaction.contains_shared_object() {
-            epoch_store
-                .acquire_shared_version_assignments_from_effects(
-                    transaction,
-                    effects.data(),
-                    self.get_object_cache_reader().as_ref(),
-                )
-                .await?;
+            epoch_store.acquire_shared_version_assignments_from_effects(
+                transaction,
+                effects.data(),
+                self.get_object_cache_reader().as_ref(),
+            )?;
         }
 
         let expected_effects_digest = effects.digest();

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1151,7 +1151,11 @@ impl AuthorityPerEpochStore {
         &self,
         checkpoint: &CheckpointSequenceNumber,
     ) -> IotaResult<Option<Accumulator>> {
-        Ok(self.tables()?.state_hash_by_checkpoint.get(checkpoint)?)
+        Ok(self
+            .tables()?
+            .state_hash_by_checkpoint
+            .get(checkpoint)
+            .expect("db error"))
     }
 
     pub fn insert_state_hash_for_checkpoint(
@@ -1159,10 +1163,11 @@ impl AuthorityPerEpochStore {
         checkpoint: &CheckpointSequenceNumber,
         accumulator: &Accumulator,
     ) -> IotaResult {
-        Ok(self
-            .tables()?
+        self.tables()?
             .state_hash_by_checkpoint
-            .insert(checkpoint, accumulator)?)
+            .insert(checkpoint, accumulator)
+            .expect("db error");
+        Ok(())
     }
 
     pub fn get_running_root_accumulator(
@@ -1932,7 +1937,7 @@ impl AuthorityPerEpochStore {
     /// catch up by state sync.
     // TODO: We should be able to pass in a vector of certs/effects and acquire them all at once.
     #[instrument(level = "trace", skip_all)]
-    pub async fn acquire_shared_version_assignments_from_effects(
+    pub fn acquire_shared_version_assignments_from_effects(
         &self,
         certificate: &VerifiedExecutableTransaction,
         effects: &TransactionEffects,
@@ -1942,7 +1947,7 @@ impl AuthorityPerEpochStore {
             &[(certificate, effects)],
             self,
             cache_reader,
-        )?;
+        );
         let mut db_batch = self.tables()?.assigned_shared_object_versions.batch();
         self.set_assigned_shared_object_versions_with_db_batch(versions, &mut db_batch)?;
         db_batch.write()?;

--- a/crates/iota-core/src/authority/authority_test_utils.rs
+++ b/crates/iota-core/src/authority/authority_test_utils.rs
@@ -121,7 +121,7 @@ pub async fn execute_certificate_with_execution_error(
     // wrong inside the VM
     let (result, execution_error_opt) = authority.try_execute_for_test(&certificate)?;
     let state_after = state_acc.accumulate_cached_live_object_set_for_testing();
-    let effects_acc = state_acc.accumulate_effects(vec![result.inner().data().clone()]);
+    let effects_acc = state_acc.accumulate_effects(&[result.inner().data().clone()]);
     state.union(&effects_acc);
 
     assert_eq!(state_after.digest(), state.digest());

--- a/crates/iota-core/src/authority/shared_object_version_manager.rs
+++ b/crates/iota-core/src/authority/shared_object_version_manager.rs
@@ -96,7 +96,7 @@ impl SharedObjVerManager {
         certs_and_effects: &[(&VerifiedExecutableTransaction, &TransactionEffects)],
         epoch_store: &AuthorityPerEpochStore,
         cache_reader: &dyn ObjectCacheRead,
-    ) -> IotaResult<AssignedTxAndVersions> {
+    ) -> AssignedTxAndVersions {
         // We don't care about the results since we can use effects to assign versions.
         // But we must call it to make sure whenever a shared object is touched the
         // first time during an epoch, either through consensus or through
@@ -110,7 +110,7 @@ impl SharedObjVerManager {
             epoch_store,
             cache_reader,
             false,
-        )?;
+        );
         let mut assigned_versions = Vec::new();
         for (cert, effects) in certs_and_effects {
             let cert_assigned_versions: Vec<_> = effects
@@ -126,7 +126,7 @@ impl SharedObjVerManager {
             );
             assigned_versions.push((tx_key, cert_assigned_versions));
         }
-        Ok(assigned_versions)
+        assigned_versions
     }
 
     pub fn assign_versions_for_certificate(
@@ -672,8 +672,7 @@ mod tests {
                 .as_slice(),
             &epoch_store,
             authority.get_object_cache_reader().as_ref(),
-        )
-        .unwrap();
+        );
         // Check that the shared object's next version is always initialized in the
         // epoch store.
         assert_eq!(

--- a/crates/iota-core/src/authority/test_authority_builder.rs
+++ b/crates/iota-core/src/authority/test_authority_builder.rs
@@ -414,7 +414,6 @@ impl<'a> TestAuthorityBuilder<'a> {
             state
                 .get_cache_commit()
                 .commit_transaction_outputs(epoch_store.epoch(), &[*genesis.transaction().digest()])
-                .await;
         }
 
         // We want to insert these objects directly instead of relying on genesis

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -454,7 +454,6 @@ impl CheckpointExecutor {
         debug!("committing checkpoint transactions to disk");
         cache_commit
             .try_commit_transaction_outputs(epoch_store.epoch(), all_tx_digests)
-            .await
             .expect("commit_transaction_outputs cannot fail");
 
         epoch_store
@@ -654,7 +653,6 @@ impl CheckpointExecutor {
                     &change_epoch_fx,
                     self.object_cache_reader.as_ref(),
                 )
-                .await
                 .expect("Acquiring shared version assignments for change_epoch tx cannot fail");
         }
 
@@ -719,7 +717,6 @@ impl CheckpointExecutor {
                     let cache_commit = self.state.get_cache_commit();
                     cache_commit
                         .try_commit_transaction_outputs(cur_epoch, &[change_epoch_tx_digest])
-                        .await
                         .expect("commit_transaction_outputs cannot fail");
                     fail_point_async!("prune-and-compact");
 
@@ -1304,13 +1301,11 @@ async fn execute_transactions(
 
     for (tx, _) in &executable_txns {
         if tx.contains_shared_object() {
-            epoch_store
-                .acquire_shared_version_assignments_from_effects(
-                    tx,
-                    digest_to_effects.get(tx.digest()).unwrap(),
-                    object_cache_reader,
-                )
-                .await?;
+            epoch_store.acquire_shared_version_assignments_from_effects(
+                tx,
+                digest_to_effects.get(tx.digest()).unwrap(),
+                object_cache_reader,
+            )?;
         }
     }
 
@@ -1381,7 +1376,7 @@ async fn finalize_checkpoint(
         )?;
 
     let checkpoint_acc =
-        accumulator.accumulate_checkpoint(effects, checkpoint.sequence_number, epoch_store)?;
+        accumulator.accumulate_checkpoint(&effects, checkpoint.sequence_number, epoch_store)?;
 
     let checkpoint_data = if state.rest_index.is_some() || data_ingestion_dir.is_some() {
         let checkpoint_data = load_checkpoint_data(

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -1394,7 +1394,7 @@ async fn finalize_checkpoint(
                 PackageStoreWithFallback::new(state.get_backing_package_store(), &checkpoint_data),
             ));
 
-            rest_index.index_checkpoint(&checkpoint_data, layout_resolver.as_mut())?;
+            rest_index.index_checkpoint(&checkpoint_data, layout_resolver.as_mut());
         }
 
         if let Some(path) = data_ingestion_dir {

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1504,7 +1504,7 @@ impl CheckpointBuilder {
                         .upgrade()
                         .expect("No checkpoints should be getting built after local configuration");
                     let acc = state_acc.accumulate_checkpoint(
-                        effects.clone(),
+                        &effects,
                         sequence_number,
                         &self.epoch_store,
                     )?;

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -157,23 +157,16 @@ pub trait ExecutionCacheCommit: Send + Sync {
     /// Durably commit the outputs of the given transactions to the database.
     /// Will be called by CheckpointExecutor to ensure that transaction outputs
     /// are written durably before marking a checkpoint as finalized.
-    fn try_commit_transaction_outputs<'a>(
-        &'a self,
+    fn try_commit_transaction_outputs(
+        &self,
         epoch: EpochId,
-        digests: &'a [TransactionDigest],
-    ) -> BoxFuture<'a, IotaResult>;
+        digests: &[TransactionDigest],
+    ) -> IotaResult;
 
     /// Non-fallible version of `try_commit_transaction_outputs`.
-    fn commit_transaction_outputs<'a>(
-        &'a self,
-        epoch: EpochId,
-        digests: &'a [TransactionDigest],
-    ) -> BoxFuture<'a, ()> {
-        Box::pin(async move {
-            self.try_commit_transaction_outputs(epoch, digests)
-                .await
-                .expect("storage access failed")
-        })
+    fn commit_transaction_outputs(&self, epoch: EpochId, digests: &[TransactionDigest]) {
+        self.try_commit_transaction_outputs(epoch, digests)
+            .expect("storage access failed");
     }
 
     /// Durably commit transactions (but not their outputs) to the database.

--- a/crates/iota-core/src/execution_cache/passthrough_cache.rs
+++ b/crates/iota-core/src/execution_cache/passthrough_cache.rs
@@ -322,14 +322,14 @@ impl AccumulatorStore for PassthroughCache {
 }
 
 impl ExecutionCacheCommit for PassthroughCache {
-    fn try_commit_transaction_outputs<'a>(
-        &'a self,
+    fn try_commit_transaction_outputs(
+        &self,
         _epoch: EpochId,
-        _digests: &'a [TransactionDigest],
-    ) -> BoxFuture<'a, IotaResult> {
+        _digests: &[TransactionDigest],
+    ) -> IotaResult {
         // Nothing needs to be done since they were already committed in
         // write_transaction_outputs
-        async { Ok(()) }.boxed()
+        Ok(())
     }
 
     fn try_persist_transactions(

--- a/crates/iota-core/src/execution_cache/proxy_cache.rs
+++ b/crates/iota-core/src/execution_cache/proxy_cache.rs
@@ -310,11 +310,11 @@ impl AccumulatorStore for ProxyCache {
 }
 
 impl ExecutionCacheCommit for ProxyCache {
-    fn try_commit_transaction_outputs<'a>(
-        &'a self,
+    fn try_commit_transaction_outputs(
+        &self,
         epoch: EpochId,
-        digests: &'a [TransactionDigest],
-    ) -> BoxFuture<'a, IotaResult> {
+        digests: &[TransactionDigest],
+    ) -> IotaResult {
         delegate_method!(self.try_commit_transaction_outputs(epoch, digests))
     }
 

--- a/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/iota-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -359,7 +359,7 @@ impl Scenario {
 
     // commit a transaction to the database
     pub async fn commit(&mut self, tx: TransactionDigest) {
-        self.cache().commit_transaction_outputs(1, &[tx]).await;
+        self.cache().commit_transaction_outputs(1, &[tx]);
         self.count_action();
     }
 
@@ -555,7 +555,7 @@ async fn test_committed() {
 
         s.assert_live(&[1, 2]);
         s.assert_dirty(&[1, 2]);
-        s.cache().commit_transaction_outputs(1, &[tx]).await;
+        s.cache().commit_transaction_outputs(1, &[tx]);
         s.assert_not_dirty(&[1, 2]);
         s.assert_cached(&[1, 2]);
 

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -57,7 +57,7 @@ use dashmap::{DashMap, mapref::entry::Entry as DashMapEntry};
 use futures::{FutureExt, future::BoxFuture};
 use iota_common::sync::notify_read::NotifyRead;
 use iota_config::WritebackCacheConfig;
-use iota_macros::{fail_point, fail_point_async};
+use iota_macros::fail_point;
 use iota_types::{
     accumulator::Accumulator,
     base_types::{EpochId, ObjectID, ObjectRef, SequenceNumber, VerifiedExecutionData},
@@ -950,12 +950,12 @@ impl WritebackCache {
 
     // Commits dirty data for the given TransactionDigest to the db.
     #[instrument(level = "debug", skip_all)]
-    async fn commit_transaction_outputs(
+    fn commit_transaction_outputs(
         &self,
         epoch: EpochId,
         digests: &[TransactionDigest],
     ) -> IotaResult {
-        fail_point_async!("writeback-cache-commit");
+        fail_point!("writeback-cache-commit");
         trace!(?digests);
 
         let mut all_outputs = Vec::with_capacity(digests.len());
@@ -1356,12 +1356,12 @@ impl WritebackCache {
 impl ExecutionCacheAPI for WritebackCache {}
 
 impl ExecutionCacheCommit for WritebackCache {
-    fn try_commit_transaction_outputs<'a>(
-        &'a self,
+    fn try_commit_transaction_outputs(
+        &self,
         epoch: EpochId,
-        digests: &'a [TransactionDigest],
-    ) -> BoxFuture<'a, IotaResult> {
-        WritebackCache::commit_transaction_outputs(self, epoch, digests).boxed()
+        digests: &[TransactionDigest],
+    ) -> IotaResult {
+        WritebackCache::commit_transaction_outputs(self, epoch, digests)
     }
 
     fn try_persist_transactions<'a>(

--- a/crates/iota-core/src/rest_index.rs
+++ b/crates/iota-core/src/rest_index.rs
@@ -517,20 +517,17 @@ impl RestIndexStore {
     ///
     /// Updates will not be committed to the database until
     /// `commit_update_for_checkpoint` is called.
-    pub fn index_checkpoint(
-        &self,
-        checkpoint: &CheckpointData,
-        resolver: &mut dyn LayoutResolver,
-    ) -> Result<(), StorageError> {
+    pub fn index_checkpoint(&self, checkpoint: &CheckpointData, resolver: &mut dyn LayoutResolver) {
         let sequence_number = checkpoint.checkpoint_summary.sequence_number;
-        let batch = self.tables.index_checkpoint(checkpoint, resolver)?;
+        let batch = self
+            .tables
+            .index_checkpoint(checkpoint, resolver)
+            .expect("db error");
 
         self.pending_updates
             .lock()
             .unwrap()
             .insert(sequence_number, batch);
-
-        Ok(())
     }
 
     /// Commits the pending updates for the provided checkpoint number.

--- a/crates/iota-core/src/state_accumulator.rs
+++ b/crates/iota-core/src/state_accumulator.rs
@@ -120,7 +120,7 @@ impl WrappedObject {
     }
 }
 
-fn accumulate_effects(effects: Vec<TransactionEffects>) -> Accumulator {
+fn accumulate_effects(effects: &[TransactionEffects]) -> Accumulator {
     let mut acc = Accumulator::default();
 
     // process insertions to the set
@@ -173,9 +173,9 @@ impl StateAccumulator {
     /// accumulator.
     pub fn accumulate_checkpoint(
         &self,
-        effects: Vec<TransactionEffects>,
+        effects: &[TransactionEffects],
         checkpoint_seq_num: CheckpointSequenceNumber,
-        epoch_store: &Arc<AuthorityPerEpochStore>,
+        epoch_store: &AuthorityPerEpochStore,
     ) -> IotaResult<Accumulator> {
         let _scope = monitored_scope("AccumulateCheckpoint");
         if let Some(acc) = epoch_store.get_state_hash_for_checkpoint(&checkpoint_seq_num)? {
@@ -356,7 +356,7 @@ impl StateAccumulator {
         Ok(running_root.clone())
     }
 
-    pub fn accumulate_effects(&self, effects: Vec<TransactionEffects>) -> Accumulator {
+    pub fn accumulate_effects(&self, effects: &[TransactionEffects]) -> Accumulator {
         accumulate_effects(effects)
     }
 }

--- a/crates/iota-core/src/test_utils.rs
+++ b/crates/iota-core/src/test_utils.rs
@@ -67,7 +67,7 @@ pub async fn send_and_confirm_transaction(
     let mut state = state_acc.accumulate_cached_live_object_set_for_testing();
     let (result, _execution_error_opt) = authority.try_execute_for_test(&certificate)?;
     let state_after = state_acc.accumulate_cached_live_object_set_for_testing();
-    let effects_acc = state_acc.accumulate_effects(vec![result.inner().data().clone()]);
+    let effects_acc = state_acc.accumulate_effects(&[result.inner().data().clone()]);
     state.union(&effects_acc);
 
     assert_eq!(state_after.digest(), state.digest());

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -3466,8 +3466,7 @@ async fn test_store_revert_wrap_move_call() {
         .commit_transaction_outputs(
             authority_state.epoch_store_for_testing().epoch(),
             &[*create_effects.transaction_digest()],
-        )
-        .await;
+        );
 
     assert!(create_effects.status().is_ok());
     assert_eq!(create_effects.created().len(), 1);
@@ -3565,8 +3564,7 @@ async fn test_store_revert_unwrap_move_call() {
                 *create_effects.transaction_digest(),
                 *wrap_effects.transaction_digest(),
             ],
-        )
-        .await;
+        );
 
     assert!(wrap_effects.status().is_ok());
     assert_eq!(wrap_effects.created().len(), 1);
@@ -3838,8 +3836,7 @@ async fn test_store_revert_add_ofield() {
                 *create_outer_effects.transaction_digest(),
                 *create_inner_effects.transaction_digest(),
             ],
-        )
-        .await;
+        );
 
     let add_txn = to_sender_signed_transaction(
         TransactionData::new_move_call(
@@ -3965,8 +3962,7 @@ async fn test_store_revert_remove_ofield() {
                 *create_inner_effects.transaction_digest(),
                 *add_effects.transaction_digest(),
             ],
-        )
-        .await;
+        );
 
     let field_v0 = add_effects.created()[0].0;
     let outer_v1 = find_by_id(&add_effects.mutated(), outer_v0.0).unwrap();
@@ -5017,7 +5013,6 @@ async fn test_consensus_message_processed() {
                     &effects1,
                     authority2.get_object_cache_reader().as_ref(),
                 )
-                .await
                 .unwrap();
             authority2.execute_for_test(&certificate);
             authority2

--- a/crates/iota-core/src/unit_tests/congestion_control_tests.rs
+++ b/crates/iota-core/src/unit_tests/congestion_control_tests.rs
@@ -393,7 +393,6 @@ async fn test_congestion_control_execution_cancellation() {
             &effects,
             authority_state_2.get_object_cache_reader().as_ref(),
         )
-        .await
         .unwrap();
     let (effects_2, execution_error) = authority_state_2.execute_for_test(&cert);
 

--- a/crates/iota-core/src/unit_tests/transaction_deny_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_deny_tests.rs
@@ -365,13 +365,10 @@ async fn test_package_denied() {
     .await
     .unwrap();
 
-    state
-        .get_cache_commit()
-        .commit_transaction_outputs(
-            state.epoch_store_for_testing().epoch(),
-            &[tx_c, tx_b, tx_a, tx_c_prime, tx_b_prime],
-        )
-        .await;
+    state.get_cache_commit().commit_transaction_outputs(
+        state.epoch_store_for_testing().epoch(),
+        &[tx_c, tx_b, tx_a, tx_c_prime, tx_b_prime],
+    );
 
     // Re-create the state such that we could deny package c.
     let state = reload_state_with_new_deny_config(

--- a/crates/iota-single-node-benchmark/src/benchmark_context.rs
+++ b/crates/iota-single-node-benchmark/src/benchmark_context.rs
@@ -123,8 +123,7 @@ impl BenchmarkContext {
                 .commit_transaction_outputs(
                     effects.executed_epoch(),
                     &[*effects.transaction_digest()],
-                )
-                .await;
+                );
             let (owner, root_object) = effects
                 .created()
                 .into_iter()
@@ -193,9 +192,7 @@ impl BenchmarkContext {
             // object store, hence requiring these objects committed to DB.
             // For checkpoint executor, in order to commit a checkpoint it is required
             // previous versions of objects are already committed.
-            cache_commit
-                .commit_transaction_outputs(epoch_id, &[*effects.transaction_digest()])
-                .await;
+            cache_commit.commit_transaction_outputs(epoch_id, &[*effects.transaction_digest()]);
         }
         self.refresh_gas_objects(new_gas_objects);
         info!("Finished preparing shared objects");


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.43.1, v1.44.3)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/437bfeee6d537926fa34e7760a780c2161f44a53
- Description:

Removes async and IotaResult from several APIs where it is not needed.

## Links to any relevant issues

Part of #5727 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
