### PR TITLE
fix(starfish): eviction acks from tracker

### DIFF
--- a/crates/starfish/core/src/commit_observer.rs
+++ b/crates/starfish/core/src/commit_observer.rs
@@ -143,6 +143,17 @@ impl CommitObserver {
             sent_sub_dags.push(solid_sub_dag);
         }
         self.report_metrics(&pending_sub_dags, &solid_sub_dags);
+
+        // Evict the ack tracker using the information from the latest solid subdag
+        if !solid_sub_dags.is_empty() {
+            let max_solid_commit_leader_round = solid_sub_dags
+                .last()
+                .expect("There should be at least one solid subdag")
+                .leader
+                .round;
+            self.commit_interpreter
+                .evict_old_acknowledgments(max_solid_commit_leader_round);
+        }
         tracing::trace!("Committed & sent {sent_sub_dags:#?}");
 
         Ok((pending_sub_dags, missing_transaction_acknowledgers))

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -93,7 +93,7 @@ pub(crate) struct DagState {
     /// transactions. Does not persist across restarts and after recovery.
     /// All transactions below this round minus MAX_TRANSACTIONS_ACK_DEPTH
     /// minus MAX_LINEARIZER_DEPTH are evicted from memory.
-    last_available_commit_leader_round: Option<Round>,
+    last_solid_commit_leader_round: Option<Round>,
 
     /// Rounds for latest blocks traversed by linearizer per authority.
     last_committed_rounds: Vec<Round>,
@@ -214,8 +214,8 @@ impl DagState {
             last_commit: last_commit.clone(),
             last_commit_round_advancement_time: None,
             last_committed_rounds: last_committed_rounds.clone(),
-            last_available_commit_leader_round: None, /* Later the commit observer might update
-                                                       * this value during recovery process. */
+            last_solid_commit_leader_round: None, /* Later the commit observer might update
+                                                   * this value during recovery process. */
             pending_commit_votes: VecDeque::new(),
             transactions_to_write: vec![],
             block_headers_to_write: vec![],
@@ -340,21 +340,18 @@ impl DagState {
         }
     }
 
-    pub fn update_last_available_commit_leader_round(
-        &mut self,
-        last_available_commit_leader_round: Round,
-    ) {
+    pub fn update_last_solid_commit_leader_round(&mut self, last_solid_commit_leader_round: Round) {
         let max_commit_round = self
             .last_committed_rounds
             .iter()
             .max()
             .expect("There should be at least one last committed round");
         info!(
-            "Last commit with available transactions has leader at round {}; last commit leader round was {}",
-            last_available_commit_leader_round, max_commit_round
+            "Last solid commit has leader at round {}; last pending commit has leader at round {}",
+            last_solid_commit_leader_round, max_commit_round
         );
-        self.last_available_commit_leader_round = Some(last_available_commit_leader_round);
-        let gap = last_available_commit_leader_round.saturating_sub(*max_commit_round);
+        self.last_solid_commit_leader_round = Some(last_solid_commit_leader_round);
+        let gap = (*max_commit_round).saturating_sub(last_solid_commit_leader_round);
         self.context
             .metrics
             .node_metrics
@@ -1148,6 +1145,15 @@ impl DagState {
 
         self.last_commit = Some(commit.clone());
 
+        if let Some(last_solid_commit_leader_round) = self.last_solid_commit_leader_round {
+            let gap = (commit.leader().round).saturating_sub(last_solid_commit_leader_round);
+            self.context
+                .metrics
+                .node_metrics
+                .gap_to_available_commit
+                .set(gap as i64);
+        }
+
         if commit_round_advanced {
             let now = std::time::Instant::now();
             if let Some(previous_time) = self.last_commit_round_advancement_time {
@@ -1264,7 +1270,7 @@ impl DagState {
     /// "last consume leader round minus MAX_TRANSACTIONS_ACK_DEPTH minus
     /// MAX_LINEARIZER_DEPTH"
     pub(crate) fn evict_transactions(&mut self) {
-        let last_solid_leader_round = self.last_available_commit_leader_round;
+        let last_solid_leader_round = self.last_solid_commit_leader_round;
         if let Some(round) = last_solid_leader_round {
             let min_round: Round =
                 round.saturating_sub(MAX_TRANSACTIONS_ACK_DEPTH + MAX_LINEARIZER_DEPTH);

--- a/crates/starfish/core/src/data_manager.rs
+++ b/crates/starfish/core/src/data_manager.rs
@@ -135,7 +135,7 @@ impl DataManager {
         if !committed.is_empty() {
             let mut dag_state_guard = self.dag_state.write();
 
-            dag_state_guard.update_last_available_commit_leader_round(
+            dag_state_guard.update_last_solid_commit_leader_round(
                 committed
                     .last()
                     .expect("We should expect at least one committed subdag")

--- a/crates/starfish/core/src/linearizer.rs
+++ b/crates/starfish/core/src/linearizer.rs
@@ -47,11 +47,6 @@ pub(crate) struct Linearizer {
     context: Arc<Context>,
     dag_state: Arc<RwLock<DagState>>,
     leader_schedule: Arc<LeaderSchedule>,
-
-    // TODO: prune this map - any entries older than latest_leader.round() - max_ack_depth -
-    //  max_linearizer_depth should be removed
-    // TODO: should this be part of the Linearizer or
-    //  its own component?
     transactions_ack_tracker: BTreeMap<BlockRef, StakeAggregator<QuorumThreshold>>,
 }
 
@@ -219,12 +214,6 @@ impl Linearizer {
 
         let mut pending_sub_dags = vec![];
 
-        let max_round_committed_leader = committed_leaders
-            .iter()
-            .map(|block| block.round())
-            .max()
-            .expect("We should expect at least one leader block");
-
         for (i, leader_block) in committed_leaders.into_iter().enumerate() {
             let reputation_scores_desc = if schedule_updated && i == 0 {
                 self.leader_schedule
@@ -258,17 +247,14 @@ impl Linearizer {
         dag_state_guard.flush();
         drop(dag_state_guard);
 
-        // Evict old acknowledgments from the tracker of the linearizer.
-        self.evict_old_acknowledgments(max_round_committed_leader);
-
-        // TODO: we should resubmit transactions from own blocks that are not sequenced
-        // and below certain round
         pending_sub_dags
     }
 
-    /// This function evicts old acknowledgments from the tracker.
-    fn evict_old_acknowledgments(&mut self, committed_leader_round: Round) {
-        let lower_bound_round = committed_leader_round
+    /// This function evicts old acknowledgments from the tracker. Should be
+    /// called for solid committed leader round since we rely on the ack
+    /// tracker in transaction synchronizer.
+    pub(crate) fn evict_old_acknowledgments(&mut self, solid_commit_leader_round: Round) {
+        let lower_bound_round = solid_commit_leader_round
             .saturating_sub(MAX_LINEARIZER_DEPTH + MAX_TRANSACTIONS_ACK_DEPTH);
         let lower_bound = BlockRef::new(
             lower_bound_round + 1,


### PR DESCRIPTION
# Description of change

Right now eviction from ack tracker in linearizer is done whenever we progress pending commits. However, we should keep this information until the commit gets solid, i.e., all transactions committed to it are locally available. Otherwise, the transaction synchronizer, which relies on the ack tracker, will not get information about authorities that marked the data as available.

## Links to any relevant issues

Fixes #8243 

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
