### PR TITLE
fix(consensus): evaluate display and debug implementations for loging

### DIFF
--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -197,7 +197,6 @@ impl BlockRef {
     }
 }
 
-// TODO: re-evaluate formats for production debugging.
 impl fmt::Display for BlockRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "B{}({},{})", self.round, self.author, self.digest)
@@ -206,7 +205,7 @@ impl fmt::Display for BlockRef {
 
 impl fmt::Debug for BlockRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "B{}({},{:?})", self.round, self.author, self.digest)
+        fmt::Display::fmt(self, f)
     }
 }
 
@@ -299,16 +298,15 @@ impl From<BlockRef> for Slot {
     }
 }
 
-// TODO: re-evaluate formats for production debugging.
 impl fmt::Display for Slot {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}{}", self.authority, self.round,)
+        write!(f, "S{}{}", self.round, self.authority)
     }
 }
 
 impl fmt::Debug for Slot {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self}")
+        fmt::Display::fmt(&self, f)
     }
 }
 
@@ -518,7 +516,6 @@ impl fmt::Display for VerifiedBlock {
     }
 }
 
-// TODO: re-evaluate formats for production debugging.
 impl fmt::Debug for VerifiedBlock {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -1636,7 +1636,7 @@ mod test {
 
     #[tokio::test]
     #[should_panic(
-        expected = "Attempted to check for slot [0]8 that is <= the last evicted round 8"
+        expected = "Attempted to check for slot S8[0] that is <= the last evicted round 8"
     )]
     async fn test_contains_cached_block_at_slot_panics_when_ask_out_of_range() {
         /// Only keep elements up to 2 rounds before the last committed round
@@ -1683,7 +1683,7 @@ mod test {
 
     #[tokio::test]
     #[should_panic(
-        expected = "Attempted to check for slot [1]3 that is <= the last gc evicted round 3"
+        expected = "Attempted to check for slot S3[1] that is <= the last gc evicted round 3"
     )]
     async fn test_contains_cached_block_at_slot_panics_when_ask_out_of_range_gc_enabled() {
         /// Keep 2 rounds from the highest committed round. This is considered

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -95,8 +95,8 @@ pub(crate) enum ConsensusError {
     #[error("Failed to verify the block's signature: {0}")]
     SignatureVerificationFailure(FastCryptoError),
 
-    #[error("Synchronizer for fetching blocks directly from {0} is saturated")]
-    SynchronizerSaturated(AuthorityIndex),
+    #[error("Synchronizer for fetching blocks directly from ([{0}],{1}) is saturated")]
+    SynchronizerSaturated(AuthorityIndex, String),
 
     #[error("Block {block_ref:?} rejected: {reason}")]
     BlockRejected { block_ref: BlockRef, reason: String },

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -362,6 +362,8 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                                 continue;
                             }
 
+                            let peer_hostname = self.context.committee.authority(peer_index).hostname.clone();
+
                             // Keep only the max allowed blocks to request. It is ok to reduce here as the scheduler
                             // task will take care syncing whatever is leftover.
                             let missing_block_refs = missing_block_refs
@@ -384,7 +386,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                                 .try_send(blocks_guard)
                                 .map_err(|err| {
                                     match err {
-                                        TrySendError::Full(_) => ConsensusError::SynchronizerSaturated(peer_index),
+                                        TrySendError::Full(_) => ConsensusError::SynchronizerSaturated(peer_index,peer_hostname),
                                         TrySendError::Closed(_) => ConsensusError::Shutdown
                                     }
                                 });
@@ -1793,7 +1795,7 @@ mod tests {
             // request and get an error with "saturated" synchronizer
             if iter.peek().is_none() {
                 match handle.fetch_blocks(missing_blocks, peer).await {
-                    Err(ConsensusError::SynchronizerSaturated(index)) => {
+                    Err(ConsensusError::SynchronizerSaturated(index, _)) => {
                         assert_eq!(index, peer);
                     }
                     _ => panic!("A saturated synchronizer error was expected"),

--- a/crates/starfish/core/src/block_header.rs
+++ b/crates/starfish/core/src/block_header.rs
@@ -271,8 +271,6 @@ impl BlockRef {
     }
 }
 
-// TODO: https://github.com/iotaledger/iota/issues/8152
-// re-evaluate formats for production debugging.
 impl fmt::Display for BlockRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "B{}({},{})", self.round, self.author, self.digest)
@@ -281,7 +279,7 @@ impl fmt::Display for BlockRef {
 
 impl fmt::Debug for BlockRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "B{}({},{:?})", self.round, self.author, self.digest)
+        fmt::Display::fmt(self, f)
     }
 }
 
@@ -440,17 +438,15 @@ impl From<BlockRef> for Slot {
     }
 }
 
-// TODO: https://github.com/iotaledger/iota/issues/8152
-// re-evaluate formats for production debugging.
 impl fmt::Display for Slot {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}{}", self.authority, self.round,)
+        write!(f, "S{}{}", self.round, self.authority)
     }
 }
 
 impl fmt::Debug for Slot {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
+        fmt::Display::fmt(self, f)
     }
 }
 
@@ -711,8 +707,6 @@ impl fmt::Display for VerifiedBlockHeader {
     }
 }
 
-// TODO: https://github.com/iotaledger/iota/issues/8152
-// re-evaluate formats for production debugging.
 impl fmt::Debug for VerifiedBlockHeader {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
@@ -728,8 +722,6 @@ impl fmt::Debug for VerifiedBlockHeader {
 }
 
 /// VerifiedTransactions are transactions that correspond to an existing block
-// TODO: https://github.com/iotaledger/iota/issues/8152
-// make a custom Debug implementation for more control over printed data
 #[derive(Clone, Debug)]
 pub struct VerifiedTransactions {
     transactions: Vec<Transaction>,

--- a/crates/starfish/core/src/dag_state.rs
+++ b/crates/starfish/core/src/dag_state.rs
@@ -2026,7 +2026,7 @@ mod test {
 
     #[tokio::test]
     #[should_panic(
-        expected = "Attempted to check for slot [0]8 that is <= the last evicted round 8"
+        expected = "Attempted to check for slot S8[0] that is <= the last evicted round 8"
     )]
     async fn test_contains_cached_block_at_slot_panics_when_ask_out_of_range() {
         /// Only keep elements up to 2 rounds before the last committed round


### PR DESCRIPTION
# Description of change

This PR:
- Defaults the `BlockRef` Debug implementation to the Display one where a shortened version of the Digest is printed out.
- Updated Slot Display and Debug implementations to reflect the `BlockRef` so now Slot is printed out as `S<round>[<auht_index>]` for example: `S8[4]` is printed out for a Slot of authority index 4 and in round 8.
- Updated `SynchronizerSaturated` error message to include the hostname as well as the index of a peer.

## Links to any relevant issues

fixes #8152.

## How the change has been tested

- [ ] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] REST API:
