### PR TITLE
feat(indexer): Return optimistic events from query_events

### DIFF
--- a/crates/iota-indexer/src/apis/indexer_api.rs
+++ b/crates/iota-indexer/src/apis/indexer_api.rs
@@ -296,7 +296,12 @@ impl IndexerApiServer for IndexerApi {
         let descending_order = descending_order.unwrap_or(false);
         let mut results = self
             .inner
-            .query_events_in_blocking_task(query, cursor, limit + 1, descending_order)
+            .query_optimistic_and_checkpointed_events_in_blocking_task(
+                query,
+                cursor,
+                limit + 1,
+                descending_order,
+            )
             .await?;
 
         let has_next_page = results.len() > limit;

--- a/crates/iota-indexer/src/indexer_reader.rs
+++ b/crates/iota-indexer/src/indexer_reader.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
-
 use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, Mutex},
@@ -57,7 +56,7 @@ use crate::{
         checkpoints::{StoredChainIdentifier, StoredCheckpoint},
         display::StoredDisplay,
         epoch::StoredEpochInfo,
-        events::StoredEvent,
+        events::{OptimisticEvent, StoredEvent},
         move_call_metrics::QueriedMoveCallMetrics,
         network_metrics::StoredNetworkMetrics,
         obj_indices::StoredObjectVersion,
@@ -71,8 +70,9 @@ use crate::{
     },
     schema::{
         address_metrics, addresses, chain_identifier, checkpoints, display, epochs, events,
-        objects, objects_history, objects_snapshot, objects_version, optimistic_transactions,
-        packages, pruner_cp_watermark, transactions, tx_digests, tx_global_order,
+        objects, objects_history, objects_snapshot, objects_version, optimistic_events,
+        optimistic_transactions, packages, pruner_cp_watermark, transactions, tx_digests,
+        tx_global_order,
     },
     store::{diesel_macro::*, package_resolver::IndexerStorePackageResolver},
     types::{IndexerResult, OwnerType},
@@ -179,34 +179,6 @@ impl<'a> QueryTransactionBlocksSqlQueryBuilder<'a> {
         }
     }
 
-    fn combine_queries(
-        query_before_global_order: String,
-        query_in_global_order: String,
-        is_descending: bool,
-        cursor_position: &Option<CursorPosition>,
-        limit: usize,
-    ) -> String {
-        if is_descending {
-            if matches!(cursor_position, Some(CursorPosition::BeforeGlobalOrder(_))) {
-                // if cursor is placed before global order bagan, and we are descending, we
-                // can safely omit global ordered entries
-                query_before_global_order
-            } else {
-                format!(
-                    "({query_in_global_order}) UNION ALL ({query_before_global_order}) LIMIT {limit}"
-                )
-            }
-        } else if matches!(cursor_position, Some(CursorPosition::InGlobalOrder(_, _))) {
-            // if cursor is placed in globally ordered area and we are ascending, we can
-            // safely omit non-global-ordered entries
-            query_in_global_order
-        } else {
-            format!(
-                "({query_before_global_order}) UNION ALL ({query_in_global_order}) LIMIT {limit}"
-            )
-        }
-    }
-
     fn get_query_before_global_order(&self, return_order_columns: bool) -> String {
         let source_table_alias = self.source_table_alias;
         let source_table_or_query = self.source_table_or_query;
@@ -283,13 +255,190 @@ impl<'a> QueryTransactionBlocksSqlQueryBuilder<'a> {
         let query_before_global_order = self.get_query_before_global_order(false);
         let query_after_global_order = self.get_query_with_global_order(false);
 
-        QueryTransactionBlocksSqlQueryBuilder::combine_queries(
+        combine_nonglobal_and_global_order_queries(
             query_before_global_order,
             query_after_global_order,
             self.is_descending,
             &self.cursor_position,
             self.limit,
         )
+    }
+}
+
+struct QueryEventsSqlQueryBuilder<'a> {
+    source_table_alias: &'a str,
+    source_table_or_query: &'a str,
+    optimistic_source_table_or_query: &'a str,
+    main_filter_condition: &'a str,
+    cursor_position: (CursorPosition, i64),
+    is_descending: bool,
+    limit: usize,
+    smallest_tx_seq_with_global_order: i64,
+}
+
+impl<'a> QueryEventsSqlQueryBuilder<'a> {
+    const STORED_EVENT_SQL_FIELDS: &'static str = "tx_sequence_number, event_sequence_number, transaction_digest, senders, package, module, event_type, timestamp_ms, bcs";
+    const STORED_EVENT_SQL_FIELDS_FOR_OPTIMISTIC_TABLE: &'static str = "-1 as tx_sequence_number, event_sequence_number, transaction_digest, senders, package, module, event_type, -1 as timestamp_ms, bcs";
+
+    fn new(
+        source_table_alias: &'a str,
+        source_table_or_query: &'a str,
+        optimistic_source_table_or_query: &'a str,
+        main_filter_condition: &'a str,
+        cursor_position: (CursorPosition, i64),
+        is_descending: bool,
+        limit: usize,
+        smallest_tx_seq_with_global_order: i64,
+    ) -> Self {
+        Self {
+            cursor_position,
+            is_descending,
+            limit,
+            source_table_alias,
+            source_table_or_query,
+            optimistic_source_table_or_query,
+            main_filter_condition,
+            smallest_tx_seq_with_global_order,
+        }
+    }
+
+    fn get_before_global_order_cursor_clause(&self) -> String {
+        let source_table_alias = self.source_table_alias;
+        if let (CursorPosition::BeforeGlobalOrder(cursor_tx_seq), event_seq) = self.cursor_position
+        {
+            let comparator = if self.is_descending { "<" } else { ">" };
+            format!(
+                "(({source_table_alias}.{TX_SEQUENCE_NUMBER_STR}, e.{EVENT_SEQUENCE_NUMBER_STR}) {comparator} ({cursor_tx_seq}, {event_seq}))"
+            )
+        } else {
+            "1 = 1".to_string()
+        }
+    }
+
+    fn get_with_global_order_cursor_clause(&self) -> String {
+        let source_table_alias = self.source_table_alias;
+        if let (CursorPosition::InGlobalOrder(global_seq, optimistic_seq), event_seq) =
+            self.cursor_position
+        {
+            let comparator = if self.is_descending { "<" } else { ">" };
+            format!(
+                "(tx_global_order.global_sequence_number, tx_global_order.optimistic_sequence_number, {source_table_alias}.{EVENT_SEQUENCE_NUMBER_STR}) \
+                 {comparator} ({global_seq}, {optimistic_seq}, {event_seq})"
+            )
+        } else {
+            "1 = 1".to_string()
+        }
+    }
+
+    fn get_query_before_global_order(&self) -> String {
+        let source_table_alias = self.source_table_alias;
+        let source_table_or_query = self.source_table_or_query;
+        let main_filter_condition = self.main_filter_condition;
+        let smallest_tx_seq_with_global_order = self.smallest_tx_seq_with_global_order;
+        let limit = self.limit;
+        let before_global_order_cursor_clause = self.get_before_global_order_cursor_clause();
+        let fields_to_select = Self::STORED_EVENT_SQL_FIELDS;
+        let order_str = if self.is_descending { "DESC" } else { "ASC" };
+        let order_clause = format!(
+            "{source_table_alias}.{TX_SEQUENCE_NUMBER_STR} {order_str}, {source_table_alias}.{EVENT_SEQUENCE_NUMBER_STR} {order_str}"
+        );
+
+        format!(
+            "SELECT {source_table_alias}.{fields_to_select}
+             FROM {source_table_or_query}
+             WHERE {main_filter_condition} AND {before_global_order_cursor_clause} \
+             AND {source_table_alias}.{TX_SEQUENCE_NUMBER_STR} < {smallest_tx_seq_with_global_order} \
+             ORDER BY {order_clause} \
+             LIMIT {limit}",
+        )
+    }
+
+    fn get_query_with_global_order(&self) -> String {
+        let source_table_alias = self.source_table_alias;
+        let source_table_or_query = self.source_table_or_query;
+        let optimistic_source_table_or_query = self.optimistic_source_table_or_query;
+        let main_filter_condition = self.main_filter_condition;
+        let limit = self.limit;
+        let global_order_cursor_clause = self.get_with_global_order_cursor_clause();
+        let fields_to_select = Self::STORED_EVENT_SQL_FIELDS;
+        let optimistic_fields_to_select = Self::STORED_EVENT_SQL_FIELDS_FOR_OPTIMISTIC_TABLE;
+        let order_str = if self.is_descending { "DESC" } else { "ASC" };
+        let order_clause = format!(
+            "tx_global_order.global_sequence_number {order_str}, tx_global_order.optimistic_sequence_number {order_str}, \
+             {source_table_alias}.{EVENT_SEQUENCE_NUMBER_STR} {order_str}"
+        );
+        let final_order_clause = format!(
+            "global_sequence_number {order_str}, optimistic_sequence_number {order_str}, {EVENT_SEQUENCE_NUMBER_STR} {order_str}"
+        );
+
+        let checkpointed_data_qry = format!(
+            "SELECT {source_table_alias}.{fields_to_select}, tx_global_order.{GLOBAL_SEQUENCE_NUMBER_STR}, tx_global_order.{OPTIMISTIC_SEQUENCE_NUMBER_STR} \
+             FROM {source_table_or_query}
+             JOIN tx_global_order ON tx_global_order.chk_tx_sequence_number = {source_table_alias}.{TX_SEQUENCE_NUMBER_STR} \
+             WHERE {main_filter_condition} AND {global_order_cursor_clause} \
+             ORDER BY {order_clause} \
+             LIMIT {limit}"
+        );
+
+        let optimistic_data_qry = format!(
+            "SELECT {optimistic_fields_to_select}, tx_global_order.{GLOBAL_SEQUENCE_NUMBER_STR}, tx_global_order.{OPTIMISTIC_SEQUENCE_NUMBER_STR} \
+             FROM {optimistic_source_table_or_query}
+             JOIN tx_global_order \
+                 ON tx_global_order.{GLOBAL_SEQUENCE_NUMBER_STR} = {source_table_alias}.{GLOBAL_SEQUENCE_NUMBER_STR} \
+                 AND tx_global_order.{OPTIMISTIC_SEQUENCE_NUMBER_STR} = {source_table_alias}.{OPTIMISTIC_SEQUENCE_NUMBER_STR} \
+             WHERE {main_filter_condition} AND {global_order_cursor_clause}  \
+             ORDER BY {order_clause} \
+             LIMIT {limit}"
+        );
+
+        format!(
+            "SELECT {fields_to_select} FROM ( \
+                 SELECT DISTINCT ON (event_sequence_number, transaction_digest) {fields_to_select}, {GLOBAL_SEQUENCE_NUMBER_STR}, {OPTIMISTIC_SEQUENCE_NUMBER_STR} \
+                 FROM (({checkpointed_data_qry}) UNION ALL ({optimistic_data_qry})) AS combined_raw \
+                 ORDER BY event_sequence_number, transaction_digest \
+             ) as combined_deduplicated \
+             ORDER BY {final_order_clause} \
+             LIMIT {limit}"
+        ) // Remove duplicates by event_sequence_number and transaction_digest, then restore order
+    }
+
+    fn get_combined_query(&self) -> String {
+        let query_before_global_order = self.get_query_before_global_order();
+        let query_after_global_order = self.get_query_with_global_order();
+
+        combine_nonglobal_and_global_order_queries(
+            query_before_global_order,
+            query_after_global_order,
+            self.is_descending,
+            &Some(self.cursor_position.0),
+            self.limit,
+        )
+    }
+}
+
+fn combine_nonglobal_and_global_order_queries(
+    query_before_global_order: String,
+    query_in_global_order: String,
+    is_descending: bool,
+    cursor_position: &Option<CursorPosition>,
+    limit: usize,
+) -> String {
+    if is_descending {
+        if matches!(cursor_position, Some(CursorPosition::BeforeGlobalOrder(_))) {
+            // if cursor is placed before global order bagan, and we are descending, we
+            // can safely omit global ordered entries
+            query_before_global_order
+        } else {
+            format!(
+                "({query_in_global_order}) UNION ALL ({query_before_global_order}) LIMIT {limit}"
+            )
+        }
+    } else if matches!(cursor_position, Some(CursorPosition::InGlobalOrder(_, _))) {
+        // if cursor is placed in globally ordered area and we are ascending, we can
+        // safely omit non-global-ordered entries
+        query_in_global_order
+    } else {
+        format!("({query_before_global_order}) UNION ALL ({query_in_global_order}) LIMIT {limit}")
     }
 }
 
@@ -1704,7 +1853,7 @@ impl IndexerReader {
                     ) // we need UNION to remove duplicates, but we need to restore order after that
                 };
 
-                let inner_query = QueryTransactionBlocksSqlQueryBuilder::combine_queries(
+                let inner_query = combine_nonglobal_and_global_order_queries(
                     inner_query_before_global_order,
                     inner_query_with_global_order,
                     is_descending,
@@ -1981,13 +2130,85 @@ impl IndexerReader {
         })
     }
 
-    async fn query_events_by_tx_digest(
+    async fn query_events_by_tx_digest_including_optimistic_data(
         &self,
         tx_digest: TransactionDigest,
         cursor: Option<EventID>,
         limit: usize,
         descending_order: bool,
     ) -> IndexerResult<Vec<IotaEvent>> {
+        let ckpt_events = self
+            .query_events_by_tx_digest_checkpointed(tx_digest, cursor, limit, descending_order)
+            .await?;
+        let optimistic_events = self
+            .query_events_by_tx_digest_optimistic(tx_digest, cursor, limit, descending_order)
+            .await?;
+
+        let deduplicated_events = ckpt_events
+            .into_iter()
+            .chain(optimistic_events.into_iter())
+            .unique_by(|event| {
+                (
+                    event.event_sequence_number,
+                    event.transaction_digest.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let mut iota_event_futures = vec![];
+        for stored_event in deduplicated_events {
+            iota_event_futures.push(tokio::task::spawn(
+                stored_event.try_into_iota_event(self.package_resolver.clone()),
+            ));
+        }
+
+        let iota_events = futures::future::join_all(iota_event_futures)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .tap_err(|e| tracing::error!("Failed to join iota event futures: {}", e))?
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .tap_err(|e| tracing::error!("Failed to collect iota event futures: {}", e))?;
+        Ok(iota_events)
+    }
+
+    async fn query_events_by_tx_digest_checkpointed_only(
+        &self,
+        tx_digest: TransactionDigest,
+        cursor: Option<EventID>,
+        limit: usize,
+        descending_order: bool,
+    ) -> IndexerResult<Vec<IotaEvent>> {
+        let ckpt_events = self
+            .query_events_by_tx_digest_checkpointed(tx_digest, cursor, limit, descending_order)
+            .await?;
+
+        let mut iota_event_futures = vec![];
+        for stored_event in ckpt_events {
+            iota_event_futures.push(tokio::task::spawn(
+                stored_event.try_into_iota_event(self.package_resolver.clone()),
+            ));
+        }
+
+        let iota_events = futures::future::join_all(iota_event_futures)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .tap_err(|e| tracing::error!("Failed to join iota event futures: {}", e))?
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .tap_err(|e| tracing::error!("Failed to collect iota event futures: {}", e))?;
+        Ok(iota_events)
+    }
+
+    async fn query_events_by_tx_digest_checkpointed(
+        &self,
+        tx_digest: TransactionDigest,
+        cursor: Option<EventID>,
+        limit: usize,
+        descending_order: bool,
+    ) -> IndexerResult<Vec<StoredEvent>> {
         let mut query = events::table.into_boxed();
 
         if let Some(cursor) = cursor {
@@ -2023,9 +2244,177 @@ impl IndexerReader {
         );
 
         let pool = self.get_pool();
-        let stored_events = run_query_async!(&pool, move |conn| {
+        run_query_async!(&pool, move |conn| {
             query.limit(limit as i64).load::<StoredEvent>(conn)
+        })
+    }
+
+    async fn query_events_by_tx_digest_optimistic(
+        &self,
+        tx_digest: TransactionDigest,
+        cursor: Option<EventID>,
+        limit: usize,
+        descending_order: bool,
+    ) -> IndexerResult<Vec<StoredEvent>> {
+        let mut query = optimistic_events::table
+            .into_boxed()
+            .inner_join(
+                tx_global_order::table.on(optimistic_events::global_sequence_number
+                    .eq(tx_global_order::global_sequence_number)
+                    .and(
+                        optimistic_events::optimistic_sequence_number
+                            .eq(tx_global_order::optimistic_sequence_number),
+                    )),
+            )
+            .filter(tx_global_order::tx_digest.eq(tx_digest.into_inner().to_vec()));
+
+        if let Some(cursor) = cursor {
+            if cursor.tx_digest != tx_digest {
+                return Err(IndexerError::InvalidArgument(
+                    "Cursor tx_digest does not match the tx_digest in the query.".into(),
+                ));
+            }
+            if descending_order {
+                query = query
+                    .filter(optimistic_events::event_sequence_number.lt(cursor.event_seq as i64));
+            } else {
+                query = query
+                    .filter(optimistic_events::event_sequence_number.gt(cursor.event_seq as i64));
+            }
+        } else if descending_order {
+            query = query.filter(optimistic_events::event_sequence_number.le(i64::MAX));
+        } else {
+            query = query.filter(optimistic_events::event_sequence_number.ge(0));
+        };
+
+        if descending_order {
+            query = query.order(optimistic_events::event_sequence_number.desc());
+        } else {
+            query = query.order(optimistic_events::event_sequence_number.asc());
+        }
+
+        let pool = self.get_pool();
+        let optimistic_events = run_query_async!(&pool, move |conn| {
+            query.limit(limit as i64).load::<OptimisticEvent>(conn)
         })?;
+        Ok(optimistic_events
+            .into_iter()
+            .map(|event| event.into())
+            .collect())
+    }
+
+    pub async fn query_optimistic_and_checkpointed_events_in_blocking_task(
+        &self,
+        filter: EventFilter,
+        cursor: Option<EventID>,
+        limit: usize,
+        descending_order: bool,
+    ) -> IndexerResult<Vec<IotaEvent>> {
+        let smallest_tx_seq_with_global_order =
+            self.get_smallest_tx_seq_with_global_order().await?;
+
+        let (tx_cursor_position, event_seq) = self
+            .resolve_query_events_cursor(
+                smallest_tx_seq_with_global_order,
+                cursor,
+                descending_order,
+            )
+            .await?;
+
+        let query = if let EventFilter::Sender(sender) = &filter {
+            let source_tables = format!(
+                "tx_senders s \
+                 JOIN events e \
+                     ON e.tx_sequence_number = s.tx_sequence_number \
+                     AND s.sender = '\\x{}'::bytea",
+                Hex::encode(sender.to_vec())
+            );
+            let optimistic_source_tables = format!(
+                "optimistic_tx_senders s \
+                 JOIN optimistic_events e \
+                     ON e.{GLOBAL_SEQUENCE_NUMBER_STR} = s.{GLOBAL_SEQUENCE_NUMBER_STR} \
+                     AND e.{OPTIMISTIC_SEQUENCE_NUMBER_STR} = s.{OPTIMISTIC_SEQUENCE_NUMBER_STR} \
+                     AND s.sender = '\\x{}'::bytea",
+                Hex::encode(sender.to_vec())
+            );
+
+            let query_builder = QueryEventsSqlQueryBuilder::new(
+                "e",
+                &source_tables,
+                &optimistic_source_tables,
+                "1 = 1",
+                (tx_cursor_position, event_seq),
+                descending_order,
+                limit,
+                smallest_tx_seq_with_global_order,
+            );
+            query_builder.get_combined_query()
+        } else if let EventFilter::Transaction(tx_digest) = filter {
+            return self
+                .query_events_by_tx_digest_including_optimistic_data(
+                    tx_digest,
+                    cursor,
+                    limit,
+                    descending_order,
+                )
+                .await;
+        } else {
+            let main_where_clause = match filter {
+                EventFilter::Package(package_id) => {
+                    format!("package = '\\x{}'::bytea", package_id.to_hex())
+                }
+                EventFilter::MoveModule { package, module } => {
+                    format!(
+                        "package = '\\x{}'::bytea AND module = '{}'",
+                        package.to_hex(),
+                        module,
+                    )
+                }
+                EventFilter::MoveEventType(struct_tag) => {
+                    let formatted_struct_tag = struct_tag.to_canonical_string(true);
+                    format!("event_type = '{formatted_struct_tag}'")
+                }
+                EventFilter::MoveEventModule { package, module } => {
+                    let package_module_prefix = format!("{}::{}", package.to_hex_literal(), module);
+                    format!("event_type LIKE '{package_module_prefix}::%'")
+                }
+                EventFilter::Sender(_) => {
+                    // Processed above
+                    unreachable!()
+                }
+                EventFilter::Transaction(_) => {
+                    // Processed above
+                    unreachable!()
+                }
+                EventFilter::MoveEventField { .. }
+                | EventFilter::All(_)
+                | EventFilter::Any(_)
+                | EventFilter::And(_, _)
+                | EventFilter::Or(_, _)
+                | EventFilter::TimeRange { .. } => {
+                    return Err(IndexerError::NotSupported(
+                        "This type of EventFilter is not supported.".into(),
+                    ));
+                }
+            };
+
+            let query_builder = QueryEventsSqlQueryBuilder::new(
+                "e",
+                "events e",
+                "optimistic_events e",
+                &main_where_clause,
+                (tx_cursor_position, event_seq),
+                descending_order,
+                limit,
+                smallest_tx_seq_with_global_order,
+            );
+            query_builder.get_combined_query()
+        };
+
+        tracing::debug!("query events: {}", query);
+        let pool = self.get_pool();
+        let stored_events = run_query_async!(&pool, move |conn| diesel::sql_query(query)
+            .load::<StoredEvent>(conn))?;
 
         let mut iota_event_futures = vec![];
         for stored_event in stored_events {
@@ -2045,7 +2434,61 @@ impl IndexerReader {
         Ok(iota_events)
     }
 
-    pub async fn query_events_in_blocking_task(
+    async fn resolve_query_events_cursor(
+        &self,
+        smallest_tx_seq_with_global_order: i64,
+        cursor: Option<EventID>,
+        descending_order: bool,
+    ) -> IndexerResult<(CursorPosition, i64)> {
+        let pool = self.get_pool();
+        let result = if let Some(cursor) = cursor {
+            let EventID {
+                tx_digest,
+                event_seq,
+            } = cursor;
+            let tx_seq = run_query_async!(&pool, move |conn| {
+                tx_digests::table
+                    .select(tx_digests::tx_sequence_number)
+                    // we filter the tx_digests table because it is indexed by digest,
+                    // transactions (and other tables) are not
+                    .filter(tx_digests::tx_digest.eq(tx_digest.into_inner().to_vec()))
+                    .first::<i64>(conn)
+                    .optional()
+            })?;
+            let tx_cursor_position = match tx_seq {
+                Some(seq) if seq < smallest_tx_seq_with_global_order => {
+                    CursorPosition::BeforeGlobalOrder(seq)
+                }
+                _ => {
+                    let pool = self.get_pool();
+                    let (global_seq, optimistic_seq) = run_query_async!(&pool, move |conn| {
+                        tx_global_order::table
+                            .select((
+                                tx_global_order::global_sequence_number,
+                                tx_global_order::optimistic_sequence_number,
+                            ))
+                            .filter(tx_global_order::tx_digest.eq(tx_digest.into_inner().to_vec()))
+                            .first::<(i64, i64)>(conn)
+                    })?;
+                    CursorPosition::InGlobalOrder(global_seq, optimistic_seq)
+                }
+            };
+            (tx_cursor_position, event_seq as i64)
+        } else if descending_order {
+            let max_tx_seq = CursorPosition::InGlobalOrder(i64::MAX, i64::MAX);
+            let max_event_seq = i64::MAX;
+            (max_tx_seq, max_event_seq)
+        } else {
+            let min_tx_seq = CursorPosition::BeforeGlobalOrder(-1);
+            let min_event_seq = 0;
+            (min_tx_seq, min_event_seq)
+        };
+
+        Ok(result)
+    }
+
+    #[expect(unused)]
+    async fn query_only_checkpointed_events_in_blocking_task(
         &self,
         filter: EventFilter,
         cursor: Option<EventID>,
@@ -2116,7 +2559,12 @@ impl IndexerReader {
             )
         } else if let EventFilter::Transaction(tx_digest) = filter {
             return self
-                .query_events_by_tx_digest(tx_digest, cursor, limit, descending_order)
+                .query_events_by_tx_digest_checkpointed_only(
+                    tx_digest,
+                    cursor,
+                    limit,
+                    descending_order,
+                )
                 .await;
         } else {
             let main_where_clause = match filter {
@@ -2186,14 +2634,12 @@ impl IndexerReader {
         let pool = self.get_pool();
         let stored_events = run_query_async!(&pool, move |conn| diesel::sql_query(query)
             .load::<StoredEvent>(conn))?;
-
         let mut iota_event_futures = vec![];
         for stored_event in stored_events {
             iota_event_futures.push(tokio::task::spawn(
                 stored_event.try_into_iota_event(self.package_resolver.clone()),
             ));
         }
-
         let iota_events = futures::future::join_all(iota_event_futures)
             .await
             .into_iter()

--- a/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/indexer_api.rs
@@ -43,6 +43,7 @@ use iota_types::{
     transaction::{CallArg, Command, ObjectArg, TransactionData},
     utils::to_sender_signed_transaction,
 };
+use itertools::Itertools;
 use jsonrpsee::http_client::HttpClient;
 use move_core_types::{
     annotated_value::MoveValue,
@@ -50,10 +51,14 @@ use move_core_types::{
     language_storage::{StructTag, TypeTag},
 };
 
-use crate::common::{
-    ApiTestSetup, execute_tx_must_succeed, indexer_wait_for_checkpoint,
-    indexer_wait_for_latest_checkpoint, indexer_wait_for_object, indexer_wait_for_transaction,
-    rpc_call_error_msg_matches, start_test_cluster_with_read_write_indexer,
+use crate::{
+    coin_api::execute_move_call,
+    common::{
+        ApiTestSetup, execute_tx_must_succeed, indexer_wait_for_checkpoint,
+        indexer_wait_for_latest_checkpoint, indexer_wait_for_object, indexer_wait_for_transaction,
+        rpc_call_error_msg_matches, start_test_cluster_with_read_write_indexer,
+    },
+    write_api::{create_basic_object, deploy_basics_pkg},
 };
 
 #[test]
@@ -116,6 +121,249 @@ fn query_events_no_events_ascending() {
 
         assert_eq!(indexer_events, EventPage::empty())
     });
+}
+
+#[test]
+fn query_events_by_sender() -> Result<(), IndexerError> {
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        cluster,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(store, 1).await;
+
+        let (sender, sender_kp): (_, AccountKeyPair) = get_key_pair();
+        let gas_ref = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(10_000_000_000),
+                sender,
+            )
+            .await;
+        indexer_wait_for_object(client, gas_ref.0, gas_ref.1).await;
+
+        let (_, package_id) = deploy_basics_pkg(sender, &sender_kp, client).await;
+        let basic_obj_1 = create_basic_object(sender, &sender_kp, client, &package_id)
+            .await
+            .unwrap();
+        let basic_obj_2 = create_basic_object(sender, &sender_kp, client, &package_id)
+            .await
+            .unwrap();
+
+        let mut expected_event_ids = Vec::new();
+        // Generate 5 events to test pagination
+        for _ in 0..5 {
+            let res = execute_move_call(
+                client,
+                sender,
+                &sender_kp,
+                package_id,
+                "object_basics".to_string(),
+                "update".to_string(),
+                type_args![].unwrap(),
+                call_args!(basic_obj_1, basic_obj_2).unwrap(),
+                None,
+            )
+            .await?;
+            assert_eq!(res.status_ok(), Some(true));
+
+            let event_id = res
+                .events
+                .as_ref()
+                .unwrap()
+                .data
+                .iter()
+                .exactly_one()
+                .unwrap()
+                .id;
+            expected_event_ids.push(event_id);
+        }
+
+        assert_paginated_filtered_events(
+            client,
+            expected_event_ids.as_slice(),
+            EventFilter::Sender(sender),
+            2,
+        )
+        .await?;
+
+        // ensure all events are checkpointed
+        indexer_wait_for_transaction(expected_event_ids.last().unwrap().tx_digest, store, client)
+            .await;
+
+        assert_paginated_filtered_events(
+            client,
+            expected_event_ids.as_slice(),
+            EventFilter::Sender(sender),
+            2,
+        )
+        .await?;
+
+        Ok::<(), IndexerError>(())
+    })
+}
+
+#[test]
+fn query_events_by_tx_digest() -> Result<(), IndexerError> {
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        cluster,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(store, 1).await;
+
+        let (sender, sender_kp): (_, AccountKeyPair) = get_key_pair();
+        let gas_ref = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(10_000_000_000),
+                sender,
+            )
+            .await;
+        indexer_wait_for_object(client, gas_ref.0, gas_ref.1).await;
+
+        let (_, package_id) = deploy_basics_pkg(sender, &sender_kp, client).await;
+        let basic_obj_1 = create_basic_object(sender, &sender_kp, client, &package_id)
+            .await
+            .unwrap();
+        let basic_obj_2 = create_basic_object(sender, &sender_kp, client, &package_id)
+            .await
+            .unwrap();
+
+        let res = execute_move_call(
+            client,
+            sender,
+            &sender_kp,
+            package_id,
+            "object_basics".to_string(),
+            "update".to_string(),
+            type_args![].unwrap(),
+            call_args!(basic_obj_1, basic_obj_2).unwrap(),
+            None,
+        )
+        .await?;
+        assert_eq!(res.status_ok(), Some(true));
+
+        let event_id = res
+            .events
+            .as_ref()
+            .unwrap()
+            .data
+            .iter()
+            .exactly_one()
+            .unwrap()
+            .id;
+
+        let all_events = client
+            .query_events(EventFilter::Transaction(res.digest), None, None, None)
+            .await
+            .unwrap();
+        let returned_event_ids: Vec<_> = all_events.data.iter().map(|e| e.id).collect();
+        assert_eq!(returned_event_ids, vec![event_id]);
+
+        // ensure event is checkpointed
+        indexer_wait_for_transaction(res.digest, store, client).await;
+
+        let all_events = client
+            .query_events(EventFilter::Transaction(res.digest), None, None, None)
+            .await
+            .unwrap();
+        let returned_event_ids: Vec<_> = all_events.data.iter().map(|e| e.id).collect();
+        assert_eq!(returned_event_ids, vec![event_id]);
+
+        Ok::<(), IndexerError>(())
+    })
+}
+
+#[test]
+fn query_events_by_package() -> Result<(), IndexerError> {
+    let ApiTestSetup {
+        runtime,
+        store,
+        client,
+        cluster,
+    } = ApiTestSetup::get_or_init();
+
+    runtime.block_on(async move {
+        indexer_wait_for_checkpoint(store, 1).await;
+
+        let (sender, sender_kp): (_, AccountKeyPair) = get_key_pair();
+        let gas_ref = cluster
+            .fund_address_and_return_gas(
+                cluster.get_reference_gas_price().await,
+                Some(10_000_000_000),
+                sender,
+            )
+            .await;
+        indexer_wait_for_object(client, gas_ref.0, gas_ref.1).await;
+
+        let (_, package_id) = deploy_basics_pkg(sender, &sender_kp, client).await;
+        let basic_obj_1 = create_basic_object(sender, &sender_kp, client, &package_id)
+            .await
+            .unwrap();
+        let basic_obj_2 = create_basic_object(sender, &sender_kp, client, &package_id)
+            .await
+            .unwrap();
+
+        // Generate multiple events by calling update function multiple times
+        let mut expected_event_ids = Vec::new();
+
+        // Generate 5 events to test pagination
+        for _ in 0..5 {
+            let res = execute_move_call(
+                client,
+                sender,
+                &sender_kp,
+                package_id,
+                "object_basics".to_string(),
+                "update".to_string(),
+                type_args![].unwrap(),
+                call_args!(basic_obj_1, basic_obj_2).unwrap(),
+                None,
+            )
+            .await?;
+            assert_eq!(res.status_ok(), Some(true));
+
+            let event_id = res
+                .events
+                .as_ref()
+                .unwrap()
+                .data
+                .iter()
+                .exactly_one()
+                .unwrap()
+                .id;
+            expected_event_ids.push(event_id);
+        }
+
+        assert_paginated_filtered_events(
+            client,
+            expected_event_ids.as_slice(),
+            EventFilter::Package(package_id),
+            2,
+        )
+        .await?;
+
+        // ensure all events are checkpointed
+        indexer_wait_for_transaction(expected_event_ids.last().unwrap().tx_digest, store, client)
+            .await;
+
+        assert_paginated_filtered_events(
+            client,
+            expected_event_ids.as_slice(),
+            EventFilter::Package(package_id),
+            2,
+        )
+        .await?;
+
+        Ok::<(), IndexerError>(())
+    })
 }
 
 #[test]
@@ -1586,4 +1834,103 @@ fn test_query_transaction_blocks_tx_kind_filter() -> Result<(), anyhow::Error> {
 
         Ok(())
     })
+}
+
+async fn assert_paginated_filtered_events(
+    client: &HttpClient,
+    expected_event_ids: &[iota_types::event::EventID],
+    filter: EventFilter,
+    page_size: usize,
+) -> Result<(), IndexerError> {
+    // Test querying all events (ascending order - default)
+    let all_events = client
+        .query_events(filter.clone(), None, None, None)
+        .await
+        .unwrap();
+
+    // Verify events are returned in ascending order
+    let returned_event_ids: Vec<_> = all_events.data.iter().map(|e| e.id).collect();
+    assert_eq!(returned_event_ids, expected_event_ids);
+
+    assert_paginated_events_ascending(client, expected_event_ids, &filter, page_size).await?;
+    assert_paginated_events_descending(client, expected_event_ids, &filter, page_size).await?;
+
+    Ok(())
+}
+
+async fn assert_paginated_events_ascending(
+    client: &HttpClient,
+    expected_event_ids: &[iota_types::event::EventID],
+    filter: &EventFilter,
+    page_size: usize,
+) -> Result<(), IndexerError> {
+    let mut cursor = None;
+    let mut events_processed = 0;
+    let total_events = expected_event_ids.len();
+
+    loop {
+        let page = client
+            .query_events(filter.clone(), cursor, Some(page_size), None)
+            .await
+            .unwrap();
+
+        let events_remaining = total_events - events_processed;
+        let expected_page_size = std::cmp::min(page_size, events_remaining);
+        let is_last_page = events_processed + expected_page_size >= total_events;
+
+        let actual_event_ids: Vec<_> = page.data.iter().map(|e| e.id).collect();
+        let expected_event_ids_slice =
+            &expected_event_ids[events_processed..events_processed + expected_page_size];
+
+        assert_eq!(actual_event_ids, expected_event_ids_slice);
+        assert_eq!(page.has_next_page, !is_last_page);
+
+        if is_last_page {
+            break;
+        }
+        cursor = page.next_cursor;
+        events_processed += expected_page_size;
+    }
+
+    Ok(())
+}
+
+async fn assert_paginated_events_descending(
+    client: &HttpClient,
+    expected_event_ids: &[iota_types::event::EventID],
+    filter: &EventFilter,
+    page_size: usize,
+) -> Result<(), IndexerError> {
+    let mut cursor = None;
+    let mut events_processed = 0;
+    let total_events = expected_event_ids.len();
+
+    // In descending order, we expect events in reverse chronological order
+    let expected_desc_events: Vec<_> = expected_event_ids.iter().rev().cloned().collect();
+
+    loop {
+        let page = client
+            .query_events(filter.clone(), cursor, Some(page_size), Some(true))
+            .await
+            .unwrap();
+
+        let events_remaining = total_events - events_processed;
+        let expected_page_size = std::cmp::min(page_size, events_remaining);
+        let is_last_page = events_processed + expected_page_size >= total_events;
+
+        let actual_event_ids: Vec<_> = page.data.iter().map(|e| e.id).collect();
+        let expected_event_ids_slice =
+            &expected_desc_events[events_processed..events_processed + expected_page_size];
+
+        assert_eq!(actual_event_ids, expected_event_ids_slice);
+        assert_eq!(page.has_next_page, !is_last_page);
+
+        if is_last_page {
+            break;
+        }
+        cursor = page.next_cursor;
+        events_processed += expected_page_size;
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
# Description of change

Return optimistic events from query_events

## Links to any relevant issues

fixes #8204

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [ ] Verification of API backward compatibility.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
