### PR TITLE
feat(starfish): add metrics for gaps between current round and latest available transactions

### DIFF
--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -340,7 +340,10 @@ impl DagState {
         }
     }
 
-    pub fn update_last_available_commit_leader_round(&mut self, round: Round) {
+    pub fn update_last_available_commit_leader_round(
+        &mut self,
+        last_available_commit_leader_round: Round,
+    ) {
         let max_commit_round = self
             .last_committed_rounds
             .iter()
@@ -348,9 +351,15 @@ impl DagState {
             .expect("There should be at least one last committed round");
         info!(
             "Last commit with available transactions has leader at round {}; last commit leader round was {}",
-            round, max_commit_round
+            last_available_commit_leader_round, max_commit_round
         );
-        self.last_available_commit_leader_round = Some(round);
+        self.last_available_commit_leader_round = Some(last_available_commit_leader_round);
+        let gap = last_available_commit_leader_round.saturating_sub(*max_commit_round);
+        self.context
+            .metrics
+            .node_metrics
+            .gap_to_available_commit
+            .set(gap as i64);
     }
 
     /// Updates internal metadata for a block.

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -104,6 +104,8 @@ pub(crate) struct NodeMetrics {
     pub(crate) proposed_block_transactions: Histogram,
     pub(crate) proposed_block_ancestors: Histogram,
     pub(crate) proposed_block_ancestors_depth: HistogramVec,
+    pub(crate) gap_to_available_commit: IntGauge,
+    pub(crate) gap_to_unavailable_transactions: IntGauge,
     pub(crate) highest_verified_authority_round: IntGaugeVec,
     pub(crate) lowest_verified_authority_round: IntGaugeVec,
     pub(crate) block_proposal_interval: Histogram,
@@ -295,6 +297,16 @@ impl NodeMetrics {
                 "core_add_blocks_batch_size",
                 "The number of blocks received from Core for processing on a single batch",
                 NUM_BUCKETS.to_vec(),
+                registry,
+            ).unwrap(),
+            gap_to_available_commit: register_int_gauge_with_registry!(
+                "gap_to_available_commit",
+                "Gap in rounds between last pending commit and last available commit",
+                registry,
+            ).unwrap(),
+            gap_to_unavailable_transactions: register_int_gauge_with_registry!(
+                "gap_to_unavailable_transactions",
+                "Gap in rounds between current round and the oldest unavailable transaction",
                 registry,
             ).unwrap(),
             core_lock_dequeued: register_int_counter_with_registry!(

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -700,6 +700,26 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
             .await
             .map_err(|_err| ConsensusError::Shutdown)?;
 
+        let dag_state = self.dag_state.clone();
+
+        // Compute the gap to unavailable transactions.
+        // If no missing transactions, the gap is zero; Otherwise, it is the difference
+        // between the highest accepted round and the earliest unavailable transaction
+        // round.
+        let accepted_round = dag_state.read().highest_accepted_round();
+        let earliest_unavailable_transaction_round = missing_transactions
+            .first_key_value()
+            .map(|(block_ref, _)| block_ref.round)
+            .unwrap_or(accepted_round);
+        let gap_to_unavailable_transactions =
+            accepted_round.saturating_sub(earliest_unavailable_transaction_round);
+        self.context
+            .metrics
+            .node_metrics
+            .gap_to_unavailable_transactions
+            .set(gap_to_unavailable_transactions as i64);
+
+        // If there are no missing transactions, we don't need to fetch anything.
         if missing_transactions.is_empty() {
             return Ok(());
         }
@@ -709,7 +729,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         let inflight_transactions_map = self.inflight_transactions_map.clone();
         let commands_sender = self.commands_sender.clone();
         let block_verifier = self.block_verifier.clone();
-        let dag_state = self.dag_state.clone();
 
         self.fetch_transactions_scheduler_task
             .spawn(monitored_future!(async move {


### PR DESCRIPTION
# Description of change

We add two metrics to improve debugging. 
`gap_to_unavailable_transactions` represents the difference between the current round and the earliest unavailable transactions. When there is no missing transactions, it is set to zero. 
`gap_to_available_commit` shows the difference between the round of the latest pending commit and the last available commit. Under good circumstances, it should be zero. A non-zero value indicates that the triangle inequality is violated or the block stream from a validator is not functioning as expected. If the value is increasing, the issue is with the transaction synchronizer.

## Links to any relevant issues

Fixes #8148 #8149 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
