### PR TITLE
chore: Update move `2024.beta` to `2024`

### DIFF
--- a/crates/iota-benchmark/src/workloads/data/adversarial/Move.toml
+++ b/crates/iota-benchmark/src/workloads/data/adversarial/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "adversarial"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-benchmark/src/workloads/data/max_package/Move.toml
+++ b/crates/iota-benchmark/src/workloads/data/max_package/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "max_package"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/coin_deny_list_v1/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/coin_deny_list_v1/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "coin_deny_list_v1"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/congestion_control/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/congestion_control/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "congestion_control"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/custom_properties_in_manifest/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/custom_properties_in_manifest/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "CustomPropertiesManifest"
 published-at = "0x777"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 main = "0x0"

--- a/crates/iota-core/src/unit_tests/data/custom_properties_in_manifest_dependency_invalid_published_at/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/custom_properties_in_manifest_dependency_invalid_published_at/Move.toml
@@ -3,7 +3,7 @@ name = "CustomPropertiesInManifestDependencyInvalidPublishedAt"
 version = "0.0.0"
 # oops we put a non-ID value for published-at...
 published-at = "mystery"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 main = "0x0"

--- a/crates/iota-core/src/unit_tests/data/custom_properties_in_manifest_dependency_missing_published_at/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/custom_properties_in_manifest_dependency_missing_published_at/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "CustomPropertiesInManifestDependencyMissingPublishedAt"
 version = "0.0.0"
-edition = "2024.beta"
+edition = "2024"
 # oops we there's no published-at field, so a package that depends on us should fail when published...
 # published-at = "0x777"
 

--- a/crates/iota-core/src/unit_tests/data/custom_properties_in_manifest_ensure_published_at/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/custom_properties_in_manifest_ensure_published_at/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "CustomPropertiesInManifestEnsurePublishedAt"
 version = "0.0.0"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 CustomPropertiesInManifestDependencyMissingPublishedAt = { local = "../custom_properties_in_manifest_dependency_missing_published_at" }

--- a/crates/iota-core/src/unit_tests/data/depends_on_basics/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/depends_on_basics/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "DependsOnBasics"
 version = "0.0.0"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Examples = { local = "../object_basics" }

--- a/crates/iota-core/src/unit_tests/data/entry_point_types/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/entry_point_types/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "entry_point_types"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/entry_point_vector/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/entry_point_vector/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "entry_point_vector"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/gas_price_feedback/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/gas_price_feedback/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gas_price_feedback"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/generate_move_lock_file/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/generate_move_lock_file/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "GenerateMoveLockFile"
 version = "0.0.0"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Examples = { local = "../object_basics" }

--- a/crates/iota-core/src/unit_tests/data/managed_coin/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/managed_coin/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "FungibleTokens"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/move_package/A/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_package/A/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "A"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 a = "0xa1"

--- a/crates/iota-core/src/unit_tests/data/move_package/B/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_package/B/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "B"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 b = "0xb1"

--- a/crates/iota-core/src/unit_tests/data/move_package/Bv2/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_package/Bv2/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "B"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 b = "0xb1"

--- a/crates/iota-core/src/unit_tests/data/move_package/Cv1/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_package/Cv1/Move.toml
@@ -2,7 +2,7 @@
 name = "C"
 version = "0.0.1"
 published-at = "0xc1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 c = "0xc1"

--- a/crates/iota-core/src/unit_tests/data/move_package/Cv2/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_package/Cv2/Move.toml
@@ -2,7 +2,7 @@
 name = "C"
 version = "0.0.2"
 published-at = "0xc2"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 c = "0xc1"

--- a/crates/iota-core/src/unit_tests/data/move_random/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_random/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Examples"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/additive_upgrade/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/additive_upgrade/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "additive_upgrade"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base_addr = "0x0"

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/additive_upgrade_invalid/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/additive_upgrade_invalid/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "additive_upgrade_invalid"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base_addr = "0x0"

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/base/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "package_upgrade_base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base_addr = "0x0"

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/base_as_dep/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/base_as_dep/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "package_upgrade_base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base_addr = "_"

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/compatibility_invalid/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/compatibility_invalid/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compatibility_invalid"
 version = "0.0.2"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base_addr = "0x0"

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/dep_on_dep/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/dep_on_dep/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dep_on_dep"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 dep_on_upgrading_package = { local = "../dep_on_upgrading_package_upgradeable" }

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/dep_on_upgrading_package/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/dep_on_upgrading_package/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dep_on_upgrading_package"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 package_upgrade_base = { local = "../base_as_dep" }

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/dep_on_upgrading_package_transitive/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/dep_on_upgrading_package_transitive/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dep_on_upgrading_package_transitive"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 package_upgrade_base = { local = "../base_as_dep" }

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/dep_on_upgrading_package_upgradeable/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/dep_on_upgrading_package_upgradeable/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dep_on_upgrading_package"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 package_upgrade_base = { local = "../base_as_dep" }

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/dep_only_upgrade/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/dep_only_upgrade/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "package_upgrade_base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base_addr = "0x0"

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/makes_another_object/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/makes_another_object/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "makes_another_object"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/makes_new_object/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/makes_new_object/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "makes_new_object"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/missing_type_v1/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/missing_type_v1/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "package_upgrade_base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base_addr = "0x0"

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/missing_type_v2/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/missing_type_v2/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "package_upgrade_base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base_addr = "0x0"

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/missing_type_v2_module_removed/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/missing_type_v2_module_removed/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "package_upgrade_base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base_addr = "0x0"

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/new_object/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/new_object/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "new_object"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/object_cross_module_ref/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/object_cross_module_ref/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "object_cross_module_ref"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/object_cross_module_ref1/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/object_cross_module_ref1/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "object_cross_module_ref1"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/object_cross_module_ref2/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/object_cross_module_ref2/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "object_cross_module_ref2"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/stage1_basic_compatibility_valid/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/stage1_basic_compatibility_valid/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stage1_basic_compatibility_valid"
 version = "0.0.2"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base_addr = "0x0"

--- a/crates/iota-core/src/unit_tests/data/move_upgrade/stage2_basic_compatibility_valid/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/move_upgrade/stage2_basic_compatibility_valid/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stage2_basic_compatibility_valid"
 version = "0.0.3"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/object_basics/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/object_basics/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Examples"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/object_no_id/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/object_no_id/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "object_no_id"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/object_owner/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/object_owner/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "object_owner"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/object_wrapping/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/object_wrapping/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "object_wrapping"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/package_deny/a/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/package_deny/a/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "A"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 B = { local = "../b" }

--- a/crates/iota-core/src/unit_tests/data/package_deny/b/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/package_deny/b/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "B"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 C = { local = "../c" }

--- a/crates/iota-core/src/unit_tests/data/package_deny/c/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/package_deny/c/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "C"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/publish_with_event/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/publish_with_event/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Examples"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/shared_object_deletion/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/shared_object_deletion/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shared_object_deletion"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/transitive_dependencies/a/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/transitive_dependencies/a/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "A"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 B = { local = "../b" }

--- a/crates/iota-core/src/unit_tests/data/transitive_dependencies/b/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/transitive_dependencies/b/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "B"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 C = { local = "../c" }

--- a/crates/iota-core/src/unit_tests/data/transitive_dependencies/c/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/transitive_dependencies/c/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "C"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/transitive_dependencies/root/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/transitive_dependencies/root/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Examples"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/tto/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/tto/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tto"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/type_params/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/type_params/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "type_params"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/data/type_params_extra/Move.toml
+++ b/crates/iota-core/src/unit_tests/data/type_params_extra/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "type_params_extra"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-core/src/unit_tests/move_package_publish_tests.rs
+++ b/crates/iota-core/src/unit_tests/move_package_publish_tests.rs
@@ -215,7 +215,7 @@ async fn test_generate_lock_file() {
 
         [move]
         version = 3
-        manifest_digest = "78ED00C216B5A73463BD935B7AD1AB6CAF8ECA9ACD7FFCC19F3462EBD1D83EC3"
+        manifest_digest = "37689E9F9E5809521FA06520D55141982F5B8F26F5C55DE4E88FA63D73E1FEFF"
         deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
         dependencies = [
           { id = "Examples", name = "Examples" },

--- a/crates/iota-core/src/unit_tests/move_package_publish_tests.rs
+++ b/crates/iota-core/src/unit_tests/move_package_publish_tests.rs
@@ -244,7 +244,7 @@ async fn test_generate_lock_file() {
 
         [move.toolchain-version]
         compiler-version = "0.0.1"
-        edition = "2024.beta"
+        edition = "2024"
         flavor = "iota"
     "##]];
     expected.assert_eq(lock_file_contents.as_str());

--- a/crates/iota-cost/tests/data/dummy_modules_publish/Move.toml
+++ b/crates/iota-cost/tests/data/dummy_modules_publish/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Examples"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/add_key_ability/Move.toml
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/add_key_ability/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "IotaExtraAddKeyAbility"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 IotaSystem = { local = "../../../../iota-framework/packages/iota-system" }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/add_struct_ability/Move.toml
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/add_struct_ability/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "IotaExtraAddStructAbility"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 IotaSystem = { local = "../../../../iota-framework/packages/iota-system" }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/base/Move.toml
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "IotaExtraBase"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 IotaSystem = { local = "../../../../iota-framework/packages/iota-system" }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/change_entry_function_signature/Move.toml
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/change_entry_function_signature/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "IotaExtraChangeEntryFunctionSignature"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 IotaSystem = { local = "../../../../iota-framework/packages/iota-system" }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/change_public_function_signature/Move.toml
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/change_public_function_signature/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "IotaExtraChangePublicFunctionSignature"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 IotaSystem = { local = "../../../../iota-framework/packages/iota-system" }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/change_struct_ability/Move.toml
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/change_struct_ability/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "IotaExtraChangeStructAbility"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 IotaSystem = { local = "../../../../iota-framework/packages/iota-system" }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/change_struct_layout/Move.toml
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/change_struct_layout/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "IotaExtraChangeStructLayout"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 IotaSystem = { local = "../../../../iota-framework/packages/iota-system" }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/change_type_constraint/Move.toml
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/change_type_constraint/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "IotaExtraChangeTypeConstraint"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 IotaSystem = { local = "../../../../iota-framework/packages/iota-system" }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/compatible/Move.toml
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/compatible/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "IotaExtraCompatible"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 IotaSystem = { local = "../../../../iota-framework/packages/iota-system" }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/extra_package/Move.toml
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/extra_package/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "IotaExtra"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 IotaSystem = { local = "../../../../iota-framework/packages/iota-system" }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/mock_iota_systems/base/Move.toml
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/mock_iota_systems/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "MockIotaSystemBase"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/mock_iota_systems/deep_upgrade/Move.toml
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/mock_iota_systems/deep_upgrade/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "IotaSystemDeepUpgrade"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/mock_iota_systems/safe_mode/Move.toml
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/mock_iota_systems/safe_mode/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "MockIotaSystemSafeMode"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-e2e-tests/tests/framework_upgrades/mock_iota_systems/shallow_upgrade/Move.toml
+++ b/crates/iota-e2e-tests/tests/framework_upgrades/mock_iota_systems/shallow_upgrade/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "IotaSystemShallowUpgrade"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-e2e-tests/tests/move_test_code/Move.toml
+++ b/crates/iota-e2e-tests/tests/move_test_code/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "move_test_code"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-framework/packages/iota-framework/Move.toml
+++ b/crates/iota-framework/packages/iota-framework/Move.toml
@@ -2,7 +2,7 @@
 name = "Iota"
 version = "0.0.1"
 published-at = "0x2"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../move-stdlib" }

--- a/crates/iota-framework/packages/iota-system/Move.toml
+++ b/crates/iota-framework/packages/iota-system/Move.toml
@@ -2,7 +2,7 @@
 name = "IotaSystem"
 version = "0.0.1"
 published-at = "0x3"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../move-stdlib" }

--- a/crates/iota-framework/packages/move-stdlib/Move.toml
+++ b/crates/iota-framework/packages/move-stdlib/Move.toml
@@ -2,7 +2,7 @@
 name = "MoveStdlib"
 version = "1.6.0"
 published-at = "0x1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 std = "0x1"

--- a/crates/iota-framework/packages/stardust/Move.toml
+++ b/crates/iota-framework/packages/stardust/Move.toml
@@ -2,7 +2,7 @@
 name = "Stardust"
 version = "0.0.1"
 published-at = "0x107a"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../move-stdlib" }

--- a/crates/iota-genesis-builder/src/stardust/native_token/package_builder.rs
+++ b/crates/iota-genesis-builder/src/stardust/native_token/package_builder.rs
@@ -68,7 +68,7 @@ module 0x0::$MODULE_NAME {
 const TOML_CONTENT: &str = r#"[package]
 name = "$PACKAGE_NAME"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "$GENESIS_REVISION" }

--- a/crates/iota-json-rpc-tests/tests/data/dummy_modules_publish/Move.toml
+++ b/crates/iota-json-rpc-tests/tests/data/dummy_modules_publish/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Examples"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-package-resolver/tests/packages/e0/Move.toml
+++ b/crates/iota-package-resolver/tests/packages/e0/Move.toml
@@ -2,7 +2,7 @@
 name = "E"
 version = "0.0.1"
 published-at = "0xe0"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../iota" }

--- a/crates/iota-package-resolver/tests/packages/std/Move.toml
+++ b/crates/iota-package-resolver/tests/packages/std/Move.toml
@@ -2,7 +2,7 @@
 name = "StdLib"
 version = "0.0.1"
 published-at = "0x1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 std = "0x1"

--- a/crates/iota-single-node-benchmark/move_package/Move.toml
+++ b/crates/iota-single-node-benchmark/move_package/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "MoveBenchmark"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../iota-framework/packages/iota-framework" }

--- a/crates/iota-single-node-benchmark/tests/data/package_publish_from_bytecode/package_a/Move.toml
+++ b/crates/iota-single-node-benchmark/tests/data/package_publish_from_bytecode/package_a/Move.toml
@@ -1,4 +1,4 @@
 [package]
 name = "A"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"

--- a/crates/iota-single-node-benchmark/tests/data/package_publish_from_bytecode/package_b/Move.toml
+++ b/crates/iota-single-node-benchmark/tests/data/package_publish_from_bytecode/package_b/Move.toml
@@ -1,4 +1,4 @@
 [package]
 name = "B"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"

--- a/crates/iota-single-node-benchmark/tests/data/package_publish_from_bytecode/package_c/Move.toml
+++ b/crates/iota-single-node-benchmark/tests/data/package_publish_from_bytecode/package_c/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "C"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 A = { local = "../package_a" }

--- a/crates/iota-single-node-benchmark/tests/data/package_publish_from_source/package_a/Move.toml
+++ b/crates/iota-single-node-benchmark/tests/data/package_publish_from_source/package_a/Move.toml
@@ -1,4 +1,4 @@
 [package]
 name = "A"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"

--- a/crates/iota-single-node-benchmark/tests/data/package_publish_from_source/package_b/Move.toml
+++ b/crates/iota-single-node-benchmark/tests/data/package_publish_from_source/package_b/Move.toml
@@ -1,4 +1,4 @@
 [package]
 name = "B"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"

--- a/crates/iota-single-node-benchmark/tests/data/package_publish_from_source/package_c/Move.toml
+++ b/crates/iota-single-node-benchmark/tests/data/package_publish_from_source/package_c/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "C"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 A = { local = "../package_a" }

--- a/crates/iota-source-validation-service/tests/fixture/custom/Move.toml
+++ b/crates/iota-source-validation-service/tests/fixture/custom/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "custom"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 custom = "0x0"

--- a/crates/iota-source-validation-service/tests/fixture/iota__main/move-stdlib/Move.toml
+++ b/crates/iota-source-validation-service/tests/fixture/iota__main/move-stdlib/Move.toml
@@ -2,7 +2,7 @@
 name = "MoveStdlib"
 version = "1.5.0"
 published-at = "0x1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 std = "0x1"

--- a/crates/iota-surfer/tests/move_building_blocks/Move.toml
+++ b/crates/iota-surfer/tests/move_building_blocks/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "MoveBuildingBlocks"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-surfer/tests/random/Move.toml
+++ b/crates/iota-surfer/tests/random/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Random"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../iota-framework/packages/iota-framework" }

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/constant_name_change/base/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/constant_name_change/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/constant_name_change/upgraded/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/constant_name_change/upgraded/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/constant_value_changed/base/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/constant_value_changed/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/constant_value_changed/upgraded/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/constant_value_changed/upgraded/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/friend_entry_changed/base/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/friend_entry_changed/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/friend_entry_changed/upgraded/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/friend_entry_changed/upgraded/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/friend_function_change/base/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/friend_function_change/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/friend_function_change/upgraded/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/friend_function_change/upgraded/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check/base/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../iota-framework/packages/move-stdlib" }

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check/upgraded/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check/upgraded/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../iota-framework/packages/move-stdlib" }

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_alpha_rename/base/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_alpha_rename/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../iota-framework/packages/move-stdlib" }

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_alpha_rename/upgraded/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_alpha_rename/upgraded/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../iota-framework/packages/move-stdlib" }

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_local_shuffle/base/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_local_shuffle/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../iota-framework/packages/move-stdlib" }

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_local_shuffle/upgraded/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_equality_check_local_shuffle/upgraded/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../iota-framework/packages/move-stdlib" }

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_inclusion_check/base/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_inclusion_check/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../iota-framework/packages/move-stdlib" }

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_inclusion_check/upgraded/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_inclusion_check/upgraded/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../iota-framework/packages/move-stdlib" }

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_invalid_equality_inclusion_check/base/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_invalid_equality_inclusion_check/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../iota-framework/packages/move-stdlib" }

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_invalid_equality_inclusion_check/upgraded/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/large_package_invalid_equality_inclusion_check/upgraded/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../iota-framework/packages/move-stdlib" }

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/private_entry_and_friend_changes/base/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/private_entry_and_friend_changes/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/private_entry_and_friend_changes/upgraded/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/private_entry_and_friend_changes/upgraded/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/private_entry_fun_entry_removed/base/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/private_entry_fun_entry_removed/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/private_entry_fun_entry_removed/upgraded/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/private_entry_fun_entry_removed/upgraded/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/public_fun_param_alpha_rename/base/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/public_fun_param_alpha_rename/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/public_fun_param_alpha_rename/upgraded/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/public_fun_param_alpha_rename/upgraded/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/public_fun_param_permute/base/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/public_fun_param_permute/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/public_fun_param_permute/upgraded/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/public_fun_param_permute/upgraded/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/public_fun_rename/base/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/public_fun_rename/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/public_fun_rename/upgraded/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/public_fun_rename/upgraded/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/struct_field_name_change/base/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/struct_field_name_change/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/struct_field_name_change/upgraded/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/struct_field_name_change/upgraded/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/struct_field_reorder/base/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/struct_field_reorder/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/struct_field_reorder/upgraded/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/struct_field_reorder/upgraded/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/struct_field_reorder_no_name_change/base/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/struct_field_reorder_no_name_change/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/struct_field_reorder_no_name_change/upgraded/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/struct_field_reorder_no_name_change/upgraded/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/struct_layout_change/base/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/struct_layout_change/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/struct_layout_change/upgraded/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/struct_layout_change/upgraded/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/struct_name_change/base/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/struct_name_change/base/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota-upgrade-compatibility-transactional-tests/tests/struct_name_change/upgraded/Move.toml
+++ b/crates/iota-upgrade-compatibility-transactional-tests/tests/struct_name_change/upgraded/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 base = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/additive_errors_v1/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/additive_errors_v1/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/additive_errors_v2/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/additive_errors_v2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/address_change_v1/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/address_change_v1/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 # represents the "deployed" package with non-zero address

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/address_change_v2/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/address_change_v2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/all_v1/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/all_v1/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/all_v2/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/all_v2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/declaration_errors_v1/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/declaration_errors_v1/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/declaration_errors_v2/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/declaration_errors_v2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/deponly_errors_v1/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/deponly_errors_v1/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/deponly_errors_v2/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/deponly_errors_v2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/entry_linking_v1/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/entry_linking_v1/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/entry_linking_v2/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/entry_linking_v2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/enum_errors_v1/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/enum_errors_v1/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/enum_errors_v2/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/enum_errors_v2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/friend_linking_v1/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/friend_linking_v1/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/friend_linking_v2/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/friend_linking_v2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/function_errors_v1/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/function_errors_v1/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/function_errors_v2/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/function_errors_v2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/missing_module_toml/addresses_first/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/missing_module_toml/addresses_first/Move.toml
@@ -3,4 +3,4 @@ upgrades = "0x0"
 
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/missing_module_toml/starts_second_line/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/missing_module_toml/starts_second_line/Move.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/policies_v1/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/policies_v1/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/policies_v2/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/policies_v2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/struct_errors_v1/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/struct_errors_v1/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/struct_errors_v2/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/struct_errors_v2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/type_param_errors_v1/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/type_param_errors_v1/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/fixtures/upgrade_errors/type_param_errors_v2/Move.toml
+++ b/crates/iota/src/unit_tests/fixtures/upgrade_errors/type_param_errors_v2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgrades"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 upgrades = "0x0"

--- a/crates/iota/src/unit_tests/snapshots/iota__upgrade_compatibility__upgrade_compatibility_tests__addresses_first.snap
+++ b/crates/iota/src/unit_tests/snapshots/iota__upgrade_compatibility__upgrade_compatibility_tests__addresses_first.snap
@@ -8,7 +8,7 @@ error[Compatibility E01006]: module missing
 4 │ ╭ [package]
 5 │ │ name = "upgrades"
 6 │ │ edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
-  │ ╰────────────────────────────────────────────────────────────────────────^ Package is missing module 'identifier'
+  │ ╰───────────────────────────────────────────────────────────────────^ Package is missing module 'identifier'
   │  
   = Modules which are part package cannot be removed during an upgrade.
   = Add missing module 'identifier' back to the package.

--- a/crates/iota/src/unit_tests/snapshots/iota__upgrade_compatibility__upgrade_compatibility_tests__addresses_first.snap
+++ b/crates/iota/src/unit_tests/snapshots/iota__upgrade_compatibility__upgrade_compatibility_tests__addresses_first.snap
@@ -7,7 +7,7 @@ error[Compatibility E01006]: module missing
   │  
 4 │ ╭ [package]
 5 │ │ name = "upgrades"
-6 │ │ edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+6 │ │ edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
   │ ╰────────────────────────────────────────────────────────────────────────^ Package is missing module 'identifier'
   │  
   = Modules which are part package cannot be removed during an upgrade.

--- a/crates/iota/src/unit_tests/snapshots/iota__upgrade_compatibility__upgrade_compatibility_tests__declarations_missing.snap
+++ b/crates/iota/src/unit_tests/snapshots/iota__upgrade_compatibility__upgrade_compatibility_tests__declarations_missing.snap
@@ -34,7 +34,7 @@ error[Compatibility E01006]: module missing
   │  
 1 │ ╭ [package]
 2 │ │ name = "upgrades"
-3 │ │ edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+3 │ │ edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
   │ ╰────────────────────────────────────────────────────────────────────────^ Package is missing module 'missing_module'
   │  
   = Modules which are part package cannot be removed during an upgrade.

--- a/crates/iota/src/unit_tests/snapshots/iota__upgrade_compatibility__upgrade_compatibility_tests__declarations_missing.snap
+++ b/crates/iota/src/unit_tests/snapshots/iota__upgrade_compatibility__upgrade_compatibility_tests__declarations_missing.snap
@@ -20,6 +20,17 @@ error[Compatibility E01001]: missing public declaration
   = Functions are part of a module's public interface and cannot be removed or changed during an upgrade.
   = Restore the original function's 'public' visibility for function 'fun_to_lose_public'.
 
+error[Compatibility E01006]: module missing
+  ┌─ /fixtures/upgrade_errors/declaration_errors_v2/Move.toml:1:1
+  │  
+1 │ ╭ [package]
+2 │ │ name = "upgrades"
+3 │ │ edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
+  │ ╰───────────────────────────────────────────────────────────────────^ Package is missing module 'missing_module'
+  │  
+  = Modules which are part package cannot be removed during an upgrade.
+  = Add missing module 'missing_module' back to the package.
+
 error[Compatibility E01001]: missing public declaration
   ┌─ /fixtures/upgrade_errors/declaration_errors_v2/sources/enum.move:5:18
   │
@@ -28,17 +39,6 @@ error[Compatibility E01001]: missing public declaration
   │
   = Enums are part of a module's public interface and cannot be removed or changed during a 'compatible' upgrade.
   = Add missing enum 'EnumToBeRemoved' back to the module 'enum_'.
-
-error[Compatibility E01006]: module missing
-  ┌─ /fixtures/upgrade_errors/declaration_errors_v2/Move.toml:1:1
-  │  
-1 │ ╭ [package]
-2 │ │ name = "upgrades"
-3 │ │ edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
-  │ ╰────────────────────────────────────────────────────────────────────────^ Package is missing module 'missing_module'
-  │  
-  = Modules which are part package cannot be removed during an upgrade.
-  = Add missing module 'missing_module' back to the package.
 
 error[Compatibility E01001]: missing public declaration
   ┌─ /fixtures/upgrade_errors/declaration_errors_v2/sources/struct.move:5:18

--- a/crates/iota/src/unit_tests/snapshots/iota__upgrade_compatibility__upgrade_compatibility_tests__starts_second_line.snap
+++ b/crates/iota/src/unit_tests/snapshots/iota__upgrade_compatibility__upgrade_compatibility_tests__starts_second_line.snap
@@ -8,7 +8,7 @@ error[Compatibility E01006]: module missing
 2 │ ╭ [package]
 3 │ │ name = "upgrades"
 4 │ │ edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
-  │ ╰────────────────────────────────────────────────────────────────────────^ Package is missing module 'identifier'
+  │ ╰───────────────────────────────────────────────────────────────────^ Package is missing module 'identifier'
   │  
   = Modules which are part package cannot be removed during an upgrade.
   = Add missing module 'identifier' back to the package.

--- a/crates/iota/src/unit_tests/snapshots/iota__upgrade_compatibility__upgrade_compatibility_tests__starts_second_line.snap
+++ b/crates/iota/src/unit_tests/snapshots/iota__upgrade_compatibility__upgrade_compatibility_tests__starts_second_line.snap
@@ -7,7 +7,7 @@ error[Compatibility E01006]: module missing
   │  
 2 │ ╭ [package]
 3 │ │ name = "upgrades"
-4 │ │ edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+4 │ │ edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
   │ ╰────────────────────────────────────────────────────────────────────────^ Package is missing module 'identifier'
   │  
   = Modules which are part package cannot be removed during an upgrade.

--- a/crates/iota/tests/data/clever_errors/Move.toml
+++ b/crates/iota/tests/data/clever_errors/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clever_errors"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 clever_errors = "0x0"

--- a/crates/iota/tests/data/depends_on_simple/Move.toml
+++ b/crates/iota/tests/data/depends_on_simple/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "depends_on_simple"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 simple = { local = "../simple" }

--- a/crates/iota/tests/data/dummy_modules_publish/Move.toml
+++ b/crates/iota/tests/data/dummy_modules_publish/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Examples"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota/tests/data/dummy_modules_upgrade/Move.toml
+++ b/crates/iota/tests/data/dummy_modules_upgrade/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Examples"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 examples = "0x0"

--- a/crates/iota/tests/data/linter/Move.toml
+++ b/crates/iota/tests/data/linter/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "linter"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota/tests/data/module_dependency_invalid/Move.toml
+++ b/crates/iota/tests/data/module_dependency_invalid/Move.toml
@@ -2,7 +2,7 @@
 name = "Invalid"
 version = "0.0.1"
 published-at = "mystery"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../iota-framework/packages/move-stdlib" }

--- a/crates/iota/tests/data/module_dependency_nonexistent/Move.toml
+++ b/crates/iota/tests/data/module_dependency_nonexistent/Move.toml
@@ -2,7 +2,7 @@
 name = "Nonexistent"
 version = "0.0.1"
 published-at = "0xabc123"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../iota-framework/packages/move-stdlib" }

--- a/crates/iota/tests/data/module_dependency_unpublished/Move.toml
+++ b/crates/iota/tests/data/module_dependency_unpublished/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Unpublished"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 # No published-at address for this package.
 # published-at = "0x0"
 

--- a/crates/iota/tests/data/module_dependency_unpublished_non_zero_address/Move.toml
+++ b/crates/iota/tests/data/module_dependency_unpublished_non_zero_address/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "UnpublishedNonZeroAddress"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 # No published-at address for this package.
 # published-at = "0x0"
 

--- a/crates/iota/tests/data/move_call_args_linter/Move.toml
+++ b/crates/iota/tests/data/move_call_args_linter/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Examples"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota/tests/data/ptb_complex_args_test_functions/Move.toml
+++ b/crates/iota/tests/data/ptb_complex_args_test_functions/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_functions"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota/tests/data/simple/Move.toml
+++ b/crates/iota/tests/data/simple/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 

--- a/crates/iota/tests/data/sod/Move.toml
+++ b/crates/iota/tests/data/sod/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sod"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota/tests/data/tree_shaking/A/Move.toml
+++ b/crates/iota/tests/data/tree_shaking/A/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 a = "0x0"

--- a/crates/iota/tests/data/tree_shaking/A_v1/Move.toml
+++ b/crates/iota/tests/data/tree_shaking/A_v1/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 a = "0x0"

--- a/crates/iota/tests/data/tree_shaking/A_v2/Move.toml
+++ b/crates/iota/tests/data/tree_shaking/A_v2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 a = "0x0"

--- a/crates/iota/tests/data/tree_shaking/B_depends_on_A/Move.toml
+++ b/crates/iota/tests/data/tree_shaking/B_depends_on_A/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "B"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 A = { local = "../A" }

--- a/crates/iota/tests/data/tree_shaking/B_depends_on_A_but_no_code_references_A/Move.toml
+++ b/crates/iota/tests/data/tree_shaking/B_depends_on_A_but_no_code_references_A/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "B"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 A = { local = "../A" }

--- a/crates/iota/tests/data/tree_shaking/C_depends_on_B_but_no_code_references_B/Move.toml
+++ b/crates/iota/tests/data/tree_shaking/C_depends_on_B_but_no_code_references_B/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "C"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 B = { local = "../B_depends_on_A_but_no_code_references_A" }

--- a/crates/iota/tests/data/tree_shaking/C_depends_on_B_which_depends_on_A/Move.toml
+++ b/crates/iota/tests/data/tree_shaking/C_depends_on_B_which_depends_on_A/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "C"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 B = { local = "../B_depends_on_A" }

--- a/crates/iota/tests/data/tree_shaking/D_depends_on_A_v1/Move.toml
+++ b/crates/iota/tests/data/tree_shaking/D_depends_on_A_v1/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "D_depends_on_A_v1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 A = { local = "../A_v1" }

--- a/crates/iota/tests/data/tree_shaking/D_depends_on_A_v1_but_no_code_references_A/Move.toml
+++ b/crates/iota/tests/data/tree_shaking/D_depends_on_A_v1_but_no_code_references_A/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "D_depends_on_A_v1_but_no_code_references_A"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 A = { local = "../A_v1" }

--- a/crates/iota/tests/data/tree_shaking/E_depends_on_A_v1_and_on_B_depends_on_A_and_code_references_A/Move.toml
+++ b/crates/iota/tests/data/tree_shaking/E_depends_on_A_v1_and_on_B_depends_on_A_and_code_references_A/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "E_depends_on_A_v1_and_on_B_depends_on_A_and_code_references_A"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 A = { local = "../A_v1", override = true }

--- a/crates/iota/tests/data/tree_shaking/E_depends_on_A_v1_and_on_B_depends_on_A_but_no_code_references_to_A_or_B/Move.toml
+++ b/crates/iota/tests/data/tree_shaking/E_depends_on_A_v1_and_on_B_depends_on_A_but_no_code_references_to_A_or_B/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "E_depends_on_A_v1_and_on_B_depends_on_A_but_no_code_references_to_A_or_B"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 A = { local = "../A_v1", override = true }

--- a/crates/iota/tests/data/tree_shaking/F_depends_on_A_as_bytecode_dep/Move.toml
+++ b/crates/iota/tests/data/tree_shaking/F_depends_on_A_as_bytecode_dep/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "F_depends_on_A_as_bytecode_dep"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 A = { local = "../A" }

--- a/crates/iota/tests/data/tree_shaking/G_unpublished/Move.toml
+++ b/crates/iota/tests/data/tree_shaking/G_unpublished/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "G_unpublished"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 

--- a/crates/iota/tests/data/tree_shaking/H_depends_on_G_unpublished/Move.toml
+++ b/crates/iota/tests/data/tree_shaking/H_depends_on_G_unpublished/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "H_depends_on_G_unpublished"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 G_unpublished = { local = "../G_unpublished" }

--- a/crates/iota/tests/data/tree_shaking/I_depends_on_D_depends_on_A_v1_but_no_code_references_A_and_on_A_v2/Move.toml
+++ b/crates/iota/tests/data/tree_shaking/I_depends_on_D_depends_on_A_v1_but_no_code_references_A_and_on_A_v2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "I_depends_on_D_depends_on_A_v1_but_no_code_references_A_and_on_A_v2"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 A = { local = "../A_v2", override = true }

--- a/crates/iota/tests/data/tree_shaking/J_system_deps/Move.toml
+++ b/crates/iota/tests/data/tree_shaking/J_system_deps/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "J_system_deps"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 # this is relative to the temp directory where this whole tree shaking dir is copied to

--- a/crates/iota/tests/data/tree_shaking/K/Move.toml
+++ b/crates/iota/tests/data/tree_shaking/K/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "K"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 k = "0x0"

--- a/crates/iota/tests/data/tree_shaking/K_v2/Move.toml
+++ b/crates/iota/tests/data/tree_shaking/K_v2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "K"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 k = "0x0"

--- a/crates/iota/tests/data/tree_shaking/L_depends_on_K/Move.toml
+++ b/crates/iota/tests/data/tree_shaking/L_depends_on_K/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "L_depends_on_K"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 K = { local = "../K" }

--- a/crates/iota/tests/data/tree_shaking/M_depends_on_L_and_K_v2_no_code_references_K_v2/Move.toml
+++ b/crates/iota/tests/data/tree_shaking/M_depends_on_L_and_K_v2_no_code_references_K_v2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "M_depends_on_L_and_K_v2_no_code_references_K_v2"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 K = { local = "../K_v2", override = true }

--- a/crates/iota/tests/data/tto/Move.toml
+++ b/crates/iota/tests/data/tto/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tto"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../iota-framework/packages/iota-framework" }

--- a/crates/iota/tests/ptb_files/publish/test_pkg/Move.toml
+++ b/crates/iota/tests/ptb_files/publish/test_pkg/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_pkg"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 

--- a/crates/iota/tests/shell_tests/implicits/example/Move.toml
+++ b/crates/iota/tests/shell_tests/implicits/example/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 example = "0x0"

--- a/crates/iota/tests/shell_tests/with_network/implicits/example/Move.toml
+++ b/crates/iota/tests/shell_tests/with_network/implicits/example/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [addresses]
 example = "0x0"

--- a/crates/iota/tests/shell_tests/with_network/move_build_bytecode_with_address_resolution/depends_on_simple/Move.toml
+++ b/crates/iota/tests/shell_tests/with_network/move_build_bytecode_with_address_resolution/depends_on_simple/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "depends_on_simple"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 simple = { local = "../simple" }

--- a/crates/iota/tests/shell_tests/with_network/move_build_bytecode_with_address_resolution/simple/Move.toml
+++ b/crates/iota/tests/shell_tests/with_network/move_build_bytecode_with_address_resolution/simple/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 

--- a/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/dependency/Move.toml
+++ b/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/dependency/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dependency"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "FRAMEWORK_DIR", override = true }

--- a/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/example/Move.toml
+++ b/crates/iota/tests/shell_tests/with_network/source_verification_deprecation/example/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [dependencies]
 Iota = { local = "FRAMEWORK_DIR" }

--- a/crates/iota/tests/snapshots/shell_tests__iota_move_new_tests__manifest_template.sh.snap
+++ b/crates/iota/tests/snapshots/shell_tests__iota_move_new_tests__manifest_template.sh.snap
@@ -15,7 +15,7 @@ exit_code: 0
 ----- stdout -----
 [package]
 name = "example"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 # license = ""           # e.g., "MIT", "GPL", "Apache 2.0"
 # authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 

--- a/crates/transaction-fuzzer/data/coin_factory/Move.toml
+++ b/crates/transaction-fuzzer/data/coin_factory/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "coin_factory"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies.Iota]
 local = "../../../iota-framework/packages/iota-framework"

--- a/crates/transaction-fuzzer/data/type_factory/Move.toml
+++ b/crates/transaction-fuzzer/data/type_factory/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "type_factory"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 typer = "0x0"

--- a/dapps/regulated-token/Move.toml
+++ b/dapps/regulated-token/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "regulated-token"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../crates/iota-framework/packages/iota-framework" }

--- a/docs/content/developer/advanced/introducing-move-2024.mdx
+++ b/docs/content/developer/advanced/introducing-move-2024.mdx
@@ -6,9 +6,9 @@ teams:
   - iotaledger/vm-language
 ---
 
-IOTA launches with the "Move 2024.beta" edition, bringing enhanced features to improve both the writing and readability of Move code. These updates refine the source language without impacting the on-chain binary representation, allowing users to enjoy a smoother experience with the latest language improvements.
+IOTA launches with the "Move 2024" edition, bringing enhanced features to improve both the writing and readability of Move code. These updates refine the source language without impacting the on-chain binary representation, allowing users to enjoy a smoother experience with the latest language improvements.
 
-The primary goal of the "Move 2024.beta" edition is to make Move easier to write and, ideally, easier to read. The minimal breaking changes introduced in the source language are designed to better prepare Move for future advancements.
+The primary goal of the "Move 2024" edition is to make Move easier to write and, ideally, easier to read. The minimal breaking changes introduced in the source language are designed to better prepare Move for future advancements.
 
 This document highlights some new features to try out and shows how to use them in your existing modules.
 
@@ -462,7 +462,7 @@ use iota_system::iota_system;
 The beta release of Move 2024 comes with some powerful new features in addition to the breaking changes described here. There are also more on the horizon, such as syntactic macros, enums with pattern matching, and other user-defined syntax extensions.
 
 #### `beta` Edition
-- `beta` (specified via `edition = "2024.beta"`) is the recommended edition. It includes all the new
+- `beta` (specified via `edition = "2024"`) is the recommended edition. It includes all the new
   features mentioned above and all breaking changes. While there is the risk of breaking changes or
   bugs in `beta`, you should feel comfortable using it in your projects. As new features are added
   and tested, they will be included in the `beta` edition. The `beta` edition will end after _all_

--- a/docs/content/developer/iota-101/move-overview/package-upgrades/upgrade.mdx
+++ b/docs/content/developer/iota-101/move-overview/package-upgrades/upgrade.mdx
@@ -376,7 +376,7 @@ Initially, your manifest might look like this:
 [package]
 name = "iota_package"
 version = "0.0.0"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 iota_package = "0x0"
@@ -506,7 +506,7 @@ Your updated manifest should look like this:
 [package]
 name = "iota_package"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 iota_package = "0x0"
@@ -624,7 +624,7 @@ Your updated manifest should look like this:
 [package]
 name = "iota_package"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 iota_package = "<ORIGINAL-PACKAGE-ID>"

--- a/docs/content/developer/iota-101/objects/versioning.mdx
+++ b/docs/content/developer/iota-101/objects/versioning.mdx
@@ -236,7 +236,7 @@ Versioning also exists in package manifest files, both in the package section an
 [package]
 name = "some_pkg"
 version = "1.0.0"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 another_pkg = { git = "https://github.com/another_pkg/another_pkg.git" , version = "2.0.0"}

--- a/docs/content/developer/references/cli/move.mdx
+++ b/docs/content/developer/references/cli/move.mdx
@@ -70,7 +70,7 @@ tests
 $ cat smart_contract_test/Move.toml
 [package]
 name = "smart_contract_test"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [dependencies]
 Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "framework/testnet" }

--- a/docs/examples/move/clt-tutorial/Move.toml
+++ b/docs/examples/move/clt-tutorial/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clt_tutorial"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "v0.2.0" }

--- a/docs/examples/move/coffee_shop/Move.toml
+++ b/docs/examples/move/coffee_shop/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coffee_shop"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [dependencies]
 Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "framework/testnet" }

--- a/docs/examples/move/cryptography/Move.toml
+++ b/docs/examples/move/cryptography/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cryptography"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../crates/iota-framework/packages/iota-framework" }

--- a/docs/examples/move/ctf/challenge_0/Move.toml
+++ b/docs/examples/move/ctf/challenge_0/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leapFrog"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 # license = ""           # e.g., "MIT", "GPL", "Apache 2.0"
 # authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 

--- a/docs/examples/move/ctf/challenge_1/Move.toml
+++ b/docs/examples/move/ctf/challenge_1/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "checkin"
 # version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "v0.2.0" }

--- a/docs/examples/move/ctf/challenge_2/Move.toml
+++ b/docs/examples/move/ctf/challenge_2/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "luckynumber"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "v0.2.0" }

--- a/docs/examples/move/ctf/challenge_3/Move.toml
+++ b/docs/examples/move/ctf/challenge_3/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "airdrop"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "v0.2.0" }

--- a/docs/examples/move/ctf/challenge_4/Move.toml
+++ b/docs/examples/move/ctf/challenge_4/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "airdrop"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "v0.2.0" }

--- a/docs/examples/move/ctf/challenge_5/Move.toml
+++ b/docs/examples/move/ctf/challenge_5/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pizza"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "v0.2.0" }

--- a/docs/examples/move/ctf/challenge_6/Move.toml
+++ b/docs/examples/move/ctf/challenge_6/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "recycle"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "v0.2.0" }

--- a/docs/examples/move/ctf/challenge_7/Move.toml
+++ b/docs/examples/move/ctf/challenge_7/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ptb"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "v0.2.0" }

--- a/docs/examples/move/ctf/challenge_8/Move.toml
+++ b/docs/examples/move/ctf/challenge_8/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "swap"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "v0.2.0" }

--- a/docs/examples/move/ctf/verifier/Move.toml
+++ b/docs/examples/move/ctf/verifier/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "verifier"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "v0.2.0" }

--- a/docs/examples/move/custom_nft/Move.toml
+++ b/docs/examples/move/custom_nft/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "custom_nft"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../crates/iota-framework/packages/iota-framework" }

--- a/docs/examples/move/evm-to-move/Move.toml
+++ b/docs/examples/move/evm-to-move/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evm-to-move"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../crates/iota-framework/packages/iota-framework" }

--- a/docs/examples/move/nft_marketplace/Move.toml
+++ b/docs/examples/move/nft_marketplace/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nft_marketplace"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/asset_tokenization/asset_tokenization/Move.toml
+++ b/examples/move/asset_tokenization/asset_tokenization/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "asset_tokenization"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/asset_tokenization/template/Move.toml
+++ b/examples/move/asset_tokenization/template/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "template"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/basics/Move.toml
+++ b/examples/move/basics/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Basics"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/coin/Move.toml
+++ b/examples/move/coin/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Coins"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/color_object/Move.toml
+++ b/examples/move/color_object/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "color_object"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/crypto/bls_signature/Move.toml
+++ b/examples/move/crypto/bls_signature/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bls_signature"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/crypto/ecdsa_k1/Move.toml
+++ b/examples/move/crypto/ecdsa_k1/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ecdsa_k1"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/crypto/elgamal/Move.toml
+++ b/examples/move/crypto/elgamal/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "elgamal"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/crypto/groth16/Move.toml
+++ b/examples/move/crypto/groth16/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "groth16"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/crypto/ibe/Move.toml
+++ b/examples/move/crypto/ibe/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ibe"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/dynamic_fields/Move.toml
+++ b/examples/move/dynamic_fields/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dynamic_fields"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/entry_functions/Move.toml
+++ b/examples/move/entry_functions/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "entry_functions"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/errors/Move.toml
+++ b/examples/move/errors/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Errors"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/first_package/Move.toml
+++ b/examples/move/first_package/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "first_package"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 # license = ""           # e.g., "MIT", "GPL", "Apache 2.0"
 # authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 

--- a/examples/move/flash_lender/Move.toml
+++ b/examples/move/flash_lender/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flash_lender"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/hero/Move.toml
+++ b/examples/move/hero/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hero"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/locked_stake/Move.toml
+++ b/examples/move/locked_stake/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Locked Stake"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/nft/Move.toml
+++ b/examples/move/nft/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "testnet_nft"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/object_bound/Move.toml
+++ b/examples/move/object_bound/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ObjectBound"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/random/raffles/Move.toml
+++ b/examples/move/random/raffles/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "raffles"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/random/random_nft/Move.toml
+++ b/examples/move/random/random_nft/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "random_nft"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/random/slot_machine/Move.toml
+++ b/examples/move/random/slot_machine/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "slot_machine"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/reviews_rating/Move.toml
+++ b/examples/move/reviews_rating/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "reviews_rating"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../crates/iota-framework/packages/iota-framework", override = true }

--- a/examples/move/simple_warrior/Move.toml
+++ b/examples/move/simple_warrior/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "simple_warrior"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/token/Move.toml
+++ b/examples/move/token/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Closed Loop Token"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/transfer-to-object/common/Move.toml
+++ b/examples/move/transfer-to-object/common/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "common"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/transfer-to-object/owned-no-tto/Move.toml
+++ b/examples/move/transfer-to-object/owned-no-tto/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "owned_no_tto"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/transfer-to-object/shared-no-tto/Move.toml
+++ b/examples/move/transfer-to-object/shared-no-tto/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shared_no_tto"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/transfer-to-object/shared-with-tto/Move.toml
+++ b/examples/move/transfer-to-object/shared-with-tto/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shared-with-tto"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/transfer-to-shared-object/Move.toml
+++ b/examples/move/transfer-to-shared-object/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "SharedCoins"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/trusted_swap/Move.toml
+++ b/examples/move/trusted_swap/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trusted_swap"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/move/vdf/Move.toml
+++ b/examples/move/vdf/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "VDF"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/tic-tac-toe/move/Move.toml
+++ b/examples/tic-tac-toe/move/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tic_tac_toe"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/trading/contracts/demo/Move.toml
+++ b/examples/trading/contracts/demo/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "demo"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../crates/iota-framework/packages/iota-framework" }

--- a/examples/trading/contracts/escrow/Move.toml
+++ b/examples/trading/contracts/escrow/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "escrow"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../crates/iota-framework/packages/iota-framework" }

--- a/external-crates/move/crates/move-analyzer/tests/completion/Move.toml
+++ b/external-crates/move/crates/move-analyzer/tests/completion/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Completion"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../move-stdlib/", addr_subst = { "std" = "0x1" } }

--- a/external-crates/move/crates/move-analyzer/tests/inlay-hints/Move.toml
+++ b/external-crates/move/crates/move-analyzer/tests/inlay-hints/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "InlayHints"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../move-stdlib/", addr_subst = { "std" = "0x1" } }

--- a/external-crates/move/crates/move-analyzer/tests/macros/Move.toml
+++ b/external-crates/move/crates/move-analyzer/tests/macros/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Macros"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../move-stdlib/", addr_subst = { "std" = "0x1" } }

--- a/external-crates/move/crates/move-analyzer/tests/move-2024/Move.toml
+++ b/external-crates/move/crates/move-analyzer/tests/move-2024/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Move2024"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../move-stdlib/", addr_subst = { "std" = "0x1" } }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/abort_assert/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/abort_assert/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abort_assert"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/abort_math/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/abort_math/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abort_math"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/abort_native/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/abort_native/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abort_native"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "framework/mainnet" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/abort_native_bytecode/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/abort_native_bytecode/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abort_native_bytecode"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/breakpoints_line/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/breakpoints_line/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "breakpoints_line"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/compound/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/compound/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compound"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/disassembly/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/disassembly/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "disassembly"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/disassembly_no_source/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/disassembly_no_source/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "disassembly_no_source"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/global_loc/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/global_loc/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "global_loc"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "framework/mainnet" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/global_write/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/global_write/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "global_write"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "framework/mainnet" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/global_write_ref/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/global_write_ref/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "global_write_ref"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "framework/mainnet" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_abort/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_abort/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macro_abort"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_breakpoint/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_breakpoint/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macro_breakpoint"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_different_different_files/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_different_different_files/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macro_different_different_files"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_different_different_files2/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_different_different_files2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macro_different_different_files2"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_different_files/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_different_files/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macro_different_files"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_different_same_files/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_different_same_files/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macro_different_same_files"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_different_same_files2/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_different_same_files2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macro_different_same_files2"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_inner_call/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_inner_call/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macro_inner_call"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_same_different_files/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_same_different_files/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macro_same_different_files"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_same_different_files2/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_same_different_files2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macro_same_different_files2"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_same_file/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/macro_same_file/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macro_same_file"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/native_fun/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/native_fun/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native_fun"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/references/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/references/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "references"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/references_deep/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/references_deep/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "references_deep"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/shadowing/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/shadowing/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shadowing"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/stepping/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/stepping/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stepping"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/stepping_call/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/stepping_call/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stepping_call"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/stepping_dbg_info_1/Move.toml
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/stepping_dbg_info_1/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stepping_dbg_info_1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-cli/src/base/new.rs
+++ b/external-crates/move/crates/move-cli/src/base/new.rs
@@ -96,7 +96,7 @@ impl New {
             w,
             r#"[package]
 name = "{name}"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 # license = ""           # e.g., "MIT", "GPL", "Apache 2.0"
 # authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 

--- a/external-crates/move/crates/move-cli/tests/build_tests/build_with_bytecode/B/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/build_with_bytecode/B/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Bar"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 B = "0x2"

--- a/external-crates/move/crates/move-cli/tests/build_tests/build_with_bytecode/C/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/build_with_bytecode/C/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Foo"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 C = "0x3"

--- a/external-crates/move/crates/move-cli/tests/build_tests/build_with_bytecode/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/build_with_bytecode/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 A = "0x2"

--- a/external-crates/move/crates/move-cli/tests/build_tests/build_with_dep_warnings/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/build_with_dep_warnings/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Test"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 SomeDep = { local = "dep" }

--- a/external-crates/move/crates/move-cli/tests/build_tests/build_with_dep_warnings/dep/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/build_with_dep_warnings/dep/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "SomeDep"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/build_tests/build_with_warnings/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/build_with_warnings/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "Test"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/build_tests/canonicalize_module/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/canonicalize_module/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Test"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 foo = "0x1"

--- a/external-crates/move/crates/move-cli/tests/build_tests/circular_dependencies/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/circular_dependencies/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Foo"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Bar = { local = "bar" }

--- a/external-crates/move/crates/move-cli/tests/build_tests/circular_dependencies/bar/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/circular_dependencies/bar/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Bar"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Foo = { local = ".." }

--- a/external-crates/move/crates/move-cli/tests/build_tests/dependency_chain/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/dependency_chain/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 A = "0x1"

--- a/external-crates/move/crates/move-cli/tests/build_tests/dependency_chain/bar/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/dependency_chain/bar/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Bar"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 A = "_"

--- a/external-crates/move/crates/move-cli/tests/build_tests/dependency_chain/foo/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/dependency_chain/foo/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Foo"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 A = "_"

--- a/external-crates/move/crates/move-cli/tests/build_tests/dependency_deprecations/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/dependency_deprecations/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 A = "0x1"

--- a/external-crates/move/crates/move-cli/tests/build_tests/dependency_deprecations/dep/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/dependency_deprecations/dep/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Dep"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 A = "_"

--- a/external-crates/move/crates/move-cli/tests/build_tests/dev_address/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/dev_address/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 A = "_"

--- a/external-crates/move/crates/move-cli/tests/build_tests/disassemble_module/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/disassemble_module/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "Test"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/build_tests/disassemble_module_source_map/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/disassemble_module_source_map/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "Test"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/build_tests/empty_module_no_deps/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/empty_module_no_deps/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/build_tests/include_exclude_stdlib/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/include_exclude_stdlib/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "build_include_exclude_stdlib"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 std = "0x1"

--- a/external-crates/move/crates/move-cli/tests/build_tests/json_errors/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/json_errors/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "Test"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration/Move.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 # this is a comment
 [addresses]

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_edition_not_allowed/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_edition_not_allowed/args.exp
@@ -2,4 +2,4 @@ Command `build`:
 Error: Error parsing '[package]' section of manifest
 
 Caused by:
-    Invalid 'edition'. Unsupported edition "2024.migration". Current supported editions include: "legacy", "2024.alpha", "2024", and "2024"
+    Invalid 'edition'. Unsupported edition "2024.migration". Current supported editions include: "legacy", "2024.alpha", "2024.beta", and "2024"

--- a/external-crates/move/crates/move-cli/tests/build_tests/migration_edition_not_allowed/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/migration_edition_not_allowed/args.exp
@@ -2,4 +2,4 @@ Command `build`:
 Error: Error parsing '[package]' section of manifest
 
 Caused by:
-    Invalid 'edition'. Unsupported edition "2024.migration". Current supported editions include: "legacy", "2024.alpha", "2024.beta", and "2024"
+    Invalid 'edition'. Unsupported edition "2024.migration". Current supported editions include: "legacy", "2024.alpha", "2024", and "2024"

--- a/external-crates/move/crates/move-cli/tests/build_tests/new_simple/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/new_simple/args.exp
@@ -2,7 +2,7 @@ Command `new P1`:
 External Command `cat P1/Move.toml`:
 [package]
 name = "P1"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 # license = ""           # e.g., "MIT", "GPL", "Apache 2.0"
 # authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 
@@ -41,7 +41,7 @@ Command `new P2 -p other_dir`:
 External Command `cat other_dir/Move.toml`:
 [package]
 name = "P2"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 # license = ""           # e.g., "MIT", "GPL", "Apache 2.0"
 # authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 

--- a/external-crates/move/crates/move-cli/tests/build_tests/rebuild_after_adding_new_source/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/rebuild_after_adding_new_source/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "Foo"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/rebuild_after_deleting_output_artifact/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "Foo"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/build_tests/rebuild_after_touching_manifest/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/rebuild_after_touching_manifest/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "Foo"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/build_tests/rebuild_after_touching_source/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/rebuild_after_touching_source/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "Foo"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/build_tests/rebuild_no_modification/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/rebuild_no_modification/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "Foo"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/build_tests/unbound_address/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/unbound_address/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 A = "_"

--- a/external-crates/move/crates/move-cli/tests/build_tests/unbound_dependency/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/unbound_dependency/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Foo = { local = "foo" }

--- a/external-crates/move/crates/move-cli/tests/metatests/cov/plain/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/metatests/cov/plain/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "plain"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/metatests/cov/two-runs-diff-module/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/metatests/cov/two-runs-diff-module/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "two-runs-diff-module"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/metatests/cov/two-runs-same-module/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/metatests/cov/two-runs-same-module/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "two-runs-same-module"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Foo"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 A = "_"

--- a/external-crates/move/crates/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/dep/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/move_unit_tests/assign_dev_addr_for_dep/dep/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Bar"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 B = "_"

--- a/external-crates/move/crates/move-cli/tests/move_unit_tests/standalone_module_with_dev_addr_assignment/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/move_unit_tests/standalone_module_with_dev_addr_assignment/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "StandaloneModule"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 A = "_"

--- a/external-crates/move/crates/move-cli/tests/move_unit_tests/standalone_module_with_regular_addr_assignment/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/move_unit_tests/standalone_module_with_regular_addr_assignment/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "StandaloneModule"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 A = "0x2"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/build_modules_and_scripts/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/build_modules_and_scripts/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "build_modules_and_scripts"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/doctor_with_stdlib/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/doctor_with_stdlib/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doctor_with_stdlib"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 std = "0x1"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/explain_arithmetic_failure/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/explain_arithmetic_failure/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "explain_arithmetic_failure"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/explain_stdlib_abort/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/explain_stdlib_abort/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "explain_stdlib_abort"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 std = "0x1"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/explain_user_module_abort/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/explain_user_module_abort/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "explain_user_module_abort"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/gas_metering/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/gas_metering/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "gas_metering"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/generate_struct_layout/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/generate_struct_layout/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "generate_struct_layout"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/module_disassemble/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/module_disassemble/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "module_publish_view"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 std = "0x1"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/module_disassemble/deps1/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/module_disassemble/deps1/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "Deps1"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/module_disassemble/deps2/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/module_disassemble/deps2/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "Deps2"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/module_publish_view/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/module_publish_view/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "module_publish_view"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/multi_module_publish/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/multi_module_publish/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "multi_module_publish"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/named_address_conflicts_in_error/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/named_address_conflicts_in_error/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "use_named_address"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 a = "0x42"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/named_address_conflicts_in_error/dep/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/named_address_conflicts_in_error/dep/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Dep"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 a = "0x41"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/package_basics/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/package_basics/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "PackageBasics"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 std = "0x1"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/print_stack_trace/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/print_stack_trace/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "print_stack_trace"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 std = "0x1"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/print_values/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/print_values/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "print_values"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 std = "0x1"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/publish_then_run/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/publish_then_run/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "publish_then_run"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/random_test_flag_correctness/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/random_test_flag_correctness/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "random_test_flag_correctness"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 std = "0x1"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/use_named_address/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/use_named_address/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "use_named_address"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 A = "0x42"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/verify_native_functions_in_multi_module_publish/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/verify_native_functions_in_multi_module_publish/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "verify_native_functions_in_publish"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/verify_native_functions_in_publish/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/verify_native_functions_in_publish/Move.toml
@@ -1,3 +1,3 @@
 [package]
 name = "verify_native_functions_in_publish"
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-cli/tests/tracing_tests/tracing-unit-tests/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/tracing_tests/tracing-unit-tests/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing_unit_tests"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [dependencies]
 MoveStdlib = { local = "../../../../move-stdlib" }

--- a/external-crates/move/crates/move-cli/tests/upload_tests/no_git_remote_package/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/upload_tests/no_git_remote_package/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Package1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 Std = "0x1"

--- a/external-crates/move/crates/move-cli/tests/upload_tests/valid_package1/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/upload_tests/valid_package1/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Package1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 Std = "0x1"

--- a/external-crates/move/crates/move-cli/tests/upload_tests/valid_package2/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/upload_tests/valid_package2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Package1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 Std = "0x1"

--- a/external-crates/move/crates/move-cli/tests/upload_tests/valid_package3/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/upload_tests/valid_package3/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Package1"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 Std = "0x1"

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/derived_line_number_assertion.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/derived_line_number_assertion.move
@@ -1,7 +1,7 @@
 // NB: Do _not_ change the number of lines in this file. Any changes to the
 // number of lines in this file may break the expected output of this test. 
 
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# run
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/derived_line_number_raw_abort.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/derived_line_number_raw_abort.move
@@ -1,7 +1,7 @@
 // NB: Do _not_ change the number of lines in this file. Any changes to the
 // number of lines in this file may break the expected output of this test. 
 
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# run
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/error_annotation.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/error_annotation.move
@@ -1,7 +1,7 @@
 // NB: Do _not_ change the number of lines in this file. Any changes to the
 // number of lines in this file may break the expected output of this test. 
 
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# run
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/error_annotation_abort.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/error_annotation_abort.move
@@ -1,7 +1,7 @@
 // NB: Do _not_ change the number of lines in this file. Any changes to the
 // number of lines in this file may break the expected output of this test. 
 
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# run
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/macro_call_line_number_abort.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/macro_call_line_number_abort.move
@@ -1,7 +1,7 @@
 // NB: Do _not_ change the number of lines in this file. Any changes to the
 // number of lines in this file may break the expected output of this test.
 
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/macro_call_line_number_assertion.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/macro_call_line_number_assertion.move
@@ -1,7 +1,7 @@
 // NB: Do _not_ change the number of lines in this file. Any changes to the
 // number of lines in this file may break the expected output of this test.
 
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_binder.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_binder.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_mut_ref.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_mut_ref.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_no_drop.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_no_drop.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_ref.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_ref.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_twice.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_twice.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_value_wildcard.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/abc_match_value_wildcard.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/at_pattern_copy.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/at_pattern_copy.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/at_pattern_drop.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/at_pattern_drop.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/at_pattern_lit.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/at_pattern_lit.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/at_pattern_reuse.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/at_pattern_reuse.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/awful_naming_0.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/awful_naming_0.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/awful_naming_1.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/awful_naming_1.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/bad_guard_1.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/bad_guard_1.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/bad_guard_2.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/bad_guard_2.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/basic.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/basic.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/bind_subject.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/bind_subject.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_at.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_at.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_in_guard.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_in_guard.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_matching.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_matching.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_mut_guard.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_mut_guard.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 
 //# publish

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_pair.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_pair.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_result.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_result.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_self.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/const_self.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/drop_ref.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/drop_ref.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/enum_no_tyargs_match.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/enum_no_tyargs_match.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/enum_poly_match.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/enum_poly_match.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/exhaustive_struct.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/exhaustive_struct.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/fib.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/fib.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/field_ordering.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/field_ordering.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m;

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard_backtrack.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard_backtrack.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard_backtrack_2.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard_backtrack_2.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard_backtrack_3.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard_backtrack_3.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard_backtrack_4.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard_backtrack_4.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard_backtrack_5.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/guard_backtrack_5.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/index_syntax_0.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/index_syntax_0.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/index_syntax_1.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/index_syntax_1.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/index_syntax_2.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/index_syntax_2.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/lit_abort.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/lit_abort.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/lit_match.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/lit_match.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/lit_mut_borrow_match.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/lit_mut_borrow_match.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/macro_match.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/macro_match.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/match_lit_mut_bind.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/match_lit_mut_bind.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/match_mut_lit.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/match_mut_lit.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/match_type.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/match_type.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/multi_or.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/multi_or.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/mut_field_alias.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/mut_field_alias.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/nested_at.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/nested_at.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/nested_bindings.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/nested_bindings.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/nested_either_borrow.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/nested_either_borrow.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/option_default.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/option_default.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/option_enum_match.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/option_enum_match.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_0.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_0.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_1.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_1.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_2.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_2.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_3.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/rhs_shadow_loop_label_3.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/stack_interp.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/stack_interp.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/stack_interp_macro.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/stack_interp_macro.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/struct_abort.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/struct_abort.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/struct_match.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/struct_match.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/struct_match_mut.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/struct_match_mut.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/struct_named.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/struct_named.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/struct_named_value.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/struct_named_value.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/true_false_abort.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/true_false_abort.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/true_false_nested_abort.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/true_false_nested_abort.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/tuple_specialize.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/matching/tuple_specialize.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/parser/byte_string.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/parser/byte_string.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# run
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/true_false_nested_abort.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/true_false_nested_abort.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/lit_abort.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/lit_abort.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/stack_interp.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/stack_interp.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/stack_interp_macro.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/stack_interp_macro.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/struct_abort.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/struct_abort.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/true_false_abort.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/true_false_abort.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/true_false_nested_abort.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/true_false_nested_abort.move
@@ -1,4 +1,4 @@
-//# init --edition 2024.beta
+//# init --edition 2024
 
 //# publish
 module 0x42::m {

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_index_fail.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_index_fail.snap
@@ -19,5 +19,5 @@ error[E00002]: DEPRECATED. unexpected spec item
 3 │       let _ = x[1];
   │               ^^^^ Specification blocks are deprecated and are no longer used
   │
-  = If this was intended to be a 'syntax' index call, consider updating your Move edition to '2024.alpha, 2024, 2024'
+  = If this was intended to be a 'syntax' index call, consider updating your Move edition to '2024.alpha, 2024.beta, 2024'
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_index_fail.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/spec_parsing_index_fail.snap
@@ -19,5 +19,5 @@ error[E00002]: DEPRECATED. unexpected spec item
 3 │       let _ = x[1];
   │               ^^^^ Specification blocks are deprecated and are no longer used
   │
-  = If this was intended to be a 'syntax' index call, consider updating your Move edition to '2024.alpha, 2024.beta, 2024'
+  = If this was intended to be a 'syntax' index call, consider updating your Move edition to '2024.alpha, 2024, 2024'
   = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.

--- a/external-crates/move/crates/move-package/tests/test_lock_file.rs
+++ b/external-crates/move/crates/move-package/tests/test_lock_file.rs
@@ -2,22 +2,24 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use expect_test::expect;
 use std::{
     fs::{self, File},
     io::{self, Read, Write},
     path::PathBuf,
 };
-use tempfile::TempDir;
 
+use expect_test::expect;
 use move_compiler::editions::{Edition, Flavor};
-use move_package::lock_file::schema::{
-    update_managed_address, ManagedAddressUpdate, ManagedPackage, ToolchainVersion,
+use move_package::{
+    BuildConfig,
+    lock_file::{
+        LockFile,
+        schema::{ManagedAddressUpdate, ManagedPackage, ToolchainVersion, update_managed_address},
+    },
+    resolution::dependency_graph::DependencyGraph,
 };
-use move_package::lock_file::LockFile;
-use move_package::resolution::dependency_graph::DependencyGraph;
-use move_package::BuildConfig;
 use move_symbol_pool::Symbol;
+use tempfile::TempDir;
 
 #[test]
 fn commit() {
@@ -164,13 +166,13 @@ flavor = "iota"
 fn update_lock_file_toolchain_version() {
     let pkg = create_test_package().unwrap();
     let move_manifest = pkg.path().join("Move.toml");
-    // The 2024.beta in the manifest should override defaults.
+    // The 2024 in the manifest should override defaults.
     fs::write(
         move_manifest,
         r#"
           [package]
           name = "test"
-          edition = "2024.beta"
+          edition = "2024"
         "#,
     )
     .unwrap();
@@ -202,7 +204,7 @@ fn update_lock_file_toolchain_version() {
 
     let expected = expect![[r#"
         compiler-version = "0.0.1"
-        edition = "2024.beta"
+        edition = "2024"
         flavor = "iota"
     "#]];
     expected.assert_eq(&toml);

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/b/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/b/Move.toml
@@ -1,5 +1,5 @@
 [package]
 name = "B"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/c/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/c/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "C"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 I1 = { local = "../i1a", override = true }

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/d/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/d/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "D"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 I2 = { local = "../i2a", override = true }

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/i1/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/i1/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "I1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 I2 = { local = "../i2" }

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/i1a/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/i1a/Move.toml
@@ -1,5 +1,5 @@
 [package]
 name = "I1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/i1b/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/i1b/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "I1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 I2 = { local = "../i2a" }

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/i2/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/i2/Move.toml
@@ -1,5 +1,5 @@
 [package]
 name = "I2"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/i2a/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/i2a/Move.toml
@@ -1,5 +1,5 @@
 [package]
 name = "I2"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/override/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/override/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 I2 = { local = "../i2a" }

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/override/Move@resolved.snap
@@ -33,7 +33,7 @@ ResolvedGraph {
             "A",
             "I2",
         },
-        manifest_digest: "68B35A0747A9DCE9298DA732B6E1E5E7C31D787C296F65C47BFD230B717438E9",
+        manifest_digest: "BD3A80B6FA65101AFC0B8A65073D6603E53B1A2E102A6B7CC69A18357FD5F8FC",
         deps_digest: "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082",
     },
     build_options: BuildConfig {
@@ -94,9 +94,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,
@@ -133,9 +131,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/override_dep_1/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/override_dep_1/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 C = { local = "../c" }

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/override_dep_1/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/override_dep_1/Move@resolved.snap
@@ -85,7 +85,7 @@ ResolvedGraph {
             "I1",
             "I2",
         },
-        manifest_digest: "46F483B57C87C7E4C7F0A75CB79B23FCB067074DE4184F1444EF7693248750AF",
+        manifest_digest: "3CAFBB33CA9218FD569B91E87341C0174BD5F206B3C9D177D2ADBD498E805E57",
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
     build_options: BuildConfig {
@@ -146,9 +146,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,
@@ -185,9 +183,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,
@@ -224,9 +220,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,
@@ -263,9 +257,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/override_dep_2/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/override_dep_2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 D = { local = "../d" }

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/override_dep_2/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/override_dep_2/Move@resolved.snap
@@ -85,7 +85,7 @@ ResolvedGraph {
             "I1",
             "I2",
         },
-        manifest_digest: "92E7897D6030E724E0706B9117898A2C327C7116281582796D9E6A4D46CBC41A",
+        manifest_digest: "31D1ECC5ED54EBE7AA21189769FC5FE64F7BA9AA93C67A89C47D76D0A2EAAAE0",
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
     build_options: BuildConfig {
@@ -146,9 +146,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,
@@ -185,9 +183,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,
@@ -224,9 +220,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,
@@ -263,9 +257,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/override_root_1/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/override_root_1/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 B = { local = "../b" }

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/override_root_1/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/override_root_1/Move@resolved.snap
@@ -77,7 +77,7 @@ ResolvedGraph {
             "I1",
             "I2",
         },
-        manifest_digest: "17A791893D0C35D072DDDC141C9D0078E8F68F9DA67842F3F698848BED229CE0",
+        manifest_digest: "A7C232F2A1F780914704EB8A7F7B85702540C9572BADE35790D27498CF201C02",
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
     build_options: BuildConfig {
@@ -138,9 +138,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,
@@ -187,9 +185,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,
@@ -215,9 +211,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,
@@ -243,9 +237,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/override_root_1_err/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/override_root_1_err/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 B = { local = "../b" }

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/override_root_2/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/override_root_2/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 B = { local = "../b" }

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/override_root_2/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/override_root_2/Move@resolved.snap
@@ -85,7 +85,7 @@ ResolvedGraph {
             "I1",
             "I2",
         },
-        manifest_digest: "14D2D202725804E83172142801302B88A39AFF9E3B279E8A6C2FACC915D1B942",
+        manifest_digest: "706896D06DE9B3273C9E0D0E32646FAD60EBC76FABCDD908DEF1722C2D9A97A8",
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
     build_options: BuildConfig {
@@ -146,9 +146,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,
@@ -195,9 +193,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,
@@ -223,9 +219,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,
@@ -262,9 +256,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/simple/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/simple/Move.toml
@@ -1,5 +1,5 @@
 [package]
 name = "A"
-edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+edition = "2024" # edition = "legacy" to use legacy (pre-2024) Move
 
 [dependencies]

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/simple/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/simple/Move@resolved.snap
@@ -59,7 +59,7 @@ ResolvedGraph {
             "I1",
             "I2",
         },
-        manifest_digest: "12C8A08C8AB11EDB29B745BDB82BC7FD01DC0E7EFD7D2741795B2998861B7937",
+        manifest_digest: "3D2F2717158B97A32C5B8622DF001DAC39F9682BE604BEC0D1CB42E41F229315",
         deps_digest: "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600",
     },
     build_options: BuildConfig {
@@ -120,9 +120,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,
@@ -148,9 +146,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,
@@ -187,9 +183,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/transitive/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/transitive/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "A"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 B = { local = "../b" }

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/transitive/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/transitive/Move@resolved.snap
@@ -93,7 +93,7 @@ ResolvedGraph {
             "I1",
             "I2",
         },
-        manifest_digest: "68B578329F4D1623334B527DD33AF39C443CF31C4ACBF808ED2350DA9C6F0BB6",
+        manifest_digest: "8BA68FAABFE2D925DD3FAFA1F23A0EBBB5AB7CD8A8363456C1A3A89CF36CDD89",
         deps_digest: "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3",
     },
     build_options: BuildConfig {
@@ -154,9 +154,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,
@@ -193,9 +191,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,
@@ -221,9 +217,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,
@@ -260,9 +254,7 @@ ResolvedGraph {
                     edition: Some(
                         Edition {
                             edition: "2024",
-                            release: Some(
-                                "beta",
-                            ),
+                            release: None,
                         },
                     ),
                     flavor: None,

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_beta/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_beta/Move.toml
@@ -2,4 +2,4 @@
 name = "name"
 license = "license"
 authors = ["some author"]
-edition = "2024"
+edition = "2024.beta"

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_beta/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_beta/Move.toml
@@ -2,4 +2,4 @@
 name = "name"
 license = "license"
 authors = ["some author"]
-edition = "2024.beta"
+edition = "2024"

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_invalid_suffix/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_invalid_suffix/Move@resolved.snap
@@ -1,4 +1,4 @@
 ---
 source: crates/move-package/tests/test_runner.rs
 ---
-Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "2024;alpha". Current supported editions include: "legacy", "2024.alpha", "2024.beta", and "2024"
+Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "2024;alpha". Current supported editions include: "legacy", "2024.alpha", "2024", and "2024"

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_invalid_suffix/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_invalid_suffix/Move@resolved.snap
@@ -1,4 +1,4 @@
 ---
 source: crates/move-package/tests/test_runner.rs
 ---
-Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "2024;alpha". Current supported editions include: "legacy", "2024.alpha", "2024", and "2024"
+Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "2024;alpha". Current supported editions include: "legacy", "2024.alpha", "2024.beta", and "2024"

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_unknown/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_unknown/Move@resolved.snap
@@ -1,4 +1,4 @@
 ---
 source: crates/move-package/tests/test_runner.rs
 ---
-Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "foobar". Current supported editions include: "legacy", "2024.alpha", "2024", and "2024"
+Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "foobar". Current supported editions include: "legacy", "2024.alpha", "2024.beta", and "2024"

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_unknown/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_unknown/Move@resolved.snap
@@ -1,4 +1,4 @@
 ---
 source: crates/move-package/tests/test_runner.rs
 ---
-Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "foobar". Current supported editions include: "legacy", "2024.alpha", "2024.beta", and "2024"
+Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "foobar". Current supported editions include: "legacy", "2024.alpha", "2024", and "2024"

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_unknown_suffix/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_unknown_suffix/Move@resolved.snap
@@ -1,4 +1,4 @@
 ---
 source: crates/move-package/tests/test_runner.rs
 ---
-Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "2024.final". Current supported editions include: "legacy", "2024.alpha", "2024.beta", and "2024"
+Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "2024.final". Current supported editions include: "legacy", "2024.alpha", "2024", and "2024"

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_unknown_suffix/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_unknown_suffix/Move@resolved.snap
@@ -1,4 +1,4 @@
 ---
 source: crates/move-package/tests/test_runner.rs
 ---
-Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "2024.final". Current supported editions include: "legacy", "2024.alpha", "2024", and "2024"
+Error parsing '[package]' section of manifest: Invalid 'edition'. Unsupported edition "2024.final". Current supported editions include: "legacy", "2024.alpha", "2024.beta", and "2024"

--- a/external-crates/move/crates/move-stdlib/Move.toml
+++ b/external-crates/move/crates/move-stdlib/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "MoveStdlib"
-edition = "2024.beta"
+edition = "2024"
 
 [addresses]
 std = "_"

--- a/sdk/create-dapp/templates/react-e2e-counter/move/counter/Move.toml
+++ b/sdk/create-dapp/templates/react-e2e-counter/move/counter/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "counter"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { git = "https://github.com/iotaledger/iota.git", subdir = "crates/iota-framework/packages/iota-framework", rev = "devnet" }

--- a/sdk/kiosk/test/e2e/data/hero/Move.toml
+++ b/sdk/kiosk/test/e2e/data/hero/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hero"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../../crates/iota-framework/packages/iota-framework" }

--- a/sdk/typescript/test/e2e/data/coin_metadata/Move.toml
+++ b/sdk/typescript/test/e2e/data/coin_metadata/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "coin_metadata"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../../crates/iota-framework/packages/iota-framework" }

--- a/sdk/typescript/test/e2e/data/demo-bear/Move.toml
+++ b/sdk/typescript/test/e2e/data/demo-bear/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "demo"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../../crates/iota-framework/packages/iota-framework" }

--- a/sdk/typescript/test/e2e/data/display_test/Move.toml
+++ b/sdk/typescript/test/e2e/data/display_test/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "display_test"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../../crates/iota-framework/packages/iota-framework" }

--- a/sdk/typescript/test/e2e/data/dynamic_fields/Move.toml
+++ b/sdk/typescript/test/e2e/data/dynamic_fields/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dynamic_fields"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../../crates/iota-framework/packages/iota-framework" }

--- a/sdk/typescript/test/e2e/data/id_entry_args/Move.toml
+++ b/sdk/typescript/test/e2e/data/id_entry_args/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "id_entry_args"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../../crates/iota-framework/packages/iota-framework" }

--- a/sdk/typescript/test/e2e/data/serializer/Move.toml
+++ b/sdk/typescript/test/e2e/data/serializer/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "serializer"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../../crates/iota-framework/packages/iota-framework" }

--- a/sdk/typescript/test/e2e/data/serializer_upgrade/Move.toml
+++ b/sdk/typescript/test/e2e/data/serializer_upgrade/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "serializer"
 version = "0.0.2"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../../crates/iota-framework/packages/iota-framework" }

--- a/sdk/typescript/test/e2e/data/tto/Move.toml
+++ b/sdk/typescript/test/e2e/data/tto/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tto"
 version = "0.0.1"
-edition = "2024.beta"
+edition = "2024"
 
 [dependencies]
 Iota = { local = "../../../../../../crates/iota-framework/packages/iota-framework" }


### PR DESCRIPTION
[run-ci]

## Description 

Updates all instances of `2024.beta` to `2024`.

Closes #5639
