### PR TITLE
fix: correct the command for unreporting validator

### DIFF
--- a/docs/content/operator/validator-node/cli-validator-command.mdx
+++ b/docs/content/operator/validator-node/cli-validator-command.mdx
@@ -145,7 +145,7 @@ To report validator peers, run:
 $IOTA_BINARY validator report-validator <reportee-address>
 ```
 
-Add `--undo-report false` if it intends to undo an existing report.
+Add `--undo-report true` if it intends to undo an existing report.
 
 Similarly, if the account is a delegatee, add the `--operation-cap-id <operation-cap-id>` option to the command.
 


### PR DESCRIPTION
# Description of change

correct the command for unreporting validator, it should be `true` not `false`.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

testing in alphanet
