### PR TITLE
fix(consensus): move storage deserialization from `TryFrom` for `VerifiedBlock`

### DIFF
--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -22,7 +22,6 @@ use crate::{
     context::Context,
     ensure,
     error::{ConsensusError, ConsensusResult},
-    network::SerializedHeaderAndTransactions,
 };
 
 /// Round number of a block.
@@ -869,40 +868,6 @@ impl Deref for VerifiedBlock {
 
     fn deref(&self) -> &Self::Target {
         &self.verified_block_header
-    }
-}
-
-impl TryFrom<SerializedHeaderAndTransactions> for VerifiedBlock {
-    type Error = ConsensusError;
-
-    fn try_from(serialized_block: SerializedHeaderAndTransactions) -> ConsensusResult<Self> {
-        let signed_block_header: SignedBlockHeader =
-            bcs::from_bytes(&serialized_block.serialized_block_header)
-                .map_err(ConsensusError::MalformedHeader)?;
-        let transactions: Vec<Transaction> =
-            bcs::from_bytes(&serialized_block.serialized_transactions)
-                .map_err(ConsensusError::MalformedTransactions)?;
-        // TODO: https://github.com/iotaledger/iota/issues/8221
-        // do we need to check the signature here?
-        let verified_block_header = VerifiedBlockHeader::new_verified(
-            signed_block_header,
-            serialized_block.serialized_block_header,
-        );
-
-        // TODO: https://github.com/iotaledger/iota/issues/8221
-        // we might need to check whether transaction commitment is consistent
-        // with the one in header
-        let verified_transactions = VerifiedTransactions::new(
-            transactions,
-            verified_block_header.reference(),
-            verified_block_header.transactions_commitment(),
-            serialized_block.serialized_transactions,
-        );
-        // Assemble the block from the header and transactions
-        Ok(VerifiedBlock::new(
-            verified_block_header,
-            verified_transactions,
-        ))
     }
 }
 

--- a/crates/starfish/core/src/storage/rocksdb_store.rs
+++ b/crates/starfish/core/src/storage/rocksdb_store.rs
@@ -19,12 +19,11 @@ use super::{CommitInfo, Store, WriteBatch};
 use crate::{
     Transaction,
     block_header::{
-        BlockHeaderAPI as _, BlockHeaderDigest, BlockRef, Round, TransactionsCommitment,
-        VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions,
+        BlockHeaderAPI as _, BlockHeaderDigest, BlockRef, Round, SignedBlockHeader,
+        TransactionsCommitment, VerifiedBlock, VerifiedBlockHeader, VerifiedTransactions,
     },
     commit::{CommitAPI as _, CommitDigest, CommitIndex, CommitRange, CommitRef, TrustedCommit},
     error::{ConsensusError, ConsensusResult},
-    network::SerializedHeaderAndTransactions,
 };
 
 /// Persistent storage with RocksDB.
@@ -213,10 +212,23 @@ impl Store for RocksDBStore {
             if let (Some(serialized_block_header), Some(serialized_transactions)) =
                 (serialized_block_header, serialized_transactions)
             {
-                let block = VerifiedBlock::try_from(SerializedHeaderAndTransactions {
-                    serialized_block_header,
+                let signed_block_header: SignedBlockHeader =
+                    bcs::from_bytes(&serialized_block_header)
+                        .map_err(ConsensusError::MalformedHeader)?;
+                let transactions: Vec<Transaction> = bcs::from_bytes(&serialized_transactions)
+                    .map_err(ConsensusError::MalformedTransactions)?;
+                // We don't check the signature as it's loaded from storage.
+                let verified_block_header =
+                    VerifiedBlockHeader::new_verified(signed_block_header, serialized_block_header);
+                // We don't check the transactions commitment as it's loaded from storage.
+                let verified_transactions = VerifiedTransactions::new(
+                    transactions,
+                    verified_block_header.reference(),
+                    verified_block_header.transactions_commitment(),
                     serialized_transactions,
-                })?;
+                );
+
+                let block = VerifiedBlock::new(verified_block_header, verified_transactions);
 
                 // Makes sure block data is not corrupted by comparing digests.
                 assert_eq!(*key, block.reference());


### PR DESCRIPTION
# Description of change

Move storage block deserialization from the `TryFrom` trait implementation for `VerifiedBlock` to where it is called in `read_blocks` storage implementation.

## Links to any relevant issues

fixes #8221 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
