### PR TITLE
fix(iota): Make `--dump-bytecode-as-base64` work with implicit deps

### DIFF
--- a/crates/iota/src/client_commands.rs
+++ b/crates/iota/src/client_commands.rs
@@ -2292,7 +2292,9 @@ pub(crate) async fn compile_package(
 
 /// Return the correct implicit dependencies for the [version], producing a
 /// warning or error if the protocol version is unknown or old
-fn implicit_deps_for_protocol_version(version: ProtocolVersion) -> anyhow::Result<Dependencies> {
+pub(crate) fn implicit_deps_for_protocol_version(
+    version: ProtocolVersion,
+) -> anyhow::Result<Dependencies> {
     if version > ProtocolVersion::MAX + 2 {
         eprintln!(
             "[{}]: The network is using protocol version {:?}, but this binary only recognizes protocol version {:?}; \

--- a/crates/iota/src/iota_commands.rs
+++ b/crates/iota/src/iota_commands.rs
@@ -63,7 +63,7 @@ use url::Url;
 use crate::name_commands;
 use crate::{
     PrintableResult,
-    client_commands::{IotaClientCommands, pkg_tree_shake},
+    client_commands::{IotaClientCommands, implicit_deps_for_protocol_version, pkg_tree_shake},
     fire_drill::{FireDrill, run_fire_drill},
     genesis_ceremony::{Ceremony, run},
     keytool::KeyToolCommand,
@@ -544,8 +544,11 @@ impl IotaCommand {
                         };
 
                         let rerooted_path = move_cli::base::reroot_path(package_path.as_deref())?;
-                        let build_config =
+                        let mut build_config =
                             resolve_lock_file_path(build_config, Some(&rerooted_path))?;
+                        let protocol_config = read_api.get_protocol_config(None).await?;
+                        build_config.implicit_dependencies =
+                            implicit_deps_for_protocol_version(protocol_config.protocol_version)?;
                         let mut pkg = IotaBuildConfig {
                             config: build_config,
                             run_bytecode_verifier: true,


### PR DESCRIPTION
## Description 

Fixes a bug where the implicit dependencies are not included when dumping move bytecode.

Upstream PR: https://github.com/MystenLabs/sui/pull/21583

Closes #6620

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: Fix a bug where implicit dependencies are not included when dumping move bytecode with the `build` command.
- [ ] Rust SDK:
- [ ] REST API: