### PR TITLE
upstream(core): Estimate commit rate in ConsensusHandler

### DIFF
--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -103,8 +103,9 @@ use crate::{
         PendingCheckpoint, PendingCheckpointContentsV1, PendingCheckpointInfo,
     },
     consensus_handler::{
-        ConsensusCommitInfo, SequencedConsensusTransaction, SequencedConsensusTransactionKey,
-        SequencedConsensusTransactionKind, VerifiedSequencedConsensusTransaction,
+        AdditionalConsensusState, ConsensusCommitInfo, SequencedConsensusTransaction,
+        SequencedConsensusTransactionKey, SequencedConsensusTransactionKind,
+        VerifiedSequencedConsensusTransaction,
     },
     epoch::{
         epoch_metrics::EpochMetrics,
@@ -2782,6 +2783,7 @@ impl AuthorityPerEpochStore {
     >(
         &self,
         transactions: Vec<SequencedConsensusTransaction>,
+        additional_state: &AdditionalConsensusState,
         consensus_stats: &ExecutionIndicesWithStats,
         checkpoint_service: &Arc<C>,
         cache_reader: &dyn ObjectCacheRead,
@@ -2989,6 +2991,7 @@ impl AuthorityPerEpochStore {
         ) = self
             .process_consensus_transactions(
                 &mut output,
+                additional_state,
                 &consensus_transactions,
                 &end_of_publish_transactions,
                 checkpoint_service,
@@ -3137,6 +3140,7 @@ impl AuthorityPerEpochStore {
         transactions: &mut VecDeque<VerifiedExecutableTransaction>,
         consensus_commit_info: &ConsensusCommitInfo,
         cancelled_txns: &BTreeMap<TransactionDigest, CancelConsensusCertificateReason>,
+        additional_state: &AdditionalConsensusState,
     ) -> IotaResult<Option<TransactionKey>> {
         {
             if consensus_commit_info.skip_consensus_commit_prologue_in_test() {
@@ -3175,8 +3179,12 @@ impl AuthorityPerEpochStore {
             }
         );
 
-        let transaction = consensus_commit_info
-            .create_consensus_commit_prologue_transaction(self.epoch(), version_assignment);
+        let transaction = consensus_commit_info.create_consensus_commit_prologue_transaction(
+            self.epoch(),
+            self.protocol_config(),
+            version_assignment,
+            additional_state,
+        );
         let consensus_commit_prologue_root = match self
             .process_consensus_system_transaction(&transaction)
         {
@@ -3251,6 +3259,7 @@ impl AuthorityPerEpochStore {
     ) -> IotaResult<Vec<VerifiedExecutableTransaction>> {
         self.process_consensus_transactions_and_commit_boundary(
             transactions,
+            &AdditionalConsensusState::new_for_tests(),
             &ExecutionIndicesWithStats::default(),
             checkpoint_service,
             cache_reader,
@@ -3309,6 +3318,7 @@ impl AuthorityPerEpochStore {
     pub(crate) async fn process_consensus_transactions<C: CheckpointServiceNotify>(
         &self,
         output: &mut ConsensusCommitOutput,
+        additional_state: &AdditionalConsensusState,
         transactions: &[VerifiedSequencedConsensusTransaction],
         end_of_publish_transactions: &[VerifiedSequencedConsensusTransaction],
         checkpoint_service: &Arc<C>,
@@ -3544,6 +3554,7 @@ impl AuthorityPerEpochStore {
             &mut verified_certificates,
             consensus_commit_info,
             &cancelled_txns,
+            additional_state,
         )?;
 
         let verified_certificates: Vec<_> = verified_certificates.into();

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1314,13 +1314,13 @@ impl CheckpointBuilder {
             .try_get_transaction_block(&root_digests[0])?
             .expect("Transaction block must exist");
 
-        Ok(match first_tx.transaction_data().kind() {
-            TransactionKind::ConsensusCommitPrologueV1(_) => {
+        Ok(first_tx
+            .transaction_data()
+            .is_consensus_commit_prologue()
+            .then(|| {
                 assert_eq!(first_tx.digest(), root_effects[0].transaction_digest());
-                Some((*first_tx.digest(), root_effects[0].clone()))
-            }
-            _ => None,
-        })
+                (*first_tx.digest(), root_effects[0].clone())
+            }))
     }
 
     /// Writes the new checkpoints to the DB storage and processes them.
@@ -1535,6 +1535,7 @@ impl CheckpointBuilder {
                     .unwrap_or_else(|| panic!("Could not find executed transaction {effects:?}"));
                 match transaction.inner().transaction_data().kind() {
                     TransactionKind::ConsensusCommitPrologueV1(_)
+                    | TransactionKind::ConsensusCommitPrologueV4(_)
                     | TransactionKind::AuthenticatorStateUpdateV1(_) => {
                         // ConsensusCommitPrologue and
                         // AuthenticatorStateUpdateV1
@@ -1889,12 +1890,8 @@ impl CheckpointBuilder {
         let ccps = root_txs
             .iter()
             .filter_map(|tx| {
-                tx.as_ref().filter(|tx| {
-                    matches!(
-                        tx.transaction_data().kind(),
-                        TransactionKind::ConsensusCommitPrologueV1(_)
-                    )
-                })
+                tx.as_ref()
+                    .filter(|tx| tx.transaction_data().is_consensus_commit_prologue())
             })
             .collect::<Vec<_>>();
 
@@ -1918,26 +1915,23 @@ impl CheckpointBuilder {
             // should be no consensus commit prologue transaction in the
             // checkpoint.
             for tx in txs.iter().flatten() {
-                assert!(!matches!(
-                    tx.transaction_data().kind(),
-                    TransactionKind::ConsensusCommitPrologueV1(_)
-                ));
+                assert!(!tx.transaction_data().is_consensus_commit_prologue());
             }
         } else {
             // If there is one consensus commit prologue, it must be the first one in the
             // checkpoint.
-            assert!(matches!(
-                txs[0].as_ref().unwrap().transaction_data().kind(),
-                TransactionKind::ConsensusCommitPrologueV1(_)
-            ));
+            assert!(
+                txs[0]
+                    .as_ref()
+                    .unwrap()
+                    .transaction_data()
+                    .is_consensus_commit_prologue()
+            );
 
             assert_eq!(ccps[0].digest(), txs[0].as_ref().unwrap().digest());
 
             for tx in txs.iter().skip(1).flatten() {
-                assert!(!matches!(
-                    tx.transaction_data().kind(),
-                    TransactionKind::ConsensusCommitPrologueV1(_)
-                ));
+                assert!(!tx.transaction_data().is_consensus_commit_prologue());
             }
         }
     }

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -3,21 +3,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, VecDeque},
     hash::Hash,
     num::NonZeroUsize,
     sync::Arc,
+    time::Duration,
 };
 
 use arc_swap::ArcSwap;
 use consensus_config::Committee as ConsensusCommittee;
 use consensus_core::{CommitConsumerMonitor, CommitIndex};
+use fastcrypto::hash::HashFunction;
 use iota_macros::{fail_point, fail_point_if};
 use iota_metrics::{monitored_mpsc::UnboundedReceiver, monitored_scope, spawn_monitored_task};
 use iota_types::{
     authenticator_state::ActiveJwk,
     base_types::{AuthorityName, EpochId, ObjectID, SequenceNumber, TransactionDigest},
-    digests::ConsensusCommitDigest,
+    digests::{AdditionalConsensusStateDigest, ConsensusCommitDigest},
     executable_transaction::{TrustedExecutableTransaction, VerifiedExecutableTransaction},
     iota_system_state::epoch_start_iota_system_state::EpochStartSystemStateTrait,
     messages_consensus::{ConsensusTransaction, ConsensusTransactionKey, ConsensusTransactionKind},
@@ -101,6 +103,54 @@ impl ConsensusHandlerInitializer {
     }
 }
 
+mod additional_consensus_state {
+    use super::*;
+    /// AdditionalConsensusState tracks any in-memory state that is retained by
+    /// ConsensusHandler between consensus commits. Because of crash
+    /// recovery, using such data is inherently risky. In order to do this
+    /// safely, we must store data from a fixed number of previous commits.
+    /// Then, at start-up, that same fixed number of already processed commits
+    /// is replayed to reconstruct the state.
+    ///
+    /// To make sure that bugs in this process appear immediately, we record the
+    /// digest of this state in ConsensusCommitPrologue, so that any
+    /// deviation causes an immediate fork.
+    #[derive(Serialize, Deserialize)]
+    pub struct AdditionalConsensusState {
+        commit_rate_estimate: CommitRateObserver,
+    }
+
+    impl AdditionalConsensusState {
+        pub fn new(additional_consensus_state_window_size: u32) -> Self {
+            Self {
+                commit_rate_estimate: CommitRateObserver::new(
+                    additional_consensus_state_window_size,
+                ),
+            }
+        }
+
+        pub fn new_for_tests() -> Self {
+            Self {
+                commit_rate_estimate: CommitRateObserver::new(10),
+            }
+        }
+
+        /// Update all internal state based on the new commit
+        pub(crate) fn observe_commit(&mut self, consensus_commit: &impl ConsensusCommitAPI) {
+            self.commit_rate_estimate
+                .observe_commit_time(consensus_commit);
+        }
+
+        /// Get the digest of the current state.
+        pub fn digest(&self) -> AdditionalConsensusStateDigest {
+            let mut hash = iota_types::crypto::DefaultHash::new();
+            bcs::serialize_into(&mut hash, self).unwrap();
+            AdditionalConsensusStateDigest::new(hash.finalize().into())
+        }
+    }
+}
+pub(crate) use additional_consensus_state::AdditionalConsensusState;
+
 pub struct ConsensusHandler<C> {
     /// A store created for each epoch. ConsensusHandler is recreated each
     /// epoch, with the corresponding store. This store is also used to get
@@ -130,6 +180,8 @@ pub struct ConsensusHandler<C> {
     processed_cache: LruCache<SequencedConsensusTransactionKey, ()>,
     transaction_scheduler: AsyncTransactionScheduler,
 
+    additional_consensus_state: AdditionalConsensusState,
+
     backpressure_subscriber: BackpressureSubscriber,
 }
 
@@ -157,6 +209,9 @@ impl<C> ConsensusHandler<C> {
         }
         let transaction_scheduler =
             AsyncTransactionScheduler::start(transaction_manager, epoch_store.clone());
+        let commit_rate_estimate_window_size = epoch_store
+            .protocol_config()
+            .get_consensus_commit_rate_estimation_window_size();
         Self {
             epoch_store,
             last_consensus_stats,
@@ -168,6 +223,9 @@ impl<C> ConsensusHandler<C> {
             metrics,
             processed_cache: LruCache::new(NonZeroUsize::new(PROCESSED_CACHE_CAP).unwrap()),
             transaction_scheduler,
+            additional_consensus_state: AdditionalConsensusState::new(
+                commit_rate_estimate_window_size,
+            ),
             backpressure_subscriber,
         }
     }
@@ -184,10 +242,13 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
     /// pure function of the commits observed, it cannot depend on any state
     /// recorded in the epoch db.
     fn handle_prior_consensus_output(&mut self, consensus_commit: impl ConsensusOutputAPI) {
-        // TODO: this will be used to recover state computed from previous commits at
-        // startup.
-        let round = consensus_commit.leader_round();
-        info!("Ignoring prior consensus commit for round {:?}", round);
+        assert!(
+            self.epoch_store
+                .protocol_config()
+                .record_additional_state_digest_in_prologue()
+        );
+        self.additional_consensus_state
+            .observe_commit(&consensus_commit);
     }
 
     #[instrument("handle_consensus_output", level = "trace", skip_all)]
@@ -204,6 +265,15 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         let last_committed_round = self.last_consensus_stats.index.last_committed_round;
 
         let round = consensus_output.leader_round();
+
+        if self
+            .epoch_store
+            .protocol_config()
+            .record_additional_state_digest_in_prologue()
+        {
+            self.additional_consensus_state
+                .observe_commit(&consensus_commit);
+        }
 
         // TODO: Is this check necessary? For now mysticeti will not
         // return more than one leader per round so we are not in danger of
@@ -405,6 +475,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             .epoch_store
             .process_consensus_transactions_and_commit_boundary(
                 all_transactions,
+                &self.additional_consensus_state,
                 &self.last_consensus_stats,
                 &self.checkpoint_service,
                 self.cache_reader.as_ref(),
@@ -853,12 +924,105 @@ impl ConsensusCommitInfo {
         VerifiedExecutableTransaction::new_system(transaction, epoch)
     }
 
+    fn consensus_commit_prologue_v4_transaction(
+        &self,
+        epoch: u64,
+        consensus_determined_version_assignments: ConsensusDeterminedVersionAssignments,
+        additional_state_digest: AdditionalConsensusStateDigest,
+    ) -> VerifiedExecutableTransaction {
+        let transaction = VerifiedTransaction::new_consensus_commit_prologue_v4(
+            epoch,
+            self.round,
+            self.timestamp,
+            self.consensus_commit_digest,
+            consensus_determined_version_assignments,
+            additional_state_digest,
+        );
+        VerifiedExecutableTransaction::new_system(transaction, epoch)
+    }
+
     pub fn create_consensus_commit_prologue_transaction(
         &self,
         epoch: u64,
+        protocol_config: &ProtocolConfig,
         cancelled_txn_version_assignment: Vec<(TransactionDigest, Vec<(ObjectID, SequenceNumber)>)>,
+        additional_state: &AdditionalConsensusState,
     ) -> VerifiedExecutableTransaction {
-        self.consensus_commit_prologue_v1_transaction(epoch, cancelled_txn_version_assignment)
+        // self.consensus_commit_prologue_v1_transaction(epoch,
+        // cancelled_txn_version_assignment)
+        let version_assignments = if protocol_config
+            .record_consensus_determined_version_assignments_in_prologue_v2()
+        {
+            Some(
+                ConsensusDeterminedVersionAssignments::CancelledTransactionsV2(
+                    cancelled_txn_version_assignment,
+                ),
+            )
+        } else if protocol_config.record_consensus_determined_version_assignments_in_prologue() {
+            Some(
+                ConsensusDeterminedVersionAssignments::CancelledTransactions(
+                    cancelled_txn_version_assignment
+                        .into_iter()
+                        .map(|(tx_digest, versions)| {
+                            (
+                                tx_digest,
+                                versions.into_iter().map(|(id, v)| (id.0, v)).collect(),
+                            )
+                        })
+                        .collect(),
+                ),
+            )
+        } else {
+            None
+        };
+
+        if protocol_config.record_additional_state_digest_in_prologue() {
+            self.consensus_commit_prologue_v4_transaction(
+                epoch,
+                version_assignments.unwrap(),
+                additional_state.digest(),
+            )
+        } else if let Some(version_assignments) = version_assignments {
+            self.consensus_commit_prologue_v3_transaction(epoch, version_assignments)
+        } else if protocol_config.include_consensus_digest_in_prologue() {
+            self.consensus_commit_prologue_v2_transaction(epoch)
+        } else {
+            self.consensus_commit_prologue_transaction(epoch)
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct CommitRateObserver {
+    ring_buffer: VecDeque<u64>,
+}
+
+impl CommitRateObserver {
+    pub fn new(window_size: u32) -> Self {
+        Self {
+            ring_buffer: VecDeque::with_capacity(window_size as usize),
+        }
+    }
+
+    pub fn observe_commit_time(&mut self, consensus_commit: &impl ConsensusCommitAPI) {
+        let commit_time = consensus_commit.commit_timestamp_ms();
+        if self.ring_buffer.len() == self.ring_buffer.capacity() {
+            self.ring_buffer.pop_front();
+        }
+        self.ring_buffer.push_back(commit_time);
+    }
+
+    #[allow(dead_code)]
+    pub fn commit_rate_estimate(&self) -> Option<Duration> {
+        if self.ring_buffer.len() <= 1 {
+            None
+        } else {
+            let first = self.ring_buffer.front().unwrap();
+            let last = self.ring_buffer.back().unwrap();
+            let duration = last.saturating_sub(*first);
+            let num_commits = self.ring_buffer.len() as u64;
+            Some(Duration::from_millis(duration.div_ceil(num_commits)))
+        }
     }
 }
 
@@ -893,6 +1057,7 @@ mod tests {
         },
         checkpoints::CheckpointServiceNoop,
         consensus_adapter::consensus_tests::{test_certificates, test_gas_objects},
+        consensus_types::consensus_output_api::ParsedTransaction,
         post_consensus_tx_reorder::PostConsensusTxReorder,
     };
 
@@ -1152,5 +1317,81 @@ mod tests {
             kind,
             tracking_id: Default::default(),
         })
+    }
+
+    #[test]
+    fn test_additional_consensus_state() {
+        #[derive(Debug)]
+        struct TestConsensusCommit {
+            round: u64,
+            timestamp: u64,
+        }
+
+        impl std::fmt::Display for TestConsensusCommit {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(
+                    f,
+                    "TestConsensusCommitAPI(round={}, timestamp={})",
+                    self.round, self.timestamp
+                )
+            }
+        }
+
+        impl ConsensusCommitAPI for TestConsensusCommit {
+            fn reputation_score_sorted_desc(&self) -> Option<Vec<(AuthorityIndex, u64)>> {
+                None
+            }
+            fn leader_round(&self) -> u64 {
+                self.round
+            }
+            fn leader_author_index(&self) -> AuthorityIndex {
+                0
+            }
+
+            /// Returns epoch UNIX timestamp in milliseconds
+            fn commit_timestamp_ms(&self) -> u64 {
+                self.timestamp
+            }
+
+            /// Returns a unique global index for each committed sub-dag.
+            fn commit_sub_dag_index(&self) -> u64 {
+                self.round
+            }
+
+            /// Returns all accepted and rejected transactions per block in the
+            /// commit in deterministic order.
+            fn transactions(&self) -> Vec<(AuthorityIndex, Vec<ParsedTransaction>)> {
+                vec![]
+            }
+
+            /// Returns the digest of consensus output.
+            fn consensus_digest(&self, _: &ProtocolConfig) -> ConsensusCommitDigest {
+                ConsensusCommitDigest::ZERO
+            }
+        }
+
+        fn observe(state: &mut AdditionalConsensusState, round: u64, timestamp: u64) {
+            state.observe_commit(&TestConsensusCommit { round, timestamp });
+        }
+
+        let mut s1 = AdditionalConsensusState::new(3);
+        observe(&mut s1, 1, 1000);
+        observe(&mut s1, 2, 2000);
+        observe(&mut s1, 3, 3000);
+        observe(&mut s1, 4, 4000);
+
+        let mut s2 = AdditionalConsensusState::new(3);
+        // Because state uses a ring buffer, we should get the same digest
+        // even though we only added the 3 latest observations.
+        observe(&mut s2, 2, 2000);
+        observe(&mut s2, 3, 3000);
+        observe(&mut s2, 4, 4000);
+
+        assert_eq!(s1.digest(), s2.digest());
+
+        observe(&mut s1, 5, 5000);
+        observe(&mut s2, 5, 5000);
+
+        assert_eq!(s1.digest(), s2.digest());
     }
 }

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -916,14 +916,14 @@ impl ConsensusCommitInfo {
     fn consensus_commit_prologue_v1_transaction(
         &self,
         epoch: u64,
-        cancelled_txn_version_assignment: Vec<(TransactionDigest, Vec<(ObjectID, SequenceNumber)>)>,
+        consensus_determined_version_assignments: ConsensusDeterminedVersionAssignments,
     ) -> VerifiedExecutableTransaction {
         let transaction = VerifiedTransaction::new_consensus_commit_prologue_v1(
             epoch,
             self.round,
             self.timestamp,
             self.consensus_commit_digest,
-            cancelled_txn_version_assignment,
+            consensus_determined_version_assignments,
         );
         VerifiedExecutableTransaction::new_system(transaction, epoch)
     }
@@ -952,49 +952,18 @@ impl ConsensusCommitInfo {
         cancelled_txn_version_assignment: Vec<(TransactionDigest, Vec<(ObjectID, SequenceNumber)>)>,
         additional_state: &AdditionalConsensusState,
     ) -> VerifiedExecutableTransaction {
-        // self.consensus_commit_prologue_v1_transaction(epoch,
-        // cancelled_txn_version_assignment)
-        todo!()
-        // let version_assignments = if protocol_config
-        //    .record_consensus_determined_version_assignments_in_prologue_v2()
-        //{
-        //    Some(
-        //        ConsensusDeterminedVersionAssignments::CancelledTransactionsV2(
-        //            cancelled_txn_version_assignment,
-        //        ),
-        //    )
-        //} else if protocol_config.
-        //} record_consensus_determined_version_assignments_in_prologue() {
-        //    Some(
-        //        ConsensusDeterminedVersionAssignments::CancelledTransactions(
-        //            cancelled_txn_version_assignment
-        //                .into_iter()
-        //                .map(|(tx_digest, versions)| {
-        //                    (
-        //                        tx_digest,
-        //                        versions.into_iter().map(|(id, v)| (id.0,
-        // v)).collect(),                    )
-        //                })
-        //                .collect(),
-        //        ),
-        //    )
-        //} else {
-        //    None
-        //};
-        // if protocol_config.record_additional_state_digest_in_prologue() {
-        //    self.consensus_commit_prologue_v4_transaction(
-        //        epoch,
-        //        version_assignments.unwrap(),
-        //        additional_state.digest(),
-        //    )
-        //} else if let Some(version_assignments) = version_assignments {
-        //    self.consensus_commit_prologue_v3_transaction(epoch,
-        // version_assignments)
-        //} else if protocol_config.include_consensus_digest_in_prologue() {
-        //    self.consensus_commit_prologue_v2_transaction(epoch)
-        //} else {
-        //    self.consensus_commit_prologue_transaction(epoch)
-        //}
+        let version_assignments = ConsensusDeterminedVersionAssignments::CancelledTransactions(
+            cancelled_txn_version_assignment,
+        );
+        if protocol_config.record_additional_state_digest_in_prologue() {
+            self.consensus_commit_prologue_v4_transaction(
+                epoch,
+                version_assignments,
+                additional_state.digest(),
+            )
+        } else {
+            self.consensus_commit_prologue_v1_transaction(epoch, version_assignments)
+        }
     }
 }
 

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -16,13 +16,17 @@ use consensus_core::{CommitConsumerMonitor, CommitIndex};
 use fastcrypto::hash::HashFunction;
 use iota_macros::{fail_point, fail_point_if};
 use iota_metrics::{monitored_mpsc::UnboundedReceiver, monitored_scope, spawn_monitored_task};
+use iota_protocol_config::ProtocolConfig;
 use iota_types::{
     authenticator_state::ActiveJwk,
     base_types::{AuthorityName, EpochId, ObjectID, SequenceNumber, TransactionDigest},
     digests::{AdditionalConsensusStateDigest, ConsensusCommitDigest},
     executable_transaction::{TrustedExecutableTransaction, VerifiedExecutableTransaction},
     iota_system_state::epoch_start_iota_system_state::EpochStartSystemStateTrait,
-    messages_consensus::{ConsensusTransaction, ConsensusTransactionKey, ConsensusTransactionKind},
+    messages_consensus::{
+        ConsensusDeterminedVersionAssignments, ConsensusTransaction, ConsensusTransactionKey,
+        ConsensusTransactionKind,
+    },
     transaction::{SenderSignedData, VerifiedTransaction},
 };
 use lru::LruCache;
@@ -136,7 +140,7 @@ mod additional_consensus_state {
         }
 
         /// Update all internal state based on the new commit
-        pub(crate) fn observe_commit(&mut self, consensus_commit: &impl ConsensusCommitAPI) {
+        pub(crate) fn observe_commit(&mut self, consensus_commit: &impl ConsensusOutputAPI) {
             self.commit_rate_estimate
                 .observe_commit_time(consensus_commit);
         }
@@ -272,7 +276,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             .record_additional_state_digest_in_prologue()
         {
             self.additional_consensus_state
-                .observe_commit(&consensus_commit);
+                .observe_commit(&consensus_output);
         }
 
         // TODO: Is this check necessary? For now mysticeti will not
@@ -950,45 +954,47 @@ impl ConsensusCommitInfo {
     ) -> VerifiedExecutableTransaction {
         // self.consensus_commit_prologue_v1_transaction(epoch,
         // cancelled_txn_version_assignment)
-        let version_assignments = if protocol_config
-            .record_consensus_determined_version_assignments_in_prologue_v2()
-        {
-            Some(
-                ConsensusDeterminedVersionAssignments::CancelledTransactionsV2(
-                    cancelled_txn_version_assignment,
-                ),
-            )
-        } else if protocol_config.record_consensus_determined_version_assignments_in_prologue() {
-            Some(
-                ConsensusDeterminedVersionAssignments::CancelledTransactions(
-                    cancelled_txn_version_assignment
-                        .into_iter()
-                        .map(|(tx_digest, versions)| {
-                            (
-                                tx_digest,
-                                versions.into_iter().map(|(id, v)| (id.0, v)).collect(),
-                            )
-                        })
-                        .collect(),
-                ),
-            )
-        } else {
-            None
-        };
-
-        if protocol_config.record_additional_state_digest_in_prologue() {
-            self.consensus_commit_prologue_v4_transaction(
-                epoch,
-                version_assignments.unwrap(),
-                additional_state.digest(),
-            )
-        } else if let Some(version_assignments) = version_assignments {
-            self.consensus_commit_prologue_v3_transaction(epoch, version_assignments)
-        } else if protocol_config.include_consensus_digest_in_prologue() {
-            self.consensus_commit_prologue_v2_transaction(epoch)
-        } else {
-            self.consensus_commit_prologue_transaction(epoch)
-        }
+        todo!()
+        // let version_assignments = if protocol_config
+        //    .record_consensus_determined_version_assignments_in_prologue_v2()
+        //{
+        //    Some(
+        //        ConsensusDeterminedVersionAssignments::CancelledTransactionsV2(
+        //            cancelled_txn_version_assignment,
+        //        ),
+        //    )
+        //} else if protocol_config.
+        //} record_consensus_determined_version_assignments_in_prologue() {
+        //    Some(
+        //        ConsensusDeterminedVersionAssignments::CancelledTransactions(
+        //            cancelled_txn_version_assignment
+        //                .into_iter()
+        //                .map(|(tx_digest, versions)| {
+        //                    (
+        //                        tx_digest,
+        //                        versions.into_iter().map(|(id, v)| (id.0,
+        // v)).collect(),                    )
+        //                })
+        //                .collect(),
+        //        ),
+        //    )
+        //} else {
+        //    None
+        //};
+        // if protocol_config.record_additional_state_digest_in_prologue() {
+        //    self.consensus_commit_prologue_v4_transaction(
+        //        epoch,
+        //        version_assignments.unwrap(),
+        //        additional_state.digest(),
+        //    )
+        //} else if let Some(version_assignments) = version_assignments {
+        //    self.consensus_commit_prologue_v3_transaction(epoch,
+        // version_assignments)
+        //} else if protocol_config.include_consensus_digest_in_prologue() {
+        //    self.consensus_commit_prologue_v2_transaction(epoch)
+        //} else {
+        //    self.consensus_commit_prologue_transaction(epoch)
+        //}
     }
 }
 
@@ -1004,7 +1010,7 @@ impl CommitRateObserver {
         }
     }
 
-    pub fn observe_commit_time(&mut self, consensus_commit: &impl ConsensusCommitAPI) {
+    pub fn observe_commit_time(&mut self, consensus_commit: &impl ConsensusOutputAPI) {
         let commit_time = consensus_commit.commit_timestamp_ms();
         if self.ring_buffer.len() == self.ring_buffer.capacity() {
             self.ring_buffer.pop_front();
@@ -1057,7 +1063,6 @@ mod tests {
         },
         checkpoints::CheckpointServiceNoop,
         consensus_adapter::consensus_tests::{test_certificates, test_gas_objects},
-        consensus_types::consensus_output_api::ParsedTransaction,
         post_consensus_tx_reorder::PostConsensusTxReorder,
     };
 
@@ -1337,7 +1342,7 @@ mod tests {
             }
         }
 
-        impl ConsensusCommitAPI for TestConsensusCommit {
+        impl ConsensusOutputAPI for TestConsensusCommit {
             fn reputation_score_sorted_desc(&self) -> Option<Vec<(AuthorityIndex, u64)>> {
                 None
             }
@@ -1360,12 +1365,15 @@ mod tests {
 
             /// Returns all accepted and rejected transactions per block in the
             /// commit in deterministic order.
-            fn transactions(&self) -> Vec<(AuthorityIndex, Vec<ParsedTransaction>)> {
+            fn transactions(
+                &self,
+            ) -> crate::consensus_types::consensus_output_api::ConsensusOutputTransactions
+            {
                 vec![]
             }
 
             /// Returns the digest of consensus output.
-            fn consensus_digest(&self, _: &ProtocolConfig) -> ConsensusCommitDigest {
+            fn consensus_digest(&self) -> ConsensusCommitDigest {
                 ConsensusCommitDigest::ZERO
             }
         }

--- a/crates/iota-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/iota-core/src/consensus_types/consensus_output_api.rs
@@ -13,7 +13,8 @@ use crate::consensus_types::AuthorityIndex;
 /// (block origin authority index, all transactions contained in the block).
 /// For each transaction, returns deserialized transaction and its serialized
 /// size.
-type ConsensusOutputTransactions = Vec<(AuthorityIndex, Vec<(ConsensusTransaction, usize)>)>;
+pub(crate) type ConsensusOutputTransactions =
+    Vec<(AuthorityIndex, Vec<(ConsensusTransaction, usize)>)>;
 
 pub(crate) trait ConsensusOutputAPI: Display {
     fn reputation_score_sorted_desc(&self) -> Option<Vec<(AuthorityIndex, u64)>>;

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -4901,7 +4901,7 @@ async fn test_consensus_commit_prologue_generation() {
             .data()
             .transaction_data()
             .kind(),
-        TransactionKind::ConsensusCommitPrologueV1(..)
+        TransactionKind::ConsensusCommitPrologueV4(..)
     ));
 
     // Tests that the system clock object is updated by the new consensus commit
@@ -6559,7 +6559,7 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
     // transaction, and it must be the first one.
     assert!(matches!(
         scheduled_txns[0].data().transaction_data().kind(),
-        TransactionKind::ConsensusCommitPrologueV1(..)
+        TransactionKind::ConsensusCommitPrologueV4(..)
     ));
     assert!(
         scheduled_txns[1].data().transaction_data().gas_price() == gas_price_of_non_cancelled_txs
@@ -6569,7 +6569,7 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
     assert_eq!(scheduled_txns.len(), 2);
     assert!(matches!(
         scheduled_txns[0].data().transaction_data().kind(),
-        TransactionKind::ConsensusCommitPrologueV1(..)
+        TransactionKind::ConsensusCommitPrologueV4(..)
     ));
     assert!(
         scheduled_txns[1].data().transaction_data().gas_price() == gas_price_of_non_cancelled_txs
@@ -6657,7 +6657,7 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
 
     // Consensus commit prologue contains cancelled txn shared object version
     // assignment.
-    if let TransactionKind::ConsensusCommitPrologueV1(prologue_txn) =
+    if let TransactionKind::ConsensusCommitPrologueV4(prologue_txn) =
         scheduled_txns[0].data().transaction_data().kind()
     {
         assert!(matches!(
@@ -6682,7 +6682,7 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
             )]
         ));
     } else {
-        panic!("First scheduled transaction must be a ConsensusCommitPrologueV1 transaction.");
+        panic!("First scheduled transaction must be a ConsensusCommitPrologueV4 transaction.");
     }
 }
 

--- a/crates/iota-core/tests/staged/iota.yaml
+++ b/crates/iota-core/tests/staged/iota.yaml
@@ -11,6 +11,9 @@ ActiveJwk:
     - jwk:
         TYPENAME: JWK
     - epoch: U64
+AdditionalConsensusStateDigest:
+  NEWTYPESTRUCT:
+    TYPENAME: Digest
 Argument:
   ENUM:
     0:
@@ -314,6 +317,19 @@ ConsensusCommitPrologueV1:
         TYPENAME: ConsensusCommitDigest
     - consensus_determined_version_assignments:
         TYPENAME: ConsensusDeterminedVersionAssignments
+ConsensusCommitPrologueV4:
+  STRUCT:
+    - epoch: U64
+    - round: U64
+    - sub_dag_index:
+        OPTION: U64
+    - commit_timestamp_ms: U64
+    - consensus_commit_digest:
+        TYPENAME: ConsensusCommitDigest
+    - consensus_determined_version_assignments:
+        TYPENAME: ConsensusDeterminedVersionAssignments
+    - additional_state_digest:
+        TYPENAME: AdditionalConsensusStateDigest
 ConsensusDeterminedVersionAssignments:
   ENUM:
     0:
@@ -1028,6 +1044,10 @@ TransactionKind:
       RandomnessStateUpdate:
         NEWTYPE:
           TYPENAME: RandomnessStateUpdate
+    6:
+      ConsensusCommitPrologueV4:
+        NEWTYPE:
+          TYPENAME: ConsensusCommitPrologueV4
 TypeArgumentError:
   ENUM:
     0:

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
@@ -4,13 +4,19 @@
 
 use async_graphql::*;
 use fastcrypto::encoding::{Base58, Encoding};
-use iota_types::messages_consensus::ConsensusCommitPrologueV1 as NativeConsensusCommitPrologueTransactionV1;
+use iota_types::{
+    digests::{AdditionalConsensusStateDigest, ConsensusCommitDigest},
+    messages_consensus::{
+        ConsensusCommitPrologueV1 as NativeConsensusCommitPrologueTransactionV1,
+        ConsensusCommitPrologueV4 as NativeConsensusCommitPrologueTransactionV4,
+    },
+};
 
 use crate::types::{date_time::DateTime, epoch::Epoch, uint53::UInt53};
 
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) struct ConsensusCommitPrologueTransaction {
-    pub native: NativeConsensusCommitPrologueTransactionV1,
+    pub native: NativeConsensusCommitPrologueTransactionV4,
     /// The checkpoint sequence number this was viewed at.
     pub checkpoint_viewed_at: u64,
 }

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/consensus_commit_prologue.rs
@@ -4,13 +4,7 @@
 
 use async_graphql::*;
 use fastcrypto::encoding::{Base58, Encoding};
-use iota_types::{
-    digests::{AdditionalConsensusStateDigest, ConsensusCommitDigest},
-    messages_consensus::{
-        ConsensusCommitPrologueV1 as NativeConsensusCommitPrologueTransactionV1,
-        ConsensusCommitPrologueV4 as NativeConsensusCommitPrologueTransactionV4,
-    },
-};
+use iota_types::messages_consensus::ConsensusCommitPrologueV4 as NativeConsensusCommitPrologueTransactionV4;
 
 use crate::types::{date_time::DateTime, epoch::Epoch, uint53::UInt53};
 

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/mod.rs
@@ -48,14 +48,18 @@ impl TransactionBlockKind {
                 checkpoint_viewed_at,
             }),
             K::ConsensusCommitPrologueV1(ccp) => {
-                T::ConsensusCommitPrologue(ConsensusCommitPrologueTransaction {
-                    native: ccp,
-                    checkpoint_viewed_at,
-                })
+                todo!()
+                // T::ConsensusCommitPrologue(ConsensusCommitPrologueTransaction
+                // { native: ccp,
+                // checkpoint_viewed_at,
+                // })
             }
-            K::ConsensusCommitPrologueV4(ccp) => T::ConsensusCommitPrologue(
-                ConsensusCommitPrologueTransaction::from_v4(ccp, checkpoint_viewed_at),
-            ),
+            K::ConsensusCommitPrologueV4(ccp) => {
+                todo!()
+                // T::ConsensusCommitPrologue(
+                // ConsensusCommitPrologueTransaction::from_v4(ccp,
+                // checkpoint_viewed_at), )
+            }
             K::AuthenticatorStateUpdateV1(asu) => {
                 T::AuthenticatorState(AuthenticatorStateUpdateTransaction {
                     native: asu,

--- a/crates/iota-graphql-rpc/src/types/transaction_block_kind/mod.rs
+++ b/crates/iota-graphql-rpc/src/types/transaction_block_kind/mod.rs
@@ -53,6 +53,9 @@ impl TransactionBlockKind {
                     checkpoint_viewed_at,
                 })
             }
+            K::ConsensusCommitPrologueV4(ccp) => T::ConsensusCommitPrologue(
+                ConsensusCommitPrologueTransaction::from_v4(ccp, checkpoint_viewed_at),
+            ),
             K::AuthenticatorStateUpdateV1(asu) => {
                 T::AuthenticatorState(AuthenticatorStateUpdateTransaction {
                     native: asu,

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -2784,6 +2784,7 @@ pub enum IotaTransactionKind {
     AuthenticatorStateUpdateV1 = 4,
     RandomnessStateUpdate = 5,
     EndOfEpochTransaction = 6,
+    ConsensusCommitPrologueV4 = 7,
 }
 
 impl IotaTransactionKind {
@@ -2802,6 +2803,7 @@ impl From<&TransactionKind> for IotaTransactionKind {
             TransactionKind::RandomnessStateUpdate(_) => Self::RandomnessStateUpdate,
             TransactionKind::EndOfEpochTransaction(_) => Self::EndOfEpochTransaction,
             TransactionKind::ProgrammableTransaction(_) => Self::ProgrammableTransaction,
+            TransactionKind::ConsensusCommitPrologueV4(_) => Self::ConsensusCommitPrologueV4,
         }
     }
 }

--- a/crates/iota-json-rpc-types/src/iota_transaction.rs
+++ b/crates/iota-json-rpc-types/src/iota_transaction.rs
@@ -18,7 +18,10 @@ use iota_types::{
     authenticator_state::ActiveJwk,
     base_types::{EpochId, IotaAddress, ObjectID, ObjectRef, SequenceNumber, TransactionDigest},
     crypto::IotaSignature,
-    digests::{ConsensusCommitDigest, ObjectDigest, TransactionEventsDigest},
+    digests::{
+        AdditionalConsensusStateDigest, ConsensusCommitDigest, ObjectDigest,
+        TransactionEventsDigest,
+    },
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     error::{ExecutionError, IotaError, IotaResult},
     event::EventID,
@@ -454,6 +457,7 @@ pub enum IotaTransactionBlockKind {
     RandomnessStateUpdate(IotaRandomnessStateUpdate),
     /// The transaction which occurs only at the end of the epoch
     EndOfEpochTransaction(IotaEndOfEpochTransaction),
+    ConsensusCommitPrologueV4(IotaConsensusCommitPrologueV4),
     // .. more transaction types go here
 }
 
@@ -474,6 +478,19 @@ impl Display for IotaTransactionBlockKind {
                     p.sub_dag_index,
                     p.commit_timestamp_ms,
                     p.consensus_commit_digest
+                )?;
+            }
+            Self::ConsensusCommitPrologueV4(p) => {
+                writeln!(writer, "Transaction Kind: Consensus Commit Prologue V4")?;
+                writeln!(
+                    writer,
+                    "Epoch: {}, Round: {}, SubDagIndex: {:?}, Timestamp: {}, ConsensusCommitDigest: {} AdditionalStateDigest: {}",
+                    p.epoch,
+                    p.round,
+                    p.sub_dag_index,
+                    p.commit_timestamp_ms,
+                    p.consensus_commit_digest,
+                    p.additional_state_digest
                 )?;
             }
             Self::ProgrammableTransaction(p) => {
@@ -519,6 +536,18 @@ impl IotaTransactionBlockKind {
                     consensus_commit_digest: p.consensus_commit_digest,
                     consensus_determined_version_assignments: p
                         .consensus_determined_version_assignments,
+                })
+            }
+            TransactionKind::ConsensusCommitPrologueV4(p) => {
+                Self::ConsensusCommitPrologueV4(IotaConsensusCommitPrologueV4 {
+                    epoch: p.epoch,
+                    round: p.round,
+                    sub_dag_index: p.sub_dag_index,
+                    commit_timestamp_ms: p.commit_timestamp_ms,
+                    consensus_commit_digest: p.consensus_commit_digest,
+                    consensus_determined_version_assignments: p
+                        .consensus_determined_version_assignments,
+                    additional_state_digest: p.additional_state_digest,
                 })
             }
             TransactionKind::ProgrammableTransaction(p) => Self::ProgrammableTransaction(
@@ -599,6 +628,18 @@ impl IotaTransactionBlockKind {
                         .consensus_determined_version_assignments,
                 })
             }
+            TransactionKind::ConsensusCommitPrologueV4(p) => {
+                Self::ConsensusCommitPrologueV4(IotaConsensusCommitPrologueV4 {
+                    epoch: p.epoch,
+                    round: p.round,
+                    sub_dag_index: p.sub_dag_index,
+                    commit_timestamp_ms: p.commit_timestamp_ms,
+                    consensus_commit_digest: p.consensus_commit_digest,
+                    consensus_determined_version_assignments: p
+                        .consensus_determined_version_assignments,
+                    additional_state_digest: p.additional_state_digest,
+                })
+            }
             TransactionKind::ProgrammableTransaction(p) => Self::ProgrammableTransaction(
                 IotaProgrammableTransactionBlock::try_from_with_package_resolver(
                     p,
@@ -666,6 +707,7 @@ impl IotaTransactionBlockKind {
         match self {
             Self::Genesis(_) => "Genesis",
             Self::ConsensusCommitPrologueV1(_) => "ConsensusCommitPrologueV1",
+            Self::ConsensusCommitPrologueV4(_) => "ConsensusCommitPrologueV4",
             Self::ProgrammableTransaction(_) => "ProgrammableTransaction",
             Self::AuthenticatorStateUpdateV1(_) => "AuthenticatorStateUpdateV1",
             Self::RandomnessStateUpdate(_) => "RandomnessStateUpdate",
@@ -1748,6 +1790,26 @@ pub struct IotaConsensusCommitPrologueV1 {
     pub commit_timestamp_ms: u64,
     pub consensus_commit_digest: ConsensusCommitDigest,
     pub consensus_determined_version_assignments: ConsensusDeterminedVersionAssignments,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct IotaConsensusCommitPrologueV4 {
+    #[schemars(with = "BigInt<u64>")]
+    #[serde_as(as = "BigInt<u64>")]
+    pub epoch: u64,
+    #[schemars(with = "BigInt<u64>")]
+    #[serde_as(as = "BigInt<u64>")]
+    pub round: u64,
+    #[schemars(with = "Option<BigInt<u64>>")]
+    #[serde_as(as = "Option<BigInt<u64>>")]
+    pub sub_dag_index: Option<u64>,
+    #[schemars(with = "BigInt<u64>")]
+    #[serde_as(as = "BigInt<u64>")]
+    pub commit_timestamp_ms: u64,
+    pub consensus_commit_digest: ConsensusCommitDigest,
+    pub consensus_determined_version_assignments: ConsensusDeterminedVersionAssignments,
+    pub additional_state_digest: AdditionalConsensusStateDigest,
 }
 
 #[serde_as]

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -1333,6 +1333,7 @@
                 "normalize_ptb_arguments": false,
                 "passkey_auth": true,
                 "protocol_defined_base_fee": true,
+                "record_additional_state_digest_in_prologue": false,
                 "relocate_event_module": true,
                 "rethrow_serialization_type_layout_errors": true,
                 "select_committee_from_eligible_validators": false,
@@ -1459,6 +1460,7 @@
                 "consensus_bad_nodes_stake_threshold": {
                   "u64": "20"
                 },
+                "consensus_commit_rate_estimation_window_size": null,
                 "consensus_gc_depth": null,
                 "consensus_max_acknowledgments_per_block": null,
                 "consensus_max_num_transactions_in_block": {
@@ -6016,6 +6018,9 @@
   ],
   "components": {
     "schemas": {
+      "AdditionalConsensusStateDigest": {
+        "$ref": "#/components/schemas/Digest"
+      },
       "AddressMetrics": {
         "description": "Provides metrics about the addresses.",
         "type": "object",
@@ -10925,6 +10930,55 @@
                 "type": "string",
                 "enum": [
                   "VersionTooHigh"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "additional_state_digest",
+              "commit_timestamp_ms",
+              "consensus_commit_digest",
+              "consensus_determined_version_assignments",
+              "epoch",
+              "kind",
+              "round"
+            ],
+            "properties": {
+              "additional_state_digest": {
+                "$ref": "#/components/schemas/AdditionalConsensusStateDigest"
+              },
+              "commit_timestamp_ms": {
+                "$ref": "#/components/schemas/BigInt_for_uint64"
+              },
+              "consensus_commit_digest": {
+                "$ref": "#/components/schemas/ConsensusCommitDigest"
+              },
+              "consensus_determined_version_assignments": {
+                "$ref": "#/components/schemas/ConsensusDeterminedVersionAssignments"
+              },
+              "epoch": {
+                "$ref": "#/components/schemas/BigInt_for_uint64"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "ConsensusCommitPrologueV4"
+                ]
+              },
+              "round": {
+                "$ref": "#/components/schemas/BigInt_for_uint64"
+              },
+              "sub_dag_index": {
+                "default": null,
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/BigInt_for_uint64"
+                  },
+                  {
+                    "type": "null"
+                  }
                 ]
               }
             }

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -2341,14 +2341,11 @@ impl ProtocolConfig {
                 17 => {
                     // Increase the committee size to 100 on all networks.
                     cfg.max_committee_members_count = Some(100);
-
-                    // TODO: when do we want to enable these features?
-                    // if chain != Chain::Mainnet && chain != Chain::Testnet {
-                    //    cfg.feature_flags.
-                    // record_additional_state_digest_in_prologue = true;
-                    //    cfg.consensus_commit_rate_estimation_window_size =
-                    // Some(10);
-                    //}
+                    // Enable recording additional state digest in prologue.
+                    if chain != Chain::Mainnet && chain != Chain::Testnet {
+                        cfg.feature_flags.record_additional_state_digest_in_prologue = true;
+                        cfg.consensus_commit_rate_estimation_window_size = Some(10);
+                    }
                 }
                 // Use this template when making changes:
                 //

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -326,6 +326,10 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     minimize_child_object_mutations: bool,
 
+    // If true, record the additional state digest in the consensus commit prologue.
+    #[serde(skip_serializing_if = "is_false")]
+    record_additional_state_digest_in_prologue: bool,
+
     // If true enable additional linkage checks.
     #[serde(skip_serializing_if = "is_false")]
     dependency_linkage_error: bool,
@@ -1174,6 +1178,10 @@ pub struct ProtocolConfig {
     /// for any single commit. Any overshoot is tracked as a debt that must
     /// be accounted for in subsequent commits.
     max_congestion_limit_overshoot_per_commit: Option<u64>,
+
+    /// The number of commits to consider when computing a deterministic commit
+    /// rate.
+    consensus_commit_rate_estimation_window_size: Option<u32>,
 }
 
 // feature flags
@@ -1385,6 +1393,11 @@ impl ProtocolConfig {
         self.feature_flags.minimize_child_object_mutations
     }
 
+    pub fn record_additional_state_digest_in_prologue(&self) -> bool {
+        self.feature_flags
+            .record_additional_state_digest_in_prologue
+    }
+
     pub fn dependency_linkage_error(&self) -> bool {
         self.feature_flags.dependency_linkage_error
     }
@@ -1393,10 +1406,20 @@ impl ProtocolConfig {
         self.feature_flags.additional_multisig_checks
     }
 
+    pub fn get_consensus_commit_rate_estimation_window_size(&self) -> u32 {
+        self.consensus_commit_rate_estimation_window_size
+            .unwrap_or(0)
+    }
+
     pub fn consensus_num_requested_prior_commits_at_startup(&self) -> u32 {
-        // TODO: this will eventually be the max of some number of other
-        // parameters.
-        0
+        // Currently there is only one parameter driving this value. If there are
+        // multiple things computed from prior consensus commits, this function
+        // must return the max of all of them.
+        let window_size = self.get_consensus_commit_rate_estimation_window_size();
+        // Ensure we are not using past commits without recording a state digest in the
+        // prologue.
+        assert!(window_size == 0 || self.record_additional_state_digest_in_prologue());
+        window_size
     }
 
     pub fn normalize_ptb_arguments(&self) -> bool {
@@ -2003,6 +2026,8 @@ impl ProtocolConfig {
             consensus_max_acknowledgments_per_block: None,
 
             max_congestion_limit_overshoot_per_commit: None,
+
+            consensus_commit_rate_estimation_window_size: None,
             // When adding a new constant, set it to None in the earliest version, like this:
             // new_constant: None,
         };
@@ -2294,6 +2319,13 @@ impl ProtocolConfig {
                     if chain != Chain::Testnet && chain != Chain::Mainnet {
                         // Switch consensus protocol to Starfish in devnet
                         cfg.feature_flags.consensus_choice = ConsensusChoice::Starfish;
+
+                        // TODO: when do we want to enable these features?
+                        // if chain != Chain::Mainnet && chain != Chain::Testnet
+                        // {    cfg.feature_flags.
+                        // record_additional_state_digest_in_prologue = true;
+                        //    cfg.consensus_commit_rate_estimation_window_size =
+                        // Some(10);
                     }
                 }
                 15 => {

--- a/crates/iota-protocol-config/src/lib.rs
+++ b/crates/iota-protocol-config/src/lib.rs
@@ -2319,13 +2319,6 @@ impl ProtocolConfig {
                     if chain != Chain::Testnet && chain != Chain::Mainnet {
                         // Switch consensus protocol to Starfish in devnet
                         cfg.feature_flags.consensus_choice = ConsensusChoice::Starfish;
-
-                        // TODO: when do we want to enable these features?
-                        // if chain != Chain::Mainnet && chain != Chain::Testnet
-                        // {    cfg.feature_flags.
-                        // record_additional_state_digest_in_prologue = true;
-                        //    cfg.consensus_commit_rate_estimation_window_size =
-                        // Some(10);
                     }
                 }
                 15 => {
@@ -2348,6 +2341,14 @@ impl ProtocolConfig {
                 17 => {
                     // Increase the committee size to 100 on all networks.
                     cfg.max_committee_members_count = Some(100);
+
+                    // TODO: when do we want to enable these features?
+                    // if chain != Chain::Mainnet && chain != Chain::Testnet {
+                    //    cfg.feature_flags.
+                    // record_additional_state_digest_in_prologue = true;
+                    //    cfg.consensus_commit_rate_estimation_window_size =
+                    // Some(10);
+                    //}
                 }
                 // Use this template when making changes:
                 //

--- a/crates/iota-rosetta/src/types.rs
+++ b/crates/iota-rosetta/src/types.rs
@@ -425,7 +425,8 @@ impl From<&IotaTransactionBlockKind> for OperationType {
     fn from(tx: &IotaTransactionBlockKind) -> Self {
         match tx {
             IotaTransactionBlockKind::Genesis(_) => OperationType::Genesis,
-            IotaTransactionBlockKind::ConsensusCommitPrologueV1(_) => {
+            IotaTransactionBlockKind::ConsensusCommitPrologueV1(_)
+            | IotaTransactionBlockKind::ConsensusCommitPrologueV4(_) => {
                 OperationType::ConsensusCommitPrologue
             }
             IotaTransactionBlockKind::ProgrammableTransaction(_) => {

--- a/crates/iota-types/src/digests.rs
+++ b/crates/iota-types/src/digests.rs
@@ -1046,6 +1046,29 @@ impl fmt::Debug for ConsensusCommitDigest {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema)]
+pub struct AdditionalConsensusStateDigest(Digest);
+
+impl AdditionalConsensusStateDigest {
+    pub const fn new(digest: [u8; 32]) -> Self {
+        Self(Digest::new(digest))
+    }
+}
+
+impl fmt::Display for AdditionalConsensusStateDigest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl fmt::Debug for AdditionalConsensusStateDigest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("AdditionalConsensusStateDigest")
+            .field(&self.0)
+            .finish()
+    }
+}
+
 mod test {
     #[allow(unused_imports)]
     use crate::digests::ChainIdentifier;

--- a/crates/iota-types/src/iota_sdk_types_conversions.rs
+++ b/crates/iota-types/src/iota_sdk_types_conversions.rs
@@ -475,6 +475,7 @@ impl TryFrom<crate::transaction::TransactionKind> for TransactionKind {
                     consensus_determined_version_assignments,
                 })
             }
+            InternalTxnKind::ConsensusCommitPrologueV4(_consensus_commit_prologue_v4) => todo!(),
             InternalTxnKind::AuthenticatorStateUpdateV1(authenticator_state_update_v1) => {
                 TransactionKind::AuthenticatorStateUpdateV1(AuthenticatorStateUpdateV1 {
                     epoch: authenticator_state_update_v1.epoch,

--- a/crates/iota-types/src/iota_sdk_types_conversions.rs
+++ b/crates/iota-types/src/iota_sdk_types_conversions.rs
@@ -475,7 +475,32 @@ impl TryFrom<crate::transaction::TransactionKind> for TransactionKind {
                     consensus_determined_version_assignments,
                 })
             }
-            InternalTxnKind::ConsensusCommitPrologueV4(_consensus_commit_prologue_v4) => todo!(),
+            InternalTxnKind::ConsensusCommitPrologueV4(consensus_commit_prologue_v4) => {
+                let consensus_determined_version_assignments = match consensus_commit_prologue_v4.consensus_determined_version_assignments {
+                    crate::messages_consensus::ConsensusDeterminedVersionAssignments::CancelledTransactions(vec) =>
+                        ConsensusDeterminedVersionAssignments::CancelledTransactions {
+                            cancelled_transactions: vec.into_iter().map(|value| CancelledTransaction {
+                                digest: value.0.into(),
+                                version_assignments:
+                                    value
+                                        .1
+                                        .into_iter()
+                                        .map(|value| VersionAssignment { object_id: value.0.into(), version: value.1.value() })
+                                        .collect(),
+                            }).collect()
+                        },
+                };
+                TransactionKind::ConsensusCommitPrologueV1(ConsensusCommitPrologueV1 {
+                    epoch: consensus_commit_prologue_v4.epoch,
+                    round: consensus_commit_prologue_v4.round,
+                    sub_dag_index: consensus_commit_prologue_v4.sub_dag_index,
+                    commit_timestamp_ms: consensus_commit_prologue_v4.commit_timestamp_ms,
+                    consensus_commit_digest: consensus_commit_prologue_v4
+                        .consensus_commit_digest
+                        .into(),
+                    consensus_determined_version_assignments,
+                })
+            }
             InternalTxnKind::AuthenticatorStateUpdateV1(authenticator_state_update_v1) => {
                 TransactionKind::AuthenticatorStateUpdateV1(AuthenticatorStateUpdateV1 {
                     epoch: authenticator_state_update_v1.epoch,

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -25,7 +25,9 @@ use crate::{
     crypto::{AuthoritySignature, DefaultHash},
     digests::{AdditionalConsensusStateDigest, ConsensusCommitDigest, Digest},
     message_envelope::{Envelope, Message, VerifiedEnvelope},
-    messages_checkpoint::{CheckpointSequenceNumber, CheckpointSignatureMessage},
+    messages_checkpoint::{
+        CheckpointSequenceNumber, CheckpointSignatureMessage, CheckpointTimestamp,
+    },
     supported_protocol_versions::{
         Chain, SupportedProtocolVersions, SupportedProtocolVersionsWithHashes,
     },
@@ -70,7 +72,7 @@ pub struct ConsensusCommitPrologueV4 {
     /// if there are multiple consensus commits per round.
     pub sub_dag_index: Option<u64>,
     /// Unix timestamp from consensus commit.
-    pub commit_timestamp_ms: TimestampMs,
+    pub commit_timestamp_ms: CheckpointTimestamp,
     /// Digest of consensus output
     pub consensus_commit_digest: ConsensusCommitDigest,
     /// Stores consensus handler determined shared object version assignments.

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -23,7 +23,7 @@ use crate::{
         AuthorityName, ConciseableName, ObjectID, ObjectRef, SequenceNumber, TransactionDigest,
     },
     crypto::{AuthoritySignature, DefaultHash},
-    digests::{ConsensusCommitDigest, Digest},
+    digests::{AdditionalConsensusStateDigest, ConsensusCommitDigest, Digest},
     message_envelope::{Envelope, Message, VerifiedEnvelope},
     messages_checkpoint::{CheckpointSequenceNumber, CheckpointSignatureMessage},
     supported_protocol_versions::{
@@ -58,6 +58,26 @@ pub struct ConsensusCommitPrologueV1 {
     pub consensus_commit_digest: ConsensusCommitDigest,
     /// Stores consensus handler determined shared object version assignments.
     pub consensus_determined_version_assignments: ConsensusDeterminedVersionAssignments,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+pub struct ConsensusCommitPrologueV4 {
+    /// Epoch of the commit prologue transaction
+    pub epoch: u64,
+    /// Consensus round of the commit
+    pub round: u64,
+    /// The sub DAG index of the consensus commit. This field will be populated
+    /// if there are multiple consensus commits per round.
+    pub sub_dag_index: Option<u64>,
+    /// Unix timestamp from consensus commit.
+    pub commit_timestamp_ms: TimestampMs,
+    /// Digest of consensus output
+    pub consensus_commit_digest: ConsensusCommitDigest,
+    /// Stores consensus handler determined shared object version assignments.
+    pub consensus_determined_version_assignments: ConsensusDeterminedVersionAssignments,
+    /// Digest of any additional state computed by the consensus handler.
+    /// Used to detect forking bugs as early as possible.
+    pub additional_state_digest: AdditionalConsensusStateDigest,
 }
 
 // In practice, JWKs are about 500 bytes of json each, plus a bit more for the

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -2597,7 +2597,7 @@ impl VerifiedTransaction {
         round: u64,
         commit_timestamp_ms: CheckpointTimestamp,
         consensus_commit_digest: ConsensusCommitDigest,
-        cancelled_txn_version_assignment: Vec<(TransactionDigest, Vec<(ObjectID, SequenceNumber)>)>,
+        consensus_determined_version_assignments: ConsensusDeterminedVersionAssignments,
     ) -> Self {
         ConsensusCommitPrologueV1 {
             epoch,
@@ -2606,10 +2606,7 @@ impl VerifiedTransaction {
             sub_dag_index: None,
             commit_timestamp_ms,
             consensus_commit_digest,
-            consensus_determined_version_assignments:
-                ConsensusDeterminedVersionAssignments::CancelledTransactions(
-                    cancelled_txn_version_assignment,
-                ),
+            consensus_determined_version_assignments,
         }
         .pipe(TransactionKind::ConsensusCommitPrologueV1)
         .pipe(Self::new_system_transaction)

--- a/crates/iota-types/src/transaction.rs
+++ b/crates/iota-types/src/transaction.rs
@@ -43,13 +43,16 @@ use crate::{
         IotaSignatureInner, RandomnessRound, Signature, Signer, ToFromBytes, default_hash,
     },
     digests::{
-        CertificateDigest, ConsensusCommitDigest, SenderSignedDataDigest, ZKLoginInputsDigest,
+        AdditionalConsensusStateDigest, CertificateDigest, ConsensusCommitDigest,
+        SenderSignedDataDigest, ZKLoginInputsDigest,
     },
     event::Event,
     execution::SharedInput,
     message_envelope::{Envelope, Message, TrustedEnvelope, VerifiedEnvelope},
     messages_checkpoint::CheckpointTimestamp,
-    messages_consensus::{ConsensusCommitPrologueV1, ConsensusDeterminedVersionAssignments},
+    messages_consensus::{
+        ConsensusCommitPrologueV1, ConsensusCommitPrologueV4, ConsensusDeterminedVersionAssignments,
+    },
     object::{MoveObject, Object, Owner},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     signature::{GenericSignature, VerifyParams},
@@ -368,6 +371,7 @@ pub enum TransactionKind {
     EndOfEpochTransaction(Vec<EndOfEpochTransactionKind>),
 
     RandomnessStateUpdate(RandomnessStateUpdate),
+    ConsensusCommitPrologueV4(ConsensusCommitPrologueV4),
     // .. more transaction types go here
     // TODO: When introducing `ConsensusCommitPrologueV2`, please add
     // and use a new variant for `ConsensusDeterminedVersionAssignments`.
@@ -1285,6 +1289,7 @@ impl TransactionKind {
         match self {
             TransactionKind::Genesis(_)
             | TransactionKind::ConsensusCommitPrologueV1(_)
+            | TransactionKind::ConsensusCommitPrologueV4(_)
             | TransactionKind::AuthenticatorStateUpdateV1(_)
             | TransactionKind::RandomnessStateUpdate(_)
             | TransactionKind::EndOfEpochTransaction(_) => true,
@@ -1327,7 +1332,7 @@ impl TransactionKind {
     /// transaction.
     pub fn shared_input_objects(&self) -> impl Iterator<Item = SharedInputObject> + '_ {
         match &self {
-            Self::ConsensusCommitPrologueV1(_) => {
+            Self::ConsensusCommitPrologueV1(_) | Self::ConsensusCommitPrologueV4(_) => {
                 Either::Left(Either::Left(iter::once(SharedInputObject {
                     id: IOTA_CLOCK_OBJECT_ID,
                     initial_shared_version: IOTA_CLOCK_OBJECT_SHARED_VERSION,
@@ -1354,7 +1359,7 @@ impl TransactionKind {
             Self::ProgrammableTransaction(pt) => {
                 Either::Right(Either::Left(pt.shared_input_objects()))
             }
-            _ => Either::Right(Either::Right(iter::empty())),
+            Self::Genesis(_) => Either::Right(Either::Right(iter::empty())),
         }
     }
 
@@ -1369,6 +1374,7 @@ impl TransactionKind {
         match &self {
             TransactionKind::Genesis(_)
             | TransactionKind::ConsensusCommitPrologueV1(_)
+            | TransactionKind::ConsensusCommitPrologueV4(_)
             | TransactionKind::AuthenticatorStateUpdateV1(_)
             | TransactionKind::RandomnessStateUpdate(_)
             | TransactionKind::EndOfEpochTransaction(_) => vec![],
@@ -1386,7 +1392,7 @@ impl TransactionKind {
             Self::Genesis(_) => {
                 vec![]
             }
-            Self::ConsensusCommitPrologueV1(_) => {
+            Self::ConsensusCommitPrologueV1(_) | Self::ConsensusCommitPrologueV4(_) => {
                 vec![InputObjectKind::SharedMoveObject {
                     id: IOTA_CLOCK_OBJECT_ID,
                     initial_shared_version: IOTA_CLOCK_OBJECT_SHARED_VERSION,
@@ -1443,6 +1449,13 @@ impl TransactionKind {
             // All transaction kinds below are assumed to be system,
             // and no validity or limit checks are performed.
             TransactionKind::Genesis(_) | TransactionKind::ConsensusCommitPrologueV1(_) => (),
+            TransactionKind::ConsensusCommitPrologueV4(_) => {
+                if !config.record_additional_state_digest_in_prologue() {
+                    return Err(UserInputError::Unsupported(
+                        "ConsensusCommitPrologueV4 is not supported".to_string(),
+                    ));
+                }
+            }
             TransactionKind::EndOfEpochTransaction(txns) => {
                 for tx in txns {
                     tx.validity_check(config)?;
@@ -1488,6 +1501,7 @@ impl TransactionKind {
         match self {
             Self::Genesis(_) => "Genesis",
             Self::ConsensusCommitPrologueV1(_) => "ConsensusCommitPrologueV1",
+            Self::ConsensusCommitPrologueV4(_) => "ConsensusCommitPrologueV4",
             Self::ProgrammableTransaction(_) => "ProgrammableTransaction",
             Self::AuthenticatorStateUpdateV1(_) => "AuthenticatorStateUpdateV1",
             Self::RandomnessStateUpdate(_) => "RandomnessStateUpdate",
@@ -1511,6 +1525,21 @@ impl Display for TransactionKind {
                     writer,
                     "Consensus determined version assignment: {:?}",
                     p.consensus_determined_version_assignments
+                )?;
+            }
+            Self::ConsensusCommitPrologueV4(p) => {
+                writeln!(writer, "Transaction Kind : Consensus Commit Prologue V4")?;
+                writeln!(writer, "Timestamp : {}", p.commit_timestamp_ms)?;
+                writeln!(writer, "Consensus Digest: {}", p.consensus_commit_digest)?;
+                writeln!(
+                    writer,
+                    "Consensus determined version assignment: {:?}",
+                    p.consensus_determined_version_assignments
+                )?;
+                writeln!(
+                    writer,
+                    "Additional State Digest: {}",
+                    p.additional_state_digest
                 )?;
             }
             Self::ProgrammableTransaction(p) => {
@@ -2025,6 +2054,8 @@ pub trait TransactionDataAPI {
     /// run at the very end of the epoch
     fn is_end_of_epoch_tx(&self) -> bool;
 
+    fn is_consensus_commit_prologue(&self) -> bool;
+
     /// Check if the transaction is sponsored (namely gas owner != sender)
     fn is_sponsored_tx(&self) -> bool;
 
@@ -2154,6 +2185,19 @@ impl TransactionDataAPI for TransactionDataV1 {
 
     fn is_end_of_epoch_tx(&self) -> bool {
         matches!(self.kind, TransactionKind::EndOfEpochTransaction(_))
+    }
+
+    fn is_consensus_commit_prologue(&self) -> bool {
+        match &self.kind {
+            TransactionKind::ConsensusCommitPrologueV1(_)
+            | TransactionKind::ConsensusCommitPrologueV4(_) => true,
+
+            TransactionKind::ProgrammableTransaction(_)
+            | TransactionKind::Genesis(_)
+            | TransactionKind::AuthenticatorStateUpdateV1(_)
+            | TransactionKind::EndOfEpochTransaction(_)
+            | TransactionKind::RandomnessStateUpdate(_) => false,
+        }
     }
 
     fn is_system_tx(&self) -> bool {
@@ -2568,6 +2612,28 @@ impl VerifiedTransaction {
                 ),
         }
         .pipe(TransactionKind::ConsensusCommitPrologueV1)
+        .pipe(Self::new_system_transaction)
+    }
+
+    pub fn new_consensus_commit_prologue_v4(
+        epoch: u64,
+        round: u64,
+        commit_timestamp_ms: CheckpointTimestamp,
+        consensus_commit_digest: ConsensusCommitDigest,
+        consensus_determined_version_assignments: ConsensusDeterminedVersionAssignments,
+        additional_state_digest: AdditionalConsensusStateDigest,
+    ) -> Self {
+        ConsensusCommitPrologueV4 {
+            epoch,
+            round,
+            // sub_dag_index is reserved for when we have multi commits per round.
+            sub_dag_index: None,
+            commit_timestamp_ms,
+            consensus_commit_digest,
+            consensus_determined_version_assignments,
+            additional_state_digest,
+        }
+        .pipe(TransactionKind::ConsensusCommitPrologueV4)
         .pipe(Self::new_system_transaction)
     }
 

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -660,6 +660,20 @@ mod checked {
                 .expect("ConsensusCommitPrologueV1 cannot fail");
                 Ok(Mode::empty_results())
             }
+            TransactionKind::ConsensusCommitPrologueV4(prologue) => {
+                setup_consensus_commit(
+                    prologue.commit_timestamp_ms,
+                    temporary_store,
+                    tx_ctx,
+                    move_vm,
+                    gas_charger,
+                    protocol_config,
+                    metrics,
+                    trace_builder_opt,
+                )
+                .expect("ConsensusCommitPrologue cannot fail");
+                Ok((Mode::empty_results(), vec![]))
+            }
             TransactionKind::ProgrammableTransaction(pt) => {
                 programmable_transactions::execution::execute::<Mode>(
                     protocol_config,

--- a/iota-execution/latest/iota-adapter/src/execution_engine.rs
+++ b/iota-execution/latest/iota-adapter/src/execution_engine.rs
@@ -671,8 +671,8 @@ mod checked {
                     metrics,
                     trace_builder_opt,
                 )
-                .expect("ConsensusCommitPrologue cannot fail");
-                Ok((Mode::empty_results(), vec![]))
+                .expect("ConsensusCommitPrologueV4 cannot fail");
+                Ok(Mode::empty_results())
             }
             TransactionKind::ProgrammableTransaction(pt) => {
                 programmable_transactions::execution::execute::<Mode>(


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.43.1, v1.44.3)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/9f4304d8323c74b372fbe7405f9ee8786636b52b
- Description:

This is built on a small system for observing state computed from N
previous commits.

In order to guard against latent forking bugs caused by such
observations, the digest of all state thus observed is added to each
commit prologue. This requires a new version (V2) of
ConsensusCommitPrologue

## Links to any relevant issues

Part of #5727 

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
