### PR TITLE
upstream(core): Add consensus data quarantining

### DIFF
--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -25,7 +25,7 @@ use fastcrypto::{
     hash::MultisetHash,
 };
 use iota_archival::reader::ArchiveReaderBalancer;
-use iota_common::debug_fatal;
+use iota_common::{debug_fatal, fatal};
 use iota_config::{
     NodeConfig,
     genesis::Genesis,
@@ -3137,6 +3137,7 @@ impl AuthorityState {
         accumulator: Arc<StateAccumulator>,
         expensive_safety_check_config: &ExpensiveSafetyCheckConfig,
         epoch_supply_change: i64,
+        epoch_last_checkpoint: CheckpointSequenceNumber,
     ) -> IotaResult<Arc<AuthorityPerEpochStore>> {
         Self::check_protocol_version(
             supported_protocol_versions,
@@ -3152,6 +3153,31 @@ impl AuthorityState {
 
         // Terminate all epoch-specific tasks (those started with within_alive_epoch).
         cur_epoch_store.epoch_terminated().await;
+
+        let highest_locally_built_checkpoint_seq = self
+            .checkpoint_store
+            .get_latest_locally_computed_checkpoint()
+            .map(|c| *c.sequence_number())
+            .unwrap_or(0);
+
+        assert!(
+            epoch_last_checkpoint >= highest_locally_built_checkpoint_seq,
+            "{epoch_last_checkpoint} >= {highest_locally_built_checkpoint_seq}"
+        );
+        if highest_locally_built_checkpoint_seq == epoch_last_checkpoint {
+            // if we built the last checkpoint locally (as opposed to receiving it from a
+            // peer), then all shared_version_assignments except the one for the
+            // ChangeEpoch transaction should have been removed
+            let num_shared_version_assignments = cur_epoch_store.num_shared_version_assignments();
+            // Note that while 1 is the typical value, 0 is possible if the node restarts
+            // after committing the last checkpoint but before reconfiguring.
+            if num_shared_version_assignments > 1 {
+                // If this happens in prod, we have a memory leak, but not a correctness issue.
+                debug_fatal!(
+                    "all shared_version_assignments should have been removed (num_shared_version_assignments: {num_shared_version_assignments})"
+                );
+            }
+        }
 
         // Safe to reconfigure now. No transactions are being executed,
         // and no epoch-specific tasks are running.
@@ -3200,6 +3226,7 @@ impl AuthorityState {
                 new_committee,
                 epoch_start_configuration,
                 expensive_safety_check_config,
+                epoch_last_checkpoint,
             )
             .await?;
         assert_eq!(new_epoch_store.epoch(), new_epoch);
@@ -3232,6 +3259,11 @@ impl AuthorityState {
             self.get_backing_package_store().clone(),
             self.get_object_store().clone(),
             &self.config.expensive_safety_check_config,
+            self.checkpoint_store
+                .get_epoch_last_checkpoint(epoch_store.epoch())
+                .unwrap()
+                .map(|c| *c.sequence_number())
+                .unwrap_or_default(),
         );
         let new_epoch = new_epoch_store.epoch();
         self.transaction_manager.reconfigure(new_epoch);
@@ -4950,6 +4982,7 @@ impl AuthorityState {
         new_committee: Committee,
         epoch_start_configuration: EpochStartConfiguration,
         expensive_safety_check_config: &ExpensiveSafetyCheckConfig,
+        epoch_last_checkpoint: CheckpointSequenceNumber,
     ) -> IotaResult<Arc<AuthorityPerEpochStore>> {
         let new_epoch = new_committee.epoch;
         info!(new_epoch = ?new_epoch, "re-opening AuthorityEpochTables for new epoch");
@@ -4966,6 +4999,7 @@ impl AuthorityState {
             self.get_object_store().clone(),
             expensive_safety_check_config,
             cur_epoch_store.get_chain_identifier(),
+            epoch_last_checkpoint,
         );
         self.epoch_store.store(new_epoch_store.clone());
         Ok(new_epoch_store)
@@ -5060,6 +5094,14 @@ impl RandomnessRoundReceiver {
         let transaction = VerifiedExecutableTransaction::new_system(transaction, epoch);
         let digest = *transaction.digest();
 
+        // Randomness state updates contain the full bls signature for the random round,
+        // which cannot necessarily be reconstructed again later. Therefore we must
+        // immediately persist this transaction. If we crash before its outputs
+        // are committed, this ensures we will be able to re-execute it.
+        self.authority_state
+            .get_cache_commit()
+            .persist_transactions(&transaction);
+
         // Send transaction to TransactionManager for execution.
         self.authority_state
             .transaction_manager()
@@ -5106,7 +5148,7 @@ impl RandomnessRoundReceiver {
             let mut effects = result.unwrap_or_else(|_| panic!("failed to get effects for randomness state update transaction at epoch {epoch}, round {round}"));
             let effects = effects.pop().expect("should return effects");
             if *effects.status() != ExecutionStatus::Success {
-                panic!(
+                fatal!(
                     "failed to execute randomness state update transaction at epoch {epoch}, round {round}: {effects:?}"
                 );
             }

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3156,7 +3156,7 @@ impl AuthorityState {
 
         let highest_locally_built_checkpoint_seq = self
             .checkpoint_store
-            .get_latest_locally_computed_checkpoint()
+            .get_latest_locally_computed_checkpoint()?
             .map(|c| *c.sequence_number())
             .unwrap_or(0);
 

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -5100,7 +5100,7 @@ impl RandomnessRoundReceiver {
         // are committed, this ensures we will be able to re-execute it.
         self.authority_state
             .get_cache_commit()
-            .persist_transactions(&transaction);
+            .persist_transaction(&transaction);
 
         // Send transaction to TransactionManager for execution.
         self.authority_state

--- a/crates/iota-core/src/authority.rs
+++ b/crates/iota-core/src/authority.rs
@@ -3162,7 +3162,7 @@ impl AuthorityState {
 
         assert!(
             epoch_last_checkpoint >= highest_locally_built_checkpoint_seq,
-            "{epoch_last_checkpoint} >= {highest_locally_built_checkpoint_seq}"
+            "expected {epoch_last_checkpoint} >= {highest_locally_built_checkpoint_seq}"
         );
         if highest_locally_built_checkpoint_seq == epoch_last_checkpoint {
             // if we built the last checkpoint locally (as opposed to receiving it from a
@@ -3174,7 +3174,8 @@ impl AuthorityState {
             if num_shared_version_assignments > 1 {
                 // If this happens in prod, we have a memory leak, but not a correctness issue.
                 debug_fatal!(
-                    "all shared_version_assignments should have been removed (num_shared_version_assignments: {num_shared_version_assignments})"
+                    "all shared_version_assignments should have been removed \
+                    (num_shared_version_assignments: {num_shared_version_assignments})"
                 );
             }
         }

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -70,7 +70,7 @@ use tap::TapOptional;
 use tokio::{sync::OnceCell, time::Instant};
 use tracing::{debug, error, info, instrument, trace, warn};
 use typed_store::{
-    DBMapUtils, Map, TypedStoreError,
+    DBMapUtils, Map,
     rocks::{
         DBBatch, DBMap, DBOptions, MetricConf, ReadWriteOptions, default_db_options,
         read_size_from_env,
@@ -2470,8 +2470,7 @@ impl AuthorityPerEpochStore {
             // for the same tx digest
             assert!(
                 user_sigs.insert(digest, sigs).is_none(),
-                "duplicate user signatures for transaction digest: {:?}",
-                digest
+                "duplicate user signatures for transaction digest: {digest:?}"
             );
         }
     }
@@ -3974,11 +3973,11 @@ impl AuthorityPerEpochStore {
         {
             // Reading from the db table is only needed when upgrading to data quarantining
             // for the first time.
+            let tables = self.tables()?;
             let db_iter = tables
                 .pending_checkpoints
                 .safe_iter_with_bounds(last.map(|height| height + 1), None);
-            db_iter
-                .collect::<Result<Vec<(CheckpointHeight, PendingCheckpoint)>, _>>()?
+            db_iter.collect::<Result<Vec<(CheckpointHeight, PendingCheckpoint)>, _>>()?
         } else {
             vec![]
         };

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -50,7 +50,7 @@ use iota_types::{
     },
     messages_consensus::{
         AuthorityCapabilitiesV1, ConsensusTransaction, ConsensusTransactionKey,
-        ConsensusTransactionKind, VersionedDkgConfirmation, check_total_jwk_size,
+        ConsensusTransactionKind, TimestampMs, VersionedDkgConfirmation, check_total_jwk_size,
     },
     signature::GenericSignature,
     storage::{BackingPackageStore, InputKey, ObjectStore},
@@ -107,12 +107,13 @@ use crate::{
     epoch::{
         epoch_metrics::EpochMetrics,
         randomness::{
-            CommitTimestampMs, DkgStatus, RandomnessManager, RandomnessReporter,
+            CommitTimestampMs, DkgStatus, RandomnessManager, RandomnessReporter, SINGLETON_KEY,
             VersionedProcessedMessage, VersionedUsedProcessedMessages,
         },
         reconfiguration::ReconfigState,
     },
-    execution_cache::ObjectCacheRead,
+    execution_cache::{ObjectCacheRead, TransactionCacheRead, cache_types::CacheResult},
+    fallback_fetch::do_fallback_lookup,
     module_cache_metrics::ResolverMetrics,
     post_consensus_tx_reorder::PostConsensusTxReorder,
     signature_verifier::*,
@@ -134,7 +135,9 @@ pub(crate) type EncG = bls12381::G2Element;
 #[path = "consensus_quarantine.rs"]
 pub(crate) mod consensus_quarantine;
 
-use consensus_quarantine::ConsensusCommitOutput;
+use consensus_quarantine::{
+    ConsensusCommitOutput, ConsensusOutputCache, ConsensusOutputQuarantine,
+};
 
 // CertLockGuard and CertTxGuard are functionally identical right now, but we
 // retain a distinction anyway. If we need to support distributed object
@@ -407,6 +410,14 @@ pub struct AuthorityPerEpochStore {
     /// and it needs to be cleared at the end of the epoch.
     tables: ArcSwapOption<AuthorityEpochTables>,
 
+    /// Holds the outputs of both consensus handler and checkpoint builder in
+    /// memory until they are proven not to have forked by a certified
+    /// checkpoint.
+    consensus_quarantine: RwLock<ConsensusOutputQuarantine>,
+    /// Holds variouis data from consensus_quarantine in a more easily
+    /// accessible form.
+    consensus_output_cache: ConsensusOutputCache,
+
     protocol_config: ProtocolConfig,
 
     // needed for re-opening epoch db.
@@ -525,39 +536,12 @@ pub struct AuthorityEpochTables {
     /// Transactions that were executed in the current epoch.
     executed_in_epoch: DBMap<TransactionDigest, ()>,
 
-    /// The tables below manage shared object locks / versions. There are three
-    /// ways they can be updated:
-    /// 1. (validators only): Upon receiving a certified transaction from
-    ///    consensus, the authority assigns the next version to each shared
-    ///    object of the transaction. The next versions of the shared objects
-    ///    are updated as well.
-    /// 2. (validators only): Upon receiving a new consensus commit, the
-    ///    authority assigns the next version of the randomness state object to
-    ///    an expected future transaction to be generated after the next random
-    ///    value is available. The next version of the randomness state object
-    ///    is updated as well.
-    /// 3. (fullnodes + validators): Upon receiving a certified effect from
-    ///    state sync, or transaction orchestrator fast execution path, the node
-    ///    assigns the shared object versions from the transaction effect. Next
-    ///    object versions are not updated.
-    ///
-    /// REQUIRED: all authorities must assign the same shared object versions
-    /// for each transaction.
+    #[allow(dead_code)]
     assigned_shared_object_versions: DBMap<TransactionKey, Vec<(ObjectID, SequenceNumber)>>,
+    /// Next available shared object versions for each shared object.
     next_shared_object_versions: DBMap<ObjectID, SequenceNumber>,
 
-    /// Certificates that have been received from clients or received from
-    /// consensus, but not yet executed. Entries are cleared after
-    /// execution. This table is critical for crash recovery, because
-    /// usually the consensus output progress is updated after a certificate
-    /// is committed into this table.
-    ///
-    /// In theory, this table may be superseded by storing consensus and
-    /// checkpoint execution progress. But it is more complex, because it
-    /// would be necessary to track inflight executions not ordered by
-    /// indices. For now, tracking inflight certificates as a map
-    /// seems easier.
-    #[default_options_override_fn = "pending_execution_table_default_config"]
+    // TODO: delete after DQ is rolled out
     pub(crate) pending_execution: DBMap<TransactionDigest, TrustedExecutableTransaction>,
 
     /// Track which transactions have been processed in
@@ -594,18 +578,7 @@ pub struct AuthorityEpochTables {
     /// Validators that have sent EndOfPublish message in this epoch
     end_of_publish: DBMap<AuthorityName, ()>,
 
-    /// This table has information for the checkpoints for which we constructed
-    /// all the data from consensus, but not yet constructed actual
-    /// checkpoint.
-    ///
-    /// Key in this table is the consensus commit height and not a checkpoint
-    /// sequence number.
-    ///
-    /// Non-empty list of transactions here might result in empty list when we
-    /// are forming checkpoint. Because we don't want to create checkpoints
-    /// with empty content(see CheckpointBuilder::write_checkpoint),
-    /// the sequence number of checkpoint does not match height here.
-    #[default_options_override_fn = "pending_checkpoints_table_default_config"]
+    #[allow(dead_code)]
     pending_checkpoints: DBMap<CheckpointHeight, PendingCheckpoint>,
 
     /// Checkpoint builder maintains internal list of transactions it included
@@ -622,9 +595,8 @@ pub struct AuthorityEpochTables {
     pub(crate) pending_checkpoint_signatures:
         DBMap<(CheckpointSequenceNumber, u64), CheckpointSignatureMessage>,
 
-    /// When we see certificate through consensus for the first time, we record
-    /// user signature for this transaction here. This will be included in the
-    /// checkpoint later.
+    /// Deprecated - pending signatures are now stored in memory.
+    #[allow(dead_code)]
     user_signatures_for_checkpoints: DBMap<TransactionDigest, Vec<GenericSignature>>,
 
     /// Maps sequence number to checkpoint summary, used by CheckpointBuilder to
@@ -718,19 +690,7 @@ fn owned_object_locked_transactions_table_default_config() -> DBOptions {
     }
 }
 
-fn pending_execution_table_default_config() -> DBOptions {
-    default_db_options()
-        .optimize_for_write_throughput()
-        .optimize_for_large_values_no_scan(1 << 10)
-}
-
 fn pending_consensus_transactions_table_default_config() -> DBOptions {
-    default_db_options()
-        .optimize_for_write_throughput()
-        .optimize_for_large_values_no_scan(1 << 10)
-}
-
-fn pending_checkpoints_table_default_config() -> DBOptions {
     default_db_options()
         .optimize_for_write_throughput()
         .optimize_for_large_values_no_scan(1 << 10)
@@ -842,6 +802,33 @@ impl AuthorityEpochTables {
         batch.write()?;
         Ok(())
     }
+
+    fn get_all_deferred_transactions(
+        &self,
+    ) -> IotaResult<BTreeMap<DeferralKey, Vec<VerifiedSequencedConsensusTransaction>>> {
+        Ok(self
+            .deferred_transactions
+            .safe_iter()
+            .collect::<Result<_, _>>()?)
+    }
+
+    fn get_all_deferred_transactions_v2(
+        &self,
+    ) -> IotaResult<BTreeMap<DeferralKey, Vec<DeferredTransaction>>> {
+        Ok(self
+            .deferred_transactions_v2
+            .safe_iter()
+            .collect::<Result<_, _>>()?)
+    }
+
+    fn get_all_user_signatures_for_checkpoints(
+        &self,
+    ) -> IotaResult<HashMap<TransactionDigest, Vec<GenericSignature>>> {
+        Ok(self
+            .user_signatures_for_checkpoints
+            .safe_iter()
+            .collect::<Result<_, _>>()?)
+    }
 }
 
 pub(crate) const MUTEX_TABLE_SIZE: usize = 1024;
@@ -861,6 +848,7 @@ impl AuthorityPerEpochStore {
         signature_verifier_metrics: Arc<SignatureVerifierMetrics>,
         expensive_safety_check_config: &ExpensiveSafetyCheckConfig,
         chain_identifier: ChainIdentifier,
+        highest_executed_checkpoint: CheckpointSequenceNumber,
     ) -> Arc<Self> {
         let current_time = Instant::now();
         let epoch_id = committee.epoch;
@@ -954,11 +942,19 @@ impl AuthorityPerEpochStore {
 
         let jwk_aggregator = Mutex::new(jwk_aggregator);
 
+        let consensus_output_cache =
+            ConsensusOutputCache::new(&epoch_start_configuration, &tables, metrics.clone());
+
         let s = Arc::new(Self {
             name,
             committee,
             protocol_config,
             tables: ArcSwapOption::new(Some(Arc::new(tables))),
+            consensus_output_cache,
+            consensus_quarantine: RwLock::new(ConsensusOutputQuarantine::new(
+                highest_executed_checkpoint,
+                metrics.clone(),
+            )),
             parent_path: parent_path.to_path_buf(),
             db_options,
             reconfig_state_mem: RwLock::new(reconfig_state),
@@ -1071,6 +1067,7 @@ impl AuthorityPerEpochStore {
         object_store: Arc<dyn ObjectStore + Send + Sync>,
         expensive_safety_check_config: &ExpensiveSafetyCheckConfig,
         chain_identifier: ChainIdentifier,
+        previous_epoch_last_checkpoint: CheckpointSequenceNumber,
     ) -> Arc<Self> {
         assert_eq!(self.epoch() + 1, new_committee.epoch);
         self.record_reconfig_halt_duration_metric();
@@ -1088,6 +1085,7 @@ impl AuthorityPerEpochStore {
             self.signature_verifier.metrics.clone(),
             expensive_safety_check_config,
             chain_identifier,
+            previous_epoch_last_checkpoint,
         )
     }
 
@@ -1096,6 +1094,7 @@ impl AuthorityPerEpochStore {
         backing_package_store: Arc<dyn BackingPackageStore + Send + Sync>,
         object_store: Arc<dyn ObjectStore + Send + Sync>,
         expensive_safety_check_config: &ExpensiveSafetyCheckConfig,
+        previous_epoch_last_checkpoint: CheckpointSequenceNumber,
     ) -> Arc<Self> {
         let next_epoch = self.epoch() + 1;
         let next_committee = Committee::new(
@@ -1111,6 +1110,7 @@ impl AuthorityPerEpochStore {
             object_store,
             expensive_safety_check_config,
             self.chain_identifier,
+            previous_epoch_last_checkpoint,
         )
     }
 
@@ -1297,6 +1297,18 @@ impl AuthorityPerEpochStore {
         Ok(())
     }
 
+    pub(crate) fn remove_shared_version_assignments<'a>(
+        &self,
+        keys: impl IntoIterator<Item = &'a TransactionKey>,
+    ) {
+        self.consensus_output_cache
+            .remove_shared_object_assignments(keys);
+    }
+
+    pub fn num_shared_version_assignments(&self) -> usize {
+        self.consensus_output_cache.num_shared_version_assignments()
+    }
+
     pub fn revert_executed_transaction(&self, tx_digest: &TransactionDigest) -> IotaResult {
         let tables = self.tables()?;
         let mut batch = tables.effects_signatures.batch();
@@ -1373,7 +1385,6 @@ impl AuthorityPerEpochStore {
                         let assigned_shared_versions = assigned_shared_versions
                             .get_or_init(|| {
                                 self.get_assigned_shared_object_versions(key)
-                                    .expect("reading assigned shared versions should not fail")
                                     .map(|versions| versions.into_iter().collect())
                             })
                             .as_ref()
@@ -1406,6 +1417,10 @@ impl AuthorityPerEpochStore {
     }
 
     pub fn get_last_consensus_stats(&self) -> IotaResult<ExecutionIndicesWithStats> {
+        assert!(
+            self.consensus_quarantine.read().is_empty(),
+            "get_last_consensus_stats should only be called at startup"
+        );
         match self.tables()?.get_last_consensus_stats()? {
             Some(stats) => Ok(stats),
             None => {
@@ -1450,9 +1465,6 @@ impl AuthorityPerEpochStore {
         Ok(result)
     }
 
-    // `pending_certificates` table related methods.
-    // Should only be used from TransactionManager.
-
     /// Gets all pending certificates. Used during recovery.
     pub fn all_pending_execution(&self) -> IotaResult<Vec<VerifiedExecutableTransaction>> {
         Ok(self
@@ -1465,7 +1477,11 @@ impl AuthorityPerEpochStore {
 
     /// Called when transaction outputs are committed to disk
     #[instrument(level = "trace", skip_all)]
-    pub fn handle_committed_transactions(&self, digests: &[TransactionDigest]) -> IotaResult<()> {
+    pub fn handle_finalized_checkpoint(
+        &self,
+        checkpoint: &CheckpointSummary,
+        digests: &[TransactionDigest],
+    ) -> IotaResult<()> {
         let tables = match self.tables() {
             Ok(tables) => tables,
             // After Epoch ends, it is no longer necessary to remove pending transactions
@@ -1473,26 +1489,18 @@ impl AuthorityPerEpochStore {
             Err(IotaError::EpochEnded(_)) => return Ok(()),
             Err(e) => return Err(e),
         };
-        let mut batch = tables.pending_execution.batch();
-        // pending_execution stores transactions received from consensus which may not
-        // have been executed yet. At this point, they have been committed to
-        // the db durably and can be removed.
-        // After end-to-end quarantining, we will not need pending_execution since the
-        // consensus log itself will be used for recovery.
-        batch.delete_batch(&tables.pending_execution, digests)?;
+        let mut batch = tables.signed_effects_digests.batch();
 
         // Now that the transaction effects are committed, we will never re-execute, so
         // we don't need to worry about equivocating.
         batch.delete_batch(&tables.signed_effects_digests, digests)?;
 
-        // Note that this does not delete keys for random transactions. The worst case
-        // result of this is that we restart at the end of the epoch and load
-        // about 160k keys into memory.
-        batch.delete_batch(
-            &tables.assigned_shared_object_versions,
-            digests.iter().map(|d| TransactionKey::Digest(*d)),
-        )?;
+        let seq = *checkpoint.sequence_number();
+
+        let mut quarantine = self.consensus_quarantine.write();
+        quarantine.update_highest_executed_checkpoint(seq, self, &mut batch)?;
         batch.write()?;
+
         Ok(())
     }
 
@@ -1514,11 +1522,11 @@ impl AuthorityPerEpochStore {
     pub fn set_shared_object_versions_for_testing(
         &self,
         tx_digest: &TransactionDigest,
-        assigned_versions: &Vec<(ObjectID, SequenceNumber)>,
+        assigned_versions: &[(ObjectID, SequenceNumber)],
     ) -> IotaResult {
-        self.tables()?
-            .assigned_shared_object_versions
-            .insert(&TransactionKey::Digest(*tx_digest), assigned_versions)?;
+        self.consensus_output_cache
+            .set_shared_object_versions_for_testing(tx_digest, assigned_versions);
+
         Ok(())
     }
 
@@ -1613,9 +1621,10 @@ impl AuthorityPerEpochStore {
             .acquire_locks(objects_to_init.iter().map(|(id, _)| *id));
         let tables = self.tables()?;
 
-        let next_versions = tables
-            .next_shared_object_versions
-            .multi_get(objects_to_init.iter().map(|(id, _)| *id))?;
+        let next_versions = self
+            .consensus_quarantine
+            .read()
+            .get_next_shared_object_versions(&tables, objects_to_init)?;
 
         let uninitialized_objects: Vec<(ObjectID, SequenceNumber)> = next_versions
             .iter()
@@ -1651,15 +1660,12 @@ impl AuthorityPerEpochStore {
             })
             .collect();
 
-        let ret = izip!(
-            objects_to_init.iter().map(|(id, _)| *id),
-            next_versions.into_iter(),
-        )
-        // take all the previously initialized versions
-        .filter_map(|(id, next_version)| next_version.map(|v| (id, v)))
-        // add all the versions we're going to write
-        .chain(versions_to_write.iter().cloned())
-        .collect();
+        let ret = izip!(objects_to_init.iter().cloned(), next_versions.into_iter(),)
+            // take all the previously initialized versions
+            .filter_map(|(id, next_version)| next_version.map(|v| (id.0, v)))
+            // add all the versions we're going to write
+            .chain(versions_to_write.iter().cloned())
+            .collect();
 
         debug!(
             ?versions_to_write,
@@ -1675,18 +1681,14 @@ impl AuthorityPerEpochStore {
     pub fn get_assigned_shared_object_versions(
         &self,
         key: &TransactionKey,
-    ) -> IotaResult<Option<Vec<(ObjectID, SequenceNumber)>>> {
-        Ok(self.tables()?.assigned_shared_object_versions.get(key)?)
+    ) -> Option<Vec<(ObjectID, SequenceNumber)>> {
+        self.consensus_output_cache
+            .get_assigned_shared_object_versions(key)
     }
 
-    fn set_assigned_shared_object_versions_with_db_batch(
-        &self,
-        versions: AssignedTxAndVersions,
-        db_batch: &mut DBBatch,
-    ) -> IotaResult {
-        debug!("set_assigned_shared_object_versions: {:?}", versions);
-        db_batch.insert_batch(&self.tables()?.assigned_shared_object_versions, versions)?;
-        Ok(())
+    fn set_assigned_shared_object_versions(&self, versions: AssignedTxAndVersions) {
+        self.consensus_output_cache
+            .insert_shared_object_assignments(&versions);
     }
 
     /// Given list of certificates, assign versions for all shared objects used
@@ -1702,7 +1704,6 @@ impl AuthorityPerEpochStore {
         cache_reader: &dyn ObjectCacheRead,
         certificates: &[VerifiedExecutableTransaction],
     ) -> IotaResult {
-        let mut db_batch = self.tables()?.assigned_shared_object_versions.batch();
         let assigned_versions = SharedObjVerManager::assign_versions_from_consensus(
             self,
             cache_reader,
@@ -1711,8 +1712,7 @@ impl AuthorityPerEpochStore {
             &BTreeMap::new(),
         )?
         .assigned_versions;
-        self.set_assigned_shared_object_versions_with_db_batch(assigned_versions, &mut db_batch)?;
-        db_batch.write()?;
+        self.set_assigned_shared_object_versions(assigned_versions);
         Ok(())
     }
 
@@ -1782,44 +1782,9 @@ impl AuthorityPerEpochStore {
             .protocol_config
             .congestion_control_gas_price_feedback_mechanism()
         {
-            self.tables()?
-                .deferred_transactions_v2
-                .safe_iter_with_bounds(Some(min), Some(max))
-                .try_for_each(|result| match result {
-                    Ok((key, txs)) => {
-                        debug!(
-                            "Loaded {:?} deferred txn with deferral key {:?}",
-                            txs.len(),
-                            key
-                        );
-                        keys.push(key);
-                        txns.push((key, txs));
-                        Ok(())
-                    }
-                    Err(err) => Err(err),
-                })?;
+            self.load_from_deferred_transactions_v2(&mut keys, &mut txns, min, max);
         } else {
-            self.tables()?
-                .deferred_transactions
-                .safe_iter_with_bounds(Some(min), Some(max))
-                .try_for_each(|result| match result {
-                    Ok((key, txs)) => {
-                        debug!(
-                            "Loaded {:?} deferred txn with deferral key {:?}",
-                            txs.len(),
-                            key
-                        );
-                        keys.push(key);
-                        txns.push((
-                            key,
-                            txs.into_iter()
-                                .map(|tx| DeferredTransaction::new(tx, None))
-                                .collect(),
-                        ));
-                        Ok(())
-                    }
-                    Err(err) => Err(err),
-                })?;
+            self.load_from_deferred_transactions_v1(&mut keys, &mut txns, min, max);
         }
 
         // verify that there are no duplicates - should be impossible due to
@@ -1839,14 +1804,70 @@ impl AuthorityPerEpochStore {
         Ok(txns)
     }
 
+    fn load_from_deferred_transactions_v2(
+        &self,
+        keys: &mut Vec<DeferralKey>,
+        txns: &mut Vec<(DeferralKey, Vec<DeferredTransaction>)>,
+        min: DeferralKey,
+        max: DeferralKey,
+    ) {
+        let mut deferred_transactions = self.consensus_output_cache.deferred_transactions_v2.lock();
+
+        for (key, transactions) in deferred_transactions.range(min..max) {
+            debug!(
+                "Loaded {:?} deferred txn with deferral key {:?}",
+                transactions.len(),
+                key
+            );
+            keys.push(*key);
+            txns.push((*key, transactions.clone()));
+        }
+
+        for key in keys {
+            deferred_transactions.remove(key);
+        }
+    }
+
+    fn load_from_deferred_transactions_v1(
+        &self,
+        keys: &mut Vec<DeferralKey>,
+        txns: &mut Vec<(DeferralKey, Vec<DeferredTransaction>)>,
+        min: DeferralKey,
+        max: DeferralKey,
+    ) {
+        let mut deferred_transactions = self.consensus_output_cache.deferred_transactions.lock();
+
+        for (key, transactions) in deferred_transactions.range(min..max) {
+            debug!(
+                "Loaded {:?} deferred txn with deferral key {:?}",
+                transactions.len(),
+                key
+            );
+            keys.push(*key);
+            txns.push((
+                *key,
+                transactions
+                    .clone()
+                    .into_iter()
+                    .map(|tx| DeferredTransaction::new(tx, None))
+                    .collect(),
+            ));
+        }
+
+        for key in keys {
+            deferred_transactions.remove(key);
+        }
+    }
+
     pub fn get_all_deferred_transactions_for_test(
         &self,
-    ) -> IotaResult<Vec<(DeferralKey, Vec<DeferredTransaction>)>> {
-        Ok(self
-            .tables()?
+    ) -> Vec<(DeferralKey, Vec<DeferredTransaction>)> {
+        self.consensus_output_cache
             .deferred_transactions_v2
-            .safe_iter()
-            .collect::<Result<Vec<_>, _>>()?)
+            .lock()
+            .iter()
+            .map(|(key, txs)| (*key, txs.clone()))
+            .collect()
     }
 
     fn get_max_execution_duration_per_commit(&self) -> Option<ExecutionTime> {
@@ -1918,7 +1939,8 @@ impl AuthorityPerEpochStore {
     /// based on the effects of that transaction.
     /// Used by full nodes who don't listen to consensus, and validators who
     /// catch up by state sync.
-    // TODO: We should be able to pass in a vector of certs/effects and acquire them all at once.
+    // TODO: We should be able to pass in a vector of certs/effects and acquire them
+    // all at once.
     #[instrument(level = "trace", skip_all)]
     pub fn acquire_shared_version_assignments_from_effects(
         &self,
@@ -1931,9 +1953,7 @@ impl AuthorityPerEpochStore {
             self,
             cache_reader,
         );
-        let mut db_batch = self.tables()?.assigned_shared_object_versions.batch();
-        self.set_assigned_shared_object_versions_with_db_batch(versions, &mut db_batch)?;
-        db_batch.write()?;
+        self.set_assigned_shared_object_versions(versions);
         Ok(())
     }
 
@@ -2005,14 +2025,14 @@ impl AuthorityPerEpochStore {
             .protocol_config
             .congestion_control_gas_price_feedback_mechanism()
         {
-            self.tables()
-                .expect("deferred transactions should not be read past end of epoch")
+            self.consensus_output_cache
                 .deferred_transactions_v2
+                .lock()
                 .is_empty()
         } else {
-            self.tables()
-                .expect("deferred transactions should not be read past end of epoch")
+            self.consensus_output_cache
                 .deferred_transactions
+                .lock()
                 .is_empty()
         }
     }
@@ -2056,19 +2076,40 @@ impl AuthorityPerEpochStore {
         key: &SequencedConsensusTransactionKey,
     ) -> IotaResult<bool> {
         Ok(self
-            .tables()?
-            .consensus_message_processed
-            .contains_key(key)?)
+            .consensus_quarantine
+            .read()
+            .is_consensus_message_processed(key)
+            || self
+                .tables()?
+                .consensus_message_processed
+                .contains_key(key)?)
     }
 
     pub fn check_consensus_messages_processed(
         &self,
         keys: impl Iterator<Item = SequencedConsensusTransactionKey>,
     ) -> IotaResult<Vec<bool>> {
-        Ok(self
-            .tables()?
-            .consensus_message_processed
-            .multi_contains_keys(keys)?)
+        let keys = keys.collect::<Vec<_>>();
+
+        let consensus_quarantine = self.consensus_quarantine.read();
+        let tables = self.tables()?;
+
+        Ok(do_fallback_lookup(
+            &keys,
+            |key| {
+                if consensus_quarantine.is_consensus_message_processed(key) {
+                    CacheResult::Hit(true)
+                } else {
+                    CacheResult::Miss
+                }
+            },
+            |keys| {
+                tables
+                    .consensus_message_processed
+                    .multi_contains_keys(keys)
+                    .expect("db error")
+            },
+        ))
     }
 
     /// Notifies the epoch store that the specified consensus messages have been
@@ -2173,10 +2214,15 @@ impl AuthorityPerEpochStore {
         digests: &[TransactionDigest],
     ) -> IotaResult<Vec<Vec<GenericSignature>>> {
         assert_eq!(transactions.len(), digests.len());
-        let signatures = self
-            .tables()?
-            .user_signatures_for_checkpoints
-            .multi_get(digests)?;
+
+        let signatures: Vec<_> = {
+            let mut user_sigs = self
+                .consensus_output_cache
+                .user_signatures_for_checkpoints
+                .lock();
+            digests.iter().map(|d| user_sigs.remove(d)).collect()
+        };
+
         let mut result = Vec::with_capacity(digests.len());
         for (signatures, transaction) in signatures.into_iter().zip(transactions.iter()) {
             let signatures = if let Some(signatures) = signatures {
@@ -2335,29 +2381,7 @@ impl AuthorityPerEpochStore {
     }
 
     pub(crate) fn get_new_jwks(&self, round: u64) -> IotaResult<Vec<ActiveJwk>> {
-        let epoch = self.epoch();
-
-        let empty_jwk_id = JwkId::new(String::new(), String::new());
-        let empty_jwk = JWK {
-            kty: String::new(),
-            e: String::new(),
-            n: String::new(),
-            alg: String::new(),
-        };
-
-        let start = (round, (empty_jwk_id.clone(), empty_jwk.clone()));
-        let end = (round + 1, (empty_jwk_id, empty_jwk));
-
-        // TODO: use a safe iterator
-        Ok(self
-            .tables()?
-            .active_jwks
-            .safe_iter_with_bounds(Some(start), Some(end))
-            .map_ok(|((r, (jwk_id, jwk)), _)| {
-                debug_assert!(round == r);
-                ActiveJwk { jwk_id, jwk, epoch }
-            })
-            .collect::<Result<Vec<_>, _>>()?)
+        self.consensus_quarantine.read().get_new_jwks(self, round)
     }
 
     pub fn jwk_active_in_current_epoch(&self, jwk_id: &JwkId, jwk: &JWK) -> bool {
@@ -2365,49 +2389,74 @@ impl AuthorityPerEpochStore {
         jwk_aggregator.has_quorum_for_key(&(jwk_id.clone(), jwk.clone()))
     }
 
+    pub(crate) fn get_randomness_last_round_timestamp(&self) -> IotaResult<Option<TimestampMs>> {
+        if let Some(ts) = self
+            .consensus_quarantine
+            .read()
+            .get_randomness_last_round_timestamp()
+        {
+            Ok(Some(ts))
+        } else {
+            Ok(self
+                .tables()?
+                .randomness_last_round_timestamp
+                .get(&SINGLETON_KEY)?)
+        }
+    }
+
+    #[cfg(test)]
     pub fn test_insert_user_signature(
         &self,
         digest: TransactionDigest,
         signatures: Vec<GenericSignature>,
     ) {
-        self.tables()
-            .expect("test should not cross epoch boundary")
+        self.consensus_output_cache
             .user_signatures_for_checkpoints
-            .insert(&digest, &signatures)
-            .unwrap();
+            .lock()
+            .insert(digest, signatures);
         let key = ConsensusTransactionKey::Certificate(digest);
         let key = SequencedConsensusTransactionKey::External(key);
-        self.tables()
-            .expect("test should not cross epoch boundary")
-            .consensus_message_processed
-            .insert(&key, &true)
-            .unwrap();
+
+        let mut output = ConsensusCommitOutput::default();
+        output.record_consensus_message_processed(key.clone());
+        output.set_default_commit_stats_for_testing();
+        self.consensus_quarantine
+            .write()
+            .push_consensus_output(output, self)
+            .expect("push_consensus_output should not fail");
         self.consensus_notify_read.notify(&key, &());
     }
 
-    fn finish_consensus_certificate_process_with_batch(
-        &self,
-        output: &mut ConsensusCommitOutput,
-        certificates: &[VerifiedExecutableTransaction],
-    ) -> IotaResult {
-        output.insert_pending_execution(certificates);
-        output.insert_user_signatures_for_checkpoints(certificates);
+    #[cfg(test)]
+    pub(crate) fn push_consensus_output_for_tests(&self, output: ConsensusCommitOutput) {
+        self.consensus_quarantine
+            .write()
+            .push_consensus_output(output, self)
+            .expect("push_consensus_output should not fail");
+    }
 
-        if cfg!(debug_assertions) {
-            for certificate in certificates {
-                // User signatures are written in the same batch as consensus certificate
-                // processed flag, which means we won't attempt to insert this
-                // twice for the same tx digest
-                assert!(
-                    !self
-                        .tables()?
-                        .user_signatures_for_checkpoints
-                        .contains_key(certificate.digest())
-                        .unwrap()
-                );
-            }
+    fn finish_consensus_certificate_process(&self, certificates: &[VerifiedExecutableTransaction]) {
+        let sigs: Vec<_> = certificates
+            .iter()
+            .map(|certificate| (*certificate.digest(), certificate.tx_signatures().to_vec()))
+            .collect();
+
+        let mut user_sigs = self
+            .consensus_output_cache
+            .user_signatures_for_checkpoints
+            .lock();
+
+        user_sigs.reserve(certificates.len());
+        for (digest, sigs) in sigs {
+            // User signatures are written in the same batch as consensus certificate
+            // processed flag, which means we won't attempt to insert this twice
+            // for the same tx digest
+            assert!(
+                user_sigs.insert(digest, sigs).is_none(),
+                "duplicate user signatures for transaction digest: {:?}",
+                digest
+            );
         }
-        Ok(())
     }
 
     pub fn get_reconfig_state_read_lock_guard(&self) -> RwLockReadGuard<ReconfigState> {
@@ -2618,7 +2667,6 @@ impl AuthorityPerEpochStore {
 
     #[instrument(level = "debug", skip_all)]
     pub(crate) async fn process_consensus_transactions_and_commit_boundary<
-        'a,
         C: CheckpointServiceNotify,
     >(
         &self,
@@ -2626,6 +2674,7 @@ impl AuthorityPerEpochStore {
         consensus_stats: &ExecutionIndicesWithStats,
         checkpoint_service: &Arc<C>,
         cache_reader: &dyn ObjectCacheRead,
+        tx_reader: &dyn TransactionCacheRead,
         consensus_commit_info: &ConsensusCommitInfo,
         authority_metrics: &Arc<AuthorityMetrics>,
     ) -> IotaResult<Vec<VerifiedExecutableTransaction>> {
@@ -2799,7 +2848,7 @@ impl AuthorityPerEpochStore {
             .collect();
 
         let (
-            transactions_to_schedule,
+            verified_transactions,
             notifications,
             lock,
             final_round,
@@ -2821,11 +2870,10 @@ impl AuthorityPerEpochStore {
                 authority_metrics,
             )
             .await?;
-        self.finish_consensus_certificate_process_with_batch(
-            &mut output,
-            &transactions_to_schedule,
-        )?;
+        self.finish_consensus_certificate_process(&verified_transactions);
         output.record_consensus_commit_stats(consensus_stats.clone());
+
+        let mut verified_transactions = verified_transactions;
 
         // Create pending checkpoints if we are still accepting tx.
         let should_accept_tx = if let Some(lock) = &lock {
@@ -2851,10 +2899,24 @@ impl AuthorityPerEpochStore {
             checkpoint_roots.extend(roots.into_iter());
 
             if let Some(randomness_round) = randomness_round {
-                randomness_roots.insert(TransactionKey::RandomnessRound(
-                    self.epoch(),
-                    randomness_round,
-                ));
+                let key = TransactionKey::RandomnessRound(self.epoch(), randomness_round);
+
+                // During crash recovery, the randomness update transaction may already have
+                // been created and executed before the crash. If it is
+                // available locally, we need to ensure it is executed.
+                if let Some(digest) = self.tables()?.transaction_key_to_digest.get(&key)? {
+                    if let Some(tx) = tx_reader.get_transaction_block(&digest) {
+                        info!(
+                            "Randomness update transaction {:?} already exists, scheduling for execution",
+                            digest
+                        );
+                        let tx =
+                            VerifiedExecutableTransaction::new_system((*tx).clone(), self.epoch());
+                        verified_transactions.push(tx);
+                    }
+                }
+
+                randomness_roots.insert(key);
             }
 
             // Determine whether to write pending checkpoint for user tx with randomness.
@@ -2889,9 +2951,9 @@ impl AuthorityPerEpochStore {
             }
         }
 
-        let mut batch = self.db_batch()?;
-        output.write_to_batch(self, &mut batch)?;
-        batch.write()?;
+        self.consensus_quarantine
+            .write()
+            .push_consensus_output(output, self)?;
 
         // Only after batch is written, notify checkpoint service to start building any
         // new pending checkpoints.
@@ -2926,7 +2988,7 @@ impl AuthorityPerEpochStore {
             self.record_end_of_message_quorum_time_metric();
         }
 
-        Ok(transactions_to_schedule)
+        Ok(verified_transactions)
     }
 
     // Adds the consensus commit prologue transaction to the beginning of input
@@ -3023,20 +3085,18 @@ impl AuthorityPerEpochStore {
             randomness_round,
             cancelled_txns,
         )?;
-        output.set_assigned_shared_object_versions(assigned_versions, shared_input_next_versions);
+
+        self.consensus_output_cache
+            .insert_shared_object_assignments(&assigned_versions);
+
+        output.set_next_shared_object_versions(shared_input_next_versions);
         Ok(())
     }
 
     pub fn get_highest_pending_checkpoint_height(&self) -> CheckpointHeight {
-        self.tables()
-            .expect("test should not cross epoch boundary")
-            .pending_checkpoints
-            .reversed_safe_iter_with_bounds(None, None)
-            .unwrap()
-            .next()
-            .transpose()
-            .unwrap()
-            .map(|(key, _)| key)
+        self.consensus_quarantine
+            .read()
+            .get_highest_pending_checkpoint_height()
             .unwrap_or_default()
     }
 
@@ -3049,6 +3109,7 @@ impl AuthorityPerEpochStore {
         transactions: Vec<SequencedConsensusTransaction>,
         checkpoint_service: &Arc<C>,
         cache_reader: &dyn ObjectCacheRead,
+        tx_reader: &dyn TransactionCacheRead,
         authority_metrics: &Arc<AuthorityMetrics>,
         skip_consensus_commit_prologue_in_test: bool,
     ) -> IotaResult<Vec<VerifiedExecutableTransaction>> {
@@ -3057,6 +3118,7 @@ impl AuthorityPerEpochStore {
             &ExecutionIndicesWithStats::default(),
             checkpoint_service,
             cache_reader,
+            tx_reader,
             &ConsensusCommitInfo::new_for_test(
                 self.get_highest_pending_checkpoint_height() / 2 + 1,
                 0,
@@ -3081,6 +3143,7 @@ impl AuthorityPerEpochStore {
             &mut output,
         )?;
         let mut batch = self.db_batch()?;
+        output.set_default_commit_stats_for_testing();
         output.write_to_batch(self, &mut batch)?;
         batch.write()?;
         Ok(())
@@ -3280,10 +3343,36 @@ impl AuthorityPerEpochStore {
         }
         let commit_has_deferred_txns = !deferred_txns.is_empty();
         let mut total_deferred_txns = 0;
-        for (key, txns) in deferred_txns.into_iter() {
-            total_deferred_txns += txns.len();
-            output.defer_transactions(key, txns);
+        {
+            if self
+                .protocol_config
+                .congestion_control_gas_price_feedback_mechanism()
+            {
+                let mut deferred_transactions =
+                    self.consensus_output_cache.deferred_transactions_v2.lock();
+                for (key, txns) in deferred_txns.into_iter() {
+                    total_deferred_txns += txns.len();
+                    deferred_transactions.insert(key, txns.clone());
+                    output.defer_transactions(key, txns);
+                }
+            } else {
+                let mut deferred_transactions =
+                    self.consensus_output_cache.deferred_transactions.lock();
+
+                for (key, txns) in deferred_txns.into_iter() {
+                    total_deferred_txns += txns.len();
+                    deferred_transactions.insert(
+                        key,
+                        txns.clone()
+                            .into_iter()
+                            .map(|tx| tx.transaction)
+                            .collect::<Vec<_>>(),
+                    );
+                    output.defer_transactions(key, txns);
+                }
+            }
         }
+
         authority_metrics
             .consensus_handler_deferred_transactions
             .inc_by(total_deferred_txns as u64);
@@ -3501,7 +3590,7 @@ impl AuthorityPerEpochStore {
                     // certificate here it means authority is byzantine and sent certificate after
                     // EndOfPublish (or we have some bug in ConsensusAdapter)
                     warn!(
-                        "[Byzantine authority] Authority {:?} sent a new, previously unseen 
+                        "[Byzantine authority] Authority {:?} sent a new, previously unseen
                             certificate {:?} after it sent EndOfPublish message to consensus",
                         certificate_author.concise(),
                         certificate.digest()
@@ -3838,7 +3927,7 @@ impl AuthorityPerEpochStore {
         checkpoint: &PendingCheckpoint,
     ) -> IotaResult {
         assert!(
-            self.get_pending_checkpoint(&checkpoint.height())?.is_none(),
+            !self.pending_checkpoint_exists(&checkpoint.height())?,
             "Duplicate pending checkpoint notification at height {:?}",
             checkpoint.height()
         );
@@ -3863,34 +3952,50 @@ impl AuthorityPerEpochStore {
         &self,
         last: Option<CheckpointHeight>,
     ) -> IotaResult<Vec<(CheckpointHeight, PendingCheckpoint)>> {
-        let tables = self.tables()?;
+        let db_results = if !self
+            .epoch_start_config()
+            .is_data_quarantine_active_from_beginning_of_epoch()
+        {
+            // Reading from the db table is only needed when upgrading to data quarantining
+            // for the first time.
+            let db_iter = tables
+                .pending_checkpoints
+                .safe_iter_with_bounds(last.map(|height| height + 1), None);
+            db_iter
+                .collect::<Result<Vec<(CheckpointHeight, PendingCheckpoint)>, _>>()?
+        } else {
+            vec![]
+        };
 
-        let db_iter = tables
-            .pending_checkpoints
-            .safe_iter_with_bounds(last.map(|height| height + 1), None);
-        db_iter
-            .collect::<Result<Vec<(CheckpointHeight, PendingCheckpoint)>, _>>()
-            .map_err(Into::into)
+        let mut quarantine_results = self
+            .consensus_quarantine
+            .read()
+            .get_pending_checkpoints(last);
+
+        // retain only the checkpoints with heights greater than the highest height in
+        // the db
+        if let Some(db_highest_height) = db_results.last().map(|(h, _)| h) {
+            quarantine_results.retain(|(h, _)| h > db_highest_height);
+        }
+
+        let mut db_results = db_results;
+        db_results.extend(quarantine_results);
+        Ok(db_results)
     }
 
-    pub fn get_pending_checkpoint(
-        &self,
-        index: &CheckpointHeight,
-    ) -> IotaResult<Option<PendingCheckpoint>> {
-        Ok(self.tables()?.pending_checkpoints.get(index)?)
+    pub fn pending_checkpoint_exists(&self, index: &CheckpointHeight) -> IotaResult<bool> {
+        Ok(self
+            .consensus_quarantine
+            .read()
+            .pending_checkpoint_exists(index))
     }
 
-    pub fn process_pending_checkpoint(
+    pub fn process_constructed_checkpoint(
         &self,
         commit_height: CheckpointHeight,
         content_info: NonEmpty<(CheckpointSummary, CheckpointContents)>,
-    ) -> IotaResult<()> {
-        let tables = self.tables()?;
-        // All created checkpoints are inserted in builder_checkpoint_summary in a
-        // single batch. This means that upon restart we can use
-        // BuilderCheckpointSummary::commit_height from the last built summary
-        // to resume building checkpoints.
-        let mut batch = tables.pending_checkpoints.batch();
+    ) {
+        let mut consensus_quarantine = self.consensus_quarantine.write();
         for (position_in_commit, (summary, transactions)) in content_info.into_iter().enumerate() {
             let sequence_number = summary.sequence_number;
             let summary = BuilderCheckpointSummary {
@@ -3898,33 +4003,15 @@ impl AuthorityPerEpochStore {
                 checkpoint_height: Some(commit_height),
                 position_in_commit,
             };
-            batch.insert_batch(
-                &tables.builder_checkpoint_summary,
-                [(&sequence_number, summary)],
-            )?;
-            batch.insert_batch(
-                &tables.builder_digest_to_checkpoint,
-                transactions
-                    .iter()
-                    .map(|tx| (tx.transaction, sequence_number)),
-            )?;
 
-            batch.delete_batch(
-                &tables.user_signatures_for_checkpoints,
-                transactions.iter().map(|tx| tx.transaction),
-            )?;
+            consensus_quarantine.insert_builder_summary(sequence_number, summary, transactions);
         }
 
-        // Find all pending checkpoints <= commit_height and remove them
-        let iter = tables
-            .pending_checkpoints
-            .safe_range_iter(0..=commit_height);
-        let keys = iter
-            .map(|c| c.map(|(h, _)| h))
-            .collect::<Result<Vec<_>, _>>()?;
-        batch.delete_batch(&tables.pending_checkpoints, &keys)?;
-
-        Ok(batch.write()?)
+        // Because builder can run behind state sync, the data may be immediately ready
+        // to be committed.
+        consensus_quarantine
+            .commit(self)
+            .expect("commit cannot fail");
     }
 
     /// Register genesis checkpoint in builder DB
@@ -3958,6 +4045,10 @@ impl AuthorityPerEpochStore {
     pub fn last_built_checkpoint_builder_summary(
         &self,
     ) -> IotaResult<Option<BuilderCheckpointSummary>> {
+        if let Some(summary) = self.consensus_quarantine.read().last_built_summary() {
+            return Ok(Some(summary.clone()));
+        }
+
         Ok(self
             .tables()?
             .builder_checkpoint_summary
@@ -3970,19 +4061,41 @@ impl AuthorityPerEpochStore {
     pub fn last_built_checkpoint_summary(
         &self,
     ) -> IotaResult<Option<(CheckpointSequenceNumber, CheckpointSummary)>> {
-        Ok(self
-            .tables()?
-            .builder_checkpoint_summary
-            .reversed_safe_iter_with_bounds(None, None)?
-            .next()
-            .transpose()?
-            .map(|(seq, s)| (seq, s.summary)))
+        if let Some(BuilderCheckpointSummary { summary, .. }) =
+            self.consensus_quarantine.read().last_built_summary()
+        {
+            let seq = *summary.sequence_number();
+            debug!(
+                "returning last_built_summary from consensus quarantine: {:?}",
+                seq
+            );
+            Ok(Some((seq, summary.clone())))
+        } else {
+            let seq = self
+                .tables()?
+                .builder_checkpoint_summary
+                .reversed_safe_iter_with_bounds(None, None)?
+                .next()
+                .transpose()?
+                .map(|(seq, s)| (seq, s.summary));
+            debug!(
+                "returning last_built_summary from builder_checkpoint_summary: {:?}",
+                seq
+            );
+            Ok(seq)
+        }
     }
 
     pub fn get_built_checkpoint_summary(
         &self,
         sequence: CheckpointSequenceNumber,
     ) -> IotaResult<Option<CheckpointSummary>> {
+        if let Some(BuilderCheckpointSummary { summary, .. }) =
+            self.consensus_quarantine.read().get_built_summary(sequence)
+        {
+            return Ok(Some(summary.clone()));
+        }
+
         Ok(self
             .tables()?
             .builder_checkpoint_summary
@@ -3994,10 +4107,25 @@ impl AuthorityPerEpochStore {
         &self,
         digests: impl Iterator<Item = &'a TransactionDigest>,
     ) -> IotaResult<Vec<bool>> {
-        Ok(self
-            .tables()?
-            .builder_digest_to_checkpoint
-            .multi_contains_keys(digests)?)
+        let digests: Vec<_> = digests.cloned().collect();
+        let tables = self.tables()?;
+        Ok(do_fallback_lookup(
+            &digests,
+            |digest| {
+                let consensus_quarantine = self.consensus_quarantine.read();
+                if consensus_quarantine.included_transaction_in_checkpoint(digest) {
+                    CacheResult::Hit(true)
+                } else {
+                    CacheResult::Miss
+                }
+            },
+            |remaining| {
+                tables
+                    .builder_digest_to_checkpoint
+                    .multi_contains_keys(remaining)
+                    .expect("db error")
+            },
+        ))
     }
 
     pub fn get_last_checkpoint_signature_index(&self) -> IotaResult<u64> {

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -414,7 +414,7 @@ pub struct AuthorityPerEpochStore {
     /// memory until they are proven not to have forked by a certified
     /// checkpoint.
     consensus_quarantine: RwLock<ConsensusOutputQuarantine>,
-    /// Holds variouis data from consensus_quarantine in a more easily
+    /// Holds various data from consensus_quarantine in a more easily
     /// accessible form.
     consensus_output_cache: ConsensusOutputCache,
 
@@ -1775,17 +1775,15 @@ impl AuthorityPerEpochStore {
         max: DeferralKey,
     ) -> IotaResult<Vec<(DeferralKey, Vec<DeferredTransaction>)>> {
         debug!("Query epoch store to load deferred txn {:?} {:?}", min, max);
-        let mut keys = Vec::new();
-        let mut txns = Vec::new();
 
-        if self
+        let (keys, txns) = if self
             .protocol_config
             .congestion_control_gas_price_feedback_mechanism()
         {
-            self.load_from_deferred_transactions_v2(&mut keys, &mut txns, min, max);
+            self.load_deferred_transactions_v2(min, max)
         } else {
-            self.load_from_deferred_transactions_v1(&mut keys, &mut txns, min, max);
-        }
+            self.load_deferred_transactions_v1(min, max)
+        };
 
         // verify that there are no duplicates - should be impossible due to
         // is_consensus_message_processed
@@ -1804,13 +1802,16 @@ impl AuthorityPerEpochStore {
         Ok(txns)
     }
 
-    fn load_from_deferred_transactions_v2(
+    fn load_deferred_transactions_v2(
         &self,
-        keys: &mut Vec<DeferralKey>,
-        txns: &mut Vec<(DeferralKey, Vec<DeferredTransaction>)>,
         min: DeferralKey,
         max: DeferralKey,
+    ) -> (
+        Vec<DeferralKey>,
+        Vec<(DeferralKey, Vec<DeferredTransaction>)>,
     ) {
+        let mut keys = Vec::new();
+        let mut txns = Vec::new();
         let mut deferred_transactions = self.consensus_output_cache.deferred_transactions_v2.lock();
 
         for (key, transactions) in deferred_transactions.range(min..max) {
@@ -1823,18 +1824,23 @@ impl AuthorityPerEpochStore {
             txns.push((*key, transactions.clone()));
         }
 
-        for key in keys {
+        for key in &keys {
             deferred_transactions.remove(key);
         }
+
+        (keys, txns)
     }
 
-    fn load_from_deferred_transactions_v1(
+    fn load_deferred_transactions_v1(
         &self,
-        keys: &mut Vec<DeferralKey>,
-        txns: &mut Vec<(DeferralKey, Vec<DeferredTransaction>)>,
         min: DeferralKey,
         max: DeferralKey,
+    ) -> (
+        Vec<DeferralKey>,
+        Vec<(DeferralKey, Vec<DeferredTransaction>)>,
     ) {
+        let mut keys = Vec::new();
+        let mut txns = Vec::new();
         let mut deferred_transactions = self.consensus_output_cache.deferred_transactions.lock();
 
         for (key, transactions) in deferred_transactions.range(min..max) {
@@ -1853,9 +1859,11 @@ impl AuthorityPerEpochStore {
             ));
         }
 
-        for key in keys {
+        for key in &keys {
             deferred_transactions.remove(key);
         }
+
+        (keys, txns)
     }
 
     pub fn get_all_deferred_transactions_for_test(

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1862,12 +1862,30 @@ impl AuthorityPerEpochStore {
     pub fn get_all_deferred_transactions_for_test(
         &self,
     ) -> Vec<(DeferralKey, Vec<DeferredTransaction>)> {
-        self.consensus_output_cache
-            .deferred_transactions_v2
-            .lock()
-            .iter()
-            .map(|(key, txs)| (*key, txs.clone()))
-            .collect()
+        if self
+            .protocol_config
+            .congestion_control_gas_price_feedback_mechanism()
+        {
+            self.consensus_output_cache
+                .deferred_transactions_v2
+                .lock()
+                .iter()
+                .map(|(key, txs)| (*key, txs.clone()))
+                .collect()
+        } else {
+            self.consensus_output_cache
+                .deferred_transactions
+                .lock()
+                .iter()
+                .map(|(key, txs)| {
+                    let converted_txs: Vec<DeferredTransaction> = txs
+                        .iter()
+                        .map(|tx| DeferredTransaction::new(tx.clone(), None))
+                        .collect();
+                    (*key, converted_txs)
+                })
+                .collect()
+        }
     }
 
     fn get_max_execution_duration_per_commit(&self) -> Option<ExecutionTime> {

--- a/crates/iota-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/iota-core/src/authority/authority_per_epoch_store.rs
@@ -1847,9 +1847,8 @@ impl AuthorityPerEpochStore {
             txns.push((
                 *key,
                 transactions
-                    .clone()
-                    .into_iter()
-                    .map(|tx| DeferredTransaction::new(tx, None))
+                    .iter()
+                    .map(|tx| DeferredTransaction::new(tx.clone(), None))
                     .collect(),
             ));
         }
@@ -3381,9 +3380,8 @@ impl AuthorityPerEpochStore {
                     total_deferred_txns += txns.len();
                     deferred_transactions.insert(
                         key,
-                        txns.clone()
-                            .into_iter()
-                            .map(|tx| tx.transaction)
+                        txns.iter()
+                            .map(|tx| tx.transaction.clone())
                             .collect::<Vec<_>>(),
                     );
                     output.defer_transactions(key, txns);

--- a/crates/iota-core/src/authority/authority_store.rs
+++ b/crates/iota-core/src/authority/authority_store.rs
@@ -900,39 +900,13 @@ impl AuthorityStore {
         Ok(())
     }
 
-    /// Commits transactions only to the db. Called by checkpoint builder. See
-    /// ExecutionCache::commit_transactions for more info
-    pub(crate) fn commit_transactions(
-        &self,
-        transactions: &[(TransactionDigest, VerifiedTransaction)],
-    ) -> IotaResult {
+    /// Commits transactions only (not effects or other transaction outputs) to
+    /// the db. See ExecutionCache::persist_transaction for more info
+    pub(crate) fn persist_transaction(&self, tx: &VerifiedExecutableTransaction) -> IotaResult {
         let mut batch = self.perpetual_tables.transactions.batch();
         batch.insert_batch(
             &self.perpetual_tables.transactions,
-            transactions
-                .iter()
-                .map(|(digest, tx)| (*digest, tx.serializable_ref())),
-        )?;
-        batch.write()?;
-        Ok(())
-    }
-
-    pub(crate) fn persist_transactions_and_effects(
-        &self,
-        transactions_and_effects: &[(VerifiedTransaction, TransactionEffects)],
-    ) -> IotaResult {
-        let mut batch = self.perpetual_tables.transactions.batch();
-        batch.insert_batch(
-            &self.perpetual_tables.transactions,
-            transactions_and_effects
-                .iter()
-                .map(|(tx, _)| (*tx.digest(), tx.serializable_ref())),
-        )?;
-        batch.insert_batch(
-            &self.perpetual_tables.effects,
-            transactions_and_effects
-                .iter()
-                .map(|(_, fx)| (fx.digest(), fx.clone())),
+            [(tx.digest(), tx.clone().into_unsigned().serializable_ref())],
         )?;
         batch.write()?;
         Ok(())

--- a/crates/iota-core/src/authority/authority_test_utils.rs
+++ b/crates/iota-core/src/authority/authority_test_utils.rs
@@ -397,6 +397,7 @@ pub async fn send_consensus(authority: &AuthorityState, cert: &VerifiedCertifica
             vec![transaction],
             &Arc::new(CheckpointServiceNoop {}),
             authority.get_object_cache_reader().as_ref(),
+            authority.get_transaction_cache_reader().as_ref(),
             &authority.metrics,
             true,
         )
@@ -422,6 +423,7 @@ pub async fn send_consensus_no_execution(authority: &AuthorityState, cert: &Veri
             vec![transaction],
             &Arc::new(CheckpointServiceNoop {}),
             authority.get_object_cache_reader().as_ref(),
+            authority.get_transaction_cache_reader().as_ref(),
             &authority.metrics,
             true,
         )
@@ -453,6 +455,7 @@ pub async fn send_batch_consensus_no_execution(
             transactions,
             &Arc::new(CheckpointServiceNoop {}),
             authority.get_object_cache_reader().as_ref(),
+            authority.get_transaction_cache_reader().as_ref(),
             &authority.metrics,
             skip_consensus_commit_prologue_in_test,
         )

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -425,9 +425,6 @@ impl ConsensusOutputCache {
             .safe_iter()
             .collect::<Result<Vec<_>, _>>()
             .expect("db error")
-            .into_iter()
-            .map(|(key, value)| (key, value.into_iter().collect::<Vec<_>>()))
-            .collect()
     }
 }
 

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -44,7 +44,6 @@ pub(crate) struct ConsensusCommitOutput {
     consensus_commit_stats: Option<ExecutionIndicesWithStats>,
 
     // transaction scheduling state
-    // shared_object_versions: Option<(AssignedTxAndVersions, HashMap<ObjectID, SequenceNumber>)>,
     next_shared_object_versions: Option<HashMap<ObjectID, SequenceNumber>>,
 
     // TODO: If we delay committing consensus output until after all deferrals have been loaded,
@@ -332,7 +331,7 @@ impl ConsensusOutputCache {
 
         let deferred_transactions_v2 = tables
             .get_all_deferred_transactions_v2()
-            .expect("load deferred transactions cannot fail");
+            .expect("load deferred transactions v2 cannot fail");
 
         if !epoch_start_configuration.is_data_quarantine_active_from_beginning_of_epoch() {
             let shared_version_assignments = Self::get_all_shared_version_assignments(tables);
@@ -471,12 +470,11 @@ impl ConsensusOutputQuarantine {
             metrics: authority_metrics,
         }
     }
-}
 
-// Write methods - all methods in this block insert new data into the
-// quarantine. There are only two sources! ConsensusHandler and
-// CheckpointBuilder.
-impl ConsensusOutputQuarantine {
+    // Write methods - all methods in this block insert new data into the
+    // quarantine. There are only two sources! ConsensusHandler and
+    // CheckpointBuilder.
+
     // Push all data gathered from a consensus commit into the quarantine.
     pub(super) fn push_consensus_output(
         &mut self,
@@ -513,6 +511,7 @@ impl ConsensusOutputQuarantine {
             .insert(sequence_number, (summary, contents));
     }
 
+    // Commit methods.
     /// Update the highest executed checkpoint and commit any data which is now
     /// below the watermark.
     pub(super) fn update_highest_executed_checkpoint(

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -560,8 +560,7 @@ impl ConsensusOutputQuarantine {
                         .remove(digest)
                         .unwrap_or_else(|| {
                             panic!(
-                                "transaction {:?} not found in builder_digest_to_checkpoint",
-                                digest
+                                "transaction {digest:?} not found in builder_digest_to_checkpoint"
                             )
                         }),
                     seq

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -2,19 +2,24 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque, hash_map};
 
+use dashmap::DashMap;
 use fastcrypto_tbls::{dkg_v1, nodes::PartyId};
 use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId};
+use iota_common::fatal;
 use iota_types::{
+    authenticator_state::ActiveJwk,
     base_types::{AuthorityName, ObjectID, SequenceNumber, TransactionDigest},
     crypto::RandomnessRound,
     error::IotaResult,
-    executable_transaction::VerifiedExecutableTransaction,
-    messages_consensus::VersionedDkgConfirmation,
+    messages_checkpoint::{CheckpointContents, CheckpointSequenceNumber},
+    messages_consensus::{TimestampMs, VersionedDkgConfirmation},
     signature::GenericSignature,
 };
-use typed_store::rocks::DBBatch;
+use parking_lot::Mutex;
+use tracing::{debug, info};
+use typed_store::{Map, rocks::DBBatch};
 
 use super::*;
 use crate::{
@@ -37,17 +42,18 @@ pub(crate) struct ConsensusCommitOutput {
     end_of_publish: BTreeSet<AuthorityName>,
     reconfig_state: Option<ReconfigState>,
     consensus_commit_stats: Option<ExecutionIndicesWithStats>,
-    pending_execution: Vec<VerifiedExecutableTransaction>,
 
     // transaction scheduling state
-    shared_object_versions: Option<(AssignedTxAndVersions, HashMap<ObjectID, SequenceNumber>)>,
+    // shared_object_versions: Option<(AssignedTxAndVersions, HashMap<ObjectID, SequenceNumber>)>,
+    next_shared_object_versions: Option<HashMap<ObjectID, SequenceNumber>>,
 
+    // TODO: If we delay committing consensus output until after all deferrals have been loaded,
+    // we can move deferred_txns to the ConsensusOutputCache and save disk bandwidth.
     deferred_txns: Vec<(DeferralKey, Vec<DeferredTransaction>)>,
     // deferred txns that have been loaded and can be removed
     deleted_deferred_txns: BTreeSet<DeferralKey>,
 
     // checkpoint state
-    user_signatures_for_checkpoints: Vec<(TransactionDigest, Vec<GenericSignature>)>,
     pending_checkpoints: Vec<PendingCheckpoint>,
 
     // random beacon state
@@ -68,28 +74,51 @@ impl ConsensusCommitOutput {
         Default::default()
     }
 
+    fn get_randomness_last_round_timestamp(&self) -> Option<TimestampMs> {
+        self.next_randomness_round.as_ref().map(|(_, ts)| *ts)
+    }
+
+    fn get_highest_pending_checkpoint_height(&self) -> Option<CheckpointHeight> {
+        self.pending_checkpoints.last().map(|cp| cp.height())
+    }
+
+    fn get_pending_checkpoints(
+        &self,
+        last: Option<CheckpointHeight>,
+    ) -> impl Iterator<Item = &PendingCheckpoint> {
+        self.pending_checkpoints.iter().filter(move |cp| {
+            if let Some(last) = last {
+                cp.height() > last
+            } else {
+                true
+            }
+        })
+    }
+
+    fn pending_checkpoint_exists(&self, index: &CheckpointHeight) -> bool {
+        self.pending_checkpoints
+            .iter()
+            .any(|cp| cp.height() == *index)
+    }
+
+    fn get_round(&self) -> Option<u64> {
+        self.consensus_commit_stats
+            .as_ref()
+            .map(|stats| stats.index.last_committed_round)
+    }
+
     pub fn insert_end_of_publish(&mut self, authority: AuthorityName) {
         self.end_of_publish.insert(authority);
     }
 
-    pub fn insert_pending_execution(&mut self, transactions: &[VerifiedExecutableTransaction]) {
-        self.pending_execution.reserve(transactions.len());
-        self.pending_execution.extend_from_slice(transactions);
-    }
-
-    pub fn insert_user_signatures_for_checkpoints(
-        &mut self,
-        transactions: &[VerifiedExecutableTransaction],
-    ) {
-        self.user_signatures_for_checkpoints.extend(
-            transactions
-                .iter()
-                .map(|tx| (*tx.digest(), tx.tx_signatures().to_vec())),
-        );
-    }
-
-    pub fn record_consensus_commit_stats(&mut self, stats: ExecutionIndicesWithStats) {
+    pub(crate) fn record_consensus_commit_stats(&mut self, stats: ExecutionIndicesWithStats) {
         self.consensus_commit_stats = Some(stats);
+    }
+
+    // in testing code we often need to write to the db outside of a consensus
+    // commit
+    pub(crate) fn set_default_commit_stats_for_testing(&mut self) {
+        self.record_consensus_commit_stats(Default::default());
     }
 
     pub fn store_reconfig_state(&mut self, state: ReconfigState) {
@@ -100,13 +129,12 @@ impl ConsensusCommitOutput {
         self.consensus_messages_processed.insert(key);
     }
 
-    pub fn set_assigned_shared_object_versions(
+    pub fn set_next_shared_object_versions(
         &mut self,
-        versions: AssignedTxAndVersions,
         next_versions: HashMap<ObjectID, SequenceNumber>,
     ) {
-        assert!(self.shared_object_versions.is_none());
-        self.shared_object_versions = Some((versions, next_versions));
+        assert!(self.next_shared_object_versions.is_none());
+        self.next_shared_object_versions = Some(next_versions);
     }
 
     pub fn defer_transactions(&mut self, key: DeferralKey, transactions: Vec<DeferredTransaction>) {
@@ -181,24 +209,21 @@ impl ConsensusCommitOutput {
             )?;
         }
 
-        if let Some(consensus_commit_stats) = &self.consensus_commit_stats {
-            batch.insert_batch(
-                &tables.last_consensus_stats,
-                [(LAST_CONSENSUS_STATS_ADDR, consensus_commit_stats)],
-            )?;
-        }
+        let consensus_commit_stats = self
+            .consensus_commit_stats
+            .expect("consensus_commit_stats must be set");
+        let round = consensus_commit_stats.index.last_committed_round;
 
         batch.insert_batch(
-            &tables.pending_execution,
-            self.pending_execution
-                .into_iter()
-                .map(|tx| (*tx.inner().digest(), tx.serializable())),
+            &tables.last_consensus_stats,
+            [(LAST_CONSENSUS_STATS_ADDR, consensus_commit_stats)],
         )?;
 
-        if let Some((assigned_versions, next_versions)) = self.shared_object_versions {
-            batch.insert_batch(&tables.assigned_shared_object_versions, assigned_versions)?;
-
-            batch.insert_batch(&tables.next_shared_object_versions, next_versions)?;
+        if let Some(next_versions) = self.next_shared_object_versions {
+            batch.insert_batch(
+                &tables.next_shared_object_versions,
+                next_versions.into_iter(),
+            )?;
         }
 
         if epoch_store
@@ -227,18 +252,6 @@ impl ConsensusCommitOutput {
             )?;
         }
 
-        batch.insert_batch(
-            &tables.user_signatures_for_checkpoints,
-            self.user_signatures_for_checkpoints,
-        )?;
-
-        batch.insert_batch(
-            &tables.pending_checkpoints,
-            self.pending_checkpoints
-                .into_iter()
-                .map(|cp| (cp.height(), cp)),
-        )?;
-
         if let Some((round, commit_timestamp)) = self.next_randomness_round {
             batch.insert_batch(&tables.randomness_next_round, [(SINGLETON_KEY, round)])?;
             batch.insert_batch(
@@ -266,9 +279,610 @@ impl ConsensusCommitOutput {
         )?;
         batch.insert_batch(
             &tables.active_jwks,
-            self.active_jwks.into_iter().map(|j| (j, ())),
+            self.active_jwks.into_iter().map(|j| {
+                // TODO: we don't need to store the round in this map if it is invariant
+                assert_eq!(j.0, round);
+                (j, ())
+            }),
         )?;
 
         Ok(())
+    }
+}
+
+/// ConsensusOutputCache holds outputs of consensus processing that do not need
+/// to be committed to disk. Data quarantining guarantees that all of this data
+/// will be used (e.g. for building checkpoints) before the consensus commit
+/// from which it originated is marked as processed. Therefore we can rely
+/// on replay of consensus commits to recover this data.
+pub(crate) struct ConsensusOutputCache {
+    // shared version assignments is a DashMap because it is read from execution so we don't
+    // want contention.
+    shared_version_assignments: DashMap<TransactionKey, Vec<(ObjectID, SequenceNumber)>>,
+
+    // deferred transactions is only used by consensus handler so there should never be lock
+    // contention
+    // - hence no need for a DashMap.
+    pub(super) deferred_transactions:
+        Mutex<BTreeMap<DeferralKey, Vec<VerifiedSequencedConsensusTransaction>>>,
+
+    // deferred transactions is only used by consensus handler so there should never be lock
+    // contention
+    // - hence no need for a DashMap.
+    pub(super) deferred_transactions_v2: Mutex<BTreeMap<DeferralKey, Vec<DeferredTransaction>>>,
+
+    // user_signatures_for_checkpoints is written to by consensus handler and read from by
+    // checkpoint builder The critical sections are small in both cases so a DashMap is
+    // probably not helpful.
+    pub(super) user_signatures_for_checkpoints:
+        Mutex<HashMap<TransactionDigest, Vec<GenericSignature>>>,
+
+    metrics: Arc<EpochMetrics>,
+}
+
+impl ConsensusOutputCache {
+    pub(crate) fn new(
+        epoch_start_configuration: &EpochStartConfiguration,
+        tables: &AuthorityEpochTables,
+        metrics: Arc<EpochMetrics>,
+    ) -> Self {
+        let deferred_transactions = tables
+            .get_all_deferred_transactions()
+            .expect("load deferred transactions cannot fail");
+
+        let deferred_transactions_v2 = tables
+            .get_all_deferred_transactions_v2()
+            .expect("load deferred transactions cannot fail");
+
+        if !epoch_start_configuration.is_data_quarantine_active_from_beginning_of_epoch() {
+            let shared_version_assignments = Self::get_all_shared_version_assignments(tables);
+
+            let user_signatures_for_checkpoints = tables
+                .get_all_user_signatures_for_checkpoints()
+                .expect("load user signatures for checkpoints cannot fail");
+
+            Self {
+                shared_version_assignments: shared_version_assignments.into_iter().collect(),
+                deferred_transactions: Mutex::new(deferred_transactions),
+                deferred_transactions_v2: Mutex::new(deferred_transactions_v2),
+                user_signatures_for_checkpoints: Mutex::new(user_signatures_for_checkpoints),
+                metrics,
+            }
+        } else {
+            Self {
+                shared_version_assignments: Default::default(),
+                deferred_transactions: Mutex::new(deferred_transactions),
+                deferred_transactions_v2: Mutex::new(deferred_transactions_v2),
+                user_signatures_for_checkpoints: Default::default(),
+                metrics,
+            }
+        }
+    }
+
+    pub fn num_shared_version_assignments(&self) -> usize {
+        self.shared_version_assignments.len()
+    }
+
+    pub fn get_assigned_shared_object_versions(
+        &self,
+        key: &TransactionKey,
+    ) -> Option<Vec<(ObjectID, SequenceNumber)>> {
+        self.shared_version_assignments
+            .get(key)
+            .map(|locks| locks.clone())
+    }
+
+    pub fn insert_shared_object_assignments(&self, versions: &AssignedTxAndVersions) {
+        trace!("insert_shared_object_assignments: {:?}", versions);
+        let mut inserted_count = 0;
+        for (key, value) in versions {
+            if self
+                .shared_version_assignments
+                .insert(*key, value.clone())
+                .is_none()
+            {
+                inserted_count += 1;
+            }
+        }
+        self.metrics
+            .shared_object_assignments_size
+            .add(inserted_count as i64);
+    }
+
+    pub fn set_shared_object_versions_for_testing(
+        &self,
+        tx_digest: &TransactionDigest,
+        assigned_versions: &[(ObjectID, SequenceNumber)],
+    ) {
+        self.shared_version_assignments.insert(
+            TransactionKey::Digest(*tx_digest),
+            assigned_versions.to_owned(),
+        );
+    }
+
+    pub fn remove_shared_object_assignments<'a>(
+        &self,
+        keys: impl IntoIterator<Item = &'a TransactionKey>,
+    ) {
+        let mut removed_count = 0;
+        for tx_key in keys {
+            if self.shared_version_assignments.remove(tx_key).is_some() {
+                removed_count += 1;
+            }
+        }
+        self.metrics
+            .shared_object_assignments_size
+            .sub(removed_count as i64);
+    }
+
+    // Used to read pre-existing shared object versions from the database after a
+    // crash. TODO: remove this once all nodes have upgraded to
+    // data-quarantining.
+    fn get_all_shared_version_assignments(
+        tables: &AuthorityEpochTables,
+    ) -> Vec<(TransactionKey, Vec<(ObjectID, SequenceNumber)>)> {
+        tables
+            .assigned_shared_object_versions
+            .safe_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .expect("db error")
+            .into_iter()
+            .map(|(key, value)| (key, value.into_iter().collect::<Vec<_>>()))
+            .collect()
+    }
+}
+
+/// ConsensusOutputQuarantine holds outputs of consensus processing in memory
+/// until the checkpoints for the commit have been certified.
+pub(crate) struct ConsensusOutputQuarantine {
+    // Output from consensus handler
+    output_queue: VecDeque<ConsensusCommitOutput>,
+
+    // Highest known certified checkpoint sequence number
+    highest_executed_checkpoint: CheckpointSequenceNumber,
+
+    // Checkpoint Builder output
+    builder_checkpoint_summary:
+        BTreeMap<CheckpointSequenceNumber, (BuilderCheckpointSummary, CheckpointContents)>,
+
+    builder_digest_to_checkpoint: HashMap<TransactionDigest, CheckpointSequenceNumber>,
+
+    // Any un-committed next versions are stored here.
+    shared_object_next_versions: RefCountedHashMap<ObjectID, SequenceNumber>,
+
+    processed_consensus_messages: RefCountedHashMap<SequencedConsensusTransactionKey, ()>,
+
+    metrics: Arc<EpochMetrics>,
+}
+
+impl ConsensusOutputQuarantine {
+    pub(super) fn new(
+        highest_executed_checkpoint: CheckpointSequenceNumber,
+        authority_metrics: Arc<EpochMetrics>,
+    ) -> Self {
+        Self {
+            highest_executed_checkpoint,
+
+            output_queue: VecDeque::new(),
+            builder_checkpoint_summary: BTreeMap::new(),
+            builder_digest_to_checkpoint: HashMap::new(),
+            shared_object_next_versions: RefCountedHashMap::new(),
+            processed_consensus_messages: RefCountedHashMap::new(),
+            metrics: authority_metrics,
+        }
+    }
+}
+
+// Write methods - all methods in this block insert new data into the
+// quarantine. There are only two sources! ConsensusHandler and
+// CheckpointBuilder.
+impl ConsensusOutputQuarantine {
+    // Push all data gathered from a consensus commit into the quarantine.
+    pub(super) fn push_consensus_output(
+        &mut self,
+        output: ConsensusCommitOutput,
+        epoch_store: &AuthorityPerEpochStore,
+    ) -> IotaResult {
+        self.insert_shared_object_next_versions(&output);
+        self.insert_processed_consensus_messages(&output);
+        self.output_queue.push_back(output);
+
+        self.metrics
+            .consensus_quarantine_queue_size
+            .set(self.output_queue.len() as i64);
+
+        // we may already have observed the certified checkpoint for this round, if
+        // state sync is running ahead of consensus, so there may be data to
+        // commit right away.
+        self.commit(epoch_store)
+    }
+
+    // Record a newly built checkpoint.
+    pub(super) fn insert_builder_summary(
+        &mut self,
+        sequence_number: CheckpointSequenceNumber,
+        summary: BuilderCheckpointSummary,
+        contents: CheckpointContents,
+    ) {
+        debug!(?sequence_number, "inserting builder summary {:?}", summary);
+        for tx in contents.iter() {
+            self.builder_digest_to_checkpoint
+                .insert(tx.transaction, sequence_number);
+        }
+        self.builder_checkpoint_summary
+            .insert(sequence_number, (summary, contents));
+    }
+
+    /// Update the highest executed checkpoint and commit any data which is now
+    /// below the watermark.
+    pub(super) fn update_highest_executed_checkpoint(
+        &mut self,
+        checkpoint: CheckpointSequenceNumber,
+        epoch_store: &AuthorityPerEpochStore,
+        batch: &mut DBBatch,
+    ) -> IotaResult {
+        self.highest_executed_checkpoint = checkpoint;
+        self.commit_with_batch(epoch_store, batch)
+    }
+
+    pub(super) fn commit(&mut self, epoch_store: &AuthorityPerEpochStore) -> IotaResult {
+        let mut batch = epoch_store.db_batch()?;
+        self.commit_with_batch(epoch_store, &mut batch)?;
+        batch.write()?;
+        Ok(())
+    }
+
+    /// Commit all data below the watermark.
+    fn commit_with_batch(
+        &mut self,
+        epoch_store: &AuthorityPerEpochStore,
+        batch: &mut DBBatch,
+    ) -> IotaResult {
+        // The commit algorithm is simple:
+        // 1. First commit all checkpoint builder state which is below the watermark.
+        // 2. Determine the consensus commit height that corresponds to the highest
+        //    committed checkpoint.
+        // 3. Commit all consensus output at that height or below.
+
+        let tables = epoch_store.tables()?;
+
+        let mut highest_committed_height = None;
+
+        while self
+            .builder_checkpoint_summary
+            .first_key_value()
+            .map(|(seq, _)| *seq <= self.highest_executed_checkpoint)
+            == Some(true)
+        {
+            let (seq, (builder_summary, contents)) =
+                self.builder_checkpoint_summary.pop_first().unwrap();
+
+            for tx in contents.iter() {
+                let digest = &tx.transaction;
+                assert_eq!(
+                    self.builder_digest_to_checkpoint
+                        .remove(digest)
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "transaction {:?} not found in builder_digest_to_checkpoint",
+                                digest
+                            )
+                        }),
+                    seq
+                );
+            }
+
+            batch.insert_batch(
+                &tables.builder_digest_to_checkpoint,
+                contents.iter().map(|tx| (tx.transaction, seq)),
+            )?;
+
+            batch.insert_batch(
+                &tables.builder_checkpoint_summary,
+                [(seq, &builder_summary)],
+            )?;
+
+            let checkpoint_height = builder_summary
+                .checkpoint_height
+                .expect("non-genesis checkpoint must have height");
+            if let Some(highest) = highest_committed_height {
+                assert!(checkpoint_height > highest);
+            }
+
+            highest_committed_height = Some(checkpoint_height);
+        }
+
+        let Some(highest_committed_height) = highest_committed_height else {
+            return Ok(());
+        };
+
+        while !self.output_queue.is_empty() {
+            // A consensus commit can have more than one pending checkpoint (a regular one
+            // and a randomnes one). We can only write the consensus commit if
+            // the highest pending checkpoint associated with it has
+            // been processed by the builder.
+            let Some(highest_in_commit) = self
+                .output_queue
+                .front()
+                .unwrap()
+                .get_highest_pending_checkpoint_height()
+            else {
+                // if highest is none, we have already written the pending checkpoint for the
+                // final epoch, so there is no more data that needs to be
+                // committed.
+                break;
+            };
+
+            if highest_in_commit <= highest_committed_height {
+                info!(
+                    "committing output with highest pending checkpoint height {:?}",
+                    highest_in_commit
+                );
+                let output = self.output_queue.pop_front().unwrap();
+                self.remove_shared_object_next_versions(&output);
+                self.remove_processed_consensus_messages(&output);
+                epoch_store.remove_shared_version_assignments(
+                    output
+                        .pending_checkpoints
+                        .iter()
+                        .flat_map(|c| c.roots().iter()),
+                );
+                output.write_to_batch(epoch_store, batch)?;
+            } else {
+                break;
+            }
+        }
+
+        self.metrics
+            .consensus_quarantine_queue_size
+            .set(self.output_queue.len() as i64);
+
+        Ok(())
+    }
+
+    fn insert_shared_object_next_versions(&mut self, output: &ConsensusCommitOutput) {
+        if let Some(next_versions) = output.next_shared_object_versions.as_ref() {
+            for (object_id, next_version) in next_versions.iter() {
+                self.shared_object_next_versions
+                    .insert(*object_id, *next_version);
+            }
+        }
+    }
+
+    fn insert_processed_consensus_messages(&mut self, output: &ConsensusCommitOutput) {
+        for tx_key in output.consensus_messages_processed.iter() {
+            self.processed_consensus_messages.insert(tx_key.clone(), ());
+        }
+    }
+
+    fn remove_processed_consensus_messages(&mut self, output: &ConsensusCommitOutput) {
+        for tx_key in output.consensus_messages_processed.iter() {
+            self.processed_consensus_messages.remove(tx_key);
+        }
+    }
+
+    fn remove_shared_object_next_versions(&mut self, output: &ConsensusCommitOutput) {
+        if let Some(next_versions) = output.next_shared_object_versions.as_ref() {
+            for object_id in next_versions.keys() {
+                if !self.shared_object_next_versions.remove(object_id) {
+                    fatal!(
+                        "Shared object next version not found in quarantine: {:?}",
+                        object_id
+                    );
+                }
+            }
+        }
+    }
+
+    // Read methods - all methods in this block return data from the quarantine
+    // which would otherwise be found in the database.
+    pub(super) fn last_built_summary(&self) -> Option<&BuilderCheckpointSummary> {
+        self.builder_checkpoint_summary
+            .values()
+            .last()
+            .map(|(summary, _)| summary)
+    }
+
+    pub(super) fn get_built_summary(
+        &self,
+        sequence: CheckpointSequenceNumber,
+    ) -> Option<&BuilderCheckpointSummary> {
+        self.builder_checkpoint_summary
+            .get(&sequence)
+            .map(|(summary, _)| summary)
+    }
+
+    pub(super) fn included_transaction_in_checkpoint(&self, digest: &TransactionDigest) -> bool {
+        self.builder_digest_to_checkpoint.contains_key(digest)
+    }
+
+    pub(super) fn is_consensus_message_processed(
+        &self,
+        key: &SequencedConsensusTransactionKey,
+    ) -> bool {
+        self.processed_consensus_messages.contains_key(key)
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.output_queue.is_empty()
+    }
+
+    pub(super) fn get_next_shared_object_versions(
+        &self,
+        tables: &AuthorityEpochTables,
+        objects_to_init: &[(ObjectID, SequenceNumber)],
+    ) -> IotaResult<Vec<Option<SequenceNumber>>> {
+        Ok(do_fallback_lookup(
+            objects_to_init,
+            |(object_id, _)| {
+                if let Some(next_version) = self.shared_object_next_versions.get(object_id) {
+                    CacheResult::Hit(Some(*next_version))
+                } else {
+                    CacheResult::Miss
+                }
+            },
+            |object_keys| {
+                tables
+                    .next_shared_object_versions
+                    .multi_get(object_keys.iter().map(|(object_id, _)| object_id))
+                    .expect("db error")
+            },
+        ))
+    }
+
+    pub(super) fn get_highest_pending_checkpoint_height(&self) -> Option<CheckpointHeight> {
+        self.output_queue
+            .back()
+            .and_then(|output| output.get_highest_pending_checkpoint_height())
+    }
+
+    pub(super) fn get_pending_checkpoints(
+        &self,
+        last: Option<CheckpointHeight>,
+    ) -> Vec<(CheckpointHeight, PendingCheckpoint)> {
+        let mut checkpoints = Vec::new();
+        for output in &self.output_queue {
+            checkpoints.extend(
+                output
+                    .get_pending_checkpoints(last)
+                    .map(|cp| (cp.height(), cp.clone())),
+            );
+        }
+        if cfg!(debug_assertions) {
+            let mut prev = None;
+            for (height, _) in &checkpoints {
+                if let Some(prev) = prev {
+                    assert!(prev < *height);
+                }
+                prev = Some(*height);
+            }
+        }
+        checkpoints
+    }
+
+    pub(super) fn pending_checkpoint_exists(&self, index: &CheckpointHeight) -> bool {
+        self.output_queue
+            .iter()
+            .any(|output| output.pending_checkpoint_exists(index))
+    }
+
+    pub(super) fn get_new_jwks(
+        &self,
+        epoch_store: &AuthorityPerEpochStore,
+        round: u64,
+    ) -> IotaResult<Vec<ActiveJwk>> {
+        let epoch = epoch_store.epoch();
+
+        // Check if the requested round is in memory
+        for output in self.output_queue.iter().rev() {
+            // unwrap safe because output will always have last consensus stats set before
+            // being added to the quarantine
+            let output_round = output.get_round().unwrap();
+            if round == output_round {
+                return Ok(output
+                    .active_jwks
+                    .iter()
+                    .map(|(_, (jwk_id, jwk))| ActiveJwk {
+                        jwk_id: jwk_id.clone(),
+                        jwk: jwk.clone(),
+                        epoch,
+                    })
+                    .collect());
+            }
+        }
+
+        // Fall back to reading from database
+        let empty_jwk_id = JwkId::new(String::new(), String::new());
+        let empty_jwk = JWK {
+            kty: String::new(),
+            e: String::new(),
+            n: String::new(),
+            alg: String::new(),
+        };
+
+        let start = (round, (empty_jwk_id.clone(), empty_jwk.clone()));
+        let end = (round + 1, (empty_jwk_id, empty_jwk));
+
+        Ok(epoch_store
+            .tables()?
+            .active_jwks
+            .safe_iter_with_bounds(Some(start), Some(end))
+            .map_ok(|((r, (jwk_id, jwk)), _)| {
+                debug_assert!(round == r);
+                ActiveJwk { jwk_id, jwk, epoch }
+            })
+            .collect::<Result<Vec<_>, _>>()?)
+    }
+
+    pub(super) fn get_randomness_last_round_timestamp(&self) -> Option<TimestampMs> {
+        self.output_queue
+            .iter()
+            .rev()
+            .filter_map(|output| output.get_randomness_last_round_timestamp())
+            .next()
+    }
+}
+
+// A wrapper around HashMap that uses refcounts to keep entries alive until
+// they are no longer needed.
+//
+// If there are N inserts for the same key, the key will not be removed until
+// there are N removes.
+//
+// It is intended to track the *latest* value for a given key, so duplicate
+// inserts are intended to overwrite any prior value.
+#[derive(Debug, Default)]
+struct RefCountedHashMap<K, V> {
+    map: HashMap<K, (usize, V)>,
+}
+
+impl<K, V> RefCountedHashMap<K, V>
+where
+    K: Clone + Eq + std::hash::Hash,
+{
+    pub fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+
+    pub fn insert(&mut self, key: K, value: V) {
+        let entry = self.map.entry(key);
+        match entry {
+            hash_map::Entry::Occupied(mut entry) => {
+                let (ref_count, v) = entry.get_mut();
+                *ref_count += 1;
+                *v = value;
+            }
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert((1, value));
+            }
+        }
+    }
+
+    // Returns true if the key was present, false otherwise.
+    // Note that the key may not be removed if present, as it may have a refcount >
+    // 1.
+    pub fn remove(&mut self, key: &K) -> bool {
+        let entry = self.map.entry(key.clone());
+        match entry {
+            hash_map::Entry::Occupied(mut entry) => {
+                let (ref_count, _) = entry.get_mut();
+                *ref_count -= 1;
+                if *ref_count == 0 {
+                    entry.remove();
+                }
+                true
+            }
+            hash_map::Entry::Vacant(_) => false,
+        }
+    }
+
+    pub fn get(&self, key: &K) -> Option<&V> {
+        self.map.get(key).map(|(_, v)| v)
+    }
+
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.map.contains_key(key)
     }
 }

--- a/crates/iota-core/src/authority/consensus_quarantine.rs
+++ b/crates/iota-core/src/authority/consensus_quarantine.rs
@@ -289,11 +289,11 @@ impl ConsensusCommitOutput {
     }
 }
 
-/// ConsensusOutputCache holds outputs of consensus processing that do not need
-/// to be committed to disk. Data quarantining guarantees that all of this data
-/// will be used (e.g. for building checkpoints) before the consensus commit
-/// from which it originated is marked as processed. Therefore we can rely
-/// on replay of consensus commits to recover this data.
+/// `ConsensusOutputCache` holds outputs of consensus processing that do not
+/// need to be committed to disk. Data quarantining guarantees that all of this
+/// data will be used (e.g. for building checkpoints) before the consensus
+/// commit from which it originated is marked as processed. Therefore we can
+/// rely on replay of consensus commits to recover this data.
 pub(crate) struct ConsensusOutputCache {
     // shared version assignments is a DashMap because it is read from execution so we don't
     // want contention.
@@ -428,7 +428,7 @@ impl ConsensusOutputCache {
     }
 }
 
-/// ConsensusOutputQuarantine holds outputs of consensus processing in memory
+/// `ConsensusOutputQuarantine` holds outputs of consensus processing in memory
 /// until the checkpoints for the commit have been certified.
 pub(crate) struct ConsensusOutputQuarantine {
     // Output from consensus handler
@@ -671,6 +671,7 @@ impl ConsensusOutputQuarantine {
 
     // Read methods - all methods in this block return data from the quarantine
     // which would otherwise be found in the database.
+
     pub(super) fn last_built_summary(&self) -> Option<&BuilderCheckpointSummary> {
         self.builder_checkpoint_summary
             .values()
@@ -818,14 +819,14 @@ impl ConsensusOutputQuarantine {
     }
 }
 
-// A wrapper around HashMap that uses refcounts to keep entries alive until
-// they are no longer needed.
-//
-// If there are N inserts for the same key, the key will not be removed until
-// there are N removes.
-//
-// It is intended to track the *latest* value for a given key, so duplicate
-// inserts are intended to overwrite any prior value.
+/// A wrapper around `HashMap` that uses ref counts to keep entries alive until
+/// they are no longer needed.
+///
+/// If there are `N` inserts for the same key, the key will not be removed until
+/// there are `N` removes.
+///
+/// It is intended to track the *latest* value for a given key, so duplicate
+/// inserts are intended to overwrite any prior value.
 #[derive(Debug, Default)]
 struct RefCountedHashMap<K, V> {
     map: HashMap<K, (usize, V)>,

--- a/crates/iota-core/src/authority/epoch_start_configuration.rs
+++ b/crates/iota-core/src/authority/epoch_start_configuration.rs
@@ -37,6 +37,11 @@ pub trait EpochStartConfigTrait {
             ExecutionCacheType::PassthroughCache
         }
     }
+
+    fn is_data_quarantine_active_from_beginning_of_epoch(&self) -> bool {
+        self.flags()
+            .contains(&EpochFlag::DataQuarantineFromBeginningOfEpoch)
+    }
 }
 
 // IMPORTANT: Assign explicit values to each variant to ensure that the values
@@ -54,6 +59,10 @@ pub enum EpochFlag {
     // lock or not, depending on the used implementation. That's why we should not switch
     // mid-epoch.
     WritebackCacheEnabled = 0,
+
+    // This flag indicates whether data quarantining has been enabled from the
+    // beginning of the epoch.
+    DataQuarantineFromBeginningOfEpoch = 1,
 }
 
 impl EpochFlag {
@@ -68,7 +77,7 @@ impl EpochFlag {
     }
 
     fn default_flags_impl(cache_type: ExecutionCacheType) -> Vec<Self> {
-        let mut new_flags = vec![];
+        let mut new_flags = vec![EpochFlag::DataQuarantineFromBeginningOfEpoch];
 
         // Load cache type from env
         if matches!(cache_type.cache_type(), ExecutionCacheType::WritebackCache) {
@@ -85,6 +94,9 @@ impl fmt::Display for EpochFlag {
         // is used as metric key
         match self {
             EpochFlag::WritebackCacheEnabled => write!(f, "WritebackCacheEnabled"),
+            EpochFlag::DataQuarantineFromBeginningOfEpoch => {
+                write!(f, "DataQuarantineFromBeginningOfEpoch")
+            }
         }
     }
 }

--- a/crates/iota-core/src/authority/test_authority_builder.rs
+++ b/crates/iota-core/src/authority/test_authority_builder.rs
@@ -300,6 +300,10 @@ impl<'a> TestAuthorityBuilder<'a> {
             signature_verifier_metrics,
             &expensive_safety_checks,
             ChainIdentifier::from(*genesis.checkpoint().digest()),
+            checkpoint_store
+                .get_highest_executed_checkpoint_seq_number()
+                .unwrap()
+                .unwrap_or(0),
         );
         let committee_store = Arc::new(CommitteeStore::new(
             path.join("epochs"),

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -23,9 +23,8 @@
 
 use std::{sync::Arc, time::Instant};
 
-use futures::{StreamExt, FuturesOrdered};
+use futures::StreamExt;
 use iota_common::{debug_fatal, fatal};
-use either::Either;
 use iota_config::node::{CheckpointExecutorConfig, RunWithRange};
 use iota_macros::fail_point;
 use iota_types::{
@@ -289,7 +288,7 @@ impl CheckpointExecutor {
                 );
 
                 self.epoch_store
-                    .handle_committed_transactions(&ckpt_state.data.tx_digests)
+                    .handle_finalized_checkpoint(&ckpt_state.data.checkpoint, &ckpt_state.data.tx_digests)
                     .expect("cannot fail");
 
                 // Once the checkpoint is finalized, we know that any randomness contained in this checkpoint has

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -23,8 +23,9 @@
 
 use std::{sync::Arc, time::Instant};
 
-use futures::StreamExt;
+use futures::{StreamExt, FuturesOrdered};
 use iota_common::{debug_fatal, fatal};
+use either::Either;
 use iota_config::node::{CheckpointExecutorConfig, RunWithRange};
 use iota_macros::fail_point;
 use iota_types::{

--- a/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/iota-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -258,6 +258,10 @@ pub async fn test_checkpoint_executor_cross_epoch() {
             // Since the expensive checks are disabled, per the line above, the value we pass here
             // won't be used.
             0,
+            checkpoint_store
+                .get_highest_executed_checkpoint_seq_number()
+                .unwrap()
+                .unwrap(),
         )
         .await
         .unwrap();

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -872,6 +872,9 @@ impl CheckpointStore {
         Ok(())
     }
 
+    /// TODO: this is only needed while upgrading from non-dataquarantine to
+    /// dataquarantine. After that it can be deleted.
+    ///
     /// Re-executes all transactions from all local, uncertified checkpoints for
     /// crash recovery. All transactions thus re-executed are guaranteed to
     /// not have any missing dependencies, because we start from the highest
@@ -924,16 +927,19 @@ impl CheckpointStore {
             let txns = cache
                 .try_multi_get_transaction_blocks(&tx_digests)
                 .expect("try_multi_get_transaction_blocks should not fail");
-            for (tx, digest) in txns.iter().zip(tx_digests.iter()) {
-                if tx.is_none() {
-                    panic!("transaction {digest:?} not found");
-                }
-            }
 
-            let txns: Vec<_> = txns
-                .into_iter()
-                .map(|tx| tx.unwrap())
-                .zip(fx_digests.into_iter())
+            let txns: Vec<_> = itertools::izip!(txns, tx_digests, fx_digests)
+                .filter_map(|(tx, digest, fx)| {
+                    if let Some(tx) = tx {
+                        Some((tx, fx))
+                    } else {
+                        info!(
+                            "transaction {:?} not found during checkpoint re-execution",
+                            digest
+                        );
+                        None
+                    }
+                })
                 // end of epoch transaction can only be executed by CheckpointExecutor
                 .filter(|(tx, _)| !tx.data().transaction_data().is_end_of_epoch_tx())
                 .map(|(tx, fx)| {
@@ -1135,6 +1141,7 @@ impl CheckpointBuilder {
             {
                 Ok(seq) => {
                     self.last_built.send_if_modified(|cur| {
+                        // when rebuilding checkpoints at startup, seq can be for an old checkpoint
                         if seq > *cur {
                             *cur = seq;
                             true
@@ -1239,6 +1246,15 @@ impl CheckpointBuilder {
 
                 // No other dependencies of this consensus commit prologue that haven't been
                 // included in any previous checkpoint.
+                if unsorted_ccp.len() != 1 {
+                    fatal!(
+                        "Expected 1 consensus commit prologue, got {:?}",
+                        unsorted_ccp
+                            .iter()
+                            .map(|e| e.transaction_digest())
+                            .collect::<Vec<_>>()
+                    );
+                }
                 assert_eq!(unsorted_ccp.len(), 1);
                 assert_eq!(unsorted_ccp[0].transaction_digest(), ccp_digest);
             }
@@ -1317,24 +1333,6 @@ impl CheckpointBuilder {
         let mut all_tx_digests =
             Vec::with_capacity(new_checkpoints.iter().map(|(_, c)| c.size()).sum());
 
-        // When upgrading to a data-quarantining build, we need to persist the
-        // transactions and effects to the database for crash recovery. After
-        // the upgrade this is no longer needed, because recovery is driven by
-        // replay of consensus commits. This only updates the content-addressed
-        // stores (similar to state sync), it does not mark any transactions as
-        // executed.
-        self.state
-            .get_cache_commit()
-            .persist_transactions_and_effects(
-                &new_checkpoints
-                    .iter()
-                    .flat_map(|(_, c)| {
-                        c.iter()
-                            .map(|digests| (digests.transaction, digests.effects))
-                    })
-                    .collect::<Vec<_>>(),
-            );
-
         for (summary, contents) in &new_checkpoints {
             debug!(
                 checkpoint_commit_height = height,
@@ -1342,11 +1340,24 @@ impl CheckpointBuilder {
                 contents_digest = ?contents.digest(),
                 "writing checkpoint",
             );
-            all_tx_digests.extend(contents.iter().map(|digests| digests.transaction));
 
-            self.output
-                .checkpoint_created(summary, contents, &self.epoch_store, &self.store)
-                .await?;
+            if let Some(previously_computed_summary) = self
+                .tables
+                .locally_computed_checkpoints
+                .get(&summary.sequence_number)?
+            {
+                if previously_computed_summary != *summary {
+                    // Panic so that we don't send out an equivocating checkpoint sig.
+                    fatal!(
+                        "Checkpoint {} was previously built with a different result: {:?} vs {:?}",
+                        summary.sequence_number,
+                        previously_computed_summary,
+                        summary
+                    );
+                }
+            }
+
+            all_tx_digests.extend(contents.iter().map(|digests| digests.transaction));
 
             self.metrics
                 .transactions_included_in_checkpoint
@@ -1367,23 +1378,14 @@ impl CheckpointBuilder {
             )?;
         }
 
-        // Durably commit transactions (but not their outputs) to the database.
-        // Called before writing a locally built checkpoint to the CheckpointStore, so
-        // that the inputs of the checkpoint cannot be lost.
-        // These transactions are guaranteed to be final unless this validator
-        // forks (i.e. constructs a checkpoint which will never be certified). In this
-        // case some non-final transactions could be left in the database.
-        //
-        // This is an intermediate solution until we delay commits to the epoch db.
-        // After we have done that, crash recovery will be done by re-processing
-        // consensus commits and pending_consensus_transactions, and this method
-        // can be removed.
-        self.state
-            .get_cache_commit()
-            .try_persist_transactions(&all_tx_digests)
-            .await?;
-
         batch.write()?;
+
+        // Send all checkpoint sigs to consensus.
+        for (summary, content) in &new_checkpoints {
+            self.output
+                .checkpoint_created(summary, content, &self.epoch_store, &self.tables)
+                .await?;
+        }
 
         for (local_checkpoint, _) in &new_checkpoints {
             if let Some(certified_checkpoint) = self
@@ -1399,7 +1401,7 @@ impl CheckpointBuilder {
 
         self.notify_aggregator.notify_one();
         self.epoch_store
-            .process_pending_checkpoint(height, new_checkpoints)?;
+            .process_constructed_checkpoint(height, new_checkpoints);
         Ok(())
     }
 
@@ -1461,17 +1463,13 @@ impl CheckpointBuilder {
 
     /// Creates checkpoints using the provided transaction effects and pending
     /// checkpoint information.
-    #[instrument(level = "debug", skip_all)]
-    async fn create_checkpoints(
-        &self,
-        all_effects: Vec<TransactionEffects>,
-        details: &PendingCheckpointInfo,
-    ) -> anyhow::Result<NonEmpty<(CheckpointSummary, CheckpointContents)>> {
-        let _scope = monitored_scope("CheckpointBuilder::create_checkpoints");
-        let total = all_effects.len();
-        let mut last_checkpoint = self.epoch_store.last_built_checkpoint_summary()?;
+    fn load_last_built_checkpoint_summary(
+        epoch_store: &AuthorityPerEpochStore,
+        tables: &CheckpointStore,
+    ) -> IotaResult<Option<(CheckpointSequenceNumber, CheckpointSummary)>> {
+        let mut last_checkpoint = epoch_store.last_built_checkpoint_summary()?;
         if last_checkpoint.is_none() {
-            let epoch = self.epoch_store.epoch();
+            let epoch = epoch_store.epoch();
             if epoch > 0 {
                 let previous_epoch = epoch - 1;
                 let last_verified = self.store.get_epoch_last_checkpoint(previous_epoch)?;
@@ -1487,6 +1485,19 @@ impl CheckpointBuilder {
                 }
             }
         }
+        Ok(last_checkpoint)
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn create_checkpoints(
+        &self,
+        all_effects: Vec<TransactionEffects>,
+        details: &PendingCheckpointInfo,
+    ) -> anyhow::Result<NonEmpty<(CheckpointSummary, CheckpointContents)>> {
+        let _scope = monitored_scope("CheckpointBuilder::create_checkpoints");
+        let total = all_effects.len();
+        let mut last_checkpoint =
+            Self::load_last_built_checkpoint_summary(&self.epoch_store, &self.tables)?;
         let last_checkpoint_seq = last_checkpoint.as_ref().map(|(seq, _)| *seq);
         debug!(
             next_checkpoint_seq = last_checkpoint_seq.unwrap_or_default() + 1,
@@ -2434,13 +2445,19 @@ impl CheckpointService {
         let notify_builder = Arc::new(Notify::new());
         let notify_aggregator = Arc::new(Notify::new());
 
-        let highest_previously_built_seq = epoch_store
-            .last_built_checkpoint_builder_summary()
-            .expect("epoch should not have ended")
-            .map(|s| s.summary.sequence_number)
+        // We may have built higher checkpoint numbers before restarting.
+        let highest_previously_built_seq = checkpoint_store
+            .get_latest_locally_computed_checkpoint()
+            .map(|s| s.sequence_number)
             .unwrap_or(0);
 
-        let (highest_currently_built_seq_tx, _) = watch::channel(highest_previously_built_seq);
+        let highest_currently_built_seq =
+            CheckpointBuilder::load_last_built_checkpoint_summary(&epoch_store, &checkpoint_store)
+                .expect("epoch should not have ended")
+                .map(|(seq, _)| seq)
+                .unwrap_or(0);
+
+        let (highest_currently_built_seq_tx, _) = watch::channel(highest_currently_built_seq);
 
         let aggregator = CheckpointAggregator::new(
             checkpoint_store.clone(),
@@ -2529,12 +2546,17 @@ impl CheckpointService {
     pub async fn wait_for_rebuilt_checkpoints(&self) {
         let highest_previously_built_seq = self.highest_previously_built_seq;
         let mut rx = self.highest_currently_built_seq_tx.subscribe();
+        let mut highest_currently_built_seq = *rx.borrow_and_update();
+        info!(
+            "Waiting for checkpoints to be rebuilt, previously built seq: {highest_previously_built_seq}, currently built seq: {highest_currently_built_seq}"
+        );
         loop {
-            let highest_currently_built_seq = *rx.borrow_and_update();
             if highest_currently_built_seq >= highest_previously_built_seq {
+                info!("Checkpoint rebuild complete");
                 break;
             }
             rx.changed().await.unwrap();
+            highest_currently_built_seq = *rx.borrow_and_update();
         }
     }
 
@@ -2548,9 +2570,8 @@ impl CheckpointService {
 
         let mut output = ConsensusCommitOutput::new();
         epoch_store.write_pending_checkpoint(&mut output, &checkpoint)?;
-        let mut batch = epoch_store.db_batch_for_test();
-        output.write_to_batch(epoch_store, &mut batch)?;
-        batch.write()?;
+        output.set_default_commit_stats_for_testing();
+        epoch_store.push_consensus_output_for_tests(output);
         self.notify_checkpoint()?;
         Ok(())
     }

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1351,10 +1351,8 @@ impl CheckpointBuilder {
                 if previously_computed_summary != *summary {
                     // Panic so that we don't send out an equivocating checkpoint sig.
                     fatal!(
-                        "Checkpoint {} was previously built with a different result: {:?} vs {:?}",
+                        "Checkpoint {} was previously built with a different result: {previously_computed_summary:?} vs {summary:?}",
                         summary.sequence_number,
-                        previously_computed_summary,
-                        summary
                     );
                 }
             }
@@ -2551,7 +2549,8 @@ impl CheckpointService {
         let mut rx = self.highest_currently_built_seq_tx.subscribe();
         let mut highest_currently_built_seq = *rx.borrow_and_update();
         info!(
-            "Waiting for checkpoints to be rebuilt, previously built seq: {highest_previously_built_seq}, currently built seq: {highest_currently_built_seq}"
+            "Waiting for checkpoints to be rebuilt, previously built seq: \
+            {highest_previously_built_seq}, currently built seq: {highest_currently_built_seq}"
         );
         loop {
             if highest_currently_built_seq >= highest_previously_built_seq {

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1381,9 +1381,9 @@ impl CheckpointBuilder {
         batch.write()?;
 
         // Send all checkpoint sigs to consensus.
-        for (summary, content) in &new_checkpoints {
+        for (summary, contents) in &new_checkpoints {
             self.output
-                .checkpoint_created(summary, content, &self.epoch_store, &self.tables)
+                .checkpoint_created(summary, contents, &self.epoch_store, &self.tables)
                 .await?;
         }
 

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -879,6 +879,7 @@ impl CheckpointStore {
     /// crash recovery. All transactions thus re-executed are guaranteed to
     /// not have any missing dependencies, because we start from the highest
     /// executed checkpoint, and proceed through checkpoints in order.
+    // tracking issue: https://github.com/iotaledger/iota/issues/8290
     #[instrument(level = "debug", skip_all)]
     pub async fn reexecute_local_checkpoints(
         &self,

--- a/crates/iota-core/src/checkpoints/mod.rs
+++ b/crates/iota-core/src/checkpoints/mod.rs
@@ -1343,6 +1343,7 @@ impl CheckpointBuilder {
             );
 
             if let Some(previously_computed_summary) = self
+                .store
                 .tables
                 .locally_computed_checkpoints
                 .get(&summary.sequence_number)?
@@ -1384,7 +1385,7 @@ impl CheckpointBuilder {
         // Send all checkpoint sigs to consensus.
         for (summary, contents) in &new_checkpoints {
             self.output
-                .checkpoint_created(summary, contents, &self.epoch_store, &self.tables)
+                .checkpoint_created(summary, contents, &self.epoch_store, &self.store)
                 .await?;
         }
 
@@ -1466,14 +1467,14 @@ impl CheckpointBuilder {
     /// checkpoint information.
     fn load_last_built_checkpoint_summary(
         epoch_store: &AuthorityPerEpochStore,
-        tables: &CheckpointStore,
+        store: &CheckpointStore,
     ) -> IotaResult<Option<(CheckpointSequenceNumber, CheckpointSummary)>> {
         let mut last_checkpoint = epoch_store.last_built_checkpoint_summary()?;
         if last_checkpoint.is_none() {
             let epoch = epoch_store.epoch();
             if epoch > 0 {
                 let previous_epoch = epoch - 1;
-                let last_verified = self.store.get_epoch_last_checkpoint(previous_epoch)?;
+                let last_verified = store.get_epoch_last_checkpoint(previous_epoch)?;
                 last_checkpoint = last_verified.map(VerifiedCheckpoint::into_summary_and_sequence);
                 if let Some((ref seq, _)) = last_checkpoint {
                     debug!(
@@ -1498,7 +1499,7 @@ impl CheckpointBuilder {
         let _scope = monitored_scope("CheckpointBuilder::create_checkpoints");
         let total = all_effects.len();
         let mut last_checkpoint =
-            Self::load_last_built_checkpoint_summary(&self.epoch_store, &self.tables)?;
+            Self::load_last_built_checkpoint_summary(&self.epoch_store, &self.store)?;
         let last_checkpoint_seq = last_checkpoint.as_ref().map(|(seq, _)| *seq);
         debug!(
             next_checkpoint_seq = last_checkpoint_seq.unwrap_or_default() + 1,
@@ -2449,6 +2450,7 @@ impl CheckpointService {
         // We may have built higher checkpoint numbers before restarting.
         let highest_previously_built_seq = checkpoint_store
             .get_latest_locally_computed_checkpoint()
+            .expect("failed to get latest locally computed checkpoint")
             .map(|s| s.sequence_number)
             .unwrap_or(0);
 

--- a/crates/iota-core/src/consensus_handler.rs
+++ b/crates/iota-core/src/consensus_handler.rs
@@ -39,7 +39,7 @@ use crate::{
     },
     checkpoints::{CheckpointService, CheckpointServiceNotify},
     consensus_types::{AuthorityIndex, consensus_output_api::ConsensusOutputAPI},
-    execution_cache::ObjectCacheRead,
+    execution_cache::{ObjectCacheRead, TransactionCacheRead},
     scoring_decision::update_low_scoring_authorities,
     transaction_manager::TransactionManager,
 };
@@ -92,6 +92,7 @@ impl ConsensusHandlerInitializer {
             self.checkpoint_service.clone(),
             self.state.transaction_manager().clone(),
             self.state.get_object_cache_reader().clone(),
+            self.state.get_transaction_cache_reader().clone(),
             self.low_scoring_authorities.clone(),
             consensus_committee,
             self.state.metrics.clone(),
@@ -114,6 +115,8 @@ pub struct ConsensusHandler<C> {
     /// cache reader is needed when determining the next version to assign for
     /// shared objects.
     cache_reader: Arc<dyn ObjectCacheRead>,
+    /// used to read randomness transactions during crash recovery
+    tx_reader: Arc<dyn TransactionCacheRead>,
     /// Reputation scores used by consensus adapter that we update, forwarded
     /// from consensus
     low_scoring_authorities: Arc<ArcSwap<HashMap<AuthorityName, u64>>>,
@@ -138,6 +141,7 @@ impl<C> ConsensusHandler<C> {
         checkpoint_service: Arc<C>,
         transaction_manager: Arc<TransactionManager>,
         cache_reader: Arc<dyn ObjectCacheRead>,
+        tx_reader: Arc<dyn TransactionCacheRead>,
         low_scoring_authorities: Arc<ArcSwap<HashMap<AuthorityName, u64>>>,
         committee: ConsensusCommittee,
         metrics: Arc<AuthorityMetrics>,
@@ -158,6 +162,7 @@ impl<C> ConsensusHandler<C> {
             last_consensus_stats,
             checkpoint_service,
             cache_reader,
+            tx_reader,
             low_scoring_authorities,
             committee,
             metrics,
@@ -391,6 +396,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 &self.last_consensus_stats,
                 &self.checkpoint_service,
                 self.cache_reader.as_ref(),
+                self.tx_reader.as_ref(),
                 &ConsensusCommitInfo::new(&consensus_output),
                 &self.metrics,
             )
@@ -399,7 +405,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
 
         fail_point_if!("correlated-crash-after-consensus-commit-boundary", || {
             let key = [commit_sub_dag_index, self.epoch_store.epoch()];
-            if iota_simulator::random::deterministic_probability(key, 0.01) {
+            if iota_simulator::random::deterministic_probability_once(key, 0.01) {
                 iota_simulator::task::kill_current_node(None);
             }
         });
@@ -855,6 +861,7 @@ mod tests {
             Arc::new(CheckpointServiceNoop {}),
             state.transaction_manager().clone(),
             state.get_object_cache_reader().clone(),
+            state.get_transaction_cache_reader().clone(),
             Arc::new(ArcSwap::default()),
             consensus_committee.clone(),
             metrics,

--- a/crates/iota-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/iota-core/src/consensus_manager/mysticeti_manager.rs
@@ -222,7 +222,9 @@ impl ConsensusManagerTrait for MysticetiManager {
         *consensus_handler = Some(handler);
 
         // Wait until all locally available commits have been processed
+        info!("replaying commits at startup");
         registered_authority.0.replay_complete().await;
+        info!("Startup commit replay complete");
     }
 
     async fn shutdown(&self) {

--- a/crates/iota-core/src/epoch/epoch_metrics.rs
+++ b/crates/iota-core/src/epoch/epoch_metrics.rs
@@ -115,6 +115,12 @@ pub struct EpochMetrics {
     /// DKG protocol, at which point the node has submitted a DKG
     /// Confirmation, for the most recent epoch.
     pub epoch_random_beacon_dkg_confirmation_time_ms: IntGauge,
+
+    /// The number of consensus output items in the quarantine.
+    pub consensus_quarantine_queue_size: IntGauge,
+
+    /// The number of shared object assignments in the quarantine.
+    pub shared_object_assignments_size: IntGauge,
 }
 
 impl EpochMetrics {
@@ -230,6 +236,18 @@ impl EpochMetrics {
             epoch_random_beacon_dkg_confirmation_time_ms: register_int_gauge_with_registry!(
                 "epoch_random_beacon_dkg_confirmation_time_ms",
                 "The amount of time taken to complete first phase of the random beacon DKG protocol, at which point the node has submitted a DKG Confirmation, for the most recent epoch",
+                registry
+            )
+            .unwrap(),
+            consensus_quarantine_queue_size: register_int_gauge_with_registry!(
+                "consensus_quarantine_queue_size",
+                "The number of consensus output items in the quarantine",
+                registry
+            )
+            .unwrap(),
+            shared_object_assignments_size: register_int_gauge_with_registry!(
+                "shared_object_assignments_size",
+                "The number of shared object assignments in the quarantine",
                 registry
             )
             .unwrap(),

--- a/crates/iota-core/src/epoch/randomness.rs
+++ b/crates/iota-core/src/epoch/randomness.rs
@@ -697,12 +697,11 @@ impl RandomnessManager {
         output: &mut ConsensusCommitOutput,
     ) -> IotaResult<Option<RandomnessRound>> {
         let epoch_store = self.epoch_store()?;
-        let tables = epoch_store.tables()?;
 
-        let last_round_timestamp = tables
-            .randomness_last_round_timestamp
-            .get(&SINGLETON_KEY)
-            .expect("typed_store should not fail");
+        let last_round_timestamp = epoch_store
+            .get_randomness_last_round_timestamp()
+            .expect("read should not fail");
+
         if let Some(last_round_timestamp) = last_round_timestamp {
             if commit_timestamp - last_round_timestamp
                 < epoch_store
@@ -841,8 +840,11 @@ mod tests {
     use tokio::sync::mpsc;
 
     use crate::{
-        authority::test_authority_builder::TestAuthorityBuilder,
         checkpoints::CheckpointStore,
+        authority::{
+            authority_per_epoch_store::{ExecutionIndices, ExecutionIndicesWithStats},
+            test_authority_builder::TestAuthorityBuilder,
+        },
         consensus_adapter::{
             ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
             MockConsensusClient,
@@ -933,6 +935,13 @@ mod tests {
         }
         for i in 0..randomness_managers.len() {
             let mut output = ConsensusCommitOutput::new();
+            output.record_consensus_commit_stats(ExecutionIndicesWithStats {
+                index: ExecutionIndices {
+                    last_committed_round: 0,
+                    ..Default::default()
+                },
+                ..Default::default()
+            });
             for (j, dkg_message) in dkg_messages.iter().cloned().enumerate() {
                 randomness_managers[i]
                     .add_message(&epoch_stores[j].name, dkg_message)
@@ -963,6 +972,13 @@ mod tests {
         }
         for i in 0..randomness_managers.len() {
             let mut output = ConsensusCommitOutput::new();
+            output.record_consensus_commit_stats(ExecutionIndicesWithStats {
+                index: ExecutionIndices {
+                    last_committed_round: 1,
+                    ..Default::default()
+                },
+                ..Default::default()
+            });
             for (j, dkg_confirmation) in dkg_confirmations.iter().cloned().enumerate() {
                 randomness_managers[i]
                     .add_confirmation(&mut output, &epoch_stores[j].name, dkg_confirmation)
@@ -1069,6 +1085,13 @@ mod tests {
         }
         for i in 0..randomness_managers.len() {
             let mut output = ConsensusCommitOutput::new();
+            output.record_consensus_commit_stats(ExecutionIndicesWithStats {
+                index: ExecutionIndices {
+                    last_committed_round: 0,
+                    ..Default::default()
+                },
+                ..Default::default()
+            });
             for (j, dkg_message) in dkg_messages.iter().cloned().enumerate() {
                 randomness_managers[i]
                     .add_message(&epoch_stores[j].name, dkg_message)

--- a/crates/iota-core/src/epoch/randomness.rs
+++ b/crates/iota-core/src/epoch/randomness.rs
@@ -840,11 +840,11 @@ mod tests {
     use tokio::sync::mpsc;
 
     use crate::{
-        checkpoints::CheckpointStore,
         authority::{
             authority_per_epoch_store::{ExecutionIndices, ExecutionIndicesWithStats},
             test_authority_builder::TestAuthorityBuilder,
         },
+        checkpoints::CheckpointStore,
         consensus_adapter::{
             ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
             MockConsensusClient,

--- a/crates/iota-core/src/epoch/randomness.rs
+++ b/crates/iota-core/src/epoch/randomness.rs
@@ -716,7 +716,7 @@ impl RandomnessManager {
         self.next_randomness_round = self
             .next_randomness_round
             .checked_add(1)
-            .expect("RandomnessRound should not overflow");
+            .ok_or_else(|| IotaError::Unknown("RandomnessRound overflow".to_string()))?;
 
         output.reserve_next_randomness_round(self.next_randomness_round, commit_timestamp);
 

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -12,6 +12,7 @@ use iota_types::{
     digests::{TransactionDigest, TransactionEffectsDigest, TransactionEventsDigest},
     effects::{TransactionEffects, TransactionEvents},
     error::{IotaError, IotaResult, UserInputError},
+    executable_transaction::VerifiedExecutableTransaction,
     iota_system_state::IotaSystemState,
     messages_checkpoint::CheckpointSequenceNumber,
     object::{Object, Owner},
@@ -169,40 +170,16 @@ pub trait ExecutionCacheCommit: Send + Sync {
             .expect("storage access failed");
     }
 
-    /// Durably commit transactions (but not their outputs) to the database.
-    /// Called before writing a locally built checkpoint to the CheckpointStore,
-    /// so that the inputs of the checkpoint cannot be lost.
-    /// These transactions are guaranteed to be final unless this validator
-    /// forks (i.e. constructs a checkpoint which will never be certified). In
-    /// this case some non-final transactions could be left in the database.
-    ///
-    /// This is an intermediate solution until we delay commits to the epoch db.
-    /// After we have done that, crash recovery will be done by
-    /// re-processing consensus commits and pending_consensus_transactions,
-    /// and this method can be removed.
-    fn try_persist_transactions<'a>(
-        &'a self,
-        digests: &'a [TransactionDigest],
-    ) -> BoxFuture<'a, IotaResult>;
+    /// Durably commit a transaction to the database. Used to store any
+    /// transactions that cannot be reconstructed at start-up by consensus
+    /// replay. Currently the only case of this is RandomnessStateUpdate.
+    fn try_persist_transactions(&self, transaction: &VerifiedExecutableTransaction) -> IotaResult;
 
     /// Non-fallible version of `try_persist_transactions`.
-    fn persist_transactions<'a>(&'a self, digests: &'a [TransactionDigest]) -> BoxFuture<'a, ()> {
-        Box::pin(async move {
-            self.try_persist_transactions(digests)
-                .await
-                .expect("storage access failed")
-        })
+    fn persist_transactions(&self, digests: &VerifiedExecutableTransaction) {
+        self.try_persist_transactions(digests)
+            .expect("storage access failed")
     }
-
-    /// Persist transactions and their effects to the database, but no other
-    /// outputs. Additionally this stores the content-addressed effects in
-    /// the database but does not add an executed_effects. This is required
-    /// for recovery from a crash when upgrading to data-quarantining.
-    /// TODO: remove this once all nodes have upgraded to data-quarantining.
-    fn persist_transactions_and_effects(
-        &self,
-        digests: &[(TransactionDigest, TransactionEffectsDigest)],
-    );
 
     // Number of pending uncommitted transactions
     fn approximate_pending_transaction_count(&self) -> u64;

--- a/crates/iota-core/src/execution_cache.rs
+++ b/crates/iota-core/src/execution_cache.rs
@@ -173,11 +173,11 @@ pub trait ExecutionCacheCommit: Send + Sync {
     /// Durably commit a transaction to the database. Used to store any
     /// transactions that cannot be reconstructed at start-up by consensus
     /// replay. Currently the only case of this is RandomnessStateUpdate.
-    fn try_persist_transactions(&self, transaction: &VerifiedExecutableTransaction) -> IotaResult;
+    fn try_persist_transaction(&self, tx: &VerifiedExecutableTransaction) -> IotaResult;
 
     /// Non-fallible version of `try_persist_transactions`.
-    fn persist_transactions(&self, digests: &VerifiedExecutableTransaction) {
-        self.try_persist_transactions(digests)
+    fn persist_transaction(&self, tx: &VerifiedExecutableTransaction) {
+        self.try_persist_transaction(tx)
             .expect("storage access failed")
     }
 

--- a/crates/iota-core/src/execution_cache/cache_types.rs
+++ b/crates/iota-core/src/execution_cache/cache_types.rs
@@ -14,6 +14,15 @@ use iota_types::base_types::SequenceNumber;
 use moka::sync::Cache as MokaCache;
 use parking_lot::Mutex;
 
+pub enum CacheResult<T> {
+    /// Entry is in the cache
+    Hit(T),
+    /// Entry is not in the cache and is known to not exist
+    NegativeHit,
+    /// Entry is not in the cache and may or may not exist in the store
+    Miss,
+}
+
 /// CachedVersionMap is a map from version to value, with the additional
 /// constraints:
 /// - The key (SequenceNumber) must be monotonically increasing for each insert.

--- a/crates/iota-core/src/execution_cache/passthrough_cache.rs
+++ b/crates/iota-core/src/execution_cache/passthrough_cache.rs
@@ -13,6 +13,7 @@ use iota_types::{
     digests::{TransactionDigest, TransactionEffectsDigest, TransactionEventsDigest},
     effects::{TransactionEffects, TransactionEvents},
     error::{IotaError, IotaResult},
+    executable_transaction::VerifiedExecutableTransaction,
     iota_system_state::{IotaSystemState, get_iota_system_state},
     message_envelope::Message,
     messages_checkpoint::CheckpointSequenceNumber,
@@ -332,32 +333,10 @@ impl ExecutionCacheCommit for PassthroughCache {
         Ok(())
     }
 
-    fn try_persist_transactions(
-        &self,
-        _digests: &[TransactionDigest],
-    ) -> BoxFuture<'_, IotaResult> {
+    fn try_persist_transactions(&self, _digests: &VerifiedExecutableTransaction) -> IotaResult {
         // Nothing needs to be done since they were already committed in
         // write_transaction_outputs
-        async { Ok(()) }.boxed()
-    }
-
-    fn persist_transactions_and_effects(
-        &self,
-        _digests: &[(TransactionDigest, TransactionEffectsDigest)],
-    ) {
-        // Nothing needs to be done since all the data was already written.
-
-        // Explanation:
-        // In the WritebackCache, the `persist_transactions_and_effects`
-        // function is responsible for writing the pending transaction
-        // outputs and effects from `dirty.pending_transaction_writes` to the
-        // store (`perpetual_tables.transactions`, `perpetual_tables.
-        // events`). The only function that adds entries to the dirty set
-        // is `try_write_transaction_outputs`.
-        //
-        // In the PassthroughCache, exactly this function
-        // `try_write_transaction_outputs` already writes the data to the store,
-        // via `write_transaction_outputs` => `write_one_transaction_outputs`.
+        Ok(())
     }
 
     fn approximate_pending_transaction_count(&self) -> u64 {

--- a/crates/iota-core/src/execution_cache/passthrough_cache.rs
+++ b/crates/iota-core/src/execution_cache/passthrough_cache.rs
@@ -333,7 +333,7 @@ impl ExecutionCacheCommit for PassthroughCache {
         Ok(())
     }
 
-    fn try_persist_transactions(&self, _digests: &VerifiedExecutableTransaction) -> IotaResult {
+    fn try_persist_transaction(&self, _tx: &VerifiedExecutableTransaction) -> IotaResult {
         // Nothing needs to be done since they were already committed in
         // write_transaction_outputs
         Ok(())

--- a/crates/iota-core/src/execution_cache/proxy_cache.rs
+++ b/crates/iota-core/src/execution_cache/proxy_cache.rs
@@ -319,8 +319,8 @@ impl ExecutionCacheCommit for ProxyCache {
         delegate_method!(self.try_commit_transaction_outputs(epoch, digests))
     }
 
-    fn try_persist_transactions(&self, digests: &VerifiedExecutableTransaction) -> IotaResult {
-        delegate_method!(self.try_persist_transactions(digests))
+    fn try_persist_transaction(&self, tx: &VerifiedExecutableTransaction) -> IotaResult {
+        delegate_method!(self.try_persist_transaction(tx))
     }
 
     fn approximate_pending_transaction_count(&self) -> u64 {

--- a/crates/iota-core/src/execution_cache/proxy_cache.rs
+++ b/crates/iota-core/src/execution_cache/proxy_cache.rs
@@ -12,6 +12,7 @@ use iota_types::{
     digests::{TransactionDigest, TransactionEffectsDigest, TransactionEventsDigest},
     effects::{TransactionEffects, TransactionEvents},
     error::{IotaError, IotaResult},
+    executable_transaction::VerifiedExecutableTransaction,
     iota_system_state::IotaSystemState,
     messages_checkpoint::CheckpointSequenceNumber,
     object::Object,
@@ -318,18 +319,8 @@ impl ExecutionCacheCommit for ProxyCache {
         delegate_method!(self.try_commit_transaction_outputs(epoch, digests))
     }
 
-    fn try_persist_transactions<'a>(
-        &'a self,
-        digests: &'a [TransactionDigest],
-    ) -> BoxFuture<'a, IotaResult> {
+    fn try_persist_transactions(&self, digests: &VerifiedExecutableTransaction) -> IotaResult {
         delegate_method!(self.try_persist_transactions(digests))
-    }
-
-    fn persist_transactions_and_effects(
-        &self,
-        digests: &[(TransactionDigest, TransactionEffectsDigest)],
-    ) {
-        delegate_method!(self.persist_transactions_and_effects(digests))
     }
 
     fn approximate_pending_transaction_count(&self) -> u64 {

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -64,6 +64,7 @@ use iota_types::{
     digests::{ObjectDigest, TransactionDigest, TransactionEffectsDigest, TransactionEventsDigest},
     effects::{TransactionEffects, TransactionEvents},
     error::{IotaError, IotaResult, UserInputError},
+    executable_transaction::VerifiedExecutableTransaction,
     iota_system_state::{IotaSystemState, get_iota_system_state},
     message_envelope::Message,
     messages_checkpoint::CheckpointSequenceNumber,
@@ -81,7 +82,7 @@ use super::{
     CheckpointCache, ExecutionCacheAPI, ExecutionCacheCommit, ExecutionCacheMetrics,
     ExecutionCacheReconfigAPI, ExecutionCacheWrite, ObjectCacheRead, StateSyncAPI, TestingAPI,
     TransactionCacheRead,
-    cache_types::{CachedVersionMap, IsNewer, MonotonicCache, Ticket},
+    cache_types::{CacheResult, CachedVersionMap, IsNewer, MonotonicCache, Ticket},
     implement_passthrough_traits,
     object_locks::ObjectLocks,
 };
@@ -94,6 +95,7 @@ use crate::{
         backpressure::BackpressureManager,
         epoch_start_configuration::{EpochFlag, EpochStartConfiguration},
     },
+    fallback_fetch::do_fallback_lookup_fallible,
     state_accumulator::AccumulatorStore,
     transaction_outputs::TransactionOutputs,
 };
@@ -190,15 +192,6 @@ impl IsNewer for LatestObjectCacheEntry {
 }
 
 type MarkerKey = (EpochId, ObjectID);
-
-enum CacheResult<T> {
-    /// Entry is in the cache
-    Hit(T),
-    /// Entry is not in the cache and is known to not exist
-    NegativeHit,
-    /// Entry is not in the cache and may or may not exist in the store
-    Miss,
-}
 
 /// UncommittedData stores execution outputs that are not yet written to the db.
 /// Entries in this struct can only be purged after they are committed.
@@ -1013,37 +1006,6 @@ impl WritebackCache {
         Ok(())
     }
 
-    fn persist_transactions_and_effects(
-        &self,
-        digests: &[(TransactionDigest, TransactionEffectsDigest)],
-    ) {
-        let mut transactions_and_effects = Vec::with_capacity(digests.len());
-        for (tx_digest, fx_digest) in digests {
-            let Some(outputs) = self
-                .dirty
-                .pending_transaction_writes
-                .get(tx_digest)
-                .map(|o| o.clone())
-            else {
-                debug!("transaction {:?} was already committed", tx_digest);
-                continue;
-            };
-
-            assert_eq!(
-                outputs.effects.digest(),
-                *fx_digest,
-                "effects digest mismatch"
-            );
-
-            transactions_and_effects
-                .push(((*outputs.transaction).clone(), outputs.effects.clone()));
-        }
-
-        self.store
-            .persist_transactions_and_effects(&transactions_and_effects)
-            .expect("db error");
-    }
-
     fn approximate_pending_transaction_count(&self) -> u64 {
         let num_commits = self
             .dirty
@@ -1188,34 +1150,6 @@ impl WritebackCache {
                 &ObjectEntry::Wrapped,
             );
         }
-    }
-
-    async fn persist_transactions(&self, digests: &[TransactionDigest]) -> IotaResult {
-        let mut txns = Vec::with_capacity(digests.len());
-        for tx_digest in digests {
-            let Some(tx) = self
-                .dirty
-                .pending_transaction_writes
-                .get(tx_digest)
-                .map(|o| o.transaction.clone())
-            else {
-                // tx should exist in the db if it is not in dirty set.
-                debug_assert!(
-                    self.store
-                        .get_transaction_block(tx_digest)
-                        .unwrap()
-                        .is_some()
-                );
-                // If the transaction is not in dirty, it does not need to be committed.
-                // This situation can happen if we build a checkpoint locally which was just
-                // executed via state sync.
-                continue;
-            };
-
-            txns.push((*tx_digest, (*tx).clone()));
-        }
-
-        self.store.commit_transactions(&txns)
     }
 
     // Move the oldest/least entry from the dirty queue to the cache queue.
@@ -1364,22 +1298,12 @@ impl ExecutionCacheCommit for WritebackCache {
         WritebackCache::commit_transaction_outputs(self, epoch, digests)
     }
 
-    fn try_persist_transactions<'a>(
-        &'a self,
-        digests: &'a [TransactionDigest],
-    ) -> BoxFuture<'a, IotaResult> {
-        WritebackCache::persist_transactions(self, digests).boxed()
+    fn try_persist_transactions(&self, tx: &VerifiedExecutableTransaction) -> IotaResult {
+        self.store.persist_transaction(tx)
     }
 
     fn approximate_pending_transaction_count(&self) -> u64 {
         WritebackCache::approximate_pending_transaction_count(self)
-    }
-
-    fn persist_transactions_and_effects(
-        &self,
-        digests: &[(TransactionDigest, TransactionEffectsDigest)],
-    ) {
-        WritebackCache::persist_transactions_and_effects(self, digests);
     }
 }
 
@@ -1467,7 +1391,7 @@ impl ObjectCacheRead for WritebackCache {
         &self,
         object_keys: &[ObjectKey],
     ) -> Result<Vec<Option<Object>>, IotaError> {
-        do_fallback_lookup(
+        do_fallback_lookup_fallible(
             object_keys,
             |key| {
                 Ok(match self.get_object_by_key_cache_only(&key.0, key.1) {
@@ -1498,7 +1422,7 @@ impl ObjectCacheRead for WritebackCache {
     }
 
     fn try_multi_object_exists_by_key(&self, object_keys: &[ObjectKey]) -> IotaResult<Vec<bool>> {
-        do_fallback_lookup(
+        do_fallback_lookup_fallible(
             object_keys,
             |key| {
                 Ok(match self.get_object_by_key_cache_only(&key.0, key.1) {
@@ -1816,7 +1740,7 @@ impl ObjectCacheRead for WritebackCache {
     }
 
     fn try_check_owned_objects_are_live(&self, owned_object_refs: &[ObjectRef]) -> IotaResult {
-        do_fallback_lookup(
+        do_fallback_lookup_fallible(
             owned_object_refs,
             |obj_ref| match self.get_object_by_id_cache_only("object_is_live", &obj_ref.0) {
                 CacheResult::Hit((version, obj)) => {
@@ -1860,7 +1784,7 @@ impl TransactionCacheRead for WritebackCache {
             .iter()
             .map(|d| (*d, self.cached.transactions.get_ticket_for_read(d)))
             .collect();
-        do_fallback_lookup(
+        do_fallback_lookup_fallible(
             &digests_and_tickets,
             |(digest, _)| {
                 self.metrics
@@ -1924,7 +1848,7 @@ impl TransactionCacheRead for WritebackCache {
                 )
             })
             .collect();
-        do_fallback_lookup(
+        do_fallback_lookup_fallible(
             &digests_and_tickets,
             |(digest, _)| {
                 self.metrics
@@ -1984,7 +1908,7 @@ impl TransactionCacheRead for WritebackCache {
             .iter()
             .map(|d| (*d, self.cached.transaction_effects.get_ticket_for_read(d)))
             .collect();
-        do_fallback_lookup(
+        do_fallback_lookup_fallible(
             &digests_and_tickets,
             |(digest, _)| {
                 self.metrics
@@ -2064,7 +1988,7 @@ impl TransactionCacheRead for WritebackCache {
             .iter()
             .map(|d| (*d, self.cached.transaction_events.get_ticket_for_read(d)))
             .collect();
-        do_fallback_lookup(
+        do_fallback_lookup_fallible(
             &digests_and_tickets,
             |(digest, _)| {
                 self.metrics
@@ -2147,49 +2071,6 @@ impl ExecutionCacheWrite for WritebackCache {
     ) -> IotaResult {
         WritebackCache::write_transaction_outputs(self, epoch_id, tx_outputs)
     }
-}
-
-/// do_fallback_lookup is a helper function for multi-get operations.
-/// It takes a list of keys and first attempts to look up each key in the cache.
-/// The cache can return a hit, a miss, or a negative hit (if the object is
-/// known to not exist). Any keys that result in a miss are then looked up in
-/// the store.
-///
-/// The "get from cache" and "get from store" behavior are implemented by the
-/// caller and provided via the get_cached_key and multiget_fallback functions.
-fn do_fallback_lookup<K: Copy, V: Default + Clone>(
-    keys: &[K],
-    get_cached_key: impl Fn(&K) -> IotaResult<CacheResult<V>>,
-    multiget_fallback: impl Fn(&[K]) -> IotaResult<Vec<V>>,
-) -> IotaResult<Vec<V>> {
-    let mut results = vec![V::default(); keys.len()];
-    let mut fallback_keys = Vec::with_capacity(keys.len());
-    let mut fallback_indices = Vec::with_capacity(keys.len());
-
-    for (i, key) in keys.iter().enumerate() {
-        match get_cached_key(key)? {
-            CacheResult::Miss => {
-                fallback_keys.push(*key);
-                fallback_indices.push(i);
-            }
-            CacheResult::NegativeHit => (),
-            CacheResult::Hit(value) => {
-                results[i] = value;
-            }
-        }
-    }
-
-    let fallback_results = multiget_fallback(&fallback_keys)?;
-    assert_eq!(fallback_results.len(), fallback_indices.len());
-    assert_eq!(fallback_results.len(), fallback_keys.len());
-
-    for (i, result) in fallback_indices
-        .into_iter()
-        .zip(fallback_results.into_iter())
-    {
-        results[i] = result;
-    }
-    Ok(results)
 }
 
 implement_passthrough_traits!(WritebackCache);

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -95,7 +95,7 @@ use crate::{
         backpressure::BackpressureManager,
         epoch_start_configuration::{EpochFlag, EpochStartConfiguration},
     },
-    fallback_fetch::do_fallback_lookup_fallible,
+    fallback_fetch::try_do_fallback_lookup,
     state_accumulator::AccumulatorStore,
     transaction_outputs::TransactionOutputs,
 };
@@ -1391,7 +1391,7 @@ impl ObjectCacheRead for WritebackCache {
         &self,
         object_keys: &[ObjectKey],
     ) -> Result<Vec<Option<Object>>, IotaError> {
-        do_fallback_lookup_fallible(
+        try_do_fallback_lookup(
             object_keys,
             |key| {
                 Ok(match self.get_object_by_key_cache_only(&key.0, key.1) {
@@ -1422,7 +1422,7 @@ impl ObjectCacheRead for WritebackCache {
     }
 
     fn try_multi_object_exists_by_key(&self, object_keys: &[ObjectKey]) -> IotaResult<Vec<bool>> {
-        do_fallback_lookup_fallible(
+        try_do_fallback_lookup(
             object_keys,
             |key| {
                 Ok(match self.get_object_by_key_cache_only(&key.0, key.1) {
@@ -1740,7 +1740,7 @@ impl ObjectCacheRead for WritebackCache {
     }
 
     fn try_check_owned_objects_are_live(&self, owned_object_refs: &[ObjectRef]) -> IotaResult {
-        do_fallback_lookup_fallible(
+        try_do_fallback_lookup(
             owned_object_refs,
             |obj_ref| match self.get_object_by_id_cache_only("object_is_live", &obj_ref.0) {
                 CacheResult::Hit((version, obj)) => {
@@ -1784,7 +1784,7 @@ impl TransactionCacheRead for WritebackCache {
             .iter()
             .map(|d| (*d, self.cached.transactions.get_ticket_for_read(d)))
             .collect();
-        do_fallback_lookup_fallible(
+        try_do_fallback_lookup(
             &digests_and_tickets,
             |(digest, _)| {
                 self.metrics
@@ -1848,7 +1848,7 @@ impl TransactionCacheRead for WritebackCache {
                 )
             })
             .collect();
-        do_fallback_lookup_fallible(
+        try_do_fallback_lookup(
             &digests_and_tickets,
             |(digest, _)| {
                 self.metrics
@@ -1908,7 +1908,7 @@ impl TransactionCacheRead for WritebackCache {
             .iter()
             .map(|d| (*d, self.cached.transaction_effects.get_ticket_for_read(d)))
             .collect();
-        do_fallback_lookup_fallible(
+        try_do_fallback_lookup(
             &digests_and_tickets,
             |(digest, _)| {
                 self.metrics
@@ -1988,7 +1988,7 @@ impl TransactionCacheRead for WritebackCache {
             .iter()
             .map(|d| (*d, self.cached.transaction_events.get_ticket_for_read(d)))
             .collect();
-        do_fallback_lookup_fallible(
+        try_do_fallback_lookup(
             &digests_and_tickets,
             |(digest, _)| {
                 self.metrics

--- a/crates/iota-core/src/execution_cache/writeback_cache.rs
+++ b/crates/iota-core/src/execution_cache/writeback_cache.rs
@@ -1298,7 +1298,7 @@ impl ExecutionCacheCommit for WritebackCache {
         WritebackCache::commit_transaction_outputs(self, epoch, digests)
     }
 
-    fn try_persist_transactions(&self, tx: &VerifiedExecutableTransaction) -> IotaResult {
+    fn try_persist_transaction(&self, tx: &VerifiedExecutableTransaction) -> IotaResult {
         self.store.persist_transaction(tx)
     }
 

--- a/crates/iota-core/src/fallback_fetch.rs
+++ b/crates/iota-core/src/fallback_fetch.rs
@@ -1,0 +1,64 @@
+// Copyright (c) 2021, Facebook, Inc. and its affiliates
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_types::error::IotaResult;
+
+use crate::execution_cache::cache_types::CacheResult;
+
+/// do_fallback_lookup is a helper function for multi-get operations.
+/// It takes a list of keys and first attempts to look up each key in the cache.
+/// The cache can return a hit, a miss, or a negative hit (if the object is
+/// known to not exist). Any keys that result in a miss are then looked up in
+/// the store.
+///
+/// The "get from cache" and "get from store" behavior are implemented by the
+/// caller and provided via the get_cached_key and multiget_fallback functions.
+pub fn do_fallback_lookup<K: Clone, V: Default + Clone>(
+    keys: &[K],
+    get_cached_key: impl Fn(&K) -> CacheResult<V>,
+    multiget_fallback: impl Fn(&[K]) -> Vec<V>,
+) -> Vec<V> {
+    do_fallback_lookup_fallible(
+        keys,
+        |key| Ok(get_cached_key(key)),
+        |keys| Ok(multiget_fallback(keys)),
+    )
+    .expect("cannot fail")
+}
+
+pub fn do_fallback_lookup_fallible<K: Clone, V: Default + Clone>(
+    keys: &[K],
+    get_cached_key: impl Fn(&K) -> IotaResult<CacheResult<V>>,
+    multiget_fallback: impl Fn(&[K]) -> IotaResult<Vec<V>>,
+) -> IotaResult<Vec<V>> {
+    let mut results = vec![V::default(); keys.len()];
+    let mut fallback_keys = Vec::with_capacity(keys.len());
+    let mut fallback_indices = Vec::with_capacity(keys.len());
+
+    for (i, key) in keys.iter().enumerate() {
+        match get_cached_key(key)? {
+            CacheResult::Miss => {
+                fallback_keys.push(key.clone());
+                fallback_indices.push(i);
+            }
+            CacheResult::NegativeHit => (),
+            CacheResult::Hit(value) => {
+                results[i] = value;
+            }
+        }
+    }
+
+    let fallback_results = multiget_fallback(&fallback_keys)?;
+    assert_eq!(fallback_results.len(), fallback_indices.len());
+    assert_eq!(fallback_results.len(), fallback_keys.len());
+
+    for (i, result) in fallback_indices
+        .into_iter()
+        .zip(fallback_results.into_iter())
+    {
+        results[i] = result;
+    }
+    Ok(results)
+}

--- a/crates/iota-core/src/fallback_fetch.rs
+++ b/crates/iota-core/src/fallback_fetch.rs
@@ -7,28 +7,31 @@ use iota_types::error::IotaResult;
 
 use crate::execution_cache::cache_types::CacheResult;
 
-/// do_fallback_lookup is a helper function for multi-get operations.
+/// `do_fallback_lookup` is the non-fallible version of
+/// `try_do_fallback_lookup`.
+pub fn do_fallback_lookup<K: Clone, V: Default + Clone>(
+    keys: &[K],
+    get_cached_key: impl Fn(&K) -> CacheResult<V>,
+    multiget_fallback: impl Fn(&[K]) -> Vec<V>,
+) -> Vec<V> {
+    try_do_fallback_lookup(
+        keys,
+        |key| Ok(get_cached_key(key)),
+        |keys| Ok(multiget_fallback(keys)),
+    )
+    .expect("try_do_fallback_lookup should not fail")
+}
+
+/// `try_do_fallback_lookup` is a helper function for multi-get operations.
 /// It takes a list of keys and first attempts to look up each key in the cache.
 /// The cache can return a hit, a miss, or a negative hit (if the object is
 /// known to not exist). Any keys that result in a miss are then looked up in
 /// the store.
 ///
 /// The "get from cache" and "get from store" behavior are implemented by the
-/// caller and provided via the get_cached_key and multiget_fallback functions.
-pub fn do_fallback_lookup<K: Clone, V: Default + Clone>(
-    keys: &[K],
-    get_cached_key: impl Fn(&K) -> CacheResult<V>,
-    multiget_fallback: impl Fn(&[K]) -> Vec<V>,
-) -> Vec<V> {
-    do_fallback_lookup_fallible(
-        keys,
-        |key| Ok(get_cached_key(key)),
-        |keys| Ok(multiget_fallback(keys)),
-    )
-    .expect("cannot fail")
-}
-
-pub fn do_fallback_lookup_fallible<K: Clone, V: Default + Clone>(
+/// caller and provided via the `get_cached_key` and `multiget_fallback`
+/// functions.
+pub fn try_do_fallback_lookup<K: Clone, V: Default + Clone>(
     keys: &[K],
     get_cached_key: impl Fn(&K) -> IotaResult<CacheResult<V>>,
     multiget_fallback: impl Fn(&[K]) -> IotaResult<Vec<V>>,
@@ -60,5 +63,6 @@ pub fn do_fallback_lookup_fallible<K: Clone, V: Default + Clone>(
     {
         results[i] = result;
     }
+
     Ok(results)
 }

--- a/crates/iota-core/src/lib.rs
+++ b/crates/iota-core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod db_checkpoint_handler;
 pub mod epoch;
 pub mod execution_cache;
 mod execution_driver;
+mod fallback_fetch;
 pub mod jsonrpc_index;
 pub mod metrics;
 pub mod mock_consensus;

--- a/crates/iota-core/src/mock_consensus.rs
+++ b/crates/iota-core/src/mock_consensus.rs
@@ -76,6 +76,7 @@ impl MockConsensusClient {
                             vec![SequencedConsensusTransaction::new_test(tx.clone())],
                             &checkpoint_service,
                             validator.get_object_cache_reader().as_ref(),
+                            validator.get_transaction_cache_reader().as_ref(),
                             &authority_metrics,
                             true,
                         )

--- a/crates/iota-core/src/transaction_input_loader.rs
+++ b/crates/iota-core/src/transaction_input_loader.rs
@@ -176,7 +176,6 @@ impl TransactionInputLoader {
                         .get_or_init(|| {
                             epoch_store
                                 .get_assigned_shared_object_versions(tx_key)
-                                .expect("loading assigned shared versions should not fail")
                                 .map(|versions| versions.into_iter().collect())
                         })
                         .as_ref()

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -4798,7 +4798,6 @@ async fn test_shared_object_transaction_ok() {
         .epoch_store_for_testing()
         .get_assigned_shared_object_versions(&certificate.key())
         .expect("Reading shared version assignments should not fail")
-        .expect("Versions should be set")
         .into_iter()
         .find_map(|(object_id, version)| {
             if object_id == shared_object_id {
@@ -4909,7 +4908,6 @@ async fn test_consensus_commit_prologue_generation() {
             .epoch_store_for_testing()
             .get_assigned_shared_object_versions(txn_key)
             .unwrap()
-            .expect("versions should be set")
             .iter()
             .filter_map(|(id, seq)| {
                 if id == &IOTA_CLOCK_OBJECT_ID {
@@ -5983,9 +5981,7 @@ async fn test_consensus_handler_per_object_congestion_control(
     // Checks that deferral keys are formed correctly.
     let epoch_store = authority.epoch_store_for_testing();
     let commit_round = epoch_store.get_highest_pending_checkpoint_height() / 2;
-    let deferred_txns = epoch_store
-        .get_all_deferred_transactions_for_test()
-        .unwrap();
+    let deferred_txns = epoch_store.get_all_deferred_transactions_for_test();
     assert_eq!(deferred_txns.len(), 1);
     assert_eq!(deferred_txns[0].1.len(), 3);
     let deferral_key = deferred_txns[0].0;
@@ -6044,8 +6040,7 @@ async fn test_consensus_handler_per_object_congestion_control(
 
     let deferred_txns = authority
         .epoch_store_for_testing()
-        .get_all_deferred_transactions_for_test()
-        .unwrap();
+        .get_all_deferred_transactions_for_test();
     assert_eq!(deferred_txns.len(), 1);
     assert_eq!(deferred_txns[0].1.len(), 1);
     let deferral_key = deferred_txns[0].0;
@@ -6072,7 +6067,6 @@ async fn test_consensus_handler_per_object_congestion_control(
         authority
             .epoch_store_for_testing()
             .get_all_deferred_transactions_for_test()
-            .unwrap()
             .is_empty()
     );
 }
@@ -6226,7 +6220,6 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
         authority
             .epoch_store_for_testing()
             .get_all_deferred_transactions_for_test()
-            .unwrap()
             .is_empty()
     );
 
@@ -6234,7 +6227,6 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
     let shared_object_version = authority
         .epoch_store_for_testing()
         .get_assigned_shared_object_versions(&cancelled_txn.key())
-        .expect("Reading shared version assignments should not fail")
         .expect("Versions should be set")
         .into_iter()
         .collect::<HashMap<_, _>>();

--- a/crates/iota-core/src/unit_tests/authority_tests.rs
+++ b/crates/iota-core/src/unit_tests/authority_tests.rs
@@ -4797,7 +4797,7 @@ async fn test_shared_object_transaction_ok() {
     let shared_object_version = authority
         .epoch_store_for_testing()
         .get_assigned_shared_object_versions(&certificate.key())
-        .expect("Reading shared version assignments should not fail")
+        .expect("Versions should be set")
         .into_iter()
         .find_map(|(object_id, version)| {
             if object_id == shared_object_id {
@@ -4907,7 +4907,7 @@ async fn test_consensus_commit_prologue_generation() {
         authority_state
             .epoch_store_for_testing()
             .get_assigned_shared_object_versions(txn_key)
-            .unwrap()
+            .expect("versions should be set")
             .iter()
             .filter_map(|(id, seq)| {
                 if id == &IOTA_CLOCK_OBJECT_ID {

--- a/crates/iota-core/src/unit_tests/consensus_tests.rs
+++ b/crates/iota-core/src/unit_tests/consensus_tests.rs
@@ -160,6 +160,7 @@ pub fn make_consensus_adapter_for_test(
                                     vec![tx],
                                     &checkpoint_service,
                                     self.state.get_object_cache_reader().as_ref(),
+                                    self.state.get_transaction_cache_reader().as_ref(),
                                     &self.state.metrics,
                                     true,
                                 )
@@ -173,6 +174,7 @@ pub fn make_consensus_adapter_for_test(
                                 vec![tx],
                                 &checkpoint_service,
                                 self.state.get_object_cache_reader().as_ref(),
+                                self.state.get_transaction_cache_reader().as_ref(),
                                 &self.state.metrics,
                                 true,
                             )

--- a/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
+++ b/crates/iota-core/src/unit_tests/gas_price_feedback_tests.rs
@@ -476,7 +476,6 @@ async fn per_object_congestion_control_mode_is_none() {
             .authority_state
             .epoch_store_for_testing()
             .get_all_deferred_transactions_for_test()
-            .unwrap()
             .is_empty()
     );
 
@@ -550,7 +549,6 @@ async fn max_execution_duration_per_commit_is_none() {
             .authority_state
             .epoch_store_for_testing()
             .get_all_deferred_transactions_for_test()
-            .unwrap()
             .is_empty()
     );
 
@@ -638,7 +636,6 @@ async fn transaction_duration_exceeds_max_execution_duration_per_commit() {
             .authority_state
             .epoch_store_for_testing()
             .get_all_deferred_transactions_for_test()
-            .unwrap()
             .is_empty()
     );
 
@@ -856,7 +853,6 @@ async fn gas_price_feedback_mechanism_is_turned_off() {
             .authority_state
             .epoch_store_for_testing()
             .get_all_deferred_transactions_for_test()
-            .unwrap()
             .is_empty()
     );
 
@@ -1008,7 +1004,6 @@ async fn gas_price_feedback_mechanism_with_max_gas_price() {
             .authority_state
             .epoch_store_for_testing()
             .get_all_deferred_transactions_for_test()
-            .unwrap()
             .is_empty()
     );
 
@@ -1186,8 +1181,7 @@ async fn gas_price_feedback_mechanism_for_multiple_commits() {
     let deferred_transactions = tester
         .authority_state
         .epoch_store_for_testing()
-        .get_all_deferred_transactions_for_test()
-        .unwrap();
+        .get_all_deferred_transactions_for_test();
     assert_eq!(deferred_transactions.len(), 1);
     assert_eq!(deferred_transactions[0].1.len(), 1);
     assert!(matches!(
@@ -1416,7 +1410,6 @@ async fn gas_price_feedback_mechanism_non_trivial_case_total_tx_count_mode() {
             .authority_state
             .epoch_store_for_testing()
             .get_all_deferred_transactions_for_test()
-            .unwrap()
             .is_empty()
     );
 
@@ -1734,7 +1727,6 @@ async fn gas_price_feedback_mechanism_non_trivial_case_total_gas_budget_mode() {
             .authority_state
             .epoch_store_for_testing()
             .get_all_deferred_transactions_for_test()
-            .unwrap()
             .is_empty()
     );
 

--- a/crates/iota-core/src/unit_tests/transaction_manager_tests.rs
+++ b/crates/iota-core/src/unit_tests/transaction_manager_tests.rs
@@ -243,14 +243,14 @@ async fn transaction_manager_object_dependency() {
         .epoch_store_for_testing()
         .set_shared_object_versions_for_testing(
             transaction_read_0.digest(),
-            &vec![(shared_object.id(), shared_version)],
+            &[(shared_object.id(), shared_version)],
         )
         .unwrap();
     state
         .epoch_store_for_testing()
         .set_shared_object_versions_for_testing(
             transaction_read_1.digest(),
-            &vec![(shared_object.id(), shared_version)],
+            &[(shared_object.id(), shared_version)],
         )
         .unwrap();
 
@@ -268,7 +268,7 @@ async fn transaction_manager_object_dependency() {
         .epoch_store_for_testing()
         .set_shared_object_versions_for_testing(
             transaction_default.digest(),
-            &vec![(shared_object.id(), shared_version)],
+            &[(shared_object.id(), shared_version)],
         )
         .unwrap();
 
@@ -291,7 +291,7 @@ async fn transaction_manager_object_dependency() {
         .epoch_store_for_testing()
         .set_shared_object_versions_for_testing(
             transaction_read_2.digest(),
-            &vec![
+            &[
                 (shared_object.id(), shared_version),
                 (shared_object_2.id(), shared_version_2),
             ],
@@ -806,7 +806,7 @@ async fn transaction_manager_with_cancelled_transactions() {
         .epoch_store_for_testing()
         .set_shared_object_versions_for_testing(
             cancelled_transaction.digest(),
-            &vec![
+            &[
                 (shared_object_1.id(), SequenceNumber::CANCELLED_READ),
                 (
                     shared_object_2.id(),

--- a/crates/iota-node/src/lib.rs
+++ b/crates/iota-node/src/lib.rs
@@ -584,6 +584,10 @@ impl IotaNode {
             signature_verifier_metrics,
             &config.expensive_safety_check_config,
             ChainIdentifier::from(*genesis.checkpoint().digest()),
+            checkpoint_store
+                .get_highest_executed_checkpoint_seq_number()
+                .expect("checkpoint store read cannot fail")
+                .unwrap_or(0),
         );
 
         info!("created epoch store");
@@ -618,8 +622,6 @@ impl IotaNode {
                 "buffer_stake_for_protocol_upgrade_bps is currently overridden"
             );
         }
-
-        info!("creating checkpoint store");
 
         checkpoint_store.insert_genesis_checkpoint(
             genesis.checkpoint(),
@@ -783,10 +785,6 @@ impl IotaNode {
                 }
             }
         }
-
-        checkpoint_store
-            .reexecute_local_checkpoints(&state, &epoch_store)
-            .await;
 
         // Start the loop that receives new randomness and generates transactions for
         // it.
@@ -1366,7 +1364,7 @@ impl IotaNode {
         let checkpoint_service = Self::build_checkpoint_service(
             config,
             consensus_adapter.clone(),
-            checkpoint_store,
+            checkpoint_store.clone(),
             epoch_store.clone(),
             state.clone(),
             state_sync_handle,
@@ -1403,6 +1401,8 @@ impl IotaNode {
             backpressure_manager,
         );
 
+        info!("Starting consensus manager");
+
         consensus_manager
             .start(
                 config,
@@ -1417,6 +1417,16 @@ impl IotaNode {
             )
             .await;
 
+        if !epoch_store
+            .epoch_start_config()
+            .is_data_quarantine_active_from_beginning_of_epoch()
+        {
+            checkpoint_store
+                .reexecute_local_checkpoints(&state, &epoch_store)
+                .await;
+        }
+
+        info!("Spawning checkpoint service");
         let checkpoint_service_tasks = checkpoint_service.spawn().await;
 
         if epoch_store.authenticator_state_enabled() {
@@ -2055,6 +2065,15 @@ impl IotaNode {
             })?
             .epoch_supply_change;
 
+        let last_checkpoint_seq = *last_checkpoint.sequence_number();
+
+        assert_eq!(
+            Some(last_checkpoint_seq),
+            self.checkpoint_store
+                .get_highest_executed_checkpoint_seq_number()
+                .expect("Error loading highest executed checkpoint sequence number")
+        );
+
         let epoch_start_configuration = EpochStartConfiguration::new(
             next_epoch_start_system_state,
             *last_checkpoint.digest(),
@@ -2073,6 +2092,7 @@ impl IotaNode {
                 accumulator,
                 &self.config.expensive_safety_check_config,
                 epoch_supply_change,
+                last_checkpoint_seq,
             )
             .await
             .expect("Reconfigure authority state cannot fail");

--- a/crates/iota-single-node-benchmark/src/mock_storage.rs
+++ b/crates/iota-single-node-benchmark/src/mock_storage.rs
@@ -71,8 +71,7 @@ impl InMemoryObjectStore {
                         .get_or_init(|| {
                             epoch_store
                                 .get_assigned_shared_object_versions(tx_key)
-                                .expect("get_assigned_shared_object_versions should not fail")
-                                .map(|l| l.into_iter().collect())
+                                .map(|versions| versions.into_iter().collect::<HashMap<_, _>>())
                         })
                         .as_ref()
                         .ok_or_else(|| IotaError::GenericAuthority {

--- a/crates/iota-single-node-benchmark/src/mock_storage.rs
+++ b/crates/iota-single-node-benchmark/src/mock_storage.rs
@@ -71,7 +71,7 @@ impl InMemoryObjectStore {
                         .get_or_init(|| {
                             epoch_store
                                 .get_assigned_shared_object_versions(tx_key)
-                                .map(|versions| versions.into_iter().collect::<HashMap<_, _>>())
+                                .map(|versions| versions.into_iter().collect())
                         })
                         .as_ref()
                         .ok_or_else(|| IotaError::GenericAuthority {

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -22,9 +22,7 @@ use crate::{
         AuthorityName, ConciseableName, ObjectID, ObjectRef, SequenceNumber, TransactionDigest,
     },
     digests::ConsensusCommitDigest,
-    messages_checkpoint::{
-        CheckpointSequenceNumber, CheckpointSignatureMessage, CheckpointTimestamp,
-    },
+    messages_checkpoint::{CheckpointSequenceNumber, CheckpointSignatureMessage},
     supported_protocol_versions::{
         Chain, SupportedProtocolVersions, SupportedProtocolVersionsWithHashes,
     },
@@ -52,7 +50,7 @@ pub struct ConsensusCommitPrologueV1 {
     /// if there are multiple consensus commits per round.
     pub sub_dag_index: Option<u64>,
     /// Unix timestamp from consensus
-    pub commit_timestamp_ms: CheckpointTimestamp,
+    pub commit_timestamp_ms: TimestampMs,
     /// Digest of consensus output
     pub consensus_commit_digest: ConsensusCommitDigest,
     /// Stores consensus handler determined shared object version assignments.

--- a/crates/iota-types/src/messages_consensus.rs
+++ b/crates/iota-types/src/messages_consensus.rs
@@ -31,6 +31,9 @@ use crate::{
     transaction::CertifiedTransaction,
 };
 
+/// Non-decreasing timestamp produced by consensus in ms.
+pub type TimestampMs = u64;
+
 /// Uses an enum to allow for future expansion of the
 /// ConsensusDeterminedVersionAssignments.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
# Description of change

- Upstream range: [v1.43.1, v1.44.3)
- Port commit: 
  - https://github.com/MystenLabs/sui/commit/e4db4a07c31bfcbcada149cc8f0ef6a73c261b13
- Description:
  - All consensus output is held in memory until all checkpoints built from that output have been committed. This ensures that the epoch db is not corrupted in the event of a fork.
  - Consensus therefore becomes the primary replay log for all crash recovery.
  - Additionally this means there are several tables that we no longer need to write to, and their contents can live in memory.

## Links to any relevant issues

Part of #8234

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): - Add metrics `consensus_quarantine_queue_size` and `shared_object_assignments_size`
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API: