### PR TITLE
upstream(core): Remove redundant synced checkpoint notifications

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -785,7 +785,7 @@ pub struct AuthorityState {
     pub rest_index: Option<Arc<RestIndexStore>>,
 
     pub subscription_handler: Arc<SubscriptionHandler>,
-    checkpoint_store: Arc<CheckpointStore>,
+    pub checkpoint_store: Arc<CheckpointStore>,
 
     committee_store: Arc<CommitteeStore>,
 

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -433,12 +433,6 @@ pub struct AuthorityPerEpochStore {
 
     executed_digests_notify_read: NotifyRead<TransactionKey, TransactionDigest>,
 
-    /// Get notified when a synced checkpoint has reached CheckpointExecutor.
-    synced_checkpoint_notify_read: NotifyRead<CheckpointSequenceNumber, ()>,
-    /// Caches the highest synced checkpoint sequence number as this has been
-    /// notified from the CheckpointExecutor
-    highest_synced_checkpoint: RwLock<CheckpointSequenceNumber>,
-
     /// This is used to notify all epoch specific tasks that epoch has ended.
     epoch_alive_notify: NotifyOnce,
 
@@ -991,8 +985,6 @@ impl AuthorityPerEpochStore {
             checkpoint_state_notify_read: NotifyRead::new(),
             running_root_notify_read: NotifyRead::new(),
             executed_digests_notify_read: NotifyRead::new(),
-            synced_checkpoint_notify_read: NotifyRead::new(),
-            highest_synced_checkpoint: RwLock::new(0),
             end_of_publish: Mutex::new(end_of_publish),
             pending_consensus_certificates: RwLock::new(pending_consensus_certificates),
             mutex_table: MutexTable::new(MUTEX_TABLE_SIZE),
@@ -2118,35 +2110,6 @@ impl AuthorityPerEpochStore {
             .map(|(registration, _)| registration);
 
         join_all(unprocessed_keys_registrations).await;
-        Ok(())
-    }
-
-    /// Notifies that a synced checkpoint of sequence number `checkpoint_seq` is
-    /// available. The source of the notification is the CheckpointExecutor.
-    /// The consumer here is guaranteed to be notified in sequence order.
-    pub fn notify_synced_checkpoint(&self, checkpoint_seq: CheckpointSequenceNumber) {
-        let mut highest_synced_checkpoint = self.highest_synced_checkpoint.write();
-        *highest_synced_checkpoint = checkpoint_seq;
-        self.synced_checkpoint_notify_read
-            .notify(&checkpoint_seq, &());
-    }
-
-    /// Get notified when a synced checkpoint of sequence number `>=
-    /// checkpoint_seq` is available.
-    pub async fn synced_checkpoint_notify(
-        &self,
-        checkpoint_seq: CheckpointSequenceNumber,
-    ) -> Result<(), IotaError> {
-        let registration = self
-            .synced_checkpoint_notify_read
-            .register_one(&checkpoint_seq);
-        {
-            let synced_checkpoint = self.highest_synced_checkpoint.read();
-            if *synced_checkpoint >= checkpoint_seq {
-                return Ok(());
-            }
-        }
-        registration.await;
         Ok(())
     }
 

--- a/crates/iota-core/src/authority_server.rs
+++ b/crates/iota-core/src/authority_server.rs
@@ -52,6 +52,7 @@ use tracing::{Instrument, error, error_span, info};
 
 use crate::{
     authority::{AuthorityState, authority_per_epoch_store::AuthorityPerEpochStore},
+    checkpoints::CheckpointStore,
     consensus_adapter::{
         ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
     },
@@ -118,6 +119,7 @@ impl AuthorityServer {
     pub fn new_for_test(state: Arc<AuthorityState>) -> Self {
         let consensus_adapter = Arc::new(ConsensusAdapter::new(
             Arc::new(LazyMysticetiClient::new()),
+            CheckpointStore::new_for_tests(),
             state.name,
             Arc::new(ConnectionMonitorStatusForTests {}),
             100_000,

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -584,8 +584,6 @@ impl CheckpointExecutor {
         let accumulator = self.accumulator.clone();
         let state = self.state.clone();
 
-        epoch_store.notify_synced_checkpoint(*checkpoint.sequence_number());
-
         pending.push_back(spawn_monitored_task!(async move {
             let epoch_store = epoch_store.clone();
             let (tx_digests, checkpoint_acc, checkpoint_data, randomness_rounds) = loop {

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -182,7 +182,6 @@ impl CheckpointStoreTables {
     pub fn new(path: &Path, metric_name: &'static str) -> Self {
         Self::open_tables_read_write(path.to_path_buf(), MetricConf::new(metric_name), None, None)
     }
-
     pub fn open_readonly(path: &Path) -> CheckpointStoreTablesReadOnly {
         Self::get_read_only_handle(
             path.to_path_buf(),
@@ -207,6 +206,11 @@ impl CheckpointStore {
             synced_checkpoint_notify_read: NotifyRead::new(),
             executed_checkpoint_notify_read: NotifyRead::new(),
         })
+    }
+
+    pub fn new_for_tests() -> Arc<Self> {
+        let ckpt_dir = tempfile::tempdir().unwrap();
+        CheckpointStore::new(ckpt_dir.path())
     }
 
     pub fn new_for_db_checkpoint_handler(path: &Path) -> Arc<Self> {

--- a/crates/iota-core/src/consensus_adapter.rs
+++ b/crates/iota-core/src/consensus_adapter.rs
@@ -50,6 +50,7 @@ use tracing::{debug, info, trace, warn};
 
 use crate::{
     authority::authority_per_epoch_store::AuthorityPerEpochStore,
+    checkpoints::CheckpointStore,
     connection_monitor::ConnectionStatus,
     consensus_handler::{SequencedConsensusTransactionKey, classify},
     epoch::reconfiguration::{ReconfigState, ReconfigurationInitiator},
@@ -222,6 +223,8 @@ pub trait ConsensusClient: Sync + Send + 'static {
 pub struct ConsensusAdapter {
     /// The network client connecting to the consensus node of this authority.
     consensus_client: Arc<dyn ConsensusClient>,
+    /// The checkpoint store for the validator
+    checkpoint_store: Arc<CheckpointStore>,
     /// Authority pubkey.
     authority: AuthorityName,
     /// The limit to number of inflight transactions at this node.
@@ -269,6 +272,7 @@ impl ConsensusAdapter {
     /// Make a new Consensus adapter instance.
     pub fn new(
         consensus_client: Arc<dyn ConsensusClient>,
+        checkpoint_store: Arc<CheckpointStore>,
         authority: AuthorityName,
         connection_monitor_status: Arc<dyn CheckConnection>,
         max_pending_transactions: usize,
@@ -282,6 +286,7 @@ impl ConsensusAdapter {
             ArcSwap::from_pointee(Arc::new(ArcSwap::from_pointee(HashMap::new())));
         Self {
             consensus_client,
+            checkpoint_store,
             authority,
             max_pending_transactions,
             max_submit_position,
@@ -302,8 +307,6 @@ impl ConsensusAdapter {
         self.low_scoring_authorities.swap(Arc::new(new_low_scoring));
     }
 
-    // TODO - this probably need to hold some kind of lock to make sure epoch does
-    // not change while we are recovering
     pub fn submit_recovered(self: &Arc<Self>, epoch_store: &Arc<AuthorityPerEpochStore>) {
         // Currently consensus worker might lose transactions on restart, so we need to
         // resend them.
@@ -947,7 +950,10 @@ impl ConsensusAdapter {
                 // notified when a checkpoint with equal or higher sequence
                 // number has been already synced. This way we don't try to unnecessarily
                 // sequence the signature for an already verified checkpoint.
-                Either::Left(epoch_store.synced_checkpoint_notify(checkpoint_sequence_number))
+                Either::Left(
+                    self.checkpoint_store
+                        .notify_read_synced_checkpoint(checkpoint_sequence_number),
+                )
             } else {
                 Either::Right(future::pending())
             };
@@ -969,8 +975,7 @@ impl ConsensusAdapter {
                         processed.expect("Storage error when waiting for transaction executed in checkpoint");
                         self.metrics.sequencing_certificate_processed.with_label_values(&["checkpoint"]).inc();
                     }
-                    processed = checkpoint_synced_future => {
-                        processed.expect("Error when waiting for checkpoint sequence number");
+                    _ = checkpoint_synced_future => {
                         self.metrics.sequencing_certificate_processed.with_label_values(&["synced_checkpoint"]).inc();
                     }
                 }
@@ -1248,6 +1253,7 @@ mod adapter_tests {
 
     use super::position_submit_certificate;
     use crate::{
+        checkpoints::CheckpointStore,
         consensus_adapter::{
             ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
         },
@@ -1280,6 +1286,7 @@ mod adapter_tests {
         // When we define max submit position and delay step
         let consensus_adapter = ConsensusAdapter::new(
             Arc::new(LazyMysticetiClient::new()),
+            CheckpointStore::new_for_tests(),
             *committee.authority_by_index(0).unwrap(),
             Arc::new(ConnectionMonitorStatusForTests {}),
             100_000,
@@ -1309,6 +1316,7 @@ mod adapter_tests {
         // Without submit position and delay step
         let consensus_adapter = ConsensusAdapter::new(
             Arc::new(LazyMysticetiClient::new()),
+            CheckpointStore::new_for_tests(),
             *committee.authority_by_index(0).unwrap(),
             Arc::new(ConnectionMonitorStatusForTests {}),
             100_000,

--- a/crates/iota-core/src/epoch/randomness.rs
+++ b/crates/iota-core/src/epoch/randomness.rs
@@ -842,6 +842,7 @@ mod tests {
 
     use crate::{
         authority::test_authority_builder::TestAuthorityBuilder,
+        checkpoints::CheckpointStore,
         consensus_adapter::{
             ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
             MockConsensusClient,
@@ -891,6 +892,7 @@ mod tests {
                 .await;
             let consensus_adapter = Arc::new(ConsensusAdapter::new(
                 Arc::new(mock_consensus_client),
+                CheckpointStore::new_for_tests(),
                 state.name,
                 Arc::new(ConnectionMonitorStatusForTests {}),
                 100_000,
@@ -1026,6 +1028,7 @@ mod tests {
                 .await;
             let consensus_adapter = Arc::new(ConsensusAdapter::new(
                 Arc::new(mock_consensus_client),
+                CheckpointStore::new_for_tests(),
                 state.name,
                 Arc::new(ConnectionMonitorStatusForTests {}),
                 100_000,

--- a/crates/iota-core/src/unit_tests/consensus_tests.rs
+++ b/crates/iota-core/src/unit_tests/consensus_tests.rs
@@ -2,10 +2,11 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashSet;
+use std::{collections::HashSet, time::Duration};
 
 use consensus_core::{BlockRef, BlockStatus};
 use fastcrypto::traits::KeyPair;
+use iota_macros::sim_test;
 use iota_protocol_config::ProtocolConfig;
 use iota_types::{
     IOTA_FRAMEWORK_PACKAGE_ID,
@@ -13,18 +14,20 @@ use iota_types::{
     crypto::deterministic_random_account_key,
     gas::GasCostSummary,
     messages_checkpoint::{
-        CheckpointContents, CheckpointSignatureMessage, CheckpointSummary, SignedCheckpointSummary,
+        CertifiedCheckpointSummary, CheckpointContents, CheckpointSignatureMessage,
+        CheckpointSummary, SignedCheckpointSummary,
     },
     object::Object,
     transaction::{
         CallArg, CertifiedTransaction, ObjectArg, TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS,
         TransactionData,
     },
-    utils::{make_committee_key, to_sender_signed_transaction},
+    utils::{make_committee_key_num, to_sender_signed_transaction},
 };
 use move_core_types::{account_address::AccountAddress, ident_str};
 use parking_lot::Mutex;
-use rand::{SeedableRng, rngs::StdRng};
+use rand::{Rng, SeedableRng, rngs::StdRng, thread_rng};
+use tokio::time::sleep;
 
 use super::*;
 use crate::{
@@ -163,11 +166,6 @@ pub fn make_consensus_adapter_for_test(
                                 .await?,
                         );
                     }
-                } else if let SequencedConsensusTransactionKey::External(
-                    ConsensusTransactionKey::CheckpointSignature(_, checkpoint_sequence_number),
-                ) = tx.transaction.key()
-                {
-                    epoch_store.notify_synced_checkpoint(checkpoint_sequence_number);
                 } else {
                     transactions.extend(
                         epoch_store
@@ -210,6 +208,7 @@ pub fn make_consensus_adapter_for_test(
             execute,
             mock_block_status_receivers: Arc::new(Mutex::new(mock_block_status_receivers)),
         }),
+        state.checkpoint_store.clone(),
         state.name,
         Arc::new(ConnectionMonitorStatusForTests {}),
         100_000,
@@ -311,12 +310,12 @@ async fn submit_multiple_transactions_to_consensus_adapter() {
     waiter.await.unwrap();
 }
 
-#[tokio::test]
+#[sim_test]
 async fn submit_checkpoint_signature_to_consensus_adapter() {
     telemetry_subscribers::init_for_testing();
 
     let mut rng = StdRng::seed_from_u64(1_100);
-    let (keys, committee) = make_committee_key(&mut rng);
+    let (keys, committee) = make_committee_key_num(1, &mut rng);
 
     // Initialize an authority
     let state = init_state_with_objects(vec![]).await;
@@ -324,7 +323,7 @@ async fn submit_checkpoint_signature_to_consensus_adapter() {
 
     // Make a new consensus adapter instance.
     let adapter = make_consensus_adapter_for_test(
-        state,
+        state.clone(),
         HashSet::new(),
         false,
         vec![with_block_status(BlockStatus::Sequenced(BlockRef::MIN))],
@@ -332,7 +331,7 @@ async fn submit_checkpoint_signature_to_consensus_adapter() {
 
     let checkpoint_summary = CheckpointSummary::new(
         &ProtocolConfig::get_for_max_version_UNSAFE(),
-        1,
+        0,
         2,
         10,
         &CheckpointContents::new_with_digests_only_for_tests([ExecutionDigests::random()]),
@@ -347,22 +346,55 @@ async fn submit_checkpoint_signature_to_consensus_adapter() {
     let authority = authority_key.public().into();
     let signed_checkpoint_summary = SignedCheckpointSummary::new(
         committee.epoch,
-        checkpoint_summary,
+        checkpoint_summary.clone(),
         authority_key,
         authority,
     );
 
-    let transactions = vec![ConsensusTransaction::new_checkpoint_signature_message(
-        CheckpointSignatureMessage {
-            summary: signed_checkpoint_summary,
-        },
-    )];
-    let waiter = adapter
-        .submit_batch(
-            &transactions,
-            Some(&epoch_store.get_reconfig_state_read_lock_guard()),
-            &epoch_store,
-        )
-        .unwrap();
-    waiter.await.unwrap();
+    let checkpoint_cert = CertifiedCheckpointSummary::new(
+        checkpoint_summary,
+        vec![signed_checkpoint_summary.auth_sig().clone()],
+        &committee,
+    )
+    .unwrap();
+
+    let verified_checkpoint_summary = checkpoint_cert.try_into_verified(&committee).unwrap();
+
+    let t1 = tokio::spawn({
+        let state = state.clone();
+        let verified_checkpoint_summary = verified_checkpoint_summary.clone();
+
+        async move {
+            let delay = Duration::from_millis(thread_rng().gen_range(0..1000));
+            sleep(delay).await;
+            state
+                .checkpoint_store
+                .insert_verified_checkpoint(&verified_checkpoint_summary)
+                .unwrap();
+            state
+                .checkpoint_store
+                .update_highest_synced_checkpoint(&verified_checkpoint_summary)
+                .unwrap();
+        }
+    });
+
+    let t2 = tokio::spawn(async move {
+        let transactions = vec![ConsensusTransaction::new_checkpoint_signature_message(
+            CheckpointSignatureMessage {
+                summary: signed_checkpoint_summary,
+            },
+        )];
+
+        let waiter = adapter
+            .submit_batch(
+                &transactions,
+                Some(&epoch_store.get_reconfig_state_read_lock_guard()),
+                &epoch_store,
+            )
+            .unwrap();
+        waiter.await.unwrap();
+    });
+
+    t1.await.unwrap();
+    t2.await.unwrap();
 }

--- a/crates/iota-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/iota-core/src/unit_tests/execution_driver_tests.rs
@@ -39,6 +39,7 @@ use crate::{
         create_object_move_transaction, do_cert, do_transaction, extract_cert, get_latest_ref,
     },
     authority_server::{ValidatorService, ValidatorServiceMetrics},
+    checkpoints::CheckpointStore,
     consensus_adapter::{
         ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
         MockConsensusClient,
@@ -755,6 +756,7 @@ async fn test_authority_txn_signing_pushback() {
     let epoch_store = authority_state.epoch_store_for_testing();
     let consensus_adapter = Arc::new(ConsensusAdapter::new(
         Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
         authority_state.name,
         Arc::new(ConnectionMonitorStatusForTests {}),
         100_000,
@@ -885,6 +887,7 @@ async fn test_authority_txn_execution_pushback() {
     // Create a validator service around the `authority_state`.
     let consensus_adapter = Arc::new(ConsensusAdapter::new(
         Arc::new(MockConsensusClient::new()),
+        CheckpointStore::new_for_tests(),
         authority_state.name,
         Arc::new(ConnectionMonitorStatusForTests {}),
         100_000,

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -1269,6 +1269,7 @@ impl IotaNode {
             connection_monitor_status.clone(),
             &validator_registry,
             client.clone(),
+            checkpoint_store.clone(),
         ));
         let consensus_manager = ConsensusManager::new(
             &config,
@@ -1503,6 +1504,7 @@ impl IotaNode {
         connection_monitor_status: Arc<ConnectionMonitorStatus>,
         prometheus_registry: &Registry,
         consensus_client: Arc<dyn ConsensusClient>,
+        checkpoint_store: Arc<CheckpointStore>,
     ) -> ConsensusAdapter {
         let ca_metrics = ConsensusAdapterMetrics::new(prometheus_registry);
         // The consensus adapter allows the authority to send user certificates through
@@ -1510,6 +1512,7 @@ impl IotaNode {
 
         ConsensusAdapter::new(
             consensus_client,
+            checkpoint_store,
             authority,
             connection_monitor_status,
             consensus_config.max_pending_transactions(),

--- a/crates/iota-single-node-benchmark/src/single_node.rs
+++ b/crates/iota-single-node-benchmark/src/single_node.rs
@@ -65,6 +65,7 @@ impl SingleValidator {
                 Arc::downgrade(&validator),
                 consensus_mode,
             )),
+            validator.checkpoint_store.clone(),
             validator.name,
             Arc::new(ConnectionMonitorStatusForTests {}),
             100_000,


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.43.1, v1.44.3)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/275464aafc15377ac9f129ccf34a56f6e4e9acaf
- Description:

Remove the redundant synced checkpoint notification from epoch store.

## Links to any relevant issues

Part of #5727 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
