### PR TITLE
upstream(json-rpc): add enums to getNormalizedMoveModule

### DIFF
--- a/crates/iota-json-rpc-types/src/iota_move.rs
+++ b/crates/iota-json-rpc-types/src/iota_move.rs
@@ -248,14 +248,10 @@ impl From<NormalizedEnum> for IotaMoveNormalizedEnum {
                 .map(|variant| {
                     (
                         variant.name.to_string(),
-                        variant
-                            .fields
-                            .into_iter()
-                            .map(IotaMoveNormalizedField::from)
-                            .collect::<Vec<IotaMoveNormalizedField>>(),
+                        variant.fields.into_iter().map(Into::into).collect(),
                     )
                 })
-                .collect::<BTreeMap<String, Vec<IotaMoveNormalizedField>>>(),
+                .collect(),
         }
     }
 }

--- a/crates/iota-json-rpc-types/src/iota_move.rs
+++ b/crates/iota-json-rpc-types/src/iota_move.rs
@@ -18,8 +18,8 @@ use itertools::Itertools;
 use move_binary_format::{
     file_format::{Ability, AbilitySet, DatatypeTyParameter, Visibility},
     normalized::{
-        Field as NormalizedField, Function as IotaNormalizedFunction, Module as NormalizedModule,
-        Struct as NormalizedStruct, Type as NormalizedType,
+        Enum as NormalizedEnum, Field as NormalizedField, Function as IotaNormalizedFunction,
+        Module as NormalizedModule, Struct as NormalizedStruct, Type as NormalizedType,
     },
 };
 use move_core_types::{
@@ -81,6 +81,14 @@ pub struct IotaMoveNormalizedStruct {
     pub fields: Vec<IotaMoveNormalizedField>,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct IotaMoveNormalizedEnum {
+    pub abilities: IotaMoveAbilitySet,
+    pub type_parameters: Vec<IotaMoveStructTypeParameter>,
+    pub variants: BTreeMap<String, Vec<IotaMoveNormalizedField>>,
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
 pub enum IotaMoveNormalizedType {
     Bool,
@@ -129,6 +137,8 @@ pub struct IotaMoveNormalizedModule {
     pub name: String,
     pub friends: Vec<IotaMoveModuleId>,
     pub structs: BTreeMap<String, IotaMoveNormalizedStruct>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub enums: BTreeMap<String, IotaMoveNormalizedEnum>,
     pub exposed_functions: BTreeMap<String, IotaMoveNormalizedFunction>,
 }
 
@@ -159,6 +169,11 @@ impl From<NormalizedModule> for IotaMoveNormalizedModule {
                 .into_iter()
                 .map(|(name, struct_)| (name.to_string(), IotaMoveNormalizedStruct::from(struct_)))
                 .collect::<BTreeMap<String, IotaMoveNormalizedStruct>>(),
+            enums: module
+                .enums
+                .into_iter()
+                .map(|(name, enum_)| (name.to_string(), IotaMoveNormalizedEnum::from(enum_)))
+                .collect(),
             exposed_functions: module
                 .functions
                 .into_iter()
@@ -214,6 +229,33 @@ impl From<NormalizedStruct> for IotaMoveNormalizedStruct {
                 .into_iter()
                 .map(IotaMoveNormalizedField::from)
                 .collect::<Vec<IotaMoveNormalizedField>>(),
+        }
+    }
+}
+
+impl From<NormalizedEnum> for IotaMoveNormalizedEnum {
+    fn from(value: NormalizedEnum) -> Self {
+        Self {
+            abilities: value.abilities.into(),
+            type_parameters: value
+                .type_parameters
+                .into_iter()
+                .map(IotaMoveStructTypeParameter::from)
+                .collect::<Vec<IotaMoveStructTypeParameter>>(),
+            variants: value
+                .variants
+                .into_iter()
+                .map(|variant| {
+                    (
+                        variant.name.to_string(),
+                        variant
+                            .fields
+                            .into_iter()
+                            .map(IotaMoveNormalizedField::from)
+                            .collect::<Vec<IotaMoveNormalizedField>>(),
+                    )
+                })
+                .collect::<BTreeMap<String, Vec<IotaMoveNormalizedField>>>(),
         }
     }
 }

--- a/crates/iota-json-rpc-types/src/iota_move.rs
+++ b/crates/iota-json-rpc-types/src/iota_move.rs
@@ -237,11 +237,7 @@ impl From<NormalizedEnum> for IotaMoveNormalizedEnum {
     fn from(value: NormalizedEnum) -> Self {
         Self {
             abilities: value.abilities.into(),
-            type_parameters: value
-                .type_parameters
-                .into_iter()
-                .map(IotaMoveStructTypeParameter::from)
-                .collect::<Vec<IotaMoveStructTypeParameter>>(),
+            type_parameters: value.type_parameters.into_iter().map(Into::into).collect(),
             variants: value
                 .variants
                 .into_iter()

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -8197,6 +8197,34 @@
           }
         }
       },
+      "IotaMoveNormalizedEnum": {
+        "type": "object",
+        "required": [
+          "abilities",
+          "typeParameters",
+          "variants"
+        ],
+        "properties": {
+          "abilities": {
+            "$ref": "#/components/schemas/IotaMoveAbilitySet"
+          },
+          "typeParameters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IotaMoveStructTypeParameter"
+            }
+          },
+          "variants": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/IotaMoveNormalizedField"
+              }
+            }
+          }
+        }
+      },
       "IotaMoveNormalizedField": {
         "type": "object",
         "required": [
@@ -8261,6 +8289,12 @@
         "properties": {
           "address": {
             "type": "string"
+          },
+          "enums": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/IotaMoveNormalizedEnum"
+            }
           },
           "exposedFunctions": {
             "type": "object",

--- a/crates/iota-open-rpc/src/examples.rs
+++ b/crates/iota-open-rpc/src/examples.rs
@@ -1049,6 +1049,7 @@ impl RpcExampleProvider {
             friends: vec![],
             name: "module".to_string(),
             structs: BTreeMap::new(),
+            enums: BTreeMap::new(),
         };
 
         Examples::new(
@@ -1072,6 +1073,7 @@ impl RpcExampleProvider {
             friends: vec![],
             name: "module".to_string(),
             structs: BTreeMap::new(),
+            enums: BTreeMap::new(),
         };
 
         Examples::new(


### PR DESCRIPTION
# Description of change

This patch adds `enums` to the `getNormalizedMoveModule` rpc response.

## Links to any relevant issues

Fixes #8237 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

### Infrastructure QA (only required for crates that are maintained by @iotaledger/infrastructure)

- [ ] Synchronization of the indexer from genesis for a network including migration objects.
- [ ] Restart of indexer synchronization locally without resetting the database.
- [ ] Restart of indexer synchronization on a production-like database.
- [ ] Deployment of services using Docker.
- [x] Verification of API backward compatibility.

### Release Notes

- [x] JSON-RPC: Include `enums` in the response of the `getNormalizedMoveModule` and `getNormalizedMoveModulesByPackage` methods
