### PR TITLE
feat: bump iota to v1.5.0-rc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1835,7 +1835,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "const-str",
  "git-version",
@@ -5390,7 +5390,7 @@ dependencies = [
 
 [[package]]
 name = "iota"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5439,7 +5439,7 @@ dependencies = [
  "iota-package-management",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.5.0-beta",
+ "iota-sdk 1.5.0-rc",
  "iota-simulator",
  "iota-source-validation",
  "iota-swarm",
@@ -5512,7 +5512,7 @@ dependencies = [
 
 [[package]]
 name = "iota-adapter-transactional-tests"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -5520,7 +5520,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "arrow-array 53.1.0",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "iota-analytics-indexer-derive"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5571,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "iota-archival"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -5602,7 +5602,7 @@ dependencies = [
 
 [[package]]
 name = "iota-authority-aggregation"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "futures",
  "iota-metrics",
@@ -5613,7 +5613,7 @@ dependencies = [
 
 [[package]]
 name = "iota-aws-orchestrator"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -5643,7 +5643,7 @@ dependencies = [
 
 [[package]]
 name = "iota-benchmark"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5664,7 +5664,7 @@ dependencies = [
  "iota-metrics",
  "iota-network",
  "iota-protocol-config",
- "iota-sdk 1.5.0-beta",
+ "iota-sdk 1.5.0-rc",
  "iota-simulator",
  "iota-storage",
  "iota-surfer",
@@ -5707,7 +5707,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cluster-test"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5725,7 +5725,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-keys",
  "iota-move-build",
- "iota-sdk 1.5.0-beta",
+ "iota-sdk 1.5.0-rc",
  "iota-swarm",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5793,7 +5793,7 @@ dependencies = [
 
 [[package]]
 name = "iota-core"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5891,7 +5891,7 @@ dependencies = [
 
 [[package]]
 name = "iota-cost"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5946,7 +5946,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5979,7 +5979,7 @@ dependencies = [
 
 [[package]]
 name = "iota-data-ingestion-core"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6013,7 +6013,7 @@ dependencies = [
 
 [[package]]
 name = "iota-e2e-tests"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6042,7 +6042,7 @@ dependencies = [
  "iota-protocol-config",
  "iota-rest-api",
  "iota-rust-sdk",
- "iota-sdk 1.5.0-beta",
+ "iota-sdk 1.5.0-rc",
  "iota-simulator",
  "iota-storage",
  "iota-swarm",
@@ -6073,7 +6073,7 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "serde_yaml",
 ]
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "iota-faucet"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -6128,7 +6128,7 @@ dependencies = [
  "iota-keys",
  "iota-metrics",
  "iota-network-stack",
- "iota-sdk 1.5.0-beta",
+ "iota-sdk 1.5.0-rc",
  "iota-types",
  "parking_lot 0.12.3",
  "prometheus",
@@ -6152,7 +6152,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6190,7 +6190,7 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-tests"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "datatest-stable",
  "iota-adapter-latest",
@@ -6211,7 +6211,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-builder"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6261,7 +6261,7 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -6271,7 +6271,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-config"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6279,7 +6279,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-e2e-tests"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6292,7 +6292,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6330,7 +6330,7 @@ dependencies = [
  "iota-network-stack",
  "iota-package-resolver",
  "iota-rest-api",
- "iota-sdk 1.5.0-beta",
+ "iota-sdk 1.5.0-rc",
  "iota-swarm-config",
  "iota-test-transaction-builder",
  "iota-types",
@@ -6363,7 +6363,7 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-client"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6376,14 +6376,14 @@ dependencies = [
 
 [[package]]
 name = "iota-graphql-rpc-headers"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "axum 0.8.4",
 ]
 
 [[package]]
 name = "iota-http"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "axum 0.8.4",
  "bytes",
@@ -6404,7 +6404,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6466,7 +6466,7 @@ dependencies = [
 
 [[package]]
 name = "iota-indexer-builder"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6482,7 +6482,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6501,7 +6501,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6556,7 +6556,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-tests"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6594,7 +6594,7 @@ dependencies = [
  "iota-open-rpc",
  "iota-open-rpc-macros",
  "iota-protocol-config",
- "iota-sdk 1.5.0-beta",
+ "iota-sdk 1.5.0-rc",
  "iota-simulator",
  "iota-swarm-config",
  "iota-test-transaction-builder",
@@ -6613,7 +6613,7 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6646,7 +6646,7 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "bip32",
@@ -6667,7 +6667,7 @@ dependencies = [
 
 [[package]]
 name = "iota-kvstore"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6685,7 +6685,7 @@ dependencies = [
 
 [[package]]
 name = "iota-ledger"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6706,7 +6706,7 @@ dependencies = [
 
 [[package]]
 name = "iota-ledger-signer"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6714,7 +6714,7 @@ dependencies = [
  "bip32",
  "clap",
  "iota-ledger",
- "iota-sdk 1.5.0-beta",
+ "iota-sdk 1.5.0-rc",
  "shared-crypto",
  "thiserror 1.0.64",
  "tokio",
@@ -6723,7 +6723,7 @@ dependencies = [
 
 [[package]]
 name = "iota-light-client"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6737,7 +6737,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-package-resolver",
  "iota-rest-api",
- "iota-sdk 1.5.0-beta",
+ "iota-sdk 1.5.0-rc",
  "iota-types",
  "move-core-types",
  "object_store 0.10.2",
@@ -6756,7 +6756,7 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -6766,7 +6766,7 @@ dependencies = [
 
 [[package]]
 name = "iota-mainnet-unlocks"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6778,7 +6778,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metric-checker"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "backoff",
@@ -6799,7 +6799,7 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6824,7 +6824,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "bin-version",
@@ -6863,7 +6863,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -6884,7 +6884,7 @@ dependencies = [
 
 [[package]]
 name = "iota-move-lsp"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "bin-version",
  "clap",
@@ -6917,7 +6917,7 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6929,7 +6929,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -6969,7 +6969,7 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anemo",
  "bcs",
@@ -6997,7 +6997,7 @@ dependencies = [
 
 [[package]]
 name = "iota-node"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7045,7 +7045,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7069,7 +7069,7 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -7081,7 +7081,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-dump"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7097,13 +7097,13 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.5.0-beta",
+ "iota-sdk 1.5.0-rc",
  "iota-types",
  "move-core-types",
  "move-package",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7134,7 +7134,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -7144,7 +7144,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "clap",
  "insta",
@@ -7159,7 +7159,7 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7168,7 +7168,7 @@ dependencies = [
 
 [[package]]
 name = "iota-proxy"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7183,7 +7183,7 @@ dependencies = [
  "hex",
  "hyper 1.4.1",
  "iota-metrics",
- "iota-sdk 1.5.0-beta",
+ "iota-sdk 1.5.0-rc",
  "iota-tls",
  "iota-types",
  "itertools 0.13.0",
@@ -7211,7 +7211,7 @@ dependencies = [
 
 [[package]]
 name = "iota-replay"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7227,7 +7227,7 @@ dependencies = [
  "iota-json-rpc-api",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.5.0-beta",
+ "iota-sdk 1.5.0-rc",
  "iota-transaction-checks",
  "iota-types",
  "jsonrpsee",
@@ -7256,7 +7256,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7285,7 +7285,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-kv"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -7312,7 +7312,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rosetta"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7329,7 +7329,7 @@ dependencies = [
  "iota-metrics",
  "iota-move-build",
  "iota-node",
- "iota-sdk 1.5.0-beta",
+ "iota-sdk 1.5.0-rc",
  "iota-swarm-config",
  "iota-types",
  "move-core-types",
@@ -7353,7 +7353,7 @@ dependencies = [
 
 [[package]]
 name = "iota-rpc-loadgen"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7363,7 +7363,7 @@ dependencies = [
  "futures",
  "iota-json-rpc-types",
  "iota-keys",
- "iota-sdk 1.5.0-beta",
+ "iota-sdk 1.5.0-rc",
  "iota-types",
  "itertools 0.13.0",
  "serde",
@@ -7438,7 +7438,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7477,7 +7477,7 @@ dependencies = [
 
 [[package]]
 name = "iota-simulator"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -7499,7 +7499,7 @@ dependencies = [
 
 [[package]]
 name = "iota-single-node-benchmark"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "async-trait",
  "bcs",
@@ -7533,7 +7533,7 @@ dependencies = [
 
 [[package]]
 name = "iota-snapshot"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7560,7 +7560,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "colored",
@@ -7570,7 +7570,7 @@ dependencies = [
  "iota-json-rpc-types",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 1.5.0-beta",
+ "iota-sdk 1.5.0-rc",
  "iota-test-transaction-builder",
  "iota-types",
  "move-binary-format",
@@ -7592,7 +7592,7 @@ dependencies = [
 
 [[package]]
 name = "iota-source-validation-service"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7607,7 +7607,7 @@ dependencies = [
  "iota-move",
  "iota-move-build",
  "iota-package-management",
- "iota-sdk 1.5.0-beta",
+ "iota-sdk 1.5.0-rc",
  "iota-source-validation",
  "move-core-types",
  "move-package",
@@ -7628,7 +7628,7 @@ dependencies = [
 
 [[package]]
 name = "iota-storage"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7679,7 +7679,7 @@ dependencies = [
 
 [[package]]
 name = "iota-surfer"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "bcs",
  "clap",
@@ -7707,7 +7707,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "futures",
@@ -7734,7 +7734,7 @@ dependencies = [
 
 [[package]]
 name = "iota-swarm-config"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -7762,7 +7762,7 @@ dependencies = [
 
 [[package]]
 name = "iota-synthetic-ingestion"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7779,12 +7779,12 @@ dependencies = [
 
 [[package]]
 name = "iota-test-transaction-builder"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "bcs",
  "iota-genesis-builder",
  "iota-move-build",
- "iota-sdk 1.5.0-beta",
+ "iota-sdk 1.5.0-rc",
  "iota-types",
  "move-core-types",
  "shared-crypto",
@@ -7792,7 +7792,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7814,7 +7814,7 @@ dependencies = [
 
 [[package]]
 name = "iota-tool"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -7836,7 +7836,7 @@ dependencies = [
  "iota-package-dump",
  "iota-protocol-config",
  "iota-replay",
- "iota-sdk 1.5.0-beta",
+ "iota-sdk 1.5.0-rc",
  "iota-snapshot",
  "iota-storage",
  "iota-types",
@@ -7859,7 +7859,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7875,7 +7875,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-checks"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "fastcrypto-zkp",
  "iota-config",
@@ -7888,7 +7888,7 @@ dependencies = [
 
 [[package]]
 name = "iota-transactional-test-runner"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7933,7 +7933,7 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8007,7 +8007,7 @@ dependencies = [
 
 [[package]]
 name = "iota-upgrade-compatibility-transactional-tests"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "datatest-stable",
@@ -8035,7 +8035,7 @@ dependencies = [
 
 [[package]]
 name = "iota-verifier-transactional-tests"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "datatest-stable",
  "iota-transactional-test-runner",
@@ -11300,7 +11300,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -13069,7 +13069,7 @@ dependencies = [
 
 [[package]]
 name = "shared-crypto"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "bcs",
  "eyre",
@@ -13194,7 +13194,7 @@ dependencies = [
 
 [[package]]
 name = "simulacrum"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -13844,7 +13844,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry-subscribers"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -13931,7 +13931,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-cluster"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "anyhow",
  "fastcrypto-zkp",
@@ -13947,7 +13947,7 @@ dependencies = [
  "iota-metrics",
  "iota-node",
  "iota-protocol-config",
- "iota-sdk 1.5.0-beta",
+ "iota-sdk 1.5.0-rc",
  "iota-simulator",
  "iota-swarm",
  "iota-swarm-config",
@@ -14764,7 +14764,7 @@ dependencies = [
 
 [[package]]
 name = "transaction-fuzzer"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "iota-core",
  "iota-move-build",
@@ -14836,7 +14836,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "async-trait",
  "bcs",
@@ -14867,7 +14867,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-derive"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -14877,7 +14877,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "serde",
  "thiserror 1.0.64",
@@ -14885,7 +14885,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store-workspace-hack"
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 dependencies = [
  "libc",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by iota-core, iota-faucet, iota-node, iota-tools, iota-sdk, iota-move-build, and iota crates.
-version = "1.5.0-beta"
+version = "1.5.0-rc"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/crates/iota-open-rpc/spec/openrpc.json
+++ b/crates/iota-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/iotaledger/iota/main/LICENSE"
     },
-    "version": "1.5.0-beta"
+    "version": "1.5.0-rc"
   },
   "methods": [
     {


### PR DESCRIPTION
Bump iota to `v1.5.0-rc` in preparation for `testnet` release.