### PR TITLE
feat(iota)!: update validator {display-metadata, list} commands

### DIFF
--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -495,7 +495,7 @@ impl IotaCommand {
                 prompt_if_no_config(&config_path, accept_defaults, true, true)?;
                 let mut context = WalletContext::new(&config_path, None, None)?;
                 if let Some(cmd) = cmd {
-                    cmd.execute(&mut context).await?.print(!json);
+                    cmd.execute(&mut context, json).await?.print(!json);
                 } else {
                     // Print help
                     let mut app: Command = IotaCommand::command();

--- a/crates/iota/src/lib.rs
+++ b/crates/iota/src/lib.rs
@@ -29,9 +29,6 @@ use colored::Colorize;
 
 pub trait PrintableResult: std::fmt::Display + std::fmt::Debug {
     fn print(&self, pretty: bool) {
-        if !self.should_print() {
-            return;
-        }
         let line = if pretty {
             format!("{self}")
         } else {
@@ -44,10 +41,6 @@ pub trait PrintableResult: std::fmt::Display + std::fmt::Debug {
             println!("{line}");
             tracing::info!("{line}")
         }
-    }
-
-    fn should_print(&self) -> bool {
-        true
     }
 }
 

--- a/crates/iota/src/unit_tests/validator_tests.rs
+++ b/crates/iota/src/unit_tests/validator_tests.rs
@@ -77,7 +77,7 @@ async fn test_become_validator() -> Result<(), anyhow::Error> {
         gas_data: GasDataArgs::default(),
         processing: TxProcessingArgs::default(),
     }
-    .execute(&mut test_cluster.wallet, json)
+    .execute(&mut test_cluster.wallet)
     .await?;
     let IotaClientCommandResult::TransactionBlock(_) = stake_result else {
         panic!("Expected TransactionBlock");

--- a/crates/iota/src/unit_tests/validator_tests.rs
+++ b/crates/iota/src/unit_tests/validator_tests.rs
@@ -104,11 +104,11 @@ async fn test_become_validator() -> Result<(), anyhow::Error> {
 
     let response = IotaValidatorCommand::DisplayMetadata {
         validator_address: None,
-        json: None,
+        json: false,
     }
     .execute(&mut test_cluster.wallet)
     .await?;
-    let IotaValidatorCommandResponse::DisplayMetadata = response else {
+    let IotaValidatorCommandResponse::DisplayMetadata(_) = response else {
         panic!("Expected DisplayMetadata");
     };
 

--- a/crates/iota/src/unit_tests/validator_tests.rs
+++ b/crates/iota/src/unit_tests/validator_tests.rs
@@ -21,6 +21,7 @@ use crate::{
 #[tokio::test]
 async fn test_become_validator() -> Result<(), anyhow::Error> {
     cleanup_fs();
+    let json = false;
     let config_dir = TempDir::new().unwrap();
 
     let mut test_cluster = TestClusterBuilder::new()
@@ -38,7 +39,7 @@ async fn test_become_validator() -> Result<(), anyhow::Error> {
         project_url: "https://www.iota.org".to_string(),
         host_name: "127.0.0.1".to_string(),
     }
-    .execute(&mut test_cluster.wallet)
+    .execute(&mut test_cluster.wallet, json)
     .await?;
     let IotaValidatorCommandResponse::MakeValidatorInfo = response else {
         panic!("Expected MakeValidatorInfo");
@@ -48,7 +49,7 @@ async fn test_become_validator() -> Result<(), anyhow::Error> {
         file: "validator.info".into(),
         gas_budget: None,
     }
-    .execute(&mut test_cluster.wallet)
+    .execute(&mut test_cluster.wallet, json)
     .await?;
     let IotaValidatorCommandResponse::BecomeCandidate(_become_candidate_tx) = response else {
         panic!("Expected BecomeCandidate");
@@ -76,7 +77,7 @@ async fn test_become_validator() -> Result<(), anyhow::Error> {
         gas_data: GasDataArgs::default(),
         processing: TxProcessingArgs::default(),
     }
-    .execute(&mut test_cluster.wallet)
+    .execute(&mut test_cluster.wallet, json)
     .await?;
     let IotaClientCommandResult::TransactionBlock(_) = stake_result else {
         panic!("Expected TransactionBlock");
@@ -90,12 +91,12 @@ async fn test_become_validator() -> Result<(), anyhow::Error> {
         },
         gas_budget: None,
     }
-    .execute(&mut test_cluster.wallet)
+    .execute(&mut test_cluster.wallet, json)
     .await
     .expect_err("Can't update metadata network address before joining validators");
 
     let response = IotaValidatorCommand::JoinValidators { gas_budget: None }
-        .execute(&mut test_cluster.wallet)
+        .execute(&mut test_cluster.wallet, json)
         .await?;
     let IotaValidatorCommandResponse::JoinValidators(_tx) = response else {
         panic!("Expected JoinValidators");
@@ -104,9 +105,8 @@ async fn test_become_validator() -> Result<(), anyhow::Error> {
 
     let response = IotaValidatorCommand::DisplayMetadata {
         validator_address: None,
-        json: false,
     }
-    .execute(&mut test_cluster.wallet)
+    .execute(&mut test_cluster.wallet, json)
     .await?;
     let IotaValidatorCommandResponse::DisplayMetadata(_) = response else {
         panic!("Expected DisplayMetadata");
@@ -118,7 +118,7 @@ async fn test_become_validator() -> Result<(), anyhow::Error> {
         },
         gas_budget: None,
     }
-    .execute(&mut test_cluster.wallet)
+    .execute(&mut test_cluster.wallet, json)
     .await?;
     if let IotaValidatorCommandResponse::UpdateMetadata(tx) = response {
         assert!(
@@ -138,7 +138,7 @@ async fn test_become_validator() -> Result<(), anyhow::Error> {
         },
         gas_budget: None,
     }
-    .execute(&mut test_cluster.wallet)
+    .execute(&mut test_cluster.wallet, json)
     .await?;
     if let IotaValidatorCommandResponse::UpdateMetadata(tx) = response {
         assert!(
@@ -150,7 +150,7 @@ async fn test_become_validator() -> Result<(), anyhow::Error> {
     };
 
     let response = IotaValidatorCommand::LeaveValidators { gas_budget: None }
-        .execute(&mut test_cluster.wallet)
+        .execute(&mut test_cluster.wallet, json)
         .await?;
     if let IotaValidatorCommandResponse::LeaveValidators(tx) = response {
         assert!(

--- a/crates/iota/src/validator_commands.rs
+++ b/crates/iota/src/validator_commands.rs
@@ -107,8 +107,6 @@ pub enum IotaValidatorCommand {
     DisplayMetadata {
         #[arg(name = "validator-address")]
         validator_address: Option<IotaAddress>,
-        #[arg(long, global = true)]
-        json: bool,
     },
     /// Update the validator metadata.
     UpdateMetadata {
@@ -150,10 +148,7 @@ pub enum IotaValidatorCommand {
     },
     /// Get a list of the validators in the network. Use the `display-metadata`
     /// command to see the complete data for a validator.
-    List {
-        #[arg(long, global = true)]
-        json: bool,
-    },
+    List,
 }
 
 #[derive(Serialize)]
@@ -203,6 +198,7 @@ impl IotaValidatorCommand {
     pub async fn execute(
         self,
         context: &mut WalletContext,
+        json: bool,
     ) -> Result<IotaValidatorCommandResponse, anyhow::Error> {
         let iota_address = context.active_address()?;
 
@@ -338,10 +334,7 @@ impl IotaValidatorCommand {
                 IotaValidatorCommandResponse::LeaveValidators(response)
             }
 
-            IotaValidatorCommand::DisplayMetadata {
-                validator_address,
-                json,
-            } => {
+            IotaValidatorCommand::DisplayMetadata { validator_address } => {
                 let validator_address = validator_address.unwrap_or(context.active_address()?);
                 // Default display with json serialization for better UX.
                 let iota_client = context.get_client().await?;
@@ -392,7 +385,7 @@ impl IotaValidatorCommand {
                 DEFAULT_EPOCH_ID.write(&mut intent_msg_bytes);
                 IotaValidatorCommandResponse::SerializedPayload(Base64::encode(&intent_msg_bytes))
             }
-            IotaValidatorCommand::List { json } => {
+            IotaValidatorCommand::List => {
                 let mut builder = Builder::default();
 
                 builder.set_header([

--- a/crates/iota/src/validator_commands.rs
+++ b/crates/iota/src/validator_commands.rs
@@ -856,12 +856,20 @@ async fn display_metadata(
 ) -> anyhow::Result<()> {
     match get_validator_summary(client, validator_address).await? {
         None => println!("{validator_address} is not a validator"),
-        Some((status, info)) => {
-            println!("{validator_address}'s validator status: {status:?}");
+        Some((status, metadata)) => {
             if json {
-                println!("{}", serde_json::to_string_pretty(&info)?);
+                let obj = serde_json::json!({
+                    "status": format!("{status:?}"),
+                    "metadata": metadata
+                });
+                println!("{}", serde_json::to_string_pretty(&obj)?);
             } else {
-                println!("{info:#?}");
+                println!("{validator_address}'s validator status: {status:?}");
+                if let serde_json::Value::Object(map) = serde_json::to_value(&metadata).unwrap() {
+                    for (key, value) in map {
+                        println!("{key}: {value}");
+                    }
+                }
             }
         }
     }

--- a/crates/iota/src/validator_commands.rs
+++ b/crates/iota/src/validator_commands.rs
@@ -150,7 +150,10 @@ pub enum IotaValidatorCommand {
     },
     /// Get a list of the validators in the network. Use the `display-metadata`
     /// command to see the complete data for a validator.
-    List,
+    List {
+        #[arg(long, global = true)]
+        json: bool,
+    },
 }
 
 #[derive(Serialize)]
@@ -389,7 +392,7 @@ impl IotaValidatorCommand {
                 DEFAULT_EPOCH_ID.write(&mut intent_msg_bytes);
                 IotaValidatorCommandResponse::SerializedPayload(Base64::encode(&intent_msg_bytes))
             }
-            IotaValidatorCommand::List => {
+            IotaValidatorCommand::List { json } => {
                 let mut builder = Builder::default();
 
                 builder.set_header([
@@ -414,6 +417,7 @@ impl IotaValidatorCommand {
                     _ => panic!("unsupported IotaSystemStateSummary"),
                 };
 
+                let mut entries = Vec::new();
                 for (
                     index,
                     IotaValidatorSummary {
@@ -433,20 +437,31 @@ impl IotaValidatorCommand {
                         .unwrap_or(true);
                     builder.push_record([
                         iota_address.to_string(),
-                        name,
+                        name.clone(),
                         staking_pool_iota_balance.to_string(),
                         pending_stake.to_string(),
                         if committee_member { "✓" } else { "" }.to_string(),
                     ]);
+                    entries.push(serde_json::json!({
+                        "iota_address": iota_address.to_string(),
+                        "name": name,
+                        "staking_pool_balance": staking_pool_iota_balance.to_string(),
+                        "pending_stake": pending_stake.to_string(),
+                        "committee_member": committee_member,
+                    }));
                 }
 
-                let table = builder
-                    .build()
-                    .with(Style::rounded())
-                    .with(Modify::new(Columns::new(2..=3)).with(Alignment::right()))
-                    .with(Modify::new(Column::from(4)).with(Alignment::center()))
-                    .to_string();
-                println!("{table}");
+                if json {
+                    println!("{}", serde_json::to_string_pretty(&entries)?);
+                } else {
+                    let table = builder
+                        .build()
+                        .with(Style::rounded())
+                        .with(Modify::new(Columns::new(2..=3)).with(Alignment::right()))
+                        .with(Modify::new(Column::from(4)).with(Alignment::center()))
+                        .to_string();
+                    println!("{table}");
+                }
 
                 IotaValidatorCommandResponse::List
             }
@@ -655,7 +670,7 @@ impl Display for IotaValidatorCommandResponse {
             IotaValidatorCommandResponse::SerializedPayload(response) => {
                 write!(writer, "Serialized payload: {response}")?;
             }
-            IotaValidatorCommandResponse::List => {}
+            IotaValidatorCommandResponse::List => return std::fmt::Result::Ok(()),
         }
         write!(f, "{}", writer.trim_end_matches('\n'))
     }

--- a/crates/iota/src/validator_commands.rs
+++ b/crates/iota/src/validator_commands.rs
@@ -160,14 +160,14 @@ pub enum IotaValidatorCommand {
 #[serde(untagged)]
 pub enum IotaValidatorCommandResponse {
     MakeValidatorInfo,
-    DisplayMetadata,
+    DisplayMetadata(String),
     BecomeCandidate(IotaTransactionBlockResponse),
     JoinValidators(IotaTransactionBlockResponse),
     LeaveValidators(IotaTransactionBlockResponse),
     UpdateMetadata(IotaTransactionBlockResponse),
     ReportValidator(IotaTransactionBlockResponse),
     SerializedPayload(String),
-    List,
+    List(String),
 }
 
 fn make_key_files(
@@ -345,8 +345,8 @@ impl IotaValidatorCommand {
                 let validator_address = validator_address.unwrap_or(context.active_address()?);
                 // Default display with json serialization for better UX.
                 let iota_client = context.get_client().await?;
-                display_metadata(&iota_client, validator_address, json).await?;
-                IotaValidatorCommandResponse::DisplayMetadata
+                let resp = display_metadata(&iota_client, validator_address, json).await?;
+                IotaValidatorCommandResponse::DisplayMetadata(resp)
             }
 
             IotaValidatorCommand::UpdateMetadata {
@@ -451,19 +451,18 @@ impl IotaValidatorCommand {
                     }));
                 }
 
-                if json {
-                    println!("{}", serde_json::to_string_pretty(&entries)?);
+                let resp = if json {
+                    serde_json::to_string_pretty(&entries)?
                 } else {
-                    let table = builder
+                    builder
                         .build()
                         .with(Style::rounded())
                         .with(Modify::new(Columns::new(2..=3)).with(Alignment::right()))
                         .with(Modify::new(Column::from(4)).with(Alignment::center()))
-                        .to_string();
-                    println!("{table}");
-                }
+                        .to_string()
+                };
 
-                IotaValidatorCommandResponse::List
+                IotaValidatorCommandResponse::List(resp)
             }
         });
         ret
@@ -646,31 +645,32 @@ async fn call_0x5(
         .map_err(|err| anyhow::anyhow!(err.to_string()))
 }
 
+impl PrintableResult for IotaValidatorCommandResponse {
+    // pretty is unused here, as this is handled for each command separately
+    fn print(&self, _pretty: bool) {
+        println!("{self}");
+    }
+}
+
 impl Display for IotaValidatorCommandResponse {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut writer = String::new();
         match self {
             IotaValidatorCommandResponse::MakeValidatorInfo => {}
-            IotaValidatorCommandResponse::DisplayMetadata => {}
-            IotaValidatorCommandResponse::BecomeCandidate(response) => {
-                write!(writer, "{}", write_transaction_response(response)?)?;
+            IotaValidatorCommandResponse::DisplayMetadata(resp)
+            | IotaValidatorCommandResponse::List(resp) => {
+                write!(writer, "{resp}")?;
             }
-            IotaValidatorCommandResponse::JoinValidators(response) => {
-                write!(writer, "{}", write_transaction_response(response)?)?;
-            }
-            IotaValidatorCommandResponse::LeaveValidators(response) => {
-                write!(writer, "{}", write_transaction_response(response)?)?;
-            }
-            IotaValidatorCommandResponse::UpdateMetadata(response) => {
-                write!(writer, "{}", write_transaction_response(response)?)?;
-            }
-            IotaValidatorCommandResponse::ReportValidator(response) => {
-                write!(writer, "{}", write_transaction_response(response)?)?;
+            IotaValidatorCommandResponse::BecomeCandidate(resp)
+            | IotaValidatorCommandResponse::JoinValidators(resp)
+            | IotaValidatorCommandResponse::LeaveValidators(resp)
+            | IotaValidatorCommandResponse::UpdateMetadata(resp)
+            | IotaValidatorCommandResponse::ReportValidator(resp) => {
+                write!(writer, "{}", write_transaction_response(resp)?)?;
             }
             IotaValidatorCommandResponse::SerializedPayload(response) => {
                 write!(writer, "Serialized payload: {response}")?;
             }
-            IotaValidatorCommandResponse::List => return std::fmt::Result::Ok(()),
         }
         write!(f, "{}", writer.trim_end_matches('\n'))
     }
@@ -706,12 +706,6 @@ impl Debug for IotaValidatorCommandResponse {
             Err(err) => format!("{err}").red().to_string(),
         };
         write!(f, "{s}")
-    }
-}
-
-impl PrintableResult for IotaValidatorCommandResponse {
-    fn should_print(&self) -> bool {
-        !matches!(self, Self::MakeValidatorInfo | Self::DisplayMetadata)
     }
 }
 
@@ -868,27 +862,30 @@ async fn display_metadata(
     client: &IotaClient,
     validator_address: IotaAddress,
     json: bool,
-) -> anyhow::Result<()> {
-    match get_validator_summary(client, validator_address).await? {
-        None => println!("{validator_address} is not a validator"),
-        Some((status, metadata)) => {
-            if json {
-                let obj = serde_json::json!({
-                    "status": format!("{status:?}"),
-                    "metadata": metadata
-                });
-                println!("{}", serde_json::to_string_pretty(&obj)?);
-            } else {
-                println!("{validator_address}'s validator status: {status:?}");
-                if let serde_json::Value::Object(map) = serde_json::to_value(&metadata).unwrap() {
-                    for (key, value) in map {
-                        println!("{key}: {value}");
+) -> anyhow::Result<String> {
+    Ok(
+        match get_validator_summary(client, validator_address).await? {
+            None => format!("{validator_address} is not a validator"),
+            Some((status, metadata)) => {
+                if json {
+                    let obj = serde_json::json!({
+                        "status": format!("{status:?}"),
+                        "metadata": metadata
+                    });
+                    serde_json::to_string_pretty(&obj)?
+                } else {
+                    let mut result = format!("{validator_address}'s validator status: {status:?}");
+                    if let serde_json::Value::Object(map) = serde_json::to_value(&metadata).unwrap()
+                    {
+                        for (key, value) in map {
+                            write!(result, "\n{key}: {value}").unwrap();
+                        }
                     }
+                    result
                 }
             }
-        }
-    }
-    Ok(())
+        },
+    )
 }
 
 async fn get_pending_candidate_summary(

--- a/crates/iota/src/validator_commands.rs
+++ b/crates/iota/src/validator_commands.rs
@@ -107,8 +107,8 @@ pub enum IotaValidatorCommand {
     DisplayMetadata {
         #[arg(name = "validator-address")]
         validator_address: Option<IotaAddress>,
-        #[arg(name = "json", long)]
-        json: Option<bool>,
+        #[arg(long, global = true)]
+        json: bool,
     },
     /// Update the validator metadata.
     UpdateMetadata {
@@ -342,7 +342,7 @@ impl IotaValidatorCommand {
                 let validator_address = validator_address.unwrap_or(context.active_address()?);
                 // Default display with json serialization for better UX.
                 let iota_client = context.get_client().await?;
-                display_metadata(&iota_client, validator_address, json.unwrap_or(true)).await?;
+                display_metadata(&iota_client, validator_address, json).await?;
                 IotaValidatorCommandResponse::DisplayMetadata
             }
 


### PR DESCRIPTION
# Description of change

Accept --json without bool for `iota validator display-metadata`
Change `iota validator display-metadata` output for --json to be a single object and for the human readable output to not contain long byte arrays
Add --json option to `iota validator list` command

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota/issues/8158
Fixes https://github.com/iotaledger/iota/issues/8159

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`iota validator list --json`:
```
[
  {
    "iota_address": "0x6f0202b12cd398166bdd3716c9aa3f0b6218ba125491f7ea2bc660fdd5e57ff8",
    "name": "validator-3.r.devnet",
    "staking_pool_balance": "54155844237017387",
    "pending_stake": "0",
    "committee_member": true
  },
  {
    "iota_address": "0x446b7abcca53c58eba6720309bee8d5017ad10fde666f397bb9c04756c182597",
    "name": "validator-2.r.devnet",
    "staking_pool_balance": "53764841553118754",
    "pending_stake": "0",
    "committee_member": true
  },
  {
    "iota_address": "0xda91b5957fe8e367b6c5d5fcbf48469f400a9395f959c35310703b2a78851afe",
    "name": "validator-0.r.devnet",
    "staking_pool_balance": "53678246265931771",
    "pending_stake": "0",
    "committee_member": true
  },
  {
    "iota_address": "0xbf73b3dc7a1e339e44f8441f20c7d4635d2b8c044c59cd46259b5c9152e68fc5",
    "name": "validator-1.r.devnet",
    "staking_pool_balance": "53723276796234697",
    "pending_stake": "0",
    "committee_member": true
  }
]
```
`iota validator display-metadata 0x6f0202b12cd398166bdd3716c9aa3f0b6218ba125491f7ea2bc660fdd5e57ff8`
```
0x6f0202b12cd398166bdd3716c9aa3f0b6218ba125491f7ea2bc660fdd5e57ff8's validator status: CommitteeMember
iotaAddress: "0x6f0202b12cd398166bdd3716c9aa3f0b6218ba125491f7ea2bc660fdd5e57ff8"
authorityPubkeyBytes: "gaZ5LT2kN7o3qMOUZeIXjEDAhLL2gNlhFY/madqtHjxcOItlsqLQIGo5REkWfsrZEVZb0znPZI2vODc3MSIndPEEsk1r9UTLyOETE/TbOoaJq52RaVarkkkJWmrbyLIc"
networkPubkeyBytes: "KOvyMWJJl5dcCwr555Z+pT0tBHFT9BEBxo4EDWpg1HE="
protocolPubkeyBytes: "IK/BkeXkC443MkPns0YIbjsSWcsc/Cwnsrl0MnBoxFA="
proofOfPossessionBytes: "kaWr7xbpdwi39S/907Xt0KeRdPln2F4xcecLifmgBAEvdB9Xkx80xiKz4RARqvG7"
name: "validator-3.r.devnet"
description: "validator-3.r.devnet"
imageUrl: ""
projectUrl: ""
netAddress: "/dns/validator-3.r.devnet.iota.cafe/tcp/8080/http"
p2pAddress: "/dns/validator-3.r.devnet.iota.cafe/udp/8084"
primaryAddress: "/dns/validator-3.r.devnet.iota.cafe/udp/8081"
nextEpochAuthorityPubkeyBytes: null
nextEpochProofOfPossession: null
nextEpochNetworkPubkeyBytes: null
nextEpochProtocolPubkeyBytes: null
nextEpochNetAddress: null
nextEpochP2pAddress: null
nextEpochPrimaryAddress: null
votingPower: "2500"
operationCapId: "0x3c4b0c221a5034ff24ff119e98e3f027210e2703da11fe744238c481f3213af3"
gasPrice: "1000"
commissionRate: "200"
nextEpochStake: "54155844237017387"
nextEpochGasPrice: "1000"
nextEpochCommissionRate: "200"
stakingPoolId: "0x763c87b2853995fb2545c0cf3cc4bbf2eb992ee13e80dff7dd016e6f588f8bf6"
stakingPoolActivationEpoch: "0"
stakingPoolDeactivationEpoch: null
stakingPoolIotaBalance: "54155844237017387"
rewardsPool: "50343955076214611"
poolTokenBalance: "2182246785964741"
pendingStake: "0"
pendingTotalIotaWithdraw: "0"
pendingPoolTokenWithdraw: "0"
exchangeRatesId: "0xca2d9cba816d89182b7fd00243cea8ca63b1dd2b2d13c39461f73f2b050a0991"
exchangeRatesSize: "270"
```
`iota validator display-metadata 0x6f0202b12cd398166bdd3716c9aa3f0b6218ba125491f7ea2bc660fdd5e57ff8 --json`
```
{
  "status": "CommitteeMember",
  "metadata": {
    "iotaAddress": "0x6f0202b12cd398166bdd3716c9aa3f0b6218ba125491f7ea2bc660fdd5e57ff8",
    "authorityPubkeyBytes": "gaZ5LT2kN7o3qMOUZeIXjEDAhLL2gNlhFY/madqtHjxcOItlsqLQIGo5REkWfsrZEVZb0znPZI2vODc3MSIndPEEsk1r9UTLyOETE/TbOoaJq52RaVarkkkJWmrbyLIc",
    "networkPubkeyBytes": "KOvyMWJJl5dcCwr555Z+pT0tBHFT9BEBxo4EDWpg1HE=",
    "protocolPubkeyBytes": "IK/BkeXkC443MkPns0YIbjsSWcsc/Cwnsrl0MnBoxFA=",
    "proofOfPossessionBytes": "kaWr7xbpdwi39S/907Xt0KeRdPln2F4xcecLifmgBAEvdB9Xkx80xiKz4RARqvG7",
    "name": "validator-3.r.devnet",
    "description": "validator-3.r.devnet",
    "imageUrl": "",
    "projectUrl": "",
    "netAddress": "/dns/validator-3.r.devnet.iota.cafe/tcp/8080/http",
    "p2pAddress": "/dns/validator-3.r.devnet.iota.cafe/udp/8084",
    "primaryAddress": "/dns/validator-3.r.devnet.iota.cafe/udp/8081",
    "nextEpochAuthorityPubkeyBytes": null,
    "nextEpochProofOfPossession": null,
    "nextEpochNetworkPubkeyBytes": null,
    "nextEpochProtocolPubkeyBytes": null,
    "nextEpochNetAddress": null,
    "nextEpochP2pAddress": null,
    "nextEpochPrimaryAddress": null,
    "votingPower": "2500",
    "operationCapId": "0x3c4b0c221a5034ff24ff119e98e3f027210e2703da11fe744238c481f3213af3",
    "gasPrice": "1000",
    "commissionRate": "200",
    "nextEpochStake": "54155844237017387",
    "nextEpochGasPrice": "1000",
    "nextEpochCommissionRate": "200",
    "stakingPoolId": "0x763c87b2853995fb2545c0cf3cc4bbf2eb992ee13e80dff7dd016e6f588f8bf6",
    "stakingPoolActivationEpoch": "0",
    "stakingPoolDeactivationEpoch": null,
    "stakingPoolIotaBalance": "54155844237017387",
    "rewardsPool": "50343955076214611",
    "poolTokenBalance": "2182246785964741",
    "pendingStake": "0",
    "pendingTotalIotaWithdraw": "0",
    "pendingPoolTokenWithdraw": "0",
    "exchangeRatesId": "0xca2d9cba816d89182b7fd00243cea8ca63b1dd2b2d13c39461f73f2b050a0991",
    "exchangeRatesSize": "270"
  }
}
```

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: Accept --json without (true/false) for `iota validator display-metadata`
Change `iota validator display-metadata` output for --json to be a single object and for the human readable output to not contain long byte arrays
Add --json option to `iota validator list` command
- [ ] Rust SDK:
- [ ] REST API:
