### PR TITLE
feat(starfish): improving transaction synchronizer

### DIFF
--- a/crates/starfish/config/src/parameters.rs
+++ b/crates/starfish/config/src/parameters.rs
@@ -151,7 +151,7 @@ impl Parameters {
 
     // Maximum number of block headers to fetch per periodic or live sync request.
     pub(crate) fn default_max_transactions_per_fetch() -> usize {
-        if cfg!(msim) { 10 } else { 1000 }
+        if cfg!(msim) { 10 } else { 100 }
     }
 
     pub(crate) fn default_sync_last_known_own_block_timeout() -> Duration {

--- a/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
+++ b/crates/starfish/config/tests/snapshots/parameters_test__parameters.snap
@@ -13,7 +13,7 @@ max_forward_time_drift:
   nanos: 500000000
 max_headers_per_commit_sync_fetch: 1000
 max_headers_per_regular_sync_fetch: 100
-max_transactions_per_fetch: 1000
+max_transactions_per_fetch: 100
 sync_last_known_own_block_timeout:
   secs: 5
   nanos: 0

--- a/crates/starfish/core/src/metrics.rs
+++ b/crates/starfish/core/src/metrics.rs
@@ -165,7 +165,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) transactions_synchronizer_fetched_transactions_by_authority: IntCounterVec,
     pub(crate) transactions_synchronizer_missing_transactions_by_authority: IntCounterVec,
     pub(crate) transactions_synchronizer_current_missing_transactions_by_authority: IntGaugeVec,
-    pub(crate) transactions_synchronizer_scheduler_inflight: IntGauge,
+    pub(crate) transactions_synchronizer_periodic_inflight: IntGauge,
     pub(crate) transactions_synchronizer_fetch_latency: HistogramVec,
     pub(crate) transactions_synchronizer_success_by_peer: IntCounterVec,
     pub(crate) transactions_synchronizer_failure_by_peer: IntCounterVec,
@@ -598,7 +598,7 @@ impl NodeMetrics {
                 &["authority"],
                 registry,
             ).unwrap(),
-            transactions_synchronizer_scheduler_inflight: register_int_gauge_with_registry!(
+            transactions_synchronizer_periodic_inflight: register_int_gauge_with_registry!(
                 "fetch_transactions_scheduler_inflight",
                 "Designates whether the transaction synchronizer scheduler task to fetch transactions is currently running",
                 registry,

--- a/crates/starfish/core/src/synchronizer.rs
+++ b/crates/starfish/core/src/synchronizer.rs
@@ -1375,6 +1375,8 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 },
                 _ = &mut fetcher_timeout => {
                     debug!("Timed out while fetching missing block headers");
+                    // Drop all pending requests immediately — frees all block guards
+                    drop(request_futures);
                     break;
                 }
             }

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -451,7 +451,11 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
 
         loop {
             // Wait for a permit asynchronously
-            let permit = semaphore.clone().acquire_owned().await.expect("We expect semaphore to be valid");
+            let permit = semaphore
+                .clone()
+                .acquire_owned()
+                .await
+                .expect("We expect semaphore to be valid");
 
             match receiver.recv().await {
                 Some(missing_transactions_block_refs) => {
@@ -475,7 +479,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                             dag_state,
                             SyncMethod::Live,
                         )
-                            .await;
+                        .await;
 
                         // Release the permit when done
                         drop(permit);

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -65,21 +65,36 @@ const FETCH_AND_PROCESS_FROM_PEERS_TIMEOUT: Duration = Duration::from_millis(700
 /// given block ref.
 const MAX_AUTHORITIES_TO_FETCH_PER_TRANSACTION: usize = 3;
 
+#[derive(Debug,Clone,Copy,Ord,Eq,PartialOrd,PartialEq)]
+enum SyncMethod {
+    Live,
+    Periodic,
+}
+impl SyncMethod {
+    fn get_string(&self) -> String {
+        match self {
+            SyncMethod::Live => "live",
+            SyncMethod::Periodic => "periodic",
+        }
+        .to_string()
+    }
+}
+
 struct ActiveRequestGuard {
     authority: AuthorityIndex,
-    sync_method: String,
-    active_requests: Arc<Mutex<BTreeMap<(AuthorityIndex, String), usize>>>,
+    sync_method: SyncMethod,
+    active_requests: Arc<Mutex<BTreeMap<(AuthorityIndex, SyncMethod), usize>>>,
 }
 
 impl ActiveRequestGuard {
     fn new(
         authority: AuthorityIndex,
-        sync_method: String,
-        active_requests: Arc<Mutex<BTreeMap<(AuthorityIndex, String), usize>>>,
+        sync_method: SyncMethod,
+        active_requests: Arc<Mutex<BTreeMap<(AuthorityIndex, SyncMethod), usize>>>,
     ) -> Self {
         {
             let mut map = active_requests.lock();
-            *map.entry((authority, sync_method.clone())).or_insert(0) += 1;
+            *map.entry((authority, sync_method)).or_insert(0) += 1;
         }
         Self {
             authority,
@@ -92,7 +107,7 @@ impl ActiveRequestGuard {
 impl Drop for ActiveRequestGuard {
     fn drop(&mut self) {
         let mut map = self.active_requests.lock();
-        if let Some(val) = map.get_mut(&(self.authority, self.sync_method.clone())) {
+        if let Some(val) = map.get_mut(&(self.authority, self.sync_method)) {
             *val = val.saturating_sub(1);
         }
     }
@@ -278,7 +293,7 @@ pub(crate) struct TransactionsSynchronizer<
     live_fetch_requests: Sender<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>>,
     core_dispatcher: Arc<D>,
     dag_state: Arc<RwLock<DagState>>,
-    active_requests: Arc<Mutex<BTreeMap<(AuthorityIndex, String), usize>>>,
+    active_requests: Arc<Mutex<BTreeMap<(AuthorityIndex, SyncMethod), usize>>>,
     fetch_transactions_scheduler_task: JoinSet<()>,
     network_client: Arc<C>,
     block_verifier: Arc<V>,
@@ -423,7 +438,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
 
     // The live fetcher task that processes fetch requests from the queue
     async fn live_fetcher(
-        active_requests: Arc<Mutex<BTreeMap<(AuthorityIndex, String), usize>>>,
+        active_requests: Arc<Mutex<BTreeMap<(AuthorityIndex, SyncMethod), usize>>>,
         network_client: Arc<C>,
         context: Arc<Context>,
         core_dispatcher: Arc<D>,
@@ -446,7 +461,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                         core_dispatcher.clone(),
                         block_verifier.clone(),
                         dag_state.clone(),
-                        "live",
+                        SyncMethod::Live,
                     ));
                 },
                 Some(_) = requests.next() => {
@@ -544,7 +559,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                     core_dispatcher,
                     block_verifier,
                     dag_state,
-                    "periodic",
+                    SyncMethod::Periodic,
                 )
                 .await;
                 context
@@ -563,14 +578,14 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
     /// Fetches missing transactions from authorities.
     async fn fetch_and_process_transactions_from_authorities(
         context: Arc<Context>,
-        active_requests: Arc<Mutex<BTreeMap<(AuthorityIndex, String), usize>>>,
+        active_requests: Arc<Mutex<BTreeMap<(AuthorityIndex, SyncMethod), usize>>>,
         inflight_transactions_map: Arc<InflightTransactionsMap>,
         network_client: Arc<C>,
         missing_transactions: BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
         core_dispatcher: Arc<D>,
         block_verifier: Arc<V>,
         dag_state: Arc<RwLock<DagState>>,
-        sync_method: &str,
+        sync_method: SyncMethod,
     ) {
         // Build a mapping from authority -> set of BlockRefs it has acknowledged
         let mut blocks_by_authority: BTreeMap<AuthorityIndex, BTreeSet<BlockRef>> = BTreeMap::new();
@@ -624,7 +639,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
             {
                 let count = active_requests
                     .lock()
-                    .get(&(authority, sync_method.to_string()))
+                    .get(&(authority, sync_method))
                     .copied()
                     .unwrap_or(0);
 
@@ -649,7 +664,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
             ) {
                 let active_request_guard = ActiveRequestGuard::new(
                     authority,
-                    sync_method.to_string(),
+                    sync_method,
                     active_requests.clone(),
                 );
 
@@ -681,11 +696,11 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
             tokio::select! {
                     Some(res) = request_futures.next() => {
                         if let Err(err) = res {
-                            warn!("[{sync_method}] Error when fetching and processing transactions from authority: {err}");
+                            warn!("[{}] Error when fetching and processing transactions from authority: {err}", sync_method.get_string());
                         }
             },
                     _ = &mut timeout => {
-                        warn!("[{sync_method}] Timed out while fetching and processing missing transactions");
+                        warn!("[{}] Timed out while fetching and processing missing transactions", sync_method.get_string());
                          // Drop all pending requests immediately — frees all transaction guards
                         drop(request_futures);
                         break;
@@ -703,15 +718,15 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         core_dispatcher: Arc<D>,
         block_verifier: Arc<V>,
         dag_state: Arc<RwLock<DagState>>,
-        sync_method: &str,
+        sync_method: SyncMethod,
         _active_guard: ActiveRequestGuard,
     ) -> ConsensusResult<()> {
         let peer_hostname = &context.committee.authority(peer).hostname;
         let total_requested = transactions_guard.block_refs.len();
 
         debug!(
-            "[{sync_method}] Syncing {} missing committed transactions from authority {} {}",
-            total_requested, peer, peer_hostname,
+            "[{}] Syncing {total_requested} missing committed transactions from authority {peer} {peer_hostname}",
+            sync_method.get_string(),
         );
 
         let (fetched_serialized_transactions, transactions_guard, _peer_index) =
@@ -754,7 +769,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         transactions_guard: TransactionsGuard,
         request_timeout: Duration,
         context: Arc<Context>,
-        sync_method: &str,
+        sync_method: SyncMethod,
     ) -> ConsensusResult<(Vec<Bytes>, TransactionsGuard, AuthorityIndex)> {
         // Track concurrent inflight requests
         let inflight_metric = &context
@@ -789,7 +804,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
             .metrics
             .node_metrics
             .transactions_synchronizer_fetch_latency
-            .with_label_values(&[peer_hostname.as_str(), sync_method])
+            .with_label_values(&[peer_hostname.as_str(), &sync_method.get_string()])
             .observe(fetch_duration.as_secs_f64());
 
         let resp = match result {
@@ -799,7 +814,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                     .metrics
                     .node_metrics
                     .transactions_synchronizer_failure_by_peer
-                    .with_label_values(&[peer_hostname.as_str(), sync_method, err.name()])
+                    .with_label_values(&[peer_hostname.as_str(), &sync_method.get_string(), err.name()])
                     .inc();
                 Err(err) // network error
             }
@@ -809,7 +824,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                     .metrics
                     .node_metrics
                     .transactions_synchronizer_failure_by_peer
-                    .with_label_values(&[peer_hostname.as_str(), sync_method, "timeout"])
+                    .with_label_values(&[peer_hostname.as_str(), &sync_method.get_string(), "timeout"])
                     .inc();
                 // timeout
                 Err(ConsensusError::NetworkRequestTimeout(err.to_string()))
@@ -820,7 +835,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                     .metrics
                     .node_metrics
                     .transactions_synchronizer_success_by_peer
-                    .with_label_values(&[peer_hostname.as_str(), sync_method])
+                    .with_label_values(&[peer_hostname.as_str(), &sync_method.get_string()])
                     .inc();
 
                 result
@@ -840,7 +855,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         context: Arc<Context>,
         block_verifier: Arc<V>,
         dag_state: Arc<RwLock<DagState>>,
-        sync_method: &str,
+        sync_method: SyncMethod,
     ) -> ConsensusResult<()> {
         // Ensure that all the returned transactions do not go over the total max
         // allowed returned transactions
@@ -901,7 +916,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
 
         metrics
             .transactions_synchronizer_fetched_transactions_by_peer
-            .with_label_values(&[peer_hostname.as_str(), sync_method])
+            .with_label_values(&[peer_hostname.as_str(), &sync_method.get_string()])
             .inc_by(transactions.len() as u64);
         for transactions in &transactions {
             let block_hostname = &context
@@ -910,12 +925,13 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                 .hostname;
             metrics
                 .transactions_synchronizer_fetched_transactions_by_authority
-                .with_label_values(&[block_hostname.as_str(), sync_method])
+                .with_label_values(&[block_hostname.as_str(), &sync_method.get_string()])
                 .inc();
         }
 
         info!(
-            "[{sync_method}] Synced and processed {} missing transactions from peer {peer_index} {peer_hostname}: {}",
+            "[{}] Synced and processed {} missing transactions from peer {peer_index} {peer_hostname}: {}",
+            sync_method.get_string(),
             transactions.len(),
             transactions
                 .iter()

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -20,7 +20,7 @@ use parking_lot::{Mutex, RwLock};
 use rand::{
     SeedableRng,
     rngs::{OsRng, StdRng},
-    seq::{IteratorRandom, SliceRandom},
+    seq::SliceRandom,
 };
 use starfish_config::AuthorityIndex;
 use tokio::{
@@ -43,15 +43,60 @@ use crate::{
 };
 
 /// The number of concurrent live transaction fetch requests
-const LIVE_FETCH_TRANSACTIONS_CONCURRENCY: usize = 5;
+const LIVE_FETCH_TRANSACTIONS_CONCURRENCY: usize = 1;
+const PERIODIC_FETCH_TRANSACTIONS_CONCURRENCY: usize = 1;
 
-/// Timeouts when fetching transactions.
-const FETCH_REQUEST_TIMEOUT: Duration = Duration::from_millis(2_000);
-const FETCH_FROM_PEERS_TIMEOUT: Duration = Duration::from_millis(4_000);
+/// The maximum number of concurrent request per authority for fetching
+/// transactions Used separately for live fetches and periodic fetches.
+const MAX_CONCURRENT_REQUESTS_PER_AUTHORITY: usize = 5;
 
-/// TODO: this should be calculated based on the number of authorities and
-///  should be at least 1/3 of all authorities + 1 by stake
+/// Timeout for the transactions synchronizer to run periodically and fetch
+/// missing transactions.
+const TRANSACTIONS_SYNCHRONIZER_TIMEOUT: Duration = Duration::from_millis(200);
+
+/// Timeout to fetch transactions from a given peer.
+const FETCH_REQUEST_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Timeout to fetch and process transactions from all peers in one call of
+/// `fetch_and_process_transactions_from_authorities`.
+const FETCH_AND_PROCESS_FROM_PEERS_TIMEOUT: Duration = Duration::from_millis(700);
+
+/// Maximum number of authorities that can concurrently fetch transactions for a
+/// given block ref.
 const MAX_AUTHORITIES_TO_FETCH_PER_TRANSACTION: usize = 3;
+
+struct ActiveRequestGuard {
+    authority: AuthorityIndex,
+    sync_method: String,
+    active_requests: Arc<Mutex<BTreeMap<(AuthorityIndex, String), usize>>>,
+}
+
+impl ActiveRequestGuard {
+    fn new(
+        authority: AuthorityIndex,
+        sync_method: String,
+        active_requests: Arc<Mutex<BTreeMap<(AuthorityIndex, String), usize>>>,
+    ) -> Self {
+        {
+            let mut map = active_requests.lock();
+            *map.entry((authority, sync_method.clone())).or_insert(0) += 1;
+        }
+        Self {
+            authority,
+            sync_method,
+            active_requests,
+        }
+    }
+}
+
+impl Drop for ActiveRequestGuard {
+    fn drop(&mut self) {
+        let mut map = self.active_requests.lock();
+        if let Some(val) = map.get_mut(&(self.authority, self.sync_method.clone())) {
+            *val = val.saturating_sub(1);
+        }
+    }
+}
 
 struct TransactionsGuard {
     map: Arc<InflightTransactionsMap>,
@@ -93,9 +138,11 @@ impl InflightTransactionsMap {
         self: &Arc<Self>,
         missing_block_refs: BTreeSet<BlockRef>,
         peer: AuthorityIndex,
+        max_number_transactions_per_fetch: usize,
     ) -> Option<TransactionsGuard> {
         let mut blocks = BTreeSet::new();
         let mut inner = self.inner.lock();
+        let mut selected_block_refs_num = 0;
 
         for block_ref in missing_block_refs {
             // check that the number of authorities that are already instructed to fetch the
@@ -103,10 +150,13 @@ impl InflightTransactionsMap {
             // already been instructed to do that.
             let authorities = inner.entry(block_ref).or_default();
             if authorities.len() < MAX_AUTHORITIES_TO_FETCH_PER_TRANSACTION
-                && authorities.get(&peer).is_none()
+                && authorities.insert(peer)
             {
-                assert!(authorities.insert(peer));
                 blocks.insert(block_ref);
+                selected_block_refs_num += 1;
+            }
+            if selected_block_refs_num >= max_number_transactions_per_fetch {
+                break;
             }
         }
 
@@ -135,17 +185,14 @@ impl InflightTransactionsMap {
         for block_ref in block_refs {
             let authorities = transactions_to_fetch
                 .get_mut(block_ref)
-                .expect("Should have found a non empty map");
-
+                .expect("We should expect a non empty map with at least one peer");
             assert!(authorities.remove(&peer), "Peer index should be present!");
-
-            // if the last one then just clean up
+            // If the last one then just clean up
             if authorities.is_empty() {
                 transactions_to_fetch.remove(block_ref);
             }
         }
     }
-
     #[cfg(test)]
     fn num_of_locked_transactions(self: &Arc<Self>) -> usize {
         let inner = self.inner.lock();
@@ -231,6 +278,7 @@ pub(crate) struct TransactionsSynchronizer<
     live_fetch_requests: Sender<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>>,
     core_dispatcher: Arc<D>,
     dag_state: Arc<RwLock<DagState>>,
+    active_requests: Arc<Mutex<BTreeMap<(AuthorityIndex, String), usize>>>,
     fetch_transactions_scheduler_task: JoinSet<()>,
     network_client: Arc<C>,
     block_verifier: Arc<V>,
@@ -262,15 +310,15 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         );
 
         let mut tasks = JoinSet::new();
-
+        let active_requests = Arc::new(Mutex::new(BTreeMap::new()));
         // Spawn the live fetcher task
         let live_fetcher_async = Self::live_fetcher(
+            active_requests.clone(),
             network_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
             dag_state.clone(),
             live_fetch_receiver,
-            commands_sender.clone(),
             block_verifier.clone(),
             inflight_transactions_map.clone(),
         );
@@ -278,7 +326,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
 
         let commands_sender_clone = commands_sender.clone();
 
-        // Spawn the task to listen to the requests & periodic runs
+        // Spawn the task to listen to the live requests & periodic runs
         tasks.spawn(monitored_future!(async move {
             let mut s = Self {
                 context,
@@ -286,6 +334,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                 live_fetch_requests: live_fetch_sender,
                 core_dispatcher,
                 fetch_transactions_scheduler_task: JoinSet::new(),
+                active_requests,
                 network_client,
                 block_verifier,
                 inflight_transactions_map,
@@ -304,9 +353,8 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
     // The main loop to listen for the submitted commands.
     #[cfg_attr(test,tracing::instrument(skip_all, name ="",fields(authority = %self.context.own_index)))]
     async fn run(&mut self) {
-        // We want the transactions synchronizer to run periodically every 200ms to
+        // We want the transactions synchronizer to run periodically to
         // fetch any missing transactions.
-        const TRANSACTIONS_SYNCHRONIZER_TIMEOUT: Duration = Duration::from_millis(200);
         let scheduler_timeout = sleep_until(Instant::now() + TRANSACTIONS_SYNCHRONIZER_TIMEOUT);
 
         tokio::pin!(scheduler_timeout);
@@ -357,8 +405,8 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                     };
                 },
                 () = &mut scheduler_timeout => {
-                    // we want to start a new task only if the previous one has already finished.
-                    if self.fetch_transactions_scheduler_task.is_empty() {
+                    // we want to start a new task only if the number of tasks is not too large.
+                    if self.fetch_transactions_scheduler_task.len() < PERIODIC_FETCH_TRANSACTIONS_CONCURRENCY {
                         if let Err(err) = self.start_fetch_missing_transactions_task().await {
                             debug!("Core is shutting down, transactions synchronizer is shutting down: {err:?}");
                             return;
@@ -375,55 +423,33 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
 
     // The live fetcher task that processes fetch requests from the queue
     async fn live_fetcher(
+        active_requests: Arc<Mutex<BTreeMap<(AuthorityIndex, String), usize>>>,
         network_client: Arc<C>,
         context: Arc<Context>,
         core_dispatcher: Arc<D>,
         dag_state: Arc<RwLock<DagState>>,
         mut receiver: Receiver<BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>>,
-        commands_sender: Sender<Command>,
         block_verifier: Arc<V>,
         inflight_transactions_map: Arc<InflightTransactionsMap>,
     ) {
-        // TODO: limit number of live requests
         let mut requests = FuturesUnordered::new();
 
         loop {
             tokio::select! {
-                Some(missing_block_refs) = receiver.recv(), if requests.len() < LIVE_FETCH_TRANSACTIONS_CONCURRENCY => {
-                    requests.push(Self::fetch_transactions_from_authorities(
+                Some(missing_transactions_block_refs) = receiver.recv(), if requests.len() < LIVE_FETCH_TRANSACTIONS_CONCURRENCY => {
+                    requests.push(Self::fetch_and_process_transactions_from_authorities(
                         context.clone(),
+                        active_requests.clone(),
                         inflight_transactions_map.clone(),
                         network_client.clone(),
-                        missing_block_refs,
+                        missing_transactions_block_refs,
+                        core_dispatcher.clone(),
+                        block_verifier.clone(),
+                        dag_state.clone(),
                         "live",
                     ));
                 },
-                Some(result) = requests.next() => {
-                    if result.is_empty() {
-                        debug!("No results returned while requesting missing transactions");
-                        continue;
-                    }
-                    // Add process_fetched_transactions futures to the FuturesUnordered collection
-                    for (transactions_guard, fetched_transactions, peer) in result {
-
-                       if let Err(err) = Self::process_fetched_transactions(
-                            fetched_transactions,
-                            peer,
-                            transactions_guard,
-                            core_dispatcher.clone(),
-                            context.clone(),
-                            commands_sender.clone(),
-                            block_verifier.clone(),
-                            dag_state.clone(),
-                            "live",
-                       )
-                       .await
-                       {
-                           warn!(
-                               "Error occurred while processing fetched blocks from peer {peer}: {err}"
-                           );
-                       }
-                    };
+                Some(_) = requests.next() => {
                 },
                 else => {
                     info!("Live fetcher task will now abort.");
@@ -431,6 +457,376 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                 }
             }
         }
+    }
+
+    /// Starts a task to fetch missing transactions from other authorities.
+    async fn start_fetch_missing_transactions_task(&mut self) -> ConsensusResult<()> {
+        info!("Kick in periodic synchronizer to fetch missing transactions");
+        // Get missing transactions from the core
+        let missing_transactions = self
+            .core_dispatcher
+            .get_missing_transaction_data()
+            .await
+            .map_err(|_err| ConsensusError::Shutdown)?;
+
+        let dag_state = self.dag_state.clone();
+
+        // Compute the gap to unavailable transactions.
+        // If no missing transactions, the gap is zero; Otherwise, it is the difference
+        // between the highest accepted round and the earliest unavailable transaction
+        // round.
+        let accepted_round = dag_state.read().highest_accepted_round();
+        let earliest_unavailable_transaction_round = missing_transactions
+            .first_key_value()
+            .map(|(block_ref, _)| block_ref.round)
+            .unwrap_or(accepted_round);
+        let gap_to_unavailable_transactions =
+            accepted_round.saturating_sub(earliest_unavailable_transaction_round);
+        self.context
+            .metrics
+            .node_metrics
+            .gap_to_unavailable_transactions
+            .set(gap_to_unavailable_transactions as i64);
+
+        // If there are no missing transactions, we don't need to fetch anything.
+        if missing_transactions.is_empty() {
+            return Ok(());
+        }
+
+        let context = self.context.clone();
+
+        // Update metrics for missing transactions per authority before fetching
+        let mut missing_transactions_per_authority = vec![0; context.committee.size()];
+        for block_ref in missing_transactions.keys() {
+            missing_transactions_per_authority[block_ref.author] += 1;
+        }
+        for (missing, (_, authority)) in missing_transactions_per_authority
+            .into_iter()
+            .zip(context.committee.authorities())
+        {
+            context
+                .metrics
+                .node_metrics
+                .transactions_synchronizer_missing_transactions_by_authority
+                .with_label_values(&[&authority.hostname.as_str()])
+                .inc_by(missing as u64);
+            context
+                .metrics
+                .node_metrics
+                .transactions_synchronizer_current_missing_transactions_by_authority
+                .with_label_values(&[&authority.hostname.as_str()])
+                .set(missing as i64);
+        }
+        let network_client = self.network_client.clone();
+        let core_dispatcher = self.core_dispatcher.clone();
+        let commands_sender = self.commands_sender.clone();
+        let block_verifier = self.block_verifier.clone();
+        let dag_state = self.dag_state.clone();
+        let inflight_transactions_map = self.inflight_transactions_map.clone();
+        let active_requests = self.active_requests.clone();
+
+        self.fetch_transactions_scheduler_task
+            .spawn(monitored_future!(async move {
+                let _scope = monitored_scope("FetchMissingTransactionsScheduler");
+                fail_point_async!("consensus-delay");
+                context
+                    .metrics
+                    .node_metrics
+                    .transactions_synchronizer_periodic_inflight
+                    .inc();
+                // Fetch and process missing transactions
+                Self::fetch_and_process_transactions_from_authorities(
+                    context.clone(),
+                    active_requests,
+                    inflight_transactions_map,
+                    network_client,
+                    missing_transactions,
+                    core_dispatcher,
+                    block_verifier,
+                    dag_state,
+                    "periodic",
+                )
+                .await;
+                context
+                    .metrics
+                    .node_metrics
+                    .transactions_synchronizer_periodic_inflight
+                    .dec();
+            }));
+        // Kick off the scheduler to fetch any remaining missing transactions
+        commands_sender
+            .try_send(Command::KickOffScheduler)
+            .map_err(|_| ConsensusError::Shutdown)?;
+        Ok(())
+    }
+
+    /// Fetches missing transactions from authorities.
+    async fn fetch_and_process_transactions_from_authorities(
+        context: Arc<Context>,
+        active_requests: Arc<Mutex<BTreeMap<(AuthorityIndex, String), usize>>>,
+        inflight_transactions_map: Arc<InflightTransactionsMap>,
+        network_client: Arc<C>,
+        missing_transactions: BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
+        core_dispatcher: Arc<D>,
+        block_verifier: Arc<V>,
+        dag_state: Arc<RwLock<DagState>>,
+        sync_method: &str,
+    ) {
+        // Build a mapping from authority -> set of BlockRefs it has acknowledged
+        let mut blocks_by_authority: BTreeMap<AuthorityIndex, BTreeSet<BlockRef>> = BTreeMap::new();
+        for (block_ref, authorities) in &missing_transactions {
+            for authority in authorities {
+                if *authority != context.own_index {
+                    blocks_by_authority
+                        .entry(*authority)
+                        .or_default()
+                        .insert(*block_ref);
+                }
+            }
+        }
+
+        // For each authority, try to lock up the
+        // maximum possible amount of acknowledged transactions and fetch
+        // those transactions. The logic is as follows:
+        // * Iterate in random order all authorities that have acknowledged missing
+        //   transactions.
+        // * Attempt to lock max_transactions_per_fetch acknowledged transactions using
+        //   the inflight_transactions_map. Some transactions may already be locked by
+        //   other authorities, but continue with the transactions that were
+        //   successfully locked.
+        // * For each authority, if transactions were successfully locked, then send a
+        //   request to the network client to fetch the transactions from the authority.
+        // * If the transactions were successfully fetched, then process them and send
+        //   them to the core for processing.
+        // Each request is performed individually to avoid blocking the
+        // synchronizer for too long, as certain peers may take a while to respond.
+        // The number of requests to each peer is limited by the parameters.
+
+        // Initialize randomness for shuffling authorities
+        let mut rng = StdRng::from_rng(OsRng).expect("OsRng should be available");
+
+        // Create an iterator over authorities with their corresponding block refs
+        // This will allow us to iterate over authorities in a stable (for test) or
+        // random order (for production).
+        let iter_authorities: Box<dyn Iterator<Item = (AuthorityIndex, BTreeSet<BlockRef>)>> =
+            if cfg!(test) {
+                // Stable order for tests
+                Box::new(blocks_by_authority.into_iter())
+            } else {
+                let mut vec: Vec<_> = blocks_by_authority.into_iter().collect();
+                vec.shuffle(&mut rng);
+                Box::new(vec.into_iter())
+            };
+
+        let mut request_futures = FuturesUnordered::new();
+
+        for (authority, authority_block_refs) in iter_authorities {
+            {
+                let count = active_requests
+                    .lock()
+                    .get(&(authority, sync_method.to_string()))
+                    .copied()
+                    .unwrap_or(0);
+
+                // Skip assigning a request if the limit is reached
+                if count >= MAX_CONCURRENT_REQUESTS_PER_AUTHORITY {
+                    let peer_hostname = &context.committee.authority(authority).hostname;
+                    debug!(
+                        "Skipping fetch for authority {peer_hostname} as the maximum number of concurrent requests is reached"
+                    );
+                    continue;
+                }
+            }
+
+            // * If transactions are successfully locked, then send a request to the network
+            //   client to fetch the transactions from the authority. If the fetch is
+            //   successful, then process the transactions and send them to the core for
+            //   processing.
+            if let Some(transactions_guard) = inflight_transactions_map.lock_transactions(
+                authority_block_refs.clone(),
+                authority,
+                context.parameters.max_transactions_per_fetch,
+            ) {
+                let active_request_guard = ActiveRequestGuard::new(
+                    authority,
+                    sync_method.to_string(),
+                    active_requests.clone(),
+                );
+
+                request_futures.push(Self::fetch_and_process_transactions_from_authority(
+                    authority,
+                    context.clone(),
+                    transactions_guard,
+                    network_client.clone(),
+                    core_dispatcher.clone(),
+                    block_verifier.clone(),
+                    dag_state.clone(),
+                    sync_method,
+                    active_request_guard,
+                ));
+            }
+        }
+
+        if request_futures.is_empty() {
+            return;
+        }
+
+        // Each fetch request has its own timeout, but processing not.
+        // Using timeout, we limit the overall time spent primarily on processing
+        let timeout = sleep(FETCH_AND_PROCESS_FROM_PEERS_TIMEOUT);
+
+        tokio::pin!(timeout);
+
+        loop {
+            tokio::select! {
+                    Some(res) = request_futures.next() => {
+                        if let Err(err) = res {
+                            warn!("[{sync_method}] Error when fetching and processing transactions from authority: {err}");
+                        }
+            },
+                    _ = &mut timeout => {
+                        warn!("[{sync_method}] Timed out while fetching and processing missing transactions");
+                         // Drop all pending requests immediately — frees all transaction guards
+                        drop(request_futures);
+                        break;
+                    }
+                }
+        }
+    }
+
+    /// Fetches and processes transactions from a specific authority peer.
+    async fn fetch_and_process_transactions_from_authority(
+        peer: AuthorityIndex,
+        context: Arc<Context>,
+        transactions_guard: TransactionsGuard,
+        network_client: Arc<C>,
+        core_dispatcher: Arc<D>,
+        block_verifier: Arc<V>,
+        dag_state: Arc<RwLock<DagState>>,
+        sync_method: &str,
+        _active_guard: ActiveRequestGuard,
+    ) -> ConsensusResult<()> {
+        let peer_hostname = &context.committee.authority(peer).hostname;
+        let total_requested = transactions_guard.block_refs.len();
+
+        debug!(
+            "[{sync_method}] Syncing {} missing committed transactions from authority {} {}",
+            total_requested, peer, peer_hostname,
+        );
+
+        let (fetched_serialized_transactions, transactions_guard, _peer_index) =
+            Self::fetch_transactions_request(
+                network_client.clone(),
+                peer,
+                transactions_guard,
+                FETCH_REQUEST_TIMEOUT,
+                context.clone(),
+                sync_method,
+            )
+            .await?;
+
+        let total_fetched = fetched_serialized_transactions.len();
+        debug!(
+            "Transactions from {total_requested} blocks requested, fetched from {total_fetched} blocks"
+        );
+
+        Self::process_fetched_transactions(
+            fetched_serialized_transactions,
+            peer,
+            transactions_guard,
+            core_dispatcher.clone(),
+            context.clone(),
+            block_verifier.clone(),
+            dag_state.clone(),
+            sync_method,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    /// Fetches transactions from a peer authority for the given block
+    /// references. Returns the fetched transactions, the transactions
+    /// guard, and the peer index.
+    async fn fetch_transactions_request(
+        network_client: Arc<C>,
+        peer: AuthorityIndex,
+        transactions_guard: TransactionsGuard,
+        request_timeout: Duration,
+        context: Arc<Context>,
+        sync_method: &str,
+    ) -> ConsensusResult<(Vec<Bytes>, TransactionsGuard, AuthorityIndex)> {
+        // Track concurrent inflight requests
+        let inflight_metric = &context
+            .metrics
+            .node_metrics
+            .transactions_synchronizer_inflight_requests;
+        inflight_metric.inc();
+        let _guard = InflightGuard {
+            metric: inflight_metric,
+        };
+
+        let block_refs = transactions_guard
+            .block_refs
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let peer_hostname = &context.committee.authority(peer).hostname;
+        let start_time = Instant::now();
+        // Fetch the transactions from the peer
+        let result = timeout(
+            request_timeout,
+            network_client.fetch_transactions(peer, block_refs.clone(), request_timeout),
+        )
+        .await;
+
+        fail_point_async!("consensus-delay");
+
+        // Record fetch latency
+        let fetch_duration = start_time.elapsed();
+        context
+            .metrics
+            .node_metrics
+            .transactions_synchronizer_fetch_latency
+            .with_label_values(&[peer_hostname.as_str(), sync_method])
+            .observe(fetch_duration.as_secs_f64());
+
+        let resp = match result {
+            Ok(Err(err)) => {
+                // Record failure
+                context
+                    .metrics
+                    .node_metrics
+                    .transactions_synchronizer_failure_by_peer
+                    .with_label_values(&[peer_hostname.as_str(), sync_method, err.name()])
+                    .inc();
+                Err(err) // network error
+            }
+            Err(err) => {
+                // Record timeout failure
+                context
+                    .metrics
+                    .node_metrics
+                    .transactions_synchronizer_failure_by_peer
+                    .with_label_values(&[peer_hostname.as_str(), sync_method, "timeout"])
+                    .inc();
+                // timeout
+                Err(ConsensusError::NetworkRequestTimeout(err.to_string()))
+            }
+            Ok(result) => {
+                // Record success
+                context
+                    .metrics
+                    .node_metrics
+                    .transactions_synchronizer_success_by_peer
+                    .with_label_values(&[peer_hostname.as_str(), sync_method])
+                    .inc();
+
+                result
+            }
+        };
+        resp.map(|txs| (txs, transactions_guard, peer))
     }
 
     /// Processes the requested raw fetched transactions from peer `peer_index`.
@@ -442,7 +838,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         requested_transactions_guard: TransactionsGuard,
         core_dispatcher: Arc<D>,
         context: Arc<Context>,
-        commands_sender: Sender<Command>,
         block_verifier: Arc<V>,
         dag_state: Arc<RwLock<DagState>>,
         sync_method: &str,
@@ -520,7 +915,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         }
 
         info!(
-            "[{sync_method}] Synced {} missing transactions from peer {peer_index} {peer_hostname}: {}",
+            "[{sync_method}] Synced and processed {} missing transactions from peer {peer_index} {peer_hostname}: {}",
             transactions.len(),
             transactions
                 .iter()
@@ -537,11 +932,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         // now release all the locked blocks as they have been fetched, verified &
         // processed
         drop(requested_transactions_guard);
-
-        // Kick off the scheduler to fetch any remaining missing transactions
-        commands_sender
-            .try_send(Command::KickOffScheduler)
-            .map_err(|_| ConsensusError::Shutdown)?;
 
         Ok(())
     }
@@ -603,374 +993,15 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
 
         Ok(collected_verified_transactions)
     }
+}
 
-    async fn fetch_transactions_request(
-        network_client: Arc<C>,
-        peer: AuthorityIndex,
-        transactions_guard: TransactionsGuard,
-        request_timeout: Duration,
-        context: Arc<Context>,
-        sync_method: &str,
-    ) -> (
-        ConsensusResult<Vec<Bytes>>,
-        TransactionsGuard,
-        AuthorityIndex,
-    ) {
-        let block_refs = transactions_guard
-            .block_refs
-            .iter()
-            .cloned()
-            .collect::<Vec<_>>();
+struct InflightGuard<'a> {
+    metric: &'a prometheus::IntGauge,
+}
 
-        let peer_hostname = &context.committee.authority(peer).hostname;
-        let start_time = Instant::now();
-        // Update inflight requests metric
-        context
-            .metrics
-            .node_metrics
-            .transactions_synchronizer_inflight_requests
-            .inc();
-        // Fetch the transactions from the peer
-        let result = timeout(
-            request_timeout,
-            network_client.fetch_transactions(peer, block_refs.clone(), request_timeout),
-        )
-        .await;
-
-        fail_point_async!("consensus-delay");
-
-        // Record fetch latency
-        let fetch_duration = start_time.elapsed();
-        context
-            .metrics
-            .node_metrics
-            .transactions_synchronizer_fetch_latency
-            .with_label_values(&[peer_hostname.as_str(), sync_method])
-            .observe(fetch_duration.as_secs_f64());
-        // Update inflight requests metric
-        context
-            .metrics
-            .node_metrics
-            .transactions_synchronizer_inflight_requests
-            .dec();
-
-        let resp = match result {
-            Ok(Err(err)) => {
-                // Record failure
-                context
-                    .metrics
-                    .node_metrics
-                    .transactions_synchronizer_failure_by_peer
-                    .with_label_values(&[peer_hostname.as_str(), sync_method, err.name()])
-                    .inc();
-                Err(err) // network error
-            }
-            Err(err) => {
-                // Record timeout failure
-                context
-                    .metrics
-                    .node_metrics
-                    .transactions_synchronizer_failure_by_peer
-                    .with_label_values(&[peer_hostname.as_str(), sync_method, "timeout"])
-                    .inc();
-                // timeout
-                Err(ConsensusError::NetworkRequestTimeout(err.to_string()))
-            }
-            Ok(result) => {
-                // Record success
-                context
-                    .metrics
-                    .node_metrics
-                    .transactions_synchronizer_success_by_peer
-                    .with_label_values(&[peer_hostname.as_str(), sync_method])
-                    .inc();
-
-                result
-            }
-        };
-        (resp, transactions_guard, peer)
-    }
-
-    /// Starts a task to fetch missing transactions from other authorities.
-    async fn start_fetch_missing_transactions_task(&mut self) -> ConsensusResult<()> {
-        // Get missing transactions from the core
-        let missing_transactions = self
-            .core_dispatcher
-            .get_missing_transaction_data()
-            .await
-            .map_err(|_err| ConsensusError::Shutdown)?;
-
-        let dag_state = self.dag_state.clone();
-
-        // Compute the gap to unavailable transactions.
-        // If no missing transactions, the gap is zero; Otherwise, it is the difference
-        // between the highest accepted round and the earliest unavailable transaction
-        // round.
-        let accepted_round = dag_state.read().highest_accepted_round();
-        let earliest_unavailable_transaction_round = missing_transactions
-            .first_key_value()
-            .map(|(block_ref, _)| block_ref.round)
-            .unwrap_or(accepted_round);
-        let gap_to_unavailable_transactions =
-            accepted_round.saturating_sub(earliest_unavailable_transaction_round);
-        self.context
-            .metrics
-            .node_metrics
-            .gap_to_unavailable_transactions
-            .set(gap_to_unavailable_transactions as i64);
-
-        // If there are no missing transactions, we don't need to fetch anything.
-        if missing_transactions.is_empty() {
-            return Ok(());
-        }
-        let context = self.context.clone();
-        let network_client = self.network_client.clone();
-        let core_dispatcher = self.core_dispatcher.clone();
-        let inflight_transactions_map = self.inflight_transactions_map.clone();
-        let commands_sender = self.commands_sender.clone();
-        let block_verifier = self.block_verifier.clone();
-
-        self.fetch_transactions_scheduler_task
-            .spawn(monitored_future!(async move {
-                let _scope = monitored_scope("FetchMissingTransactionsScheduler");
-                // Update metrics for missing transactions per authority before fetching
-                let mut missing_transactions_per_authority = vec![0; context.committee.size()];
-                for block_ref in missing_transactions.keys() {
-                    missing_transactions_per_authority[block_ref.author] += 1;
-                }
-                for (missing, (_, authority)) in missing_transactions_per_authority
-                    .into_iter()
-                    .zip(context.committee.authorities())
-                {
-                    context
-                        .metrics
-                        .node_metrics
-                        .transactions_synchronizer_missing_transactions_by_authority
-                        .with_label_values(&[&authority.hostname.as_str()])
-                        .inc_by(missing as u64);
-                    context
-                        .metrics
-                        .node_metrics
-                        .transactions_synchronizer_current_missing_transactions_by_authority
-                        .with_label_values(&[&authority.hostname.as_str()])
-                        .set(missing as i64);
-                }
-
-                context
-                    .metrics
-                    .node_metrics
-                    .transactions_synchronizer_scheduler_inflight
-                    .inc();
-                let total_requested = missing_transactions.len();
-
-                fail_point_async!("consensus-delay");
-                // Fetch the missing transactions from other authorities
-                let results = Self::fetch_transactions_from_authorities(
-                    context.clone(),
-                    inflight_transactions_map,
-                    network_client,
-                    missing_transactions,
-                    "periodic",
-                )
-                .await;
-                context
-                    .metrics
-                    .node_metrics
-                    .transactions_synchronizer_scheduler_inflight
-                    .dec();
-                if results.is_empty() {
-                    warn!("No results returned while requesting missing transactions");
-                    return;
-                }
-                let mut total_fetched = 0;
-                for (transactions_guard, fetched_transactions, peer) in results {
-                    total_fetched += fetched_transactions.len();
-
-                    if let Err(err) = Self::process_fetched_transactions(
-                        fetched_transactions,
-                        peer,
-                        transactions_guard,
-                        core_dispatcher.clone(),
-                        context.clone(),
-                        commands_sender.clone(),
-                        block_verifier.clone(),
-                        dag_state.clone(),
-                        "periodic",
-                    )
-                    .await
-                    {
-                        warn!(
-                            "Error occurred while processing fetched blocks from peer {peer}: {err}"
-                        );
-                    }
-                }
-
-                debug!(
-                    "Total blocks requested to fetch: {}, total fetched: {}",
-                    total_requested, total_fetched
-                );
-            }));
-        Ok(())
-    }
-
-    /// Fetches missing transactions from other authorities.
-    async fn fetch_transactions_from_authorities(
-        context: Arc<Context>,
-        inflight_transactions_map: Arc<InflightTransactionsMap>,
-        network_client: Arc<C>,
-        missing_transactions: BTreeMap<BlockRef, BTreeSet<AuthorityIndex>>,
-        sync_method: &str,
-    ) -> Vec<(TransactionsGuard, Vec<Bytes>, AuthorityIndex)> {
-        let mut rng = StdRng::from_rng(OsRng).expect("OsRng should be available");
-
-        // Build a mapping from authority -> set of BlockRefs it has acknowledged
-        let mut blocks_by_authority: BTreeMap<AuthorityIndex, BTreeSet<BlockRef>> = BTreeMap::new();
-        for (block_ref, authorities) in &missing_transactions {
-            for authority in authorities {
-                if *authority != context.own_index {
-                    blocks_by_authority
-                        .entry(*authority)
-                        .or_default()
-                        .insert(*block_ref);
-                }
-            }
-        }
-
-        let mut request_futures = FuturesUnordered::new();
-
-        // For each authority, randomize and try to lock up the
-        // maximum possible amount of acknowledged transactions in blocks.
-        // The logic is as follows:
-        // * Iterate all authorities that have acknowledged missing transactions.
-        // * Randomly select up to max_transactions_per_fetch missing transactions
-        //   acknowledged by the authority.
-        // * Attempt to lock the selected transactions using the
-        //   inflight_transactions_map. Some transactions may already be locked by other
-        //   authorities, but continue with the transactions that were successfully
-        //   locked. If no transactions can be locked and there are remaining missing
-        //   transactions acknowledged by the authority, then try again with a new
-        //   random selection. TODO: This part of the logic needs to be improved!
-
-        // Create an iterator over authorities with their corresponding block refs
-        // This will allow us to iterate over authorities in a stable (for test) or
-        // random order
-
-        let iter_authorities: Box<dyn Iterator<Item = (AuthorityIndex, BTreeSet<BlockRef>)>> =
-            if cfg!(test) {
-                // Stable order for tests
-                Box::new(blocks_by_authority.into_iter())
-            } else {
-                let mut vec: Vec<_> = blocks_by_authority.into_iter().collect();
-                vec.shuffle(&mut rng);
-                Box::new(vec.into_iter())
-            };
-
-        for (authority, authority_block_refs) in iter_authorities {
-            let peer_hostname = &context.committee.authority(authority).hostname;
-            // Remove block_refs already assigned to another peer
-            let mut available_refs: BTreeSet<_> = authority_block_refs.clone();
-            // .difference(&assigned_block_refs)
-            // .cloned()
-            // .collect();
-            while !available_refs.is_empty() {
-                // TODO: remove this and use inflight_transactions_map to choose transactions
-                //  randomly
-                let selected_block_refs = available_refs
-                    .iter()
-                    .choose_multiple(&mut rng, context.parameters.max_transactions_per_fetch)
-                    .into_iter()
-                    .cloned()
-                    .collect::<BTreeSet<_>>();
-
-                if selected_block_refs.is_empty() {
-                    break;
-                }
-
-                // * If transactions are successfully locked, then send a request to the network
-                //   client to fetch the transactions from the authority.
-                if let Some(transactions_guard) = inflight_transactions_map
-                    .lock_transactions(selected_block_refs.clone(), authority)
-                {
-                    debug!(
-                        "[{sync_method}] Syncing {} missing committed transactions from authority {} {}: {}",
-                        selected_block_refs.len(),
-                        authority,
-                        peer_hostname,
-                        selected_block_refs
-                            .iter()
-                            .map(|b| b.to_string())
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    );
-                    // assigned_block_refs.extend(&selected_block_refs);
-                    // TODO: we need to measure how many requests are sent in each run and possibly
-                    //  limit that. This can be limited after we implement Starfish with shards as
-                    //  there will definitely be more requests performed
-                    request_futures.push(Self::fetch_transactions_request(
-                        network_client.clone(),
-                        authority,
-                        transactions_guard,
-                        FETCH_REQUEST_TIMEOUT,
-                        context.clone(),
-                        sync_method,
-                    ));
-                    break;
-                } else {
-                    // Remove attempted refs and try again with the rest
-                    available_refs
-                        .retain(|ref_to_remove| !selected_block_refs.contains(ref_to_remove));
-                }
-            }
-        }
-
-        let mut results = Vec::new();
-        let fetcher_timeout = sleep(FETCH_FROM_PEERS_TIMEOUT);
-
-        tokio::pin!(fetcher_timeout);
-
-        // Track the number of concurrent requests
-        context
-            .metrics
-            .node_metrics
-            .transactions_synchronizer_inflight_requests
-            .set(request_futures.len() as i64);
-
-        loop {
-            tokio::select! {
-                Some((response, transactions_guard, peer_index)) = request_futures.next() => {
-                    let peer_hostname = &context.committee.authority(peer_index).hostname;
-                    match response {
-                        Ok(fetched_blocks) => {
-                            results.push((transactions_guard, fetched_blocks, peer_index));
-
-                            // Update concurrent requests metric
-                            context.metrics.node_metrics.transactions_synchronizer_inflight_requests
-                                .set(request_futures.len() as i64);
-
-                            // no more pending requests are left, break the loop
-                            if request_futures.is_empty() {
-                                break;
-                            }
-                        },
-                        Err(e) => {
-                            warn!("Error while trying to fetch transactions from peer {peer_index} {peer_hostname}. Error: {e}");
-                            // we don't necessarily need to do, but dropping the guard here to unlock the blocks
-                            drop(transactions_guard);
-
-                            // Update concurrent requests metric
-                            context.metrics.node_metrics.transactions_synchronizer_inflight_requests
-                                .set(request_futures.len() as i64);
-                        }
-                    }
-                },
-                _ = &mut fetcher_timeout => {
-                    debug!("Timed out while fetching missing blocks");
-                    break;
-                }
-            }
-        }
-
-        results
+impl<'a> Drop for InflightGuard<'a> {
+    fn drop(&mut self) {
+        self.metric.dec();
     }
 }
 
@@ -1734,8 +1765,8 @@ mod tests {
         handle.stop().await.unwrap();
     }
 
-    #[test]
-    fn inflight_transactions_map() {
+    #[tokio::test]
+    async fn inflight_transactions_map() {
         telemetry_subscribers::init_for_testing();
         // GIVEN
         let map = InflightTransactionsMap::new();
@@ -1745,6 +1776,7 @@ mod tests {
             BlockRef::new(12, AuthorityIndex::new_for_test(3), BlockHeaderDigest::MIN),
             BlockRef::new(15, AuthorityIndex::new_for_test(2), BlockHeaderDigest::MIN),
         ];
+        let context = Context::new_for_test(4).0;
         let missing_block_refs = some_block_refs.iter().cloned().collect::<BTreeSet<_>>();
 
         // Lock & unlock transactions
@@ -1755,14 +1787,22 @@ mod tests {
             for i in 0..=2 {
                 let authority = AuthorityIndex::new_for_test(i);
 
-                let guard = map.lock_transactions(missing_block_refs.clone(), authority);
+                let guard = map.lock_transactions(
+                    missing_block_refs.clone(),
+                    authority,
+                    context.parameters.max_transactions_per_fetch,
+                );
                 let guard = guard.expect("Guard should be created");
                 assert_eq!(guard.block_refs.len(), 4);
 
                 all_guards.push(guard);
 
                 // trying to acquire any of them again will not succeed
-                let guard = map.lock_transactions(missing_block_refs.clone(), authority);
+                let guard = map.lock_transactions(
+                    missing_block_refs.clone(),
+                    authority,
+                    context.parameters.max_transactions_per_fetch,
+                );
                 assert!(guard.is_none());
             }
 
@@ -1770,14 +1810,22 @@ mod tests {
             // number of allowed peers (MAX_AUTHORITIES_TO_FETCH_PER_TRANSACTION = 3)
             let authority_3 = AuthorityIndex::new_for_test(3);
 
-            let guard = map.lock_transactions(missing_block_refs.clone(), authority_3);
+            let guard = map.lock_transactions(
+                missing_block_refs.clone(),
+                authority_3,
+                context.parameters.max_transactions_per_fetch,
+            );
             assert!(guard.is_none());
 
             // Explicitly drop the guard of authority 1 and try for authority 3 again - it
             // will now succeed
             drop(all_guards.remove(0));
 
-            let guard = map.lock_transactions(missing_block_refs.clone(), authority_3);
+            let guard = map.lock_transactions(
+                missing_block_refs.clone(),
+                authority_3,
+                context.parameters.max_transactions_per_fetch,
+            );
             let guard = guard.expect("Guard should be successfully acquired");
 
             assert_eq!(guard.block_refs, missing_block_refs);
@@ -1789,7 +1837,6 @@ mod tests {
             assert_eq!(map.num_of_locked_transactions(), 0);
         }
     }
-
     struct MockNetworkClient {
         transactions: Arc<Mutex<HashMap<(AuthorityIndex, BlockRef), Bytes>>>,
         error_peers: Arc<Mutex<HashMap<AuthorityIndex, ConsensusError>>>,

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -65,7 +65,7 @@ const FETCH_AND_PROCESS_FROM_PEERS_TIMEOUT: Duration = Duration::from_millis(700
 /// given block ref.
 const MAX_AUTHORITIES_TO_FETCH_PER_TRANSACTION: usize = 3;
 
-#[derive(Debug,Clone,Copy,Ord,Eq,PartialOrd,PartialEq)]
+#[derive(Debug, Clone, Copy, Ord, Eq, PartialOrd, PartialEq)]
 enum SyncMethod {
     Live,
     Periodic,
@@ -662,11 +662,8 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                 authority,
                 context.parameters.max_transactions_per_fetch,
             ) {
-                let active_request_guard = ActiveRequestGuard::new(
-                    authority,
-                    sync_method,
-                    active_requests.clone(),
-                );
+                let active_request_guard =
+                    ActiveRequestGuard::new(authority, sync_method, active_requests.clone());
 
                 request_futures.push(Self::fetch_and_process_transactions_from_authority(
                     authority,
@@ -814,7 +811,11 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                     .metrics
                     .node_metrics
                     .transactions_synchronizer_failure_by_peer
-                    .with_label_values(&[peer_hostname.as_str(), &sync_method.get_string(), err.name()])
+                    .with_label_values(&[
+                        peer_hostname.as_str(),
+                        &sync_method.get_string(),
+                        err.name(),
+                    ])
                     .inc();
                 Err(err) // network error
             }
@@ -824,7 +825,11 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
                     .metrics
                     .node_metrics
                     .transactions_synchronizer_failure_by_peer
-                    .with_label_values(&[peer_hostname.as_str(), &sync_method.get_string(), "timeout"])
+                    .with_label_values(&[
+                        peer_hostname.as_str(),
+                        &sync_method.get_string(),
+                        "timeout",
+                    ])
                     .inc();
                 // timeout
                 Err(ConsensusError::NetworkRequestTimeout(err.to_string()))

--- a/crates/starfish/core/src/transactions_synchronizer.rs
+++ b/crates/starfish/core/src/transactions_synchronizer.rs
@@ -25,7 +25,7 @@ use rand::{
 use starfish_config::AuthorityIndex;
 use tokio::{
     runtime::Handle,
-    sync::{mpsc::error::TrySendError, oneshot},
+    sync::{Semaphore, mpsc::error::TrySendError, oneshot},
     task::{JoinError, JoinSet},
     time::{Instant, sleep, sleep_until, timeout},
 };
@@ -447,26 +447,42 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher>
         block_verifier: Arc<V>,
         inflight_transactions_map: Arc<InflightTransactionsMap>,
     ) {
-        let mut requests = FuturesUnordered::new();
+        let semaphore = Arc::new(Semaphore::new(LIVE_FETCH_TRANSACTIONS_CONCURRENCY));
 
         loop {
-            tokio::select! {
-                Some(missing_transactions_block_refs) = receiver.recv(), if requests.len() < LIVE_FETCH_TRANSACTIONS_CONCURRENCY => {
-                    requests.push(Self::fetch_and_process_transactions_from_authorities(
-                        context.clone(),
-                        active_requests.clone(),
-                        inflight_transactions_map.clone(),
-                        network_client.clone(),
-                        missing_transactions_block_refs,
-                        core_dispatcher.clone(),
-                        block_verifier.clone(),
-                        dag_state.clone(),
-                        SyncMethod::Live,
-                    ));
-                },
-                Some(_) = requests.next() => {
-                },
-                else => {
+            // Wait for a permit asynchronously
+            let permit = semaphore.clone().acquire_owned().await.expect("We expect semaphore to be valid");
+
+            match receiver.recv().await {
+                Some(missing_transactions_block_refs) => {
+                    let context = context.clone();
+                    let active_requests = active_requests.clone();
+                    let inflight_transactions_map = inflight_transactions_map.clone();
+                    let network_client = network_client.clone();
+                    let core_dispatcher = core_dispatcher.clone();
+                    let block_verifier = block_verifier.clone();
+                    let dag_state = dag_state.clone();
+
+                    tokio::spawn(async move {
+                        Self::fetch_and_process_transactions_from_authorities(
+                            context,
+                            active_requests,
+                            inflight_transactions_map,
+                            network_client,
+                            missing_transactions_block_refs,
+                            core_dispatcher,
+                            block_verifier,
+                            dag_state,
+                            SyncMethod::Live,
+                        )
+                            .await;
+
+                        // Release the permit when done
+                        drop(permit);
+                    });
+                }
+                None => {
+                    // Channel closed → shutdown
                     info!("Live fetcher task will now abort.");
                     break;
                 }


### PR DESCRIPTION
# Description of change

In this PR, we improve the transaction synchronizer in Starfish. Main changes:
- we join fetching and processing transactions into one method `fetch_and_process_transactions_from_authorities` to reuse this for live and periodic syncing
- we make at most one fetch request to a given authority in one call of `fetch_and_process_transactions_from_authorities`
- we track the number of concurrent requests to each authority and limit that value using a new struct in synchronizer called `active_requests`
- we process transactions after fetching for each authority individually. While this creates much more calls to the core thread, this improves the syncing process significantly since it was slowed down by the slowest response in the previous implementation. Later on we can add one/a few active thread(s) that will take all fetched bytes and process them, removing duplicates and sending processed transactions to the core thread on a regular basis.
- we changed some parameters for fetching transactions, but they might require further changes once the protocol is tested on a larger network with longer discrepancies. 

## Links to any relevant issues

Fixes #8147 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [x] Protocol: Improvements in Starfish tx synchronizer
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
