### PR TITLE
chore(indexer): ignore flaky system_state_v2 test

### DIFF
--- a/crates/iota-indexer/tests/rpc-tests/governance_api.rs
+++ b/crates/iota-indexer/tests/rpc-tests/governance_api.rs
@@ -480,6 +480,7 @@ fn test_timelocked_unstaking() {
 }
 
 #[test]
+#[ignore = "https://github.com/iotaledger/iota/issues/6127"]
 fn get_latest_iota_system_state_v2() {
     let ApiTestSetup {
         runtime,


### PR DESCRIPTION
# Description of change

This patch simply ignores a flaking tests until further investigated and resolved
