### PR TITLE
fix(CI): Add `consensus` folder to release notes directories

### DIFF
--- a/scripts/release_notes/release_notes.py
+++ b/scripts/release_notes/release_notes.py
@@ -48,6 +48,7 @@ INTERESTING_DIRECTORIES = [
     "kiosk",
     "nre",
     "iota-execution",
+    "consensus",
 ]
 
 # Start release notes with these sections, if they contain relevant

--- a/scripts/release_notes/release_notes.py
+++ b/scripts/release_notes/release_notes.py
@@ -41,14 +41,14 @@ RE_NOTE = re.compile(
 # considered when generating release notes.
 INTERESTING_DIRECTORIES = [
     "crates",
-    "dashboards",
-    "doc",
+    "consensus",
     "docker",
+    "docs",
     "external-crates",
+    "iota-execution",
     "kiosk",
     "nre",
-    "iota-execution",
-    "consensus",
+    "sdk",
 ]
 
 # Start release notes with these sections, if they contain relevant


### PR DESCRIPTION
## Description 

Adds the `consensus` folder to the release notes script's set of filtered folders. Because it is missing, PRs like #8086 have been excluded although they contain release notes.

EDIT: I have also removed the outdated values and renamed `doc` to `docs`, as well as added `sdk` to the list.

## Test plan 

Tested locally using
```
python3 ./scripts/release_notes/release_notes.py generate 1d5ace3065184893d1f2f064087f76b889093366 d77803582a4eca06559b85696cfbfcec91e8f4a4;
```

Output:
```
## Protocol
#### IOTA Protocol Version in this release: `11`

https://github.com/iotaledger/iota/pull/8103: Properly update a validator commission rate when `set_candidate_validator_commission_rate` is called.

## Nodes (Validators and Full nodes)

https://github.com/iotaledger/iota/pull/8070: - Add a compaction filter for pruning the objects table.

https://github.com/iotaledger/iota/pull/8128: Added congestion tracker that is run by full nodes and processes shared-object transactions' effects each checkpoint.

https://github.com/iotaledger/iota/pull/8086: Improvements in the scoring function

## Indexer

https://github.com/iotaledger/iota/pull/8074: the `iota-data-ingestion-core` `CheckpointReader` applies the `ReaderOptions.timeout_secs` also for historical checkpoint reads, previously only live checkpoint reads were respecting the provided timeout value.

## JSON-RPC

https://github.com/iotaledger/iota/pull/8128: Added a new field to `DryRunTransactionBlockResponse`, namely `suggested_gas_price: Option<u64>`.

## CLI

https://github.com/iotaledger/iota/pull/8187: Accept --json without (true/false) for `iota validator display-metadata`
Change `iota validator display-metadata` output for --json to be a single object and for the human readable output to not contain long byte arrays
Add --json option to `iota validator list` command

https://github.com/iotaledger/iota/pull/8197: Fix a bug where implicit dependencies are not included when dumping move bytecode with the `build` command.
```